### PR TITLE
allow Stache's AssetContainerRepository::find() to return null

### DIFF
--- a/app/Stache/Repositories/AssetContainerRepository.php
+++ b/app/Stache/Repositories/AssetContainerRepository.php
@@ -24,7 +24,7 @@ class AssetContainerRepository implements RepositoryContract
         return $this->store->getItems($keys);
     }
 
-    public function find($id): AssetContainer
+    public function find($id): ?AssetContainer
     {
         return $this->findByHandle($id);
     }


### PR DESCRIPTION
This makes sense, since it calls `findByHandle()`, which already may return null.

Without this fix, our code threw an exception. We use `find()` to check if a `collection` field in our content data corresponds to a container we configured in Statamic, and if not, we fall back to a generic `media` container we have. For example, content with `collection: image` in our datastore maps to the Statamic container `image`, and `collection: pdf` content would be mapped to the `media` container.

With this fix, the implementation is also more consistent with the AssetContainerRepository contract.