### PR TITLE
Arr:wrap the $urls instead of casting to array

### DIFF
--- a/src/Tags/Assets.php
+++ b/src/Tags/Assets.php
@@ -82,7 +82,7 @@ class Assets extends Tags
             return;
         }
 
-        $urls = (array) $urls;
+        $urls = Arr::wrap($urls);
 
         $this->assets = new AssetCollection;
 


### PR DESCRIPTION
This solves an issue for when the tag is referenced with a single asset