### PR TITLE
React to user changing field name

### DIFF
--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -12,7 +12,7 @@
                     <svg-icon class="h-4 w-4 mr-1 inline-block text-grey-70" :name="fieldtype.icon"></svg-icon>
                     {{ fieldtype.title }}
                 </small>
-                {{ values['display'] || config.display || config.handle }}
+                {{ values.display || config.display || config.handle }}
             </h1>
             <button
                 class="text-grey-50 hover:text-grey-80 mr-3 text-sm"


### PR DESCRIPTION
When a user created a new field in a new blueprint, when they updated the display name in the input, that was not reflected in the title of the stack element.

After some debugging (and looking at the wrong `.vue` files) I managed to figure out a fix.

This pull request resolves #694.