### PR TITLE
Fixed empty mail config in Utilities

### DIFF
--- a/resources/views/utilities/email.blade.php
+++ b/resources/views/utilities/email.blade.php
@@ -50,15 +50,27 @@
             </tr>
             <tr>
                 <th class="pl-2 py-1 w-1/4">Encryption</th>
-                <td><code>{{ config('mail.encryption') }}</code></td>
+                <td>
+                    @if (config('mail.encryption'))
+                        <code>{{ config('mail.encryption') }}</code>
+                    @endif
+                </td>
             </tr>
             <tr>
                 <th class="pl-2 py-1 w-1/4">Username</th>
-                <td><code>{{ config('mail.username') }}</code></td>
+                <td>
+                    @if (config('mail.username'))
+                        <code>{{ config('mail.username') }}</code>
+                    @endif
+                </td>
             </tr>
             <tr>
                 <th class="pl-2 py-1 w-1/4">Password</th>
-                <td><code>{{ config('mail.password') }}</code></td>
+                <td>
+                    @if (config('mail.password'))
+                        <code>{{ config('mail.password') }}</code>
+                    @endif
+                </td>
             </tr>
             <tr>
                 <th class="pl-2 py-1 w-1/4">Sendmail</th>


### PR DESCRIPTION
Prevent to show empty **code** tag if encryption, username or password is empty

From this:
![Schermata 2019-10-07 alle 22 05 20](https://user-images.githubusercontent.com/779534/66344766-e8904280-e94e-11e9-8702-f861be5a14ac.png)

To this:
![Schermata 2019-10-07 alle 22 05 45](https://user-images.githubusercontent.com/779534/66344775-ed54f680-e94e-11e9-9898-fd106eca52a6.png)
