### PR TITLE
reuse the item's blueprint for all its values in preProcessForIndex()

### DIFF
--- a/src/Data/DataCollection.php
+++ b/src/Data/DataCollection.php
@@ -218,8 +218,9 @@ class DataCollection extends IlluminateCollection
     public function preProcessForIndex()
     {
         return $this->each(function ($item) {
+            $blueprint = $item->blueprint();
             foreach ($item->values() as $key => $value) {
-                if ($field = $item->blueprint()->field($key)) {
+                if ($field = $blueprint->field($key)) {
                     $processed = $field->setValue($value)->preProcessIndex()->value();
                     $item->setSupplement($key, $processed);
                 }


### PR DESCRIPTION
With this change, the same blueprint instance is used for all values of an item when pre-processing a collection of entries for a listing.

This change made loading entry listings much faster for us, our one benchmark went from 7 seconds to 1 second.