### PR TITLE
cache a user's permissions

### DIFF
--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -323,12 +323,12 @@ class User extends BaseUser
     }
 
     /**
-    * Write to the user's meta YAML file
-    *
-    * @param  string $key
-    * @param  mixed $value
-    * @return void
-    */
+     * Write to the user's meta YAML file
+     *
+     * @param  string $key
+     * @param  mixed $value
+     * @return void
+     */
     public function setMeta($key, $value)
     {
         $yaml = YAML::parse(File::get($this->metaPath(), ''));


### PR DESCRIPTION
This change avoids redundant lookups of a user's role(s) in the filesystem.

Without this change, a user with `super: true` had fast listings while users without `super: true` but with a role with `super: true` had much slower listings.

@jojotl: correct me, please, if I explained this wrong :)