### PR TITLE
clean up SortableList usages inside Grid

### DIFF
--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -102,9 +102,11 @@ export default {
     },
 
     watch: {
-
-        rows(rows) {
-            this.update(rows);
+        value(newVal) {
+            if (JSON.stringify(this.rows) == JSON.stringify(newVal)) {
+                return;
+            }
+            this.rows = newVal;
         },
 
         isReorderable: {
@@ -142,15 +144,18 @@ export default {
 
             this.updateRowMeta(id, this.meta.new);
             this.rows.push(row);
+            this.update(this.rows);
         },
 
         updated(index, row) {
             this.rows.splice(index, 1, row);
+            this.update(this.rows);
         },
 
         removed(index) {
             if (confirm(__('Are you sure?'))) {
                 this.rows.splice(index, 1);
+                this.update(this.rows);
             }
         },
 
@@ -161,10 +166,11 @@ export default {
 
             this.updateRowMeta(row._id, this.meta.existing[old_id]);
             this.rows.push(row);
+            this.update(this.rows);
         },
 
         sorted(rows) {
-            this.rows = rows;
+            this.update(rows);
         },
 
         getReplicatorPreviewText() {

--- a/resources/js/components/fieldtypes/grid/Stacked.vue
+++ b/resources/js/components/fieldtypes/grid/Stacked.vue
@@ -1,12 +1,13 @@
 <template>
 
     <sortable-list
-        v-model="sortableRows"
+        :value="rows"
         :vertical="true"
         :item-class="sortableItemClass"
         :handle-class="sortableHandleClass"
         @dragstart="$emit('focus')"
         @dragend="$emit('blur')"
+        @input="(rows) => $emit('sorted', rows)"
     >
         <div class="grid-stacked" slot-scope="{}">
             <stacked-row

--- a/resources/js/components/fieldtypes/grid/Table.vue
+++ b/resources/js/components/fieldtypes/grid/Table.vue
@@ -13,12 +13,13 @@
             </tr>
         </thead>
         <sortable-list
-            v-model="sortableRows"
+            :value="rows"
             :vertical="true"
             :item-class="sortableItemClass"
             :handle-class="sortableHandleClass"
             @dragstart="$emit('focus')"
             @dragend="$emit('blur')"
+            @input="(rows) => $emit('sorted', rows)"
         >
             <tbody slot-scope="{}">
                 <grid-row

--- a/resources/js/components/fieldtypes/grid/View.vue
+++ b/resources/js/components/fieldtypes/grid/View.vue
@@ -3,12 +3,6 @@ export default {
 
     props: ['fields', 'rows', 'meta', 'name'],
 
-    data() {
-        return {
-            sortableRows: this.rows
-        }
-    },
-
     computed: {
 
         sortableItemClass() {
@@ -27,14 +21,6 @@ export default {
             sortableHandleClass: this.sortableHandleClass
         }
     },
-
-    watch: {
-
-        sortableRows(rows) {
-            this.$emit('sorted', rows);
-        }
-
-    }
 
 }
 </script>

--- a/resources/js/components/sortable/SortableList.vue
+++ b/resources/js/components/sortable/SortableList.vue
@@ -78,7 +78,6 @@ export default {
 
         sortable.on('sortable:stop', ({ oldIndex, newIndex }) => {
             this.$emit('input', move(this.value, oldIndex, newIndex))
-            this.$emit('sorted', this.value);
         })
 
         this.$on('hook:destroyed', () => {


### PR DESCRIPTION
- remove sortableRows and its watcher from View
- don't use v-model when using SortableList inside Grid
- pass rows as :value instead and proxy input event to sorted event
- don't watch rows in Grid; instead watch value to make Grid reactive (see #738, fixes #648)