### PR TITLE
Fix padding in form edit

### DIFF
--- a/resources/views/forms/edit.blade.php
+++ b/resources/views/forms/edit.blade.php
@@ -1,5 +1,4 @@
 @extends('statamic::layout')
-@section('content-class', 'publishing')
 @section('title', __('Edit Form'))
 
 @section('content')


### PR DESCRIPTION
Removed `publishing` class because it reset page wrapper padding.