### PR TITLE
Fix filtering by collections in Entries fieldtype

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -79,7 +79,7 @@ class Entries extends Relationship
     {
         $query = Entry::query();
 
-        if ($collections = $request->collections) {
+        if ($collections = $this->config('collections')) {
             $query->whereIn('collection', $collections);
         }
 


### PR DESCRIPTION
Get collections from config, not from request, when loading items to list in entries selector.

Fixes #791.