### PR TITLE
preprocess fields before returning them to the selector stack listing

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -50,7 +50,7 @@ class Entries extends Relationship
             $query->orderBy($sort, $this->getSortDirection($request));
         }
 
-        return $query->paginate();
+        return $query->paginate()->preProcessForIndex();
     }
 
     public function getSortColumn($request)


### PR DESCRIPTION
without this, entries and assets linked via our custom relationship fieldtypes didn't show up in the stack listings.