### PR TITLE
Optimize performance of Blueprint::fields

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -72,9 +72,7 @@ class Blueprint
 
         $this->validateUniqueHandles();
 
-        $fields = $this->sections()->map->fields()->reduce(function ($carry, $fields) {
-            return $carry->merge($fields);
-        }, new Fields);
+        $fields = new Fields($this->sections()->map->fields()->flatMap->items());
 
         $this->fieldsCache = $fields;
 


### PR DESCRIPTION
We noticed that one of the things slowing down our entry listings is the processing of blueprint fields. This commit changes the way fields are merged into a new Fields instance after collecting them from the sections config. Instead of using the merge method of the Fields instance, which would recreate every field multiple times, it merges the underlying items collection first, before creating a new Fields instance from all items.

This change drastically reduced the number of times "createField" gets called on our entry listing pages (22000 before and 9000 times after this change on a page with 50 entries).
