### PR TITLE
Fix invalid signature for TermRepository::make

### DIFF
--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -92,7 +92,7 @@ class TermRepository implements RepositoryContract
         return new TermQueryBuilder($this->store);
     }
 
-    public function make($slug = null): Term
+    public function make(string $slug = null): Term
     {
         return (new \Statamic\Taxonomies\Term)->slug($slug);
     }


### PR DESCRIPTION
Makes the `TermRepository::make` signature compatible with the interface.