### PR TITLE
Improve performance of Blueprint::ensureField()

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -146,18 +146,16 @@ class Blueprint
 
     public function ensureField($handle, $field, $section = null, $prepend = false)
     {
-        if ($this->hasField($handle)) {
-            // Loop through all sections looking for the handle so we can ensure the required config
-            foreach($this->contents['sections'] ?? [] as $section_key => $blueprint_section) {
-                foreach ($blueprint_section['fields'] as $field_key => $blueprint_field) {
-                    if (array_get($blueprint_field, 'handle') == $handle) {
-                        $this->contents['sections'][$section_key]['fields'][$field_key]['field'] = array_merge(
-                            $field,
-                            $this->contents['sections'][$section_key]['fields'][$field_key]['field']
-                        );
+        // Loop through all sections looking for the handle so we can ensure the required config
+        foreach($this->contents['sections'] ?? [] as $section_key => $blueprint_section) {
+            foreach ($blueprint_section['fields'] as $field_key => $blueprint_field) {
+                if (array_get($blueprint_field, 'handle') == $handle) {
+                    $this->contents['sections'][$section_key]['fields'][$field_key]['field'] = array_merge(
+                        $field,
+                        $this->contents['sections'][$section_key]['fields'][$field_key]['field']
+                    );
 
-                        return $this->resetFieldsCache();
-                    }
+                    return $this->resetFieldsCache();
                 }
             }
         }


### PR DESCRIPTION
Checking the existence of a field in `ensureField()` using `hasField()` has a hidden performance penalty, as it will also implicitly rebuild the field cache of a blueprint instance in case it is empty.
This results in the field cache being rebuilt multiple times when `Collection::ensureEntryBlueprintFields` gets called. 
