### PR TITLE
Fix 404 error using "Send Test Email"

### DIFF
--- a/src/CP/Utilities/CoreUtilities.php
+++ b/src/CP/Utilities/CoreUtilities.php
@@ -47,7 +47,7 @@ class CoreUtilities
             ->description('Check email configuration and send a test.')
             ->docsUrl(Statamic::docsUrl('utilities/email'))
             ->routes(function ($router) {
-                $router->post('email', [EmailController::class, 'send']);
+                $router->post('/', [EmailController::class, 'send']);
             })
             ->register();
     }


### PR DESCRIPTION
The "Send Test Email" (Utilities -> Email ) throw a 404 error