### PR TITLE
Users fieldtype works if `max_items` == 1

### DIFF
--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Fieldtypes;
 
-use Statamic\Facades\User;
 use Statamic\CP\Column;
+use Statamic\Facades\User;
 
 class Users extends Relationship
 {
@@ -33,9 +33,9 @@ class Users extends Relationship
             'options' => [
                 'default' => 'Stack Selector',
                 'select' => 'Select Dropdown',
-                'typeahead' => 'Typeahead Field'
-            ]
-        ]
+                'typeahead' => 'Typeahead Field',
+            ],
+        ],
     ];
 
     public function preProcess($data)
@@ -81,7 +81,13 @@ class Users extends Relationship
 
     public function preProcessIndex($data)
     {
-        return $this->augment($data)->map(function ($user) use ($data) {
+        $users = $this->augment($data);
+
+        if ($this->config('max_items') === 1) {
+            $users = collect([$users]);
+        }
+
+        return $users->map(function ($user) {
             return [
                 'id' => $user->id(),
                 'title' => $user->get('name', $user->email()),


### PR DESCRIPTION
Users fieldtype wasn't checking to see if the augment was returning a single user.