### PR TITLE
Fixed “Add row” text not displayed on Grid Field

### DIFF
--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -25,7 +25,7 @@
         <button
             class="btn"
             v-if="canAddRows"
-            v-text="__('Add Row')"
+            v-text="addRowButtonLabel"
             @click.prevent="addRow" />
 
     </div>
@@ -78,6 +78,10 @@ export default {
 
         canAddRows() {
             return !this.isReadOnly && this.value.length < this.maxRows;
+        },
+
+        addRowButtonLabel() {
+            return this.config.add_row || __('Add Row');
         },
 
         hasMaxRows() {


### PR DESCRIPTION
Closes https://github.com/statamic/three-cms/issues/837

If specified, the "Add row" text was displayed on publish form.

![Schermata 2019-10-29 alle 00 18 15](https://user-images.githubusercontent.com/779534/67725204-d2bbed80-f9e1-11e9-9428-7be981ab62bf.png)
---
![Schermata 2019-10-29 alle 00 18 22](https://user-images.githubusercontent.com/779534/67725207-d51e4780-f9e1-11e9-94cc-10773dc4956a.png)
