### PR TITLE
Allows only enter and escape on “Create Folder” dialog

### DIFF
--- a/resources/js/components/assets/Folder/Folder.vue
+++ b/resources/js/components/assets/Folder/Folder.vue
@@ -76,7 +76,9 @@ export default {
 
     created() {
         // Allow key commands with a focused input
-        this.$mousetrap.prototype.stopCallback = function () { return false; }
+        this.$mousetrap.prototype.stopCallback = (e) => {
+            return ! ['enter', 'escape'].includes(e.code.toLowerCase());
+        }
 
         this.$mousetrap.bind('enter', this.submit)
         this.$mousetrap.bind('esc', this.cancel)


### PR DESCRIPTION
If you try to write "Folder" in the "Create Folder" dialog of Assets section, the focus was moved to the search field.

![bug_folder](https://user-images.githubusercontent.com/779534/67726396-fd0faa00-f9e5-11e9-9310-bf50a0cf484b.gif)

This PR allows key commands on the "Create Folder" dialog with a focused input but only for "enter" and "escape" keys.
