### PR TITLE
live preview reload iframe on update

### DIFF
--- a/resources/js/components/live-preview/LivePreview.vue
+++ b/resources/js/components/live-preview/LivePreview.vue
@@ -212,6 +212,8 @@ export default {
 
             this.loading = true;
 
+            this.$refs.iframe.contentDocument.location.reload(true);
+
             this.$axios.post(this.url, this.payload, { cancelToken: source.token }).then(response => {
                 this.updateIframeContents(response.data);
             }).catch(e => {

--- a/resources/js/components/live-preview/Popout.vue
+++ b/resources/js/components/live-preview/Popout.vue
@@ -47,6 +47,8 @@ export default {
 
             this.channel.postMessage({ event: 'popout.loading' });
 
+            this.$refs.iframe.contentDocument.location.reload(true);
+
             this.$axios.post(this.url, this.payload, { cancelToken: source.token }).then(response => {
                 this.updateIframeContents(response.data);
             }).catch(e => {


### PR DESCRIPTION
Issue: [#832](https://github.com/statamic/three-cms/issues/832)

The location reload is set before the update because that was the only way it worked. Maybe you have another solution?