### PR TITLE
include collection in action context in entries listing

### DIFF
--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -22,6 +22,7 @@
                         <data-list-search v-model="searchQuery" />
                         <data-list-bulk-actions
                             :url="actionUrl"
+                            :context="{collection: collection}"
                             @started="actionStarted"
                             @completed="actionCompleted"
                         />

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -43,11 +43,11 @@ class EntriesController extends CpController
 
         $entries = $query
             ->paginate(request('perPage'))
-            ->supplement(function ($entry) {
+            ->supplement(function ($entry) use ($collection) {
                 return [
                     'viewable' => User::current()->can('view', $entry),
                     'editable' => User::current()->can('edit', $entry),
-                    'actions' => Action::for('entries', [], $entry),
+                    'actions' => Action::for('entries', ['collection' => $collection->handle()], $entry),
                 ];
             })
             ->preProcessForIndex();


### PR DESCRIPTION
This change makes the collection available to Actions when the `$key` is `entries`, as already documented here: https://statamic.dev/extending/actions