### PR TITLE
SelectFieldtype: actually use false when config.reset_on_options_change == false

### DIFF
--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -12,7 +12,7 @@
         :taggable="config.taggable"
         :push-tags="config.push_tags"
         :multiple="config.multiple"
-        :reset-on-options-change="config.reset_on_options_change || true"
+        :reset-on-options-change="typeof config.reset_on_options_change === 'boolean' ? config.reset_on_options_change : true"
         :close-on-select="!config.taggable"
         :value="value" />
 </template>


### PR DESCRIPTION
Before, due to the `|| true`, explicitly setting `reset_on_options_change` to `false` had no effect.