### PR TITLE
Center crop previews around the focal point

### DIFF
--- a/resources/js/components/assets/Editor/FocalPointEditor.vue
+++ b/resources/js/components/assets/Editor/FocalPointEditor.vue
@@ -43,14 +43,21 @@
         </div>
         <div v-for="n in 9" :key="n"
              :class="`frame frame-${n}`">
-            <div class="frame-image" :style="{ backgroundImage: 'url('+bgImage+')', backgroundPosition: bgPosition, transform: bgTransform, transformOrigin: bgPosition }" />
+            <focal-point-preview-frame :x="x" :y="y" :z="z" :image-url="image" :image-dimensions="imageDimensions" />
         </div>
     </div>
 
 </template>
 
 <script>
+import FocalPointPreviewFrame from './FocalPointPreviewFrame.vue';
+
 export default {
+
+    components: {
+        FocalPointPreviewFrame,
+    },
+
 
     props: [
         'data',   // The initial focus point data stored in the asset, if applicable.
@@ -64,24 +71,11 @@ export default {
             y: 50,
             z: 1,
             reticleSize: 0,
+            imageDimensions: {
+                w: 100,
+                h: 100
+            }
         }
-    },
-
-
-    computed: {
-
-        bgPosition() {
-            return this.x + '% ' + this.y + '%';
-        },
-
-        bgImage() {
-            return encodeURI(this.image);
-        },
-
-        bgTransform() {
-            return `scale(${this.z})`;
-        }
-
     },
 
 
@@ -91,14 +85,15 @@ export default {
         this.x = coords[0];
         this.y = coords[1];
         this.z = coords[2] || 1;
+        const image = this.$refs.image;
+        this.imageDimensions = { w: image.clientWidth, h: image.clientHeight };
     },
 
 
     watch: {
 
         z(z) {
-            const image = this.$refs.image;
-            const smaller = Math.min(image.clientWidth, image.clientHeight);
+            const smaller = Math.min(this.imageDimensions.w, this.imageDimensions.h);
             this.reticleSize = smaller / z;
         }
 

--- a/resources/js/components/assets/Editor/FocalPointPreviewFrame.vue
+++ b/resources/js/components/assets/Editor/FocalPointPreviewFrame.vue
@@ -1,0 +1,123 @@
+<template>
+    <div class="frame-image" ref="frame" :style="{ backgroundImage: `url(${encodeURI(imageUrl)})`, backgroundPosition: backgroundPosition, transform: `scale(${z})`, transformOrigin: transformOrigin }"
+    />
+</template>
+
+<script>
+export default {
+
+    props: [
+        'x',
+        'y',
+        'z',
+        'imageUrl',
+        'imageDimensions'
+    ],
+
+
+    data() {
+        return {
+            frameDimensions: {
+                w: 100,
+                h: 100
+            }
+        };
+    },
+
+
+    mounted() {
+        const frame = this.$refs['frame'];
+        // this is not responsive, but w/e
+        this.frameDimensions = {
+            w: frame.clientWidth,
+            h: frame.clientHeight
+        };
+    },
+
+
+    computed: {
+
+        // the dimensions of the image when used as a background of the frame so that it's shorter dimensions matches the frame dimension along that axis
+        bgImageDimensions() {
+            const ratio = ({ w, h }) => w / h;
+            if (ratio(this.imageDimensions) > ratio(this.frameDimensions)) {
+                // height of the image is shorter than width
+                return {
+                    // background image will be the same height as the frame
+                    h: this.frameDimensions.h,
+                    // width of the background image is proportional to the scaling of the heights
+                    w:
+                        (this.frameDimensions.h / this.imageDimensions.h) *
+                        this.imageDimensions.w,
+                };
+            } else {
+                return {
+                    // background image will be the same width as the frame
+                    w: this.frameDimensions.w,
+                    // height of the background image is proportional to the scaling of the widths
+                    h:
+                        (this.frameDimensions.w / this.imageDimensions.w) *
+                        this.imageDimensions.h,
+                };
+            }
+        },
+
+        // the width of the frame relative to the width of the image behind it, in percent
+        frameWidthPercent() {
+            return (this.frameDimensions.w / this.bgImageDimensions.w) * 100;
+        },
+
+        // the height of the frame relative to the height of the image behind it, in percent
+        frameHeightPercent() {
+            return (this.frameDimensions.h / this.bgImageDimensions.h) * 100;
+        },
+
+        // how much the frame should be offset from the left of the image, in percent
+        relOffsetLeft() {
+            let ol = this.x - this.frameWidthPercent / 2;
+            ol = Math.max(ol, 0);
+            return Math.min(ol, 100 - this.frameWidthPercent);
+        },
+
+        // how much the frame should be offset from the left of the image, in px
+        offsetLeft() {
+            return (this.relOffsetLeft * this.bgImageDimensions.w) / 100;
+        },
+
+        // how much the frame should be offset from the top of the image, in percent
+        relOffsetTop() {
+            let ot = this.y - this.frameHeightPercent / 2;
+            ot = Math.max(ot, 0);
+            return Math.min(ot, 100 - this.frameHeightPercent);
+        },
+
+        // how much the frame should be offset from the top of the image, in px
+        offsetTop() {
+            return (this.relOffsetTop * this.bgImageDimensions.h) / 100;
+        },
+
+        // the background image is offset using the offsets of the frame "above" it
+        // since the offsets are for the frame relative to the image, we negate them
+        // to get the offsets for the background relative to the frame instead.
+        backgroundPosition() {
+            return `-${this.offsetLeft}px -${this.offsetTop}px`;
+        },
+
+        // the center of the scaling transformation, in percent (relative to the frame dimensions);
+        // this has to be calculated because the focal point is not the center of the frame.
+        transformOrigin() {
+            const origin = {
+                x:
+                    ((this.x - this.relOffsetLeft) / this.frameWidthPercent) *
+                    100,
+                y:
+                    ((this.y - this.relOffsetTop) / this.frameHeightPercent) *
+                    100,
+            };
+            return `${origin.x}% ${origin.y}%`;
+        }
+
+    }
+
+};
+</script>


### PR DESCRIPTION
This is more intuitive (crops should try to have the focal point in their middle) than just shifting the background image by the focal point offset (which means focal points far from the middle of the original image appear on the edge of the crops).

This change gives previews more accurate with our rendering pipeline where we lifted the logic in this code from; the changes necessary to port this improved behavior to your front end side are not included in this PR. I don't even know if that's possible, since this logic requires you to know the source image aspect ratio as well as the ratio you want to crop it to. Let me know if I should try to do that before you consider merging.

We did not port our zooming logic fully and instead try to approximate it using the same `scale()` CSS transformation as before, but adjust the `transform-origin` to zoom towards the focal point. Ideally, zoom would be applied before cropping but that's not feasible when using the source image as background image (which forces you to use CSS scaling to zoom instead of real scaling, then cropping).

Feel free to ask questions; I know that most of these things are not obvious.

Some comparison shots:

| new | old |
|-----|----|
| ![Screenshot_2019-11-06 Edit Entry ‹ Artikel ‹ Collections ‹ Statamic](https://user-images.githubusercontent.com/1760908/68281594-50ce6300-0078-11ea-83c7-5b321e6c2e57.jpg) | ![Screenshot_2019-11-06 Edit Entry ‹ Artikel ‹ Collections ‹ Statamic(3)](https://user-images.githubusercontent.com/1760908/68281626-62176f80-0078-11ea-97fb-6009a55b19c8.jpg) |
| ![Screenshot_2019-11-06 Edit Entry ‹ Artikel ‹ Collections ‹ Statamic(1)](https://user-images.githubusercontent.com/1760908/68281648-6ba0d780-0078-11ea-9bf6-cf126e48e224.jpg) | ![Screenshot_2019-11-06 Edit Entry ‹ Artikel ‹ Collections ‹ Statamic(4)](https://user-images.githubusercontent.com/1760908/68281665-7196b880-0078-11ea-8d74-acd4200bba5c.jpg) |
| ![Screenshot_2019-11-06 Edit Entry ‹ Artikel ‹ Collections ‹ Statamic(2)](https://user-images.githubusercontent.com/1760908/68281680-78bdc680-0078-11ea-814d-be4b7c68220e.jpg) | ![Screenshot_2019-11-06 Edit Entry ‹ Artikel ‹ Collections ‹ Statamic(5)](https://user-images.githubusercontent.com/1760908/68281687-7f4c3e00-0078-11ea-9da4-178a631d774c.jpg) |

You can see that focal points close to the center of the image are mostly unaffected and only slightly corrected (first example), while focal points at the edges of the image are much better centered in crops (example 2). In example 3 you see that zooming isn't perfect yet, in that it doesn't improve the centering of the focal point in the crop, but it also doesn't make it worse due to the `transform-origin` adjustment.