### PR TITLE
Data-List // Table // update display of svg in sortable column

### DIFF
--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -14,7 +14,7 @@
                     @click.prevent="changeSortColumn(column.field)"
                 >
                     <span v-text="column.label" />
-                    <svg v-if="column.sortable === true" :class="sharedState.sortDirection" height="8" width="8" viewBox="0 0 10 6.5">
+                    <svg v-if="sharedState.sortColumn === column.field" :class="sharedState.sortDirection" height="8" width="8" viewBox="0 0 10 6.5">
                         <path d="M9.9,1.4L5,6.4L0,1.4L1.4,0L5,3.5L8.5,0L9.9,1.4z"/>
                     </svg>
                 </th>


### PR DESCRIPTION
The svg arrow for sortable columns is always rendered at the table head of data listing (visible or not). This has the effect that the lines jump (screenshot).
I updated the condition because it looks like the arrow is only displayed in the selected column. See if that works for you.