### PR TITLE
selector // enlarge search input

### DIFF
--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -25,7 +25,7 @@
                             <data-list-search
                                 v-if="search"
                                 v-model="searchQuery"
-                                class="bg-transparent p-0" />
+                                class="w-full bg-transparent p-0" />
                         </div>
 
                         <button


### PR DESCRIPTION
The search input in the selector is too short. After a few characters, the text is no longer displayed completely.
The behavior should be fixed with this PR.

![Bildschirmfoto 2019-11-14 um 13 42 02 (3) ](https://user-images.githubusercontent.com/54707973/68860885-ae068c00-06ea-11ea-8262-d5b4d4fcfddb.png)
