### PR TITLE
Fixed slug validation rule for entries

### DIFF
--- a/src/Stache/Repositories/EntryRepository.php
+++ b/src/Stache/Repositories/EntryRepository.php
@@ -118,7 +118,7 @@ class EntryRepository implements RepositoryContract
     {
         return [
             'title' => 'required',
-            'slug' => 'required|unique_entry_value:'.$collection->handle().',null,'.$site,
+            'slug' => 'required|unique_entry_value:'.$collection->handle().',null,'.$site->handle(),
         ];
     }
 


### PR DESCRIPTION
If you try to save an entry without a slug you receive this exception:

![Schermata 2019-11-19 alle 23 30 22](https://user-images.githubusercontent.com/779534/69192931-ef9d9980-0b25-11ea-922b-44f852027a74.png)

Slug validation rule for entries must use $site->handle()