### PR TITLE
Fix Laravel docs link that uses semver from 6.x

### DIFF
--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -59,6 +59,11 @@ export default {
 
         laravelDocsLink() {
             let version = new RegExp('([0-9]+\.[0-9])\.[0-9]+').exec(this.laravelVersion)[1];
+            let majorVersion = Number(version.split('.', 1)[0]);
+
+            if (majorVersion >= 6) {
+                version = `${majorVersion}.x`;
+            }
 
             return `https://laravel.com/docs/${version}/validation#available-validation-rules`;
         },


### PR DESCRIPTION
Laravel docs link was generated incorrectly if you are using Laravel 6

![Schermata 2019-11-20 alle 00 26 13](https://user-images.githubusercontent.com/779534/69196327-7f474600-0b2e-11ea-9b23-b58ea7f6ea97.png)


Using Laravel 5 the docs link works fine:
```
https://laravel.com/docs/5.8/validation#available-validation-rules
https://laravel.com/docs/5.7/validation#available-validation-rules
...
```

But from version 6, Laravel framework follows semver ... so docs url no longer contains the minor version but must use ".x".

```
https://laravel.com/docs/6.3/validation#available-validation-rules   <-- wrong
https://laravel.com/docs/6.x/validation#available-validation-rules   <-- ok
```