### PR TITLE
Use “default” view if template doesn’t exists

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -11,6 +11,7 @@ class View
     protected $layout;
     protected $template;
     protected $cascadeContent;
+    protected $defaultTemplate = 'default';
 
     public static function make($template = null)
     {
@@ -63,7 +64,10 @@ class View
     {
         $cascade = $this->gatherData();
 
-        $contents = view($this->template, $cascade);
+        $contents = view()->first([
+            $this->template,
+            $this->defaultTemplate,
+        ], $cascade);
 
         if ($this->layout) {
             $contents = view($this->layout, array_merge($cascade, [


### PR DESCRIPTION
Statamic should fallback to "default" view if template does not exists.

Example collection:
```yaml
title: Blog
route: 'blog/{slug}'
blueprints:
  - post
structure: blog
revisions: false
date: true
sort_dir: desc
date_behavior:
  past: public
  future: private
```

Error in frontend:

![Schermata 2019-11-21 alle 22 00 55](https://user-images.githubusercontent.com/779534/69378431-a2006880-0cae-11ea-98fd-647c46ab7001.png)
