### PR TITLE
fix: use defaultValue in custom fieldtype PHP stub

### DIFF
--- a/src/Console/Commands/stubs/fieldtype.php.stub
+++ b/src/Console/Commands/stubs/fieldtype.php.stub
@@ -11,7 +11,7 @@ class DummyClass extends Fieldtype
      *
      * @return array
      */
-    public function blank()
+    public function defaultValue()
     {
         return null;
     }


### PR DESCRIPTION
As per a conversation on Discord, this PR updates the PHP stub generated by `php please make:fieldtype` to use `defaultValue` instead of the outdated `blank` method.

<img width="868" alt="Screen Shot 2019-12-01 at 12 58 52 PM" src="https://user-images.githubusercontent.com/5148596/69917973-5716eb80-143a-11ea-9426-743cf17a84c3.png">

❤️ 