### PR TITLE
:sparkles: Enter now submits the rename action

### DIFF
--- a/resources/js/components/fieldtypes/TextFieldtype.vue
+++ b/resources/js/components/fieldtypes/TextFieldtype.vue
@@ -2,6 +2,7 @@
     <text-input
         ref="input"
         :value="value"
+        :classes="config.classes"
         :autofocus="config.autofocus"
         :autoselect="config.autoselect"
         :type="config.input"

--- a/resources/js/components/inputs/Text.vue
+++ b/resources/js/components/inputs/Text.vue
@@ -5,6 +5,7 @@
             <input
                 ref="input"
                 class="input-text"
+                :class="classes"
                 :name="name"
                 :value="value"
                 :type="type"
@@ -32,6 +33,7 @@ export default {
     props: {
         name: {},
         disabled: { default: false },
+        classes: { default: null },
         isReadOnly: { type: Boolean, default: false },
         placeholder: { required: false },
         type: { default: "text" },

--- a/resources/js/components/modals/ConfirmationModal.vue
+++ b/resources/js/components/modals/ConfirmationModal.vue
@@ -47,11 +47,15 @@ export default {
     methods: {
         dismiss() {
             this.$emit('cancel')
+        },
+        submit() {
+            this.$emit('confirm')
         }
     },
 
     created() {
         this.$mousetrap.bind('esc', this.dismiss)
+        this.$mousetrap.bind('enter', this.submit)
     },
 }
 </script>

--- a/src/Actions/RenameAsset.php
+++ b/src/Actions/RenameAsset.php
@@ -29,6 +29,7 @@ class RenameAsset extends Action
             'filename' => [
                 'type' => 'text',
                 'validate' => 'required', // TODO: Better filename validation
+                'classes' => 'mousetrap'
             ]
         ];
     }


### PR DESCRIPTION
This PR uses Mousetrap to allow binding of the `enter` key while still focused inside a text fieldtype. This addresses #1040.