### PR TITLE
Change to Statamic url methods

### DIFF
--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -3,13 +3,13 @@
 <meta name="viewport" content="width=device-width">
 <meta name="robots" content="noindex,nofollow">
 <title>@yield('title', $title ?? __('Here')) ‹ Statamic</title>
-<link rel="icon" type="image/png" href="{{ Statamic::assetUrl('img/favicon-32x32.png') }}" sizes="32x32" />
-<link rel="icon" type="image/png" href="{{ Statamic::assetUrl('img/favicon-16x16.png') }}" sizes="16x16" />
-<link rel="shortcut icon" type="image/x-icon" href="{{ Statamic::assetUrl('img/favicon.ico') }}" sizes="16x16 32x32"/>
-<link href="{{ Statamic::assetUrl('css/cp.css') }}?v={{ Statamic::version() }}" rel="stylesheet" />
+<link rel="icon" type="image/png" href="{{ Statamic::cpAssetUrl('img/favicon-32x32.png') }}" sizes="32x32" />
+<link rel="icon" type="image/png" href="{{ Statamic::cpAssetUrl('img/favicon-16x16.png') }}" sizes="16x16" />
+<link rel="shortcut icon" type="image/x-icon" href="{{ Statamic::cpAssetUrl('img/favicon.ico') }}" sizes="16x16 32x32"/>
+<link href="{{ Statamic::cpAssetUrl('css/cp.css') }}?v={{ Statamic::version() }}" rel="stylesheet" />
 
 @foreach (Statamic::availableStyles(request()) as $name => $path)
-<link href="{{ Statamic::url("vendor/$name/css/$path") }}" rel="stylesheet" />
+<link href="{{ Statamic::vendorAssetUrl("vendor/$name/css/$path") }}" rel="stylesheet" />
 @endforeach
 
 @stack('head')

--- a/resources/views/partials/scripts.blade.php
+++ b/resources/views/partials/scripts.blade.php
@@ -1,9 +1,9 @@
-<script src="{{ Statamic::assetUrl('js/manifest.js') }}?v={{ Statamic::version() }}"></script>
-<script src="{{ Statamic::assetUrl('js/vendor.js') }}?v={{ Statamic::version() }}"></script>
-<script src="{{ Statamic::assetUrl('js/app.js') }}?v={{ Statamic::version() }}"></script>
+<script src="{{ Statamic::cpAssetUrl('js/manifest.js') }}?v={{ Statamic::version() }}"></script>
+<script src="{{ Statamic::cpAssetUrl('js/vendor.js') }}?v={{ Statamic::version() }}"></script>
+<script src="{{ Statamic::cpAssetUrl('js/app.js') }}?v={{ Statamic::version() }}"></script>
 
 @foreach (Statamic::availableScripts(request()) as $name => $path)
-    <script src="{{ Statamic::url("vendor/$name/js/$path") }}"></script>
+    <script src="{{ Statamic::vendorAssetUrl("$name/js/$path") }}"></script>
 @endforeach
 
 <script>

--- a/resources/views/structures/show.blade.php
+++ b/resources/views/structures/show.blade.php
@@ -10,7 +10,7 @@
         submit-url="{{ cp_route('structures.pages.store', $structure->handle()) }}"
         edit-url="{{ cp_route('structures.edit', $structure->handle()) }}"
         create-url="{{ $hasCollection ? cp_route('collections.entries.create', [$structure->collection()->handle(), $site]) : null }}"
-        sound-drop-url="{{ Statamic::assetUrl('audio/click.mp3') }}"
+        sound-drop-url="{{ Statamic::cpAssetUrl('audio/click.mp3') }}"
         site="{{ $site }}"
         :localizations="{{ json_encode($localizations) }}"
         :collections="{{ json_encode($collections) }}"

--- a/src/Http/Controllers/CP/Assets/ThumbnailController.php
+++ b/src/Http/Controllers/CP/Assets/ThumbnailController.php
@@ -150,6 +150,6 @@ class ThumbnailController extends Controller
             return;
         }
 
-        return redirect(Statamic::assetUrl('img/filetypes/' . $this->asset->extension() . '.png'));
+        return redirect(Statamic::cpAssetUrl('img/filetypes/' . $this->asset->extension() . '.png'));
     }
 }

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -23,7 +23,7 @@ class JavascriptComposer
             'csrfToken' => csrf_token(),
             'cpRoot' => str_start(config('statamic.cp.route'), '/'),
             'urlPath' => '/' . request()->path(),
-            'resourceUrl' => Statamic::assetUrl(),
+            'resourceUrl' => Statamic::cpAssetUrl(),
             'locales' => config('statamic.system.locales'),
             'flash' => Statamic::flash(),
             'ajaxTimeout' => config('statamic.system.ajax_timeout'),

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -146,14 +146,14 @@ class Statamic
         );
     }
 
-    public static function assetUrl($url = '/')
+    public static function vendorAssetUrl($url = '/')
     {
-        return static::url('vendor/statamic/cp/' . $url);
+        return asset(URL::tidy('vendor/' . $url));
     }
 
-    public static function url($url = '/')
+    public static function cpAssetUrl($url = '/')
     {
-        return URL::tidy(Site::default()->url() . '/' . $url);
+        return static::vendorAssetUrl('statamic/cp/' . $url);
     }
 
     public static function flash()


### PR DESCRIPTION
`Statamic::url()` is removed. It wasn't being used in core except by `assetUrl()` in the same class. It was also basing itself off the first site's URL. If you want to run all your Statamic sites in subdirectories (like in #1049), it would break. You should totally be able to do that, and you can after this PR.

Added `Statamic::vendorAssetUrl()` that gets a URL in the `public/vendor` directory. It now also uses Laravel's `asset()` helper, which will allow everything to be served correctly when using [Laravel Vapor](https://vapor.laravel.com). (Doesn't make Statamic 100% usable on Vapor, but it's a step in the right direction.)

`Statamic::assetUrl()` is now `cpAssetUrl()`. A bit more explicit.

Closes #1049