### PR TITLE
make RelationshipFieldtype a proper reactive component

### DIFF
--- a/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
+++ b/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
@@ -2,7 +2,7 @@
 
     <relationship-input
         :name="name"
-        v-model="selections"
+        :value="value"
         :mode="config.mode"
         :can-edit="canEdit"
         :config="config"
@@ -24,6 +24,7 @@
         :taggable="taggable"
         @focus="$emit('focus')"
         @blur="$emit('blur')"
+        @input="selectionUpdated"
         @item-data-updated="itemDataUpdated"
     />
 
@@ -38,7 +39,6 @@ export default {
 
     data() {
         return {
-            selections: _.clone(this.value),
             initialData: this.meta.data
         }
     },
@@ -133,20 +133,13 @@ export default {
 
     },
 
-    watch: {
-
-        selections(selections) {
-            this.update(this.selections);
-        },
-
-        value(value) {
-            if (JSON.stringify(value) == JSON.stringify(this.selections)) return;
-            this.selections = value;
-        }
-
-    },
 
     methods: {
+
+        selectionUpdated(selection) {
+            if (JSON.stringify(selection) == JSON.stringify(this.value)) return;
+            this.update(selection);
+        },
 
         itemDataUpdated(data) {
             const meta = clone(this.meta);

--- a/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
+++ b/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
@@ -24,7 +24,7 @@
         :taggable="taggable"
         @focus="$emit('focus')"
         @blur="$emit('blur')"
-        @input="selectionUpdated"
+        @input="update"
         @item-data-updated="itemDataUpdated"
     />
 
@@ -135,11 +135,6 @@ export default {
 
 
     methods: {
-
-        selectionUpdated(selection) {
-            if (JSON.stringify(selection) == JSON.stringify(this.value)) return;
-            this.update(selection);
-        },
 
         itemDataUpdated(data) {
             const meta = clone(this.meta);


### PR DESCRIPTION
Duplicate of #899 because the repository renaming and publishing broke that PR:

> ... by removing the disconnect via `selections` between its `:value` prop and what's emitted with `@input` events.
>
> Without this, passing in entry IDs in `:value` resulted in an `@input` event being emitted immediately (due to the watcher on `this.selection` and `data()` setting it to a clone of `this.value`).
>
> As a side effect, it became simpler and should be more performant because there are no watchers left.
>
> We found this bug when we wrapped the fieldtype, as always... :D

Now fixes #910, too.