### PR TITLE
Fixed “multisite” command if doesn’t exists collections

### DIFF
--- a/src/Console/Commands/Multisite.php
+++ b/src/Console/Commands/Multisite.php
@@ -143,6 +143,10 @@ class Multisite extends Command
     {
         $collection = Collection::all()->first();
 
+        if ( ! $collection) {
+            return false;
+        }
+
         $dir = "content/collections/{$collection->handle()}/{$this->siteOne}";
 
         return File::isDirectory($dir);


### PR DESCRIPTION
If doesn't exists collections the <code>php please multisite</code> command returns
```
Call to a member function handle() on null
```