### PR TITLE
fix focal point zoom reticle only showing up when manually changing zoom

### DIFF
--- a/resources/js/components/assets/Editor/FocalPointEditor.vue
+++ b/resources/js/components/assets/Editor/FocalPointEditor.vue
@@ -70,7 +70,6 @@ export default {
             x: 50,
             y: 50,
             z: 1,
-            reticleSize: 0,
             imageDimensions: null,
         }
     },
@@ -85,14 +84,13 @@ export default {
     },
 
 
-    watch: {
+    computed: {
 
-        z(z) {
-            if (!this.imageDimensions) return 0;
-
+        reticleSize() {
+            if (!this.imageDimensions || !this.z) return 0;
             const smaller = Math.min(this.imageDimensions.w, this.imageDimensions.h);
-            this.reticleSize = smaller / z;
-        }
+            return smaller / this.z;
+        },
 
     },
 


### PR DESCRIPTION
Currently, the circle indicating the zoom level doesn't show up until after you manually change the zoom. Turning it into a computed property should make it work correctly.