### PR TITLE
Revert the scope / cascade behavior introduced in v3

### DIFF
--- a/src/Data/Augmentable.php
+++ b/src/Data/Augmentable.php
@@ -14,15 +14,25 @@ trait Augmentable
             $fields = collect();
         }
 
-        return collect($this->augmentedArrayData())
-            ->map(function ($value, $handle) use ($fields) {
-                if (! $fields->has($handle)) {
-                    return $value;
-                }
+        // Convert provided data into values.
+        $values = collect($this->augmentedArrayData())->map(function ($value, $handle) use ($fields) {
+            if (! $fields->has($handle)) {
+                return $value;
+            }
 
-                return new Value($value, $handle, $fields->get($handle)->fieldtype(), $this);
-            })
-            ->all();
+            return new Value($value, $handle, $fields->get($handle)->fieldtype(), $this);
+        });
+
+        // Any values that aren't in the data but are in the blueprint should have their defaults/nulls added.
+        if ($blueprint) {
+            foreach ($fields as $handle => $field) {
+                if (! $values->has($handle)) {
+                    $values[$handle] = new Value($field->defaultValue(), $handle, $field->fieldtype(), $this);
+                }
+            }
+        }
+
+        return $values->all();
     }
 
     public function augmentedArrayData()

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1479,6 +1479,22 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Place variables in a scope
+     *
+     * @param  $value
+     * @param  $params
+     * @return array
+     */
+    public function scope($value, $params)
+    {
+        if (! $scope = Arr::get($params, 0)) {
+            throw new \Exception('Scope modifier requires a name.');
+        }
+
+        return Arr::addScope($value, $scope);
+    }
+
+    /**
      * Returns a segment by number from any valid URL or UI
      *
      * @param  $value

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -2,8 +2,9 @@
 
 namespace Statamic\Support;
 
-use Statamic\Data\DataCollection;
+use Exception;
 use Illuminate\Support\Arr as IlluminateArr;
+use Statamic\Data\DataCollection;
 
 class Arr extends IlluminateArr
 {
@@ -38,6 +39,24 @@ class Arr extends IlluminateArr
         }
 
         return parent::has($array, $key);
+    }
+
+    public static function addScope($array, $scope)
+    {
+        if (static::isAssoc($array)) {
+            $array[$scope] = $array;
+            return $array;
+        }
+
+        return collect($array)->map(function ($value) use ($scope) {
+            if (! is_array($value)) {
+                throw new Exception('Scopes can only be added to associative or multidimensional arrays.');
+            }
+
+            $value[$scope] = $value;
+
+            return $value;
+        })->all();
     }
 
     /**

--- a/src/Tags/Tags.php
+++ b/src/Tags/Tags.php
@@ -166,7 +166,7 @@ abstract class Tags
         }
 
         return Antlers::usingParser($this->parser, function ($antlers) use ($data, $supplement) {
-            return $antlers->parseLoop($this->content, $data, $supplement);
+            return $antlers->parseLoop($this->content, $data, $supplement, $this->context->all());
         });
     }
 

--- a/src/Tags/Tags.php
+++ b/src/Tags/Tags.php
@@ -147,6 +147,10 @@ abstract class Tags
      */
     public function parse($data = [])
     {
+        if ($scope = $this->get('scope')) {
+            $data = Arr::addScope($data, $scope);
+        }
+
         return Antlers::usingParser($this->parser, function ($antlers) use ($data) {
             return $antlers->parse($this->content, array_merge($this->context->all(), $data));
         });
@@ -163,6 +167,10 @@ abstract class Tags
     {
         if ($as = $this->params->get('as')) {
             return $this->parse([$as => $data]);
+        }
+
+        if ($scope = $this->get('scope')) {
+            $data = Arr::addScope($data, $scope);
         }
 
         return Antlers::usingParser($this->parser, function ($antlers) use ($data, $supplement) {

--- a/src/Tags/Tags.php
+++ b/src/Tags/Tags.php
@@ -148,7 +148,7 @@ abstract class Tags
     public function parse($data = [])
     {
         return Antlers::usingParser($this->parser, function ($antlers) use ($data) {
-            return $antlers->parse($this->content, $data);
+            return $antlers->parse($this->content, array_merge($this->context->all(), $data));
         });
     }
 

--- a/src/View/Antlers/Antlers.php
+++ b/src/View/Antlers/Antlers.php
@@ -35,14 +35,15 @@ class Antlers
      * @param string  $content
      * @param array   $data
      * @param bool    $supplement
+     * @param array   $context
      * @return string
      */
-    public function parseLoop($content, $data, $supplement = true)
+    public function parseLoop($content, $data, $supplement = true, $context = [])
     {
         $total  = count($data);
         $i = 0;
 
-        return collect($data)->reduce(function ($carry, $item) use ($content, &$i, $total, $supplement) {
+        return collect($data)->reduce(function ($carry, $item) use ($content, &$i, $total, $supplement, $context) {
             if ($supplement) {
                 $item = array_merge($item, [
                     'index' => $i,
@@ -55,7 +56,7 @@ class Antlers
 
             $i++;
 
-            return $carry . $this->parse($content, $item);
+            return $carry . $this->parse($content, array_merge($context, $item));
         }, '');
     }
 }

--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -891,6 +891,12 @@ class Parser
             $next_tag = null;
             $children = Arr::get($data, $array_key);
 
+            // if the array key is scoped, we'll add a scope to the array
+            if (strpos($array_key, ':') !== false) {
+                $scope = explode(':', $array_key)[0];
+                $children = Arr::addScope($children, $scope);
+            }
+
             $child_count = count($children);
             $count = 1;
 

--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -291,8 +291,8 @@ class Parser
             // so it can be parsed over like the other cases, and then we'll pick out the first one after.
             $value = ($associative = Arr::assoc($value)) ? [$value] : $this->addLoopIterationVariables($value);
 
-            $parses = collect($value)->map(function ($iteration) use ($contents) {
-                return $this->parseLoopInstance($contents, $iteration);
+            $parses = collect($value)->map(function ($iteration) use ($contents, $data) {
+                return $this->parseLoopInstance($contents, array_merge($data, $iteration));
             });
 
             // Again, associative arrays just need the single iteration, so we'll grab

--- a/tests/Support/ArrTest.php
+++ b/tests/Support/ArrTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use Statamic\Support\Arr;
+
+class ArrTest extends TestCase
+{
+    /** @test */
+    function it_adds_scope_to_associative_array()
+    {
+        $arr = [
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ];
+
+        $expected = [
+            'foo' => 'bar',
+            'baz' => 'qux',
+            'myscope' => [
+                'foo' => 'bar',
+                'baz' => 'qux',
+            ]
+        ];
+
+        $this->assertEquals($expected, Arr::addScope($arr, 'myscope'));
+    }
+
+    /** @test */
+    function it_adds_scope_to_multidimensional_array()
+    {
+        $arr = [
+            [
+                'foo' => 'bar',
+                'baz' => 'qux',
+            ],
+            [
+                'foo' => 'bar2',
+                'baz' => 'qux2',
+            ],
+        ];
+
+        $expected = [
+            [
+                'foo' => 'bar',
+                'baz' => 'qux',
+                'myscope' => [
+                    'foo' => 'bar',
+                    'baz' => 'qux',
+                ]
+            ],
+            [
+                'foo' => 'bar2',
+                'baz' => 'qux2',
+                'myscope' => [
+                    'foo' => 'bar2',
+                    'baz' => 'qux2',
+                ]
+            ],
+        ];
+
+        $this->assertEquals($expected, Arr::addScope($arr, 'myscope'));
+    }
+
+    /** @test */
+    function it_doesnt_add_scope_to_lists()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Scopes can only be added to associative or multidimensional arrays.');
+
+        Arr::addScope(['one', 'two'], 'scope');
+    }
+}

--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -1141,6 +1141,34 @@ EOT;
     }
 
     /** @test */
+    function scope_modifier_can_add_scopes()
+    {
+        $context = [
+            'drink' => 'whisky',
+            'food' => 'burger',
+            'array' => [
+                ['drink' => 'juice'],
+                ['drink' => 'smoothie'],
+            ]
+        ];
+
+        $template = <<<EOT
+{{ food }} {{ drink }}
+{{ array scope="s" }}
+-{{ s:food }}- {{ s:drink }}
+{{ /array }}
+EOT;
+
+        $expected = <<<EOT
+burger whisky
+-- juice
+-- smoothie
+
+EOT;
+        $this->assertEquals($expected, Antlers::parse($template, $context));
+    }
+
+    /** @test */
     function it_can_reach_into_the_cascade()
     {
         $cascade = $this->mock(Cascade::class, function ($m) {

--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -966,14 +966,14 @@ EOT;
         $template = <<<EOT
 {{ string }}
 {{ tag }}
-    {{ count }} {{ if first }}first{{ else }}not-first{{ /if }} {{ if last }}last{{ else }}not-last{{ /if }} {{ one }} {{ two }} >{{ string }}<
+    {{ count }} {{ if first }}first{{ else }}not-first{{ /if }} {{ if last }}last{{ else }}not-last{{ /if }} {{ one }} {{ two }} {{ string }}
 {{ /tag }}
 EOT;
 
         $expected = <<<EOT
 Hello wilderness
-    1 first not-last a b ><
-    2 not-first last c d ><
+    1 first not-last a b Hello wilderness
+    2 not-first last c d Hello wilderness
 
 EOT;
 
@@ -1019,14 +1019,14 @@ EOT;
         $template = <<<EOT
 {{ string }}
 {{ tag }}
-    {{ count }} {{ if first }}first{{ else }}not-first{{ /if }} {{ if last }}last{{ else }}not-last{{ /if }} {{ one }} {{ two }} >{{ string }}<
+    {{ count }} {{ if first }}first{{ else }}not-first{{ /if }} {{ if last }}last{{ else }}not-last{{ /if }} {{ one }} {{ two }} {{ string }}
 {{ /tag }}
 EOT;
 
         $expected = <<<EOT
 Hello wilderness
-    1 first not-last a b ><
-    2 not-first last c d ><
+    1 first not-last a b Hello wilderness
+    2 not-first last c d Hello wilderness
 
 EOT;
 


### PR DESCRIPTION
### The original problem

A common problem people ran into in Statamic v2 was needing to ["fight the cascade"](https://docs.statamic.com/knowledge-base/wrong-variables).

For example: You're on an entry's page, looping through other entries using a collection tag, and one of the entries doesn't have a variable, but it exists on the outer entry. The entry in the loop will inherit the value from the outer entry, instead of being null/missing like you probably expect. (More detailed example in the link above)

The solution was to use the `scope` parameter and variable prefix to force the template to only use vars from that loop iteration.

This workaround was fine, but you'd have to know about it, and it became a frequent question needing to be answered.


### The solution we added to v3

To fight this problem, we made any tag pairs **not inherit** the context around it. You'd only have access to the variables within that loop. We introduced a new `scope` tag so that you can manually create scopes if you needed to reach into data outside the loop.

While that solved the problem above, we soon realized that you need to use this new scope tag way more than we originally expected, and introduced more confusion in other areas.


### Rolling on back

So, it's going back to how it worked in v2. Data now cascades into the tag pairs once again similar to the way v2 does. No need for that new scope tag.

The tag is staying though. It's still useful to be able to "snapshot" data at a certain point and be able to reference it from several tag pairs deep.


### Smarter inheritance

We didn't want to back to "fighting the cascade", so we solved it a different way.

The `collection` tag (and other similar tags that use augmentation, like `taxonomy`, `assets`, etc) will now **explicitly** add default values (nulls, empty arrays, etc) for fields in the blueprint that aren't already there. Now, if a value is missing from an entry in the loop, it won't inherit from the outside.

You no longer need that `scope=""` workaround (but if you liked doing that, you still can).