### PR TITLE
Keyboard shortcut JS API

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -57,12 +57,10 @@ Statamic.booting(Statamic => {
 });
 
 Vue.prototype.$axios = axios;
-Vue.prototype.$mousetrap = require('mousetrap');
-require('mousetrap/plugins/global-bind/mousetrap-global-bind');
-
 Vue.prototype.$events = new Vue();
 Vue.prototype.$echo = Statamic.$echo;
 Vue.prototype.$bard = Statamic.$bard;
+Vue.prototype.$keys = Statamic.$keys;
 
 window.moment = Vue.moment = Vue.prototype.$moment = require('moment');
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -172,7 +172,7 @@ Statamic.app({
     mounted() {
         this.bindWindowResizeListener();
 
-        this.$mousetrap.bind(['command+\\'], e => {
+        this.$keys.bind(['command+\\'], e => {
             e.preventDefault();
             this.toggleNav();
         });

--- a/resources/js/components/FavoriteCreator.vue
+++ b/resources/js/components/FavoriteCreator.vue
@@ -87,7 +87,7 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bindGlobal(['esc'], e => {
+        this.$keys.bindGlobal(['esc'], e => {
             this.$refs.popper.doClose();
         });
     }

--- a/resources/js/components/GlobalSearch.vue
+++ b/resources/js/components/GlobalSearch.vue
@@ -192,7 +192,7 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bind(['/', 'ctrl+f', 'alt+f', 'shift+f'], e => {
+        this.$keys.bind(['/', 'ctrl+f', 'alt+f', 'shift+f'], e => {
             e.preventDefault();
             this.focus();
         });

--- a/resources/js/components/ModalDialog.vue
+++ b/resources/js/components/ModalDialog.vue
@@ -25,6 +25,12 @@ import { mixin as clickaway } from 'vue-clickaway';
 export default {
     mixins: [ clickaway ],
 
+    data() {
+        return {
+            keybinding: null,
+        }
+    },
+
     props: {
         show: {
             type: Boolean,
@@ -54,16 +60,15 @@ export default {
     },
 
     created() {
-        this.$keys.bind('esc', this.dismiss)
+        this.keybinding = this.$keys.bind('esc', this.dismiss)
     },
 
     destroyed() {
-        this.$keys.unbind('esc')
+        this.keybinding.destroy();
     },
 
     methods: {
         dismiss: function() {
-            console.log('Go away modal!')
             this.$emit('close')
         }
     },

--- a/resources/js/components/ModalDialog.vue
+++ b/resources/js/components/ModalDialog.vue
@@ -54,11 +54,11 @@ export default {
     },
 
     created() {
-        this.$mousetrap.bind('esc', this.dismiss)
+        this.$keys.bind('esc', this.dismiss)
     },
 
     destroyed() {
-        this.$mousetrap.unbind('esc')
+        this.$keys.unbind('esc')
     },
 
     methods: {

--- a/resources/js/components/Statamic.js
+++ b/resources/js/components/Statamic.js
@@ -1,11 +1,13 @@
 import Vue from 'vue';
 import Echo from './Echo';
 import Bard from './Bard';
+import Keys from './keys/Keys';
 import Hooks from './Hooks';
 import Components from './Components';
 import FieldConditions from './FieldConditions';
 const echo = new Echo;
 const bard = new Bard;
+const keys = new Keys;
 const hooks = new Hooks;
 const components = new Components;
 const conditions = new FieldConditions;
@@ -43,6 +45,10 @@ export default new Vue({
 
         $conditions() {
             return conditions;
+        },
+
+        $keys() {
+            return keys;
         },
 
         user() {

--- a/resources/js/components/asset-containers/EditForm.vue
+++ b/resources/js/components/asset-containers/EditForm.vue
@@ -85,7 +85,7 @@ export default {
     },
 
     created() {
-        this.$mousetrap.bindGlobal(['mod+s'], e => {
+        this.$keys.bindGlobal(['mod+s'], e => {
             e.preventDefault();
             this.submit();
         });

--- a/resources/js/components/assets/Folder/Folder.vue
+++ b/resources/js/components/assets/Folder/Folder.vue
@@ -76,12 +76,12 @@ export default {
 
     created() {
         // Allow key commands with a focused input
-        this.$mousetrap.prototype.stopCallback = (e) => {
+        this.$keys.prototype.stopCallback = (e) => {
             return ! ['enter', 'escape'].includes(e.code.toLowerCase());
         }
 
-        this.$mousetrap.bind('enter', this.submit)
-        this.$mousetrap.bind('esc', this.cancel)
+        this.$keys.bind('enter', this.submit)
+        this.$keys.bind('esc', this.cancel)
     },
 
 }

--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -54,7 +54,7 @@ export default {
     },
 
     created() {
-        this.$mousetrap.bindGlobal(['mod+s'], e => {
+        this.$keys.bindGlobal(['mod+s'], e => {
             e.preventDefault();
             this.save();
         });

--- a/resources/js/components/collections/EditForm.vue
+++ b/resources/js/components/collections/EditForm.vue
@@ -88,7 +88,7 @@ export default {
     },
 
     created() {
-        this.$mousetrap.bindGlobal(['mod+s'], e => {
+        this.$keys.bindGlobal(['mod+s'], e => {
             e.preventDefault();
             this.submit();
         });

--- a/resources/js/components/collections/Wizard.vue
+++ b/resources/js/components/collections/Wizard.vue
@@ -364,11 +364,11 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bindGlobal(['command+return'], e => {
+        this.$keys.bindGlobal(['command+return'], e => {
             this.next();
         });
 
-        this.$mousetrap.bindGlobal(['command+delete'], e => {
+        this.$keys.bindGlobal(['command+delete'], e => {
             this.previous();
         });
     }

--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -133,7 +133,7 @@ export default {
     },
 
     created() {
-        this.$mousetrap.bind('esc', this.dismiss)
+        this.$keys.bind('esc', this.dismiss)
     },
 }
 </script>

--- a/resources/js/components/data-list/Filters.vue
+++ b/resources/js/components/data-list/Filters.vue
@@ -127,7 +127,7 @@ export default {
     },
 
     created() {
-        this.$mousetrap.bind('esc', this.dismiss)
+        this.$keys.bind('esc', this.dismiss)
     },
 
 }

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -318,7 +318,9 @@ export default {
             confirmingPublish: false,
             readOnly: this.initialReadOnly,
             isRoot: this.initialIsRoot,
-            permalink: this.initialPermalink
+            permalink: this.initialPermalink,
+
+            saveKeyBinding: null,
         }
     },
 
@@ -586,7 +588,7 @@ export default {
     },
 
     mounted() {
-        this.$keys.bindGlobal(['mod+s'], e => {
+        this.saveKeyBinding = this.$keys.bindGlobal('mod+s', e => {
             e.preventDefault();
             if (this.confirmingPublish) return;
             this.save();
@@ -597,6 +599,10 @@ export default {
 
     created() {
         window.history.replaceState({}, document.title, document.location.href.replace('created=true', ''));
+    },
+
+    destroyed() {
+        this.saveKeyBinding.destroy();
     }
 
 }

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -20,7 +20,7 @@
             <div class="pt-px text-2xs text-grey-60 flex mr-2" v-if="readOnly">
                 <svg-icon name="lock" class="w-4 mr-sm -mt-sm" /> {{ __('Read Only') }}
             </div>
-            
+
             <div class="hidden md:flex items-center">
                 <button
                     v-if="!readOnly"
@@ -586,7 +586,7 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bindGlobal(['mod+s'], e => {
+        this.$keys.bindGlobal(['mod+s'], e => {
             e.preventDefault();
             if (this.confirmingPublish) return;
             this.save();

--- a/resources/js/components/fieldtypes/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/MarkdownFieldtype.vue
@@ -559,7 +559,7 @@ export default {
             }
         });
 
-        this.$mousetrap.bind('esc', this.closeFullScreen)
+        this.$keys.bind('esc', this.closeFullScreen)
 
         this.trackHeightUpdates();
     }

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -235,7 +235,7 @@ export default {
         this.json = this.editor.getJSON().content;
         this.html = this.editor.getHTML();
 
-        this.$mousetrap.bind('esc', this.closeFullscreen)
+        this.$keys.bind('esc', this.closeFullscreen)
 
         this.$nextTick(() => this.mounted = true);
     },

--- a/resources/js/components/forms/Wizard.vue
+++ b/resources/js/components/forms/Wizard.vue
@@ -180,11 +180,11 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bindGlobal(['command+return'], e => {
+        this.$keys.bindGlobal(['command+return'], e => {
             this.next();
         });
 
-        this.$mousetrap.bindGlobal(['command+delete'], e => {
+        this.$keys.bindGlobal(['command+delete'], e => {
             this.previous();
         });
     }

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -325,7 +325,7 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bindGlobal(['mod+s'], e => {
+        this.$keys.bindGlobal(['mod+s'], e => {
             e.preventDefault();
             this.save();
         });

--- a/resources/js/components/keys/Binding.js
+++ b/resources/js/components/keys/Binding.js
@@ -1,0 +1,34 @@
+const mousetrap = require('mousetrap');
+
+export default class Binding {
+
+    constructor(bindings) {
+        this.bindings = bindings;
+    }
+
+    bind(bindings, callback) {
+        if (typeof bindings === 'string') bindings = [bindings];
+
+        bindings.forEach(binding => {
+            this.bindings[binding] = this.bindings[binding] || [];
+            this.bindings[binding].push(callback);
+            this.bindMousetrap(binding, callback);
+        });
+
+        this.bound = bindings;
+
+        return this;
+    }
+
+    destroy() {
+        this.bound.forEach(binding => {
+            this.bindings[binding].pop();
+            const previous = this.bindings[binding].slice(-1)[0];
+            previous ? mousetrap.bind(binding, previous) : mousetrap.unbind(binding);
+        });
+    }
+
+    bindMousetrap(binding, callback) {
+        mousetrap.bind(binding, callback);
+    }
+}

--- a/resources/js/components/keys/GlobalBinding.js
+++ b/resources/js/components/keys/GlobalBinding.js
@@ -1,0 +1,11 @@
+import Binding from './Binding';
+const mousetrap = require('mousetrap');
+require('mousetrap/plugins/global-bind/mousetrap-global-bind');
+
+export default class GlobalBinding extends Binding {
+
+    bindMousetrap(binding, callback) {
+        mousetrap.bindGlobal(binding, callback);
+    }
+
+}

--- a/resources/js/components/keys/Keys.js
+++ b/resources/js/components/keys/Keys.js
@@ -1,0 +1,17 @@
+import Binding from './Binding';
+import GlobalBinding from './GlobalBinding';
+
+export default class Keys {
+    constructor() {
+        this.bindings = {};
+        this.globals = {};
+    }
+
+    bind(bindings, callback) {
+        return new Binding(this.bindings).bind(bindings, callback);
+    }
+
+    bindGlobal(bindings, callback) {
+        return new GlobalBinding(this.globals).bind(bindings, callback);
+    }
+}

--- a/resources/js/components/live-preview/LivePreview.vue
+++ b/resources/js/components/live-preview/LivePreview.vue
@@ -186,7 +186,7 @@ export default {
     created() {
         this.editorWidth = localStorage.getItem(widthLocalStorageKey) || 400
 
-        this.$mousetrap.bindGlobal('mod+shift+p', () => {
+        this.$keys.bindGlobal('mod+shift+p', () => {
             this.previewing ? this.close() : this.$emit('opened-via-keyboard');
         });
     },
@@ -196,7 +196,7 @@ export default {
     },
 
     destroyed() {
-        this.$mousetrap.unbind('mod+shift+p');
+        this.$keys.unbind('mod+shift+p');
     },
 
     methods: {

--- a/resources/js/components/live-preview/LivePreview.vue
+++ b/resources/js/components/live-preview/LivePreview.vue
@@ -113,6 +113,7 @@ export default {
             popoutResponded: false,
             loading: true,
             extras: {},
+            keybinding: null,
         }
     },
 
@@ -186,7 +187,7 @@ export default {
     created() {
         this.editorWidth = localStorage.getItem(widthLocalStorageKey) || 400
 
-        this.$keys.bindGlobal('mod+shift+p', () => {
+        this.keybinding = this.$keys.bindGlobal('mod+shift+p', () => {
             this.previewing ? this.close() : this.$emit('opened-via-keyboard');
         });
     },
@@ -196,7 +197,7 @@ export default {
     },
 
     destroyed() {
-        this.$keys.unbind('mod+shift+p');
+        this.keybinding.destroy();
     },
 
     methods: {

--- a/resources/js/components/modals/ConfirmationModal.vue
+++ b/resources/js/components/modals/ConfirmationModal.vue
@@ -54,8 +54,8 @@ export default {
     },
 
     created() {
-        this.$mousetrap.bind('esc', this.dismiss)
-        this.$mousetrap.bind('enter', this.submit)
+        this.$keys.bind('esc', this.dismiss)
+        this.$keys.bind('enter', this.submit)
     },
 }
 </script>

--- a/resources/js/components/modals/KeyboardShortcutsModal.vue
+++ b/resources/js/components/modals/KeyboardShortcutsModal.vue
@@ -51,7 +51,8 @@ export default {
 
     data() {
         return {
-            open: false
+            open: false,
+            keybinding: null,
         }
     },
 
@@ -59,9 +60,9 @@ export default {
 
         open(open) {
             if (open) {
-                this.$keys.bind('esc', () => this.open = false);
+                this.keybinding = this.$keys.bind('esc', () => this.open = false);
             } else {
-                this.$keys.unbind('esc');
+                this.keybinding.destroy();
             }
         },
     },

--- a/resources/js/components/modals/KeyboardShortcutsModal.vue
+++ b/resources/js/components/modals/KeyboardShortcutsModal.vue
@@ -59,9 +59,9 @@ export default {
 
         open(open) {
             if (open) {
-                this.$mousetrap.bind('esc', () => this.open = false);
+                this.$keys.bind('esc', () => this.open = false);
             } else {
-                this.$mousetrap.unbind('esc');
+                this.$keys.unbind('esc');
             }
         },
     },
@@ -73,7 +73,7 @@ export default {
     },
 
     created() {
-        this.$mousetrap.bind('?', () => this.open = !this.open);
+        this.$keys.bind('?', () => this.open = !this.open);
 
         this.$events.$on('keyboard-shortcuts.open', () => {
            this.open = true;

--- a/resources/js/components/publish/PublishForm.vue
+++ b/resources/js/components/publish/PublishForm.vue
@@ -88,7 +88,7 @@ export default {
     },
 
     created() {
-        this.$mousetrap.bindGlobal(['mod+s'], e => {
+        this.$keys.bindGlobal(['mod+s'], e => {
             e.preventDefault();
             this.submit();
         });

--- a/resources/js/components/revision-history/History.vue
+++ b/resources/js/components/revision-history/History.vue
@@ -71,7 +71,7 @@ export default {
             this.loading = false;
             this.revisions = response.data.reverse();
         });
-        this.$mousetrap.bindGlobal(['esc'], e => {
+        this.$keys.bindGlobal(['esc'], e => {
             this.close();
         });
     },

--- a/resources/js/components/roles/PublishForm.vue
+++ b/resources/js/components/roles/PublishForm.vue
@@ -140,7 +140,7 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bindGlobal(['mod+s'], e => {
+        this.$keys.bindGlobal(['mod+s'], e => {
             e.preventDefault();
             this.save();
         });

--- a/resources/js/components/stacks/Stack.vue
+++ b/resources/js/components/stacks/Stack.vue
@@ -134,7 +134,7 @@ export default {
     mounted() {
         this.visible = true;
 
-        this.$mousetrap.bindGlobal(['esc'], e => {
+        this.$keys.bindGlobal(['esc'], e => {
             this.close();
         });
     }

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -197,7 +197,7 @@ export default {
     created() {
         this.updateTreeData();
 
-        this.$mousetrap.bindGlobal(['mod+s'], e => {
+        this.$keys.bindGlobal(['mod+s'], e => {
             e.preventDefault();
             this.save();
         });

--- a/resources/js/components/structures/Wizard.vue
+++ b/resources/js/components/structures/Wizard.vue
@@ -216,11 +216,11 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bindGlobal(['command+return'], e => {
+        this.$keys.bindGlobal(['command+return'], e => {
             this.next();
         });
 
-        this.$mousetrap.bindGlobal(['command+delete'], e => {
+        this.$keys.bindGlobal(['command+delete'], e => {
             this.previous();
         });
     }

--- a/resources/js/components/taxonomies/EditForm.vue
+++ b/resources/js/components/taxonomies/EditForm.vue
@@ -85,7 +85,7 @@ export default {
     },
 
     created() {
-        this.$mousetrap.bindGlobal(['command+s'], e => {
+        this.$keys.bindGlobal(['command+s'], e => {
             e.preventDefault();
             this.submit();
         });

--- a/resources/js/components/taxonomies/Wizard.vue
+++ b/resources/js/components/taxonomies/Wizard.vue
@@ -185,11 +185,11 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bindGlobal(['command+return'], e => {
+        this.$keys.bindGlobal(['command+return'], e => {
             this.next();
         });
 
-        this.$mousetrap.bindGlobal(['command+delete'], e => {
+        this.$keys.bindGlobal(['command+delete'], e => {
             this.previous();
         });
     }

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -514,7 +514,7 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bindGlobal(['mod+s'], e => {
+        this.$keys.bindGlobal(['mod+s'], e => {
             e.preventDefault();
             if (this.confirmingPublish) return;
             this.canPublish ? this.confirmPublish() : this.save();

--- a/resources/js/components/user-groups/PublishForm.vue
+++ b/resources/js/components/user-groups/PublishForm.vue
@@ -130,7 +130,7 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bindGlobal(['mod+s'], e => {
+        this.$keys.bindGlobal(['mod+s'], e => {
             e.preventDefault();
             this.save();
         });

--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -122,7 +122,7 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bindGlobal(['mod+s'], e => {
+        this.$keys.bindGlobal(['mod+s'], e => {
             e.preventDefault();
             this.save();
         });

--- a/resources/js/components/users/Wizard.vue
+++ b/resources/js/components/users/Wizard.vue
@@ -264,11 +264,11 @@ export default {
     },
 
     mounted() {
-        this.$mousetrap.bindGlobal(['command+return'], e => {
+        this.$keys.bindGlobal(['command+return'], e => {
             this.next();
         });
 
-        this.$mousetrap.bindGlobal(['command+delete'], e => {
+        this.$keys.bindGlobal(['command+delete'], e => {
             this.previous();
         });
     }


### PR DESCRIPTION
This PR adds a new `$keys` API that is a light wrapper for the mousetrap library.

### Issue

The main problem this fixes is that mousetrap couldn't revert to a previous binding. You could only remove it entirely.

So lets say we have a publish form where we bind cmd+s to save.
Then you open a stack that has another publish form. Now cmd+s saves that form.
Close the stack. You'd expect cmd+s to save your original form. It doesn't, since the latest binding is still in effect. It would attempt to save the form that's no longer there.

If that binding was destroyed at the same time the stack was, then you may think it's solved. But it's not, it just removes the binding all together. So if you hit cmd+s on the original form, it wouldn't work at all.

### Usage

Bind a keyboard shortcut in a similar way to how you would with mousetrap. You will get a reference to a `Binding` object. To unbind, `destroy` it.

```
data() {
  return {
    binding: null
  },
},
created() {
  this.binding = this.$keys.bind('mod+s', this.save);
},
destroyed() {
  this.binding.destroy();
},
methods: {
  save() { 
    //
  }
}
```

When destroying the binding, it will revert back to the previous binding if one existed.

**Breaking change**
`this.$mousetrap` has been removed in favor of this.

Closes #1006