### PR TITLE
Wrong name for ImageMagick Driver

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -35,7 +35,7 @@ return [
         |--------------------------------------------------------------------------
         |
         | The driver that will be used under the hood for image manipulation.
-        | Supported: "gd" or "imagemagick" (if installed on your server)
+        | Supported: "gd" or "imagick" (if installed on your server)
         |
         */
 


### PR DESCRIPTION
The driver for ImageMagick is called imagick.
See: http://image.intervention.io/getting_started/configuration