### PR TITLE
Fix untranslated content

### DIFF
--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -9,7 +9,7 @@
     <div class="card auth-card mx-auto">
         <div class="text-center pb-2 mb-2">
             <h1 class="mb-2 text-lg text-grey-80">{{ __('Forgot Your Password?') }}</h1>
-            <p class="text-sm text-grey">{{ __('messages.forgot_password_enter_email') }}</p>
+            <p class="text-sm text-grey">{{ __('statamic::messages.forgot_password_enter_email') }}</p>
         </div>
 
         @if (session('status'))

--- a/resources/views/blueprints/create.blade.php
+++ b/resources/views/blueprints/create.blade.php
@@ -22,7 +22,7 @@
 
         <div class="flex items-center">
             <button class="btn btn-primary">{{ __('Create') }}</button>
-            <p class="text-xs text-grey-60 ml-2">{{ __('messages.blueprints_button_help_text') }}</p>
+            <p class="text-xs text-grey-60 ml-2">{{ __('statamic::messages.blueprints_button_help_text') }}</p>
         </div>
 
     </form>

--- a/resources/views/fieldsets/create.blade.php
+++ b/resources/views/fieldsets/create.blade.php
@@ -22,7 +22,7 @@
 
         <div class="flex items-center">
             <button class="btn btn-primary">{{ __('Create') }}</button>
-            <p class="text-xs text-grey-60 ml-2">{{ __('messages.fieldsets_button_help_text') }}</p>
+            <p class="text-xs text-grey-60 ml-2">{{ __('statamic::messages.fieldsets_button_help_text') }}</p>
         </div>
 
     </form>


### PR DESCRIPTION
These translation keys were being output instead of their values (`messages.forgot_password_enter_email` instead of `Enter your email address so we can send a reset password link.`). Fixed by prefixing with `statamic::` translation identifier.