### PR TITLE
[WIP] Markdown updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "league/commonmark": "^1.1",
         "league/commonmark-ext-autolink": "^1.0",
         "league/commonmark-ext-smartpunct": "^1.1",
+        "league/commonmark-ext-strikethrough": "^1.0",
         "league/commonmark-ext-table": "^2.1",
         "league/csv": "^9.0",
         "league/glide": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,13 @@
     "license": "proprietary",
     "require": {
         "composer/composer": "^1.7",
-        "erusev/parsedown": "^1.8@beta",
-        "erusev/parsedown-extra": "^0.8@beta",
         "facade/ignition-contracts": "^1.0",
         "guzzlehttp/guzzle": "^6.3",
         "laravel/framework": "5.6.* || 5.7.* || 5.8.* || ^6.0",
         "laravel/helpers": "^1.1",
+        "league/commonmark": "^1.1",
+        "league/commonmark-ext-autolink": "^1.0",
+        "league/commonmark-ext-table": "^2.1",
         "league/csv": "^9.0",
         "league/glide": "^1.1",
         "michelf/php-smartypants": "^1.8",
@@ -26,6 +27,7 @@
         "symfony/var-exporter": "^4.3",
         "symfony/yaml": "^4.1@dev",
         "twistor/flysystem-guzzle": "^6.0",
+        "webuni/commonmark-attributes-extension": "^1.0",
         "wilderborn/partyline": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "league/commonmark-ext-table": "^2.1",
         "league/csv": "^9.0",
         "league/glide": "^1.1",
-        "michelf/php-smartypants": "^1.8",
         "pixelfear/composer-dist-plugin": "^0.1.0",
         "scrumpy/html-to-prosemirror": "^0.5.2",
         "scrumpy/prosemirror-to-html": "^0.7.1",

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "laravel/helpers": "^1.1",
         "league/commonmark": "^1.1",
         "league/commonmark-ext-autolink": "^1.0",
+        "league/commonmark-ext-smartpunct": "^1.1",
         "league/commonmark-ext-table": "^2.1",
         "league/csv": "^9.0",
         "league/glide": "^1.1",

--- a/src/Facades/Markdown.php
+++ b/src/Facades/Markdown.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Statamic\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Statamic\Markdown\Manager;
+
+class Markdown extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return Manager::class;
+    }
+}

--- a/src/Fieldtypes/Markdown.php
+++ b/src/Fieldtypes/Markdown.php
@@ -67,7 +67,7 @@ class Markdown extends Fieldtype
             $markdown = $markdown->withAutoLinks();
         }
 
-        $html = $markdown->parse($value);
+        $html = $markdown->parse((string) $value);
 
         if ($this->config('smartypants')) {
             $html = Html::smartypants($html);

--- a/src/Fieldtypes/Markdown.php
+++ b/src/Fieldtypes/Markdown.php
@@ -51,6 +51,7 @@ class Markdown extends Fieldtype
         'parser' => [
             'type' => 'text',
             'instructions' => 'The name of a customized Markdown parser. Leave blank to use the default.',
+            'width' => 50,
         ]
 
     ];

--- a/src/Fieldtypes/Markdown.php
+++ b/src/Fieldtypes/Markdown.php
@@ -53,13 +53,21 @@ class Markdown extends Fieldtype
 
     public function augment($value)
     {
-        $markdown = new \ParsedownExtra();
+        $markdown = \Statamic\Facades\Markdown::newParser();
 
-        $html = $markdown
-                ->setBreaksEnabled($this->config('automatic_line_breaks'))
-                ->setMarkupEscaped($this->config('escape_markup'))
-                ->setUrlsLinked($this->config('automatic_links'))
-                ->text($value);
+        if ($this->config('automatic_line_breaks')) {
+            $markdown = $markdown->withAutoLineBreaks();
+        }
+
+        if ($this->config('escape_markup')) {
+            $markdown = $markdown->withMarkupEscaping();
+        }
+
+        if ($this->config('automatic_links')) {
+            $markdown = $markdown->withAutoLinks();
+        }
+
+        $html = $markdown->parse($value);
 
         if ($this->config('smartypants')) {
             $html = Html::smartypants($html);

--- a/src/Fieldtypes/Markdown.php
+++ b/src/Fieldtypes/Markdown.php
@@ -53,7 +53,7 @@ class Markdown extends Fieldtype
 
     public function augment($value)
     {
-        $markdown = \Statamic\Facades\Markdown::newParser();
+        $markdown = \Statamic\Facades\Markdown::makeParser();
 
         if ($this->config('automatic_line_breaks')) {
             $markdown = $markdown->withAutoLineBreaks();

--- a/src/Fieldtypes/Markdown.php
+++ b/src/Fieldtypes/Markdown.php
@@ -67,11 +67,11 @@ class Markdown extends Fieldtype
             $markdown = $markdown->withAutoLinks();
         }
 
-        $html = $markdown->parse((string) $value);
-
         if ($this->config('smartypants')) {
-            $html = Html::smartypants($html);
+            $markdown = $markdown->withSmartPunctuation();
         }
+
+        $html = $markdown->parse((string) $value);
 
         return $html;
     }

--- a/src/Fieldtypes/Markdown.php
+++ b/src/Fieldtypes/Markdown.php
@@ -48,12 +48,18 @@ class Markdown extends Fieldtype
             'instructions' => 'Automatically convert straight quotes into curly quotes, dashes into en/em-dashes, and other similar text transformations.',
             'width' => 50,
         ],
+        'parser' => [
+            'type' => 'text',
+            'instructions' => 'The name of a customized Markdown parser. Leave blank to use the default.',
+        ]
 
     ];
 
     public function augment($value)
     {
-        $markdown = \Statamic\Facades\Markdown::makeParser();
+        $markdown = \Statamic\Facades\Markdown::parser(
+            $this->config('parser', 'default')
+        );
 
         if ($this->config('automatic_line_breaks')) {
             $markdown = $markdown->withAutoLineBreaks();

--- a/src/Markdown/Manager.php
+++ b/src/Markdown/Manager.php
@@ -2,24 +2,48 @@
 
 namespace Statamic\Markdown;
 
+use InvalidArgumentException;
 use Statamic\Markdown\Parser;
 
 class Manager
 {
-    protected $defaultParser;
-
-    public function __construct($defaultParser)
-    {
-        $this->defaultParser = $defaultParser;
-    }
+    protected $parsers = [];
 
     public function __call($method, $args)
     {
-        return $this->defaultParser->$method(...$args);
+        return $this->defaultParser()->$method(...$args);
     }
 
     public function makeParser(array $config = []): Parser
     {
         return new Parser($config);
+    }
+
+    public function defaultParser()
+    {
+        if (! $this->hasParser('default')) {
+            $this->setParser('default', $this->makeParser());
+        }
+
+        return $this->parser('default');
+    }
+
+    public function parser(string $name)
+    {
+        if (! $this->hasParser($name)) {
+            throw new InvalidArgumentException("Markdown parser [$name] is not defined.");
+        }
+
+        return $this->parsers[$name];
+    }
+
+    public function setParser(string $name, Parser $parser = null)
+    {
+        $this->parsers[$name] = $parser;
+    }
+
+    public function hasParser(string $name): bool
+    {
+        return isset($this->parsers[$name]);
     }
 }

--- a/src/Markdown/Manager.php
+++ b/src/Markdown/Manager.php
@@ -13,7 +13,7 @@ class Manager
 
     public function __call($method, $args)
     {
-        return $this->defaultParser()->$method(...$args);
+        return $this->parser('default')->$method(...$args);
     }
 
     public function makeParser(array $config = []): Parser
@@ -21,17 +21,12 @@ class Manager
         return new Parser($config);
     }
 
-    public function defaultParser()
-    {
-        if (! $this->hasParser('default')) {
-            $this->parsers['default'] = $this->makeParser();
-        }
-
-        return $this->parser('default');
-    }
-
     public function parser(string $name)
     {
+        if ($name === 'default' && !$this->hasParser('default')) {
+            return $this->parsers['default'] = $this->makeParser();
+        }
+
         if (! $this->hasParser($name)) {
             throw new InvalidArgumentException("Markdown parser [$name] is not defined.");
         }

--- a/src/Markdown/Manager.php
+++ b/src/Markdown/Manager.php
@@ -18,7 +18,7 @@ class Manager
         return $this->defaultParser->$method(...$args);
     }
 
-    public function newParser(array $config = []): Parser
+    public function makeParser(array $config = []): Parser
     {
         return new Parser($config);
     }

--- a/src/Markdown/Manager.php
+++ b/src/Markdown/Manager.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Markdown;
 
+use Closure;
 use InvalidArgumentException;
 use Statamic\Markdown\Parser;
 
@@ -22,7 +23,7 @@ class Manager
     public function defaultParser()
     {
         if (! $this->hasParser('default')) {
-            $this->setParser('default', $this->makeParser());
+            $this->parsers['default'] = $this->makeParser();
         }
 
         return $this->parser('default');
@@ -37,13 +38,13 @@ class Manager
         return $this->parsers[$name];
     }
 
-    public function setParser(string $name, Parser $parser = null)
-    {
-        $this->parsers[$name] = $parser;
-    }
-
     public function hasParser(string $name): bool
     {
         return isset($this->parsers[$name]);
+    }
+
+    public function extend(string $name, Closure $closure)
+    {
+        $this->parsers[$name] = $closure($this->makeParser());
     }
 }

--- a/src/Markdown/Manager.php
+++ b/src/Markdown/Manager.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Statamic\Markdown;
+
+use Statamic\Markdown\Parser;
+
+class Manager
+{
+    protected $defaultParser;
+
+    public function __construct($defaultParser)
+    {
+        $this->defaultParser = $defaultParser;
+    }
+
+    public function __call($method, $args)
+    {
+        return $this->defaultParser->$method(...$args);
+    }
+
+    public function newParser(array $config = []): Parser
+    {
+        return new Parser($config);
+    }
+}

--- a/src/Markdown/Manager.php
+++ b/src/Markdown/Manager.php
@@ -5,6 +5,7 @@ namespace Statamic\Markdown;
 use Closure;
 use InvalidArgumentException;
 use Statamic\Markdown\Parser;
+use UnexpectedValueException;
 
 class Manager
 {
@@ -45,6 +46,12 @@ class Manager
 
     public function extend(string $name, Closure $closure)
     {
-        $this->parsers[$name] = $closure($this->makeParser());
+        $parser = $closure($this->makeParser());
+
+        if (! $parser instanceof Parser) {
+            throw new UnexpectedValueException('A ' . Parser::class . ' instance is expected.');
+        }
+
+        $this->parsers[$name] = $parser;
     }
 }

--- a/src/Markdown/Parser.php
+++ b/src/Markdown/Parser.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Statamic\Markdown;
+
+use Closure;
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment;
+use League\CommonMark\Ext\Autolink\AutolinkExtension;
+use Statamic\Support\Arr;
+
+class Parser
+{
+    protected $converter;
+    protected $extensions = [];
+    protected $config = [];
+
+    public function __construct(array $config = [])
+    {
+        $this->config = $config;
+    }
+
+    public function parse($markdown): string
+    {
+        return $this->converter()->convertToHtml($markdown);
+    }
+
+    public function converter(): CommonMarkConverter
+    {
+        if ($this->converter) {
+            return $this->converter;
+        }
+
+        $env = Environment::createCommonMarkEnvironment();
+
+        $env->mergeConfig($this->config);
+
+        foreach ($this->extensions as $closure) {
+            foreach (Arr::wrap($closure()) as $ext) {
+                $env->addExtension($ext);
+            }
+        }
+
+        return $this->converter = new CommonMarkConverter([], $env);
+    }
+
+    public function environment(): Environment
+    {
+        return $this->converter()->getEnvironment();
+    }
+
+    public function extend(Closure $closure): self
+    {
+        $this->converter = null;
+
+        $this->extensions[] = $closure;
+
+        return $this;
+    }
+
+    public function withAutoLinks(): Parser
+    {
+        $parser = new static;
+
+        return $parser->extend(function () {
+            return new AutolinkExtension;
+        });
+    }
+
+    public function withAutoLineBreaks(): Parser
+    {
+        return new self(array_replace_recursive($this->environment()->getConfig(), [
+            'renderer' => [
+                'soft_break' => "<br />\n",
+            ]
+        ]));
+    }
+
+    public function withMarkupEscaping(): Parser
+    {
+        return new self(array_replace_recursive($this->environment()->getConfig(), [
+            'html_input' => 'escape'
+        ]));
+    }
+}

--- a/src/Markdown/Parser.php
+++ b/src/Markdown/Parser.php
@@ -6,6 +6,7 @@ use Closure;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
 use League\CommonMark\Ext\Autolink\AutolinkExtension;
+use League\CommonMark\Ext\SmartPunct\SmartPunctExtension;
 use Statamic\Support\Arr;
 
 class Parser
@@ -80,5 +81,14 @@ class Parser
         return new self(array_replace_recursive($this->environment()->getConfig(), [
             'html_input' => 'escape'
         ]));
+    }
+
+    public function withSmartPunctuation(): Parser
+    {
+        $parser = new static;
+
+        return $parser->extend(function () {
+            return new SmartPunctExtension;
+        });
     }
 }

--- a/src/Markdown/Parser.php
+++ b/src/Markdown/Parser.php
@@ -49,7 +49,7 @@ class Parser
         return $this->converter()->getEnvironment();
     }
 
-    public function extend(Closure $closure): self
+    public function addExtension(Closure $closure): self
     {
         $this->converter = null;
 
@@ -58,11 +58,16 @@ class Parser
         return $this;
     }
 
+    public function addExtensions(Closure $closure): self
+    {
+        return $this->addExtension($closure);
+    }
+
     public function withAutoLinks(): Parser
     {
         $parser = new static;
 
-        return $parser->extend(function () {
+        return $parser->addExtension(function () {
             return new AutolinkExtension;
         });
     }
@@ -87,7 +92,7 @@ class Parser
     {
         $parser = new static;
 
-        return $parser->extend(function () {
+        return $parser->addExtension(function () {
             return new SmartPunctExtension;
         });
     }

--- a/src/Markdown/Parser.php
+++ b/src/Markdown/Parser.php
@@ -19,7 +19,7 @@ class Parser
         $this->config = $config;
     }
 
-    public function parse($markdown): string
+    public function parse(string $markdown): string
     {
         return $this->converter()->convertToHtml($markdown);
     }

--- a/src/Markdown/Parser.php
+++ b/src/Markdown/Parser.php
@@ -74,6 +74,17 @@ class Parser
         return $exts;
     }
 
+    public function withStatamicDefaults()
+    {
+        return $this->newInstance()->addExtensions(function () {
+            return [
+                new \League\CommonMark\Ext\Table\TableExtension,
+                new \Webuni\CommonMark\AttributesExtension\AttributesExtension,
+                new \League\CommonMark\Ext\Strikethrough\StrikethroughExtension,
+            ];
+        });
+    }
+
     public function withAutoLinks(): Parser
     {
         return $this->newInstance()->addExtension(function () {

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -20,6 +20,7 @@ use Statamic\Facades\Theme;
 use Statamic\Facades\Config;
 use Statamic\Facades\Helper;
 use Statamic\Facades\Localization;
+use Statamic\Facades\Markdown;
 use Stringy\StaticStringy as Stringy;
 use Statamic\Modifiers\Modifier;
 
@@ -1099,9 +1100,15 @@ class CoreModifiers extends Modifier
      * @param $value
      * @return mixed
      */
-    public function markdown($value)
+    public function markdown($value, $params)
     {
-        return Html::markdown($value);
+        $parser = $params[0] ?? 'default';
+
+        if (in_array($parser, [true, 'true', ''])) {
+            $parser = 'default';
+        }
+
+        return Markdown::parser($parser)->parse($value);
     }
 
     /**

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1631,18 +1631,6 @@ class CoreModifiers extends Modifier
     }
 
     /**
-     * Parse with SmartyPants. Aren't you fancy?
-     *
-     * @param $value
-     * @param $params
-     * @return string
-     */
-    public function smartypants($value, $params)
-    {
-        return Html::smartypants($value, Arr::get($params, 0 , 1));
-    }
-
-    /**
      * Sort an array by key $params[0] and direction $params[1]
      *
      * @param $value

--- a/src/Providers/MarkdownServiceProvider.php
+++ b/src/Providers/MarkdownServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Statamic\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use League\CommonMark\Ext\Strikethrough\StrikethroughExtension;
 use League\CommonMark\Ext\Table\TableExtension;
 use Statamic\Facades\Markdown;
 use Statamic\Markdown\Manager;
@@ -24,6 +25,7 @@ class MarkdownServiceProvider extends ServiceProvider
             return [
                 new TableExtension,
                 new AttributesExtension,
+                new StrikethroughExtension,
             ];
         });
     }

--- a/src/Providers/MarkdownServiceProvider.php
+++ b/src/Providers/MarkdownServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Statamic\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use League\CommonMark\Ext\Table\TableExtension;
+use Statamic\Facades\Markdown;
+use Statamic\Markdown\Manager;
+use Statamic\Markdown\Parser;
+use Webuni\CommonMark\AttributesExtension\AttributesExtension;
+
+class MarkdownServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton(Manager::class, function () {
+            return new Manager(new Parser);
+        });
+    }
+
+    public function boot()
+    {
+        Markdown::extend(function () {
+            return [
+                new TableExtension,
+                new AttributesExtension,
+            ];
+        });
+    }
+}

--- a/src/Providers/MarkdownServiceProvider.php
+++ b/src/Providers/MarkdownServiceProvider.php
@@ -20,7 +20,7 @@ class MarkdownServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        Markdown::extend(function () {
+        Markdown::addExtensions(function () {
             return [
                 new TableExtension,
                 new AttributesExtension,

--- a/src/Providers/MarkdownServiceProvider.php
+++ b/src/Providers/MarkdownServiceProvider.php
@@ -3,12 +3,9 @@
 namespace Statamic\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use League\CommonMark\Ext\Strikethrough\StrikethroughExtension;
-use League\CommonMark\Ext\Table\TableExtension;
 use Statamic\Facades\Markdown;
 use Statamic\Markdown\Manager;
 use Statamic\Markdown\Parser;
-use Webuni\CommonMark\AttributesExtension\AttributesExtension;
 
 class MarkdownServiceProvider extends ServiceProvider
 {
@@ -21,12 +18,8 @@ class MarkdownServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        Markdown::addExtensions(function () {
-            return [
-                new TableExtension,
-                new AttributesExtension,
-                new StrikethroughExtension,
-            ];
+        Markdown::extend('default', function ($parser) {
+            return $parser->withStatamicDefaults();
         });
     }
 }

--- a/src/Providers/StatamicServiceProvider.php
+++ b/src/Providers/StatamicServiceProvider.php
@@ -26,6 +26,7 @@ class StatamicServiceProvider extends AggregateServiceProvider
         \Statamic\Stache\ServiceProvider::class,
         AuthServiceProvider::class,
         GlideServiceProvider::class,
+        MarkdownServiceProvider::class,
         \Statamic\Search\ServiceProvider::class,
         \Statamic\StaticCaching\ServiceProvider::class,
         \Statamic\Revisions\ServiceProvider::class,

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Support;
 
-use ParsedownExtra;
 use Michelf\SmartyPants;
 use Illuminate\Support\HtmlString;
+use Statamic\Facades\Markdown;
 
 class Html
 {
@@ -312,7 +312,7 @@ class Html
 
     public static function markdown($string)
     {
-        return (new ParsedownExtra)->text($string);
+        return Markdown::parse($string);
     }
 
     public static function smartypants($string, $behavior = null)

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Support;
 
-use Michelf\SmartyPants;
 use Illuminate\Support\HtmlString;
 use Statamic\Facades\Markdown;
 
@@ -313,11 +312,6 @@ class Html
     public static function markdown($string)
     {
         return Markdown::parse($string);
-    }
-
-    public static function smartypants($string, $behavior = null)
-    {
-        return SmartyPants::defaultTransform($string, $behavior ?? SmartyPants::ATTR_DEFAULT);
     }
 
     /**

--- a/tests/Fieldtypes/MarkdownTest.php
+++ b/tests/Fieldtypes/MarkdownTest.php
@@ -11,7 +11,7 @@ class MarkdownTest extends TestCase
     /** @test */
     function it_augments_to_html()
     {
-        $this->assertEquals(
+        $this->assertEqualsTrimmed(
             '<p>Paragraph with <strong>bold</strong> and <em>italic</em> text.</p>',
             $this->fieldtype()->augment('Paragraph with **bold** and _italic_ text.')
         );
@@ -21,13 +21,13 @@ class MarkdownTest extends TestCase
     function it_augments_with_smartypants()
     {
         $default = $this->fieldtype();
-        $this->assertEquals('<p>Some "quoted" text.</p>', $default->augment('Some "quoted" text.'));
+        $this->assertEqualsTrimmed('<p>Some "quoted" text.</p>', $default->augment('Some "quoted" text.'));
 
         $enabled = $this->fieldtype(['smartypants' => true]);
-        $this->assertEquals('<p>Some &#8220;quoted&#8221; text.</p>', $enabled->augment('Some "quoted" text.'));
+        $this->assertEqualsTrimmed('<p>Some &#8220;quoted&#8221; text.</p>', $enabled->augment('Some "quoted" text.'));
 
         $disabled = $this->fieldtype(['smartypants' => false]);
-        $this->assertEquals('<p>Some "quoted" text.</p>', $disabled->augment('Some "quoted" text.'));
+        $this->assertEqualsTrimmed('<p>Some "quoted" text.</p>', $disabled->augment('Some "quoted" text.'));
     }
 
     /** @test */
@@ -48,10 +48,11 @@ EOT;
         $expected = <<<EOT
 <p>Paragraph with <code>some code</code>.</p>
 <p>Paragraph that hasn&#8217;t got any &#8220;code&#8221;.</p>
-<pre><code class="language-js">code block</code></pre>
+<pre><code class="language-js">code block
+</code></pre>
 EOT;
 
-        $this->assertEquals($expected, $md->augment($value));
+        $this->assertEqualsTrimmed($expected, $md->augment($value));
     }
 
     /** @test */
@@ -62,13 +63,13 @@ EOT;
         $unreplaced = '<p>before http://example.com after</p>';
 
         $default = $this->fieldtype();
-        $this->assertEquals($unreplaced, $default->augment($value));
+        $this->assertEqualsTrimmed($unreplaced, $default->augment($value));
 
         $enabled = $this->fieldtype(['automatic_links' => true]);
-        $this->assertEquals($replaced, $enabled->augment($value));
+        $this->assertEqualsTrimmed($replaced, $enabled->augment($value));
 
         $disabled = $this->fieldtype(['automatic_links' => false]);
-        $this->assertEquals($unreplaced, $disabled->augment($value));
+        $this->assertEqualsTrimmed($unreplaced, $disabled->augment($value));
     }
 
     /** @test */
@@ -79,13 +80,13 @@ EOT;
         $unescaped = '<p>before <div>in the div</div> after</p>';
 
         $default = $this->fieldtype();
-        $this->assertEquals($unescaped, $default->augment($value));
+        $this->assertEqualsTrimmed($unescaped, $default->augment($value));
 
         $enabled = $this->fieldtype(['escape_markup' => true]);
-        $this->assertEquals($escaped, $enabled->augment($value));
+        $this->assertEqualsTrimmed($escaped, $enabled->augment($value));
 
         $disabled = $this->fieldtype(['escape_markup' => false]);
-        $this->assertEquals($unescaped, $disabled->augment($value));
+        $this->assertEqualsTrimmed($unescaped, $disabled->augment($value));
     }
 
     /** @test */
@@ -107,17 +108,22 @@ second line</p>
 EOT;
 
         $default = $this->fieldtype();
-        $this->assertEquals($withoutBreaks, $default->augment($value));
+        $this->assertEqualsTrimmed($withoutBreaks, $default->augment($value));
 
         $enabled = $this->fieldtype(['automatic_line_breaks' => true]);
-        $this->assertEquals($withBreaks, $enabled->augment($value));
+        $this->assertEqualsTrimmed($withBreaks, $enabled->augment($value));
 
         $disabled = $this->fieldtype(['automatic_line_breaks' => false]);
-        $this->assertEquals($withoutBreaks, $disabled->augment($value));
+        $this->assertEqualsTrimmed($withoutBreaks, $disabled->augment($value));
     }
 
     private function fieldtype($config = [])
     {
         return (new Markdown)->setField(new Field('test', array_merge(['type' => 'markdown'], $config)));
+    }
+
+    private function assertEqualsTrimmed($expected, $actual)
+    {
+        $this->assertEquals($expected, rtrim($actual));
     }
 }

--- a/tests/Fieldtypes/MarkdownTest.php
+++ b/tests/Fieldtypes/MarkdownTest.php
@@ -21,13 +21,13 @@ class MarkdownTest extends TestCase
     function it_augments_with_smartypants()
     {
         $default = $this->fieldtype();
-        $this->assertEqualsTrimmed('<p>Some "quoted" text.</p>', $default->augment('Some "quoted" text.'));
+        $this->assertEqualsTrimmed('<p>Some &quot;quoted&quot; text.</p>', $default->augment('Some "quoted" text.'));
 
         $enabled = $this->fieldtype(['smartypants' => true]);
-        $this->assertEqualsTrimmed('<p>Some &#8220;quoted&#8221; text.</p>', $enabled->augment('Some "quoted" text.'));
+        $this->assertEqualsTrimmed('<p>Some “quoted” text.</p>', $enabled->augment('Some "quoted" text.'));
 
         $disabled = $this->fieldtype(['smartypants' => false]);
-        $this->assertEqualsTrimmed('<p>Some "quoted" text.</p>', $disabled->augment('Some "quoted" text.'));
+        $this->assertEqualsTrimmed('<p>Some &quot;quoted&quot; text.</p>', $disabled->augment('Some "quoted" text.'));
     }
 
     /** @test */
@@ -47,7 +47,7 @@ EOT;
 
         $expected = <<<EOT
 <p>Paragraph with <code>some code</code>.</p>
-<p>Paragraph that hasn&#8217;t got any &#8220;code&#8221;.</p>
+<p>Paragraph that hasn’t got any “code”.</p>
 <pre><code class="language-js">code block
 </code></pre>
 EOT;

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -211,7 +211,7 @@ class FrontendTest extends TestCase
 
         $response = $this->get('about');
 
-        $this->assertEquals("<h1>Foo <em>Bar</em></h1># Foo *Bar*", trim($response->content()));
+        $this->assertEquals("<h1>Foo <em>Bar</em></h1>\n# Foo *Bar*", trim($response->content()));
     }
 
     /** @test */

--- a/tests/Markdown/ManagerTest.php
+++ b/tests/Markdown/ManagerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Markdown;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Statamic\Markdown\Manager;
+use Statamic\Markdown\Parser;
+
+class ManagerTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    /** @test */
+    function it_forwards_calls_to_default_parser()
+    {
+        $defaultParser = Mockery::mock(Parser::class);
+        $defaultParser->shouldReceive('foo')->once()->andReturn('bar');
+
+        $this->assertEquals('bar', (new Manager($defaultParser))->foo());
+    }
+
+    /** @test */
+    function it_makes_a_new_parser_instance()
+    {
+        $defaultParser = new Parser;
+
+        $manager = new Manager($defaultParser);
+
+        $config = ['foo' => 'bar'];
+
+        $parser = $manager->newParser($config);
+
+        $this->assertInstanceOf(Parser::class, $parser);
+        $this->assertNotSame($parser, $defaultParser);
+        $this->assertEquals('bar', $parser->environment()->getConfig('foo'));
+    }
+}

--- a/tests/Markdown/ManagerTest.php
+++ b/tests/Markdown/ManagerTest.php
@@ -7,6 +7,7 @@ use Mockery;
 use PHPUnit\Framework\TestCase;
 use Statamic\Markdown\Manager;
 use Statamic\Markdown\Parser;
+use UnexpectedValueException;
 
 class ManagerTest extends TestCase
 {
@@ -60,5 +61,16 @@ class ManagerTest extends TestCase
 
         $this->assertSame($parserA, $manager->parser('a'));
         $this->assertNotSame($parserB, $manager->parser('a'));
+    }
+
+    /** @test */
+    function it_throws_an_exception_if_extending_without_returning_a_parser()
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('A ' . Parser::class . ' instance is expected.');
+
+        (new Manager)->extend('a', function ($parser) {
+            //
+        });
     }
 }

--- a/tests/Markdown/ManagerTest.php
+++ b/tests/Markdown/ManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Markdown;
 
+use InvalidArgumentException;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Statamic\Markdown\Manager;
@@ -20,22 +21,42 @@ class ManagerTest extends TestCase
         $defaultParser = Mockery::mock(Parser::class);
         $defaultParser->shouldReceive('foo')->once()->andReturn('bar');
 
-        $this->assertEquals('bar', (new Manager($defaultParser))->foo());
+        $manager = new Manager;
+        $manager->setParser('default', $defaultParser);
+
+        $this->assertEquals('bar', $manager->foo());
     }
 
     /** @test */
     function it_makes_a_new_parser_instance()
     {
-        $defaultParser = new Parser;
+        $manager = new Manager;
+        $manager->setParser('default', $defaultParser = new Parser);
 
-        $manager = new Manager($defaultParser);
-
-        $config = ['foo' => 'bar'];
-
-        $parser = $manager->makeParser($config);
+        $parser = $manager->makeParser($config = ['foo' => 'bar']);
 
         $this->assertInstanceOf(Parser::class, $parser);
         $this->assertNotSame($parser, $defaultParser);
         $this->assertEquals('bar', $parser->environment()->getConfig('foo'));
+    }
+
+    /** @test */
+    function parser_instances_can_be_saved_and_retrieved()
+    {
+        $manager = new Manager;
+
+        try {
+            $parser = $manager->parser('a');
+        } catch (InvalidArgumentException $e) {
+            $this->assertEquals('Markdown parser [a] is not defined.', $e->getMessage());
+        }
+
+        $parserA = $manager->makeParser();
+        $parserB = $manager->makeParser();
+
+        $manager->setParser('a', $parserA);
+
+        $this->assertSame($parserA, $manager->parser('a'));
+        $this->assertNotSame($parserB, $manager->parser('a'));
     }
 }

--- a/tests/Markdown/ManagerTest.php
+++ b/tests/Markdown/ManagerTest.php
@@ -34,7 +34,7 @@ class ManagerTest extends TestCase
         $parser = $manager->makeParser($config = ['foo' => 'bar']);
 
         $this->assertInstanceOf(Parser::class, $parser);
-        $this->assertNotSame($parser, $manager->defaultParser());
+        $this->assertNotSame($parser, $manager->parser('default'));
         $this->assertEquals('bar', $parser->environment()->getConfig('foo'));
     }
 

--- a/tests/Markdown/ManagerTest.php
+++ b/tests/Markdown/ManagerTest.php
@@ -32,7 +32,7 @@ class ManagerTest extends TestCase
 
         $config = ['foo' => 'bar'];
 
-        $parser = $manager->newParser($config);
+        $parser = $manager->makeParser($config);
 
         $this->assertInstanceOf(Parser::class, $parser);
         $this->assertNotSame($parser, $defaultParser);

--- a/tests/Markdown/MarkdownTest.php
+++ b/tests/Markdown/MarkdownTest.php
@@ -143,4 +143,15 @@ EOT;
             rtrim(Markdown::withMarkupEscaping()->parse('<div></div>'))
         );
     }
+
+    /** @test */
+    function it_uses_smart_punctuation_on_demand()
+    {
+        $this->assertParses('<p>&quot;Foo&quot; -- Bar...</p>', '"Foo" -- Bar...');
+
+        $this->assertEquals(
+            '<p>“Foo” – Bar…</p>',
+            rtrim(Markdown::withSmartPunctuation()->parse('"Foo" -- Bar...'))
+        );
+    }
 }

--- a/tests/Markdown/MarkdownTest.php
+++ b/tests/Markdown/MarkdownTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Markdown;
+
+use Statamic\Facades\Markdown;
+use Tests\TestCase;
+
+class MarkdownTest extends TestCase
+{
+    function assertParses($expectedHtml, $markdown)
+    {
+        $this->assertEquals($expectedHtml, rtrim(Markdown::parse($markdown)));
+    }
+
+    /** @test */
+    function it_parses_markdown()
+    {
+        $this->assertParses("<h1>Heading One</h1>", '# Heading One');
+    }
+
+    /** @test */
+    function it_parses_markdown_inside_markup()
+    {
+        $markdown = <<<EOT
+<div>
+
+# Heading
+
+</div>
+
+## Another Heading
+EOT;
+
+        $html = <<<EOT
+<div>
+<h1>Heading</h1>
+</div>
+<h2>Another Heading</h2>
+EOT;
+
+        $this->assertParses($html, $markdown);
+    }
+
+    /** @test */
+    function it_parses_attributes()
+    {
+        $this->assertParses(
+            '<h2 class="main header" id="the-heading" lang="en">Heading</h2>',
+            '## Heading {.main .header #the-heading lang=en}'
+        );
+    }
+
+    /** @test */
+    function it_parses_code_blocks()
+    {
+        $markdown = <<<EOT
+# Heading
+
+``` yaml
+foo: bar
+```
+
+Paragraph
+EOT;
+
+        $html = <<<EOT
+<h1>Heading</h1>
+<pre><code class="language-yaml">foo: bar
+</code></pre>
+<p>Paragraph</p>
+EOT;
+        $this->assertParses($html, $markdown);
+    }
+    /** @test */
+    function it_parses_tables()
+    {
+        $markdown = <<<EOT
+# Heading
+
+| Header One | Header Two |
+|-----|-----|
+| 1.1 | 1.2 |
+| 2.1 | 2.2 |
+
+Paragraph
+EOT;
+
+        $html = <<<EOT
+<h1>Heading</h1>
+<table>
+<thead>
+<tr>
+<th>Header One</th>
+<th>Header Two</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1.1</td>
+<td>1.2</td>
+</tr>
+<tr>
+<td>2.1</td>
+<td>2.2</td>
+</tr>
+</tbody>
+</table>
+<p>Paragraph</p>
+EOT;
+
+        $this->assertParses($html, $markdown);
+    }
+
+    /** @test */
+    function it_does_not_automatically_convert_urls_to_links()
+    {
+        $this->assertParses('<p>https://example.com</p>', 'https://example.com');
+
+        $this->assertEquals(
+            '<p><a href="https://example.com">https://example.com</a></p>',
+            rtrim(Markdown::withAutoLinks()->parse('https://example.com'))
+        );
+    }
+
+    /** @test */
+    function it_does_not_automatically_convert_line_breaks()
+    {
+        $this->assertParses("<p>foo\nbar</p>", "foo\nbar");
+
+        $this->assertEquals(
+            "<p>foo<br />\nbar</p>",
+            rtrim(Markdown::withAutoLineBreaks()->parse("foo\nbar"))
+        );
+    }
+
+    /** @test */
+    function it_escapes_markup()
+    {
+        $this->assertParses('<div></div>', '<div></div>');
+
+        $this->assertEquals(
+            '&lt;div&gt;&lt;/div&gt;',
+            rtrim(Markdown::withMarkupEscaping()->parse('<div></div>'))
+        );
+    }
+}

--- a/tests/Markdown/MarkdownTest.php
+++ b/tests/Markdown/MarkdownTest.php
@@ -19,6 +19,12 @@ class MarkdownTest extends TestCase
     }
 
     /** @test */
+    function it_parses_strikethrough()
+    {
+        $this->assertParses("<h1>Heading <del>One</del></h1>", '# Heading ~~One~~');
+    }
+
+    /** @test */
     function it_parses_markdown_inside_markup()
     {
         $markdown = <<<EOT

--- a/tests/Markdown/MarkdownTest.php
+++ b/tests/Markdown/MarkdownTest.php
@@ -123,7 +123,7 @@ EOT;
     }
 
     /** @test */
-    function it_does_not_automatically_convert_line_breaks()
+    function it_converts_line_breaks_on_demand()
     {
         $this->assertParses("<p>foo\nbar</p>", "foo\nbar");
 
@@ -134,7 +134,7 @@ EOT;
     }
 
     /** @test */
-    function it_escapes_markup()
+    function it_escapes_markup_on_demand()
     {
         $this->assertParses('<div></div>', '<div></div>');
 

--- a/tests/Markdown/ParserTest.php
+++ b/tests/Markdown/ParserTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Markdown;
+
+use League\CommonMark\ConfigurableEnvironmentInterface;
+use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\Inline\Element\Text;
+use League\CommonMark\Inline\Parser\InlineParserInterface;
+use League\CommonMark\InlineParserContext;
+use PHPUnit\Framework\TestCase;
+use Statamic\Markdown\Parser;
+
+class ParserTest extends TestCase
+{
+    function setUp() : void
+    {
+        $this->parser = new Parser;
+    }
+
+    /** @test */
+    function it_parses_markdown()
+    {
+        $this->assertEquals("<h1>Heading One</h1>\n", $this->parser->parse('# Heading One'));
+    }
+
+    /** @test */
+    function it_adds_an_extension()
+    {
+        $this->assertEquals("<p>smile :)</p>\n", $this->parser->parse('smile :)'));
+
+        $this->parser->extend(function () {
+            return new SmileyExtension;
+        });
+
+        $this->assertEquals("<p>smile 😀</p>\n", $this->parser->parse('smile :)'));
+    }
+
+    /** @test */
+    function it_adds_extensions_using_an_array()
+    {
+        $this->assertEquals("<p>smile :) frown :(</p>\n", $this->parser->parse('smile :) frown :('));
+
+        $this->parser->extend(function () {
+            return [new SmileyExtension, new FrownyExtension];
+        });
+
+        $this->assertEquals("<p>smile 😀 frown 🙁</p>\n", $this->parser->parse('smile :) frown :('));
+    }
+}
+
+class SmileyExtension implements ExtensionInterface
+{
+    public function register(ConfigurableEnvironmentInterface $environment)
+    {
+        $environment->addInlineParser(new SmileyParser);
+    }
+}
+
+class FrownyExtension implements ExtensionInterface
+{
+    public function register(ConfigurableEnvironmentInterface $environment)
+    {
+        $environment->addInlineParser(new FrownyParser);
+    }
+}
+
+/**
+ * Inspired by https://commonmark.thephpleague.com/1.0/customization/inline-parsing/
+ */
+class SmileyParser implements InlineParserInterface
+{
+    protected $emoji = '😀';
+    protected $char = ')';
+
+    public function getCharacters(): array
+    {
+        return [':'];
+    }
+
+    public function parse(InlineParserContext $inlineContext): bool
+    {
+        $cursor = $inlineContext->getCursor();
+
+        $nextChar = $cursor->peek();
+        if ($nextChar !== $this->char) {
+            return false;
+        }
+
+        $cursor->advanceBy(2);
+
+        if ($nextChar === $this->char) {
+            $inlineContext->getContainer()->appendChild(new Text($this->emoji));
+        }
+
+        return true;
+    }
+}
+
+class FrownyParser extends SmileyParser
+{
+    protected $emoji = '🙁';
+    protected $char = '(';
+}

--- a/tests/Markdown/ParserTest.php
+++ b/tests/Markdown/ParserTest.php
@@ -28,7 +28,7 @@ class ParserTest extends TestCase
     {
         $this->assertEquals("<p>smile :)</p>\n", $this->parser->parse('smile :)'));
 
-        $this->parser->extend(function () {
+        $this->parser->addExtension(function () {
             return new SmileyExtension;
         });
 
@@ -40,7 +40,7 @@ class ParserTest extends TestCase
     {
         $this->assertEquals("<p>smile :) frown :(</p>\n", $this->parser->parse('smile :) frown :('));
 
-        $this->parser->extend(function () {
+        $this->parser->addExtensions(function () {
             return [new SmileyExtension, new FrownyExtension];
         });
 

--- a/tests/Markdown/ParserTest.php
+++ b/tests/Markdown/ParserTest.php
@@ -14,7 +14,7 @@ class ParserTest extends TestCase
 {
     function setUp() : void
     {
-        $this->parser = new Parser;
+        $this->parser = new Parser(['foo' => 'bar']);
     }
 
     /** @test */
@@ -45,6 +45,36 @@ class ParserTest extends TestCase
         });
 
         $this->assertEquals("<p>smile 😀 frown 🙁</p>\n", $this->parser->parse('smile :) frown :('));
+    }
+
+    /** @test */
+    function it_creates_a_new_instance_based_on_the_current_instance()
+    {
+        $this->parser->addExtension(function () {
+            return new SmileyExtension;
+        });
+
+        $config = $this->parser->config();
+        $this->assertEquals('bar', $config['foo']);
+        $this->assertArrayNotHasKey('hello', $config);
+        $this->assertCount(1, $this->parser->extensions());
+
+        $newParser = $this->parser->newInstance([
+            'foo' => 'baz',
+            'hello' => 'world',
+        ]);
+
+        $newParser->addExtension(function () {
+            return new FrownyExtension;
+        });
+
+        $this->assertNotSame($this->parser, $newParser);
+        $newConfig = $newParser->config();
+        $this->assertEquals('baz', $newConfig['foo']);
+        $this->assertEquals('world', $newConfig['hello']);
+        $this->assertArrayNotHasKey('hello', $this->parser->config());
+        $this->assertCount(2, $newParser->extensions());
+        $this->assertCount(1, $this->parser->extensions());
     }
 }
 

--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -412,21 +412,21 @@ EOT;
     {
         $template = "{{ content|markdown|lower }}";
 
-        $this->assertEquals("<p>paragraph</p>", Antlers::parse($template, $this->variables));
+        $this->assertEquals("<p>paragraph</p>\n", Antlers::parse($template, $this->variables));
     }
 
     public function testChainedStandardModifiersRelaxedOnContent()
     {
         $template = "{{ content | markdown | lower }}";
 
-        $this->assertEquals("<p>paragraph</p>", Antlers::parse($template, $this->variables));
+        $this->assertEquals("<p>paragraph</p>\n", Antlers::parse($template, $this->variables));
     }
 
     public function testChainedParameterModifiersOnContent()
     {
         $template = "{{ content markdown='true' lower='true' }}";
 
-        $this->assertEquals("<p>paragraph</p>", Antlers::parse($template, $this->variables));
+        $this->assertEquals("<p>paragraph</p>\n", Antlers::parse($template, $this->variables));
     }
 
     public function testConditionsWithModifiers()


### PR DESCRIPTION
### Swap Parsedown for [league/commonmark](https://commonmark.thephpleague.com/)

The commonmark package follows the spec, which is great, plus has an extension ecosystem so developers can more easily add custom features. Also, Laravel now uses it.

### Markdown facade

You can now do Markdown-y things using a dedicated facade.

``` php
Statamic\Facades\Markdown::parse('# Heading');
```

`Statamic\Support\Html::markdown('# Heading')` will still work (it just uses the facade now).

### Multiple Parsers

Any methods called on the facade are forwarded to the `default` parser.

You are free to create new parsers that are configured differently, and even have different extensions enabled.

``` php
$parser = Markdown::makeParser($config); // accepts an optional league/commonmark config array
$parser->addExtension(function () { ... }); // see extensibility section
$parser->parse('# Heading');
```

You can create them ahead of time and reuse when needed.

``` php
Markdown::extend('my-parser', function ($parser) {
  // The $parser argument given to this closure is a
  // fresh parser instance for you to customize.
  return $parser->addExtensions(...)->withAutoLinks();
});

Markdown::parser('my-parser')->parse('# Heading');
```

### Extensiblity

Since league/commonmark has an extension system, developers can add custom functionality to their own projects, or package them up them into addons.

``` php
Statamic\Facades\Markdown::addExtensions(function () {
  return [
    new SomeCommonMarkExtension(),
    new AnotherExtension(),
  ];
});
```

The `addExtension` (singular) method is also supported that doesn't require an array.

### Modifier

The `markdown` modifier can target a custom parser.

```
{{ text | markdown:foo }} use the "foo" parser instead of the default one

{{ text markdown="foo" }} param syntax, too
```

### Fieldtype

The `markdown` fieldtype can target a custom parser.

``` yaml
handle: content
field:
  type: markdown
  parser: foo
```

### Bundle some extensions

A few extensions were added to mimic the important parts of what Parsedown Extra supported.

- GFM Tables
- HTML Attributes (eg. `# heading {.someclass #someid}`)
- Strikethrough (eg. `~~strikethrough~~`)

The following are available but disabled by default:

- Autolinking (available using `Markdown::withAutoLinks()->parse(...)`
- HTML escaping (`Markdown::withMarkupEscaping()->parse()`)
- Automatic line breaks (`Markdown::withAutoLineBreaks()`)

Closes #1173
Closes #1172 