### PR TITLE
Add Authorizable contract to User

### DIFF
--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -4,6 +4,7 @@ namespace Statamic\Auth;
 
 use ArrayAccess;
 use Illuminate\Auth\Passwords\CanResetPassword;
+use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 use Illuminate\Foundation\Auth\Access\Authorizable;
@@ -21,7 +22,13 @@ use Statamic\Notifications\PasswordReset as PasswordResetNotification;
 use Statamic\Support\Arr;
 use Statamic\Fields\Value;
 
-abstract class User implements UserContract, Authenticatable, CanResetPasswordContract, AugmentableContract, ArrayAccess
+abstract class User implements 
+    UserContract,
+    Authenticatable,
+    CanResetPasswordContract,
+    AugmentableContract,
+    ArrayAccess,
+    AuthorizableContract
 {
     use Authorizable, Notifiable, CanResetPassword, Augmentable;
 


### PR DESCRIPTION
The User class needs to implement the `Authorizable` contract same as the base [User](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Foundation/Auth/User.php) in Laravel.

I found that without this, it breaks compatibility with other packages that expect a User object to be authorizable (ie. spatie/laravel-permissions) and we get this error:

> Argument 1 passed to Spatie\Permission\PermissionRegistrar::Spatie\Permission\{closure}() must be an instance of Illuminate\Contracts\Auth\Access\Authorizable, instance of Statamic\Auth\File\User given

Wasn't sure if this would break anything but I found that the same User object uses the `Authorizable` trait as well, so this shouldn't break anything.