### PR TITLE
Execute setLastLogin() only when the given User is a Statamic User

### DIFF
--- a/src/Auth/SetLastLoginTimestamp.php
+++ b/src/Auth/SetLastLoginTimestamp.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Auth;
 
+use Statamic\Contracts\Auth\User as StatamicUser;
 use Statamic\Facades\User;
 use Illuminate\Auth\Events\Login;
 
@@ -9,6 +10,8 @@ class SetLastLoginTimestamp
 {
     public function handle(Login $event)
     {
-        User::fromUser($event->user)->setLastLogin(now());
+        if ($event->user instanceof StatamicUser) {
+            User::fromUser($event->user)->setLastLogin(now());
+        }
     }
 }


### PR DESCRIPTION
Checks whether a User from the Login event is indeed a Statamic User - if so, we can let the listener do its thing. Fixes #1194 