### PR TITLE
Fix bug with deleting blueprints & fieldsets

### DIFF
--- a/resources/js/components/blueprints/Listing.vue
+++ b/resources/js/components/blueprints/Listing.vue
@@ -22,7 +22,7 @@
                 :bodyText="__('Are you sure you want to delete this blueprint?')"
                 :buttonText="__('Delete')"
                 :danger="true"
-                @confirm="deleteRow(cp_url('fields/blueprints'), __('Blueprint deleted'))"
+                @confirm="deleteRow('fields/blueprints', __('Blueprint deleted'))"
                 @cancel="cancelDeleteRow"
             />
         </div>

--- a/resources/js/components/fieldsets/Listing.vue
+++ b/resources/js/components/fieldsets/Listing.vue
@@ -22,7 +22,7 @@
                 :bodyText="__('Are you sure you want to delete this fieldset?')"
                 :buttonText="__('Delete')"
                 :danger="true"
-                @confirm="deleteRow(cp_url('fields/fieldsets'), __('Fieldset deleted'))"
+                @confirm="deleteRow('fields/fieldsets', __('Fieldset deleted'))"
                 @cancel="cancelDeleteRow"
             />
         </div>


### PR DESCRIPTION
In ea2066d, a bug was created where blueprints & fieldsets would fail to delete because the URL would duplicate the `cp` part of the URL, causing it to look like this: `https://iamlittle.test/cp/cp/fields/blueprints/youtubeEmbed`.

It's because a `cp_url` was added around the url in listing components and it's also used inside `DeletesListingRow.js`.

After this fix, blueprints should be deletable once again!