### PR TITLE
Ability to get labels for select, radio, and checkboxes fieldtypes.

### DIFF
--- a/src/Fields/LabeledValue.php
+++ b/src/Fields/LabeledValue.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Statamic\Fields;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+
+class LabeledValue implements Arrayable
+{
+    protected $value;
+    protected $label;
+
+    public function __construct($value, $label)
+    {
+        $this->value = $value;
+        $this->label = $label;
+    }
+
+    public function value()
+    {
+        return $this->value;
+    }
+
+    public function label()
+    {
+        return $this->label;
+    }
+
+    public function __toString()
+    {
+        return $this->value;
+    }
+
+    public function toArray()
+    {
+        return [
+            'key' => $this->value,
+            'value' => $this->value,
+            'label' => $this->label,
+        ];
+    }
+}

--- a/src/Fields/LabeledValue.php
+++ b/src/Fields/LabeledValue.php
@@ -28,7 +28,7 @@ class LabeledValue implements Arrayable
 
     public function __toString()
     {
-        return $this->value;
+        return $this->value ?? '';
     }
 
     public function toArray()

--- a/src/Fieldtypes/Checkboxes.php
+++ b/src/Fieldtypes/Checkboxes.php
@@ -20,16 +20,16 @@ class Checkboxes extends Fieldtype
 
     public function augment($values)
     {
-        $augmented = [];
-
         if (is_null($values)) {
             return [];
         }
 
-        foreach ($values as $key => $value) {
-            $augmented[$key] = ['value' => $value, 'label' => array_get($this->config('options'), $value)];
-        }
-
-        return $augmented;
+        return collect($values)->map(function ($value) {
+            return [
+                'key' => $value,
+                'value' => $value,
+                'label' => array_get($this->config('options'), $value, $value)
+            ];
+        })->all();
     }
 }

--- a/src/Fieldtypes/Radio.php
+++ b/src/Fieldtypes/Radio.php
@@ -3,6 +3,7 @@
 namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
+use Statamic\Fields\LabeledValue;
 
 class Radio extends Fieldtype
 {
@@ -17,4 +18,9 @@ class Radio extends Fieldtype
             'instructions' => 'Show the radio buttons in a row.'
         ]
     ];
+
+    public function augment($value)
+    {
+        return new LabeledValue($value, array_get($this->config('options'), $value, $value));
+    }
 }

--- a/src/Fieldtypes/Select.php
+++ b/src/Fieldtypes/Select.php
@@ -3,6 +3,7 @@
 namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
+use Statamic\Fields\LabeledValue;
 
 class Select extends Fieldtype
 {
@@ -62,7 +63,7 @@ class Select extends Fieldtype
 
     public function augment($value)
     {
-        return array_get($this->config('options'), $value, $value);
+        return new LabeledValue($value, array_get($this->config('options'), $value, $value));
     }
 
     public function preProcess($value)

--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -1234,6 +1234,10 @@ class Parser
             $context = $context->toAugmentedArray();
         }
 
+        if ($context instanceof Arrayable) {
+            $context = $context->toArray();
+        }
+
         // It will do this recursively until it's out of colon delimiters or values.
         if (is_array($context)) {
             return $this->getVariableExistenceAndValue($rest, $context);

--- a/tests/Fields/LabeledValueTest.php
+++ b/tests/Fields/LabeledValueTest.php
@@ -22,6 +22,7 @@ class LabeledValueTest extends TestCase
     function it_converts_to_a_string()
     {
         $this->assertEquals('world', (string) new LabeledValue('world', 'World'));
+        $this->assertEquals('',  (string) new LabeledValue(null, null));
     }
 
     /** @test */

--- a/tests/Fields/LabeledValueTest.php
+++ b/tests/Fields/LabeledValueTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Fields;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use Statamic\Fields\LabeledValue;
+use Tests\TestCase;
+
+class LabeledValueTest extends TestCase
+{
+    /** @test */
+    function it_gets_the_label_and_value()
+    {
+        $obj = new LabeledValue('world', 'World');
+
+        $this->assertEquals('world', $obj->value());
+        $this->assertEquals('World', $obj->label());
+    }
+
+    /** @test */
+    function it_converts_to_a_string()
+    {
+        $this->assertEquals('world', (string) new LabeledValue('world', 'World'));
+    }
+
+    /** @test */
+    function it_converts_to_an_array()
+    {
+        $val = new LabeledValue('world', 'World');
+
+        $this->assertInstanceOf(Arrayable::class, $val);
+        $this->assertEquals([
+            'key' => 'world',
+            'value' => 'world',
+            'label' => 'World'
+        ], $val->toArray());
+    }
+}

--- a/tests/Fieldtypes/CheckboxesTest.php
+++ b/tests/Fieldtypes/CheckboxesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use Statamic\Facades\Antlers;
+use Statamic\Fields\Field;
+use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Checkboxes;
+use Tests\TestCase;
+
+class CheckboxesTest extends TestCase
+{
+    /** @test */
+    function it_augments_to_empty_array_when_null()
+    {
+        $this->assertEquals([], $this->fieldtype()->augment(null));
+    }
+
+    /** @test */
+    function it_augments_to_LabeledValue_equivalents_for_looping()
+    {
+        $this->assertEquals([
+            ['key' => 'au', 'value' => 'au', 'label' => 'Australia'],
+            ['key' => 'ca', 'value' => 'ca', 'label' => 'Canada'],
+        ], $this->fieldtype()->augment(['au', 'ca']));
+    }
+
+    /** @test */
+    function it_augments_to_LabeledValue_equivalents_for_looping_with_no_keys()
+    {
+        $fieldtype = $this->fieldtype([
+            'options' => [
+                'au',
+                'ca',
+                'us',
+            ]
+        ]);
+
+        $this->assertEquals([
+            ['key' => 'au', 'value' => 'au', 'label' => 'au'],
+            ['key' => 'ca', 'value' => 'ca', 'label' => 'ca'],
+        ], $fieldtype->augment(['au', 'ca']));
+    }
+
+    function fieldtype($config = [])
+    {
+        return (new Checkboxes)->setField(new Field('test', array_merge([
+            'type' => 'checkboxes',
+            'options' => [
+                'au' => 'Australia',
+                'ca' => 'Canada',
+                'us' => 'USA',
+            ]
+        ], $config)));
+    }
+}

--- a/tests/Fieldtypes/RadioTest.php
+++ b/tests/Fieldtypes/RadioTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use Statamic\Fields\Field;
+use Statamic\Fields\LabeledValue;
+use Statamic\Fieldtypes\Radio;
+use Tests\TestCase;
+
+class RadioTest extends TestCase
+{
+    /** @test */
+    function it_augments_to_a_LabeledValue_object_with_options_with_keys()
+    {
+        $field = (new Radio)->setField(new Field('test', [
+            'type' => 'radio',
+            'options' => [
+                'au' => 'Australia',
+                'ca' => 'Canada',
+                'us' => 'USA',
+            ]
+        ]));
+
+        $augmented = $field->augment('au');
+        $this->assertInstanceOf(LabeledValue::class, $augmented);
+        $this->assertEquals('au', $augmented->value());
+        $this->assertEquals('Australia', $augmented->label());
+    }
+
+    /** @test */
+    function it_augments_to_a_LabeledValue_object_with_options_without_keys()
+    {
+        $field = (new Radio)->setField(new Field('test', [
+            'type' => 'radio',
+            'options' => [
+                'Australia',
+                'Canada',
+                'USA',
+            ]
+        ]));
+
+        $augmented = $field->augment('Australia');
+        $this->assertInstanceOf(LabeledValue::class, $augmented);
+        $this->assertEquals('Australia', $augmented->value());
+        $this->assertEquals('Australia', $augmented->label());
+    }
+}

--- a/tests/Fieldtypes/SelectTest.php
+++ b/tests/Fieldtypes/SelectTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use Statamic\Fields\Field;
+use Statamic\Fields\LabeledValue;
+use Statamic\Fieldtypes\Select;
+use Tests\TestCase;
+
+class SelectTest extends TestCase
+{
+    /** @test */
+    function it_augments_to_a_LabeledValue_object_with_options_with_keys()
+    {
+        $field = (new Select)->setField(new Field('test', [
+            'type' => 'select',
+            'options' => [
+                'au' => 'Australia',
+                'ca' => 'Canada',
+                'us' => 'USA',
+            ]
+        ]));
+
+        $augmented = $field->augment('au');
+        $this->assertInstanceOf(LabeledValue::class, $augmented);
+        $this->assertEquals('au', $augmented->value());
+        $this->assertEquals('Australia', $augmented->label());
+    }
+
+    /** @test */
+    function it_augments_to_a_LabeledValue_object_with_options_without_keys()
+    {
+        $field = (new Select)->setField(new Field('test', [
+            'type' => 'select',
+            'options' => [
+                'Australia',
+                'Canada',
+                'USA',
+            ]
+        ]));
+
+        $augmented = $field->augment('Australia');
+        $this->assertInstanceOf(LabeledValue::class, $augmented);
+        $this->assertEquals('Australia', $augmented->value());
+        $this->assertEquals('Australia', $augmented->label());
+    }
+}


### PR DESCRIPTION
This PR is a solution for being able to get a select/radio/checkboxes field's label within templates.
- In v2 you just couldn't.
- In v3 we made `select` fields augment straight to the label, and you could get the value by using the raw modifier. That seemed to cause more confusion. **This PR reverts it**, but adds a way to easily get the label on demand.

``` yaml
fields:
  -
    handle: country
    field:
      type: select
      options:
        au: Australia
        ca: Canada
        us: USA     
```

``` yaml
country: au
```
```
{{ country }}         // au
{{ country:label }}   // Australia

{{ country }}
  {{ label }}         // Australia
  {{ value }}         // au
  {{ key }}           // au
{{ /country }}
```

This now works for `select`, `radio`, and `checkboxes` fieldtypes.

Parser bonus: Also now, when a `Value`'s augmented value is `Arrayable`, the parser can get values through there. So you could do `{{ arrayable_object:a_key_from_its_toArray_method }}`
This already worked most of the time since usually the only `Arrayable` things were `Illuminate\Support\Collection` objects, which we already handled by calling `toAugmentedArray`.