### PR TITLE
Allow filters to be displayed right next to the listings search bar

### DIFF
--- a/resources/js/components/data-list/Filter.vue
+++ b/resources/js/components/data-list/Filter.vue
@@ -10,7 +10,11 @@
             :errors="errors"
             @updated="$emit('changed', $event)"
         >
-            <publish-fields slot-scope="{ setFieldValue }" :fields="filter.fields" @updated="setFieldValue" />
+            <publish-fields
+                slot-scope="{ setFieldValue }"
+                :fields="filter.fields"
+                :no-form-group="noFormGroup"
+                @updated="setFieldValue" />
         </publish-container>
     </div>
 
@@ -28,6 +32,7 @@ export default {
     props: {
         filter: Object,
         values: Object,
+        noFormGroup: Boolean,
     },
 
     data() {

--- a/resources/js/components/data-list/Filter.vue
+++ b/resources/js/components/data-list/Filter.vue
@@ -8,6 +8,7 @@
             :values="values || defaultValues"
             :meta="filter.meta"
             :errors="errors"
+            :track-dirty-state="false"
             @updated="$emit('changed', $event)"
         >
             <publish-fields

--- a/resources/js/components/data-list/Filters.vue
+++ b/resources/js/components/data-list/Filters.vue
@@ -1,5 +1,13 @@
 <template>
     <div>
+        <data-list-filter
+            v-for="filter in level1Filters"
+            :key="filter.handle"
+            class="mr-1 w-fit-content"
+            :filter="filter"
+            :values="activeFilters[filter.handle]"
+            :no-form-group="true"
+            @changed="filterChanged(filter.handle, $event)" />
         <button class="btn-flat btn-icon-only dropdown-toggle relative" @click="filtering = !filtering">
             <svg-icon name="filter-text" class="w-4 h-4 mr-1" />
             <span>{{ __('Filters') }}</span>
@@ -71,6 +79,9 @@ export default {
     },
 
     computed: {
+        level1Filters() {
+            return this.filters.filter(filter => filter.level1);
+        },
 
         standardFilters() {
             return this.filters.filter(filter => filter.handle !== 'fields');

--- a/resources/js/components/data-list/Filters.vue
+++ b/resources/js/components/data-list/Filters.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <data-list-filter
-            v-for="filter in level1Filters"
+            v-for="filter in promotedFilters"
             :key="filter.handle"
             class="mr-1 w-fit-content"
             :filter="filter"
@@ -79,8 +79,8 @@ export default {
     },
 
     computed: {
-        level1Filters() {
-            return this.filters.filter(filter => filter.level1);
+        promotedFilters() {
+            return this.filters.filter(filter => filter.promoted);
         },
 
         standardFilters() {

--- a/resources/js/components/data-list/Filters.vue
+++ b/resources/js/components/data-list/Filters.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="flex">
         <data-list-filter
             v-for="filter in promotedFilters"
             :key="filter.handle"

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -40,26 +40,28 @@ export default {
         },
         isRoot: {
             // intentionally not a boolean. we rely on it being undefined in places.
+        },
+        trackDirtyState: {
+            type: Boolean,
+            default: () => false
         }
     },
 
     data() {
         return {
             components: [], // extra components to be injected
-            managesVuexModule: true,
+            managesVuexModule: true // false when the Vuex module already exists, i.e. some other container created it before us
         }
     },
 
     created() {
         this.managesVuexModule = this.registerVuexModule();
-        if (!this.managesVuexModule) return;
         this.$events.$emit('publish-container-created', this);
     },
 
     destroyed() {
-        if (!this.managesVuexModule) return;
-        this.removeVuexModule();
-        this.clearDirtyState();
+        if (this.trackDirtyState) this.clearDirtyState();
+        if (this.managesVuexModule) this.removeVuexModule();
         this.$events.$emit('publish-container-destroyed', this);
     },
 
@@ -176,11 +178,11 @@ export default {
 
         emitUpdatedEvent(values) {
             this.$emit('updated', values);
-            this.dirty();
+            if (this.trackDirtyState) this.dirty();
         },
 
         saved() {
-            this.clearDirtyState();
+            if (this.trackDirtyState) this.clearDirtyState();
         },
 
         clearDirtyState() {

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -46,15 +46,18 @@ export default {
     data() {
         return {
             components: [], // extra components to be injected
+            managesVuexModule: true,
         }
     },
 
     created() {
-        this.registerVuexModule();
+        this.managesVuexModule = this.registerVuexModule();
+        if (!this.managesVuexModule) return;
         this.$events.$emit('publish-container-created', this);
     },
 
     destroyed() {
+        if (!this.managesVuexModule) return;
         this.removeVuexModule();
         this.clearDirtyState();
         this.$events.$emit('publish-container-destroyed', this);
@@ -84,7 +87,7 @@ export default {
             if (this.$store.state.hasOwnProperty('publish')
             && this.$store.state.publish.hasOwnProperty(this.name)) {
                 this.$store.commit(`publish/${this.name}/initialize`, initial);
-                return;
+                return false;
             }
 
             this.$store.registerModule(['publish', this.name], {
@@ -163,6 +166,8 @@ export default {
                     }
                 }
             });
+
+            return true;
         },
 
         removeVuexModule() {

--- a/resources/js/components/publish/Field.vue
+++ b/resources/js/components/publish/Field.vue
@@ -7,7 +7,7 @@
     >
     <div slot-scope="{ meta, value, loading: loadingMeta }" :class="classes">
         <div class="field-inner">
-            <label class="publish-field-label" :class="{'font-bold': config.bold}">
+            <label v-if="!notInGroup" class="publish-field-label" :class="{'font-bold': config.bold}">
                 <span class="cursor-pointer" :class="{'font-mono bg-grey-20 py-px px-sm text-xs': showHandle}" v-text="labelText" @click="toggleLabel" />
                 <i class="required ml-sm" v-if="config.required">*</i>
                 <avatar v-if="isLocked" :user="lockingUser" class="w-4 rounded-full -mt-px ml-1 mr-1" v-tooltip="lockingUser.name" />
@@ -92,6 +92,7 @@ export default {
         syncable: Boolean,
         namePrefix: String,
         errorKeyPrefix: String,
+        notInGroup: Boolean,
     },
 
     data() {
@@ -126,7 +127,8 @@ export default {
 
         classes() {
             return [
-                'form-group publish-field',
+                this.notInGroup ? '' : 'form-group',
+                'publish-field',
                 `${this.config.component || this.config.type}-fieldtype`,
                 `field-${tailwind_width_class(this.config.width)}`,
                 this.isReadOnly ? 'read-only-field' : '',

--- a/resources/js/components/publish/Fields.vue
+++ b/resources/js/components/publish/Fields.vue
@@ -12,6 +12,7 @@
             :errors="errors[field.handle]"
             :read-only="readOnly"
             :syncable="syncable"
+            :not-in-group="noFormGroup"
             @input="$emit('updated', field.handle, $event)"
             @meta-updated="$emit('meta-updated', field.handle, $event)"
             @synced="$emit('synced', field.handle)"
@@ -43,6 +44,7 @@ export default {
         },
         readOnly: Boolean,
         syncable: Boolean,
+        noFormGroup: Boolean,
     },
 
     computed: {

--- a/src/Query/Scopes/Filter.php
+++ b/src/Query/Scopes/Filter.php
@@ -21,6 +21,11 @@ abstract class Filter extends Scope implements Arrayable
         return false;
     }
 
+    public function level1()
+    {
+        return false;
+    }
+
     public function visibleTo($key)
     {
         return true;
@@ -65,6 +70,7 @@ abstract class Filter extends Scope implements Arrayable
             'title' => $this->title(),
             'extra' => $this->extra(),
             'required' => $this->required(),
+            'level1' => $this->level1(),
             'fields' => $this->fields()->toPublishArray(),
             'meta' => $this->fields()->meta(),
             'values' => $this->fields()->all()->map->defaultValue(),

--- a/src/Query/Scopes/Filter.php
+++ b/src/Query/Scopes/Filter.php
@@ -21,7 +21,7 @@ abstract class Filter extends Scope implements Arrayable
         return false;
     }
 
-    public function level1()
+    public function promoted()
     {
         return false;
     }
@@ -70,7 +70,7 @@ abstract class Filter extends Scope implements Arrayable
             'title' => $this->title(),
             'extra' => $this->extra(),
             'required' => $this->required(),
-            'level1' => $this->level1(),
+            'promoted' => $this->promoted(),
             'fields' => $this->fields()->toPublishArray(),
             'meta' => $this->fields()->meta(),
             'values' => $this->fields()->all()->map->defaultValue(),


### PR DESCRIPTION
This isn't a finished implementation, but rather a proof-of-concept of a feature that's very important for our users: we'd like to have filters that are more accessible from the listing than opening the 'Filters' pane and finding the filter in there.

This way it sorta works with select field filters, but the width is too small when not specifying a default value (setting a placeholder doesn't help), but that's more of an issue with the select fieldtype.

Is this a feature you would support in the core? For us, this UX is must-have, and I'm happy to change the implementation up entirely given the right pointers.