### PR TITLE
Select-Fieldtype emit @focus and @blur events

### DIFF
--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -14,7 +14,9 @@
         :multiple="config.multiple"
         :reset-on-options-change="resetOnOptionsChange"
         :close-on-select="!config.taggable"
-        :value="value" />
+        :value="value"
+        @search:focus="$emit('focus')"
+        @search:blur="$emit('blur')" />
 </template>
 
 <script>


### PR DESCRIPTION
There were some problems with locking elements when multiple users were working on the same entry. To lock the elements correctly, we need to emit the events `@focus` and `@blur`.