### PR TITLE
Add `sort` config to collection widget. References #1342.

### DIFF
--- a/resources/views/widgets/collection.blade.php
+++ b/resources/views/widgets/collection.blade.php
@@ -5,8 +5,8 @@
     </div>
     <collection-widget
         collection="{{ $collection->handle() }}"
-        initial-sort-column="title"
-        initial-sort-direction="asc"
+        initial-sort-column="{{ $sortColumn }}"
+        initial-sort-direction="{{ $sortDirection }}"
         :initial-per-page="{{ $limit }}"
     ></collection-widget>
 </div>

--- a/src/Widgets/Collection.php
+++ b/src/Widgets/Collection.php
@@ -26,10 +26,32 @@ class Collection extends Widget
             return;
         }
 
-        $title = $this->config('title', $collection->title());
-        $button = __('New :thing', ['thing' => $collection->entryBlueprint()->title()]);
-        $limit = $this->config('limit', 5);
+        [$sortColumn, $sortDirection] = $this->parseSort($collection);
 
-        return view('statamic::widgets.collection', compact('collection', 'title', 'button', 'limit'));
+        return view('statamic::widgets.collection', [
+            'collection' => $collection,
+            'title' => $this->config('title', $collection->title()),
+            'button' => __('New :thing', ['thing' => $collection->entryBlueprint()->title()]),
+            'limit' => $this->config('limit', 5),
+            'sortColumn' => $sortColumn,
+            'sortDirection' => $sortDirection,
+        ]);
+    }
+
+    /**
+     * Parse collection sort column and direction, similar to sorting works on collection tag.
+     *
+     * @param \Statamic\Entries\Collection $collection
+     * @return array
+     */
+    protected function parseSort($collection)
+    {
+        $default = $collection->dated() ? 'date:desc' : 'title:asc';
+        $sort = $this->config('order_by') ?? $this->config('sort') ?? $default;
+        $exploded = explode(':', $sort);
+        $column = $exploded[0];
+        $direction = $exploded[1] ?? 'asc';
+
+        return [$column, $direction];
     }
 }

--- a/src/Widgets/Collection.php
+++ b/src/Widgets/Collection.php
@@ -39,7 +39,7 @@ class Collection extends Widget
     }
 
     /**
-     * Parse collection sort column and direction, similar to sorting works on collection tag.
+     * Parse sort column and direction, similar to how sorting works on collection tag.
      *
      * @param \Statamic\Entries\Collection $collection
      * @return array


### PR DESCRIPTION
Allows for `sort` or `order_by` control (like collection tag) on collection widget.  ie)

```php
[
    'type' => 'collection',
    'collection' => 'daughters',
    'width' => 50,
    'limit' => 5,
    'sort' => 'non_favourite:desc',
],
```

Defaults to `date:desc` on dated collections, and `title:asc` on non-dated collections.

Closes #1342.