### PR TITLE
Fixed issue with loading the user detail page

### DIFF
--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -145,10 +145,8 @@ class UsersController extends CpController
         ];
     }
 
-    public function edit(Request $request, $id)
+    public function edit(Request $request, $user)
     {
-        $user = User::find($id);
-
         $this->authorize('edit', $user);
 
         $blueprint = $user->blueprint();


### PR DESCRIPTION
Before this fix, the `$id` variable was an instance of `User` instead of being an ID. So I figured that there is no point in finding a `$user` from a user instance as we already have one.

Hopefully that makes sense 😃

Here's a [Flare link](https://flareapp.io/share/lm2Q0A5x) for the bug I was hitting.