### PR TITLE
Don't show widget pagination if only has single page

### DIFF
--- a/resources/js/components/entries/Widget.vue
+++ b/resources/js/components/entries/Widget.vue
@@ -24,6 +24,7 @@
                     </template>
                 </data-list-table>
                 <data-list-pagination
+                    v-if="meta.last_page != 1"
                     class="py-1 border-t bg-grey-20 rounded-b-lg text-sm"
                     :resource-meta="meta"
                     @page-selected="page = $event"


### PR DESCRIPTION
If a collections widget does not have more than 1 page, then the background of the pagination element will be displayed with no links.

This pull request hides the pagination background element if there is only one page.

## Before
![image](https://user-images.githubusercontent.com/19637309/74572744-8805b780-4f77-11ea-94e9-f80e5cdd4285.png)

## After
![image](https://user-images.githubusercontent.com/19637309/74572778-918f1f80-4f77-11ea-817d-05fb7f1e5c32.png)
