### PR TITLE
🚀 Debugbar can be bound but not enabled which can cause performance issues

### DIFF
--- a/src/View/Debugbar/AddRequestMessage.php
+++ b/src/View/Debugbar/AddRequestMessage.php
@@ -15,7 +15,7 @@ class AddRequestMessage
      */
     public function handle(ViewRendered $event)
     {
-        if (! app()->bound('debugbar')) {
+        if (! app()->bound('debugbar') || ! app('debugbar')->isEnabled()) {
             return;
         }
 

--- a/src/View/Debugbar/AddVariables.php
+++ b/src/View/Debugbar/AddVariables.php
@@ -14,7 +14,7 @@ class AddVariables
      */
     public function handle(ViewRendered $event)
     {
-        if (! app()->bound('debugbar')) {
+        if (! app()->bound('debugbar') || ! app('debugbar')->isEnabled()) {
             return;
         }
 


### PR DESCRIPTION
If you install with `composer install` through a lock file, debugbar can be installed which causes it to be bound into the container. It's still disabled though.

However not checking that debugbar is enabled will cause the view to always get all variables and can cause performance problems

The callgraph below shows about 10.000 calls to flatMap that don't need to be happening when the debugbar is disabled

<img width="666" alt="image" src="https://user-images.githubusercontent.com/3626559/74610401-341fdd80-50f3-11ea-88d2-6aef16774364.png">