### PR TITLE
🚀 Store an entry's blueprint in the Blink cache

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -88,13 +88,15 @@ class Entry implements Contract, Augmentable, Responsable, Localization, ArrayAc
 
     public function blueprint()
     {
-        return $this->fluentlyGetOrSet('blueprint')
-            ->getter(function ($blueprint) {
-                return $blueprint
-                    ? $this->collection()->ensureEntryBlueprintFields(Blueprint::find($blueprint))
-                    : $this->defaultBlueprint();
-            })
-            ->args(func_get_args());
+        return Blink::once("entry-blueprint-{$this->id()}", function () {
+            return $this->fluentlyGetOrSet('blueprint')
+                ->getter(function ($blueprint) {
+                    return $blueprint
+                        ? $this->collection()->ensureEntryBlueprintFields(Blueprint::find($blueprint))
+                        : $this->defaultBlueprint();
+                })
+                ->args(func_get_args());
+        });
     }
 
     public function collectionHandle()

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -88,15 +88,13 @@ class Entry implements Contract, Augmentable, Responsable, Localization, ArrayAc
 
     public function blueprint()
     {
-        return Blink::once("entry-blueprint-{$this->id()}", function () {
-            return $this->fluentlyGetOrSet('blueprint')
-                ->getter(function ($blueprint) {
-                    return $blueprint
-                        ? $this->collection()->ensureEntryBlueprintFields(Blueprint::find($blueprint))
-                        : $this->defaultBlueprint();
-                })
-                ->args(func_get_args());
-        });
+        return $this->fluentlyGetOrSet('blueprint')
+            ->getter(function ($blueprint) {
+                return $blueprint
+                    ? $this->collection()->ensureEntryBlueprintFields(Blueprint::find($blueprint))
+                    : $this->defaultBlueprint();
+            })
+            ->args(func_get_args());
     }
 
     public function collectionHandle()
@@ -193,13 +191,15 @@ class Entry implements Contract, Augmentable, Responsable, Localization, ArrayAc
 
     public function defaultBlueprint()
     {
-        if ($blueprint = $this->value('blueprint')) {
-            return $this->collection()->ensureEntryBlueprintFields(
-                Blueprint::find($blueprint)
-            );
-        }
+        return Blink::once("entry-defaultblueprint-{$this->id()}", function () {
+            if ($blueprint = $this->value('blueprint')) {
+                return $this->collection()->ensureEntryBlueprintFields(
+                    Blueprint::find($blueprint)
+                );
+            }
 
-        return $this->collection()->entryBlueprint();
+            return $this->collection()->entryBlueprint();
+        });
     }
 
     public function save()


### PR DESCRIPTION
Getting the blueprint of an Entry is a fairly expensive operation, and balloons up to a lot of internal calls, if we store this once for the request it helps the performance quite a bit.

Call graph: https://blackfire.io/profiles/bb1a8568-12c4-4214-afbf-b7176f771108/graph

Starts from here:
<img width="505" alt="image" src="https://user-images.githubusercontent.com/3626559/74611257-5ec16480-50fa-11ea-8850-3d3fc4f01498.png">

And ends with about 30k calls here
<img width="938" alt="image" src="https://user-images.githubusercontent.com/3626559/74611293-a647f080-50fa-11ea-9463-05c07c50203f.png">
