### PR TITLE
Hide grid heading if field is hidden

### DIFF
--- a/resources/js/components/fieldtypes/grid/HeaderCell.vue
+++ b/resources/js/components/fieldtypes/grid/HeaderCell.vue
@@ -1,7 +1,7 @@
 <template>
 
     <th>
-        <div class="flex items-center justify-between">
+        <div v-if="field.type != 'hidden'" class="flex items-center justify-between">
             <div>{{ field.display || field.handle }}</div>
             <div
                 v-if="field.instructions"


### PR DESCRIPTION
Previously, the headings for hidden fieldtypes in a Grid fieldtype with the table layout were shown, even though the actual input was hidden.

This pull request hides the headings if the fieldtype is `hidden`.

Fixes #1368