### PR TITLE
Fix localizing problem when in structures

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -32,6 +32,7 @@ Route::group([
     });
 
     Route::get('structures/{collection}/entries/{entry}/{slug}', 'Collections\EntriesController@edit')->name('structures.entries.edit');
+    Route::post('structures/{collection}/entries/{entry}/{slug}/localize', 'Collections\LocalizeEntryController')->name('structures.entries.localize');
 
     Route::group(['namespace' => 'Collections'], function () {
         Route::resource('collections', 'CollectionsController');

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -5,7 +5,6 @@ namespace Statamic\Entries;
 use ArrayAccess;
 use Statamic\Facades;
 use Statamic\Statamic;
-use Statamic\Support\Arr;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Facades\Blink;
@@ -497,6 +496,10 @@ class Entry implements Contract, Augmentable, Responsable, Localization, ArrayAc
         }
 
         if (! $id = $this->id()) {
+            return null;
+        }
+
+        if (! $this->structure()->in($this->locale())->page($id)) {
             return null;
         }
 


### PR DESCRIPTION
Fixes #964

The change in the routes file fixes the 404 when clicking on the site button in the structure context.

The change in `Entry.php` fixes the error when trying to return a parent of `null`.

Please feel free to edit this to your style - it is probably more of a quick fix. But my clients need to be able to switch sites when in the structures context.