### PR TITLE
Fixed new term authorisation.

### DIFF
--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -20,6 +20,7 @@ use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Http\Resources\CP\Taxonomies\Terms;
 use Statamic\Http\Resources\CP\Taxonomies\Term as TermResource;
 use Statamic\Contracts\Entries\Entry as EntryContract;
+use Statamic\Contracts\Taxonomies\Term as TermContract;
 
 class TermsController extends CpController
 {


### PR DESCRIPTION
A namespacing issue meant non-superusers were unable to create terms even if they had the permission to do so.