### PR TITLE
Make listing obey collection order

### DIFF
--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -105,6 +105,7 @@ export default {
             }).then(response => {
                 this.columns = response.data.meta.columns;
                 this.sortColumn = response.data.meta.sortColumn;
+                this.sortDirection = response.data.meta.sortDirection;
                 this.activeFilters = {...response.data.meta.filters};
                 this.items = Object.values(response.data.data);
                 this.meta = response.data.meta;

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -50,6 +50,7 @@ class EntriesController extends CpController
             ->additional(['meta' => [
                 'filters' => $request->filters,
                 'sortColumn' => $sortField,
+                'sortDirection' => $sortDirection,
             ]]);
     }
 


### PR DESCRIPTION
Fixes a bug where a collection's configured sort direction wasn't used after clearing the search query in the listing.