### PR TITLE
Allow file download on Action response

### DIFF
--- a/resources/js/components/data-list/Actions.vue
+++ b/resources/js/components/data-list/Actions.vue
@@ -34,12 +34,29 @@ export default {
                 values
             };
 
-            this.$axios.post(this.url, payload).then(response => {
+            this.$axios.post(this.url, payload, { responseType: 'blob' }).then(response => {
                 this.$emit('completed');
+
+                if (response.headers['content-disposition']) {
+                    this.downloadFileFromResponse(response)
+                }
             }).catch(error => {
                 this.$toast.error(error.response.data.message);
                 this.$emit('completed');
             });
+        },
+
+        downloadFileFromResponse(response) {
+            const attachmentMatch = response.headers['content-disposition'].match(/^attachment.+filename="([^"]+)"/i)
+            if (attachmentMatch && attachmentMatch.length) {
+                const filename = attachmentMatch.length >= 2 ? attachmentMatch[1] : 'file.txt'
+                const url = window.URL.createObjectURL(new Blob([response.data]));
+                const link = document.createElement('a');
+                link.href = url;
+                link.setAttribute('download', filename);
+                document.body.appendChild(link);
+                link.click();
+            }
         }
 
     }

--- a/src/Http/Controllers/CP/ActionController.php
+++ b/src/Http/Controllers/CP/ActionController.php
@@ -33,7 +33,7 @@ abstract class ActionController extends CpController
 
         abort_unless($unauthorized->isEmpty(), 403, 'You are not authorized to run this action.');
 
-        $action->run($items, $request->all());
+        return $action->run($items, $request->all());
     }
 
     abstract protected function getSelectedItems($items, $context);


### PR DESCRIPTION
This pr should allow the creation of actions with file downloads.

In a project I have created an action to allow the user to download selected entries to an excel spreadsheet.
Unfortunately this does not work, because the `ActionController` does not actually return the actions return value and therefore does not respond with my file.

My action looks as follows:
```php
public function run($items, $values)
{
    $filename = 'file.xlsx';
    $file = Excel::download(collect($items), $filename);
    return $file;
}
```

A simple return on the execution of my action in the `ActionController` solves this problem.

In the frontend the `Actions.vue` mixin only needs to handle the response accordingly. I have added the code for that as well.

The only not so clean thing about my changes is the `responseType: 'blob'` option on the axios request but since you currently don't handle the response at all anyway, I thought it's okay for now. I have not found a way around that so far.