### PR TITLE
Use `explode` to split form attrs

### DIFF
--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -30,7 +30,7 @@ trait RendersForms
         $attrs = collect($defaultAttrs)
             ->merge($this->getList('attr'))
             ->mapWithKeys(function ($attr) {
-                $bits = preg_split('/:(?!\/{2})/', $attr);
+                $bits = explode(':', $attr, 2);
                 return [$bits[0] => $bits[1] ?? null];
             })
             ->map(function ($value, $attr) {


### PR DESCRIPTION
Fixes #1473, but I'm not sure if there was a specific reason you were doing it the way you were.

The issue occurs because the action attr ends up as: `action:http://localhost:8000/!/forms` and gets split into three bits: `action`, `http://localhost` and `8000/!/forms` when it should be two: `action` and `http://localhost:8000/!/forms`