### PR TITLE
Allow the REST API to identify Entries by Slug

### DIFF
--- a/config/api.php
+++ b/config/api.php
@@ -39,4 +39,16 @@ return [
 
     'pagination_size' => 50,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Entry Route Model Bindings
+    |--------------------------------------------------------------------------
+    |
+    | The properties used to identify entries.
+    |
+    */
+
+    'entry_route_identifier' => env('STATAMIC_API_ENTRY_ROUTE_IDENTIFIER', 'id'),
+
+
 ];

--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -71,7 +71,7 @@ class RouteServiceProvider extends ServiceProvider
                 ->first();
 
             throw_if(
-                ! $entry || $entry->collection()->id() !== $route->parameter('collection')->id(),
+                ! $entry,
                 new NotFoundHttpException("Entry [$handle] not found.")
             );
 


### PR DESCRIPTION
This PR should allow a Content API consumer to fetch an entry by its slug instead of its id.

**Problem:**
I often use statamic headless with a nuxt frontend application. With other cms I often had to write an API myself for it to be headless. The Content API therefore is an amazing addition on top of statamic.
The only problem I have with it is the identification of an entry by its id.
This is a dealbreaker since I do not want the route in my frontend to contain an awful id but without it I cannot fetch the entry from the cms.

**Solution:**
This PR addresses this issue by adding the config variable `statamic.api.entry_route_identifier` allowing me to configure the property to use to identify an entry.
It can also be configured using the env variable `STATAMIC_API_ENTRY_ROUTE_IDENTIFIER`.

**Result:**
If I set this to `'slug'` the route to my blog article would be `/api/collections/articles/entries/my-article` instead of `/api/collections/articles/entries/d5365a3e-46ca-4ff9-bc77-75a8199079ac`.
If it's empty or set to `'id'` it will work the same way as it did until now.