### PR TITLE
Fix mousetrap on asset’s folder dialog

### DIFF
--- a/resources/js/components/assets/Folder/Folder.vue
+++ b/resources/js/components/assets/Folder/Folder.vue
@@ -76,9 +76,9 @@ export default {
 
     created() {
         // Allow key commands with a focused input
-        this.$keys.prototype.stopCallback = (e) => {
-            return ! ['enter', 'escape'].includes(e.code.toLowerCase());
-        }
+        this.$keys.stop(e => {
+            return ! ['enter', 'escape'].includes(e.code.toLowerCase())
+        })
 
         this.$keys.bind('enter', this.submit)
         this.$keys.bind('esc', this.cancel)

--- a/resources/js/components/keys/Binding.js
+++ b/resources/js/components/keys/Binding.js
@@ -28,6 +28,10 @@ export default class Binding {
         });
     }
 
+    stop(callback) {
+        mousetrap.prototype.stopCallback = callback;
+    }
+
     bindMousetrap(binding, callback) {
         mousetrap.bind(binding, callback);
     }

--- a/resources/js/components/keys/Keys.js
+++ b/resources/js/components/keys/Keys.js
@@ -11,6 +11,10 @@ export default class Keys {
         return new Binding(this.bindings).bind(bindings, callback);
     }
 
+    stop(callback) {
+        return new Binding(this.bindings).stop(callback);
+    }
+
     bindGlobal(bindings, callback) {
         return new GlobalBinding(this.globals).bind(bindings, callback);
     }


### PR DESCRIPTION
The asset's folder dialog throw this error in console when it's opened:

![Schermata 2020-03-18 alle 09 02 05](https://user-images.githubusercontent.com/779534/76939430-a7865c00-68f8-11ea-821a-5321abf3b7a8.png)

This PR restore the ability to use Mousetrap's `stopCallback` method to allow key commands with a focused input