### PR TITLE
Collection augmentation

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -2,8 +2,10 @@
 
 namespace Statamic\Entries;
 
+use Statamic\Contracts\Data\Augmentable as AugmentableContract;
 use Statamic\Contracts\Entries\Collection as Contract;
 use Statamic\Data\ExistsAsFile;
+use Statamic\Data\HasAugmentedData;
 use Statamic\Facades;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Blueprint;
@@ -18,9 +20,9 @@ use Statamic\Structures\CollectionStructure;
 use Statamic\Support\Arr;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Collection implements Contract
+class Collection implements Contract, AugmentableContract
 {
-    use FluentlyGetsAndSets, ExistsAsFile;
+    use FluentlyGetsAndSets, ExistsAsFile, HasAugmentedData;
 
     protected $handle;
     protected $routes = [];
@@ -576,5 +578,18 @@ class Collection implements Contract
     public static function __callStatic($method, $parameters)
     {
         return Facades\Collection::{$method}(...$parameters);
+    }
+
+    public function __toString()
+    {
+        return $this->handle();
+    }
+
+    public function augmentedArrayData()
+    {
+        return [
+            'title' => $this->title(),
+            'handle' => $this->handle(),
+        ];
     }
 }

--- a/src/Tags/ArrayAccessor.php
+++ b/src/Tags/ArrayAccessor.php
@@ -12,6 +12,17 @@ class ArrayAccessor extends Collection
         return Arr::getFirst($this->items, Arr::wrap($key), $default);
     }
 
+    public function hasAny(array $keys)
+    {
+        foreach ($keys as $key) {
+            if ($this->has($key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function explode($key, $default = null)
     {
         if (! $value = $this->get($key)) {

--- a/src/Tags/Collection/Collection.php
+++ b/src/Tags/Collection/Collection.php
@@ -21,7 +21,9 @@ class Collection extends Tags
     {
         $this->parameters['from'] = $this->method;
 
-        return $this->index();
+        return $this->output(
+            $this->entries()->get()
+        );
     }
 
     /**
@@ -29,6 +31,10 @@ class Collection extends Tags
      */
     public function index()
     {
+        if (! $this->params->hasAny(['from', 'in', 'folder', 'use', 'collection'])) {
+            return $this->context->get('collection');
+        }
+
         return $this->output(
             $this->entries()->get()
         );

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -4,9 +4,11 @@ namespace Tests\Data\Entries;
 
 use Facades\Statamic\Fields\BlueprintRepository;
 use Facades\Tests\Factories\EntryFactory;
+use Statamic\Contracts\Data\Augmentable;
 use Statamic\Entries\Collection;
 use Statamic\Entries\Entry;
 use Statamic\Facades;
+use Statamic\Facades\Antlers;
 use Statamic\Facades\Site;
 use Statamic\Facades\Structure;
 use Statamic\Fields\Blueprint;
@@ -412,6 +414,36 @@ class CollectionTest extends TestCase
 
         $this->assertNotSame($structure, $collection->structure());
         $this->assertEquals(13, $collection->structure()->maxDepth());
+    }
+
+    /** @test */
+    function it_gets_the_handle_when_casting_to_a_string()
+    {
+        $collection = (new Collection)->handle('test');
+
+        $this->assertEquals('test', (string) $collection);
+    }
+
+    /** @test */
+    function it_augments()
+    {
+        $collection = (new Collection)->handle('test');
+
+        $this->assertInstanceof(Augmentable::class, $collection);
+        $this->assertEquals([
+            'title' => 'Test',
+            'handle' => 'test',
+        ], $collection->toAugmentedArray());
+    }
+
+    /** @test */
+    function it_augments_in_the_parser()
+    {
+        $collection = (new Collection)->handle('test');
+
+        $this->assertEquals('test', Antlers::parse('{{ mycollection }}', ['mycollection' => $collection]));
+
+        $this->assertEquals('test Test', Antlers::parse('{{ mycollection }}{{ handle }} {{ title }}{{ /mycollection }}', ['mycollection' => $collection]));
     }
 
     private function makeStructure()

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -7,6 +7,7 @@ use Facades\Tests\Factories\EntryFactory;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Entries\Collection;
 use Statamic\Entries\Entry;
+use Statamic\Exceptions\CollectionNotFoundException;
 use Statamic\Facades;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Site;
@@ -441,9 +442,18 @@ class CollectionTest extends TestCase
     {
         $collection = (new Collection)->handle('test');
 
-        $this->assertEquals('test', Antlers::parse('{{ mycollection }}', ['mycollection' => $collection]));
+        $this->assertEquals('test', Antlers::parse('{{ collection }}', ['collection' => $collection]));
 
-        $this->assertEquals('test Test', Antlers::parse('{{ mycollection }}{{ handle }} {{ title }}{{ /mycollection }}', ['mycollection' => $collection]));
+        $this->assertEquals('test Test', Antlers::parse('{{ collection }}{{ handle }} {{ title }}{{ /collection }}', ['collection' => $collection]));
+
+        $this->assertEquals('test', Antlers::parse('{{ collection:handle }}', ['collection' => $collection]));
+
+        try {
+            Antlers::parse('{{ collection from="somewhere" }}{{ title }}{{ /collection }}', ['collection' => $collection]);
+            $this->fail('Exception not thrown');
+        } catch (CollectionNotFoundException $e) {
+            $this->assertEquals('Collection [somewhere] not found', $e->getMessage());
+        }
     }
 
     private function makeStructure()

--- a/tests/Tags/Collection/CollectionTest.php
+++ b/tests/Tags/Collection/CollectionTest.php
@@ -4,6 +4,7 @@ namespace Tests\Tags\Collection;
 
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection as SupportCollection;
 use Statamic\Exceptions\CollectionNotFoundException;
 use Statamic\Facades;
 use Statamic\Facades\Antlers;
@@ -466,6 +467,28 @@ class CollectionTest extends TestCase
             'c' => null,
             'd' => 'Banana'
         ], $items);
+    }
+
+    /** @test */
+    function when_using_the_tag_without_any_parameters_that_define_the_collection_it_will_get_the_collection_object_from_context()
+    {
+        $item = Facades\Collection::make();
+
+        $this->collectionTag->setContext(['collection' => $item]);
+
+        // Without a param that would instruct Statamic which collection to get, we just return the collection from context.
+        // Which essentially gives the illusion that the tag wasn't run, and a collection variable was accessed.
+        $this->assertEquals($item, $this->collectionTag->setParameters([])->index());
+
+        // Sanity check that *any* parameter isn't the thing that causes it.
+        $this->assertEquals($item, $this->collectionTag->setParameters(['something' => 'else'])->index());
+
+        // Using one of the inclusive params results in an Illuminate\Support\Collection (ie. a list of entries)
+        $this->assertInstanceOf(SupportCollection::class, $this->collectionTag->setParameters(['from' => 'music'])->index());
+        $this->assertInstanceOf(SupportCollection::class, $this->collectionTag->setParameters(['in' => 'music'])->index());
+        $this->assertInstanceOf(SupportCollection::class, $this->collectionTag->setParameters(['folder' => 'music'])->index());
+        $this->assertInstanceOf(SupportCollection::class, $this->collectionTag->setParameters(['use' => 'music'])->index());
+        $this->assertInstanceOf(SupportCollection::class, $this->collectionTag->setParameters(['collection' => 'music'])->index());
     }
 
     private function setTagParameters($parameters)


### PR DESCRIPTION
Collection objects can be augmented. You can access their data in templates.

The collection tag/variable without any params that indicate how to retrieve a collection (eg. `from`, `in`, etc) will just let you access the current context's collection.

```
{{ collection }} {{ title }} {{ /collection }} // Blog blog
```

With one of those params, it'll run the tag:

```
{{ collection from="blog" }} {{ title }}, {{ /collection }} // Entry One, Entry Two
```

When used as a single tag, it'll get the handle:

```
{{ collection }} // blog
```

As a single tag, you can get nested values:

```
{{ collection:title }} // Blog
```

Caveat: The tag pair plus nested syntax will conflict:

```
{{ collection:title }}
  {{ handle }}
{{ /collection:title }}
```

Would you think this should loop through entries in the `title` collection? No, it'll recognize there's a title variable and try to access it. In these cases, you should be more specific. `{{ collection from="title" }}` Not really a big deal though since you probably won't have a collection named `title` or `handle`.

Closes #1420 
Closes #1487