### PR TITLE
Updates as per Laravel 7 upgrade guide

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "composer/composer": "^1.7",
         "facade/ignition-contracts": "^1.0",
         "guzzlehttp/guzzle": "^6.3",
-        "laravel/framework": "5.6.* || 5.7.* || 5.8.* || ^6.0",
+        "laravel/framework": "5.6.* || 5.7.* || 5.8.* || ^6.0 || ^7.0",
         "laravel/helpers": "^1.1",
         "league/commonmark": "^1.3",
         "league/csv": "^9.0",
@@ -32,7 +32,7 @@
         "fzaninotto/faker": "~1.4",
         "google/cloud-translate": "^1.6",
         "mockery/mockery": "~1.0",
-        "nunomaduro/collision": "^3.0",
+        "nunomaduro/collision": "3.0 || ^4.1",
         "orchestra/testbench": "3.8 || 4.0"
     },
     "config": {

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace Statamic\Exceptions;
 
 use Exception;
+use Throwable;
 use Statamic\Statamic;
 use Illuminate\Support\Facades\View;
 use App\Exceptions\Handler as ExceptionHandler;
@@ -11,7 +12,7 @@ use Illuminate\Auth\Access\AuthorizationException as IlluminateAuthException;
 
 class Handler extends ExceptionHandler
 {
-    public function render($request, Exception $e)
+    public function render($request, Throwable $e)
     {
         if ($e instanceof NotFoundHttpException && Statamic::isApiRoute()) {
             return response()->json(['message' => $e->getMessage() ?: 'Not found.'], 404);
@@ -27,11 +28,11 @@ class Handler extends ExceptionHandler
     /**
      * Render an exception to a string using Symfony.
      *
-     * @param  \Exception  $e
+     * @param  Throwable  $e
      * @param  bool  $debug
      * @return string
      */
-    protected function renderExceptionWithSymfony(Exception $e, $debug)
+    protected function renderExceptionWithSymfony(Throwable $e, $debug)
     {
         return (new SymfonyExceptionHandler($debug))->getHtml(
             FlattenException::create($e)

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -2,12 +2,11 @@
 
 namespace Statamic\Exceptions;
 
-use Exception;
 use Throwable;
 use Statamic\Statamic;
 use Illuminate\Support\Facades\View;
 use App\Exceptions\Handler as ExceptionHandler;
-use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Illuminate\Auth\Access\AuthorizationException as IlluminateAuthException;
 
 class Handler extends ExceptionHandler

--- a/src/Http/Resources/API/AssetResource.php
+++ b/src/Http/Resources/API/AssetResource.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Http\Resources\API;
 
-use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Http\Resources\Json\JSONResource;
 
-class AssetResource extends Resource
+class AssetResource extends JSONResource
 {
     /**
      * Transform the resource into an array.

--- a/src/Http/Resources/API/AssetResource.php
+++ b/src/Http/Resources/API/AssetResource.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Http\Resources\API;
 
-use Illuminate\Http\Resources\Json\JSONResource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
-class AssetResource extends JSONResource
+class AssetResource extends JsonResource
 {
     /**
      * Transform the resource into an array.

--- a/src/Http/Resources/API/EntryResource.php
+++ b/src/Http/Resources/API/EntryResource.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Http\Resources\API;
 
-use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Http\Resources\Json\JSONResource;
 
-class EntryResource extends Resource
+class EntryResource extends JSONResource
 {
     /**
      * Transform the resource into an array.

--- a/src/Http/Resources/API/EntryResource.php
+++ b/src/Http/Resources/API/EntryResource.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Http\Resources\API;
 
-use Illuminate\Http\Resources\Json\JSONResource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
-class EntryResource extends JSONResource
+class EntryResource extends JsonResource
 {
     /**
      * Transform the resource into an array.

--- a/src/Http/Resources/API/GlobalSetResource.php
+++ b/src/Http/Resources/API/GlobalSetResource.php
@@ -3,9 +3,9 @@
 namespace Statamic\Http\Resources\API;
 
 use Statamic\Statamic;
-use Illuminate\Http\Resources\Json\JSONResource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
-class GlobalSetResource extends JSONResource
+class GlobalSetResource extends JsonResource
 {
     /**
      * Transform the resource into an array.

--- a/src/Http/Resources/API/GlobalSetResource.php
+++ b/src/Http/Resources/API/GlobalSetResource.php
@@ -2,10 +2,10 @@
 
 namespace Statamic\Http\Resources\API;
 
-use Illuminate\Http\Resources\Json\Resource;
 use Statamic\Statamic;
+use Illuminate\Http\Resources\Json\JSONResource;
 
-class GlobalSetResource extends Resource
+class GlobalSetResource extends JSONResource
 {
     /**
      * Transform the resource into an array.

--- a/src/Http/Resources/API/TermResource.php
+++ b/src/Http/Resources/API/TermResource.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Http\Resources\API;
 
-use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Http\Resources\Json\JSONResource;
 
-class TermResource extends Resource
+class TermResource extends JSONResource
 {
     /**
      * Transform the resource into an array.

--- a/src/Http/Resources/API/TermResource.php
+++ b/src/Http/Resources/API/TermResource.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Http\Resources\API;
 
-use Illuminate\Http\Resources\Json\JSONResource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
-class TermResource extends JSONResource
+class TermResource extends JsonResource
 {
     /**
      * Transform the resource into an array.

--- a/src/Http/Resources/API/UserResource.php
+++ b/src/Http/Resources/API/UserResource.php
@@ -2,10 +2,10 @@
 
 namespace Statamic\Http\Resources\API;
 
-use Illuminate\Http\Resources\Json\Resource;
 use Statamic\Statamic;
+use Illuminate\Http\Resources\Json\JSONResource;
 
-class UserResource extends Resource
+class UserResource extends JSONResource
 {
     /**
      * Transform the resource into an array.

--- a/src/Http/Resources/API/UserResource.php
+++ b/src/Http/Resources/API/UserResource.php
@@ -3,9 +3,9 @@
 namespace Statamic\Http\Resources\API;
 
 use Statamic\Statamic;
-use Illuminate\Http\Resources\Json\JSONResource;
+use Illuminate\Http\Resources\Json\JsonResource;
 
-class UserResource extends JSONResource
+class UserResource extends JsonResource
 {
     /**
      * Transform the resource into an array.

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -6,19 +6,14 @@ use Statamic\Tags;
 use Statamic\Actions;
 use Statamic\Fieldtypes;
 use Statamic\Query\Scopes;
-use Statamic\Modifiers\Modifier;
-use Statamic\Extensions\FileStore;
-use Statamic\Modifiers\CoreModifiers;
-use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\ServiceProvider;
 use Statamic\Extend\Manifest;
-use Illuminate\Console\DetectsApplicationNamespace;
+use Statamic\Modifiers\Modifier;
+use Illuminate\Filesystem\Filesystem;
+use Statamic\Modifiers\CoreModifiers;
+use Illuminate\Support\ServiceProvider;
 
 class ExtensionServiceProvider extends ServiceProvider
 {
-    use DetectsApplicationNamespace;
-
     /**
      * Aliases for modifiers bundled with Statamic.
      *


### PR DESCRIPTION
Not sure if this is something you're open to, but this seems to get Statamic up to Laravel 7, although you need to wait for https://github.com/mrclay/minify/pull/666 to actually get there.

However all of these changes should work for L5.8+ regardless to be ready!