### PR TITLE
Allow empty bard augmentation

### DIFF
--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -20,6 +20,10 @@ class Augmentor
 
     public function augment($value)
     {
+        if (!$value) {
+            return '';
+        }
+
         if (is_string($value)) {
             return $value;
         }

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -84,6 +84,12 @@ class BardTest extends TestCase
     }
 
     /** @test */
+    function it_doesnt_augment_when_empty()
+    {
+        $this->assertEquals('', $this->bard()->augment(null));
+    }
+
+    /** @test */
     function it_augments_to_html_when_there_are_no_sets()
     {
         $data = [


### PR DESCRIPTION
This PR should fix the issue where an empty bard cannot be augmented and causes an error exception as discussed in #1335

**Problem:**
The augmentor doesn't check for an empty bard value and instead tries to convert it to html.

**Solution:**
In the bard augmentor I simply added a check whether the value is empty. If so I return an empty string.