### PR TITLE
Shallow augmentation

### DIFF
--- a/src/Auth/AugmentedUser.php
+++ b/src/Auth/AugmentedUser.php
@@ -24,6 +24,7 @@ class AugmentedUser extends AbstractAugmented
                 'is_user',
                 'last_login',
                 'avatar',
+                'api_url',
             ])
             ->merge($this->roleHandles())
             ->merge($this->groupHandles())

--- a/src/Auth/AugmentedUser.php
+++ b/src/Auth/AugmentedUser.php
@@ -37,6 +37,10 @@ class AugmentedUser extends AbstractAugmented
             return true;
         }
 
+        if ($handle === 'is_super') {
+            return $this->data->isSuper();
+        }
+
         if (Str::startsWith($handle, 'is_')) {
             return in_array(Str::after($handle, 'is_'), $this->roles());
         }

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -18,10 +18,11 @@ use Statamic\Data\TracksQueriedColumns;
 use Statamic\Facades;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\URL;
+use Statamic\Fields\Value;
 use Statamic\Notifications\ActivateAccount as ActivateAccountNotification;
 use Statamic\Notifications\PasswordReset as PasswordResetNotification;
+use Statamic\Statamic;
 use Statamic\Support\Arr;
-use Statamic\Fields\Value;
 
 abstract class User implements
     UserContract,
@@ -108,6 +109,11 @@ abstract class User implements
     public function updateUrl()
     {
         return cp_route('users.update', $this->id());
+    }
+
+    public function apiUrl()
+    {
+        return Statamic::apiRoute('users.show', $this->id());
     }
 
     public function newAugmentedInstance()
@@ -242,5 +248,10 @@ abstract class User implements
     public function defaultAugmentedArrayKeys()
     {
         return $this->selectedQueryColumns;
+    }
+
+    protected function shallowAugmentedArrayKeys()
+    {
+        return ['id', 'name', 'email', 'api_url'];
     }
 }

--- a/src/Contracts/Data/Augmentable.php
+++ b/src/Contracts/Data/Augmentable.php
@@ -6,4 +6,7 @@ interface Augmentable
 {
     public function augmentedValue($key);
     public function toAugmentedArray($keys = null);
+    public function toAugmentedValues($keys = null);
+    public function toShallowAugmentedArray();
+    public function toShallowAugmentedValues();
 }

--- a/src/Contracts/Data/Augmentable.php
+++ b/src/Contracts/Data/Augmentable.php
@@ -6,7 +6,7 @@ interface Augmentable
 {
     public function augmentedValue($key);
     public function toAugmentedArray($keys = null);
-    public function toAugmentedValues($keys = null);
+    public function toAugmentedCollection($keys = null);
     public function toShallowAugmentedArray();
-    public function toShallowAugmentedValues();
+    public function toShallowAugmentedCollection();
 }

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -36,7 +36,7 @@ abstract class AbstractAugmented implements Augmented
             $arr[$key] = $this->get($key);
         }
 
-        return $arr;
+        return new AugmentedValues($arr);
     }
 
     abstract protected function keys();

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -36,7 +36,7 @@ abstract class AbstractAugmented implements Augmented
             $arr[$key] = $this->get($key);
         }
 
-        return new AugmentedValues($arr);
+        return new AugmentedCollection($arr);
     }
 
     abstract protected function keys();

--- a/src/Data/AugmentedCollection.php
+++ b/src/Data/AugmentedCollection.php
@@ -9,7 +9,7 @@ use JsonSerializable;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Fields\Value;
 
-class AugmentedValues extends Collection
+class AugmentedCollection extends Collection
 {
     public function jsonSerialize()
     {

--- a/src/Data/AugmentedData.php
+++ b/src/Data/AugmentedData.php
@@ -5,7 +5,7 @@ namespace Statamic\Data;
 use Illuminate\Support\Collection;
 use Statamic\Data\AbstractAugmented;
 
-class AugmentedArray extends AbstractAugmented
+class AugmentedData extends AbstractAugmented
 {
     protected $data;
     protected $array;

--- a/src/Data/AugmentedValues.php
+++ b/src/Data/AugmentedValues.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Statamic\Data;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Collection;
+use JsonSerializable;
+use Statamic\Contracts\Data\Augmentable;
+use Statamic\Fields\Value;
+
+class AugmentedValues extends Collection
+{
+    public function jsonSerialize()
+    {
+        return array_map(function ($value) {
+            if ($value instanceof Value) {
+                $value = $value->shallow();
+            }
+
+            if ($value instanceof Augmentable) {
+                return $value->toShallowAugmentedArray();
+            }
+
+            if ($value instanceof JsonSerializable) {
+                return $value->jsonSerialize();
+            } elseif ($value instanceof Jsonable) {
+                return json_decode($value->toJson(), true);
+            } elseif ($value instanceof Arrayable) {
+                return $value->toArray();
+            }
+
+            return $value;
+        }, $this->all());
+    }
+}

--- a/src/Data/HasAugmentedData.php
+++ b/src/Data/HasAugmentedData.php
@@ -8,7 +8,7 @@ trait HasAugmentedData
 
     public function newAugmentedInstance()
     {
-        return new AugmentedArray($this, $this->augmentedArrayData());
+        return new AugmentedData($this, $this->augmentedArrayData());
     }
 
     public function augmentedArrayData()

--- a/src/Data/HasAugmentedInstance.php
+++ b/src/Data/HasAugmentedInstance.php
@@ -11,9 +11,24 @@ trait HasAugmentedInstance
         return $this->augmented()->get($key);
     }
 
-    public function toAugmentedArray($keys = null)
+    public function toAugmentedValues($keys = null)
     {
         return $this->augmented()->select($keys ?? $this->defaultAugmentedArrayKeys());
+    }
+
+    public function toAugmentedArray($keys = null)
+    {
+        return $this->toAugmentedValues($keys)->all();
+    }
+
+    public function toShallowAugmentedValues()
+    {
+        return $this->augmented()->select($this->shallowAugmentedArrayKeys());
+    }
+
+    public function toShallowAugmentedArray()
+    {
+        return $this->toShallowAugmentedValues()->all();
     }
 
     public function augmented()
@@ -26,5 +41,10 @@ trait HasAugmentedInstance
     protected function defaultAugmentedArrayKeys()
     {
         return null;
+    }
+
+    protected function shallowAugmentedArrayKeys()
+    {
+        return ['id', 'title', 'api_url'];
     }
 }

--- a/src/Data/HasAugmentedInstance.php
+++ b/src/Data/HasAugmentedInstance.php
@@ -11,24 +11,24 @@ trait HasAugmentedInstance
         return $this->augmented()->get($key);
     }
 
-    public function toAugmentedValues($keys = null)
+    public function toAugmentedCollection($keys = null)
     {
         return $this->augmented()->select($keys ?? $this->defaultAugmentedArrayKeys());
     }
 
     public function toAugmentedArray($keys = null)
     {
-        return $this->toAugmentedValues($keys)->all();
+        return $this->toAugmentedCollection($keys)->all();
     }
 
-    public function toShallowAugmentedValues()
+    public function toShallowAugmentedCollection()
     {
         return $this->augmented()->select($this->shallowAugmentedArrayKeys());
     }
 
     public function toShallowAugmentedArray()
     {
-        return $this->toShallowAugmentedValues()->all();
+        return $this->toShallowAugmentedCollection()->all();
     }
 
     public function augmented()

--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -32,7 +32,7 @@ class AugmentedEntry extends AbstractAugmented
 
     protected function updatedBy()
     {
-        return optional($this->data->lastModifiedBy())->toAugmentedArray();
+        return $this->data->lastModifiedBy();
     }
 
     protected function updatedAt()
@@ -48,5 +48,10 @@ class AugmentedEntry extends AbstractAugmented
     protected function permalink()
     {
         return $this->get('absolute_url');
+    }
+
+    protected function parent()
+    {
+        return null;
     }
 }

--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -18,6 +18,7 @@ class AugmentedEntry extends AbstractAugmented
                 'edit_url',
                 'permalink',
                 'amp_url',
+                'api_url',
                 'published',
                 'private',
                 'date',

--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -49,9 +49,4 @@ class AugmentedEntry extends AbstractAugmented
     {
         return $this->get('absolute_url');
     }
-
-    protected function parent()
-    {
-        return null;
-    }
 }

--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -117,6 +117,11 @@ abstract class Fieldtype implements Arrayable
         return $value;
     }
 
+    public function shallowAugment($value)
+    {
+        return $this->augment($value);
+    }
+
     public function toArray(): array
     {
         return [

--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -17,13 +17,15 @@ class Value implements IteratorAggregate, JsonSerializable
     protected $parser;
     protected $context;
     protected $augmentable;
+    protected $shallow = false;
 
-    public function __construct($value, $handle = null, $fieldtype = null, $augmentable = null)
+    public function __construct($value, $handle = null, $fieldtype = null, $augmentable = null, $shallow = false)
     {
         $this->raw = $value;
         $this->handle = $handle;
         $this->fieldtype = $fieldtype;
         $this->augmentable = $augmentable;
+        $this->shallow = $shallow;
 
         if ($fieldtype && $fieldtype->field()) {
             $this->fieldtype->field()->setParent($augmentable);
@@ -41,7 +43,9 @@ class Value implements IteratorAggregate, JsonSerializable
             return $this->raw;
         }
 
-        $value = $this->fieldtype->augment($this->raw);
+        $value = $this->shallow
+            ? $this->fieldtype->shallowAugment($this->raw)
+            : $this->fieldtype->augment($this->raw);
 
         if ($this->shouldParse()) {
             $value = $this->parse($value);
@@ -112,5 +116,10 @@ class Value implements IteratorAggregate, JsonSerializable
     public function handle()
     {
         return $this->handle;
+    }
+
+    public function shallow()
+    {
+        return new static($this->raw, $this->handle, $this->fieldtype, $this->augmentable, true);
     }
 }

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -113,22 +113,30 @@ class Assets extends Fieldtype
 
     public function augment($value)
     {
-        $assets = collect($value)->map(function ($path) {
-            return $this->container()->asset($path);
-        })->filter()->values();
-
-        if (Statamic::shallowAugmentationEnabled()) {
-            $assets = $assets->map(function ($asset) {
-                return [
-                    'id' => $asset->id(),
-                    'url' => $asset->url(),
-                    'permalink' => $asset->absoluteUrl(),
-                    'api_url' => $asset->apiUrl(),
-                ];
-            });
-        }
+        $assets = $this->getAssetsForAugmentation($value);
 
         return $this->config('max_files') === 1 ? $assets->first() : $assets;
+    }
+
+    public function shallowAugment($value)
+    {
+        $assets = $this->getAssetsForAugmentation($value)->map(function ($asset) {
+            return [
+                'id' => $asset->id(),
+                'url' => $asset->url(),
+                'permalink' => $asset->absoluteUrl(),
+                'api_url' => $asset->apiUrl(),
+            ];
+        });
+
+        return $this->config('max_files') === 1 ? $assets->first() : $assets;
+    }
+
+    private function getAssetsForAugmentation($value)
+    {
+        return collect($value)->map(function ($path) {
+            return $this->container()->asset($path);
+        })->filter()->values();
     }
 
     protected function container()

--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -215,11 +215,18 @@ abstract class Relationship extends Fieldtype
             return $this->augmentValue($value);
         });
 
-        if (Statamic::shallowAugmentationEnabled()) {
-            $values = $values->map(function ($value) {
-                return $this->shallowAugmentValue($value);
-            });
-        }
+        return $this->config('max_items') === 1 ? $values->first() : $values;
+    }
+
+    public function shallowAugment($values)
+    {
+        $values = collect($values)->map(function ($value) {
+            return $this->augmentValue($value);
+        });
+
+        $values = $values->map(function ($value) {
+            return $this->shallowAugmentValue($value);
+        });
 
         return $this->config('max_items') === 1 ? $values->first() : $values;
     }

--- a/src/Fieldtypes/Taxonomy.php
+++ b/src/Fieldtypes/Taxonomy.php
@@ -18,6 +18,30 @@ class Taxonomy extends Relationship
 
     public function augment($value)
     {
+        $terms = $this->getTermsForAugmentation($value);
+
+        return $this->config('max_items') === 1 ? $terms->first() : $terms;
+    }
+
+    public function shallowAugment($value)
+    {
+        $terms = $this->getTermsForAugmentation($value);
+
+        $terms = collect($terms->map(function ($term) {
+            return [
+                'id' => $term->id(),
+                'slug' => $term->slug(),
+                'url' => $term->url(),
+                'permalink' => $term->absoluteUrl(),
+                'api_url' => $term->apiUrl(),
+            ];
+        }));
+
+        return $this->config('max_items') === 1 ? $terms->first() : $terms;
+    }
+
+    private function getTermsForAugmentation($value)
+    {
         $handle = $taxonomy = null;
 
         if ($this->usingSingleTaxonomy()) {
@@ -25,7 +49,7 @@ class Taxonomy extends Relationship
             $taxonomy = Facades\Taxonomy::findByHandle($handle);
         }
 
-        $terms = (new TermCollection(Arr::wrap($value)))
+        return (new TermCollection(Arr::wrap($value)))
             ->map(function ($value) use ($handle, $taxonomy) {
                 if ($taxonomy) {
                     $slug = $value;
@@ -47,20 +71,6 @@ class Taxonomy extends Relationship
                     ->collection($entry->collection())
                     ->in($entry->locale());
             });
-
-        if (Statamic::shallowAugmentationEnabled()) {
-            $terms = collect($terms->map(function ($term) {
-                return [
-                    'id' => $term->id(),
-                    'slug' => $term->slug(),
-                    'url' => $term->url(),
-                    'permalink' => $term->absoluteUrl(),
-                    'api_url' => $term->apiUrl(),
-                ];
-            }));
-        }
-
-        return $this->config('max_items') === 1 ? $terms->first() : $terms;
     }
 
     public function process($data)

--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -24,8 +24,6 @@ class ApiController extends Controller
      */
     public function __construct(Request $request)
     {
-        Statamic::enableShallowAugmentation();
-
         $this->request = $request;
     }
 

--- a/src/Http/Resources/API/EntryResource.php
+++ b/src/Http/Resources/API/EntryResource.php
@@ -14,8 +14,6 @@ class EntryResource extends Resource
      */
     public function toArray($request)
     {
-        return array_merge($this->resource->toAugmentedArray(), [
-            'api_url' => $this->resource->apiUrl(),
-        ]);
+        return $this->resource->toAugmentedValues();
     }
 }

--- a/src/Http/Resources/API/EntryResource.php
+++ b/src/Http/Resources/API/EntryResource.php
@@ -14,6 +14,6 @@ class EntryResource extends Resource
      */
     public function toArray($request)
     {
-        return $this->resource->toAugmentedValues();
+        return $this->resource->toAugmentedCollection();
     }
 }

--- a/src/Http/Resources/API/TermResource.php
+++ b/src/Http/Resources/API/TermResource.php
@@ -14,6 +14,6 @@ class TermResource extends Resource
      */
     public function toArray($request)
     {
-        return $this->resource->toAugmentedValues();
+        return $this->resource->toAugmentedCollection();
     }
 }

--- a/src/Http/Resources/API/TermResource.php
+++ b/src/Http/Resources/API/TermResource.php
@@ -14,8 +14,6 @@ class TermResource extends Resource
      */
     public function toArray($request)
     {
-        return array_merge($this->resource->toAugmentedArray(), [
-            'api_url' => $this->resource->apiUrl(),
-        ]);
+        return $this->resource->toAugmentedValues();
     }
 }

--- a/src/Http/Resources/API/UserResource.php
+++ b/src/Http/Resources/API/UserResource.php
@@ -15,12 +15,14 @@ class UserResource extends Resource
      */
     public function toArray($request)
     {
-        return [
-            'id' => $this->resource->id(),
-            'email' => $this->resource->email(),
-            'name' => $this->resource->get('name'),
-            'is_super' => $this->resource->isSuper(),
-            'api_url' => Statamic::apiRoute('users.show', $this->resource->id()),
-        ];
+        $fields = ['id', 'email', 'name', 'is_super', 'api_url'];
+
+        // If fields have been selected, we want to only allow a subset of the allowed fields defined above.
+        if ($selected = $this->resource->selectedQueryColumns()) {
+            $diff = array_intersect($selected, $fields);
+            $fields = empty($diff) ? $fields : $diff;
+        }
+
+        return $this->resource->toAugmentedValues($fields);
     }
 }

--- a/src/Http/Resources/API/UserResource.php
+++ b/src/Http/Resources/API/UserResource.php
@@ -23,6 +23,6 @@ class UserResource extends Resource
             $fields = empty($diff) ? $fields : $diff;
         }
 
-        return $this->resource->toAugmentedValues($fields);
+        return $this->resource->toAugmentedCollection($fields);
     }
 }

--- a/src/Providers/CollectionsServiceProvider.php
+++ b/src/Providers/CollectionsServiceProvider.php
@@ -160,5 +160,14 @@ class CollectionsServiceProvider extends ServiceProvider
                 return $value instanceof Arrayable ? $value->toArray() : $value;
             }, $this->items);
         });
+
+        Collection::macro('toAugmentedValues', function ($keys = null) {
+            return array_map(function ($value) use ($keys) {
+                if ($value instanceof Augmentable) {
+                    return $value->toAugmentedValues($keys);
+                }
+                return $value instanceof Arrayable ? $value->toArray() : $value;
+            }, $this->items);
+        });
     }
 }

--- a/src/Providers/CollectionsServiceProvider.php
+++ b/src/Providers/CollectionsServiceProvider.php
@@ -161,10 +161,10 @@ class CollectionsServiceProvider extends ServiceProvider
             }, $this->items);
         });
 
-        Collection::macro('toAugmentedValues', function ($keys = null) {
+        Collection::macro('toAugmentedCollection', function ($keys = null) {
             return array_map(function ($value) use ($keys) {
                 if ($value instanceof Augmentable) {
-                    return $value->toAugmentedValues($keys);
+                    return $value->toAugmentedCollection($keys);
                 }
                 return $value instanceof Arrayable ? $value->toArray() : $value;
             }, $this->items);

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -34,7 +34,6 @@ class Statamic
         Authorize::class,
         LocalizeCp::class,
     ];
-    protected static $shallowAugmentation = false;
 
     public static function version()
     {
@@ -260,20 +259,5 @@ class Statamic
     public static function docsUrl($url)
     {
         return URL::tidy('https://statamic.dev/' . $url);
-    }
-
-    public static function enableShallowAugmentation()
-    {
-        static::$shallowAugmentation = true;
-    }
-
-    public static function disableShallowAugmentation()
-    {
-        static::$shallowAugmentation = false;
-    }
-
-    public static function shallowAugmentationEnabled()
-    {
-        return static::$shallowAugmentation;
     }
 }

--- a/src/Taxonomies/AugmentedTerm.php
+++ b/src/Taxonomies/AugmentedTerm.php
@@ -18,6 +18,7 @@ class AugmentedTerm extends AbstractAugmented
                 'is_term',
                 'entries',
                 'entries_count',
+                'api_url',
             ])->all();
     }
 

--- a/tests/Auth/UserContractTests.php
+++ b/tests/Auth/UserContractTests.php
@@ -192,6 +192,7 @@ trait UserContractTests
             'title' => 'john@example.com',
             'edit_url' => 'http://localhost/cp/users/123/edit',
             'last_login' => null,
+            'api_url' => 'http://localhost/api/users/123',
         ], $this->additionalToArrayValues()), $arr);
     }
 

--- a/tests/Data/AugmentedTest.php
+++ b/tests/Data/AugmentedTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Facades\Statamic\Fields\FieldtypeRepository;
 use Statamic\Data\AbstractAugmented;
+use Statamic\Data\AugmentedValues;
 use Statamic\Data\ContainsData;
 use Statamic\Facades\Blueprint;
 use Statamic\Fields\Fieldtype;
@@ -135,6 +136,8 @@ class AugmentedTest extends TestCase
             }
         };
 
+        $result = $augmented->all();
+        $this->assertInstanceOf(AugmentedValues::class, $result);
         $this->assertEquals([
             'foo' => $foo = new Value('bar', 'foo', $fieldtype, $this->blueprintThing),
             'slug' => $slug = new Value('the-thing', 'slug', $fieldtype, $this->blueprintThing),
@@ -142,23 +145,27 @@ class AugmentedTest extends TestCase
             'hello' => 'world',
             'unused' => $unused = new Value(null, 'unused', $fieldtype, $this->blueprintThing),
             'supplemented' => 'supplemented value',
-        ], $augmented->all());
+        ], $result->all());
 
+        $result = $augmented->select(['foo', 'hello']);
+        $this->assertInstanceOf(AugmentedValues::class, $result);
         $this->assertEquals([
             'foo' => $foo,
             'hello' => 'world',
-        ], $augmented->select(['foo', 'hello']));
+        ], $result->all());
 
         $this->assertEquals([
             'foo' => $foo,
-        ], $augmented->select('foo'));
+        ], $augmented->select('foo')->all());
 
+        $result = $augmented->except(['slug', 'hello']);
+        $this->assertInstanceOf(AugmentedValues::class, $result);
         $this->assertEquals([
             'foo' => $foo,
             'the_slug' => 'the-thing',
             'unused' => $unused,
             'supplemented' => 'supplemented value',
-        ], $augmented->except(['slug', 'hello']));
+        ], $result->all());
 
         $this->assertEquals([
             'foo' => $foo,
@@ -166,7 +173,7 @@ class AugmentedTest extends TestCase
             'the_slug' => 'the-thing',
             'unused' => $unused,
             'supplemented' => 'supplemented value',
-        ], $augmented->except('hello'));
+        ], $augmented->except('hello')->all());
     }
 
     /** @test */

--- a/tests/Data/AugmentedTest.php
+++ b/tests/Data/AugmentedTest.php
@@ -4,7 +4,7 @@ namespace Tests;
 
 use Facades\Statamic\Fields\FieldtypeRepository;
 use Statamic\Data\AbstractAugmented;
-use Statamic\Data\AugmentedValues;
+use Statamic\Data\AugmentedCollection;
 use Statamic\Data\ContainsData;
 use Statamic\Facades\Blueprint;
 use Statamic\Fields\Fieldtype;
@@ -137,7 +137,7 @@ class AugmentedTest extends TestCase
         };
 
         $result = $augmented->all();
-        $this->assertInstanceOf(AugmentedValues::class, $result);
+        $this->assertInstanceOf(AugmentedCollection::class, $result);
         $this->assertEquals([
             'foo' => $foo = new Value('bar', 'foo', $fieldtype, $this->blueprintThing),
             'slug' => $slug = new Value('the-thing', 'slug', $fieldtype, $this->blueprintThing),
@@ -148,7 +148,7 @@ class AugmentedTest extends TestCase
         ], $result->all());
 
         $result = $augmented->select(['foo', 'hello']);
-        $this->assertInstanceOf(AugmentedValues::class, $result);
+        $this->assertInstanceOf(AugmentedCollection::class, $result);
         $this->assertEquals([
             'foo' => $foo,
             'hello' => 'world',
@@ -159,7 +159,7 @@ class AugmentedTest extends TestCase
         ], $augmented->select('foo')->all());
 
         $result = $augmented->except(['slug', 'hello']);
-        $this->assertInstanceOf(AugmentedValues::class, $result);
+        $this->assertInstanceOf(AugmentedCollection::class, $result);
         $this->assertEquals([
             'foo' => $foo,
             'the_slug' => 'the-thing',

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -323,7 +323,7 @@ class EntryTest extends TestCase
             'baz' => 'qux',
             'last_modified' => $carbon = Carbon::createFromTimestamp($lastModified),
             'updated_at' => $carbon,
-            'updated_by' => $user->toAugmentedArray(),
+            'updated_by' => $user,
             'url' => '/blog/test',
             'permalink' => 'http://localhost/blog/test',
         ], $entry->toAugmentedArray());

--- a/tests/Data/HasAugmentedDataTest.php
+++ b/tests/Data/HasAugmentedDataTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Facades\Statamic\Fields\FieldtypeRepository;
+use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Data\ContainsData;
 use Statamic\Data\HasAugmentedData;
@@ -22,7 +23,7 @@ class HasAugmentedDataTest extends TestCase
             }
         });
 
-        $thing = new class {
+        $thing = new class implements Augmentable {
             use HasAugmentedData, ContainsData;
             public function __construct()
             {
@@ -61,14 +62,14 @@ class HasAugmentedDataTest extends TestCase
             'bar' => 'BAR',
             'baz' => new Value(null, 'baz', $fieldtype, $thing),
         ];
-        $this->assertEquals($expectedArr, $thing->augmented()->all());
+        $this->assertEquals($expectedArr, $thing->augmented()->all()->all());
         $this->assertEquals($expectedArr, $thing->toAugmentedArray());
 
         $expectedSelectArr = [
             'foo' => new Value('FOO', 'foo', $fieldtype, $thing),
             'bar' => 'BAR',
         ];
-        $this->assertEquals($expectedSelectArr, $thing->augmented()->select(['foo', 'bar']));
+        $this->assertEquals($expectedSelectArr, $thing->augmented()->select(['foo', 'bar'])->all());
         $this->assertEquals($expectedSelectArr, $thing->toAugmentedArray(['foo', 'bar']));
     }
 }

--- a/tests/Data/HasAugmentedInstanceTest.php
+++ b/tests/Data/HasAugmentedInstanceTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Statamic\Contracts\Data\Augmented;
+use Statamic\Data\AugmentedValues;
 use Statamic\Data\HasAugmentedInstance;
 
 class HasAugmentedInstanceTest extends TestCase
@@ -12,8 +13,8 @@ class HasAugmentedInstanceTest extends TestCase
     {
         $mock = $this->mock(Augmented::class);
         $mock->shouldReceive('get')->with('foo')->once()->andReturn('bar');
-        $mock->shouldReceive('select')->with(null)->once()->andReturn(['foo', 'bar', 'baz']);
-        $mock->shouldReceive('select')->with(['one'])->once()->andReturn(['foo']);
+        $mock->shouldReceive('select')->with(null)->once()->andReturn(new AugmentedValues(['foo', 'bar', 'baz']));
+        $mock->shouldReceive('select')->with(['one'])->once()->andReturn(new AugmentedValues(['foo']));
 
         $thing = new class($mock) {
             use HasAugmentedInstance;
@@ -40,7 +41,7 @@ class HasAugmentedInstanceTest extends TestCase
     function augmented_thing_can_define_the_default_array_keys()
     {
         $mock = $this->mock(Augmented::class);
-        $mock->shouldReceive('select')->with(['foo', 'bar'])->once()->andReturn(['foo', 'bar']);
+        $mock->shouldReceive('select')->with(['foo', 'bar'])->once()->andReturn(new AugmentedValues(['foo', 'bar']));
 
         $thing = new class($mock) {
             use HasAugmentedInstance;

--- a/tests/Data/HasAugmentedInstanceTest.php
+++ b/tests/Data/HasAugmentedInstanceTest.php
@@ -3,7 +3,7 @@
 namespace Tests;
 
 use Statamic\Contracts\Data\Augmented;
-use Statamic\Data\AugmentedValues;
+use Statamic\Data\AugmentedCollection;
 use Statamic\Data\HasAugmentedInstance;
 
 class HasAugmentedInstanceTest extends TestCase
@@ -13,8 +13,8 @@ class HasAugmentedInstanceTest extends TestCase
     {
         $mock = $this->mock(Augmented::class);
         $mock->shouldReceive('get')->with('foo')->once()->andReturn('bar');
-        $mock->shouldReceive('select')->with(null)->once()->andReturn(new AugmentedValues(['foo', 'bar', 'baz']));
-        $mock->shouldReceive('select')->with(['one'])->once()->andReturn(new AugmentedValues(['foo']));
+        $mock->shouldReceive('select')->with(null)->once()->andReturn(new AugmentedCollection(['foo', 'bar', 'baz']));
+        $mock->shouldReceive('select')->with(['one'])->once()->andReturn(new AugmentedCollection(['foo']));
 
         $thing = new class($mock) {
             use HasAugmentedInstance;
@@ -41,7 +41,7 @@ class HasAugmentedInstanceTest extends TestCase
     function augmented_thing_can_define_the_default_array_keys()
     {
         $mock = $this->mock(Augmented::class);
-        $mock->shouldReceive('select')->with(['foo', 'bar'])->once()->andReturn(new AugmentedValues(['foo', 'bar']));
+        $mock->shouldReceive('select')->with(['foo', 'bar'])->once()->andReturn(new AugmentedCollection(['foo', 'bar']));
 
         $thing = new class($mock) {
             use HasAugmentedInstance;

--- a/tests/Fields/ValueTest.php
+++ b/tests/Fields/ValueTest.php
@@ -10,6 +10,46 @@ use Tests\TestCase;
 class ValueTest extends TestCase
 {
     /** @test */
+    function it_augments_through_the_fieldtype()
+    {
+        $fieldtype = new class extends Fieldtype {
+            public function augment($data)
+            {
+                return strtoupper($data) . '!';
+            }
+            public function shallowAugment($data)
+            {
+                return $data . ' shallow';
+            }
+        };
+
+        $value = new Value('test', null, $fieldtype);
+
+        $this->assertEquals('TEST!', $value->value());
+    }
+
+    /** @test */
+    function it_shallow_augments_through_the_fieldtype()
+    {
+        $fieldtype = new class extends Fieldtype {
+            public function augment($data)
+            {
+                return strtoupper($data) . '!';
+            }
+            public function shallowAugment($data)
+            {
+                return $data . ' shallow';
+            }
+        };
+
+        $value = new Value('test', null, $fieldtype);
+
+        $this->assertNotSame($value, $value->shallow());
+        $this->assertInstanceOf(Value::class, $value->shallow());
+        $this->assertEquals('test shallow', $value->shallow()->value());
+    }
+
+    /** @test */
     function it_converts_to_string_using_the_augmented_value()
     {
         $fieldtype = new class extends Fieldtype {

--- a/tests/Fieldtypes/AssetsTest.php
+++ b/tests/Fieldtypes/AssetsTest.php
@@ -51,9 +51,7 @@ class AssetsTest extends TestCase
     /** @test */
     function it_shallow_augments_to_a_collection_of_assets()
     {
-        Statamic::enableShallowAugmentation();
-
-        $augmented = $this->fieldtype()->augment(['foo/one.txt', 'bar/two.txt', 'unknown.txt']);
+        $augmented = $this->fieldtype()->shallowAugment(['foo/one.txt', 'bar/two.txt', 'unknown.txt']);
 
         $this->assertInstanceOf(Collection::class, $augmented);
         $this->assertEquals([
@@ -75,9 +73,7 @@ class AssetsTest extends TestCase
     /** @test */
     function it_shallow_augments_to_a_single_asset_when_max_files_is_one()
     {
-        Statamic::enableShallowAugmentation();
-
-        $augmented = $this->fieldtype(['max_files' => 1])->augment(['foo/one.txt']);
+        $augmented = $this->fieldtype(['max_files' => 1])->shallowAugment(['foo/one.txt']);
 
         $this->assertEquals([
             'id' => 'test::foo/one.txt',

--- a/tests/Fieldtypes/EntriesTest.php
+++ b/tests/Fieldtypes/EntriesTest.php
@@ -47,9 +47,7 @@ class EntriesTest extends TestCase
     /** @test */
     function it_shallow_augments_to_a_collection_of_enties()
     {
-        Statamic::enableShallowAugmentation();
-
-        $augmented = $this->fieldtype()->augment(['123', '456']);
+        $augmented = $this->fieldtype()->shallowAugment(['123', '456']);
 
         $this->assertInstanceOf(Collection::class, $augmented);
         $this->assertEquals([
@@ -71,9 +69,7 @@ class EntriesTest extends TestCase
     /** @test */
     function it_shallow_augments_to_a_single_entry_when_max_items_is_one()
     {
-        Statamic::enableShallowAugmentation();
-
-        $augmented = $this->fieldtype(['max_items' => 1])->augment(['123']);
+        $augmented = $this->fieldtype(['max_items' => 1])->shallowAugment(['123']);
 
         $this->assertEquals([
             'id' => '123',

--- a/tests/Fieldtypes/TaxonomyTest.php
+++ b/tests/Fieldtypes/TaxonomyTest.php
@@ -67,9 +67,7 @@ class TaxonomyTest extends TestCase
     /** @test */
     function it_shallow_augments_slugs_to_a_collection_of_terms_when_using_a_single_taxonomy()
     {
-        Statamic::enableShallowAugmentation();
-
-        $augmented = $this->fieldtype(['taxonomy' => 'tags'])->augment(['one', 'two']);
+        $augmented = $this->fieldtype(['taxonomy' => 'tags'])->shallowAugment(['one', 'two']);
 
         $this->assertInstanceOf(Collection::class, $augmented);
         $this->assertNotInstanceOf(TermCollection::class, $augmented);
@@ -95,9 +93,7 @@ class TaxonomyTest extends TestCase
     /** @test */
     function it_shallow_augments_to_a_single_term_when_max_items_is_one()
     {
-        Statamic::enableShallowAugmentation();
-
-        $augmented = $this->fieldtype(['taxonomy' => 'tags', 'max_items' => 1])->augment(['one']);
+        $augmented = $this->fieldtype(['taxonomy' => 'tags', 'max_items' => 1])->shallowAugment(['one']);
 
         $this->assertEquals([
             'id' => 'tags::one',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,8 +42,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             $this->deleteFakeStacheDirectory();
         }
 
-        Statamic::disableShallowAugmentation();
-
         parent::tearDown();
     }
 


### PR DESCRIPTION
We had the concept of global shallow augmentation, mainly used in the API, by doing `Statamic::enableShallowAugmentation()`. Then inside fieldtypes, they could check if that's enabled and return a smaller subset of data. 

That's no more. Instead, fieldtypes get a `shallowAugment` method, in addition to the `augment` method that already exists.

When json serializing arrays containing Value objects, it would happen all the way down the tree. In some cases, this would result in an infinite loop. For example, #1513.
To get around this, we now have an AugmentedCollection that will perform shallow augmentation on nested values. The top level is the only one that gets everything.

Since it's only done when JSON serializing, you're still able to traverse that recursive situation in Antlers:

```
{{ title }}
{{ updated_by }}
    {{ name }}
    {{ related_entries }}
        {{ title }}
        {{ updated_by:name }}
    {{ /related_entries }}
{{ /updated_by }}
```

If you're trying to spit out some JSON, you should use `$item->toAugmentableCollection()` rather than `toAugmentableArray`.

In addition to the core changes that allow this stuff to happen, this PR also:
- Removes the global shallow augmentation stuff
- Updates the API to use these things
- The user api uses augmentation properly, and adds a whitelist.
- Adds apiUrl to user

Closes #1513