### PR TITLE
Fix Password Resets from the Control Panel

### DIFF
--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -10,8 +10,6 @@ class PasswordController extends CpController
 {
     public function update(Request $request, $user)
     {
-        $user = User::find($user);
-
         $this->authorize('editPassword', $user);
 
         $request->validate([


### PR DESCRIPTION
I've fixed a bug where users were getting 'Unable to change password' when trying to reset user passwords through the Control Panel.

## Related Issues
Fixes #1561 and #1556 