### PR TITLE
Fixes save of existing user for database users

### DIFF
--- a/src/Validation/UniqueUserValue.php
+++ b/src/Validation/UniqueUserValue.php
@@ -18,6 +18,6 @@ class UniqueUserValue
             return true;
         }
 
-        return (int) $except === $existing->id();
+        return $except == $existing->id();
     }
 }

--- a/src/Validation/UniqueUserValue.php
+++ b/src/Validation/UniqueUserValue.php
@@ -18,6 +18,6 @@ class UniqueUserValue
             return true;
         }
 
-        return $except === $existing->id();
+        return (int) $except === $existing->id();
     }
 }


### PR DESCRIPTION
The value of `$except` is a string in a fresh v3 install (for me at least), the identical-to comparison operator therefore means it's not possible to edit an existing user. Typecasting `$except` to an integer fixes this.