### PR TITLE
Add ability to return a redirect from an Action (closes #1496)

### DIFF
--- a/resources/js/components/data-list/Actions.vue
+++ b/resources/js/components/data-list/Actions.vue
@@ -36,6 +36,10 @@ export default {
 
             this.$axios.post(this.url, payload).then(response => {
                 this.$emit('completed');
+
+                if (response.data.redirect) {
+                    window.location = response.data.redirect;
+                }
             }).catch(error => {
                 this.$toast.error(error.response.data.message);
                 this.$emit('completed');

--- a/src/Http/Controllers/CP/ActionController.php
+++ b/src/Http/Controllers/CP/ActionController.php
@@ -33,7 +33,7 @@ abstract class ActionController extends CpController
 
         abort_unless($unauthorized->isEmpty(), 403, 'You are not authorized to run this action.');
 
-        $action->run($items, $request->all());
+        return $action->run($items, $request->all());
     }
 
     abstract protected function getSelectedItems($items, $context);


### PR DESCRIPTION
By returning the Action's `run` method we can check its data. This allows us to return a `redirect` URL as per suggested in https://github.com/statamic/cms/issues/1496. Tested locally and works nicely, but if this isn't the implementation you want feel free to close.