### PR TITLE
Allow Actions to only be shown in Inline Actions menu

### DIFF
--- a/resources/js/components/data-list/BulkActions.vue
+++ b/resources/js/components/data-list/BulkActions.vue
@@ -57,7 +57,7 @@ export default {
 
             let actions = rows.reduce((carry, row) => carry.concat(row.actions), []);
 
-            actions = _.uniq(actions, 'handle');
+            actions = _.uniq(actions, 'handle').filter(action => ! action.inlineOnly);
 
             // Remove any actions that are missing from any row. If you can't apply the action
             // to all of the selected items, you should not see the button. There's server

--- a/resources/js/components/data-list/BulkActions.vue
+++ b/resources/js/components/data-list/BulkActions.vue
@@ -57,7 +57,7 @@ export default {
 
             let actions = rows.reduce((carry, row) => carry.concat(row.actions), []);
 
-            actions = _.uniq(actions, 'handle').filter(action => ! action.inlineOnly);
+            actions = _.uniq(actions, 'handle').filter(action => action.bulk);
 
             // Remove any actions that are missing from any row. If you can't apply the action
             // to all of the selected items, you should not see the button. There's server

--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -20,7 +20,7 @@ abstract class Action implements Arrayable
     protected $dangerous = false;
     protected $fields = [];
     protected $context = [];
-    protected $inlineOnly = false;
+    protected $bulk = true;
 
     public function filter($item)
     {
@@ -73,7 +73,7 @@ abstract class Action implements Arrayable
             'fields' => $this->fields()->toPublishArray(),
             'meta' => $this->fields()->meta(),
             'context' => $this->context,
-            'inlineOnly' => $this->inlineOnly,
+            'bulk' => $this->bulk,
         ];
     }
 }

--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -20,6 +20,7 @@ abstract class Action implements Arrayable
     protected $dangerous = false;
     protected $fields = [];
     protected $context = [];
+    protected $inlineOnly = false;
 
     public function filter($item)
     {
@@ -71,7 +72,8 @@ abstract class Action implements Arrayable
             'dangerous' => $this->dangerous,
             'fields' => $this->fields()->toPublishArray(),
             'meta' => $this->fields()->meta(),
-            'context' => $this->context
+            'context' => $this->context,
+            'inlineOnly' => $this->inlineOnly,
         ];
     }
 }


### PR DESCRIPTION
Hi gents! 

This PR allows for Actions to only be shown in the Inline Actions contextual menu, hiding it from the Bulk Actions area at the top of Data Lists.

My particular use-case for this is for Impersonator; allowing users to start an Impersonation session directly from the Users Listing view. Since users are only ever allowed to choose 1 account to authenticate as, it makes sense to remove it from Bulk Actions and only show it in a singular contextual menu.

As you'll see from the code changes, all it takes is 1 new (optional) property in an Action class, which defaults to show both Action menus from the abstract class:

```
abstract class Action implements Arrayable
{
    protected $inlineOnly = false;
    //...
```

I thought about the naming of this property for a while and landed on `$inlineOnly`, but happy to change this to something different. Since the filtering is only happening inside of `BulkActions.vue`, perhaps you'd prefer the naming to be the inverse, something like `$hideFromBulkActions` (doesn't really roll off the tongue though...). 

Look forward to hearing your feedback, would very much like to see this (or a similar PR) make it into core.

Thanks!