### PR TITLE
Hide the Live Preview when a collection has no route

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -99,7 +99,7 @@
                                     <div class="p-2 flex items-center -mx-1">
                                         <button
                                             class="flex items-center justify-center btn-flat w-full mx-1 px-1"
-                                            v-if="isBase"
+                                            v-if="isBase && livePreviewUrl"
                                             @click="openLivePreview">
                                             <svg-icon name="synchronize" class="w-5 h-5 mr-1" />
                                             <span>{{ __('Live Preview') }}</span>

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -182,7 +182,9 @@ class Entry implements Contract, Augmentable, Responsable, Localization, ArrayAc
 
     public function livePreviewUrl()
     {
-        return $this->cpUrl('collections.entries.preview.edit');
+        return $this->collection()->route($this->locale())
+            ? $this->cpUrl('collections.entries.preview.edit')
+            : null;
     }
 
     protected function cpUrl($route)

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -256,7 +256,7 @@ class EntriesController extends CpController
                     'exists' => false,
                     'published' => false,
                     'url' => cp_route('collections.entries.create', [$collection->handle(), $handle]),
-                    'livePreviewUrl' => cp_route('collections.entries.preview.create', [$collection->handle(), $handle]),
+                    'livePreviewUrl' => $collection->route($handle) ? cp_route('collections.entries.preview.create', [$collection->handle(), $handle]) : null,
                 ];
             })->all(),
             'revisionsEnabled' => $collection->revisionsEnabled(),


### PR DESCRIPTION
This references #1183. It's possible we may want to _explicitly_ disable Live Preview if there are cases where you may want to be able to render a live preview with an external URL (e.g. headless), but I'm not sure if that's possible or even makes sense really. Hence the PR.