### PR TITLE
Don't show both 'Publish' and 'Unpublish'

### DIFF
--- a/src/Actions/Publish.php
+++ b/src/Actions/Publish.php
@@ -14,16 +14,12 @@ class Publish extends Action
 
     public function filter($item)
     {
-        return $item instanceof Entry;
+        return $item instanceof Entry && ! $item->published();
     }
 
     public function authorize($user, $entry)
     {
-        if ($entry->status() != 'published') {
-            return $user->can('publish', $entry);
-        }
-
-        return false;
+        return $user->can('publish', $entry);
     }
 
     public function confirmationText()

--- a/src/Actions/Publish.php
+++ b/src/Actions/Publish.php
@@ -19,7 +19,11 @@ class Publish extends Action
 
     public function authorize($user, $entry)
     {
-        return $user->can('publish', $entry);
+        if ($entry->status() != 'published') {
+            return $user->can('publish', $entry);
+        }
+
+        return false;
     }
 
     public function confirmationText()

--- a/src/Actions/Unpublish.php
+++ b/src/Actions/Unpublish.php
@@ -9,16 +9,12 @@ class Unpublish extends Action
 {
     public function filter($item)
     {
-        return $item instanceof Entry;
+        return $item instanceof Entry && $item->published();
     }
 
     public function authorize($user, $entry)
     {
-        if ($entry->status() === 'published') {
-            return $user->can('publish', $entry);
-        }
-
-        return false;
+        return $user->can('publish', $entry);
     }
 
     public function confirmationText()

--- a/src/Actions/Unpublish.php
+++ b/src/Actions/Unpublish.php
@@ -14,7 +14,11 @@ class Unpublish extends Action
 
     public function authorize($user, $entry)
     {
-        return $user->can('publish', $entry);
+        if ($entry->status() === 'published') {
+            return $user->can('publish', $entry);
+        }
+
+        return false;
     }
 
     public function confirmationText()


### PR DESCRIPTION
Previously, both `Publish` and `Unpublish` would be shown for entries in data table regardless of whether or not they are already published or not.

This pull request fixes that issue. There's probably a cleaner way to do it with ternary operators.

Fixes #1614