### PR TITLE
Add a hook for 'entry.unpublishing'

### DIFF
--- a/resources/js/components/entries/PublishActions.vue
+++ b/resources/js/components/entries/PublishActions.vue
@@ -177,6 +177,17 @@ export default {
         },
 
         submitUnpublish() {
+            this.runBeforeUnpublishHook();
+        },
+
+        runBeforeUnpublishHook() {
+            Statamic.$hooks
+                .run('entry.unpublishing', { collection: this.collection, message: this.revisionMessage, storeName: this.publishContainer })
+                .then(this.performUnpublishRequest)
+                .catch(e => this.handleAxiosError(e));
+        },
+
+        performUnpublishRequest() {
             const payload = { message: this.revisionMessage };
 
             this.$axios.post(this.actions.unpublish, { data: payload }).then(response => {


### PR DESCRIPTION
This PR extends the already existing hooks with `entry.publishing`.

We would like to react if an entry is published or unpublished. We use 'entry.publishing' for the publish action. To notice that an entry will be unpublished we have added 'entry.unpublishing'.

Maybe the hooks could be extended with `entry.unpublished` but we don't need that hook right now. What do you think?