### PR TITLE
Improve actions

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -73,7 +73,7 @@
                             </div>
 
                             <data-list-bulk-actions
-                                :url="actionUrl"
+                                :url="bulkActionsUrl"
                                 :context="actionContext"
                                 @started="actionStarted"
                                 @completed="actionCompleted"
@@ -121,7 +121,7 @@
 
                                                 <data-list-inline-actions
                                                     :item="folder.path"
-                                                    :url="folderActionUrl"
+                                                    :url="runFolderActionUrl"
                                                     :actions="folderActions(folder)"
                                                     @started="actionStarted"
                                                     @completed="actionCompleted"
@@ -155,7 +155,7 @@
                                         <div class="divider" v-if="asset.actions.length" />
                                         <data-list-inline-actions
                                             :item="asset.id"
-                                            :url="actionUrl"
+                                            :url="runActionUrl"
                                             :actions="asset.actions"
                                             @started="actionStarted"
                                             @completed="actionCompleted"
@@ -289,7 +289,9 @@ export default {
             sortColumn: 'basename',
             sortDirection: 'asc',
             mode: 'table',
-            folderActionUrl: null,
+            runActionUrl: null,
+            bulkActionsUrl: null,
+            runFolderActionUrl: null,
         }
     },
 
@@ -449,8 +451,9 @@ export default {
                 } else {
                     this.folder = data.data.folder;
                     this.folders = data.data.folder.folders;
-                    this.actionUrl = data.links.asset_actions;
-                    this.folderActionUrl = data.links.folder_actions;
+                    this.runActionUrl = data.links.run_asset_action;
+                    this.bulkActionsUrl = data.links.bulk_asset_actions;
+                    this.runFolderActionUrl = data.links.run_folder_action;
                 }
 
                 this.loadingAssets = false;

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -144,7 +144,7 @@
                 v-if="actions.length"
                 :id="id"
                 :actions="actions"
-                :url="actionUrl"
+                :url="runActionUrl"
                 @started="actionStarted"
                 @completed="actionCompleted" />
         </portal>
@@ -257,7 +257,7 @@ export default {
                 this.asset = data;
                 this.values = data.values;
                 this.meta = data.meta;
-                this.actionUrl = data.actionUrl;
+                this.runActionUrl = data.runActionUrl;
                 this.actions = data.actions;
                 this.getFieldset();
             });

--- a/resources/js/components/assets/Editor/EditorActions.vue
+++ b/resources/js/components/assets/Editor/EditorActions.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-import Actions from '../../data-list/Actions.vue';
+import Actions from '../../data-list/Actions.js';
 
 export default {
 

--- a/resources/js/components/collections/View.vue
+++ b/resources/js/components/collections/View.vue
@@ -82,7 +82,8 @@
             :initial-sort-column="sortColumn"
             :initial-sort-direction="sortDirection"
             :filters="filters"
-            :action-url="actionUrl"
+            :run-action-url="runActionUrl"
+            :bulk-actions-url="bulkActionsUrl"
             :reordering="reordering"
             :reorder-url="reorderUrl"
             :site="site"
@@ -167,7 +168,8 @@ export default {
         sortColumn: { type: String, required: true },
         sortDirection: { type: String, required: true },
         filters: { type: Array, required: true },
-        actionUrl: { type: String, required: true },
+        runActionUrl: { type: String, required: true },
+        bulkActionsUrl: { type: String, required: true },
         reorderUrl: { type: String, required: true },
         blueprints: { type: Array, required: true },
         site: { type: String, required: true },

--- a/resources/js/components/data-list/Actions.js
+++ b/resources/js/components/data-list/Actions.js
@@ -1,4 +1,3 @@
-<script>
 import DataListAction from './Action.vue';
 
 export default {
@@ -49,4 +48,3 @@ export default {
     }
 
 }
-</script>

--- a/resources/js/components/data-list/Actions.js
+++ b/resources/js/components/data-list/Actions.js
@@ -13,9 +13,11 @@ export default {
     computed: {
 
         sortedActions() {
+            let actions = _.sortBy(this.actions, 'title');
+
             return [
-                ...this.actions.filter(action => !action.dangerous),
-                ...this.actions.filter(action => action.dangerous)
+                ...actions.filter(action => !action.dangerous),
+                ...actions.filter(action => action.dangerous)
             ];
         },
 

--- a/resources/js/components/data-list/BulkActions.vue
+++ b/resources/js/components/data-list/BulkActions.vue
@@ -28,6 +28,7 @@
 
 <script>
 import Actions from './Actions.js';
+import qs from 'qs';
 
 export default {
 
@@ -70,13 +71,20 @@ export default {
                 return;
             }
 
-            let params = { selections: this.selections };
+            let params = {
+                selections: this.selections,
+            };
 
             if (this.context) {
                 params.context = this.context;
             }
 
-            this.$axios.get(this.url, { params }).then(response => {
+            let config = {
+                params,
+                paramsSerializer: params => qs.stringify(params, {arrayFormat: 'brackets'})
+            };
+
+            this.$axios.get(this.url, config).then(response => {
                 this.actions = response.data;
             });
         },

--- a/resources/js/components/data-list/BulkActions.vue
+++ b/resources/js/components/data-list/BulkActions.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-import Actions from './Actions.vue';
+import Actions from './Actions.js';
 
 export default {
 

--- a/resources/js/components/data-list/BulkActions.vue
+++ b/resources/js/components/data-list/BulkActions.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-import Actions from './Actions.js';
+import Actions from './Actions';
 import qs from 'qs';
 
 export default {

--- a/resources/js/components/data-list/BulkActions.vue
+++ b/resources/js/components/data-list/BulkActions.vue
@@ -42,8 +42,13 @@ export default {
         }
     },
 
-    computed: {
+    data() {
+        return {
+            actions: [],
+        };
+    },
 
+    computed: {
         selections() {
             return this.sharedState.selections;
         },
@@ -51,47 +56,31 @@ export default {
         hasSelections() {
             return this.selections.length > 0;
         },
+    },
 
-        actions() {
-            const rows = this.sharedState.rows.filter(row => this.selections.includes(row.id));
-
-            let actions = rows.reduce((carry, row) => carry.concat(row.actions), []);
-
-            actions = _.uniq(actions, 'handle').filter(action => action.bulk);
-
-            // Remove any actions that are missing from any row. If you can't apply the action
-            // to all of the selected items, you should not see the button. There's server
-            // side authorization for when the action is executed anyway, just in case.
-            rows.forEach(row => {
-                actions = actions.filter(action => row.actions.map(a => a.handle).includes(action.handle));
-            });
-
-            return _.sortBy(actions, 'title');
-        }
-
+    watch: {
+        selections: 'getActions',
     },
 
     methods: {
-
-        getActions(selections) {
-            if (selections.length === 0) {
+        getActions() {
+            if (this.selections.length === 0) {
                 this.actions = [];
 
                 return;
             }
 
-            let params = {selections};
+            let params = { selections: this.selections };
 
             if (this.context) {
                 params.context = this.context;
             }
 
-            this.$axios.get(this.url, {params}).then(response => {
+            this.$axios.get(this.url, { params }).then(response => {
                 this.actions = response.data;
             });
         },
-
-    }
+    },
 
 }
 </script>

--- a/resources/js/components/data-list/HasActions.js
+++ b/resources/js/components/data-list/HasActions.js
@@ -1,7 +1,8 @@
 export default {
 
     props: {
-        actionUrl: String,
+        runActionUrl: String,
+        bulkActionsUrl: String,
     },
 
     methods: {

--- a/resources/js/components/data-list/InlineActions.vue
+++ b/resources/js/components/data-list/InlineActions.vue
@@ -21,7 +21,7 @@
 
 
 <script>
-import Actions from './Actions.vue';
+import Actions from './Actions.js';
 
 export default {
 

--- a/resources/js/components/data-list/InlineActions.vue
+++ b/resources/js/components/data-list/InlineActions.vue
@@ -21,7 +21,7 @@
 
 
 <script>
-import Actions from './Actions.js';
+import Actions from './Actions';
 
 export default {
 

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -46,7 +46,7 @@
                     <div v-show="items.length === 0" class="p-3 text-center text-grey-50" v-text="__('No results')" />
 
                     <data-list-bulk-actions
-                        :url="actionUrl"
+                        :url="bulkActionsUrl"
                         @started="actionStarted"
                         @completed="actionCompleted"
                     />
@@ -79,7 +79,7 @@
                                 <div class="divider" v-if="entry.actions.length" />
                                 <data-list-inline-actions
                                     :item="entry.id"
-                                    :url="actionUrl"
+                                    :url="runActionUrl"
                                     :actions="entry.actions"
                                     @started="actionStarted"
                                     @completed="actionCompleted"

--- a/resources/js/components/forms/SubmissionListing.vue
+++ b/resources/js/components/forms/SubmissionListing.vue
@@ -28,7 +28,7 @@
                     <div v-show="items.length === 0" class="p-3 text-center text-grey-50" v-text="__('No results')" />
 
                     <data-list-bulk-actions
-                        :url="actionUrl"
+                        :url="bulkActionsUrl"
                         @started="actionStarted"
                         @completed="actionCompleted"
                     />
@@ -48,7 +48,7 @@
                                 <dropdown-item :text="__('View')" :redirect="submission.url" />
                                 <data-list-inline-actions
                                     :item="submission.id"
-                                    :url="actionUrl"
+                                    :url="runActionUrl"
                                     :actions="submission.actions"
                                     @started="actionStarted"
                                     @completed="actionCompleted"

--- a/resources/js/components/terms/Listing.vue
+++ b/resources/js/components/terms/Listing.vue
@@ -45,7 +45,7 @@
                     <div v-show="items.length === 0" class="p-3 text-center text-grey-50" v-text="__('No results')" />
 
                     <data-list-bulk-actions
-                        :url="actionUrl"
+                        :url="bulkActionsUrl"
                         @started="actionStarted"
                         @completed="actionCompleted"
                     />
@@ -73,7 +73,7 @@
                                 <div class="divider" />
                                 <data-list-inline-actions
                                     :item="term.id"
-                                    :url="actionUrl"
+                                    :url="runActionUrl"
                                     :actions="term.actions"
                                     @started="actionStarted"
                                     @completed="actionCompleted"

--- a/resources/js/components/users/Listing.vue
+++ b/resources/js/components/users/Listing.vue
@@ -17,7 +17,7 @@
                 <div class="card p-0 relative">
                     <data-list-bulk-actions
                         class="rounded"
-                        :url="actionUrl"
+                        :url="bulkActionsUrl"
                         @started="actionStarted"
                         @completed="actionCompleted"
                     />
@@ -39,7 +39,7 @@
                                 <dropdown-item :text="__('View')" :redirect="user.edit_url" v-else />
                                 <data-list-inline-actions
                                     :item="user.id"
-                                    :url="actionUrl"
+                                    :url="runActionUrl"
                                     :actions="user.actions"
                                     @started="actionStarted"
                                     @completed="actionCompleted"

--- a/resources/views/collections/show.blade.php
+++ b/resources/views/collections/show.blade.php
@@ -14,7 +14,8 @@
         sort-column="{{ $collection->sortField() }}"
         sort-direction="{{ $collection->sortDirection() }}"
         :filters="{{ $filters->toJson() }}"
-        action-url="{{ cp_route('collections.entries.actions', $collection->handle()) }}"
+        run-action-url="{{ cp_route('collections.entries.actions.run', $collection->handle()) }}"
+        bulk-actions-url="{{ cp_route('collections.entries.actions.bulk-actions', $collection->handle()) }}"
         reorder-url="{{ cp_route('collections.entries.reorder', $collection->handle()) }}"
         site="{{ $site }}"
 

--- a/resources/views/collections/show.blade.php
+++ b/resources/views/collections/show.blade.php
@@ -15,7 +15,7 @@
         sort-direction="{{ $collection->sortDirection() }}"
         :filters="{{ $filters->toJson() }}"
         run-action-url="{{ cp_route('collections.entries.actions.run', $collection->handle()) }}"
-        bulk-actions-url="{{ cp_route('collections.entries.actions.bulk-actions', $collection->handle()) }}"
+        bulk-actions-url="{{ cp_route('collections.entries.actions.bulk', $collection->handle()) }}"
         reorder-url="{{ cp_route('collections.entries.reorder', $collection->handle()) }}"
         site="{{ $site }}"
 

--- a/resources/views/forms/show.blade.php
+++ b/resources/views/forms/show.blade.php
@@ -51,7 +51,7 @@
     <form-submission-listing
         form="{{ $form->handle() }}"
         run-action-url="{{ cp_route('forms.submissions.actions.run', $form->handle()) }}"
-        bulk-actions-url="{{ cp_route('forms.submissions.actions.bulk-actions', $form->handle()) }}"
+        bulk-actions-url="{{ cp_route('forms.submissions.actions.bulk', $form->handle()) }}"
         initial-sort-column="datestamp"
         initial-sort-direction="desc"
         v-cloak

--- a/resources/views/forms/show.blade.php
+++ b/resources/views/forms/show.blade.php
@@ -50,7 +50,8 @@
 
     <form-submission-listing
         form="{{ $form->handle() }}"
-        action-url="{{ cp_route('forms.submissions.actions', $form->handle()) }}"
+        run-action-url="{{ cp_route('forms.submissions.actions.run', $form->handle()) }}"
+        bulk-actions-url="{{ cp_route('forms.submissions.actions.bulk-actions', $form->handle()) }}"
         initial-sort-column="datestamp"
         initial-sort-direction="desc"
         v-cloak

--- a/resources/views/taxonomies/show.blade.php
+++ b/resources/views/taxonomies/show.blade.php
@@ -44,7 +44,8 @@
             initial-sort-column="{{ $taxonomy->sortField() }}"
             initial-sort-direction="{{ $taxonomy->sortDirection() }}"
             :filters="{{ $filters->toJson() }}"
-            action-url="{{ cp_route('taxonomies.terms.actions', $taxonomy->handle()) }}"
+            run-action-url="{{ cp_route('taxonomies.terms.actions.run', $taxonomy->handle()) }}"
+            bulk-actions-url="{{ cp_route('taxonomies.terms.actions.bulk-actions', $taxonomy->handle()) }}"
         ></term-list>
 
     @else

--- a/resources/views/taxonomies/show.blade.php
+++ b/resources/views/taxonomies/show.blade.php
@@ -45,7 +45,7 @@
             initial-sort-direction="{{ $taxonomy->sortDirection() }}"
             :filters="{{ $filters->toJson() }}"
             run-action-url="{{ cp_route('taxonomies.terms.actions.run', $taxonomy->handle()) }}"
-            bulk-actions-url="{{ cp_route('taxonomies.terms.actions.bulk-actions', $taxonomy->handle()) }}"
+            bulk-actions-url="{{ cp_route('taxonomies.terms.actions.bulk', $taxonomy->handle()) }}"
         ></term-list>
 
     @else

--- a/resources/views/usergroups/show.blade.php
+++ b/resources/views/usergroups/show.blade.php
@@ -33,7 +33,8 @@
         listing-key="usergroup-users"
         group="{{ $group->id() }}"
         :filters="{{ $filters->toJson() }}"
-        action-url="{{ cp_route('users.actions') }}"
+        run-action-url="{{ cp_route('users.actions.run') }}"
+        bulk-actions-url="{{ cp_route('users.actions.bulk-actions') }}"
     ></user-listing>
 
 @endsection

--- a/resources/views/usergroups/show.blade.php
+++ b/resources/views/usergroups/show.blade.php
@@ -34,7 +34,7 @@
         group="{{ $group->id() }}"
         :filters="{{ $filters->toJson() }}"
         run-action-url="{{ cp_route('users.actions.run') }}"
-        bulk-actions-url="{{ cp_route('users.actions.bulk-actions') }}"
+        bulk-actions-url="{{ cp_route('users.actions.bulk') }}"
     ></user-listing>
 
 @endsection

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -19,7 +19,8 @@
         initial-sort-column="email"
         initial-sort-direction="asc"
         :filters="{{ $filters->toJson() }}"
-        action-url="{{ cp_route('users.actions') }}"
+        run-action-url="{{ cp_route('users.actions.run') }}"
+        bulk-actions-url="{{ cp_route('users.actions.bulk-actions') }}"
     ></user-listing>
 
     @include('statamic::partials.docs-callout', [

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -20,7 +20,7 @@
         initial-sort-direction="asc"
         :filters="{{ $filters->toJson() }}"
         run-action-url="{{ cp_route('users.actions.run') }}"
-        bulk-actions-url="{{ cp_route('users.actions.bulk-actions') }}"
+        bulk-actions-url="{{ cp_route('users.actions.bulk') }}"
     ></user-listing>
 
     @include('statamic::partials.docs-callout', [

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -42,7 +42,7 @@ Route::group([
         Route::group(['prefix' => 'collections/{collection}/entries'], function () {
             Route::get('/', 'EntriesController@index')->name('collections.entries.index');
             Route::post('actions', 'EntryActionController@run')->name('collections.entries.actions.run');
-            Route::get('actions', 'EntryActionController@bulkActions')->name('collections.entries.actions.bulk-actions');
+            Route::get('actions', 'EntryActionController@bulkActions')->name('collections.entries.actions.bulk');
             Route::get('create/{site}', 'EntriesController@create')->name('collections.entries.create');
             Route::post('create/{site}/preview', 'EntryPreviewController@create')->name('collections.entries.preview.create');
             Route::post('reorder', 'ReorderEntriesController')->name('collections.entries.reorder');
@@ -73,7 +73,7 @@ Route::group([
         Route::group(['prefix' => 'taxonomies/{taxonomy}/terms'], function () {
             Route::get('/', 'TermsController@index')->name('taxonomies.terms.index');
             Route::post('actions', 'TermActionController@run')->name('taxonomies.terms.actions.run');
-            Route::get('actions', 'TermActionController@bulkActions')->name('taxonomies.terms.actions.bulk-actions');
+            Route::get('actions', 'TermActionController@bulkActions')->name('taxonomies.terms.actions.bulk');
             Route::get('create/{site}', 'TermsController@create')->name('taxonomies.terms.create');
             Route::post('create/{site}/preview', 'TermPreviewController@create')->name('taxonomies.terms.preview.create');
             Route::post('{site}', 'TermsController@store')->name('taxonomies.terms.store');
@@ -113,7 +113,7 @@ Route::group([
         Route::post('asset-containers/{asset_container}/folders', 'FoldersController@store');
         Route::patch('asset-containers/{asset_container}/folders/{path}', 'FoldersController@update')->where('path', '.*');
         Route::post('assets/actions', 'ActionController@run')->name('assets.actions.run');
-        Route::get('assets/actions', 'ActionController@bulkActions')->name('assets.actions.bulk-actions');
+        Route::get('assets/actions', 'ActionController@bulkActions')->name('assets.actions.bulk');
         Route::get('assets/browse', 'BrowserController@index')->name('assets.browse.index');
         Route::get('assets/browse/search/{asset_container}', 'BrowserController@search');
         Route::post('assets/browse/folders/{asset_container}/actions', 'FolderActionController@run')->name('assets.folders.actions.run');
@@ -157,7 +157,7 @@ Route::group([
 
     Route::group(['namespace' => 'Forms'], function () {
         Route::post('forms/{form}/submissions/actions', 'SubmissionActionController@run')->name('forms.submissions.actions.run');
-        Route::get('forms/{form}/submissions/actions', 'SubmissionActionController@bulkActions')->name('forms.submissions.actions.bulk-actions');
+        Route::get('forms/{form}/submissions/actions', 'SubmissionActionController@bulkActions')->name('forms.submissions.actions.bulk');
         Route::resource('forms', 'FormsController');
         Route::resource('forms.submissions', 'FormSubmissionsController');
         Route::get('forms/{form}/export/{type}', 'FormExportController@export')->name('forms.export');
@@ -165,7 +165,7 @@ Route::group([
 
     Route::group(['namespace' => 'Users'], function () {
         Route::post('users/actions', 'UserActionController@run')->name('users.actions.run');
-        Route::get('users/actions', 'UserActionController@bulkActions')->name('users.actions.bulk-actions');
+        Route::get('users/actions', 'UserActionController@bulkActions')->name('users.actions.bulk');
         Route::resource('users', 'UsersController');
         Route::patch('users/{user}/password', 'PasswordController@update')->name('users.password.update');
         Route::get('account', 'AccountController')->name('account');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -155,9 +155,10 @@ Route::group([
     Route::post('addons/uninstall', 'AddonsController@uninstall');
 
     Route::group(['namespace' => 'Forms'], function () {
+        Route::post('forms/{form}/submissions/actions', 'SubmissionActionController@run')->name('forms.submissions.actions.run');
+        Route::get('forms/{form}/submissions/actions', 'SubmissionActionController@bulkActions')->name('forms.submissions.actions.bulk-actions');
         Route::resource('forms', 'FormsController');
         Route::resource('forms.submissions', 'FormSubmissionsController');
-        Route::post('forms/{form}/submissions/actions', 'SubmissionActionController')->name('forms.submissions.actions');
         Route::get('forms/{form}/export/{type}', 'FormExportController@export')->name('forms.export');
     });
 

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -112,10 +112,11 @@ Route::group([
         Route::resource('asset-containers', 'AssetContainersController');
         Route::post('asset-containers/{asset_container}/folders', 'FoldersController@store');
         Route::patch('asset-containers/{asset_container}/folders/{path}', 'FoldersController@update')->where('path', '.*');
-        Route::post('assets/actions', 'ActionController')->name('assets.actions');
+        Route::post('assets/actions', 'ActionController@run')->name('assets.actions.run');
+        Route::get('assets/actions', 'ActionController@bulkActions')->name('assets.actions.bulk-actions');
         Route::get('assets/browse', 'BrowserController@index')->name('assets.browse.index');
         Route::get('assets/browse/search/{asset_container}', 'BrowserController@search');
-        Route::post('assets/browse/folders/{asset_container}/actions', 'FolderActionController')->name('assets.folders.actions');
+        Route::post('assets/browse/folders/{asset_container}/actions', 'FolderActionController@run')->name('assets.folders.actions.run');
         Route::get('assets/browse/folders/{asset_container}/{path?}', 'BrowserController@folder')->where('path', '.*');
         Route::get('assets/browse/{asset_container}/{path?}/edit', 'BrowserController@edit')->where('path', '.*')->name('assets.browse.edit');
         Route::get('assets/browse/{asset_container}/{path?}', 'BrowserController@show')->where('path', '.*')->name('assets.browse.show');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -72,7 +72,8 @@ Route::group([
 
         Route::group(['prefix' => 'taxonomies/{taxonomy}/terms'], function () {
             Route::get('/', 'TermsController@index')->name('taxonomies.terms.index');
-            Route::post('actions', 'TermActionController')->name('taxonomies.terms.actions');
+            Route::post('actions', 'TermActionController@run')->name('taxonomies.terms.actions.run');
+            Route::get('actions', 'TermActionController@bulkActions')->name('taxonomies.terms.actions.bulk-actions');
             Route::get('create/{site}', 'TermsController@create')->name('taxonomies.terms.create');
             Route::post('create/{site}/preview', 'TermPreviewController@create')->name('taxonomies.terms.preview.create');
             Route::post('{site}', 'TermsController@store')->name('taxonomies.terms.store');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -41,7 +41,8 @@ Route::group([
 
         Route::group(['prefix' => 'collections/{collection}/entries'], function () {
             Route::get('/', 'EntriesController@index')->name('collections.entries.index');
-            Route::post('actions', 'EntryActionController')->name('collections.entries.actions');
+            Route::post('actions', 'EntryActionController@run')->name('collections.entries.actions.run');
+            Route::get('actions', 'EntryActionController@bulkActions')->name('collections.entries.actions.bulk-actions');
             Route::get('create/{site}', 'EntriesController@create')->name('collections.entries.create');
             Route::post('create/{site}/preview', 'EntryPreviewController@create')->name('collections.entries.preview.create');
             Route::post('reorder', 'ReorderEntriesController')->name('collections.entries.reorder');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -162,7 +162,8 @@ Route::group([
     });
 
     Route::group(['namespace' => 'Users'], function () {
-        Route::post('users/actions', 'UserActionController')->name('users.actions');
+        Route::post('users/actions', 'UserActionController@run')->name('users.actions.run');
+        Route::get('users/actions', 'UserActionController@bulkActions')->name('users.actions.bulk-actions');
         Route::resource('users', 'UsersController');
         Route::patch('users/{user}/password', 'PasswordController@update')->name('users.password.update');
         Route::get('account', 'AccountController')->name('account');

--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -26,7 +26,7 @@ abstract class Action implements Arrayable
         return true;
     }
 
-    public function visibleBulk($items)
+    public function visibleToBulk($items)
     {
         $allowedOnItems = $items->filter(function ($item) {
             return $this->visibleTo($item);

--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -22,19 +22,19 @@ abstract class Action implements Arrayable
     protected $context = [];
     protected $bulk = true;
 
-    public function filter($item)
+    public function visibleTo($item)
     {
         return true;
     }
 
-    public function filterBulk($items)
+    public function visibleBulk($items)
     {
         if (! $this->bulk) {
             return false;
         }
 
         $allowedOnItems = $items->filter(function ($item) {
-            return $this->filter($item);
+            return $this->visibleTo($item);
         });
 
         return $items->count() === $allowedOnItems->count();

--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -20,7 +20,6 @@ abstract class Action implements Arrayable
     protected $dangerous = false;
     protected $fields = [];
     protected $context = [];
-    protected $bulk = true;
 
     public function visibleTo($item)
     {
@@ -29,10 +28,6 @@ abstract class Action implements Arrayable
 
     public function visibleBulk($items)
     {
-        if (! $this->bulk) {
-            return false;
-        }
-
         $allowedOnItems = $items->filter(function ($item) {
             return $this->visibleTo($item);
         });

--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -27,6 +27,33 @@ abstract class Action implements Arrayable
         return true;
     }
 
+    public function filterBulk($items)
+    {
+        if (! $this->bulk) {
+            return false;
+        }
+
+        $allowedOnItems = $items->filter(function ($item) {
+            return $this->filter($item);
+        });
+
+        return $items->count() === $allowedOnItems->count();
+    }
+
+    public function authorize($user, $item)
+    {
+        return true;
+    }
+
+    public function authorizeBulk($user, $items)
+    {
+        $authorizedOnItems = $items->filter(function ($item) use ($user) {
+            return $this->authorize($user, $item);
+        });
+
+        return $items->count() === $authorizedOnItems->count();
+    }
+
     public function context($context)
     {
         $this->context = $context;
@@ -37,11 +64,6 @@ abstract class Action implements Arrayable
     protected function fieldItems()
     {
         return $this->fields;
-    }
-
-    public function authorize($user, $item)
-    {
-        return true;
     }
 
     public function redirect()
@@ -73,7 +95,6 @@ abstract class Action implements Arrayable
             'fields' => $this->fields()->toPublishArray(),
             'meta' => $this->fields()->meta(),
             'context' => $this->context,
-            'bulk' => $this->bulk,
         ];
     }
 }

--- a/src/Actions/ActionRepository.php
+++ b/src/Actions/ActionRepository.php
@@ -24,7 +24,7 @@ class ActionRepository
     {
         return $this->all()
             ->each->context($context)
-            ->filter->filter($item)
+            ->filter->visibleTo($item)
             ->filter->authorize(User::current(), $item)
             ->values();
     }
@@ -33,7 +33,7 @@ class ActionRepository
     {
         return $this->all()
             ->each->context($context)
-            ->filter->filterBulk($items)
+            ->filter->visibleBulk($items)
             ->filter->authorizeBulk(User::current(), $items)
             ->values();
     }

--- a/src/Actions/ActionRepository.php
+++ b/src/Actions/ActionRepository.php
@@ -33,7 +33,7 @@ class ActionRepository
     {
         return $this->all()
             ->each->context($context)
-            ->filter->visibleBulk($items)
+            ->filter->visibleToBulk($items)
             ->filter->authorizeBulk(User::current(), $items)
             ->values();
     }

--- a/src/Actions/ActionRepository.php
+++ b/src/Actions/ActionRepository.php
@@ -28,4 +28,13 @@ class ActionRepository
             ->filter->authorize(User::current(), $item)
             ->values();
     }
+
+    public function forBulk($items, $context = [])
+    {
+        return $this->all()
+            ->each->context($context)
+            ->filter->filterBulk($items)
+            ->filter->authorizeBulk(User::current(), $items)
+            ->values();
+    }
 }

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -13,7 +13,7 @@ class Delete extends Action
         return __('Delete');
     }
 
-    public function filter($item)
+    public function visibleTo($item)
     {
         return true;
     }

--- a/src/Actions/MoveAsset.php
+++ b/src/Actions/MoveAsset.php
@@ -13,7 +13,7 @@ class MoveAsset extends Action
         return __('Move');
     }
 
-    public function filter($item)
+    public function visibleTo($item)
     {
         return $item instanceof Asset;
     }

--- a/src/Actions/Publish.php
+++ b/src/Actions/Publish.php
@@ -17,6 +17,19 @@ class Publish extends Action
         return $item instanceof Entry && ! $item->published();
     }
 
+    public function filterBulk($items)
+    {
+        if ($items->whereInstanceOf(Entry::class)->count() !== $items->count()) {
+            return false;
+        }
+
+        if ($items->filter->published()->count() === $items->count()) {
+            return false;
+        }
+
+        return true;
+    }
+
     public function authorize($user, $entry)
     {
         return $user->can('publish', $entry);

--- a/src/Actions/Publish.php
+++ b/src/Actions/Publish.php
@@ -12,12 +12,12 @@ class Publish extends Action
         return __('Publish');
     }
 
-    public function filter($item)
+    public function visibleTo($item)
     {
         return $item instanceof Entry && ! $item->published();
     }
 
-    public function filterBulk($items)
+    public function visibleBulk($items)
     {
         if ($items->whereInstanceOf(Entry::class)->count() !== $items->count()) {
             return false;

--- a/src/Actions/Publish.php
+++ b/src/Actions/Publish.php
@@ -17,7 +17,7 @@ class Publish extends Action
         return $item instanceof Entry && ! $item->published();
     }
 
-    public function visibleBulk($items)
+    public function visibleToBulk($items)
     {
         if ($items->whereInstanceOf(Entry::class)->count() !== $items->count()) {
             return false;

--- a/src/Actions/RenameAsset.php
+++ b/src/Actions/RenameAsset.php
@@ -11,7 +11,7 @@ class RenameAsset extends Action
         return __('Rename');
     }
 
-    public function filter($item)
+    public function visibleTo($item)
     {
         return $item instanceof Asset;
     }

--- a/src/Actions/SendPasswordReset.php
+++ b/src/Actions/SendPasswordReset.php
@@ -11,7 +11,7 @@ class SendPasswordReset extends Action
         return __('Send Password Reset');
     }
 
-    public function filter($item)
+    public function visibleTo($item)
     {
         return $item instanceof UserContract;
     }

--- a/src/Actions/Unpublish.php
+++ b/src/Actions/Unpublish.php
@@ -12,6 +12,19 @@ class Unpublish extends Action
         return $item instanceof Entry && $item->published();
     }
 
+    public function filterBulk($items)
+    {
+        if ($items->whereInstanceOf(Entry::class)->count() !== $items->count()) {
+            return false;
+        }
+
+        if ($items->reject->published()->count() === $items->count()) {
+            return false;
+        }
+
+        return true;
+    }
+
     public function authorize($user, $entry)
     {
         return $user->can('publish', $entry);

--- a/src/Actions/Unpublish.php
+++ b/src/Actions/Unpublish.php
@@ -7,12 +7,12 @@ use Statamic\Facades\User;
 
 class Unpublish extends Action
 {
-    public function filter($item)
+    public function visibleTo($item)
     {
         return $item instanceof Entry && $item->published();
     }
 
-    public function filterBulk($items)
+    public function visibleBulk($items)
     {
         if ($items->whereInstanceOf(Entry::class)->count() !== $items->count()) {
             return false;

--- a/src/Actions/Unpublish.php
+++ b/src/Actions/Unpublish.php
@@ -12,7 +12,7 @@ class Unpublish extends Action
         return $item instanceof Entry && $item->published();
     }
 
-    public function visibleBulk($items)
+    public function visibleToBulk($items)
     {
         if ($items->whereInstanceOf(Entry::class)->count() !== $items->count()) {
             return false;

--- a/src/Http/Controllers/CP/ActionController.php
+++ b/src/Http/Controllers/CP/ActionController.php
@@ -9,7 +9,7 @@ use Statamic\Facades\User;
 
 abstract class ActionController extends CpController
 {
-    public function __invoke(Request $request)
+    public function run(Request $request)
     {
         $data = $request->validate([
             'action' => 'required',
@@ -40,6 +40,20 @@ abstract class ActionController extends CpController
         }
 
         return [];
+    }
+
+    public function bulkActions(Request $request)
+    {
+        $data = $request->validate([
+            'selections' => 'required|array',
+            'context' => 'sometimes',
+        ]);
+
+        $context = $data['context'] ?? [];
+
+        $items = $this->getSelectedItems(collect($data['selections']), $context);
+
+        return Action::forBulk($items, $context);
     }
 
     abstract protected function getSelectedItems($items, $context);

--- a/src/Http/Resources/CP/Assets/Asset.php
+++ b/src/Http/Resources/CP/Assets/Asset.php
@@ -40,7 +40,7 @@ class Asset extends Resource
             $this->merge($this->publishFormData()),
 
             'allowDownloading' => $this->container()->allowDownloading(),
-            'actionUrl' => cp_route('assets.actions'),
+            'runActionUrl' => cp_route('assets.actions.run'),
             'actions' => Action::for($this->resource, ['container' => $this->container()->handle()]),
         ];
     }

--- a/src/Http/Resources/CP/Assets/FolderAssetsCollection.php
+++ b/src/Http/Resources/CP/Assets/FolderAssetsCollection.php
@@ -30,8 +30,9 @@ class FolderAssetsCollection extends ResourceCollection
     {
         return [
             'links' => [
-                'asset_actions' => cp_route('assets.actions'),
-                'folder_actions' => cp_route('assets.folders.actions', $this->folder->container()->id())
+                'run_asset_action' => cp_route('assets.actions.run'),
+                'bulk_asset_actions' => cp_route('assets.actions.bulk-actions'),
+                'run_folder_action' => cp_route('assets.folders.actions.run', $this->folder->container()->id()),
             ]
         ];
     }

--- a/src/Http/Resources/CP/Assets/FolderAssetsCollection.php
+++ b/src/Http/Resources/CP/Assets/FolderAssetsCollection.php
@@ -31,7 +31,7 @@ class FolderAssetsCollection extends ResourceCollection
         return [
             'links' => [
                 'run_asset_action' => cp_route('assets.actions.run'),
-                'bulk_asset_actions' => cp_route('assets.actions.bulk-actions'),
+                'bulk_asset_actions' => cp_route('assets.actions.bulk'),
                 'run_folder_action' => cp_route('assets.folders.actions.run', $this->folder->container()->id()),
             ]
         ];

--- a/tests/Feature/Assets/BrowserTest.php
+++ b/tests/Feature/Assets/BrowserTest.php
@@ -265,7 +265,7 @@ class BrowserTest extends TestCase
     {
         return [
             'meta',
-            'links' => ['folder_actions', 'asset_actions'],
+            'links' => ['run_folder_action', 'run_asset_action'],
             'data' => [
                 'assets' => [
                     ['id', 'size_formatted', 'last_modified_relative', 'actions'],


### PR DESCRIPTION
- Adds `visibleToBulk()` method to better control when bulk actions are shown.
- Implements @jackmcdade's suggestion (see https://github.com/statamic/cms/pull/1650#issuecomment-611816554) on publish/unpublish actions.
- Removes `$bulk` property.
    - Introduced by https://github.com/statamic/cms/pull/1612; Can use `visibleToBulk()` method instead.
- Renames `filter()` to `visibleTo()`.
    - For consistency with `visibleToBulk()` and our `visibleTo()` pattern.
