### PR TITLE
Fix issue where query is still performed when updated_by is null

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -424,7 +424,9 @@ class Entry implements Contract, Augmentable, Responsable, Localization
 
     public function lastModifiedBy()
     {
-        return User::find($this->get('updated_by'));
+        return $this->has('updated_by')
+            ? User::find($this->get('updated_by'))
+            : null;
     }
 
     public function status()


### PR DESCRIPTION
This PR fixes an issue I was having where the Entry queries for a user even if updated_by is not set. This is when the user repository is set to eloquent.

It's similar to the existing check on `lastModified()` and `UserRepository` already returns `null` if the user doesn't exist in the database.

![image](https://user-images.githubusercontent.com/6128583/79097576-aa0e9100-7d92-11ea-8b9b-b746be832b97.png)