### PR TITLE
Augmentation tweaks ...

### DIFF
--- a/src/Assets/AugmentedAssetContainer.php
+++ b/src/Assets/AugmentedAssetContainer.php
@@ -19,13 +19,6 @@ class AugmentedAssetContainer extends AbstractAugmented
         ];
     }
 
-    public function augmentableKeys()
-    {
-        // Override this to prevent the default behavior of looking at the
-        // blueprint for the keys. Those are for the assets, not the container.
-        return $this->keys();
-    }
-
     protected function disk()
     {
         return $this->data->diskHandle();

--- a/src/Auth/AugmentedUser.php
+++ b/src/Auth/AugmentedUser.php
@@ -10,25 +10,31 @@ use Statamic\Support\Str;
 
 class AugmentedUser extends AbstractAugmented
 {
-    protected function keys()
+    public function keys()
     {
         return $this->data->data()->keys()
             ->merge(collect($this->data->supplements() ?? [])->keys())
-            ->merge([
-                'id',
-                'name',
-                'title',
-                'email',
-                'initials',
-                'edit_url',
-                'is_user',
-                'last_login',
-                'avatar',
-                'api_url',
-            ])
+            ->merge($this->commonKeys())
             ->merge($this->roleHandles())
             ->merge($this->groupHandles())
-            ->all();
+            ->merge($this->blueprintFields()->keys())
+            ->unique()->sort()->values()->all();
+    }
+
+    private function commonKeys()
+    {
+        return [
+            'id',
+            'name',
+            'title',
+            'email',
+            'initials',
+            'edit_url',
+            'is_user',
+            'last_login',
+            'avatar',
+            'api_url',
+        ];
     }
 
     public function get($handle)

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -23,14 +23,14 @@ abstract class AbstractAugmented implements Augmented
 
     public function except($keys)
     {
-        return $this->select(array_diff($this->augmentableKeys(), Arr::wrap($keys)));
+        return $this->select(array_diff($this->keys(), Arr::wrap($keys)));
     }
 
     public function select($keys = null)
     {
         $arr = [];
 
-        $keys = Arr::wrap($keys ?: $this->augmentableKeys());
+        $keys = Arr::wrap($keys ?: $this->keys());
 
         foreach ($keys as $key) {
             $arr[$key] = $this->get($key);
@@ -39,24 +39,31 @@ abstract class AbstractAugmented implements Augmented
         return new AugmentedCollection($arr);
     }
 
-    abstract protected function keys();
+    abstract public function keys();
 
     public function get($handle)
     {
-        if (method_exists($this, $method = Str::camel($handle)) && !in_array($method, ['select', 'except'])) {
+        $method = Str::camel($handle);
+
+        if ($this->methodExistsOnThisClass($method)) {
             return $this->$method();
         }
 
-        if (method_exists($this->data, $method = Str::camel($handle))) {
+        if (method_exists($this->data, $method)) {
             return $this->wrapValue($this->data->$method(), $handle);
         }
 
         return $this->wrapValue($this->getFromData($handle), $handle);
     }
 
+    private function methodExistsOnThisClass($method)
+    {
+        return method_exists($this, $method) && !in_array($method, ['select', 'except']);
+    }
+
     protected function getFromData($handle)
     {
-        $value = $this->data->get($handle);
+        $value = method_exists($this->data, 'value') ? $this->data->value($handle) : $this->data->get($handle);
 
         if (method_exists($this->data, 'getSupplement')) {
             $value = $this->data->getSupplement($handle) ?? $value;
@@ -81,15 +88,10 @@ abstract class AbstractAugmented implements Augmented
         );
     }
 
-    private function blueprintFields()
+    protected function blueprintFields()
     {
         return (method_exists($this->data, 'blueprint') && $blueprint = $this->data->blueprint())
             ? $blueprint->fields()->all()
             : collect();
-    }
-
-    protected function augmentableKeys()
-    {
-        return $this->blueprintFields()->keys()->merge($this->keys())->all();
     }
 }

--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -6,28 +6,35 @@ use Statamic\Data\AbstractAugmented;
 
 class AugmentedEntry extends AbstractAugmented
 {
-    protected function keys()
+    public function keys()
     {
-        return $this->data->data()->keys()
+        return $this->data->values()->keys()
             ->merge($this->data->supplements()->keys())
-            ->merge([
-                'id',
-                'slug',
-                'uri',
-                'url',
-                'edit_url',
-                'permalink',
-                'amp_url',
-                'api_url',
-                'published',
-                'private',
-                'date',
-                'is_entry',
-                'collection',
-                'last_modified',
-                'updated_at',
-                'updated_by',
-            ])->all();
+            ->merge($this->commonKeys())
+            ->merge($this->blueprintFields()->keys())
+            ->unique()->sort()->values()->all();
+    }
+
+    private function commonKeys()
+    {
+        return [
+            'id',
+            'slug',
+            'uri',
+            'url',
+            'edit_url',
+            'permalink',
+            'amp_url',
+            'api_url',
+            'published',
+            'private',
+            'date',
+            'is_entry',
+            'collection',
+            'last_modified',
+            'updated_at',
+            'updated_by',
+        ];
     }
 
     protected function updatedBy()

--- a/src/Structures/AugmentedPage.php
+++ b/src/Structures/AugmentedPage.php
@@ -18,7 +18,7 @@ class AugmentedPage extends AugmentedEntry
         }
     }
 
-    protected function keys()
+    public function keys()
     {
         if ($this->hasEntry) {
             return parent::keys();

--- a/src/Taxonomies/AugmentedTerm.php
+++ b/src/Taxonomies/AugmentedTerm.php
@@ -6,21 +6,30 @@ use Statamic\Data\AbstractAugmented;
 
 class AugmentedTerm extends AbstractAugmented
 {
-    protected function keys()
+    public function keys()
     {
         return $this->data->data()->keys()
-            ->merge([
-                'id',
-                'slug',
-                'uri',
-                'url',
-                'title',
-                'is_term',
-                'entries',
-                'entries_count',
-                'api_url',
-                'taxonomy'
-            ])->all();
+            ->merge($this->commonKeys())
+            ->merge($this->blueprintFields()->keys())
+            ->unique()->sort()->values()->all();
+    }
+
+    private function commonKeys()
+    {
+        return [
+            'id',
+            'slug',
+            'uri',
+            'url',
+            'permalink',
+            'title',
+            'is_term',
+            'entries',
+            'entries_count',
+            'api_url',
+            'taxonomy',
+            'edit_url',
+        ];
     }
 
     protected function entries()
@@ -36,5 +45,10 @@ class AugmentedTerm extends AbstractAugmented
     protected function isTerm()
     {
         return true;
+    }
+
+    protected function permalink()
+    {
+        return $this->get('absolute_url');
     }
 }

--- a/tests/Auth/AugmentedUserTest.php
+++ b/tests/Auth/AugmentedUserTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Auth;
+
+use Carbon\Carbon;
+use Mockery;
+use Statamic\Auth\AugmentedUser;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\User;
+use Statamic\Fields\Value;
+use Tests\Data\AugmentedTestCase;
+use Tests\FakesRoles;
+use Tests\FakesUserGroups;
+
+class AugmentedUserTest extends AugmentedTestCase
+{
+    use FakesRoles;
+    use FakesUserGroups;
+
+    /** @test */
+    function it_gets_values()
+    {
+        Carbon::setTestNow('2020-04-15 13:00:00');
+
+        $blueprint = Blueprint::find('user');
+        $contents = $blueprint->contents();
+        $contents['sections']['main']['fields'] = array_merge($contents['sections']['main']['fields'], [
+            ['handle' => 'two', 'field' => ['type' => 'text']],
+            ['handle' => 'four', 'field' => ['type' => 'text']],
+            ['handle' => 'unused_in_bp', 'field' => ['type' => 'text']],
+        ]);
+        $blueprint->setContents($contents);
+        Blueprint::shouldReceive('find')->with('user')->andReturn($blueprint);
+
+        $this->setTestRoles([
+            'role_one' => [],
+            'role_two' => [],
+        ]);
+        $this->setTestUserGroups([
+            'group_one' => [],
+            'group_two' => [],
+        ]);
+
+        $user = tap(User::make()
+            ->id('user-id')
+            ->data([
+                'name' => 'John Smith',
+                'one' => 'the "one" value on the user',
+                'two' => 'the "two" value on the user and in the blueprint',
+            ])
+            ->email('john@example.com')
+            ->assignRole('role_one')
+            ->addToGroup('group_one')
+            ->setSupplement('three', 'the "three" value supplemented on the user')
+            ->setSupplement('four', 'the "four" value supplemented on the user and in the blueprint')
+        )->save();
+
+        $user->setMeta('last_login', '1486131000');
+
+        $augmented = new AugmentedUser($user);
+
+        $expectations = [
+            'id'         => ['type' => 'string', 'value' => 'user-id'],
+            'name'       => ['type' => Value::class, 'value' => 'John Smith'],
+            'title'      => ['type' => 'string', 'value' => 'john@example.com'],
+            'email'      => ['type' => Value::class, 'value' => 'john@example.com'],
+            'initials'   => ['type' => 'string', 'value' => 'JS'],
+            'edit_url'   => ['type' => 'string', 'value' => 'http://localhost/cp/users/user-id/edit'],
+            'is_user'    => ['type' => 'bool', 'value' => true],
+            'last_login' => ['type' => Carbon::class, 'value' => '2017-02-03 14:10'],
+            'avatar'     => ['type' => 'string', 'value' => null],
+            'api_url'    => ['type' => 'string', 'value' => 'http://localhost/api/users/user-id'],
+
+            'roles'       => ['type' => 'array', 'value' => ['role_one']],
+            'is_role_one' => ['type' => 'bool', 'value' => true],
+            'is_role_two' => ['type' => 'bool', 'value' => false],
+
+            'groups'       => ['type' => 'array', 'value' => ['group_one']],
+            'in_group_one' => ['type' => 'bool', 'value' => true],
+            'in_group_two' => ['type' => 'bool', 'value' => false],
+
+            'one'          => ['type' => 'string', 'value' => 'the "one" value on the user'],
+            'two'          => ['type' => Value::class, 'value' => 'the "two" value on the user and in the blueprint'],
+            'three'        => ['type' => 'string', 'value' => 'the "three" value supplemented on the user'],
+            'four'         => ['type' => Value::class, 'value' => 'the "four" value supplemented on the user and in the blueprint'],
+            'unused_in_bp' => ['type' => Value::class, 'value' => null],
+        ];
+
+        $this->assertAugmentedCorrectly($expectations, $augmented);
+    }
+}

--- a/tests/Data/AugmentedTest.php
+++ b/tests/Data/AugmentedTest.php
@@ -37,6 +37,24 @@ class AugmentedTest extends TestCase
     }
 
     /** @test */
+    function it_gets_a_single_value_by_key_using_the_value_method_if_it_exists()
+    {
+        $thingWithValueMethod = new class($this->thing->data()) extends Thing {
+            public function value($key)
+            {
+                return $this->get($key) ? $this->get($key) . ' (value)' : null;
+            }
+        };
+
+        $augmented = new class($thingWithValueMethod) extends BaseAugmentedThing {
+            //
+        };
+
+        $this->assertEquals('bar (value)', $augmented->get('foo'));
+        $this->assertNull($augmented->get('unknown'));
+    }
+
+    /** @test */
     function it_gets_a_value_from_the_thing_if_theres_a_method()
     {
         $augmented = new class($this->thing) extends BaseAugmentedThing {
@@ -143,7 +161,6 @@ class AugmentedTest extends TestCase
             'slug' => $slug = new Value('the-thing', 'slug', $fieldtype, $this->blueprintThing),
             'the_slug' => 'the-thing',
             'hello' => 'world',
-            'unused' => $unused = new Value(null, 'unused', $fieldtype, $this->blueprintThing),
             'supplemented' => 'supplemented value',
         ], $result->all());
 
@@ -163,7 +180,6 @@ class AugmentedTest extends TestCase
         $this->assertEquals([
             'foo' => $foo,
             'the_slug' => 'the-thing',
-            'unused' => $unused,
             'supplemented' => 'supplemented value',
         ], $result->all());
 
@@ -171,7 +187,6 @@ class AugmentedTest extends TestCase
             'foo' => $foo,
             'slug' => $slug,
             'the_slug' => 'the-thing',
-            'unused' => $unused,
             'supplemented' => 'supplemented value',
         ], $augmented->except('hello')->all());
     }

--- a/tests/Data/AugmentedTestCase.php
+++ b/tests/Data/AugmentedTestCase.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Data;
+
+use Carbon\Carbon;
+use Statamic\Contracts\Auth\User;
+use Statamic\Fields\Value;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class AugmentedTestCase extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    protected function assertAugmentedCorrectly($expectations, $augmented)
+    {
+        $this->assertEquals(
+            collect($expectations)->keys()->sort()->values()->all(),
+            $augmented->keys()
+        );
+
+        foreach ($expectations as $key => $expectation) {
+            $actual = $augmented->get($key);
+
+            if (! in_array($expectation['type'], ['string', 'bool', 'array', 'int'])) {
+                $this->assertInstanceOf($expectation['type'], $actual, "Key '{$key}' is not a {$expectation['type']}");
+            }
+
+            switch ($expectation['type']) {
+                case Value::class:
+                    $this->assertSame($expectation['value'], $actual->value(), "Key '{$key}' does not match expected value.");
+                    break;
+
+                case Carbon::class:
+                    $this->assertTrue(
+                        Carbon::createFromFormat('Y-m-d H:i', $expectation['value'])->eq($actual),
+                        "Key '{$key}' does not match the expected date."
+                    );
+                    break;
+
+                case User::class:
+                    $this->assertEquals($expectation['value'], $actual->id());
+                    break;
+
+                default:
+                    if (isset($expectation['value'])) {
+                        $this->assertSame(
+                            $expectation['value'],
+                            $actual,
+                            "Key '{$key}' does not match expected value."
+                        );
+                    }
+            }
+        }
+    }
+}

--- a/tests/Data/Entries/AugmentedEntryTest.php
+++ b/tests/Data/Entries/AugmentedEntryTest.php
@@ -2,18 +2,21 @@
 
 namespace Tests\Data\Entries;
 
+use Carbon\Carbon;
+use Facades\Tests\Factories\EntryFactory;
 use Mockery;
-use PHPUnit\Framework\TestCase;
+use Statamic\Contracts\Auth\User as UserContract;
+use Statamic\Contracts\Entries\Collection as CollectionContract;
 use Statamic\Entries\AugmentedEntry;
 use Statamic\Entries\Entry;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Collection;
+use Statamic\Facades\User;
+use Statamic\Fields\Value;
+use Tests\Data\AugmentedTestCase;
 
-class AugmentedEntryTest extends TestCase
+class AugmentedEntryTest extends AugmentedTestCase
 {
-    public function tearDown(): void
-    {
-        Mockery::close();
-    }
-
     /** @test */
     function it_has_a_parent_method()
     {
@@ -23,5 +26,86 @@ class AugmentedEntryTest extends TestCase
         $augmented = new AugmentedEntry($entry);
 
         $this->assertEquals('the parent', $augmented->get('parent'));
+    }
+
+    /** @test */
+    function it_gets_values()
+    {
+        Carbon::setTestNow('2020-04-15 13:00:00');
+        config(['statamic.amp.enabled' => true]);
+
+        $blueprint = Blueprint::makeFromFields([
+            'two' => ['type' => 'text'],
+            'four' => ['type' => 'text'],
+            'six' => ['type' => 'text'],
+            'unused_in_bp' => ['type' => 'text']
+        ]);
+        Blueprint::shouldReceive('find')->with('test')->andReturn($blueprint);
+
+        $collection = tap(Collection::make('test')
+            ->routes('/test/{slug}')
+            ->ampable(true)
+            ->cascade(['seven' => 'the "seven" value from the collection']))
+            ->save();
+
+        EntryFactory::id('origin-id')
+            ->data([
+                'five' => 'the "five" value from the origin',
+                'six' => 'the "six" value from the origin and in the blueprint',
+            ])
+            ->collection('test')
+            ->create();
+
+        User::make()->id('test-user')->save();
+
+        $entry = EntryFactory::id('entry-id')
+            ->collection('test')
+            ->slug('entry-slug')
+            ->data([
+                'one' => 'the "one" value on the entry',
+                'two' => 'the "two" value on the entry and in the blueprint',
+                'updated_by' => 'test-user',
+                'updated_at' => '1486131000'
+            ])
+            ->create();
+
+        $entry
+            ->origin('origin-id')
+            ->date('2018-01-03-1705')
+            ->blueprint('test')
+            ->setSupplement('three', 'the "three" value supplemented on the entry')
+            ->setSupplement('four', 'the "four" value supplemented on the entry and in the blueprint');
+
+        $augmented = new AugmentedEntry($entry);
+
+        $expectations = [
+            'id'            => ['type' => 'string', 'value' => 'entry-id'],
+            'slug'          => ['type' => Value::class, 'value' => 'entry-slug'],
+            'uri'           => ['type' => 'string', 'value' => '/test/entry-slug'],
+            'url'           => ['type' => 'string', 'value' => '/test/entry-slug'],
+            'edit_url'      => ['type' => 'string', 'value' => 'http://localhost/cp/collections/test/entries/entry-id/entry-slug'],
+            'permalink'     => ['type' => 'string', 'value' => 'http://localhost/test/entry-slug'],
+            'amp_url'       => ['type' => 'string', 'value' => 'http://localhost/amp/test/entry-slug'],
+            'api_url'       => ['type' => 'string', 'value' => 'http://localhost/api/collections/test/entries/entry-id'],
+            'published'     => ['type' => 'bool', 'value' => true],
+            'private'       => ['type' => 'bool', 'value' => false],
+            'date'          => ['type' => Carbon::class, 'value' => '2018-01-03 17:05'],
+            'is_entry'      => ['type' => 'bool', 'value' => true],
+            'collection'    => ['type' => CollectionContract::class, 'value' => $collection],
+            'last_modified' => ['type' => Carbon::class, 'value' => '2017-02-03 14:10'],
+            'updated_at'    => ['type' => Carbon::class, 'value' => '2017-02-03 14:10'],
+            'updated_by'    => ['type' => UserContract::class, 'value' => 'test-user'],
+            'one'           => ['type' => 'string', 'value' => 'the "one" value on the entry'],
+            'two'           => ['type' => Value::class, 'value' => 'the "two" value on the entry and in the blueprint'],
+            'three'         => ['type' => 'string', 'value' => 'the "three" value supplemented on the entry'],
+            'four'          => ['type' => Value::class, 'value' => 'the "four" value supplemented on the entry and in the blueprint'],
+            'five'          => ['type' => 'string', 'value' => 'the "five" value from the origin'],
+            'six'           => ['type' => Value::class, 'value' => 'the "six" value from the origin and in the blueprint'],
+            'seven'         => ['type' => 'string', 'value' => 'the "seven" value from the collection'],
+            'title'         => ['type' => Value::class, 'value' => null],
+            'unused_in_bp'  => ['type' => Value::class, 'value' => null],
+        ];
+
+        $this->assertAugmentedCorrectly($expectations, $augmented);
     }
 }

--- a/tests/Data/HasAugmentedDataTest.php
+++ b/tests/Data/HasAugmentedDataTest.php
@@ -61,7 +61,6 @@ class HasAugmentedDataTest extends TestCase
         $expectedArr = [
             'foo' => new Value('FOO', 'foo', $fieldtype, $thing),
             'bar' => 'BAR',
-            'baz' => new Value(null, 'baz', $fieldtype, $thing),
         ];
         $this->assertEquals($expectedArr, $thing->augmented()->all()->all());
         $this->assertEquals($expectedArr, $thing->toAugmentedArray());

--- a/tests/Data/Taxonomies/AugmentedTermTest.php
+++ b/tests/Data/Taxonomies/AugmentedTermTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Data\Taxonomies;
+
+use Carbon\Carbon;
+use Statamic\Contracts\Auth\User as UserContract;
+use Statamic\Contracts\Taxonomies\Taxonomy as TaxonomyContract;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Taxonomy;
+use Statamic\Facades\Term;
+use Statamic\Fields\Value;
+use Statamic\Stache\Query\EntryQueryBuilder;
+use Statamic\Taxonomies\AugmentedTerm;
+use Tests\Data\AugmentedTestCase;
+
+class AugmentedTermTest extends AugmentedTestCase
+{
+    /** @test */
+    function it_gets_values()
+    {
+        Carbon::setTestNow('2020-04-15 13:00:00');
+
+        $blueprint = Blueprint::makeFromFields([
+            'two' => ['type' => 'text'],
+            'unused_in_bp' => ['type' => 'text']
+        ]);
+        Blueprint::shouldReceive('find')->with('test')->andReturn($blueprint);
+
+        $taxonomy = tap(Taxonomy::make('test'))->save();
+
+        $term = Term::make()
+            ->taxonomy('test')
+            ->blueprint('test')
+            ->in('en')
+            ->slug('term-slug')
+            ->data([
+                'one' => 'the "one" value on the term',
+                'two' => 'the "two" value on the term and in the blueprint',
+            ]);
+
+        $augmented = new AugmentedTerm($term);
+
+        $expectations = [
+            'id'            => ['type' => 'string', 'value' => 'test::term-slug'],
+            'slug'          => ['type' => Value::class, 'value' => 'term-slug'],
+            'title'         => ['type' => Value::class, 'value' => 'term-slug'],
+            'uri'           => ['type' => 'string', 'value' => '/test/term-slug'],
+            'url'           => ['type' => 'string', 'value' => '/test/term-slug'],
+            'edit_url'      => ['type' => 'string', 'value' => 'http://localhost/cp/taxonomies/test/terms/term-slug/en'],
+            'permalink'     => ['type' => 'string', 'value' => 'http://localhost/test/term-slug'],
+            'api_url'       => ['type' => 'string', 'value' => 'http://localhost/api/taxonomies/test/terms/term-slug'],
+            'is_term'       => ['type' => 'bool', 'value' => true],
+            'taxonomy'      => ['type' => TaxonomyContract::class, 'value' => $taxonomy],
+            'entries_count' => ['type' => 'int', 'value' => 0],
+            'entries'       => ['type' => EntryQueryBuilder::class],
+            'one'           => ['type' => 'string', 'value' => 'the "one" value on the term'],
+            'two'           => ['type' => Value::class, 'value' => 'the "two" value on the term and in the blueprint'],
+            'unused_in_bp'  => ['type' => Value::class, 'value' => null],
+        ];
+
+        $this->assertAugmentedCorrectly($expectations, $augmented);
+    }
+}


### PR DESCRIPTION
- AugmentedEntry's keys method now uses values() instead of data(), which lets origin entry values and injected collection values be used. Closes #1517, Closes #1678
- Data is retrieved using the value method if it exists, by default.
- Blueprint fields no longer get merged in by default. The keys method should it do it manually.
- keys method is public
- Removed augmentableKeys method
- Added fields to term
- Sorted fields for no important reason, other than its easier to scan.
- More test coverage
- Tidy up code

