### PR TITLE
Range Tag

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -133,6 +133,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Tags\Partial::class,
         Tags\Path::class,
         Tags\Query::class,
+        Tags\Range::class,
         Tags\Redirect::class,
         Tags\Relate::class,
         Tags\Rotate::class,

--- a/src/Tags/Range.php
+++ b/src/Tags/Range.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Statamic\Tags;
+
+use Statamic\Tags\Tags;
+
+class Range extends Tags
+{
+    public function index()
+    {
+        $from   = $this->getInt('from', 1);
+        $to     = $this->getInt('to', null);
+        $times  = $this->getInt('times', null);
+        $vars = [];
+
+        if ($times) {
+            $to = $times;
+        }
+
+        foreach(range($from, $to) as $i) {
+            $vars[] = [
+                'value' => $i,
+            ];
+        }
+
+        return $this->parseLoop($vars);
+    }
+}

--- a/src/Tags/Range.php
+++ b/src/Tags/Range.php
@@ -6,6 +6,8 @@ use Statamic\Tags\Tags;
 
 class Range extends Tags
 {
+    protected static $aliases = ['loop'];
+
     public function index()
     {
         $from   = $this->params->int('from', 1);

--- a/src/Tags/Range.php
+++ b/src/Tags/Range.php
@@ -9,13 +9,8 @@ class Range extends Tags
     public function index()
     {
         $from   = $this->params->int('from', 1);
-        $to     = $this->params->int('to', null);
-        $times  = $this->params->int('times', null);
+        $to     = $this->params->int(['to', 'times']);
         $vars = [];
-
-        if ($times) {
-            $to = $times;
-        }
 
         foreach(range($from, $to) as $i) {
             $vars[] = [

--- a/src/Tags/Range.php
+++ b/src/Tags/Range.php
@@ -8,9 +8,9 @@ class Range extends Tags
 {
     public function index()
     {
-        $from   = $this->getInt('from', 1);
-        $to     = $this->getInt('to', null);
-        $times  = $this->getInt('times', null);
+        $from   = $this->params->int('from', 1);
+        $to     = $this->params->int('to', null);
+        $times  = $this->params->int('times', null);
         $vars = [];
 
         if ($times) {
@@ -23,6 +23,6 @@ class Range extends Tags
             ];
         }
 
-        return $this->parseLoop($vars);
+        return $vars;
     }
 }


### PR DESCRIPTION
Out of my discussion in [`statamic/ideas`](https://github.com/statamic/ideas/issues/147), I've built out the range tag.

Like @jasonvarga suggested, I've changed the way it works a little to using PHP's `range` function.

The usage of the tag is the same as the issue, just instead of `loop` it's `range`, see below.

```
<select name="quantity">
   {{ range from='1' :to='max_quantity' }}
      <option value="{{ value }}">{{ value }}</option>
   {{ /range }}
</select>
```