### PR TITLE
Remove reference to SaveCreatedId listener

### DIFF
--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -7,9 +7,6 @@ use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvi
 class EventServiceProvider extends ServiceProvider
 {
     protected $listen = [
-        \Statamic\Events\DataIdCreated::class => [
-            \Statamic\Stache\Listeners\SaveCreatedId::class
-        ],
         'Form.submission.created' => [
             \Statamic\Forms\Listeners\SendEmails::class
         ],


### PR DESCRIPTION
The `\Statamic\Stache\Listeners\SaveCreatedId` class no longer exists in the Statamic codebase, so there should be no need to point to the listener.

(Originally noticed this because [lorisleiva/laravel-actions](https://github.com/lorisleiva/laravel-actions) tried reading the class and it doesn't exist so was throwing an error)