### PR TITLE
Fieldsets use Blueprint syntax

### DIFF
--- a/resources/js/components/blueprints/Fields.vue
+++ b/resources/js/components/blueprints/Fields.vue
@@ -24,7 +24,9 @@
 
         <div class="blueprint-section-field-actions flex mt-1 -mx-sm">
             <div class="px-sm">
-                <link-fields @linked="$emit('field-linked', $event)" />
+                <link-fields
+                    :exclude-fieldset="excludeFieldset"
+                    @linked="$emit('field-linked', $event)" />
             </div>
             <div class="px-sm">
                 <button class="btn w-full flex justify-center items-center" @click="isSelectingNewFieldtype = true;">
@@ -84,6 +86,7 @@ export default {
         editingField: {},
         isSectionExpanded: Boolean,
         suggestableConditionFields: Array,
+        excludeFieldset: String,
     },
 
     data() {

--- a/resources/js/components/blueprints/LinkFields.vue
+++ b/resources/js/components/blueprints/LinkFields.vue
@@ -88,6 +88,10 @@ import uniqid from 'uniqid';
 
 export default {
 
+    props: {
+        excludeFieldset: String
+    },
+
     data() {
         let fields = this.$config.get('fieldsetFields');
         let fieldsets = this.$config.get('fieldsets');
@@ -97,14 +101,18 @@ export default {
             reference: null,
             fieldset: null,
             importPrefix: null,
-            fieldSuggestions: Object.values(fields).map(field => {
+            fieldSuggestions: Object.values(fields).filter(field => {
+                return field.fieldset.handle != this.excludeFieldset;
+            }).map(field => {
                 return {
                     value: `${field.fieldset.handle}.${field.handle}`,
                     label: field.display,
                     fieldset: fieldsets[field.fieldset.handle].title
                 };
             }),
-            fieldsetSuggestions: Object.values(fieldsets).map(fieldset => {
+            fieldsetSuggestions: Object.values(fieldsets).filter(fieldset => {
+                return fieldset.handle != this.excludeFieldset;
+            }).map(fieldset => {
                 return {
                     value: fieldset.handle,
                     label: fieldset.title,

--- a/resources/js/components/fieldsets/EditForm.vue
+++ b/resources/js/components/fieldsets/EditForm.vue
@@ -23,7 +23,11 @@
 
         </div>
 
-        <div class="card">
+        <div class="content mt-5 mb-2">
+            <h2 v-text="__('Fields')" />
+        </div>
+
+        <div class="card" :class="{ 'pt-1': !fields.length }">
             <fields
                 :fields="fieldset.fields"
                 :editing-field="editingField"

--- a/resources/js/components/fieldsets/EditForm.vue
+++ b/resources/js/components/fieldsets/EditForm.vue
@@ -32,6 +32,7 @@
                 :fields="fieldset.fields"
                 :editing-field="editingField"
                 :exclude-fieldset="fieldset.handle"
+                :is-section-expanded="true"
                 @field-created="fieldCreated"
                 @field-updated="fieldUpdated"
                 @field-linked="fieldLinked"

--- a/resources/js/components/fieldsets/EditForm.vue
+++ b/resources/js/components/fieldsets/EditForm.vue
@@ -27,6 +27,7 @@
             <fields
                 :fields="fieldset.fields"
                 :editing-field="editingField"
+                :exclude-fieldset="fieldset.handle"
                 @field-created="fieldCreated"
                 @field-updated="fieldUpdated"
                 @field-linked="fieldLinked"

--- a/resources/views/fieldsets/edit.blade.php
+++ b/resources/views/fieldsets/edit.blade.php
@@ -6,10 +6,7 @@
     <fieldset-edit-form
         action="{{ cp_route('fieldsets.update', $fieldset->handle()) }}"
         breadcrumb-url="{{ cp_route('fieldsets.index') }}"
-        :initial-fieldset="{{ json_encode([
-            'title' => $fieldset->title(),
-            'fields' => $fieldset->fields()->all()->values()
-        ]) }}"
+        :initial-fieldset="{{ json_encode($fieldsetVueObject) }}"
     ></fieldset-edit-form>
 
 @endsection

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -44,11 +44,7 @@ class Fieldset
     {
         $fields = array_get($this->contents, 'fields', []);
 
-        $fields = collect($fields)->map(function ($field, $handle) {
-            return compact('handle', 'field');
-        })->values();
-
-        return new Fields($fields->all());
+        return new Fields($fields);
     }
 
     public function field(string $handle): ?Field

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -25,6 +25,17 @@ class Fieldset
 
     public function setContents(array $contents)
     {
+        $fields = array_get($contents, 'fields', []);
+
+        // Support legacy syntax
+        if (! empty($fields) && array_keys($fields)[0] !== 0) {
+            $fields = collect($fields)->map(function ($field, $handle) {
+                return compact('handle', 'field');
+            })->values()->all();
+        }
+
+        $contents['fields'] = $fields;
+
         $this->contents = $contents;
 
         return $this;

--- a/src/Http/Controllers/CP/Fields/FieldsetController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsetController.php
@@ -43,6 +43,7 @@ class FieldsetController extends CpController
 
         $vue = [
             'title' => $fieldset->title(),
+            'handle' => $fieldset->handle(),
             'fields' => collect(Arr::get($fieldset->contents(), 'fields'))->map(function ($field, $i) {
                 return array_merge(FieldTransformer::toVue($field), ['_id' => $i]);
             })->all()

--- a/src/Http/Controllers/CP/Fields/FieldsetController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsetController.php
@@ -118,13 +118,14 @@ class FieldsetController extends CpController
 
     private function save(Fieldset $fieldset, Request $request)
     {
-        $fields = collect($request->fields)->mapWithKeys(function ($field) {
+        $fields = collect($request->fields)->map(function ($field) {
             $field = Arr::removeNullValues($field);
             $field = Arr::except($field, ['_id', 'isNew']);
             if (Arr::get($field, 'width') === 100) {
                 unset($field['width']);
             }
-            return [Arr::pull($field, 'handle') => $field];
+            $handle = Arr::pull($field, 'handle');
+            return compact('handle', 'field');
         })->all();
 
         $fieldset->setContents([

--- a/src/Http/Controllers/CP/Fields/FieldsetController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsetController.php
@@ -43,7 +43,7 @@ class FieldsetController extends CpController
 
         $vue = [
             'title' => $fieldset->title(),
-            'fields' => collect($fieldset->contents()['fields'])->map(function ($field, $i) {
+            'fields' => collect(Arr::get($fieldset->contents(), 'fields'))->map(function ($field, $i) {
                 return array_merge(FieldTransformer::toVue($field), ['_id' => $i]);
             })->all()
         ];

--- a/src/Http/Controllers/CP/Fields/FieldsetController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsetController.php
@@ -2,12 +2,13 @@
 
 namespace Statamic\Http\Controllers\CP\Fields;
 
+use Illuminate\Http\Request;
 use Statamic\Facades;
+use Statamic\Fields\Fieldset;
+use Statamic\Fields\FieldTransformer;
+use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
-use Illuminate\Http\Request;
-use Statamic\Fields\Fieldset;
-use Statamic\Http\Controllers\CP\CpController;
 
 class FieldsetController extends CpController
 {
@@ -40,7 +41,17 @@ class FieldsetController extends CpController
     {
         $fieldset = Facades\Fieldset::find($fieldset);
 
-        return view('statamic::fieldsets.edit', compact('fieldset'));
+        $vue = [
+            'title' => $fieldset->title(),
+            'fields' => collect($fieldset->contents()['fields'])->map(function ($field, $i) {
+                return array_merge(FieldTransformer::toVue($field), ['_id' => $i]);
+            })->all()
+        ];
+
+        return view('statamic::fieldsets.edit', [
+            'fieldset' => $fieldset,
+            'fieldsetVueObject' => $vue
+        ]);
     }
 
     public function update(Request $request, $fieldset)
@@ -52,7 +63,12 @@ class FieldsetController extends CpController
             'fields' => 'array',
         ]);
 
-        $this->save($fieldset, $request);
+        $fieldset->setContents([
+            'title' => $request->title,
+            'fields' => collect($request->fields)->map(function ($field) {
+                return FieldTransformer::fromVue($field);
+            })->all()
+        ])->save();
 
         return response('', 204);
     }
@@ -114,23 +130,5 @@ class FieldsetController extends CpController
         ])->save();
 
         return ['success' => true];
-    }
-
-    private function save(Fieldset $fieldset, Request $request)
-    {
-        $fields = collect($request->fields)->map(function ($field) {
-            $field = Arr::removeNullValues($field);
-            $field = Arr::except($field, ['_id', 'isNew']);
-            if (Arr::get($field, 'width') === 100) {
-                unset($field['width']);
-            }
-            $handle = Arr::pull($field, 'handle');
-            return compact('handle', 'field');
-        })->all();
-
-        $fieldset->setContents([
-            'title' => $request->title,
-            'fields' => $fields
-        ])->save();
     }
 }

--- a/tests/Fakes/Fieldtypes/FieldtypeWithPreprocessableConfigField.php
+++ b/tests/Fakes/Fieldtypes/FieldtypeWithPreprocessableConfigField.php
@@ -9,6 +9,8 @@ class FieldtypeWithPreprocessableConfigField extends Fieldtype
 {
     public function getConfigFieldset()
     {
-        return FieldsetFactory::withFields(['test' => ['type' => 'baz']])->create();
+        return FieldsetFactory::withFields([
+            ['handle' => 'test', 'field' => ['type' => 'baz']],
+        ])->create();
     }
 }

--- a/tests/Feature/Fieldsets/UpdateFieldsetTest.php
+++ b/tests/Feature/Fieldsets/UpdateFieldsetTest.php
@@ -145,7 +145,9 @@ class UpdateFieldsetTest extends TestCase
         $this->assertCount(0, Facades\Fieldset::all());
         $fieldset = (new Fieldset)->setHandle('test')->setContents($originalContents = [
             'title' => 'Test',
-            'fields' => ['foo' => 'bar']
+            'fields' => [
+                ['handle' => 'foo', 'field' => 'bar']
+            ]
         ])->save();
 
         $this

--- a/tests/Feature/Fieldsets/UpdateFieldsetTest.php
+++ b/tests/Feature/Fieldsets/UpdateFieldsetTest.php
@@ -55,23 +55,25 @@ class UpdateFieldsetTest extends TestCase
                 'title' => 'Updated title',
                 'fields' => [
                     [
-                        '_id' => 'id-one',
-                        'handle' => 'one',
-                        'type' => 'textarea',
-                        'display' => 'First Field',
-                        'instructions' => 'First field instructions',
-                        'foo' => 'bar',
-                        'width' => 50,
+                        '_id' => 'id-s1-f1',
+                        'handle' => 'one-one',
+                        'type' => 'reference',
+                        'field_reference' => 'somefieldset.somefield',
+                        'config' => [
+                            'foo' => 'bar',
+                            'baz' => 'qux', // not in config_overrides so it shouldn't get saved
+                        ],
+                        'config_overrides' => ['foo']
                     ],
                     [
-                        '_id' => 'id-two',
-                        'handle' => 'two',
-                        'type' => 'text',
-                        'display' => 'Second Field',
-                        'instructions' => 'Second field instructions',
-                        'baz' => 'qux',
-                        'width' => 100,
-                    ],
+                        '_id' => 'id-s1-f1',
+                        'handle' => 'one-two',
+                        'type' => 'inline',
+                        'config' => [
+                            'type' => 'text',
+                            'foo' => 'bar',
+                        ]
+                    ]
                 ]
             ])
             ->assertStatus(204);
@@ -80,22 +82,17 @@ class UpdateFieldsetTest extends TestCase
             'title' => 'Updated title',
             'fields' => [
                 [
-                    'handle' => 'one',
-                    'field' => [
-                        'type' => 'textarea',
-                        'display' => 'First Field',
-                        'instructions' => 'First field instructions',
+                    'handle' => 'one-one',
+                    'field' => 'somefieldset.somefield',
+                    'config' => [
                         'foo' => 'bar',
-                        'width' => 50,
-                    ],
+                    ]
                 ],
                 [
-                    'handle' => 'two',
+                    'handle' => 'one-two',
                     'field' => [
                         'type' => 'text',
-                        'display' => 'Second Field',
-                        'instructions' => 'Second field instructions',
-                        'baz' => 'qux'
+                        'foo' => 'bar',
                     ]
                 ]
             ]

--- a/tests/Feature/Fieldsets/UpdateFieldsetTest.php
+++ b/tests/Feature/Fieldsets/UpdateFieldsetTest.php
@@ -79,18 +79,24 @@ class UpdateFieldsetTest extends TestCase
         $this->assertEquals([
             'title' => 'Updated title',
             'fields' => [
-                'one' => [
-                    'type' => 'textarea',
-                    'display' => 'First Field',
-                    'instructions' => 'First field instructions',
-                    'foo' => 'bar',
-                    'width' => 50,
+                [
+                    'handle' => 'one',
+                    'field' => [
+                        'type' => 'textarea',
+                        'display' => 'First Field',
+                        'instructions' => 'First field instructions',
+                        'foo' => 'bar',
+                        'width' => 50,
+                    ],
                 ],
-                'two' => [
-                    'type' => 'text',
-                    'display' => 'Second Field',
-                    'instructions' => 'Second field instructions',
-                    'baz' => 'qux'
+                [
+                    'handle' => 'two',
+                    'field' => [
+                        'type' => 'text',
+                        'display' => 'Second Field',
+                        'instructions' => 'Second field instructions',
+                        'baz' => 'qux'
+                    ]
                 ]
             ]
         ], Facades\Fieldset::find('test')->contents());
@@ -120,7 +126,9 @@ class UpdateFieldsetTest extends TestCase
         $this->assertCount(0, Facades\Fieldset::all());
         $fieldset = (new Fieldset)->setHandle('test')->setContents($originalContents = [
             'title' => 'Test',
-            'fields' => ['foo' => 'bar']
+            'fields' => [
+                ['handle' => 'foo', 'field' => ['type' => 'bar']]
+            ]
         ])->save();
 
         $this

--- a/tests/Fields/BlueprintRepositoryTest.php
+++ b/tests/Fields/BlueprintRepositoryTest.php
@@ -168,7 +168,7 @@ EOT;
         File::shouldReceive('makeDirectory')->with('/path/to/resources/blueprints')->once();
         File::shouldReceive('put')->with('/path/to/resources/blueprints/the_test_blueprint.yaml', $expectedYaml)->once();
 
-        $fieldset = (new Blueprint)->setHandle('the_test_blueprint')->setContents([
+        $blueprint = (new Blueprint)->setHandle('the_test_blueprint')->setContents([
             'title' => 'Test Blueprint',
             'sections' => [
                 'one' => [
@@ -195,6 +195,6 @@ EOT;
             ]
         ]);
 
-        $this->repo->save($fieldset);
+        $this->repo->save($blueprint);
     }
 }

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -127,7 +127,10 @@ class BlueprintTest extends TestCase
             ->andReturn((new Fieldset)->setHandle('partial')->setContents([
                 'title' => 'Partial',
                 'fields' => [
-                    'three' => ['type' => 'text'],
+                    [
+                        'handle' => 'three',
+                        'field' => ['type' => 'text'],
+                    ],
                 ],
             ]));
 
@@ -367,7 +370,10 @@ class BlueprintTest extends TestCase
             ->andReturn((new Fieldset)->setHandle('partial')->setContents([
                 'title' => 'Partial',
                 'fields' => [
-                    'three' => ['type' => 'text'],
+                    [
+                        'handle' => 'three',
+                        'field' => ['type' => 'text'],
+                    ],
                 ],
             ]));
 

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -41,7 +41,9 @@ class BlueprintTest extends TestCase
         $contents = [
             'sections' => [
                 'main' => [
-                    'fields' => ['one' => ['type' => 'text']]
+                    'fields' => [
+                        ['handle' => 'one', 'field' => ['type' => 'text']]
+                    ]
                 ]
             ]
         ];

--- a/tests/Fields/FieldRepositoryTest.php
+++ b/tests/Fields/FieldRepositoryTest.php
@@ -21,7 +21,10 @@ class FieldRepositoryTest extends TestCase
             return (new Fieldset)->setHandle('test')->setContents([
                 'title' => 'Test',
                 'fields' => [
-                    'one' => ['type' => 'textarea', 'display' => 'First Field'],
+                    [
+                        'handle' => 'one',
+                        'field' => ['type' => 'textarea', 'display' => 'First Field'],
+                    ]
                 ]
             ]);
         });

--- a/tests/Fields/FieldsTest.php
+++ b/tests/Fields/FieldsTest.php
@@ -41,8 +41,8 @@ class FieldsTest extends TestCase
             ->with('fieldset_three')
             ->andReturnUsing(function () {
                 return (new Fieldset)->setHandle('fieldset_three')->setContents(['fields' => [
-                    'foo' => ['type' => 'textarea'],
-                    'bar' => ['type' => 'text'],
+                    ['handle' => 'foo', 'field' => ['type' => 'textarea']],
+                    ['handle' => 'bar', 'field' => ['type' => 'text']],
                 ]]);
             });
 
@@ -156,12 +156,14 @@ class FieldsTest extends TestCase
     {
         $fieldset = (new Fieldset)->setHandle('partial')->setContents([
             'fields' => [
-                'one' => [
-                    'type' => 'text'
+                [
+                    'handle' => 'one',
+                    'field' => ['type' => 'text'],
                 ],
-                'two' => [
-                    'type' => 'textarea'
-                ]
+                [
+                    'handle' => 'two',
+                    'field' => ['type' => 'textarea'],
+                ],
             ]
         ]);
 
@@ -182,12 +184,14 @@ class FieldsTest extends TestCase
     {
         $fieldset = (new Fieldset)->setHandle('partial')->setContents([
             'fields' => [
-                'one' => [
-                    'type' => 'text'
+                [
+                    'handle' => 'one',
+                    'field' => ['type' => 'text'],
                 ],
-                'two' => [
-                    'type' => 'textarea'
-                ]
+                [
+                    'handle' => 'two',
+                    'field' => ['type' => 'textarea']
+                ],
             ]
         ]);
 

--- a/tests/Fields/FieldsetRepositoryTest.php
+++ b/tests/Fields/FieldsetRepositoryTest.php
@@ -28,12 +28,16 @@ class FieldsetRepositoryTest extends TestCase
         $contents = <<<'EOT'
 title: Test Fieldset
 fields:
-  one:
-    type: text
-    display: First Field
-  two:
-    type: text
-    display: Second Field
+  -
+    handle: one
+    field:
+      type: text
+      display: First Field
+  -
+    handle: two
+    field:
+      type: text
+      display: Second Field
 EOT;
         File::shouldReceive('exists')->with('/path/to/resources/fieldsets/test.yaml')->once()->andReturnTrue();
         File::shouldReceive('get')->with('/path/to/resources/fieldsets/test.yaml')->once()->andReturn($contents);
@@ -148,9 +152,11 @@ EOT;
         $expectedYaml = <<<'EOT'
 title: 'Test Fieldset'
 fields:
-  foo:
-    type: textarea
-    bar: baz
+  -
+    handle: foo
+    field:
+      type: textarea
+      bar: baz
 
 EOT;
         File::shouldReceive('exists')->with('/path/to/resources/fieldsets')->once()->andReturnFalse();
@@ -160,7 +166,10 @@ EOT;
         $fieldset = (new Fieldset)->setHandle('the_test_fieldset')->setContents([
             'title' => 'Test Fieldset',
             'fields' => [
-                'foo' => ['type' => 'textarea', 'bar' => 'baz']
+                [
+                    'handle' => 'foo',
+                    'field' => ['type' => 'textarea', 'bar' => 'baz']
+                ],
             ]
         ]);
 

--- a/tests/Fields/FieldsetTest.php
+++ b/tests/Fields/FieldsetTest.php
@@ -30,7 +30,9 @@ class FieldsetTest extends TestCase
         $this->assertEquals([], $fieldset->contents());
 
         $contents = [
-            'fields' => ['one' => ['type' => 'text']]
+            'fields' => [
+                ['handle' => 'one', 'field' => ['type' => 'text']]
+            ],
         ];
 
         $return = $fieldset->setContents($contents);
@@ -64,11 +66,13 @@ class FieldsetTest extends TestCase
 
         $fieldset->setContents([
             'fields' => [
-                'one' => [
-                    'type' => 'text'
+                [
+                    'handle' => 'one',
+                    'field' => ['type' => 'text'],
                 ],
-                'two' => [
-                    'type' => 'textarea'
+                [
+                    'handle' => 'two',
+                    'field' => ['type' => 'textarea'],
                 ]
             ]
         ]);
@@ -88,9 +92,12 @@ class FieldsetTest extends TestCase
 
         $fieldset->setContents([
             'fields' => [
-                'one' => [
-                    'type' => 'textarea',
-                    'display' => 'First field'
+                [
+                    'handle' => 'one',
+                    'field' => [
+                        'type' => 'textarea',
+                        'display' => 'First field'
+                    ],
                 ]
             ]
         ]);

--- a/tests/Fields/FieldsetTest.php
+++ b/tests/Fields/FieldsetTest.php
@@ -86,6 +86,30 @@ class FieldsetTest extends TestCase
     }
 
     /** @test */
+    function it_gets_fields_using_legacy_syntax()
+    {
+        $fieldset = new Fieldset;
+
+        $fieldset->setContents([
+            'fields' => [
+                'one' => [
+                    'type' => 'text',
+                ],
+                'two' => [
+                    'type' => 'textarea',
+                ]
+            ]
+        ]);
+
+        $fields = $fieldset->fields();
+
+        $this->assertInstanceOf(Fields::class, $fields);
+        $this->assertEveryItemIsInstanceOf(Field::class, $fields = $fields->all());
+        $this->assertEquals(['one', 'two'], $fields->map->handle()->values()->all());
+        $this->assertEquals(['text', 'textarea'], $fields->map->type()->values()->all());
+    }
+
+    /** @test */
     function gets_a_single_field()
     {
         $fieldset = new Fieldset;

--- a/tests/Fields/FieldsetTest.php
+++ b/tests/Fields/FieldsetTest.php
@@ -30,11 +30,7 @@ class FieldsetTest extends TestCase
         $this->assertEquals([], $fieldset->contents());
 
         $contents = [
-            'sections' => [
-                'main' => [
-                    'fields' => ['one' => ['type' => 'text']]
-                ]
-            ]
+            'fields' => ['one' => ['type' => 'text']]
         ];
 
         $return = $fieldset->setContents($contents);

--- a/tests/Fieldtypes/NestedFieldsTest.php
+++ b/tests/Fieldtypes/NestedFieldsTest.php
@@ -84,7 +84,7 @@ class NestedFieldsTest extends TestCase
     function it_preprocesses_from_blueprint_format_to_vue()
     {
         $testFieldset = Fieldset::make('test')->setContents(['fields' => [
-            'bar' => ['type' => 'text']
+            ['handle' => 'bar', 'field' => ['type' => 'text']]
         ]]);
         Fieldset::shouldReceive('all')->andReturn(collect([$testFieldset]));
 


### PR DESCRIPTION
In order to support importing fieldsets into fieldsets, the fieldset syntax needs to use the same one as blueprints do.

ie. Instead of this:

```
fields:
  myfield:
    type: text
```

It should be

```
fields:
  -
    handle: myfield
    field:
      type: text
```

Then we're able to use the `import` syntax just like Blueprints.

- [x] Code changes
- [x] UI/UX changes
- [ ] Handle circular references (fieldset importing itself, etc)

Closes statamic/ideas#130