### PR TITLE
Site URLs shouldn't have trailing slashes

### DIFF
--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -38,16 +38,22 @@ class Site
 
     public function url()
     {
-        return Str::ensureRight($this->config['url'], '/');
+        $url = $this->config['url'];
+
+        if ($url === '/') {
+            return '/';
+        }
+
+        return Str::removeRight($url, '/');
     }
 
     public function absoluteUrl()
     {
         if (Str::startsWith($url = $this->url(), '/')) {
-            return Str::ensureLeft($url, request()->getSchemeAndHttpHost());
+            $url = Str::ensureLeft($url, request()->getSchemeAndHttpHost());
         }
 
-        return $url;
+        return Str::removeRight($url, '/');
     }
 
     public function relativePath($url)

--- a/tests/Facades/ConfigTest.php
+++ b/tests/Facades/ConfigTest.php
@@ -135,10 +135,10 @@ class ConfigTest extends TestCase
     {
         $this->fakeSiteConfig();
 
-        $this->assertEquals('http://test.com/', Config::getSiteUrl());
-        $this->assertEquals('http://test.com/', Config::getSiteUrl('en'));
-        $this->assertEquals('http://fr.test.com/', Config::getSiteUrl('fr'));
-        $this->assertEquals('http://test.com/de/', Config::getSiteUrl('de'));
+        $this->assertEquals('http://test.com', Config::getSiteUrl());
+        $this->assertEquals('http://test.com', Config::getSiteUrl('en'));
+        $this->assertEquals('http://fr.test.com', Config::getSiteUrl('fr'));
+        $this->assertEquals('http://test.com/de', Config::getSiteUrl('de'));
     }
 
     /** @test */

--- a/tests/Sites/SiteTest.php
+++ b/tests/Sites/SiteTest.php
@@ -64,6 +64,30 @@ class SiteTest extends TestCase
     }
 
     /** @test */
+    function gets_url_given_a_relative_url()
+    {
+        $site = new Site('en', ['url' => '/']);
+
+        $this->assertEquals('/', $site->url());
+    }
+
+    /** @test */
+    function gets_url_given_a_relative_url_and_subdirectory()
+    {
+        $site = new Site('en', ['url' => '/sub']);
+
+        $this->assertEquals('/sub', $site->url());
+    }
+
+    /** @test */
+    function gets_url_given_a_relative_url_and_subdirectory_with_trailing_slash()
+    {
+        $site = new Site('en', ['url' => '/sub/']);
+
+        $this->assertEquals('/sub', $site->url());
+    }
+
+    /** @test */
     function gets_absolute_url()
     {
         $this->assertEquals(

--- a/tests/Sites/SiteTest.php
+++ b/tests/Sites/SiteTest.php
@@ -48,63 +48,63 @@ class SiteTest extends TestCase
     }
 
     /** @test */
-    function gets_url()
+    function gets_url_when_given_a_trailing_slash()
     {
         $site = new Site('en', ['url' => 'http://test.com/']);
 
-        $this->assertEquals('http://test.com/', $site->url());
+        $this->assertEquals('http://test.com', $site->url());
     }
 
     /** @test */
-    function gets_url_without_trailing_slash()
+    function gets_url_when_not_given_a_trailing_slash()
     {
         $site = new Site('en', ['url' => 'http://test.com']);
 
-        $this->assertEquals('http://test.com/', $site->url());
+        $this->assertEquals('http://test.com', $site->url());
     }
 
     /** @test */
     function gets_absolute_url()
     {
         $this->assertEquals(
-            'http://a-defined-absolute-url.com/',
+            'http://a-defined-absolute-url.com',
             (new Site('en', ['url' => 'http://a-defined-absolute-url.com/']))->absoluteUrl()
         );
 
         $this->assertEquals(
-            'http://a-defined-absolute-url.com/',
+            'http://a-defined-absolute-url.com',
             (new Site('en', ['url' => 'http://a-defined-absolute-url.com']))->absoluteUrl()
         );
 
         $this->assertEquals(
-            'http://absolute-url-resolved-from-request.com/',
+            'http://absolute-url-resolved-from-request.com',
             (new Site('en', ['url' => '/']))->absoluteUrl()
         );
 
         $this->assertEquals(
-            'http://absolute-url-resolved-from-request.com/fr/',
+            'http://absolute-url-resolved-from-request.com/fr',
             (new Site('en', ['url' => '/fr/']))->absoluteUrl()
         );
 
         $this->assertEquals(
-            'http://absolute-url-resolved-from-request.com/fr/',
+            'http://absolute-url-resolved-from-request.com/fr',
             (new Site('en', ['url' => '/fr']))->absoluteUrl()
         );
 
         $this->get('/something');
 
         $this->assertEquals(
-            'http://absolute-url-resolved-from-request.com/',
+            'http://absolute-url-resolved-from-request.com',
             (new Site('en', ['url' => '/']))->absoluteUrl()
         );
 
         $this->assertEquals(
-            'http://absolute-url-resolved-from-request.com/fr/',
+            'http://absolute-url-resolved-from-request.com/fr',
             (new Site('en', ['url' => '/fr/']))->absoluteUrl()
         );
 
         $this->assertEquals(
-            'http://absolute-url-resolved-from-request.com/fr/',
+            'http://absolute-url-resolved-from-request.com/fr',
             (new Site('en', ['url' => '/fr']))->absoluteUrl()
         );
     }

--- a/tests/Sites/SitesTest.php
+++ b/tests/Sites/SitesTest.php
@@ -66,7 +66,7 @@ class SitesTest extends TestCase
     {
         $this->sites->setConfig('sites.en.url', 'http://foobar.com/');
 
-        $this->assertEquals('http://foobar.com/', $this->sites->get('en')->url());
+        $this->assertEquals('http://foobar.com', $this->sites->get('en')->url());
     }
 
     /** @test */

--- a/tests/View/CascadeTest.php
+++ b/tests/View/CascadeTest.php
@@ -138,18 +138,18 @@ class CascadeTest extends TestCase
         $cascade = $this->cascade()->withSite(Site::get('en'));
 
         tap($cascade->hydrate()->toArray(), function ($cascade) {
-            $this->assertEquals('http://test.com/', $cascade['homepage']);
+            $this->assertEquals('http://test.com', $cascade['homepage']);
 
             $this->assertEquals('en', $cascade['site']);
             $this->assertEquals('English', $cascade['site_name']);
             $this->assertEquals('en_US', $cascade['site_locale']);
             $this->assertEquals('en', $cascade['site_short_locale']);
-            $this->assertEquals('http://test.com/', $cascade['site_url']);
+            $this->assertEquals('http://test.com', $cascade['site_url']);
 
             $this->assertEquals('en', $cascade['locale']);
             $this->assertEquals('English', $cascade['locale_name']);
             $this->assertEquals('en_US', $cascade['locale_full']);
-            $this->assertEquals('http://test.com/', $cascade['locale_url']);
+            $this->assertEquals('http://test.com', $cascade['locale_url']);
         });
     }
 
@@ -159,18 +159,18 @@ class CascadeTest extends TestCase
         $cascade = $this->cascade()->withSite(Site::get('fr'));
 
         tap($this->cascade()->hydrate()->toArray(), function ($cascade) {
-            $this->assertEquals('http://fr.test.com/', $cascade['homepage']);
+            $this->assertEquals('http://fr.test.com', $cascade['homepage']);
 
             $this->assertEquals('fr', $cascade['site']);
             $this->assertEquals('French', $cascade['site_name']);
             $this->assertEquals('fr_FR', $cascade['site_locale']);
             $this->assertEquals('fr', $cascade['site_short_locale']);
-            $this->assertEquals('http://fr.test.com/', $cascade['site_url']);
+            $this->assertEquals('http://fr.test.com', $cascade['site_url']);
 
             $this->assertEquals('fr', $cascade['locale']);
             $this->assertEquals('French', $cascade['locale_name']);
             $this->assertEquals('fr_FR', $cascade['locale_full']);
-            $this->assertEquals('http://fr.test.com/', $cascade['locale_url']);
+            $this->assertEquals('http://fr.test.com', $cascade['locale_url']);
         });
     }
 
@@ -180,18 +180,18 @@ class CascadeTest extends TestCase
         $cascade = $this->cascade()->withSite(Site::get('de'));
 
         tap($this->cascade()->hydrate()->toArray(), function ($cascade) {
-            $this->assertEquals('http://test.com/de/', $cascade['homepage']);
+            $this->assertEquals('http://test.com/de', $cascade['homepage']);
 
             $this->assertEquals('de', $cascade['site']);
             $this->assertEquals('German', $cascade['site_name']);
             $this->assertEquals('de_DE', $cascade['site_locale']);
             $this->assertEquals('de', $cascade['site_short_locale']);
-            $this->assertEquals('http://test.com/de/', $cascade['site_url']);
+            $this->assertEquals('http://test.com/de', $cascade['site_url']);
 
             $this->assertEquals('de', $cascade['locale']);
             $this->assertEquals('German', $cascade['locale_name']);
             $this->assertEquals('de_DE', $cascade['locale_full']);
-            $this->assertEquals('http://test.com/de/', $cascade['locale_url']);
+            $this->assertEquals('http://test.com/de', $cascade['locale_url']);
         });
     }
 


### PR DESCRIPTION
Things like `{{ site_url }}` would force a trailing slash. Sometimes unnecessary, usually ugly.

Now it doesn't. If your site url ends with a slash, it'll get stripped off.

```php
'sites' => [
    'default' => [
        'url' => 'http://mysite.com/', // becomes 'http://mysite.com'
    ]
]
```

A relative urls and subdirectories still work:
- `/` stays as `/`
- `/subdirectory/` becomes `/subdirectory`