### PR TITLE
Fix deadlock in ThumbnailController::generate

### DIFF
--- a/src/Http/Controllers/CP/Assets/ThumbnailController.php
+++ b/src/Http/Controllers/CP/Assets/ThumbnailController.php
@@ -95,12 +95,14 @@ class ThumbnailController extends Controller
 
         Cache::put($this->mutex(), true, now()->addMinutes(120));
 
-        $path = $this->generator->generateByAsset(
-            $this->asset,
-            $this->size ? ['p' => $this->getPreset()] : []
-        );
-
-        Cache::forget($this->mutex());
+        try {
+            $path = $this->generator->generateByAsset(
+                $this->asset,
+                $this->size ? ['p' => $this->getPreset()] : []
+            );
+        } finally {
+            Cache::forget($this->mutex());
+        }
 
         return $path;
     }


### PR DESCRIPTION
The `generate()` function in ThumbnailController.php has a potential deadlock which occurs when an exception is thrown before the mutex is released. In this case the mutex will be locked for the next two hours. Subsequent requests to the same thumbnail url will hang in `waitIfProcessing()`. Depending on the php server setup and the configured timeouts this can lead to a situation where these requests pile up and exhaust the available server processes.

This PR adds a finally block to make sure the mutex gets released in case of an error.

Also the cache time of two hours seems a bit high to me. Is there a specific reason for that?