### PR TITLE
fix findByUrl for multisite

### DIFF
--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -3,7 +3,6 @@
 namespace Statamic\Sites;
 
 use Statamic\Support\Str;
-use Statamic\Statamic;
 
 class Sites
 {
@@ -41,7 +40,7 @@ class Sites
         $url = Str::ensureRight($url, '/');
 
         return collect($this->sites)->filter(function ($site) use ($url) {
-            return Str::startsWith($url, $site->absoluteUrl());
+            return Str::startsWith($url, Str::ensureRight($site->absoluteUrl(), '/'));
         })->sortByDesc->url()->first();
     }
 


### PR DESCRIPTION
Before this change entry slugs starting with the same string as a site slug threw a 404 in the default site.

The problem: you make sure that the trailing slash is removed in the method `absoluteUrl()` in `Sites/Site.php`:

```
public function absoluteUrl()
{
    if (Str::startsWith($url = $this->url(), '/')) {
        $url = Str::ensureLeft($url, request()->getSchemeAndHttpHost());
    }

    return Str::removeRight($url, '/');
}
```

But now you check for example if the url `https://mysite.test/english-publications/` starts with the site `https://mysite.test/en` in the method findByUrl, which falsely tells the website that the site `en` is active. I corrected this by making sure that the comparison string always ends with a `/`.

