### PR TITLE
Add versioning param to addon urls

### DIFF
--- a/src/Console/Processes/Composer.php
+++ b/src/Console/Processes/Composer.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Console\Processes;
 
+use Statamic\Facades\Blink;
 use Statamic\Jobs\RunComposer;
 use Illuminate\Support\Facades\Cache;
 
@@ -50,11 +51,12 @@ class Composer extends Process
      */
     public function installedVersion(string $package)
     {
-        $version = collect(json_decode(file_get_contents($this->basePath . 'composer.lock'))->packages)
-            ->keyBy('name')
-            ->get($package)
-            ->version;
-
+        $packages = Blink::once('composer-packages', function() {
+            return collect(json_decode(file_get_contents($this->basePath . 'composer.lock'))->packages)
+                ->keyBy('name');
+        });
+        $version = $packages->get($package)->version;
+        
         return $this->normalizeVersion($version);
     }
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\Gate;
 use Statamic\Exceptions\NotBootedException;
+use Facades\Statamic\Console\Processes\Composer;
 
 abstract class AddonServiceProvider extends ServiceProvider
 {
@@ -288,12 +289,13 @@ abstract class AddonServiceProvider extends ServiceProvider
     {
         $name = $this->getAddon()->id();
         $filename = pathinfo($path, PATHINFO_FILENAME);
+        $version =  Composer::installedVersion($name);
 
         $this->publishes([
             $path => public_path("vendor/{$name}/js/{$filename}.js"),
         ]);
 
-        Statamic::script($name, $filename);
+        Statamic::script($name, $filename, "v={$version}");
     }
 
     public function registerExternalScript(string $url)
@@ -305,12 +307,13 @@ abstract class AddonServiceProvider extends ServiceProvider
     {
         $name = $this->getAddon()->id();
         $filename = pathinfo($path, PATHINFO_FILENAME);
+        $version =  Composer::installedVersion($name);
 
         $this->publishes([
             $path => public_path("vendor/{$name}/css/{$filename}.css"),
         ]);
 
-        Statamic::style($name, $filename);
+        Statamic::style($name, $filename, "v={$version}");
     }
 
     protected function schedule($schedule)

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -37,9 +37,13 @@ class Statamic
         return static::$externalScripts;
     }
 
-    public static function script($name, $path)
+    public static function script($name, $path, $query = '')
     {
-        static::$scripts[$name] = str_finish($path, '.js');
+        $url = str_finish($path, '.js');
+        if ($query) {
+            $url .= '?' . $query;
+        }
+        static::$scripts[$name] = $url;
 
         return new static;
     }
@@ -56,9 +60,13 @@ class Statamic
         return static::$styles;
     }
 
-    public static function style($name, $path)
+    public static function style($name, $path, $query = '')
     {
-        static::$styles[$name] = str_finish($path, '.css');
+        $url = str_finish($path, '.css');
+        if ($query) {
+            $url .= '?' . $query;
+        }
+        static::$styles[$name] = $url;
 
         return new static;
     }


### PR DESCRIPTION
Added versioning to stylesheet and javascript urls from addons. 
Also added support for query strings in `Statamic::style` and `Statamic::script` to allow custom cache busting params.