### PR TITLE
Fix join modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -720,7 +720,10 @@ class CoreModifiers extends Modifier
      */
     public function joinplode($value, $params)
     {
-        $value = array_column($value, 'value');
+        // If the items are passed in as arrays, we just want to get the values
+        if (is_array(array_values($value)[0])) {
+            $value = array_column($value, 'value');
+        }
         
         // Workaround to support pipe characters. If there are multiple params
         // that means a pipe was used. We'll just join them for now.

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -720,6 +720,8 @@ class CoreModifiers extends Modifier
      */
     public function joinplode($value, $params)
     {
+        $value = array_column($value, 'value');
+        
         // Workaround to support pipe characters. If there are multiple params
         // that means a pipe was used. We'll just join them for now.
         if (count($params) > 1) {


### PR DESCRIPTION
Right now the join modifier will return an `Array to String conversion` error when you try and use the `join` modifier on an array created by a select field, like this:

```
project_tag:
  - branding
  - content
```

This is caused as the `$value` being passed into the modifier is two arrays, like so:

![image](https://user-images.githubusercontent.com/19637309/80586392-cc4c1400-8a0c-11ea-8042-1ea733660d53.png)

This pull request will check if what's being passed in to the `$value` is an array, if it is, we'll just get values from inside those arrays instead.

Fixes #1753