### PR TITLE
Use email template from form config

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -9,6 +9,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Statamic\View\View;
 
 class Email extends Mailable
 {
@@ -57,8 +58,19 @@ class Email extends Mailable
 
     protected function addViews()
     {
+        $template = array_get($this->config, 'template');
         $html = array_get($this->config, 'html');
         $text = array_get($this->config, 'text');
+        
+        if ($template) {
+            $view = (new View)
+                ->template($template)
+                ->layout(null)
+                ->with($this->submission->toArray())
+                ->render();
+
+            return $this->html($view);
+        }
 
         if (!$text && !$html) {
             return $this->automagic();

--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -65,7 +65,6 @@ class Email extends Mailable
         if ($template) {
             $view = (new View)
                 ->template($template)
-                ->layout(null)
                 ->with($this->submission->toArray())
                 ->render();
 


### PR DESCRIPTION
This pull request allows for a template to be used when sending form submission emails. [See the documentation on it here](https://statamic.dev/forms#emails).

Before this pull request you could add the `template` key to a form email configuration but it would be left un used.

This pull request gets the template defined inside the config and renders that template with the submission data.

Both Antlers and Blade views get rendered correctly in my testing.