### PR TITLE
Fix html and text email fields being stripped

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -114,7 +114,7 @@ class Form implements FormContract
             ->setter(function ($emails) {
                 return collect($emails)
                     ->map(function ($email) {
-                        return collect($email)->only(['to', 'from', 'reply_to', 'subject', 'template'])->filter()->all();
+                        return collect($email)->only(['to', 'from', 'reply_to', 'subject', 'text', 'html'])->filter()->all();
                     })
                     ->filter()
                     ->all();


### PR DESCRIPTION
When you provided the `html` and `text` fields as part of an email configuration of a form, like below, the `html` and `text` fields never actually got passed into the right place.

```yaml
email:
  -
    to: my@email.com
    subject: 'Contact Form'
    from: mail@email.com
    reply_to: "{{ email }}"
    html: emails.html.contact
    text: emails.text.contact
```

This pull request adds the html and text values to the email form map. I've also removed the `template` one.