### PR TITLE
Fix for wrong time format at forms. Closes #1706

### DIFF
--- a/resources/views/forms/submission.blade.php
+++ b/resources/views/forms/submission.blade.php
@@ -8,7 +8,7 @@
             'url' => cp_route('forms.show', $submission->form->handle()),
             'title' =>  $submission->form->title()
         ])
-        <h1>{{ $submission->date()->format('M j, Y @ h:m') }}</h1>
+        <h1>{{ $submission->date()->format('M j, Y @ h:i') }}</h1>
     </header>
 
     <div class="card" v-pre>

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -333,9 +333,9 @@ class Form implements FormContract
     public function dateFormat()
     {
         // TODO: Should this be a form.yaml config, a config/forms.php config, or a global config?
-        return 'M j, Y @ h:m';
+        return 'M j, Y @ h:i';
 
-        // return $this->formset()->get('date_format', 'M j, Y @ h:m');
+        // return $this->formset()->get('date_format', 'M j, Y @ h:i');
     }
 
     public function sanitize()


### PR DESCRIPTION
`m` is for month and `i` for minutes 
Fix for #1706 issue