### PR TITLE
Remove prefixed locale on multi sites from glide url

### DIFF
--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -162,6 +162,12 @@ class Glide extends Tags
 
             return;
         }
+        
+        // Get current locale
+        $locale = $this->get(['site', 'locale'], Site::current()->handle());
+
+        // Remove locale prefix from URL.
+        $url = preg_replace('%^((?:https?:)?(?://)?[^/]*)/' . $locale . '/%i', '$1/', $url);
 
         $url = ($this->getBool('absolute')) ? URL::makeAbsolute($url) : URL::makeRelative($url);
 


### PR DESCRIPTION
When using a multisite, glide will prefix the current locale. As a result, the images can't be found anymore. 

A workaround has been, to create symlinks or mess with the Nginx config. 

Can't we solve this problem via PHP? Are there cases, where it does make sense to have the locale prefixed to the images?
It would be easy to a config setting inside the assets config file to disable this behavior if someone wants this behavior.

This change would instantly make glide images available on all multisites, without messing with symlinks or config files. 

Obviously this code does need a refactor. Before doing that, I wanted to discuss this and ask if such kind of behavior would be merged at all?