### PR TITLE
Nav tag `depth` variable

### DIFF
--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -42,9 +42,9 @@ class Structure extends Tags
         return $this->toArray($tree);
     }
 
-    public function toArray($tree, $parent = null)
+    public function toArray($tree, $parent = null, $depth = 1)
     {
-        return collect($tree)->map(function ($item) use ($parent) {
+        return collect($tree)->map(function ($item) use ($parent, $depth) {
             $page = $item['page'];
 
             if ($page->reference() && ! $page->referenceExists()) {
@@ -56,11 +56,12 @@ class Structure extends Tags
             }
 
             $data = $page->toAugmentedArray();
-            $children = empty($item['children']) ? [] : $this->toArray($item['children'], $data);
+            $children = empty($item['children']) ? [] : $this->toArray($item['children'], $data, $depth + 1);
 
             return array_merge($data, [
                 'children'    => $children,
                 'parent'      => $parent,
+                'depth'       => $depth,
                 'is_current'  => rtrim(URL::getCurrent(), '/') == rtrim($page->url(), '/'),
                 'is_parent'   => URL::isAncestor($page->uri()),
                 'is_external' => URL::isExternal($page->absoluteUrl()),


### PR DESCRIPTION
Implementing the nav tag's `depth` variable...

![image](https://user-images.githubusercontent.com/5187394/82741755-6315a300-9d23-11ea-9bd7-d7cb495645b9.png)

PR'ing because I'm not sure the implications with and without `root: true`.