### PR TITLE
turn off template inheritence in fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/TemplateFieldtype.vue
+++ b/resources/js/components/fieldtypes/TemplateFieldtype.vue
@@ -16,46 +16,47 @@
 </template>
 
 <script>
-export default {
+    export default {
+        mixins: [Fieldtype],
 
-    mixins: [Fieldtype],
+        data: function() {
+            return {
+                loading: true,
+                options: []
+            };
+        },
 
-    data: function() {
-        return {
-            loading: true,
-            options: []
-        }
-    },
+        mounted() {
+            this.$axios.get(cp_url("api/templates")).then(response => {
+                var templates = response.data;
 
-    mounted() {
-        this.$axios.get(cp_url('api/templates')).then(response => {
+                // Filter out partials
+                if (this.config.hide_partials) {
+                    templates = _.reject(templates, function(template) {
+                        return template.match(/(^_.*|\/_.*|\._.*)/g);
+                    });
+                }
 
-            var templates = response.data;
+                // Set default
+                var options = [];
 
-            // Filter out partials
-            if (this.config.hide_partials) {
-                templates = _.reject(templates, function(template) {
-                    return template.match(/(^_.*|\/_.*|\._.*)/g);
+                if (!this.config.hide_default) {
+                    options.push({
+                        label: __("Inherit (Default)"),
+                        value: null
+                    });
+                }
+
+                _.each(templates, function(template) {
+                    options.push({
+                        label: template,
+                        value: template
+                    });
                 });
-            }
 
-            // Set default
-            var options = [{
-                label: __('Inherit (Default)'),
-                value: null
-            }];
-
-            _.each(templates, function(template) {
-                options.push({
-                    label: template,
-                    value: template
-                });
+                this.options = options;
+                this.loading = false;
             });
-
-            this.options = options;
-            this.loading = false;
-        });
-    }
-
-};
+        }
+    };
 </script>

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -126,6 +126,7 @@ return [
     'template' => [
         'config' => [
             'hide_partials' => 'Partials are rarely intended to be used as templates.',
+            'hide_default' => 'Don\'t inherit the template',
         ],
     ],
     'text' => [

--- a/src/Fieldtypes/Template.php
+++ b/src/Fieldtypes/Template.php
@@ -15,7 +15,14 @@ class Template extends Fieldtype
                 'instructions' => __('statamic::fieldtypes.template.config.hide_partials'),
                 'type' => 'toggle',
                 'default' => true,
-                'width' => 50,
+                'width' => 25,
+            ],
+            'hide_default' => [
+                'display' => __('Hide Default'),
+                'instructions' => __('statamic::fieldtypes.template.config.hide_default'),
+                'type' => 'toggle',
+                'default' => true,
+                'width' => 25,
             ],
         ];
     }


### PR DESCRIPTION
I use the `template` fieldtype so users can choose the email template. There is no template to "inherit" from, so allow that to be turned off.