### PR TITLE
The actual used multisite will be detected correctly. Closes #1874

### DIFF
--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -81,7 +81,8 @@ class Sites
         });
     }
     
-    protected function absoluteUrl($site) {
+    protected function absoluteUrl($site) 
+    {
         return Str::ensureRight($site->absoluteUrl(), '/');
     }
 }

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -81,7 +81,7 @@ class Sites
         });
     }
     
-    protected function absoluteUrl($site) 
+    protected function absoluteUrl($site)
     {
         return Str::ensureRight($site->absoluteUrl(), '/');
     }

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -40,7 +40,7 @@ class Sites
         $url = Str::ensureRight($url, '/');
 
         return collect($this->sites)->filter(function ($site) use ($url) {
-            return Str::startsWith($url, $site->absoluteUrl());
+            return Str::startsWith($url, $this->absoluteUrl($site));
         })->sortByDesc->url()->first();
     }
 
@@ -79,5 +79,9 @@ class Sites
         return collect($config)->map(function ($site, $handle) {
             return new Site($handle, $site);
         });
+    }
+    
+    protected function absoluteUrl($site) {
+        return Str::ensureRight($site->absoluteUrl(), '/');
     }
 }


### PR DESCRIPTION
This PR will patch the following issue:
https://github.com/statamic/cms/issues/1874

The `absoluteUrl()` method form the Site class, will remove the `/` from the absolute url. 
This will lead to the behavior, that a string like
`mypage.com/datenschutz` 
will be detected as a `da` handle from a multisite. 

We want it to check against`mypage.com/da/` but not against  `mypage.com/daANYTHING`

When checking if the url starts with a handle from a multisite, we need to make sure that we add the `/` to the right, like done in the added `absoluteUrl()` methods. 