### PR TITLE
Separate reset password and account activation

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -74,8 +74,8 @@ return [
     */
 
     'passwords' => [
-        'resets' => 'resets',
-        'activations' => 'resets',
+        'resets' => config('auth.defaults.passwords'),
+        'activations' => config('auth.defaults.passwords'),
     ],
 
 ];

--- a/config/users.php
+++ b/config/users.php
@@ -62,4 +62,20 @@ return [
         //
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Password Brokers
+    |--------------------------------------------------------------------------
+    |
+    | When resetting passwords, Statamic uses an appropriate password broker.
+    | Here you may define which broker should be used for each situation.
+    | You may want a longer expiry for user activations, for example.
+    |
+    */
+
+    'passwords' => [
+        'resets' => 'resets',
+        'activations' => 'resets',
+    ],
+
 ];

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -3,11 +3,11 @@
 
 @section('content')
 
-    <h1 class="mb-3 pt-7 text-center text-grey-80">{{ __('Reset Password') }}</h1>
+    <h1 class="mb-3 pt-7 text-center text-grey-80">{{ $title }}</h1>
 
     <div class="card auth-card mx-auto">
 
-        <form method="POST" action="{{ route('statamic.password.reset.action') }}">
+        <form method="POST" action="{{ $action }}">
             @csrf
 
             <input type="hidden" name="token" value="{{ $token }}">
@@ -42,9 +42,7 @@
                 <input id="password-confirm" type="password" class="input-text input-text" name="password_confirmation" required>
             </div>
 
-            <button type="submit" class="btn-primary">
-                {{ __('Reset Password') }}
-            </button>
+            <button type="submit" class="btn-primary">{{ $title }}</button>
 
         </form>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,9 @@ Route::name('statamic.')->group(function () {
             Route::post('password/email', 'ForgotPasswordController@sendResetLinkEmail')->name('password.email');
             Route::get('password/reset/{token}', 'ResetPasswordController@showResetForm')->name('password.reset');
             Route::post('password/reset', 'ResetPasswordController@reset')->name('password.reset.action');
+
+            Route::get('activate/{token}', 'ActivateAccountController@showResetForm')->name('account.activate');
+            Route::post('activate', 'ActivateAccountController@reset')->name('account.activate.action');
         });
 
         Statamic::additionalActionRoutes();

--- a/src/Actions/SendPasswordReset.php
+++ b/src/Actions/SendPasswordReset.php
@@ -35,6 +35,10 @@ class SendPasswordReset extends Action
 
     public function run($users, $values)
     {
-        $users->each->generateTokenAndSendPasswordResetNotification();
+        $users->each(function ($user) {
+            $user->password()
+                ? $user->generateTokenAndSendPasswordResetNotification()
+                : $user->generateTokenAndSendActivateAccountNotification();
+        });
     }
 }

--- a/src/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Auth/Passwords/PasswordBrokerManager.php
@@ -18,6 +18,7 @@ class PasswordBrokerManager extends BaseManager
         return new TokenRepository(
             $this->app['files'],
             $this->app['hash'],
+            $config['table'],
             $key,
             $config['expire'],
             $config['throttle'] ?? 0

--- a/src/Auth/Passwords/PasswordReset.php
+++ b/src/Auth/Passwords/PasswordReset.php
@@ -4,14 +4,21 @@ namespace Statamic\Auth\Passwords;
 
 class PasswordReset
 {
+    const BROKER_RESETS = 'resets';
+    const BROKER_ACTIVATIONS = 'activations';
+
     protected static $url;
     protected static $redirect;
 
-    public static function url($token)
+    public static function url($token, $broker)
     {
+        $route = $broker === self::BROKER_ACTIVATIONS ? 'statamic.account.activate' : 'statamic.password.reset';
+
+        $defaultUrl = route($route, $token);
+
         $url = static::$url
             ? sprintf('%s?token=%s', static::$url, $token)
-            : route('statamic.password.reset', $token);
+            : $defaultUrl;
 
         parse_str(parse_url($url, PHP_URL_QUERY) ?: '', $query);
 

--- a/src/Auth/Passwords/TokenRepository.php
+++ b/src/Auth/Passwords/TokenRepository.php
@@ -17,7 +17,7 @@ class TokenRepository extends DatabaseTokenRepository
     protected $expires;
     protected $path;
 
-    public function __construct(Filesystem $files, HasherContract $hasher, $hashKey, $expires = 60, $throttle = 60)
+    public function __construct(Filesystem $files, HasherContract $hasher, $table, $hashKey, $expires = 60, $throttle = 60)
     {
         $this->files = $files;
         $this->hasher = $hasher;
@@ -25,7 +25,7 @@ class TokenRepository extends DatabaseTokenRepository
         $this->expires = $expires * 60;
         $this->throttle = $throttle;
 
-        $this->path = storage_path('statamic/password_resets.yaml');
+        $this->path = storage_path("statamic/password_resets/$table.yaml");
     }
 
     public function create(CanResetPasswordContract $user)
@@ -92,6 +92,10 @@ class TokenRepository extends DatabaseTokenRepository
 
     protected function putResets($resets)
     {
+        if (! $this->files->isDirectory($dir = dirname($this->path))) {
+            $this->files->makeDirectory($dir);
+        }
+
         $this->files->put($this->path, YAML::dump($resets->all()));
     }
 }

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -182,11 +182,12 @@ abstract class User implements
 
     public function sendPasswordResetNotification($token)
     {
-        $notification = $this->password()
-            ? new PasswordResetNotification($token)
-            : new ActivateAccountNotification($token);
+        $this->notify(new PasswordResetNotification($token));
+    }
 
-        $this->notify($notification);
+    public function sendActivateAccountNotification($token)
+    {
+        $this->notify(new ActivateAccountNotification($token));
     }
 
     public function generateTokenAndSendPasswordResetNotification()
@@ -194,14 +195,23 @@ abstract class User implements
         $this->sendPasswordResetNotification($this->generatePasswordResetToken());
     }
 
-    public function getPasswordResetUrl()
+    public function generateTokenAndSendActivateAccountNotification()
     {
-        return PasswordReset::url($this->generatePasswordResetToken());
+        $this->sendActivateAccountNotification($this->generateActivateAccountToken());
     }
 
     public function generatePasswordResetToken()
     {
-        return Password::broker()->createToken($this);
+        $broker = config('statamic.users.passwords.'.PasswordReset::BROKER_RESETS);
+
+        return Password::broker($broker)->createToken($this);
+    }
+
+    public function generateActivateAccountToken()
+    {
+        $broker = config('statamic.users.passwords.'.PasswordReset::BROKER_ACTIVATIONS);
+
+        return Password::broker($broker)->createToken($this);
     }
 
     public static function __callStatic($method, $parameters)

--- a/src/Http/Controllers/ActivateAccountController.php
+++ b/src/Http/Controllers/ActivateAccountController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Statamic\Http\Controllers;
+
+use Illuminate\Support\Facades\Password;
+use Statamic\Auth\Passwords\PasswordReset;
+
+class ActivateAccountController extends ResetPasswordController
+{
+    protected function resetFormAction()
+    {
+        return route('statamic.account.activate.action');
+    }
+
+    protected function resetFormTitle()
+    {
+        return __('Activate Account');
+    }
+
+    public function broker()
+    {
+        return Password::broker(PasswordReset::BROKER_ACTIVATIONS);
+    }
+}

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\CP\Users;
 
 use Illuminate\Http\Request;
+use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\CP\Column;
 use Statamic\Facades\Blueprint;
@@ -127,12 +128,15 @@ class UsersController extends CpController
         if ($request->invitation['send']) {
             ActivateAccount::subject($request->invitation['subject']);
             ActivateAccount::body($request->invitation['message']);
-            $user->generateTokenAndSendPasswordResetNotification();
+            $user->generateTokenAndSendActivateAccountNotification();
+            $url = null;
+        } else {
+            $url = PasswordReset::url($user->generateActivateAccountToken(), PasswordReset::BROKER_ACTIVATIONS);
         }
 
         return [
             'redirect' => $user->editUrl(),
-            'activationUrl' => $request->invitation['send'] ? null : $user->getPasswordResetUrl(),
+            'activationUrl' => $url,
         ];
     }
 

--- a/src/Http/Controllers/ForgotPasswordController.php
+++ b/src/Http/Controllers/ForgotPasswordController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
 use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Auth\SendsPasswordResetEmails;
 use Statamic\Facades\URL;
@@ -31,5 +32,10 @@ class ForgotPasswordController extends Controller
         }
 
         return $this->traitSendResetLinkEmail($request);
+    }
+
+    public function broker()
+    {
+        return Password::broker(PasswordReset::BROKER_RESETS);
     }
 }

--- a/src/Http/Controllers/ResetPasswordController.php
+++ b/src/Http/Controllers/ResetPasswordController.php
@@ -3,6 +3,8 @@
 namespace Statamic\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
+use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Auth\ResetsPasswords;
 use Statamic\Http\Middleware\RedirectIfAuthenticated;
 
@@ -19,9 +21,22 @@ class ResetPasswordController extends Controller
 
     public function showResetForm(Request $request, $token = null)
     {
-        return view('statamic::auth.passwords.reset')->with(
-            ['token' => $token, 'email' => $request->email]
-        );
+        return view('statamic::auth.passwords.reset')->with([
+            'token' => $token,
+            'email' => $request->email,
+            'action' => $this->resetFormAction(),
+            'title' => $this->resetFormTitle(),
+        ]);
+    }
+
+    protected function resetFormAction()
+    {
+        return route('statamic.password.reset.action');
+    }
+
+    protected function resetFormTitle()
+    {
+        return __('Reset Password');
     }
 
     public function redirectPath()
@@ -37,5 +52,10 @@ class ResetPasswordController extends Controller
         $user->password($password);
 
         $this->traitResetPassword($user, $password);
+    }
+
+    public function broker()
+    {
+        return Password::broker(PasswordReset::BROKER_RESETS);
     }
 }

--- a/src/Notifications/ActivateAccount.php
+++ b/src/Notifications/ActivateAccount.php
@@ -39,7 +39,7 @@ class ActivateAccount extends PasswordReset
         return (new MailMessage)
             ->subject(static::$subject ?? __('statamic::messages.activate_account_notification_subject'))
             ->line(static::$body ?? __('statamic::messages.activate_account_notification_body'))
-            ->action(__('Activate Account'), PasswordResetManager::url($this->token));
+            ->action(__('Activate Account'), PasswordResetManager::url($this->token, PasswordResetManager::BROKER_ACTIVATIONS));
     }
 
     /**

--- a/src/Notifications/PasswordReset.php
+++ b/src/Notifications/PasswordReset.php
@@ -5,7 +5,7 @@ namespace Statamic\Notifications;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
-use Statamic\Auth\Passwords\PasswordReset as PasswordResetUrl;
+use Statamic\Auth\Passwords\PasswordReset as PasswordResetManager;
 
 class PasswordReset extends Notification
 {
@@ -40,7 +40,7 @@ class PasswordReset extends Notification
         return (new MailMessage)
             ->subject(__('statamic::messages.reset_password_notification_subject'))
             ->line(__('statamic::messages.reset_password_notification_body'))
-            ->action(__('Reset Password'), PasswordResetUrl::url($this->token))
+            ->action(__('Reset Password'), PasswordResetManager::url($this->token, PasswordResetManager::BROKER_RESETS))
             ->line(__('statamic::messages.reset_password_notification_no_action'));
     }
 


### PR DESCRIPTION
### Problem

When creating an account for someone else, we send an activation email which is basically just a password reset with different words.

The reset link in there expires after an hour (by default) which is fine, but when creating a new user, it might be too short of a time before they even see the email sitting in their inbox.

### Solution

This PR separates regular password resets from account activations.

Previously when you try to reset a password, it would change the notification based on whether you had a password. Now, we'll send an activation notification when you create a user, and a regular password reset everywhere else.

### Password Brokers

Laravel uses a [password broker](https://github.com/laravel/laravel/blob/master/config/auth.php#L96-L101) to manage password reset tokens. The broker can have an expiration length set.

This PR introduces a config that lets you define which broker to use when it's doing an account activation vs. a regular password reset.

By default it'll be configured to use the same for both, just by looking at the defaults. This should prevent any issues when people install Statamic into an existing Laravel app.

``` php
// config/statamic/users.php

'passwords' => [
    'resets' => config('auth.defaults.passwords'),
    'activations' => config('auth.defaults.passwords'),
],
```

But in our `statamic/statamic` repo, we'll tweak the defaults:

``` php
// config/statamic/users.php

'passwords' => [
    'resets' => 'resets',
    'activations' => 'activations',
],
```
``` php
// config/auth.php

'defaults' => [
    'guard' => 'web',
    'passwords' => 'resets',
],

'passwords' => [
    'resets' => [
        'provider' => 'users',
        'table' => 'password_resets',
        'expire' => 60, // 1 hour
    ],
    'activations' => [
        'provider' => 'users',
        'table' => 'password_activations',
        'expire' => 4320, // 3 days
    ],
],
```

### Password Reset YAML Files

When Statamic notices that it's configured to store users in files, it overrides how password reset tokens are stored. It puts them into a YAML file instead of a database.

This PR will store them in separate files for each broker, named after the `table` in the config.