### PR TITLE
Add missing exclude data to StaticCacheManager::getConfig

### DIFF
--- a/src/StaticCaching/StaticCacheManager.php
+++ b/src/StaticCaching/StaticCacheManager.php
@@ -44,6 +44,7 @@ class StaticCacheManager extends Manager
         }
 
         return array_merge($config, [
+            'exclude' => $this->app['config']['statamic.static_caching.exclude'] ?? [],
             'base_url' => $this->app['request']->root(),
             'locale' => Site::current()->handle(),
         ]);


### PR DESCRIPTION
Fixes #1841

Exclusions for the static caching half measure are currently not working. The bug can be reproduced following the steps in the issue above.

It looks like the config data in StaticCacheManager::getConfig is pulling directly from "statamic.static_caching.strategies.$name", but the AbstractCacher expects an exclude key in the config data, which was not being set. This one-line fix ensures the exclude data is also passed along to the config.