### PR TITLE
Fix false positive return from hasOrigin()

### DIFF
--- a/src/Data/HasOrigin.php
+++ b/src/Data/HasOrigin.php
@@ -36,7 +36,7 @@ trait HasOrigin
 
     public function hasOrigin()
     {
-        return $this->origin !== null;
+        return $this->origin() !== null;
     }
 
     public function isRoot()


### PR DESCRIPTION
After the last two updates I had to change this core file manually to get my multisite website running. The method checks the attribute `$this->origin`, not what comes out of the method `$this->origin()`. In my case this was a problem, because in the method `values()` it actually checks the attribute through `hasOrigin()` (which seemingly is not null) but then uses the method (which is null). The website then breaks with the error `Call to a member function values() on null`.