### PR TITLE
Use filesystem disks instead of paths for glide cache.

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -53,7 +53,7 @@ return [
         */
 
         'cache' => false,
-        'cache_path' => public_path('img'),
+        'cache_disk' => 'manipulation_cache',
 
         /*
         |--------------------------------------------------------------------------

--- a/src/Console/Commands/GlideClear.php
+++ b/src/Console/Commands/GlideClear.php
@@ -36,7 +36,7 @@ class GlideClear extends Command
      */
     public function handle()
     {
-        // Get the glide server cache path.
+        // Get the cache disk.
         $cacheDisk = Storage::disk(Config::get('statamic.assets.image_manipulation.cache_disk'));
 
         // Delete the cached images.

--- a/src/Console/Commands/GlideClear.php
+++ b/src/Console/Commands/GlideClear.php
@@ -2,13 +2,10 @@
 
 namespace Statamic\Console\Commands;
 
-use Facades\Statamic\Imaging\GlideServer;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Statamic\Console\RunsInPlease;
-use Statamic\Facades\File;
-use Statamic\Facades\Folder;
 use Statamic\Facades\Config;
 
 class GlideClear extends Command

--- a/src/Console/Commands/GlideClear.php
+++ b/src/Console/Commands/GlideClear.php
@@ -5,9 +5,11 @@ namespace Statamic\Console\Commands;
 use Facades\Statamic\Imaging\GlideServer;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
 use Statamic\Console\RunsInPlease;
 use Statamic\Facades\File;
 use Statamic\Facades\Folder;
+use Statamic\Facades\Config;
 
 class GlideClear extends Command
 {
@@ -35,15 +37,10 @@ class GlideClear extends Command
     public function handle()
     {
         // Get the glide server cache path.
-        $cachePath = GlideServer::cachePath();
+        $cacheDisk = Storage::disk(Config::get('statamic.assets.image_manipulation.cache_disk'));
 
         // Delete the cached images.
-        collect(Folder::getFilesRecursively($cachePath))->each(function ($path) {
-            File::delete($path);
-        });
-
-        // Clean up subfolders.
-        Folder::deleteEmptySubfolders($cachePath);
+        $cacheDisk->deleteDirectory('http');
 
         // Remove the cached keys so the middleware doesn't try to load a non existent image.
         collect(Cache::get('glide::paths', []))->keys()->each(function ($key) {

--- a/src/Imaging/GlideServer.php
+++ b/src/Imaging/GlideServer.php
@@ -5,6 +5,7 @@ namespace Statamic\Imaging;
 use League\Glide\ServerFactory;
 use Statamic\Facades\Config;
 use Statamic\Facades\Image;
+use Illuminate\Support\Facades\Storage;
 use Statamic\Imaging\ResponseFactory as LaravelResponseFactory;
 
 class GlideServer
@@ -18,7 +19,7 @@ class GlideServer
     {
         return ServerFactory::create([
             'source'   => base_path(), // this gets overriden on the fly by the image generator
-            'cache'    => $this->cachePath(),
+            'cache'    => $this->cacheDisk(),
             'response' => new LaravelResponseFactory(app('request')),
             'driver'   => Config::get('statamic.assets.image_manipulation.driver'),
             'cache_with_file_extensions' => true,
@@ -27,14 +28,14 @@ class GlideServer
     }
 
     /**
-     * Get glide cache path.
+     * Get glide cache.
      *
-     * @return string
+     * @return string|\League\Flysystem\Filesystem
      */
-    public function cachePath()
+    public function cacheDisk()
     {
         return Config::get('statamic.assets.image_manipulation.cache')
-            ? Config::get('statamic.assets.image_manipulation.cache_path')
+            ? Storage::disk(Config::get('statamic.assets.image_manipulation.cache_disk'))->getDriver()
             : storage_path('statamic/glide');
     }
 

--- a/src/Imaging/GlideServer.php
+++ b/src/Imaging/GlideServer.php
@@ -2,10 +2,10 @@
 
 namespace Statamic\Imaging;
 
+use Illuminate\Support\Facades\Storage;
 use League\Glide\ServerFactory;
 use Statamic\Facades\Config;
 use Statamic\Facades\Image;
-use Illuminate\Support\Facades\Storage;
 use Statamic\Imaging\ResponseFactory as LaravelResponseFactory;
 
 class GlideServer

--- a/src/Providers/GlideServiceProvider.php
+++ b/src/Providers/GlideServiceProvider.php
@@ -45,12 +45,11 @@ class GlideServiceProvider extends ServiceProvider
 
     private function getBuilder()
     {
-        $route = Config::get('statamic.assets.image_manipulation.route');
-
         if (Config::get('statamic.assets.image_manipulation.cache')) {
             $route = $this->app->make(\Illuminate\Contracts\Filesystem\Factory::class)
-                          ->disk(Config::get('statamic.assets.image_manipulation.cache_disk'))
-                          ->url('');
+                ->disk(Config::get('statamic.assets.image_manipulation.cache_disk'))
+                ->url('');
+
             return new StaticUrlBuilder($this->app->make(ImageGenerator::class), [
                 'route' => $route,
             ]);
@@ -58,7 +57,7 @@ class GlideServiceProvider extends ServiceProvider
 
         return new GlideUrlBuilder([
             'key' => (Config::get('statamic.assets.image_manipulation.secure')) ? Config::getAppKey() : null,
-            'route' => $route,
+            'route' => Config::get('statamic.assets.image_manipulation.route'),
         ]);
     }
 

--- a/src/Providers/GlideServiceProvider.php
+++ b/src/Providers/GlideServiceProvider.php
@@ -8,7 +8,6 @@ use League\Glide\Server;
 use Statamic\Contracts\Imaging\ImageManipulator;
 use Statamic\Contracts\Imaging\UrlBuilder;
 use Statamic\Facades\Config;
-use Statamic\Facades\URL;
 use Statamic\Imaging\GlideImageManipulator;
 use Statamic\Imaging\GlideUrlBuilder;
 use Statamic\Imaging\ImageGenerator;

--- a/src/Providers/GlideServiceProvider.php
+++ b/src/Providers/GlideServiceProvider.php
@@ -48,8 +48,11 @@ class GlideServiceProvider extends ServiceProvider
         $route = Config::get('statamic.assets.image_manipulation.route');
 
         if (Config::get('statamic.assets.image_manipulation.cache')) {
+            $route = $this->app->make(\Illuminate\Contracts\Filesystem\Factory::class)
+                          ->disk(Config::get('statamic.assets.image_manipulation.cache_disk'))
+                          ->url('');
             return new StaticUrlBuilder($this->app->make(ImageGenerator::class), [
-                'route' => URL::prependSiteUrl($route),
+                'route' => $route,
             ]);
         }
 


### PR DESCRIPTION
Glide already has support for Flysystem Filesystems. Currently, if you use Glide with assets on a filesystem based, for example, on s3 you would again deliver assets from your server and not have the benefits of s3.
This pull request would change it so that instead of a simple path you can now specify a disk for the glide cache to live in.