### PR TITLE
Shallow augmented fields come from the items

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -630,4 +630,9 @@ class Entry implements Contract, Augmentable, Responsable, Localization
     {
         return $this->selectedQueryColumns;
     }
+
+    protected function shallowAugmentedArrayKeys()
+    {
+        return ['id', 'title', 'url', 'permalink', 'api_url'];
+    }
 }

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -127,14 +127,7 @@ class Assets extends Fieldtype
 
     public function shallowAugment($value)
     {
-        $assets = $this->getAssetsForAugmentation($value)->map(function ($asset) {
-            return [
-                'id' => $asset->id(),
-                'url' => $asset->url(),
-                'permalink' => $asset->absoluteUrl(),
-                'api_url' => $asset->apiUrl(),
-            ];
-        });
+        $assets = $this->getAssetsForAugmentation($value)->map->toShallowAugmentedCollection();
 
         return $this->config('max_files') === 1 ? $assets->first() : $assets;
     }

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -178,13 +178,7 @@ class Entries extends Relationship
 
     protected function shallowAugmentValue($value)
     {
-        return [
-            'id' => $value->id(),
-            'title' => $value->value('title'),
-            'url' => $value->url(),
-            'permalink' => $value->absoluteUrl(),
-            'api_url' => $value->apiUrl(),
-        ];
+        return $value->toShallowAugmentedCollection();
     }
 
     public function getSelectionFilters()

--- a/src/Fieldtypes/Taxonomy.php
+++ b/src/Fieldtypes/Taxonomy.php
@@ -37,16 +37,7 @@ class Taxonomy extends Relationship
     {
         $terms = $this->getTermsForAugmentation($value);
 
-        $terms = collect($terms->map(function ($term) {
-            return [
-                'id' => $term->id(),
-                'title' => $term->title(),
-                'slug' => $term->slug(),
-                'url' => $term->url(),
-                'permalink' => $term->absoluteUrl(),
-                'api_url' => $term->apiUrl(),
-            ];
-        }));
+        $terms = collect($terms)->map->toShallowAugmentedCollection();
 
         return $this->config('max_items') === 1 ? $terms->first() : $terms;
     }

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -397,6 +397,11 @@ class LocalizedTerm implements Term, Responsable, Augmentable
         return $this->selectedQueryColumns;
     }
 
+    protected function shallowAugmentedArrayKeys()
+    {
+        return ['id', 'title', 'slug', 'url', 'permalink', 'api_url'];
+    }
+
     public function lastModified()
     {
         return $this->has('updated_at')

--- a/tests/Fieldtypes/AssetsTest.php
+++ b/tests/Fieldtypes/AssetsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Fieldtypes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use Statamic\Contracts\Assets\Asset;
+use Statamic\Data\AugmentedCollection;
 use Statamic\Facades\AssetContainer;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Assets\Assets;
@@ -53,6 +54,7 @@ class AssetsTest extends TestCase
         $augmented = $this->fieldtype()->shallowAugment(['foo/one.txt', 'bar/two.txt', 'unknown.txt']);
 
         $this->assertInstanceOf(Collection::class, $augmented);
+        $this->assertEveryItemIsInstanceOf(AugmentedCollection::class, $augmented);
         $this->assertEquals([
             [
                 'id' => 'test::foo/one.txt',
@@ -66,7 +68,7 @@ class AssetsTest extends TestCase
                 'permalink' => 'http://localhost/assets/bar/two.txt',
                 'api_url' => 'http://localhost/api/assets/test/bar/two.txt',
             ],
-        ], $augmented->all());
+        ], $augmented->toArray());
     }
 
     /** @test */
@@ -74,12 +76,13 @@ class AssetsTest extends TestCase
     {
         $augmented = $this->fieldtype(['max_files' => 1])->shallowAugment(['foo/one.txt']);
 
+        $this->assertInstanceOf(AugmentedCollection::class, $augmented);
         $this->assertEquals([
             'id' => 'test::foo/one.txt',
             'url' => '/assets/foo/one.txt',
             'permalink' => 'http://localhost/assets/foo/one.txt',
             'api_url' => 'http://localhost/api/assets/test/foo/one.txt',
-        ], $augmented);
+        ], $augmented->toArray());
     }
 
     public function fieldtype($config = [])

--- a/tests/Fieldtypes/EntriesTest.php
+++ b/tests/Fieldtypes/EntriesTest.php
@@ -5,6 +5,7 @@ namespace Tests\Fieldtypes;
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Entries\Entry;
+use Statamic\Data\AugmentedCollection;
 use Statamic\Facades;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Entries;
@@ -49,6 +50,7 @@ class EntriesTest extends TestCase
         $augmented = $this->fieldtype()->shallowAugment(['123', '456']);
 
         $this->assertInstanceOf(Collection::class, $augmented);
+        $this->assertEveryItemIsInstanceOf(AugmentedCollection::class, $augmented);
         $this->assertEquals([
             [
                 'id' => '123',
@@ -64,7 +66,7 @@ class EntriesTest extends TestCase
                 'permalink' => 'http://localhost/blog/two',
                 'api_url' => 'http://localhost/api/collections/blog/entries/456',
             ],
-        ], $augmented->all());
+        ], $augmented->toArray());
     }
 
     /** @test */
@@ -72,13 +74,14 @@ class EntriesTest extends TestCase
     {
         $augmented = $this->fieldtype(['max_items' => 1])->shallowAugment(['123']);
 
+        $this->assertInstanceOf(AugmentedCollection::class, $augmented);
         $this->assertEquals([
             'id' => '123',
             'title' => 'One',
             'url' => '/blog/one',
             'permalink' => 'http://localhost/blog/one',
             'api_url' => 'http://localhost/api/collections/blog/entries/123',
-        ], $augmented);
+        ], $augmented->toArray());
     }
 
     public function fieldtype($config = [])

--- a/tests/Fieldtypes/TaxonomyTest.php
+++ b/tests/Fieldtypes/TaxonomyTest.php
@@ -4,6 +4,7 @@ namespace Tests\Fieldtypes;
 
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Collection;
+use Statamic\Data\AugmentedCollection;
 use Statamic\Facades;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Taxonomy;
@@ -70,6 +71,7 @@ class TaxonomyTest extends TestCase
 
         $this->assertInstanceOf(Collection::class, $augmented);
         $this->assertNotInstanceOf(TermCollection::class, $augmented);
+        $this->assertEveryItemIsInstanceOf(AugmentedCollection::class, $augmented);
         $this->assertCount(2, $augmented);
         $this->assertEquals([
             [
@@ -88,7 +90,7 @@ class TaxonomyTest extends TestCase
                 'permalink' => 'http://localhost/tags/two',
                 'api_url' => 'http://localhost/api/taxonomies/tags/terms/two',
             ],
-        ], $augmented->all());
+        ], $augmented->toArray());
     }
 
     /** @test */
@@ -96,6 +98,7 @@ class TaxonomyTest extends TestCase
     {
         $augmented = $this->fieldtype(['taxonomy' => 'tags', 'max_items' => 1])->shallowAugment(['one']);
 
+        $this->assertInstanceOf(AugmentedCollection::class, $augmented);
         $this->assertEquals([
             'id' => 'tags::one',
             'title' => 'one',
@@ -103,7 +106,7 @@ class TaxonomyTest extends TestCase
             'url' => '/tags/one',
             'permalink' => 'http://localhost/tags/one',
             'api_url' => 'http://localhost/api/taxonomies/tags/terms/one',
-        ], $augmented);
+        ], $augmented->toArray());
     }
 
     public function fieldtype($config = [])


### PR DESCRIPTION
Currently, fieldtypes are responsible for determining what gets used when shallow augmenting an item. This PR moves the responsibility into the items themselves. (Entry, Asset, Term, etc)

Now if you want to customize what keys are used, you can override a single method on the item as outlined in #1897

```php
public function register()
{
    $this->app->bind(\Statamic\Contracts\Assets\Asset::class, \App\CustomAsset::class);
}
```

``` php
class CustomAsset extends Asset
{
    protected function shallowAugmentedArrayKeys()
    {
        return ['url', 'alt'];
    }
}
```

Closes #1757 