### PR TITLE
Fix AddonServiceProvider bootViews method

### DIFF
--- a/src/Extend/Manifest.php
+++ b/src/Extend/Manifest.php
@@ -41,7 +41,7 @@ class Manifest extends PackageManifest
         $namespace = join('\\', $providerParts);
 
         $autoload = $package['autoload']['psr-4'][$namespace.'\\'];
-        $directory = Str::removeRight(dirname($reflector->getFileName()), $autoload);
+        $directory = Str::removeRight(dirname($reflector->getFileName()), rtrim($autoload, '/'));
 
         $json = json_decode(File::get($directory.'/composer.json'), true);
         $statamic = $json['extra']['statamic'] ?? [];

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -277,7 +277,7 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected function bootViews()
     {
         $this->loadViewsFrom(
-            $this->getAddon()->directory().'/../resources/views',
+            $this->getAddon()->directory().'resources/views',
             $this->viewNamespace ?? $this->getAddon()->packageName()
         );
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -277,7 +277,7 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected function bootViews()
     {
         $this->loadViewsFrom(
-            $this->getAddon()->directory().'resources/views',
+            $this->getAddon()->directory().'/../resources/views',
             $this->viewNamespace ?? $this->getAddon()->packageName()
         );
 


### PR DESCRIPTION
The docs reference a structure similar to the following for an addon:

```
/
| src/
| resources/
  | views/
```

but the `bootViews` method currently generates a path that tries to load views from a folder that will never exist, something like `addon/srcresources/views`.

This PR fixes that by adding the necessary path part (`/../`) to the method to make this work as expected.