### PR TITLE
Composer 2 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     ],
     "license": "proprietary",
     "require": {
-        "composer/composer": "^1.7",
         "facade/ignition-contracts": "^1.0",
         "guzzlehttp/guzzle": "^6.3",
         "laravel/framework": "^6.0 || ^7.0",
@@ -29,6 +28,7 @@
         "wilderborn/partyline": "^1.0"
     },
     "require-dev": {
+        "composer/composer": "^1.7",
         "fzaninotto/faker": "~1.4",
         "google/cloud-translate": "^1.6",
         "mockery/mockery": "~1.0",

--- a/src/Console/Processes/Composer.php
+++ b/src/Console/Processes/Composer.php
@@ -32,7 +32,7 @@ class Composer extends Process
      */
     public function installed()
     {
-        return collect(json_decode($this->runComposerCommand('show', '--direct', '--format=json'))->installed)
+        return collect(json_decode($this->runComposerCommand('show', '--direct', '--format=json', '--no-plugins'))->installed)
             ->keyBy('name')
             ->map(function ($package) {
                 $package->version = $this->normalizeVersion($package->version);
@@ -67,7 +67,7 @@ class Composer extends Process
      */
     public function installedPath(string $package)
     {
-        return collect(json_decode($this->runComposerCommand('show', '--direct', '--path', '--format=json'))->installed)
+        return collect(json_decode($this->runComposerCommand('show', '--direct', '--path', '--format=json', '--no-plugins'))->installed)
             ->keyBy('name')
             ->get($package)
             ->path;

--- a/src/Console/Processes/Composer.php
+++ b/src/Console/Processes/Composer.php
@@ -7,22 +7,20 @@ use Statamic\Jobs\RunComposer;
 
 class Composer extends Process
 {
-    public $memoryLimit;
+    private $composerCommand;
 
     /**
      * Instantiate composer process.
      *
      * @param mixed $basePath
      */
-    public function __construct($basePath = null)
+    public function __construct($basePath = null, $command = 'composer')
     {
         parent::__construct($basePath);
 
-        // Set this process to eleven.
-        $this->toEleven();
+        $this->composerCommand = $command;
 
-        // Set memory limit for child process to eleven.
-        $this->memoryLimit = config('statamic.system.php_memory_limit');
+        $this->toEleven();
     }
 
     /**
@@ -183,11 +181,7 @@ class Composer extends Process
      */
     private function prepareProcessArguments($parts)
     {
-        return array_merge([
-            $this->phpBinary(),
-            "-d memory_limit={$this->memoryLimit}",
-            'vendor/bin/composer',
-        ], $parts);
+        return array_merge([$this->composerCommand], $parts);
     }
 
     /**

--- a/src/Extend/Manifest.php
+++ b/src/Extend/Manifest.php
@@ -18,7 +18,8 @@ class Manifest extends PackageManifest
         $packages = [];
 
         if ($this->files->exists($path = $this->vendorPath.'/composer/installed.json')) {
-            $packages = json_decode($this->files->get($path), true);
+            $installed = json_decode($this->files->get($path), true);
+            $packages = $installed['packages'] ?? $installed;
         }
 
         $this->write(collect($packages)->filter(function ($package) {

--- a/tests/Composer/ComposerTest.php
+++ b/tests/Composer/ComposerTest.php
@@ -24,7 +24,7 @@ class ComposerTest extends TestCase
         copy($this->basePath('composer.lock'), $this->basePath('composer.lock.bak'));
         Cache::forget('composer.test/package');
 
-        Composer::swap(new \Statamic\Console\Processes\Composer($this->basePath()));
+        Composer::swap(new \Statamic\Console\Processes\Composer($this->basePath(), 'vendor/bin/composer'));
     }
 
     public function tearDown(): void


### PR DESCRIPTION
You can try out Composer v2 alpha by running `composer self-update --snapshot`. It's nice and snappy.

The main issue you would likely run into was not being able to install Statamic because the pixelfear/composer-dist-plugin was not compatible with Composer 2. The [0.1.4 release](https://github.com/pixelfear/composer-dist-plugin/releases/tag/v0.1.4) solves this.

This PR fixes a few related things too.
- Addons not being discovered because the installed.json changed.
- Composer commands (inside the CP, etc) will now use the global composer rather than a local one. This prevents composer 2 being used on the command line but composer 1 being used in the CP.
- The --no-plugins flag is used when grabbing JSON from composer output to prevent any warnings from making it unusable.