### PR TITLE
Add session:value and test

### DIFF
--- a/src/Tags/Session.php
+++ b/src/Tags/Session.php
@@ -22,6 +22,7 @@ class Session extends Tags
     public function value()
     {
         $key = $this->params->get('key');
+
         return session()->get($key, $this->params->get('default'));
     }
 

--- a/src/Tags/Session.php
+++ b/src/Tags/Session.php
@@ -19,6 +19,12 @@ class Session extends Tags
         dump(session()->all());
     }
 
+    public function value()
+    {
+        $key = $this->params->get('key');
+        return session()->get($key, $this->params->get('default'));
+    }
+
     public function set()
     {
         foreach ($this->params as $key => $value) {

--- a/tests/Tags/SessionTagTest.php
+++ b/tests/Tags/SessionTagTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Tags;
+
+use Illuminate\Support\Facades\File;
+use Statamic\Facades\Parse;
+use Tests\TestCase;
+
+class SessionTagTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+    }
+
+    private function tag($tag)
+    {
+        return Parse::template($tag, []);
+    }
+
+    /** @test */
+    public function it_gets_session_key()
+    {
+        session()->put('the-90s-are', 'rad');
+        $this->assertEquals('rad', $this->tag('{{ session:value key="the-90s-are" }}'));
+    }
+
+}

--- a/tests/Tags/SessionTagTest.php
+++ b/tests/Tags/SessionTagTest.php
@@ -2,18 +2,11 @@
 
 namespace Tests\Tags;
 
-use Illuminate\Support\Facades\File;
 use Statamic\Facades\Parse;
 use Tests\TestCase;
 
 class SessionTagTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-
-    }
-
     private function tag($tag)
     {
         return Parse::template($tag, []);
@@ -25,5 +18,4 @@ class SessionTagTest extends TestCase
         session()->put('the-90s-are', 'rad');
         $this->assertEquals('rad', $this->tag('{{ session:value key="the-90s-are" }}'));
     }
-
 }


### PR DESCRIPTION
I needed to grab a session key that was a local variable (specifically, `page:slug`), and `session:page:view` did not work.

Added a convenience method `{{ session:value :key="your-var" }}` so I could do `{{ session:value :key="page:slug" }}`.

Includes test!