### PR TITLE
Fix #1933: Multisite on windows

### DIFF
--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -25,7 +25,7 @@ class CollectionEntriesStore extends ChildStore
     public function getFileFilter(SplFileInfo $file)
     {
         $dir = str_finish($this->directory(), '/');
-        $relative = $file->getPathname();
+        $relative = Path::tidy($file->getPathname());
 
         if (substr($relative, 0, strlen($dir)) == $dir) {
             $relative = substr($relative, strlen($dir));


### PR DESCRIPTION
Cleaning the path fixes the comparsion between the directory and the file path which contained backslashes.

Fixes #1933 