### PR TITLE
Aliases for Addon Tags, Modifiers and Widgets

### DIFF
--- a/src/Modifiers/Modifier.php
+++ b/src/Modifiers/Modifier.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Modifiers;
 
+use Statamic\Extend\HasAliases;
 use Statamic\Extend\HasHandle;
 use Statamic\Support\Str;
 
@@ -10,7 +11,7 @@ use Statamic\Support\Str;
  */
 class Modifier
 {
-    use HasHandle;
+    use HasHandle, HasAliases;
 
     protected static $binding = 'modifiers';
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -75,6 +75,10 @@ abstract class AddonServiceProvider extends ServiceProvider
     {
         foreach ($this->tags as $class) {
             $class::register();
+            
+            foreach ($class::aliases() as $alias) {
+                $this->app['statamic.tags'][$alias] = $class;
+            }
         }
 
         return $this;
@@ -93,6 +97,10 @@ abstract class AddonServiceProvider extends ServiceProvider
     {
         foreach ($this->modifiers as $class) {
             $class::register();
+            
+            foreach ($class::aliases() as $alias) {
+                $this->app['statamic.modifiers'][$alias] = $class;
+            }
         }
 
         return $this;
@@ -102,6 +110,10 @@ abstract class AddonServiceProvider extends ServiceProvider
     {
         foreach ($this->widgets as $class) {
             $class::register();
+            
+            foreach ($class::aliases() as $alias) {
+                $this->app['statamic.widgets'][$alias] = $class;
+            }
         }
 
         return $this;

--- a/src/Widgets/Widget.php
+++ b/src/Widgets/Widget.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Widgets;
 
+use Statamic\Extend\HasAliases;
 use Statamic\Extend\HasHandle;
 use Statamic\Extend\HasTitle;
 use Statamic\Extend\RegistersItself;
@@ -9,7 +10,7 @@ use Statamic\Support\Str;
 
 abstract class Widget
 {
-    use RegistersItself, HasTitle, HasHandle {
+    use RegistersItself, HasAliases, HasTitle, HasHandle {
         handle as protected traitHandle;
     }
 


### PR DESCRIPTION
This pull request allows for addons to register aliases for tags, modifiers and widgets. It fixes #1894.