### PR TITLE
Antlers parsing and noparse tweaks

### DIFF
--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use IteratorAggregate;
 use JsonSerializable;
 use Statamic\Contracts\Data\Augmentable;
+use Statamic\Support\Str;
 use Statamic\View\Antlers\Parser;
 
 class Value implements IteratorAggregate, JsonSerializable
@@ -14,8 +15,6 @@ class Value implements IteratorAggregate, JsonSerializable
     protected $raw;
     protected $handle;
     protected $fieldtype;
-    protected $parser;
-    protected $context;
     protected $augmentable;
     protected $shallow = false;
 
@@ -47,10 +46,6 @@ class Value implements IteratorAggregate, JsonSerializable
             ? $this->fieldtype->shallowAugment($this->raw)
             : $this->fieldtype->augment($this->raw);
 
-        if ($this->shouldParse()) {
-            $value = $this->parse($value);
-        }
-
         return $value;
     }
 
@@ -75,30 +70,26 @@ class Value implements IteratorAggregate, JsonSerializable
         return new ArrayIterator($this->value());
     }
 
-    public function parseUsing(Parser $parser, $context)
+    public function shouldParseAntlers()
     {
-        $this->parser = $parser;
-        $this->context = $context;
-
-        return $this;
+        return $this->fieldtype && $this->fieldtype->config('antlers');
     }
 
-    public function shouldParse()
+    public function antlersValue(Parser $parser, $variables)
     {
-        if (! $this->parser || ! $this->fieldtype) {
-            return false;
+        $value = $this->value();
+
+        if (! is_string($value)) {
+            return $value;
         }
 
-        return $this->fieldtype->config('antlers');
-    }
+        if ($this->shouldParseAntlers()) {
+            return $parser->parse($value, $variables);
+        }
 
-    public function parse($value)
-    {
-        $value = $this->parser->parse($value, $this->context);
-
-        // After parsing, reset the values. Wherever the parser needs to
-        // parse this object, it would add itself and the contextual data.
-        $this->parser = $this->context = null;
+        if (Str::contains($value, '{')) {
+            return $parser->extractNoparse(str_replace('{{', '@{{', $value));
+        }
 
         return $value;
     }

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -3,7 +3,10 @@
 namespace Statamic\Fieldtypes\Bard;
 
 use Scrumpy\ProseMirrorToHtml\Renderer;
+use Statamic\Fields\Field;
 use Statamic\Fields\Fields;
+use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Text;
 use Statamic\Support\Arr;
 
 class Augmentor
@@ -106,8 +109,17 @@ class Augmentor
                 return $this->sets[$matches[1]];
             }
 
-            return ['type' => 'text', 'text' => $html];
+            return ['type' => 'text', 'text' => $this->textValue($html)];
         });
+    }
+
+    protected function textValue($value)
+    {
+        $fieldtype = (new Text)->setField(new Field('text', [
+            'antlers' => $this->fieldtype->config('antlers'),
+        ]));
+
+        return new Value($value, 'text', $fieldtype);
     }
 
     protected function augmentSets($value, $shallow)

--- a/src/Tags/Context.php
+++ b/src/Tags/Context.php
@@ -3,45 +3,13 @@
 namespace Statamic\Tags;
 
 use Statamic\Fields\Value;
-use Statamic\View\Antlers\Parser;
 
 class Context extends ArrayAccessor
 {
-    protected $parser;
-
-    public function setParser(Parser $parser)
-    {
-        $this->parser = $parser;
-
-        return $this;
-    }
-
-    public function get($key, $default = null)
-    {
-        $value = parent::get($key, $default);
-
-        if ($value instanceof Value) {
-            $value = $value->parseUsing($this->parser, $this->items)->value();
-        }
-
-        return $value;
-    }
-
     public function raw($key, $default = null)
     {
         $value = parent::get($key, $default);
 
         return $value instanceof Value ? $value->raw() : $value;
-    }
-
-    public function value($key, $default = null)
-    {
-        $value = parent::get($key, $default);
-
-        if (! $value instanceof Value) {
-            $value = new Value($value);
-        }
-
-        return $value->parseUsing($this->parser, $this->items);
     }
 }

--- a/src/Tags/Tags.php
+++ b/src/Tags/Tags.php
@@ -105,7 +105,7 @@ abstract class Tags
 
     public function setContext($context)
     {
-        $this->context = (new Context($context))->setParser($this->parser);
+        $this->context = new Context($context);
 
         return $this;
     }
@@ -150,7 +150,9 @@ abstract class Tags
         }
 
         return Antlers::usingParser($this->parser, function ($antlers) use ($data) {
-            return $antlers->parse($this->content, array_merge($this->context->all(), $data));
+            return $antlers
+                ->parse($this->content, array_merge($this->context->all(), $data))
+                ->withoutExtractions();
         });
     }
 
@@ -172,7 +174,9 @@ abstract class Tags
         }
 
         return Antlers::usingParser($this->parser, function ($antlers) use ($data, $supplement) {
-            return $antlers->parseLoop($this->content, $data, $supplement, $this->context->all());
+            return $antlers
+                ->parseLoop($this->content, $data, $supplement, $this->context->all())
+                ->withoutExtractions();
         });
     }
 

--- a/src/View/Antlers/Antlers.php
+++ b/src/View/Antlers/Antlers.php
@@ -40,23 +40,6 @@ class Antlers
      */
     public function parseLoop($content, $data, $supplement = true, $context = [])
     {
-        $total = count($data);
-        $i = 0;
-
-        return collect($data)->reduce(function ($carry, $item) use ($content, &$i, $total, $supplement, $context) {
-            if ($supplement) {
-                $item = array_merge($item, [
-                    'index' => $i,
-                    'count' => $i + 1,
-                    'total_results' => $total,
-                    'first' => ($i === 0),
-                    'last' => ($i === $total - 1),
-                ]);
-            }
-
-            $i++;
-
-            return $carry.$this->parse($content, array_merge($context, $item));
-        }, '');
+        return new AntlersLoop($this->parser(), $content, $data, $supplement, $context);
     }
 }

--- a/src/View/Antlers/AntlersLoop.php
+++ b/src/View/Antlers/AntlersLoop.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Statamic\View\Antlers;
+
+class AntlersLoop extends AntlersString
+{
+    protected $parser;
+    protected $string;
+    protected $variables;
+    protected $supplement;
+    protected $context;
+
+    public function __construct($parser, $string, $variables, $supplement, $context)
+    {
+        $this->parser = $parser;
+        $this->string = $string;
+        $this->variables = $variables;
+        $this->supplement = $supplement;
+        $this->context = $context;
+    }
+
+    public function __toString()
+    {
+        $total = count($this->variables);
+        $i = 0;
+
+        $contents = collect($this->variables)->reduce(function ($carry, $item) use (&$i, $total) {
+            if ($this->supplement) {
+                $item = array_merge($item, [
+                    'index' => $i,
+                    'count' => $i + 1,
+                    'total_results' => $total,
+                    'first' => ($i === 0),
+                    'last' => ($i === $total - 1),
+                ]);
+            }
+
+            $i++;
+
+            $parsed = $this->parser
+                ->parse($this->string, array_merge($this->context, $item))
+                ->withoutExtractions();
+
+            return $carry.$parsed;
+        }, '');
+
+        $string = new AntlersString($contents, $this->parser);
+
+        return (string) ($this->injectExtractions ? $string : $string->withoutExtractions());
+    }
+}

--- a/src/View/Antlers/AntlersString.php
+++ b/src/View/Antlers/AntlersString.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Statamic\View\Antlers;
+
+class AntlersString
+{
+    protected $string;
+    protected $parser;
+    protected $injectExtractions = true;
+
+    public function __construct(string $string, Parser $parser)
+    {
+        $this->string = $string;
+        $this->parser = $parser;
+    }
+
+    public function withoutExtractions()
+    {
+        $this->injectExtractions = false;
+
+        return $this;
+    }
+
+    public function __toString()
+    {
+        return $this->injectExtractions
+            ? $this->parser->injectNoparse($this->string)
+            : $this->string;
+    }
+}

--- a/src/View/Antlers/Engine.php
+++ b/src/View/Antlers/Engine.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Exceptions;
 use Statamic\Facades\Parse;
+use Statamic\Fields\Value;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Tags\Loader as TagLoader;
@@ -87,11 +88,11 @@ class Engine implements EngineInterface
 
         $contents = $parser->parseView($path, $contents, $data);
 
-        if (array_pop($this->injectExtractions) !== false) {
-            $contents = $parser->injectNoparse($contents);
+        if (array_pop($this->injectExtractions) === false) {
+            $contents->withoutExtractions();
         }
 
-        return $contents;
+        return (string) $contents;
     }
 
     protected function getContents($path)
@@ -165,6 +166,10 @@ class Engine implements EngineInterface
                 } else {
                     $output = Arr::assoc($output) ? $tag->parse($output) : $tag->parseLoop($output);
                 }
+            }
+
+            if ($output instanceof Value) {
+                $output = $output->antlersValue($parser, $context);
             }
 
             return $output;

--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -143,7 +143,7 @@ class Parser
      *
      * @param  string        $text      Text to parse
      * @param  array|object  $data      Array or object to use
-     * @return string
+     * @return AntlersString
      */
     public function parse($text, $data = [])
     {
@@ -182,7 +182,7 @@ class Parser
             $text = $this->parseCallbackTags($text, $data, null);
         }
 
-        return $text;
+        return new AntlersString($text, $this);
     }
 
     protected function normalizeData($data)
@@ -1045,7 +1045,7 @@ class Parser
      * @param  string $text The text to extract from
      * @return string
      */
-    protected function extractNoparse($text)
+    public function extractNoparse($text)
     {
         // Ignore @{{ tags }} so we don't have to write JavaScript like animals.
         if ($this->preg_match_all($this->ignoreRegex, $text, $matches, PREG_SET_ORDER)) {
@@ -1161,7 +1161,7 @@ class Parser
         }
 
         if ($data instanceof Value) {
-            $data = $data->parseUsing($this, $context)->value();
+            $data = $data->antlersValue($this, $context);
         }
 
         return $data;
@@ -1381,7 +1381,7 @@ class Parser
             return $data->value();
         }
 
-        $value = $data->parseUsing($this, $context)->value();
+        $value = $data->antlersValue($this, $context);
 
         if (Str::startsWith($modifier, ':')) {
             $parameters = array_map(function ($param) use ($context) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -60,7 +60,7 @@ class View
         return $this;
     }
 
-    public function render()
+    public function render(): string
     {
         $cascade = $this->gatherData();
 

--- a/tests/Tags/ThemeTagsTest.php
+++ b/tests/Tags/ThemeTagsTest.php
@@ -18,7 +18,7 @@ class ThemeTagsTest extends TestCase
         parent::setUp();
     }
 
-    private function tag($tag)
+    private function tag($tag): string
     {
         return Parse::template($tag, []);
     }
@@ -113,11 +113,13 @@ class ThemeTagsTest extends TestCase
 
     public function testOutputsFileContents()
     {
-        $contents = File::get('site/themes/redwood/package.json');
+        File::shouldReceive('disk')->andReturn($disk = \Mockery::mock());
+        $disk->shouldReceive('exists')->with('test.txt')->once()->andReturnTrue();
+        $disk->shouldReceive('get')->with('test.txt')->andReturn('contents');
 
         $this->assertEquals(
-            $contents,
-            $this->tag('{{ theme:output src="package.json" }}')
+            'contents',
+            $this->tag('{{ theme:output src="test.txt" }}')
         );
     }
 

--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -241,7 +241,7 @@ EOT;
     {
         $template = '{{ missing|upper }}';
 
-        $this->assertEquals(null, Antlers::parse($template, $this->variables));
+        $this->assertEquals('', Antlers::parse($template, $this->variables));
     }
 
     public function testUnclosedArrayVariablePairsShouldBeNull()
@@ -251,7 +251,7 @@ EOT;
 
         $template = '{{ simple }}';
 
-        $this->assertEquals(null, Antlers::parse($template, $this->variables));
+        $this->assertEquals('', Antlers::parse($template, $this->variables));
     }
 
     public function testSingleCondition()
@@ -274,7 +274,7 @@ EOT;
         $should_fail = '{{ if string == "failure" or string == "womp" }}yes{{ endif }}';
 
         $this->assertEquals('yes', Antlers::parse($should_pass, $this->variables));
-        $this->assertEquals(null, Antlers::parse($should_fail, $this->variables));
+        $this->assertEquals('', Antlers::parse($should_fail, $this->variables));
     }
 
     public function testOrExistanceConditions()
@@ -286,8 +286,8 @@ EOT;
 
         $this->assertEquals('yes', Antlers::parse($should_pass, $this->variables));
         $this->assertEquals('yes', Antlers::parse($should_also_pass, $this->variables));
-        $this->assertEquals(null, Antlers::parse($should_fail, $this->variables));
-        $this->assertEquals(null, Antlers::parse($should_also_fail, $this->variables));
+        $this->assertEquals('', Antlers::parse($should_fail, $this->variables));
+        $this->assertEquals('', Antlers::parse($should_also_fail, $this->variables));
     }
 
     public function testConditionsOnOverlappingVariableNames()
@@ -377,18 +377,18 @@ EOT;
     {
         $this->assertEquals('Pass', Antlers::parse('{{ string ?= "Pass" }}', $this->variables));
         $this->assertEquals('Pass', Antlers::parse('{{ associative:one ?= "Pass" }}', $this->variables));
-        $this->assertEquals(null, Antlers::parse('{{ missing ?= "Pass" }}', $this->variables));
-        $this->assertEquals(null, Antlers::parse('{{ missing:thing ?= "Pass" }}', $this->variables));
+        $this->assertEquals('', Antlers::parse('{{ missing ?= "Pass" }}', $this->variables));
+        $this->assertEquals('', Antlers::parse('{{ missing:thing ?= "Pass" }}', $this->variables));
 
         // Negating with !
-        $this->assertEquals(null, Antlers::parse('{{ !string ?= "Pass" }}', $this->variables));
-        $this->assertEquals(null, Antlers::parse('{{ !associative:one ?= "Pass" }}', $this->variables));
+        $this->assertEquals('', Antlers::parse('{{ !string ?= "Pass" }}', $this->variables));
+        $this->assertEquals('', Antlers::parse('{{ !associative:one ?= "Pass" }}', $this->variables));
         $this->assertEquals('Pass', Antlers::parse('{{ !missing ?= "Pass" }}', $this->variables));
         $this->assertEquals('Pass', Antlers::parse('{{ !missing:thing ?= "Pass" }}', $this->variables));
 
         // and with spaces
-        $this->assertEquals(null, Antlers::parse('{{ ! string ?= "Pass" }}', $this->variables));
-        $this->assertEquals(null, Antlers::parse('{{ ! associative:one ?= "Pass" }}', $this->variables));
+        $this->assertEquals('', Antlers::parse('{{ ! string ?= "Pass" }}', $this->variables));
+        $this->assertEquals('', Antlers::parse('{{ ! associative:one ?= "Pass" }}', $this->variables));
         $this->assertEquals('Pass', Antlers::parse('{{ ! missing ?= "Pass" }}', $this->variables));
         $this->assertEquals('Pass', Antlers::parse('{{ ! missing:thing ?= "Pass" }}', $this->variables));
     }
@@ -446,14 +446,14 @@ EOT;
     {
         $template = '{{ simple|length }}';
 
-        $this->assertEquals(3, Antlers::parse($template, $this->variables));
+        $this->assertEquals('3', Antlers::parse($template, $this->variables));
     }
 
     public function testSingleStandardArrayModifierRelaxed()
     {
         $template = '{{ simple | length }}';
 
-        $this->assertEquals(3, Antlers::parse($template, $this->variables));
+        $this->assertEquals('3', Antlers::parse($template, $this->variables));
     }
 
     public function testChainedStandardArrayModifiersTightOnContent()

--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -1262,7 +1262,7 @@ EOT;
             'augmented the value with howdy in it',
             (string) Antlers::parse('{{ test }}', [
                 'test' => $value,
-                'var' => 'howdy'
+                'var' => 'howdy',
             ])
         );
     }
@@ -1285,7 +1285,7 @@ EOT;
             'augmented the value with {{ var }} in it',
             (string) Antlers::parse('{{ test }}', [
                 'test' => $value,
-                'var' => 'howdy'
+                'var' => 'howdy',
             ])
         );
     }

--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -13,6 +13,7 @@ use Statamic\Data\HasAugmentedData;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Entry;
 use Statamic\Fields\Blueprint;
+use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\LabeledValue;
 use Statamic\Fields\Value;
@@ -619,36 +620,28 @@ EOT;
     }
 
     /** @test */
-    public function it_doesnt_parse_noparse_tags_and_requires_extractions_to_be_reinjected()
+    public function it_doesnt_parse_noparse_tags()
     {
-        $parser = Antlers::parser();
+        $parsed = Antlers::parse('{{ noparse }}{{ string }}{{ /noparse }} {{ string }}', $this->variables);
 
-        $parsed = $parser->parse('{{ noparse }}{{ string }}{{ /noparse }} {{ string }}', $this->variables);
-
-        $this->assertEquals('noparse_ac3458695912d204af897d3c67f93cbe Hello wilderness', $parsed);
-
-        $this->assertEquals('{{ string }} Hello wilderness', $parser->injectNoparse($parsed));
+        $this->assertEquals('{{ string }} Hello wilderness', $parsed);
     }
 
     /** @test */
-    public function it_doesnt_parse_data_in_noparse_modifiers_and_requires_extractions_to_be_reinjected()
+    public function it_doesnt_parse_data_in_noparse_modifiers()
     {
-        $parser = Antlers::parser();
-
         $variables = [
             'string' => 'hello',
             'content' => 'before {{ string }} after',
         ];
 
-        $parsed = $parser->parse('{{ content | noparse }} {{ string }}', $variables);
+        $parsed = Antlers::parse('{{ content | noparse }} {{ string }}', $variables);
 
-        $this->assertEquals('noparse_6d6accbda6a2c1f2e7dd3932dcc70012 hello', $parsed);
-
-        $this->assertEquals('before {{ string }} after hello', $parser->injectNoparse($parsed));
+        $this->assertEquals('before {{ string }} after hello', $parsed);
     }
 
     /** @test */
-    public function it_doesnt_parse_data_in_noparse_modifiers_with_null_coalescence_and_requires_extractions_to_be_reinjected()
+    public function it_doesnt_parse_data_in_noparse_modifiers_with_null_coalescence()
     {
         $parser = Antlers::parser();
 
@@ -657,12 +650,11 @@ EOT;
             'content' => 'before {{ string }} after',
         ];
         $parsed = $parser->parse('{{ missing or content | noparse }} {{ string }}', $variables);
-        $this->assertEquals('noparse_6d6accbda6a2c1f2e7dd3932dcc70012 hello', $parsed);
-        $this->assertEquals('before {{ string }} after hello', $parser->injectNoparse($parsed));
+        $this->assertEquals('before {{ string }} after hello', $parsed);
     }
 
     /** @test */
-    public function it_doesnt_parse_noparse_tags_inside_callbacks_and_requires_extractions_to_be_reinjected()
+    public function it_doesnt_parse_noparse_tags_inside_callbacks()
     {
         (new class extends Tags {
             public static $handle = 'tag';
@@ -690,25 +682,18 @@ EOT;
 {{ /tag:loop }}
 EOT;
 
-        $expectedBeforeInjection = <<<'EOT'
-noparse_ac3458695912d204af897d3c67f93cbe
-    0 noparse_ac3458695912d204af897d3c67f93cbe One
-    1 noparse_ac3458695912d204af897d3c67f93cbe Two
-EOT;
-
-        $expectedAfterInjection = <<<'EOT'
+        $expected = <<<'EOT'
 {{ string }}
     0 {{ string }} One
     1 {{ string }} Two
 EOT;
 
         $parsed = $parser->parse($template, $this->variables);
-        $this->assertEquals($expectedBeforeInjection, trim($parsed));
-        $this->assertEquals($expectedAfterInjection, trim($parser->injectNoparse($parsed)));
+        $this->assertEquals($expected, trim($parsed));
     }
 
     /** @test */
-    public function it_doesnt_parse_data_in_noparse_modifiers_inside_callbacks_and_requires_extractions_to_be_reinjected()
+    public function it_doesnt_parse_data_in_noparse_modifiers_inside_callbacks()
     {
         $this->app['statamic.tags']['test'] = \Foo\Bar\Tags\Test::class;
 
@@ -747,21 +732,14 @@ EOT;
 {{ /tag:loop }}
 EOT;
 
-        $expectedBeforeInjection = <<<'EOT'
-noparse_0548be789865a16ab6e495f84a3080c0
-    1 noparse_aa4a7fa8e2faf61751b68038fee92c4d One
-    2 noparse_aa4a7fa8e2faf61751b68038fee92c4d Two
-EOT;
-
-        $expectedAfterInjection = <<<'EOT'
+        $expected = <<<'EOT'
 beforesingle {{ string }} aftersingle
     1 beforepair {{ string }} afterpair One
     2 beforepair {{ string }} afterpair Two
 EOT;
 
         $parsed = $parser->parse($template);
-        $this->assertEquals($expectedBeforeInjection, trim($parsed));
-        $this->assertEquals($expectedAfterInjection, trim($parser->injectNoparse($parsed)));
+        $this->assertEquals($expected, trim($parsed));
     }
 
     /** @test */
@@ -954,7 +932,7 @@ EOT;
 
         $expected = <<<'EOT'
 augmented before hello after
-augmented before  after
+augmented before {{ string }} after
 EOT;
 
         $variables = [
@@ -963,11 +941,27 @@ EOT;
             'string' => 'hello',
         ];
 
-        $this->assertEquals($expected, Antlers::parse($template, $variables));
-        $this->assertEquals('AUGMENTED BEFORE HELLO AFTER', Antlers::parse('{{ parseable | upper }}', $variables));
-        $this->assertEquals('AUGMENTED BEFORE  AFTER', Antlers::parse('{{ non_parseable | upper }}', $variables));
-        $this->assertEquals('AUGMENTED BEFORE HELLO AFTER', Antlers::parse('{{ parseable upper="true" }}', $variables));
-        $this->assertEquals('AUGMENTED BEFORE  AFTER', Antlers::parse('{{ non_parseable upper="true" }}', $variables));
+        $this->assertEquals($expected, (string) Antlers::parse($template, $variables));
+
+        $this->assertEquals(
+            'shmaugmented before hello after',
+            (string) Antlers::parse('{{ parseable | replace:aug:shmaug }}', $variables)
+        );
+
+        $this->assertEquals(
+            'shmaugmented before {{ string }} after',
+            (string) Antlers::parse('{{ non_parseable | replace:aug:shmaug }}', $variables)
+        );
+
+        $this->assertEquals(
+            'shmaugmented before hello after',
+            (string) Antlers::parse('{{ parseable replace="aug|shmaug" }}', $variables)
+        );
+
+        $this->assertEquals(
+            'shmaugmented before {{ string }} after',
+            (string) Antlers::parse('{{ non_parseable replace="aug|shmaug" }}', $variables)
+        );
     }
 
     /** @test */
@@ -1172,6 +1166,128 @@ Hello wilderness
 EOT;
 
         $this->assertEquals($expected, Antlers::parse($template, $this->variables));
+    }
+
+    /** @test */
+    public function callback_tags_that_return_value_objects_gets_parsed()
+    {
+        (new class extends Tags {
+            public static $handle = 'tag';
+
+            public function index()
+            {
+                $fieldtype = new class extends Fieldtype {
+                    public function augment($value)
+                    {
+                        return 'augmented '.$value;
+                    }
+                };
+
+                return new Value('the value', null, $fieldtype);
+            }
+        })::register();
+
+        $this->assertEquals('augmented the value', Antlers::parse('{{ tag }}'));
+    }
+
+    /** @test */
+    public function callback_tags_that_return_value_objects_with_antlers_gets_parsed()
+    {
+        (new class extends Tags {
+            public static $handle = 'tag';
+
+            public function index()
+            {
+                $fieldtype = new class extends Fieldtype {
+                    public function augment($value)
+                    {
+                        return 'augmented '.$value;
+                    }
+                };
+
+                $fieldtype->setField(new Field('test', ['antlers' => true]));
+
+                return new Value('the value with {{ var }} in it', null, $fieldtype);
+            }
+        })::register();
+
+        $this->assertEquals(
+            'augmented the value with howdy in it',
+            (string) Antlers::parse('{{ tag }}', ['var' => 'howdy'])
+        );
+    }
+
+    /** @test */
+    public function callback_tags_that_return_value_objects_with_antlers_disabled_does_not_get_parsed()
+    {
+        (new class extends Tags {
+            public static $handle = 'tag';
+
+            public function index()
+            {
+                $fieldtype = new class extends Fieldtype {
+                    public function augment($value)
+                    {
+                        return 'augmented '.$value;
+                    }
+                };
+
+                $fieldtype->setField(new Field('test', ['antlers' => false]));
+
+                return new Value('the value with {{ var }} in it', null, $fieldtype);
+            }
+        })::register();
+
+        $this->assertEquals(
+            'augmented the value with {{ var }} in it',
+            (string) Antlers::parse('{{ tag }}', ['var' => 'howdy'])
+        );
+    }
+
+    /** @test */
+    public function value_objects_with_antlers_gets_parsed()
+    {
+        $fieldtype = new class extends Fieldtype {
+            public function augment($value)
+            {
+                return 'augmented '.$value;
+            }
+        };
+
+        $fieldtype->setField(new Field('test', ['antlers' => true]));
+
+        $value = new Value('the value with {{ var }} in it', null, $fieldtype);
+
+        $this->assertEquals(
+            'augmented the value with howdy in it',
+            (string) Antlers::parse('{{ test }}', [
+                'test' => $value,
+                'var' => 'howdy'
+            ])
+        );
+    }
+
+    /** @test */
+    public function value_objects_with_antlers_disabled_do_not_get_parsed()
+    {
+        $fieldtype = new class extends Fieldtype {
+            public function augment($value)
+            {
+                return 'augmented '.$value;
+            }
+        };
+
+        $fieldtype->setField(new Field('test', ['antlers' => false]));
+
+        $value = new Value('the value with {{ var }} in it', null, $fieldtype);
+
+        $this->assertEquals(
+            'augmented the value with {{ var }} in it',
+            (string) Antlers::parse('{{ test }}', [
+                'test' => $value,
+                'var' => 'howdy'
+            ])
+        );
     }
 
     /** @test */


### PR DESCRIPTION
tldr: Setting `antlers: true` will work better.

Fields have `antlers: false` by default.
If you add `{{ stuff }}` to your fields, you'll see `{{ stuff }}`.
If you set `antlers: true`, `{{ stuff }}` will get parsed and swapped with the value of `stuff`.

---

A little info on noparse.

When the Antlers parser wants to avoid parsing stuff (eg. because you wrapped something with `{{ noparse }}...{{ /noparse }}`) it'll "extract" it and replace it with `noparse_somehash`.

Since there may be multiple parses (eg. nested loops, partials, etc), we hold all the extractions until the very end.

Once everything is done, after the template gets injected into the layout, *then* we get the parser to put back all the extracted noparses. That way, we avoid them accidentally getting parsed.

One problem was that in some cases, the extractions weren't being held on all the way till the end.

---

Details:

- An antlers parse returns an `AntlersString`, a thin wrapper allowing you to opt out of injecting noparse extractions.
- `Antlers::parse()` etc will re-inject noparse extractions by default
- `Antlers::parseLoop()` gets a `AntlersLoop` object that lets you opt out of injecting noparse too. It moves the parsing a little later, when you convert it to a string.
- When tags parse/parseLoop, they don't inject noparse extractions. They'll leave it for the `View` to do that at the end.
- Value objects with fields configured with antlers: false (the default) will have any antlers tags extracted (by adding @ before them, acting as noparses)
- Context class doesn't parse values, it just gives back the value objects. The parser will deal with parsing.
- Remove value method from Context class. It was unused.
- Bard respects the antlers setting. Closes #1783 