### PR TITLE
Extension cleanup and better aliasing support

### DIFF
--- a/src/Extend/RegistersItself.php
+++ b/src/Extend/RegistersItself.php
@@ -6,6 +6,19 @@ trait RegistersItself
 {
     public static function register()
     {
-        return app('statamic.'.static::$binding)[static::handle()] = static::class;
+        $key = self::class;
+        $extensions = app('statamic.extensions');
+
+        $extensions[$key] = with($extensions[$key] ?? collect(), function ($bindings) {
+            $bindings[static::handle()] = static::class;
+
+            if (method_exists(static::class, 'aliases')) {
+                foreach (static::aliases() as $alias) {
+                    $bindings[$alias] = static::class;
+                }
+            }
+
+            return $bindings;
+        });
     }
 }

--- a/src/Modifiers/Loader.php
+++ b/src/Modifiers/Loader.php
@@ -13,11 +13,13 @@ class Loader
      */
     public function load($name)
     {
-        if (! ($modifiers = app('statamic.modifiers'))->has($name)) {
+        $key = Str::snake($name);
+
+        if (! ($modifiers = app('statamic.modifiers'))->has($key)) {
             throw new ModifierNotFoundException($name);
         }
 
-        if (Str::contains($class = $modifiers->get($name), 'CoreModifiers@')) {
+        if (Str::contains($class = $modifiers->get($key), 'CoreModifiers@')) {
             [$class, $method] = explode('@', $class);
         }
 

--- a/src/Modifiers/Modifier.php
+++ b/src/Modifiers/Modifier.php
@@ -2,21 +2,14 @@
 
 namespace Statamic\Modifiers;
 
+use Statamic\Extend\HasAliases;
 use Statamic\Extend\HasHandle;
-use Statamic\Support\Str;
+use Statamic\Extend\RegistersItself;
 
 /**
  * Modify values within templates.
  */
 class Modifier
 {
-    use HasHandle;
-
-    protected static $binding = 'modifiers';
-
-    public static function register()
-    {
-        // Not using RegistersItself trait because modifiers bind with camel cased keys, not snake case.
-        return app('statamic.'.static::$binding)[Str::camel(static::handle())] = static::class;
-    }
+    use HasHandle, RegistersItself, HasAliases;
 }

--- a/src/Modifiers/Modify.php
+++ b/src/Modifiers/Modify.php
@@ -5,7 +5,6 @@ namespace Statamic\Modifiers;
 use ArrayIterator;
 use Exception;
 use Statamic\Support\Arr;
-use Statamic\Support\Str;
 
 class Modify implements \IteratorAggregate
 {

--- a/src/Modifiers/Modify.php
+++ b/src/Modifiers/Modify.php
@@ -141,10 +141,6 @@ class Modify implements \IteratorAggregate
         // We should make sure it's always an array.
         $params = (array) $params;
 
-        // Templates will use snake_case to specify modifiers, so we'll
-        // convert them to the correct PSR-2 modifier method name.
-        $modifier = Str::camel($modifier);
-
         try {
             // Attempt to run the modifier. If it worked, awesome,
             // we'll have successfully returned a modified value.

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -5,54 +5,27 @@ namespace Statamic\Providers;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\ServiceProvider;
 use Statamic\Actions;
+use Statamic\Actions\Action;
 use Statamic\Extend\Manifest;
+use Statamic\Fields\Fieldtype;
 use Statamic\Fieldtypes;
 use Statamic\Modifiers\CoreModifiers;
 use Statamic\Modifiers\Modifier;
 use Statamic\Query\Scopes;
+use Statamic\Query\Scopes\Scope;
+use Statamic\Support\Str;
 use Statamic\Tags;
+use Statamic\Widgets;
 
 class ExtensionServiceProvider extends ServiceProvider
 {
-    /**
-     * Aliases for modifiers bundled with Statamic.
-     *
-     * @var array
-     */
-    protected $bundledModifierAliases = [
-        '+' => 'add',
-        '-' => 'subtract',
-        '*' => 'multiply',
-        '/' => 'divide',
-        '%' => 'mod',
-        '^' => 'exponent',
-        'ago' => 'relative',
-        'until' => 'relative',
-        'since' => 'relative',
-        'specialchars' => 'sanitize',
-        'htmlspecialchars' => 'sanitize',
-        'striptags' => 'stripTags',
-        'join' => 'joinplode',
-        'implode' => 'joinplode',
-        'list' => 'joinplode',
-        'piped' => 'optionList',
-        'json' => 'toJson',
-        'email' => 'obfuscateEmail',
-        'l10n' => 'formatLocalized',
-        'lowercase' => 'lower',
-        'tz' => 'timezone',
-        'inFuture' => 'isFuture',
-        'inPast' => 'isPast',
-        'as' => 'alias',
-    ];
-
-    /**
-     * Widgets bundled with Statamic.
-     *
-     * @var array
-     */
-    protected $bundledWidgets = [
-        'getting-started', 'collection', 'template', 'updater', 'form',
+    protected $actions = [
+        Actions\Delete::class,
+        Actions\Publish::class,
+        Actions\Unpublish::class,
+        Actions\SendPasswordReset::class,
+        Actions\MoveAsset::class,
+        Actions\RenameAsset::class,
     ];
 
     protected $fieldtypes = [
@@ -104,6 +77,43 @@ class ExtensionServiceProvider extends ServiceProvider
         Fieldtypes\Video::class,
         Fieldtypes\Yaml::class,
         \Statamic\Forms\Fieldtype::class,
+    ];
+
+    protected $modifierAliases = [
+        '+' => 'add',
+        '-' => 'subtract',
+        '*' => 'multiply',
+        '/' => 'divide',
+        '%' => 'mod',
+        '^' => 'exponent',
+        'ago' => 'relative',
+        'until' => 'relative',
+        'since' => 'relative',
+        'specialchars' => 'sanitize',
+        'htmlspecialchars' => 'sanitize',
+        'striptags' => 'stripTags',
+        'join' => 'joinplode',
+        'implode' => 'joinplode',
+        'list' => 'joinplode',
+        'piped' => 'optionList',
+        'json' => 'toJson',
+        'email' => 'obfuscateEmail',
+        'l10n' => 'formatLocalized',
+        'lowercase' => 'lower',
+        'tz' => 'timezone',
+        'inFuture' => 'isFuture',
+        'inPast' => 'isPast',
+        'as' => 'alias',
+    ];
+
+    protected $scopes = [
+        Scopes\Filters\Fields::class,
+        Scopes\Filters\Blueprint::class,
+        Scopes\Filters\Status::class,
+        Scopes\Filters\Site::class,
+        Scopes\Filters\UserRole::class,
+        Scopes\Filters\UserGroup::class,
+        Scopes\Filters\Collection::class,
     ];
 
     protected $tags = [
@@ -158,6 +168,15 @@ class ExtensionServiceProvider extends ServiceProvider
         \Statamic\Search\Tags::class,
     ];
 
+    protected $widgets = [
+        Widgets\Collection::class,
+        Widgets\GettingStarted::class,
+        Widgets\Header::class,
+        Widgets\Template::class,
+        Widgets\Updater::class,
+        Forms\Widget::class,
+    ];
+
     /**
      * Register any application services.
      *
@@ -171,204 +190,64 @@ class ExtensionServiceProvider extends ServiceProvider
             $this->app->bootstrapPath().'/cache/addons.php'
         ));
 
-        $this->registerTags();
-        $this->registerModifiers();
-        $this->registerFieldtypes();
-        $this->registerScopes();
-        $this->registerActions();
-        $this->registerWidgets();
+        $this->app->instance('statamic.extensions', collect());
+
+        collect([
+            'fieldtypes' => Fieldtype::class,
+            'modifiers' => Modifier::class,
+            'tags' => Tags\Tags::class,
+            'scopes' => Scope::class,
+            'actions' => Action::class,
+        ])->each(function ($class, $key) {
+            return $this->app->bind('statamic.'.$key, function ($app) use ($class) {
+                return $app['statamic.extensions'][$class];
+            });
+        });
+
+        collect()
+            ->merge($this->tags)
+            ->merge($this->fieldtypes)
+            ->merge($this->scopes)
+            ->merge($this->actions)
+            ->merge($this->widgets)
+            ->each(function ($class) {
+                $class::register();
+            });
+
+        collect([
+            'Tags' => Tags::class,
+            'Modifiers' => Modifier::class,
+            'Fieldtypes' => Fieldtype::class,
+            'Scopes' => Scopes::class,
+            'Actions' => Action::class,
+            'Widgets' => Widget::class,
+        ])->each(function ($class, $dir) {
+            $this->registerExtensionsInAppFolder($dir, $class);
+        });
+
+        $this->registerBundledModifiers();
     }
 
-    /**
-     * Register tags.
-     *
-     * @return void
-     */
-    protected function registerTags()
-    {
-        $parent = 'statamic.tags';
-
-        $this->registerParent($parent);
-
-        foreach ($this->tags as $tag) {
-            $this->registerExtension($tag, $parent);
-            $this->registerAliases($tag, $parent);
-        }
-
-        $this->registerExtensionsInAppFolder('Tags', \Statamic\Tags\Tags::class);
-    }
-
-    /**
-     * Register modifiers.
-     *
-     * @return void
-     */
-    protected function registerModifiers()
-    {
-        $parent = 'statamic.modifiers';
-
-        $this->registerParent($parent);
-        $this->registerBundledModifiers($parent);
-        $this->registerExtensionsInAppFolder('Modifiers', \Statamic\Modifiers\Modifier::class);
-    }
-
-    /**
-     * Register bundled modifiers.
-     *
-     * @param string $parent
-     * @return void
-     */
-    protected function registerBundledModifiers($parent)
+    protected function registerBundledModifiers()
     {
         $methods = array_diff(
             get_class_methods(CoreModifiers::class),
             get_class_methods(Modifier::class)
         );
 
+        $modifiers = collect();
+
         foreach ($methods as $method) {
-            $this->app[$parent][$method] = "Statamic\\Modifiers\\CoreModifiers@{$method}";
+            $modifiers[Str::snake($method)] = "Statamic\\Modifiers\\CoreModifiers@{$method}";
         }
 
-        foreach ($this->bundledModifierAliases as $alias => $actual) {
-            $this->app[$parent][$alias] = "Statamic\\Modifiers\\CoreModifiers@{$actual}";
-        }
-    }
-
-    /**
-     * Register fieldtypes.
-     *
-     * @return void
-     */
-    protected function registerFieldtypes()
-    {
-        $parent = 'statamic.fieldtypes';
-
-        $this->registerParent($parent);
-
-        foreach ($this->fieldtypes as $fieldtype) {
-            $this->registerExtension($fieldtype, $parent);
+        foreach ($this->modifierAliases as $alias => $actual) {
+            $modifiers[$alias] = "Statamic\\Modifiers\\CoreModifiers@{$actual}";
         }
 
-        $this->registerExtensionsInAppFolder('Fieldtypes', \Statamic\Fields\Fieldtype::class);
-    }
-
-    /**
-     * Register scopes.
-     *
-     * @return void
-     */
-    protected function registerScopes()
-    {
-        $parent = 'statamic.scopes';
-
-        $scopes = [
-            Scopes\Filters\Fields::class,
-            Scopes\Filters\Blueprint::class,
-            Scopes\Filters\Status::class,
-            Scopes\Filters\Site::class,
-            Scopes\Filters\UserRole::class,
-            Scopes\Filters\UserGroup::class,
-            Scopes\Filters\Collection::class,
-        ];
-
-        $this->registerParent($parent);
-
-        foreach ($scopes as $scope) {
-            $this->registerExtension($scope, $parent);
-        }
-
-        $this->registerExtensionsInAppFolder('Scopes', \Statamic\Query\Scopes\Scope::class);
-    }
-
-    /**
-     * Register actions.
-     *
-     * @return void
-     */
-    protected function registerActions()
-    {
-        $parent = 'statamic.actions';
-
-        $actions = [
-            Actions\Delete::class,
-            Actions\Publish::class,
-            Actions\Unpublish::class,
-            Actions\SendPasswordReset::class,
-            Actions\MoveAsset::class,
-            Actions\RenameAsset::class,
-        ];
-
-        $this->registerParent($parent);
-
-        foreach ($actions as $action) {
-            $this->registerExtension($action, $parent);
-        }
-
-        $this->registerExtensionsInAppFolder('Actions', \Statamic\Actions\Action::class);
-    }
-
-    /**
-     * Register widgets.
-     *
-     * @return void
-     */
-    protected function registerWidgets()
-    {
-        $parent = 'statamic.widgets';
-
-        $widgets = [
-            \Statamic\Widgets\Collection::class,
-            \Statamic\Widgets\GettingStarted::class,
-            \Statamic\Widgets\Header::class,
-            \Statamic\Widgets\Template::class,
-            \Statamic\Widgets\Updater::class,
-            \Statamic\Forms\Widget::class,
-        ];
-
-        $this->registerParent($parent);
-
-        foreach ($widgets as $widget) {
-            $this->registerExtension($widget, $parent);
-        }
-
-        $this->registerExtensionsInAppFolder('Widgets', \Statamic\Widgets\Widget::class);
-    }
-
-    /**
-     * Register parent.
-     *
-     * @param string $parent
-     * @return void
-     */
-    protected function registerParent($parent)
-    {
-        $this->app->instance($parent, collect());
-    }
-
-    /**
-     * Register extension.
-     *
-     * @param string $extension
-     * @param string $parent
-     * @return void
-     */
-    protected function registerExtension($extension, $parent)
-    {
-        $this->app[$parent][$extension::handle()] = $extension;
-    }
-
-    /**
-     * Register aliases.
-     *
-     * @param string $extension
-     * @param string $parent
-     * @return void
-     */
-    protected function registerAliases($extension, $parent)
-    {
-        foreach ($extension::aliases() as $alias) {
-            $this->app[$parent][$alias] = $extension;
-        }
+        $this->app['statamic.extensions'][Modifier::class] = collect()
+            ->merge($this->app['statamic.extensions'][Modifier::class] ?? [])
+            ->merge($modifiers);
     }
 
     /**

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -254,19 +254,15 @@ class ExtensionServiceProvider extends ServiceProvider
 
     protected function registerCoreModifiers()
     {
-        $methods = array_diff(
-            get_class_methods(CoreModifiers::class),
-            get_class_methods(Modifier::class)
-        );
-
         $modifiers = collect();
+        $methods = array_diff(get_class_methods(CoreModifiers::class), get_class_methods(Modifier::class));
 
         foreach ($methods as $method) {
-            $modifiers[Str::snake($method)] = "Statamic\\Modifiers\\CoreModifiers@{$method}";
+            $modifiers[Str::snake($method)] = CoreModifiers::class.'@'.$method;
         }
 
         foreach ($this->modifierAliases as $alias => $actual) {
-            $modifiers[$alias] = "Statamic\\Modifiers\\CoreModifiers@{$actual}";
+            $modifiers[$alias] = CoreModifiers::class.'@'.$actual;
         }
 
         $this->app['statamic.extensions'][Modifier::class] = collect()

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -174,7 +174,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Widgets\Header::class,
         Widgets\Template::class,
         Widgets\Updater::class,
-        Forms\Widget::class,
+        \Statamic\Forms\Widget::class,
     ];
 
     /**

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -252,6 +252,21 @@ class ExtensionServiceProvider extends ServiceProvider
         }
     }
 
+    protected function registerAppExtensions($folder, $requiredClass)
+    {
+        if (! $this->app['files']->exists($path = app_path($folder))) {
+            return;
+        }
+
+        foreach ($this->app['files']->files($path) as $file) {
+            $class = $file->getBasename('.php');
+            $fqcn = $this->app->getNamespace()."{$folder}\\{$class}";
+            if (is_subclass_of($fqcn, $requiredClass)) {
+                $fqcn::register();
+            }
+        }
+    }
+
     protected function registerCoreModifiers()
     {
         $modifiers = collect();
@@ -268,20 +283,5 @@ class ExtensionServiceProvider extends ServiceProvider
         $this->app['statamic.extensions'][Modifier::class] = collect()
             ->merge($this->app['statamic.extensions'][Modifier::class] ?? [])
             ->merge($modifiers);
-    }
-
-    protected function registerAppExtensions($folder, $requiredClass)
-    {
-        if (! $this->app['files']->exists($path = app_path($folder))) {
-            return;
-        }
-
-        foreach ($this->app['files']->files($path) as $file) {
-            $class = $file->getBasename('.php');
-            $fqcn = $this->app->getNamespace()."{$folder}\\{$class}";
-            if (is_subclass_of($fqcn, $requiredClass)) {
-                $fqcn::register();
-            }
-        }
     }
 }

--- a/src/Widgets/Widget.php
+++ b/src/Widgets/Widget.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Widgets;
 
+use Statamic\Extend\HasAliases;
 use Statamic\Extend\HasHandle;
 use Statamic\Extend\HasTitle;
 use Statamic\Extend\RegistersItself;
@@ -9,7 +10,7 @@ use Statamic\Support\Str;
 
 abstract class Widget
 {
-    use RegistersItself, HasTitle, HasHandle {
+    use RegistersItself, HasTitle, HasHandle, HasAliases {
         handle as protected traitHandle;
     }
 


### PR DESCRIPTION
Mostly a cleanup, but this PR adds support for tag, modifier, and widget aliasing.

By adding `protected static $aliases = ['foo', 'bar'];`, your tag/modifier/widget can be used by another name without needing to duplicate the whole class.

Calling `::register` on a class will now also register its aliases, if there are any.

Closes #1894 
Closes #1938 