### PR TITLE
Remove the menu entry "Create child" on root node in collections

### DIFF
--- a/resources/js/components/collections/View.vue
+++ b/resources/js/components/collections/View.vue
@@ -114,18 +114,18 @@
                     v-tooltip="__('Redirect')" />
             </template>
 
-            <template #branch-options="{ branch, removeBranch, orphanChildren, depth }">
+            <template #branch-options="{ branch, removeBranch, orphanChildren, depth, isRoot }">
                 <template v-if="depth < structureMaxDepth">
-
                     <h6 class="px-1" v-text="__('Create Child Entry')" v-if="blueprints.length > 1" />
                     <li class="divider" v-if="blueprints.length > 1" />
                     <dropdown-item
                         v-for="blueprint in blueprints"
                         :key="blueprint.handle"
+                        v-if="!isRoot"
                         @click="createEntry(blueprint.handle, branch.id)"
                         v-text="blueprints.length > 1 ? blueprint.title : __('Create Child Entry')" />
                 </template>
-                <li class="divider"></li>
+                <li class="divider" v-if="!isRoot"></li>
                 <dropdown-item
                     :text="__('Delete')"
                     class="warning"

--- a/resources/js/components/structures/Branch.vue
+++ b/resources/js/components/structures/Branch.vue
@@ -27,6 +27,7 @@
                     <slot name="branch-options"
                         :branch="page"
                         :depth="depth"
+                        :isRoot="isRoot"
                         :remove-branch="remove"
                         :orphan-children="orphanChildren"
                     />


### PR DESCRIPTION
This PR removes the menu entry "Create child" from the root node menu.

![NoChildNodeOnRoot](https://user-images.githubusercontent.com/363363/85204424-a9572580-b314-11ea-9258-84a5d9b185cb.gif)

Closes #1948