### PR TITLE
Pagination with offset

### DIFF
--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -154,10 +154,6 @@ class Entries
         $this->queryScopes($query);
         $this->queryOrderBys($query);
 
-        if ($this->parameters->has(['paginate', 'offset'])) {
-            $this->queryPaginationFriendlyOffset($query);
-        }
-
         return $query;
     }
 
@@ -364,17 +360,6 @@ class Entries
         if (! $this->parameters->bool(['redirects', 'links'], false)) {
             $query->where('redirect', '=', null);
         }
-    }
-
-    protected function queryPaginationFriendlyOffset($query)
-    {
-        $offsetIds = (clone $query)
-            ->limit($this->parameters->get('offset'))
-            ->get('id')
-            ->map->id()
-            ->all();
-
-        $this->queryNotInCondition($query, 'id', $offsetIds);
     }
 
     protected function queryableConditionParams()

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -154,6 +154,10 @@ class Entries
         $this->queryScopes($query);
         $this->queryOrderBys($query);
 
+        if ($this->parameters->has(['paginate', 'offset'])) {
+            $this->queryPaginationFriendlyOffset($query);
+        }
+
         return $query;
     }
 
@@ -360,6 +364,17 @@ class Entries
         if (! $this->parameters->bool(['redirects', 'links'], false)) {
             $query->where('redirect', '=', null);
         }
+    }
+
+    protected function queryPaginationFriendlyOffset($query)
+    {
+        $offsetIds = (clone $query)
+            ->limit($this->parameters->get('offset'))
+            ->get('id')
+            ->map->id()
+            ->all();
+
+        $this->queryNotInCondition($query, 'id', $offsetIds);
     }
 
     protected function queryableConditionParams()

--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -6,33 +6,47 @@ trait GetsQueryResults
 {
     protected function results($query)
     {
-        $params = $this->parsePaginationParameters();
+        $this->setPaginationParameterPrecedence();
 
-        if ($paginate = $params['paginate']) {
-            return $query->paginate($paginate);
+        if ($paginate = $this->parameters->get('paginate')) {
+            return $this->paginatedResults($query, $paginate);
         }
 
-        if ($limit = $params['limit']) {
+        if ($limit = $this->parameters->get('limit')) {
             $query->limit($limit);
         }
 
-        if ($offset = $params['offset']) {
+        if ($offset = $this->parameters->get('offset')) {
             $query->offset($offset);
         }
 
         return $query->get();
     }
 
-    protected function parsePaginationParameters()
+    protected function setPaginationParameterPrecedence()
     {
-        $paginate = $this->parameters->get('paginate');
-        $limit = $this->parameters->get('limit');
-        $offset = $this->parameters->get('offset');
+        if ($this->parameters->get('paginate') === true) {
+            $this->parameters->put('paginate', $this->parameters->get('limit'));
+        }
+    }
 
-        if ($paginate === true) {
-            $paginate = $limit;
+    protected function paginatedResults($query, $perPage)
+    {
+        if ($offset = $this->parameters->get('offset')) {
+            $this->queryPaginationFriendlyOffset($query, $offset);
         }
 
-        return compact('paginate', 'limit', 'offset');
+        return $query->paginate($perPage);
+    }
+
+    protected function queryPaginationFriendlyOffset($query, $offset)
+    {
+        $offsetIds = (clone $query)
+            ->limit($offset)
+            ->get('id')
+            ->map->id()
+            ->all();
+
+        $query->whereNotin('id', $offsetIds);
     }
 }


### PR DESCRIPTION
We want to be able to support using `offset` with `paginate` on query tags, ie)

```
{{ collection:news as="posts" offset="1" paginate="12" }}
```

To make it easier to style featured posts differently, and because it was something we supported in v2.

PS. This had to be done on the tag level, because there doesn't seem to be an Eloquent-friendly way to do it on the query builder.