### PR TITLE
Catch the DirectoryNotFoundException when clearing static cache

### DIFF
--- a/src/Console/Commands/StaticClear.php
+++ b/src/Console/Commands/StaticClear.php
@@ -5,6 +5,7 @@ namespace Statamic\Console\Commands;
 use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
 use Statamic\StaticCaching\Cacher as StaticCacher;
+use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 
 class StaticClear extends Command
 {
@@ -31,7 +32,11 @@ class StaticClear extends Command
      */
     public function handle()
     {
-        app(StaticCacher::class)->flush();
+        try {
+            app(StaticCacher::class)->flush();
+        } catch (DirectoryNotFoundException $e) {
+            // Catch the exception but don't do anything with it
+        }
 
         $this->info('Your static page cache is now so very, very empty.');
     }


### PR DESCRIPTION
In the following cases the cache folder does not exist:

* A vanilla installation when the user just changed the caching strategy
to 'full' in `static_caching.php` and did not visit the website yet
* After the user flushed the cache, since the command deletes the cache
folder

Just catch the exception and do nothing else with it. Printing an error
notice to the user is IMO not necessary because:

* Its normal behavior that the folder is not there as it got deleted by
the command itself.
* The cache is empty and this is exactly what the user expects from the
command

Closes #1972