### PR TITLE
Add BlueprintFoundOnFile event

### DIFF
--- a/src/Events/Data/BlueprintFoundOnFile.php
+++ b/src/Events/Data/BlueprintFoundOnFile.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Statamic\Events\Data;
+
+use Statamic\Events\Event;
+
+class BlueprintFoundOnFile extends Event
+{
+    public $blueprint;
+    public $type;
+    public $data;
+
+    public function __construct($blueprint)
+    {
+        $this->blueprint = $blueprint;
+    }
+}

--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -37,6 +37,7 @@ class BlueprintRepository
 
         if ($cached = array_get($this->blueprints, $handle)) {
             event(new BlueprintFoundOnFile($cached));
+
             return $cached;
         }
 

--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -3,6 +3,7 @@
 namespace Statamic\Fields;
 
 use Illuminate\Support\Collection;
+use Statamic\Events\Data\BlueprintFoundOnFile;
 use Statamic\Facades\File;
 use Statamic\Facades\Path;
 use Statamic\Facades\YAML;
@@ -35,6 +36,7 @@ class BlueprintRepository
         }
 
         if ($cached = array_get($this->blueprints, $handle)) {
+            event(new BlueprintFoundOnFile($cached));
             return $cached;
         }
 
@@ -47,6 +49,8 @@ class BlueprintRepository
         $blueprint = (new Blueprint)
             ->setHandle($handle)
             ->setContents(YAML::parse(File::get($path)));
+
+        event(new BlueprintFoundOnFile($blueprint));
 
         $this->blueprints[$handle] = $blueprint;
 


### PR DESCRIPTION
Emitted after a blueprint has either been found on file or in the blueprints cache.

Solves https://github.com/statamic/ideas/issues/211 by adding a way to modify blueprints after they are retrieved for validation when saving entries.

I'm not sure but this may also need to be added to the BlueprintRepository@all method