### PR TITLE
Adding cache invalidation logic for URL defined in static_caching.php…

### DIFF
--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -25,7 +25,7 @@ class DefaultInvalidator implements Invalidator
         }
 
         if ($this->rules !== 'all' && ! empty($this->rules['collections'])) {
-            if (!empty($this->rules['collections'][$item->collectionHandle()])) {
+            if (! empty($this->rules['collections'][$item->collectionHandle()])) {
                 $invalidateUrls = $this->rules['collections'][$item->collectionHandle()]['urls'];
 
                 if (is_array($invalidateUrls) && ! empty($invalidateUrls)) {

--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -35,7 +35,5 @@ class DefaultInvalidator implements Invalidator
                 }
             }
         }
-
     }
-
 }

--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -15,7 +15,7 @@ class DefaultInvalidator implements Invalidator
 
     public function invalidate($item)
     {
-        if ($this->rules === 'all') {
+        if ($this->rules['rules'] === 'all') {
             return $this->cacher->flush();
         }
 
@@ -23,5 +23,16 @@ class DefaultInvalidator implements Invalidator
         if ($url = $item->url()) {
             $this->cacher->invalidateUrl($url);
         }
+
+        if($this->rules['rules'] !== 'all' && !empty($this->rules['rules']['collections'])) {
+            $invalidateUrls = $this->rules['rules']['collections'][$item->collectionHandle()]['urls'];
+
+            if(is_array($invalidateUrls) && !empty($invalidateUrls)) {
+                foreach($invalidateUrls as $urlToInvalidate) {
+                    $this->cacher->invalidateUrl($urlToInvalidate);
+                }
+            }
+        }
+
     }
 }

--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Statamic\StaticCaching;
+use Illuminate\Support\Facades\Log;
 
 class DefaultInvalidator implements Invalidator
 {
@@ -15,7 +16,7 @@ class DefaultInvalidator implements Invalidator
 
     public function invalidate($item)
     {
-        if ($this->rules['rules'] === 'all') {
+        if ($this->rules === 'all') {
             return $this->cacher->flush();
         }
 
@@ -24,15 +25,18 @@ class DefaultInvalidator implements Invalidator
             $this->cacher->invalidateUrl($url);
         }
 
-        if($this->rules['rules'] !== 'all' && ! empty($this->rules['rules']['collections'])) {
-            $invalidateUrls = $this->rules['rules']['collections'][$item->collectionHandle()]['urls'];
+        if ($this->rules !== 'all' && !empty($this->rules['collections'])) {
+            if (!empty($this->rules['collections'][$item->collectionHandle()])) {
+                $invalidateUrls = $this->rules['collections'][$item->collectionHandle()]['urls'];
 
-            if(is_array($invalidateUrls) && ! empty($invalidateUrls)) {
-                foreach($invalidateUrls as $urlToInvalidate) {
-                    $this->cacher->invalidateUrl($urlToInvalidate);
+                if (is_array($invalidateUrls) && !empty($invalidateUrls)) {
+                    foreach ($invalidateUrls as $urlToInvalidate) {
+                        $this->cacher->invalidateUrl($urlToInvalidate);
+                    }
                 }
             }
         }
 
     }
+
 }

--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace Statamic\StaticCaching;
-use Illuminate\Support\Facades\Log;
 
 class DefaultInvalidator implements Invalidator
 {
@@ -25,11 +24,11 @@ class DefaultInvalidator implements Invalidator
             $this->cacher->invalidateUrl($url);
         }
 
-        if ($this->rules !== 'all' && !empty($this->rules['collections'])) {
+        if ($this->rules !== 'all' && ! empty($this->rules['collections'])) {
             if (!empty($this->rules['collections'][$item->collectionHandle()])) {
                 $invalidateUrls = $this->rules['collections'][$item->collectionHandle()]['urls'];
 
-                if (is_array($invalidateUrls) && !empty($invalidateUrls)) {
+                if (is_array($invalidateUrls) && ! empty($invalidateUrls)) {
                     foreach ($invalidateUrls as $urlToInvalidate) {
                         $this->cacher->invalidateUrl($urlToInvalidate);
                     }

--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -24,10 +24,10 @@ class DefaultInvalidator implements Invalidator
             $this->cacher->invalidateUrl($url);
         }
 
-        if($this->rules['rules'] !== 'all' && !empty($this->rules['rules']['collections'])) {
+        if($this->rules['rules'] !== 'all' && ! empty($this->rules['rules']['collections'])) {
             $invalidateUrls = $this->rules['rules']['collections'][$item->collectionHandle()]['urls'];
 
-            if(is_array($invalidateUrls) && !empty($invalidateUrls)) {
+            if(is_array($invalidateUrls) && ! empty($invalidateUrls)) {
                 foreach($invalidateUrls as $urlToInvalidate) {
                     $this->cacher->invalidateUrl($urlToInvalidate);
                 }

--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -23,7 +23,7 @@ class ServiceProvider extends LaravelServiceProvider
 
             return new $class(
                 $app[Cacher::class],
-                $app['config']['statamic.static_caching.invalidation']
+                $app['config']['statamic.static_caching.invalidation.rules']
             );
         });
     }


### PR DESCRIPTION
Addressing issue: #1427 
There were 2 issues in src/StaticCaching/DefaultInvalidator.php:
1) service provider was missing .rules reference
2) By URL invalidation logic was missing (added in lines 26 - 43)

There is also another potential issue when route for collection is not defiend -> item->url always point to root page / and invalidates it.

*_I need this for 2 sites that are close to production hence my fix proposal._