### PR TITLE
use html-to-prosemirror and prosemirror-to-html from new namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         "league/csv": "^9.0",
         "league/glide": "^1.1",
         "pixelfear/composer-dist-plugin": "^0.1.0",
-        "scrumpy/html-to-prosemirror": "^0.7.0",
-        "scrumpy/prosemirror-to-html": "^0.10.0",
         "spatie/blink": "^1.1.2",
         "statamic/stringy": "^3.1",
         "symfony/var-exporter": "^4.3",
         "symfony/yaml": "^4.1@dev",
         "twistor/flysystem-guzzle": "^6.0",
+        "ueberdosis/html-to-prosemirror": "^0.7.0",
+        "ueberdosis/prosemirror-to-html": "^1.0",
         "wilderborn/partyline": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/yaml": "^4.1@dev",
         "twistor/flysystem-guzzle": "^6.0",
         "ueberdosis/html-to-prosemirror": "^0.7.0",
-        "ueberdosis/prosemirror-to-html": "^1.0",
+        "ueberdosis/prosemirror-to-html": "^0.10.0",
         "wilderborn/partyline": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
We moved html-to-prosemirror and prosemirror-to-html to a new organization, more on this here: https://github.com/scrumpy/tiptap/issues/759

See also:
https://packagist.org/packages/scrumpy/html-to-prosemirror
https://packagist.org/packages/scrumpy/prosemirror-to-html

TL;DR 
* tiptap and related packages move to a new organization name, but it’s the same people (me and others)
* we plan to focus on open source work, so it’s good news