### PR TITLE
Add hyphened locale

### DIFF
--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -38,6 +38,11 @@ class Site implements Augmentable
     {
         return explode('-', str_replace('_', '-', $this->locale()))[0];
     }
+    
+    public function hyphenedLocale()
+    {
+        return str_replace('_', '-', $this->locale());
+    }
 
     public function url()
     {
@@ -84,6 +89,7 @@ class Site implements Augmentable
             'name' => $this->name(),
             'locale' => $this->locale(),
             'short_locale' => $this->shortLocale(),
+            'hyphened_locale' => $this->hyphenedLocale(),
             'url' => $this->url(),
         ];
     }


### PR DESCRIPTION
This makes a `{{ site:hyphenedLocale }}` available which outputs the site's locale in `ISO 3166-1 alpha-2` format. This is useful to get a valid regional locale that can be used for things like the `lang` attribute, e.g. `<html lang="en-GB">`