### PR TITLE
Allow fields with required condition to be nullable

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -73,18 +73,7 @@ class Field implements Arrayable
 
     protected function addNullableRule($rules)
     {
-        $nullable = true;
-
-        foreach ($rules as $rule) {
-            if (preg_match('/^required_?/', $rule)) {
-                $nullable = false;
-                break;
-            }
-        }
-
-        if ($nullable) {
-            $rules[] = 'nullable';
-        }
+        $rules[] = 'nullable';
 
         return $rules;
     }

--- a/tests/Fields/FieldTest.php
+++ b/tests/Fields/FieldTest.php
@@ -80,7 +80,7 @@ class FieldTest extends TestCase
         ]);
 
         $this->assertEquals([
-            'test' => ['required', 'min:2'],
+            'test' => ['required', 'min:2', 'nullable'],
         ], $field->rules());
     }
 
@@ -119,7 +119,7 @@ class FieldTest extends TestCase
         ]);
 
         $this->assertEquals([
-            'test' => ['required', 'array', 'min:2', 'max:5'],
+            'test' => ['required', 'array', 'min:2', 'max:5', 'nullable'],
         ], $field->rules());
     }
 
@@ -143,8 +143,8 @@ class FieldTest extends TestCase
         ]);
 
         $this->assertEquals([
-            'test' => ['required'],
-            'test.*.one' => ['required', 'min:2'],
+            'test' => ['required', 'nullable'],
+            'test.*.one' => ['required', 'min:2', 'nullable'],
             'test.*.two' => ['max:2', 'nullable'],
         ], $field->rules());
     }

--- a/tests/Fields/FieldTest.php
+++ b/tests/Fields/FieldTest.php
@@ -227,7 +227,7 @@ class FieldTest extends TestCase
     }
 
     /** @test */
-    public function it_adds_nullable_rule_when_not_required()
+    public function it_adds_nullable_rule_by_default()
     {
         $fieldtype = new class extends Fieldtype {
             protected $rules = null;
@@ -259,9 +259,9 @@ class FieldTest extends TestCase
         ]);
 
         $this->assertEquals(['test' => ['min:2', 'nullable']], $nullableField->rules());
-        $this->assertEquals(['test' => ['required', 'min:2']], $booleanRequiredField->rules());
-        $this->assertEquals(['test' => ['required', 'min:2']], $validateRequiredField->rules());
-        $this->assertEquals(['test' => ['required_if:foo', 'min:2']], $validateRequiredIfField->rules());
+        $this->assertEquals(['test' => ['required', 'min:2', 'nullable']], $booleanRequiredField->rules());
+        $this->assertEquals(['test' => ['required', 'min:2', 'nullable']], $validateRequiredField->rules());
+        $this->assertEquals(['test' => ['required_if:foo', 'min:2', 'nullable']], $validateRequiredIfField->rules());
     }
 
     /** @test */


### PR DESCRIPTION
Fields should be nullable by default, so this condition is not necessary: https://github.com/statamic/cms/blob/master/src/Fields/Field.php#L79

All the rules below will work in any case:
```
'field_1' => 'nullable|required_if:toggle,true',
'field_2' => 'nullable|required_with=field_1',
'field_3' => 'nullable|required',
```

Closes: https://github.com/statamic/cms/issues/2074