### PR TITLE
Fix Review command error after last array key

### DIFF
--- a/src/Translator/Commands/Review.php
+++ b/src/Translator/Commands/Review.php
@@ -41,7 +41,7 @@ class Review extends Command
         $lang = $input->getArgument('lang');
 
         if ($file = $input->getArgument('file')) {
-            return $this->reviewKeyFile($lang, $file);
+            $this->reviewKeyFile($lang, $file);
         }
 
         $this->reviewStringFile($lang);


### PR DESCRIPTION
When you finish to translate a file, the Review command returns this error:
```
Uncaught TypeError: Return value of "Statamic\Translator\Commands\Review::execute()" must be of the type int, "null" returned
```

This PR fix this error.