### PR TITLE
Glide does handle unsupported file formats.

### DIFF
--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -15,19 +15,21 @@ use Statamic\Support\Str;
 class Glide extends Tags
 {
     /**
-     * Allowed file extension for the gd image manipulation driver.
-     * (Glide does rely on the intervention package)
-     * http://image.intervention.io/getting_started/formats
+     * Allowed file formats for the gd image manipulation driver in combinatino with glide.
+     
+     * Glide does use the intervention package under the hood.
+     * See http://image.intervention.io/getting_started/formats for mor information.
      */
     const ALLOWED_FILE_FORMATS_GD = ['jpeg', 'jpg', 'png', 'gif', 'webp'];
 
     /**
-     * Allowed file extension for the imagick image manipulation driver in combination with glide.
-     * (Glide does rely on the intervention package)
-     * http://image.intervention.io/getting_started/formats
+     * Allowed file formats for the imagick image manipulation driver in combination with glide.
+     * 
+     * Glide does use the intervention package under the hood.
+     * See http://image.intervention.io/getting_started/formats for mor information.
      */
     const ALLOWED_FILE_FORMATS_IMAGICK = ['jpeg', 'jpg', 'png', 'gif', 'tif', 'bmp', 'psd', 'webp'];
-    
+
     /**
      * Maps to {{ glide:[field] }}.
      *
@@ -282,8 +284,7 @@ class Glide extends Tags
     {
         return app(Server::class);
     }
-    
-    
+
     /**
      * Checking against a whitelist of allowed file extensions.
      *

--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -16,7 +16,7 @@ class Glide extends Tags
 {
     /**
      * Allowed file formats for the gd image manipulation driver in combinatino with glide.
-     
+     *
      * Glide does use the intervention package under the hood.
      * See http://image.intervention.io/getting_started/formats for mor information.
      */
@@ -24,7 +24,7 @@ class Glide extends Tags
 
     /**
      * Allowed file formats for the imagick image manipulation driver in combination with glide.
-     * 
+     *
      * Glide does use the intervention package under the hood.
      * See http://image.intervention.io/getting_started/formats for mor information.
      */


### PR DESCRIPTION
Glide is a great tool to resize images, but can't handle some file formats like SVG files. It does make sense. Why would you want to resize a SVG image?

This PR does make it possible to pass any kind of image to glide. Should a specific format be not supported, glide will return the original path and the image would be shown in every case. 

A common use case will make this more clear. 

**Until now you would check if fx an SVG is among the images.**
```
{{ customers }}
    {{ if logo:extension !== "svg" }}
        <img src="{{ glide:logo width='165' quality='100' }}">
    {{ else }}
        <img src="{{ logo }}">
    {{ /if }}
{{ /customers }}
```

**The same result if this PR gets approved**
```
{{ customers }}
    <img src="{{ glide:logo width='165' quality='100' }}">
{{ /customers }}
```

The SVG format is not supported, so the original path would be returned.

@jasonvarga I am not sure about the Exception.