### PR TITLE
Fix cp axios requests when in subdirectory

### DIFF
--- a/resources/js/components/AddonList.vue
+++ b/resources/js/components/AddonList.vue
@@ -170,7 +170,7 @@
             getAddons() {
                 this.loading = true;
 
-                this.$axios.get(cp_url('api/addons'), {'params': this.params}).then(response => {
+                this.$axios.get(cp_url('/api/addons'), {'params': this.params}).then(response => {
                     this.loading = false;
                     this.initializing = false;
                     this.rows = response.data.data;

--- a/resources/js/components/AddonList.vue
+++ b/resources/js/components/AddonList.vue
@@ -170,7 +170,7 @@
             getAddons() {
                 this.loading = true;
 
-                this.$axios.get(window.Statamic.$config.get('cpRoot')+'/api/addons', {'params': this.params}).then(response => {
+                this.$axios.get(cp_url('api/addons'), {'params': this.params}).then(response => {
                     this.loading = false;
                     this.initializing = false;
                     this.rows = response.data.data;

--- a/resources/js/components/updater/Updater.vue
+++ b/resources/js/components/updater/Updater.vue
@@ -142,7 +142,7 @@
             getChangelog() {
                 this.gettingChangelog = true;
 
-                this.$axios.get(cp_url(`updater/${this.slug}/changelog`)).then(response => {
+                this.$axios.get(cp_url(`/updater/${this.slug}/changelog`)).then(response => {
                     this.gettingChangelog = false;
                     this.changelog = response.data.changelog;
                     this.currentVersion = response.data.currentVersion;
@@ -156,7 +156,7 @@
             },
 
             installExplicitVersion(version) {
-                this.$axios.post(cp_url(`updater/${this.slug}/install`), {'version': version}, this.toEleven);
+                this.$axios.post(cp_url(`/updater/${this.slug}/install`), {'version': version}, this.toEleven);
 
                 this.$store.commit('statamic/composer', {
                     processing: true,

--- a/resources/js/components/updater/Updater.vue
+++ b/resources/js/components/updater/Updater.vue
@@ -142,7 +142,7 @@
             getChangelog() {
                 this.gettingChangelog = true;
 
-                this.$axios.get(`/cp/updater/${this.slug}/changelog`).then(response => {
+                this.$axios.get(cp_url(`updater/${this.slug}/changelog`)).then(response => {
                     this.gettingChangelog = false;
                     this.changelog = response.data.changelog;
                     this.currentVersion = response.data.currentVersion;
@@ -156,7 +156,7 @@
             },
 
             installExplicitVersion(version) {
-                this.$axios.post(`/cp/updater/${this.slug}/install`, {'version': version}, this.toEleven);
+                this.$axios.post(cp_url(`updater/${this.slug}/install`), {'version': version}, this.toEleven);
 
                 this.$store.commit('statamic/composer', {
                     processing: true,


### PR DESCRIPTION
When running in a sub-directory (e.g. domain.com/docs), some axios requests to cp routes are not passed through the `cp_url` function. This results in 404s because they go to `domain.com` instead of `domain.com/docs`.

This is preventing the Updates and Addons pages from working.