### PR TITLE
Fix section fieldtype label margin

### DIFF
--- a/resources/sass/components/fieldtypes/section.scss
+++ b/resources/sass/components/fieldtypes/section.scss
@@ -11,10 +11,10 @@
         &:first-child {
             @apply .rounded-t .border-t-0;
         }
-    }
 
-    label {
-        @apply .uppercase .text-sm .font-bold mb-2;
+        .field-inner > label {
+            @apply .uppercase .text-sm .font-bold .mt-1;
+        }
     }
 
     .help-block {


### PR DESCRIPTION
The current specificity of field type labels leaves a section field type looking a bit off. This fixes the specificity for styling that field type label and changes it to just have equal margin on top and bottom.

Before:

![Screen Shot 2020-07-29 at 1 42 14 PM](https://user-images.githubusercontent.com/114763/88834250-8fc1bd00-d1a1-11ea-9011-23bc3e7663c6.png)

After:

![Screen Shot 2020-07-29 at 1 40 27 PM](https://user-images.githubusercontent.com/114763/88834264-95b79e00-d1a1-11ea-8cbe-64d884294e2c.png)
