### PR TITLE
Add GlideImageGenerated event to ImageGenerator

### DIFF
--- a/src/Events/GlideImageGenerated.php
+++ b/src/Events/GlideImageGenerated.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Events;
+
+class GlideImageGenerated extends Event
+{
+    public $path;
+
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+}

--- a/src/Events/GlideImageGenerated.php
+++ b/src/Events/GlideImageGenerated.php
@@ -5,9 +5,11 @@ namespace Statamic\Events;
 class GlideImageGenerated extends Event
 {
     public $path;
+    public $params;
 
-    public function __construct($path)
+    public function __construct($path, $params)
     {
         $this->path = $path;
+        $this->params = $params;
     }
 }

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
 use League\Glide\Server;
+use Statamic\Events\GlideImageGenerated;
 use Statamic\Facades\Config;
 use Statamic\Facades\File;
 use Twistor\Flysystem\GuzzleAdapter;
@@ -145,7 +146,7 @@ class ImageGenerator
 
         $path = $this->server->makeImage($image, $this->params);
 
-        // TODO: GlideImageGenerated event
+        GlideImageGenerated::dispatch($path);
 
         return $path;
     }

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -146,7 +146,7 @@ class ImageGenerator
 
         $path = $this->server->makeImage($image, $this->params);
 
-        GlideImageGenerated::dispatch($path);
+        GlideImageGenerated::dispatch($path, $this->params);
 
         return $path;
     }


### PR DESCRIPTION
This PR adds a missing event to /Statamic/Imaging/ImageGenerator. It was already noted as a TODO and is implemented pretty much the same as it was in V2.