### PR TITLE
Fix for Email.php to evaluate html view AntlerString for use with Mailer

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -65,10 +65,14 @@ class Email extends Mailable
         }
 
         if ($text) {
-            $this->text($text);
+            $this->text((string) $text);
         }
 
-        return $this->view($html);
+        if ($html) {
+            $this->view((string) $html);
+        }
+
+        return $this;
     }
 
     protected function addData()

--- a/tests/Forms/EmailTest.php
+++ b/tests/Forms/EmailTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Forms;
+
+use Mockery as m;
+use Statamic\Facades\Antlers;
+use Statamic\Forms\Email;
+use Statamic\Forms\Submission;
+use Tests\TestCase;
+
+class EmailTest extends TestCase
+{
+    /** @test */
+    public function it_sets_html_view_as_string()
+    {
+        /** @var Submission */
+        $submission = m::mock(Submission::class);
+        $submission->shouldReceive('toArray')->andReturn([]);
+
+        $email = new Email($submission, [
+            'to' => Antlers::parse('test@example.com'),
+            'html' => Antlers::parse('emails/test'),
+        ]);
+
+        $email->build();
+
+        $this->assertTrue(is_string($email->view), 'View is not a string.');
+        $this->assertEquals('emails/test', $email->view);
+    }
+}


### PR DESCRIPTION
Fixes #2131 by casting AntlerString to string so Laravel Mailer will know it can use the view.