### PR TITLE
Make configs and translations publishable

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -29,7 +29,7 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected $externalScripts = [];
     protected $publishables = [];
     protected $configs = [];
-    protected $languages = [];
+    protected $translations = [];
     protected $routes = [];
     protected $middlewareGroups = [];
     protected $viewNamespace;
@@ -55,7 +55,7 @@ abstract class AddonServiceProvider extends ServiceProvider
                 ->bootScripts()
                 ->bootPublishables()
                 ->bootConfigs()
-                ->bootLanguages()
+                ->bootTranslations()
                 ->bootRoutes()
                 ->bootMiddleware()
                 ->bootViews()
@@ -174,10 +174,10 @@ abstract class AddonServiceProvider extends ServiceProvider
         return $this;
     }
 
-    protected function bootLanguages()
+    protected function bootTranslations()
     {
-        foreach ($this->languages as $origin) {
-            $this->registerLanguages($origin);
+        foreach ($this->translation as $origin) {
+            $this->registerTranslations($origin);
         }
 
         return $this;
@@ -352,27 +352,27 @@ abstract class AddonServiceProvider extends ServiceProvider
         ], $this->getAddon()->slug());
     }
 
-    protected function registerLanguages(string $origin)
+    protected function registerTranslations(string $origin)
     {
         $package = $this->getAddon()->packageName(); 
         $destination = resource_path("lang/vendor/{$package}");
 
-        $originLanguages = collect(File::allFiles($origin))->map(function ($language) {
-            return $language->getRelativePathname();
+        $originTranslations = collect(File::allFiles($origin))->map(function ($translation) {
+            return $translation->getRelativePathname();
         });
 
         if (File::isDirectory($destination)) {
-            $destinationLanguages = collect(File::allFiles($destination))->map(function ($language) {
-                return $language->getRelativePathname();
+            $destinationTranslations = collect(File::allFiles($destination))->map(function ($translation) {
+                return $translation->getRelativePathname();
             });
         }
         
-        $languages = $originLanguages->diff($destinationLanguages ?? collect())
-            ->mapWithKeys(function ($language) use ($origin, $destination) {
-                return ["{$origin}/$language" => "{$destination}/{$language}"];
+        $translations = $originTranslations->diff($destinationTranslations ?? collect())
+            ->mapWithKeys(function ($translation) use ($origin, $destination) {
+                return ["{$origin}/$translation" => "{$destination}/{$translation}"];
             });
         
-        $this->publishes($languages->all(), $this->getAddon()->slug());
+        $this->publishes($translations->all(), $this->getAddon()->slug());
     }
 
     protected function schedule($schedule)

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -166,13 +166,13 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootConfig()
     {
-        if (! $this->config) {
-            return $this;
-        }
-
         $filename = $this->getAddon()->slug();
         $directory = $this->getAddon()->directory();
         $origin = "{$directory}config/{$filename}.php";
+
+        if (! $this->config || ! file_exists($origin)) {
+            return $this;
+        }
 
         $this->mergeConfigFrom($origin, $filename);
 
@@ -185,13 +185,13 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootTranslations()
     {
-        if (! $this->translations) {
-            return $this;
-        }
-
         $slug = $this->getAddon()->slug();
         $directory = $this->getAddon()->directory();
         $origin = "{$directory}resources/lang";
+
+        if (! $this->translations || ! file_exists($origin)) {
+            return $this;
+        }
 
         $this->loadTranslationsFrom($origin, $slug);
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -31,8 +31,8 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected $middlewareGroups = [];
     protected $viewNamespace;
     protected $publishAfterInstall = true;
-    protected $mergeAndPublishConfig = true;
-    protected $loadAndPublishTranslations = true;
+    protected $config = true;
+    protected $translations = true;
 
     public function boot()
     {
@@ -53,7 +53,7 @@ abstract class AddonServiceProvider extends ServiceProvider
                 ->bootStylesheets()
                 ->bootScripts()
                 ->bootPublishables()
-                ->bootConfigs()
+                ->bootConfig()
                 ->bootTranslations()
                 ->bootRoutes()
                 ->bootMiddleware()
@@ -164,9 +164,9 @@ abstract class AddonServiceProvider extends ServiceProvider
         return $this;
     }
 
-    protected function bootConfigs()
+    protected function bootConfig()
     {
-        if (! $this->mergeAndPublishConfig) {
+        if (! $this->config) {
             return $this;
         }
 
@@ -185,11 +185,10 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootTranslations()
     {
-        if (! $this->loadAndPublishTranslations) {
+        if (! $this->translations) {
             return $this;
         }
 
-        $package = $this->getAddon()->packageName();
         $slug = $this->getAddon()->slug();
         $directory = $this->getAddon()->directory();
         $origin = "{$directory}resources/lang";
@@ -197,7 +196,7 @@ abstract class AddonServiceProvider extends ServiceProvider
         $this->loadTranslationsFrom($origin, $slug);
 
         $this->publishes([
-            $origin => resource_path("lang/vendor/{$package}")
+            $origin => resource_path("lang/vendor/{$slug}")
         ], "{$slug}-translations");
 
         return $this;

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -176,7 +176,7 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootTranslations()
     {
-        foreach ($this->translation as $origin) {
+        foreach ($this->translations as $origin) {
             $this->registerTranslations($origin);
         }
 


### PR DESCRIPTION
I had to open a new PR because I had to change the target branch. This is the same PR as #2135. 

## Summary

An addon's config and translations now automatically merge and load. 

You can also publish the files:

```bash
// Config
vendor:publish --tag="addon-slug-config"

// Translations
vendor:publish --tag="addon-slug-translations"
```

If you don't want to merge the config and load the translations you can opt-out of it by setting the following properties in the addon's Service Provider:

```php
protected $config = false;
protected $translations = false;
```