### PR TITLE
Override a blueprint field

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -262,6 +262,13 @@ class Field implements Arrayable
         return array_get($this->config, $key, $fallback);
     }
 
+    public function set(string $key, $value)
+    {
+        array_set($this->config, $key, $value);
+        
+        return $this;
+    }
+
     private function preProcessedConfig()
     {
         $fieldtype = $this->fieldtype();


### PR DESCRIPTION
With this PR you can set a key-value pair on a blueprint field and save the field back to the blueprint.
This is a prototype of this idea: [Get and set blueprint fields #261](https://github.com/statamic/ideas/issues/261)

**How I accomplish this:**
- Added a `set($key, $value)` method to `Statamic\Fields\Field::class` that makes it possible to set a key-value pair to a field's config. 
- Added a `mergeField($handle, $fieldConfig)` to `Statamic\Fields\Blueprint::class` to override the config of an existing field. To accomplish this, I added a new `$override` parameter to the `ensureFieldInSection()` method. When the argument to this parameter is `true`, the `addEnsuredFieldToContents()` method will merge the config the other way around.

There might be some moving parts I didn't catch yet. But the basic idea is working like this:

```php
$blueprint = Blueprint::find($handle);

$fieldToMerge = $blueprint->field($handle)->set($key, $value)->config();

$blueprint->mergeField($handle, $fieldToMerge)->save();
```

This doesn't yet support to update the field's handle as well. That would be the cherry on the top.

There might even be an easier way to achieve all this with existing methods. Not sure.