### PR TITLE
Track last update

### DIFF
--- a/config/cp.php
+++ b/config/cp.php
@@ -75,4 +75,16 @@ return [
 
     'link_to_docs' => true,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Track Last Update
+    |--------------------------------------------------------------------------
+    |
+    | Automatically sets "updated_by" user id and "updated_at" timestamp
+    | when content is updated.
+    |
+    */
+
+    'track_last_update' => true,
+
 ];

--- a/src/Data/TracksLastModified.php
+++ b/src/Data/TracksLastModified.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Statamic\Data;
+
+use Illuminate\Support\Carbon;
+use Statamic\Facades\User;
+
+trait TracksLastModified
+{
+    public function lastModified()
+    {
+        return $this->has('updated_at')
+            ? Carbon::createFromTimestamp($this->get('updated_at'))
+            : $this->fileLastModified();
+    }
+
+    public function lastModifiedBy()
+    {
+        return $this->has('updated_by')
+            ? User::find($this->get('updated_by'))
+            : null;
+    }
+
+    public function updateLastModified($user = null)
+    {
+        if (! config('statamic.cp.track_last_update')) {
+            return $this;
+        }
+
+        return $this
+            ->set('updated_by', optional($user ?: User::current())->id())
+            ->set('updated_at', Carbon::now()->timestamp);
+    }
+
+    public function touch()
+    {
+        $this->updateLastModified()->save();
+    }
+}

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -13,6 +13,7 @@ use Statamic\Data\ExistsAsFile;
 use Statamic\Data\HasAugmentedInstance;
 use Statamic\Data\HasOrigin;
 use Statamic\Data\Publishable;
+use Statamic\Data\TracksLastModified;
 use Statamic\Data\TracksQueriedColumns;
 use Statamic\Events\EntryDeleted;
 use Statamic\Events\EntrySaved;
@@ -23,7 +24,6 @@ use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
-use Statamic\Facades\User;
 use Statamic\Revisions\Revisable;
 use Statamic\Routing\Routable;
 use Statamic\Statamic;
@@ -35,7 +35,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization
         uri as routableUri;
     }
 
-    use ContainsData, ExistsAsFile, HasAugmentedInstance, FluentlyGetsAndSets, Revisable, Publishable, TracksQueriedColumns;
+    use ContainsData, ExistsAsFile, HasAugmentedInstance, FluentlyGetsAndSets, Revisable, Publishable, TracksQueriedColumns, TracksLastModified;
     use HasOrigin {
         value as originValue;
         values as originValues;
@@ -409,20 +409,6 @@ class Entry implements Contract, Augmentable, Responsable, Localization
             ->published($attrs['published'])
             ->data($attrs['data'])
             ->slug($attrs['slug']);
-    }
-
-    public function lastModified()
-    {
-        return $this->has('updated_at')
-            ? Carbon::createFromTimestamp($this->get('updated_at'))
-            : $this->fileLastModified();
-    }
-
-    public function lastModifiedBy()
-    {
-        return $this->has('updated_by')
-            ? User::find($this->get('updated_by'))
-            : null;
     }
 
     public function status()

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -189,10 +189,7 @@ class EntriesController extends CpController
                 $entry->published($request->published);
             }
 
-            $entry
-                ->set('updated_by', User::fromUser($request->user())->id())
-                ->set('updated_at', now()->timestamp)
-                ->save();
+            $entry->updateLastModified()->save();
         }
 
         return new EntryResource($entry->fresh());
@@ -299,10 +296,7 @@ class EntriesController extends CpController
                 'user' => User::fromUser($request->user()),
             ]);
         } else {
-            $entry
-                ->set('updated_by', User::fromUser($request->user())->id())
-                ->set('updated_at', now()->timestamp)
-                ->save();
+            $entry->updateLastModified()->save();
         }
 
         return new EntryResource($entry);

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -176,10 +176,7 @@ class TermsController extends CpController
                 $term->published($request->published);
             }
 
-            $term
-                ->set('updated_by', User::fromUser($request->user())->id())
-                ->set('updated_at', now()->timestamp)
-                ->save();
+            $term->updateLastModified()->save();
         }
 
         return new TermResource($term);
@@ -266,10 +263,7 @@ class TermsController extends CpController
                 'user' => User::fromUser($request->user()),
             ]);
         } else {
-            $term
-                ->set('updated_by', User::fromUser($request->user())->id())
-                ->set('updated_at', now()->timestamp)
-                ->save();
+            $term->updateLastModified()->save();
         }
 
         return ['data' => ['redirect' => $term->editUrl()]];

--- a/src/Revisions/Revisable.php
+++ b/src/Revisions/Revisable.php
@@ -73,8 +73,7 @@ trait Revisable
 
         $item
             ->published(true)
-            ->set('updated_at', Carbon::now()->timestamp)
-            ->set('updated_by', ($user = $options['user'] ?? false)->id())
+            ->updateLastModified($user = $options['user'] ?? false)
             ->save();
 
         $item
@@ -95,8 +94,7 @@ trait Revisable
 
         $item
             ->published(false)
-            ->set('updated_at', Carbon::now()->timestamp)
-            ->set('updated_by', ($user = $options['user'] ?? false)->id())
+            ->updateLastModified($user = $options['user'] ?? false)
             ->save();
 
         $item
@@ -115,8 +113,7 @@ trait Revisable
     {
         $this
             ->published(false)
-            ->set('updated_at', Carbon::now()->timestamp)
-            ->set('updated_by', ($user = $options['user'] ?? false)->id())
+            ->updateLastModified($user = $options['user'] ?? false)
             ->save();
 
         $this

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -9,10 +9,10 @@ use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Data\HasAugmentedInstance;
 use Statamic\Data\Publishable;
+use Statamic\Data\TracksLastModified;
 use Statamic\Data\TracksQueriedColumns;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Site;
-use Statamic\Facades\User;
 use Statamic\Http\Responses\DataResponse;
 use Statamic\Revisions\Revisable;
 use Statamic\Routing\Routable;
@@ -20,7 +20,7 @@ use Statamic\Statamic;
 
 class LocalizedTerm implements Term, Responsable, Augmentable
 {
-    use Revisable, Routable, Publishable, HasAugmentedInstance, TracksQueriedColumns;
+    use Revisable, Routable, Publishable, HasAugmentedInstance, TracksQueriedColumns, TracksLastModified;
 
     protected $locale;
     protected $term;
@@ -411,12 +411,5 @@ class LocalizedTerm implements Term, Responsable, Augmentable
         return $this->has('updated_at')
             ? Carbon::createFromTimestamp($this->get('updated_at'))
             : $this->term->fileLastModified();
-    }
-
-    public function lastModifiedBy()
-    {
-        return $this->has('updated_by')
-            ? User::find($this->get('updated_by'))
-            : null;
     }
 }

--- a/tests/Data/TracksLastModifiedTest.php
+++ b/tests/Data/TracksLastModifiedTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Data;
+
+use Illuminate\Support\Carbon;
+use Statamic\Facades;
+use Tests\TestCase;
+
+class TracksLastModifiedTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $collection = Facades\Collection::make('pages');
+        $collection->save();
+
+        $this->entry = Facades\Entry::make()
+            ->collection($collection)
+            ->locale(Facades\Site::default()->handle());
+
+        $this->user = Facades\User::make()->email('hoff@baywatch.com')->save();
+    }
+
+    public function tearDown(): void
+    {
+        Facades\Collection::all()->each->delete();
+        Facades\Entry::all()->each->delete();
+        Facades\User::all()->each->delete();
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_gets_last_updated_at_from_file()
+    {
+        $this->assertFalse($this->entry->has('updated_at'));
+        $this->assertEquals($this->entry->fileLastModified()->timestamp, $this->entry->lastModified()->timestamp);
+    }
+
+    /** @test */
+    public function it_updates_and_gets_last_updated_at_from_data()
+    {
+        $this->assertFalse($this->entry->has('updated_at'));
+
+        $this->entry->updateLastModified()->save();
+
+        $this->assertTrue($this->entry->has('updated_at'));
+        $this->assertEquals(Carbon::parse($this->entry->get('updated_at'))->timestamp, $this->entry->lastModified()->timestamp);
+    }
+
+    /** @test */
+    public function it_updates_and_gets_last_updated_by()
+    {
+        $this->assertNull($this->entry->lastModifiedBy());
+
+        $this->actingAs($this->user);
+
+        $this->entry->updateLastModified()->save();
+
+        $this->assertTrue($this->entry->has('updated_by'));
+        $this->assertEquals('hoff@baywatch.com', $this->entry->lastModifiedBy()->email());
+    }
+
+    /** @test */
+    public function it_updates_last_modified_with_custom_user()
+    {
+        $this->actingAs($this->user);
+
+        $this->entry->updateLastModified()->save();
+
+        $this->assertEquals('hoff@baywatch.com', $this->entry->lastModifiedBy()->email());
+
+        $casey = Facades\User::make()->email('casey@baywatch.com')->save();
+
+        $this->entry->updateLastModified($casey)->save();
+
+        $this->assertEquals('casey@baywatch.com', $this->entry->lastModifiedBy()->email());
+    }
+
+    /** @test */
+    public function it_doesnt_get_last_updated_by_when_there_is_no_user_in_data()
+    {
+        $this->assertNull($this->entry->lastModifiedBy());
+
+        $this->entry->updateLastModified()->save();
+
+        $this->assertFalse($this->entry->has('updated_by'));
+        $this->assertNull($this->entry->lastModifiedBy());
+    }
+
+    /** @test */
+    public function it_can_touch_item_similar_to_eloquent()
+    {
+        $this->actingAs($this->user);
+
+        $this->assertFalse($this->entry->has('updated_at'));
+        $this->assertFalse($this->entry->has('updated_by'));
+
+        $touched = $this->entry->touch();
+
+        $this->assertNull($touched);
+        $this->assertTrue($this->entry->has('updated_at'));
+        $this->assertTrue($this->entry->has('updated_by'));
+        $this->assertEquals(Carbon::parse($this->entry->get('updated_at'))->timestamp, $this->entry->lastModified()->timestamp);
+        $this->assertEquals('hoff@baywatch.com', $this->entry->lastModifiedBy()->email());
+    }
+
+    /** @test */
+    public function it_will_not_update_when_config_is_last_modified()
+    {
+        $this->actingAs($this->user);
+
+        $this->assertFalse($this->entry->has('updated_at'));
+        $this->assertFalse($this->entry->has('updated_by'));
+
+        Facades\Config::set('statamic.cp.track_last_update', false);
+
+        $this->entry->updateLastModified()->save();
+        $this->entry->touch();
+
+        $this->assertFalse($this->entry->has('updated_at'));
+        $this->assertFalse($this->entry->has('updated_by'));
+    }
+}


### PR DESCRIPTION
- Add new `updateLastModified()` and `touch()` functionality to entries and terms.
- Add new `touch()` method similar to Eloquent's.
- Add config option to disable `updated_at` and `updated_by` tracking. Closes #1339.