### PR TITLE
Make the container field to a required 

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -434,7 +434,7 @@ export default {
         loadContainers() {
             this.$axios.get(cp_url('asset-containers')).then(response => {
                 this.containers = _.chain(response.data).indexBy('id').value();
-                this.container = this.containers[this.selectedContainer];
+                this.container = this.selectedContainer != undefined ? this.containers[this.selectedContainer] : this.containers[Object.keys(this.containers)[0]];
                 this.mode = this.$preferences.get(`assets.${this.container.id}.mode`, this.mode);
             });
         },

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -35,6 +35,7 @@ class Assets extends Fieldtype
                 'max_items' => 1,
                 'mode' => 'select',
                 'width' => 50,
+                'validate' => 'required',
             ],
             'folder' => [
                 'display' => __('Folder'),


### PR DESCRIPTION
**The Problem:**
#1523 
If you have added an asset field to fieldset/blueprints and did not defined a container a clientside exeception will occur when you remove an image (after adding one). That will cause an infinity loop in the loading section =>

That infinity loading is caused by an exception which goes back to =>

![Bildschirmfoto 2020-08-13 um 08 17 33](https://user-images.githubusercontent.com/3373530/90103561-fec31800-dd42-11ea-8f57-af23f345eb96.png)

"container" can be undefined. This will allways be the case if you do not define the "asset-container" in the field settings:

![Bildschirmfoto 2020-08-13 um 08 16 02](https://user-images.githubusercontent.com/3373530/90103682-36ca5b00-dd43-11ea-8d83-7606bbb55609.png)


**The solution:**
- Add a required flag to the field to ensure there will always be a value
- Add undefined check in Browser.vue file