### PR TITLE
Debug Command

### DIFF
--- a/src/Console/Commands/DebugCommand.php
+++ b/src/Console/Commands/DebugCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Statamic\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Application;
+use Statamic\Console\RunsInPlease;
+use Statamic\Facades\Addon;
+use Statamic\Statamic;
+
+class DebugCommand extends Command
+{
+    use RunsInPlease;
+
+    protected $signature = 'statamic:debug';
+    protected $description = 'Displays debug information about Statamic';
+
+    public function handle()
+    {
+        $this->line('Statamic version: '.Statamic::version());
+        $this->line('PHP version: '.phpversion());
+        $this->line('Laravel version: '.Application::VERSION);
+        $this->line('Statamic Pro: '.(Statamic::pro() === 1 ? 'True' : 'False'));
+        $this->line('');
+        $this->info('Installed Addons');
+
+        foreach (Addon::all() as $addon) {
+            $this->line($addon->name().' - '.$addon->version());
+        }
+    }
+}

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -12,6 +12,7 @@ class ConsoleServiceProvider extends ServiceProvider
         Commands\ListCommand::class,
         Commands\AddonsDiscover::class,
         Commands\AssetsMeta::class,
+        Commands\DebugCommand::class,
         Commands\GlideClear::class,
         Commands\Install::class,
         Commands\MakeAction::class,


### PR DESCRIPTION
After talking with Jason yesterday, I've created a command which can be run by a user and will output information, like Statamic version, PHP version, installed addons etc.

It should be helpful to replace the bottom part in Github issues asking about environment information etc, where it could ask users to run this command instead and paste the output into the Github issue.

Implements #267. Let me know if there's any changes you'd like me to make to this.

## Screenshots
I've taken a screenshot of the command output.

![image](https://user-images.githubusercontent.com/19637309/90166457-30af9b00-dd92-11ea-9596-cf850aee910d.png)
