### PR TITLE
Prevent home page with query parameters to generate 404

### DIFF
--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -20,7 +20,8 @@ class Sites
         return $this->sites;
     }
 
-    public function default()
+    public function
+    default()
     {
         return $this->sites->first();
     }
@@ -47,7 +48,7 @@ class Sites
     public function current()
     {
         return $this->current
-            ?? $this->findByUrl(request()->getUri())
+            ?? $this->findByUrl(substr(request()->getUri(), 0, strpos(request()->getUri(), '?')))
             ?? $this->default();
     }
 

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -46,8 +46,15 @@ class Sites
 
     public function current()
     {
+        // check if the URI has request parameters and strip them
+        if (Str::contains(request()->getUri(), '?')) {
+            $url = substr(request()->getUri(), 0, strpos(request()->getUri(), '?'));
+        } else {
+            $url = request()->getUri();
+        }
+
         return $this->current
-            ?? $this->findByUrl(substr(request()->getUri(), 0, strpos(request()->getUri(), '?')))
+            ?? $this->findByUrl($url)
             ?? $this->default();
     }
 

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -20,8 +20,7 @@ class Sites
         return $this->sites;
     }
 
-    public function
-    default()
+    public function default()
     {
         return $this->sites->first();
     }


### PR DESCRIPTION
This PR closes #2207 

This PR prevents a localized home page to generate a 404 if query parameters are present.

**Why this should be merged asap?** Many sites link to other sites with some way of tracking using query parameters. A 404 that is generated creates a huge problem.

**What is the initial problem?**
As of debugging the error, I encountered one thing. ``Site::current()`` will default to the default site if query parameters on a localized home page are present. Furthermore, the ``$url`` variable will be the full url (``https://somepage.com/de``) instead of just the slug (``/``). The result of that is that the requested page can't be found.

**Solution**
Strip query parameters when scanning for the current site.