### PR TITLE
Fix issues with Addon Auto-publishing

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -31,6 +31,7 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected $routes = [];
     protected $middlewareGroups = [];
     protected $viewNamespace;
+    protected $hasPublishables = false;
     protected $publishAfterInstall = true;
 
     public function boot()
@@ -171,6 +172,7 @@ abstract class AddonServiceProvider extends ServiceProvider
             });
 
         if ($publishables->count() >= 1) {
+            $this->publishables = true;
             $this->publishes($publishables->all(), $this->getAddon()->slug());
         }
 
@@ -351,7 +353,7 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootPublishAfterInstall()
     {
-        if (! $this->publishAfterInstall) {
+        if (! $this->publishAfterInstall || ! $this->hasPublishables) {
             return $this;
         }
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -171,7 +171,7 @@ abstract class AddonServiceProvider extends ServiceProvider
                 return [$origin => public_path("vendor/{$package}/{$destination}")];
             });
 
-        if ($publishables->count() >= 1) {
+        if ($publishables->isNotEmpty()) {
             $this->publishables = true;
             $this->publishes($publishables->all(), $this->getAddon()->slug());
         }

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -31,7 +31,6 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected $routes = [];
     protected $middlewareGroups = [];
     protected $viewNamespace;
-    protected $hasPublishables = false;
     protected $publishAfterInstall = true;
 
     public function boot()
@@ -172,8 +171,9 @@ abstract class AddonServiceProvider extends ServiceProvider
             });
 
         if ($publishables->isNotEmpty()) {
-            $this->publishables = true;
             $this->publishes($publishables->all(), $this->getAddon()->slug());
+        } else {
+            $this->$publishAfterInstall = false;
         }
 
         return $this;
@@ -353,7 +353,7 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootPublishAfterInstall()
     {
-        if (! $this->publishAfterInstall || ! $this->hasPublishables) {
+        if (! $this->publishAfterInstall) {
             return $this;
         }
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -170,7 +170,7 @@ abstract class AddonServiceProvider extends ServiceProvider
                 return [$origin => public_path("vendor/{$package}/{$destination}")];
             });
 
-        if ($publishables->count() >= 1) {}
+        if ($publishables->count() >= 1) {
             $this->publishes($publishables->all(), $this->getAddon()->slug());
         }
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -170,7 +170,9 @@ abstract class AddonServiceProvider extends ServiceProvider
                 return [$origin => public_path("vendor/{$package}/{$destination}")];
             });
 
-        $this->publishes($publishables->all(), $this->getAddon()->slug());
+        if ($publishables->count() >= 1) {}
+            $this->publishes($publishables->all(), $this->getAddon()->slug());
+        }
 
         return $this;
     }


### PR DESCRIPTION
For the most part, addon auto-publishing works fine, there's just two things I've fixed in this pull request:

* when an addon has no publishable assets, Statamic shouldn't register publishable stuff (it was doing `$this->publishes` even if there was nothing needing published)
* it also sorts an issue where it would try and publish an addon's stuff even if a tag didn't exist or there wasn't anything to publish. Even after the last thing was fixed, it still wouldn't solve this issue:

![image](https://user-images.githubusercontent.com/19637309/90308444-6d38df00-ded7-11ea-81fd-55db7245d608.png)

This PR fixes #2231. Hopefully this pull request is helpful.