### PR TITLE
Fix ID not being generated for manually created users

### DIFF
--- a/src/Stache/Stores/UsersStore.php
+++ b/src/Stache/Stores/UsersStore.php
@@ -30,8 +30,12 @@ class UsersStore extends BasicStore
     {
         $data = YAML::file($path)->parse($contents);
 
+        if (! $id = array_pull($data, 'id')) {
+            $id = app('stache')->generateId();
+        }
+
         $user = User::make()
-            ->id(array_pull($data, 'id'))
+            ->id($id)
             ->initialPath($path)
             ->email(pathinfo($path, PATHINFO_FILENAME))
             ->preferences(array_pull($data, 'preferences', []))


### PR DESCRIPTION
This pull request fixes an issue where if a user was created manually (ie. in the files) and it didn't already contain an ID, one would be generated. This fix stops this issue from happening:

```
(1/1) ErrorExceptionfile_put_contents(.../storage/framework/cache/data/stache/items/users/): failed to open stream: Is a directory
```

I fixed the issue by copying the equivalent on the `CollectionEntriesStore`. I left out the `$idGenerated` function, wasn't sure what that did and if it was needed, let me know if you'd like me to add that.

This pull request fixes #2138. I copied the user file from that issue to ensure it was fixed, and it worked!