### PR TITLE
ignore partials when they’re in the ‘partials’ folder

### DIFF
--- a/resources/js/components/fieldtypes/TemplateFieldtype.vue
+++ b/resources/js/components/fieldtypes/TemplateFieldtype.vue
@@ -36,7 +36,7 @@ export default {
             // Filter out partials
             if (this.config.hide_partials) {
                 templates = _.reject(templates, function(template) {
-                    return template.match(/(^_.*|\/_.*|\._.*)/g);
+                    return template.startsWith('partials/') || template.match(/(^_.*|\/_.*|\._.*)/g);
                 });
             }
 


### PR DESCRIPTION
if `hide_partials` is true, also remove the partials that are in the `partials` folder.