### PR TITLE
Center-align addon list background images

### DIFF
--- a/resources/js/components/AddonList.vue
+++ b/resources/js/components/AddonList.vue
@@ -52,7 +52,7 @@
                 <div class="addon-grid my-4" :class="{ 'opacity-50': loading }">
                     <div class="addon-card bg-white text-grey-80 h-full shadow rounded cursor-pointer relative" v-for="addon in addons" :key="addon.id" @click="showAddon(addon)">
                         <span class="badge absolute top-0 left-0 mt-1 ml-1" v-if="addon.installed">Installed</span>
-                        <div class="h-64 rounded-t bg-cover" :style="'background-image: url(\''+getCover(addon)+'\')'"></div>
+                        <div class="h-64 rounded-t bg-cover bg-center" :style="'background-image: url(\''+getCover(addon)+'\')'"></div>
                         <div class="px-3 mb-2 relative text-center">
                             <a :href="addon.seller.website" class="relative">
                                 <img :src="addon.seller.avatar" :alt="addon.seller.name" class="rounded-full h-14 w-14 z-30 bg-white relative -mt-4 border-2 border-white inline">


### PR DESCRIPTION
Tiny fix for the addon list view which doesn't seem to center-align images atm. On certain screensizes it's barely noticeable, but sometimes it's quite drastic, see before/after screenshots:

**Before**

![Screenshot 2020-08-22 at 11 58 24](https://user-images.githubusercontent.com/5065331/90953928-fa4bdd00-e46f-11ea-83c6-6322bf75b12b.jpg)

**After**

![Screenshot 2020-08-22 at 11 58 58](https://user-images.githubusercontent.com/5065331/90953927-f750ec80-e46f-11ea-8cea-ac14d893676d.jpg)



Let me know if there's any issues/questions!