### PR TITLE
Set locale to 'default' when creating a new Entry

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -45,7 +45,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization
     protected $collection;
     protected $blueprint;
     protected $date;
-    protected $locale;
+    protected $locale = 'default';
     protected $localizations;
     protected $afterSaveCallbacks = [];
 

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -62,7 +62,12 @@ class Entry implements Contract, Augmentable, Responsable, Localization
 
     public function locale($locale = null)
     {
-        return $this->fluentlyGetOrSet('locale')->args(func_get_args());
+        return $this
+            ->fluentlyGetOrSet('locale')
+            ->getter(function ($locale) {
+                return $locale ?? Site::default()->handle();
+            })
+            ->args(func_get_args());
     }
 
     public function site()
@@ -118,7 +123,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization
     {
         return [
             'collection' => $this->collectionHandle(),
-            'locale' => $this->locale,
+            'locale' => $this->locale(),
             'origin' => $this->hasOrigin() ? $this->origin()->id() : null,
             'slug' => $this->slug(),
             'date' => optional($this->date())->format('Y-m-d-Hi'),
@@ -230,10 +235,6 @@ class Entry implements Contract, Augmentable, Responsable, Localization
             return false;
         }
 
-        if (! $this->locale) {
-            $this->locale(Site::default()->handle());
-        }
-
         Facades\Entry::save($this);
 
         if ($this->id()) {
@@ -282,7 +283,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization
             return null;
         }
 
-        return $this->structure()->in($this->locale)
+        return $this->structure()->in($this->locale())
             ->flattenedPages()
             ->map->reference()
             ->flip()->get($this->id) + 1;
@@ -459,7 +460,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization
 
     public function in($locale)
     {
-        if ($locale === $this->locale) {
+        if ($locale === $this->locale()) {
             return $this;
         }
 

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -45,7 +45,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization
     protected $collection;
     protected $blueprint;
     protected $date;
-    protected $locale = 'default';
+    protected $locale;
     protected $localizations;
     protected $afterSaveCallbacks = [];
 
@@ -228,6 +228,10 @@ class Entry implements Contract, Augmentable, Responsable, Localization
 
         if (EntrySaving::dispatch($this) === false) {
             return false;
+        }
+
+        if (! $this->locale) {
+            $this->locale(Site::default()->handle());
         }
 
         Facades\Entry::save($this);

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -29,22 +29,12 @@ class EntryTest extends TestCase
     public function it_sets_and_gets_the_locale()
     {
         $entry = new Entry;
-        $this->assertEquals('default', $entry->locale());
+        $this->assertNull($entry->locale());
 
         $return = $entry->locale('en');
 
         $this->assertEquals($entry, $return);
         $this->assertEquals('en', $entry->locale());
-    }
-
-    /** @test */
-    public function the_locale_is_default_by_default()
-    {
-        $entry = new Entry();
-
-        $return = $entry->locale();
-
-        $this->assertSame('default', $return);
     }
 
     /** @test */

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -29,12 +29,22 @@ class EntryTest extends TestCase
     public function it_sets_and_gets_the_locale()
     {
         $entry = new Entry;
-        $this->assertNull($entry->locale());
+        $this->assertEquals('default', $entry->locale());
 
         $return = $entry->locale('en');
 
         $this->assertEquals($entry, $return);
         $this->assertEquals('en', $entry->locale());
+    }
+
+    /** @test */
+    public function the_locale_is_default_by_default()
+    {
+        $entry = new Entry();
+
+        $return = $entry->locale();
+
+        $this->assertSame('default', $return);
     }
 
     /** @test */

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -29,7 +29,7 @@ class EntryTest extends TestCase
     public function it_sets_and_gets_the_locale()
     {
         $entry = new Entry;
-        $this->assertNull($entry->locale());
+        $this->assertEquals('en', $entry->locale());
 
         $return = $entry->locale('en');
 


### PR DESCRIPTION
This pull request will set the locale to `default` whenever a new `Entry` is created. This means when using the `Entry` facade, you'll no longer need to use the `->locale()` method when creating/making an entry (unless you want to override it, obviously).

I've added a new test for this change and updated an existing one. Although, maybe we don't need that extra test and the existing one is fine?

This pull request fixes #1389.