### PR TITLE
Fix error on login with wrong password on windows (#952)

### DIFF
--- a/src/Auth/ThrottlesLogins.php
+++ b/src/Auth/ThrottlesLogins.php
@@ -98,7 +98,7 @@ trait ThrottlesLogins
      */
     protected function throttleKey(Request $request)
     {
-        return Str::lower($request->input($this->username())).'|'.$request->ip();
+        return Str::lower($request->input($this->username())).'#'.$request->ip();
     }
 
     /**


### PR DESCRIPTION
Directory names can not use pipes on windows [1] so the cache key of the throttleKey must not use a pipe.
I replaced it with a hash which should be safe to use there.

I could not spot any other places using a pipe for such keys.

Fancy email addresses or an IPv6 could still break this code, maybe hashing these values be a good idea.

[1] https://en.wikipedia.org/wiki/Filename#In_Windows