### PR TITLE
IDE Hint change

### DIFF
--- a/src/Facades/Term.php
+++ b/src/Facades/Term.php
@@ -11,7 +11,7 @@ use Statamic\Contracts\Taxonomies\TermRepository;
  * @method static whereInTaxonomy(array $handles)
  * @method static find($id)
  * @method static findByUri(string $uri)
- * @method static findBySlug(string $slug, string $collection)
+ * @method static findBySlug(string $slug, string $taxonomy)
  * @method static make(string $slug = null)
  * @method static query()
  * @method static save($entry)


### PR DESCRIPTION
Was doing some source-diving into the Term facade & repository this morning. Discovered this small thing in the facade which would cause the IDE intelligence to show `$collection` instead of `$taxonomy` in the method name. I've fixed it up, per [the repositories method signature](https://github.com/statamic/cms/blob/2547cc6a0403de057130e599c66a3c94d6359531/src/Stache/Repositories/TermRepository.php#L82).