### PR TITLE
Add error tag for the default laravel error bag

### DIFF
--- a/src/Tags/Error.php
+++ b/src/Tags/Error.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Tags;
+
+use Statamic\Tags\Tags;
+
+class Error extends Tags
+{
+    protected $errors;
+
+    /**
+     * {{ error:fieldname }}
+     */
+    public function wildcard(string $name)
+    {
+        /**
+         * Are there errors at all?
+         */
+        if (count($this->context['errors']) === 0) {
+            return false;
+        }
+
+        /**
+         * Does our default error bag exist
+         */
+        if (isset($this->context['errors']->default)) {
+            return false;
+        }
+
+        /**
+         * Let's fetch all errors
+         */
+        $this->errors = $this->context['errors']->default;
+
+        /**
+         * Does an error exist with the given name
+         */
+        if (! $this->errors->has($name)) {
+            return false;
+        }
+
+        /**
+         * Return the error message
+         */
+        return $this->errors->get($name)[0];
+    }
+}


### PR DESCRIPTION
There are some cases, where forms won't be created via the Statamic form tag. If this case appears, there is no way in antlers to fetch those errors. 

If creating a form without the form tag, you can easily fetch errors like:
```
{{ error:name }} // Will return the message

{{ if {error:name }} Do something, add a class or similar {{ /if }}
```

**Would a PR like this be merged? Is there an interest in integrating this behavior into antlers?**

This is what I build for a client and would be a great starting point, but is clearly a draft at this state. Before finishing it off, I wanted to get some opinions first 😎