### PR TITLE
Add placeholder attr to form fields

### DIFF
--- a/resources/views/extend/forms/fields/default.antlers.html
+++ b/resources/views/extend/forms/fields/default.antlers.html
@@ -1,1 +1,1 @@
-<input type="text" name="{{ handle }}" {{ if old }}value="{{ old }}"{{ /if }}>
+<input type="text" name="{{ handle }}" placeholder="{{ placeholder ?? '' }} {{ if old }}value="{{ old }}"{{ /if }}>

--- a/resources/views/extend/forms/fields/default.antlers.html
+++ b/resources/views/extend/forms/fields/default.antlers.html
@@ -1,1 +1,1 @@
-<input type="text" name="{{ handle }}" placeholder="{{ placeholder ?? '' }}" {{ if old }}value="{{ old }}"{{ /if }}>
+<input type="text" name="{{ handle }}" {{ if placeholder }}placeholder="{{ placeholder }}"{{ /if }} {{ if old }}value="{{ old }}"{{ /if }}>

--- a/resources/views/extend/forms/fields/default.antlers.html
+++ b/resources/views/extend/forms/fields/default.antlers.html
@@ -1,1 +1,1 @@
-<input type="text" name="{{ handle }}" {{ if placeholder }}placeholder="{{ placeholder }}"{{ /if }} {{ if old }}value="{{ old }}"{{ /if }}>
+<input type="text" name="{{ handle }}" {{ if placeholder }}placeholder="{{ placeholder }}"{{ /if }}{{ if old }}value="{{ old }}"{{ /if }}>

--- a/resources/views/extend/forms/fields/default.antlers.html
+++ b/resources/views/extend/forms/fields/default.antlers.html
@@ -1,1 +1,1 @@
-<input type="text" name="{{ handle }}" placeholder="{{ placeholder ?? '' }} {{ if old }}value="{{ old }}"{{ /if }}>
+<input type="text" name="{{ handle }}" placeholder="{{ placeholder ?? '' }}" {{ if old }}value="{{ old }}"{{ /if }}>

--- a/resources/views/extend/forms/fields/text.antlers.html
+++ b/resources/views/extend/forms/fields/text.antlers.html
@@ -1,1 +1,1 @@
-<input type="{{ input_type ?? 'text' }}" name="{{ handle }}" {{ if placeholder }}placeholder="{{ placeholder }}"{{ /if }} {{ if old }}value="{{ old }}"{{ /if }}>
+<input type="{{ input_type ?? 'text' }}" name="{{ handle }}" {{ if placeholder }}placeholder="{{ placeholder }}"{{ /if }}{{ if old }}value="{{ old }}"{{ /if }}>

--- a/resources/views/extend/forms/fields/text.antlers.html
+++ b/resources/views/extend/forms/fields/text.antlers.html
@@ -1,1 +1,1 @@
-<input type="{{ input_type ?? 'text' }}" name="{{ handle }}" placeholder="{{ placeholder ?? '' }} {{ if old }}value="{{ old }}"{{ /if }}>
+<input type="{{ input_type ?? 'text' }}" name="{{ handle }}" placeholder="{{ placeholder ?? '' }}" {{ if old }}value="{{ old }}"{{ /if }}>

--- a/resources/views/extend/forms/fields/text.antlers.html
+++ b/resources/views/extend/forms/fields/text.antlers.html
@@ -1,1 +1,1 @@
-<input type="{{ input_type ?? 'text' }}" name="{{ handle }}" placeholder="{{ placeholder ?? '' }}" {{ if old }}value="{{ old }}"{{ /if }}>
+<input type="{{ input_type ?? 'text' }}" name="{{ handle }}" {{ if placeholder }}placeholder="{{ placeholder }}"{{ /if }} {{ if old }}value="{{ old }}"{{ /if }}>

--- a/resources/views/extend/forms/fields/text.antlers.html
+++ b/resources/views/extend/forms/fields/text.antlers.html
@@ -1,1 +1,1 @@
-<input type="{{ input_type ?? 'text' }}" name="{{ handle }}" {{ if old }}value="{{ old }}"{{ /if }}>
+<input type="{{ input_type ?? 'text' }}" name="{{ handle }}" placeholder="{{ placeholder ?? '' }} {{ if old }}value="{{ old }}"{{ /if }}>


### PR DESCRIPTION
The text and textarea fieldtypes have a placeholder field (when created in the cp), but the default templates to render those fields don't. This pull request would render them as expected.