### PR TITLE
Fix taxonomy fields on none localized entry types.

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fieldtypes;
 
+use Statamic\Contracts\Data\Localization;
 use Statamic\CP\Column;
 use Statamic\Exceptions\TermsFieldtypeBothOptionsUsedException;
 use Statamic\Exceptions\TermsFieldtypeTaxonomyOptionUsed;
@@ -88,7 +89,7 @@ class Terms extends Relationship
                     $term->collection($entry->collection());
                 }
 
-                $locale = $entry
+                $locale = $entry && $entry instanceof Localization
                     ? $entry->locale()
                     : Site::current()->handle();
 


### PR DESCRIPTION
This PR resolves an issue with attaching terms to each other due to the Taxonomy class not implementing localization, you can reproduce the error with the following steps:

1. Create a couple test tags
2. Update the tags blueprint to include a taxonomy terms field
3. Attach a term to another

Now when you try to access the tags index view within the CP you will get the following error:

`Call to undefined method Statamic\Taxonomies\Taxonomy::locale()`

We are using this funcationality to create sub categories and link them to parent categories, this worked in the beta but seems to have changed since.