### PR TITLE
Improve multisite Glide support

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -11,7 +11,7 @@ Route::name('statamic.')->group(function () {
      * Glide
      * On-the-fly URL-based image transforms.
      */
-    if (!config('statamic.assets.image_manipulation.cache')) {
+    if (! config('statamic.assets.image_manipulation.cache')) {
         Site::all()->map(function ($site) {
             return URL::makeRelative($site->url());
         })->unique()->each(function ($sitePrefix) {

--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -10,6 +10,7 @@ use League\Glide\Signatures\SignatureFactory;
 use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Config;
+use Statamic\Facades\Site;
 use Statamic\Imaging\ImageGenerator;
 use Statamic\Support\Str;
 
@@ -141,8 +142,10 @@ class GlideController extends Controller
             return;
         }
 
+        $path = Str::after($this->request->url(), Site::current()->absoluteUrl());
+
         try {
-            SignatureFactory::create(Config::getAppKey())->validateRequest($this->request->path(), $_GET);
+            SignatureFactory::create(Config::getAppKey())->validateRequest($path, $_GET);
         } catch (SignatureException $e) {
             abort(400, $e->getMessage());
         }

--- a/src/Providers/GlideServiceProvider.php
+++ b/src/Providers/GlideServiceProvider.php
@@ -14,6 +14,7 @@ use Statamic\Imaging\GlideUrlBuilder;
 use Statamic\Imaging\ImageGenerator;
 use Statamic\Imaging\PresetGenerator;
 use Statamic\Imaging\StaticUrlBuilder;
+use Statamic\Support\Str;
 
 class GlideServiceProvider extends ServiceProvider
 {
@@ -49,7 +50,7 @@ class GlideServiceProvider extends ServiceProvider
 
         if (Config::get('statamic.assets.image_manipulation.cache')) {
             return new StaticUrlBuilder($this->app->make(ImageGenerator::class), [
-                'route' => URL::prependSiteUrl($route),
+                'route' => Str::start($route, '/'),
             ]);
         }
 

--- a/src/Providers/GlideServiceProvider.php
+++ b/src/Providers/GlideServiceProvider.php
@@ -8,7 +8,6 @@ use League\Glide\Server;
 use Statamic\Contracts\Imaging\ImageManipulator;
 use Statamic\Contracts\Imaging\UrlBuilder;
 use Statamic\Facades\Config;
-use Statamic\Facades\URL;
 use Statamic\Imaging\GlideImageManipulator;
 use Statamic\Imaging\GlideUrlBuilder;
 use Statamic\Imaging\ImageGenerator;


### PR DESCRIPTION
This PR aims to solve a long running problem where Glide URLs in a subdirectory based site would have the subdirectory in it, causing 404s.

e.g. You have `/` and `/fr` set up as sites.

Generate an image on /, you get something like `/img/image.jpg`, which works.
Generate one on `/fr`, you get something like `/fr/img/image.jpg`, which 404s because there's no Glide route at `/fr/img`.

A solution was to use symlinks, which always felt quite hacky, and only really worked when using the cached setup. As pointed out [in this comment](https://github.com/statamic/cms/pull/1953#issuecomment-687279915), adding a symlink would break the root url anyway.

This PR now makes the Glide routes available for every subdirectory-based site.

When using cached mode, the URLs will always be from the top level.

Unrelated to multisite, it also removes the Glide routes entirely if the cached option is being used, since the images get generated on demand in your template and the actual images get served.

Closes #1953 
Closes #1304