### PR TITLE
Email settings: prevent show empty <code>

### DIFF
--- a/resources/views/utilities/email.blade.php
+++ b/resources/views/utilities/email.blade.php
@@ -36,15 +36,27 @@
             @endif
             <tr>
                 <th class="pl-2 py-1 w-1/4">{{ __('Default From Address') }}</th>
-                <td><code>{{ config('mail.from.address') }}</code></td>
+                <td>
+                    @if (config('mail.from.address'))
+                        <code>{{ config('mail.from.address') }}</code>
+                    @endif
+                </td>
             </tr>
             <tr>
                 <th class="pl-2 py-1 w-1/4">{{ __('Default From Name') }}</th>
-                <td><code>{{ config('mail.from.name') }}</code></td>
+                <td>
+                    @if (config('mail.from.name'))
+                        <code>{{ config('mail.from.name') }}</code>
+                    @endif
+                </td>
             </tr>
             <tr>
                 <th class="pl-2 py-1 w-1/4">{{ __('Markdown theme') }}</th>
-                <td><code>{{ config('mail.markdown.theme') }}</code></td>
+                <td>
+                    @if (config('mail.markdown.theme'))
+                        <code>{{ config('mail.markdown.theme') }}</code>
+                    @endif
+                </td>
             </tr>
             <tr>
                 <th class="pl-2 py-1 w-1/4">{{ __('Markdown paths') }}</th>


### PR DESCRIPTION
In Utilities > Email configuration, if a value is empty, an empty `<code>` tag is shown:

![Schermata 2020-09-07 alle 22 54 29](https://user-images.githubusercontent.com/779534/92416459-da9a0180-f15d-11ea-87ee-65c41654328b.png)
