### PR TITLE
Fix CP Listing breaking when there's a missing user

### DIFF
--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -97,6 +97,10 @@ class Users extends Relationship
         }
 
         return $users->map(function ($user) {
+            if (! $user) {
+                return null;
+            }
+
             return [
                 'id' => $user->id(),
                 'title' => $user->get('name', $user->email()),


### PR DESCRIPTION
This pull request fixes an issue where if you had a User fieldtype field in your collection blueprint, you had it select for articles but then you deleted one of those users, an exception would previously been thrown. Now in this PR, the user will just display blank.

This bug appeared on the entries listing page in the CP if you had the User field setup to display.

This pull request fixes #2398.

## Screenshot
In this screenshot, `fvfvfv` is the entry with the missing user.

![image](https://user-images.githubusercontent.com/19637309/93018455-ccb60780-f5c7-11ea-84e0-f96cbf072646.png)
