### PR TITLE
Add v-ifs to Collections Listing component

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -7,9 +7,9 @@
                 </template>
                 <template slot="actions" slot-scope="{ row: collection, index }">
                     <dropdown-list>
-                        <dropdown-item :text="__('Edit Collection')" :redirect="collection.edit_url" />
-                        <dropdown-item :text="__('Edit Blueprints')" :redirect="collection.blueprints_url" />
-                        <dropdown-item :text="__('Scaffold Resources')" :redirect="collection.scaffold_url" />
+                        <dropdown-item v-if="collection.editable" :text="__('Edit Collection')" :redirect="collection.edit_url" />
+                        <dropdown-item v-if="collection.blueprint_editable" :text="__('Edit Blueprints')" :redirect="collection.blueprints_url" />
+                        <dropdown-item v-if="collection.editable" :text="__('Scaffold Resources')" :redirect="collection.scaffold_url" />
                         <dropdown-item
                             v-if="collection.deleteable"
                             :text="__('Delete Collection')"

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -33,6 +33,8 @@ class CollectionsController extends CpController
                 'blueprints_url' => cp_route('collections.blueprints.index', $collection->handle()),
                 'scaffold_url' => cp_route('collections.scaffold', $collection->handle()),
                 'deleteable' => User::current()->can('delete', $collection),
+                'editable' => User::current()->can('edit', $collection),
+                'blueprint_editable' => User::current()->can('configure fields'),
             ];
         })->values();
 

--- a/tests/Feature/Collections/ViewCollectionListingTest.php
+++ b/tests/Feature/Collections/ViewCollectionListingTest.php
@@ -39,6 +39,8 @@ class ViewCollectionListingTest extends TestCase
                     'blueprints_url' => 'http://localhost/cp/collections/foo/blueprints',
                     'scaffold_url' => 'http://localhost/cp/collections/foo/scaffold',
                     'deleteable' => true,
+                    'editable' => true,
+                    'blueprint_editable' => true,
                 ],
                 [
                     'id' => 'bar',
@@ -50,6 +52,8 @@ class ViewCollectionListingTest extends TestCase
                     'blueprints_url' => 'http://localhost/cp/collections/bar/blueprints',
                     'scaffold_url' => 'http://localhost/cp/collections/bar/scaffold',
                     'deleteable' => true,
+                    'editable' => true,
+                    'blueprint_editable' => true,
                 ],
             ]))
             ->assertDontSee('no-results');


### PR DESCRIPTION
This pull request adds in a few `v-if` statements that were missing from the Collection Listing component. 

Previously, the action items would appear for anyone, regardless of their permissions. Obviously when the user clicked on it, they wouldn't be able to do the action due to server side permissions, yay! 🎉

This PR adds some properties to each of the collection items before they get passed to the frontend. I implemented it this way as couldn't see anywhere in Vue or Vuex where the user permissions were stored.

I've tested this with different combinations for non-super users (just edit fields, just manage collections and both together). I've also tested this for super users and the same behaviour as normal continues.

This pull request fixes #2136.