### PR TITLE
Throw an exception if collection not found

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fieldtypes;
 
+use Statamic\Exceptions\CollectionNotFoundException;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Scope;
@@ -149,8 +150,13 @@ class Entries extends Relationship
 
         $collections = $this->getConfiguredCollections();
 
-        return collect($collections)->flatMap(function ($collection) use ($collections) {
-            $collection = Collection::findByHandle($collection);
+        return collect($collections)->flatMap(function ($collectionHandle) use ($collections) {
+            $collection = Collection::findByHandle($collectionHandle);
+
+            if (! $collection) {
+                throw new CollectionNotFoundException($collectionHandle);
+            }
+
             $blueprints = $collection->entryBlueprints();
 
             return $blueprints->map(function ($blueprint) use ($collection, $collections, $blueprints) {

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -153,9 +153,7 @@ class Entries extends Relationship
         return collect($collections)->flatMap(function ($collectionHandle) use ($collections) {
             $collection = Collection::findByHandle($collectionHandle);
 
-            if (! $collection) {
-                throw new CollectionNotFoundException($collectionHandle);
-            }
+            throw_if(!$collection, CollectionNotFoundException($collectionHandle));
 
             $blueprints = $collection->entryBlueprints();
 

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -153,7 +153,7 @@ class Entries extends Relationship
         return collect($collections)->flatMap(function ($collectionHandle) use ($collections) {
             $collection = Collection::findByHandle($collectionHandle);
 
-            throw_if(!$collection, CollectionNotFoundException($collectionHandle));
+            throw_if(!$collection, new CollectionNotFoundException($collectionHandle));
 
             $blueprints = $collection->entryBlueprints();
 

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -153,7 +153,7 @@ class Entries extends Relationship
         return collect($collections)->flatMap(function ($collectionHandle) use ($collections) {
             $collection = Collection::findByHandle($collectionHandle);
 
-            throw_if(!$collection, new CollectionNotFoundException($collectionHandle));
+            throw_if(! $collection, new CollectionNotFoundException($collectionHandle));
 
             $blueprints = $collection->entryBlueprints();
 


### PR DESCRIPTION
This pull request fixes #1788. It will now throw a `CollectionNotFoundException` when a collection is not found.