### PR TITLE
Sidebar width should be fixed

### DIFF
--- a/resources/sass/components/publish.scss
+++ b/resources/sass/components/publish.scss
@@ -91,7 +91,7 @@ code.parent-url {
     @apply flex-shrink-0;
     margin-left: 20px;
 
-    max-width: 300px;
+    width: 300px;
 
     .publish-section-actions {
         @apply border-b;


### PR DESCRIPTION
This pull request sets the width of the sidebar on the publish forms to a fixed 300px, instead of it being `max-width`. Without this being a fixed width, it causes issues like in the below screenshot.

![image](https://user-images.githubusercontent.com/19637309/93140721-d5e3c900-f6da-11ea-8805-45a07543206d.png)

This pull request fixes #2081.