### PR TITLE
Section Fieldtype should not be listable

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -107,6 +107,10 @@ class Field implements Arrayable
             return true;
         }
 
+        if ($this->config()['type'] === 'section') {
+            return false;
+        }
+
         return (bool) $this->get('listable');
     }
 

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -96,6 +96,9 @@ class FieldsController extends CpController
                 ],
                 'default' => 'hidden',
                 'width' => 50,
+                'unless' => [
+                    'type' => 'section',
+                ],
             ],
         ]);
 


### PR DESCRIPTION
This pull request makes it so fields with the `Section` fieldtype should no longer be listable or appear as columns anywhere in the CP.

## Changes
* If a field is has the type of `section`, it will no longer be listable and will no longer show as as column when you click the 'column dropdown' on the collection entries listing page.

* When a user adds/updates a section field in the Fieldset/Blueprint builder, they will no longer see the option to configure if it's listable or not. I thought it would make sense to hide/remove this option as we override it anyway in the `Field` class.

## Related Issues
It fixes #2117 and fixes #2013.