### PR TITLE
Security Info: OWASP Open Redirect Link is dead

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,4 +43,4 @@ We are only interested in vulnerabilities that affect Statamic itself, tested ag
 - Any behavior that is clearly documented.
 - Issues discovered while scanning a site you don’t own without permission
 - Missing CSRF tokens on forms (unless you have a proof of concept, many forms either don't need CSRF or are mitigated in other ways) and "logout" CSRF attacks
-- [Open redirects](https://www.owasp.org/index.php/open_redirect)
+- [Open redirects](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html)


### PR DESCRIPTION
I can't find any modern equivalent to the original link, but the one I've enclosed gives some information? Or might be worth replacing with some other source. 👍

**EDIT: Actually the link I've provided does seem to be the updated source as per**  (legacy / archival site) https://wiki.owasp.org/index.php/open_redirect