### PR TITLE
Bring 'cache_tags_enabled' configuration option back in v3

### DIFF
--- a/config/system.php
+++ b/config/system.php
@@ -92,7 +92,7 @@ return [
     |
     */
 
-    'enable_cache_tags' => env('ENABLE_CACHE_TAGS', true),
+    'cache_tags_enabled' => env('STATAMIC_CACHE_TAGS_ENABLED', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/system.php
+++ b/config/system.php
@@ -92,7 +92,7 @@ return [
     |
     */
 
-    'enable_cache_tags' => true,
+    'enable_cache_tags' => env('ENABLE_CACHE_TAGS', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/system.php
+++ b/config/system.php
@@ -83,6 +83,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Enable Cache Tags
+    |--------------------------------------------------------------------------
+    |
+    | Sometimes you'll want to be able to disable the {{ cache }} tags in
+    | Antlers, so here is where you can do that. Otherwise, it will be
+    | enabled all the time.
+    |
+    */
+
+    'enable_cache_tags' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Intensive Operations
     |--------------------------------------------------------------------------
     |

--- a/src/Tags/Cache.php
+++ b/src/Tags/Cache.php
@@ -24,7 +24,7 @@ class Cache extends Tags
 
     private function isEnabled()
     {
-        if (! config('statamic.system.enable_cache_tags')) {
+        if (! config('statamic.system.enable_cache_tags', true)) {
             return false;
         }
 

--- a/src/Tags/Cache.php
+++ b/src/Tags/Cache.php
@@ -24,7 +24,9 @@ class Cache extends Tags
 
     private function isEnabled()
     {
-        // TODO: make a global config
+        if (! config('statamic.system.enable_cache_tags')) {
+            return false;
+        }
 
         // Only get requests. This disables the cache during live preview.
         return request()->method() === 'GET';

--- a/src/Tags/Cache.php
+++ b/src/Tags/Cache.php
@@ -24,7 +24,7 @@ class Cache extends Tags
 
     private function isEnabled()
     {
-        if (! config('statamic.system.enable_cache_tags', true)) {
+        if (! config('statamic.system.cache_tags_enabled', true)) {
             return false;
         }
 


### PR DESCRIPTION
This pull request adds in the `cache_tags_enabled` configuration option that existed in Statamic v2 [(docs)](https://v2.statamic.com/caching#frag-off).

I've added the configuration option in the `system.php` file. I wasn't sure where would be best so I popped it in there. The help text for it could also be improved. 

I'm leaving this as a draft pull request for now until I have some time to properly test it.

This PR closes #2418.