### PR TITLE
Fix Avatar Augmentation issues

### DIFF
--- a/src/Auth/AugmentedUser.php
+++ b/src/Auth/AugmentedUser.php
@@ -47,6 +47,10 @@ class AugmentedUser extends AbstractAugmented
             return $this->data->isSuper();
         }
 
+        if ($handle === 'avatar') {
+            return $this->data->avatar();
+        }
+
         if (Str::startsWith($handle, 'is_')) {
             return in_array(Str::after($handle, 'is_'), $this->roles());
         }


### PR DESCRIPTION
This pull request fixes the issue where the below snippet of code wouldn't return anything...

```
{{ user }}
  {{ avatar }}
{{ /user }}
```

This issue would also happen if you had a user field, like for an `author` and you tried to get the avatar inside an `{{ author }}` tag pair.

This PR fixes #2017.