### PR TITLE
Fixes #2307

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -88,7 +88,7 @@ class Terms extends Relationship
                     $term->collection($entry->collection());
                 }
 
-                $locale = $entry
+                $locale = $entry && method_exists($entry, 'locale')
                     ? $entry->locale()
                     : Site::current()->handle();
 


### PR DESCRIPTION
Also see the [mentioned issue](https://github.com/statamic/cms/issues/2307#issue-687251011); the relevant part copied here for completeness:

> I get an error after referencing another taxonomy with a "Taxonomy Terms" field:
> `Call to undefined method Statamic\\Taxonomies\\Taxonomy::locale() at
/Users/username/Documents/Valet/projectname/vendor/statamic/cms/src/Fieldtypes/Terms.php:96)`

As you can see, in `Terms.php` at line 96 (Statamic 3.0.9) there is a call to `$entry->locale()`, as you can see it's assumed that we have an Entry. Since in this case we have a Taxonomy, and the `locale()` method doesn't exist the whole API request fails.

I propose to use the same fallback as already implemented (when an entry doesn't exist), and that is to fall back to the site locale.