### PR TITLE
Allow transforming of search index values

### DIFF
--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -70,14 +70,19 @@ class Searchables
 
         return collect($fields)->mapWithKeys(function ($field) use ($searchable) {
             $value = method_exists($searchable, $field) ? $searchable->{$field}() : $searchable->get($field);
-
             return [$field => $value];
         })->flatMap(function ($value, $field) use ($transformers) {
             if (! isset($transformers[$field]) || ! $transformers[$field] instanceof Closure) {
                 return [$field => $value];
             }
 
-            return $transformers[$field]($value);
+            $transformedValue = $transformers[$field]($value);
+
+            if (is_array($transformedValue)) {
+                return $transformedValue;
+            }
+
+            return [$field => $transformedValue];
         })->all();
     }
 }

--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -70,6 +70,7 @@ class Searchables
 
         return collect($fields)->mapWithKeys(function ($field) use ($searchable) {
             $value = method_exists($searchable, $field) ? $searchable->{$field}() : $searchable->get($field);
+
             return [$field => $value];
         })->flatMap(function ($value, $field) use ($transformers) {
             if (! isset($transformers[$field]) || ! $transformers[$field] instanceof Closure) {

--- a/tests/Search/SearchablesTest.php
+++ b/tests/Search/SearchablesTest.php
@@ -2,10 +2,7 @@
 
 namespace Tests\Search;
 
-use Mockery;
 use Statamic\Facades\Entry;
-use Statamic\Search\Algolia\Index;
-use Statamic\Search\ItemResolver;
 use Statamic\Search\Searchables;
 use Tests\TestCase;
 
@@ -21,8 +18,8 @@ class SearchablesTest extends TestCase
             'transformers' => [
                 'title' => function ($value) {
                     return strtoupper($value);
-                }
-            ]
+                },
+            ],
         ]);
 
         $index = app(\Statamic\Search\Comb\Index::class, [
@@ -51,8 +48,8 @@ class SearchablesTest extends TestCase
                         'title' => $value,
                         'title_upper' => strtoupper($value),
                     ];
-                }
-            ]
+                },
+            ],
         ]);
 
         $index = app(\Statamic\Search\Comb\Index::class, [

--- a/tests/Search/SearchablesTest.php
+++ b/tests/Search/SearchablesTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Search;
+
+use Mockery;
+use Statamic\Facades\Entry;
+use Statamic\Search\Algolia\Index;
+use Statamic\Search\ItemResolver;
+use Statamic\Search\Searchables;
+use Tests\TestCase;
+
+class SearchablesTest extends TestCase
+{
+    /** @test */
+    public function it_transforms_values_set_in_the_config_file()
+    {
+        config()->set('statamic.search.indexes.default', [
+            'fields' => [
+                'title',
+            ],
+            'transformers' => [
+                'title' => function ($value) {
+                    return strtoupper($value);
+                }
+            ]
+        ]);
+
+        $index = app(\Statamic\Search\Comb\Index::class, [
+            'name' => 'default',
+            'config' => config('statamic.search.indexes.default'),
+        ]);
+
+        $searchable = Entry::make()->data(['title' => 'Hello']);
+        $searchables = new Searchables($index);
+
+        $this->assertEquals([
+            'title' => 'HELLO',
+        ], $searchables->fields($searchable));
+    }
+
+    /** @test */
+    public function if_a_transformer_returns_an_array_it_gets_combined_into_the_results()
+    {
+        config()->set('statamic.search.indexes.default', [
+            'fields' => [
+                'title',
+            ],
+            'transformers' => [
+                'title' => function ($value) {
+                    return [
+                        'title' => $value,
+                        'title_upper' => strtoupper($value),
+                    ];
+                }
+            ]
+        ]);
+
+        $index = app(\Statamic\Search\Comb\Index::class, [
+            'name' => 'default',
+            'config' => config('statamic.search.indexes.default'),
+        ]);
+
+        $searchable = Entry::make()->data(['title' => 'Hello']);
+        $searchables = new Searchables($index);
+
+        $this->assertEquals([
+            'title' => 'Hello',
+            'title_upper' => 'HELLO',
+        ], $searchables->fields($searchable));
+    }
+}


### PR DESCRIPTION
This PR allows you to add a `transformers` key to your search index configuration:

For example, when you have a location field that saves all raw data in the entry:

```php
'indexes' => [
        'locations => [
            'driver' => 'algolia',
            'searchables' => 'collection:locations',
            'fields' => [
                'title',
                'address',
            ],
            'transformers' => [
                'address' => function ($address) {
                    if (is_null($address)) {
                        return null;
                    }

                    return [
                        '_geoloc' => $address['rawAnswer']['hits'][0]['_geoloc'],
                        'country' => $address['rawAnswer']['hits'][0]['country'],
                        'city' => $address['rawAnswer']['hits'][0]['city'],
                        'postcode' => $address['rawAnswer']['hits'][0]['postcode'],
                    ];
                }
            ]
        ],

    ],
```

This would result in a document like this:

```php
[
    'title' => 'A new location',
    '_geoloc' => [
        'lat' => 51.3345,
        'lng' => 4.3712,
    ],
    'country' => 'Belgium',
    'city' => 'Antwerp',
    'postcode' => 2940,
]
```

Which is important for Algolia, because the `_geoloc` data has to be top-level.