### PR TITLE
Update Bard Dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/var-exporter": "^4.3",
         "symfony/yaml": "^4.1 || ^5.1",
         "twistor/flysystem-guzzle": "^6.0",
-        "ueberdosis/html-to-prosemirror": "^0.7.0",
+        "ueberdosis/html-to-prosemirror": "^1.0",
         "ueberdosis/prosemirror-to-html": "^2.0",
         "wilderborn/partyline": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/yaml": "^4.1 || ^5.1",
         "twistor/flysystem-guzzle": "^6.0",
         "ueberdosis/html-to-prosemirror": "^0.7.0",
-        "ueberdosis/prosemirror-to-html": "^0.10.0",
+        "ueberdosis/prosemirror-to-html": "^2.0",
         "wilderborn/partyline": "^1.0"
     },
     "require-dev": {

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -190,7 +190,7 @@ class Bard extends Replicator
         }
 
         if (is_string($value)) {
-            $doc = (new \Scrumpy\HtmlToProseMirror\Renderer)->render($value);
+            $doc = (new \HtmlToProseMirror\Renderer)->render($value);
             $value = $doc['content'];
         } elseif ($this->isLegacyData($value)) {
             $value = $this->convertLegacyData($value);
@@ -285,7 +285,7 @@ class Bard extends Replicator
                 if (empty($set['text'])) {
                     return;
                 }
-                $doc = (new \Scrumpy\HtmlToProseMirror\Renderer)->render($set['text']);
+                $doc = (new \HtmlToProseMirror\Renderer)->render($set['text']);
 
                 return $doc['content'];
             }

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Fieldtypes;
 
-use Scrumpy\ProseMirrorToHtml\Renderer;
+use ProseMirrorToHtml\Renderer;
 use Statamic\Fields\Fields;
 use Statamic\Fieldtypes\Bard\Augmentor;
 use Statamic\Query\Scopes\Filters\Fields\Bard as BardFilter;

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -93,21 +93,12 @@ class Augmentor
 
     public function convertToHtml($value)
     {
-        $renderer = new Renderer;
-
-        $renderer->replaceNode(DefaultImageNode::class, CustomImageNode::class);
-
-        $renderer->addNodes([
-            SetNode::class,
-        ]);
-
-        $renderer->addNodes(static::$customNodes);
-        $renderer->addMarks(static::$customMarks);
-
-        return $renderer->render([
-            'type' => 'doc',
-            'content' => $value,
-        ]);
+        return (new Renderer)
+            ->replaceNode(DefaultImageNode::class, CustomImageNode::class)
+            ->addNode(SetNode::class)
+            ->addNodes(static::$customNodes)
+            ->addMarks(static::$customMarks)
+            ->render(['type' => 'doc', 'content' => $value]);
     }
 
     public static function addNode($node)

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -2,10 +2,12 @@
 
 namespace Statamic\Fieldtypes\Bard;
 
+use ProseMirrorToHtml\Nodes\Image as DefaultImageNode;
 use ProseMirrorToHtml\Renderer;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fields;
 use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Bard\ImageNode as CustomImageNode;
 use Statamic\Fieldtypes\Text;
 use Statamic\Support\Arr;
 
@@ -92,8 +94,10 @@ class Augmentor
     public function convertToHtml($value)
     {
         $renderer = new Renderer;
+
+        $renderer->replaceNode(DefaultImageNode::class, CustomImageNode::class);
+
         $renderer->addNodes([
-            ImageNode::class,
             SetNode::class,
         ]);
 

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Fieldtypes\Bard;
 
-use Scrumpy\ProseMirrorToHtml\Renderer;
+use ProseMirrorToHtml\Renderer;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fields;
 use Statamic\Fields\Value;
@@ -74,7 +74,7 @@ class Augmentor
         return collect($value)->reject(function ($value) {
             return $value['type'] === 'set'
                 && Arr::get($value, 'attrs.enabled', true) === false;
-        });
+        })->values();
     }
 
     protected function addSetIndexes($value)

--- a/src/Fieldtypes/Bard/ImageNode.php
+++ b/src/Fieldtypes/Bard/ImageNode.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Fieldtypes\Bard;
 
-use Scrumpy\ProseMirrorToHtml\Nodes\Node;
+use ProseMirrorToHtml\Nodes\Node;
 use Statamic\Facades\Asset;
 use Statamic\Support\Str;
 

--- a/src/Fieldtypes/Bard/SetNode.php
+++ b/src/Fieldtypes/Bard/SetNode.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Fieldtypes\Bard;
 
-use Scrumpy\ProseMirrorToHtml\Nodes\Node;
+use ProseMirrorToHtml\Nodes\Node;
 
 class SetNode extends Node
 {


### PR DESCRIPTION
This PR updates the `html-to-prosemirror` and `prosemirror-to-html` packages.

- `Scrumpy` has been removed from their namespace.
- Added `values()` to `removeDisabledSets()` because it didn't like that the keys were not zero indexed. It would result in nothing being output. I think it's [this change](https://github.com/ueberdosis/prosemirror-to-html/compare/0.10.0...2.1.0#diff-6bad14fcad6d24f73a6ab908bc699d95R177).
- Closes #2517 because the updated version of prosemirror-to-html includes the strike mark by default.
- Replace the now-default image node with our own custom one which has the asset url support.