### PR TITLE
Fix Term Title not being displayed

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -209,7 +209,7 @@ class Terms extends Relationship
 
         return [
             'id' => $id,
-            'title' => $term->value('title'),
+            'title' => $term->title(),
             'published' => $term->published(),
             'private' => $term->private(),
             'edit_url' => $term->editUrl(),


### PR DESCRIPTION
This pull request fixes an issue where the title for terms might not be displayed inside a `Taxonomy Term` fieldtype. 

I can't figure out why it wasn't being displayed but if I was to take a guess it would be because the `title` wasn't part of the Term's data and the `value` method couldn't pick it up?

This PR closes #2528.