### PR TITLE
Stop forcing prepended 'ensuredFields' to the top of the blueprint.

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -205,12 +205,10 @@ class Blueprint implements Augmentable
 
         // Set the field config in it's proper place.
         if (! $imported) {
-            if ($prepend && $exists) {
-                $fields->forget($handle)->prepend($field);
-            } elseif ($prepend && ! $exists) {
-                $fields->prepend($field);
-            } elseif ($exists) {
+            if ($exists) {
                 $fields->put($handle, $field);
+            } elseif (! $exists && $prepend) {
+                $fields->prepend($field);
             } else {
                 $fields->push($field);
             }


### PR DESCRIPTION
Only prepend fields when they are missing in the blueprint; don't force them to the top if they exist in the blueprint. Fixes #2173.

I left in the `! $exists` for readability; you can leave it out if you prefer to.