### PR TITLE
Added down method to Statamic Auth Migrations

### DIFF
--- a/src/Console/Commands/stubs/auth/statamic_auth_tables.php.stub
+++ b/src/Console/Commands/stubs/auth/statamic_auth_tables.php.stub
@@ -33,4 +33,20 @@ class StatamicAuthTables extends Migration
             $table->string('group_id');
         });
     }
+
+    /**
+     * Reverse the migrations.
+     */
+     public function down()
+     {
+         Schema::table('users', function (Blueprint $blueprint) {
+             $table->dropColumn('super');
+             $table->dropColumn('avatar');
+             $table->dropColumn('preferences');
+             $table->dropColumn('last_login');
+         });
+
+         Schema::dropIfExists('role_user');
+         Schema::dropIfExists('group_user');
+     }
 }

--- a/src/Console/Commands/stubs/auth/statamic_auth_tables.php.stub
+++ b/src/Console/Commands/stubs/auth/statamic_auth_tables.php.stub
@@ -44,6 +44,7 @@ class StatamicAuthTables extends Migration
              $table->dropColumn('avatar');
              $table->dropColumn('preferences');
              $table->dropColumn('last_login');
+             $table->string('password')->nullable(false)->change();
          });
 
          Schema::dropIfExists('role_user');


### PR DESCRIPTION
This pull request adds a `down` method to the auth database migration run by users who want to move their site's users to a database.

Previously, there was no `down` method that would drop columns added by the `up` method.

This PR closes #2543