### PR TITLE
Laravel 8 support - bring guzzle adapter in house

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
         laravel: [8.*, 7.*, 6.*]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
+        dependency-version: prefer-lowest
+        additional-deps: '"mockery/mockery:>=1.2.3"'
         include:
           - laravel: 8.*
             testbench: 6.*
@@ -25,8 +27,9 @@ jobs:
           - laravel: 6.*
             testbench: 4.*
           - php: 7.4
-            dependency-version: prefer-lowest
-            additional-deps: '"mockery/mockery:>=1.2.3"'
+        exclude:
+          - laravel: 8.*
+            php: 7.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,6 @@ jobs:
             testbench: 5.*
           - laravel: 6.*
             testbench: 4.*
-          - php: 7.4
         exclude:
           - laravel: 8.*
             php: 7.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,6 @@ jobs:
         laravel: [8.*, 7.*, 6.*]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
-        dependency-version: prefer-lowest
-        additional-deps: '"mockery/mockery:>=1.2.3"'
         include:
           - laravel: 8.*
             testbench: 6.*
@@ -26,6 +24,9 @@ jobs:
             testbench: 5.*
           - laravel: 6.*
             testbench: 4.*
+          - php: 7.4
+            dependency-version: prefer-lowest
+            additional-deps: '"mockery/mockery:>=1.2.3"'
         exclude:
           - laravel: 8.*
             php: 7.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,12 @@ jobs:
     strategy:
       matrix:
         php: [7.4, 7.3, 7.2]
-        laravel: [7.*, 6.*]
+        laravel: [8.*, 7.*, 6.*]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
+          - laravel: 8.*
+            testbench: 6.*
           - laravel: 7.*
             testbench: 5.*
           - laravel: 6.*

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "statamic/stringy": "^3.1",
         "symfony/var-exporter": "^4.3",
         "symfony/yaml": "^4.1 || ^5.1",
-        "twistor/flysystem-guzzle": "^6.0",
         "ueberdosis/html-to-prosemirror": "^1.0",
         "ueberdosis/prosemirror-to-html": "^2.0",
         "wilderborn/partyline": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,10 @@
     "require": {
         "composer/composer": "^1.10",
         "facade/ignition-contracts": "^1.0",
-        "guzzlehttp/guzzle": "^6.3",
-        "laravel/framework": "^6.0 || ^7.0",
+        "guzzlehttp/guzzle": "^6.3 || ^7.0",
+        "laravel/framework": "^6.0 || ^7.0 || ^8.0",
         "laravel/helpers": "^1.1",
+        "laravel/legacy-factories": "^1.0",
         "league/commonmark": "^1.5",
         "league/csv": "^9.0",
         "league/glide": "^1.1",
@@ -30,7 +31,7 @@
         "fzaninotto/faker": "~1.4",
         "google/cloud-translate": "^1.6",
         "mockery/mockery": "^1.2.3",
-        "orchestra/testbench": "^4.0 || ^5.0"
+        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "laravel/framework": "^6.0 || ^7.0 || ^8.0",
         "laravel/helpers": "^1.1",
-        "laravel/legacy-factories": "^1.0",
         "league/commonmark": "^1.5",
         "league/csv": "^9.0",
         "league/glide": "^1.1",
@@ -30,6 +29,7 @@
     "require-dev": {
         "fzaninotto/faker": "~1.4",
         "google/cloud-translate": "^1.6",
+        "laravel/legacy-factories": "^1.0",
         "mockery/mockery": "^1.2.3",
         "orchestra/testbench": "^4.0 || ^5.0 || ^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "require-dev": {
         "fzaninotto/faker": "~1.4",
         "google/cloud-translate": "^1.6",
-        "laravel/legacy-factories": "^1.0",
         "mockery/mockery": "^1.2.3",
         "orchestra/testbench": "^4.0 || ^5.0 || ^6.0"
     },

--- a/src/Imaging/GuzzleAdapter.php
+++ b/src/Imaging/GuzzleAdapter.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace Statamic\Imaging;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Uri;
+use League\Flysystem\AdapterInterface;
+use League\Flysystem\Config;
+use League\Flysystem\Util\MimeType;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Uses Guzzle as a backend for HTTP URLs.
+ */
+class GuzzleAdapter implements AdapterInterface
+{
+    /**
+     * Whether this endpoint supports head requests.
+     *
+     * @var bool
+     */
+    protected $supportsHead = true;
+
+    /**
+     * The base URL.
+     *
+     * @var string
+     */
+    protected $base;
+
+    /**
+     * The Guzzle HTTP client.
+     *
+     * @var \GuzzleHttp\ClientInterface
+     */
+    protected $client;
+
+    /**
+     * The visibility of this adapter.
+     *
+     * @var string
+     */
+    protected $visibility = AdapterInterface::VISIBILITY_PUBLIC;
+
+    /**
+     * Constructs a GuzzleAdapter object.
+     *
+     * @param string                      $base         The base URL.
+     * @param \GuzzleHttp\ClientInterface $client       An optional Guzzle client.
+     * @param bool                        $supportsHead Whether the client supports HEAD requests.
+     */
+    public function __construct($base, ClientInterface $client = null, $supportsHead = true)
+    {
+        $this->base = rtrim($base, '/').'/';
+        $this->client = $client ?: new Client();
+        $this->supportsHead = $supportsHead;
+
+        if (isset(parse_url($base)['user'])) {
+            $this->visibility = AdapterInterface::VISIBILITY_PRIVATE;
+        }
+    }
+
+    /**
+     * Returns the base URL.
+     *
+     * @return string The base URL.
+     */
+    public function getBaseUrl()
+    {
+        return $this->base;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function copy($path, $newpath)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createDir($path, Config $config)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($path)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteDir($path)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadata($path)
+    {
+        if (! $response = $this->head($path)) {
+            return false;
+        }
+
+        return [
+            'type' => 'file',
+            'path' => $path,
+        ] + $this->getResponseMetadata($path, $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMimetype($path)
+    {
+        return $this->getMetadata($path);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSize($path)
+    {
+        return $this->getMetadata($path);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTimestamp($path)
+    {
+        return $this->getMetadata($path);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVisibility($path)
+    {
+        return [
+            'path' => $path,
+            'visibility' => $this->visibility,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($path)
+    {
+        return (bool) $this->head($path);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function listContents($directory = '', $recursive = false)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($path)
+    {
+        if (! $response = $this->get($path)) {
+            return false;
+        }
+
+        return [
+            'path' => $path,
+            'contents' => (string) $response->getBody(),
+        ] + $this->getResponseMetadata($path, $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function readStream($path)
+    {
+        if (! $response = $this->get($path)) {
+            return false;
+        }
+
+        return [
+            'path' => $path,
+            'stream' => $response->getBody()->detach(),
+        ] + $this->getResponseMetadata($path, $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rename($path, $newpath)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setVisibility($path, $visibility)
+    {
+        throw new \LogicException('GuzzleAdapter does not support visibility. Path: '.$path.', visibility: '.$visibility);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update($path, $contents, Config $conf)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateStream($path, $resource, Config $config)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($path, $contents, Config $config)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writeStream($path, $resource, Config $config)
+    {
+        return false;
+    }
+
+    /**
+     * Performs a GET request.
+     *
+     * @param string $path The path to GET.
+     *
+     * @return \GuzzleHttp\Psr7\Response|false The response or false if failed.
+     */
+    protected function get($path)
+    {
+        try {
+            $response = $this->client->get($this->base.$path);
+        } catch (BadResponseException $e) {
+            return false;
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            return false;
+        }
+
+        return $response;
+    }
+
+    /**
+     * Returns the mimetype of a response.
+     *
+     * @param string $path
+     * @param \Psr\Http\Message\ResponseInterface $response
+     *
+     * @return string
+     */
+    protected function getMimetypeFromResponse($path, ResponseInterface $response)
+    {
+        if ($mimetype = $response->getHeader('Content-Type')) {
+            list($mimetype) = explode(';', reset($mimetype), 2);
+
+            return trim($mimetype);
+        }
+
+        // Try to guess from file extension.
+        $uri = new Uri($path);
+
+        return MimeType::detectByFilename($uri->getPath());
+    }
+
+    /**
+     * Returns the metadata array for a response.
+     *
+     * @param string $path
+     * @param \Psr\Http\Message\ResponseInterface $response
+     *
+     * @return array
+     */
+    protected function getResponseMetadata($path, ResponseInterface $response)
+    {
+        $metadata = [
+            'visibility' => $this->visibility,
+            'mimetype' => $this->getMimetypeFromResponse($path, $response),
+        ];
+
+        if ($last_modified = $response->getHeader('Last-Modified')) {
+            $last_modified = strtotime(reset($last_modified));
+
+            if ($last_modified !== false) {
+                $metadata['timestamp'] = $last_modified;
+            }
+        }
+
+        if ($length = $response->getHeader('Content-Length')) {
+            $length = reset($length);
+
+            if (is_numeric($length)) {
+                $metadata['size'] = (int) $length;
+            }
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * Performs a HEAD request.
+     *
+     * @param string $path The path to HEAD.
+     *
+     * @return \GuzzleHttp\Psr7\Response|false The response or false if failed.
+     */
+    protected function head($path)
+    {
+        if (! $this->supportsHead) {
+            return $this->get($path);
+        }
+
+        try {
+            $response = $this->client->head($this->base.$path);
+        } catch (ClientException $e) {
+            if ($e->getResponse()->getStatusCode() === 405) {
+                $this->supportsHead = false;
+
+                return $this->get($path);
+            }
+
+            return false;
+        } catch (BadResponseException $e) {
+            return false;
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            return false;
+        }
+
+        return $response;
+    }
+}

--- a/src/Imaging/GuzzleAdapter.php
+++ b/src/Imaging/GuzzleAdapter.php
@@ -282,7 +282,7 @@ class GuzzleAdapter implements AdapterInterface
     protected function getMimetypeFromResponse($path, ResponseInterface $response)
     {
         if ($mimetype = $response->getHeader('Content-Type')) {
-            list($mimetype) = explode(';', reset($mimetype), 2);
+            [$mimetype] = explode(';', reset($mimetype), 2);
 
             return trim($mimetype);
         }

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -9,7 +9,6 @@ use League\Glide\Server;
 use Statamic\Events\GlideImageGenerated;
 use Statamic\Facades\Config;
 use Statamic\Facades\File;
-use Twistor\Flysystem\GuzzleAdapter;
 
 class ImageGenerator
 {

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\Auth\Eloquent;
 
-use Faker\Generator as Faker;
-use Illuminate\Database\Eloquent\Factory;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Statamic\Auth\Eloquent\User as EloquentUser;
@@ -19,6 +17,8 @@ class EloquentUserTest extends TestCase
 {
     use UserContractTests, PermissibleContractTests, HasPreferencesTests;
 
+    private $num = 0;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -30,15 +30,6 @@ class EloquentUserTest extends TestCase
         // TODO: The migration has been added into the test, but the implementation could be broken if the real
         // migration is different from what's in here. We should find a way to reference the actual migrations.
         $this->loadMigrationsFrom(__DIR__.'/__migrations__');
-
-        app(Factory::class)->define(User::class, function (Faker $faker) {
-            return [
-                'name' => $faker->name,
-                'email' => $faker->unique()->safeEmail,
-                // 'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
-                'remember_token' => str_random(10),
-            ];
-        });
     }
 
     /** @test */
@@ -97,8 +88,15 @@ class EloquentUserTest extends TestCase
 
     public function makeUser()
     {
-        return (new EloquentUser)
-            ->model(factory(User::class)->create());
+        $num = ++$this->num;
+
+        $user = User::create([
+            'name' => "Test Testerson {$num}",
+            'email' => "test-{$num}@test.com",
+            'remember_token' => str_random(10),
+        ]);
+
+        return (new EloquentUser)->model($user);
     }
 
     public function createPermissible()

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -89,15 +89,14 @@ class EloquentUserTest extends TestCase
 
     public function makeUser()
     {
-        $num = ++$this->num;
-
-        $user = User::create([
-            'name' => "Test Testerson {$num}",
-            'email' => "test-{$num}@test.com",
-            'remember_token' => str_random(10),
-        ]);
-
-        return (new EloquentUser)->model($user);
+        return (new EloquentUser)
+            ->model(User::create([
+                'name' => $this->faker->name,
+                'email' => $this->faker->unique()->safeEmail,
+                // 'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
+                'remember_token' => str_random(10),
+            ])
+        );
     }
 
     public function createPermissible()

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Auth\Eloquent;
 
+use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Statamic\Auth\Eloquent\User as EloquentUser;
@@ -12,7 +13,6 @@ use Tests\Auth\PermissibleContractTests;
 use Tests\Auth\UserContractTests;
 use Tests\Preferences\HasPreferencesTests;
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
 
 class EloquentUserTest extends TestCase
 {

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -18,8 +18,6 @@ class EloquentUserTest extends TestCase
 {
     use UserContractTests, PermissibleContractTests, HasPreferencesTests, WithFaker;
 
-    private $num = 0;
-
     public function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
The Guzzle Adapter package doesn't support Guzzle 7 via constraints but does work with no changes. License was MIT, so brought in house so we can support Laravel 8.

All tests pass.