### PR TITLE
Use blink cache in the blueprint repository

### DIFF
--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -3,6 +3,7 @@
 namespace Statamic\Fields;
 
 use Closure;
+use Statamic\Facades\Blink;
 use Statamic\Facades\File;
 use Statamic\Facades\Path;
 use Statamic\Facades\YAML;
@@ -11,6 +12,10 @@ use Statamic\Support\Str;
 
 class BlueprintRepository
 {
+    private const BLINK_FOUND = 'blueprints.found';
+    private const BLINK_FROM_FILE = 'blueprints.from-file';
+    private const BLINK_NAMESPACE_PATHS = 'blueprints.paths-in-namespace';
+
     protected $directory;
     protected $fallbacks = [];
 
@@ -28,15 +33,17 @@ class BlueprintRepository
 
     public function find($blueprint): ?Blueprint
     {
-        if (! $blueprint) {
-            return null;
-        }
+        return Blink::store(self::BLINK_FOUND)->once($blueprint, function () use ($blueprint) {
+            if (! $blueprint) {
+                return null;
+            }
 
-        $path = $this->directory.'/'.str_replace('.', '/', $blueprint).'.yaml';
+            $path = $this->directory.'/'.str_replace('.', '/', $blueprint).'.yaml';
 
-        return File::exists($path)
-            ? $this->makeBlueprintFromFile($path)
-            : $this->findFallback($blueprint);
+            return File::exists($path)
+                ? $this->makeBlueprintFromFile($path)
+                : $this->findFallback($blueprint);
+        });
     }
 
     public function setFallback($handle, Closure $blueprint)
@@ -61,12 +68,23 @@ class BlueprintRepository
 
     public function save(Blueprint $blueprint)
     {
+        $this->clearBlinkCaches();
+
         $blueprint->writeFile();
     }
 
     public function delete(Blueprint $blueprint)
     {
+        $this->clearBlinkCaches();
+
         $blueprint->deleteFile();
+    }
+
+    private function clearBlinkCaches()
+    {
+        Blink::store(self::BLINK_FOUND)->flush();
+        Blink::store(self::BLINK_FROM_FILE)->flush();
+        Blink::store(self::BLINK_NAMESPACE_PATHS)->flush();
     }
 
     public function make($handle = null)
@@ -124,31 +142,35 @@ class BlueprintRepository
 
     private function filesIn($namespace)
     {
-        $namespace = str_replace('/', '.', $namespace);
-        $namespaceDir = str_replace('.', '/', $namespace);
-        $directory = $this->directory.'/'.$namespaceDir;
+        return Blink::store(self::BLINK_NAMESPACE_PATHS)->once($namespace, function () use ($namespace) {
+            $namespace = str_replace('/', '.', $namespace);
+            $namespaceDir = str_replace('.', '/', $namespace);
+            $directory = $this->directory.'/'.$namespaceDir;
 
-        if (! File::exists(Str::removeRight($directory, '/'))) {
-            return collect();
-        }
+            if (! File::exists(Str::removeRight($directory, '/'))) {
+                return collect();
+            }
 
-        return File::withAbsolutePaths()->getFilesByType($directory, 'yaml');
+            return File::withAbsolutePaths()->getFilesByType($directory, 'yaml');
+        });
     }
 
     private function makeBlueprintFromFile($path)
     {
-        [$namespace, $handle] = $this->getNamespaceAndHandle(
-            Str::after(Str::before($path, '.yaml'), $this->directory.'/')
-        );
+        return Blink::store(self::BLINK_FROM_FILE)->once($path, function () use ($path) {
+            [$namespace, $handle] = $this->getNamespaceAndHandle(
+                Str::after(Str::before($path, '.yaml'), $this->directory.'/')
+            );
 
-        $contents = YAML::file($path)->parse();
+            $contents = YAML::file($path)->parse();
 
-        return (new Blueprint)
-            ->setOrder(Arr::pull($contents, 'order'))
-            ->setInitialPath($path)
-            ->setHandle($handle)
-            ->setNamespace($namespace ?? null)
-            ->setContents($contents);
+            return (new Blueprint)
+                ->setOrder(Arr::pull($contents, 'order'))
+                ->setInitialPath($path)
+                ->setHandle($handle)
+                ->setNamespace($namespace ?? null)
+                ->setContents($contents);
+        });
     }
 
     private function getNamespaceAndHandle($blueprint)


### PR DESCRIPTION
This PR adds some optimizations related to retrieving blueprints. Simple stuff - just wrapping existing logic in blink closures.

Depending on how your site is set up, how much content you have, number of collections, what you're putting in your templates, etc - that we might end up repeating a lot of blueprint work.

Instead of constantly reading files and parsing YAML, it will only do it once.

In one test site, this reduced load time by about a second.