### PR TITLE
Forgot password form tag

### DIFF
--- a/src/Auth/SendsPasswordResetEmails.php
+++ b/src/Auth/SendsPasswordResetEmails.php
@@ -80,7 +80,7 @@ trait SendsPasswordResetEmails
      */
     protected function sendResetLinkResponse(Request $request, $response)
     {
-        session()->flash('user.forgot_password.success', __('Password reset email has been sent.'));
+        session()->flash('user.forgot_password.success', __(Password::RESET_LINK_SENT));
 
         $redirect = $request->has('_redirect')
             ? redirect($request->input('_redirect'))

--- a/src/Auth/SendsPasswordResetEmails.php
+++ b/src/Auth/SendsPasswordResetEmails.php
@@ -57,7 +57,14 @@ trait SendsPasswordResetEmails
      */
     protected function validateEmail(Request $request)
     {
-        $request->validateWithBag('user.forgot_password', ['email' => 'required|email']);
+        // Workaround for `$request->validateWithBag()` not being available in older Laravel versions.
+        try {
+            $request->validate(['email' => 'required|email']);
+        } catch (ValidationException $e) {
+            $e->errorBag = 'user.forgot_password';
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Auth/SendsPasswordResetEmails.php
+++ b/src/Auth/SendsPasswordResetEmails.php
@@ -57,7 +57,7 @@ trait SendsPasswordResetEmails
      */
     protected function validateEmail(Request $request)
     {
-        $request->validate(['email' => 'required|email']);
+        $request->validateWithBag('user.forgot_password', ['email' => 'required|email']);
     }
 
     /**

--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -207,29 +207,30 @@ class UserTags extends Tags
      */
     public function forgotPasswordForm()
     {
-        $data = [
-            'errors' => [],
-        ];
+        $data = $this->getFormSession('user.forgot_password');
 
-        if (session('email_sent')) {
-            return $this->parse(['email_sent' => true, 'success' => true]);
-        }
+        // Alias for backwards compatibility.
+        $data['email_sent'] = $data['success'];
 
-        if (session('errors')) {
-            $data['errors'] = session('errors')->all();
-        }
-
-        $knownParams = ['redirect', 'allow_request_redirect', 'reset_url'];
+        $knownParams = ['redirect', 'error_redirect', 'allow_request_redirect', 'reset_url'];
 
         $html = $this->formOpen(route('statamic.password.email'), 'POST', $knownParams);
 
+        $params = [];
+
         if ($redirect = $this->getRedirectUrl()) {
-            $html .= '<input type="hidden" name="redirect" value="'.$redirect.'" />';
+            $params['redirect'] = $this->parseRedirect($redirect);
         }
 
-        if ($reset_url = $this->params->get('reset_url')) {
-            $html .= '<input type="hidden" name="reset_url" value="'.$reset_url.'" />';
+        if ($errorRedirect = $this->getErrorRedirectUrl()) {
+            $params['error_redirect'] = $this->parseRedirect($errorRedirect);
         }
+
+        if ($resetUrl = $this->params->get('reset_url')) {
+            $params['reset_url'] = $resetUrl;
+        }
+
+        $html .= $this->formMetaFields($params);
 
         $html .= $this->parse($data);
 

--- a/tests/Tags/User/ForgotPasswordFormTest.php
+++ b/tests/Tags/User/ForgotPasswordFormTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Tests\Tags\User;
+
+use Illuminate\Support\Facades\Password;
+use Statamic\Facades\Parse;
+use Statamic\Facades\User;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ForgotPasswordFormTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    private function tag($tag)
+    {
+        return Parse::template($tag, []);
+    }
+
+    /** @test */
+    public function it_renders_form()
+    {
+        $output = $this->tag('{{ user:forgot_password_form }}{{ /user:forgot_password_form }}');
+
+        $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/password/email">', $output);
+        $this->assertStringContainsString('<input type="hidden" name="_token" value="">', $output);
+        $this->assertStringEndsWith('</form>', $output);
+    }
+
+    /** @test */
+    public function it_renders_form_with_params()
+    {
+        $output = $this->tag('{{ user:forgot_password_form redirect="/submitted" error_redirect="/errors" reset_url="/resetting" class="form" id="form" }}{{ /user:forgot_password_form }}');
+
+        $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/password/email" class="form" id="form">', $output);
+        $this->assertStringContainsString('<input type="hidden" name="_redirect" value="/submitted" />', $output);
+        $this->assertStringContainsString('<input type="hidden" name="_error_redirect" value="/errors" />', $output);
+        $this->assertStringContainsString('<input type="hidden" name="_reset_url" value="/resetting" />', $output);
+    }
+
+    /** @test */
+    public function it_renders_form_with_redirects_to_anchor()
+    {
+        $output = $this->tag('{{ user:forgot_password_form redirect="#form" error_redirect="#form" }}{{ /user:forgot_password_form }}');
+
+        $this->assertStringContainsString('<input type="hidden" name="_redirect" value="http://localhost#form" />', $output);
+        $this->assertStringContainsString('<input type="hidden" name="_error_redirect" value="http://localhost#form" />', $output);
+    }
+
+    /** @test */
+    public function it_wont_send_password_reset_email_and_renders_errors()
+    {
+        $this
+            ->post('/!/auth/password/email', [
+                'email' => 'san@holo.com',
+            ])
+            ->assertLocation('/');
+
+        $output = $this->tag(<<<'EOT'
+{{ user:forgot_password_form }}
+    {{ errors }}
+        <p class="error">{{ value }}</p>
+    {{ /errors }}
+    <p class="success">{{ success }}</p>
+    <p class="email_sent">{{ email_sent }}</p>
+{{ /user:forgot_password_form }}
+EOT
+        );
+
+        preg_match_all('/<p class="error">(.+)<\/p>/U', $output, $errors);
+        preg_match_all('/<p class="success">(.+)<\/p>/U', $output, $success);
+        preg_match_all('/<p class="email_sent">(.+)<\/p>/U', $output, $emailSent);
+
+        $this->assertEquals(['We can\'t find a user with that email address.'], $errors[1]);
+        $this->assertEmpty($success[1]);
+        $this->assertEmpty($emailSent[1]);
+    }
+
+    /** @test */
+    public function it_will_send_password_reset_email_and_render_success()
+    {
+        $this->simulateSuccessfulPasswordResetEmail();
+
+        User::make()
+            ->email('san@holo.com')
+            ->password('chewy')
+            ->save();
+
+        $this
+            ->post('/!/auth/password/email', [
+                'email' => 'san@holo.com',
+            ])
+            ->assertLocation('/');
+
+        $output = $this->tag(<<<'EOT'
+{{ user:forgot_password_form }}
+    {{ errors }}
+        <p class="error">{{ value }}</p>
+    {{ /errors }}
+
+    <p class="success">{{ success }}</p>
+    <p class="email_sent">{{ email_sent }}</p>
+{{ /user:forgot_password_form }}
+EOT
+        );
+
+        preg_match_all('/<p class="error">(.+)<\/p>/U', $output, $errors);
+        preg_match_all('/<p class="success">(.+)<\/p>/U', $output, $success);
+        preg_match_all('/<p class="email_sent">(.+)<\/p>/U', $output, $emailSent);
+
+        $this->assertEmpty($errors[1]);
+        $this->assertEquals(['Password reset email has been sent.'], $success[1]);
+        $this->assertEquals(['Password reset email has been sent.'], $emailSent[1]);
+    }
+
+    /** @test */
+    public function it_will_send_password_reset_email_and_follow_custom_redirect_with_success()
+    {
+        $this->simulateSuccessfulPasswordResetEmail();
+
+        User::make()
+            ->email('san@holo.com')
+            ->password('chewy')
+            ->save();
+
+        $this
+            ->post('/!/auth/password/email', [
+                'email' => 'san@holo.com',
+                '_redirect' => '/password-reset-successful',
+            ])
+            ->assertLocation('/password-reset-successful');
+
+        $output = $this->tag(<<<'EOT'
+{{ user:forgot_password_form }}
+    {{ errors }}
+        <p class="error">{{ value }}</p>
+    {{ /errors }}
+
+    <p class="success">{{ success }}</p>
+    <p class="email_sent">{{ email_sent }}</p>
+{{ /user:forgot_password_form }}
+EOT
+        );
+
+        preg_match_all('/<p class="error">(.+)<\/p>/U', $output, $errors);
+        preg_match_all('/<p class="success">(.+)<\/p>/U', $output, $success);
+        preg_match_all('/<p class="email_sent">(.+)<\/p>/U', $output, $emailSent);
+
+        $this->assertEmpty($errors[1]);
+        $this->assertEquals(['Password reset email has been sent.'], $success[1]);
+        $this->assertEquals(['Password reset email has been sent.'], $emailSent[1]);
+    }
+
+    /** @test */
+    public function it_wont_log_user_in_and_follow_custom_error_redirect_with_errors()
+    {
+        $this
+            ->post('/!/auth/password/email', [
+                'email' => 'san@holo.com',
+                '_error_redirect' => '/password-reset-error',
+            ])
+            ->assertLocation('/password-reset-error');
+
+        $output = $this->tag(<<<'EOT'
+{{ user:forgot_password_form }}
+    {{ errors }}
+        <p class="error">{{ value }}</p>
+    {{ /errors }}
+    <p class="success">{{ success }}</p>
+    <p class="email_sent">{{ email_sent }}</p>
+{{ /user:forgot_password_form }}
+EOT
+        );
+
+        preg_match_all('/<p class="error">(.+)<\/p>/U', $output, $errors);
+        preg_match_all('/<p class="success">(.+)<\/p>/U', $output, $success);
+        preg_match_all('/<p class="email_sent">(.+)<\/p>/U', $output, $emailSent);
+
+        $this->assertEquals(['We can\'t find a user with that email address.'], $errors[1]);
+        $this->assertEmpty($success[1]);
+        $this->assertEmpty($emailSent[1]);
+    }
+
+    /** @test */
+    public function it_will_use_redirect_query_param_off_url()
+    {
+        $this->get('/?redirect=password-reset-successful&error_redirect=password-reset-failure');
+
+        $expectedRedirect = '<input type="hidden" name="_redirect" value="password-reset-successful" />';
+        $expectedErrorRedirect = '<input type="hidden" name="_error_redirect" value="password-reset-failure" />';
+
+        $output = $this->tag('{{ user:forgot_password_form }}{{ /user:forgot_password_form }}');
+
+        $this->assertStringNotContainsString($expectedRedirect, $output);
+        $this->assertStringNotContainsString($expectedErrorRedirect, $output);
+
+        $output = $this->tag('{{ user:forgot_password_form allow_request_redirect="true" }}{{ /user:forgot_password_form }}');
+
+        $this->assertStringContainsString($expectedRedirect, $output);
+        $this->assertStringContainsString($expectedErrorRedirect, $output);
+    }
+
+    protected function simulateSuccessfulPasswordResetEmail()
+    {
+        $success = new class {
+            public function sendResetLink()
+            {
+                return Password::RESET_LINK_SENT;
+            }
+        };
+
+        Password::shouldReceive('broker')->andReturn($success);
+    }
+}

--- a/tests/Tags/User/ForgotPasswordFormTest.php
+++ b/tests/Tags/User/ForgotPasswordFormTest.php
@@ -71,7 +71,7 @@ EOT
         preg_match_all('/<p class="success">(.+)<\/p>/U', $output, $success);
         preg_match_all('/<p class="email_sent">(.+)<\/p>/U', $output, $emailSent);
 
-        $this->assertEquals(['We can\'t find a user with that email address.'], $errors[1]);
+        $this->assertEquals([__(Password::INVALID_USER)], $errors[1]);
         $this->assertEmpty($success[1]);
         $this->assertEmpty($emailSent[1]);
     }
@@ -109,8 +109,8 @@ EOT
         preg_match_all('/<p class="email_sent">(.+)<\/p>/U', $output, $emailSent);
 
         $this->assertEmpty($errors[1]);
-        $this->assertEquals(['Password reset email has been sent.'], $success[1]);
-        $this->assertEquals(['Password reset email has been sent.'], $emailSent[1]);
+        $this->assertEquals([__(Password::RESET_LINK_SENT)], $success[1]);
+        $this->assertEquals([__(Password::RESET_LINK_SENT)], $emailSent[1]);
     }
 
     /** @test */
@@ -147,8 +147,8 @@ EOT
         preg_match_all('/<p class="email_sent">(.+)<\/p>/U', $output, $emailSent);
 
         $this->assertEmpty($errors[1]);
-        $this->assertEquals(['Password reset email has been sent.'], $success[1]);
-        $this->assertEquals(['Password reset email has been sent.'], $emailSent[1]);
+        $this->assertEquals([__(Password::RESET_LINK_SENT)], $success[1]);
+        $this->assertEquals([__(Password::RESET_LINK_SENT)], $emailSent[1]);
     }
 
     /** @test */
@@ -176,7 +176,7 @@ EOT
         preg_match_all('/<p class="success">(.+)<\/p>/U', $output, $success);
         preg_match_all('/<p class="email_sent">(.+)<\/p>/U', $output, $emailSent);
 
-        $this->assertEquals(['We can\'t find a user with that email address.'], $errors[1]);
+        $this->assertEquals([__(Password::INVALID_USER)], $errors[1]);
         $this->assertEmpty($success[1]);
         $this->assertEmpty($emailSent[1]);
     }


### PR DESCRIPTION
Several improvements to forgot password form tag...

- Fix broken `email_sent` / `success` output.
- Scope success and error output to message bag so that it plays nice with other forms on page.
- Clean up code and make consistent with user login and register form tags.

Closes #1777.