### PR TITLE
Fix mount variable causing incorrect urls

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -171,6 +171,17 @@ class Collection implements Contract, AugmentableContract
         return optional($mount->in($site))->url();
     }
 
+    public function uri($site = null)
+    {
+        if (! $mount = $this->mount()) {
+            return null;
+        }
+
+        $site = $site ?? $this->sites()->first();
+
+        return optional($mount->in($site))->uri();
+    }
+
     public function showUrl()
     {
         return cp_route('collections.show', $this->handle());

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -160,9 +160,15 @@ class Collection implements Contract, AugmentableContract
             ->args(func_get_args());
     }
 
-    public function url()
+    public function url($site = null)
     {
-        return optional($this->mount())->url();
+        if (! $mount = $this->mount()) {
+            return null;
+        }
+
+        $site = $site ?? $this->sites()->first();
+
+        return optional($mount->in($site))->url();
     }
 
     public function showUrl()

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -564,7 +564,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
             'id' => $this->id(),
             'slug' => $this->slug(),
             'published' => $this->published(),
-            'mount' => $this->collection()->url($this->locale()),
+            'mount' => $this->collection()->uri($this->locale()),
         ]);
 
         if ($this->hasDate()) {

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -564,7 +564,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
             'id' => $this->id(),
             'slug' => $this->slug(),
             'published' => $this->published(),
-            'mount' => $this->collection()->url(),
+            'mount' => $this->collection()->url($this->locale()),
         ]);
 
         if ($this->hasDate()) {


### PR DESCRIPTION
When using `{mount}` in a route, it was getting the `url` of the mounted entry. The problem was twofold:

1. The collection wasn't localizing the mounted entry, so the url would always be for whichever site the entry was in.
2. Since it was calling url, and not uri, we'd see the site root twice. Once in the collection's mounted entry's url, and again after the uri was built.

Closes #1977 