### PR TITLE
Prevent handling collection changes on every request

### DIFF
--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -90,12 +90,12 @@ class CollectionsStore extends BasicStore
 
         parent::handleFileChanges();
 
-        // TODO: only update urls for structured collection that were modified.
-        Collection::all()->each->updateEntryUris();
+        foreach ($this->modified as $collection) {
+            $collection->updateEntryUris();
 
-        // TODO: only update order indexes for collections that were modified.
-        Collection::all()->filter->orderable()->each(function ($collection) {
-            Stache::store('entries')->store($collection->handle())->index('order')->update();
-        });
+            if ($collection->orderable()) {
+                Stache::store('entries')->store($collection->handle())->index('order')->update();
+            }
+        }
     }
 }

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -20,6 +20,7 @@ abstract class Store
     protected $paths;
     protected $fileItems;
     protected $shouldCacheFileItems = false;
+    protected $modified;
 
     public function directory($directory = null)
     {
@@ -156,6 +157,8 @@ abstract class Store
 
     public function handleFileChanges()
     {
+        $this->modified = collect();
+
         // We only want to act on any file changes one time per store.
         if ($this->fileChangesHandled) {
             return;
@@ -268,6 +271,8 @@ abstract class Store
                 $index->updateItem($item);
             });
         });
+
+        $this->modified = $modified;
     }
 
     protected function handleModifiedItem($item)


### PR DESCRIPTION
When you change a collection's route, the entries need to have their urls updated.
And, when you change a orderable collection's tree, the `order` index needs to be updated.

At the moment, this happens on every request to all collections.

This PR makes it so the actions are only performed for collections that have been modified.