### PR TITLE
Eager load structure tree entries

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -276,6 +276,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
         if ($this->id()) {
             Blink::store('structure-page-entries')->forget($this->id());
             Blink::store('structure-uris')->forget($this->id());
+            Blink::forget('structure-entries-collection::'.$this->collectionHandle().'-'.$this->locale());
         }
 
         $this->taxonomize();

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -276,7 +276,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
         if ($this->id()) {
             Blink::store('structure-page-entries')->forget($this->id());
             Blink::store('structure-uris')->forget($this->id());
-            Blink::forget('structure-entries-collection::'.$this->collectionHandle().'-'.$this->locale());
+            Blink::store('structure-entries')->flush();
         }
 
         $this->taxonomize();

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -11,7 +11,6 @@ use Statamic\Contracts\Routing\UrlBuilder;
 use Statamic\Data\HasAugmentedInstance;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
-use Statamic\Facades\Entry as EntryAPI;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 
@@ -108,7 +107,7 @@ class Page implements Entry, Augmentable, Responsable, Protectable
         }
 
         return Blink::store('structure-page-entries')->once($this->reference, function () {
-            return EntryAPI::find($this->reference);
+            return $this->tree->entry($this->reference);
         });
     }
 

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -285,4 +285,17 @@ class Tree implements Localization
 
         return [$match, array_values($branches)];
     }
+
+    public function entry($entry)
+    {
+        $blink = 'structure-entries-'.$this->structure->handle().'-'.$this->locale();
+
+        $entries = Blink::once($blink, function () {
+            $refs = $this->flattenedPages()->map->reference()->filter()->all();
+
+            return \Statamic\Facades\Entry::query()->whereIn('id', $refs)->get()->keyBy->id();
+        });
+
+        return $entries->get($entry);
+    }
 }

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -288,9 +288,9 @@ class Tree implements Localization
 
     public function entry($entry)
     {
-        $blink = 'structure-entries-'.$this->structure->handle().'-'.$this->locale();
+        $blink = $this->structure->handle().'-'.$this->locale();
 
-        $entries = Blink::once($blink, function () {
+        $entries = Blink::store('structure-entries')->once($blink, function () {
             $refs = $this->flattenedPages()->map->reference()->filter()->all();
 
             return \Statamic\Facades\Entry::query()->whereIn('id', $refs)->get()->keyBy->id();

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -637,6 +637,7 @@ class EntryTest extends TestCase
         $mock->shouldReceive('store')->with('structure-uris')->once()->andReturn(
             $this->mock(\Spatie\Blink\Blink::class)->shouldReceive('forget')->with('a')->once()->getMock()
         );
+        $mock->shouldReceive('forget')->with('structure-entries-collection::test-en')->once();
 
         $entry->save();
     }

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -637,7 +637,9 @@ class EntryTest extends TestCase
         $mock->shouldReceive('store')->with('structure-uris')->once()->andReturn(
             $this->mock(\Spatie\Blink\Blink::class)->shouldReceive('forget')->with('a')->once()->getMock()
         );
-        $mock->shouldReceive('forget')->with('structure-entries-collection::test-en')->once();
+        $mock->shouldReceive('store')->with('structure-entries')->once()->andReturn(
+            $this->mock(\Spatie\Blink\Blink::class)->shouldReceive('flush')->getMock()
+        );
 
         $entry->save();
     }

--- a/tests/Data/Structures/PageTest.php
+++ b/tests/Data/Structures/PageTest.php
@@ -39,7 +39,9 @@ class PageTest extends TestCase
             ->with('example-page')
             ->andReturn($entry = new Entry);
 
-        $page = new Page;
+        $tree = $this->mock(Tree::class)->shouldReceive('entry')->with('example-page')->once()->andReturn($entry)->getMock();
+
+        $page = (new Page)->setTree($tree);
         $this->assertNull($page->entry());
 
         $return = $page->setEntry('example-page');
@@ -55,7 +57,9 @@ class PageTest extends TestCase
             ->with(3)
             ->andReturn($entry = new Entry);
 
-        $page = new Page;
+        $tree = $this->mock(Tree::class)->shouldReceive('entry')->with(3)->once()->andReturn($entry)->getMock();
+
+        $page = (new Page)->setTree($tree);
         $this->assertNull($page->entry());
 
         $return = $page->setEntry(3);

--- a/tests/Tags/StructureTagTest.php
+++ b/tests/Tags/StructureTagTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Tags;
 
 use Facades\Tests\Factories\EntryFactory;
+use Statamic\Contracts\Entries\QueryBuilder;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Nav;
@@ -133,19 +134,17 @@ EOT;
 
     private function createNav()
     {
-        $one = EntryFactory::collection('pages')->data(['title' => 'One', 'nav_title' => 'Navtitle One'])->create();
-        $oneOne = EntryFactory::collection('pages')->data(['title' => 'One One', 'nav_title' => 'Navtitle One One'])->create();
-        $two = EntryFactory::collection('pages')->data(['title' => 'Two', 'foo' => 'notbar'])->create();
-        $three = EntryFactory::collection('pages')->data(['title' => 'Three'])->create();
-        $threeOne = EntryFactory::collection('pages')->data(['title' => 'Three One', 'nav_title' => 'Navtitle Three One'])->create();
-        $threeTwo = EntryFactory::collection('pages')->data(['title' => 'Three Two', 'foo' => 'notbar'])->create();
+        $one = EntryFactory::collection('pages')->id('1')->data(['title' => 'One', 'nav_title' => 'Navtitle One'])->create();
+        $oneOne = EntryFactory::collection('pages')->id('1-1')->data(['title' => 'One One', 'nav_title' => 'Navtitle One One'])->create();
+        $two = EntryFactory::collection('pages')->id('2')->data(['title' => 'Two', 'foo' => 'notbar'])->create();
+        $three = EntryFactory::collection('pages')->id('3')->data(['title' => 'Three'])->create();
+        $threeOne = EntryFactory::collection('pages')->id('3-1')->data(['title' => 'Three One', 'nav_title' => 'Navtitle Three One'])->create();
+        $threeTwo = EntryFactory::collection('pages')->id('3-2')->data(['title' => 'Three Two', 'foo' => 'notbar'])->create();
 
-        Entry::shouldReceive('find')->with('1')->andReturn($one);
-        Entry::shouldReceive('find')->with('1-1')->andReturn($oneOne);
-        Entry::shouldReceive('find')->with('2')->andReturn($two);
-        Entry::shouldReceive('find')->with('3')->andReturn($three);
-        Entry::shouldReceive('find')->with('3-1')->andReturn($threeOne);
-        Entry::shouldReceive('find')->with('3-2')->andReturn($threeTwo);
+        $builder = $this->mock(QueryBuilder::class);
+        $builder->shouldReceive('whereIn')->with('id', ['1', '1-1', '2', '3', '3-1', '3-2'])->andReturnSelf();
+        $builder->shouldReceive('get')->andReturn(collect([$one, $oneOne, $two, $three, $threeOne, $threeTwo]));
+        Entry::shouldReceive('query')->andReturn($builder);
 
         $this->makeNav([
             ['entry' => '1', 'children' => [


### PR DESCRIPTION
This PR adds eager loading when looking up an page's entry in a structure tree.

At the moment when we need to do page/entry lookups, it does them all separately. Now, it'll do a whereIn the first time and blink-cache them:

Before:

```
select * from `entries` where `id` = 1
select * from `entries` where `id` = 2
select * from `entries` where `id` = 3
select * from `entries` where `id` = 4
select * from `entries` where `id` = 5
```

After:

```
select * from `entries` where `id` in (1, 2, 3, 4, 5)
```

...and this example only has 5 pages in the tree.