### PR TITLE
Fixed validation rule label bug

### DIFF
--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -127,7 +127,7 @@ export default {
         },
 
         laravelRules() {
-            return _.chain(RULES)
+            return _.chain(clone(RULES))
                 .filter(rule => rule.minVersion ? SemVer.gte(this.laravelVersion, rule.minVersion) : true)
                 .filter(rule => rule.maxVersion ? SemVer.lte(this.laravelVersion, rule.maxVersion) : true)
                 .map(rule => {


### PR DESCRIPTION
This fixes #2540 

When the `RULES` object is run through lodash's chain command, the object itself is getting filtered and mapped for some reason. By cloning the object, it stops this odd behavior and allows the rule label to get built properly.

Lion-O would be proud.