### PR TITLE
`key` parameter for Cache tag

### DIFF
--- a/src/Tags/Cache.php
+++ b/src/Tags/Cache.php
@@ -34,6 +34,10 @@ class Cache extends Tags
 
     private function getCacheKey()
     {
+        if ($this->params->has('key')) {
+            return $this->params->get('key');
+        }
+
         $hash = [
             'content' => $this->content,
             'params' => $this->params->all(),


### PR DESCRIPTION
This pull request adds the ability for a developer to specify the cache key they want to use when using Statamic's `{{ cache }}` tag.

Instead of Statamic creating a random cache key, a developer can specify it with the `key` param.

```
{{ cache key="the_alphabet" }}
a b c d e f g h i j k l m n o p q r s t u v w x y z
{{ /cache }}
```

This PR implements statamic/ideas#349.