### PR TITLE
Make Listing component a Global Mixin

### DIFF
--- a/resources/js/bootstrap/mixins.js
+++ b/resources/js/bootstrap/mixins.js
@@ -2,12 +2,13 @@
 import Vue from 'vue'
 import Fieldtype from '../components/fieldtypes/Fieldtype.vue'
 import IndexFieldtype from '../components/fieldtypes/IndexFieldtype.vue'
-import BardToolbarButton from '../components/fieldtypes/bard/ToolbarButton.vue';
+import BardToolbarButton from '../components/fieldtypes/bard/ToolbarButton.vue'
+import Listing from '../components/Listing.vue'
 
 window.Fieldtype = Fieldtype;
 window.IndexFieldtype = IndexFieldtype;
 window.BardToolbarButton = BardToolbarButton;
-
+window.Listing = Listing;
 
 Vue.mixin({
     methods: {


### PR DESCRIPTION
This pull request makes the `components/Listing.vue` component a global mixin. This means that addon developers no longer need to do imports from vendor directories to use this component.

Instead, now it can be imported as a mixin:

**Before:**
```js
import Listing from "../../../vendor/statamic/cms/resources/js/components/Listing";

export default {
    components: {
        Listing,
    },
}
```

**After:**
```js
export default {
    mixins: [Listing],
}
```

---

This PR closes #2559.