### PR TITLE
Fix parse frontMatter for all line ending types

### DIFF
--- a/src/Facades/Endpoint/Parse.php
+++ b/src/Facades/Endpoint/Parse.php
@@ -62,7 +62,7 @@ class Parse
         $data = [];
         $content = $string;
 
-        if (Str::startsWith($string, '---'.PHP_EOL)) {
+        if (preg_match('/^---[\r\n?|\n]/', $string)) {
             $data = self::YAML($string);
             $content = $data['content'];
             unset($data['content']);


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/2603

You might want to check for other places where you use PHP_EOL for parsing.