### PR TITLE
Provide context to the recursive children in the structure tag

### DIFF
--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -65,7 +65,7 @@ class Structure extends Tags
                 'is_current'  => rtrim(URL::getCurrent(), '/') == rtrim($page->url(), '/'),
                 'is_parent'   => Site::current()->url() === $page->url() ? false : URL::isAncestorOf(URL::getCurrent(), $page->url()),
                 'is_external' => URL::isExternal($page->absoluteUrl()),
-            ]);
+            ], $this->context->all());
         })->filter()->values()->all();
     }
 }


### PR DESCRIPTION
This pull request fixes #2609 by providing context when using recursive children inside the nav/structure tag.

Currently, inside of recursive children, you're not able to see the data for the global page. In the below example, you wouldn't be able to access `{{ current_url }}` in any of the children. 

```html
{{ nav:collection:pages }}
    <li>current_url: {{ current_url or 'nada' }}</li>

    {{ if children }}
        {{ *recursive children* }}
    {{ /if }}
{{ /nav:collection:pages }}
```

The above example is something this PR fixes. It does this by providing the context available to the tag and merging it with the entry & structure data for the child.