### PR TITLE
Fix issues with using boolean attributes on SVG tag

### DIFF
--- a/src/Tags/Concerns/RendersAttributes.php
+++ b/src/Tags/Concerns/RendersAttributes.php
@@ -14,9 +14,11 @@ trait RendersAttributes
     {
         return collect($attributes)
             ->map(function ($value, $attribute) {
-                return $value === true
-                    ? $attribute
-                    : sprintf('%s="%s"', $attribute, $value);
+                if ($value === true) {
+                    $value = 'true';
+                }
+
+                return sprintf('%s="%s"', $attribute, $value);
             })
             ->implode(' ');
     }


### PR DESCRIPTION
Currently, when you add an attribute, like `aria-hidden="true"` to an SVG tag, the value won't be returned. As pointed out by Lighthouse in the related issue, this is considered to be invalid. (it would be returned simply as `aria-hidden`)

However, with this pull request, the value of true will now be output like it should be: `aria-hidden="true"`.

This PR fixes #2605. 