### PR TITLE
Fix: Password Reset validation messages are not shown

### DIFF
--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -23,11 +23,13 @@
 
             <div class="mb-4">
                 <label for="email" class="mb-1">{{ __('Email Address') }}</label>
-                @if ($errors->has('email'))
-                    <small class="block text-red -mt-1 mb-1">{{ $errors->first('email') }}</small>
-                @endif
                 <input id="email" type="text" class="input-text input-text" name="email" value="{{ old('email') }}" >
+
+                @error('email', 'user.forgot_password')
+                    <div class="text-red text-xs mt-1">{{ $message }}</div>
+                @enderror
             </div>
+
             <button type="submit" class="btn-primary">
                 {{ __('Submit') }}
             </button>

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -19,21 +19,21 @@
             <div class="mb-4">
                 <label for="email"  class="mb-1">{{ __('Email Address') }}</label>
 
-                @if ($errors->has('email'))
-                    <small class="block text-red -mt-1 mb-1">{{ $errors->first('email') }}</small>
-                @endif
-
                 <input id="email" type="email" class="input-text input-text" name="email" value="{{ $email ?? old('email') }}" autofocus required>
+
+                @error('email')
+                    <div class="text-red text-xs mt-1">{{ $message }}</div>
+                @enderror
             </div>
 
             <div class="mb-4">
                 <label for="password" class="mb-1">{{ __('Password') }}</label>
 
-                @if ($errors->has('password'))
-                    <small class="block text-red -mt-1 mb-1">{{ $errors->first('password') }}</small>
-                @endif
-
                 <input id="password" type="password" class="input-text input-text" name="password" required>
+
+                @error('password')
+                    <div class="text-red text-xs mt-1">{{ $message }}</div>
+                @enderror
             </div>
 
             <div class="mb-4">


### PR DESCRIPTION
## Bug Description
Password Reset validation messages are not shown after an invalid submit.

## How to Reproduce
Try to submit the "Forgot Your Password" form without fill the email field.

## Environment
Statamic 3.0.16 Pro
Laravel 8.9.0
PHP 7.4.9
No addons installed

## What I have fixed

“Forgot password” view retrieve errors from the "default" validation bag but it uses a custom one: https://github.com/statamic/cms/blob/e923a27b35d8711337f422bcd7a64cdbf621f5b4/src/Auth/SendsPasswordResetEmails.php#L64

**UI**: “Forgot” and “Reset” password views display validation errors above fields while in CP error messages are displayed below.