### PR TITLE
Use docs-callout for Licensing section

### DIFF
--- a/resources/views/licensing.blade.php
+++ b/resources/views/licensing.blade.php
@@ -110,8 +110,9 @@
 
     @endif
 
-    <div class="flex justify-center text-center mt-4">
-        <div class="bg-white rounded-full px-3 py-1 shadow-sm text-sm text-grey-70">{{ __('Learn more about') }} <a href="{{ Statamic::docsUrl('licensing') }}" class="text-blue hover:text-blue-dark">{{ __('Licensing') }}</a>.</div>
-    </div>
+    @include('statamic::partials.docs-callout', [
+        'topic' => __('Licensing'),
+        'url' => Statamic::docsUrl('licensing')
+    ])
 
 @stop


### PR DESCRIPTION
Use the `docs-callout` partial for Licensing like other sections does.