### PR TITLE
Augment date value and index

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -82,6 +82,11 @@ class Date extends Fieldtype
         ];
     }
 
+    public function augment($value)
+    {
+        return Carbon::createFromFormat($this->dateFormat($value), $value);
+    }
+
     public function filter()
     {
         return new DateFilter($this);

--- a/src/Stache/Indexes/Value.php
+++ b/src/Stache/Indexes/Value.php
@@ -25,8 +25,16 @@ class Value extends Index
             return $item->queryEntries()->count();
         }
 
-        return method_exists($item, $method)
-            ? $item->{$method}()
-            : $item->value($this->name);
+        if (method_exists($item, $method)) {
+            return $item->{$method}();
+        }
+
+        $field = $item->blueprint()->field($this->name);
+
+        if ($field && $field->fieldtype()->handle() === 'date') {
+            return $item->augmentedValue($this->name)->value();
+        }
+
+        return $item->value($this->name);
     }
 }


### PR DESCRIPTION
When querying against a date field, this works:

```php
$query->where('date', '>=', \Carbon\Carbon::today());
```

But not against a custom date field:

```php
$query->where('event_start', '>=', \Carbon\Carbon::today());
```

We found out that this is because the date string is indexed to the stache on custom date fields, rather than the Carbon instance.  This fix in the `Stache\Indexes\Value` is a bit hacky, as are the other guards mentioned in https://github.com/statamic/cms/issues/1759.  Not sure how to approach.

That said, we realized when doing this that the `Date` fieldtype had no `augment()` implementation.  It should probably augment to Carbon, but this might be a breaking change for some people?