### PR TITLE
Add find method to query builder

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -129,6 +129,11 @@ abstract class Builder implements Contract
         return $this;
     }
 
+    public function find($id, $columns = ['*'])
+    {
+        return $this->where('id', $id)->get($columns)->first();
+    }
+
     public function first()
     {
         return $this->get()->first();

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -10,18 +10,21 @@ class BuilderTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private function createDummyCollectionAndEntries()
+    {
+        Collection::make('posts')->save();
+
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'author' => 'John Doe'])->create();
+        $entry = EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'author' => 'John Doe'])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'author' => 'John Doe'])->create();
+
+        return $entry;
+    }
+
     /** @test **/
     public function entry_is_found_within_all_created_entries_using_entry_facade_with_find_method()
     {
-        Collection::make('posts')->structureContents([
-            'root' => true,
-            'tree' => [['entry' => '2']],
-        ])->save();
-
-        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'author' => 'John Doe'])->create();
-        $searchedEntry = EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'author' => 'John Doe'])->create();
-        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'author' => 'John Doe'])->create();
-
+        $searchedEntry = $this->createDummyCollectionAndEntries();
         $retrievedEntry = Entry::query()->find($searchedEntry->id());
 
         $this->assertSame($searchedEntry, $retrievedEntry);
@@ -30,17 +33,8 @@ class BuilderTest extends TestCase
     /** @test **/
     public function entry_is_found_within_all_created_entries_and_select_query_columns_are_set_using_entry_facade_with_find_method_with_columns_param()
     {
-        Collection::make('posts')->structureContents([
-            'root' => true,
-            'tree' => [['entry' => '2']],
-        ])->save();
-
-        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'author' => 'John Doe'])->create();
-        $searchedEntry = EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'author' => 'John Doe'])->create();
-        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'author' => 'John Doe'])->create();
-
+        $searchedEntry = $this->createDummyCollectionAndEntries();
         $columns = ['title'];
-
         $retrievedEntry = Entry::query()->find($searchedEntry->id(), $columns);
 
         $this->assertSame($searchedEntry, $retrievedEntry);

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests;
+
+use Facades\Tests\Factories\EntryFactory;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+
+class BuilderTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    /** @test **/
+    public function entry_is_found_within_all_created_entries_using_entry_facade_with_find_method()
+    {
+        Collection::make('posts')->structureContents([
+            'root' => true,
+            'tree' => [['entry' => '2']],
+        ])->save();
+
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'author' => 'John Doe'])->create();
+        $searchedEntry = EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'author' => 'John Doe'])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'author' => 'John Doe'])->create();
+
+        $retrievedEntry = Entry::query()->find($searchedEntry->id());
+
+        $this->assertSame($searchedEntry, $retrievedEntry);
+    }
+
+    /** @test **/
+    public function entry_is_found_within_all_created_entries_and_select_query_columns_are_set_using_entry_facade_with_find_method_with_columns_param()
+    {
+        Collection::make('posts')->structureContents([
+            'root' => true,
+            'tree' => [['entry' => '2']],
+        ])->save();
+
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'author' => 'John Doe'])->create();
+        $searchedEntry = EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'author' => 'John Doe'])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'author' => 'John Doe'])->create();
+
+        $columns = ['title'];
+
+        $retrievedEntry = Entry::query()->find($searchedEntry->id(), $columns);
+
+        $this->assertSame($searchedEntry, $retrievedEntry);
+        $this->assertSame($retrievedEntry->selectedQueryColumns(), $columns);
+    }
+}


### PR DESCRIPTION
This pull request adds a `find` method to the Statamic\Query\Builder class.

The method takes an ID as the first parameter and an optional array of columns as a second parameter (this array is passed to the `get` method to set `selectedQueryColumns `). It returns the first entry matching the ID (there should only be one of course).

Usage:
```php
Entry::query()->find('the-searched-id');

// or a more "verbose" and exhaustive alternative

Collection::find('posts')->queryEntries()->find('the-searched-id');
```

I didn't add PHPDoc comment blocks or comments because there weren't any. Same goes for type hinting. If that's an issue, I can adjust as needed.