### PR TITLE
non public pages wont show the visit URL link

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -100,7 +100,7 @@
 
                                 <div :class="{ 'hi': !shouldShowSidebar }">
 
-                                    <div class="p-2 flex items-center -mx-1">
+                                    <div v-if="permalink || (isBase && livePreviewUrl)" class="p-2 flex items-center -mx-1">
                                         <button
                                             class="flex items-center justify-center btn-flat w-full mx-1 px-1"
                                             v-if="isBase && livePreviewUrl"

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -361,6 +361,15 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
         return $this->hasDate() && $this->date()->format('H:i:s') !== '00:00:00';
     }
 
+    public function hasPublicUrl()
+    {
+        return $this->collection()->routes()
+                   ->filter(function ($route) {
+                       return $route !== null;
+                   })
+                   ->count() > 0;
+    }
+
     public function sites()
     {
         return $this->collection()->sites();

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -105,7 +105,7 @@ class EntriesController extends CpController
             'hasOrigin' => $hasOrigin,
             'originValues' => $originValues ?? null,
             'originMeta' => $originMeta ?? null,
-            'permalink' => $entry->absoluteUrl(),
+            'permalink' => ($entry->hasPublicUrl() ? $entry->absoluteUrl() : null),
             'localizations' => $collection->sites()->map(function ($handle) use ($entry) {
                 $localized = $entry->in($handle);
                 $exists = $localized !== null;


### PR DESCRIPTION
Implemented my idea/fix: https://github.com/statamic/ideas/issues/347 

If the routes of an enties collection returns nothing, we won't send a permalink to the CP's entry edit page. If no permalink is given, the "visit url button" will not show.

![image](https://user-images.githubusercontent.com/67788644/95687265-c9cc2800-0c02-11eb-9955-29e44f176aaf.png)
![image](https://user-images.githubusercontent.com/67788644/95687270-ce90dc00-0c02-11eb-8c99-8a61dd6ef4fd.png)
