### PR TITLE
Improve query params manipulation

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -38,6 +38,28 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Adds a query param matching the specified key/value pair.
+     *
+     * @param $value
+     * @param $params
+     * @return string
+     */
+    public function addQueryParam($value, $params)
+    {
+        if (isset($params[0])) {
+            // If a "?" is present in the URL, it means we should prepend "&" to the query param. Else, prepend "?".
+            $character = (strpos($value, '?') !== false) ? '&' : '?';
+
+            // Build the query param. If the second param is not set, just set the value as empty.
+            $queryParam = "{$params[0]}=" . ($params[1] ?? '');
+
+            return "{$value}{$character}{$queryParam}";
+        }
+
+        return $value;
+    }
+
+    /**
      * Creates a sentence list from the given array and the ability to set the glue.
      *
      * @param $value
@@ -1522,6 +1544,31 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Removes a query param matching the specified key if it exists.
+     *
+     * @param $value
+     * @param $params
+     * @return string
+     */
+    public function removeQueryParam($value, $params)
+    {
+        if (isset($params[0])) {
+            // Remove query params from the URL.
+            $url = strtok($value, '?');
+
+            // Build an associative array based on the query string.
+            parse_str(parse_url($value, PHP_URL_QUERY), $queryAssociativeArray);
+
+            // Remove the query param matching the specified key.
+            unset($queryAssociativeArray[$params[0]]);
+
+            return $url . (empty($queryAssociativeArray) ? '' : '?' . http_build_query($queryAssociativeArray));
+        }
+
+        return $value;
+    }
+
+    /**
      * Returns a new string with the suffix $params[0] removed, if present.
      *
      * @param $value
@@ -1692,6 +1739,32 @@ class CoreModifiers extends Modifier
         $oxford_comma = Arr::get($params, 1, true);
 
         return Str::makeSentenceList($value, $glue, $oxford_comma);
+    }
+
+    /**
+     * Sets a query param matching the specified key/value pair.
+     * If the key exists, its value gets updated. Else, the key/value pair gets added.
+     *
+     * @param $value
+     * @param $params
+     * @return string
+     */
+    public function setQueryParam($value, $params)
+    {
+        if (isset($params[0])) {
+            // Remove query params from the URL.
+            $url = strtok($value, '?');
+
+            // Build an associative array based on the query string.
+            parse_str(parse_url($value, PHP_URL_QUERY), $queryAssociativeArray);
+
+            // Update the existing param that matches the specified key, or add it if it doesn't exist.
+            $queryAssociativeArray[$params[0]] = $params[1] ?? '';
+
+            return "{$url}?" . http_build_query($queryAssociativeArray);
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -58,7 +58,7 @@ class CoreModifiers extends Modifier
             $character = (strpos($value, '?') !== false) ? '&' : '?';
 
             // Build the query param. If the second param is not set, just set the value as empty.
-            $queryParam = "{$params[0]}=" . ($params[1] ?? '');
+            $queryParam = "{$params[0]}=".($params[1] ?? '');
 
             $value = "{$url}{$character}{$queryParam}{$anchor}";
         }
@@ -1576,7 +1576,7 @@ class CoreModifiers extends Modifier
             // Remove the query param matching the specified key.
             unset($queryAssociativeArray[$params[0]]);
 
-            $value = $url . (empty($queryAssociativeArray) ? '' : '?' . http_build_query($queryAssociativeArray)) . $anchor;
+            $value = $url.(empty($queryAssociativeArray) ? '' : '?'.http_build_query($queryAssociativeArray)).$anchor;
         }
 
         return $value;
@@ -1782,7 +1782,7 @@ class CoreModifiers extends Modifier
             // Update the existing param that matches the specified key, or add it if it doesn't exist.
             $queryAssociativeArray[$params[0]] = $params[1] ?? '';
 
-            $value = "{$url}?" . http_build_query($queryAssociativeArray) . $anchor;
+            $value = "{$url}?".http_build_query($queryAssociativeArray).$anchor;
         }
 
         return $value;

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -172,6 +172,7 @@ class Cascade
 
             // Request
             'current_url' => $this->request->url(),
+            'current_full_url' => $this->request->fullUrl(),
             'current_uri' => URL::format($this->request->path()),
             'get_post' => Arr::sanitize($this->request->all()),
             'get' => Arr::sanitize($this->request->query->all()),

--- a/tests/Modifiers/AddQueryParamTest.php
+++ b/tests/Modifiers/AddQueryParamTest.php
@@ -16,12 +16,14 @@ class AddQueryParamTest extends TestCase
         $this->assertSame("{$this->baseUrl}?q=", $this->modify($this->baseUrl, ['q']));
         $this->assertSame("{$this->baseUrl}?q=test", $this->modify($this->baseUrl, $this->queryParam));
         $this->assertSame("{$this->baseUrl}?sourceid=chrome&q=test", $this->modify("{$this->baseUrl}?sourceid=chrome", $this->queryParam));
+        $this->assertSame("{$this->baseUrl}?q=test#test", $this->modify("{$this->baseUrl}#test", $this->queryParam));
     }
 
     /** @test */
     public function it_does_nothing_if_no_parameters_are_passed()
     {
         $this->assertSame($this->baseUrl, $this->modify($this->baseUrl));
+        $this->assertSame("{$this->baseUrl}#test", $this->modify("{$this->baseUrl}#test"));
     }
 
     private function modify(string $url, ?array $queryParam = null)

--- a/tests/Modifiers/AddQueryParamTest.php
+++ b/tests/Modifiers/AddQueryParamTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class AddQueryParamTest extends TestCase
+{
+    protected $baseUrl = 'https://www.google.com/search';
+    protected $queryParam = ['q', 'test'];
+
+    /** @test */
+    public function it_adds_a_new_query_param()
+    {
+        $this->assertSame("{$this->baseUrl}?q=", $this->modify($this->baseUrl, ['q']));
+        $this->assertSame("{$this->baseUrl}?q=test", $this->modify($this->baseUrl, $this->queryParam));
+        $this->assertSame("{$this->baseUrl}?sourceid=chrome&q=test", $this->modify("{$this->baseUrl}?sourceid=chrome", $this->queryParam));
+    }
+
+    /** @test */
+    public function it_does_nothing_if_no_parameters_are_passed()
+    {
+        $this->assertSame($this->baseUrl, $this->modify($this->baseUrl));
+    }
+
+    private function modify(string $url, ?array $queryParam = null)
+    {
+        if (is_null($queryParam)) {
+            return Modify::value($url)->addQueryParam()->fetch();
+        }
+
+        return Modify::value($url)->addQueryParam($queryParam)->fetch();
+    }
+}

--- a/tests/Modifiers/RemoveQueryParamTest.php
+++ b/tests/Modifiers/RemoveQueryParamTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class RemoveQueryParamTest extends TestCase
+{
+    protected $baseUrl = 'https://www.google.com/search';
+    protected $queryParamKey = 'q';
+
+    /** @test */
+    public function it_removes_an_existing_query_param()
+    {
+        $this->assertSame($this->baseUrl, $this->modify("{$this->baseUrl}?q=statamic", $this->queryParamKey));
+        $this->assertSame($this->baseUrl, $this->modify("{$this->baseUrl}?q=statamic", $this->queryParamKey));
+        $this->assertSame("{$this->baseUrl}?sourceid=chrome", $this->modify("{$this->baseUrl}?q=statamic&sourceid=chrome", $this->queryParamKey));
+        $this->assertSame("{$this->baseUrl}?sourceid=chrome", $this->modify("{$this->baseUrl}?sourceid=chrome&q=statamic", $this->queryParamKey));
+    }
+
+    /** @test */
+    public function it_does_nothing_if_the_query_param_key_does_not_exist()
+    {
+        $this->assertSame($this->baseUrl, $this->modify($this->baseUrl, $this->queryParamKey));
+        $this->assertSame("{$this->baseUrl}?sourceid=chrome", $this->modify("{$this->baseUrl}?sourceid=chrome", $this->queryParamKey));
+    }
+
+    /** @test */
+    public function it_does_nothing_if_no_parameters_are_passed()
+    {
+        $this->assertSame($this->baseUrl, $this->modify($this->baseUrl));
+    }
+
+    private function modify(string $url, ?string $queryParamKey = null)
+    {
+        if (is_null($queryParamKey)) {
+            return Modify::value($url)->removeQueryParam()->fetch();
+        }
+
+        return Modify::value($url)->removeQueryParam($queryParamKey)->fetch();
+    }
+}

--- a/tests/Modifiers/RemoveQueryParamTest.php
+++ b/tests/Modifiers/RemoveQueryParamTest.php
@@ -27,6 +27,12 @@ class RemoveQueryParamTest extends TestCase
         $this->assertSame("{$this->baseUrl}?sourceid=chrome", $this->modify("{$this->baseUrl}?sourceid=chrome", $this->queryParamKey));
     }
 
+    /** @test */
+    public function it_does_nothing_if_no_parameters_are_passed()
+    {
+        $this->assertSame($this->baseUrl, $this->modify($this->baseUrl));
+    }
+
     private function modify(string $url, ?string $queryParamKey = null)
     {
         if (is_null($queryParamKey)) {

--- a/tests/Modifiers/RemoveQueryParamTest.php
+++ b/tests/Modifiers/RemoveQueryParamTest.php
@@ -14,7 +14,7 @@ class RemoveQueryParamTest extends TestCase
     public function it_removes_an_existing_query_param()
     {
         $this->assertSame($this->baseUrl, $this->modify("{$this->baseUrl}?q=statamic", $this->queryParamKey));
-        $this->assertSame($this->baseUrl, $this->modify("{$this->baseUrl}?q=statamic", $this->queryParamKey));
+        $this->assertSame("{$this->baseUrl}#test", $this->modify("{$this->baseUrl}?q=statamic#test", $this->queryParamKey));
         $this->assertSame("{$this->baseUrl}?sourceid=chrome", $this->modify("{$this->baseUrl}?q=statamic&sourceid=chrome", $this->queryParamKey));
         $this->assertSame("{$this->baseUrl}?sourceid=chrome", $this->modify("{$this->baseUrl}?sourceid=chrome&q=statamic", $this->queryParamKey));
     }
@@ -23,13 +23,8 @@ class RemoveQueryParamTest extends TestCase
     public function it_does_nothing_if_the_query_param_key_does_not_exist()
     {
         $this->assertSame($this->baseUrl, $this->modify($this->baseUrl, $this->queryParamKey));
+        $this->assertSame("{$this->baseUrl}#test", $this->modify("{$this->baseUrl}#test", $this->queryParamKey));
         $this->assertSame("{$this->baseUrl}?sourceid=chrome", $this->modify("{$this->baseUrl}?sourceid=chrome", $this->queryParamKey));
-    }
-
-    /** @test */
-    public function it_does_nothing_if_no_parameters_are_passed()
-    {
-        $this->assertSame($this->baseUrl, $this->modify($this->baseUrl));
     }
 
     private function modify(string $url, ?string $queryParamKey = null)

--- a/tests/Modifiers/SetQueryParamTest.php
+++ b/tests/Modifiers/SetQueryParamTest.php
@@ -15,6 +15,7 @@ class SetQueryParamTest extends TestCase
     {
         $this->assertSame("{$this->baseUrl}?q=", $this->modify("{$this->baseUrl}?q=statamic", ['q']));
         $this->assertSame("{$this->baseUrl}?q=test", $this->modify("{$this->baseUrl}?q=statamic", $this->queryParam));
+        $this->assertSame("{$this->baseUrl}?q=test#test", $this->modify("{$this->baseUrl}?q=statamic#test", $this->queryParam));
         $this->assertSame("{$this->baseUrl}?q=test&sourceid=chrome", $this->modify("{$this->baseUrl}?q=statamic&sourceid=chrome", $this->queryParam));
         $this->assertSame("{$this->baseUrl}?sourceid=chrome&q=test", $this->modify("{$this->baseUrl}?sourceid=chrome&q=statamic", $this->queryParam));
     }
@@ -24,6 +25,7 @@ class SetQueryParamTest extends TestCase
     {
         $this->assertSame("{$this->baseUrl}?q=", $this->modify($this->baseUrl, ['q']));
         $this->assertSame("{$this->baseUrl}?q=test", $this->modify($this->baseUrl, $this->queryParam));
+        $this->assertSame("{$this->baseUrl}?q=test#test", $this->modify("{$this->baseUrl}#test", $this->queryParam));
         $this->assertSame("{$this->baseUrl}?sourceid=chrome&q=test", $this->modify("{$this->baseUrl}?sourceid=chrome", $this->queryParam));
     }
 

--- a/tests/Modifiers/SetQueryParamTest.php
+++ b/tests/Modifiers/SetQueryParamTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class SetQueryParamTest extends TestCase
+{
+    protected $baseUrl = 'https://www.google.com/search';
+    protected $queryParam = ['q', 'test'];
+
+    /** @test */
+    public function it_updates_an_existing_query_param()
+    {
+        $this->assertSame("{$this->baseUrl}?q=", $this->modify("{$this->baseUrl}?q=statamic", ['q']));
+        $this->assertSame("{$this->baseUrl}?q=test", $this->modify("{$this->baseUrl}?q=statamic", $this->queryParam));
+        $this->assertSame("{$this->baseUrl}?q=test&sourceid=chrome", $this->modify("{$this->baseUrl}?q=statamic&sourceid=chrome", $this->queryParam));
+        $this->assertSame("{$this->baseUrl}?sourceid=chrome&q=test", $this->modify("{$this->baseUrl}?sourceid=chrome&q=statamic", $this->queryParam));
+    }
+
+    /** @test */
+    public function it_adds_a_non_existant_query_param()
+    {
+        $this->assertSame("{$this->baseUrl}?q=", $this->modify($this->baseUrl, ['q']));
+        $this->assertSame("{$this->baseUrl}?q=test", $this->modify($this->baseUrl, $this->queryParam));
+        $this->assertSame("{$this->baseUrl}?sourceid=chrome&q=test", $this->modify("{$this->baseUrl}?sourceid=chrome", $this->queryParam));
+    }
+
+    /** @test */
+    public function it_does_nothing_if_no_parameters_are_passed()
+    {
+        $this->assertSame($this->baseUrl, $this->modify($this->baseUrl));
+    }
+
+    private function modify(string $url, ?array $queryParam = null)
+    {
+        if (is_null($queryParam)) {
+            return Modify::value($url)->setQueryParam()->fetch();
+        }
+
+        return Modify::value($url)->setQueryParam($queryParam)->fetch();
+    }
+}

--- a/tests/View/CascadeTest.php
+++ b/tests/View/CascadeTest.php
@@ -122,10 +122,11 @@ class CascadeTest extends TestCase
     /** @test */
     public function it_hydrates_request_variables()
     {
-        $this->get('/test');
+        $this->get('/test?test=test');
 
         tap($this->cascade()->hydrate()->toArray(), function ($cascade) {
             $this->assertEquals('http://test.com/test', $cascade['current_url']);
+            $this->assertEquals('http://test.com/test?test=test', $cascade['current_full_url']);
             $this->assertEquals('/test', $cascade['current_uri']);
         });
     }


### PR DESCRIPTION
**This pull request adds the following:**

1. The `current_full_url` cascade contextual variable which behaves the same as `current_url` but includes query parameters
2. An `add_query_param` modifier which adds the specified key/value pair to the URL as a valid query param
3. A `set_query_param` modifier which adds the specified key/value pair to the URL (or updates the matching key) as a valid query param
4. A `remove_query_param` modifier which removes the query param matching the specified key (if it exists) from the URL

**Usage**
```html
{{ url add_query_param="category|dogs" }}
{{ url set_query_param="category|dogs" }}
{{ url remove_query_param="category" }}

<!-- or -->

{{ url add_query_param:category:dogs }}
{{ url set_query_param:category:dogs }}
{{ url remove_query_param:category }}
```

**Todo list**
- [x] Add a `current_full_url` cascade contextual variable which returns the complete URL
- [x] Add an `add_query_param` modifier which adds the specified key/value pair to the URL as a valid query param
- [x] Add a `set_query_param`  which adds the specified key/value pair to the URL (or updates the matching key) as a valid query param
- [x] Add a `remove_query_param`  which removes the query param matching the specified key (if it exists) from the URL
- [x] Make sure to preserve the anchor tag if it was specified

*As for the implementation, there's a way of doing it with regex, but it's not much shorter, so contact me if you want a regex version (already saved a version aside for the `setQueryParam` modifier).*