### PR TITLE
Invalidate Static Cache when GlobalSet or Navigation is saved

### DIFF
--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -3,6 +3,8 @@
 namespace Statamic\StaticCaching;
 
 use Statamic\Contracts\Entries\Entry;
+use Statamic\Contracts\Globals\GlobalSet;
+use Statamic\Contracts\Structures\Nav;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Support\Arr;
 
@@ -23,15 +25,24 @@ class DefaultInvalidator implements Invalidator
             return $this->cacher->flush();
         }
 
-        // Invalidate the item's own URL.
-        if ($url = $item->url()) {
-            $this->cacher->invalidateUrl($url);
-        }
-
         if ($item instanceof Entry) {
+            // Invalidate the item's own URL.
+            if ($url = $item->url()) {
+                $this->cacher->invalidateUrl($url);
+            }
+
             $this->invalidateEntryUrls($item);
         } elseif ($item instanceof Term) {
+            // Invalidate the item's own URL.
+            if ($url = $item->url()) {
+                $this->cacher->invalidateUrl($url);
+            }
+
             $this->invalidateTermUrls($item);
+        } elseif ($item instanceof GlobalSet) {
+            $this->cacher->invalidateUrls($this->cacher->getUrls());
+        } elseif ($item instanceof Nav) {
+            $this->cacher->invalidateUrls($this->cacher->getUrls());
         }
     }
 

--- a/src/StaticCaching/Invalidate.php
+++ b/src/StaticCaching/Invalidate.php
@@ -5,6 +5,10 @@ namespace Statamic\StaticCaching;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Statamic\Events\EntryDeleted;
 use Statamic\Events\EntrySaved;
+use Statamic\Events\GlobalSetDeleted;
+use Statamic\Events\GlobalSetSaved;
+use Statamic\Events\NavDeleted;
+use Statamic\Events\NavSaved;
 use Statamic\Events\TermDeleted;
 use Statamic\Events\TermSaved;
 
@@ -17,6 +21,10 @@ class Invalidate implements ShouldQueue
         EntryDeleted::class => 'invalidateEntry',
         TermSaved::class => 'invalidateTerm',
         TermDeleted::class => 'invalidateTerm',
+        GlobalSetSaved::class => 'invalidateGlobalSet',
+        GlobalSetDeleted::class => 'invalidateGlobalSet',
+        NavSaved::class => 'invalidateNav',
+        NavDeleted::class => 'invalidateNav',
     ];
 
     public function __construct(Invalidator $invalidator)
@@ -39,5 +47,15 @@ class Invalidate implements ShouldQueue
     public function invalidateTerm($event)
     {
         $this->invalidator->invalidate($event->term);
+    }
+
+    public function invalidateGlobalSet($event)
+    {
+        $this->invalidator->invalidate($event->globals);
+    }
+
+    public function invalidateNav($event)
+    {
+        $this->invalidator->invalidate($event->nav);
     }
 }


### PR DESCRIPTION
This pull request will implement the rest of #2393. It will invalidate the static cache whenever a Global Set or a Navigation is saved or deleted.

I had to move the item url check into the individual if statements for entries and terms as Globals and Nav's don't have the `url()` method and the check would fail.

Closes #2393.