### PR TITLE
Cast filter values to booleans on Content API

### DIFF
--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -52,6 +52,13 @@ class ApiController extends Controller
     {
         collect($this->request->filter ?? [])
             ->each(function ($value, $filter) use ($query) {
+                if ($value === 'true') {
+                    $value = true;
+                } elseif ($value === 'false') {
+                    $value = false;
+                }
+
+
                 if (Str::contains($filter, ':')) {
                     [$field, $condition] = explode(':', $filter);
                 } else {

--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -58,7 +58,6 @@ class ApiController extends Controller
                     $value = false;
                 }
 
-
                 if (Str::contains($filter, ':')) {
                     [$field, $condition] = explode(':', $filter);
                 } else {


### PR DESCRIPTION
This PR fixes #1736. 

Previously, when using a filter in the Content API, like the one in the URL below, `true` would be string which wouldn't work for the check (`true` !== `'true'`), where as now, it will be cast to a boolean and the check will work.

```
http://statamic.test/api/collections/pages/entries?filter[published]=true
```