### PR TITLE
Fix searchable item checking

### DIFF
--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -3,12 +3,13 @@
 namespace Statamic\Search;
 
 use Closure;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Term;
 use Statamic\Facades\User;
+use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class Searchables
 {
@@ -21,7 +22,7 @@ class Searchables
 
     public function all(): Collection
     {
-        $searchables = collect(Arr::wrap($this->index->config()['searchables']));
+        $searchables = $this->getConfiguredSearchables();
 
         if ($searchables->contains('all')) {
             return collect()
@@ -60,7 +61,73 @@ class Searchables
 
     public function contains($searchable)
     {
-        return $this->all()->has($searchable->id());
+        $searchables = $this->getConfiguredSearchables();
+
+        if ($searchables->contains('all')) {
+            return true;
+        }
+
+        if ($searchable instanceof \Statamic\Contracts\Entries\Entry) {
+            $collections = $this->searchableCollections();
+
+            return $collections->isNotEmpty()
+                && ($collections->contains('*')
+                || $collections->contains($searchable->collectionHandle()));
+        }
+
+        if ($searchable instanceof \Statamic\Contracts\Taxonomies\Term) {
+            $taxonomies = $this->searchableTaxonomies();
+
+            return $taxonomies->isNotEmpty()
+                && ($taxonomies->contains('*')
+                || $taxonomies->contains($searchable->taxonomyHandle()));
+        }
+
+        if ($searchable instanceof \Statamic\Contracts\Assets\Asset) {
+            $containers = $this->searchableAssetContainers();
+
+            return $containers->isNotEmpty()
+                && ($containers->contains('*')
+                || $containers->contains($searchable->containerHandle()));
+        }
+
+        if ($searchable instanceof \Statamic\Contracts\Auth\User) {
+            return $searchables->contains('users');
+        }
+
+        return false;
+    }
+
+    private function getConfiguredSearchables()
+    {
+        return collect(Arr::wrap($this->index->config()['searchables']));
+    }
+
+    private function searchableCollections()
+    {
+        return $this->getConfiguredSearchables()->filter(function ($item) {
+            return Str::startsWith($item, 'collection:');
+        })->map(function ($item) {
+            return Str::after($item, 'collection:');
+        });
+    }
+
+    private function searchableTaxonomies()
+    {
+        return $this->getConfiguredSearchables()->filter(function ($item) {
+            return Str::startsWith($item, 'taxonomy:');
+        })->map(function ($item) {
+            return Str::after($item, 'taxonomy:');
+        });
+    }
+
+    private function searchableAssetContainers()
+    {
+        return $this->getConfiguredSearchables()->filter(function ($item) {
+            return Str::startsWith($item, 'assets:');
+        })->map(function ($item) {
+            return Str::after($item, 'assets:');
+        });
     }
 
     public function fields($searchable): array

--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -71,24 +71,21 @@ class Searchables
             $collections = $this->searchableCollections();
 
             return $collections->isNotEmpty()
-                && ($collections->contains('*')
-                || $collections->contains($searchable->collectionHandle()));
+                && ($collections->contains('*') || $collections->contains($searchable->collectionHandle()));
         }
 
         if ($searchable instanceof \Statamic\Contracts\Taxonomies\Term) {
             $taxonomies = $this->searchableTaxonomies();
 
             return $taxonomies->isNotEmpty()
-                && ($taxonomies->contains('*')
-                || $taxonomies->contains($searchable->taxonomyHandle()));
+                && ($taxonomies->contains('*') || $taxonomies->contains($searchable->taxonomyHandle()));
         }
 
         if ($searchable instanceof \Statamic\Contracts\Assets\Asset) {
             $containers = $this->searchableAssetContainers();
 
             return $containers->isNotEmpty()
-                && ($containers->contains('*')
-                || $containers->contains($searchable->containerHandle()));
+                && ($containers->contains('*') || $containers->contains($searchable->containerHandle()));
         }
 
         if ($searchable instanceof \Statamic\Contracts\Auth\User) {

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -60,7 +60,7 @@ class Term implements TermContract
 
     public function taxonomyHandle()
     {
-        return $this->taxonomy()->handle();
+        return $this->taxonomy;
     }
 
     public function path()

--- a/tests/Search/SearchablesTest.php
+++ b/tests/Search/SearchablesTest.php
@@ -2,12 +2,150 @@
 
 namespace Tests\Search;
 
+use Illuminate\Support\Collection;
+use Statamic\Assets\AssetCollection;
+use Statamic\Auth\UserCollection;
+use Statamic\Entries\EntryCollection;
+use Statamic\Facades\Asset;
 use Statamic\Facades\Entry;
+use Statamic\Facades\Term;
+use Statamic\Facades\User;
 use Statamic\Search\Searchables;
+use Statamic\Taxonomies\TermCollection;
 use Tests\TestCase;
 
 class SearchablesTest extends TestCase
 {
+    /** @test */
+    public function all_searchables_include_entries_terms_assets_and_users()
+    {
+        $entries = [$entryA = Entry::make(), $entryB = Entry::make()];
+        Entry::shouldReceive('all')->once()->andReturn(EntryCollection::make($entries));
+        $terms = [$termA = Term::make(), $termB = Term::make()];
+        Term::shouldReceive('all')->once()->andReturn(TermCollection::make($terms));
+        $assets = [$assetA = Asset::make(), $assetB = Asset::make()];
+        Asset::shouldReceive('all')->once()->andReturn(AssetCollection::make($assets));
+        $users = [$userA = User::make(), $userB = User::make()];
+        User::shouldReceive('all')->once()->andReturn(UserCollection::make($users));
+
+        $searchables = $this->makeSearchables(['searchables' => 'all']);
+
+        $items = $searchables->all();
+        $this->assertInstanceOf(Collection::class, $items);
+        $this->assertEquals([
+            $entryA,
+            $entryB,
+            $termA,
+            $termB,
+            $assetA,
+            $assetB,
+            $userA,
+            $userB,
+        ], $items->all());
+    }
+
+    /** @test */
+    public function it_gets_searchable_entries_in_specific_collections()
+    {
+        Term::shouldReceive('all')->never();
+        Term::shouldReceive('whereTaxonomy')->never();
+        Asset::shouldReceive('all')->never();
+        Asset::shouldReceive('whereContainer')->never();
+        User::shouldReceive('all')->never();
+
+        $blog = [$entryA = Entry::make(), $entryB = Entry::make()];
+        $pages = [$entryC = Entry::make(), $entryD = Entry::make()];
+        Entry::shouldReceive('whereCollection')->with('blog')->once()->andReturn(EntryCollection::make($blog));
+        Entry::shouldReceive('whereCollection')->with('pages')->once()->andReturn(EntryCollection::make($pages));
+
+        $searchables = $this->makeSearchables(['searchables' => ['collection:blog', 'collection:pages']]);
+        $this->assertEquals([$entryA, $entryB, $entryC, $entryD], $searchables->all()->all());
+    }
+
+    /** @test */
+    public function it_gets_searchable_entries_in_all_collections()
+    {
+        Term::shouldReceive('all')->never();
+        Term::shouldReceive('whereTaxonomy')->never();
+        Asset::shouldReceive('all')->never();
+        Asset::shouldReceive('whereContainer')->never();
+        User::shouldReceive('all')->never();
+
+        $entries = [$entryA = Entry::make(), $entryB = Entry::make()];
+        Entry::shouldReceive('all')->once()->andReturn(EntryCollection::make($entries));
+
+        $searchables = $this->makeSearchables(['searchables' => ['collection:*']]);
+        $this->assertEquals([$entryA, $entryB], $searchables->all()->all());
+    }
+
+    /** @test */
+    public function it_gets_searchable_terms_in_specific_taxonomies()
+    {
+        Entry::shouldReceive('all')->never();
+        Entry::shouldReceive('whereTaxonomy')->never();
+        Asset::shouldReceive('all')->never();
+        Asset::shouldReceive('whereContainer')->never();
+        User::shouldReceive('all')->never();
+
+        $tags = [$termA = Term::make(), $termB = Term::make()];
+        $categories = [$termC = Term::make(), $termD = Term::make()];
+        Term::shouldReceive('whereTaxonomy')->with('tags')->once()->andReturn(TermCollection::make($tags));
+        Term::shouldReceive('whereTaxonomy')->with('categories')->once()->andReturn(TermCollection::make($categories));
+
+        $searchables = $this->makeSearchables(['searchables' => ['taxonomy:tags', 'taxonomy:categories']]);
+        $this->assertEquals([$termA, $termB, $termC, $termD], $searchables->all()->all());
+    }
+
+    /** @test */
+    public function it_gets_searchable_terms_in_all_taxonomies()
+    {
+        Entry::shouldReceive('all')->never();
+        Entry::shouldReceive('whereCollection')->never();
+        Asset::shouldReceive('all')->never();
+        Asset::shouldReceive('whereContainer')->never();
+        User::shouldReceive('all')->never();
+
+        $terms = [$termA = Term::make(), $termB = Term::make()];
+        Term::shouldReceive('all')->once()->andReturn(TermCollection::make($terms));
+
+        $searchables = $this->makeSearchables(['searchables' => ['taxonomy:*']]);
+        $this->assertEquals([$termA, $termB], $searchables->all()->all());
+    }
+
+    /** @test */
+    public function it_gets_searchable_assets_in_specific_containers()
+    {
+        Entry::shouldReceive('all')->never();
+        Entry::shouldReceive('whereCollection')->never();
+        Term::shouldReceive('all')->never();
+        Term::shouldReceive('whereTaxonomy')->never();
+        User::shouldReceive('all')->never();
+
+        $images = [$assetA = Asset::make(), $assetB = Asset::make()];
+        $documents = [$assetC = Asset::make(), $assetD = Asset::make()];
+        Asset::shouldReceive('whereContainer')->with('images')->once()->andReturn(AssetCollection::make($images));
+        Asset::shouldReceive('whereContainer')->with('documents')->once()->andReturn(AssetCollection::make($documents));
+
+        $searchables = $this->makeSearchables(['searchables' => ['assets:images', 'assets:documents']]);
+        $this->assertEquals([$assetA, $assetB, $assetC, $assetD], $searchables->all()->all());
+    }
+
+    /** @test */
+    public function it_gets_searchable_assets_in_all_containers()
+    {
+        Entry::shouldReceive('all')->never();
+        Entry::shouldReceive('whereCollection')->never();
+        Term::shouldReceive('all')->never();
+        Term::shouldReceive('whereTaxonomy')->never();
+        User::shouldReceive('all')->never();
+
+        $assets = [$assetA = Asset::make(), $assetB = Asset::make()];
+        Asset::shouldReceive('all')->once()->andReturn(AssetCollection::make($assets));
+
+        $searchables = $this->makeSearchables(['searchables' => ['assets:*']]);
+        $this->assertEquals([$assetA, $assetB], $searchables->all()->all());
+    }
+
     /** @test */
     public function it_transforms_values_set_in_the_config_file()
     {
@@ -64,5 +202,14 @@ class SearchablesTest extends TestCase
             'title' => 'Hello',
             'title_upper' => 'HELLO',
         ], $searchables->fields($searchable));
+    }
+
+    private function makeSearchables($config)
+    {
+        $index = $this->mock(\Statamic\Search\Index::class);
+
+        $index->shouldReceive('config')->andReturn($config);
+
+        return new Searchables($index);
     }
 }

--- a/tests/Search/SearchablesTest.php
+++ b/tests/Search/SearchablesTest.php
@@ -61,6 +61,8 @@ class SearchablesTest extends TestCase
         foreach ($everything as $searchable) {
             $this->assertTrue($searchables->contains($searchable));
         }
+
+        $this->assertFalse($searchables->contains(new NotSearchable));
     }
 
     /** @test */
@@ -91,6 +93,7 @@ class SearchablesTest extends TestCase
         $this->assertFalse($searchables->contains($asset));
         $this->assertFalse($searchables->contains($user));
         $this->assertFalse($searchables->contains($entry));
+        $this->assertFalse($searchables->contains(new NotSearchable));
     }
 
     /** @test */
@@ -116,6 +119,7 @@ class SearchablesTest extends TestCase
         $this->assertFalse($searchables->contains($term));
         $this->assertFalse($searchables->contains($asset));
         $this->assertFalse($searchables->contains($user));
+        $this->assertFalse($searchables->contains(new NotSearchable));
     }
 
     /** @test */
@@ -146,6 +150,7 @@ class SearchablesTest extends TestCase
         $this->assertFalse($searchables->contains($asset));
         $this->assertFalse($searchables->contains($user));
         $this->assertFalse($searchables->contains($term));
+        $this->assertFalse($searchables->contains(new NotSearchable));
     }
 
     /** @test */
@@ -171,6 +176,7 @@ class SearchablesTest extends TestCase
         $this->assertFalse($searchables->contains($entry));
         $this->assertFalse($searchables->contains($asset));
         $this->assertFalse($searchables->contains($user));
+        $this->assertFalse($searchables->contains(new NotSearchable));
     }
 
     /** @test */
@@ -207,6 +213,7 @@ class SearchablesTest extends TestCase
         $this->assertFalse($searchables->contains($asset));
         $this->assertFalse($searchables->contains($user));
         $this->assertFalse($searchables->contains($term));
+        $this->assertFalse($searchables->contains(new NotSearchable));
     }
 
     /** @test */
@@ -232,6 +239,7 @@ class SearchablesTest extends TestCase
         $this->assertFalse($searchables->contains($entry));
         $this->assertFalse($searchables->contains($term));
         $this->assertFalse($searchables->contains($user));
+        $this->assertFalse($searchables->contains(new NotSearchable));
     }
 
     /** @test */
@@ -259,6 +267,7 @@ class SearchablesTest extends TestCase
         $this->assertFalse($searchables->contains($entry));
         $this->assertFalse($searchables->contains($term));
         $this->assertFalse($searchables->contains($asset));
+        $this->assertFalse($searchables->contains(new NotSearchable));
     }
 
     /** @test */
@@ -327,4 +336,9 @@ class SearchablesTest extends TestCase
 
         return new Searchables($index);
     }
+}
+
+class NotSearchable
+{
+    //
 }


### PR DESCRIPTION
Closes #1722 

When you save an entry (or term, or asset, etc) it updates the search indexes.
It looks through all the configured indexes, and checks whether the entry belongs in that index.

It did this by getting all the items that _should_ be in the index, and check to see if that entry was in that array. Stupid in hindsight, but was simple to write originally and wasn't testing with enough content to notice a performance issue.

When you have a butt-tonne of entries (or assets, as per the issue) it has to do a lot of work to get _all_ of them.
The problem is compounded when your assets are on S3 which is even slower.

This check has been reworked to just check against the rules and doesn't need to bother getting all the searchables.

Saving an entry on my 14,000-asset test site went from 7 seconds down to 150ms.

Code is not the prettiest but I'll take that over the load time.