### PR TITLE
Make statamic caching strategies available in your .env file

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -12,7 +12,7 @@ return [
     |
     */
 
-    'strategy' => env('STATAMIC_CACHING_STRATEGY', true),
+    'strategy' => env('STATAMIC_CACHING_STRATEGY', null),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -12,7 +12,7 @@ return [
     |
     */
 
-    'strategy' => env('STATAMIC_CACHING_STRATEGY', null),
+    'strategy' => env('STATAMIC_STATIC_CACHING_STRATEGY', null),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -12,7 +12,7 @@ return [
     |
     */
 
-    'strategy' => null,
+    'strategy' => env('STATAMIC_CACHING_STRATEGY', true),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
There are cases, where you want to use different caching strategies in different environments. 

You might want a caching strategy in production, but not locally for your development. Making it available in your .env does make it easy to change those strategies, depending on your environment.