### PR TITLE
Pass along field parent

### DIFF
--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -197,7 +197,7 @@ class Fields
             $field->setConfig(array_merge($field->config(), $overrides));
         }
 
-        return $field->setHandle($config['handle']);
+        return $field->setParent($this->parent)->setHandle($config['handle']);
     }
 
     private function getImportedFields(array $config): array
@@ -206,7 +206,7 @@ class Fields
             throw new \Exception("Fieldset {$config['import']} not found.");
         }
 
-        $fields = $fieldset->fields()->all();
+        $fields = $fieldset->fields()->all()->each->setParent($this->parent);
 
         if ($overrides = $config['config'] ?? null) {
             $fields = $fields->map(function ($field, $handle) use ($overrides) {

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -5,7 +5,6 @@ namespace Statamic\Fieldtypes\Bard;
 use ProseMirrorToHtml\Nodes\Image as DefaultImageNode;
 use ProseMirrorToHtml\Renderer;
 use Statamic\Fields\Field;
-use Statamic\Fields\Fields;
 use Statamic\Fields\Value;
 use Statamic\Fieldtypes\Bard\ImageNode as CustomImageNode;
 use Statamic\Fieldtypes\Text;
@@ -138,11 +137,11 @@ class Augmentor
         $augmentMethod = $shallow ? 'shallowAugment' : 'augment';
 
         return $value->map(function ($set) use ($augmentMethod) {
-            if (! $config = $this->fieldtype->config("sets.{$set['type']}.fields")) {
+            if (! $this->fieldtype->config("sets.{$set['type']}.fields")) {
                 return $set;
             }
 
-            $values = (new Fields($config))->addValues($set)->{$augmentMethod}()->values()->all();
+            $values = $this->fieldtype->fields($set['type'])->addValues($set)->{$augmentMethod}()->values()->all();
 
             return array_merge($values, ['type' => $set['type']]);
         })->all();

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -102,7 +102,7 @@ class Grid extends Fieldtype
 
     private function fields()
     {
-        return new Fields($this->config('fields'));
+        return new Fields($this->config('fields'), $this->field()->parent());
     }
 
     public function rules(): array

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -51,9 +51,9 @@ class Replicator extends Fieldtype
         ]);
     }
 
-    protected function fields($set)
+    public function fields($set)
     {
-        return new Fields($this->config("sets.$set.fields"));
+        return new Fields($this->config("sets.$set.fields"), $this->field()->parent());
     }
 
     public function extraRules(): array
@@ -99,13 +99,13 @@ class Replicator extends Fieldtype
         return collect($values)->reject(function ($set, $key) {
             return array_get($set, 'enabled', true) === false;
         })->map(function ($set) use ($shallow) {
-            if (! $config = $this->config("sets.{$set['type']}.fields")) {
+            if (! $this->config("sets.{$set['type']}.fields")) {
                 return $set;
             }
 
             $augmentMethod = $shallow ? 'shallowAugment' : 'augment';
 
-            $values = (new Fields($config))->addValues($set)->{$augmentMethod}()->values();
+            $values = $this->fields($set['type'])->addValues($set)->{$augmentMethod}()->values();
 
             return $values->merge(['type' => $set['type']])->all();
         })->values()->all();


### PR DESCRIPTION
The field "parent" is the item that has the field on it. (i.e. an entry)
This lets a fieldtype know the context its being used for.

It was originally added in ea374e8 but only applied to regular inline fields.
This PR passes the parent along to referenced fields, and fields via imported fieldsets.
This PR also makes sure that Bard, Replicator, and Grid fields pass the parent along.