### PR TITLE
Localize based on entry's locale

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -192,6 +192,9 @@ class Entries extends Relationship
     {
         if (is_string($value)) {
             $value = Entry::find($value);
+            if ($entry = $this->field()->parent()) {
+                $value = $value->in($entry->locale());
+            }
         }
 
         return $value;


### PR DESCRIPTION
Fixes #2507 

The `entries` fieldtype will now localize its selections when augmenting based on the locale of the parent entry.

For example:
- Have an entry in english
- Have an entries fieldtype with a few english entries selected
- Translate it to french

When you're viewing the french entry on the frontend and you loop over the entries, you would probably expect that they would be the french versions.

This PR does exactly that. Any entries that _aren't_ localized into that site will simply be filtered out.

If you *are* expecting the existing behavior, we can add a feature that would bring that back. In our eyes, the previous behavior was a bug.