### PR TITLE
Localize Form Emails

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -8,7 +8,7 @@ use Illuminate\Queue\SerializesModels;
 use Statamic\Facades\Config;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Parse;
-use Statamic\Facades\Site;
+use Statamic\Sites\Site;
 use Statamic\Support\Str;
 
 class Email extends Mailable
@@ -17,11 +17,14 @@ class Email extends Mailable
 
     protected $submission;
     protected $config;
+    protected $site;
 
-    public function __construct(Submission $submission, array $config)
+    public function __construct(Submission $submission, array $config, Site $site)
     {
         $this->submission = $submission;
         $this->config = $this->parseConfig($config);
+        $this->site = $site;
+        $this->locale($site->shortLocale());
     }
 
     public function build()
@@ -86,8 +89,8 @@ class Email extends Mailable
             'date'       => now(),
             'now'        => now(),
             'today'      => now(),
-            'site'       => $site = Site::current()->handle(),
-            'locale'     => $site,
+            'site'       => $this->site->handle(),
+            'locale'     => $this->site->handle(),
         ]);
 
         return $this->with($data);
@@ -110,11 +113,11 @@ class Email extends Mailable
         $data = [];
 
         foreach (GlobalSet::all() as $global) {
-            if (! $global->existsIn(Site::current()->handle())) {
+            if (! $global->existsIn($this->site->handle())) {
                 continue;
             }
 
-            $global = $global->in(Site::current()->handle());
+            $global = $global->in($this->site->handle());
 
             $data[$global->handle()] = $global->toAugmentedArray();
         }

--- a/src/Forms/SendEmails.php
+++ b/src/Forms/SendEmails.php
@@ -10,19 +10,19 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Mail;
 use Statamic\Contracts\Forms\Submission;
 use Statamic\Facades\Antlers;
+use Statamic\Sites\Site;
 
 class SendEmails implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     protected $submission;
+    protected $site;
 
-    protected $locale;
-
-    public function __construct(Submission $submission, $locale)
+    public function __construct(Submission $submission, Site $site)
     {
         $this->submission = $submission;
-        $this->locale = $locale;
+        $this->site = $site;
     }
 
     /**
@@ -33,7 +33,7 @@ class SendEmails implements ShouldQueue
     public function handle()
     {
         $this->parseEmailConfigs($this->submission)->each(function ($config) {
-            Mail::send((new Email($this->submission, $config))->locale($this->locale));
+            Mail::send(new Email($this->submission, $config, $this->site));
         });
     }
 

--- a/src/Forms/SendEmails.php
+++ b/src/Forms/SendEmails.php
@@ -17,9 +17,12 @@ class SendEmails implements ShouldQueue
 
     protected $submission;
 
-    public function __construct(Submission $submission)
+    protected $locale;
+
+    public function __construct(Submission $submission, $locale)
     {
         $this->submission = $submission;
+        $this->locale = $locale;
     }
 
     /**
@@ -30,7 +33,7 @@ class SendEmails implements ShouldQueue
     public function handle()
     {
         $this->parseEmailConfigs($this->submission)->each(function ($config) {
-            Mail::send(new Email($this->submission, $config));
+            Mail::send((new Email($this->submission, $config))->locale($this->locale));
         });
     }
 

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -62,7 +62,7 @@ class FormController extends Controller
         }
 
         SubmissionCreated::dispatch($submission);
-        SendEmails::dispatch($submission, Site::findByUrl(URL::previous())->shortLocale());
+        SendEmails::dispatch($submission, Site::findByUrl(URL::previous()));
 
         return $this->formSuccess($params, $submission);
     }

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\MessageBag;
 use Illuminate\Validation\ValidationException;
 use Statamic\Contracts\Forms\Submission;
@@ -13,6 +14,7 @@ use Statamic\Events\FormSubmitted;
 use Statamic\Events\SubmissionCreated;
 use Statamic\Exceptions\SilentFormFailureException;
 use Statamic\Facades\Form;
+use Statamic\Facades\Site;
 use Statamic\Forms\Exceptions\FileContentTypeRequiredException;
 use Statamic\Forms\SendEmails;
 use Statamic\Support\Arr;
@@ -60,7 +62,7 @@ class FormController extends Controller
         }
 
         SubmissionCreated::dispatch($submission);
-        SendEmails::dispatch($submission);
+        SendEmails::dispatch($submission, Site::findByUrl(URL::previous())->shortLocale());
 
         return $this->formSuccess($params, $submission);
     }

--- a/tests/Forms/EmailTest.php
+++ b/tests/Forms/EmailTest.php
@@ -14,19 +14,36 @@ class EmailTest extends TestCase
     /** @test */
     public function it_sets_html_view_as_string()
     {
-        /** @var Submission */
-        $submission = m::mock(Submission::class);
-        $submission->shouldReceive('toArray')->andReturn([]);
-        $submission->shouldReceive('toAugmentedArray')->andReturn([]);
-
-        $email = new Email($submission, [
-            'to' => Antlers::parse('test@example.com'),
-            'html' => Antlers::parse('emails/test'),
-        ], Site::default());
+        $email = $this->makeEmail();
 
         $email->build();
 
         $this->assertTrue(is_string($email->view), 'View is not a string.');
         $this->assertEquals('emails/test', $email->view);
+    }
+
+    /** @test */
+    public function the_sites_locale_gets_used_on_the_mailable()
+    {
+        Site::setConfig(['sites' => [
+            'one' => ['locale' => 'en_US', 'url' => '/one'],
+            'two' => ['locale' => 'fr_Fr', 'url' => '/two'],
+        ]]);
+
+        $this->assertEquals('en', $this->makeEmail(Site::get('one'))->locale);
+        $this->assertEquals('fr', $this->makeEmail(Site::get('two'))->locale);
+    }
+
+    private function makeEmail($site = null)
+    {
+        /** @var Submission */
+        $submission = m::mock(Submission::class);
+        $submission->shouldReceive('toArray')->andReturn([]);
+        $submission->shouldReceive('toAugmentedArray')->andReturn([]);
+
+        return new Email($submission, [
+            'to' => Antlers::parse('test@example.com'),
+            'html' => Antlers::parse('emails/test'),
+        ], $site ?? Site::default());
     }
 }

--- a/tests/Forms/EmailTest.php
+++ b/tests/Forms/EmailTest.php
@@ -4,6 +4,7 @@ namespace Tests\Forms;
 
 use Mockery as m;
 use Statamic\Facades\Antlers;
+use Statamic\Facades\Site;
 use Statamic\Forms\Email;
 use Statamic\Forms\Submission;
 use Tests\TestCase;
@@ -21,7 +22,7 @@ class EmailTest extends TestCase
         $email = new Email($submission, [
             'to' => Antlers::parse('test@example.com'),
             'html' => Antlers::parse('emails/test'),
-        ]);
+        ], Site::default());
 
         $email->build();
 


### PR DESCRIPTION
This PR passes along the site where the form was submitted into the mailable.

The translator will use the appropriate locale.
Any globals will be localized to the appropriate site.

Fixes #2386 