### PR TITLE
Add null check to avoid an exception if a linked item got deleted 

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -192,7 +192,7 @@ class Entries extends Relationship
     {
         if (is_string($value)) {
             $value = Entry::find($value);
-            if ($entry = $this->field()->parent()) {
+            if ($value != null && $entry = $this->field()->parent()) {
                 $value = $value->in($entry->locale());
             }
         }


### PR DESCRIPTION
**Problem:**

Let's asume you have a collection (eg. Pages) with a field where you refer to another collection entry.
If the entry behind "link" is removed but you refer to that in the antler file somewhere the page throws an exception:

![Bildschirmfoto 2020-10-15 um 12 05 29](https://user-images.githubusercontent.com/3373530/96109956-86620a00-0edf-11eb-84dc-15210ed90004.png)

cause:

![Bildschirmfoto 2020-10-15 um 11 38 23](https://user-images.githubusercontent.com/3373530/96109972-895cfa80-0edf-11eb-81a1-35dd1dd6c860.png)

**Proposal:**

Add the nullcheck to avoid the exception throwing.
