### PR TITLE
Data tables fix for screens less then 768px

### DIFF
--- a/resources/js/components/AddonList.vue
+++ b/resources/js/components/AddonList.vue
@@ -73,14 +73,14 @@
             <h6 class="mt-4">{{ __('Unlisted Addons') }}</h6>
             <div class="card p-0 mt-1">
                 <div class="data-table-wrapper">
-                    <table class="data-table">
-                        <tbody>
-                            <tr v-for="addon in unlisted" :key="addon.package">
-                                <td v-text="addon.name" />
-                                <td v-text="addon.package" />
-                            </tr>
-                        </tbody>
-                    </table>
+                <table class="data-table">
+                    <tbody>
+                        <tr v-for="addon in unlisted" :key="addon.package">
+                            <td v-text="addon.name" />
+                            <td v-text="addon.package" />
+                        </tr>
+                    </tbody>
+                </table>
                 </div>
             </div>
         </template>

--- a/resources/js/components/AddonList.vue
+++ b/resources/js/components/AddonList.vue
@@ -72,14 +72,16 @@
         <template v-if="unlisted.length && !showingAddon">
             <h6 class="mt-4">{{ __('Unlisted Addons') }}</h6>
             <div class="card p-0 mt-1">
-                <table class="data-table">
-                    <tbody>
-                        <tr v-for="addon in unlisted" :key="addon.package">
-                            <td v-text="addon.name" />
-                            <td v-text="addon.package" />
-                        </tr>
-                    </tbody>
-                </table>
+                <div class="data-table-wrapper">
+                    <table class="data-table">
+                        <tbody>
+                            <tr v-for="addon in unlisted" :key="addon.package">
+                                <td v-text="addon.name" />
+                                <td v-text="addon.package" />
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </template>
 

--- a/resources/js/components/collections/Scaffolder.vue
+++ b/resources/js/components/collections/Scaffolder.vue
@@ -4,49 +4,51 @@
             <header class="mb-3">
                 <p class="text-grey" v-text="__('messages.collection_scaffold_instructions')" />
             </header>
-             <table class="data-table border rounded">
-                <tbody>
-                    <tr>
-                        <td class="checkbox-column border-r" @click="selected.blueprint = ! selected.blueprint">
-                            <div class="flex items-center h-full">
-                                <input type="checkbox" v-model="selected.blueprint" class="mr-2" id="field_blueprint" />
-                            </div>
-                        </td>
-                        <td class="border-r">
-                            <label for="field_blueprint" v-text="__('Blueprint')" />
-                        </td>
-                        <td :class="{'opacity-25': ! selected.blueprint }">
-                            <input type="text" v-model="blueprint" class="input-text">
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="checkbox-column border-r" @click="selected.index = ! selected.index">
-                            <div class="flex items-center h-full">
-                                <input type="checkbox" v-model="selected.index" class="mr-2" id="field_index" />
-                            </div>
-                        </td>
-                        <td class="border-r">
-                            <label for="field_index" v-text="__('Index Template')" />
-                        </td>
-                        <td :class="{'opacity-25': ! selected.index }">
-                            <input type="text" v-model="index" class="input-text font-mono">
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="checkbox-column border-r" @click="selected.show = ! selected.show">
-                            <div class="flex items-center h-full">
-                                <input type="checkbox" v-model="selected.show" class="mr-2" id="field_template" />
-                            </div>
-                        </td>
-                        <td class="border-r">
-                            <label for="field_template" v-text="__('Show Template')" />
-                        </td>
-                        <td :class="{'opacity-25': ! selected.show }">
-                            <input type="text" v-model="show" class="input-text font-mono">
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <div class="data-table-wrapper">
+                <table class="data-table border rounded">
+                    <tbody>
+                        <tr>
+                            <td class="checkbox-column border-r" @click="selected.blueprint = ! selected.blueprint">
+                                <div class="flex items-center h-full">
+                                    <input type="checkbox" v-model="selected.blueprint" class="mr-2" id="field_blueprint" />
+                                </div>
+                            </td>
+                            <td class="border-r">
+                                <label for="field_blueprint" v-text="__('Blueprint')" />
+                            </td>
+                            <td :class="{'opacity-25': ! selected.blueprint }">
+                                <input type="text" v-model="blueprint" class="input-text">
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="checkbox-column border-r" @click="selected.index = ! selected.index">
+                                <div class="flex items-center h-full">
+                                    <input type="checkbox" v-model="selected.index" class="mr-2" id="field_index" />
+                                </div>
+                            </td>
+                            <td class="border-r">
+                                <label for="field_index" v-text="__('Index Template')" />
+                            </td>
+                            <td :class="{'opacity-25': ! selected.index }">
+                                <input type="text" v-model="index" class="input-text font-mono">
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="checkbox-column border-r" @click="selected.show = ! selected.show">
+                                <div class="flex items-center h-full">
+                                    <input type="checkbox" v-model="selected.show" class="mr-2" id="field_template" />
+                                </div>
+                            </td>
+                            <td class="border-r">
+                                <label for="field_template" v-text="__('Show Template')" />
+                            </td>
+                            <td :class="{'opacity-25': ! selected.show }">
+                                <input type="text" v-model="show" class="input-text font-mono">
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
 
         <div class="flex justify-center mt-4">

--- a/resources/js/components/collections/Scaffolder.vue
+++ b/resources/js/components/collections/Scaffolder.vue
@@ -5,49 +5,49 @@
                 <p class="text-grey" v-text="__('messages.collection_scaffold_instructions')" />
             </header>
             <div class="data-table-wrapper">
-                <table class="data-table border rounded">
-                    <tbody>
-                        <tr>
-                            <td class="checkbox-column border-r" @click="selected.blueprint = ! selected.blueprint">
-                                <div class="flex items-center h-full">
-                                    <input type="checkbox" v-model="selected.blueprint" class="mr-2" id="field_blueprint" />
-                                </div>
-                            </td>
-                            <td class="border-r">
-                                <label for="field_blueprint" v-text="__('Blueprint')" />
-                            </td>
-                            <td :class="{'opacity-25': ! selected.blueprint }">
-                                <input type="text" v-model="blueprint" class="input-text">
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="checkbox-column border-r" @click="selected.index = ! selected.index">
-                                <div class="flex items-center h-full">
-                                    <input type="checkbox" v-model="selected.index" class="mr-2" id="field_index" />
-                                </div>
-                            </td>
-                            <td class="border-r">
-                                <label for="field_index" v-text="__('Index Template')" />
-                            </td>
-                            <td :class="{'opacity-25': ! selected.index }">
-                                <input type="text" v-model="index" class="input-text font-mono">
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="checkbox-column border-r" @click="selected.show = ! selected.show">
-                                <div class="flex items-center h-full">
-                                    <input type="checkbox" v-model="selected.show" class="mr-2" id="field_template" />
-                                </div>
-                            </td>
-                            <td class="border-r">
-                                <label for="field_template" v-text="__('Show Template')" />
-                            </td>
-                            <td :class="{'opacity-25': ! selected.show }">
-                                <input type="text" v-model="show" class="input-text font-mono">
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+            <table class="data-table border rounded">
+                <tbody>
+                    <tr>
+                        <td class="checkbox-column border-r" @click="selected.blueprint = ! selected.blueprint">
+                            <div class="flex items-center h-full">
+                                <input type="checkbox" v-model="selected.blueprint" class="mr-2" id="field_blueprint" />
+                            </div>
+                        </td>
+                        <td class="border-r">
+                            <label for="field_blueprint" v-text="__('Blueprint')" />
+                        </td>
+                        <td :class="{'opacity-25': ! selected.blueprint }">
+                            <input type="text" v-model="blueprint" class="input-text">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="checkbox-column border-r" @click="selected.index = ! selected.index">
+                            <div class="flex items-center h-full">
+                                <input type="checkbox" v-model="selected.index" class="mr-2" id="field_index" />
+                            </div>
+                        </td>
+                        <td class="border-r">
+                            <label for="field_index" v-text="__('Index Template')" />
+                        </td>
+                        <td :class="{'opacity-25': ! selected.index }">
+                            <input type="text" v-model="index" class="input-text font-mono">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="checkbox-column border-r" @click="selected.show = ! selected.show">
+                            <div class="flex items-center h-full">
+                                <input type="checkbox" v-model="selected.show" class="mr-2" id="field_template" />
+                            </div>
+                        </td>
+                        <td class="border-r">
+                            <label for="field_template" v-text="__('Show Template')" />
+                        </td>
+                        <td :class="{'opacity-25': ! selected.show }">
+                            <input type="text" v-model="show" class="input-text font-mono">
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
             </div>
         </div>
 

--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -1,77 +1,77 @@
 <template>
     <div class="data-table-wrapper">
-        <table class="data-table" :class="{ 'opacity-50': loading }">
-            <thead v-if="allowBulkActions || allowColumnPicker || visibleColumns.length > 1">
-                <tr>
-                    <th class="checkbox-column" v-if="allowBulkActions || reorderable">
-                        <data-list-toggle-all ref="toggleAll" v-if="allowBulkActions" />
-                    </th>
-                    <th
-                        v-for="column in visibleColumns"
-                        :key="column.field"
-                        :class="{
-                            'current-column': sharedState.sortColumn === column.field,
-                            'sortable-column': column.sortable === true,
-                            'cursor-not-allowed': !sortable,
-                        }"
-                        @click.prevent="changeSortColumn(column.field)"
+    <table class="data-table" :class="{ 'opacity-50': loading }">
+        <thead v-if="allowBulkActions || allowColumnPicker || visibleColumns.length > 1">
+            <tr>
+                <th class="checkbox-column" v-if="allowBulkActions || reorderable">
+                    <data-list-toggle-all ref="toggleAll" v-if="allowBulkActions" />
+                </th>
+                <th
+                    v-for="column in visibleColumns"
+                    :key="column.field"
+                    :class="{
+                        'current-column': sharedState.sortColumn === column.field,
+                        'sortable-column': column.sortable === true,
+                        'cursor-not-allowed': !sortable,
+                    }"
+                    @click.prevent="changeSortColumn(column.field)"
+                >
+                    <span v-text="column.label" />
+                    <svg v-if="sharedState.sortColumn === column.field" :class="sharedState.sortDirection" height="8" width="8" viewBox="0 0 10 6.5">
+                        <path d="M9.9,1.4L5,6.4L0,1.4L1.4,0L5,3.5L8.5,0L9.9,1.4z" fill="currentColor"/>
+                    </svg>
+                </th>
+                <th class="actions-column">
+                    <data-list-column-picker :preferences-key="columnPreferencesKey" v-if="allowColumnPicker" />
+                </th>
+            </tr>
+        </thead>
+        <sortable-list
+            :value="rows"
+            :vertical="true"
+            item-class="sortable-row"
+            handle-class="table-drag-handle"
+            @input="$emit('reordered', $event)"
+        >
+        <tbody>
+            <slot name="tbody-start" />
+            <tr v-for="(row, index) in rows" :key="row.id" class="sortable-row outline-none" :class="{'row-selected': sharedState.selections.includes(row.id)}">
+                <td class="table-drag-handle" v-if="reorderable"></td>
+                <td class="checkbox-column" v-if="allowBulkActions && !reorderable">
+                    <input
+                        v-if="!reorderable"
+                        type="checkbox"
+                        :value="row.id"
+                        v-model="sharedState.selections"
+                        :disabled="reachedSelectionLimit && !sharedState.selections.includes(row.id)"
+                        :id="`checkbox-${row.id}`"
+                    />
+                </td>
+                <td v-for="column in visibleColumns" :key="column.field" @click="rowClicked(row)">
+                    <slot
+                        :name="`cell-${column.field}`"
+                        :value="row[column.value || column.field]"
+                        :values="row"
+                        :row="row"
+                        :index="actualIndex(row)"
+                        :display-index="index"
+                        :checkbox-id="`checkbox-${row.id}`"
                     >
-                        <span v-text="column.label" />
-                        <svg v-if="sharedState.sortColumn === column.field" :class="sharedState.sortDirection" height="8" width="8" viewBox="0 0 10 6.5">
-                            <path d="M9.9,1.4L5,6.4L0,1.4L1.4,0L5,3.5L8.5,0L9.9,1.4z" fill="currentColor"/>
-                        </svg>
-                    </th>
-                    <th class="actions-column">
-                        <data-list-column-picker :preferences-key="columnPreferencesKey" v-if="allowColumnPicker" />
-                    </th>
-                </tr>
-            </thead>
-            <sortable-list
-                :value="rows"
-                :vertical="true"
-                item-class="sortable-row"
-                handle-class="table-drag-handle"
-                @input="$emit('reordered', $event)"
-            >
-            <tbody>
-                <slot name="tbody-start" />
-                <tr v-for="(row, index) in rows" :key="row.id" class="sortable-row outline-none" :class="{'row-selected': sharedState.selections.includes(row.id)}">
-                    <td class="table-drag-handle" v-if="reorderable"></td>
-                    <td class="checkbox-column" v-if="allowBulkActions && !reorderable">
-                        <input
-                            v-if="!reorderable"
-                            type="checkbox"
-                            :value="row.id"
-                            v-model="sharedState.selections"
-                            :disabled="reachedSelectionLimit && !sharedState.selections.includes(row.id)"
-                            :id="`checkbox-${row.id}`"
-                        />
-                    </td>
-                    <td v-for="column in visibleColumns" :key="column.field" @click="rowClicked(row)">
-                        <slot
-                            :name="`cell-${column.field}`"
-                            :value="row[column.value || column.field]"
-                            :values="row"
-                            :row="row"
-                            :index="actualIndex(row)"
-                            :display-index="index"
-                            :checkbox-id="`checkbox-${row.id}`"
-                        >
-                            <table-field :handle="column.field" :value="row[column.value || column.field]" :values="row" :fieldtype="column.fieldtype" :key="column.field" />
-                        </slot>
-                    </td>
-                    <td class="actions-column">
-                        <slot
-                            name="actions"
-                            :row="row"
-                            :index="actualIndex(row)"
-                            :display-index="index"
-                        ></slot>
-                    </td>
-                </tr>
-            </tbody>
-            </sortable-list>
-        </table>
+                        <table-field :handle="column.field" :value="row[column.value || column.field]" :values="row" :fieldtype="column.fieldtype" :key="column.field" />
+                    </slot>
+                </td>
+                <td class="actions-column">
+                    <slot
+                        name="actions"
+                        :row="row"
+                        :index="actualIndex(row)"
+                        :display-index="index"
+                    ></slot>
+                </td>
+            </tr>
+        </tbody>
+        </sortable-list>
+    </table>
     </div>
 </template>
 

--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -1,76 +1,78 @@
 <template>
-    <table class="data-table" :class="{ 'opacity-50': loading }">
-        <thead v-if="allowBulkActions || allowColumnPicker || visibleColumns.length > 1">
-            <tr>
-                <th class="checkbox-column" v-if="allowBulkActions || reorderable">
-                    <data-list-toggle-all ref="toggleAll" v-if="allowBulkActions" />
-                </th>
-                <th
-                    v-for="column in visibleColumns"
-                    :key="column.field"
-                    :class="{
-                        'current-column': sharedState.sortColumn === column.field,
-                        'sortable-column': column.sortable === true,
-                        'cursor-not-allowed': !sortable,
-                    }"
-                    @click.prevent="changeSortColumn(column.field)"
-                >
-                    <span v-text="column.label" />
-                    <svg v-if="sharedState.sortColumn === column.field" :class="sharedState.sortDirection" height="8" width="8" viewBox="0 0 10 6.5">
-                        <path d="M9.9,1.4L5,6.4L0,1.4L1.4,0L5,3.5L8.5,0L9.9,1.4z" fill="currentColor"/>
-                    </svg>
-                </th>
-                <th class="actions-column">
-                    <data-list-column-picker :preferences-key="columnPreferencesKey" v-if="allowColumnPicker" />
-                </th>
-            </tr>
-        </thead>
-        <sortable-list
-            :value="rows"
-            :vertical="true"
-            item-class="sortable-row"
-            handle-class="table-drag-handle"
-            @input="$emit('reordered', $event)"
-        >
-        <tbody>
-            <slot name="tbody-start" />
-            <tr v-for="(row, index) in rows" :key="row.id" class="sortable-row outline-none" :class="{'row-selected': sharedState.selections.includes(row.id)}">
-                <td class="table-drag-handle" v-if="reorderable"></td>
-                <td class="checkbox-column" v-if="allowBulkActions && !reorderable">
-                    <input
-                        v-if="!reorderable"
-                        type="checkbox"
-                        :value="row.id"
-                        v-model="sharedState.selections"
-                        :disabled="reachedSelectionLimit && !sharedState.selections.includes(row.id)"
-                        :id="`checkbox-${row.id}`"
-                    />
-                </td>
-                <td v-for="column in visibleColumns" :key="column.field" @click="rowClicked(row)">
-                    <slot
-                        :name="`cell-${column.field}`"
-                        :value="row[column.value || column.field]"
-                        :values="row"
-                        :row="row"
-                        :index="actualIndex(row)"
-                        :display-index="index"
-                        :checkbox-id="`checkbox-${row.id}`"
+    <div class="data-table-wrapper">
+        <table class="data-table" :class="{ 'opacity-50': loading }">
+            <thead v-if="allowBulkActions || allowColumnPicker || visibleColumns.length > 1">
+                <tr>
+                    <th class="checkbox-column" v-if="allowBulkActions || reorderable">
+                        <data-list-toggle-all ref="toggleAll" v-if="allowBulkActions" />
+                    </th>
+                    <th
+                        v-for="column in visibleColumns"
+                        :key="column.field"
+                        :class="{
+                            'current-column': sharedState.sortColumn === column.field,
+                            'sortable-column': column.sortable === true,
+                            'cursor-not-allowed': !sortable,
+                        }"
+                        @click.prevent="changeSortColumn(column.field)"
                     >
-                        <table-field :handle="column.field" :value="row[column.value || column.field]" :values="row" :fieldtype="column.fieldtype" :key="column.field" />
-                    </slot>
-                </td>
-                <td class="actions-column">
-                    <slot
-                        name="actions"
-                        :row="row"
-                        :index="actualIndex(row)"
-                        :display-index="index"
-                    ></slot>
-                </td>
-            </tr>
-        </tbody>
-        </sortable-list>
-    </table>
+                        <span v-text="column.label" />
+                        <svg v-if="sharedState.sortColumn === column.field" :class="sharedState.sortDirection" height="8" width="8" viewBox="0 0 10 6.5">
+                            <path d="M9.9,1.4L5,6.4L0,1.4L1.4,0L5,3.5L8.5,0L9.9,1.4z" fill="currentColor"/>
+                        </svg>
+                    </th>
+                    <th class="actions-column">
+                        <data-list-column-picker :preferences-key="columnPreferencesKey" v-if="allowColumnPicker" />
+                    </th>
+                </tr>
+            </thead>
+            <sortable-list
+                :value="rows"
+                :vertical="true"
+                item-class="sortable-row"
+                handle-class="table-drag-handle"
+                @input="$emit('reordered', $event)"
+            >
+            <tbody>
+                <slot name="tbody-start" />
+                <tr v-for="(row, index) in rows" :key="row.id" class="sortable-row outline-none" :class="{'row-selected': sharedState.selections.includes(row.id)}">
+                    <td class="table-drag-handle" v-if="reorderable"></td>
+                    <td class="checkbox-column" v-if="allowBulkActions && !reorderable">
+                        <input
+                            v-if="!reorderable"
+                            type="checkbox"
+                            :value="row.id"
+                            v-model="sharedState.selections"
+                            :disabled="reachedSelectionLimit && !sharedState.selections.includes(row.id)"
+                            :id="`checkbox-${row.id}`"
+                        />
+                    </td>
+                    <td v-for="column in visibleColumns" :key="column.field" @click="rowClicked(row)">
+                        <slot
+                            :name="`cell-${column.field}`"
+                            :value="row[column.value || column.field]"
+                            :values="row"
+                            :row="row"
+                            :index="actualIndex(row)"
+                            :display-index="index"
+                            :checkbox-id="`checkbox-${row.id}`"
+                        >
+                            <table-field :handle="column.field" :value="row[column.value || column.field]" :values="row" :fieldtype="column.fieldtype" :key="column.field" />
+                        </slot>
+                    </td>
+                    <td class="actions-column">
+                        <slot
+                            name="actions"
+                            :row="row"
+                            :index="actualIndex(row)"
+                            :display-index="index"
+                        ></slot>
+                    </td>
+                </tr>
+            </tbody>
+            </sortable-list>
+        </table>
+    </div>
 </template>
 
 <script>

--- a/resources/sass/elements/tables.scss
+++ b/resources/sass/elements/tables.scss
@@ -29,9 +29,7 @@
 }
 
 .data-table {
-	@apply text-left text-grey outline-none max-w-full block;
-	overflow-x: auto;
-	width: fit-content;
+	@apply text-left text-grey outline-none w-full max-w-full overflow-x-auto;
 
     thead {
 		// @apply bg-grey-20 text-grey-90 uppercase text-2xs tracking-wide outline-none;
@@ -122,12 +120,6 @@
 
 	.sortable-row.draggable-mirror {
 		display: none;
-	}
-}
-
-@screen md {
-	.data-table {
-		@apply w-full table;
 	}
 }
 

--- a/resources/sass/elements/tables.scss
+++ b/resources/sass/elements/tables.scss
@@ -28,8 +28,12 @@
     @apply py-1.5 pr-2 flex items-center border-t;
 }
 
+.data-table-wrapper {
+    @apply max-w-full min-w-full overflow-x-auto;
+}
+
 .data-table {
-	@apply text-left text-grey outline-none w-full max-w-full overflow-x-auto;
+	@apply text-left text-grey outline-none min-w-full;
 
     thead {
 		// @apply bg-grey-20 text-grey-90 uppercase text-2xs tracking-wide outline-none;
@@ -120,6 +124,12 @@
 
 	.sortable-row.draggable-mirror {
 		display: none;
+	}
+}
+
+@screen md {
+	.data-table {
+		@apply w-full;
 	}
 }
 

--- a/resources/views/blueprints/index.blade.php
+++ b/resources/views/blueprints/index.blade.php
@@ -32,21 +32,21 @@
         <h3 class="little-heading pl-0 mb-1">{{ __('Collections') }}</h3>
         <div class="card p-0 mb-2">
             <div class="data-table-wrapper">
-                <table class="data-table">
-            @endif
-                    @foreach ($collection->entryBlueprints() as $blueprint)
-                        <tr>
-                            <td>
-                                <div class="flex items-center">
-                                    <div class="w-4 h-4 mr-2">@svg('content-writing')</div>
-                                    <a href="{{ cp_route('collections.blueprints.edit', [$collection, $blueprint]) }}">{{ $blueprint->title() }}</a>
-                                </div>
-                            </td>
-                            <td class="text-right text-2xs">{{ $collection->title() }}</td>
-                        </tr>
-                    @endforeach
-            @if ($loop->last)
-                </table>
+            <table class="data-table">
+        @endif
+                @foreach ($collection->entryBlueprints() as $blueprint)
+                    <tr>
+                        <td>
+                            <div class="flex items-center">
+                                <div class="w-4 h-4 mr-2">@svg('content-writing')</div>
+                                <a href="{{ cp_route('collections.blueprints.edit', [$collection, $blueprint]) }}">{{ $blueprint->title() }}</a>
+                            </div>
+                        </td>
+                        <td class="text-right text-2xs">{{ $collection->title() }}</td>
+                    </tr>
+                @endforeach
+        @if ($loop->last)
+            </table>
             </div>
         </div>
         @endif
@@ -57,21 +57,21 @@
         <h3 class="little-heading pl-0 mb-1">{{ __('Taxonomies') }}</h3>
         <div class="card p-0 mb-2">
             <div class="data-table-wrapper">
-                <table class="data-table">
-            @endif
-                    @foreach ($taxonomy->termBlueprints() as $blueprint)
-                        <tr>
-                            <td>
-                                <div class="flex items-center">
-                                    <div class="w-4 h-4 mr-2">@svg('tags')</div>
-                                    <a href="{{ cp_route('taxonomies.blueprints.edit', [$taxonomy, $blueprint]) }}">{{ $blueprint->title() }}</a>
-                                </div>
-                            </td>
-                            <td class="text-right text-2xs">{{ $taxonomy->title() }}</td>
-                        </tr>
-                    @endforeach
-            @if ($loop->last)
-                </table>
+            <table class="data-table">
+        @endif
+                @foreach ($taxonomy->termBlueprints() as $blueprint)
+                    <tr>
+                        <td>
+                            <div class="flex items-center">
+                                <div class="w-4 h-4 mr-2">@svg('tags')</div>
+                                <a href="{{ cp_route('taxonomies.blueprints.edit', [$taxonomy, $blueprint]) }}">{{ $blueprint->title() }}</a>
+                            </div>
+                        </td>
+                        <td class="text-right text-2xs">{{ $taxonomy->title() }}</td>
+                    </tr>
+                @endforeach
+        @if ($loop->last)
+            </table>
             </div>
         </div>
         @endif
@@ -82,18 +82,18 @@
         <h3 class="little-heading pl-0 mb-1">{{ __('Globals') }}</h3>
         <div class="card p-0 mb-2">
             <div class="data-table-wrapper">
-                <table class="data-table">
-            @endif
-                    <tr>
-                        <td>
-                            <div class="flex items-center">
-                                <div class="w-4 h-4 mr-2">@svg('earth')</div>
-                                <a href="{{ cp_route('globals.blueprint.edit', $set->handle()) }}">{{ $set->title() }}</a>
-                            </div>
-                        </td>
-                    </tr>
-            @if ($loop->last)
-                </table>
+            <table class="data-table">
+        @endif
+                <tr>
+                    <td>
+                        <div class="flex items-center">
+                            <div class="w-4 h-4 mr-2">@svg('earth')</div>
+                            <a href="{{ cp_route('globals.blueprint.edit', $set->handle()) }}">{{ $set->title() }}</a>
+                        </div>
+                    </td>
+                </tr>
+        @if ($loop->last)
+            </table>
             </div>
         </div>
         @endif
@@ -104,18 +104,18 @@
         <h3 class="little-heading pl-0 mb-1">{{ __('Asset Containers') }}</h3>
         <div class="card p-0 mb-2">
             <div class="data-table-wrapper">
-                <table class="data-table">
-            @endif
-                    <tr>
-                        <td>
-                            <div class="flex items-center">
-                                <div class="w-4 h-4 mr-2">@svg('assets')</div>
-                                <a href="{{ cp_route('asset-containers.blueprint.edit', $container->handle()) }}">{{ $container->title() }}</a>
-                            </div>
-                        </td>
-                    </tr>
-            @if ($loop->last)
-                </table>
+            <table class="data-table">
+        @endif
+                <tr>
+                    <td>
+                        <div class="flex items-center">
+                            <div class="w-4 h-4 mr-2">@svg('assets')</div>
+                            <a href="{{ cp_route('asset-containers.blueprint.edit', $container->handle()) }}">{{ $container->title() }}</a>
+                        </div>
+                    </td>
+                </tr>
+        @if ($loop->last)
+            </table>
             </div>
         </div>
         @endif
@@ -126,18 +126,18 @@
         <h3 class="little-heading pl-0 mb-1">{{ __('Forms') }}</h3>
         <div class="card p-0 mb-2">
             <div class="data-table-wrapper">
-                <table class="data-table">
-            @endif
-                    <tr>
-                        <td>
-                            <div class="flex items-center">
-                                <div class="w-4 h-4 mr-2">@svg('drawer-file')</div>
-                                <a href="{{ cp_route('forms.blueprint.edit', $form->handle()) }}">{{ $form->title() }}</a>
-                            </div>
-                        </td>
-                    </tr>
-            @if ($loop->last)
-                </table>
+            <table class="data-table">
+        @endif
+                <tr>
+                    <td>
+                        <div class="flex items-center">
+                            <div class="w-4 h-4 mr-2">@svg('drawer-file')</div>
+                            <a href="{{ cp_route('forms.blueprint.edit', $form->handle()) }}">{{ $form->title() }}</a>
+                        </div>
+                    </td>
+                </tr>
+        @if ($loop->last)
+            </table>
             </div>
         </div>
         @endif
@@ -146,16 +146,16 @@
     <h3 class="little-heading pl-0 mb-1">{{ __('Other') }}</h3>
     <div class="card p-0 mb-2">
         <div class="data-table-wrapper">
-            <table class="data-table">
-                <tr>
-                    <td>
-                        <div class="flex items-center">
-                            <div class="w-4 h-4 mr-2">@svg('users')</div>
-                            <a href="{{ cp_route('users.blueprint.edit') }}">{{ __('User') }}</a>
-                        </div>
-                    </td>
-                </tr>
-            </table>
+        <table class="data-table">
+            <tr>
+                <td>
+                    <div class="flex items-center">
+                        <div class="w-4 h-4 mr-2">@svg('users')</div>
+                        <a href="{{ cp_route('users.blueprint.edit') }}">{{ __('User') }}</a>
+                    </div>
+                </td>
+            </tr>
+        </table>
         </div>
     </div>
 

--- a/resources/views/blueprints/index.blade.php
+++ b/resources/views/blueprints/index.blade.php
@@ -31,21 +31,23 @@
         @if ($loop->first)
         <h3 class="little-heading pl-0 mb-1">{{ __('Collections') }}</h3>
         <div class="card p-0 mb-2">
-            <table class="data-table">
-        @endif
-                @foreach ($collection->entryBlueprints() as $blueprint)
-                    <tr>
-                        <td>
-                            <div class="flex items-center">
-                                <div class="w-4 h-4 mr-2">@svg('content-writing')</div>
-                                <a href="{{ cp_route('collections.blueprints.edit', [$collection, $blueprint]) }}">{{ $blueprint->title() }}</a>
-                            </div>
-                        </td>
-                        <td class="text-right text-2xs">{{ $collection->title() }}</td>
-                    </tr>
-                @endforeach
-        @if ($loop->last)
-            </table>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+            @endif
+                    @foreach ($collection->entryBlueprints() as $blueprint)
+                        <tr>
+                            <td>
+                                <div class="flex items-center">
+                                    <div class="w-4 h-4 mr-2">@svg('content-writing')</div>
+                                    <a href="{{ cp_route('collections.blueprints.edit', [$collection, $blueprint]) }}">{{ $blueprint->title() }}</a>
+                                </div>
+                            </td>
+                            <td class="text-right text-2xs">{{ $collection->title() }}</td>
+                        </tr>
+                    @endforeach
+            @if ($loop->last)
+                </table>
+            </div>
         </div>
         @endif
     @endforeach
@@ -54,21 +56,23 @@
         @if ($loop->first)
         <h3 class="little-heading pl-0 mb-1">{{ __('Taxonomies') }}</h3>
         <div class="card p-0 mb-2">
-            <table class="data-table">
-        @endif
-                @foreach ($taxonomy->termBlueprints() as $blueprint)
-                    <tr>
-                        <td>
-                            <div class="flex items-center">
-                                <div class="w-4 h-4 mr-2">@svg('tags')</div>
-                                <a href="{{ cp_route('taxonomies.blueprints.edit', [$taxonomy, $blueprint]) }}">{{ $blueprint->title() }}</a>
-                            </div>
-                        </td>
-                        <td class="text-right text-2xs">{{ $taxonomy->title() }}</td>
-                    </tr>
-                @endforeach
-        @if ($loop->last)
-            </table>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+            @endif
+                    @foreach ($taxonomy->termBlueprints() as $blueprint)
+                        <tr>
+                            <td>
+                                <div class="flex items-center">
+                                    <div class="w-4 h-4 mr-2">@svg('tags')</div>
+                                    <a href="{{ cp_route('taxonomies.blueprints.edit', [$taxonomy, $blueprint]) }}">{{ $blueprint->title() }}</a>
+                                </div>
+                            </td>
+                            <td class="text-right text-2xs">{{ $taxonomy->title() }}</td>
+                        </tr>
+                    @endforeach
+            @if ($loop->last)
+                </table>
+            </div>
         </div>
         @endif
     @endforeach
@@ -77,18 +81,20 @@
         @if ($loop->first)
         <h3 class="little-heading pl-0 mb-1">{{ __('Globals') }}</h3>
         <div class="card p-0 mb-2">
-            <table class="data-table">
-        @endif
-                <tr>
-                    <td>
-                        <div class="flex items-center">
-                            <div class="w-4 h-4 mr-2">@svg('earth')</div>
-                            <a href="{{ cp_route('globals.blueprint.edit', $set->handle()) }}">{{ $set->title() }}</a>
-                        </div>
-                    </td>
-                </tr>
-        @if ($loop->last)
-            </table>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+            @endif
+                    <tr>
+                        <td>
+                            <div class="flex items-center">
+                                <div class="w-4 h-4 mr-2">@svg('earth')</div>
+                                <a href="{{ cp_route('globals.blueprint.edit', $set->handle()) }}">{{ $set->title() }}</a>
+                            </div>
+                        </td>
+                    </tr>
+            @if ($loop->last)
+                </table>
+            </div>
         </div>
         @endif
     @endforeach
@@ -97,18 +103,20 @@
         @if ($loop->first)
         <h3 class="little-heading pl-0 mb-1">{{ __('Asset Containers') }}</h3>
         <div class="card p-0 mb-2">
-            <table class="data-table">
-        @endif
-                <tr>
-                    <td>
-                        <div class="flex items-center">
-                            <div class="w-4 h-4 mr-2">@svg('assets')</div>
-                            <a href="{{ cp_route('asset-containers.blueprint.edit', $container->handle()) }}">{{ $container->title() }}</a>
-                        </div>
-                    </td>
-                </tr>
-        @if ($loop->last)
-            </table>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+            @endif
+                    <tr>
+                        <td>
+                            <div class="flex items-center">
+                                <div class="w-4 h-4 mr-2">@svg('assets')</div>
+                                <a href="{{ cp_route('asset-containers.blueprint.edit', $container->handle()) }}">{{ $container->title() }}</a>
+                            </div>
+                        </td>
+                    </tr>
+            @if ($loop->last)
+                </table>
+            </div>
         </div>
         @endif
     @endforeach
@@ -117,34 +125,38 @@
         @if ($loop->first)
         <h3 class="little-heading pl-0 mb-1">{{ __('Forms') }}</h3>
         <div class="card p-0 mb-2">
-            <table class="data-table">
+            <div class="data-table-wrapper">
+                <table class="data-table">
+            @endif
+                    <tr>
+                        <td>
+                            <div class="flex items-center">
+                                <div class="w-4 h-4 mr-2">@svg('drawer-file')</div>
+                                <a href="{{ cp_route('forms.blueprint.edit', $form->handle()) }}">{{ $form->title() }}</a>
+                            </div>
+                        </td>
+                    </tr>
+            @if ($loop->last)
+                </table>
+            </div>
+        </div>
         @endif
-                <tr>
-                    <td>
-                        <div class="flex items-center">
-                            <div class="w-4 h-4 mr-2">@svg('drawer-file')</div>
-                            <a href="{{ cp_route('forms.blueprint.edit', $form->handle()) }}">{{ $form->title() }}</a>
-                        </div>
-                    </td>
-        @if ($loop->last)
-                </tr>
-        </table>
-        @endif
-    </div>
     @endforeach
 
     <h3 class="little-heading pl-0 mb-1">{{ __('Other') }}</h3>
     <div class="card p-0 mb-2">
-        <table class="data-table">
-            <tr>
-                <td>
-                    <div class="flex items-center">
-                        <div class="w-4 h-4 mr-2">@svg('users')</div>
-                        <a href="{{ cp_route('users.blueprint.edit') }}">{{ __('User') }}</a>
-                    </div>
-                </td>
-            </tr>
-        </table>
+        <div class="data-table-wrapper">
+            <table class="data-table">
+                <tr>
+                    <td>
+                        <div class="flex items-center">
+                            <div class="w-4 h-4 mr-2">@svg('users')</div>
+                            <a href="{{ cp_route('users.blueprint.edit') }}">{{ __('User') }}</a>
+                        </div>
+                    </td>
+                </tr>
+            </table>
+        </div>
     </div>
 
     @include('statamic::partials.docs-callout', [

--- a/resources/views/licensing.blade.php
+++ b/resources/views/licensing.blade.php
@@ -33,35 +33,39 @@
 
         <h6 class="mt-4">Site</h6>
         <div class="card p-0 mt-1">
-            <table class="data-table">
-                <tr>
-                    <td class="w-64 font-bold">
-                        <span class="little-dot {{ $site->valid() ? 'bg-green' : 'bg-red' }} mr-1"></span>
-                        {{ $site->key() ?? __('No license key') }}
-                    </td>
-                    <td class="relative">
-                        {{ $site->domain()['url'] ?? '' }}
-                        @if ($site->hasMultipleDomains())
-                            <span class="text-2xs">({{ trans_choice('and :count more', $site->additionalDomainCount()) }})</span>
-                        @endif
-                    </td>
-                    <td class="text-right text-red">{{ $site->invalidReason() }}</td>
-                </tr>
-            </table>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+                    <tr>
+                        <td class="w-64 font-bold">
+                            <span class="little-dot {{ $site->valid() ? 'bg-green' : 'bg-red' }} mr-1"></span>
+                            {{ $site->key() ?? __('No license key') }}
+                        </td>
+                        <td class="relative">
+                            {{ $site->domain()['url'] ?? '' }}
+                            @if ($site->hasMultipleDomains())
+                                <span class="text-2xs">({{ trans_choice('and :count more', $site->additionalDomainCount()) }})</span>
+                            @endif
+                        </td>
+                        <td class="text-right text-red">{{ $site->invalidReason() }}</td>
+                    </tr>
+                </table>
+            </div>
         </div>
 
         <h6 class="mt-4">Core</h6>
         <div class="card p-0 mt-1">
-            <table class="data-table">
-                <tr>
-                    <td class="w-64 font-bold">
-                        <span class="little-dot {{ $statamic->valid() ? 'bg-green' : 'bg-red' }} mr-1"></span>
-                        Statamic @if ($statamic->pro())<span class="text-pink">Pro</span>@else Free @endif
-                    </td>
-                    <td>{{ $statamic->version() }}</td>
-                    <td class="text-right text-red">{{ $statamic->invalidReason() }}</td>
-                </tr>
-            </table>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+                    <tr>
+                        <td class="w-64 font-bold">
+                            <span class="little-dot {{ $statamic->valid() ? 'bg-green' : 'bg-red' }} mr-1"></span>
+                            Statamic @if ($statamic->pro())<span class="text-pink">Pro</span>@else Free @endif
+                        </td>
+                        <td>{{ $statamic->version() }}</td>
+                        <td class="text-right text-red">{{ $statamic->invalidReason() }}</td>
+                    </tr>
+                </table>
+            </div>
         </div>
 
         <h6 class="mt-4">{{ __('Addons') }}</h6>
@@ -69,36 +73,40 @@
         <p class="text-sm text-grey mt-1">{{ __('No addons installed') }}</p>
         @else
         <div class="card p-0 mt-1">
-            <table class="data-table">
-                @foreach ($addons as $addon)
-                    <tr>
-                        <td class="w-64 mr-1">
-                            <span class="little-dot {{ $addon->valid() ? 'bg-green' : 'bg-red' }} mr-1"></span>
-                            <span class="font-bold">{{ $addon->name() }}</span>
-                            @if ($addon->edition())<span class="badge uppercase font-bold text-grey-60">{{ $addon->edition() ?? '' }}</span>@endif
-                        </td>
-                        <td>{{ $addon->version() }}</td>
-                        <td class="text-right text-red">{{ $addon->invalidReason() }}</td>
-                    </tr>
-                @endforeach
-            </table>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+                    @foreach ($addons as $addon)
+                        <tr>
+                            <td class="w-64 mr-1">
+                                <span class="little-dot {{ $addon->valid() ? 'bg-green' : 'bg-red' }} mr-1"></span>
+                                <span class="font-bold">{{ $addon->name() }}</span>
+                                @if ($addon->edition())<span class="badge uppercase font-bold text-grey-60">{{ $addon->edition() ?? '' }}</span>@endif
+                            </td>
+                            <td>{{ $addon->version() }}</td>
+                            <td class="text-right text-red">{{ $addon->invalidReason() }}</td>
+                        </tr>
+                    @endforeach
+                </table>
+            </div>
         </div>
         @endif
 
         @if (!$unlistedAddons->isEmpty())
         <h6 class="mt-4">{{ __('Unlisted Addons') }}</h6>
         <div class="card p-0 mt-1">
-            <table class="data-table">
-                @foreach ($unlistedAddons as $addon)
-                    <tr>
-                        <td class="w-64 font-bold mr-1">
-                            <span class="little-dot bg-green mr-1"></span>
-                            {{ $addon->name() }}
-                        </td>
-                        <td>{{ $addon->version() }}</td>
-                    </tr>
-                @endforeach
-            </table>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+                    @foreach ($unlistedAddons as $addon)
+                        <tr>
+                            <td class="w-64 font-bold mr-1">
+                                <span class="little-dot bg-green mr-1"></span>
+                                {{ $addon->name() }}
+                            </td>
+                            <td>{{ $addon->version() }}</td>
+                        </tr>
+                    @endforeach
+                </table>
+            </div>
         </div>
         @endif
 

--- a/resources/views/licensing.blade.php
+++ b/resources/views/licensing.blade.php
@@ -34,37 +34,37 @@
         <h6 class="mt-4">Site</h6>
         <div class="card p-0 mt-1">
             <div class="data-table-wrapper">
-                <table class="data-table">
-                    <tr>
-                        <td class="w-64 font-bold">
-                            <span class="little-dot {{ $site->valid() ? 'bg-green' : 'bg-red' }} mr-1"></span>
-                            {{ $site->key() ?? __('No license key') }}
-                        </td>
-                        <td class="relative">
-                            {{ $site->domain()['url'] ?? '' }}
-                            @if ($site->hasMultipleDomains())
-                                <span class="text-2xs">({{ trans_choice('and :count more', $site->additionalDomainCount()) }})</span>
-                            @endif
-                        </td>
-                        <td class="text-right text-red">{{ $site->invalidReason() }}</td>
-                    </tr>
-                </table>
+            <table class="data-table">
+                <tr>
+                    <td class="w-64 font-bold">
+                        <span class="little-dot {{ $site->valid() ? 'bg-green' : 'bg-red' }} mr-1"></span>
+                        {{ $site->key() ?? __('No license key') }}
+                    </td>
+                    <td class="relative">
+                        {{ $site->domain()['url'] ?? '' }}
+                        @if ($site->hasMultipleDomains())
+                            <span class="text-2xs">({{ trans_choice('and :count more', $site->additionalDomainCount()) }})</span>
+                        @endif
+                    </td>
+                    <td class="text-right text-red">{{ $site->invalidReason() }}</td>
+                </tr>
+            </table>
             </div>
         </div>
 
         <h6 class="mt-4">Core</h6>
         <div class="card p-0 mt-1">
             <div class="data-table-wrapper">
-                <table class="data-table">
-                    <tr>
-                        <td class="w-64 font-bold">
-                            <span class="little-dot {{ $statamic->valid() ? 'bg-green' : 'bg-red' }} mr-1"></span>
-                            Statamic @if ($statamic->pro())<span class="text-pink">Pro</span>@else Free @endif
-                        </td>
-                        <td>{{ $statamic->version() }}</td>
-                        <td class="text-right text-red">{{ $statamic->invalidReason() }}</td>
-                    </tr>
-                </table>
+            <table class="data-table">
+                <tr>
+                    <td class="w-64 font-bold">
+                        <span class="little-dot {{ $statamic->valid() ? 'bg-green' : 'bg-red' }} mr-1"></span>
+                        Statamic @if ($statamic->pro())<span class="text-pink">Pro</span>@else Free @endif
+                    </td>
+                    <td>{{ $statamic->version() }}</td>
+                    <td class="text-right text-red">{{ $statamic->invalidReason() }}</td>
+                </tr>
+            </table>
             </div>
         </div>
 
@@ -74,19 +74,19 @@
         @else
         <div class="card p-0 mt-1">
             <div class="data-table-wrapper">
-                <table class="data-table">
-                    @foreach ($addons as $addon)
-                        <tr>
-                            <td class="w-64 mr-1">
-                                <span class="little-dot {{ $addon->valid() ? 'bg-green' : 'bg-red' }} mr-1"></span>
-                                <span class="font-bold">{{ $addon->name() }}</span>
-                                @if ($addon->edition())<span class="badge uppercase font-bold text-grey-60">{{ $addon->edition() ?? '' }}</span>@endif
-                            </td>
-                            <td>{{ $addon->version() }}</td>
-                            <td class="text-right text-red">{{ $addon->invalidReason() }}</td>
-                        </tr>
-                    @endforeach
-                </table>
+            <table class="data-table">
+                @foreach ($addons as $addon)
+                    <tr>
+                        <td class="w-64 mr-1">
+                            <span class="little-dot {{ $addon->valid() ? 'bg-green' : 'bg-red' }} mr-1"></span>
+                            <span class="font-bold">{{ $addon->name() }}</span>
+                            @if ($addon->edition())<span class="badge uppercase font-bold text-grey-60">{{ $addon->edition() ?? '' }}</span>@endif
+                        </td>
+                        <td>{{ $addon->version() }}</td>
+                        <td class="text-right text-red">{{ $addon->invalidReason() }}</td>
+                    </tr>
+                @endforeach
+            </table>
             </div>
         </div>
         @endif
@@ -95,17 +95,17 @@
         <h6 class="mt-4">{{ __('Unlisted Addons') }}</h6>
         <div class="card p-0 mt-1">
             <div class="data-table-wrapper">
-                <table class="data-table">
-                    @foreach ($unlistedAddons as $addon)
-                        <tr>
-                            <td class="w-64 font-bold mr-1">
-                                <span class="little-dot bg-green mr-1"></span>
-                                {{ $addon->name() }}
-                            </td>
-                            <td>{{ $addon->version() }}</td>
-                        </tr>
-                    @endforeach
-                </table>
+            <table class="data-table">
+                @foreach ($unlistedAddons as $addon)
+                    <tr>
+                        <td class="w-64 font-bold mr-1">
+                            <span class="little-dot bg-green mr-1"></span>
+                            {{ $addon->name() }}
+                        </td>
+                        <td>{{ $addon->version() }}</td>
+                    </tr>
+                @endforeach
+            </table>
             </div>
         </div>
         @endif

--- a/resources/views/updater/index.blade.php
+++ b/resources/views/updater/index.blade.php
@@ -9,46 +9,52 @@
 
     <h6 class="mt-4">Core</h6>
     <div class="card p-0 mt-1">
-        <table class="data-table">
-            <tr>
-                <td class="w-64"><a href="{{ route('statamic.cp.updater.product', 'statamic') }}" class="text-blue font-bold">Statamic</a></td>
-                <td>{{ $statamic->currentVersion() }}</td>
-                @if ($count = $statamic->availableUpdatesCount())
-                    <td class="text-right"><span class="badge-sm bg-green btn-sm">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
-                @else
-                    <td class="text-right">{{ __('Up to date')}}</td>
-                @endif
-            </tr>
-        </table>
-    </div>
-
-    <h6 class="mt-4">{{ __('Addons') }}</h6>
-    <div class="card p-0 mt-1">
-        <table class="data-table">
-            @foreach ($addons as $addon)
+        <div class="data-table-wrapper">
+            <table class="data-table">
                 <tr>
-                    <td class="w-64"><a href="{{ route('statamic.cp.updater.product', $addon->slug()) }}" class="text-blue font-bold mr-1">{{ $addon->name() }}</a>
-                    <td>{{ $addon->version() }}</td>
-                    @if ($count = $addon->changelog()->availableUpdatesCount())
+                    <td class="w-64"><a href="{{ route('statamic.cp.updater.product', 'statamic') }}" class="text-blue font-bold">Statamic</a></td>
+                    <td>{{ $statamic->currentVersion() }}</td>
+                    @if ($count = $statamic->availableUpdatesCount())
                         <td class="text-right"><span class="badge-sm bg-green btn-sm">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
                     @else
                         <td class="text-right">{{ __('Up to date')}}</td>
                     @endif
                 </tr>
-            @endforeach
-        </table>
+            </table>
+        </div>
+    </div>
+
+    <h6 class="mt-4">{{ __('Addons') }}</h6>
+    <div class="card p-0 mt-1">
+        <div class="data-table-wrapper">
+            <table class="data-table">
+                @foreach ($addons as $addon)
+                    <tr>
+                        <td class="w-64"><a href="{{ route('statamic.cp.updater.product', $addon->slug()) }}" class="text-blue font-bold mr-1">{{ $addon->name() }}</a>
+                        <td>{{ $addon->version() }}</td>
+                        @if ($count = $addon->changelog()->availableUpdatesCount())
+                            <td class="text-right"><span class="badge-sm bg-green btn-sm">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
+                        @else
+                            <td class="text-right">{{ __('Up to date')}}</td>
+                        @endif
+                    </tr>
+                @endforeach
+            </table>
+        </div>
     </div>
 
     <h6 class="mt-4">{{ __('Unlisted Addons') }}</h6>
     <div class="card p-0 mt-1">
-        <table class="data-table">
-            @foreach ($unlistedAddons as $addon)
-                <tr>
-                    <td class="w-64">{{ $addon->name() }}</td>
-                    <td>{{ $addon->version() }}</td>
-                </tr>
-            @endforeach
-        </table>
+        <div class="data-table-wrapper">
+            <table class="data-table">
+                @foreach ($unlistedAddons as $addon)
+                    <tr>
+                        <td class="w-64">{{ $addon->name() }}</td>
+                        <td>{{ $addon->version() }}</td>
+                    </tr>
+                @endforeach
+            </table>
+        </div>
     </div>
 
     @include('statamic::partials.docs-callout', [

--- a/resources/views/updater/index.blade.php
+++ b/resources/views/updater/index.blade.php
@@ -10,50 +10,50 @@
     <h6 class="mt-4">Core</h6>
     <div class="card p-0 mt-1">
         <div class="data-table-wrapper">
-            <table class="data-table">
-                <tr>
-                    <td class="w-64"><a href="{{ route('statamic.cp.updater.product', 'statamic') }}" class="text-blue font-bold">Statamic</a></td>
-                    <td>{{ $statamic->currentVersion() }}</td>
-                    @if ($count = $statamic->availableUpdatesCount())
-                        <td class="text-right"><span class="badge-sm bg-green btn-sm">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
-                    @else
-                        <td class="text-right">{{ __('Up to date')}}</td>
-                    @endif
-                </tr>
-            </table>
+        <table class="data-table">
+            <tr>
+                <td class="w-64"><a href="{{ route('statamic.cp.updater.product', 'statamic') }}" class="text-blue font-bold">Statamic</a></td>
+                <td>{{ $statamic->currentVersion() }}</td>
+                @if ($count = $statamic->availableUpdatesCount())
+                    <td class="text-right"><span class="badge-sm bg-green btn-sm">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
+                @else
+                    <td class="text-right">{{ __('Up to date')}}</td>
+                @endif
+            </tr>
+        </table>
         </div>
     </div>
 
     <h6 class="mt-4">{{ __('Addons') }}</h6>
     <div class="card p-0 mt-1">
         <div class="data-table-wrapper">
-            <table class="data-table">
-                @foreach ($addons as $addon)
-                    <tr>
-                        <td class="w-64"><a href="{{ route('statamic.cp.updater.product', $addon->slug()) }}" class="text-blue font-bold mr-1">{{ $addon->name() }}</a>
-                        <td>{{ $addon->version() }}</td>
-                        @if ($count = $addon->changelog()->availableUpdatesCount())
-                            <td class="text-right"><span class="badge-sm bg-green btn-sm">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
-                        @else
-                            <td class="text-right">{{ __('Up to date')}}</td>
-                        @endif
-                    </tr>
-                @endforeach
-            </table>
+        <table class="data-table">
+            @foreach ($addons as $addon)
+                <tr>
+                    <td class="w-64"><a href="{{ route('statamic.cp.updater.product', $addon->slug()) }}" class="text-blue font-bold mr-1">{{ $addon->name() }}</a>
+                    <td>{{ $addon->version() }}</td>
+                    @if ($count = $addon->changelog()->availableUpdatesCount())
+                        <td class="text-right"><span class="badge-sm bg-green btn-sm">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
+                    @else
+                        <td class="text-right">{{ __('Up to date')}}</td>
+                    @endif
+                </tr>
+            @endforeach
+        </table>
         </div>
     </div>
 
     <h6 class="mt-4">{{ __('Unlisted Addons') }}</h6>
     <div class="card p-0 mt-1">
         <div class="data-table-wrapper">
-            <table class="data-table">
-                @foreach ($unlistedAddons as $addon)
-                    <tr>
-                        <td class="w-64">{{ $addon->name() }}</td>
-                        <td>{{ $addon->version() }}</td>
-                    </tr>
-                @endforeach
-            </table>
+        <table class="data-table">
+            @foreach ($unlistedAddons as $addon)
+                <tr>
+                    <td class="w-64">{{ $addon->name() }}</td>
+                    <td>{{ $addon->version() }}</td>
+                </tr>
+            @endforeach
+        </table>
         </div>
     </div>
 

--- a/resources/views/utilities/email.blade.php
+++ b/resources/views/utilities/email.blade.php
@@ -29,45 +29,45 @@
     <p class="text-sm text-grey mb-2">{!! __('statamic::messages.email_utility_configuration_description', ['path' => config_path('mail.php')]) !!}</p>
     <div class="card p-0">
         <div class="data-table-wrapper">
-            <table class="data-table">
-                @if (config('mail.mailers'))
-                    @include('statamic::utilities.partials.email-l7')
-                @else
-                    @include('statamic::utilities.partials.email-l6')
-                @endif
-                <tr>
-                    <th class="pl-2 py-1 w-1/4">{{ __('Default From Address') }}</th>
-                    <td>
-                        @if (config('mail.from.address'))
-                            <code>{{ config('mail.from.address') }}</code>
-                        @endif
-                    </td>
-                </tr>
-                <tr>
-                    <th class="pl-2 py-1 w-1/4">{{ __('Default From Name') }}</th>
-                    <td>
-                        @if (config('mail.from.name'))
-                            <code>{{ config('mail.from.name') }}</code>
-                        @endif
-                    </td>
-                </tr>
-                <tr>
-                    <th class="pl-2 py-1 w-1/4">{{ __('Markdown theme') }}</th>
-                    <td>
-                        @if (config('mail.markdown.theme'))
-                            <code>{{ config('mail.markdown.theme') }}</code>
-                        @endif
-                    </td>
-                </tr>
-                <tr>
-                    <th class="pl-2 py-1 w-1/4">{{ __('Markdown paths') }}</th>
-                    <td>
-                        @foreach (config('mail.markdown.paths') as $path)
-                            <code>{{ $path }}</code><br>
-                        @endforeach
-                    </td>
-                </tr>
-            </table>
+        <table class="data-table">
+            @if (config('mail.mailers'))
+                @include('statamic::utilities.partials.email-l7')
+            @else
+                @include('statamic::utilities.partials.email-l6')
+            @endif
+            <tr>
+                <th class="pl-2 py-1 w-1/4">{{ __('Default From Address') }}</th>
+                <td>
+                    @if (config('mail.from.address'))
+                        <code>{{ config('mail.from.address') }}</code>
+                    @endif
+                </td>
+            </tr>
+            <tr>
+                <th class="pl-2 py-1 w-1/4">{{ __('Default From Name') }}</th>
+                <td>
+                    @if (config('mail.from.name'))
+                        <code>{{ config('mail.from.name') }}</code>
+                    @endif
+                </td>
+            </tr>
+            <tr>
+                <th class="pl-2 py-1 w-1/4">{{ __('Markdown theme') }}</th>
+                <td>
+                    @if (config('mail.markdown.theme'))
+                        <code>{{ config('mail.markdown.theme') }}</code>
+                    @endif
+                </td>
+            </tr>
+            <tr>
+                <th class="pl-2 py-1 w-1/4">{{ __('Markdown paths') }}</th>
+                <td>
+                    @foreach (config('mail.markdown.paths') as $path)
+                        <code>{{ $path }}</code><br>
+                    @endforeach
+                </td>
+            </tr>
+        </table>
         </div>
     </div>
 

--- a/resources/views/utilities/email.blade.php
+++ b/resources/views/utilities/email.blade.php
@@ -28,45 +28,47 @@
     <h2 class="mt-5 mb-1 font-bold text-lg">{{ __('Configuration') }}</h2>
     <p class="text-sm text-grey mb-2">{!! __('statamic::messages.email_utility_configuration_description', ['path' => config_path('mail.php')]) !!}</p>
     <div class="card p-0">
-        <table class="data-table">
-            @if (config('mail.mailers'))
-                @include('statamic::utilities.partials.email-l7')
-            @else
-                @include('statamic::utilities.partials.email-l6')
-            @endif
-            <tr>
-                <th class="pl-2 py-1 w-1/4">{{ __('Default From Address') }}</th>
-                <td>
-                    @if (config('mail.from.address'))
-                        <code>{{ config('mail.from.address') }}</code>
-                    @endif
-                </td>
-            </tr>
-            <tr>
-                <th class="pl-2 py-1 w-1/4">{{ __('Default From Name') }}</th>
-                <td>
-                    @if (config('mail.from.name'))
-                        <code>{{ config('mail.from.name') }}</code>
-                    @endif
-                </td>
-            </tr>
-            <tr>
-                <th class="pl-2 py-1 w-1/4">{{ __('Markdown theme') }}</th>
-                <td>
-                    @if (config('mail.markdown.theme'))
-                        <code>{{ config('mail.markdown.theme') }}</code>
-                    @endif
-                </td>
-            </tr>
-            <tr>
-                <th class="pl-2 py-1 w-1/4">{{ __('Markdown paths') }}</th>
-                <td>
-                    @foreach (config('mail.markdown.paths') as $path)
-                        <code>{{ $path }}</code><br>
-                    @endforeach
-                </td>
-            </tr>
-        </table>
+        <div class="data-table-wrapper">
+            <table class="data-table">
+                @if (config('mail.mailers'))
+                    @include('statamic::utilities.partials.email-l7')
+                @else
+                    @include('statamic::utilities.partials.email-l6')
+                @endif
+                <tr>
+                    <th class="pl-2 py-1 w-1/4">{{ __('Default From Address') }}</th>
+                    <td>
+                        @if (config('mail.from.address'))
+                            <code>{{ config('mail.from.address') }}</code>
+                        @endif
+                    </td>
+                </tr>
+                <tr>
+                    <th class="pl-2 py-1 w-1/4">{{ __('Default From Name') }}</th>
+                    <td>
+                        @if (config('mail.from.name'))
+                            <code>{{ config('mail.from.name') }}</code>
+                        @endif
+                    </td>
+                </tr>
+                <tr>
+                    <th class="pl-2 py-1 w-1/4">{{ __('Markdown theme') }}</th>
+                    <td>
+                        @if (config('mail.markdown.theme'))
+                            <code>{{ config('mail.markdown.theme') }}</code>
+                        @endif
+                    </td>
+                </tr>
+                <tr>
+                    <th class="pl-2 py-1 w-1/4">{{ __('Markdown paths') }}</th>
+                    <td>
+                        @foreach (config('mail.markdown.paths') as $path)
+                            <code>{{ $path }}</code><br>
+                        @endforeach
+                    </td>
+                </tr>
+            </table>
+        </div>
     </div>
 
 @stop

--- a/resources/views/utilities/phpinfo.blade.php
+++ b/resources/views/utilities/phpinfo.blade.php
@@ -12,25 +12,29 @@
     </header>
 
     <div class="card p-0">
-        <table class="data-table">
-            <tr>
-                <th class="pl-2 py-1 w-1/4">PHP Version</th>
-                <td>{{ PHP_VERSION }}</td>
-            </tr>
-        </table>
+        <div class="data-table-wrapper">
+            <table class="data-table">
+                <tr>
+                    <th class="pl-2 py-1 w-1/4">PHP Version</th>
+                    <td>{{ PHP_VERSION }}</td>
+                </tr>
+            </table>
+        </div>
     </div>
 
     @foreach ($phpinfo as $section => $items)
         <h2 class="mt-4 mb-1 font-bold text-lg">{{ $section }}</h2>
         <div class="card p-0">
-            <table class="data-table">
-                @foreach ($items as $name => $value)
-                <tr>
-                    <th class="pl-2 py-1 w-1/4">{{ $name }}</th>
-                    <td>{{ is_array($value) ? join(', ', $value) : $value }}</td>
-                </tr>
-                @endforeach
-            </table>
+            <div class="data-table-wrapper">
+                <table class="data-table">
+                    @foreach ($items as $name => $value)
+                    <tr>
+                        <th class="pl-2 py-1 w-1/4">{{ $name }}</th>
+                        <td>{{ is_array($value) ? join(', ', $value) : $value }}</td>
+                    </tr>
+                    @endforeach
+                </table>
+            </div>
         </div>
     @endforeach
 

--- a/resources/views/utilities/phpinfo.blade.php
+++ b/resources/views/utilities/phpinfo.blade.php
@@ -13,12 +13,12 @@
 
     <div class="card p-0">
         <div class="data-table-wrapper">
-            <table class="data-table">
-                <tr>
-                    <th class="pl-2 py-1 w-1/4">PHP Version</th>
-                    <td>{{ PHP_VERSION }}</td>
-                </tr>
-            </table>
+        <table class="data-table">
+            <tr>
+                <th class="pl-2 py-1 w-1/4">PHP Version</th>
+                <td>{{ PHP_VERSION }}</td>
+            </tr>
+        </table>
         </div>
     </div>
 
@@ -26,14 +26,14 @@
         <h2 class="mt-4 mb-1 font-bold text-lg">{{ $section }}</h2>
         <div class="card p-0">
             <div class="data-table-wrapper">
-                <table class="data-table">
-                    @foreach ($items as $name => $value)
-                    <tr>
-                        <th class="pl-2 py-1 w-1/4">{{ $name }}</th>
-                        <td>{{ is_array($value) ? join(', ', $value) : $value }}</td>
-                    </tr>
-                    @endforeach
-                </table>
+            <table class="data-table">
+                @foreach ($items as $name => $value)
+                <tr>
+                    <th class="pl-2 py-1 w-1/4">{{ $name }}</th>
+                    <td>{{ is_array($value) ? join(', ', $value) : $value }}</td>
+                </tr>
+                @endforeach
+            </table>
             </div>
         </div>
     @endforeach


### PR DESCRIPTION
This PR address the issue raised in #2595.

The primary issue was with using `width: fit-content` and setting the data table to `display: block`. I was able to add a min-width of 100% while testing, but the child thead, tbody, etc. didn't respect the min width.

I removed the fit-content and moved the css for a data-table once it hits the medium screen to the base `.data-table` class.

There are a few concerns that I have with the data-table. I'm assuming that the fit-content was in hopes of having the table get wrapped in a div so that on smaller screens in could be scrolled horizontally, but none of the wrapping components, primarily the card class, have overflow-x set to auto, so it wouldn't scroll any way.

If you have thoughts, suggestions, whatever, let me know, and I can help address them. Thanks!