### PR TITLE
Bugfix/translationfiles conflicts with collection

### DIFF
--- a/resources/views/partials/nav-main.blade.php
+++ b/resources/views/partials/nav-main.blade.php
@@ -17,10 +17,10 @@
                                         @foreach ($item->children() as $child)
                                             <li class="{{ $child->isActive() ? 'current' : '' }}">
                                                 <a href="{{ $child->url() }}">
-                                                    @if (is_array(__($child->name())) == true && data_get(__($child->name()),'nav') === null)
+                                                    @if (is_array(__($child->name())) == true && data_get(__($child->name()), strtolower($child->name())) === null)
                                                         {{$child->name()}}
                                                     @else
-                                                        {{ is_array(__($child->name())) ? __($child->name().'.nav') : __($child->name()) }}
+                                                        {{ is_array(__($child->name())) ? __($child->name().'.'.strtolower($child->name())) : __($child->name()) }}
                                                     @endif 
                                                 </a>
                                             </li>

--- a/resources/views/partials/nav-main.blade.php
+++ b/resources/views/partials/nav-main.blade.php
@@ -16,7 +16,13 @@
                                     <ul>
                                         @foreach ($item->children() as $child)
                                             <li class="{{ $child->isActive() ? 'current' : '' }}">
-                                                <a href="{{ $child->url() }}">{{ __($child->name()) }}</a>
+                                                <a href="{{ $child->url() }}">
+                                                    @if (is_array(__($child->name())) == true && data_get(__($child->name()),'nav') === null)
+                                                        {{$child->name()}}
+                                                    @else
+                                                        {{ is_array(__($child->name())) ? __($child->name().'.nav') : __($child->name()) }}
+                                                    @endif 
+                                                </a>
                                             </li>
                                         @endforeach
                                     </ul>

--- a/resources/views/partials/nav-mobile.blade.php
+++ b/resources/views/partials/nav-mobile.blade.php
@@ -16,11 +16,11 @@
                                     @foreach ($item->children() as $child)
                                         <li class="{{ $child->isActive() ? 'current' : '' }}">
                                             <a href="{{ $child->url() }}">
-                                                @if (is_array(__($child->name())) == true && data_get(__($child->name()),'nav') === null)
+                                                @if (is_array(__($child->name())) == true && data_get(__($child->name()), strtolower($child->name())) === null)
                                                     {{$child->name()}}
                                                 @else
-                                                    {{ is_array(__($child->name())) ? __($child->name().'.nav') : __($child->name()) }}
-                                                @endif  
+                                                    {{ is_array(__($child->name())) ? __($child->name().'.'.strtolower($child->name())) : __($child->name()) }}
+                                                @endif 
                                             </a>
                                         </li>
                                     @endforeach

--- a/resources/views/partials/nav-mobile.blade.php
+++ b/resources/views/partials/nav-mobile.blade.php
@@ -15,7 +15,13 @@
                                 <ul>
                                     @foreach ($item->children() as $child)
                                         <li class="{{ $child->isActive() ? 'current' : '' }}">
-                                            <a href="{{ $child->url() }}">{{ __($child->name()) }}</a>
+                                            <a href="{{ $child->url() }}">
+                                                @if (is_array(__($child->name())) == true && data_get(__($child->name()),'nav') === null)
+                                                    {{$child->name()}}
+                                                @else
+                                                    {{ is_array(__($child->name())) ? __($child->name().'.nav') : __($child->name()) }}
+                                                @endif  
+                                            </a>
                                         </li>
                                     @endforeach
                                 </ul>

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -227,7 +227,13 @@ class Statamic
 
     public static function crumb(...$values)
     {
-        return implode(' ‹ ', array_map('__', $values));
+        return implode(' ‹ ', collect(array_map('__', $values))->map(function($value, $index) use ($values){
+            if (is_array($value)){
+                $key = strtolower($values[$index]);
+                return data_get($value, $key) != null ? data_get($value, $key) : $values[$index];
+            }
+            return $value;
+        })->toArray());
     }
 
     public static function docsUrl($url)

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -230,7 +230,7 @@ class Statamic
         return implode(' ‹ ', collect(array_map('__', $values))->map(function($value, $index) use ($values){
             if (is_array($value)){
                 $key = strtolower($values[$index]);
-                return data_get($value, $key) != null ? data_get($value, $key) : $values[$index];
+                return data_get($value, $key) != null && is_array(data_get($value, $key)) == false ? data_get($value, $key) : $values[$index];
             }
             return $value;
         })->toArray());


### PR DESCRIPTION
**Problem:**
Asume you have a collection with the name "Blog".
If you create a translation with the name "blog" two things will happen.

1) The nav-main.blade and the nav-mobile.blade will throw an exeception cause they are using __() for translation purpose.
2) The collection overview page will (or more precise the Statamic::crumb static function) will throw an exception also related to that problem.

![Bildschirmfoto 2020-10-16 um 16 14 45](https://user-images.githubusercontent.com/3373530/96275761-68c19d00-0fd2-11eb-9186-086d8638cc1d.png)

**Proposal**
2 Modifications were made:
1) nav blade files where modified:
eg. If the collection name is "Blog" the bladefile will try to find blog as key in the translation file and will return it otherwise it will return the key in that case "Blog"
2) The crumb function tries to achieve the same.

**If not accepted**
Workarround:
Do not use laravel translation file with the same filename.
