### PR TITLE
Fix issue where an empty taxonomy parameter would return no results

### DIFF
--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -302,6 +302,10 @@ class Entries
         collect($this->params)->filter(function ($value, $key) {
             return $key === 'taxonomy' || Str::startsWith($key, 'taxonomy:');
         })->each(function ($values, $param) use ($query) {
+            if (empty($values)) {
+                return;
+            }
+
             $taxonomy = substr($param, 9);
             [$taxonomy, $modifier] = array_pad(explode(':', $taxonomy), 2, 'any');
 

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -302,15 +302,15 @@ class Entries
         collect($this->params)->filter(function ($value, $key) {
             return $key === 'taxonomy' || Str::startsWith($key, 'taxonomy:');
         })->each(function ($values, $param) use ($query) {
-            if (empty($values)) {
-                return;
-            }
-
             $taxonomy = substr($param, 9);
             [$taxonomy, $modifier] = array_pad(explode(':', $taxonomy), 2, 'any');
 
             if (is_string($values)) {
-                $values = explode('|', $values);
+                $values = array_filter(explode('|', $values));
+            }
+
+            if (count($values) === 0) {
+                return;
             }
 
             $values = collect($values)->map(function ($term) use ($taxonomy) {

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -466,6 +466,7 @@ class EntriesTest extends TestCase
         $this->makeEntry('3')->data(['tags' => ['meh']])->save();
 
         $this->assertEquals([1, 2, 3], $this->getEntries(['taxonomy:tags' => ''])->map->slug()->all());
+        $this->assertEquals([1, 2, 3], $this->getEntries(['taxonomy:tags' => '|'])->map->slug()->all());
     }
 }
 

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -457,6 +457,16 @@ class EntriesTest extends TestCase
 
         $this->getEntries(['taxonomy:tags:xyz' => 'test']);
     }
+
+    /** @test */
+    public function it_returns_all_entries_where_taxonomy_parameter_value_is_empty()
+    {
+        $this->makeEntry('1')->save();
+        $this->makeEntry('2')->data(['tags' => ['rad']])->save();
+        $this->makeEntry('3')->data(['tags' => ['meh']])->save();
+
+        $this->assertEquals([1, 2, 3], $this->getEntries(['taxonomy:tags' => ''])->map->slug()->all());
+    }
 }
 
 class PostType extends Scope


### PR DESCRIPTION
This PR fixes #2293.

In v2, when you had an empty `taxonomy` param on the `collection` tag, all results would be displayed, just without taxonomy filtering.

However, in v3, if the `taxonomy` parameter was empty, no results would be returned.