### PR TITLE
Fix issue when long field names go outside of the section element

### DIFF
--- a/resources/js/components/blueprints/ImportField.vue
+++ b/resources/js/components/blueprints/ImportField.vue
@@ -5,13 +5,13 @@
             <div class="blueprint-drag-handle w-4 border-r"></div>
             <div class="flex flex-1 items-center justify-between">
                 <div class="flex items-center flex-1 pr-2 py-1 pl-1">
-                    <svg-icon class="text-grey-70 mr-1" name="paperclip" v-tooltip="__('Linked fieldset')" />
-                    <a @click="$emit('edit')">
+                    <svg-icon class="flex-none text-grey-70 mr-1" name="paperclip" v-tooltip="__('Linked fieldset')" />
+                    <a class="break-all" @click="$emit('edit')">
                         <span v-text="__('Fieldset')" />
                         <span class="font-mono text-3xs text-grey-60">{{ field.fieldset }}</span>
                     </a>
                 </div>
-                <div class="pr-1 flex">
+                <div class="flex-none pr-1 flex">
                     <button @click.prevent="$emit('deleted')" class="text-grey-60 hover:text-grey-100"><svg-icon name="trash" /></button>
                     <stack name="field-settings" v-if="isEditing" @closed="editorClosed">
                         <field-settings

--- a/resources/js/components/blueprints/RegularField.vue
+++ b/resources/js/components/blueprints/RegularField.vue
@@ -5,11 +5,11 @@
             <div class="blueprint-drag-handle w-4 border-r"></div>
             <div class="flex flex-1 items-center justify-between">
                 <div class="flex items-center flex-1 pr-2 py-1 pl-1">
-                    <svg-icon class="text-grey-70 mr-1" :name="field.icon" v-tooltip="tooltipText" />
-                    <a v-text="labelText" @click="$emit('edit')" />
+                    <svg-icon class="text-grey-70 mr-1 flex-none" :name="field.icon" v-tooltip="tooltipText" />
+                    <a class="break-all" v-text="labelText" @click="$emit('edit')" />
                     <svg-icon name="hyperlink" v-if="isReferenceField" class="text-grey-60 text-3xs ml-1" v-tooltip="__('Imported from fieldset') + ': ' + field.field_reference" />
                 </div>
-                <div class="pr-1 flex">
+                <div class="flex-none pr-1 flex">
                     <width-selector v-model="width" class="mr-1" />
                     <button v-if="canDefineLocalizable"
                         class="hover:text-grey-100 mr-1"

--- a/resources/sass/components/blueprints.scss
+++ b/resources/sass/components/blueprints.scss
@@ -15,6 +15,7 @@
 }
 
 .blueprint-drag-handle {
+    @apply flex-none;
     cursor: move;
     background: rgba(black, 0.01) url('../img/drag-dots.svg') 50% 50% no-repeat;
 }


### PR DESCRIPTION
This PR fixes #2670 

Added “flex-none” to controls and Tailwind class “break-all” to wrap word when overflow