### PR TITLE
Fixes variable name in down command

### DIFF
--- a/src/Console/Commands/stubs/auth/statamic_auth_tables.php.stub
+++ b/src/Console/Commands/stubs/auth/statamic_auth_tables.php.stub
@@ -39,7 +39,7 @@ class StatamicAuthTables extends Migration
      */
      public function down()
      {
-         Schema::table('users', function (Blueprint $blueprint) {
+         Schema::table('users', function (Blueprint $table) {
              $table->dropColumn('super');
              $table->dropColumn('avatar');
              $table->dropColumn('preferences');


### PR DESCRIPTION
Running migrate:rollback failed due to the incorrect variable name.