### PR TITLE
Replace null coalescing operator with elvis operator

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -206,7 +206,7 @@ class Field implements Arrayable
 
     public function preProcess()
     {
-        $value = $this->value ?? $this->defaultValue();
+        $value = $this->value ?: $this->defaultValue();
 
         $value = $this->fieldtype()->preProcess($value);
 


### PR DESCRIPTION
Replace null coalescing operator with elvis operator so that empty strings return the default value. Fix for #2677