### PR TITLE
Taxonomy term association syncing

### DIFF
--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -102,10 +102,8 @@ class TaxonomyTermsStore extends ChildStore
             return [Str::slug($value) => $value];
         });
 
+        $indexes = $this->resolveIndexes()->except('associations');
         $associations = $this->index('associations');
-        $ids = $this->index('id');
-        $titles = $this->index('title');
-        $uris = $this->index('uri');
 
         foreach ($terms as $slug => $value) {
             $associations->push([
@@ -114,20 +112,13 @@ class TaxonomyTermsStore extends ChildStore
                 'entry' => $entry->id(),
                 'site' => $entry->locale(),
             ]);
-
-            $key = $entry->locale().'::'.$slug;
-
-            $titles->put($key, $value);
-
-            $term = $this->makeTerm($taxonomy, $slug);
-
-            $uris->put($key, $term->uri());
-            $ids->put($key, $term->id());
         }
-
         $associations->cache();
-        $titles->cache();
-        $uris->cache();
+
+        foreach ($terms as $slug => $value) {
+            $term = $this->makeTerm($taxonomy, $slug);
+            $indexes->each->updateItem($term);
+        }
     }
 
     protected function makeTerm($taxonomy, $slug)

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -103,6 +103,7 @@ class TaxonomyTermsStore extends ChildStore
         });
 
         $associations = $this->index('associations');
+        $ids = $this->index('id');
         $titles = $this->index('title');
         $uris = $this->index('uri');
 
@@ -118,7 +119,10 @@ class TaxonomyTermsStore extends ChildStore
 
             $titles->put($key, $value);
 
-            $uris->put($key, $this->makeTerm($taxonomy, $slug)->uri());
+            $term = $this->makeTerm($taxonomy, $slug);
+
+            $uris->put($key, $term->uri());
+            $ids->put($key, $term->id());
         }
 
         $associations->cache();


### PR DESCRIPTION
When you're editing an entry in the CP and add a new term to it, it wouldn't show the title until you clear the cache.

This is because when we sync the associations, we were only pushing the new title. The ID was never being inserted into the index. So when you queried for terms by ID later (e.g. through a `terms` fieldtype) it couldn't find the ID in the index.

Now, instead of explicitly updating only the uri and title indexes, it just updates _any_ that are required.

Fixes #1982 