### PR TITLE
Fix term paths when saving

### DIFF
--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -212,7 +212,7 @@ class TaxonomyTermsStore extends ChildStore
 
             $this->forgetItem($key);
 
-            $this->setPath($key, $item->path());
+            $this->setPath($key, $item->locale().'::'.$item->path());
 
             $this->resolveIndexes()->each->updateItem($item);
 

--- a/tests/Stache/Stores/EntriesStoreTest.php
+++ b/tests/Stache/Stores/EntriesStoreTest.php
@@ -126,6 +126,8 @@ class EntriesStoreTest extends TestCase
         $this->assertFileEqualsString($path = $this->directory.'/blog/2017-07-04.test.md', $entry->fileContents());
         @unlink($path);
         $this->assertFileNotExists($path);
+
+        $this->assertEquals($path, $this->parent->store('blog')->paths()->get('123'));
     }
 
     /** @test */

--- a/tests/Stache/Stores/TermsStoreTest.php
+++ b/tests/Stache/Stores/TermsStoreTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Stache\Stores;
+
+use Statamic\Facades;
+use Statamic\Facades\Stache;
+use Statamic\Stache\Stores\TermsStore;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class TermsStoreTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->parent = (new TermsStore)->directory(
+            $this->directory = __DIR__.'/../__fixtures__/content/taxonomies'
+        );
+
+        Stache::registerStore($this->parent);
+
+        Stache::store('taxonomies')->directory($this->directory);
+    }
+
+    /** @test */
+    public function it_saves_to_disk()
+    {
+        $term = Facades\Term::make('test')->taxonomy('tags');
+        $term->in('en')->set('title', 'Test');
+
+        $this->parent->store('tags')->save($term);
+
+        $this->assertFileEqualsString($path = $this->directory.'/tags/test.yaml', $term->fileContents());
+        @unlink($path);
+        $this->assertFileNotExists($path);
+
+        $this->assertEquals('en::'.$path, $this->parent->store('tags')->paths()->get('en::test'));
+    }
+}


### PR DESCRIPTION
The paths in the taxonomy terms store are different from every other store in the Stache. They paths are prefixed with the locale. This is because terms are the only items that have all their localizations in one file.

```
[
  'en::tag-one' => 'en::/path/to/tag-one.yaml',
  'fr::tag-one' => 'fr::/path/to/tag-one.yaml',
]
```

We do this so if we were to flip the array (to get an ID by path) it wouldn't get merged.

When saving a term, it was just storing the path. It wasn't prefixing it with the locale which is why there was an error sometimes. It was trying to explode the path at the `::` but it wasn't there.

Fixes #2020 