### PR TITLE
Taxonomy cache fixes

### DIFF
--- a/src/Stache/Indexes/Terms/Associations.php
+++ b/src/Stache/Indexes/Terms/Associations.php
@@ -30,6 +30,13 @@ class Associations extends Index
             })->all();
     }
 
+    public function forgetEntry($id)
+    {
+        $this->items = $this->items()->reject(function ($association) use ($id) {
+            return $association['entry'] === $id;
+        })->all();
+    }
+
     public function updateItem($item)
     {
         //

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -105,6 +105,8 @@ class TaxonomyTermsStore extends ChildStore
         $indexes = $this->resolveIndexes()->except('associations');
         $associations = $this->index('associations');
 
+        $associations->forgetEntry($entry->id());
+
         foreach ($terms as $slug => $value) {
             $associations->push([
                 'value' => $value,

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -207,7 +207,7 @@ class TaxonomyTermsStore extends ChildStore
 
             $this->forgetItem($key);
 
-            $this->setPath($key, $item->path());
+            $this->setPath($key, $item->locale().'::'.$item->path());
 
             $this->resolveIndexes()->each->updateItem($item);
 

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -102,10 +102,8 @@ class TaxonomyTermsStore extends ChildStore
             return [Str::slug($value) => $value];
         });
 
+        $indexes = $this->resolveIndexes()->except('associations');
         $associations = $this->index('associations');
-        $ids = $this->index('id');
-        $titles = $this->index('title');
-        $uris = $this->index('uri');
 
         foreach ($terms as $slug => $value) {
             $associations->push([
@@ -114,20 +112,13 @@ class TaxonomyTermsStore extends ChildStore
                 'entry' => $entry->id(),
                 'site' => $entry->locale(),
             ]);
-
-            $key = $entry->locale().'::'.$slug;
-
-            $titles->put($key, $value);
-
-            $term = $this->makeTerm($taxonomy, $slug);
-
-            $uris->put($key, $term->uri());
-            $ids->put($key, $term->id());
         }
-
         $associations->cache();
-        $titles->cache();
-        $uris->cache();
+
+        foreach ($terms as $slug => $value) {
+            $term = $this->makeTerm($taxonomy, $slug);
+            $indexes->each->updateItem($term);
+        }
     }
 
     protected function makeTerm($taxonomy, $slug)

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -103,6 +103,7 @@ class TaxonomyTermsStore extends ChildStore
         });
 
         $associations = $this->index('associations');
+        $ids = $this->index('id');
         $titles = $this->index('title');
         $uris = $this->index('uri');
 
@@ -118,7 +119,10 @@ class TaxonomyTermsStore extends ChildStore
 
             $titles->put($key, $value);
 
-            $uris->put($key, $this->makeTerm($taxonomy, $slug)->uri());
+            $term = $this->makeTerm($taxonomy, $slug);
+
+            $uris->put($key, $term->uri());
+            $ids->put($key, $term->id());
         }
 
         $associations->cache();

--- a/tests/Stache/Stores/EntriesStoreTest.php
+++ b/tests/Stache/Stores/EntriesStoreTest.php
@@ -126,6 +126,8 @@ class EntriesStoreTest extends TestCase
         $this->assertFileEqualsString($path = $this->directory.'/blog/2017-07-04.test.md', $entry->fileContents());
         @unlink($path);
         $this->assertFileNotExists($path);
+
+        $this->assertEquals($path, $this->parent->store('blog')->paths()->get('123'));
     }
 
     /** @test */

--- a/tests/Stache/Stores/TermsStoreTest.php
+++ b/tests/Stache/Stores/TermsStoreTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Stache\Stores;
+
+use Statamic\Facades;
+use Statamic\Facades\Stache;
+use Statamic\Stache\Stores\TermsStore;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class TermsStoreTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->parent = (new TermsStore)->directory(
+            $this->directory = __DIR__.'/../__fixtures__/content/taxonomies'
+        );
+
+        Stache::registerStore($this->parent);
+
+        Stache::store('taxonomies')->directory($this->directory);
+    }
+
+    /** @test */
+    public function it_saves_to_disk()
+    {
+        $term = Facades\Term::make('test')->taxonomy('tags');
+        $term->in('en')->set('title', 'Test');
+
+        $this->parent->store('tags')->save($term);
+
+        $this->assertFileEqualsString($path = $this->directory.'/tags/test.yaml', $term->fileContents());
+        @unlink($path);
+        $this->assertFileNotExists($path);
+
+        $this->assertEquals('en::'.$path, $this->parent->store('tags')->paths()->get('en::test'));
+    }
+}


### PR DESCRIPTION
This fixes a handful of taxonomy + stache + cache related issues:

- Terms not deleting when you try to delete them #1349
- Terms showing the slug instead of the title #1982 
- An undefined offset 1 error when creating terms #2020 
- Entry keeping term association when you remove it. #1870 
- Terms showing their id instead of the title when you create new ones on the entry edit page.

This is a combination of PRs #2684 and #2685 

Fixes #1982 
Fixes #1349
Fixes #2020
Fixes #1870 