### PR TITLE
Bring back smartypants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "league/commonmark": "^1.5",
         "league/csv": "^9.0",
         "league/glide": "^1.1",
+        "michelf/php-smartypants": "^1.8",
         "pixelfear/composer-dist-plugin": "^0.1.0",
         "spatie/blink": "^1.1.2",
         "statamic/stringy": "^3.1",

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1855,6 +1855,18 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Parse with SmartyPants. Aren't you fancy?
+     *
+     * @param $value
+     * @param $params
+     * @return string
+     */
+    public function smartypants($value, $params)
+    {
+        return Html::smartypants($value);
+    }
+
+    /**
      * Sort an array by key $params[0] and direction $params[1].
      *
      * @param $value

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -3,6 +3,7 @@
 namespace Statamic\Support;
 
 use Illuminate\Support\HtmlString;
+use Michelf\SmartyPants;
 use Statamic\Facades\Config;
 use Statamic\Facades\Markdown;
 
@@ -313,6 +314,11 @@ class Html
     public static function markdown($string)
     {
         return Markdown::parse($string);
+    }
+
+    public static function smartypants($string)
+    {
+        return SmartyPants::defaultTransform($string, SmartyPants::ATTR_DEFAULT);
     }
 
     /**


### PR DESCRIPTION
Due to popular demand (at least 3 whole people 🤷). This PR brings back the `smartypants` modifier and a `Statamic\Support\Html::smartypants()` method if you want to use it from PHP.

Previously there was the ability to choose the 'behavior' but you had to pass in arbitrary constants which were ints and it was just a bit weird. I didn't include those. If someone needs them, we can think about a better way. Doing `{{ words | smartypants:2 }}` doesn't make sense.

Closes #2683 
Closes #2139 
Closes statamic/docs#203