### PR TITLE
User password double hashing

### DIFF
--- a/src/Http/Controllers/ResetPasswordController.php
+++ b/src/Http/Controllers/ResetPasswordController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Auth\ResetsPasswords;
@@ -10,9 +11,7 @@ use Statamic\Http\Middleware\RedirectIfAuthenticated;
 
 class ResetPasswordController extends Controller
 {
-    use ResetsPasswords {
-        resetPassword as protected traitResetPassword;
-    }
+    use ResetsPasswords;
 
     public function __construct()
     {
@@ -44,14 +43,9 @@ class ResetPasswordController extends Controller
         return request('redirect') ?? route('statamic.site');
     }
 
-    protected function resetPassword($user, $password)
+    protected function setUserPassword($user, $password)
     {
-        // We override because the parent (trait) method hashes the password first,
-        // but the Statamic User class's password method also hashes, which would
-        // result in a double-hashed password. Also, it uses the mutator style.
         $user->password($password);
-
-        $this->traitResetPassword($user, $password);
     }
 
     public function broker()


### PR DESCRIPTION
When using the reset password utility through the Statamic CP, the following call is made within the `\Statamic\Http\Controllers\CP\Users\PasswordController` => `$user->password($password)->save()`.
This means that my implemented `\App\Models\User->password($password)` must have the following code
```
public function password($password) {
    $this->setPasswordAttribute($password);

    return $this;
}

public function setPasswordAttribute($password) {
     $this->attributes['password'] = Hash::make($password);
}
```

However, in the `\Statamic\Http\Controllers\ResetPasswordController` the following call is done
```
public function resetPassword($user, $password) {
    $user->password($password);

    $this->traitResetPassword($user, $password);
    // Which is effectively the following code below...
    /*
    $this->setUserPassword($user, $password); // Which is $user->password = Hash::make($password);

    $user->setRememberToken(Str::random(60));

    $user->save();

    event(new PasswordReset($user));

    $this->guard()->login($user);
    */
}
```
As we can see through following the method call chain the password is effectively hashed twice making the reset password email utility functionally broken.

Also, we have two different uses of the same method `$user->password($password)` with one function assuming it does not hash the password and another that does assume it hashes the password. I'm assuming the later is correct which is why this PR has been created. Otherwise, if the former is correct, I'll create a PR that puts `Hash::make($password)` within the `PasswordController's` function.