### PR TITLE
Fix long Select fields from overflowing

### DIFF
--- a/resources/sass/vendors/vue-select.scss
+++ b/resources/sass/vendors/vue-select.scss
@@ -1,5 +1,5 @@
 .v-select {
-	@apply rounded;
+	@apply rounded min-w-0;
 	position: relative;
 	font-family: inherit
 }
@@ -54,6 +54,10 @@
 	.vs--disabled & {
 		@apply bg-grey-20;
 	}
+}
+
+.vs__selected-options {
+    @apply min-w-0;
 }
 
 .v-select:not(.vs--unsearchable) .vs__selected-options {


### PR DESCRIPTION
By default, the flex wrappers around the select field will inherit their width from their content, allowing them to overflow the container when the value is really long.

![overflow](https://user-images.githubusercontent.com/2236267/96681427-15ca4b80-132c-11eb-9a64-d7281cfb9e7f.png)

Setting a min-width of 0 allows them to shrink to the containing element.

![contained](https://user-images.githubusercontent.com/2236267/96681441-1e228680-132c-11eb-907f-8cb1585d46de.png)