### PR TITLE
Convert value to number, on Text fieldtype with input_type of Number

### DIFF
--- a/src/Fieldtypes/Text.php
+++ b/src/Fieldtypes/Text.php
@@ -55,6 +55,15 @@ class Text extends Fieldtype
         ];
     }
 
+    public function process($data)
+    {
+        if ($this->config('input_type') === 'number') {
+            return (int) $data;
+        }
+
+        return $data;
+    }
+
     public function preProcessIndex($value)
     {
         if ($value) {


### PR DESCRIPTION
References #2703.

Previously, if you had a text field, with an `input_type` of number, the value would be saved as a string, with the single quotes around the value in the YAML.

However, with this pull request, that value will now be converted to an integer if the type is a number.

I couldn't find an existing Text Fieldtype test so I didn't write a test for it but I could create one if you want.