### PR TITLE
Fix data being passed into recursive vars

### DIFF
--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -58,7 +58,7 @@ class Structure extends Tags
             $data = $page->toAugmentedArray();
             $children = empty($item['children']) ? [] : $this->toArray($item['children'], $data, $depth + 1);
 
-            return array_merge($this->context->all(), $data, [
+            return array_merge($data, [
                 'children'    => $children,
                 'parent'      => $parent,
                 'depth'       => $depth,

--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -932,7 +932,7 @@ class Parser
                     $has_children = false;
                 }
 
-                $replacement = $this->parse($orig_text, $child);
+                $replacement = $this->parse($orig_text, array_merge($data, $child));
 
                 // If this is the first loop we'll use $tag as reference, if not
                 // we'll use the previous tag ($next_tag)

--- a/tests/Fixtures/Addon/Tags/RecursiveChildren.php
+++ b/tests/Fixtures/Addon/Tags/RecursiveChildren.php
@@ -18,6 +18,7 @@ class RecursiveChildren extends \Statamic\Tags\Tags
                         'children' => [
                             [
                                 'title' => 'Four',
+                                'foo' => 'Baz',
                             ],
                         ],
                     ],

--- a/tests/Tags/StructureTagTest.php
+++ b/tests/Tags/StructureTagTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Tags;
 
+use Facades\Tests\Factories\EntryFactory;
 use Statamic\Facades\Antlers;
+use Statamic\Facades\Entry;
 use Statamic\Facades\Nav;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -14,16 +16,7 @@ class StructureTagTest extends TestCase
     /** @test */
     public function it_renders()
     {
-        $this->makeNav([
-            ['title' => 'One', 'children' => [
-                ['title' => 'One One'],
-            ]],
-            ['title' => 'Two'],
-            ['title' => 'Three', 'children' => [
-                ['title' => 'Three One'],
-                ['title' => 'Three Two'],
-            ]],
-        ]);
+        $this->createNav();
 
         // The html uses <i> tags (could be any tag, but i is short) to prevent whitespace comparison issues in the assertion.
         $template = <<<'EOT'
@@ -52,7 +45,7 @@ EOT;
         </ul>
     </li>
     <li>
-        <i>Two bar</i>
+        <i>Two notbar</i>
     </li>
     <li>
         <i>Three bar</i>
@@ -61,7 +54,7 @@ EOT;
                 <i>Three One bar</i>
             </li>
             <li>
-                <i>Three Two bar</i>
+                <i>Three Two notbar</i>
             </li>
         </ul>
     </li>
@@ -74,6 +67,61 @@ EOT;
         ]));
     }
 
+    /** @test */
+    public function it_renders_with_scope()
+    {
+        $this->createNav();
+
+        // The html uses <i> tags (could be any tag, but i is short) to prevent whitespace comparison issues in the assertion.
+        $template = <<<'EOT'
+<ul>
+{{ nav:test scope="n" }}
+    <li>
+        <i>{{ n:nav_title or title }} {{ foo }}</i>
+        {{ if children }}
+        <ul>
+            {{ *recursive n:children* }}
+        </ul>
+        {{ /if }}
+    </li>
+{{ /nav:test }}
+</ul>
+EOT;
+
+        $expected = <<<'EOT'
+<ul>
+    <li>
+        <i>Navtitle One bar</i>
+        <ul>
+            <li>
+                <i>Navtitle One One bar</i>
+            </li>
+        </ul>
+    </li>
+    <li>
+        <i>Two notbar</i>
+    </li>
+    <li>
+        <i>Three bar</i>
+        <ul>
+            <li>
+                <i>Navtitle Three One bar</i>
+            </li>
+            <li>
+                <i>Three Two notbar</i>
+            </li>
+        </ul>
+    </li>
+</ul>
+EOT;
+
+        $this->assertXmlStringEqualsXmlString($expected, (string) Antlers::parse($template, [
+            'foo' => 'bar', // to test that cascade is inherited.
+            'title' => 'outer title', // to test that cascade the page's data takes precedence over the cascading data.
+            'nav_title' => 'outer nav_title', // to test that the cascade doesn't leak into the iterated scope
+        ]));
+    }
+
     private function makeNav($tree)
     {
         $nav = Nav::make('test');
@@ -81,5 +129,33 @@ EOT;
         $nav->addTree($nav->makeTree('en')->tree($tree));
 
         $nav->save();
+    }
+
+    private function createNav()
+    {
+        $one = EntryFactory::collection('pages')->data(['title' => 'One', 'nav_title' => 'Navtitle One'])->create();
+        $oneOne = EntryFactory::collection('pages')->data(['title' => 'One One', 'nav_title' => 'Navtitle One One'])->create();
+        $two = EntryFactory::collection('pages')->data(['title' => 'Two', 'foo' => 'notbar'])->create();
+        $three = EntryFactory::collection('pages')->data(['title' => 'Three'])->create();
+        $threeOne = EntryFactory::collection('pages')->data(['title' => 'Three One', 'nav_title' => 'Navtitle Three One'])->create();
+        $threeTwo = EntryFactory::collection('pages')->data(['title' => 'Three Two', 'foo' => 'notbar'])->create();
+
+        Entry::shouldReceive('find')->with('1')->andReturn($one);
+        Entry::shouldReceive('find')->with('1-1')->andReturn($oneOne);
+        Entry::shouldReceive('find')->with('2')->andReturn($two);
+        Entry::shouldReceive('find')->with('3')->andReturn($three);
+        Entry::shouldReceive('find')->with('3-1')->andReturn($threeOne);
+        Entry::shouldReceive('find')->with('3-2')->andReturn($threeTwo);
+
+        $this->makeNav([
+            ['entry' => '1', 'children' => [
+                ['entry' => '1-1'],
+            ]],
+            ['entry' => '2'],
+            ['entry' => '3', 'children' => [
+                ['entry' => '3-1'],
+                ['entry' => '3-2'],
+            ]],
+        ]);
     }
 }

--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -575,11 +575,11 @@ EOT;
         // the variables are inside RecursiveChildren@index
         $this->app['statamic.tags']['recursive_children'] = \Tests\Fixtures\Addon\Tags\RecursiveChildren::class;
 
-        $template = '<ul>{{ recursive_children }}<li>{{ title }}{{ if children }}<ul>{{ *recursive children* }}</ul>{{ /if }}</li>{{ /recursive_children }}</ul>';
+        $template = '<ul>{{ recursive_children }}<li>{{ title }}.{{ foo }}{{ if children }}<ul>{{ *recursive children* }}</ul>{{ /if }}</li>{{ /recursive_children }}</ul>';
 
-        $expected = '<ul><li>One<ul><li>Two</li><li>Three<ul><li>Four</li></ul></li></ul></li></ul>';
+        $expected = '<ul><li>One.Bar<ul><li>Two.Bar</li><li>Three.Bar<ul><li>Four.Baz</li></ul></li></ul></li></ul>';
 
-        $this->assertEquals($expected, $this->parse($template, []));
+        $this->assertEquals($expected, $this->parse($template, ['foo' => 'Bar']));
     }
 
     public function testRecursiveChildrenWithScope()
@@ -587,11 +587,11 @@ EOT;
         // the variables are inside RecursiveChildren@index
         $this->app['statamic.tags']['recursive_children'] = \Tests\Fixtures\Addon\Tags\RecursiveChildren::class;
 
-        $template = '<ul>{{ recursive_children scope="item" }}<li>{{ item:title }}{{ if item:children }}<ul>{{ *recursive item:children* }}</ul>{{ /if }}</li>{{ /recursive_children }}</ul>';
+        $template = '<ul>{{ recursive_children scope="item" }}<li>{{ item:title }}.{{ item:foo }}.{{ foo }}{{ if item:children }}<ul>{{ *recursive item:children* }}</ul>{{ /if }}</li>{{ /recursive_children }}</ul>';
 
-        $expected = '<ul><li>One<ul><li>Two</li><li>Three<ul><li>Four</li></ul></li></ul></li></ul>';
+        $expected = '<ul><li>One..Bar<ul><li>Two..Bar</li><li>Three..Bar<ul><li>Four.Baz.Baz</li></ul></li></ul></li></ul>';
 
-        $this->assertEquals($expected, $this->parse($template, []));
+        $this->assertEquals($expected, $this->parse($template, ['foo' => 'Bar']));
     }
 
     public function testEmptyValuesAreNotOverriddenByPreviousIteration()


### PR DESCRIPTION
This fixes an issue that #2610 introduced.
While that PR looked like it was working fine, it was actually causing data to be overridden where it wasn't supposed to.

This PR reverts that PR, and fixes the underlying issue instead.

One of the most common examples of this is a nav where you have alternative titles (here, a `nav_title` var).

```
{{ nav }}
  {{ nav_title or title }}
{{ /nav }}
```

This will work fine until you're actually _on_ a page that has a nav_title. Then the nav_title of the actual page will trickle down into every item of the nav loop.

A workaround for this is to use the `scope` parameter to say "I want a variable from this iteration without the parent context leaking into it".

```
{{ nav scope="iteration" }}
  {{ iteration:nav_title or title }}
{{ /nav }}
```

PR 2610 broke this behavior by merging the context into every iteration. The scoped variable would no longer only have its own values.

The issue that 2610 was trying to solve was the make the top level variables (like current page vars, globals, etc) available inside the recursive children. Instead, the parser will now merge the data appropriately. The structure tag doesn't need to do it.