### PR TITLE
Add a global tag() helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -2,9 +2,9 @@
 
 use Barryvdh\Debugbar\LaravelDebugbar;
 use Statamic\Facades\Path;
-use Statamic\Tags\Loader as TagLoader;
 use Statamic\Statamic;
 use Statamic\Support\Str;
+use Statamic\Tags\Loader as TagLoader;
 use Statamic\View\Antlers\Parser;
 
 function cp_route($route, $params = [])

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -24,7 +24,6 @@ if (! function_exists('debugbar')) {
     }
 }
 
-
 function tag(string $name, array $params = [])
 {
     if ($pos = strpos($name, ':')) {


### PR DESCRIPTION
This uses the code in https://github.com/statamic/cms/blob/master/src/View/Antlers/Engine.php#L133-L152 to return the output of a tag, it might be worth to extract this piece and make it available on the Engine.

This allows Blade to do the following:

```
@foreach (tag('collection:news', ['limit' => 1]) as $entry)
    {{ $entry->get('title') }}
@endforeach
```

I don't know that much of the Engine/Antlers internals, so if there's a better way to do this I'm all for it!

It's also missing augmentation, not sure how to handle that