### PR TITLE
Add .overflow-hidden to cards

### DIFF
--- a/resources/sass/components/cards.scss
+++ b/resources/sass/components/cards.scss
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .card {
-    @apply .shadow .bg-white .rounded-md .p-1;
+    @apply .shadow .bg-white .rounded-md .p-1 .overflow-hidden;
 }
 
 @screen md {


### PR DESCRIPTION
In Firefox, hovering a table row causes the link/row background to overflow the card and show square corners:

<img width="500" alt="Screen Shot 2020-10-24 at 4 17 59 PM (2)" src="https://user-images.githubusercontent.com/18192441/97092886-8ff11d80-1615-11eb-9713-ab6f886fbaac.png">

After adding `.overflow-hidden`:

<img width="500" alt="Screen Shot 2020-10-24 at 4 19 35 PM" src="https://user-images.githubusercontent.com/18192441/97092902-a7c8a180-1615-11eb-9a1c-a7f9e77de415.png">

It actually does overflow in Chrome too, but only by a pixel or two and the corner stays round. Not noticeable unless you're really looking for it, but I was. 😅 

<img width="500" alt="Kapture 2020-10-24 at 16 30 02" src="https://user-images.githubusercontent.com/18192441/97092981-5a006900-1616-11eb-9001-c1b7e0fbe12c.gif">