### PR TITLE
Show radio label on indexes

### DIFF
--- a/src/Fieldtypes/Radio.php
+++ b/src/Fieldtypes/Radio.php
@@ -64,4 +64,9 @@ class Radio extends Fieldtype
 
         return $value;
     }
+
+    public function preProcessIndex($value)
+    {
+        return collect($this->config('options'))->get($value);
+    }
 }


### PR DESCRIPTION
This PR fixes #2730.

Previously, when you added a Radio field to the columns in an Entry listing, the key of the option selected would be displayed. 

Now, with this pull request, the label of the Radio field will be displayed instead.