### PR TITLE
add ziggy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "statamic/stringy": "^3.1",
         "symfony/var-exporter": "^4.3",
         "symfony/yaml": "^4.1 || ^5.1",
+        "tightenco/ziggy": "^0.9.4",
         "ueberdosis/html-to-prosemirror": "^1.0",
         "ueberdosis/prosemirror-to-html": "^2.0",
         "wilderborn/partyline": "^1.0"

--- a/resources/views/partials/scripts.blade.php
+++ b/resources/views/partials/scripts.blade.php
@@ -1,3 +1,4 @@
+@routes
 <script src="{{ Statamic::cpAssetUrl('js/manifest.js') }}?v={{ Statamic::version() }}"></script>
 <script src="{{ Statamic::cpAssetUrl('js/vendor.js') }}?v={{ Statamic::version() }}"></script>
 <script src="{{ Statamic::cpAssetUrl('js/app.js') }}?v={{ Statamic::version() }}"></script>
@@ -18,4 +19,3 @@
     ])));
     Statamic.start();
 </script>
-


### PR DESCRIPTION
Right now we have to hard code our routes in any addon Vue components we make.

Ziggy allows us to use our Laravel named routes so we don't have to update routes in multiple places when we change them.