### PR TITLE
Action download - Check if method response is string, rather than Response

### DIFF
--- a/src/Http/Controllers/CP/ActionController.php
+++ b/src/Http/Controllers/CP/ActionController.php
@@ -3,7 +3,6 @@
 namespace Statamic\Http\Controllers\CP;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Statamic\Facades\Action;
 use Statamic\Facades\User;
 
@@ -38,7 +37,7 @@ abstract class ActionController extends CpController
         if ($redirect = $action->redirect($items, $values)) {
             return ['redirect' => $redirect];
         } elseif ($download = $action->download($items, $values)) {
-            return $download instanceof Response ? $download : response()->download($download);
+            return is_string($download) ? response()->download($download) : $download;
         }
 
         return [];


### PR DESCRIPTION
I recently tried to return a download from an action. But I ran into an issue. I couldn't use the Laravel examples in the `download` method.

```php
return response()->streamDownload(function () {
    echo GitHub::api('repo')
                ->contents()
                ->readme('laravel', 'laravel')['contents'];
}, 'laravel-readme.md');
```
The code above doesn't return a `Response` object, but rather a `ResponseInterface` or something.

I had to use the exact `Response` object to make a download.

```php
return new Response('content of file', 200, [
    'Content-Disposition' => 'attachment; filename="filename"',
]);
```

It makes more sense to check if `$download` is a string, because that is what `response()->download()` expects.