### PR TITLE
Make `is_url` modifier work with linked entries

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1032,7 +1032,7 @@ class CoreModifiers extends Modifier
      */
     public function isUrl($value)
     {
-        return filter_var($value, FILTER_VALIDATE_URL) !== false;
+        return Str::isUrl($value);
     }
 
     /**


### PR DESCRIPTION
This PR fixes #2739. The `is_url` modifier now returns true on strings that start with `http://`, `https://`, and `/`.