### PR TITLE
Allow any method for statamic route

### DIFF
--- a/src/Mixins/Router.php
+++ b/src/Mixins/Router.php
@@ -9,7 +9,7 @@ class Router
     public function statamic()
     {
         return function ($uri, $view, $data = []) {
-            return $this->get($uri, [FrontendController::class, 'route'])
+            return $this->any($uri, [FrontendController::class, 'route'])
                 ->defaults('view', $view)
                 ->defaults('data', $data);
         };


### PR DESCRIPTION
Currently, only get method is allowed for statamic routes, which makes it impossible to have pages that should handle POST requests. 