### PR TITLE
Addons can get their directory without needing it in the manifest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests",
-            "Foo\\Bar\\": "tests/fixtures/Addon"
+            "Foo\\Bar\\": "tests/Fixtures/Addon"
         }
     }
 }

--- a/src/Extend/Addon.php
+++ b/src/Extend/Addon.php
@@ -3,6 +3,7 @@
 namespace Statamic\Extend;
 
 use Facades\Statamic\Licensing\LicenseManager;
+use ReflectionClass;
 use Statamic\Facades\File;
 use Statamic\Facades\Path;
 use Statamic\Facades\URL;
@@ -62,6 +63,13 @@ final class Addon
      * @var string
      */
     protected $autoload;
+
+    /**
+     * The service provider class.
+     *
+     * @var string
+     */
+    protected $provider;
 
     /**
      * The name of the addon. eg. "Bloodhound Search".
@@ -162,8 +170,8 @@ final class Addon
         $instance = self::make($package['id']);
 
         $keys = [
-            'id', 'slug', 'editions', 'marketplaceId', 'marketplaceSlug', 'marketplaceSellerSlug', 'name', 'namespace', 'directory',
-            'autoload', 'description', 'package', 'version', 'latestVersion', 'url', 'developer', 'developerUrl', 'isCommercial',
+            'id', 'slug', 'editions', 'marketplaceId', 'marketplaceSlug', 'marketplaceSellerSlug', 'name', 'namespace',
+            'autoload', 'provider', 'description', 'package', 'version', 'latestVersion', 'url', 'developer', 'developerUrl', 'isCommercial',
         ];
 
         foreach (Arr::only($package, $keys) as $key => $value) {
@@ -297,7 +305,7 @@ final class Addon
     public function hasFile($path)
     {
         if (! $this->directory()) {
-            throw new \Exception('Cannot check files without a directory specified.');
+            throw new \Exception('Cannot check files without a provider specified.');
         }
 
         return File::exists(Path::assemble($this->directory(), $path));
@@ -312,7 +320,7 @@ final class Addon
     public function getFile($path)
     {
         if (! $this->directory()) {
-            throw new \Exception('Cannot get files without a directory specified.');
+            throw new \Exception('Cannot get files without a provider specified.');
         }
 
         return File::get(Path::assemble($this->directory(), $path));
@@ -327,7 +335,7 @@ final class Addon
     public function putFile($path, $contents)
     {
         if (! $this->directory()) {
-            throw new \Exception('Cannot write files without a directory specified.');
+            throw new \Exception('Cannot write files without a provider specified.');
         }
 
         File::put(
@@ -391,6 +399,28 @@ final class Addon
         $this->$method = $args[0];
 
         return $this;
+    }
+
+    /**
+     * The directory the package is located within. eg. "/path/to/vendor/statamic/bloodhound".
+     *
+     * @return string
+     */
+    public function directory()
+    {
+        if (! $this->provider) {
+            return null;
+        }
+
+        if ($this->directory) {
+            return $this->directory;
+        }
+
+        $reflector = new ReflectionClass($this->provider);
+
+        $dir = Str::removeRight(dirname($reflector->getFileName()), rtrim($this->autoload, '/'));
+
+        return $this->directory = Str::removeRight($dir, '/');
     }
 
     public function existsOnMarketplace()

--- a/src/Extend/Manifest.php
+++ b/src/Extend/Manifest.php
@@ -60,8 +60,8 @@ class Manifest extends PackageManifest
             'latestVersion' => data_get($marketplaceData, 'latest_version', null),
             'version' => Str::removeLeft($package['version'], 'v'),
             'namespace' => $namespace,
-            'directory' => $directory,
             'autoload' => $autoload,
+            'provider' => $provider,
 
             // Local data for marketplace GUI?
             'name' => $statamic['name'] ?? Arr::last($providerParts),

--- a/tests/Fixtures/Addon/TestAddonServiceProvider.php
+++ b/tests/Fixtures/Addon/TestAddonServiceProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Foo\Bar;
+
+use Statamic\Providers\AddonServiceProvider;
+
+class TestAddonServiceProvider extends AddonServiceProvider
+{
+    //
+}


### PR DESCRIPTION
Currently, when you run `php please addons:discover`, (which happens when you composer install) it'll generate a cache file in `bootstrap/cache/addons.php` that has information about all the addons.

One of the things that get stored in there are the paths of each addon. It's a full path so it might be something like `/Users/jason/addons/addon-name`.

This isn't an issue if you're using Git and Composer to deploy, because the contents of`bootstrap/cache` will be ignored and regenerated whenever you composer install on the server.

However, some users don't use Composer on their server, and just plop files up there through FTP. Now the server will see paths from the user's local dev environment instead of the server's paths, and things will break.

This PR makes it so that directories aren't stored in the manifest, making the file more portable.

See https://github.com/statamic/seo-pro/issues/135