### PR TITLE
Enable translating field attributes when validating fields.

### DIFF
--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fields;
 
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Validator as LaravelValidator;
 
 class Validator
@@ -70,8 +71,17 @@ class Validator
             $this->fields->preProcessValidatables()->values()->all(),
             $this->rules(),
             [],
-            $this->fields->all()->map->display()->all()
+            $this->fieldAttributes()
         );
+    }
+
+    private function fieldAttributes()
+    {
+        return $this->fields->all()->map(function ($field) {
+            $handle = 'validation.attributes.'.$field->handle();
+
+            return Lang::has($handle) ? Lang::get($handle) : $field->display();
+        })->all();
     }
 
     public static function explodeRules($rules)


### PR DESCRIPTION
This fixes the issue of not being able to translate attribute names when validating forms.

It enables utilizing Laravels custom validation rules for form validations without changing previous behaviour.

You can now specify custom attribute names and messages by adding configuration for the fields' `handle` in `/resources/lang/{locale}/validation.php`:

```php
<?php

return [
    // ...

    /*
    |--------------------------------------------------------------------------
    | Custom Validation Language Lines
    |--------------------------------------------------------------------------
    |
    | Here you may specify custom validation messages for attributes using the
    | convention "attribute.rule" to name the lines. This makes it quick to
    | specify a specific custom language line for a given attribute rule.
    |
    */

    'custom' => [
        'accept_privacy_policy' => [
            'required' => 'Please accept the privacy policy.',
        ],
    ],

    /*
    |--------------------------------------------------------------------------
    | Custom Validation Attributes
    |--------------------------------------------------------------------------
    |
    | The following language lines are used to swap our attribute placeholder
    | with something more reader friendly such as "E-Mail Address" instead
    | of "email". This simply helps us make our message more expressive.
    |
    */

    'attributes' => [
        'accept_privacy_policy' => 'privacy policy',
    ],
];
```

If a custom validation attribute or message doesn't exist, it falls back to the current behaviour of displaying the configured field display name.

I only found this issue from Statamic 2: https://github.com/statamic/v2-hub/issues/1135