### PR TITLE
Collapse Replicator Sets By Default

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -150,6 +150,12 @@ export default {
             this.collapsed = _.pluck(this.values, '_id');
         },
 
+        collapseAllByDefault() {
+            if (this.config.collapsed) {
+                this.collapseAll();
+            }
+        },
+
         expandAll() {
             this.collapsed = [];
         },
@@ -162,6 +168,10 @@ export default {
             }, 1);
         },
 
+    },
+
+    mounted() {
+        this.collapseAllByDefault();
     },
 
     watch: {


### PR DESCRIPTION
This PR takes a crack at a very much [requested feature](https://github.com/statamic/ideas/issues/233) to allow replicator sets to be collapsed by default.

You can collapse all sets by setting `collapsed: true` on a replicator field in the blueprint.

The code checks `this.config.collapsed` and triggers the `collapseAll` method on `mounted` if its value is true.