### PR TITLE
Add version() method to Addon class

### DIFF
--- a/src/Extend/Addon.php
+++ b/src/Extend/Addon.php
@@ -372,7 +372,7 @@ final class Addon
 
         return version_compare($this->version, $this->latestVersion, '=');
     }
-    
+
     public function version()
     {
         return $this->version();

--- a/src/Extend/Addon.php
+++ b/src/Extend/Addon.php
@@ -375,7 +375,7 @@ final class Addon
 
     public function version()
     {
-        return $this->version();
+        return $this->version;
     }
 
     public function license()

--- a/src/Extend/Addon.php
+++ b/src/Extend/Addon.php
@@ -372,6 +372,11 @@ final class Addon
 
         return version_compare($this->version, $this->latestVersion, '=');
     }
+    
+    public function version()
+    {
+        return $this->version();
+    }
 
     public function license()
     {


### PR DESCRIPTION
This pull request adds the `version()` method to the Addon class. The property can be seen if you `dd` an addon but before now there was no way to actually access it directly (as the property itself is `protected`).