### PR TITLE
Support navigation and globals in the static caching invalidation

### DIFF
--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -3,6 +3,8 @@
 namespace Statamic\StaticCaching;
 
 use Statamic\Contracts\Entries\Entry;
+use Statamic\Contracts\Globals\GlobalSet;
+use Statamic\Contracts\Structures\Nav;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Support\Arr;
 
@@ -23,33 +25,50 @@ class DefaultInvalidator implements Invalidator
             return $this->cacher->flush();
         }
 
-        // Invalidate the item's own URL.
-        if ($url = $item->url()) {
-            $this->cacher->invalidateUrl($url);
-        }
-
         if ($item instanceof Entry) {
             $this->invalidateEntryUrls($item);
         } elseif ($item instanceof Term) {
             $this->invalidateTermUrls($item);
+        } elseif ($item instanceof Nav) {
+            $this->invalidateNavUrls($item);
+        } elseif ($item instanceof GlobalSet) {
+            $this->invalidateGlobalUrls($item);
         }
     }
 
     protected function invalidateEntryUrls($entry)
     {
-        $collection = $entry->collectionHandle();
+        if ($url = $entry->url()) {
+            $this->cacher->invalidateUrl($url);
+        }
 
         $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "collections.$collection.urls")
+            Arr::get($this->rules, "collections.{$entry->collectionHandle()}.urls")
         );
     }
 
     protected function invalidateTermUrls($term)
     {
-        $taxonomy = $term->taxonomyHandle();
+        if ($url = $term->url()) {
+            $this->cacher->invalidateUrl($url);
+        }
 
         $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "taxonomies.$taxonomy.urls")
+            Arr::get($this->rules, "taxonomies.{$term->taxonomyHandle()}.urls")
+        );
+    }
+
+    protected function invalidateNavUrls($nav)
+    {
+        $this->cacher->invalidateUrls(
+            Arr::get($this->rules, "navigation.{$nav->handle()}.urls")
+        );
+    }
+
+    protected function invalidateGlobalUrls($set)
+    {
+        $this->cacher->invalidateUrls(
+            Arr::get($this->rules, "globals.{$set->handle()}.urls")
         );
     }
 }

--- a/src/StaticCaching/Invalidate.php
+++ b/src/StaticCaching/Invalidate.php
@@ -5,6 +5,10 @@ namespace Statamic\StaticCaching;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Statamic\Events\EntryDeleted;
 use Statamic\Events\EntrySaved;
+use Statamic\Events\GlobalSetDeleted;
+use Statamic\Events\GlobalSetSaved;
+use Statamic\Events\NavDeleted;
+use Statamic\Events\NavSaved;
 use Statamic\Events\TermDeleted;
 use Statamic\Events\TermSaved;
 
@@ -17,6 +21,10 @@ class Invalidate implements ShouldQueue
         EntryDeleted::class => 'invalidateEntry',
         TermSaved::class => 'invalidateTerm',
         TermDeleted::class => 'invalidateTerm',
+        GlobalSetSaved::class => 'invalidateGlobalSet',
+        GlobalSetDeleted::class => 'invalidateGlobalSet',
+        NavSaved::class => 'invalidateNav',
+        NavDeleted::class => 'invalidateNav',
     ];
 
     public function __construct(Invalidator $invalidator)
@@ -39,5 +47,15 @@ class Invalidate implements ShouldQueue
     public function invalidateTerm($event)
     {
         $this->invalidator->invalidate($event->term);
+    }
+
+    public function invalidateGlobalSet($event)
+    {
+        $this->invalidator->invalidate($event->globals);
+    }
+
+    public function invalidateNav($event)
+    {
+        $this->invalidator->invalidate($event->nav);
     }
 }


### PR DESCRIPTION
Duncan's PR #2639 was wiping out all the URLs when you edit a nav or global. Rather, you can define the URLs like you can with collections and taxonomies.

```php
'invalidation' => [

    'rules' => [
        'globals' => [
            'settings' => [
                'urls' => [
                    '/*'
                ]
            ]
        ],
        'navigation' => [
            'links' => [
                'urls' => [
                    '/*'
                ]
            ]
        ]
    ],

],
```

In there, you're free to just tell it to wipe them all, if that's what you want.

Also clean up tests by using regular mocks, not spies, and do a little tidying.

Closes #2639
Closes #2393