### PR TITLE
Pass name to custom driver

### DIFF
--- a/src/Support/Manager.php
+++ b/src/Support/Manager.php
@@ -41,7 +41,7 @@ abstract class Manager
         }
 
         if (isset($this->customCreators[$config['driver']])) {
-            return $this->callCustomCreator($config);
+            return $this->callCustomCreator($config, $name);
         } else {
             $driverMethod = 'create'.camel_case($config['driver']).'Driver';
 
@@ -60,9 +60,9 @@ abstract class Manager
         return $this;
     }
 
-    protected function callCustomCreator(array $config)
+    protected function callCustomCreator(array $config, string $name)
     {
-        return $this->customCreators[$config['driver']]($this->app, $config);
+        return $this->customCreators[$config['driver']]($this->app, $config, $name);
     }
 
     protected function invalidImplementationMessage($name)


### PR DESCRIPTION
When creating a custom driver the name from the config is not passed.

In my case I'm extending with a custom search driver, but the index name `public` is currently not available in the custom creator callback. So the custom driver don't know how to name the index.

This PR passes the config name as a third parameter to the custom creator callback.

Example config:

    'indexes' => [
        'public' => [
             'driver' => '<my-custom-driver>',
             'searchables' => 'collection:<my-collection-name>',
             'fields' => ['title', 'description'],
        ],
    ],

