### PR TITLE
Filter components in "TemplateFieldtype"

### DIFF
--- a/resources/js/components/fieldtypes/TemplateFieldtype.vue
+++ b/resources/js/components/fieldtypes/TemplateFieldtype.vue
@@ -33,10 +33,12 @@ export default {
 
             var templates = response.data;
 
-            // Filter out partials
+            // Filter out partials and components
             if (this.config.hide_partials) {
                 templates = _.reject(templates, function(template) {
-                    return template.startsWith('partials/') || template.match(/(^_.*|\/_.*|\._.*)/g);
+                    return template.startsWith('partials/')
+                        || template.startsWith('components/')
+                        || template.match(/(^_.*|\/_.*|\._.*)/g);
                 });
             }
 


### PR DESCRIPTION
Since Statamic is a Laravel package, `components` should also be filtered out within the template field.

I suggest that the existing `hide_partials` config can also handle `components`.  

:bowtie: 