### PR TITLE
Replicator / Bard Performance

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -157,6 +157,7 @@ export default {
             fullScreenMode: false,
             buttons: [],
             collapsed: this.meta.collapsed,
+            previews: this.meta.previews,
             mounted: false,
         }
     },
@@ -276,6 +277,15 @@ export default {
             const meta = this.meta;
             meta.collapsed = value;
             this.updateMeta(meta);
+        },
+
+        previews: {
+            deep: true,
+            handler(value) {
+                const meta = clone(this.meta);
+                meta.previews = value;
+                this.updateMeta(meta);
+            }
         }
 
     },
@@ -487,6 +497,10 @@ export default {
             });
 
             return exts;
+        },
+
+        updateSetPreviews(set, previews) {
+            this.previews[set] = previews;
         }
     }
 }

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -48,7 +48,7 @@
                 @meta-updated="metaUpdated(field.handle, $event)"
                 @focus="focused"
                 @blur="blurred"
-                @replicator-preview-updated="previews[field.handle] = $event"
+                @replicator-preview-updated="previewUpdated(field.handle, $event)"
             />
         </div>
     </div>
@@ -92,6 +92,10 @@ export default {
             return this.options.bard.meta.existing[this.node.attrs.id];
         },
 
+        previews() {
+            return this.options.bard.meta.previews[this.node.attrs.id];
+        },
+
         collapsed() {
             return this.options.bard.meta.collapsed.includes(this.node.attrs.id);
         },
@@ -123,10 +127,6 @@ export default {
 
     },
 
-    created() {
-        this.initPreviews();
-    },
-
     methods: {
 
         updated(handle, value) {
@@ -140,6 +140,12 @@ export default {
             let meta = clone(this.meta);
             meta[handle] = value;
             this.options.bard.updateSetMeta(this.node.attrs.id, meta);
+        },
+
+        previewUpdated(handle, value) {
+            let previews = clone(this.previews);
+            previews[handle] = value;
+            this.options.bard.updateSetPreviews(this.node.attrs.id, previews);
         },
 
         destroy() {

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -33,7 +33,7 @@
                 </dropdown-list>
             </div>
         </div>
-        <div class="replicator-set-body" v-show="!collapsed" v-if="index !== undefined">
+        <div class="replicator-set-body" v-if="!collapsed && index !== undefined">
             <set-field
                 v-for="field in fields"
                 v-show="showField(field)"

--- a/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
+++ b/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
@@ -1,11 +1,5 @@
 export default {
 
-    data() {
-        return {
-            previews: {},
-        }
-    },
-
     computed: {
         previewText() {
             const previews = _(this.previews).filter((value, handle) => {
@@ -28,14 +22,6 @@ export default {
                     return JSON.stringify(value);
                 })
                 .join(' / ');
-        }
-    },
-
-    methods: {
-        initPreviews() {
-            let previews = {};
-            this.fields.forEach(field => previews[field.handle] = null);
-            this.previews = previews;
         }
     }
 

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -29,6 +29,7 @@
                     :is-read-only="isReadOnly"
                     :collapsed="collapsed.includes(set._id)"
                     :error-key-prefix="errorKeyPrefix || handle"
+                    :previews="previews[set._id]"
                     @collapsed="collapseSet(set._id)"
                     @expanded="expandSet(set._id)"
                     @updated="updated"
@@ -36,6 +37,7 @@
                     @removed="removed(set, index)"
                     @focus="focused = true"
                     @blur="blurred"
+                    @previews-updated="previews[set._id] = $event"
                 >
                     <template v-slot:picker v-if="!isReadOnly && index !== values.length-1">
                         <set-picker
@@ -80,6 +82,7 @@ export default {
             values: this.value,
             focused: false,
             collapsed: this.meta.collapsed,
+            previews: this.meta.previews,
         }
     },
 
@@ -203,6 +206,12 @@ export default {
         collapsed(value) {
             const meta = this.meta;
             meta.collapsed = value;
+            this.updateMeta(meta);
+        },
+
+        previews(previews) {
+            let meta = this.meta;
+            meta.previews = previews;
             this.updateMeta(meta);
         }
 

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -48,7 +48,7 @@
                 @meta-updated="metaUpdated(field.handle, $event)"
                 @focus="$emit('focus')"
                 @blur="$emit('blur')"
-                @replicator-preview-updated="previews[field.handle] = $event"
+                @replicator-preview-updated="previewUpdated(field.handle, $event)"
             />
         </div>
 
@@ -115,6 +115,7 @@ export default {
             type: String
         },
         isReadOnly: Boolean,
+        previews: Object,
     },
 
     computed: {
@@ -141,10 +142,6 @@ export default {
 
     },
 
-    created() {
-        this.initPreviews();
-    },
-
     methods: {
 
         updated(handle, value) {
@@ -157,6 +154,12 @@ export default {
             let meta = clone(this.meta);
             meta[handle] = value;
             this.$emit('meta-updated', meta);
+        },
+
+        previewUpdated(handle, value) {
+            let previews = clone(this.previews);
+            previews[handle] = value;
+            this.$emit('previews-updated', previews);
         },
 
         destroy() {

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -32,7 +32,7 @@
             </div>
         </div>
 
-        <div class="replicator-set-body" v-show="!collapsed">
+        <div class="replicator-set-body" v-if="!collapsed">
             <set-field
                 v-for="field in fields"
                 v-show="showField(field)"

--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -175,12 +175,16 @@ export default {
         });
     },
 
+    beforeDestroy() {
+        this.setLoadingProgress(false);
+    },
+
     watch: {
 
         loading: {
             immediate: true,
             handler(loading) {
-                this.$progress.loading(`relationship-fieldtype-${this._uid}`, loading);
+                this.setLoadingProgress(loading);
             }
         },
 
@@ -262,6 +266,10 @@ export default {
         selectFieldSelected(selectedItemData) {
             this.$emit('item-data-updated', selectedItemData.map(item => ({ id: item.id, title: item.title })));
             this.update(selectedItemData.map(item => item.id));
+        },
+
+        setLoadingProgress(state) {
+            this.$progress.loading(`relationship-fieldtype-${this._uid}`, state);
         }
 
     }

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -324,11 +324,18 @@ class Bard extends Replicator
             return (new Fields($set['fields']))->addValues($defaults[$handle])->meta();
         })->toArray();
 
+        $previews = collect($existing)->map(function ($fields) {
+            return collect($fields)->map(function () {
+                return null;
+            })->all();
+        })->all();
+
         return [
             'existing' => $existing,
             'new' => $new,
             'defaults' => $defaults,
             'collapsed' => [],
+            'previews' => $previews,
             '__collaboration' => ['existing'],
         ];
     }

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -133,7 +133,7 @@ class Replicator extends Fieldtype
     public function preload()
     {
         return [
-            'existing' => collect($this->field->value())->mapWithKeys(function ($set) {
+            'existing' => $existing = collect($this->field->value())->mapWithKeys(function ($set) {
                 $config = $this->config("sets.{$set['type']}.fields", []);
 
                 return [$set['_id'] => (new Fields($config))->addValues($set)->meta()];
@@ -145,6 +145,11 @@ class Replicator extends Fieldtype
                 return (new Fields($set['fields']))->all()->map->defaultValue();
             })->all(),
             'collapsed' => [],
+            'previews' => collect($existing)->map(function ($fields) {
+                return collect($fields)->map(function () {
+                    return null;
+                })->all();
+            })->all(),
         ];
     }
 }


### PR DESCRIPTION
Replicator fields with lots of set blocks (like, really _a lot of them_) can cause slow downs because of how many components need to be created and rendered on the page. This would typically happen for people using Replicators as page builders. When you try to add a new set, it might take a few seconds before anything happens.

At the moment when you collapse a set, it just hides it with CSS (using Vue's `v-show` directive). This PR will properly hide it using `v-if`, which takes it off the page. Vue no longer needs to do any rendering, event handling, etc. Now, you can improve performance drastically by using the collapse by default #2771 or accordion 979daebec8337d9e6caf753e4e13e39ed96edcd6 options.

A side effect of this is that the collapsed previews get wiped out. So this PR also moves those into the Replicator/Bard meta data. They'll persist when you change to/from live preview.

Something I noticed too was that that when collapsing all sets by default, if you have a relationship field, it doesn't have a chance to undo the 'loading' state before the component is destroyed, so you end up with a infinite loading bar at the top of the screen. This PR fixes that too.