### PR TITLE
Check origin if a value is empty for a searchable

### DIFF
--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -161,6 +161,10 @@ class Searchables
         return collect($fields)->mapWithKeys(function ($field) use ($searchable) {
             $value = method_exists($searchable, $field) ? $searchable->{$field}() : $searchable->get($field);
 
+            if (is_null($value) && $searchable->hasOrigin()) {
+                $value = $searchable->originValue($field);
+            }
+
             return [$field => $value];
         })->flatMap(function ($value, $field) use ($transformers) {
             if (! isset($transformers[$field]) || ! $transformers[$field] instanceof Closure) {

--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -159,11 +159,7 @@ class Searchables
         $transformers = $this->index->config()['transformers'] ?? [];
 
         return collect($fields)->mapWithKeys(function ($field) use ($searchable) {
-            $value = method_exists($searchable, $field) ? $searchable->{$field}() : $searchable->get($field);
-
-            if (is_null($value) && $searchable->hasOrigin()) {
-                $value = $searchable->originValue($field);
-            }
+            $value = method_exists($searchable, $field) ? $searchable->{$field}() : $searchable->value($field);
 
             return [$field => $value];
         })->flatMap(function ($value, $field) use ($transformers) {


### PR DESCRIPTION
Translated items often have `NULL` as a value, but in the search index you want the origin's value included, this adds that value