### PR TITLE
Add dedicated entriesCount method for counting a term's entries

### DIFF
--- a/src/Stache/Indexes/Value.php
+++ b/src/Stache/Indexes/Value.php
@@ -22,7 +22,7 @@ class Value extends Index
         }
 
         if ($method === 'entriesCount') {
-            return $item->queryEntries()->count();
+            return $item->entriesCount();
         }
 
         return method_exists($item, $method)

--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -113,6 +113,15 @@ class TermRepository implements RepositoryContract
         return app(Term::class)->slug($slug);
     }
 
+    public function entriesCount(Term $term): int
+    {
+        return $this->store->store($term->taxonomyHandle())
+            ->index('associations')
+            ->items()
+            ->where('value', $term->slug())
+            ->count();
+    }
+
     protected function ensureAssociations()
     {
         Taxonomy::all()->each(function ($taxonomy) {

--- a/src/Taxonomies/AugmentedTerm.php
+++ b/src/Taxonomies/AugmentedTerm.php
@@ -49,11 +49,6 @@ class AugmentedTerm extends AbstractAugmented
         return $this->data->queryEntries()->where('site', $this->data->locale());
     }
 
-    protected function entriesCount()
-    {
-        return $this->entries()->count();
-    }
-
     protected function isTerm()
     {
         return true;

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -193,6 +193,11 @@ class LocalizedTerm implements Term, Responsable, Augmentable, Protectable
         return $this->term->entries();
     }
 
+    public function entriesCount()
+    {
+        return $this->term->entriesCount();
+    }
+
     protected function revisionKey()
     {
         return vsprintf('taxonomies/%s/%s/%s', [

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -147,12 +147,7 @@ class Term implements TermContract
     public function entriesCount()
     {
         return Blink::once('term-entries-count-'.$this->id(), function () {
-            return Stache::store('terms')
-                ->store($this->taxonomy)
-                ->index('associations')
-                ->items()
-                ->where('value', $this->slug())
-                ->count();
+            return Facades\Term::entriesCount($this);
         });
     }
 

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -144,6 +144,18 @@ class Term implements TermContract
         return $this->queryEntries()->get();
     }
 
+    public function entriesCount()
+    {
+        return Blink::once('term-entries-count-'.$this->id(), function () {
+            return Stache::store('terms')
+                ->store($this->taxonomy)
+                ->index('associations')
+                ->items()
+                ->where('value', $this->slug())
+                ->count();
+        });
+    }
+
     public function queryEntries()
     {
         $entries = $this->collection

--- a/tests/Data/Taxonomies/TermTest.php
+++ b/tests/Data/Taxonomies/TermTest.php
@@ -4,6 +4,7 @@ namespace Tests\Data\Taxonomies;
 
 use Facades\Statamic\Fields\BlueprintRepository;
 use Mockery;
+use Statamic\Facades;
 use Statamic\Facades\Taxonomy;
 use Statamic\Fields\Blueprint;
 use Statamic\Taxonomies\Term;
@@ -72,5 +73,18 @@ class TermTest extends TestCase
 
         $this->assertEquals('the new blueprint', $term->blueprint());
         $this->assertEquals('the new blueprint', $term->blueprint());
+    }
+
+    /** @test */
+    public function it_gets_the_entry_count_through_the_repository()
+    {
+        $term = (new Term)->taxonomy('tags')->slug('foo');
+
+        $mock = \Mockery::mock(Facades\Term::getFacadeRoot())->makePartial();
+        Facades\Term::swap($mock);
+        $mock->shouldReceive('entriesCount')->with($term)->andReturn(7)->once();
+
+        $this->assertEquals(7, $term->entriesCount());
+        $this->assertEquals(7, $term->entriesCount());
     }
 }


### PR DESCRIPTION
When building the stache and you have a lot of terms, getting the entry count is a pretty expensive operation and can slow it down. (If you're using `entries_count` in your templates, you'll want to have it [configured](https://statamic.dev/stache#configuring-additional-indexes) to be indexed up front.)

Having a dedicated method gives us the ability to make a more performant query. In this case, filter down the entry-term associations in the Stache rather than perform a query. Also, we can throw it in the blink cache.

On one particular term-heavy test site, the cache build time dropped about 30 seconds.