### PR TITLE
Stache Locks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "pixelfear/composer-dist-plugin": "^0.1.4",
         "spatie/blink": "^1.1.2",
         "statamic/stringy": "^3.1",
+        "symfony/lock": "^5.1",
         "symfony/var-exporter": "^4.3",
         "symfony/yaml": "^4.1 || ^5.1",
         "ueberdosis/html-to-prosemirror": "^1.0",

--- a/config/stache.php
+++ b/config/stache.php
@@ -85,6 +85,19 @@ return [
         //
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Locking
+    |--------------------------------------------------------------------------
+    |
+    | In order to prevent concurrent requests from updating the Stache at
+    | the same and wasting resources, it will be "locked" so subsequent
+    | requests will have to wait until the first has been completed.
+    |
+    | https://statamic.dev/stache#locks
+    |
+    */
+
     'lock' => [
         'enabled' => true,
         'timeout' => 30,

--- a/config/stache.php
+++ b/config/stache.php
@@ -85,4 +85,9 @@ return [
         //
     ],
 
+    'lock' => [
+        'enabled' => true,
+        'timeout' => 30,
+    ],
+
 ];

--- a/src/Http/Middleware/StacheLock.php
+++ b/src/Http/Middleware/StacheLock.php
@@ -13,7 +13,7 @@ class StacheLock
         $lock = Stache::lock('stache-warming');
 
         while (! $lock->acquire()) {
-            if (time() - $start >= config('statamic.stache.lock.timeout')) {
+            if (time() - $start >= config('statamic.stache.lock.timeout', 30)) {
                 return $this->outputRefreshResponse($request);
             }
 

--- a/src/Http/Middleware/StacheLock.php
+++ b/src/Http/Middleware/StacheLock.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Statamic\Http\Middleware;
+
+use Closure;
+use Statamic\Facades\Stache;
+
+class StacheLock
+{
+    public function handle($request, Closure $next)
+    {
+        $start = time();
+        $lock = Stache::lock('stache-warming');
+
+        while (! $lock->acquire()) {
+            if (time() - $start >= config('statamic.stache.lock.timeout')) {
+                return $this->outputRefreshResponse($request);
+            }
+
+            sleep(1);
+        }
+
+        $lock->release();
+
+        return $next($request);
+    }
+
+    private function outputRefreshResponse($request)
+    {
+        $html = $request->ajax() || $request->wantsJson()
+            ? __('Service Unavailable')
+            : sprintf('<meta http-equiv="refresh" content="1; URL=\'%s\'" />', $request->getUri());
+
+        return response($html, 503, ['Retry-After' => 1]);
+    }
+}

--- a/src/Http/Middleware/StacheLock.php
+++ b/src/Http/Middleware/StacheLock.php
@@ -9,6 +9,10 @@ class StacheLock
 {
     public function handle($request, Closure $next)
     {
+        if (! config('statamic.stache.lock.enabled', true)) {
+            return $next($request);
+        }
+
         $start = time();
         $lock = Stache::lock('stache-warming');
 

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -125,6 +125,7 @@ class AppServiceProvider extends ServiceProvider
     protected function registerMiddlewareGroup()
     {
         $this->app->make(Router::class)->middlewareGroup('statamic.web', [
+            \Statamic\Http\Middleware\StacheLock::class,
             \Statamic\Http\Middleware\Localize::class,
             \Statamic\StaticCaching\Middleware\Cache::class,
         ]);

--- a/src/Stache/NullLockStore.php
+++ b/src/Stache/NullLockStore.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Statamic\Stache;
+
+use Symfony\Component\Lock\BlockingStoreInterface;
+use Symfony\Component\Lock\Key;
+
+class NullLockStore implements BlockingStoreInterface
+{
+    public function save(Key $key)
+    {
+        //
+    }
+
+    public function delete(Key $key)
+    {
+        //
+    }
+
+    public function exists(Key $key)
+    {
+        //
+    }
+
+    public function putOffExpiration(Key $key, float $ttl)
+    {
+        //
+    }
+
+    public function waitAndSave(Key $key)
+    {
+        //
+    }
+}

--- a/src/Stache/ServiceProvider.php
+++ b/src/Stache/ServiceProvider.php
@@ -3,15 +3,18 @@
 namespace Statamic\Stache;
 
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
+use Statamic\Facades\File;
 use Statamic\Facades\Site;
 use Statamic\Stache\Query\EntryQueryBuilder;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\FlockStore;
 
 class ServiceProvider extends LaravelServiceProvider
 {
     public function register()
     {
         $this->app->singleton(Stache::class, function () {
-            return new Stache;
+            return (new Stache)->setLockFactory($this->locks());
         });
 
         $this->app->alias(Stache::class, 'stache');
@@ -34,5 +37,23 @@ class ServiceProvider extends LaravelServiceProvider
         $stache->registerStores(collect(config('statamic.stache.stores'))->map(function ($config) {
             return app($config['class'])->directory($config['directory']);
         })->all());
+    }
+
+    private function locks()
+    {
+        if (config('statamic.stache.lock.enabled', true)) {
+            $store = $this->createFileLockStore();
+        } else {
+            $store = new NullLockStore;
+        }
+
+        return new LockFactory($store);
+    }
+
+    private function createFileLockStore()
+    {
+        File::makeDirectory($dir = storage_path('statamic/stache-locks'));
+
+        return new FlockStore($dir);
     }
 }

--- a/src/Stache/Stache.php
+++ b/src/Stache/Stache.php
@@ -8,6 +8,8 @@ use Statamic\Extensions\FileStore;
 use Statamic\Facades\File;
 use Statamic\Stache\Stores\Store;
 use Statamic\Support\Str;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
 use Wilderborn\Partyline\Facade as Partyline;
 
 class Stache
@@ -16,6 +18,8 @@ class Stache
     protected $stores;
     protected $startTime;
     protected $updateIndexes = true;
+    protected $lockFactory;
+    protected $locks = [];
 
     public function __construct()
     {
@@ -95,11 +99,15 @@ class Stache
     {
         Partyline::comment('Warming Stache...');
 
+        $lock = tap($this->lock('stache-warming'))->acquire(true);
+
         $this->startTimer();
 
         $this->stores()->each->warm();
 
         $this->stopTimer();
+
+        $lock->release();
     }
 
     public function instance()
@@ -172,5 +180,21 @@ class Stache
     public function shouldUpdateIndexes()
     {
         return $this->updateIndexes;
+    }
+
+    public function setLockFactory(LockFactory $lockFactory)
+    {
+        $this->lockFactory = $lockFactory;
+
+        return $this;
+    }
+
+    public function lock($name): LockInterface
+    {
+        if (isset($this->locks[$name])) {
+            return $this->locks[$name];
+        }
+
+        return $this->locks[$name] = $this->lockFactory->createLock($name);
     }
 }


### PR DESCRIPTION
This PR adds support for locks within the Stache.

If a request is made on the site while the stache is being warmed, it will just wait until the warming is finished. This prevents the subsequent response from triggering _another_ cache build, which would increase CPU and memory usage.

If the second request (any subsequent request) waits for 30 seconds (configurable) it'll exit with a 503 status, and a meta refresh tag that'll just re-request the page.

At the moment it only locks when "warming". e.g. when you run `php please stache:warm`.
More locking features will be added later, like Redis support, and cache updates outside of the stache:warm command.

Closes #552 