### PR TITLE
Replace fzaninotto/faker with fakerphp/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "wilderborn/partyline": "^1.0"
     },
     "require-dev": {
-        "fzaninotto/faker": "~1.4",
+        "fakerphp/faker": "~1.10",
         "google/cloud-translate": "^1.6",
         "mockery/mockery": "^1.2.3",
         "orchestra/testbench": "^4.0 || ^5.0 || ^6.0"


### PR DESCRIPTION
Hey,

fzaninotto/faker development has been discontinued and the project archived as you can read [here](https://marmelab.com/blog/2020/10/21/sunsetting-faker.html).

However, the Laravel core team has started maintaining their own fork, which will also be used in the Laravel projects from now on, according to tweet from [Taylor Otwell](https://twitter.com/taylorotwell/status/1321091021342650377?s=20)

Kind regards,
g