### PR TITLE
Make embed_url modifier load embeds without cookies from Vimeo / YouTube

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2388,7 +2388,15 @@ class CoreModifiers extends Modifier
     public function embedUrl($url)
     {
         if (Str::contains($url, 'vimeo')) {
-            return str_replace('/vimeo.com', '/player.vimeo.com/video', $url);
+            $url = str_replace('/vimeo.com', '/player.vimeo.com/video', $url);
+
+            if (Str::contains($url, '?')) {
+                $url = str_replace('?', '?dnt=1&', $url);
+            } else {
+                $url .= '?dnt=1';
+            }
+
+            return $url;
         }
 
         if (Str::contains($url, 'youtu.be')) {

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2387,8 +2387,8 @@ class CoreModifiers extends Modifier
      */
     public function embedUrl($url)
     {
-        if (Str::contains($url, 'youtube')) {
-            return str_replace('watch?v=', 'embed/', $url);
+        if (Str::contains($url, 'vimeo')) {
+            return str_replace('/vimeo.com', '/player.vimeo.com/video', $url);
         }
 
         if (Str::contains($url, 'youtu.be')) {
@@ -2398,12 +2398,14 @@ class CoreModifiers extends Modifier
             if (Str::contains($url, '?t=')) {
                 $url = str_replace('?t=', '?start=', $url);
             }
-
-            return $url;
         }
 
-        if (Str::contains($url, 'vimeo')) {
-            return str_replace('/vimeo.com', '/player.vimeo.com/video', $url);
+        if (Str::contains($url, 'youtube.com/watch?v=')) {
+            $url = str_replace('watch?v=', 'embed/', $url);
+        }
+
+        if (Str::contains($url, 'youtube.com')) {
+            $url = str_replace('youtube.com', 'youtube-nocookie.com', $url);
         }
 
         return $url;

--- a/tests/Modifiers/EmbedUrlTest.php
+++ b/tests/Modifiers/EmbedUrlTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class EmbedUrlTest extends TestCase
+{
+    /** @test */
+    public function it_leaves_urls_from_unknown_providers_untouched()
+    {
+        $this->assertEquals('https://statamic.com/video/hello', $this->embed('https://statamic.com/video/hello'));
+    }
+
+    /** @test */
+    public function it_transforms_vimeo_urls()
+    {
+        $embedUrl = 'https://player.vimeo.com/video/71360261?dnt=1';
+
+        $this->assertEquals($embedUrl, $this->embed('https://vimeo.com/71360261'));
+
+        $this->assertEquals(
+            $embedUrl.'&foo=bar',
+            $this->embed('https://vimeo.com/71360261?foo=bar'),
+            'It appends the do not track query param if a query string already exists.'
+        );
+    }
+
+    /** @test */
+    public function it_transforms_youtube_urls()
+    {
+        $embedUrl = 'https://www.youtube-nocookie.com/embed/s72r_wu_NVY';
+
+        $this->assertEquals(
+            $embedUrl,
+            $this->embed('https://www.youtube.com/watch?v=s72r_wu_NVY')
+        );
+        $this->assertEquals(
+            $embedUrl,
+            $this->embed('https://youtu.be/s72r_wu_NVY'),
+            'It transforms shortened youtube video sharing links'
+        );
+
+        $this->assertEquals(
+            $embedUrl.'?start=559',
+            $this->embed('https://youtu.be/s72r_wu_NVY?t=559'),
+            'It transforms the start time parameter of shortened sharing links'
+        );
+    }
+
+    public function embed($url)
+    {
+        return Modify::value($url)->embedUrl()->fetch();
+    }
+}


### PR DESCRIPTION
Youtube has a no-cookie feature when embedding videos via the `youtube-nocookie.com`-url. This way users are not tracked and reference to these cookies can be removed from privacy policies & cookie consent popovers.

Same goes for vimeo videos with the `dnt` query parameter set.