### PR TITLE
Initialize id on submission to prevent duplicates

### DIFF
--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -44,6 +44,7 @@ class FormController extends Controller
         $fields = $fields->addValues($values);
 
         $submission = $form->makeSubmission()->data($values);
+        $submission->id(microtime(true));
 
         try {
             $this->withLocale($site->shortLocale(), function () use ($fields) {


### PR DESCRIPTION
Fixes #2822, prevents creation of duplicate submissions when the submission is edited and saved through the SubmissionCreated event.