### PR TITLE
Don't use "After Save" options when editing an entry in a stack through a relationship field

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -23,7 +23,7 @@
 
                 <save-button-options
                     v-if="!readOnly"
-                    :show-options="!revisionsEnabled"
+                    :show-options="!revisionsEnabled && !isInline"
                     :button-class="saveButtonClass"
                     :preferences-prefix="preferencesPrefix"
                 >
@@ -290,6 +290,7 @@ export default {
         method: String,
         amp: Boolean,
         isCreating: Boolean,
+        isInline: Boolean,
         initialReadOnly: Boolean,
         initialIsRoot: Boolean,
         initialPermalink: String,
@@ -492,12 +493,12 @@ export default {
                     }
 
                     // If the user has opted to create another entry, redirect them to create page.
-                    if (this.afterSaveOption === 'create_another') {
+                    if (!this.isInline && this.afterSaveOption === 'create_another') {
                         window.location = this.createAnotherUrl;
                     }
 
                     // If the user has opted to go to listing (default/null option), redirect them there.
-                    else if (this.afterSaveOption === null) {
+                    else if (!this.isInline && this.afterSaveOption === null) {
                         window.location = this.listingUrl;
                     }
 

--- a/resources/js/components/inputs/relationship/InlinePublishForm.vue
+++ b/resources/js/components/inputs/relationship/InlinePublishForm.vue
@@ -18,6 +18,7 @@
             v-bind="componentPropValues"
             :method="method"
             :is-creating="creating"
+            :is-inline="true"
             :publish-container="publishContainer"
             @saved="saved"
         >


### PR DESCRIPTION
This fixes #2469 ["After Save" options should not be used inside Stacks] specifically for when editing an entry through a relationship field. 

Maybe this is sufficient, or maybe a more generic solution is desired and this code can be inspiration for it.

This would also fix #2448.