### PR TITLE
Hydrate object with cached data before return

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -127,5 +127,6 @@ return [
     */
 
     'cache_meta' => true,
+    'file_listing_cache_length' => 60,
 
 ];

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -127,7 +127,7 @@ class Asset implements AssetContract, Augmentable
 
         if (!$this->meta && $cached = Cache::get($this->metaCacheKey())) {  
             $this->meta = $cached;
-            $this->hydrate();
+            $this->data = collect($cached['data']);
         }
 
         if ($this->meta) {

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -125,8 +125,9 @@ class Asset implements AssetContract, Augmentable
             return $this->generateMeta();
         }
 
-        if ($cached = Cache::get($this->metaCacheKey())) {
-            return $cached;
+        if (!$this->meta && $cached = Cache::get($this->metaCacheKey())) {  
+            $this->meta = $cached;
+            $this->hydrate();
         }
 
         if ($this->meta) {

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -126,7 +126,7 @@ class Asset implements AssetContract, Augmentable
         }
 
         if ($cached = Cache::get($this->metaCacheKey())) {
-            $this->meta = $cached;
+            return $cached;
         }
 
         if ($this->meta) {

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -125,7 +125,7 @@ class Asset implements AssetContract, Augmentable
             return $this->generateMeta();
         }
 
-        if (!$this->meta && $cached = Cache::get($this->metaCacheKey())) {
+        if (! $this->meta && $cached = Cache::get($this->metaCacheKey())) {
             $this->meta = $cached;
             $this->data = collect($cached['data']);
         }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -125,7 +125,7 @@ class Asset implements AssetContract, Augmentable
             return $this->generateMeta();
         }
 
-        if (!$this->meta && $cached = Cache::get($this->metaCacheKey())) {  
+        if (!$this->meta && $cached = Cache::get($this->metaCacheKey())) {
             $this->meta = $cached;
             $this->data = collect($cached['data']);
         }


### PR DESCRIPTION
When data is fetched from the cache the `data` key is overwritten with an empty collection in: 

        if ($this->meta) {
            return array_merge($this->meta, ['data' => $this->data->all()]);
        }

.. as `$this->data` isn't hydrated.

This PR :

- don't hit cache if object is hydrated and hydrate the `data` property
- adds the new configuration option to `config/assets.php`

