### PR TITLE
Require the container config field on the asset fieldtype

### DIFF
--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -35,6 +35,7 @@ class Assets extends Fieldtype
                 'max_items' => 1,
                 'mode' => 'select',
                 'width' => 50,
+                'validate' => 'required',
             ],
             'folder' => [
                 'display' => __('Folder'),


### PR DESCRIPTION
This pull request implements #2752 and #1166.

The issue was that when you add an asset fieldtype to one of your blueprints and you go and edit or create an entry with that blueprint, an exception is thrown asking for a container.

This pull request adds the `required` validation rule to the `container` configuration option on the Asset fieldtype.

I know the original plan was that you'd only need to specify the `container` if you had more than 1 container setup. Not sure if that's still the plan. If so, feel free to close this PR.