### PR TITLE
Ability to disable edit_url and api_url in Content API

### DIFF
--- a/config/api.php
+++ b/config/api.php
@@ -39,4 +39,16 @@ return [
 
     'pagination_size' => 50,
 
+    /*
+    |--------------------------------------------------------------------------
+    | URLs
+    |--------------------------------------------------------------------------
+    |
+    | Whether or not keys like edit_url or api_url are exposed via your
+    | API endpoints.
+    |
+    */
+
+    'disable_urls' => true,
+
 ];

--- a/src/Data/AugmentedCollection.php
+++ b/src/Data/AugmentedCollection.php
@@ -29,6 +29,13 @@ class AugmentedCollection extends Collection
         return $this->shallowNesting;
     }
 
+    public function withoutUrls()
+    {
+        $this->forget(['api_url', 'edit_url']);
+
+        return $this;
+    }
+
     public function toArray()
     {
         return $this->map(function ($value) {

--- a/src/Http/Resources/API/AssetResource.php
+++ b/src/Http/Resources/API/AssetResource.php
@@ -14,9 +14,14 @@ class AssetResource extends JsonResource
      */
     public function toArray($request)
     {
-        return $this->resource
+        $collection = $this->resource
             ->toAugmentedCollection()
-            ->withShallowNesting()
-            ->toArray();
+            ->withShallowNesting();
+
+        if (config('statamic.api.disable_urls', false)) {
+            $collection->withoutUrls();
+        }
+
+        return $collection->toArray();
     }
 }


### PR DESCRIPTION
This pull request implements #1756.

At the moment, the way I've implemented this is where I've added a `withoutUrls` method to the `AugmentedCollection` class that is called from the resource if the configuration value is `true`.

However, I'm not entirely convinced this is the best way to go about it. I'd love some feedback about the best way to do it before I go ahead and implement it for the rest of the API resources.