### PR TITLE
Prevent root page with children

### DIFF
--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -152,6 +152,11 @@ export default {
         },
 
         treeChanged(node, tree) {
+            if (!this.validate()) {
+                this.updateTreeData();
+                return;
+            }
+            
             this.treeUpdated(tree);
         },
 
@@ -161,6 +166,19 @@ export default {
             this.pages = tree.getPureData();
             this.$refs.soundDrop.play();
             this.$emit('changed');
+        },
+
+        validate() {
+            let isValid = true;
+            th.depthFirstSearch(this.treeData, (childNode) => {
+                const index = childNode.parent.children.indexOf(childNode);
+                const level = childNode._vm.level;
+                const isRoot = this.expectsRoot && level === 1 && index === 0;
+                if (isRoot && childNode.children.length > 0) {
+                    isValid = false;
+                } 
+            });
+            return isValid;
         },
 
         save() {

--- a/src/Http/Controllers/CP/Collections/CollectionStructureController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionStructureController.php
@@ -29,6 +29,8 @@ class CollectionStructureController extends CpController
 
         $tree = $this->toTree($request->pages);
 
+        $tree = $collection->structure()->validateTree($tree, $request->site);
+
         $collection
             ->structure()
             ->in($request->site)


### PR DESCRIPTION
This PR fixes #2647. 

On the front any drag actions that result in a root node with children are rejected. On the back end the structure tree is validated before saving.