### PR TITLE
Add a {{ sites }} tag to loop over sites

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -154,6 +154,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Tags\Set::class,
         Tags\Section::class,
         Tags\Session::class,
+        Tags\Sites::class,
         Tags\Structure::class,
         Tags\Svg::class,
         Tags\Taxonomy\Taxonomy::class,

--- a/src/Tags/Sites.php
+++ b/src/Tags/Sites.php
@@ -17,5 +17,4 @@ class Sites extends Tags
             ];
         })->values()->all();
     }
-
 }

--- a/src/Tags/Sites.php
+++ b/src/Tags/Sites.php
@@ -8,7 +8,7 @@ class Sites extends Tags
 {
     public function index()
     {
-        return collect(Site::all())->map(function($site) {
+        return collect(Site::all())->map(function ($site) {
             return [
                 'handle' => $site->handle(),
                 'name' => $site->name(),

--- a/src/Tags/Sites.php
+++ b/src/Tags/Sites.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Statamic\Tags;
+
+use Statamic\Facades\Site;
+
+class Sites extends Tags
+{
+    public function index()
+    {
+        return collect(Site::all())->map(function($site) {
+            return [
+                'handle' => $site->handle(),
+                'name' => $site->name(),
+                'locale' => $site->locale(),
+                'url' => $site->url(),
+            ];
+        })->values()->all();
+    }
+
+}

--- a/tests/Tags/SitesTagTest.php
+++ b/tests/Tags/SitesTagTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Tags;
+
+use Statamic\Facades\Parse;
+use Statamic\Facades\Site;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class SitesTagTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutEvents();
+
+        Site::setConfig(['sites' => [
+            'en' => ['url' => '/en', 'name' => 'English', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr', 'name' => 'French', 'locale' => 'fr_FR'],
+            'es' => ['url' => '/es', 'name' => 'Spanish', 'locale' => 'es_ES'],
+        ]]);
+    }
+
+    private function tag($tag)
+    {
+        return (string) Parse::template($tag);
+    }
+
+    /** @test */
+    public function it_renders_sites()
+    {
+        $this->assertEquals(
+            '<en English en_US /en><fr French fr_FR /fr><es Spanish es_ES /es>',
+            $this->tag('{{ sites }}<{{ handle }} {{ name }} {{ locale }} {{ url }}>{{ /sites }}')
+        );
+    }
+}


### PR DESCRIPTION
This PR fixes #2513.

It can be used like this, following the example in the issue:
```
{{ sites }}
    {{ handle }} {{ name }} {{ locale }} {{ url }} <br>
{{ /sites }}
```
```
<?php
return [
    'sites' => [
        'default' => [
            'name' => 'English',
            'locale' => 'en_US',
            'url' => '/',
        ],
        'french' => [
            'name' => 'French',
            'locale' => 'fr_FR',
            'url' => '/french/',
        ],
    ]
],
```
```
english English en_US /
french French fr_FR /french/
```
