### PR TITLE
Blueprint optimizations

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -211,6 +211,15 @@ class Collection implements Contract, AugmentableContract
 
     public function entryBlueprints()
     {
+        $blink = 'collection-entry-blueprints-'.$this->handle();
+
+        return Blink::once($blink, function () {
+            return $this->getEntryBlueprints();
+        });
+    }
+
+    private function getEntryBlueprints()
+    {
         $blueprints = Blueprint::in('collections/'.$this->handle());
 
         if ($blueprints->isEmpty()) {

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -228,8 +228,6 @@ class Collection implements Contract, AugmentableContract
             ? $this->entryBlueprints()->first()
             : $this->entryBlueprints()->keyBy->handle()->get($blueprint);
 
-        $blueprint = $blueprint ? $this->ensureEntryBlueprintFields($blueprint) : null;
-
         if ($blueprint) {
             EntryBlueprintFound::dispatch($blueprint->setParent($entry ?? $this), $entry);
         }

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -233,15 +233,37 @@ class Collection implements Contract, AugmentableContract
 
     public function entryBlueprint($blueprint = null, $entry = null)
     {
-        $blueprint = is_null($blueprint)
-            ? $this->entryBlueprints()->first()
-            : $this->entryBlueprints()->keyBy->handle()->get($blueprint);
-
-        if ($blueprint) {
-            EntryBlueprintFound::dispatch($blueprint->setParent($entry ?? $this), $entry);
+        if (! $blueprint = $this->getBaseEntryBlueprint($blueprint)) {
+            return null;
         }
 
+        $blueprint->setParent($entry ?? $this);
+
+        $this->dispatchEntryBlueprintFoundEvent($blueprint, $entry);
+
         return $blueprint;
+    }
+
+    private function getBaseEntryBlueprint($blueprint)
+    {
+        $blink = 'collection-entry-blueprint-'.$this->handle().'-'.$blueprint;
+
+        return Blink::once($blink, function () use ($blueprint) {
+            return is_null($blueprint)
+                ? $this->entryBlueprints()->first()
+                : $this->entryBlueprints()->keyBy->handle()->get($blueprint);
+        });
+    }
+
+    private function dispatchEntryBlueprintFoundEvent($blueprint, $entry)
+    {
+        $id = optional($entry)->id() ?? 'null';
+
+        $blink = 'collection-entry-blueprint-'.$this->handle().'-'.$blueprint->handle().'-'.$id;
+
+        Blink::once($blink, function () use ($blueprint, $entry) {
+            EntryBlueprintFound::dispatch($blueprint, $entry);
+        });
     }
 
     public function fallbackEntryBlueprint()

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -14,6 +14,7 @@ use Statamic\Events\BlueprintDeleted;
 use Statamic\Events\BlueprintSaved;
 use Statamic\Exceptions\DuplicateFieldException;
 use Statamic\Facades;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Path;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
@@ -102,6 +103,18 @@ class Blueprint implements Augmentable
     }
 
     public function contents(): array
+    {
+        return Blink::once($this->contentsBlinkKey(), function () {
+            return $this->getContents();
+        });
+    }
+
+    private function contentsBlinkKey()
+    {
+        return "blueprint-contents-{$this->namespace()}-{$this->handle()}";
+    }
+
+    private function getContents()
     {
         $contents = $this->contents;
 
@@ -418,6 +431,8 @@ class Blueprint implements Augmentable
     protected function resetFieldsCache()
     {
         $this->fieldsCache = null;
+
+        Blink::forget($this->contentsBlinkKey());
 
         return $this;
     }

--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -6,6 +6,7 @@ use Facades\Statamic\Fields\FieldRepository;
 use Facades\Statamic\Fields\FieldsetRepository;
 use Facades\Statamic\Fields\Validator;
 use Illuminate\Support\Collection;
+use Statamic\Facades\Blink;
 
 class Fields
 {
@@ -202,6 +203,12 @@ class Fields
 
     private function getImportedFields(array $config): array
     {
+        $blink = 'blueprint-imported-fields-'.md5(json_encode($config));
+
+        if (Blink::has($blink)) {
+            return Blink::get($blink);
+        }
+
         if (! $fieldset = FieldsetRepository::find($config['import'])) {
             throw new \Exception("Fieldset {$config['import']} not found.");
         }
@@ -223,7 +230,11 @@ class Fields
             });
         }
 
-        return $fields->all();
+        $result = $fields->all();
+
+        Blink::put($blink, $result);
+
+        return $result;
     }
 
     public function meta()


### PR DESCRIPTION
tl;dr: Added more stuff into the blink cache.

The main issue this is solving is that when we try to get augmented values for entries etc, it needs to look into the blueprint to see the fieldtype. This happens for every field. So this PR will reduce repeated lookups etc.

Building the contents of a blueprint is an expensive operation, especially where fields have been been appended (which is often, for entries). Now it'll only happen once per blueprint, and be reset appropriately.

Getting an entry's blueprint (e.g. `$entry->blueprint()`) would get all of the collection's blueprints and then grab the appropriate one. Now it'll only get them all one time. 
The second part of this is the EntryBlueprintFound event, which lets devs add fields to the blueprint (like SEO Pro) - it needs to know the entry too. Now the event will only be dispatched once per entry.

Finally, when importing a fieldset into a blueprint or other fieldset, the fields will be remembered here too.

Closes #2700 
Might help #2704 