### PR TITLE
Add missing code to use OAuth with users in a database

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -16,6 +16,8 @@ class User extends BaseUser
 {
     use ContainsSupplementalData, HasPreferences;
 
+    public $timestamps = false;
+
     protected $model;
     protected $roles;
     protected $groups;

--- a/src/Auth/Eloquent/UserRepository.php
+++ b/src/Auth/Eloquent/UserRepository.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Statamic\Auth\UserCollection;
 use Statamic\Auth\UserRepository as BaseRepository;
 use Statamic\Contracts\Auth\User as UserContract;
+use Statamic\OAuth\Provider;
 
 class UserRepository extends BaseRepository
 {
@@ -52,7 +53,9 @@ class UserRepository extends BaseRepository
 
     public function findByOAuthId(string $provider, string $id): ?UserContract
     {
-        // todo
+        return $this->find(
+            (new Provider($provider))->getUserId($id)
+        );
     }
 
     public function model($method, ...$args)


### PR DESCRIPTION
- The missing implementation of the findByOAuthId method in Statamic\Auth\Eloquent\UserRepository can be just like the one in Statamic\Stache\Repositories\UserRepository
- The User model needs a public property $timestamps which can be set to false. The property is expected by the Illuminate\Auth\EloquentUserProvider.

Fixes #2388