### PR TITLE
Pass current blueprint into 'Create Another' URL

### DIFF
--- a/resources/views/entries/create.blade.php
+++ b/resources/views/entries/create.blade.php
@@ -14,7 +14,7 @@
         :revisions="{{ Statamic\Support\Str::bool($revisionsEnabled ) }}"
         :breadcrumbs="{{ $breadcrumbs->toJson() }}"
         site="{{ $locale }}"
-        create-another-url="{{ cp_route('collections.entries.create', [$collection, $locale]) }}"
+        create-another-url="{{ cp_route('collections.entries.create', [$collection, $locale, 'blueprint' => $blueprint['handle']]) }}"
         listing-url="{{ cp_route('collections.show', $collection) }}"
     ></base-entry-create-form>
 


### PR DESCRIPTION
This pull request fixes #2885.

Whenever you'd have a collection with multiple blueprints and you picked one from the create list (that's not the first one) and you then used the `Create Another` mode when creating. The next entry would go back to using the default blueprint (the first one in that create list).

I saw that the `create` method of the `EntriesController` pulled a `blueprint` from the request so I just passed it the relevant prop.

Hopefully that makes sense, let me know if you have any questions.