### PR TITLE
Use directories from Stache config in Install Command

### DIFF
--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -50,11 +50,11 @@ class Install extends Command
     protected function createFiles()
     {
         $gitkeeps = [
-            base_path('content/assets'),
-            base_path('content/collections'),
-            base_path('content/globals'),
-            base_path('content/taxonomies'),
-            base_path('content/navigation'),
+            config('statamic.stache.stores.asset-containers.directory'),
+            config('statamic.stache.stores.collections.directory'),
+            config('statamic.stache.stores.globals.directory'),
+            config('statamic.stache.stores.taxonomies.directory'),
+            config('statamic.stache.stores.navigation.directory'),
             base_path('users'),
         ];
 

--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -55,7 +55,7 @@ class Install extends Command
             config('statamic.stache.stores.globals.directory'),
             config('statamic.stache.stores.taxonomies.directory'),
             config('statamic.stache.stores.navigation.directory'),
-            base_path('users'),
+            config('statamic.users.repositories.file.paths.users'),
         ];
 
         $gitignores = [


### PR DESCRIPTION
This pull request updates the array of directories created during the `php please install` command so that instead of the paths being hard coded, they will come from the configuration inside the `config/statamic/stache.php` file.

For the users directory, the path instead comes from the `config/statamic/users.php` file.

This PR closes #1400.