### PR TITLE
Allow for passing custom icons to CP Nav Items

### DIFF
--- a/resources/views/nav/updates.blade.php
+++ b/resources/views/nav/updates.blade.php
@@ -1,6 +1,6 @@
 <li class="{{ $item->isActive() ? 'current' : '' }}">
     <a href="{{ $item->url() }}">
-        <i>@svg($item->icon())</i><span>{{ __($item->name()) }}</span>
+        <i>{!! $item->icon() !!}</i><span>{{ __($item->name()) }}</span>
         <updates-badge class="ml-1"></updates-badge>
     </a>
 </li>

--- a/resources/views/partials/nav-main.blade.php
+++ b/resources/views/partials/nav-main.blade.php
@@ -10,7 +10,7 @@
                         @unless ($item->view())
                             <li class="{{ $item->isActive() ? 'current' : '' }}">
                                 <a href="{{ $item->url() }}">
-                                    <i>@svg($item->icon())</i><span>{{ __($item->name()) }}</span>
+                                    <i>{!! $item->icon() !!}</i><span>{{ __($item->name()) }}</span>
                                 </a>
                                 @if ($item->children() && $item->isActive())
                                     <ul>

--- a/resources/views/partials/nav-mobile.blade.php
+++ b/resources/views/partials/nav-mobile.blade.php
@@ -9,7 +9,7 @@
                     @unless ($item->view())
                         <li class="{{ $item->isActive() ? 'current' : '' }}">
                             <a href="{{ $item->url() }}">
-                                <i>@svg($item->icon())</i><span>{{ __($item->name()) }}</span>
+                                <i>{!! $item->icon() !!}</i><span>{{ __($item->name()) }}</span>
                             </a>
                             @if ($item->children() && $item->isActive())
                                 <ul>

--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -3,6 +3,8 @@
 namespace Statamic\CP\Navigation;
 
 use Statamic\Facades\CP\Nav;
+use Statamic\Facades\File;
+use Statamic\Statamic;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
@@ -92,7 +94,16 @@ class NavItem
      */
     public function icon($icon = null)
     {
-        return $this->fluentlyGetOrSet('icon')->value($icon);
+        return $this
+            ->fluentlyGetOrSet('icon')
+            ->setter(function ($value) {
+                if (File::exists(public_path("vendor/statamic/cp/svg/{$value}.svg"))) {
+                    return Statamic::svg($value);
+                }
+
+                return $value;
+            })
+            ->value($icon);
     }
 
     /**

--- a/tests/Facades/CP/NavTest.php
+++ b/tests/Facades/CP/NavTest.php
@@ -106,6 +106,23 @@ class NavTest extends TestCase
     }
 
     /** @test */
+    public function is_can_create_a_nav_item_with_a_custom_svg_icon()
+    {
+        $this->actingAs(tap(User::make()->makeSuper())->save());
+
+        Nav::utilities('Geocities Importer')
+            ->url('#')
+            ->icon('<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" /></svg>');
+
+        $item = Nav::build()->get('Utilities')->last();
+
+        $this->assertEquals('Utilities', $item->section());
+        $this->assertEquals('Geocities Importer', $item->name());
+        $this->assertEquals(config('app.url').'/cp/#', $item->url());
+        $this->assertEquals('<svg><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" /></svg>', $item->icon());
+    }
+
+    /** @test */
     public function it_can_get_and_modify_an_existing_item()
     {
         $this->actingAs(tap(User::make()->makeSuper())->save());


### PR DESCRIPTION
This pull request allows for developers to pass custom SVG icons to their Control Panel Nav Items. This PR closes #1452.

Here's a quick overview of the things I've changed:

* When creating a `NavItem` and using the `->icon()` method, a developer can either provide the name of an icon in Statamic's `resources/svg` directory or they can provide a string of an SVG. 

* Instead of using the `@svg` blade directive to display icons, I've changed it for a inlining it with Blade. This works for both Statamic icons and custom SVGs as they are all strings when they are returned from the `->setter` method.