### PR TITLE
Fix issue when special characters are in asset path

### DIFF
--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -29,7 +29,7 @@ class AssetsController extends CpController
 
     public function show($asset)
     {
-        $asset = Asset::find(base64_decode($asset));
+        $asset = Asset::find(utf8_encode(base64_decode($asset)));
 
         // TODO: Auth
 
@@ -38,7 +38,7 @@ class AssetsController extends CpController
 
     public function update(Request $request, $asset)
     {
-        $asset = Asset::find(base64_decode($asset));
+        $asset = Asset::find(utf8_encode(base64_decode($asset)));
 
         $this->authorize('edit', $asset);
 


### PR DESCRIPTION
This pull request fixes an issue that happens when a directory or filename in an asset path includes a special character.

Somehow when you wrap `utf8_encode`, it fixes an issue where there was a `b` in front of the string. Apparently, it's something to do with literal strings 🤷‍♂️

This PR will fix #2353.