### PR TITLE
Eloquent OAuth

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -357,4 +357,22 @@ class User extends BaseUser
     {
         $this->model()->preferences = array_merge($this->getPreferences(), Arr::wrap($preferences));
     }
+
+    public function __set($key, $value)
+    {
+        if ($key === 'timestamps') {
+            return $this->model()->timestamps = $value;
+        }
+
+        return $this->$key = $value;
+    }
+
+    public function __get($key)
+    {
+        if ($key === 'timestamps') {
+            return $this->model()->timestamps;
+        }
+
+        return $this->$key;
+    }
 }

--- a/src/Auth/Eloquent/UserRepository.php
+++ b/src/Auth/Eloquent/UserRepository.php
@@ -50,11 +50,6 @@ class UserRepository extends BaseRepository
         return $this->makeUser($model);
     }
 
-    public function findByOAuthId(string $provider, string $id): ?UserContract
-    {
-        // todo
-    }
-
     public function model($method, ...$args)
     {
         $model = $this->config['model'];

--- a/src/Auth/UserRepository.php
+++ b/src/Auth/UserRepository.php
@@ -5,6 +5,7 @@ namespace Statamic\Auth;
 use Statamic\Contracts\Auth\User;
 use Statamic\Contracts\Auth\UserRepository as RepositoryContract;
 use Statamic\Facades\Blueprint;
+use Statamic\OAuth\Provider;
 
 abstract class UserRepository implements RepositoryContract
 {
@@ -52,5 +53,12 @@ abstract class UserRepository implements RepositoryContract
             'roles' => ['type' => 'user_roles', 'width' => 50],
             'groups' => ['type' => 'user_groups', 'width' => 50],
         ])->setHandle('user');
+    }
+
+    public function findByOAuthId(string $provider, string $id): ?User
+    {
+        return $this->find(
+            (new Provider($provider))->getUserId($id)
+        );
     }
 }

--- a/src/Stache/Repositories/UserRepository.php
+++ b/src/Stache/Repositories/UserRepository.php
@@ -8,7 +8,6 @@ use Statamic\Auth\File\UserGroupRepository;
 use Statamic\Auth\UserCollection;
 use Statamic\Auth\UserRepository as BaseRepository;
 use Statamic\Contracts\Auth\User;
-use Statamic\OAuth\Provider;
 use Statamic\Stache\Query\UserQueryBuilder;
 use Statamic\Stache\Stache;
 
@@ -64,13 +63,6 @@ class UserRepository extends BaseRepository
     public function delete(User $user)
     {
         $this->store->delete($user);
-    }
-
-    public function findByOAuthId(string $provider, string $id): ?User
-    {
-        return $this->find(
-            (new Provider($provider))->getUserId($id)
-        );
     }
 
     public function fromUser($user): ?User


### PR DESCRIPTION
This PR fixes OAuth when the Eloquent driver is enabled.

The file based auth stuff works just as well for Eloquent, so just moved that to the abstract repo. If someone wants to put columns in their users table, they're welcome to make a migration and override the method on their own repo.

As pointed out in #2879, there's an error where Laravel tries to access the timestamps property. Rather than make a property that just doesn't do anything, it'll now pass it along to the actual model.

Fixes #2388 
Closes #2879 