### PR TITLE
Add assets:generate-presets command

### DIFF
--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -56,7 +56,7 @@ class AssetsGeneratePresets extends Command
     }
 
     /**
-     * Generate user provided presets
+     * Generate user provided presets.
      *
      * @return void
      */
@@ -72,7 +72,7 @@ class AssetsGeneratePresets extends Command
     }
 
     /**
-     * Generate thumbnails required by the control panel
+     * Generate thumbnails required by the control panel.
      *
      * @return void
      */
@@ -86,7 +86,7 @@ class AssetsGeneratePresets extends Command
     }
 
     /**
-     * Generate supplied presets
+     * Generate supplied presets.
      *
      * @param array $presets
      * @return void

--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Statamic\Console\Commands;
+
+use Illuminate\Console\Command;
+use Statamic\Console\RunsInPlease;
+use Statamic\Facades\Asset;
+use Statamic\Facades\Image;
+use Statamic\Imaging\ImageGenerator;
+use Statamic\Imaging\PresetGenerator;
+
+class AssetsGeneratePresets extends Command
+{
+    use RunsInPlease;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'statamic:assets:generate-presets';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate asset preset manipulations.';
+
+    /**
+     * @var ImageGenerator
+     */
+    protected $imageGenerator;
+
+    /**
+     * @var \Statamic\Assets\AssetCollection
+     */
+    protected $imageAssets;
+
+    /**
+     * Execute the console command.
+     *
+     * @param ImageGenerator $imageGenerator
+     */
+    public function handle(ImageGenerator $imageGenerator)
+    {
+        $this->imageGenerator = $imageGenerator;
+
+        $this->imageAssets = Asset::all()->filter(function ($asset) {
+            return $asset->isImage();
+        });
+
+        $this->generateUserPresets();
+
+        $this->generateCpThumbnails();
+    }
+
+    /**
+     * Generate user provided presets
+     *
+     * @return void
+     */
+    protected function generateUserPresets()
+    {
+        $presets = config('statamic.assets.image_manipulation.presets', []);
+
+        if (empty($presets)) {
+            return $this->line('<fg=red>[✗]</> No user defined presets.');
+        }
+
+        $this->generatePresets($presets);
+    }
+
+    /**
+     * Generate thumbnails required by the control panel
+     *
+     * @return void
+     */
+    private function generateCpThumbnails()
+    {
+        if (! config('statamic.cp.enabled')) {
+            return;
+        }
+
+        $this->generatePresets(Image::getCpImageManipulationPresets());
+    }
+
+    /**
+     * Generate supplied presets
+     *
+     * @param array $presets
+     * @return void
+     */
+    private function generatePresets($presets)
+    {
+        $generator = new PresetGenerator($this->imageGenerator, $presets);
+
+        foreach ($presets as $preset => $params) {
+            $bar = $this->output->createProgressBar($this->imageAssets->count());
+            $bar->setFormat("[%current%/%max%] Generating <comment>$preset</comment>... %filename%");
+
+            foreach ($this->imageAssets as $asset) {
+                $bar->setMessage($asset->basename(), 'filename');
+                $generator->generate($asset, $preset);
+                $bar->advance();
+            }
+
+            $bar->setFormat("<info>[✓] Images generated for <comment>$preset</comment>.</info>");
+            $bar->finish();
+
+            $this->output->newLine();
+        }
+    }
+}

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -11,6 +11,7 @@ class ConsoleServiceProvider extends ServiceProvider
     protected $commands = [
         Commands\ListCommand::class,
         Commands\AddonsDiscover::class,
+        Commands\AssetsGeneratePresets::class,
         Commands\AssetsMeta::class,
         Commands\GlideClear::class,
         Commands\Install::class,


### PR DESCRIPTION
Ports the command to generate assets presets `php please assets:generate-presets` from v2. Closes #2277.