### PR TITLE
Throw out toenail clippings

### DIFF
--- a/resources/js/components/fieldtypes/assets/Asset.js
+++ b/resources/js/components/fieldtypes/assets/Asset.js
@@ -32,10 +32,6 @@ export default {
             return this.asset.thumbnail;
         },
 
-        toenail() {
-            return this.asset.toenail;
-        },
-
         label() {
             return this.asset.basename;
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -2,6 +2,7 @@
 
 namespace Statamic;
 
+use Statamic\Facades\Image;
 use Statamic\Facades\Site;
 
 /**
@@ -156,9 +157,11 @@ class Config
      * Get the image manipulation presets.
      *
      * @return array
+     * @deprecated Use Statamic\Facades\Image::userManipulationPresets()
+     *             or Image::manipulationPresets() to get merged with CP presets.
      */
     public function getImageManipulationPresets()
     {
-        return config('statamic.assets.image_manipulation.presets', []);
+        return Image::userManipulationPresets();
     }
 }

--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -40,6 +40,7 @@ class AssetsGeneratePresets extends Command
     public function __construct(PresetGenerator $generator)
     {
         $this->generator = $generator;
+        parent::__construct();
     }
 
     /**

--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -5,6 +5,7 @@ namespace Statamic\Console\Commands;
 use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
 use Statamic\Facades\Asset;
+use Statamic\Facades\Config;
 use Statamic\Facades\Image;
 use Statamic\Imaging\PresetGenerator;
 
@@ -62,7 +63,7 @@ class AssetsGeneratePresets extends Command
      */
     protected function generateUserPresets()
     {
-        $presets = config('statamic.assets.image_manipulation.presets', []);
+        $presets = Config::getImageManipulationPresets();
 
         if (empty($presets)) {
             return $this->line('<fg=red>[✗]</> No user defined presets.');

--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Image;
-use Statamic\Imaging\ImageGenerator;
 use Statamic\Imaging\PresetGenerator;
 
 class AssetsGeneratePresets extends Command
@@ -28,24 +27,25 @@ class AssetsGeneratePresets extends Command
     protected $description = 'Generate asset preset manipulations.';
 
     /**
-     * @var ImageGenerator
+     * @var PresetGenerator
      */
-    protected $imageGenerator;
+    protected $generator;
 
     /**
      * @var \Statamic\Assets\AssetCollection
      */
     protected $imageAssets;
 
+    public function __construct(PresetGenerator $generator)
+    {
+        $this->generator = $generator;
+    }
+
     /**
      * Execute the console command.
-     *
-     * @param ImageGenerator $imageGenerator
      */
-    public function handle(ImageGenerator $imageGenerator)
+    public function handle()
     {
-        $this->imageGenerator = $imageGenerator;
-
         $this->imageAssets = Asset::all()->filter(function ($asset) {
             return $asset->isImage();
         });
@@ -93,15 +93,13 @@ class AssetsGeneratePresets extends Command
      */
     private function generatePresets($presets)
     {
-        $generator = new PresetGenerator($this->imageGenerator, $presets);
-
         foreach ($presets as $preset => $params) {
             $bar = $this->output->createProgressBar($this->imageAssets->count());
             $bar->setFormat("[%current%/%max%] Generating <comment>$preset</comment>... %filename%");
 
             foreach ($this->imageAssets as $asset) {
                 $bar->setMessage($asset->basename(), 'filename');
-                $generator->generate($asset, $preset);
+                $this->generator->generate($asset, $preset);
                 $bar->advance();
             }
 

--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -63,7 +63,7 @@ class AssetsGeneratePresets extends Command
      */
     protected function generateUserPresets()
     {
-        $presets = Config::getImageManipulationPresets();
+        $presets = Image::userManipulationPresets();
 
         if (empty($presets)) {
             return $this->line('<fg=red>[✗]</> No user defined presets.');

--- a/src/Facades/Image.php
+++ b/src/Facades/Image.php
@@ -8,7 +8,9 @@ use Statamic\Imaging\Manager;
 /**
  * @method static string|\Statamic\Contracts\Imaging\ImageManipulator manipulate($item = null, $params = null)
  * @method static \Statamic\Contracts\Imaging\ImageManipulator manipulator()
- * @method static array getCpImageManipulationPresets()
+ * @method static array manipulationPresets()
+ * @method static array userManipulationPresets()
+ * @method static array cpManipulationPresets()
  *
  * @see \Statamic\Imaging\Manager
  */

--- a/src/Http/Resources/CP/Assets/Asset.php
+++ b/src/Http/Resources/CP/Assets/Asset.php
@@ -34,7 +34,6 @@ class Asset extends JsonResource
                     'height' => $this->height(),
                     'preview' => $this->previewUrl(),
                     'thumbnail' => $this->thumbnailUrl('small'),
-                    'toenail' => $this->thumbnailUrl('large'),
                 ];
             }),
 

--- a/src/Http/Resources/CP/Assets/FolderAsset.php
+++ b/src/Http/Resources/CP/Assets/FolderAsset.php
@@ -23,7 +23,6 @@ class FolderAsset extends JsonResource
                 return [
                     'is_image' => true,
                     'thumbnail' => $this->thumbnailUrl('small'),
-                    'toenail' => $this->thumbnailUrl('large'),
                 ];
             }),
 

--- a/src/Imaging/GlideServer.php
+++ b/src/Imaging/GlideServer.php
@@ -22,7 +22,7 @@ class GlideServer
             'response' => new LaravelResponseFactory(app('request')),
             'driver'   => Config::get('statamic.assets.image_manipulation.driver'),
             'cache_with_file_extensions' => true,
-            'presets' => $this->presets(),
+            'presets' => Image::manipulationPresets(),
         ]);
     }
 
@@ -36,21 +36,5 @@ class GlideServer
         return Config::get('statamic.assets.image_manipulation.cache')
             ? Config::get('statamic.assets.image_manipulation.cache_path')
             : storage_path('statamic/glide');
-    }
-
-    /**
-     * Get glide presets.
-     *
-     * @return array
-     */
-    private function presets()
-    {
-        $presets = Config::getImageManipulationPresets();
-
-        if (config('statamic.cp.enabled')) {
-            $presets = array_merge($presets, Image::getCpImageManipulationPresets());
-        }
-
-        return $presets;
     }
 }

--- a/src/Imaging/Manager.php
+++ b/src/Imaging/Manager.php
@@ -48,7 +48,6 @@ class Manager
     public function getCpImageManipulationPresets()
     {
         return [
-            'cp_thumbnail_small' => ['w' => '300', 'fit' => 'crop'],
             'cp_thumbnail_small_landscape' => ['w' => '400', 'h' => '300', 'fit' => 'crop'],
             'cp_thumbnail_small_portrait' => ['h' => '300', 'fit' => 'crop'],
             'cp_thumbnail_small_square' => ['w' => '300', 'h' => '300'],

--- a/src/Imaging/Manager.php
+++ b/src/Imaging/Manager.php
@@ -52,7 +52,6 @@ class Manager
             'cp_thumbnail_small_landscape' => ['w' => '400', 'h' => '300', 'fit' => 'crop'],
             'cp_thumbnail_small_portrait' => ['h' => '300', 'fit' => 'crop'],
             'cp_thumbnail_small_square' => ['w' => '300', 'h' => '300'],
-            'cp_thumbnail_large' => ['w' => '1000', 'h' => '1000'],
         ];
     }
 }

--- a/src/Imaging/Manager.php
+++ b/src/Imaging/Manager.php
@@ -41,16 +41,50 @@ class Manager
     }
 
     /**
+     * Get the image manipulation presets.
+     *
+     * @return array
+     */
+    public function manipulationPresets()
+    {
+        $presets = $this->userManipulationPresets();
+
+        if (config('statamic.cp.enabled')) {
+            $presets = array_merge($presets, $this->cpManipulationPresets());
+        }
+
+        return $presets;
+    }
+
+    /**
+     * Get the user defined image manipulation presets.
+     *
+     * @return array
+     */
+    public function userManipulationPresets()
+    {
+        return config('statamic.assets.image_manipulation.presets', []);
+    }
+
+    /**
      * Get the image manipulation presets required by the control panel.
      *
      * @return array
      */
-    public function getCpImageManipulationPresets()
+    public function cpManipulationPresets()
     {
         return [
             'cp_thumbnail_small_landscape' => ['w' => '400', 'h' => '300', 'fit' => 'crop'],
             'cp_thumbnail_small_portrait' => ['h' => '300', 'fit' => 'crop'],
             'cp_thumbnail_small_square' => ['w' => '300', 'h' => '300'],
         ];
+    }
+
+    /**
+     * @deprecated
+     */
+    public function getCpImageManipulationPresets()
+    {
+        return $this->cpManipulationPresets();
     }
 }

--- a/src/Providers/GlideServiceProvider.php
+++ b/src/Providers/GlideServiceProvider.php
@@ -8,6 +8,7 @@ use League\Glide\Server;
 use Statamic\Contracts\Imaging\ImageManipulator;
 use Statamic\Contracts\Imaging\UrlBuilder;
 use Statamic\Facades\Config;
+use Statamic\Facades\Image;
 use Statamic\Imaging\GlideImageManipulator;
 use Statamic\Imaging\GlideUrlBuilder;
 use Statamic\Imaging\ImageGenerator;
@@ -38,7 +39,7 @@ class GlideServiceProvider extends ServiceProvider
         $this->app->bind(PresetGenerator::class, function ($app) {
             return new PresetGenerator(
                 $app->make(ImageGenerator::class),
-                Config::getImageManipulationPresets()
+                Image::manipulationPresets()
             );
         });
     }

--- a/tests/Feature/Assets/BrowserTest.php
+++ b/tests/Feature/Assets/BrowserTest.php
@@ -268,7 +268,7 @@ class BrowserTest extends TestCase
             'data' => [
                 'assets' => [
                     ['id', 'size_formatted', 'last_modified_relative', 'actions'],
-                    ['id', 'size_formatted', 'last_modified_relative', 'actions', 'thumbnail', 'toenail'],
+                    ['id', 'size_formatted', 'last_modified_relative', 'actions', 'thumbnail'],
                 ],
                 'folder' => [
                     'title', 'path', 'parent_path', 'actions', 'folders',


### PR DESCRIPTION
PR #2909 pointed out a few leftover issues.

- We were still using "large" preset for CP thumbnails (aka "toenail"), even though it's not used in the CP anymore. Removed that.
- The toenail code was still littered throughout the codebase. Again, never rendered, so it's gone.
- `Config::getImageManipulationPresets()` is a bit weird. Made some better named methods in the `Image` facade and deprecated the existing ones.
- When you uploaded an image, it would only generate user defined presets. Now it'll generate the CP ones too.
- Tidied up the generate command a tad.