### PR TITLE
Fix issue where $values isn't countable

### DIFF
--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -309,7 +309,7 @@ class Entries
                 $values = array_filter(explode('|', $values));
             }
 
-            if ((is_countable($values) && count($values) === 0) || is_null($values)) {
+            if (is_null($values) || count($values) === 0) {
                 return;
             }
 

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -309,7 +309,7 @@ class Entries
                 $values = array_filter(explode('|', $values));
             }
 
-            if (count($values) === 0) {
+            if ((is_countable($values) && count($values) === 0) || is_null($values)) {
                 return;
             }
 


### PR DESCRIPTION
This pull request where `$values` is null or isn't countable. This PR fixes #2904.

I think this is probably something I introduced in #2672.