### PR TITLE
Fixed paginationFriendlyOffset

### DIFF
--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -45,7 +45,7 @@ trait GetsQueryResults
     {
         $offsetIds = (clone $query)
             ->limit($offset)
-            ->get('id')
+            ->get(['id'])
             ->map->id()
             ->all();
 


### PR DESCRIPTION
When I've switched to eloquent driver and wanted to paginate my collection I had `in_array() expects parameter 2 to be array, string given` error which led me to conclusion that In _GetsQueryResults::queryPaginationFriendlyOffset_ **id** is given as a string to _get_ method. Later on _EloquentQueryBuilder::selectableColumns_ requires (indirectly) columns param to be array.

May better solution would be to change _selectableColumns_ method instead of _paginationFriendlyOffset_.