### PR TITLE
🐛 add status to LocalizedTerm

### DIFF
--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -331,8 +331,6 @@ class LocalizedTerm implements Term, Responsable, Augmentable, Protectable
 
     public function status()
     {
-        // Though Terms don't really need a status concept
-        // this will allow them to be included in Search Results
         return 'published';
     }
 

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -329,6 +329,13 @@ class LocalizedTerm implements Term, Responsable, Augmentable, Protectable
         ])->all();
     }
 
+    public function status()
+    {
+        // Though Terms don't really need a status concept
+        // this will allow them to be included in Search Results
+        return 'published';
+    }
+
     public function toResponse($request)
     {
         if (! view()->exists($this->template())) {


### PR DESCRIPTION
This adds a status of `published` for all terms which fixes #2949 

Currently there is no concept of status for Taxonomy Terms which makes sense. Maybe this should be expanded upon later to check if any terms exist? But for now, since all terms are considered published in other senses, it feels like a sensible default to start with. 