### PR TITLE
Fix isInGroup for eloquent user driver

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -169,7 +169,7 @@ class User extends BaseUser
         return $this->groups = $this->groups
             ?? (new UserGroups($this))->all()->map(function ($row) {
                 return UserGroup::find($row->group_id);
-            });
+            })->keyBy->handle();
     }
 
     protected function setGroups($groups)


### PR DESCRIPTION
This PR fixes the `isInGroup` function for the Eloquent user driver. It does this by changing the collection returned by `getGroups` to key by handle. This makes it the same as the `getRoles` function in the Eloquent driver and the `getGroups` in the File driver. When the groups collection is keyed by the handle, the `has()` check in the `isInGroup` function will work properly.