### PR TITLE
Add a hidden input_type to the text fieldtype

### DIFF
--- a/src/Fieldtypes/Text.php
+++ b/src/Fieldtypes/Text.php
@@ -24,6 +24,7 @@ class Text extends Fieldtype
                 'options' => [
                     'color',
                     'email',
+                    'hidden',
                     'month',
                     'number',
                     'password',


### PR DESCRIPTION
This is especially useful when building forms where you want to pass hidden dynamic data