### PR TITLE
Improve visual spacing when adding replicator blocks

### DIFF
--- a/resources/sass/components/fieldtypes/replicator.scss
+++ b/resources/sass/components/fieldtypes/replicator.scss
@@ -8,6 +8,10 @@
 
 .replicator-set {
     @apply mb-5 shadow-set rounded bg-white outline-none relative;
+
+    &:first-child {
+        @apply mt-3;
+    }
 }
 
 .replicator-set-header {


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/2725836/100874439-de12ff80-34a4-11eb-9c47-aedc1c804898.png)

After:
![after](https://user-images.githubusercontent.com/2725836/100874444-e0755980-34a4-11eb-845d-d1fec8798bb7.png)
