### PR TITLE
Get rid of GitHub action warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
         composer: [1, 2]
         laravel: [8.*, 7.*, 6.*]
         dependency-version: [prefer-lowest, prefer-stable]
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         include:
           - laravel: 8.*
             testbench: 6.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,11 +39,11 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v${{ matrix.composer }}
-          extension-csv: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
 
   slack:
     name: Slack Notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [php-tests, js-tests]
     if: always()
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           - laravel: 8.*
             php: 7.2
 
-    name: P${{ matrix.php }} - C${{ matrix.composer }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - C${{ matrix.composer }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
         run: vendor/bin/phpunit
 
   js-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 
     name: JavaScript tests


### PR DESCRIPTION
> Ubuntu-latest workflows will use Ubuntu-20.04 soon. For more details, see https://github.com/actions/virtual-environments/issues/1816

Updated `ubuntu-latest` to `ubuntu-20.04` to test out the upcoming change.
Everything in the tests workflow runs fine. The release workflow isn't complicated, I'm confident it'll work.

> setup-php v1 is deprecated.
> Please upgrade to v2 - https://github.com/shivammathur/setup-php/wiki/Switch-to-v2

Followed the upgrade instructions. It works fine.

> Input 'extension-csv' has been deprecated with message: The extension-csv property is deprecated. Use extensions instead.

This is solved by updating `setup-php`

![image](https://user-images.githubusercontent.com/105211/101045019-f723bb00-354d-11eb-977e-76bf380a4eed.png)

Much better.