### PR TITLE
Filter collection widget by active site

### DIFF
--- a/src/Widgets/Collection.php
+++ b/src/Widgets/Collection.php
@@ -4,6 +4,7 @@ namespace Statamic\Widgets;
 
 use Statamic\Facades\Collection as CollectionAPI;
 use Statamic\Facades\Scope;
+use Statamic\Facades\Site;
 use Statamic\Facades\User;
 
 class Collection extends Widget
@@ -33,6 +34,7 @@ class Collection extends Widget
             'collection' => $collection,
             'filters' => Scope::filters('entries', [
                 'collection' => $collection->handle(),
+                'site' => Site::current()->handle(),
             ]),
             'title' => $this->config('title', $collection->title()),
             'button' => __('New :thing', ['thing' => $collection->entryBlueprint()->title()]),


### PR DESCRIPTION
The collection widget in the dashboard showed items from all sites which was a little confusing to clients (especially when dealing with items with the same title in multiple locales).

This filters the result by the currently active site (selectable through the dropdown in the top navbar).