### PR TITLE
Fix 500 errors for an empty search string.

### DIFF
--- a/src/Http/Controllers/CP/SearchController.php
+++ b/src/Http/Controllers/CP/SearchController.php
@@ -5,26 +5,31 @@ namespace Statamic\Http\Controllers\CP;
 use Illuminate\Http\Request;
 use Statamic\Facades\Search;
 use Statamic\Facades\User;
+use Statamic\Search\Comb\Exceptions\NoQuery;
 
 class SearchController extends CpController
 {
     public function __invoke(Request $request)
     {
-        return Search::index()
-            ->ensureExists()
-            ->search($request->query('q'))
-            ->get()
-            ->filter(function ($item) {
-                return User::current()->can('view', $item);
-            })
-            ->take(10)
-            ->map(function ($item) {
-                return $item->toAugmentedCollection([
-                    'title', 'edit_url',
-                    'collection', 'is_entry',
-                    'taxonomy', 'is_term',
-                    'container', 'is_asset',
-                ])->withShallowNesting();
-            });
+        try {
+            return Search::index()
+                ->ensureExists()
+                ->search($request->query('q'))
+                ->get()
+                ->filter(function ($item) {
+                    return User::current()->can('view', $item);
+                })
+                ->take(10)
+                ->map(function ($item) {
+                    return $item->toAugmentedCollection([
+                        'title', 'edit_url',
+                        'collection', 'is_entry',
+                        'taxonomy', 'is_term',
+                        'container', 'is_asset',
+                    ])->withShallowNesting();
+                });
+        } catch (NoQuery $e) {
+            return [];
+        }
     }
 }


### PR DESCRIPTION
When you search for a space or other whitespace in the CP, a 500 error would be returned. This solves it, by gracefully returning an empty result set. This fixes #2971.