### PR TITLE
Fix 500 errors for an empty search string

### DIFF
--- a/src/Search/Comb/Index.php
+++ b/src/Search/Comb/Index.php
@@ -3,6 +3,7 @@
 namespace Statamic\Search\Comb;
 
 use Statamic\Facades\File;
+use Statamic\Search\Comb\Exceptions\NoQuery;
 use Statamic\Search\Comb\Exceptions\NoResultsFound;
 use Statamic\Search\Comb\Exceptions\NotEnoughCharacters;
 use Statamic\Search\Documents;

--- a/src/Search/Comb/Index.php
+++ b/src/Search/Comb/Index.php
@@ -26,7 +26,7 @@ class Index extends BaseIndex
 
         try {
             $results = $comb->lookUp($query)['data'];
-        } catch (NoResultsFound | NotEnoughCharacters $e) {
+        } catch (NoResultsFound | NotEnoughCharacters | NoQuery $e) {
             return collect();
         }
 


### PR DESCRIPTION
Fixes #2971, this time staying inside the `Statamic\Search\Comb` namespace.