### PR TITLE
Add UserBlueprintEvent

### DIFF
--- a/src/Auth/UserRepository.php
+++ b/src/Auth/UserRepository.php
@@ -4,6 +4,7 @@ namespace Statamic\Auth;
 
 use Statamic\Contracts\Auth\User;
 use Statamic\Contracts\Auth\UserRepository as RepositoryContract;
+use Statamic\Events\UserBlueprintFound;
 use Statamic\Facades\Blueprint;
 use Statamic\OAuth\Provider;
 
@@ -47,12 +48,16 @@ abstract class UserRepository implements RepositoryContract
 
     public function blueprint()
     {
-        return Blueprint::find('user') ?? Blueprint::makeFromFields([
+        $blueprint = Blueprint::find('user') ?? Blueprint::makeFromFields([
             'name' => ['type' => 'text', 'display' => 'Name'],
             'email' => ['type' => 'text', 'input_type' => 'email', 'display' => 'Email Address'],
             'roles' => ['type' => 'user_roles', 'width' => 50],
             'groups' => ['type' => 'user_groups', 'width' => 50],
         ])->setHandle('user');
+
+        UserBlueprintFound::dispatch($blueprint);
+
+        return $blueprint;
     }
 
     public function findByOAuthId(string $provider, string $id): ?User

--- a/src/Events/UserBlueprintFound.php
+++ b/src/Events/UserBlueprintFound.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Events;
+
+class UserBlueprintFound extends Event
+{
+    public $blueprint;
+
+    public function __construct($blueprint)
+    {
+        $this->blueprint = $blueprint;
+    }
+}


### PR DESCRIPTION
This PR adds a new `UserBlueprintEvent` to make it inline with the other BlueprintFound events like `EntryBlueprintFound` and to help with v2 compatibility.

Unlike the `EntryBlueprintFound` event though, I've not been able to implement the `$user` parameter as adding this would mean updating the `blueprint` method signature to include a `$user` so it can be passed in from the `User.php` file. If I updated it, it would be considered a breaking change for anyone who has bound their own `UserRepository`.

This PR addresses #2905.