### PR TITLE
rows should start at 1

### DIFF
--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -8,8 +8,8 @@
             class="grid-item-header"
             :class="{ [sortableHandleClass]: grid.isReorderable }"
         >
-            {{ index }}
             <button v-if="canDelete" class="icon icon-cross cursor-pointer" @click="$emit('removed', index)" :aria-label="__('Delete Row')" />
+            {{ index + 1 }}
         </div>
         <publish-fields-container>
             <publish-field


### PR DESCRIPTION
It looks odd when you have a stacked grid and the first element shows `0`.

People count from 1.