### PR TITLE
only trigger update if value has really changed

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -282,6 +282,9 @@ export default {
         previews: {
             deep: true,
             handler(value) {
+                if (JSON.stringify(this.meta.previews) === JSON.stringify(value)) {
+                    return
+                }
                 const meta = this.meta;
                 meta.previews = value;
                 this.updateMeta(meta);


### PR DESCRIPTION
This fixes #2959 

There where circular events caused by the previews watcher in BardFieldtype.vue

The watcher should update meta data only if there is e diff to the new value to prevent them.

Tested with the simple Neste Bard Setup deschribed in the issue.

---

This is my very first OS PR. So please let me know if I sould do anything diffrent or better