### PR TITLE
Allow hiding of fields from CP.

### DIFF
--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -18,6 +18,15 @@
                 </div>
                 <input type="text" name="title" class="input-text" v-model="blueprint.title" autofocus="autofocus">
             </div>
+
+            <div class="form-group">
+                <label class="block">{{ __('Hidden') }}</label>
+                <small class="help-block">{{ __('messages.blueprints_hide_instructions') }}</small>
+                <div v-if="errors.hide">
+                    <small class="help-block text-red" v-for="(error, i) in errors.hide" :key="i" v-text="error" />
+                </div>
+                <toggle-input name="hide" v-model="blueprint.hide" />
+            </div>
         </div>
 
         <div class="content mt-5 mb-2" v-if="useSections">

--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -21,11 +21,11 @@
 
             <div class="form-group">
                 <label class="block">{{ __('Hidden') }}</label>
-                <small class="help-block">{{ __('messages.blueprints_hide_instructions') }}</small>
-                <div v-if="errors.hide">
-                    <small class="help-block text-red" v-for="(error, i) in errors.hide" :key="i" v-text="error" />
+                <small class="help-block">{{ __('messages.blueprints_hidden_instructions') }}</small>
+                <div v-if="errors.hidden">
+                    <small class="help-block text-red" v-for="(error, i) in errors.hidden" :key="i" v-text="error" />
                 </div>
-                <toggle-input name="hide" v-model="blueprint.hide" />
+                <toggle-input name="hidden" v-model="blueprint.hidden" />
             </div>
         </div>
 

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -19,6 +19,7 @@ return [
     'asset_folders_directory_instructions' => 'We recommend avoiding spaces and special characters to keep URLs clean.',
     'blueprints_intro' => 'Blueprints define and organize fields to create the content models for collections, forms, and other data types.',
     'blueprints_title_instructions' => 'Usually a singular noun, like Article or Product',
+    'blueprints_hide_instructions' => 'Hides the blueprint from the create buttons in the CP',
     'cache_utility_application_cache_description' => 'Laravel\'s unified cache used by Statamic, third party addons, and composer packages.',
     'cache_utility_description' => 'Manage and view important information about Statamic\'s various caching layers.',
     'cache_utility_image_cache_description' => 'The image cache stores copies of all transformed and resized images.',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -19,7 +19,7 @@ return [
     'asset_folders_directory_instructions' => 'We recommend avoiding spaces and special characters to keep URLs clean.',
     'blueprints_intro' => 'Blueprints define and organize fields to create the content models for collections, forms, and other data types.',
     'blueprints_title_instructions' => 'Usually a singular noun, like Article or Product',
-    'blueprints_hide_instructions' => 'Hides the blueprint from the create buttons in the CP',
+    'blueprints_hidden_instructions' => 'Hides the blueprint from the create buttons in the CP',
     'cache_utility_application_cache_description' => 'Laravel\'s unified cache used by Statamic, third party addons, and composer packages.',
     'cache_utility_description' => 'Manage and view important information about Statamic\'s various caching layers.',
     'cache_utility_image_cache_description' => 'The image cache stores copies of all transformed and resized images.',

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -26,6 +26,7 @@ class Blueprint implements Augmentable
     protected $handle;
     protected $namespace;
     protected $order;
+    protected $hide;
     protected $initialPath;
     protected $contents;
     protected $fieldsCache;
@@ -70,6 +71,22 @@ class Blueprint implements Augmentable
     public function order()
     {
         return $this->order;
+    }
+
+    public function setHide($hide)
+    {
+        if (! is_null($hide)) {
+            $hide = (bool) $hide;
+        }
+
+        $this->hide = $hide;
+
+        return $this;
+    }
+
+    public function hide()
+    {
+        return $this->hide;
     }
 
     public function setInitialPath(string $path)

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -26,7 +26,7 @@ class Blueprint implements Augmentable
     protected $handle;
     protected $namespace;
     protected $order;
-    protected $hide = false;
+    protected $hidden = false;
     protected $initialPath;
     protected $contents;
     protected $fieldsCache;
@@ -73,20 +73,20 @@ class Blueprint implements Augmentable
         return $this->order;
     }
 
-    public function setHide(?bool $hide)
+    public function setHidden(?bool $hidden)
     {
-        if (is_null($hide)) {
-            $hide = false;
+        if (is_null($hidden)) {
+            $hidden = false;
         }
 
-        $this->hide = $hide;
+        $this->hidden = $hidden;
 
         return $this;
     }
 
-    public function hide()
+    public function hidden()
     {
-        return $this->hide;
+        return $this->hidden;
     }
 
     public function setInitialPath(string $path)
@@ -145,7 +145,7 @@ class Blueprint implements Augmentable
 
         return array_filter(
             array_merge([
-                'hide' => $this->hide,
+                'hide' => $this->hidden,
                 'order' => $this->order,
             ], $contents)
         );

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -26,7 +26,7 @@ class Blueprint implements Augmentable
     protected $handle;
     protected $namespace;
     protected $order;
-    protected $hide;
+    protected $hide = false;
     protected $initialPath;
     protected $contents;
     protected $fieldsCache;
@@ -73,10 +73,10 @@ class Blueprint implements Augmentable
         return $this->order;
     }
 
-    public function setHide($hide)
+    public function setHide(?bool $hide)
     {
-        if (! is_null($hide)) {
-            $hide = (bool) $hide;
+        if (is_null($hide)) {
+            $hide = false;
         }
 
         $this->hide = $hide;
@@ -144,7 +144,10 @@ class Blueprint implements Augmentable
         }
 
         return array_filter(
-            array_merge(['order' => $this->order], $contents)
+            array_merge([
+                'hide' => $this->hide,
+                'order' => $this->order,
+            ], $contents)
         );
     }
 

--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -165,6 +165,7 @@ class BlueprintRepository
             $contents = YAML::file($path)->parse();
 
             return (new Blueprint)
+                ->setHide(Arr::pull($contents, 'hide'))
                 ->setOrder(Arr::pull($contents, 'order'))
                 ->setInitialPath($path)
                 ->setHandle($handle)

--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -165,7 +165,7 @@ class BlueprintRepository
             $contents = YAML::file($path)->parse();
 
             return (new Blueprint)
-                ->setHide(Arr::pull($contents, 'hide'))
+                ->setHidden(Arr::pull($contents, 'hide'))
                 ->setOrder(Arr::pull($contents, 'order'))
                 ->setInitialPath($path)
                 ->setHandle($handle)

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -51,9 +51,10 @@ class CollectionsController extends CpController
     {
         $this->authorize('view', $collection, __('You are not authorized to view this collection.'));
 
-        $blueprints = $collection->entryBlueprints()
+        $blueprints = $collection
+            ->entryBlueprints()
             ->reject(function ($blueprint) {
-                return $blueprint->hide();
+                return $blueprint->hidden();
             })
             ->map(function ($blueprint) {
                 return [

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -51,12 +51,16 @@ class CollectionsController extends CpController
     {
         $this->authorize('view', $collection, __('You are not authorized to view this collection.'));
 
-        $blueprints = $collection->entryBlueprints()->map(function ($blueprint) {
-            return [
-                'handle' => $blueprint->handle(),
-                'title' => $blueprint->title(),
-            ];
-        });
+        $blueprints = $collection->entryBlueprints()
+            ->reject(function($blueprint) {
+                return $blueprint->hide();
+            })
+            ->map(function ($blueprint) {
+                return [
+                    'handle' => $blueprint->handle(),
+                    'title' => $blueprint->title(),
+                ];
+            });
 
         $site = $request->site ? Site::get($request->site) : Site::selected();
 

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -61,7 +61,7 @@ class CollectionsController extends CpController
                     'handle' => $blueprint->handle(),
                     'title' => $blueprint->title(),
                 ];
-            });
+            })->values();
 
         $site = $request->site ? Site::get($request->site) : Site::selected();
 

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -52,7 +52,7 @@ class CollectionsController extends CpController
         $this->authorize('view', $collection, __('You are not authorized to view this collection.'));
 
         $blueprints = $collection->entryBlueprints()
-            ->reject(function($blueprint) {
+            ->reject(function ($blueprint) {
                 return $blueprint->hide();
             })
             ->map(function ($blueprint) {

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -53,9 +53,7 @@ class CollectionsController extends CpController
 
         $blueprints = $collection
             ->entryBlueprints()
-            ->reject(function ($blueprint) {
-                return $blueprint->hidden();
-            })
+            ->reject->hidden()
             ->map(function ($blueprint) {
                 return [
                     'handle' => $blueprint->handle(),

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -38,6 +38,7 @@ trait ManagesBlueprints
         })->all();
 
         $blueprint->setContents(array_filter([
+            'hide' => $request->hide,
             'title' => $request->title,
             'sections' => $sections,
         ]));
@@ -77,6 +78,7 @@ trait ManagesBlueprints
         return [
             'title' => $blueprint->title(),
             'handle' => $blueprint->handle(),
+            'hide' => $blueprint->hide() ?? false,
             'sections' => $blueprint->sections()->map(function ($section, $i) {
                 return array_merge($this->sectionToVue($section), ['_id' => $i]);
             })->values()->all(),

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -38,7 +38,7 @@ trait ManagesBlueprints
         })->all();
 
         $blueprint->setContents(array_filter([
-            'hide' => $request->hide,
+            'hide' => $request->hidden,
             'title' => $request->title,
             'sections' => $sections,
         ]));
@@ -78,7 +78,7 @@ trait ManagesBlueprints
         return [
             'title' => $blueprint->title(),
             'handle' => $blueprint->handle(),
-            'hide' => $blueprint->hide() ?? false,
+            'hidden' => $blueprint->hidden(),
             'sections' => $blueprint->sections()->map(function ($section, $i) {
                 return array_merge($this->sectionToVue($section), ['_id' => $i]);
             })->values()->all(),

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -48,7 +48,7 @@ class TaxonomiesController extends CpController
         $this->authorize('view', $taxonomy);
 
         $blueprints = $taxonomy->termBlueprints()
-            ->reject(function($blueprint) {
+            ->reject(function ($blueprint) {
                 return $blueprint->hide();
             })
             ->map(function ($blueprint) {

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -47,12 +47,16 @@ class TaxonomiesController extends CpController
     {
         $this->authorize('view', $taxonomy);
 
-        $blueprints = $taxonomy->termBlueprints()->map(function ($blueprint) {
-            return [
-                'handle' => $blueprint->handle(),
-                'title' => $blueprint->title(),
-            ];
-        });
+        $blueprints = $taxonomy->termBlueprints()
+            ->reject(function($blueprint) {
+                return $blueprint->hide();
+            })
+            ->map(function ($blueprint) {
+                return [
+                    'handle' => $blueprint->handle(),
+                    'title' => $blueprint->title(),
+                ];
+            });
 
         $columns = $taxonomy
             ->termBlueprint()

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -49,9 +49,7 @@ class TaxonomiesController extends CpController
 
         $blueprints = $taxonomy
             ->termBlueprints()
-            ->reject(function ($blueprint) {
-                return $blueprint->hidden();
-            })
+            ->reject->hidden()
             ->map(function ($blueprint) {
                 return [
                     'handle' => $blueprint->handle(),

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -57,7 +57,7 @@ class TaxonomiesController extends CpController
                     'handle' => $blueprint->handle(),
                     'title' => $blueprint->title(),
                 ];
-            });
+            })->values();
 
         $columns = $taxonomy
             ->termBlueprint()

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -47,9 +47,10 @@ class TaxonomiesController extends CpController
     {
         $this->authorize('view', $taxonomy);
 
-        $blueprints = $taxonomy->termBlueprints()
+        $blueprints = $taxonomy
+            ->termBlueprints()
             ->reject(function ($blueprint) {
-                return $blueprint->hide();
+                return $blueprint->hidden();
             })
             ->map(function ($blueprint) {
                 return [

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -64,6 +64,22 @@ class BlueprintTest extends TestCase
     }
 
     /** @test */
+    public function it_gets_the_hide_property_which_is_false_by_default()
+    {
+        $blueprint = new Blueprint;
+        $this->assertSame(false, $blueprint->hide());
+
+        $blueprint->setHide(true);
+        $this->assertSame(true, $blueprint->hide());
+
+        $blueprint->setHide(false);
+        $this->assertSame(false, $blueprint->hide());
+
+        $blueprint->setHide(null);
+        $this->assertSame(false, $blueprint->hide());
+    }
+
+    /** @test */
     public function the_title_falls_back_to_a_humanized_handle()
     {
         $blueprint = (new Blueprint)->setHandle('the_blueprint_handle');

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -64,19 +64,19 @@ class BlueprintTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_the_hide_property_which_is_false_by_default()
+    public function it_gets_the_hidden_property_which_is_false_by_default()
     {
         $blueprint = new Blueprint;
-        $this->assertSame(false, $blueprint->hide());
+        $this->assertSame(false, $blueprint->hidden());
 
-        $blueprint->setHide(true);
-        $this->assertSame(true, $blueprint->hide());
+        $blueprint->setHidden(true);
+        $this->assertSame(true, $blueprint->hidden());
 
-        $blueprint->setHide(false);
-        $this->assertSame(false, $blueprint->hide());
+        $blueprint->setHidden(false);
+        $this->assertSame(false, $blueprint->hidden());
 
-        $blueprint->setHide(null);
-        $this->assertSame(false, $blueprint->hide());
+        $blueprint->setHidden(null);
+        $this->assertSame(false, $blueprint->hidden());
     }
 
     /** @test */


### PR DESCRIPTION
Closes #2419.

I've added the 'hidden' field to where the title is usually displayed when editing blueprints. This means that you can't set blueprints to 'hidden' when the title is not being displayed (globals, asset containers etc).

- [x] Allow hiding of collection blueprints.
- [x] Allow hiding of taxonomy blueprints.
- [x] Update/add tests to include hide functionality.

Edit: N.B. the key in blueprint is `hide` (see: https://github.com/statamic/cms/issues/2419#issuecomment-743302040)