### PR TITLE
Wire up white label config options

### DIFF
--- a/config/cp.php
+++ b/config/cp.php
@@ -92,12 +92,12 @@ return [
     | Login Theme
     |--------------------------------------------------------------------------
     |
-    | Optionally spice up the login screen and choose
-    | between "rad" or "business" modes.
+    | Optionally spice up the login and other outside-the-control-panel
+    | screens. You may choose between "rad" or "business" themes.
     |
     */
 
-    'login_theme' => env('STATAMIC_LOGIN_THEME', 'rad'),
+    'theme' => env('STATAMIC_THEME', 'rad'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/cp.php
+++ b/config/cp.php
@@ -104,13 +104,15 @@ return [
     | White Labeling
     |--------------------------------------------------------------------------
     |
-    | When in Pro Mode you may replace the Statamic name and logo with those
-    | your choosing, as long as they're not intended to mislead.
+    | When in Pro Mode you may replace the Statamic name, logo, and add your
+    | own CSS to the control panel to match your company or client brand.
     |
     */
 
-    'cms_name' => env('STATAMIC_CMS_NAME', 'Statamic'),
+    'custom_cms_name' => env('STATAMIC_CUSTOM_CMS_NAME', 'Statamic'),
 
-    'logo_url' => env('STATAMIC_LOGO_URL', null),
+    'custom_logo_url' => env('STATAMIC_CUSTOM_LOGO_URL', null),
+
+    'custom_css_url' => env('STATAMIC_CUSTOM_CSS_URL', null),
 
 ];

--- a/config/cp.php
+++ b/config/cp.php
@@ -104,14 +104,17 @@ return [
     | White Labeling
     |--------------------------------------------------------------------------
     |
-    | When in Pro Mode you may replace the Statamic name, logo, and add your
-    | own CSS to the control panel to match your company or client brand.
+    | When in Pro Mode you may replace the Statamic name, logo, favicon,
+    | and add your own CSS to the control panel to match your
+    | company client brand.
     |
     */
 
     'custom_cms_name' => env('STATAMIC_CUSTOM_CMS_NAME', 'Statamic'),
 
     'custom_logo_url' => env('STATAMIC_CUSTOM_LOGO_URL', null),
+
+    'custom_favicon_url' => env('STATAMIC_CUSTOM_FAVICON_URL', null),
 
     'custom_css_url' => env('STATAMIC_CUSTOM_CSS_URL', null),
 

--- a/config/cp.php
+++ b/config/cp.php
@@ -73,7 +73,7 @@ return [
     |
     */
 
-    'link_to_docs' => false,
+    'link_to_docs' => env('STATAMIC_LINK_TO_DOCS', true),
 
     /*
     |--------------------------------------------------------------------------
@@ -85,7 +85,7 @@ return [
     |
     */
 
-    'support_link' => env('SUPPORT_LINK', 'https://statamic.com/support'),
+    'support_url' => env('STATAMIC_SUPPORT_URL', 'https://statamic.com/support'),
 
     /*
     |--------------------------------------------------------------------------
@@ -97,7 +97,7 @@ return [
     |
     */
 
-    'login_theme' => env('login_mode', 'rad'),
+    'login_theme' => env('STATAMIC_LOGIN_THEME', 'rad'),
 
     /*
     |--------------------------------------------------------------------------
@@ -109,8 +109,8 @@ return [
     |
     */
 
-    'cms_name' => env('CMS_NAME', 'Statamic'),
+    'cms_name' => env('STATAMIC_CMS_NAME', 'Statamic'),
 
-    'logo_path' =>  env('LOGO_PATH', null),
+    'logo_url' =>  env('STATAMIC_LOGO_URL', null),
 
 ];

--- a/config/cp.php
+++ b/config/cp.php
@@ -73,6 +73,44 @@ return [
     |
     */
 
-    'link_to_docs' => true,
+    'link_to_docs' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Support Link
+    |--------------------------------------------------------------------------
+    |
+    | Set the location of the support link in the "Useful Links" header
+    | dropdown. Use 'false' to remove it entirely.
+    |
+    */
+
+    'support_link' => env('SUPPORT_LINK', 'https://statamic.com/support'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Login Theme
+    |--------------------------------------------------------------------------
+    |
+    | Optionally spice up the login screen and choose
+    | between "rad" or "business" modes.
+    |
+    */
+
+    'login_theme' => env('login_mode', 'rad'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | White Labeling
+    |--------------------------------------------------------------------------
+    |
+    | When in Pro Mode you may replace the Statamic name and logo with those
+    | your choosing, as long as they're not intended to mislead.
+    |
+    */
+
+    'cms_name' => env('CMS_NAME', 'Statamic'),
+
+    'logo_path' =>  env('LOGO_PATH', null),
 
 ];

--- a/config/cp.php
+++ b/config/cp.php
@@ -106,7 +106,7 @@ return [
     |
     | When in Pro Mode you may replace the Statamic name, logo, favicon,
     | and add your own CSS to the control panel to match your
-    | company client brand.
+    | company or client's brand.
     |
     */
 

--- a/config/cp.php
+++ b/config/cp.php
@@ -111,6 +111,6 @@ return [
 
     'cms_name' => env('STATAMIC_CMS_NAME', 'Statamic'),
 
-    'logo_url' =>  env('STATAMIC_LOGO_URL', null),
+    'logo_url' => env('STATAMIC_LOGO_URL', null),
 
 ];

--- a/resources/sass/components/global-header.scss
+++ b/resources/sass/components/global-header.scss
@@ -140,3 +140,8 @@
         height: 49px;
     }
 }
+
+.global-header .white-label-logo {
+    max-height: 32px;
+    max-width: 280px;
+}

--- a/resources/sass/components/login.scss
+++ b/resources/sass/components/login.scss
@@ -17,7 +17,7 @@
 /* Rad Mode Stylez
   ========================================================================== */
 
-.outside.rad-mode {
+.outside.rad-theme {
     .auth-card {
         @apply .rounded-lg;
         box-shadow:

--- a/resources/sass/components/login.scss
+++ b/resources/sass/components/login.scss
@@ -7,6 +7,12 @@
    transition: .12s ease-out;
 }
 
+.outside .white-label-logo {
+    @apply mx-auto mb-4;
+    max-width: 300px;
+}
+
+
 
 /* Rad Mode Stylez
   ========================================================================== */

--- a/resources/sass/core/layout.scss
+++ b/resources/sass/core/layout.scss
@@ -101,7 +101,7 @@ a {
 }
 
  // Alternate rad mode for a more playful vibe
-.outside.rad-mode {
+.outside.rad-theme {
     background: #12c2e9;
     background: linear-gradient(45deg, #f64f59, #c471ed, #12c2e9);
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -3,13 +3,8 @@
 @section('title', __('Log in'))
 
 @section('content')
-<div class="logo pt-7">
-    @if (Statamic::pro() && config('statamic.cp.logo_url'))
-        <img src="{{ config('statamic.cp.logo_url') }}" alt="{{ config('statamic.cp.cms_name') }}" class="white-label-logo">
-    @else
-        @svg('statamic-wordmark')
-    @endif
-</div>
+
+@include('statamic::partials.outside-logo')
 
 <div class="card auth-card mx-auto">
     <login inline-template :show-email-login="!{{ $str::bool($oauth) }}" :has-error="{{ $str::bool(count($errors) > 0) }}">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,11 +1,15 @@
 @inject('str', 'Statamic\Support\Str')
 @extends('statamic::outside')
-@section('body_class', 'rad-mode')
+@section('body_class', config('statamic.cp.login_theme').'-mode')
 @section('title', __('Log in'))
 
 @section('content')
 <div class="logo pt-7">
-    @svg('statamic-wordmark')
+    @if (Statamic::pro() && config('statamic.cp.logo_path'))
+        <img src="{{ config('statamic.cp.logo_path') }}" alt="{{ config('statamic.cp.cms_name') }}" class="white-label-logo">
+    @else
+        @svg('statamic-wordmark')
+    @endif
 </div>
 
 <div class="card auth-card mx-auto">

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,12 +1,11 @@
 @inject('str', 'Statamic\Support\Str')
 @extends('statamic::outside')
-@section('body_class', config('statamic.cp.login_theme').'-mode')
 @section('title', __('Log in'))
 
 @section('content')
 <div class="logo pt-7">
-    @if (Statamic::pro() && config('statamic.cp.logo_path'))
-        <img src="{{ config('statamic.cp.logo_path') }}" alt="{{ config('statamic.cp.cms_name') }}" class="white-label-logo">
+    @if (Statamic::pro() && config('statamic.cp.logo_url'))
+        <img src="{{ config('statamic.cp.logo_url') }}" alt="{{ config('statamic.cp.cms_name') }}" class="white-label-logo">
     @else
         @svg('statamic-wordmark')
     @endif

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,5 +1,4 @@
 @extends('statamic::outside')
-@section('body_class', 'rad-mode')
 
 @section('content')
     <div class="logo pt-7">

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -1,9 +1,7 @@
 @extends('statamic::outside')
 
 @section('content')
-    <div class="logo pt-7">
-        @svg('statamic-wordmark')
-    </div>
+    @include('statamic::partials.outside-logo')
 
     <div class="card auth-card mx-auto">
         <div class="text-center pb-2 mb-2">

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -1,5 +1,4 @@
 @extends('statamic::outside')
-@section('body_class', 'rad-mode')
 
 @section('content')
 

--- a/resources/views/auth/unauthorized.blade.php
+++ b/resources/views/auth/unauthorized.blade.php
@@ -2,9 +2,7 @@
 @section('title', __('Unauthorized'))
 
 @section('content')
-<div class="logo pt-7">
-    @svg('statamic-wordmark')
-</div>
+@include('statamic::partials.outside-logo')
 
 <div class="card auth-card mx-auto text-center text-grey-70">
     <div class="mb-3">{{ __('Unauthorized') }}</div>

--- a/resources/views/auth/unauthorized.blade.php
+++ b/resources/views/auth/unauthorized.blade.php
@@ -1,5 +1,4 @@
 @extends('statamic::outside')
-@section('body_class', 'rad-mode')
 @section('title', __('Unauthorized'))
 
 @section('content')

--- a/resources/views/outside.blade.php
+++ b/resources/views/outside.blade.php
@@ -3,7 +3,7 @@
     <head>
         @include('statamic::partials.head')
     </head>
-    <body class="outside {{ config('statamic.cp.theme') }}-mode @yield('body_class')">
+    <body class="outside {{ config('statamic.cp.theme') }}-theme @yield('body_class')">
         <div id="statamic">
             @yield('content')
         </div>

--- a/resources/views/outside.blade.php
+++ b/resources/views/outside.blade.php
@@ -3,7 +3,7 @@
     <head>
         @include('statamic::partials.head')
     </head>
-    <body class="outside @yield('body_class')">
+    <body class="outside {{ config('statamic.cp.login_theme') }}-mode @yield('body_class')">
         <div id="statamic">
             @yield('content')
         </div>

--- a/resources/views/outside.blade.php
+++ b/resources/views/outside.blade.php
@@ -3,7 +3,7 @@
     <head>
         @include('statamic::partials.head')
     </head>
-    <body class="outside {{ config('statamic.cp.login_theme') }}-mode @yield('body_class')">
+    <body class="outside {{ config('statamic.cp.theme') }}-mode @yield('body_class')">
         <div id="statamic">
             @yield('content')
         </div>

--- a/resources/views/partials/favicon.antlers.html
+++ b/resources/views/partials/favicon.antlers.html
@@ -1,0 +1,2 @@
+<link rel="icon" type="image/png" href="{{ glide :src="favicon_url" format="png" height="32" width="32" }}" sizes="32x32" />
+<link rel="icon" type="image/png" href="{{ glide :src="favicon_url" format="png" height="16" width="16" }}" sizes="16x16" />

--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -5,8 +5,8 @@
         <button class="nav-toggle md:hidden ml-sm flex-shrink-0" @click="toggleMobileNav" v-else v-cloak aria-label="{{ __('Toggle Mobile Nav') }}">@svg('close')</button>
         <a href="{{ route('statamic.cp.index') }}" class="flex items-end">
             <div v-tooltip="version" class="hidden md:block flex-shrink-0">
-                @if (Statamic::pro() && config('statamic.cp.logo_url'))
-                    <img src="{{ config('statamic.cp.logo_url') }}" alt="{{ config('statamic.cp.cms_name') }}" class="white-label-logo">
+                @if (Statamic::pro() && config('statamic.cp.custom_logo_url'))
+                    <img src="{{ config('statamic.cp.custom_logo_url') }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo">
                 @else
                     @svg('statamic-wordmark')
                     @if (Statamic::pro())<span class="font-bold text-4xs align-top">PRO</span>@endif

--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -5,13 +5,12 @@
         <button class="nav-toggle md:hidden ml-sm flex-shrink-0" @click="toggleMobileNav" v-else v-cloak aria-label="{{ __('Toggle Mobile Nav') }}">@svg('close')</button>
         <a href="{{ route('statamic.cp.index') }}" class="flex items-end">
             <div v-tooltip="version" class="hidden md:block flex-shrink-0">
-                @if (Statamic::pro() && config('statamic.cp.logo_path'))
-                    <img src="{{ config('statamic.cp.logo_path') }}" alt="{{ config('statamic.cp.cms_name') }}" class="white-label-logo">
+                @if (Statamic::pro() && config('statamic.cp.logo_url'))
+                    <img src="{{ config('statamic.cp.logo_url') }}" alt="{{ config('statamic.cp.cms_name') }}" class="white-label-logo">
                 @else
                     @svg('statamic-wordmark')
                     @if (Statamic::pro())<span class="font-bold text-4xs align-top">PRO</span>@endif
                 @endif
-
             </div>
         </a>
     </div>

--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -1,22 +1,27 @@
 <div class="global-header">
-    <div class="lg:w-56 pl-1 md:pl-3 h-full flex items-center">
+    <div class="lg:flex-1 pl-1 md:pl-3 h-full flex items-center">
         <button class="nav-toggle hidden md:block ml-sm flex-shrink-0" @click="toggleNav" aria-label="{{ __('Toggle Nav') }}">@svg('burger')</button>
         <button class="nav-toggle md:hidden ml-sm flex-shrink-0" @click="toggleMobileNav" v-if="! mobileNavOpen" aria-label="{{ __('Toggle Mobile Nav') }}">@svg('burger')</button>
         <button class="nav-toggle md:hidden ml-sm flex-shrink-0" @click="toggleMobileNav" v-else v-cloak aria-label="{{ __('Toggle Mobile Nav') }}">@svg('close')</button>
         <a href="{{ route('statamic.cp.index') }}" class="flex items-end">
             <div v-tooltip="version" class="hidden md:block flex-shrink-0">
-                @svg('statamic-wordmark')
-                @if (Statamic::pro())<span class="font-bold text-4xs align-top">PRO</span>@endif
+                @if (Statamic::pro() && config('statamic.cp.logo_path'))
+                    <img src="{{ config('statamic.cp.logo_path') }}" alt="{{ config('statamic.cp.cms_name') }}" class="white-label-logo">
+                @else
+                    @svg('statamic-wordmark')
+                    @if (Statamic::pro())<span class="font-bold text-4xs align-top">PRO</span>@endif
+                @endif
+
             </div>
         </a>
     </div>
 
-    <div class="sm:px-4 w-full flex-1 mx-auto" :class="wrapperClass">
+    <div class="sm:px-4 w-full flex-1 lg:flex items-center justify-center mx-auto" :class="wrapperClass">
         <global-search endpoint="{{ cp_route('search') }}" placeholder="{{ __('Search...') }}">
         </global-search>
     </div>
 
-    <div class="lg:absolute top-0 right-0 head-link h-full md:pr-3 flex items-center">
+    <div class="head-link h-full md:pr-3 flex items-center justify-end lg:flex-1">
 
         @if (Statamic\Facades\Site::hasMultiple())
             <global-site-selector>
@@ -38,15 +43,19 @@
                 </button>
             </template>
 
+            @if (config('statamic.cp.link_to_docs'))
             <dropdown-item external-link="https://statamic.dev" class="flex items-center">
                 <span>{{__('Documentation')}}</span>
                 <i class="w-3 block ml-1">@svg('external-link')</i>
             </dropdown-item>
+            @endif
 
-            <dropdown-item external-link="https://statamic.com/forum" class="flex items-center">
+            @if (config('statamic.cp.support_link'))
+            <dropdown-item external-link="{{ config('statamic.cp.support_link') }}" class="flex items-center">
                 <span>{{__('Support')}}</span>
                 <i class="w-3 block ml-1">@svg('external-link')</i>
             </dropdown-item>
+            @endif
 
             <dropdown-item @click="$events.$emit('keyboard-shortcuts.open')" class="flex items-center">
                 <span>{{__('Keyboard Shortcuts')}}</span>

--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -49,8 +49,8 @@
             </dropdown-item>
             @endif
 
-            @if (config('statamic.cp.support_link'))
-            <dropdown-item external-link="{{ config('statamic.cp.support_link') }}" class="flex items-center">
+            @if (config('statamic.cp.support_url'))
+            <dropdown-item external-link="{{ config('statamic.cp.support_url') }}" class="flex items-center">
                 <span>{{__('Support')}}</span>
                 <i class="w-3 block ml-1">@svg('external-link')</i>
             </dropdown-item>

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -2,11 +2,15 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 <meta name="viewport" content="width=device-width">
 <meta name="robots" content="noindex,nofollow">
-<title>@yield('title', $title ?? __('Here')) ‹ Statamic</title>
+<title>@yield('title', $title ?? __('Here')) ‹ {{ Statamic::pro() ? config('statamic.cp.custom_cms_name', 'Statamic') : 'Statamic' }}</title>
 <link rel="icon" type="image/png" href="{{ Statamic::cpAssetUrl('img/favicon-32x32.png') }}" sizes="32x32" />
 <link rel="icon" type="image/png" href="{{ Statamic::cpAssetUrl('img/favicon-16x16.png') }}" sizes="16x16" />
 <link rel="shortcut icon" type="image/x-icon" href="{{ Statamic::cpAssetUrl('img/favicon.ico') }}" sizes="16x16 32x32"/>
 <link href="{{ Statamic::cpAssetUrl('css/cp.css') }}?v={{ Statamic::version() }}" rel="stylesheet" />
+
+@if (Statamic::pro() && config('statamic.cp.custom_css_url'))
+<link href="{{ config('statamic.cp.custom_css_url') }}?v={{ Statamic::version() }}" rel="stylesheet" />
+@endif
 
 @foreach (Statamic::availableStyles(request()) as $package => $paths)
     @foreach ($paths as $path)

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -2,10 +2,17 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 <meta name="viewport" content="width=device-width">
 <meta name="robots" content="noindex,nofollow">
+
 <title>@yield('title', $title ?? __('Here')) ‹ {{ Statamic::pro() ? config('statamic.cp.custom_cms_name', 'Statamic') : 'Statamic' }}</title>
-<link rel="icon" type="image/png" href="{{ Statamic::cpAssetUrl('img/favicon-32x32.png') }}" sizes="32x32" />
-<link rel="icon" type="image/png" href="{{ Statamic::cpAssetUrl('img/favicon-16x16.png') }}" sizes="16x16" />
-<link rel="shortcut icon" type="image/x-icon" href="{{ Statamic::cpAssetUrl('img/favicon.ico') }}" sizes="16x16 32x32"/>
+
+@if (Statamic::pro() && config('statamic.cp.custom_favicon_url'))
+    @include('statamic::partials.favicon', ['favicon_url' => config('statamic.cp.custom_favicon_url')])
+@else
+    <link rel="icon" type="image/png" href="{{ Statamic::cpAssetUrl('img/favicon-32x32.png') }}" sizes="32x32" />
+    <link rel="icon" type="image/png" href="{{ Statamic::cpAssetUrl('img/favicon-16x16.png') }}" sizes="16x16" />
+    <link rel="shortcut icon" type="image/x-icon" href="{{ Statamic::cpAssetUrl('img/favicon.ico') }}" sizes="16x16 32x32"/>
+@endif
+
 <link href="{{ Statamic::cpAssetUrl('css/cp.css') }}?v={{ Statamic::version() }}" rel="stylesheet" />
 
 @if (Statamic::pro() && config('statamic.cp.custom_css_url'))

--- a/resources/views/partials/outside-logo.blade.php
+++ b/resources/views/partials/outside-logo.blade.php
@@ -1,0 +1,7 @@
+<div class="logo pt-7">
+    @if (Statamic::pro() && config('statamic.cp.logo_url'))
+        <img src="{{ config('statamic.cp.logo_url') }}" alt="{{ config('statamic.cp.cms_name') }}" class="white-label-logo">
+    @else
+        @svg('statamic-wordmark')
+    @endif
+</div>

--- a/resources/views/partials/outside-logo.blade.php
+++ b/resources/views/partials/outside-logo.blade.php
@@ -1,6 +1,6 @@
 <div class="logo pt-7">
-    @if (Statamic::pro() && config('statamic.cp.logo_url'))
-        <img src="{{ config('statamic.cp.logo_url') }}" alt="{{ config('statamic.cp.cms_name') }}" class="white-label-logo">
+    @if (Statamic::pro() && config('statamic.cp.custom_logo_url'))
+        <img src="{{ config('statamic.cp.custom_logo_url') }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo">
     @else
         @svg('statamic-wordmark')
     @endif


### PR DESCRIPTION
This PR adds the following `cp` config options that only work when Pro is enabled:

- `support_link`: Customizable or disableable support link
- `login_theme`: With `rad` and `business` modes
- `cms_name`: With which to replace the word "Statamic"
- `logo_path`: With which to replace the Statamic logo