### PR TITLE
Support for non-content blueprints

### DIFF
--- a/resources/views/blueprints/create.blade.php
+++ b/resources/views/blueprints/create.blade.php
@@ -1,0 +1,29 @@
+@extends('statamic::layout')
+@section('title', __('Create Blueprint'))
+
+@section('content')
+<form action="{{ $action }}" method="POST">
+    @csrf
+    <div class="max-w-lg mt-2 mx-auto">
+        <div class="rounded p-3 lg:px-7 lg:py-5 shadow bg-white">
+            <header class="text-center mb-6">
+                <h1 class="mb-3">{{ __('Create Blueprint') }}</h1>
+                <p class="text-grey">{{ __('statamic::messages.blueprints_intro') }}</p>
+            </header>
+            <div class="mb-5">
+                <label class="font-bold text-base mb-sm" for="name">{{ __('Title') }}</label>
+                <input type="text" name="title" value="{{ old('title') }}" class="input-text" autofocus required tabindex="1">
+                <div class="text-2xs text-grey-60 mt-1 flex items-center">
+                    {{ __('statamic::messages.blueprints_title_instructions') }}
+                </div>
+            </div>
+        </div>
+
+        <div class="flex justify-center mt-4">
+            <button tabindex="4" class="btn-primary mx-auto btn-lg">
+                {{ __('Create Blueprint')}}
+            </button>
+        </div>
+    </div>
+</form>
+@stop

--- a/resources/views/blueprints/edit.blade.php
+++ b/resources/views/blueprints/edit.blade.php
@@ -1,0 +1,21 @@
+@extends('statamic::layout')
+@section('title', __('Edit Blueprint'))
+
+@section('content')
+
+    @include('statamic::partials.breadcrumb', [
+        'url' => cp_route('blueprints.index'),
+        'title' => __('Blueprints'),
+    ])
+
+    <blueprint-builder
+        action="{{ cp_route('blueprints.update', ['blueprint' => $blueprint->handle()]) }}"
+        :initial-blueprint="{{ json_encode($blueprintVueObject) }}"
+    ></blueprint-builder>
+
+    @include('statamic::partials.docs-callout', [
+        'topic' => __('Blueprints'),
+        'url' => Statamic::docsUrl('blueprints')
+    ])
+
+@endsection

--- a/resources/views/blueprints/index.blade.php
+++ b/resources/views/blueprints/index.blade.php
@@ -23,6 +23,9 @@
                 @if ($loop->first)<h6 class="p-1 mt-2">{{ __('Taxonomies') }}</h6>@endif
                 <dropdown-item redirect="{{ cp_route('taxonomies.blueprints.create', $taxonomy) }}">{{ $taxonomy->title() }}</dropdown-item>
             @endforeach
+
+            <h6 class="p-1 mt-2">Other</h6>
+            <dropdown-item redirect="{{ cp_route('blueprints.create') }}">Miscellaneous</dropdown-item>
         </dropdown-list>
         </div>
     </div>

--- a/resources/views/blueprints/index.blade.php
+++ b/resources/views/blueprints/index.blade.php
@@ -144,6 +144,25 @@
                     </div>
                 </td>
             </tr>
+            @foreach ($miscBlueprints as $blueprint)
+                <tr>
+                    <td class="flex flex-row justify-between">
+                        <div class="flex items-center">
+                            <div class="w-4 h-4 mr-2">@svg('generic')</div>
+                            <a href="{{ cp_route('blueprints.edit', ['blueprint' => $blueprint->handle()]) }}">{{ $blueprint->title() }}</a>
+                        </div>
+
+                        <dropdown-list>
+                            <form action="{{ cp_route('blueprints.destroy', ['blueprint' => $blueprint->handle()]) }}" method="POST">
+                                @csrf
+                                @method('DELETE')
+
+                                <dropdown-item class="warning" text="Delete"></dropdown-item>
+                            </form>
+                        </dropdown-list>
+                    </td>
+                </tr>
+            @endforeach
         </table>
     </div>
 

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -142,6 +142,8 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::post('fieldsets/quick', 'FieldsetController@quickStore');
         Route::post('fieldsets/{fieldset}/fields', 'FieldsetFieldController@store');
         Route::get('blueprints', 'BlueprintController@index')->name('blueprints.index');
+        Route::get('blueprints/create', 'BlueprintController@create')->name('blueprints.create');
+        Route::post('blueprints/create', 'BlueprintController@store')->name('blueprints.store');
         Route::get('blueprints/{blueprint}', 'BlueprintController@edit')->name('blueprints.edit');
         Route::patch('blueprints/{blueprint}', 'BlueprintController@update')->name('blueprints.update');
         Route::delete('bluprints/{blueprint}', 'BlueprintController@destroy')->name('blueprints.destroy');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -142,6 +142,9 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::post('fieldsets/quick', 'FieldsetController@quickStore');
         Route::post('fieldsets/{fieldset}/fields', 'FieldsetFieldController@store');
         Route::get('blueprints', 'BlueprintController@index')->name('blueprints.index');
+        Route::get('blueprints/{blueprint}', 'BlueprintController@edit')->name('blueprints.edit');
+        Route::patch('blueprints/{blueprint}', 'BlueprintController@update')->name('blueprints.update');
+        Route::delete('bluprints/{blueprint}', 'BlueprintController@destroy')->name('blueprints.destroy');
         Route::get('fieldtypes', 'FieldtypesController@index');
     });
 

--- a/src/Http/Controllers/CP/Fields/BlueprintController.php
+++ b/src/Http/Controllers/CP/Fields/BlueprintController.php
@@ -28,6 +28,24 @@ class BlueprintController extends CpController
         ]);
     }
 
+    public function create()
+    {
+        return view('statamic::blueprints.create', [
+            'action' => cp_route('blueprints.store'),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate(['title' => 'required']);
+
+        $blueprint = $this->storeBlueprint($request, '');
+
+        return redirect()
+            ->cpRoute('blueprints.edit', [$blueprint])
+            ->with('success', __('Blueprint created'));
+    }
+
     public function edit($blueprint)
     {
         if ($blueprint === 'user') {
@@ -55,6 +73,8 @@ class BlueprintController extends CpController
 
         $blueprint->delete();
 
-        return redirect()->back();
+        return redirect()
+            ->cpRoute('blueprints.index')
+            ->with('success', __('Blueprint deleted'));
     }
 }

--- a/src/Http/Controllers/CP/Fields/BlueprintController.php
+++ b/src/Http/Controllers/CP/Fields/BlueprintController.php
@@ -2,10 +2,14 @@
 
 namespace Statamic\Http\Controllers\CP\Fields;
 
+use Illuminate\Http\Request;
+use Statamic\Facades\Blueprint;
 use Statamic\Http\Controllers\CP\CpController;
 
 class BlueprintController extends CpController
 {
+    use ManagesBlueprints;
+
     public function __construct()
     {
         $this->middleware(\Illuminate\Auth\Middleware\Authorize::class.':configure fields');
@@ -13,6 +17,44 @@ class BlueprintController extends CpController
 
     public function index()
     {
-        return view('statamic::blueprints.index');
+        $miscBlueprints = collect(Blueprint::in(''))
+            ->reject(function ($blueprint) {
+                return $blueprint->handle() === 'user';
+            })
+            ->toArray();
+
+        return view('statamic::blueprints.index', [
+            'miscBlueprints' => $miscBlueprints,
+        ]);
+    }
+
+    public function edit($blueprint)
+    {
+        if ($blueprint === 'user') {
+            return redirect(cp_route('users.blueprint.edit'));
+        }
+
+        $blueprint = Blueprint::find($blueprint);
+
+        return view('statamic::blueprints.edit', [
+            'blueprint' => $blueprint,
+            'blueprintVueObject' => $this->toVueObject($blueprint),
+        ]);
+    }
+
+    public function update(Request $request, $blueprint)
+    {
+        $request->validate(['sections' => 'array']);
+
+        $this->updateBlueprint($request, Blueprint::find($blueprint));
+    }
+
+    public function destroy($blueprint)
+    {
+        $blueprint = Blueprint::find($blueprint);
+
+        $blueprint->delete();
+
+        return redirect()->back();
     }
 }


### PR DESCRIPTION
This pull request allows you to edit blueprints that aren't attached to content (collections, taxonomies, assets, users, etc). 

Now whenever a user goes to the blueprint page, under the 'Other' section, they will be able to see any extra blueprints they have defined in their `resources/blueprints` folder.

For example, this could be useful for [Runway](https://github.com/doublethreedigital/runway) where a user can create & update a custom blueprint and they can specify the blueprint's handle instead of providing a blueprint via an array.

## Changes
* Created new create, update and delete routes, controller methods and views.
* Displays any misc blueprints under the 'Other' section of the Blueprints page

## Related Issues
Implements statamic/ideas#408