### PR TITLE
Patch hidden blueprint functionality

### DIFF
--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -37,11 +37,13 @@ trait ManagesBlueprints
             ]];
         })->all();
 
-        $blueprint->setContents(array_filter([
-            'hide' => $request->hidden,
-            'title' => $request->title,
-            'sections' => $sections,
-        ]));
+        $blueprint->setContents(array_merge(
+            ['hide' => $request->hidden],
+            array_filter([
+                'title' => $request->title,
+                'sections' => $sections,
+            ])
+        ));
 
         return $blueprint;
     }

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -37,13 +37,12 @@ trait ManagesBlueprints
             ]];
         })->all();
 
-        $blueprint->setContents(array_merge(
-            ['hide' => $request->hidden],
-            array_filter([
+        $blueprint
+            ->setHidden($request->hidden)
+            ->setContents(array_filter([
                 'title' => $request->title,
                 'sections' => $sections,
-            ])
-        ));
+            ]));
 
         return $blueprint;
     }


### PR DESCRIPTION
Not sure how this happened since in my initial testing it did work, but right now it's not possible to turn off the 'hidden' toggle on a blueprint. This is because the `false` value will get filtered out... I've provided a patch so it will actually turn it off.

This will fix #3032.