### PR TITLE
Add confirmation to modal before updating

### DIFF
--- a/resources/js/components/updater/Release.vue
+++ b/resources/js/components/updater/Release.vue
@@ -21,8 +21,8 @@
 
         <confirmation-modal
             v-if="confirmationPrompt"
-            :title="packageName"
-            :bodyText="__('Are you sure you want to :type to :version?', { type: confirmationPrompt.type, version: confirmationPrompt.version })"
+            :title="confirmationTitle"
+            :bodyText="confirmationText"
             :buttonText="__('Confirm')"
             :danger="true"
             @confirm="$emit('install')"
@@ -45,6 +45,24 @@ export default {
     data() {
         return {
             confirmationPrompt: null,
+        }
+    },
+
+    computed: {
+        confirmationTitle() {
+            let attrs = { name: this.packageName }
+
+            return this.confirmationPrompt.type === 'downgrade'
+                ? __('Downgrade :name', attrs)
+                : __('Update :name', attrs)
+        },
+
+        confirmationText() {
+            let attrs = { version: this.confirmationPrompt.version }
+
+            return this.confirmationPrompt.type === 'downgrade'
+                ? __('Are you sure you want to downgrade to :version?', attrs)
+                : __('Are you sure you want to update to :version?', attrs)
         }
     },
 

--- a/resources/js/components/updater/Release.vue
+++ b/resources/js/components/updater/Release.vue
@@ -8,8 +8,8 @@
             </div>
             <div v-if="showActions">
                 <button v-if="release.type === 'current'" class="btn opacity-50" disabled v-text="__('Current Version')" />
-                <button v-else-if="release.latest" @click="confirmationOpen = true" class="btn" v-text="__('Update to Latest')" />
-                <button v-else @click="confirmationOpen = true" class="btn">
+                <button v-else-if="release.latest" @click="confirmationPrompt = release" class="btn" v-text="__('Update to Latest')" />
+                <button v-else @click="confirmationPrompt = release" class="btn">
                     <template v-if="release.type === 'upgrade'">{{ __('Update to :version', { version: release.version }) }}</template>
                     <template v-if="release.type === 'downgrade'">{{ __('Downgrade to :version', { version: release.version }) }}</template>
                 </button>
@@ -20,13 +20,13 @@
         </div>
 
         <confirmation-modal
-            v-if="confirmationOpen"
-            :title="__('Update Statamic')"
-            :bodyText="__('Are you sure you want to update Statamic?')"
+            v-if="confirmationPrompt"
+            :title="packageName"
+            :bodyText="__('Are you sure you want to :type to :version?', { type: confirmationPrompt.type, version: confirmationPrompt.version })"
             :buttonText="__('Confirm')"
             :danger="true"
             @confirm="$emit('install')"
-            @cancel="confirmationOpen = false"
+            @cancel="confirmationPrompt = null"
         >
         </confirmation-modal>
     </div>
@@ -38,12 +38,13 @@ export default {
 
     props: {
         release: { type: Object, required: true },
+        packageName: { type: String, required: true },
         showActions: { type: Boolean }
     },
 
     data() {
         return {
-            confirmationOpen: false,
+            confirmationPrompt: null,
         }
     },
 

--- a/resources/js/components/updater/Release.vue
+++ b/resources/js/components/updater/Release.vue
@@ -8,8 +8,8 @@
             </div>
             <div v-if="showActions">
                 <button v-if="release.type === 'current'" class="btn opacity-50" disabled v-text="__('Current Version')" />
-                <button v-else-if="release.latest" @click="$emit('install')" class="btn" v-text="__('Update to Latest')" />
-                <button v-else @click="$emit('install')" class="btn">
+                <button v-else-if="release.latest" @click="confirmationOpen = true" class="btn" v-text="__('Update to Latest')" />
+                <button v-else @click="confirmationOpen = true" class="btn">
                     <template v-if="release.type === 'upgrade'">{{ __('Update to :version', { version: release.version }) }}</template>
                     <template v-if="release.type === 'downgrade'">{{ __('Downgrade to :version', { version: release.version }) }}</template>
                 </button>
@@ -18,6 +18,17 @@
         <div class="card-body">
             <div v-html="release.body"></div>
         </div>
+
+        <confirmation-modal
+            v-if="confirmationOpen"
+            :title="__('Update Statamic')"
+            :bodyText="__('Are you sure you want to update Statamic?')"
+            :buttonText="__('Confirm')"
+            :danger="true"
+            @confirm="$emit('install')"
+            @cancel="confirmationOpen = false"
+        >
+        </confirmation-modal>
     </div>
 
 </template>
@@ -28,7 +39,13 @@ export default {
     props: {
         release: { type: Object, required: true },
         showActions: { type: Boolean }
-    }
+    },
+
+    data() {
+        return {
+            confirmationOpen: false,
+        }
+    },
 
 }
 </script>

--- a/resources/js/components/updater/Release.vue
+++ b/resources/js/components/updater/Release.vue
@@ -25,7 +25,7 @@
             :bodyText="confirmationText"
             :buttonText="__('Confirm')"
             :danger="true"
-            @confirm="$emit('install')"
+            @confirm="confirm"
             @cancel="confirmationPrompt = null"
         >
         </confirmation-modal>
@@ -65,6 +65,15 @@ export default {
                 : __('Are you sure you want to update to :version?', attrs)
         }
     },
+
+    methods: {
+
+        confirm() {
+            this.confirmationPrompt = null;
+            this.$nextTick(() => this.$emit('install'));
+        }
+
+    }
 
 }
 </script>

--- a/resources/js/components/updater/Updater.vue
+++ b/resources/js/components/updater/Updater.vue
@@ -36,6 +36,7 @@
                 v-for="release in unlicensedReleases"
                 :key="release.version"
                 :release="release"
+                :package-name="name"
                 :show-actions="showActions"
                 @install="installExplicitVersion(release.version)"
             />
@@ -45,6 +46,7 @@
             v-for="release in licensedReleases"
             :key="release.version"
             :release="release"
+            :package-name="name"
             :show-actions="showActions"
             @install="installExplicitVersion(release.version)"
         />


### PR DESCRIPTION
This pull request adds a confirmation modal to the Statamic updater before the site begins to update. Closes #884.