### PR TITLE
Read-only Publish toggle on Entries

### DIFF
--- a/resources/js/components/entries/BaseCreateForm.vue
+++ b/resources/js/components/entries/BaseCreateForm.vue
@@ -17,6 +17,7 @@
         :revisions-enabled="revisions"
         :breadcrumbs="breadcrumbs"
         :initial-site="site"
+        :can-manage-publish-state="canManagePublishState"
         :create-another-url="createAnotherUrl"
         :listing-url="listingUrl"
         @saved="saved"
@@ -37,6 +38,7 @@ export default {
         'revisions',
         'breadcrumbs',
         'site',
+        'canManagePublishState',
         'createAnotherUrl',
         'listingUrl',
     ],

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -121,7 +121,7 @@
 
                                 <div class="flex items-center border-t justify-between px-2 py-1" v-if="!revisionsEnabled">
                                     <label v-text="__('Published')" class="publish-field-label font-medium" />
-                                    <toggle-input :value="published" @input="setFieldValue('published', $event)" />
+                                    <toggle-input :value="published" :read-only="!canManagePublishState" @input="setFieldValue('published', $event)" />
                                 </div>
 
                                 <div class="border-t p-2" v-if="revisionsEnabled && !isCreating">
@@ -297,6 +297,7 @@ export default {
         revisionsEnabled: Boolean,
         preloadedAssets: Array,
         canEditBlueprint: Boolean,
+        canManagePublishState: Boolean,
         createAnotherUrl: String,
         listingUrl: String,
     },

--- a/resources/views/entries/create.blade.php
+++ b/resources/views/entries/create.blade.php
@@ -16,7 +16,7 @@
         site="{{ $locale }}"
         create-another-url="{{ cp_route('collections.entries.create', [$collection, $locale, 'blueprint' => $blueprint['handle']]) }}"
         listing-url="{{ cp_route('collections.show', $collection) }}"
-        :can-manage-publish-state="{{ Statamic\Support\Str::bool($user->can('publish '.$collection.' entries')) }}"
+        :can-manage-publish-state="{{ Statamic\Support\Str::bool($canManagePublishState) }}"
     ></base-entry-create-form>
 
 @endsection

--- a/resources/views/entries/create.blade.php
+++ b/resources/views/entries/create.blade.php
@@ -16,6 +16,7 @@
         site="{{ $locale }}"
         create-another-url="{{ cp_route('collections.entries.create', [$collection, $locale, 'blueprint' => $blueprint['handle']]) }}"
         listing-url="{{ cp_route('collections.show', $collection) }}"
+        :can-manage-publish-state="{{ Statamic\Support\Str::bool($user->can('publish '.$collection.' entries')) }}"
     ></base-entry-create-form>
 
 @endsection

--- a/resources/views/entries/edit.blade.php
+++ b/resources/views/entries/edit.blade.php
@@ -30,7 +30,7 @@
         :preloaded-assets="{{ json_encode($preloadedAssets) }}"
         :breadcrumbs="{{ $breadcrumbs->toJson() }}"
         :can-edit-blueprint="{{ $str::bool($user->can('configure fields')) }}"
-        :can-manage-publish-state="{{ $str::bool($user->can('publish', $entry)) }}"
+        :can-manage-publish-state="{{ $str::bool($canManagePublishState) }}"
         create-another-url="{{ cp_route('collections.entries.create', [$collection, $locale]) }}"
         listing-url="{{ cp_route('collections.show', $collection) }}"
     ></entry-publish-form>

--- a/resources/views/entries/edit.blade.php
+++ b/resources/views/entries/edit.blade.php
@@ -30,7 +30,7 @@
         :preloaded-assets="{{ json_encode($preloadedAssets) }}"
         :breadcrumbs="{{ $breadcrumbs->toJson() }}"
         :can-edit-blueprint="{{ $str::bool($user->can('configure fields')) }}"
-        :can-manage-publish-state="{{ $str::bool($user->can('publish '.$collection.' entries')) }}"
+        :can-manage-publish-state="{{ $str::bool($user->can('publish', $entry)) }}"
         create-another-url="{{ cp_route('collections.entries.create', [$collection, $locale]) }}"
         listing-url="{{ cp_route('collections.show', $collection) }}"
     ></entry-publish-form>

--- a/resources/views/entries/edit.blade.php
+++ b/resources/views/entries/edit.blade.php
@@ -30,6 +30,7 @@
         :preloaded-assets="{{ json_encode($preloadedAssets) }}"
         :breadcrumbs="{{ $breadcrumbs->toJson() }}"
         :can-edit-blueprint="{{ $str::bool($user->can('configure fields')) }}"
+        :can-manage-publish-state="{{ $str::bool($user->can('publish '.$collection.' entries')) }}"
         create-another-url="{{ cp_route('collections.entries.create', [$collection, $locale]) }}"
         listing-url="{{ cp_route('collections.show', $collection) }}"
     ></entry-publish-form>

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -42,6 +42,7 @@ class Entries extends Relationship
         'revisionsEnabled' => 'revisionsEnabled',
         'breadcrumbs' => 'breadcrumbs',
         'collectionHandle' => 'collection',
+        'canManagePublishState' => 'canManagePublishState',
     ];
 
     protected function configFieldItems(): array

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -127,6 +127,7 @@ class EntriesController extends CpController
             'preloadedAssets' => $this->extractAssetsFromValues($values),
             'revisionsEnabled' => $entry->revisionsEnabled(),
             'breadcrumbs' => $this->breadcrumbs($collection),
+            'canManagePublishState' => User::current()->can('publish', $entry),
         ];
 
         if ($request->wantsJson()) {
@@ -254,6 +255,7 @@ class EntriesController extends CpController
             })->all(),
             'revisionsEnabled' => $collection->revisionsEnabled(),
             'breadcrumbs' => $this->breadcrumbs($collection),
+            'canManagePublishState' => User::current()->can('publish '.$collection->handle().' entries'),
         ];
 
         if ($request->wantsJson()) {

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -189,7 +189,7 @@ class EntriesController extends CpController
                 ->user(User::current())
                 ->save();
         } else {
-            if (! $entry->revisionsEnabled()) {
+            if (! $entry->revisionsEnabled() && User::current()->can('publish', $entry)) {
                 $entry->published($request->published);
             }
 

--- a/tests/Feature/Entries/StoreEntryTest.php
+++ b/tests/Feature/Entries/StoreEntryTest.php
@@ -114,6 +114,14 @@ class StoreEntryTest extends TestCase
         $this->assertCount(0, Entry::all());
     }
 
+    /** @test */
+    public function user_without_permission_to_manage_publish_state_cannot_change_publish_status()
+    {
+        // when revisions are disabled
+
+        $this->markTestIncomplete();
+    }
+
     private function store($payload)
     {
         return $this->post(cp_route('collections.entries.store', ['blog', 'en']), $payload);

--- a/tests/Feature/Entries/UpdateEntryTest.php
+++ b/tests/Feature/Entries/UpdateEntryTest.php
@@ -177,6 +177,14 @@ class UpdateEntryTest extends TestCase
         ], $entry->data());
     }
 
+    /** @test */
+    public function user_without_permission_to_manage_publish_state_cannot_change_publish_status()
+    {
+        // when revisions are disabled
+
+        $this->markTestIncomplete();
+    }
+
     private function save($entry, $payload)
     {
         return $this->patch($entry->updateUrl(), $payload);


### PR DESCRIPTION
This PR fixes #1011 where if the 'manage publish state' permission isn't checked on a role and when a user in the role tries, they would be able to toggle the publish state.

This PR fixes this bug from the front-end by passing in a new `can-manage-publish-state` prop of whether or not the user has permission to manage publish state on that collection. 

However it does seem like it could be a good idea to also enforce this on the backend side as well. What do you think?