### PR TITLE
Add 'mount' variable to entries

### DIFF
--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -5,6 +5,7 @@ namespace Statamic\View;
 use Illuminate\Http\Request;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Facades;
+use Statamic\Facades\Collection;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\URL;
 use Statamic\Sites\Site;
@@ -141,6 +142,8 @@ class Cascade
         $variables = $this->content instanceof Augmentable
             ? $this->content->toAugmentedArray()
             : $this->content->toArray();
+
+        $variables['mount'] = Collection::findByMount($this->content()->entry());
 
         foreach ($variables as $key => $value) {
             $this->set($key, $value);


### PR DESCRIPTION
This PR adds in the `mount` variable to entries to maintain compatibility with v2. This PR implements #1352.

The variable returns a Collection object but maybe it should just return the handle of the associated collection? I'm not sure how it was done in v2. 