### PR TITLE
Fix for #1776

### DIFF
--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -240,7 +240,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
 
     public function url()
     {
-        return ($this->collection ? $this->collection->url() : '') . $this->uri();
+        return ($this->collection ? $this->collection->url() : '').$this->uri();
     }
 
     public function collection($collection = null)

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Statamic\Contracts\Data\Augmentable as AugmentableContract;
 use Statamic\Contracts\Taxonomies\Taxonomy as Contract;
 use Statamic\Data\ContainsCascadingData;
+use Statamic\Data\ContainsSupplementalData;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Data\HasAugmentedData;
 use Statamic\Events\TaxonomyDeleted;
@@ -22,7 +23,7 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class Taxonomy implements Contract, Responsable, AugmentableContract
 {
-    use FluentlyGetsAndSets, ExistsAsFile, HasAugmentedData, ContainsCascadingData;
+    use FluentlyGetsAndSets, ExistsAsFile, HasAugmentedData, ContainsCascadingData, ContainsSupplementalData;
 
     protected $handle;
     protected $title;
@@ -235,6 +236,11 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
     public function uri()
     {
         return str_replace('_', '-', '/'.$this->handle);
+    }
+
+    public function url()
+    {
+        return $this->uri();
     }
 
     public function collection($collection = null)

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -240,7 +240,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
 
     public function url()
     {
-        return $this->collection->url() . $this->uri();
+        return ($this->collection ? $this->collection->url() : '') . $this->uri();
     }
 
     public function collection($collection = null)

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -240,7 +240,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
 
     public function url()
     {
-        return Site::current();
+        return $this->collection->url() . $this->uri();
     }
 
     public function collection($collection = null)

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -240,7 +240,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
 
     public function url()
     {
-        return $this->uri();
+        return Site::current();
     }
 
     public function collection($collection = null)
@@ -324,6 +324,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
         return [
             'title' => $this->title(),
             'handle' => $this->handle(),
+            'url' => $this->url(),
         ];
     }
 }

--- a/tests/Data/Taxonomies/TaxonomyTest.php
+++ b/tests/Data/Taxonomies/TaxonomyTest.php
@@ -97,4 +97,22 @@ class TaxonomyTest extends TestCase
         $this->assertEquals($blueprint, $taxonomy->termBlueprint('tags'));
         $this->assertNull($taxonomy->termBlueprint('two'));
     }
+
+    /** @test */
+    public function it_returns_a_url_for_breadcrumbs()
+    {
+        $taxonomy = (new Taxonomy)->handle('tags');
+        $this->assertEquals("/tags", $taxonomy->url());
+    }
+
+    /** @test */
+    public function it_gets_and_sets_supplemental_data()
+    {
+        $taxonomy = (new Taxonomy)->handle('tags');
+
+        $return = $taxonomy->setSupplement('foo', 'bar');
+
+        $this->assertEquals($taxonomy, $return);
+        $this->assertEquals('bar', $taxonomy->getSupplement('foo'));
+    }
 }

--- a/tests/Data/Taxonomies/TaxonomyTest.php
+++ b/tests/Data/Taxonomies/TaxonomyTest.php
@@ -102,7 +102,7 @@ class TaxonomyTest extends TestCase
     public function it_returns_a_url_for_breadcrumbs()
     {
         $taxonomy = (new Taxonomy)->handle('tags');
-        $this->assertEquals('http://localhost', $taxonomy->url()->url());
+        $this->assertEquals("/tags", $taxonomy->url());
     }
 
     /** @test */

--- a/tests/Data/Taxonomies/TaxonomyTest.php
+++ b/tests/Data/Taxonomies/TaxonomyTest.php
@@ -102,7 +102,7 @@ class TaxonomyTest extends TestCase
     public function it_returns_a_url_for_breadcrumbs()
     {
         $taxonomy = (new Taxonomy)->handle('tags');
-        $this->assertEquals("/tags", $taxonomy->url());
+        $this->assertEquals('/tags', $taxonomy->url());
     }
 
     /** @test */

--- a/tests/Data/Taxonomies/TaxonomyTest.php
+++ b/tests/Data/Taxonomies/TaxonomyTest.php
@@ -102,7 +102,7 @@ class TaxonomyTest extends TestCase
     public function it_returns_a_url_for_breadcrumbs()
     {
         $taxonomy = (new Taxonomy)->handle('tags');
-        $this->assertEquals('/tags', $taxonomy->url());
+        $this->assertEquals('http://localhost', $taxonomy->url()->url());
     }
 
     /** @test */


### PR DESCRIPTION
This pull request implements a fix for issue #1776 by:

* Adding a `url()` method to `Statamic\Taxonomies\Taxonomy` so as to enable getting the URL for use in the breadcrumbs
* Pulling in the existing trait `Statamic\Data\ContainsSupplementalData` so that taxonomy can be set as current
