### PR TITLE
Composer require & update --with-dependencies

### DIFF
--- a/src/Console/Processes/Composer.php
+++ b/src/Console/Processes/Composer.php
@@ -82,8 +82,8 @@ class Composer extends Process
     public function require(string $package, string $version = null)
     {
         $version
-            ? $this->queueComposerCommand('require', $package, $version)
-            : $this->queueComposerCommand('require', $package);
+            ? $this->queueComposerCommand('require', $package, $version, '--update-with-dependencies')
+            : $this->queueComposerCommand('require', $package, '--update-with-dependencies');
     }
 
     /**
@@ -103,7 +103,7 @@ class Composer extends Process
      */
     public function update(string $package)
     {
-        $this->queueComposerCommand('update', $package);
+        $this->queueComposerCommand('update', $package, '--with-dependencies');
     }
 
     /**


### PR DESCRIPTION
Always require and update `--with-dependencies` to avoid version conflicts.  Fixes #2548.

_Note: We shouldn't `--with-all-dependencies` though, as we want to respect the user's composer.json/lock.  If they've explicitly required another package, it should be up to them to update it._