### PR TITLE
Add 'mount' variable to Entries - Take #2

### DIFF
--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -67,6 +67,6 @@ class AugmentedEntry extends AbstractAugmented
 
     protected function mount()
     {
-        return Collection::findByMount($this->data);
+        return $this->data->value('mount') ?? Collection::findByMount($this->data);
     }
 }

--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -3,6 +3,7 @@
 namespace Statamic\Entries;
 
 use Statamic\Data\AbstractAugmented;
+use Statamic\Facades\Collection;
 
 class AugmentedEntry extends AbstractAugmented
 {
@@ -32,6 +33,7 @@ class AugmentedEntry extends AbstractAugmented
             'order',
             'is_entry',
             'collection',
+            'mount',
             'last_modified',
             'updated_at',
             'updated_by',
@@ -61,5 +63,10 @@ class AugmentedEntry extends AbstractAugmented
     protected function parent()
     {
         return $this->data->parent();
+    }
+
+    protected function mount()
+    {
+        return Collection::findByMount($this->data);
     }
 }

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -5,7 +5,6 @@ namespace Statamic\View;
 use Illuminate\Http\Request;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Facades;
-use Statamic\Facades\Collection;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\URL;
 use Statamic\Sites\Site;
@@ -142,8 +141,6 @@ class Cascade
         $variables = $this->content instanceof Augmentable
             ? $this->content->toAugmentedArray()
             : $this->content->toArray();
-
-        $variables['mount'] = Collection::findByMount($this->content()->entry());
 
         foreach ($variables as $key => $value) {
             $this->set($key, $value);

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -5,6 +5,7 @@ namespace Statamic\View;
 use Illuminate\Http\Request;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Facades;
+use Statamic\Facades\Collection;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\URL;
 use Statamic\Sites\Site;
@@ -141,6 +142,8 @@ class Cascade
         $variables = $this->content instanceof Augmentable
             ? $this->content->toAugmentedArray()
             : $this->content->toArray();
+
+        $variables['mount'] = Collection::findByMount($this->content()->entry());
 
         foreach ($variables as $key => $value) {
             $this->set($key, $value);

--- a/tests/Data/Entries/AugmentedEntryTest.php
+++ b/tests/Data/Entries/AugmentedEntryTest.php
@@ -93,6 +93,7 @@ class AugmentedEntryTest extends AugmentedTestCase
             'order'         => ['type' => 'null', 'value' => null], // todo: test for when this is an int
             'is_entry'      => ['type' => 'bool', 'value' => true],
             'collection'    => ['type' => CollectionContract::class, 'value' => $collection],
+            'mount'         => ['type' => 'null', 'value' => null],
             'last_modified' => ['type' => Carbon::class, 'value' => '2017-02-03 14:10'],
             'updated_at'    => ['type' => Carbon::class, 'value' => '2017-02-03 14:10'],
             'updated_by'    => ['type' => UserContract::class, 'value' => 'test-user'],

--- a/tests/Data/Entries/AugmentedEntryTest.php
+++ b/tests/Data/Entries/AugmentedEntryTest.php
@@ -76,6 +76,8 @@ class AugmentedEntryTest extends AugmentedTestCase
             ->setSupplement('three', 'the "three" value supplemented on the entry')
             ->setSupplement('four', 'the "four" value supplemented on the entry and in the blueprint');
 
+        $mount = tap(Collection::make('mountable')->mount($entry->id()))->save();
+
         $augmented = new AugmentedEntry($entry);
 
         $expectations = [
@@ -93,7 +95,7 @@ class AugmentedEntryTest extends AugmentedTestCase
             'order'         => ['type' => 'null', 'value' => null], // todo: test for when this is an int
             'is_entry'      => ['type' => 'bool', 'value' => true],
             'collection'    => ['type' => CollectionContract::class, 'value' => $collection],
-            'mount'         => ['type' => 'null', 'value' => null],
+            'mount'         => ['type' => CollectionContract::class, 'value' => $mount],
             'last_modified' => ['type' => Carbon::class, 'value' => '2017-02-03 14:10'],
             'updated_at'    => ['type' => Carbon::class, 'value' => '2017-02-03 14:10'],
             'updated_by'    => ['type' => UserContract::class, 'value' => 'test-user'],

--- a/tests/Data/Entries/AugmentedEntryTest.php
+++ b/tests/Data/Entries/AugmentedEntryTest.php
@@ -112,4 +112,25 @@ class AugmentedEntryTest extends AugmentedTestCase
 
         $this->assertAugmentedCorrectly($expectations, $augmented);
     }
+
+    /** @test */
+    public function it_gets_the_mount_from_the_value_first_if_it_exists()
+    {
+        $mount = tap(Collection::make('a'))->save();
+
+        $entry = EntryFactory::id('entry-id')
+            ->collection('test')
+            ->slug('entry-slug')
+            ->create();
+
+        $augmented = new AugmentedEntry($entry);
+
+        $this->assertNull($augmented->get('mount'));
+
+        $mount->mount($entry->id())->save();
+        $this->assertEquals($mount, $augmented->get('mount'));
+
+        $entry->set('mount', 'b');
+        $this->assertEquals('b', $augmented->get('mount'));
+    }
 }


### PR DESCRIPTION
This PR implements a new `mount` variable to entries when they are augmented, as [suggested by Jason](https://github.com/statamic/cms/pull/3040#issuecomment-749063934) on my previous PR.

This feels a lot cleaner than doing it directly on the Cascade class. Let me know if there's any changes you'd like me to make to this.

This PR implements #1352.