### PR TITLE
Implement findOrFail on the user repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "extra": {
         "download-dist": {
-            "url": "https://github.com/statamic/cms/releases/download/{$version}/dist.tar.gz",
+            "url": "https://github.com/edalzell/cms/releases/download/{$version}/dist.tar.gz",
             "path": "resources/dist"
         },
         "laravel": {

--- a/src/Auth/Eloquent/UserRepository.php
+++ b/src/Auth/Eloquent/UserRepository.php
@@ -42,7 +42,7 @@ class UserRepository extends BaseRepository
         return null;
     }
 
-    public function findOrFail($id, $columns = []): User
+    public function findOrFail($id, $columns = []): UserContract
     {
         $result = $this->find($id);
 

--- a/src/Auth/Eloquent/UserRepository.php
+++ b/src/Auth/Eloquent/UserRepository.php
@@ -3,6 +3,7 @@
 namespace Statamic\Auth\Eloquent;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Statamic\Auth\UserCollection;
 use Statamic\Auth\UserRepository as BaseRepository;
 use Statamic\Contracts\Auth\User as UserContract;
@@ -39,6 +40,17 @@ class UserRepository extends BaseRepository
         }
 
         return null;
+    }
+
+    public function findOrFail($id, $columns = []): ?User
+    {
+        $result = $this->find($id);
+
+        if (! is_null($result)) {
+            return $result;
+        }
+
+        throw (new ModelNotFoundException)->setModel(Model::class, $id);
     }
 
     public function findByEmail(string $email): ?UserContract

--- a/src/Auth/Eloquent/UserRepository.php
+++ b/src/Auth/Eloquent/UserRepository.php
@@ -42,7 +42,7 @@ class UserRepository extends BaseRepository
         return null;
     }
 
-    public function findOrFail($id, $columns = []): ?User
+    public function findOrFail($id, $columns = []): User
     {
         $result = $this->find($id);
 

--- a/src/Contracts/Auth/UserRepository.php
+++ b/src/Contracts/Auth/UserRepository.php
@@ -12,7 +12,7 @@ interface UserRepository
 
     public function find($id): ?User;
 
-    public function findOrFail($id, $columns = []): ?User;
+    public function findOrFail($id, $columns = []): User;
 
     public function findByEmail(string $email): ?User;
 

--- a/src/Contracts/Auth/UserRepository.php
+++ b/src/Contracts/Auth/UserRepository.php
@@ -12,6 +12,8 @@ interface UserRepository
 
     public function find($id): ?User;
 
+    public function findOrFail($id, $columns = []): ?User;
+
     public function findByEmail(string $email): ?User;
 
     public function findByOAuthId(string $provider, string $id): ?User;

--- a/src/Stache/Repositories/UserRepository.php
+++ b/src/Stache/Repositories/UserRepository.php
@@ -42,7 +42,7 @@ class UserRepository extends BaseRepository
         return $this->store->getItem($id);
     }
 
-    public function findOrFail($id, $columns = []): ?User
+    public function findOrFail($id, $columns = []): User
     {
         $result = $this->find($id);
 

--- a/src/Stache/Repositories/UserRepository.php
+++ b/src/Stache/Repositories/UserRepository.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Stache\Repositories;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Statamic\Auth\File\RoleRepository;
 use Statamic\Auth\File\User as FileUser;
 use Statamic\Auth\File\UserGroupRepository;
@@ -39,6 +40,17 @@ class UserRepository extends BaseRepository
     public function find($id): ?User
     {
         return $this->store->getItem($id);
+    }
+
+    public function findOrFail($id, $columns = []): ?User
+    {
+        $result = $this->find($id);
+
+        if (! is_null($result)) {
+            return $result;
+        }
+
+        throw (new ModelNotFoundException)->setModel(FileUser::class, $id);
     }
 
     public function findByEmail(string $email): ?User


### PR DESCRIPTION
Use case:

Trying to use a Laravel package: https://github.com/grosv/laravel-passwordless-login to implement passwordless login.

As it's a Laravel package, it expects the `User` "model" to have `findOrFail` implemented.