### PR TITLE
Add UserRegistering event

### DIFF
--- a/src/Events/UserRegistering.php
+++ b/src/Events/UserRegistering.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class UserRegistering extends Event
+{
+    public $user;
+
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -58,18 +58,18 @@ class UserController extends Controller
             return $this->userRegistrationFailure($validator->errors());
         }
 
-        try {
-            $values = $fields->process()->values()->except(['email', 'groups', 'roles']);
+        $values = $fields->process()->values()->except(['email', 'groups', 'roles']);
 
-            $user = User::make()
+        $user = User::make()
             ->email($request->email)
             ->password($request->password)
             ->data($values);
 
-            if ($roles = config('statamic.users.new_user_roles')) {
-                $user->roles($roles);
-            }
+        if ($roles = config('statamic.users.new_user_roles')) {
+            $user->roles($roles);
+        }
 
+        try {
             throw_if(UserRegistering::dispatch($user) === false, new SilentFormFailureException);
         } catch (ValidationException $e) {
             return $this->userRegistrationFailure($e->errors());

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -5,9 +5,8 @@ namespace Statamic\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\MessageBag;
-use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Events\UserRegistered;
+use Statamic\Events\UserRegistering;
 use Statamic\Facades\User;
 
 class UserController extends Controller
@@ -53,10 +52,8 @@ class UserController extends Controller
 
         $validator = Validator::make($request->all(), $fieldRules);
 
-        $errorResponse = $request->has('_error_redirect') ? redirect($request->input('_error_redirect')) : back();
-
         if ($validator->fails()) {
-            return $errorResponse->withErrors($validator->errors(), 'user.register');
+            return $this->userRegistrationFailure($validator->errors());
         }
 
         $values = $fields->process()->values()->except(['email', 'groups', 'roles']);
@@ -70,7 +67,9 @@ class UserController extends Controller
             $user->roles($roles);
         }
 
-        // TODO: Registering event
+        if (UserRegistering::dispatch($user) === false) {
+            return $this->userRegistrationSuccess(true);
+        }
 
         $user->save();
 
@@ -78,45 +77,23 @@ class UserController extends Controller
 
         Auth::login($user);
 
-        $response = $request->has('_redirect') ? redirect($request->get('_redirect')) : back();
-
-        session()->flash('user.register.success', __('Registration successful.'));
-
-        return $response;
+        return $this->userRegistrationSuccess();
     }
 
-    /**
-     * Run the `user.registering` event.
-     *
-     * This allows the registration to be short-circuited before it gets saved and show errors.
-     * Or, the user may be modified. Lastly, an addon could just 'do something' here without
-     * modifying/stopping the registration.
-     *
-     * Expects an array of event responses (multiple listeners can listen for the same event).
-     * Each response in the array should be another array with an `errors` array.
-     *
-     * @param  UserContract $user
-     * @return MessageBag
-     */
-    protected function runRegisteringEvent(UserContract $user)
+    private function userRegistrationFailure($errors = null)
     {
-        $errors = [];
+        $errorResponse = request()->has('_error_redirect') ? redirect(request()->input('_error_redirect')) : back();
 
-        $responses = event('user.registering', $user);
+        return $errorResponse->withErrors($errors, 'user.register');
+    }
 
-        foreach ($responses as $response) {
-            // Ignore any non-arrays
-            if (! is_array($response)) {
-                continue;
-            }
+    private function userRegistrationSuccess(bool $silentFailure = false)
+    {
+        $response = request()->has('_redirect') ? redirect(request()->get('_redirect')) : back();
 
-            // If the event returned errors, tack those onto the array.
-            if ($response_errors = array_get($response, 'errors')) {
-                $errors = array_merge($response_errors, $errors);
-                continue;
-            }
-        }
+        session()->flash('user.register.success', __('Registration successful.'));
+        session()->flash('user.registered', ! $silentFailure);
 
-        return new MessageBag($errors);
+        return $response;
     }
 }

--- a/src/Tags/Concerns/GetsFormSession.php
+++ b/src/Tags/Concerns/GetsFormSession.php
@@ -26,6 +26,12 @@ trait GetsFormSession
             $data['submission_created'] = true;
         }
 
+        // Only include this boolean if it's actually passed in session;
+        // It will be for user registration submissions, but not form submissions.
+        if ($this->getFromFormSession($formName, 'user_created')) {
+            $data['user_created'] = true;
+        }
+
         return $data;
     }
 

--- a/tests/Feature/Users/UserRegistrationTest.php
+++ b/tests/Feature/Users/UserRegistrationTest.php
@@ -40,7 +40,6 @@ class UserRegistrationTest extends TestCase
     /** @test */
     public function user_not_saved_when_user_registration_returns_false()
     {
-        // need to register the "legacy" way so it works on L6 & L7
         Event::listen(UserRegistering::class, function () {
             return false;
         });

--- a/tests/Feature/Users/UserRegistrationTest.php
+++ b/tests/Feature/Users/UserRegistrationTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature\Users;
 
 use Illuminate\Support\Facades\Event;
 use Statamic\Events\UserRegistered;
+use Statamic\Events\UserRegistering;
+use Statamic\Facades\User;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -12,7 +14,7 @@ class UserRegistrationTest extends TestCase
     use PreventSavingStacheItemsToDisk;
 
     /** @test */
-    public function events_dispatched_when_user_registered()
+    public function user_registered_event_dispatched_when_user_registered()
     {
         Event::fake();
 
@@ -21,5 +23,31 @@ class UserRegistrationTest extends TestCase
             ->assertRedirect();
 
         Event::assertDispatched(UserRegistered::class);
+    }
+
+    /** @test */
+    public function user_registering_event_dispatched_when_user_registered()
+    {
+        Event::fake();
+
+        $this
+            ->post(route('statamic.register'), ['email'=>'foo@bar.com', 'password'=>'password', 'password_confirmation'=>'password'])
+            ->assertRedirect();
+
+        Event::assertDispatched(UserRegistering::class);
+    }
+
+    /** @test */
+    public function user_not_saved_when_user_registration_returns_false()
+    {
+        Event::listen(function (UserRegistering $event) {
+            return false;
+        });
+
+        $this
+            ->post(route('statamic.register'), ['email'=>'foo@bar.com', 'password'=>'password', 'password_confirmation'=>'password'])
+            ->assertRedirect();
+
+        $this->assertNull(User::findByEmail('foo@bar.com'));
     }
 }

--- a/tests/Feature/Users/UserRegistrationTest.php
+++ b/tests/Feature/Users/UserRegistrationTest.php
@@ -14,19 +14,7 @@ class UserRegistrationTest extends TestCase
     use PreventSavingStacheItemsToDisk;
 
     /** @test */
-    public function user_registered_event_dispatched_when_user_registered()
-    {
-        Event::fake();
-
-        $this
-            ->post(route('statamic.register'), ['email'=>'foo@bar.com', 'password'=>'password', 'password_confirmation'=>'password'])
-            ->assertRedirect();
-
-        Event::assertDispatched(UserRegistered::class);
-    }
-
-    /** @test */
-    public function user_registering_event_dispatched_when_user_registered()
+    public function events_dispatched_when_user_registered()
     {
         Event::fake();
 
@@ -35,11 +23,14 @@ class UserRegistrationTest extends TestCase
             ->assertRedirect();
 
         Event::assertDispatched(UserRegistering::class);
+        Event::assertDispatched(UserRegistered::class);
     }
 
     /** @test */
     public function user_not_saved_when_user_registration_returns_false()
     {
+        Event::fake([UserRegistered::class]);
+
         Event::listen(UserRegistering::class, function () {
             return false;
         });
@@ -49,5 +40,6 @@ class UserRegistrationTest extends TestCase
             ->assertRedirect();
 
         $this->assertNull(User::findByEmail('foo@bar.com'));
+        Event::assertNotDispatched(UserRegistered::class);
     }
 }

--- a/tests/Feature/Users/UserRegistrationTest.php
+++ b/tests/Feature/Users/UserRegistrationTest.php
@@ -40,7 +40,8 @@ class UserRegistrationTest extends TestCase
     /** @test */
     public function user_not_saved_when_user_registration_returns_false()
     {
-        Event::listen(function (UserRegistering $event) {
+        // need to register the "legacy" way so it works on L6 & L7
+        Event::listen(UserRegistering::class, function () {
             return false;
         });
 


### PR DESCRIPTION
Other part of https://github.com/statamic/cms/issues/2395.

Based it on how form handles it, added a couple of tests.

Needed for Akismet, which needs to be able to stop user registration the same way it does form submissions.

Closes https://github.com/silentzco/statamic-akismet/issues/5