### PR TITLE
Fix is_parent not working with redirect '@child'

### DIFF
--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -82,11 +82,15 @@ class URL
      */
     public function isAncestorOf($child, $ancestor)
     {
+        if ($ancestor === '') {
+            return false;
+        }
+        
         $child = Str::before($child, '?');
         $child = Str::ensureRight($child, '/');
         $ancestor = Str::ensureRight($ancestor, '/');
 
-        if ($child === $ancestor || $ancestor === '/') {
+        if ($child === $ancestor) {
             return false;
         }
 

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -82,10 +82,6 @@ class URL
      */
     public function isAncestorOf($child, $ancestor)
     {
-        if ($ancestor === '') {
-            return false;
-        }
-
         $child = Str::before($child, '?');
         $child = Str::ensureRight($child, '/');
         $ancestor = Str::ensureRight($ancestor, '/');

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -85,7 +85,7 @@ class URL
         if ($ancestor === '') {
             return false;
         }
-        
+
         $child = Str::before($child, '?');
         $child = Str::ensureRight($child, '/');
         $ancestor = Str::ensureRight($ancestor, '/');

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -86,7 +86,7 @@ class URL
         $child = Str::ensureRight($child, '/');
         $ancestor = Str::ensureRight($ancestor, '/');
 
-        if ($child === $ancestor) {
+        if ($child === $ancestor || $ancestor === '/') {
             return false;
         }
 

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -6,7 +6,6 @@ use Statamic\Contracts\Structures\Structure as StructureContract;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Structures\TreeBuilder;
-use Statamic\Support\Str;
 
 class Structure extends Tags
 {
@@ -58,14 +57,13 @@ class Structure extends Tags
 
             $data = $page->toAugmentedArray();
             $children = empty($item['children']) ? [] : $this->toArray($item['children'], $data, $depth + 1);
-            $redirect_child = isset($data['redirect']) ? $data['redirect']->raw() == '@child' : false;
 
             return array_merge($data, [
                 'children'    => $children,
                 'parent'      => $parent,
                 'depth'       => $depth,
                 'is_current'  => rtrim(URL::getCurrent(), '/') == rtrim($page->url(), '/'),
-                'is_parent'   => Site::current()->url() === $page->url() ? false : URL::isAncestorOf(URL::getCurrent(), $redirect_child ? Str::beforeLast($page->url(), '/') : $page->url()), // remove last URL segment if redirect is @child
+                'is_parent'   => Site::current()->url() === $page->url() ? false : URL::isAncestorOf(URL::getCurrent(), $page->uri()),
                 'is_external' => URL::isExternal($page->absoluteUrl()),
             ]);
         })->filter()->values()->all();

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -57,13 +57,14 @@ class Structure extends Tags
 
             $data = $page->toAugmentedArray();
             $children = empty($item['children']) ? [] : $this->toArray($item['children'], $data, $depth + 1);
+            $redirect_child = isset($data['redirect']) ? $data['redirect']->raw() == '@child' : false;
 
             return array_merge($data, [
                 'children'    => $children,
                 'parent'      => $parent,
                 'depth'       => $depth,
                 'is_current'  => rtrim(URL::getCurrent(), '/') == rtrim($page->url(), '/'),
-                'is_parent'   => Site::current()->url() === $page->url() ? false : URL::isAncestorOf(URL::getCurrent(), $page->url()),
+                'is_parent'   => Site::current()->url() === $page->url() ? false : URL::isAncestorOf(URL::getCurrent(), $redirect_child ? Str::beforeLast($page->url(), '/') : $page->url()), // remove last URL segment if redirect is @child
                 'is_external' => URL::isExternal($page->absoluteUrl()),
             ]);
         })->filter()->values()->all();

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -6,6 +6,7 @@ use Statamic\Contracts\Structures\Structure as StructureContract;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Structures\TreeBuilder;
+use Statamic\Support\Str;
 
 class Structure extends Tags
 {


### PR DESCRIPTION
Fixes #2359

- [x] Fix issue

**Why does this work?**
The uri() method gives the actual URL of the entry, while the url() method gives the url() of the child in case of redirect child. This way, the isAncestorOf() method delivers correct results.