### PR TITLE
Ability to ignore query strings in static caching

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -79,4 +79,17 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Ignoring Query Strings
+    |--------------------------------------------------------------------------
+    |
+    | Statamic will cache pages of the same URL but with different query
+    | parameters separately. This is useful for pages with pagination.
+    | If you'd like to ignore the query strings, you may do so.
+    |
+    */
+
+    'ignore_query_strings' => false,
+
 ];

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -136,7 +136,7 @@ class FileCacher extends AbstractCacher
         return sprintf('%s%s_%s.html',
             $this->getCachePath(),
             $parts['path'],
-            array_get($parts, 'query', '')
+            $this->config('ignore_query_strings') ? '' : array_get($parts, 'query', '')
         );
     }
 }

--- a/src/StaticCaching/StaticCacheManager.php
+++ b/src/StaticCaching/StaticCacheManager.php
@@ -45,6 +45,7 @@ class StaticCacheManager extends Manager
 
         return array_merge($config, [
             'exclude' => $this->app['config']['statamic.static_caching.exclude'] ?? [],
+            'ignore_query_strings' => $this->app['config']['statamic.static_caching.ignore_query_strings'] ?? false,
             'base_url' => $this->app['request']->root(),
             'locale' => Site::current()->handle(),
         ]);

--- a/tests/StaticCaching/FileCacherTest.php
+++ b/tests/StaticCaching/FileCacherTest.php
@@ -67,6 +67,25 @@ class FileCacherTest extends TestCase
     }
 
     /** @test */
+    public function gets_file_path_from_url_and_ignores_query_strings()
+    {
+        $cacher = $this->fileCacher([
+            'path' => 'test/path',
+            'ignore_query_strings' => true,
+        ]);
+
+        $this->assertEquals(
+            'test/path/foo/bar_.html',
+            $cacher->getFilePath('http://domain.com/foo/bar?baz=qux&one=two')
+        );
+
+        $this->assertEquals(
+            'test/path/foo/bar_.html',
+            $cacher->getFilePath('http://domain.com/foo/bar')
+        );
+    }
+
+    /** @test */
     public function gets_file_path_with_multiple_locations()
     {
         $cacher = $this->fileCacher([


### PR DESCRIPTION
The ignore_query_strings was half implemented when ported from v2. Not enough for it to be usable, though.

If you added it to your config file, it wasn't being sent through to the drivers. Now it it.
Also, the file cacher would write query strings into the filename even if they're supposed to be ignored.