### PR TITLE
Add horizontal rule to Bard

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -93,6 +93,7 @@ import {
     CodeBlock,
     HardBreak,
     Heading,
+    HorizontalRule,
     OrderedList,
     BulletList,
     ListItem,
@@ -458,6 +459,7 @@ export default {
             if (btns.includes('anchor')) exts.push(new Link({ vm: this }));
             if (btns.includes('removeformat')) exts.push(new RemoveFormat());
             if (btns.includes('image')) exts.push(new Image({ bard: this }));
+            if (btns.includes('horizontalrule')) exts.push(new HorizontalRule());
 
             if (btns.includes('orderedlist') || btns.includes('unorderedlist')) {
                 if (btns.includes('orderedlist')) exts.push(new OrderedList());

--- a/resources/js/components/fieldtypes/bard/buttons.js
+++ b/resources/js/components/fieldtypes/bard/buttons.js
@@ -20,6 +20,7 @@ const availableButtons = () => [
     { name: 'image', text: __('Image'), command: 'image', args: { src: '' }, icon: 'picture-o', condition: (config) => config.container },
     { name: 'code', text: __('Inline Code'), command: 'code', svg: 'angle-brackets-bold' },
     { name: 'codeblock', text: __('Code Block'), command: 'code_block', svg: 'code-block' },
+    { name: 'horizontalrule', text: __('Horizontal Rule'), command: 'horizontal_rule', svg: 'range' },
 ];
 
 const addButtonHtml = (buttons) => {


### PR DESCRIPTION
Adds the ability to use a horizontal rule in bard.

You have to add the button to your bard field in order to be able to use it.
If you have the button enabled, then 3 dashes will be a keyboard shortcut for it.

Closes #3074﻿
