### PR TITLE
Remove ability to set root entry as parent when saving entry

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -156,6 +156,14 @@ class EntriesController extends CpController
 
         $parent = $values->pull('parent');
 
+        if (! is_null($parent)) {
+            $parentEntry = Entry::find($parent);
+
+            if (optional($parentEntry)->isRoot()) {
+                $parent = null;
+            }
+        }
+
         if ($explicitBlueprint = $values->pull('blueprint')) {
             $entry->blueprint($explicitBlueprint);
         }


### PR DESCRIPTION
I saw several issues (and PRs) around this (#1948, #1666, #2647) through other UI bits, but nothing for using a `parent` field when updating an entry. Since that field is part of the publish form and isn't required, I thought in the controller made the most sense. If there's another preferred way to accomplish this, I can update.

This bit us with a client a few weeks ago, but thankfully the sorting tree UI has already been patched around this.