### PR TITLE
Remove route model binding for users

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -171,7 +171,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
     });
 
     Route::group(['namespace' => 'Users'], function () {
-        Route::post('users/actions', 'UserActionController@run')->name('users.actions.run');
+    Route::post('users/actions', 'UserActionController@run')->name('users.actions.run');
         Route::get('users/actions', 'UserActionController@bulkActions')->name('users.actions.bulk');
         Route::get('users/blueprint', 'UserBlueprintController@edit')->name('users.blueprint.edit');
         Route::patch('users/blueprint', 'UserBlueprintController@update')->name('users.blueprint.update');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -171,7 +171,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
     });
 
     Route::group(['namespace' => 'Users'], function () {
-    Route::post('users/actions', 'UserActionController@run')->name('users.actions.run');
+        Route::post('users/actions', 'UserActionController@run')->name('users.actions.run');
         Route::get('users/actions', 'UserActionController@bulkActions')->name('users.actions.bulk');
         Route::get('users/blueprint', 'UserBlueprintController@edit')->name('users.blueprint.edit');
         Route::patch('users/blueprint', 'UserBlueprintController@update')->name('users.blueprint.update');

--- a/src/Http/Controllers/API/UsersController.php
+++ b/src/Http/Controllers/API/UsersController.php
@@ -20,7 +20,7 @@ class UsersController extends ApiController
     {
         throw_unless(
             $user = User::find($user),
-            new NotFoundHttpException("User [$user] not found.")
+            new NotFoundHttpException()
         );
 
         return app(UserResource::class)::make($user);

--- a/src/Http/Controllers/API/UsersController.php
+++ b/src/Http/Controllers/API/UsersController.php
@@ -16,11 +16,11 @@ class UsersController extends ApiController
         );
     }
 
-    public function show($user)
+    public function show($id)
     {
         throw_unless(
-            $user = User::find($user),
-            new NotFoundHttpException()
+            $user = User::find($id),
+            new NotFoundHttpException("User [$id] not found.")
         );
 
         return app(UserResource::class)::make($user);

--- a/src/Http/Controllers/API/UsersController.php
+++ b/src/Http/Controllers/API/UsersController.php
@@ -17,6 +17,8 @@ class UsersController extends ApiController
 
     public function show($user)
     {
+        $user = User::find($user);
+
         return app(UserResource::class)::make($user);
     }
 }

--- a/src/Http/Controllers/API/UsersController.php
+++ b/src/Http/Controllers/API/UsersController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\API;
 
 use Illuminate\Http\Request;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\User;
 use Statamic\Http\Resources\API\UserResource;
 
@@ -17,7 +18,10 @@ class UsersController extends ApiController
 
     public function show($user)
     {
-        $user = User::find($user);
+        throw_unless(
+            $user = User::find($user),
+            new NotFoundHttpException("User [$user] not found.")
+        );
 
         return app(UserResource::class)::make($user);
     }

--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\CP\Users;
 
 use Illuminate\Http\Request;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 
@@ -10,7 +11,10 @@ class PasswordController extends CpController
 {
     public function update(Request $request, $user)
     {
-        $user = User::find($user);
+        throw_unless(
+            $user = User::find($user),
+            new NotFoundHttpException("User [$user] not found.")
+        );
 
         $this->authorize('editPassword', $user);
 

--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -13,7 +13,7 @@ class PasswordController extends CpController
     {
         throw_unless(
             $user = User::find($user),
-            new NotFoundHttpException("User [$user] not found.")
+            new NotFoundHttpException()
         );
 
         $this->authorize('editPassword', $user);

--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -3,12 +3,15 @@
 namespace Statamic\Http\Controllers\CP\Users;
 
 use Illuminate\Http\Request;
+use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 
 class PasswordController extends CpController
 {
     public function update(Request $request, $user)
     {
+        $user = User::find($user);
+
         $this->authorize('editPassword', $user);
 
         $request->validate([

--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -11,10 +11,7 @@ class PasswordController extends CpController
 {
     public function update(Request $request, $user)
     {
-        throw_unless(
-            $user = User::find($user),
-            new NotFoundHttpException()
-        );
+        throw_unless($user = User::find($user), new NotFoundHttpException);
 
         $this->authorize('editPassword', $user);
 

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -148,7 +148,7 @@ class UsersController extends CpController
     {
         throw_unless(
             $user = User::find($user),
-            new NotFoundHttpException("User [$user] not found.")
+            new NotFoundHttpException()
         );
 
         $this->authorize('edit', $user);
@@ -195,7 +195,7 @@ class UsersController extends CpController
     {
         throw_unless(
             $user = User::find($user),
-            new NotFoundHttpException("User [$user] not found.")
+            new NotFoundHttpException()
         );
 
         $this->authorize('edit', $user);
@@ -228,7 +228,7 @@ class UsersController extends CpController
     {
         throw_unless(
             $user = User::find($user),
-            new NotFoundHttpException("User [$user] not found.")
+            new NotFoundHttpException()
         );
 
         if (! $user = User::find($user)) {

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -145,6 +145,8 @@ class UsersController extends CpController
 
     public function edit(Request $request, $user)
     {
+        $user = User::find($user);
+
         $this->authorize('edit', $user);
 
         $blueprint = $user->blueprint();
@@ -187,6 +189,8 @@ class UsersController extends CpController
 
     public function update(Request $request, $user)
     {
+        $user = User::find($user);
+
         $this->authorize('edit', $user);
 
         $fields = $user->blueprint()->fields()->except(['password'])->addValues($request->all());
@@ -215,6 +219,8 @@ class UsersController extends CpController
 
     public function destroy($user)
     {
+        $user = User::find($user);
+
         if (! $user = User::find($user)) {
             return $this->pageNotFound();
         }

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -146,10 +146,7 @@ class UsersController extends CpController
 
     public function edit(Request $request, $user)
     {
-        throw_unless(
-            $user = User::find($user),
-            new NotFoundHttpException()
-        );
+        throw_unless($user = User::find($user), new NotFoundHttpException);
 
         $this->authorize('edit', $user);
 
@@ -193,10 +190,7 @@ class UsersController extends CpController
 
     public function update(Request $request, $user)
     {
-        throw_unless(
-            $user = User::find($user),
-            new NotFoundHttpException()
-        );
+        throw_unless($user = User::find($user), new NotFoundHttpException);
 
         $this->authorize('edit', $user);
 
@@ -226,10 +220,7 @@ class UsersController extends CpController
 
     public function destroy($user)
     {
-        throw_unless(
-            $user = User::find($user),
-            new NotFoundHttpException()
-        );
+        throw_unless($user = User::find($user), new NotFoundHttpException);
 
         if (! $user = User::find($user)) {
             return $this->pageNotFound();

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\CP\Column;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Scope;
 use Statamic\Facades\User;
 use Statamic\Facades\UserGroup;
@@ -145,7 +146,10 @@ class UsersController extends CpController
 
     public function edit(Request $request, $user)
     {
-        $user = User::find($user);
+        throw_unless(
+            $user = User::find($user),
+            new NotFoundHttpException("User [$user] not found.")
+        );
 
         $this->authorize('edit', $user);
 
@@ -189,7 +193,10 @@ class UsersController extends CpController
 
     public function update(Request $request, $user)
     {
-        $user = User::find($user);
+        throw_unless(
+            $user = User::find($user),
+            new NotFoundHttpException("User [$user] not found.")
+        );
 
         $this->authorize('edit', $user);
 
@@ -219,7 +226,10 @@ class UsersController extends CpController
 
     public function destroy($user)
     {
-        $user = User::find($user);
+        throw_unless(
+            $user = User::find($user),
+            new NotFoundHttpException("User [$user] not found.")
+        );
 
         if (! $user = User::find($user)) {
             return $this->pageNotFound();

--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -14,7 +14,6 @@ use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
 use Statamic\Facades\Term;
-use Statamic\Facades\User;
 use Statamic\Mixins\Router;
 
 class RouteServiceProvider extends ServiceProvider
@@ -41,7 +40,6 @@ class RouteServiceProvider extends ServiceProvider
         $this->bindSites();
         $this->bindRevisions();
         $this->bindForms();
-        $this->bindUsers();
     }
 
     protected function bindCollections()
@@ -176,18 +174,6 @@ class RouteServiceProvider extends ServiceProvider
             );
 
             return $form;
-        });
-    }
-
-    protected function bindUsers()
-    {
-        Route::bind('user', function ($handle, $route) {
-            throw_unless(
-                $user = User::find($handle),
-                new NotFoundHttpException("User [$handle] not found.")
-            );
-
-            return $user;
         });
     }
 }


### PR DESCRIPTION
This pull request resolves #2316, where issues crop up in existing Laravel apps if people are using route model binding to bind to their `User` model.

This PR just straight out removes the route model binding and replaces it with a lookup in the controllers where it is referenced with `Entry::find($id)`.

While working on this PR, I've also found posts on the Discord by some developers complaining that Statamic's route model binding is a bit generic and can cause issues if used side by side on an existing Laravel app. I'm happy to make any changes to any of the other route model binding stuff if that's something you'd like me to do.

Let me know if you have anything you'd like me to change.