### PR TITLE
Glide Controller should throw 404 instead of exception

### DIFF
--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -147,7 +147,7 @@ class GlideController extends Controller
         try {
             SignatureFactory::create(Config::getAppKey())->validateRequest($path, $_GET);
         } catch (SignatureException $e) {
-            abort(400, $e->getMessage());
+            abort(404);
         }
     }
 }


### PR DESCRIPTION
This pull request closes #3070. It will return a 404 if an image is not found, instead of throwing an exception.