### PR TITLE
Add filters to the addon AddonServiceProvider.php

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -19,6 +19,7 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected $listen = [];
     protected $subscribe = [];
     protected $tags = [];
+    protected $filters = [];
     protected $fieldtypes = [];
     protected $modifiers = [];
     protected $widgets = [];
@@ -45,6 +46,7 @@ abstract class AddonServiceProvider extends ServiceProvider
             $this
                 ->bootEvents()
                 ->bootTags()
+                ->bootFilters()
                 ->bootFieldtypes()
                 ->bootModifiers()
                 ->bootWidgets()
@@ -81,6 +83,15 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected function bootTags()
     {
         foreach ($this->tags as $class) {
+            $class::register();
+        }
+
+        return $this;
+    }
+
+    protected function bootFilters()
+    {
+        foreach ($this->filters as $class) {
             $class::register();
         }
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -20,6 +20,7 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected $subscribe = [];
     protected $tags = [];
     protected $scopes = [];
+    protected $actions = [];
     protected $fieldtypes = [];
     protected $modifiers = [];
     protected $widgets = [];
@@ -47,6 +48,7 @@ abstract class AddonServiceProvider extends ServiceProvider
                 ->bootEvents()
                 ->bootTags()
                 ->bootScopes()
+                ->bootActions()
                 ->bootFieldtypes()
                 ->bootModifiers()
                 ->bootWidgets()
@@ -92,6 +94,15 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected function bootScopes()
     {
         foreach ($this->scopes as $class) {
+            $class::register();
+        }
+
+        return $this;
+    }
+
+    protected function bootActions()
+    {
+        foreach ($this->actions as $class) {
             $class::register();
         }
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -19,7 +19,7 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected $listen = [];
     protected $subscribe = [];
     protected $tags = [];
-    protected $filters = [];
+    protected $scopes = [];
     protected $fieldtypes = [];
     protected $modifiers = [];
     protected $widgets = [];
@@ -46,7 +46,7 @@ abstract class AddonServiceProvider extends ServiceProvider
             $this
                 ->bootEvents()
                 ->bootTags()
-                ->bootFilters()
+                ->bootScopes()
                 ->bootFieldtypes()
                 ->bootModifiers()
                 ->bootWidgets()
@@ -89,9 +89,9 @@ abstract class AddonServiceProvider extends ServiceProvider
         return $this;
     }
 
-    protected function bootFilters()
+    protected function bootScopes()
     {
-        foreach ($this->filters as $class) {
+        foreach ($this->scopes as $class) {
             $class::register();
         }
 


### PR DESCRIPTION
I did notice that we explicitly do allow to register tags, fieldtypes, modifiers, widgets and others, but **no filters**. 

This PR does add the possibility to register filters like other components: https://statamic.dev/extending/addons#registering-components
```php

protected $filters = [
    \Acme\Example\Filters\First::class,
    \Acme\Example\Filters\Second::class,
    // etc...
];

```

I am happy to update the docs as well, if this is getting merged. 