### PR TITLE
Fix date handling in revisions

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -28,6 +28,7 @@ use Statamic\Facades\Stache;
 use Statamic\Revisions\Revisable;
 use Statamic\Routing\Routable;
 use Statamic\Statamic;
+use Statamic\Support\Arr;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class Entry implements Contract, Augmentable, Responsable, Localization, Protectable
@@ -434,6 +435,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
             'id' => $this->id(),
             'slug' => $this->slug(),
             'published' => $this->published(),
+            'date' => $this->collection()->dated() ? $this->date()->timestamp : null,
             'data' => $this->data()->except(['updated_by', 'updated_at'])->all(),
         ];
     }
@@ -448,10 +450,16 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
 
         $attrs = $revision->attributes();
 
-        return $entry
+        $entry
             ->published($attrs['published'])
             ->data($attrs['data'])
             ->slug($attrs['slug']);
+
+        if ($this->collection()->dated() && ($date = Arr::get($attrs, 'date'))) {
+            $entry->date(Carbon::createFromTimestamp($date));
+        }
+
+        return $entry;
     }
 
     public function status()

--- a/tests/Factories/EntryFactory.php
+++ b/tests/Factories/EntryFactory.php
@@ -11,6 +11,7 @@ class EntryFactory
     protected $id;
     protected $slug;
     protected $data;
+    protected $date;
     protected $published;
     protected $order;
     protected $locale;
@@ -50,6 +51,13 @@ class EntryFactory
         return $this;
     }
 
+    public function date($date)
+    {
+        $this->date = $date;
+
+        return $this;
+    }
+
     public function published($published)
     {
         $this->published = $published;
@@ -78,6 +86,7 @@ class EntryFactory
             ->collection($this->createCollection())
             ->slug($this->slug)
             ->data($this->data)
+            ->date($this->date)
             ->origin($this->origin)
             ->published($this->published);
 
@@ -112,6 +121,7 @@ class EntryFactory
         $this->id = null;
         $this->slug = null;
         $this->data = [];
+        $this->date = null;
         $this->published = true;
         $this->order = null;
         $this->locale = 'en';

--- a/tests/Feature/Revisions/RevisionsTest.php
+++ b/tests/Feature/Revisions/RevisionsTest.php
@@ -22,7 +22,7 @@ class RevisionsTest extends TestCase
         Carbon::setTestNow($now = Carbon::parse('2019-03-25 13:15'));
 
         $revision = EntryFactory::id('123')
-            ->collection(Collection::make('test'))
+            ->collection(tap(Collection::make('test'))->save())
             ->slug('my-entry')
             ->data(['foo' => 'bar'])
             ->make()
@@ -37,8 +37,26 @@ class RevisionsTest extends TestCase
         $this->assertEquals($user, $revision->user());
         $this->assertEquals($now, $revision->date());
         $this->assertEquals('collections/test/en/123', $revision->key());
-        $this->assertEquals(['id' => '123', 'published' => true, 'slug' => 'my-entry', 'data' => ['foo' => 'bar']], $revision->attributes());
+        $this->assertEquals(['id' => '123', 'published' => true, 'slug' => 'my-entry', 'data' => ['foo' => 'bar'], 'date' => null], $revision->attributes());
         $this->assertEquals('123', $revision->attribute('id'));
         $this->assertEquals('/path/to/collections/test/en/123/'.$now->timestamp.'.yaml', $revision->path());
+    }
+
+    /** @test */
+    public function a_revision_can_be_made_from_a_dated_entry()
+    {
+        config(['statamic.revisions.path' => '/path/to']);
+
+        Carbon::setTestNow($now = Carbon::parse('2019-03-25 13:15'));
+
+        $revision = EntryFactory::id('123')
+            ->collection(tap(Collection::make('test')->dated(true))->save())
+            ->slug('my-entry')
+            ->data(['foo' => 'bar'])
+            ->date('2016-12-25')
+            ->make()
+            ->makeRevision();
+
+        $this->assertEquals(['id' => '123', 'published' => true, 'slug' => 'my-entry', 'data' => ['foo' => 'bar'], 'date' => '1482624000'], $revision->attributes());
     }
 }


### PR DESCRIPTION
Fixes #2397 

When creating an entry from a revision, it wasn't applying the date. So when it would build an entry based on a revision, it would always just use the original entry's date.

We'll now write the date as a timestamp into the entry revision attributes which gets used when creating a revision (and working copy). When an entry is created from a revision (or working copy), it'll now use that date.

The check for the `date` inside the `$attrs` happens in the condition in order to prevent an error when you have a revision/working copy created before this change - otherwise you'd get an "undefined index 'date'" error.

Also adds a `date` method to the EntryFactory helper class.