### PR TITLE
Table fieldtype fixes

### DIFF
--- a/resources/js/components/fieldtypes/TableFieldtype.vue
+++ b/resources/js/components/fieldtypes/TableFieldtype.vue
@@ -107,6 +107,7 @@ export default {
 
         value(value, oldValue) {
             if (JSON.stringify(value) == JSON.stringify(oldValue)) return;
+            if (JSON.stringify(value) == JSON.stringify(this.sortableToArray(this.data))) return;
             this.data = this.arrayToSortable(value);
         }
     },
@@ -202,13 +203,6 @@ export default {
         deleteCancelled() {
             this.deletingRow = false;
             this.deletingColumn = false;
-        },
-
-        arrayToSortable(arr) {
-            return _.map(arr, value => {
-                return this.data.find(v => JSON.stringify(v.value) == JSON.stringify(value))
-                    || new SortableKeyValue(null, value);
-            });
         }
     }
 

--- a/resources/js/components/fieldtypes/TableFieldtype.vue
+++ b/resources/js/components/fieldtypes/TableFieldtype.vue
@@ -13,7 +13,7 @@
                             </a>
                         </div>
                     </th>
-                    <th class="row-controls" v-if="canDeleteColumns"></th>
+                    <th class="row-controls" v-if="canDeleteRows"></th>
                 </tr>
             </thead>
 
@@ -31,7 +31,7 @@
                         <td v-for="(cell, cellIndex) in row.value.cells">
                             <input type="text" v-model="row.value.cells[cellIndex]" class="input-text" :readonly="isReadOnly" @focus="$emit('focus')" @blur="$emit('blur')" />
                         </td>
-                        <td class="row-controls" v-if="canDeleteColumns">
+                        <td class="row-controls" v-if="canDeleteRows">
                             <button @click="confirmDeleteRow(rowIndex)" class="inline opacity-25 text-lg antialiased hover:opacity-75" :aria-label="__('Delete Row')">&times;</button>
                         </td>
                     </tr>
@@ -137,6 +137,10 @@ export default {
         },
 
         canAddRows() {
+            return !this.isReadOnly;
+        },
+
+        canDeleteRows() {
             return !this.isReadOnly;
         },
 


### PR DESCRIPTION
This fixes #2470 

Adding top down reactivity in c975aa3 caused #1447 which was solved by 4536ef2 but then caused #2470

This commit implements c975aa3 in a smarter way, which will prevent all the sortable _id keys being regenerated which prevents a dom update, which caused #1447.

Got that? Phew.

This PR also fixes #2790 - The logic for showing the delete row button was using canDeleteColumns instead of canDeleteRows.