### PR TITLE
Fix 404s within the CP rendering on front-end

### DIFF
--- a/src/Exceptions/NotFoundHttpException.php
+++ b/src/Exceptions/NotFoundHttpException.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Exceptions;
 
+use Statamic\Statamic;
 use Statamic\View\View;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException as SymfonyException;
 
@@ -9,6 +10,10 @@ class NotFoundHttpException extends SymfonyException
 {
     public function render()
     {
+        if (Statamic::isCpRoute()) {
+            return response()->view('statamic::errors.404', [], 404);
+        }
+
         if (view()->exists('errors.404')) {
             return response($this->contents(), 404);
         }


### PR DESCRIPTION
#3088 pointed this out to me.

When you visit a URL with a route binding, (like the users in that PR, or /cp/collections/non-existent) you get your front-end 404 view rather than a CP based one.