### PR TITLE
Fixes filterWhereIn and filterWhereNotIn

### DIFF
--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -138,7 +138,7 @@ abstract class Builder extends BaseBuilder
                     }
                 }
             }
-            
+
             return ! in_array($value, $where['values']);
         });
     }

--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -123,6 +123,7 @@ abstract class Builder extends BaseBuilder
                     }
                 }
             }
+
             return in_array($value, $where['values']);
         });
     }
@@ -137,6 +138,7 @@ abstract class Builder extends BaseBuilder
                     }
                 }
             }
+            
             return ! in_array($value, $where['values']);
         });
     }

--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -116,6 +116,13 @@ abstract class Builder extends BaseBuilder
     protected function filterWhereIn($values, $where)
     {
         return $values->filter(function ($value) use ($where) {
+            if (is_array($value)) {
+                foreach ($value as $term) {
+                    if (in_array($term, $where['values'])) {
+                        return true;
+                    }
+                }
+            }
             return in_array($value, $where['values']);
         });
     }
@@ -123,6 +130,13 @@ abstract class Builder extends BaseBuilder
     protected function filterWhereNotIn($values, $where)
     {
         return $values->filter(function ($value) use ($where) {
+            if (is_array($value)) {
+                foreach ($value as $term) {
+                    if (in_array($term, $where['values'])) {
+                        return false;
+                    }
+                }
+            }
             return ! in_array($value, $where['values']);
         });
     }

--- a/tests/Tags/Concerns/QueriesConditionsTest.php
+++ b/tests/Tags/Concerns/QueriesConditionsTest.php
@@ -106,17 +106,19 @@ class QueriesConditionsTest extends TestCase
         $this->makeEntry('cat')->set('type', 'feline')->save();
         $this->makeEntry('lion')->set('type', 'feline')->save();
         $this->makeEntry('horse')->set('type', 'equine')->save();
+        $this->makeEntry('horse')->set('type', 'equine')->save();
+        $this->makeEntry('sphinx')->set('type', ['feline', 'aves'])->save();
         $this->makeEntry('bigfoot')->save();
 
-        $this->assertCount(7, $this->getEntries());
+        $this->assertCount(8, $this->getEntries());
         $this->assertEquals(['dog', 'wolf'], $this->getEntries(['type:in' => ['canine']])->map->slug()->all());
-        $this->assertEquals(['tiger', 'cat', 'lion'], $this->getEntries(['type:in' => ['feline']])->map->slug()->all());
-        $this->assertEquals(['dog', 'wolf', 'tiger', 'cat', 'lion'], $this->getEntries(['type:in' => ['canine', 'feline']])->map->slug()->all());
+        $this->assertEquals(['tiger', 'cat', 'lion', 'sphinx'], $this->getEntries(['type:in' => ['feline']])->map->slug()->all());
+        $this->assertEquals(['dog', 'wolf', 'tiger', 'cat', 'lion', 'sphinx'], $this->getEntries(['type:in' => ['canine', 'feline']])->map->slug()->all());
         $this->assertEquals(['horse'], $this->getEntries(['type:in' => ['equine']])->map->slug()->all());
 
         // Handles pipe array syntax
         $this->assertEquals(
-            ['dog', 'wolf', 'tiger', 'cat', 'lion'],
+            ['dog', 'wolf', 'tiger', 'cat', 'lion', 'sphinx'],
             $this->getEntries(['type:in' => 'canine|feline'])->map->slug()->all()
         );
     }
@@ -130,11 +132,12 @@ class QueriesConditionsTest extends TestCase
         $this->makeEntry('cat')->set('type', 'feline')->save();
         $this->makeEntry('lion')->set('type', 'feline')->save();
         $this->makeEntry('horse')->set('type', 'equine')->save();
+        $this->makeEntry('sphinx')->set('type', ['feline', 'aves'])->save();
         $this->makeEntry('bigfoot')->save();
 
-        $this->assertCount(7, $this->getEntries());
+        $this->assertCount(8, $this->getEntries());
         $this->assertEquals(
-            ['tiger', 'cat', 'lion', 'horse', 'bigfoot'],
+            ['tiger', 'cat', 'lion', 'horse', 'sphinx', 'bigfoot'],
             $this->getEntries(['type:not_in' => ['canine']])->map->slug()->all()
         );
         $this->assertEquals(
@@ -146,7 +149,7 @@ class QueriesConditionsTest extends TestCase
             $this->getEntries(['type:not_in' => ['canine', 'feline']])->map->slug()->all()
         );
         $this->assertEquals(
-            ['dog', 'wolf', 'tiger', 'cat', 'lion', 'bigfoot'],
+            ['dog', 'wolf', 'tiger', 'cat', 'lion', 'sphinx', 'bigfoot'],
             $this->getEntries(['type:not_in' => ['equine']])->map->slug()->all()
         );
 

--- a/tests/Tags/Concerns/QueriesConditionsTest.php
+++ b/tests/Tags/Concerns/QueriesConditionsTest.php
@@ -106,7 +106,6 @@ class QueriesConditionsTest extends TestCase
         $this->makeEntry('cat')->set('type', 'feline')->save();
         $this->makeEntry('lion')->set('type', 'feline')->save();
         $this->makeEntry('horse')->set('type', 'equine')->save();
-        $this->makeEntry('horse')->set('type', 'equine')->save();
         $this->makeEntry('sphinx')->set('type', ['feline', 'aves'])->save();
         $this->makeEntry('bigfoot')->save();
 


### PR DESCRIPTION
filterWhereIn and filterWhereNotIn were not working for fields that get saved as an array, like a multiple select field.

Fixes https://github.com/statamic/cms/issues/3095