### PR TITLE
Fix some tree issues

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -177,8 +177,13 @@ class EntriesController extends CpController
 
         if ($collection->structure() && ! $collection->orderable()) {
             $entry->afterSave(function ($entry) use ($parent) {
-                $entry->structure()
-                    ->in($entry->locale())
+                $tree = $entry->structure()->in($entry->locale());
+
+                if (optional($tree->page($parent))->isRoot()) {
+                    $parent = null;
+                }
+
+                $tree
                     ->move($entry->id(), $parent)
                     ->save();
             });

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -7,6 +7,7 @@ use Statamic\Data\ExistsAsFile;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
+use Statamic\Support\Arr;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class Tree implements Localization
@@ -239,6 +240,10 @@ class Tree implements Localization
     {
         if (optional($this->page($entry)->parent())->id() === $target) {
             return $this;
+        }
+
+        if ($this->structure()->expectsRoot() && Arr::get($this->tree, '0.entry') === $target) {
+            throw new \Exception('Root page cannot have children');
         }
 
         [$match, $branches] = $this->removeFromInBranches($entry, $this->tree);

--- a/tests/Data/Structures/TreeTest.php
+++ b/tests/Data/Structures/TreeTest.php
@@ -402,6 +402,85 @@ class TreeTest extends TestCase
         $tree->tree();
     }
 
+    /** @test */
+    public function it_cannot_move_into_root_if_structure_expects_root()
+    {
+        $this->expectExceptionMessage('Root page cannot have children');
+
+        $tree = $this->tree()->tree([
+            [
+                'entry' => 'pages-home',
+            ],
+            [
+                'entry' => 'pages-about',
+                'children' => [
+                    [
+                        'entry' => 'pages-board',
+                    ],
+                    [
+                        'entry' => 'pages-directors',
+                    ],
+                ],
+            ],
+            [
+                'entry' => 'pages-blog',
+            ],
+        ]);
+
+        $tree->move('pages-board', 'pages-home');
+    }
+
+    /** @test */
+    public function it_can_move_into_root_if_structure_does_not_expect_root()
+    {
+        $tree = $this->tree();
+        $tree->structure()->expectsRoot(false);
+
+        $tree->tree([
+            [
+                'entry' => 'pages-home',
+            ],
+            [
+                'entry' => 'pages-about',
+                'children' => [
+                    [
+                        'entry' => 'pages-board',
+                    ],
+                    [
+                        'entry' => 'pages-directors',
+                    ],
+                ],
+            ],
+            [
+                'entry' => 'pages-blog',
+            ],
+        ]);
+
+        $tree->move('pages-board', 'pages-home');
+
+        $this->assertEquals([
+            [
+                'entry' => 'pages-home',
+                'children' => [
+                    [
+                        'entry' => 'pages-board',
+                    ],
+                ],
+            ],
+            [
+                'entry' => 'pages-about',
+                'children' => [
+                    [
+                        'entry' => 'pages-directors',
+                    ],
+                ],
+            ],
+            [
+                'entry' => 'pages-blog',
+            ],
+        ], $tree->tree());
+    }
+
     protected function tree()
     {
         return (new Tree)


### PR DESCRIPTION
Closes #3083 

This fixes what 3083 was trying to do.

When you save an entry, if the selected "parent" field is the root, it'll make it so it doesn't try to make it a child. It'll just place it at the top level.

This will also now throw an exception if you try to move a page into the root at the code level.