### PR TITLE
If entry hasn't been created, return null as API URL

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -248,11 +248,11 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
 
     public function apiUrl()
     {
-        if (! $this->id) {
+        if (! $id = $this->id()) {
             return null;
         }
 
-        return Statamic::apiRoute('collections.entries.show', [$this->collectionHandle(), $this->id()]);
+        return Statamic::apiRoute('collections.entries.show', [$this->collectionHandle(), $id]);
     }
 
     public function reference()

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -248,6 +248,10 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
 
     public function apiUrl()
     {
+        if (! $this->id) {
+            return null;
+        }
+
         return Statamic::apiRoute('collections.entries.show', [$this->collectionHandle(), $this->id()]);
     }
 


### PR DESCRIPTION
This pull request fixes #2953.

When the API was enabled and you tried to use the live preview feature when creating a new entry, it would error out about missing parameters. Essentially, the issue was that the `$this->id()` was returning as null, as no entry had been created yet. I've added a check in before it returns the route.

From what I can tell, the reason it didn't happen when the API was disabled was because the API routes weren't registered at that point as there's a check in the `routes/routes.php` file.