### PR TITLE
Time should not be saved if time is disabled on Date field

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -111,7 +111,7 @@ class Date extends Fieldtype
             $data = array_get($data, 'start', null);
         }
 
-        return Carbon::createFromFormat($this->dateFormat($data), $data)->format('Y-m-d H:i');
+        return Carbon::createFromFormat($this->dateFormat($data), $data)->format($this->config('time_enabled') ? 'Y-m-d H:i' : 'Y-m-d');
     }
 
     public function process($data)


### PR DESCRIPTION
This pull request resolves #2497, where the time would always be saved, even if the `time_enabled` config setting was set to `false`.

The issue seems to have come from the `preProcess` function of the Date fieldtype where it was formatting the date value to one that can then be understood by Moment on the frontend.

Essentially, it was just a case of adding a ternary to check if time is enabled, if yes the format will be `Y-m-d H:i`, otherwise it will be `Y-m-d`.