### PR TITLE
Fix documents not being removed from search index

### DIFF
--- a/src/Search/Algolia/Index.php
+++ b/src/Search/Algolia/Index.php
@@ -43,7 +43,7 @@ class Index extends BaseIndex
 
     public function delete($document)
     {
-        $this->getIndex()->deleteObject($document->id());
+        $this->getIndex()->deleteObject($document->reference());
     }
 
     public function deleteIndex()

--- a/src/Search/Comb/Index.php
+++ b/src/Search/Comb/Index.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Search\Comb;
 
-use Statamic\Entries\Entry;
 use Statamic\Facades\File;
 use Statamic\Search\Comb\Exceptions\NoQuery;
 use Statamic\Search\Comb\Exceptions\NoResultsFound;

--- a/src/Search/Comb/Index.php
+++ b/src/Search/Comb/Index.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Search\Comb;
 
+use Statamic\Entries\Entry;
 use Statamic\Facades\File;
 use Statamic\Search\Comb\Exceptions\NoQuery;
 use Statamic\Search\Comb\Exceptions\NoResultsFound;
@@ -92,7 +93,7 @@ class Index extends BaseIndex
             return;
         }
 
-        $data->forget($document->id());
+        $data->forget($document->reference());
 
         $this->save($data);
     }


### PR DESCRIPTION
This pull request fixes #2727. Currently, when you delete an entry, it will not be removed from the search index, it will just stay there until the end of days.

This PR fixes that, where when an entry is deleted, it will also be deleted from the search index as well.

This PR not only fixes it for entries but also for anything else that is held in the search index.

 In the index, documents are stored by their `reference` (eg. `entry::the-entry-id`) but when deleting, it was trying to find a document called `the-entry-id` (by the ID), which obviously wasn't found. This ID basically just passes the reference instead of the ID.