### PR TITLE
Multisite command improvements

### DIFF
--- a/src/Console/Commands/Multisite.php
+++ b/src/Console/Commands/Multisite.php
@@ -53,6 +53,8 @@ class Multisite extends Command
 
         $config = $this->updateSiteConfig();
 
+        $this->comment('Converting...');
+
         Collection::all()->each(function ($collection) {
             $this->moveCollectionContent($collection);
             $this->updateCollection($collection);
@@ -70,6 +72,7 @@ class Multisite extends Command
         });
 
         Cache::clear();
+        $this->checkLine('Cache cleared.');
 
         $this->attemptToWriteSiteConfig($config);
 

--- a/src/Console/Commands/Multisite.php
+++ b/src/Console/Commands/Multisite.php
@@ -43,6 +43,8 @@ class Multisite extends Command
 
         $this->siteTwo = $this->ask('Handle of the second site', 'two');
 
+        $this->clearStache();
+
         $config = $this->updateSiteConfig();
 
         Collection::all()->each(function ($collection) {
@@ -67,6 +69,13 @@ class Multisite extends Command
 
         $this->comment('[!] Update <comment>config/statamic/sites.php</comment>\'s sites array to the following:');
         $this->line(VarExporter::export($config));
+    }
+
+    protected function clearStache()
+    {
+        Stache::clear();
+        $this->checkLine('Stache cleared.');
+        $this->line('');
     }
 
     protected function updateSiteConfig()

--- a/src/Ignition/Solutions/EnableStatamicPro.php
+++ b/src/Ignition/Solutions/EnableStatamicPro.php
@@ -3,9 +3,7 @@
 namespace Statamic\Ignition\Solutions;
 
 use Facade\IgnitionContracts\RunnableSolution;
-use Statamic\Facades\File;
 use Statamic\Statamic;
-use Statamic\Support\Str;
 
 class EnableStatamicPro implements RunnableSolution
 {
@@ -38,17 +36,7 @@ class EnableStatamicPro implements RunnableSolution
 
     public function run(array $parameters = [])
     {
-        $path = config_path('statamic/editions.php');
-
-        $contents = File::get($path);
-
-        if (! Str::contains($contents, "'pro' => false,")) {
-            throw new \Exception('Could not reliably update the config file.');
-        }
-
-        $contents = str_replace("'pro' => false,", "'pro' => true,", $contents);
-
-        File::put($path, $contents);
+        Statamic::enablePro();
     }
 
     public function getRunParameters(): array

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Statamic\Facades\File;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
+use Statamic\Support\Str;
 use Stringy\StaticStringy;
 
 class Statamic
@@ -32,6 +33,21 @@ class Statamic
     public static function pro()
     {
         return config('statamic.editions.pro');
+    }
+
+    public static function enablePro()
+    {
+        $path = config_path('statamic/editions.php');
+
+        $contents = File::get($path);
+
+        if (! Str::contains($contents, "'pro' => false,")) {
+            throw new \Exception('Could not reliably update the config file.');
+        }
+
+        $contents = str_replace("'pro' => false,", "'pro' => true,", $contents);
+
+        File::put($path, $contents);
     }
 
     public static function availableScripts(Request $request)


### PR DESCRIPTION
- Fixes #2802 by clearing the Stache at the start of the command.
- It will now tell you that Pro is required (if you don't already have it enabled) and offer to enable it.
- It will now update the sites config file for you rather than just telling you to do it.
- If either instance of updating the config files fail, it'll tell you how to manually do it.
- Added some minor output improvements now that it's doing a little more.

![image](https://user-images.githubusercontent.com/105211/104959969-52e0c100-59a1-11eb-820b-a6e48d06514a.png)
