### PR TITLE
Allow translation of email subjects

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -30,7 +30,7 @@ class Email extends Mailable
     public function build()
     {
         $this
-            ->subject($this->config['subject'] ?? __('Form Submission'))
+            ->subject($this->config['subject'] ? __($this->config['subject']) : __('Form Submission'))
             ->addAddresses()
             ->addViews()
             ->addData();

--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -30,7 +30,7 @@ class Email extends Mailable
     public function build()
     {
         $this
-            ->subject($this->config['subject'] ? __($this->config['subject']) : __('Form Submission'))
+            ->subject(isset($this->config['subject']) ? __($this->config['subject']) : __('Form Submission'))
             ->addAddresses()
             ->addViews()
             ->addData();


### PR DESCRIPTION
This is a nice band-aid solution to allow translation of the subject of form emails.

Closes #2994 