### PR TITLE
Use site to determine taxonomy url

### DIFF
--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -5,7 +5,6 @@ namespace Statamic\Stache\Repositories;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Contracts\Taxonomies\TermRepository as RepositoryContract;
 use Statamic\Facades\Collection;
-use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
 use Statamic\Stache\Query\TermQueryBuilder;
 use Statamic\Stache\Stache;

--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -46,16 +46,16 @@ class TermRepository implements RepositoryContract
     public function findByUri(string $uri, string $site = null): ?Term
     {
         $collection = Collection::all()
-            ->first(function ($collection) use ($uri) {
+            ->first(function ($collection) use ($uri, $site) {
                 if (Str::startsWith($uri, $collection->url())) {
                     return true;
                 }
 
-                return Site::hasMultiple() ? false : Str::startsWith($uri, '/'.$collection->handle());
+                return Str::startsWith($uri, $collection->uri($site));
             });
 
         if ($collection) {
-            $uri = Str::after($uri, $collection->url() ?? $collection->handle());
+            $uri = Str::after($uri, $collection->uri($site) ?? $collection->handle());
         }
 
         $uri = Str::removeLeft($uri, '/');


### PR DESCRIPTION
This fixes an issue when translating collection routes in combination with translated taxonomies