### PR TITLE
Inject and mock yaml dumper

### DIFF
--- a/src/Yaml/Yaml.php
+++ b/src/Yaml/Yaml.php
@@ -13,6 +13,12 @@ use Symfony\Component\Yaml\Yaml as SymfonyYaml;
 class Yaml
 {
     protected $file;
+    protected $yaml;
+
+    public function __construct(SymfonyYaml $yaml)
+    {
+        $this->yaml = $yaml;
+    }
 
     public function file($file)
     {
@@ -51,7 +57,7 @@ class Yaml
         }
 
         try {
-            $yaml = SymfonyYaml::parse($str);
+            $yaml = $this->yaml->parse($str);
         } catch (\Exception $e) {
             throw $this->viewException($e, $str);
         }
@@ -81,7 +87,7 @@ class Yaml
             $data['content'] = $content;
         }
 
-        return SymfonyYaml::dump($data, 100, 2, SymfonyYaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+        return $this->yaml->dump($data, 100, 2, SymfonyYaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
     }
 
     /**

--- a/tests/Yaml/YamlTest.php
+++ b/tests/Yaml/YamlTest.php
@@ -5,6 +5,8 @@ namespace Tests\Yaml;
 use Exception;
 use Statamic\Facades\YAML;
 use Statamic\Yaml\ParseException;
+use Statamic\Yaml\Yaml as StatamicYaml;
+use Symfony\Component\Yaml\Yaml as SymfonyYaml;
 use Tests\TestCase;
 
 class YamlTest extends TestCase
@@ -19,19 +21,16 @@ class YamlTest extends TestCase
             'array' => ['one', 'two'],
         ];
 
-        $expected = <<<'EOT'
-foo: bar
-two_words: 'two words'
-multiline: |
-  first
-  second
-array:
-  - one
-  - two
+        $symfonyYaml = $this->mock(SymfonyYaml::class)
+            ->shouldReceive('dump')
+            ->with($array, 100, 2, SymfonyYaml::DUMP_MULTI_LINE_LITERAL_BLOCK)
+            ->once()
+            ->andReturn('some properly dumped yaml from symfony')
+            ->getMock();
 
-EOT;
+        $this->app->instance(StatamicYaml::class, new StatamicYaml($symfonyYaml));
 
-        $this->assertEqualsIgnoringLineEndings($expected, YAML::dump($array));
+        $this->assertEquals('some properly dumped yaml from symfony', YAML::dump($array));
     }
 
     /** @test */


### PR DESCRIPTION
Symfony recently released a new version of the yaml component which slightly changes how multilines are dumped. It was causing our tests to fail in a very minor way - but still fails.

Rather than testing the actual yaml is dumped correctly, mock it. Symfony's Yaml component is already under test.
This fixes the tests before and after 5.2.2