### PR TITLE
Renames @svg directive to @statamic_svg to fix potential conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@
 
 ## 3.0.34 (2020-12-09)
 
-### What's new 
+### What's new
 - PHP 8 support. [#2944](https://github.com/statamic/cms/issues/2944)
 
 ### What's fixed
@@ -340,7 +340,7 @@
 - `Str::isUrl()` checks more URLs. [#2759](https://github.com/statamic/cms/issues/2759)
 - Dutch translation has been updated. [#2754](https://github.com/statamic/cms/issues/2754)
 - The Entry facade docblock has been updated. [#2720](https://github.com/statamic/cms/issues/2720)
-- The `@svg` Blade directive is only registered on CP routes. Prevents conflicts with things like Blade UI Kit. [99e812e6c](https://github.com/statamic/cms/commit/99e812e6c)
+- The `@statamic_svg` Blade directive is only registered on CP routes. Prevents conflicts with things like Blade UI Kit. [99e812e6c](https://github.com/statamic/cms/commit/99e812e6c)
 - The `shuffle` modifier works for Collections. [#2709](https://github.com/statamic/cms/issues/2709)
 - The `.idea` directory is git ignored, and we now require `ext-json`, which improves the experience for PhpStorm users. [#2735](https://github.com/statamic/cms/issues/2735)
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -5,7 +5,7 @@
 
 @section('content')
 <div class="logo pt-7">
-    @svg('statamic-wordmark')
+    @statamic_svg('statamic-wordmark')
 </div>
 
 <div class="card auth-card mx-auto">

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -3,7 +3,7 @@
 
 @section('content')
     <div class="logo pt-7">
-        @svg('statamic-wordmark')
+        @statamic_svg('statamic-wordmark')
     </div>
 
     <div class="card auth-card mx-auto">

--- a/resources/views/auth/unauthorized.blade.php
+++ b/resources/views/auth/unauthorized.blade.php
@@ -4,7 +4,7 @@
 
 @section('content')
 <div class="logo pt-7">
-    @svg('statamic-wordmark')
+    @statamic_svg('statamic-wordmark')
 </div>
 
 <div class="card auth-card mx-auto text-center text-grey-70">

--- a/resources/views/blueprints/index.blade.php
+++ b/resources/views/blueprints/index.blade.php
@@ -37,7 +37,7 @@
                     <tr>
                         <td>
                             <div class="flex items-center">
-                                <div class="w-4 h-4 mr-2">@svg('content-writing')</div>
+                                <div class="w-4 h-4 mr-2">@statamic_svg('content-writing')</div>
                                 <a href="{{ cp_route('collections.blueprints.edit', [$collection, $blueprint]) }}">{{ $blueprint->title() }}</a>
                             </div>
                         </td>
@@ -60,7 +60,7 @@
                     <tr>
                         <td>
                             <div class="flex items-center">
-                                <div class="w-4 h-4 mr-2">@svg('tags')</div>
+                                <div class="w-4 h-4 mr-2">@statamic_svg('tags')</div>
                                 <a href="{{ cp_route('taxonomies.blueprints.edit', [$taxonomy, $blueprint]) }}">{{ $blueprint->title() }}</a>
                             </div>
                         </td>
@@ -82,7 +82,7 @@
                 <tr>
                     <td>
                         <div class="flex items-center">
-                            <div class="w-4 h-4 mr-2">@svg('earth')</div>
+                            <div class="w-4 h-4 mr-2">@statamic_svg('earth')</div>
                             <a href="{{ cp_route('globals.blueprint.edit', $set->handle()) }}">{{ $set->title() }}</a>
                         </div>
                     </td>
@@ -102,7 +102,7 @@
                 <tr>
                     <td>
                         <div class="flex items-center">
-                            <div class="w-4 h-4 mr-2">@svg('assets')</div>
+                            <div class="w-4 h-4 mr-2">@statamic_svg('assets')</div>
                             <a href="{{ cp_route('asset-containers.blueprint.edit', $container->handle()) }}">{{ $container->title() }}</a>
                         </div>
                     </td>
@@ -122,7 +122,7 @@
                 <tr>
                     <td>
                         <div class="flex items-center">
-                            <div class="w-4 h-4 mr-2">@svg('drawer-file')</div>
+                            <div class="w-4 h-4 mr-2">@statamic_svg('drawer-file')</div>
                             <a href="{{ cp_route('forms.blueprint.edit', $form->handle()) }}">{{ $form->title() }}</a>
                         </div>
                     </td>
@@ -139,7 +139,7 @@
             <tr>
                 <td>
                     <div class="flex items-center">
-                        <div class="w-4 h-4 mr-2">@svg('users')</div>
+                        <div class="w-4 h-4 mr-2">@statamic_svg('users')</div>
                         <a href="{{ cp_route('users.blueprint.edit') }}">{{ __('User') }}</a>
                     </div>
                 </td>

--- a/resources/views/collections/empty.blade.php
+++ b/resources/views/collections/empty.blade.php
@@ -15,7 +15,7 @@
     <div class="flex flex-wrap">
         <a href="{{ cp_route('collections.edit', $collection->handle()) }}" class="w-full lg:w-1/2 p-2 flex items-start hover:bg-grey-20 rounded-md group">
             <div class="h-8 w-8 mr-2 text-grey-80">
-                @svg('hammer-wrench')
+                @statamic_svg('hammer-wrench')
             </div>
             <div class="flex-1 mb-2 md:mb-0 md:mr-3">
                 <h3 class="mb-1 text-blue">{{ __('Configure Collection') }} &rarr;</h3>
@@ -29,7 +29,7 @@
             class="w-full lg:w-1/2 p-2 flex items-start hover:bg-grey-20 rounded-md group"
         >
             <div class="h-8 w-8 mr-2 text-grey-80">
-                @svg('content-writing')
+                @statamic_svg('content-writing')
             </div>
             <div class="flex-1 mb-2 md:mb-0 md:mr-3">
                 <h3 class="mb-1 text-blue">{{ __('Create Entry') }} @if (!$multipleBlueprints)&rarr;@endif</h3>
@@ -44,7 +44,7 @@
         @if ($multipleBlueprints)</div>@else</a>@endif
         <a href="{{ cp_route('collections.scaffold', $collection->handle()) }}" class="w-full lg:w-1/2 p-2 flex items-start hover:bg-grey-20 rounded-md group">
             <div class="h-8 w-8 mr-2 text-grey-80">
-                @svg('crane')
+                @statamic_svg('crane')
             </div>
             <div class="flex-1 mb-2 md:mb-0 md:mr-3">
                 <h3 class="mb-1 text-blue">{{ __('Scaffold Resources') }} &rarr;</h3>
@@ -53,7 +53,7 @@
         </a>
         <a href="{{ Statamic::docsUrl('collections') }}" target="_blank" class="w-full lg:w-1/2 p-2 flex items-start hover:bg-grey-20 rounded-md group">
             <div class="h-8 w-8 mr-2 text-grey-80">
-                @svg('book-pages')
+                @statamic_svg('book-pages')
             </div>
             <div class="flex-1 mb-2 md:mb-0 md:mr-3">
                 <h3 class="mb-1 text-blue">{{ __('Read the Documentation') }} &rarr;</h3>

--- a/resources/views/fields/index.blade.php
+++ b/resources/views/fields/index.blade.php
@@ -13,7 +13,7 @@
                     <div class="p-3">
                         <h2><a href="{{ cp_route('blueprints.index') }}" class="text-grey-90 hover:text-blue">{{ __('Blueprints') }}</a></h2>
                         <p>{{ __('statamic::messages.fields_blueprints_description') }}</p>
-                        <p><a href="{{ Statamic::docsUrl('blueprints') }}" class="font-bold text-blue">{{ __('Read the Docs') }}</a><span class="inline-block text-blue w-4 h-4 ml-1">@svg('external-link')</span></p>
+                        <p><a href="{{ Statamic::docsUrl('blueprints') }}" class="font-bold text-blue">{{ __('Read the Docs') }}</a><span class="inline-block text-blue w-4 h-4 ml-1">@statamic_svg('external-link')</span></p>
                     </div>
                     <div class="flex p-3 border-t items-center">
                         <a href="{{ cp_route('blueprints.create') }}" class="btn-primary mr-2">{{ __('Create Blueprint') }}</a>
@@ -30,7 +30,7 @@
                     <div class="p-3">
                         <h2>{{ __('Fieldsets') }}</h2>
                         <p>{{ __('statamic::messages.fields_fieldsets_description') }}</p>
-                        <p><a href="{{ Statamic::docsUrl('fieldsets') }}" class="font-bold text-blue">{{ __('Read the Docs') }}</a><span class="inline-block text-blue w-4 h-4 ml-1">@svg('external-link')</span></p>
+                        <p><a href="{{ Statamic::docsUrl('fieldsets') }}" class="font-bold text-blue">{{ __('Read the Docs') }}</a><span class="inline-block text-blue w-4 h-4 ml-1">@statamic_svg('external-link')</span></p>
                     </div>
                     <div class="flex p-3 border-t items-center">
                         <a href="{{ cp_route('fieldsets.create') }}" class="btn-primary mr-2">{{ __('Create Fieldset') }}</a>

--- a/resources/views/forms/show.blade.php
+++ b/resources/views/forms/show.blade.php
@@ -59,7 +59,7 @@
     >
         <div slot="no-results" class="text-center border-2 border-dashed rounded-lg">
             <div class="max-w-md mx-auto px-4 py-8">
-                @svg('empty/form')
+                @statamic_svg('empty/form')
                 <h1 class="my-3">{{ __('No submissions') }}</h1>
             </div>
         </div>

--- a/resources/views/licensing.blade.php
+++ b/resources/views/licensing.blade.php
@@ -20,7 +20,7 @@
                     <a href="{{ cp_route('utilities.licensing.refresh') }}" class="btn-primary btn-lg">{{ __('Try again') }}</a>
                 </div>
                 <div class="hidden md:block w-1/2 pl-6">
-                    @svg('empty/navigation')
+                    @statamic_svg('empty/navigation')
                 </div>
             </div>
         </div>

--- a/resources/views/partials/breadcrumb.blade.php
+++ b/resources/views/partials/breadcrumb.blade.php
@@ -1,7 +1,7 @@
 <div class="flex">
     <a href="{{ $url }}" class="flex-initial flex p-1 -m-1 items-center text-xs text-grey-70 hover:text-grey-90">
         <div class="h-6 rotate-180 svg-icon using-svg">
-            @svg('chevron-right')
+            @statamic_svg('chevron-right')
         </div>
         <span>{{ $title }}</span>
     </a>

--- a/resources/views/partials/create-first.blade.php
+++ b/resources/views/partials/create-first.blade.php
@@ -1,7 +1,7 @@
 <div class="no-results border-dashed border-2">
     <div class="text-center max-w-md mx-auto mt-5 rounded-lg px-4 py-8">
 
-        @svg($svg)
+        @statamic_svg($svg)
 
         <h1 class="my-3">
             @if ($can ?? $user->can('super'))

--- a/resources/views/partials/empty-state.blade.php
+++ b/resources/views/partials/empty-state.blade.php
@@ -19,7 +19,7 @@
             @endunless
         </div>
         <div class="hidden md:block w-1/2 pl-6">
-            @svg($svg ?? 'empty/content')
+            @statamic_svg($svg ?? 'empty/content')
         </div>
     </div>
 </div>

--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -1,11 +1,11 @@
 <div class="global-header">
     <div class="lg:w-56 pl-1 md:pl-3 h-full flex items-center">
-        <button class="nav-toggle hidden md:block ml-sm flex-shrink-0" @click="toggleNav" aria-label="{{ __('Toggle Nav') }}">@svg('burger')</button>
-        <button class="nav-toggle md:hidden ml-sm flex-shrink-0" @click="toggleMobileNav" v-if="! mobileNavOpen" aria-label="{{ __('Toggle Mobile Nav') }}">@svg('burger')</button>
-        <button class="nav-toggle md:hidden ml-sm flex-shrink-0" @click="toggleMobileNav" v-else v-cloak aria-label="{{ __('Toggle Mobile Nav') }}">@svg('close')</button>
+        <button class="nav-toggle hidden md:block ml-sm flex-shrink-0" @click="toggleNav" aria-label="{{ __('Toggle Nav') }}">@statamic_svg('burger')</button>
+        <button class="nav-toggle md:hidden ml-sm flex-shrink-0" @click="toggleMobileNav" v-if="! mobileNavOpen" aria-label="{{ __('Toggle Mobile Nav') }}">@statamic_svg('burger')</button>
+        <button class="nav-toggle md:hidden ml-sm flex-shrink-0" @click="toggleMobileNav" v-else v-cloak aria-label="{{ __('Toggle Mobile Nav') }}">@statamic_svg('close')</button>
         <a href="{{ route('statamic.cp.index') }}" class="flex items-end">
             <div v-tooltip="version" class="hidden md:block flex-shrink-0">
-                @svg('statamic-wordmark')
+                @statamic_svg('statamic-wordmark')
                 @if (Statamic::pro())<span class="font-bold text-4xs align-top">PRO</span>@endif
             </div>
         </a>
@@ -20,7 +20,7 @@
 
         @if (Statamic\Facades\Site::hasMultiple())
             <global-site-selector>
-                <template slot="icon">@svg('sites')</template>
+                <template slot="icon">@statamic_svg('sites')</template>
             </global-site-selector>
         @endif
 
@@ -28,24 +28,24 @@
 
         @if (config('telescope.enabled'))
             <a class="hidden md:block h-6 w-6 p-sm text-grey ml-2 hover:text-grey-80" href="/{{ config('telescope.path') }}" target="_blank" v-tooltip="'Laravel Telescope'">
-                @svg('telescope')
+                @statamic_svg('telescope')
             </a>
         @endif
         <dropdown-list v-cloak>
             <template v-slot:trigger>
                 <button class="hidden md:block h-6 w-6 ml-2 p-sm text-grey hover:text-grey-80" v-tooltip="__('Useful Links')" aria-label="{{ __('View Useful Links') }}">
-                    @svg('book-open')
+                    @statamic_svg('book-open')
                 </button>
             </template>
 
             <dropdown-item external-link="https://statamic.dev" class="flex items-center">
                 <span>{{__('Documentation')}}</span>
-                <i class="w-3 block ml-1">@svg('external-link')</i>
+                <i class="w-3 block ml-1">@statamic_svg('external-link')</i>
             </dropdown-item>
 
             <dropdown-item external-link="https://statamic.com/forum" class="flex items-center">
                 <span>{{__('Support')}}</span>
-                <i class="w-3 block ml-1">@svg('external-link')</i>
+                <i class="w-3 block ml-1">@statamic_svg('external-link')</i>
             </dropdown-item>
 
             <dropdown-item @click="$events.$emit('keyboard-shortcuts.open')" class="flex items-center">
@@ -54,7 +54,7 @@
         </dropdown-list>
 
         <a class="hidden md:block h-6 w-6 p-sm text-grey ml-2 hover:text-grey-80" href="{{ Statamic\Facades\Site::selected()->url() }}" target="_blank" v-tooltip="'{{ __('View Site') }}'" aria-label="{{ __('View Site') }}">
-            @svg('browser-com')
+            @statamic_svg('browser-com')
         </a>
         <dropdown-list v-cloak>
             <template v-slot:trigger>

--- a/resources/views/partials/licensing-alerts.blade.php
+++ b/resources/views/partials/licensing-alerts.blade.php
@@ -32,7 +32,7 @@
                             <button @click="hideBanner" class="mr-2 text-2xs opacity-50 hover:opacity-75">{{ __('Dismiss') }}</button>
                             @can('access licensing utility')
                             <a href="{{ cp_route('utilities.licensing') }}" class="text-white hover:text-yellow flex items-center" aria-label="{{ __('Go to Your License Settings') }}">
-                                @svg('arrow-right')
+                                @statamic_svg('arrow-right')
                             </a>
                             @endcan
                         </div>
@@ -44,7 +44,7 @@
                             <button @click="hideBanner" class="mr-2 text-2xs opacity-50 hover:opacity-75">{{ __('Dismiss') }}</button>
                             @can('access licensing utility')
                                 <a href="{{ cp_route('utilities.licensing') }}" class="text-white hover:text-yellow flex items-center" aria-label="{{ __('Go to Your License Settings') }}">
-                                    @svg('arrow-right')
+                                    @statamic_svg('arrow-right')
                                 </a>
                             @endcan
                         </div>

--- a/resources/views/playground.blade.php
+++ b/resources/views/playground.blade.php
@@ -199,7 +199,7 @@
                 </div>
                 <div class="text-4xl mb-2">89</div>
                 <div class="flex items-center ">
-                    <span class="w-4 h-4 text-green mr-1">@svg('performance-increase')</span>
+                    <span class="w-4 h-4 text-green mr-1">@statamic_svg('performance-increase')</span>
                     <span class="leading-none text-sm">8.54% Increase</span>
                 </div>
             </div>
@@ -214,7 +214,7 @@
                 </div>
                 <div class="text-4xl mb-2">35</div>
                 <div class="flex items-center ">
-                    <span class="w-4 h-4 text-green mr-1">@svg('performance-increase')</span>
+                    <span class="w-4 h-4 text-green mr-1">@statamic_svg('performance-increase')</span>
                     <span class="leading-none text-sm">2.15% Increase</span>
                 </div>
             </div>
@@ -229,7 +229,7 @@
                 </div>
                 <div class="text-4xl mb-2 text-grey-40">251</div>
                 <div class="flex items-center ">
-                    <span class="w-4 h-4 text-green mr-1">@svg('performance-increase')</span>
+                    <span class="w-4 h-4 text-green mr-1">@statamic_svg('performance-increase')</span>
                     <span class="leading-none text-grey-40 text-sm">8.54% Increase</span>
                 </div>
             </div>

--- a/resources/views/taxonomies/empty.blade.php
+++ b/resources/views/taxonomies/empty.blade.php
@@ -15,7 +15,7 @@
     <div class="flex flex-wrap">
         <a href="{{ cp_route('taxonomies.edit', $taxonomy->handle()) }}" class="w-full lg:w-1/2 p-2 flex items-start hover:bg-grey-20 rounded-md group">
             <div class="h-8 w-8 mr-2 text-grey-80">
-                @svg('hammer-wrench')
+                @statamic_svg('hammer-wrench')
             </div>
             <div class="flex-1 mb-2 md:mb-0 md:mr-3">
                 <h3 class="mb-1 text-blue">{{ __('Configure Taxonomy') }} &rarr;</h3>
@@ -24,7 +24,7 @@
         </a>
         <a href="{{ cp_route('taxonomies.terms.create', [$taxonomy->handle(), $site]) }}" class="w-full lg:w-1/2 p-2 flex items-start hover:bg-grey-20 rounded-md group">
             <div class="h-8 w-8 mr-2 text-grey-80">
-                @svg('content-writing')
+                @statamic_svg('content-writing')
             </div>
             <div class="flex-1 mb-2 md:mb-0 md:mr-3">
                 <h3 class="mb-1 text-blue">{{ __('Create Term') }} &rarr;</h3>
@@ -33,7 +33,7 @@
         </a>
         <a href="{{ Statamic::docsUrl('taxonomies') }}" target="_blank" class="w-full lg:w-1/2 p-2 flex items-start hover:bg-grey-20 rounded-md group">
             <div class="h-8 w-8 mr-2 text-grey-80">
-                @svg('book-pages')
+                @statamic_svg('book-pages')
             </div>
             <div class="flex-1 mb-2 md:mb-0 md:mr-3">
                 <h3 class="mb-1 text-blue">{{ __('Read the Documentation') }} &rarr;</h3>

--- a/resources/views/utilities/index.blade.php
+++ b/resources/views/utilities/index.blade.php
@@ -12,7 +12,7 @@
         @foreach ($utilities as $utility)
             <a href="{{ $utility->url() }}" class="w-full lg:w-1/2 p-2 md:flex items-start hover:bg-grey-20 rounded-md group">
                 <div class="h-8 w-8 mr-2 text-grey-80">
-                    @svg($utility->icon())
+                    @statamic_svg($utility->icon())
                 </div>
                 <div class="text-blue flex-1 mb-2 md:mb-0 md:mr-3">
                     <h3>{{ $utility->title() }}</h3>

--- a/resources/views/widgets/getting-started.blade.php
+++ b/resources/views/widgets/getting-started.blade.php
@@ -6,7 +6,7 @@
     <div class="flex flex-wrap p-2">
         <a href="https://statamic.dev" class="w-full lg:w-1/2 p-2 flex items-start hover:bg-grey-20 rounded-md group">
             <div class="h-8 w-8 mr-2 text-grey-80">
-                @svg('book-pages')
+                @statamic_svg('book-pages')
             </div>
             <div class="flex-1">
                 <h3 class="mb-1 text-blue">{{ __('Read the Documentation') }}</h3>
@@ -16,7 +16,7 @@
         @if (!Statamic::pro())
         <a href="https://statamic.dev/licensing" class="w-full lg:w-1/2 p-2 flex items-start hover:bg-grey-20 rounded-md group">
             <div class="h-8 w-8 mr-2 text-grey-80">
-                @svg('pro-ribbon')
+                @statamic_svg('pro-ribbon')
             </div>
             <div class="flex-1">
                 <h3 class="mb-1 text-blue">{{ __('Enable Pro Mode') }}</h3>
@@ -26,7 +26,7 @@
         @endif
         <a href="{{ cp_route('collections.create') }}" class="w-full lg:w-1/2 p-2 flex items-start hover:bg-grey-20 rounded-md group">
             <div class="h-8 w-8 mr-2 text-grey-80">
-                @svg('content-writing')
+                @statamic_svg('content-writing')
             </div>
             <div class="flex-1">
                 <h3 class="mb-1 text-blue">{{ __('Create a Collection') }}</h3>
@@ -35,7 +35,7 @@
         </a>
         <a href="{{ cp_route('blueprints.index') }}" class="w-full lg:w-1/2 p-2 flex items-start hover:bg-grey-20 rounded-md group">
             <div class="h-8 w-8 mr-2 text-grey-80">
-                @svg('blueprints')
+                @statamic_svg('blueprints')
             </div>
             <div class="flex-1">
                 <h3 class="mb-1 text-blue">{{ __('Create a Blueprint') }}</h3>
@@ -44,7 +44,7 @@
         </a>
         <a href="{{ cp_route('navigation.create') }}" class="w-full lg:w-1/2 p-2 flex items-start hover:bg-grey-20 rounded-md group">
             <div class="h-8 w-8 mr-2 text-grey-80">
-                @svg('hierarchy-files')
+                @statamic_svg('hierarchy-files')
             </div>
             <div class="flex-1">
                 <h3 class="mb-1 text-blue">{{ __('Create a Navigation') }}</h3>

--- a/resources/views/widgets/updater.blade.php
+++ b/resources/views/widgets/updater.blade.php
@@ -2,11 +2,11 @@
     <div class="rounded-l py-2 md:w-40 border-r h-full flex items-center justify-center bg-grey-10">
         @if ($count)
             <div class="svg-icon flex px-1 items-center justify-center h-full" style="width: 9rem; ">
-                @svg('marketing/tooter-yay')
+                @statamic_svg('marketing/tooter-yay')
             </div>
         @else
             <div class="svg-icon w-24 flex px-1 items-center justify-center h-full">
-                @svg('marketing/tooter-nay')
+                @statamic_svg('marketing/tooter-nay')
             </div>
         @endif
     </div>
@@ -25,7 +25,7 @@
     @if ($hasStatamicUpdate)
         <div class="px-3 py-1 border-t flex items-center">
             <div class="h-4 w-4 mr-1 text-blue">
-                @svg('hammer-wrench')
+                @statamic_svg('hammer-wrench')
             </div>
             <div class="flex-1 mr-3">
                 <a href="{{ cp_route('updater.product', 'statamic') }}"class="text-blue text-sm font-bold">Statamic Core</a>
@@ -36,7 +36,7 @@
     @foreach ($updatableAddons as $slug => $name)
         <div class="px-3 py-1 border-t flex items-center">
             <div class="h-4 w-4 mr-1 text-blue">
-                @svg('addons')
+                @statamic_svg('addons')
             </div>
             <div class="flex-1 mr-3">
                 <a href="{{ cp_route('updater.product', $slug) }}" class="text-blue text-sm font-bold">{{ $name }}</a>

--- a/src/Http/Middleware/CP/ControlPanel.php
+++ b/src/Http/Middleware/CP/ControlPanel.php
@@ -9,7 +9,7 @@ class ControlPanel
 {
     public function handle($request, Closure $next)
     {
-        Blade::directive('svg', function ($expression) {
+        Blade::directive('statamic_svg', function ($expression) {
             return "<?php echo Statamic::svg({$expression}) ?>";
         });
 


### PR DESCRIPTION
This PR is a suggested fix for #3162.

This might have breaking changes for addons that use the `@svg` directive to access Statamic's own set of SVG assets, so understand if this needs to be rejected.