### PR TITLE
Apply order by traits to search results

### DIFF
--- a/src/Search/Tags.php
+++ b/src/Search/Tags.php
@@ -10,7 +10,8 @@ use Statamic\Tags\Tags as BaseTags;
 class Tags extends BaseTags
 {
     use Concerns\OutputsItems,
-        Concerns\QueriesConditions;
+        Concerns\QueriesConditions,
+        Concerns\QueriesOrderBys;
     use Concerns\GetsQueryResults {
         results as getQueryResults;
     }
@@ -33,6 +34,7 @@ class Tags extends BaseTags
         $this->querySite($builder);
         $this->queryStatus($builder);
         $this->queryConditions($builder);
+        $this->queryOrderBys($builder);
 
         $results = $this->getQueryResults($builder);
         $results = $this->addResultTypes($results);


### PR DESCRIPTION
Allows for sorting of search:results tag (e.g. `{{ search:results sort="title:asc" }}` )
Issue reference: #2383

Suggested fix by @jasonvarga on Discord... I've just applied the logic he suggested.

The only possible problem I can see is that you can't sort by search_score:asc or search_score:desc as thing stand.

Apologies if I've missed anything else required to contribute, do let me know if I need to do anything more.