### PR TITLE
[3.1] GraphQL query an entry by slug or URI

### DIFF
--- a/src/GraphQL/Queries/EntryQuery.php
+++ b/src/GraphQL/Queries/EntryQuery.php
@@ -22,6 +22,8 @@ class EntryQuery extends Query
     {
         return [
             'id' => GraphQL::string(),
+            'slug' => GraphQL::string(),
+            'collection' => GraphQL::string(),
         ];
     }
 
@@ -29,8 +31,16 @@ class EntryQuery extends Query
     {
         $query = Facades\Entry::query();
 
-        if ($id = $args['id']) {
+        if ($id = $args['id'] ?? null) {
             $query->where('id', $id);
+        }
+
+        if ($slug = $args['slug'] ?? null) {
+            $query->where('slug', $slug);
+        }
+
+        if ($collection = $args['collection'] ?? null) {
+            $query->where('collection', $collection);
         }
 
         return $query->limit(1)->get()->first();

--- a/src/GraphQL/Queries/EntryQuery.php
+++ b/src/GraphQL/Queries/EntryQuery.php
@@ -24,6 +24,7 @@ class EntryQuery extends Query
             'id' => GraphQL::string(),
             'slug' => GraphQL::string(),
             'collection' => GraphQL::string(),
+            'uri' => GraphQL::string(),
         ];
     }
 
@@ -41,6 +42,10 @@ class EntryQuery extends Query
 
         if ($collection = $args['collection'] ?? null) {
             $query->where('collection', $collection);
+        }
+
+        if ($uri = $args['uri'] ?? null) {
+            $query->where('uri', $uri);
         }
 
         return $query->limit(1)->get()->first();

--- a/tests/Feature/GraphQL/EntryTest.php
+++ b/tests/Feature/GraphQL/EntryTest.php
@@ -124,6 +124,28 @@ GQL;
     }
 
     /** @test */
+    public function it_queries_an_entry_by_uri()
+    {
+        $query = <<<'GQL'
+{
+    entry(uri: "/events/event-two") {
+        id
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => [
+                'entry' => [
+                    'id' => '4',
+                ],
+            ]]);
+    }
+
+    /** @test */
     public function it_can_add_custom_fields_to_interface()
     {
         GraphQL::addField('EntryInterface', 'one', function () {

--- a/tests/Feature/GraphQL/EntryTest.php
+++ b/tests/Feature/GraphQL/EntryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\GraphQL;
 
 use Facades\Statamic\Fields\BlueprintRepository;
+use Facades\Tests\Factories\EntryFactory;
 use Statamic\Facades\GraphQL;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -68,6 +69,56 @@ GQL;
                         'title' => 'Events',
                         'handle' => 'events',
                     ],
+                ],
+            ]]);
+    }
+
+    /** @test */
+    public function it_queries_an_entry_by_slug()
+    {
+        EntryFactory::collection('blog')->id('123')->slug('foo')->create();
+        EntryFactory::collection('events')->id('456')->slug('foo')->create();
+
+        $query = <<<'GQL'
+{
+    entry(slug: "foo") {
+        id
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => [
+                'entry' => [
+                    'id' => '123',
+                ],
+            ]]);
+    }
+
+    /** @test */
+    public function it_queries_an_entry_by_slug_and_collection()
+    {
+        EntryFactory::collection('blog')->id('123')->slug('foo')->create();
+        EntryFactory::collection('events')->id('456')->slug('foo')->create();
+
+        $query = <<<'GQL'
+{
+    entry(slug: "foo", collection: "events") {
+        id
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => [
+                'entry' => [
+                    'id' => '456',
                 ],
             ]]);
     }


### PR DESCRIPTION
Add the ability to query an entry by slug or URI.

Closes statamic/ideas#456