### PR TITLE
Fix Taxonomy facade accessor

### DIFF
--- a/src/Facades/Taxonomy.php
+++ b/src/Facades/Taxonomy.php
@@ -3,7 +3,7 @@
 namespace Statamic\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use Statamic\Stache\Repositories\TaxonomyRepository;
+use Statamic\Contracts\Taxonomies\TaxonomyRepository;
 
 /**
  * @method static \Illuminate\Support\Collection all()


### PR DESCRIPTION
It would appear you couldn't override the taxonomy repository because the Stache one would always be used.﻿
