### PR TITLE
Improve cached asset handling

### DIFF
--- a/src/Assets/QueryBuilder.php
+++ b/src/Assets/QueryBuilder.php
@@ -3,6 +3,7 @@
 namespace Statamic\Assets;
 
 use Exception;
+use Illuminate\Support\Facades\Cache;
 use Statamic\Contracts\Assets\AssetContainer;
 use Statamic\Contracts\Assets\QueryBuilder as Contract;
 use Statamic\Facades;
@@ -30,7 +31,12 @@ class QueryBuilder extends BaseQueryBuilder implements Contract
             $assets = $this->convertPathsToAssets($assets);
         }
 
-        return $this->collect($assets);
+        $assets = $this->collect($assets);
+
+        // If any assets were deleted through the filesystem (e.g. by hand or through git)
+        // during the file listing cache window, the conversion above would have resulted
+        // in nulls. In that case, we'll just remove the nulls.
+        return $assets->filter()->values();
     }
 
     protected function limitItems($items)
@@ -57,11 +63,30 @@ class QueryBuilder extends BaseQueryBuilder implements Contract
     {
         $items = parent::get($columns);
 
-        if (! $this->requiresAssetInstances()) {
-            $items = $this->convertPathsToAssets($items);
+        // If we required asset instances, they would have already been converted.
+        if ($this->requiresAssetInstances()) {
+            return $items;
         }
 
-        return $items;
+        $items = $this->convertPathsToAssets($items);
+
+        // If any assets were deleted through the filesystem (e.g. manually or through git)
+        // during the file listing cache window, the conversion above would have resulted
+        // in nulls. In that case, we'll bust the cache and requery. We also only care
+        // when it's being limited like in pagination or when using the take method.
+        if ($this->hasAnyNulls($items) && $this->limit) {
+            Cache::forget($this->container->filesCacheKey());
+            Cache::forget($this->container->filesCacheKey($this->folder));
+
+            return $this->get($columns);
+        }
+
+        return $items->filter()->values();
+    }
+
+    private function hasAnyNulls($items)
+    {
+        return $items->reject()->isNotEmpty();
     }
 
     private function requiresAssetInstances()

--- a/src/Assets/QueryBuilder.php
+++ b/src/Assets/QueryBuilder.php
@@ -33,9 +33,9 @@ class QueryBuilder extends BaseQueryBuilder implements Contract
 
         $assets = $this->collect($assets);
 
-        // If any assets were deleted through the filesystem (e.g. by hand or through git)
-        // during the file listing cache window, the conversion above would have resulted
-        // in nulls. In that case, we'll just remove the nulls.
+        // If any assets were deleted through the filesystem (e.g. manually or
+        // through git) during the file listing cache window, the conversion
+        // above would have resulted in nulls. We remove the nulls here.
         return $assets->filter()->values();
     }
 


### PR DESCRIPTION
In #2828 we added caching to asset listings.

Inside the asset query builder it converts paths to asset objects. As part of that, if the asset file doesn't exist, it'll return null.

We discovered an issue where if you delete an asset by hand during the cache window (through the filesystem or by git), you'd get an error because the asset path (which was still in the cache) was converted to null (because the actual file doesn't exist).

We fixed this by filtering out null values when you don't care how many are supposed to be returned.
But when you do care (like when using `paginate`, or `take`), we'll check if there are any nulls, if there are we bust the cache and requery.
