### PR TITLE
Improve nested subfield handling in GraphQL

### DIFF
--- a/src/GraphQL/Types/GridItemType.php
+++ b/src/GraphQL/Types/GridItemType.php
@@ -3,6 +3,7 @@
 namespace Statamic\GraphQL\Types;
 
 use Rebing\GraphQL\Support\Type;
+use Statamic\Fields\Value;
 
 class GridItemType extends Type
 {
@@ -16,6 +17,16 @@ class GridItemType extends Type
 
     public function fields(): array
     {
-        return $this->fieldtype->fields()->toGql()->all();
+        return $this->fieldtype->fields()->toGql()
+            ->map(function ($field) {
+                $field['resolve'] = function ($row, $args, $context, $info) {
+                    $value = $row[$info->fieldName];
+
+                    return $value instanceof Value ? $value->value() : $value;
+                };
+
+                return $field;
+            })
+            ->all();
     }
 }

--- a/src/GraphQL/Types/ReplicatorSetType.php
+++ b/src/GraphQL/Types/ReplicatorSetType.php
@@ -3,6 +3,7 @@
 namespace Statamic\GraphQL\Types;
 
 use Statamic\Facades\GraphQL;
+use Statamic\Fields\Value;
 
 class ReplicatorSetType extends \Rebing\GraphQL\Support\Type
 {
@@ -24,6 +25,15 @@ class ReplicatorSetType extends \Rebing\GraphQL\Support\Type
                     'type' => GraphQL::nonNull(GraphQL::string()),
                 ],
             ])
+            ->map(function ($field) {
+                $field['resolve'] = function ($row, $args, $context, $info) {
+                    $value = $row[$info->fieldName];
+
+                    return $value instanceof Value ? $value->value() : $value;
+                };
+
+                return $field;
+            })
             ->all();
     }
 }

--- a/tests/Feature/GraphQL/Fieldtypes/BardFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/BardFieldtypeTest.php
@@ -260,4 +260,84 @@ GQL;
                 ],
             ]]);
     }
+
+    /**
+     * @test
+     * @see https://github.com/statamic/cms/issues/3200
+     **/
+    public function it_outputs_bard_fields_with_value_based_subfields()
+    {
+        // Using an `entries` field set to max_items 1, which would augment
+        // to a Value object. This test is checking that the Value object
+        // is converted appropriately to an Entry. A similar thing would
+        // happen for `assets` fields converting to Asset objects, etc.
+
+        EntryFactory::collection('blog')->id('1')->data([
+            'title' => 'Main Post',
+            'things' => [
+                [
+                    'type' => 'relation',
+                    'entry' => '2',
+                ],
+            ],
+        ])->create();
+
+        EntryFactory::collection('blog')->id('2')->data(['title' => 'Other Post'])->create();
+
+        $article = Blueprint::makeFromFields([
+            'things' => [
+                'type' => 'bard',
+                'sets' => [
+                    'relation' => [
+                        'fields' => [
+                            [
+                                'handle' => 'entry',
+                                'field' => ['type' => 'entries', 'max_items' => 1],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        BlueprintRepository::shouldReceive('in')->with('collections/blog')->andReturn(collect([
+            'article' => $article->setHandle('article'),
+        ]));
+
+        $query = <<<'GQL'
+{
+    entry(id: "1") {
+        title
+        ... on Entry_Blog_Article {
+            things {
+                ... on Set_Things_Relation {
+                    type
+                    entry {
+                        title
+                    }
+                }
+            }
+        }
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => [
+                'entry' => [
+                    'title' => 'Main Post',
+                    'things' => [
+                        [
+                            'type' => 'relation',
+                            'entry' => [
+                                'title' => 'Other Post',
+                            ],
+                        ],
+                    ],
+                ],
+            ]]);
+    }
 }

--- a/tests/Feature/GraphQL/Fieldtypes/GridFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/GridFieldtypeTest.php
@@ -73,7 +73,10 @@ GQL;
             ]]);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @see https://github.com/statamic/cms/issues/3200
+     **/
     public function it_outputs_nested_grid_fields()
     {
         EntryFactory::collection('blog')->id('1')->data([
@@ -169,6 +172,72 @@ GQL;
                             'drink' => 'water',
                             'extras' => [
                                 ['item' => 'dressing'],
+                            ],
+                        ],
+                    ],
+                ],
+            ]]);
+    }
+
+    /** @test */
+    public function it_outputs_grid_fields_with_value_based_subfields()
+    {
+        // Using an `entries` field set to max_items 1, which would augment
+        // to a Value object. This test is checking that the Value object
+        // is converted appropriately to an Entry. A similar thing would
+        // happen for `assets` fields converting to Asset objects, etc.
+
+        EntryFactory::collection('blog')->id('1')->data([
+            'title' => 'Main Post',
+            'things' => [
+                ['entry' => '2'],
+            ],
+        ])->create();
+
+        EntryFactory::collection('blog')->id('2')->data(['title' => 'Other Post'])->create();
+
+        $article = Blueprint::makeFromFields([
+            'things' => [
+                'type' => 'grid',
+                'fields' => [
+                    [
+                        'handle' => 'entry',
+                        'field' => ['type' => 'entries', 'max_items' => 1],
+                    ],
+                ],
+            ],
+        ]);
+
+        BlueprintRepository::shouldReceive('in')->with('collections/blog')->andReturn(collect([
+            'article' => $article->setHandle('article'),
+        ]));
+
+        $query = <<<'GQL'
+{
+    entry(id: "1") {
+        title
+        ... on Entry_Blog_Article {
+            things {
+                entry {
+                    title
+                }
+            }
+        }
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => [
+                'entry' => [
+                    'title' => 'Main Post',
+                    'things' => [
+                        [
+                            'entry' => [
+                                'title' => 'Other Post',
                             ],
                         ],
                     ],

--- a/tests/Feature/GraphQL/Fieldtypes/ReplicatorFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/ReplicatorFieldtypeTest.php
@@ -195,4 +195,84 @@ GQL;
                 ],
             ]]);
     }
+
+    /**
+     * @test
+     * @see https://github.com/statamic/cms/issues/3200
+     **/
+    public function it_outputs_replicator_fields_with_value_based_subfields()
+    {
+        // Using an `entries` field set to max_items 1, which would augment
+        // to a Value object. This test is checking that the Value object
+        // is converted appropriately to an Entry. A similar thing would
+        // happen for `assets` fields converting to Asset objects, etc.
+
+        EntryFactory::collection('blog')->id('1')->data([
+            'title' => 'Main Post',
+            'things' => [
+                [
+                    'type' => 'relation',
+                    'entry' => '2',
+                ],
+            ],
+        ])->create();
+
+        EntryFactory::collection('blog')->id('2')->data(['title' => 'Other Post'])->create();
+
+        $article = Blueprint::makeFromFields([
+            'things' => [
+                'type' => 'replicator',
+                'sets' => [
+                    'relation' => [
+                        'fields' => [
+                            [
+                                'handle' => 'entry',
+                                'field' => ['type' => 'entries', 'max_items' => 1],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        BlueprintRepository::shouldReceive('in')->with('collections/blog')->andReturn(collect([
+            'article' => $article->setHandle('article'),
+        ]));
+
+        $query = <<<'GQL'
+{
+    entry(id: "1") {
+        title
+        ... on Entry_Blog_Article {
+            things {
+                ... on Set_Things_Relation {
+                    type
+                    entry {
+                        title
+                    }
+                }
+            }
+        }
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => [
+                'entry' => [
+                    'title' => 'Main Post',
+                    'things' => [
+                        [
+                            'type' => 'relation',
+                            'entry' => [
+                                'title' => 'Other Post',
+                            ],
+                        ],
+                    ],
+                ],
+            ]]);
+    }
 }


### PR DESCRIPTION
This makes sure `Value` objects are converted appropriately inside Bard, Replicator, and Grid fields.

Fixes #3200 