### PR TITLE
Adding ENV Variable for Statamic Asset Caching

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -52,7 +52,7 @@ return [
         |
         */
 
-        'cache' => false,
+        'cache' => env('STATAMIC_ASSETS_CACHE', false),
         'cache_path' => public_path('img'),
 
         /*


### PR DESCRIPTION
Added a ENV variable to Statamic's Assets Caching Config.
Now the dev can have it set to false (by default) while production can have it on, all without having to push up an updated config file.