### PR TITLE
Date augmenting and ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - Nav and Collection structure tree API endpoints [#2999](https://github.com/statamic/cms/issues/2999)
 - Entry author permissions [#3053](https://github.com/statamic/cms/issues/3053)
 
+### What's changing
+- The `date` fieldtype now augments to Carbon instances. If you use them in Antlers without any modifiers, they will now be output using the default
+  `date_format` (e.g. January 1st, 2020). Previously, the raw value (e.g. 2020-01-02) would have been output. Actual entry dates (i.e. the `date` field) would have behaved this way already. If you were using a modifier (e.g. `format`), there will be no change.
+
 
 
 ## 3.0.42 (2021-02-04)

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -95,16 +95,12 @@ class Date extends Fieldtype
         }
 
         if ($this->config('mode') === 'range') {
-
             // If switching from single to range, all bets are off.
             if (! is_array($data)) {
                 return null;
             }
 
-            return [
-                'start' => Carbon::parse($data['start'])->format('Y-m-d'),
-                'end' => Carbon::parse($data['end'])->format('Y-m-d'),
-            ];
+            return $data;
         }
 
         // If switching from range mode to single, use the start date.
@@ -151,7 +147,24 @@ class Date extends Fieldtype
             return $value;
         }
 
-        return Carbon::createFromFormat($this->dateFormat($value), $value);
+        if ($this->config('mode') === 'range') {
+            return [
+                'start' => Carbon::createFromFormat($this->dateFormat($value['start']), $value['start'])->startOfDay(),
+                'end' => Carbon::createFromFormat($this->dateFormat($value['end']), $value['end'])->startOfDay(),
+            ];
+        }
+
+        $date = Carbon::createFromFormat($this->dateFormat($value), $value);
+
+        // Make sure that if it was only a date saved, then the time would be reset
+        // to the beginning of the day, otherwise it would inherit the hour and
+        // minute from the current time. If they've defined a custom format
+        // we'll skip this since it'll already be what they wanted.
+        if (! $this->config('format') && strlen($value) === 10) {
+            $date->startOfDay();
+        }
+
+        return $date;
     }
 
     public function toGqlType()

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -3,8 +3,10 @@
 namespace Statamic\Fieldtypes;
 
 use Carbon\Carbon;
+use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 use Statamic\GraphQL\Fields\DateField;
+use Statamic\GraphQL\Types\DateRangeType;
 use Statamic\Query\Scopes\Filters\Fields\Date as DateFilter;
 
 class Date extends Fieldtype
@@ -169,6 +171,10 @@ class Date extends Fieldtype
 
     public function toGqlType()
     {
+        if ($this->config('mode') === 'range') {
+            return GraphQL::type(DateRangeType::NAME);
+        }
+
         return new DateField;
     }
 }

--- a/src/GraphQL/Fields/DateField.php
+++ b/src/GraphQL/Fields/DateField.php
@@ -2,12 +2,15 @@
 
 namespace Statamic\GraphQL\Fields;
 
+use Closure;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Field;
 
 class DateField extends Field
 {
+    private $valueResolver;
+
     public function type(): Type
     {
         return Type::string();
@@ -24,7 +27,7 @@ class DateField extends Field
 
     protected function resolve($entry, $args, $context, ResolveInfo $info)
     {
-        if (! $date = $entry->resolveGqlValue($info->fieldName)) {
+        if (! $date = $this->getValueResolver()($entry, $args, $context, $info)) {
             return null;
         }
 
@@ -33,5 +36,19 @@ class DateField extends Field
         }
 
         return (string) $date;
+    }
+
+    public function setValueResolver(Closure $resolver)
+    {
+        $this->valueResolver = $resolver;
+
+        return $this;
+    }
+
+    public function getValueResolver()
+    {
+        return $this->valueResolver ?? function ($entry, $args, $context, $info) {
+            return $entry->resolveGqlValue($info->fieldName);
+        };
     }
 }

--- a/src/GraphQL/TypeRegistrar.php
+++ b/src/GraphQL/TypeRegistrar.php
@@ -7,6 +7,7 @@ use Statamic\GraphQL\Types\AssetContainerType;
 use Statamic\GraphQL\Types\AssetInterface;
 use Statamic\GraphQL\Types\CollectionStructureType;
 use Statamic\GraphQL\Types\CollectionType;
+use Statamic\GraphQL\Types\DateRangeType;
 use Statamic\GraphQL\Types\EntryInterface;
 use Statamic\GraphQL\Types\GlobalSetInterface;
 use Statamic\GraphQL\Types\JsonArgument;
@@ -33,6 +34,7 @@ class TypeRegistrar
         }
 
         GraphQL::addType(JsonArgument::class);
+        GraphQL::addType(DateRangeType::class);
         GraphQL::addType(SiteType::class);
         GraphQL::addType(LabeledValueType::class);
         GraphQL::addType(CollectionType::class);

--- a/src/GraphQL/Types/DateRangeType.php
+++ b/src/GraphQL/Types/DateRangeType.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Statamic\GraphQL\Types;
+
+use Statamic\GraphQL\Fields\DateField;
+
+class DateRangeType extends \Rebing\GraphQL\Support\Type
+{
+    const NAME = 'DateRange';
+
+    protected $attributes = [
+        'name' => self::NAME,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'start' => (new DateField)->setValueResolver(function ($item) {
+                return $item['start'];
+            }),
+            'end' => (new DateField)->setValueResolver(function ($item) {
+                return $item['end'];
+            }),
+        ];
+    }
+}

--- a/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
@@ -37,4 +37,38 @@ GQL;
             'undefined' => null,
         ]);
     }
+
+    /** @test */
+    public function it_gets_date_ranges()
+    {
+        // The statamic.system.date_format config will set this
+        // earlier on so we'll override it here for the test.
+        Carbon::setToStringFormat('Y-m-d g:ia');
+
+        $this->createEntryWithFields([
+            'filled' => [
+                'value' => [
+                    'start' => '2017-12-25',
+                    'end' => '2020-04-27',
+                ],
+                'field' => ['type' => 'date', 'mode' => 'range'],
+            ],
+            'undefined' => [
+                'value' => null,
+                'field' => ['type' => 'date', 'mode' => 'range'],
+            ],
+        ]);
+
+        $query = <<<'GQL'
+default: filled { start, end }
+formatted: filled { start(format: "U"), end(format: "U") }
+undefined { start, end }
+GQL;
+
+        $this->assertGqlEntryHas($query, [
+            'default' => ['start' => '2017-12-25 12:00am', 'end' => '2020-04-27 12:00am'],
+            'formatted' => ['start' => '1514160000', 'end' => '1587945600'],
+            'undefined' => null,
+        ]);
+    }
 }

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use Carbon\Carbon;
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Date;
+use Tests\TestCase;
+
+class DateTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Set "now" to an arbitrary time so we can make sure that when date
+        // instances are created in the fieldtype, they aren't inheriting
+        // default values from the current time.
+        Carbon::setTestNow(Carbon::createFromFormat('Y-m-d H:i', '2010-12-25 13:43'));
+    }
+
+    /** @test */
+    public function it_augments_a_date()
+    {
+        $augmented = $this->fieldtype()->augment('2012-01-04');
+
+        $this->assertInstanceOf(Carbon::class, $augmented);
+        $this->assertEquals('2012 Jan 04 00:00', $augmented->format('Y M d H:i'));
+    }
+
+    /** @test */
+    public function it_augments_a_datetime()
+    {
+        $augmented = $this->fieldtype()->augment('2012-01-04 15:32');
+
+        $this->assertInstanceOf(Carbon::class, $augmented);
+        $this->assertEquals('2012 Jan 04 15:32', $augmented->format('Y M d H:i'));
+    }
+
+    /** @test */
+    public function it_augments_null()
+    {
+        $augmented = $this->fieldtype()->augment(null);
+
+        $this->assertNull($augmented);
+    }
+
+    /** @test */
+    public function it_augments_a_carbon_instance()
+    {
+        $instance = new Carbon;
+        $augmented = $this->fieldtype()->augment($instance);
+
+        $this->assertSame($instance, $augmented);
+    }
+
+    /** @test */
+    public function it_augments_a_range()
+    {
+        $augmented = $this->fieldtype(['mode' => 'range'])->augment([
+            'start' => '2012-01-04',
+            'end' => '2013-02-06',
+        ]);
+
+        $this->assertIsArray($augmented);
+        $this->assertEquals(['start', 'end'], array_keys($augmented));
+        $this->assertInstanceOf(Carbon::class, $augmented['start']);
+        $this->assertInstanceOf(Carbon::class, $augmented['end']);
+        $this->assertEquals('2012 Jan 04 00:00', $augmented['start']->format('Y M d H:i'));
+        $this->assertEquals('2013 Feb 06 00:00', $augmented['end']->format('Y M d H:i'));
+    }
+
+    /** @test */
+    public function it_augments_a_null_range()
+    {
+        $augmented = $this->fieldtype(['mode' => 'range'])->augment(null);
+
+        $this->assertNull($augmented);
+    }
+
+    public function fieldtype($config = [])
+    {
+        $field = new Field('test', array_merge([
+            'type' => 'date',
+        ], $config));
+
+        return (new Date)->setField($field);
+    }
+}


### PR DESCRIPTION
When [testing out another date range issue](https://github.com/statamic/cms/issues/2349#issuecomment-776299830), I was using the 3.1 branch, and noticed I had broken date ranges.

This is because I added augmentation to the date fieldtype, but didn't include support for ranges.

This PR adds support for augmenting date ranges, explains the breaking change in the changelog, and adds support for querying date ranges in GraphQL.

```graphql
range {
  start(format: "Y-m-d")
  end(format: "Y-m-d")
}
```