### PR TITLE
Wrap Eloquent User::find logic inside Blink

### DIFF
--- a/src/Auth/Eloquent/UserRepository.php
+++ b/src/Auth/Eloquent/UserRepository.php
@@ -46,11 +46,13 @@ class UserRepository extends BaseRepository
 
     public function findByEmail(string $email): ?UserContract
     {
-        if (! $model = $this->model('where', 'email', $email)->first()) {
-            return null;
-        }
+        return Blink::once("eloquent-user-find-{$email}", function () use ($email) {
+            if (! $model = $this->model('where', 'email', $email)->first()) {
+                return null;
+            }
 
-        return $this->makeUser($model);
+            return $this->makeUser($model);
+        });
     }
 
     public function model($method, ...$args)

--- a/src/Auth/Eloquent/UserRepository.php
+++ b/src/Auth/Eloquent/UserRepository.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Statamic\Auth\UserCollection;
 use Statamic\Auth\UserRepository as BaseRepository;
 use Statamic\Contracts\Auth\User as UserContract;
+use Statamic\Facades\Blink;
 
 class UserRepository extends BaseRepository
 {
@@ -34,11 +35,13 @@ class UserRepository extends BaseRepository
 
     public function find($id): ?UserContract
     {
-        if ($model = $this->model('find', $id)) {
-            return $this->makeUser($model);
-        }
+        return Blink::once("eloquent-user-find-{$id}", function () use ($id) {
+            if ($model = $this->model('find', $id)) {
+                return $this->makeUser($model);
+            }
 
-        return null;
+            return null;
+        });
     }
 
     public function findByEmail(string $email): ?UserContract

--- a/src/Auth/Eloquent/UserRepository.php
+++ b/src/Auth/Eloquent/UserRepository.php
@@ -46,13 +46,11 @@ class UserRepository extends BaseRepository
 
     public function findByEmail(string $email): ?UserContract
     {
-        return Blink::once("eloquent-user-find-{$email}", function () use ($email) {
-            if (! $model = $this->model('where', 'email', $email)->first()) {
-                return null;
-            }
+        if (! $model = $this->model('where', 'email', $email)->first()) {
+            return null;
+        }
 
-            return $this->makeUser($model);
-        });
+        return $this->makeUser($model);
     }
 
     public function model($method, ...$args)
@@ -83,7 +81,6 @@ class UserRepository extends BaseRepository
         $user->saveToDatabase();
 
         Blink::forget("eloquent-user-find-{$user->id()}");
-        Blink::forget("eloquent-user-find-{$user->email()}");
     }
 
     public function delete(UserContract $user)
@@ -91,7 +88,6 @@ class UserRepository extends BaseRepository
         $user->model()->delete();
 
         Blink::forget("eloquent-user-find-{$user->id()}");
-        Blink::forget("eloquent-user-find-{$user->email()}");
     }
 
     public function fromUser($user): ?UserContract

--- a/src/Auth/Eloquent/UserRepository.php
+++ b/src/Auth/Eloquent/UserRepository.php
@@ -81,11 +81,17 @@ class UserRepository extends BaseRepository
     public function save(UserContract $user)
     {
         $user->saveToDatabase();
+
+        Blink::forget("eloquent-user-find-{$user->id()}");
+        Blink::forget("eloquent-user-find-{$user->email()}");
     }
 
     public function delete(UserContract $user)
     {
         $user->model()->delete();
+
+        Blink::forget("eloquent-user-find-{$user->id()}");
+        Blink::forget("eloquent-user-find-{$user->email()}");
     }
 
     public function fromUser($user): ?UserContract


### PR DESCRIPTION
This PR closes #1511, where for each entry in your site, a database query would be made to find the `updated_by` user. 

This PR fixes that by caching the database query so it's only needed to be done once per request.