### PR TITLE
Save new terms with a lowercase title too

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -275,14 +275,8 @@ class Terms extends Relationship
 
     protected function createTermFromString($string, $taxonomy)
     {
-        // The entered string will be treated as the term's title. If it's the same
-        // as the slug, an actual term object/file won't need to be created.
-        if ($string === ($slug = Str::slug($string))) {
-            return "{$taxonomy}::{$slug}";
-        }
-
         $term = Facades\Term::make()
-            ->slug($slug)
+            ->slug(Str::slug($string))
             ->taxonomy(Facades\Taxonomy::findByHandle($taxonomy))
             ->set('title', $string);
 


### PR DESCRIPTION
Fixes #3228.

For some reason new terms were intentionally not saved when the slug matched the title. This PR removes that code.