### PR TITLE
Create a event helper trait

### DIFF
--- a/src/Support/Traits/EventHelper.php
+++ b/src/Support/Traits/EventHelper.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Statamic\Support\Traits;
+
+use Statamic\Events\EntrySaved;
+use Statamic\Events\FormSubmitted;
+
+trait EventHelper
+{
+    public function hasHandle($name, $event): bool
+    {
+        if ($event instanceof EntrySaved) {
+            // TODO: Check against all existing Entry events
+            return $event->entry->handle() === $name;
+        }
+
+        if ($event instanceof FormSubmitted) {
+            // TODO: Check against all existing Form events
+            return $event->submission->form->handle() === $name;
+        }
+
+        // TODO: Check against other Event types
+
+        return false;
+    }
+
+    public function isEntry($event): bool
+    {
+        if ($event instanceof EntrySaved) {
+            return true;
+        }
+
+        // TODO: Check against all registration form events
+
+        return false;
+    }
+
+    public function isForm($event): bool
+    {
+        if ($event instanceof FormSubmitted) {
+            return true;
+        }
+
+        // TODO: Check against all registration form events
+
+        return false;
+    }
+}


### PR DESCRIPTION
This is me tinkering out loud with a problem I do run into all the time if working with events. 

_Is the core team interested in such a PR and is this interesting for the community at all 💁‍♂️?_
I will gladly work on this PR in case there is some interest in this little helper trait. 

**Why is this helpful?**
In my personal case I often hook into events. For example to do something specific if an Entry to a specific Collection has been created or if a form has be sent and I want to do something specials as well. 
Often I need to send a mail on certain events, but only a certain one. 

**How could the API look like?**
Personally, I always had cases where I wanted to only hook into a specific form or into a specific collection. I would prefer a short and clean syntax  to make that possible. 

A practical example of how the API might look like, if using the EvenHelper trait I did draft in this PR. 
```php
class SaveRegistration
{
    use EventHelper;

    public function handle(FormSubmitted $event)
    {
        if (! $this->isForm($event) && ! $this->hasHandle('registrations')) {
            return;
        }

       // Do what needs to be done in case the registrations form has been used.
    }
}
```

In case of enough interest, I will PR a description to the docs as well of course.

NOTICE: It's only a first sketch, nothing final, to get some feedback before proceeding. Let me know what you think.