### PR TITLE
Split checking of static cache vs getting it

### DIFF
--- a/src/StaticCaching/Cacher.php
+++ b/src/StaticCaching/Cacher.php
@@ -15,6 +15,14 @@ interface Cacher
     public function cachePage(Request $request, $content);
 
     /**
+     * Check if a page has been cached.
+     *
+     * @param Request $request
+     * @return bool
+     */
+    public function hasCachedPage(Request $request);
+
+    /**
      * Get a cached page.
      *
      * @param Request $request

--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -274,4 +274,9 @@ abstract class AbstractCacher implements Cacher
 
         return $this->normalizeKey($this->makeHash($domain).'.urls');
     }
+
+    public function hasCachedPage(Request $request)
+    {
+        return $this->getCachedPage($request) !== null;
+    }
 }

--- a/src/StaticCaching/Cachers/ApplicationCacher.php
+++ b/src/StaticCaching/Cachers/ApplicationCacher.php
@@ -12,6 +12,11 @@ class ApplicationCacher extends AbstractCacher
     protected $cache;
 
     /**
+     * @var string|null
+     */
+    private $cached;
+
+    /**
      * Cache a page.
      *
      * @param \Illuminate\Http\Request $request     Request associated with the page to be cached
@@ -43,12 +48,28 @@ class ApplicationCacher extends AbstractCacher
     }
 
     /**
+     * Check if a page has been cached.
+     *
+     * @param Request $request
+     * @return bool
+     */
+    public function hasCachedPage(Request $request)
+    {
+        return (bool) $this->cached = $this->getFromCache($request);
+    }
+
+    /**
      * Get a cached page.
      *
      * @param Request $request
      * @return string
      */
     public function getCachedPage(Request $request)
+    {
+        return $this->cached ?? $this->getFromCache($request);
+    }
+
+    private function getFromCache(Request $request)
     {
         $url = $this->getUrl($request);
 

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -63,6 +63,13 @@ class FileCacher extends AbstractCacher
         return File::get($this->getFilePath($url));
     }
 
+    public function hasCachedPage(Request $request)
+    {
+        $url = $this->getUrl($request);
+
+        return File::exists($this->getFilePath($url));
+    }
+
     /**
      * Flush out the entire static cache.
      *

--- a/src/StaticCaching/Cachers/NullCacher.php
+++ b/src/StaticCaching/Cachers/NullCacher.php
@@ -12,6 +12,11 @@ class NullCacher implements Cacher
         //
     }
 
+    public function hasCachedPage(Request $request)
+    {
+        return false;
+    }
+
     public function getCachedPage(Request $request)
     {
         //

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -27,8 +27,8 @@ class Cache
      */
     public function handle($request, Closure $next)
     {
-        if ($this->canBeCached($request) && ($cached = $this->cacher->getCachedPage($request))) {
-            return response($cached);
+        if ($this->canBeCached($request) && $this->cacher->hasCachedPage($request)) {
+            return response($this->cacher->getCachedPage($request));
         }
 
         $response = $next($request);


### PR DESCRIPTION
Fixes #3209 

When a request is made, we get the cached response up front - if there is one, we'll use it.
It was done this way so there wouldn't be separate cache hits for checking and getting. The point of this feature is speed so every little bit helped. 😄 

However, this causes a log when the page is generated in #3209.

This PR splits up checking for the existing cache vs. getting it. Checking the existing cache won't trigger a log.

For half measure, the overhead is now alleviated even with a separate "has" method by storing the cached value in a property.

For full measure, you'll have the same number of file operations as before.
Uncached pages get one for checking the cache, and another for writing it.
Cached pages with the server rewrite set up won't even hit PHP.
Cached pages with the server rewrite _not_ set up will still see the cached page and get the speed, but also get the log.

This is very very sorta breaking because there's now a new method in the interface, but most of the time you'll be extending AbstractCacher or another existing driver, which both define it.