### PR TITLE
feat: add pluck modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2530,6 +2530,7 @@ class CoreModifiers extends Modifier
         $mapped = $value->map(function ($value) use ($fieldName) {
             return $value->get($fieldName);
         });
+
         return $mapped->toArray();
     }
 }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2523,4 +2523,13 @@ class CoreModifiers extends Modifier
 
         return $value;
     }
+
+    public function pluck($value, $params, $context)
+    {
+        $fieldName = array_get($params, 0);
+        $mapped = $value->map(function ($value) use ($fieldName) {
+            return $value->get($fieldName);
+        });
+        return $mapped->toArray();
+    }
 }


### PR DESCRIPTION
As per [a conversation on Discord](https://discord.com/channels/489818810157891584/489819906540568593/811354656453689385), I've added a `pluck` modifier that can be used to map over values of a collection and select a given field, such that they can subsequently be passed to an array modifier such as `sentence_list`.

For example,
```antlers
{{ related_services | pluck:title | sentence_list }}
```

Happy to make any modifications necessary!