### PR TITLE
Keep text field width within limits in Firefox

### DIFF
--- a/resources/sass/elements/forms.scss
+++ b/resources/sass/elements/forms.scss
@@ -83,8 +83,7 @@ input.input-text-minimal:read-only,
     }
 
     .input-text {
-        @apply .flex-1 border-grey-50;
-        min-width: 0;
+        @apply .flex-1 border-grey-50 min-w-0;
     }
 
     .input-text:not(:first-child) {

--- a/resources/sass/elements/forms.scss
+++ b/resources/sass/elements/forms.scss
@@ -84,6 +84,7 @@ input.input-text-minimal:read-only,
 
     .input-text {
         @apply .flex-1 border-grey-50;
+        min-width: 0;
     }
 
     .input-text:not(:first-child) {


### PR DESCRIPTION
Fixes #2935