### PR TITLE
Fix issues with empty asset meta files

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -89,7 +89,7 @@ class Asset implements AssetContract, Augmentable
     {
         $this->meta = $this->meta();
 
-        $this->data = collect($this->meta['data']);
+        $this->data = collect(Arr::get($this->meta, 'data', []));
 
         return $this;
     }
@@ -360,7 +360,7 @@ class Asset implements AssetContract, Augmentable
      */
     public function lastModified()
     {
-        return Carbon::createFromTimestamp($this->meta()['last_modified']);
+        return Carbon::createFromTimestamp(Arr::get($this->meta(), 'last_modified'));
     }
 
     /**
@@ -492,7 +492,10 @@ class Asset implements AssetContract, Augmentable
      */
     public function dimensions()
     {
-        return [$this->meta()['width'], $this->meta()['height']];
+        return [
+            Arr::get($this->meta(), 'width'),
+            Arr::get($this->meta(), 'height'),
+        ];
     }
 
     /**
@@ -554,7 +557,7 @@ class Asset implements AssetContract, Augmentable
      */
     public function size()
     {
-        return $this->meta()['size'];
+        return Arr::get($this->meta(), 'size');
     }
 
     /**


### PR DESCRIPTION
This PR fixes #3257, where if an asset's meta file is empty, the assets browser will just spit out some beautiful errors.

The PR essentially swaps out using arrays like you normally would `$array['key']` and uses Laravel's `Arr` helper instead.

The initial issue only seemed to report an issue with the array thing in a single place (in the `size` method), however I've also added it in a couple of other places to be safe, let me know if you just want me to fix it in the `size` method instead.