### PR TITLE
Parameters can now access:nested:variables

### DIFF
--- a/src/Tags/Parameters.php
+++ b/src/Tags/Parameters.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Tags;
 
+use Statamic\Facades\Antlers;
 use Statamic\Fields\Value;
 use Statamic\Support\Str;
 
@@ -17,7 +18,7 @@ class Parameters extends ArrayAccessor
             // Values in parameters prefixed with a colon should be treated as the corresponding field's value in the context.
             if (Str::startsWith($key, ':')) {
                 $key = substr($key, 1);
-                $value = \Statamic\Facades\Antlers::parser()->getVariable($value, $context->all());
+                $value = Antlers::parser()->getVariable($value, $context->all());
             }
 
             if ($value instanceof Value) {

--- a/src/Tags/Parameters.php
+++ b/src/Tags/Parameters.php
@@ -17,7 +17,7 @@ class Parameters extends ArrayAccessor
             // Values in parameters prefixed with a colon should be treated as the corresponding field's value in the context.
             if (Str::startsWith($key, ':')) {
                 $key = substr($key, 1);
-                $value = $context->get($value);
+                $value = \Statamic\Facades\Antlers::parser()->getVariable($value, $context->all());
             }
 
             if ($value instanceof Value) {

--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -1157,7 +1157,7 @@ class Parser
      * @param  mixed        $default Default value to use if not found
      * @return mixed
      */
-    protected function getVariable($key, $context, $default = null)
+    public function getVariable($key, $context, $default = null)
     {
         [$key, $modifiers] = $this->parseModifiers($key);
 

--- a/tests/Tags/ParametersTest.php
+++ b/tests/Tags/ParametersTest.php
@@ -230,6 +230,22 @@ class ParametersTest extends TestCase
     }
 
     /** @test */
+    public function it_can_use_modifiers()
+    {
+        $context = new Context(['foo' => 'bar']);
+
+        $params = Parameters::make([
+            ':evaluated' => 'foo|upper',
+            ':double_quotes' => '"double"|upper',
+            ':single_quotes' => "'single'|upper",
+        ], $context);
+
+        $this->assertSame('BAR', $params->get('evaluated'));
+        $this->assertSame('DOUBLE', $params->get('double_quotes'));
+        $this->assertSame('SINGLE', $params->get('single_quotes'));
+    }
+
+    /** @test */
     public function it_is_iterable()
     {
         $expected = [

--- a/tests/Tags/ParametersTest.php
+++ b/tests/Tags/ParametersTest.php
@@ -198,10 +198,35 @@ class ParametersTest extends TestCase
         $this->assertSame('fallback', $this->params->float('unknown', 'fallback'));
     }
 
-    /** @test */
-    public function it_gets_nested()
+    /**
+     * @test
+     * @see https://github.com/statamic/cms/issues/3248
+     */
+    public function it_gets_nested_values()
     {
-        $this->assertSame('bar', $this->params->get(':evaluatednested'));
+        $augmentable = new class implements \Statamic\Contracts\Data\Augmentable {
+            use \Statamic\Data\HasAugmentedData;
+
+            public function augmentedArrayData()
+            {
+                return [
+                    'foo' => 'a',
+                ];
+            }
+        };
+
+        $context = new Context([
+            'array' => ['foo' => 'b'],
+            'object' => $augmentable,
+        ]);
+
+        $params = Parameters::make([
+            ':arr' => 'array:foo',
+            ':obj' => 'object:foo',
+        ], $context);
+
+        $this->assertSame('b', $params->get('arr'));
+        $this->assertSame('a', $params->get('obj'));
     }
 
     /** @test */

--- a/tests/Tags/ParametersTest.php
+++ b/tests/Tags/ParametersTest.php
@@ -238,11 +238,15 @@ class ParametersTest extends TestCase
             ':evaluated' => 'foo|upper',
             ':double_quotes' => '"double"|upper',
             ':single_quotes' => "'single'|upper",
+            ':double_quotes_with_spaces' => '"double" | upper',
+            ':single_quotes_with_spaces' => "'single' | upper",
         ], $context);
 
         $this->assertSame('BAR', $params->get('evaluated'));
         $this->assertSame('DOUBLE', $params->get('double_quotes'));
         $this->assertSame('SINGLE', $params->get('single_quotes'));
+        $this->assertSame('DOUBLE', $params->get('double_quotes_with_spaces'));
+        $this->assertSame('SINGLE', $params->get('single_quotes_with_spaces'));
     }
 
     /** @test */

--- a/tests/Tags/ParametersTest.php
+++ b/tests/Tags/ParametersTest.php
@@ -199,6 +199,12 @@ class ParametersTest extends TestCase
     }
 
     /** @test */
+    public function it_gets_nested()
+    {
+        $this->assertSame('bar', $this->params->get(':evaluatednested'));
+    }
+
+    /** @test */
     public function it_is_iterable()
     {
         $expected = [

--- a/tests/Tags/ParametersTest.php
+++ b/tests/Tags/ParametersTest.php
@@ -236,17 +236,17 @@ class ParametersTest extends TestCase
 
         $params = Parameters::make([
             ':evaluated' => 'foo|upper',
-            ':double_quotes' => '"double"|upper',
-            ':single_quotes' => "'single'|upper",
-            ':double_quotes_with_spaces' => '"double" | upper',
-            ':single_quotes_with_spaces' => "'single' | upper",
+            ':double_quotes' => '"double"|upper|reverse',
+            ':single_quotes' => "'single'|upper|reverse",
+            ':double_quotes_with_spaces' => '"double" | upper | reverse',
+            ':single_quotes_with_spaces' => "'single' | upper | reverse",
         ], $context);
 
         $this->assertSame('BAR', $params->get('evaluated'));
-        $this->assertSame('DOUBLE', $params->get('double_quotes'));
-        $this->assertSame('SINGLE', $params->get('single_quotes'));
-        $this->assertSame('DOUBLE', $params->get('double_quotes_with_spaces'));
-        $this->assertSame('SINGLE', $params->get('single_quotes_with_spaces'));
+        $this->assertSame('ELBUOD', $params->get('double_quotes'));
+        $this->assertSame('ELGNIS', $params->get('single_quotes'));
+        $this->assertSame('ELBUOD', $params->get('double_quotes_with_spaces'));
+        $this->assertSame('ELGNIS', $params->get('single_quotes_with_spaces'));
     }
 
     /** @test */


### PR DESCRIPTION
But the test fails because (I believe) the mocked data isn't correct.

Fixes #3248 