### PR TITLE
Remove ctrl+f binding to global search

### DIFF
--- a/resources/js/components/GlobalSearch.vue
+++ b/resources/js/components/GlobalSearch.vue
@@ -188,7 +188,7 @@ export default {
     },
 
     mounted() {
-        this.$keys.bind(['/', 'ctrl+f', 'alt+f', 'shift+f'], e => {
+        this.$keys.bind(['/', 'alt+f', 'shift+f'], e => {
             e.preventDefault();
             this.focus();
         });


### PR DESCRIPTION
We should not bind `ctrl+f` to global search. This overrides default browser behavior where the intention is very different from a site search. i.e. looking for a string on the page is very different from a global search of collections `/` is an appropriate convention or `cmd+s` in some cases.

Consider the example of looking for something specific on the PHP info page... this is really hard right now!

One user put it well when they said: anyone that knows about shortcut keys like `cmd+f` will be frustrated by this. At worst I think it could impact accessibility for those that need it most.

Please strongly consider this change :)

Inspired by this conversation:

https://twitter.com/MikeRiethmuller/status/1361462097968726016

https://twitter.com/statamic/status/1362063842335948800