### PR TITLE
Show valid data for a Form field in the content API (take 2)

### DIFF
--- a/src/Forms/AugmentedForm.php
+++ b/src/Forms/AugmentedForm.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Forms;
+
+use Statamic\Data\AbstractAugmented;
+
+class AugmentedForm extends AbstractAugmented
+{
+    public function keys()
+    {
+        return ['handle', 'title', 'fields'];
+    }
+}

--- a/src/Forms/AugmentedForm.php
+++ b/src/Forms/AugmentedForm.php
@@ -8,6 +8,6 @@ class AugmentedForm extends AbstractAugmented
 {
     public function keys()
     {
-        return ['handle', 'title'];
+        return ['handle', 'title', 'fields'];
     }
 }

--- a/src/Forms/AugmentedForm.php
+++ b/src/Forms/AugmentedForm.php
@@ -8,6 +8,6 @@ class AugmentedForm extends AbstractAugmented
 {
     public function keys()
     {
-        return ['handle', 'title', 'fields'];
+        return ['handle', 'title'];
     }
 }

--- a/src/Forms/Fieldtype.php
+++ b/src/Forms/Fieldtype.php
@@ -73,4 +73,9 @@ class Fieldtype extends Relationship
     {
         return Facades\Form::find($value);
     }
+
+    protected function shallowAugmentValue($value)
+    {
+        return $value->toShallowAugmentedCollection();
+    }
 }

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -340,4 +340,9 @@ class Form implements FormContract, Augmentable
     {
         return new AugmentedForm($this);
     }
+
+    protected function shallowAugmentedArrayKeys()
+    {
+        return ['handle', 'title'];
+    }
 }

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -2,8 +2,11 @@
 
 namespace Statamic\Forms;
 
+use Statamic\Contracts\Data\Augmentable;
+use Statamic\Contracts\Data\Augmented;
 use Statamic\Contracts\Forms\Form as FormContract;
 use Statamic\Contracts\Forms\Submission;
+use Statamic\Data\HasAugmentedInstance;
 use Statamic\Events\FormBlueprintFound;
 use Statamic\Events\FormDeleted;
 use Statamic\Events\FormSaved;
@@ -15,9 +18,9 @@ use Statamic\Forms\Exceptions\BlueprintUndefinedException;
 use Statamic\Support\Arr;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Form implements FormContract
+class Form implements FormContract, Augmentable
 {
-    use FluentlyGetsAndSets;
+    use FluentlyGetsAndSets, HasAugmentedInstance;
 
     protected $handle;
     protected $title;
@@ -331,5 +334,10 @@ class Form implements FormContract
         return $this->fields()->filter(function ($field) {
             return $field->fieldtype()->handle() === 'assets';
         })->isNotEmpty();
+    }
+
+    public function newAugmentedInstance(): Augmented
+    {
+        return new AugmentedForm($this);
     }
 }


### PR DESCRIPTION
Fixes #3182 by making the form augmentable. Returns handle, title and fields.