### PR TITLE
Show entries with published status only in content API

### DIFF
--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -10,7 +10,7 @@ class CollectionEntriesController extends ApiController
     public function index($collection, Request $request)
     {
         return app(EntryResource::class)::collection(
-            $this->filterSortAndPaginate($collection->queryEntries())
+            $this->filterSortAndPaginate($collection->queryEntries()->where('status', 'published'))
         );
     }
 


### PR DESCRIPTION
Fixes #2910.

Hides drafts and respects the collection's past and future date behaviours.