### PR TITLE
Fix disabled select input styling issues

### DIFF
--- a/resources/sass/vendors/vue-select.scss
+++ b/resources/sass/vendors/vue-select.scss
@@ -20,6 +20,9 @@
 .vs--disabled .vs__search,
 .vs--disabled .vs__selected {
 	cursor: not-allowed;
+}
+
+.vs--disabled .vs__dropdown-toggle {
 	@apply bg-grey-20;
 }
 
@@ -90,18 +93,18 @@
 	@apply flex items-center;
 }
 
-.vs__actions .vs__open-indicator {
-	@include clickable;
-	@apply flex items-center rounded-r px-1 text-sm flex-shrink-0;
-	height: 2.375rem;
-}
-
 .vs--searchable .vs__dropdown-toggle {
 	cursor: text
 }
 
 .vs--unsearchable .vs__dropdown-toggle {
 	cursor: pointer
+}
+
+.vs__open-indicator {
+	@include clickable;
+	@apply flex items-center rounded-r px-1 text-sm flex-shrink-0;
+	height: 2.375rem;
 }
 
 .vs__open-indicator svg {


### PR DESCRIPTION
* Only put the grey background on the container element (fixes #3073)
* Make sure the button that opens the dropdown also has a 'not-allowed' cursor

This applies to all ```read_only``` fields with a select input.