### PR TITLE
[3.1] Show entries with published status only in content API

### DIFF
--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -9,7 +9,7 @@ class CollectionEntriesController extends ApiController
     public function index($collection)
     {
         return app(EntryResource::class)::collection(
-            $this->filterSortAndPaginate($collection->queryEntries())
+            $this->filterSortAndPaginate($collection->queryEntries()->where('status', 'published'))
         );
     }
 


### PR DESCRIPTION
Fixes #2910

Hides drafts and respects the collection's past and future date behaviours.