### PR TITLE
Bring back {{ template }} variable from v2

### DIFF
--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -5,6 +5,7 @@ namespace Statamic\View;
 use Illuminate\Http\Request;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Facades;
+use Statamic\Facades\Blink;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\URL;
 use Statamic\Sites\Site;
@@ -179,6 +180,7 @@ class Cascade
             'get' => Arr::sanitize($this->request->query->all()),
             'post' => $this->request->isMethod('post') ? Arr::sanitize($this->request->request->all()) : [],
             'old' => Arr::sanitize(old(null, [])),
+            'template' => Blink::get('statamic-template'),
 
             'site' => $this->site,
             'sites' => Facades\Site::all()->values(),

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -3,6 +3,7 @@
 namespace Statamic\View;
 
 use Facades\Statamic\View\Cascade;
+use Statamic\Facades\Blink;
 use Statamic\Support\Str;
 use Statamic\View\Events\ViewRendered;
 
@@ -56,6 +57,8 @@ class View
         }
 
         $this->template = $template;
+
+        Blink::put('statamic-template', $template);
 
         return $this;
     }

--- a/tests/View/Antlers/ViewTest.php
+++ b/tests/View/Antlers/ViewTest.php
@@ -3,6 +3,7 @@
 namespace Tests\View\Antlers;
 
 use Illuminate\Support\Facades\Event;
+use Statamic\Facades\Blink;
 use Statamic\View\Events\ViewRendered;
 use Statamic\View\View;
 use Tests\FakesViews;
@@ -138,6 +139,8 @@ class ViewTest extends TestCase
     /** @test */
     public function gets_template()
     {
+        Blink::shouldReceive('put')->with('statamic-template', 'foo')->once();
+
         $view = (new View)->template('foo');
 
         $this->assertEquals('foo', $view->template());

--- a/tests/View/CascadeTest.php
+++ b/tests/View/CascadeTest.php
@@ -4,6 +4,7 @@ namespace Tests\View;
 
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Carbon;
+use Statamic\Facades\Blink;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
@@ -250,6 +251,19 @@ class CascadeTest extends TestCase
         tap($this->cascade()->hydrate()->toArray(), function ($cascade) {
             $expected = ['foo' => 'bar', 'script' => '&lt;script&gt;', 'tag' => '&lbrace;&lbrace; foo &rbrace;&rbrace;'];
             $this->assertEquals($expected, $cascade['old']);
+        });
+    }
+
+    /** @test */
+    public function it_hydrates_template()
+    {
+        Blink::shouldReceive('get')->with('statamic-template')->andReturn('eins')->once();
+
+        $this->get('/');
+
+        tap($this->cascade()->hydrate()->toArray(), function ($cascade) {
+            $expected = 'eins';
+            $this->assertEquals($expected, $cascade['template']);
         });
     }
 


### PR DESCRIPTION
This PR closes #1848 by bringing back the `{{ template }}` variable which wasn't ported over from v2.

I couldn't find any clever 'Laravel way' to get the current view so I decided to store the template in the Blink cache and then output that as a variable in the cascade.

I've also added some tests to cover both the side in the Antlers View and the Cascade so we can verify it's always there and returns as expected.

The one downside to this solution is that it that `template` will just be `null` for a non-Statamic route. However personally, I would assume `template` would return something for Statamic routes as you don't really have the concepts of templates/layouts in standard Blade views for example. So this is probably fine?