### PR TITLE
Preserve numeric keys in the Array fieldtype

### DIFF
--- a/src/Fieldtypes/Arr.php
+++ b/src/Fieldtypes/Arr.php
@@ -36,7 +36,7 @@ class Arr extends Fieldtype
 
     public function preProcess($data)
     {
-        return array_merge($this->blankKeyed(), $data ?? []);
+        return array_replace($this->blankKeyed(), $data ?? []);
     }
 
     public function preProcessConfig($data)


### PR DESCRIPTION
This fixes #3156 because the Array field type is also used in configuring the options of a Select field type.