### PR TITLE
Control Panel: Fix range field input overflowing flex container

### DIFF
--- a/resources/js/components/fieldtypes/RangeFieldtype.vue
+++ b/resources/js/components/fieldtypes/RangeFieldtype.vue
@@ -13,7 +13,7 @@
                 :readonly="isReadOnly"
                 :disabled="isReadOnly"
                 :id="fieldId"
-                class="flex-1"
+                class="flex-1 min-w-0"
             />
             <div class="rounded border px-1 py-sm mx-1 bg-grey-10">{{ val }}</div>
             <div v-if="config.append" v-text="config.append" />


### PR DESCRIPTION
Flex items have `min-width: auto` by default. To prevent the `<input type="range">` from overflowing the container, I set `min-width: 0` by using the existing Tailwind class `min-w-0`.

Here is a before and after comparison in Chrome, Firefox and Safari. The range field has a width of 25%.

**Before:**
![range-before](https://user-images.githubusercontent.com/77532479/108819510-398fed80-75bb-11eb-8cab-c5a0b7f098ee.jpg)

----

**After:** 
![range-after](https://user-images.githubusercontent.com/77532479/108819530-3f85ce80-75bb-11eb-8e8c-76f10151d484.jpg)
