### PR TITLE
Allows Addon Developers to Version CSS and JavaScript Assets (re. #3294)

### DIFF
--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -73,7 +73,7 @@ class Statamic
         if (is_null($version)) {
             return '';
         } elseif (is_string($version)) {
-            return '?v=' . e($version);
+            return '?v='.e($version);
         } elseif (is_array($version)) {
             return '?'.http_build_query($version);
         } elseif ($version instanceof Collection) {

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -75,23 +75,12 @@ class Statamic
         } else if (is_string($version)) {
             return '?v=' . e($version);
         } else if (is_array($version)) {
-            return self::buildQueryString($version);
+            return '?'.http_build_query($version);
         } else if ($version instanceof Collection) {
-            return self::buildQueryString($version->all());
+            return '?'.http_build_query($version->all());
         }
 
         return '';
-    }
-
-    protected static function buildQueryString(array $parameters)
-    {
-        $queryParts = [];
-
-        foreach ($parameters as $name => $value) {
-            $queryParts[] = urlencode(e($name)).'='.urlencode(e(strval($value)));
-        }
-
-        return '?'.implode('&', $queryParts);
     }
 
     public static function externalScript($url)

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -4,6 +4,7 @@ namespace Statamic;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Statamic\Facades\File;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
@@ -60,11 +61,37 @@ class Statamic
         return static::$externalScripts;
     }
 
-    public static function script($name, $path)
+    public static function script($name, $path, $version = null)
     {
-        static::$scripts[$name][] = str_finish($path, '.js');
+        static::$scripts[$name][] = str_finish($path, '.js').self::getResourceSuffix($version);
 
         return new static;
+    }
+
+    protected static function getResourceSuffix($version)
+    {
+        if (is_null($version)) {
+            return '';
+        } else if (is_string($version)) {
+            return '?v=' . e($version);
+        } else if (is_array($version)) {
+            return self::buildQueryString($version);
+        } else if ($version instanceof Collection) {
+            return self::buildQueryString($version->all());
+        }
+
+        return '';
+    }
+
+    protected static function buildQueryString(array $parameters)
+    {
+        $queryParts = [];
+
+        foreach ($parameters as $name => $value) {
+            $queryParts[] = urlencode(e($name)).'='.urlencode(e(strval($value)));
+        }
+
+        return '?'.implode('&', $queryParts);
     }
 
     public static function externalScript($url)
@@ -79,9 +106,9 @@ class Statamic
         return static::$styles;
     }
 
-    public static function style($name, $path)
+    public static function style($name, $path, $version = null)
     {
-        static::$styles[$name][] = str_finish($path, '.css');
+        static::$styles[$name][] = str_finish($path, '.css').self::getResourceSuffix($version);
 
         return new static;
     }

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -72,11 +72,11 @@ class Statamic
     {
         if (is_null($version)) {
             return '';
-        } else if (is_string($version)) {
+        } elseif (is_string($version)) {
             return '?v=' . e($version);
-        } else if (is_array($version)) {
+        } elseif (is_array($version)) {
             return '?'.http_build_query($version);
-        } else if ($version instanceof Collection) {
+        } elseif ($version instanceof Collection) {
             return '?'.http_build_query($version->all());
         }
 

--- a/tests/Extend/ResourcesPathsTest.php
+++ b/tests/Extend/ResourcesPathsTest.php
@@ -1,0 +1,141 @@
+<?php
+
+
+namespace Statamic\Testing\Extend;
+
+use Illuminate\Support\Facades\Request;
+use Statamic\Statamic;
+use Tests\TestCase;
+
+class ResourcesPathsTest extends TestCase
+{
+
+    /** @test */
+    public function scripts_can_be_created_without_version()
+    {
+        Statamic::script('test', 'test');
+
+        $allScripts = Statamic::availableScripts(Request::create('/'));
+
+        $this->assertArrayHasKey('test', $allScripts);
+
+        $testScripts = $allScripts['test'];
+
+        $this->assertIsArray($testScripts);
+        $this->assertContains('test.js', $testScripts);
+    }
+
+    /** @test */
+    public function styles_can_be_created_without_version()
+    {
+        Statamic::style('test', 'test');
+
+        $allStyles = Statamic::availableStyles(Request::create('/'));
+
+        $this->assertArrayHasKey('test', $allStyles);
+
+        $testStyles = $allStyles['test'];
+
+        $this->assertIsArray($testStyles);
+        $this->assertContains('test.css', $testStyles);
+    }
+
+    /** @test */
+    public function scripts_can_be_created_with_version()
+    {
+        Statamic::script('test', 'test');
+        Statamic::script('test', 'versioned', '2.1.0');
+
+        $allScripts = Statamic::availableScripts(Request::create('/'));
+
+        $this->assertArrayHasKey('test', $allScripts);
+
+        $testScripts = $allScripts['test'];
+
+        $this->assertIsArray($testScripts);
+        $this->assertContains('test.js', $testScripts);
+        $this->assertContains('versioned.js?v=2.1.0', $testScripts);
+    }
+
+    /** @test */
+    public function styles_can_be_created_with_version()
+    {
+        Statamic::style('test', 'test');
+        Statamic::style('test', 'versioned', '2.1.0');
+
+        $allStyles = Statamic::availableStyles(Request::create('/'));
+
+        $this->assertArrayHasKey('test', $allStyles);
+
+        $testStyles = $allStyles['test'];
+
+        $this->assertIsArray($testStyles);
+        $this->assertContains('test.css', $testStyles);
+        $this->assertContains('versioned.css?v=2.1.0', $testStyles);
+    }
+
+    /** @test */
+    public function scripts_cannot_inject_html()
+    {
+        Statamic::script('test', 'test', '"><script></script><script src="');
+
+        $allScripts = Statamic::availableScripts(Request::create('/'));
+
+        $this->assertArrayHasKey('test', $allScripts);
+
+        $testScripts = $allScripts['test'];
+
+        $this->assertIsArray($testScripts);
+        $this->assertNotContains('test.js?v='.'"><script></script><script src="', $testScripts);
+    }
+
+    /** @test */
+    public function styles_cannot_inject_html()
+    {
+        Statamic::style('test', 'test', '"><script></script><link href="');
+
+        $allStyles = Statamic::availableStyles(Request::create('/'));
+
+        $this->assertArrayHasKey('test', $allStyles);
+
+        $testStyles = $allStyles['test'];
+
+        $this->assertIsArray($testStyles);
+        $this->assertNotContains('test.css?v='.'"><script></script><link href="', $testStyles);
+    }
+
+    /** @test */
+    public function scripts_can_supply_custom_parameters()
+    {
+        Statamic::script('test', 'paramtest', ['v' => '3.1.0', 'key' => 'apikey']);
+        Statamic::script('test', 'collecttest', collect(['v' => '3.1.0', 'key' => 'apikey', 'name' => 'test']));
+
+        $allScripts = Statamic::availableScripts(Request::create('/'));
+
+        $this->assertArrayHasKey('test', $allScripts);
+
+        $testScripts = $allScripts['test'];
+
+        $this->assertIsArray($testScripts);
+        $this->assertContains('paramtest.js?v=3.1.0&key=apikey', $testScripts);
+        $this->assertContains('collecttest.js?v=3.1.0&key=apikey&name=test', $testScripts);
+    }
+
+    /** @test */
+    public function styles_can_supply_custom_parameters()
+    {
+        Statamic::style('test', 'paramtest', ['v' => '3.1.0', 'key' => 'apikey']);
+        Statamic::style('test', 'collecttest', collect(['v' => '3.1.0', 'key' => 'apikey', 'name' => 'test']));
+
+        $allStyles = Statamic::availableStyles(Request::create('/'));
+
+        $this->assertArrayHasKey('test', $allStyles);
+
+        $testStyles = $allStyles['test'];
+
+        $this->assertIsArray($testStyles);
+        $this->assertContains('paramtest.css?v=3.1.0&key=apikey', $testStyles);
+        $this->assertContains('collecttest.css?v=3.1.0&key=apikey&name=test', $testStyles);
+    }
+
+}

--- a/tests/Extend/ResourcesPathsTest.php
+++ b/tests/Extend/ResourcesPathsTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Statamic\Testing\Extend;
 
 use Illuminate\Support\Facades\Request;
@@ -9,7 +8,6 @@ use Tests\TestCase;
 
 class ResourcesPathsTest extends TestCase
 {
-
     /** @test */
     public function scripts_can_be_created_without_version()
     {
@@ -137,5 +135,4 @@ class ResourcesPathsTest extends TestCase
         $this->assertContains('paramtest.css?v=3.1.0&key=apikey', $testStyles);
         $this->assertContains('collecttest.css?v=3.1.0&key=apikey&name=test', $testStyles);
     }
-
 }


### PR DESCRIPTION
This PR adds a third `$version` parameter to both the `Statamic::script` and `Statamic::style` methods and resolves #3294.

When not used (set to `null` by default), the existing current behavior is retained so there should be no breaking changes.

When a string is supplied, a `?v=` parameter is tacked onto the end of the generated URL:

```php
Statamic::script('test', 'script', '1.2.0'); // Produces: script.js?v=1.2.0
```

When an array (or `Collection`) instance is is suppled as the argument multiple query parameters will be included in the final URL:

```php
Statamic::script('test', 'script', ['v' => '1.2.0', 'key' => 'api-key']); // Produces: script.js?v=1.2.0&key=api-key
```