### PR TITLE
Shallow augment the user data passed to scripts

### DIFF
--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -68,7 +68,7 @@ class JavascriptComposer
             return [];
         }
 
-        return array_merge($user->toAugmentedArray(), [
+        return array_merge($user->toShallowAugmentedArray(), [
             'preferences' => Preference::all(),
             'permissions' => $user->permissions()->all(),
         ]);


### PR DESCRIPTION
To prevent cyclic references in the user blueprint from bricking the control panel.

Fixes #2855.

I can't think of any use cases where this would be a breaking change, if there are maybe we can merge this in 3.1? If there are any other issues feel free to close this PR (with issue) since I solved it for our applications by overriding the view composer.