### PR TITLE
#3241 - Adds &nbsp's for each paragraph rather than the last one

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2375,9 +2375,9 @@ class CoreModifiers extends Modifier
      * @param $value
      * @return string
      */
-    public function widont($value)
+    public function widont($value, $params)
     {
-        return Str::widont($value);
+        return Str::widont($value, $params);
     }
 
     /**

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2375,8 +2375,11 @@ class CoreModifiers extends Modifier
      * @param $value
      * @return string
      */
-    public function widont($value, $params)
+    public function widont($value, $params = 1)
     {
+        //Not Sure why its an array when running a test
+        $params = Arr::get($params, 0, '1');
+
         return Str::widont($value, $params);
     }
 

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2375,9 +2375,9 @@ class CoreModifiers extends Modifier
      * @param $value
      * @return string
      */
-    public function widont($value, $params = 1)
+    public function widont($value, $params)
     {
-        //Not Sure why its an array when running a test
+
         $params = Arr::get($params, 0, '1');
 
         return Str::widont($value, $params);

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2377,7 +2377,6 @@ class CoreModifiers extends Modifier
      */
     public function widont($value, $params)
     {
-
         $params = Arr::get($params, 0, '1');
 
         return Str::widont($value, $params);

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -177,9 +177,9 @@ class Str extends \Illuminate\Support\Str
             }, $value);
 
             // step 2, replace all spaces based on params with &nbsp;
-            $value = preg_replace_callback("/(?<!<[p|li|h1|h2|h3|h4|h5|h6|div|figcaption])([^\s]\s)([^\s]*\s?){{$params}}(<\/(?:p|li|h1|h2|h3|h4|h5|h6|div|figcaption)>)/", function($matches) {
+            $value = preg_replace_callback("/(?<!<[p|li|h1|h2|h3|h4|h5|h6|div|figcaption])([^\s]\s)([^\s]*\s?){{$params}}(<\/(?:p|li|h1|h2|h3|h4|h5|h6|div|figcaption)>)/", function ($matches) {
                 return preg_replace("/([\s])/", '&nbsp;', rtrim($matches[0]));
-            },$value);
+            }, $value);
 
             // step 3, re-replace the code from step 1 with spaces
             return str_replace('%###%##%', ' ', $value);
@@ -189,10 +189,9 @@ class Str extends \Illuminate\Support\Str
 
             $value = preg_replace_callback(
                 "/([^\s]\s)([^\s]*\s?){{$params}}$/im",
-                function($matches) {
+                function ($matches) {
                     return preg_replace("/([\s])/", '&nbsp;', rtrim($matches[0]));
-                    },
-                $value);
+                    }, $value);
 
 
             return $value;

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -186,7 +186,6 @@ class Str extends \Illuminate\Support\Str
 
         // otherwise
         } else {
-
             $value = preg_replace_callback("/([^\s]\s)([^\s]*\s?){{$params}}$/im", function ($matches) {
                 return preg_replace("/([\s])/", '&nbsp;', rtrim($matches[0]));
             }, $value);

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -165,7 +165,7 @@ class Str extends \Illuminate\Support\Str
      * @param string $value
      * @return string
      */
-    public static function widont($value, $params = 1)
+    public static function widont($value, $words = 1)
     {
         // thanks to Shaun Inman for inspiration here
         // http://www.shauninman.com/archive/2008/08/25/widont_2_1_1
@@ -177,7 +177,7 @@ class Str extends \Illuminate\Support\Str
             }, $value);
 
             // step 2, replace all spaces based on params with &nbsp;
-            $value = preg_replace_callback("/(?<!<[p|li|h1|h2|h3|h4|h5|h6|div|figcaption])([^\s]\s)([^\s]*\s?){{$params}}(<\/(?:p|li|h1|h2|h3|h4|h5|h6|div|figcaption)>)/", function ($matches) {
+            $value = preg_replace_callback("/(?<!<[p|li|h1|h2|h3|h4|h5|h6|div|figcaption])([^\s]\s)([^\s]*\s?){{$words}}(<\/(?:p|li|h1|h2|h3|h4|h5|h6|div|figcaption)>)/", function ($matches) {
                 return preg_replace("/([\s])/", '&nbsp;', rtrim($matches[0]));
             }, $value);
 
@@ -186,11 +186,9 @@ class Str extends \Illuminate\Support\Str
 
         // otherwise
         } else {
-            $value = preg_replace_callback("/([^\s]\s)([^\s]*\s?){{$params}}$/im", function ($matches) {
+            return preg_replace_callback("/([^\s]\s)([^\s]*\s?){{$words}}$/im", function ($matches) {
                 return preg_replace("/([\s])/", '&nbsp;', rtrim($matches[0]));
             }, $value);
-
-            return $value;
         }
     }
 

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -165,11 +165,13 @@ class Str extends \Illuminate\Support\Str
      * @param string $value
      * @return string
      */
-    public static function widont($value)
+    public static function widont($value, $params)
     {
+        //Not Sure why its an array when running a test
+        $params = Arr::get($params, 0, '1');
+
         // thanks to Shaun Inman for inspiration here
         // http://www.shauninman.com/archive/2008/08/25/widont_2_1_1
-
         // if there are content tags
         if (preg_match("/<\/(?:p|li|h1|h2|h3|h4|h5|h6|figcaption)>/ism", $value)) {
             // step 1, replace spaces in HTML tags with a code
@@ -177,15 +179,27 @@ class Str extends \Illuminate\Support\Str
                 return str_replace(' ', '%###%##%', $matches[0]);
             }, $value);
 
-            // step 2, replace last space with &nbsp;
-            $value = preg_replace("/(?<!<[p|li|h1|h2|h3|h4|h5|h6|div|figcaption])([^\s])[ \t]+([^\s]+(?:[\s]*<\/(?:p|li|h1|h2|h3|h4|h5|h6|div|figcaption)>))/", '$1&nbsp;$2', rtrim($value));
+            // step 2, replace all spaces based on params with &nbsp;
+            $value = preg_replace_callback("/(?<!<[p|li|h1|h2|h3|h4|h5|h6|div|figcaption])([^\s]\s)([^\s]*\s?){{$params}}(<\/(?:p|li|h1|h2|h3|h4|h5|h6|div|figcaption)>)/", function($matches) {
+                return preg_replace("/([\s])/", '&nbsp;', rtrim($matches[0]));
+            },$value);
 
             // step 3, re-replace the code from step 1 with spaces
             return str_replace('%###%##%', ' ', $value);
 
         // otherwise
         } else {
-            return preg_replace("/([^\s])\s+([^\s]+)\s*$/im", '$1&nbsp;$2', rtrim($value));
+
+            $value = preg_replace_callback(
+                "/([^\s]\s)([^\s]*\s?){{$params}}$/im",
+                function($matches) {
+                    return preg_replace("/([\s])/", '&nbsp;', rtrim($matches[0]));
+                    },
+                $value);
+
+
+            return $value;
+
         }
     }
 

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -178,7 +178,7 @@ class Str extends \Illuminate\Support\Str
             }, $value);
 
             // step 2, replace last space with &nbsp;
-            $value = preg_replace("/(?<!<[p|li|h1|h2|h3|h4|h5|h6|div|figcaption])([^\s])[ \t]+([^\s]+(?:[\s]*<\/(?:p|li|h1|h2|h3|h4|h5|h6|div|figcaption)>))$/im", '$1&nbsp;$2', rtrim($value));
+            $value = preg_replace("/(?<!<[p|li|h1|h2|h3|h4|h5|h6|div|figcaption])([^\s])[ \t]+([^\s]+(?:[\s]*<\/(?:p|li|h1|h2|h3|h4|h5|h6|div|figcaption)>))/", '$1&nbsp;$2', rtrim($value));
 
             // step 3, re-replace the code from step 1 with spaces
             return str_replace('%###%##%', ' ', $value);

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -165,11 +165,8 @@ class Str extends \Illuminate\Support\Str
      * @param string $value
      * @return string
      */
-    public static function widont($value, $params)
+    public static function widont($value, $params = 1)
     {
-        //Not Sure why its an array when running a test
-        $params = Arr::get($params, 0, '1');
-
         // thanks to Shaun Inman for inspiration here
         // http://www.shauninman.com/archive/2008/08/25/widont_2_1_1
         // if there are content tags

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -187,15 +187,11 @@ class Str extends \Illuminate\Support\Str
         // otherwise
         } else {
 
-            $value = preg_replace_callback(
-                "/([^\s]\s)([^\s]*\s?){{$params}}$/im",
-                function ($matches) {
-                    return preg_replace("/([\s])/", '&nbsp;', rtrim($matches[0]));
-                    }, $value);
-
+            $value = preg_replace_callback("/([^\s]\s)([^\s]*\s?){{$params}}$/im", function ($matches) {
+                return preg_replace("/([\s])/", '&nbsp;', rtrim($matches[0]));
+            }, $value);
 
             return $value;
-
         }
     }
 

--- a/tests/Modifiers/WidontTest.php
+++ b/tests/Modifiers/WidontTest.php
@@ -32,13 +32,13 @@ class WidontTest extends TestCase
             Lorem ipsum dolor sit amet.
             Lorem ipsum dolor sit amet.
             Lorem ipsum dolor sit amet.
-            EOD;
+EOD;
 
         $expected = <<<'EOD'
             Lorem ipsum dolor sit&nbsp;amet.
             Lorem ipsum dolor sit&nbsp;amet.
             Lorem ipsum dolor sit&nbsp;amet.
-            EOD;
+EOD;
 
         $this->assertEquals($expected, $this->modify($value, 1));
     }

--- a/tests/Modifiers/WidontTest.php
+++ b/tests/Modifiers/WidontTest.php
@@ -1,0 +1,112 @@
+<?php
+
+
+namespace Tests\Modifiers;
+
+
+use PhpParser\Node\Expr\AssignOp\Mod;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class WidontTest extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function it_adds_space_to_plain_text()
+    {
+        $value = 'Lorem ipsum dolor sit amet.';
+
+        $this->assertEquals('Lorem ipsum dolor sit&nbsp;amet.', $this->modify($value));
+    }
+
+
+    /** @test */
+    public function it_uses_params_to_add_space_to_plain_text()
+    {
+        $value = 'Lorem ipsum dolor sit amet.';
+
+        $this->assertEquals('Lorem ipsum dolor&nbsp;sit&nbsp;amet.', $this->modify($value, 2));
+    }
+
+    /** @test */
+    public function it_uses_params_to_add_space_to_long_broken_text()
+    {
+        $value = <<<EOD
+            Lorem ipsum dolor sit amet.
+            Lorem ipsum dolor sit amet.
+            Lorem ipsum dolor sit amet.
+            EOD;
+
+        $expected = <<<EOD
+            Lorem ipsum dolor sit&nbsp;amet.
+            Lorem ipsum dolor sit&nbsp;amet.
+            Lorem ipsum dolor sit&nbsp;amet.
+            EOD;
+
+        $this->assertEquals($expected, $this->modify($value, 1));
+
+    }
+
+
+    /** @test */
+    public function it_adds_space_to_text_within_html_tags()
+    {
+        $value1 = '<p>Lorem ipsum dolor sit amet.</p>';
+        $value2 = '<h1>Lorem ipsum dolor sit amet.</h1>';
+        $value3 = '<h2>Lorem ipsum dolor sit amet.</h2>';
+
+        $this->assertEquals('<p>Lorem ipsum dolor sit&nbsp;amet.</p>', $this->modify($value1, 1));
+        $this->assertEquals('<h1>Lorem ipsum dolor sit&nbsp;amet.</h1>', $this->modify($value2, 1));
+        $this->assertEquals('<h2>Lorem ipsum dolor sit&nbsp;amet.</h2>', $this->modify($value3, 1));
+
+    }
+
+    /** @test */
+    public function it_adds_space_to_text_within_multiple_html_tags()
+    {
+        $value = '<p>Lorem ipsum dolor sit amet.</p><p>Consectetur adipiscing elit.</p>';
+
+        $this->assertEquals('<p>Lorem ipsum dolor sit&nbsp;amet.</p><p>Consectetur adipiscing&nbsp;elit.</p>', $this->modify($value));
+
+    }
+
+    /** @test */
+    public function it_uses_params_to_add_space_to_text_within_html_tags()
+    {
+        $value1 = '<p>Lorem ipsum dolor sit amet.</p>';
+        $value2 = '<h1>Lorem ipsum dolor sit amet.</h1>';
+        $value3 = '<h2>Lorem ipsum dolor sit amet.</h2>';
+
+        $this->assertEquals('<p>Lorem ipsum dolor&nbsp;sit&nbsp;amet.</p>', $this->modify($value1, 2));
+        $this->assertEquals('<h1>Lorem ipsum&nbsp;dolor&nbsp;sit&nbsp;amet.</h1>', $this->modify($value2, 3));
+        $this->assertEquals('<h2>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet.</h2>', $this->modify($value3, 4));
+
+    }
+
+    /** @test */
+    public function it_uses_params_to_add_space_to_text_within_multiple_html_tags()
+    {
+        $value = '<p>Lorem ipsum dolor sit amet.</p><p>Consectetur adipiscing elit.</p>';
+
+        $this->assertEquals('<p>Lorem ipsum dolor&nbsp;sit&nbsp;amet.</p><p>Consectetur&nbsp;adipiscing&nbsp;elit.</p>', $this->modify($value, 2));
+
+    }
+
+
+    /** @test */
+    public function it_pases_bard_test()
+    {
+        $value = '<p>Lorem ipsum dolor sit amet.</p><p></p><p>Consectetur adipiscing elit.</p>';
+
+        $this->assertEquals('<p>Lorem ipsum dolor sit&nbsp;amet.</p><p></p><p>Consectetur adipiscing&nbsp;elit.</p>', $this->modify($value, 1));
+
+    }
+
+
+    public function modify($value, $params = 1)
+    {
+        return Modify::value($value)->widont($params)->fetch();
+    }
+}

--- a/tests/Modifiers/WidontTest.php
+++ b/tests/Modifiers/WidontTest.php
@@ -1,10 +1,7 @@
 <?php
 
-
 namespace Tests\Modifiers;
 
-
-use PhpParser\Node\Expr\AssignOp\Mod;
 use Statamic\Modifiers\Modify;
 use Tests\TestCase;
 
@@ -21,7 +18,6 @@ class WidontTest extends TestCase
         $this->assertEquals('Lorem ipsum dolor sit&nbsp;amet.', $this->modify($value));
     }
 
-
     /** @test */
     public function it_uses_params_to_add_space_to_plain_text()
     {
@@ -33,22 +29,20 @@ class WidontTest extends TestCase
     /** @test */
     public function it_uses_params_to_add_space_to_long_broken_text()
     {
-        $value = <<<EOD
+        $value = <<<'EOD'
             Lorem ipsum dolor sit amet.
             Lorem ipsum dolor sit amet.
             Lorem ipsum dolor sit amet.
             EOD;
 
-        $expected = <<<EOD
+        $expected = <<<'EOD'
             Lorem ipsum dolor sit&nbsp;amet.
             Lorem ipsum dolor sit&nbsp;amet.
             Lorem ipsum dolor sit&nbsp;amet.
             EOD;
 
         $this->assertEquals($expected, $this->modify($value, 1));
-
     }
-
 
     /** @test */
     public function it_adds_space_to_text_within_html_tags()
@@ -60,7 +54,6 @@ class WidontTest extends TestCase
         $this->assertEquals('<p>Lorem ipsum dolor sit&nbsp;amet.</p>', $this->modify($value1, 1));
         $this->assertEquals('<h1>Lorem ipsum dolor sit&nbsp;amet.</h1>', $this->modify($value2, 1));
         $this->assertEquals('<h2>Lorem ipsum dolor sit&nbsp;amet.</h2>', $this->modify($value3, 1));
-
     }
 
     /** @test */
@@ -69,7 +62,6 @@ class WidontTest extends TestCase
         $value = '<p>Lorem ipsum dolor sit amet.</p><p>Consectetur adipiscing elit.</p>';
 
         $this->assertEquals('<p>Lorem ipsum dolor sit&nbsp;amet.</p><p>Consectetur adipiscing&nbsp;elit.</p>', $this->modify($value));
-
     }
 
     /** @test */
@@ -82,7 +74,6 @@ class WidontTest extends TestCase
         $this->assertEquals('<p>Lorem ipsum dolor&nbsp;sit&nbsp;amet.</p>', $this->modify($value1, 2));
         $this->assertEquals('<h1>Lorem ipsum&nbsp;dolor&nbsp;sit&nbsp;amet.</h1>', $this->modify($value2, 3));
         $this->assertEquals('<h2>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet.</h2>', $this->modify($value3, 4));
-
     }
 
     /** @test */
@@ -91,9 +82,7 @@ class WidontTest extends TestCase
         $value = '<p>Lorem ipsum dolor sit amet.</p><p>Consectetur adipiscing elit.</p>';
 
         $this->assertEquals('<p>Lorem ipsum dolor&nbsp;sit&nbsp;amet.</p><p>Consectetur&nbsp;adipiscing&nbsp;elit.</p>', $this->modify($value, 2));
-
     }
-
 
     /** @test */
     public function it_pases_bard_test()
@@ -101,9 +90,7 @@ class WidontTest extends TestCase
         $value = '<p>Lorem ipsum dolor sit amet.</p><p></p><p>Consectetur adipiscing elit.</p>';
 
         $this->assertEquals('<p>Lorem ipsum dolor sit&nbsp;amet.</p><p></p><p>Consectetur adipiscing&nbsp;elit.</p>', $this->modify($value, 1));
-
     }
-
 
     public function modify($value, $params = 1)
     {

--- a/tests/Modifiers/WidontTest.php
+++ b/tests/Modifiers/WidontTest.php
@@ -40,7 +40,7 @@ EOD;
             Lorem ipsum dolor sit&nbsp;amet.
 EOD;
 
-        $this->assertEquals($expected, $this->modify($value, 1));
+        $this->assertEquals($expected, $this->modify($value));
     }
 
     /** @test */
@@ -50,9 +50,9 @@ EOD;
         $value2 = '<h1>Lorem ipsum dolor sit amet.</h1>';
         $value3 = '<h2>Lorem ipsum dolor sit amet.</h2>';
 
-        $this->assertEquals('<p>Lorem ipsum dolor sit&nbsp;amet.</p>', $this->modify($value1, 1));
-        $this->assertEquals('<h1>Lorem ipsum dolor sit&nbsp;amet.</h1>', $this->modify($value2, 1));
-        $this->assertEquals('<h2>Lorem ipsum dolor sit&nbsp;amet.</h2>', $this->modify($value3, 1));
+        $this->assertEquals('<p>Lorem ipsum dolor sit&nbsp;amet.</p>', $this->modify($value1));
+        $this->assertEquals('<h1>Lorem ipsum dolor sit&nbsp;amet.</h1>', $this->modify($value2));
+        $this->assertEquals('<h2>Lorem ipsum dolor sit&nbsp;amet.</h2>', $this->modify($value3));
     }
 
     /** @test */
@@ -88,10 +88,10 @@ EOD;
     {
         $value = '<p>Lorem ipsum dolor sit amet.</p><p></p><p>Consectetur adipiscing elit.</p>';
 
-        $this->assertEquals('<p>Lorem ipsum dolor sit&nbsp;amet.</p><p></p><p>Consectetur adipiscing&nbsp;elit.</p>', $this->modify($value, 1));
+        $this->assertEquals('<p>Lorem ipsum dolor sit&nbsp;amet.</p><p></p><p>Consectetur adipiscing&nbsp;elit.</p>', $this->modify($value));
     }
 
-    public function modify($value, $params = 1)
+    public function modify($value, $params = [])
     {
         return Modify::value($value)->widont($params)->fetch();
     }

--- a/tests/Modifiers/WidontTest.php
+++ b/tests/Modifiers/WidontTest.php
@@ -7,7 +7,6 @@ use Tests\TestCase;
 
 class WidontTest extends TestCase
 {
-
     /**
      * @test
      */


### PR DESCRIPTION
Fixes #3241

Before
```
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean finibus orci a turpis vestibulum ornare.</p><p>Pellentesque interdum at odio ut tristique. Quisque in dui non turpis eleifend dignissim.</p><p>Etiam ultricies sem massa, imperdiet lobortis velit luctus eu. Morbi bibendum tortor vel ultricies&nbsp;tempor.</p>
```

After
```
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean finibus orci a turpis vestibulum&nbsp;ornare.</p><p>Pellentesque interdum at odio ut tristique. Quisque in dui non turpis eleifend&nbsp;dignissim.</p><p>Etiam ultricies sem massa, imperdiet lobortis velit luctus eu. Morbi bibendum tortor vel ultricies&nbsp;tempor.</p>
```

However, it doesnt take into consideration the params. Will push an update to add support for that.