### PR TITLE
Multisite: Auto Publish

### DIFF
--- a/config/sites.php
+++ b/config/sites.php
@@ -19,6 +19,7 @@ return [
             'name' => config('app.name'),
             'locale' => 'en_US',
             'url' => '/',
+            'autopublish' => false,
         ],
 
     ],

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -316,6 +316,19 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
             EntrySaved::dispatch($this);
         }
 
+        if ($isNew && is_null($this->localizations)) {
+            \Statamic\Facades\Site::all()
+                ->filter(function ($site) {
+                    return $site->autoPublish();
+                })
+                ->reject(function ($site) {
+                    return $site->handle() === $this->site()->handle();
+                })
+                ->each(function ($site) {
+                    $this->makeLocalization($site->handle())->saveQuietly();
+                });
+        }
+
         return true;
     }
 

--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -70,6 +70,13 @@ class Site implements Augmentable
         return $path === '' ? '/' : $path;
     }
 
+    public function autoPublish()
+    {
+        return isset($this->config['autopublish'])
+            ? $this->config['autopublish']
+            : false;
+    }
+
     private function removePath($url)
     {
         $parsed = parse_url($url);
@@ -85,6 +92,7 @@ class Site implements Augmentable
             'locale' => $this->locale(),
             'short_locale' => $this->shortLocale(),
             'url' => $this->url(),
+            'autopublish' => $this->autopublish(),
         ];
     }
 


### PR DESCRIPTION
This PR introduces the ability to 'auto-publish' entries, if enabled, in some multi-site setups. This PR, if merged, closes statamic/ideas#478.

## Use case

This could be useful if you have a UK site and a US site, where there are slight variations in the content. For example, the US site might have 'color' but the UK site would have 'colour'.

## Configuration

The current way. have this setup is that, for each site you would configure whether or not you'd like it to autopublish content from other sites.

```php
'sites' => [
  'default' => [
    'name' => config('app.name'),
    'locale' => 'en_US',
    'url' => '/',
  ],

  'non-default' => [
    'name' => 'non-default',
    'locale' => 'en_US',
    'url' => '/non-default/',
    'autopublish' => true,
  ],
],
```

## Checklist

* [X] Auto publishing of entries
* [ ] Auto publishing of taxonomy terms
* [ ] Auto publishing of global sets