### PR TITLE
Use custom queue connection

### DIFF
--- a/config/git.php
+++ b/config/git.php
@@ -29,7 +29,7 @@ return [
     |
     */
 
-    'connection' => env('STATAMIC_GIT_QUEUE_CONNECTION');
+    'connection' => env('STATAMIC_GIT_QUEUE_CONNECTION'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/git.php
+++ b/config/git.php
@@ -19,20 +19,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Queue Connection
-    |--------------------------------------------------------------------------
-    |
-    | You may choose which queue connection should be used when dispatching
-    | commit jobs. Unless specified, the default connection will be used.
-    |
-    | https://statamic.dev/git-integration#queueing-commits
-    |
-    */
-
-    'queue' => env('STATAMIC_GIT_QUEUE_CONNECTION'),
-
-    /*
-    |--------------------------------------------------------------------------
     | Automatically Run
     |--------------------------------------------------------------------------
     |
@@ -44,6 +30,19 @@ return [
 
     'automatic' => env('STATAMIC_GIT_AUTOMATIC', true),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Connection
+    |--------------------------------------------------------------------------
+    |
+    | You may choose which queue connection should be used when dispatching
+    | commit jobs. Unless specified, the default connection will be used.
+    |
+    | https://statamic.dev/git-integration#queueing-commits
+    |
+    */
+
+    'queue_connection' => env('STATAMIC_GIT_QUEUE_CONNECTION'),
     /*
     |--------------------------------------------------------------------------
     | Dispatch Delay

--- a/config/git.php
+++ b/config/git.php
@@ -19,6 +19,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Queue Connection
+    |--------------------------------------------------------------------------
+    |
+    | The default queue connection is used when dispatching the jobs.
+    | If you want to use a different queue connection for the git integration
+    | set `STATAMIC_GIT_QUEUE_CONNECTION` in your `.env` to a valid queue connection.
+    | See `config/queues.php` for the possible values.
+    |
+    */
+
+    'connection' => env('STATAMIC_GIT_QUEUE_CONNECTION');
+
+    /*
+    |--------------------------------------------------------------------------
     | Automatically Run
     |--------------------------------------------------------------------------
     |

--- a/config/git.php
+++ b/config/git.php
@@ -22,14 +22,14 @@ return [
     | Queue Connection
     |--------------------------------------------------------------------------
     |
-    | The default queue connection is used when dispatching the jobs.
-    | If you want to use a different queue connection for the git integration
-    | set `STATAMIC_GIT_QUEUE_CONNECTION` in your `.env` to a valid queue connection.
-    | See `config/queues.php` for the possible values.
+    | You may choose which queue connection should be used when dispatching
+    | commit jobs. Unless specified, the default connection will be used.
+    |
+    | https://statamic.dev/git-integration#queueing-commits
     |
     */
 
-    'connection' => env('STATAMIC_GIT_QUEUE_CONNECTION'),
+    'queue' => env('STATAMIC_GIT_QUEUE_CONNECTION'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/git.php
+++ b/config/git.php
@@ -43,6 +43,7 @@ return [
     */
 
     'queue_connection' => env('STATAMIC_GIT_QUEUE_CONNECTION'),
+
     /*
     |--------------------------------------------------------------------------
     | Dispatch Delay

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -75,7 +75,7 @@ class Git
         }
 
         CommitJob::dispatch($message)
-            ->onConnection(config('statamic.git.queue'))
+            ->onConnection(config('statamic.git.queue_connection'))
             ->delay($delayInMinutes ?? null);
     }
 

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -75,7 +75,7 @@ class Git
         }
 
         CommitJob::dispatch($message)
-            ->onConnection(config('statamic.git.connection'))
+            ->onConnection(config('statamic.git.queue'))
             ->delay($delayInMinutes ?? null);
     }
 

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -74,7 +74,9 @@ class Git
             $message = null;
         }
 
-        CommitJob::dispatch($message)->delay($delayInMinutes ?? null);
+        CommitJob::dispatch($message)
+            ->onConnection(config('statamic.git.connection'))
+            ->delay($delayInMinutes ?? null);
     }
 
     /**


### PR DESCRIPTION
This allows the connection used by the git integration to be different than the default.

Work around for https://github.com/statamic/cms/issues/3291 so default queue connection is `sync` but git uses `redis`