### PR TITLE
Don't inject files to the Fieldset Repository

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -106,7 +106,7 @@ class AppServiceProvider extends ServiceProvider
                 ->setRepository('user', \Statamic\Contracts\Auth\UserRepository::class);
         });
 
-        $this->app->bind(\Statamic\Fields\BlueprintRepository::class, function ($app) {
+        $this->app->bind(\Statamic\Fields\BlueprintRepository::class, function () {
             return (new \Statamic\Fields\BlueprintRepository)
                 ->setDirectory(resource_path('blueprints'))
                 ->setFallback('default', function () {

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -107,7 +107,7 @@ class AppServiceProvider extends ServiceProvider
         });
 
         $this->app->bind(\Statamic\Fields\BlueprintRepository::class, function ($app) {
-            return (new \Statamic\Fields\BlueprintRepository($app['files']))
+            return (new \Statamic\Fields\BlueprintRepository)
                 ->setDirectory(resource_path('blueprints'))
                 ->setFallback('default', function () {
                     return \Statamic\Facades\Blueprint::makeFromFields([
@@ -117,7 +117,7 @@ class AppServiceProvider extends ServiceProvider
         });
 
         $this->app->bind(\Statamic\Fields\FieldsetRepository::class, function () {
-            return (new \Statamic\Fields\FieldsetRepository())
+            return (new \Statamic\Fields\FieldsetRepository)
                 ->setDirectory(resource_path('fieldsets'));
         });
     }

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -116,8 +116,8 @@ class AppServiceProvider extends ServiceProvider
                 });
         });
 
-        $this->app->bind(\Statamic\Fields\FieldsetRepository::class, function ($app) {
-            return (new \Statamic\Fields\FieldsetRepository($app['files']))
+        $this->app->bind(\Statamic\Fields\FieldsetRepository::class, function () {
+            return (new \Statamic\Fields\FieldsetRepository())
                 ->setDirectory(resource_path('fieldsets'));
         });
     }


### PR DESCRIPTION
I think this might be removed. There is no constructor defined for FieldsetRepositories or did I miss something?

https://github.com/statamic/cms/blob/3.0/src/Fields/FieldsetRepository.php

co-authored: @juliawarnke