### PR TITLE
Add `route` param to `redirect tag

### DIFF
--- a/src/Tags/Redirect.php
+++ b/src/Tags/Redirect.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Tags;
 
+use Illuminate\Support\Facades\Route;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Fields\Value;
 
@@ -16,6 +17,10 @@ class Redirect extends Tags
 
     public function index()
     {
+        if ($route = $this->params->get('route')) {
+            return $this->redirect(route($route));
+        }
+
         return $this->redirect(
             $this->params->get(['to', 'url'])
         );

--- a/src/Tags/Redirect.php
+++ b/src/Tags/Redirect.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Tags;
 
-use Illuminate\Support\Facades\Route;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Fields\Value;
 


### PR DESCRIPTION
Some syntactic sugar to turn this:

```
{{ redirect to="{route:login}" }}
```

Into this:

```
{{ redirect route="login" }}
```

Which is much nicer.