### PR TITLE
Avoid missing fieldset import to break cp forms

### DIFF
--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -19,7 +19,7 @@ class FieldsetRepository
         return $this;
     }
 
-    public function find(string $handle): ?Fieldset
+    public function find(string $handle): Fieldset
     {
         if ($cached = array_get($this->fieldsets, $handle)) {
             return $cached;

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -28,9 +28,7 @@ class FieldsetRepository
         $handle = str_replace('/', '.', $handle);
         $path = str_replace('.', '/', $handle);
 
-        if (! File::exists($path = "{$this->directory}/{$path}.yaml")) {
-            return null;
-        }
+        $content = File::exists($path) ? YAML::file($path)->parse() : $this->notFoundContent($handle);
 
         $fieldset = (new Fieldset)
             ->setHandle($handle)
@@ -89,5 +87,22 @@ class FieldsetRepository
     public function delete(Fieldset $fieldset)
     {
         File::delete("{$this->directory}/{$fieldset->handle()}.yaml");
+    }
+
+    protected function notFoundContent(string $handle): array
+    {
+        return [
+            'handle' => $handle,
+            'fields' => [
+                [
+                    'handle' => 'not-found',
+                    'field' => [
+                        'type' => 'section',
+                        'display' => 'Fieldset not found.',
+                        'instructions' => 'You tried to import \''.$handle.'\' but the file could not be found. Please check if the fieldset has been removed or renamed.',
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/tests/Fields/FieldsetRepositoryTest.php
+++ b/tests/Fields/FieldsetRepositoryTest.php
@@ -68,12 +68,22 @@ EOT;
         $this->assertEquals($fieldset, $this->repo->find('sub/test'));
     }
 
-    /** @test */
-    public function it_returns_null_if_fieldset_doesnt_exist()
+    /**
+     * Test the added functionality in App\Fields\FieldsetRepository.
+     * @test
+     */
+    public function it_returns_not_found_content_if_fieldset_doesnt_exist()
     {
         File::shouldReceive('exists')->with('/path/to/resources/fieldsets/unknown.yaml')->once()->andReturnFalse();
 
-        $this->assertNull($this->repo->find('unknown'));
+        $fieldset = $this->repo->find('unknown');
+
+        $this->assertInstanceOf(Fieldset::class, $fieldset);
+        $this->assertEquals('unknown', $fieldset->handle());
+        $this->assertEquals('not-found', $fieldset->fields()->all()->first()->handle());
+        $this->assertEquals('Fieldset not found.', $fieldset->fields()->all()->first()->display());
+        $this->assertEquals('section', $fieldset->fields()->all()->first()->type());
+        $this->assertEquals('You tried to import \''.$fieldset->handle().'\' but the file could not be found. Please check if the fieldset has been removed or renamed.', $fieldset->fields()->all()->first()->instructions());
     }
 
     /** @test */


### PR DESCRIPTION
The problem: 
When a user changes the slug of a an imported fieldset cp forms will break.

The suggested solution:
Instead of returning null and thereby throw an exception when the fieldset could not be found, we return a section fieldtype with a message, that the imported fieldset does not exist.

The question is if people would prefer a section fieldtype to display the error message or if a new fieldtype should be created for it?