### PR TITLE
Add inheritable Structure values

### DIFF
--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -29,6 +29,7 @@ class Page implements Entry, Augmentable, Responsable, Protectable
     protected $url;
     protected $title;
     protected $depth;
+    protected $protect;
     protected $inheritableValues = [
         'protect',
     ];

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -14,6 +14,7 @@ use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
+use Illuminate\Support\Str;
 
 class Page implements Entry, Augmentable, Responsable, Protectable
 {
@@ -28,6 +29,9 @@ class Page implements Entry, Augmentable, Responsable, Protectable
     protected $url;
     protected $title;
     protected $depth;
+    protected $inheritableValues = [
+        'protect',
+    ];
 
     public function setUrl($url)
     {

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -135,7 +135,7 @@ class Page implements Entry, Augmentable, Responsable, Protectable
 
     public function impressProtectOnEntry($entry)
     {
-        if ($entry->getProtectionScheme()) {
+        if (! is_null($entry->getProtectionScheme())) {
             return;
         }
 

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -127,8 +127,7 @@ class Page implements Entry, Augmentable, Responsable, Protectable
                     $page->{$method}($entry);
                 }
             }
-        }
-        while ($page = $page->parent());
+        } while ($page = $page->parent());
 
         return $entry;
     }

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -3,6 +3,7 @@
 namespace Statamic\Structures;
 
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Statamic\Contracts\Auth\Protect\Protectable;
 use Statamic\Contracts\Data\Augmentable;
@@ -14,7 +15,6 @@ use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
-use Illuminate\Support\Str;
 
 class Page implements Entry, Augmentable, Responsable, Protectable
 {

--- a/src/Structures/Pages.php
+++ b/src/Structures/Pages.php
@@ -68,6 +68,7 @@ class Pages
                 ->setUrl($branch['url'] ?? null)
                 ->setTitle($branch['title'] ?? null)
                 ->setDepth($this->depth)
+                ->setProtect($branch['protect'] ?? null)
                 ->setChildren($branch['children'] ?? []);
 
             if ($this->route) {


### PR DESCRIPTION
A possible solution for https://github.com/statamic/ideas/issues/481

Adds support for `protect` initially, but is flexible enough that it could be used for other values too.

With this PR, you can manually set `protect` on a tree's branch to set the protection for a whole section of that Collection.

<img width="511" alt="Screenshot 2021-03-02 at 12 28 10" src="https://user-images.githubusercontent.com/31628/109648644-c5bd8a00-7b52-11eb-8bd5-24e7ee38a779.png">

Doesn't yet add anything to the CP UI to support reading/updating this value there. If you change the tree via the UI and save it, this will be erased.

TODO:
- [ ] Add UI support for reading/updating the `protect` value
- [ ] Rewrite for v3.1 when ready (See https://github.com/statamic/cms/pull/2768)