### PR TITLE
Ability to hide collections

### DIFF
--- a/src/CP/Navigation/CoreNav.php
+++ b/src/CP/Navigation/CoreNav.php
@@ -72,7 +72,7 @@ class CoreNav
             ->icon('content-writing')
             ->can('index', Collection::class)
             ->children(function () {
-                return CollectionAPI::all()->sortBy->title()->map(function ($collection) {
+                return CollectionAPI::all()->sortBy->title()->reject->hidden()->map(function ($collection) {
                     return Nav::item($collection->title())
                               ->url($collection->showUrl())
                               ->can('view', $collection);

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -424,7 +424,7 @@ class Collection implements Contract, AugmentableContract
                 'past' => $this->pastDateBehavior,
                 'future' => $this->futureDateBehavior,
             ],
-            'hidden' => $this->hidden,
+            'hidden' => $this->hidden ? true : null,
         ]));
 
         if (! Site::hasMultiple()) {

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -43,6 +43,7 @@ class Collection implements Contract, AugmentableContract
     protected $sortDirection;
     protected $ampable = false;
     protected $revisions = false;
+    protected $hidden = false;
     protected $positions;
     protected $defaultPublishState = true;
     protected $futureDateBehavior = 'public';
@@ -423,6 +424,7 @@ class Collection implements Contract, AugmentableContract
                 'past' => $this->pastDateBehavior,
                 'future' => $this->futureDateBehavior,
             ],
+            'hidden' => $this->hidden,
         ]));
 
         if (! Site::hasMultiple()) {
@@ -494,6 +496,7 @@ class Collection implements Contract, AugmentableContract
             'mount' => $this->mount,
             'taxonomies' => $this->taxonomies,
             'revisions' => $this->revisions,
+            'hidden' => $this->hidden,
         ];
     }
 
@@ -517,6 +520,15 @@ class Collection implements Contract, AugmentableContract
                 }
 
                 return $enabled;
+            })
+            ->args(func_get_args());
+    }
+
+    public function hidden($hidden = null)
+    {
+        return $this->fluentlyGetOrSet('hidden')
+            ->getter(function ($hidden) {
+                return $hidden ?? false;
             })
             ->args(func_get_args());
     }

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -22,6 +22,8 @@ class CollectionsController extends CpController
 
         $collections = Collection::all()->filter(function ($collection) {
             return User::current()->can('view', $collection);
+        })->reject(function ($collection) {
+            return $collection->hidden();
         })->map(function ($collection) {
             return [
                 'id' => $collection->handle(),

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -52,7 +52,8 @@ class CollectionsStore extends BasicStore
             ->structureContents(array_get($data, 'structure'))
             ->sortField(array_get($data, 'sort_by'))
             ->sortDirection(array_get($data, 'sort_dir'))
-            ->taxonomies(array_get($data, 'taxonomies'));
+            ->taxonomies(array_get($data, 'taxonomies'))
+            ->hidden(array_get($data, 'hidden'));
 
         if ($dateBehavior = array_get($data, 'date_behavior')) {
             $collection

--- a/tests/Stache/FeatureTest.php
+++ b/tests/Stache/FeatureTest.php
@@ -207,7 +207,7 @@ class FeatureTest extends TestCase
 
         $this->assertStringEqualsFile(
             $path = __DIR__.'/__fixtures__/content/collections/new.yaml',
-            "title: 'New Collection'\nrevisions: true\ndate: true\ndefault_status: draft\ninject:\n  foo: bar\n"
+            "title: 'New Collection'\nrevisions: true\nhidden: false\ndate: true\ndefault_status: draft\ninject:\n  foo: bar\n"
         );
         @unlink($path);
     }

--- a/tests/Stache/FeatureTest.php
+++ b/tests/Stache/FeatureTest.php
@@ -207,7 +207,7 @@ class FeatureTest extends TestCase
 
         $this->assertStringEqualsFile(
             $path = __DIR__.'/__fixtures__/content/collections/new.yaml',
-            "title: 'New Collection'\nrevisions: true\nhidden: false\ndate: true\ndefault_status: draft\ninject:\n  foo: bar\n"
+            "title: 'New Collection'\nrevisions: true\ndate: true\ndefault_status: draft\ninject:\n  foo: bar\n"
         );
         @unlink($path);
     }


### PR DESCRIPTION
This PR implements the ability to 'hide' collections, which essentially means the Collection is hidden from the CP Nav and from the Collection Index page.

### Hiding a collection

If a developer wanted to hide a specific collection, they could add `hidden: true` to the Collection YAML file and the collection would disappear. ✨ 

I've not included a way for a collection to be hidden from the Control Panel, only from directly editing the YAML file. However, if you'd like it to be editable from the CP, let me know and I'll add that in.

---

This PR closes statamic/ideas#259. 