### PR TITLE
🐛 try/catch to check if folder exists to improve performance of asset containers

### DIFF
--- a/src/Filesystem/AbstractAdapter.php
+++ b/src/Filesystem/AbstractAdapter.php
@@ -9,11 +9,11 @@ abstract class AbstractAdapter implements Filesystem
 {
     public function get($path, $fallback = null)
     {
-        if (! $this->exists($path)) {
+        try {
+            return $this->filesystem->get($this->normalizePath($path));
+        } catch (\Exception $e) {
             return $fallback;
         }
-
-        return $this->filesystem->get($this->normalizePath($path));
     }
 
     public function exists($path = null)


### PR DESCRIPTION
Improves #3216 

Using object storage/S3 you're no longer hammered with expensive "lists" requests when you have a lot of folders.

Currently loading an asset container a ListObject request is made for the root, for every folder it contains 2 additional ListObject calls are made when "exists()" is called when checking if a folder exists. 

Having a root folder with 100 files and 10 folders 21 ListObject calls are made when 1 is sufficient.

Instead of checking with exists, we can just do a get on the filesystem, if it fails we can return the fallback and assume it doesn't exists. 