### PR TITLE
Get email via property

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -379,6 +379,10 @@ class User extends BaseUser
             return $this->model()->timestamps;
         }
 
+        if ($key == 'email') {
+            return $this->email();
+        }
+
         return $this->$key;
     }
 }

--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -62,6 +62,15 @@ class User extends BaseUser
         return $this->get($key);
     }
 
+    public function __get($key)
+    {
+        if ($key == 'email') {
+            return $this->email();
+        }
+
+        return $this->get($key);
+    }
+
     public function id($id = null)
     {
         return $this->fluentlyGetOrSet('id')->args(func_get_args());

--- a/tests/Auth/UserContractTests.php
+++ b/tests/Auth/UserContractTests.php
@@ -35,6 +35,12 @@ trait UserContractTests
     }
 
     /** @test */
+    public function it_gets_email_as_property()
+    {
+        $this->assertEquals('john@example.com', $this->user()->email);
+    }
+
+    /** @test */
     public function gets_the_name()
     {
         $this->assertEquals('John', $this->makeUser()->set('name', 'John')->name());


### PR DESCRIPTION
Added `email` property getter for file users so that I can pass a collection of Statamic users to the `Mail::to` method. That method expects a `name` & `email` field.