### PR TITLE
Composer package versions

### DIFF
--- a/src/UpdateScripts/UpdateScript.php
+++ b/src/UpdateScripts/UpdateScript.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\UpdateScripts;
 
+use Composer\Package\Version\VersionParser;
 use Illuminate\Filesystem\Filesystem;
 use Statamic\Console\Composer\Lock;
 use Statamic\Console\NullConsole;
@@ -66,8 +67,9 @@ abstract class UpdateScript
      */
     public function isUpdatingTo($version)
     {
-        $newVersion = Lock::file()->getInstalledVersion($this->package());
-        $oldVersion = Lock::file(self::BACKUP_PATH)->getInstalledVersion($this->package());
+        $version = (new VersionParser)->normalize($version);
+        $newVersion = Lock::file()->getNormalizedInstalledVersion($this->package());
+        $oldVersion = Lock::file(self::BACKUP_PATH)->getNormalizedInstalledVersion($this->package());
 
         return version_compare($version, $newVersion, '<=') && version_compare($version, $oldVersion, '>');
     }

--- a/tests/Composer/ComposerLockTest.php
+++ b/tests/Composer/ComposerLockTest.php
@@ -119,24 +119,24 @@ class ComposerLockTest extends TestCase
     public function it_can_gets_normalized_version_of_a_package_from_composer_lock()
     {
         PackToTheFuture::generateComposerLockForMultiple([
-            'package/one' => '1.0.0', // Doesn't need normalizing.
+            'package/one' => '1.0.0',
             'package/two' => '2.0',
             'package/three' => '3',
             'package/four' => 'v4.0.0',
             'package/five' => 'v5.0',
             'package/six' => 'v6',
-            'package/seven' => '7.1.0-beta.1', // Doesn't need normalizing.
+            'package/seven' => '7.1.0-beta.1',
             'package/eight' => 'v8.1.0-beta.1',
         ], $this->lockPath);
 
-        $this->assertEquals('1.0.0', Lock::file()->getInstalledVersion('package/one'));
-        $this->assertEquals('2.0.0', Lock::file()->getInstalledVersion('package/two'));
-        $this->assertEquals('3.0.0', Lock::file()->getInstalledVersion('package/three'));
-        $this->assertEquals('4.0.0', Lock::file()->getInstalledVersion('package/four'));
-        $this->assertEquals('5.0.0', Lock::file()->getInstalledVersion('package/five'));
-        $this->assertEquals('6.0.0', Lock::file()->getInstalledVersion('package/six'));
-        $this->assertEquals('7.1.0-beta.1', Lock::file()->getInstalledVersion('package/seven'));
-        $this->assertEquals('8.1.0-beta.1', Lock::file()->getInstalledVersion('package/eight'));
+        $this->assertEquals('1.0.0.0', Lock::file()->getNormalizedInstalledVersion('package/one'));
+        $this->assertEquals('2.0.0.0', Lock::file()->getNormalizedInstalledVersion('package/two'));
+        $this->assertEquals('3.0.0.0', Lock::file()->getNormalizedInstalledVersion('package/three'));
+        $this->assertEquals('4.0.0.0', Lock::file()->getNormalizedInstalledVersion('package/four'));
+        $this->assertEquals('5.0.0.0', Lock::file()->getNormalizedInstalledVersion('package/five'));
+        $this->assertEquals('6.0.0.0', Lock::file()->getNormalizedInstalledVersion('package/six'));
+        $this->assertEquals('7.1.0.0-beta1', Lock::file()->getNormalizedInstalledVersion('package/seven'));
+        $this->assertEquals('8.1.0.0-beta1', Lock::file()->getNormalizedInstalledVersion('package/eight'));
     }
 
     /** @test */

--- a/tests/UpdateScripts/UpdateScriptTest.php
+++ b/tests/UpdateScripts/UpdateScriptTest.php
@@ -124,6 +124,19 @@ class UpdateScriptTest extends TestCase
     }
 
     /** @test */
+    public function it_properly_normalizes_the_version_you_pass_in_when_checking_for_updating_to_a_version()
+    {
+        PackToTheFuture::generateComposerLock('statamic/cms', '3.1.0-beta.1', $this->previousLockPath);
+        PackToTheFuture::generateComposerLock('statamic/cms', 'v3.1.0', $this->lockPath);
+
+        $script = $this->register(UpdatePermissions::class);
+
+        $this->assertTrue($script->isUpdatingTo('3.1'));
+        $this->assertTrue($script->isUpdatingTo('3.1.0'));
+        $this->assertFalse($script->isUpdatingTo('3.1.1'));
+    }
+
+    /** @test */
     public function it_can_check_if_version_is_normalized_when_user_overrides_lock_version()
     {
         PackToTheFuture::generateComposerLock('statamic/cms', '3.0', $this->previousLockPath);


### PR DESCRIPTION
This fixes an issue where `$this->isUpdatingTo('3.1')` wouldn't work but `3.1.0` would.

This also scraps our version normalizing code in favor of Composer's. They already have a full-fledged thing.
But since their method normalizes the versions to 4 digits (e.g. `3.0.0.0`), I've made a separate `getNormalizedInstalledVersion` that does the normalizing. `getInstalledVersion` just uses whatever is actually installed with Composer.

This lets us use the normalized version for `version_compare`, but the regular one for displaying.