### PR TITLE
[3.1] Ability to set target of CP Nav Items

### DIFF
--- a/resources/views/partials/nav-main.blade.php
+++ b/resources/views/partials/nav-main.blade.php
@@ -9,7 +9,7 @@
                     @foreach ($items as $item)
                         @unless ($item->view())
                             <li class="{{ $item->isActive() ? 'current' : '' }}">
-                                <a href="{{ $item->url() }}">
+                                <a href="{{ $item->url() }}" target="{{ $item->target() }}">
                                     <i>{!! $item->icon() !!}</i><span>{{ __($item->name()) }}</span>
                                 </a>
                                 @if ($item->children() && $item->isActive())

--- a/resources/views/partials/nav-mobile.blade.php
+++ b/resources/views/partials/nav-mobile.blade.php
@@ -8,7 +8,7 @@
                 @foreach ($items as $item)
                     @unless ($item->view())
                         <li class="{{ $item->isActive() ? 'current' : '' }}">
-                            <a href="{{ $item->url() }}">
+                            <a href="{{ $item->url() }}" target="{{ $item->target() }}">
                                 <i>{!! $item->icon() !!}</i><span>{{ __($item->name()) }}</span>
                             </a>
                             @if ($item->children() && $item->isActive())

--- a/src/CP/Navigation/CoreNav.php
+++ b/src/CP/Navigation/CoreNav.php
@@ -187,7 +187,8 @@ class CoreNav
         if (config('statamic.graphql.enabled') && Statamic::pro()) {
             Nav::tools('GraphQL')
                 ->route('graphql.index')
-                ->icon('array');
+                ->icon('array')
+                ->target('_blank');
         }
 
         return $this;

--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -201,6 +201,12 @@ class NavItem
         return $this->fluentlyGetOrSet('view')->value($view);
     }
 
+    /**
+     * Get or set target attribute.
+     *
+     * @param string|null $target
+     * @return mixed
+     */
     public function target($target = null)
     {
         return $this->fluentlyGetOrSet('target')

--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -200,4 +200,13 @@ class NavItem
     {
         return $this->fluentlyGetOrSet('view')->value($view);
     }
+
+    public function target($target = null)
+    {
+        return $this->fluentlyGetOrSet('target')
+            ->getter(function ($value) {
+                return $value ?? '_self';
+            })
+            ->value($target);
+    }
 }

--- a/tests/Facades/CP/NavTest.php
+++ b/tests/Facades/CP/NavTest.php
@@ -80,6 +80,7 @@ class NavTest extends TestCase
         $this->assertEquals('Droids', $item->section());
         $this->assertEquals('R2-D2', $item->name());
         $this->assertEquals('http://localhost/r2', $item->url());
+        $this->assertEquals('_self', $item->target());
     }
 
     /** @test */
@@ -91,7 +92,8 @@ class NavTest extends TestCase
             ->active('threepio*')
             ->url('/human-cyborg-relations')
             ->view('cp.nav.importer')
-            ->can('index', 'DroidsClass');
+            ->can('index', 'DroidsClass')
+            ->target('_blank');
 
         $item = Nav::build()->get('Droids')->first();
 
@@ -102,6 +104,7 @@ class NavTest extends TestCase
         $this->assertEquals('threepio*', $item->active());
         $this->assertEquals('index', $item->authorization()->ability);
         $this->assertEquals('DroidsClass', $item->authorization()->arguments);
+        $this->assertEquals('_blank', $item->target());
     }
 
     /** @test */


### PR DESCRIPTION
This PR implements the ability for developers to set the [HTML target attribute](https://www.w3schools.com/tags/att_a_target.asp) for CP Nav Item links.

Developers can just pass a `->target` method when adding their nav item, here's a below example:

```php
Nav::extend(function ($nav) {
    $nav->create('Store')
        ->section('Jack & Sons Inc.')
        ->route('store.index')
        ->icon('shopping-cart')
        ->target('_blank');
});
```

Personally, I've got no need for this in my addons, however adding this feature could fix #3299 by opening the GraphQL explorer in a new tab, instead of the current one.

If merged, I'll open a PR on the docs repo as well, ready for when 3.1 is released.