### PR TITLE
[3.1] Filter published entries in GraphQL

### DIFF
--- a/src/GraphQL/Queries/EntriesQuery.php
+++ b/src/GraphQL/Queries/EntriesQuery.php
@@ -52,9 +52,7 @@ class EntriesQuery extends Query
             $this->filterQuery($query, $filters);
         }
 
-        if ($sort = $args['sort'] ?? null) {
-            $this->sortQuery($query, $sort);
-        }
+        $this->sortQuery($query, $args['sort'] ?? []);
 
         return $query->paginate($args['limit'] ?? 1000);
     }
@@ -82,6 +80,10 @@ class EntriesQuery extends Query
 
     private function sortQuery($query, $sorts)
     {
+        if (empty($sorts)) {
+            $sorts = ['id'];
+        }
+
         foreach ($sorts as $sort) {
             $order = 'asc';
 

--- a/src/GraphQL/Queries/EntriesQuery.php
+++ b/src/GraphQL/Queries/EntriesQuery.php
@@ -57,7 +57,7 @@ class EntriesQuery extends Query
 
     private function filterQuery($query, $filters)
     {
-        if (! isset($filters['status'])) {
+        if (! isset($filters['status']) && ! isset($filters['published'])) {
             $filters['status'] = 'published';
         }
 

--- a/src/GraphQL/Queries/EntriesQuery.php
+++ b/src/GraphQL/Queries/EntriesQuery.php
@@ -48,9 +48,7 @@ class EntriesQuery extends Query
             $query->whereIn('collection', $collection);
         }
 
-        if ($filters = $args['filter'] ?? null) {
-            $this->filterQuery($query, $filters);
-        }
+        $this->filterQuery($query, $args['filter'] ?? []);
 
         $this->sortQuery($query, $args['sort'] ?? []);
 
@@ -59,6 +57,10 @@ class EntriesQuery extends Query
 
     private function filterQuery($query, $filters)
     {
+        if (! isset($filters['status'])) {
+            $filters['status'] = 'published';
+        }
+
         foreach ($filters as $field => $definitions) {
             if (! is_array($definitions)) {
                 $definitions = [['equals' => $definitions]];

--- a/src/GraphQL/Types/EntryInterface.php
+++ b/src/GraphQL/Types/EntryInterface.php
@@ -45,6 +45,9 @@ class EntryInterface extends InterfaceType
             'private' => [
                 'type' => GraphQL::nonNull(GraphQL::boolean()),
             ],
+            'status' => [
+                'type' => GraphQL::nonNull(GraphQL::string()),
+            ],
             'collection' => [
                 'type' => GraphQL::nonNull(GraphQL::type(CollectionType::NAME)),
             ],

--- a/tests/Feature/GraphQL/CreatesQueryableTestEntries.php
+++ b/tests/Feature/GraphQL/CreatesQueryableTestEntries.php
@@ -46,7 +46,7 @@ trait CreatesQueryableTestEntries
 
         EntryFactory::collection('events')->id('4')->slug('event-two')->data(['title' => 'Event Two'])->create();
 
-        EntryFactory::collection('food')->id('5')->data([
+        EntryFactory::collection('food')->id('5')->slug('hamburger')->data([
             'title' => 'Hamburger',
             'calories' => 350,
         ])->create();

--- a/tests/Feature/GraphQL/CreatesQueryableTestEntries.php
+++ b/tests/Feature/GraphQL/CreatesQueryableTestEntries.php
@@ -11,12 +11,17 @@ trait CreatesQueryableTestEntries
 {
     public function createEntries()
     {
-        Collection::make('blog')->routes(['en' => '/blog/{slug}'])->save();
+        Collection::make('blog')
+            ->routes(['en' => '/blog/{slug}'])
+            ->dated(true)
+            ->futureDateBehavior('private')
+            ->save();
         Collection::make('events')->routes(['en' => '/events/{slug}'])->save();
         Collection::make('food')->routes(['en' => '/food/{slug}'])->save();
 
         EntryFactory::collection('blog')
             ->id('1')
+            ->date(now()->subMonths(2))
             ->slug('standard-blog-post')
             ->data([
                 'title' => 'Standard Blog Post',
@@ -26,6 +31,7 @@ trait CreatesQueryableTestEntries
 
         EntryFactory::collection('blog')
             ->id('2')
+            ->date(now()->subMonths(3))
             ->slug('art-directed-blog-post')
             ->data([
                 'blueprint' => 'art_directed',

--- a/tests/Feature/GraphQL/EntriesTest.php
+++ b/tests/Feature/GraphQL/EntriesTest.php
@@ -485,6 +485,7 @@ GQL;
     public function it_only_shows_published_entries_by_default()
     {
         $this->createEntries();
+        Entry::find(1)->date(now()->addMonths(2))->save();
         Entry::find(2)->published(false)->save();
         Entry::find(4)->published(false)->save();
 
@@ -504,7 +505,6 @@ GQL;
             ->post('/graphql', ['query' => $query])
             ->assertGqlOk()
             ->assertExactJson(['data' => ['entries' => ['data' => [
-                ['id' => '1', 'title' => 'Standard Blog Post'],
                 ['id' => '3', 'title' => 'Event One'],
                 ['id' => '5', 'title' => 'Hamburger'],
             ]]]]);
@@ -527,6 +527,25 @@ GQL;
                 ->assertExactJson(['data' => ['entries' => ['data' => [
                     ['id' => '2', 'title' => 'Art Directed Blog Post'],
                     ['id' => '4', 'title' => 'Event Two'],
+                ]]]]);
+
+        $query = <<<'GQL'
+{
+    entries(filter: {status: "scheduled"}) {
+        data {
+            id
+            title
+        }
+    }
+}
+GQL;
+
+        $this
+                ->withoutExceptionHandling()
+                ->post('/graphql', ['query' => $query])
+                ->assertGqlOk()
+                ->assertExactJson(['data' => ['entries' => ['data' => [
+                    ['id' => '1', 'title' => 'Standard Blog Post'],
                 ]]]]);
     }
 }

--- a/tests/Feature/GraphQL/EntriesTest.php
+++ b/tests/Feature/GraphQL/EntriesTest.php
@@ -69,8 +69,8 @@ GQL;
     {
         $this->createEntries();
         // Add some more entries to be able to make pagination assertions a little more obvious
-        EntryFactory::collection('food')->id('6')->data(['title' => 'Cheeseburger'])->create();
-        EntryFactory::collection('food')->id('7')->data(['title' => 'Fries'])->create();
+        EntryFactory::collection('food')->id('6')->slug('cheeseburger')->data(['title' => 'Cheeseburger'])->create();
+        EntryFactory::collection('food')->id('7')->slug('fries')->data(['title' => 'Fries'])->create();
 
         $query = <<<'GQL'
 {
@@ -251,17 +251,23 @@ GQL;
     {
         $this->createEntries();
 
-        EntryFactory::collection('blog')->id('6')->data([
-            'title' => 'That was so rad!',
-        ])->create();
+        EntryFactory::collection('blog')
+            ->id('6')
+            ->slug('that-was-so-rad')
+            ->data(['title' => 'That was so rad!'])
+            ->create();
 
-        EntryFactory::collection('blog')->id('7')->data([
-            'title' => 'I wish I was as cool as Daniel Radcliffe!',
-        ])->create();
+        EntryFactory::collection('blog')
+            ->id('7')
+            ->slug('as-cool-as-radcliffe')
+            ->data(['title' => 'I wish I was as cool as Daniel Radcliffe!'])
+            ->create();
 
-        EntryFactory::collection('blog')->id('8')->data([
-            'title' => 'I hate radishes.',
-        ])->create();
+        EntryFactory::collection('blog')
+            ->id('8')
+            ->slug('i-hate-radishes')
+            ->data(['title' => 'I hate radishes.'])
+            ->create();
 
         $query = <<<'GQL'
 {
@@ -330,17 +336,23 @@ GQL;
     {
         $this->createEntries();
 
-        EntryFactory::collection('blog')->id('6')->data([
-            'title' => 'This is rad',
-        ])->create();
+        EntryFactory::collection('blog')
+            ->id('6')
+            ->slug('this-is-rad')
+            ->data(['title' => 'This is rad'])
+            ->create();
 
-        EntryFactory::collection('blog')->id('7')->data([
-            'title' => 'This is awesome',
-        ])->create();
+        EntryFactory::collection('blog')
+            ->id('7')
+            ->slug('this-is-awesome')
+            ->data(['title' => 'This is awesome'])
+            ->create();
 
-        EntryFactory::collection('blog')->id('8')->data([
-            'title' => 'This is both rad and awesome',
-        ])->create();
+        EntryFactory::collection('blog')
+            ->id('8')
+            ->slug('this-is-rad-and-awesome')
+            ->data(['title' => 'This is both rad and awesome'])
+            ->create();
 
         $query = <<<'GQL'
 {

--- a/tests/Feature/GraphQL/EntriesTest.php
+++ b/tests/Feature/GraphQL/EntriesTest.php
@@ -511,7 +511,48 @@ GQL;
 
         $query = <<<'GQL'
 {
+    entries(filter: {published: true}) {
+        data {
+            id
+            title
+        }
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => ['entries' => ['data' => [
+                ['id' => '1', 'title' => 'Standard Blog Post'],
+                ['id' => '3', 'title' => 'Event One'],
+                ['id' => '5', 'title' => 'Hamburger'],
+            ]]]]);
+
+        $query = <<<'GQL'
+{
     entries(filter: {status: "draft"}) {
+        data {
+            id
+            title
+        }
+    }
+}
+GQL;
+
+        $this
+                ->withoutExceptionHandling()
+                ->post('/graphql', ['query' => $query])
+                ->assertGqlOk()
+                ->assertExactJson(['data' => ['entries' => ['data' => [
+                    ['id' => '2', 'title' => 'Art Directed Blog Post'],
+                    ['id' => '4', 'title' => 'Event Two'],
+                ]]]]);
+
+        $query = <<<'GQL'
+{
+    entries(filter: {published: false}) {
         data {
             id
             title

--- a/tests/Feature/GraphQL/EntryTest.php
+++ b/tests/Feature/GraphQL/EntryTest.php
@@ -53,6 +53,7 @@ class EntryTest extends TestCase
         permalink
         published
         private
+        status
         date
         last_modified
         collection {
@@ -83,6 +84,7 @@ GQL;
                     'permalink' => 'http://localhost/events/event-one',
                     'published' => true,
                     'private' => false,
+                    'status' => 'published',
                     'date' => 'November 3rd, 2017',
                     'last_modified' => 'December 25th, 2017',
                     'collection' => [


### PR DESCRIPTION
This PR ensures that draft and scheduled entries aren't shown in entries queries by default.

If you filter on `status` or `published`, the default behavior goes away and does whatever you've asked for instead.

This PR also:
- Performs a default sort on `id`. This is mainly to make it more predictable in tests.
- Adds a `status` field to entries

Ref statamic/ideas#459