### PR TITLE
Remove remaining asset folder yaml reads

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -18,7 +18,6 @@ use Statamic\Facades\File;
 use Statamic\Facades\Search;
 use Statamic\Facades\Stache;
 use Statamic\Facades\URL;
-use Statamic\Facades\YAML;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
@@ -342,16 +341,7 @@ class AssetContainer implements AssetContainerContract, Augmentable
      */
     public function assetFolder($path)
     {
-        $filePath = ltrim("{$path}/folder.yaml", '/');
-
-        $contents = $this->disk()->get($filePath, '');
-
-        $data = YAML::parse($contents);
-
-        return (new AssetFolder)
-            ->container($this)
-            ->path($path)
-            ->title(array_get($data, 'title'));
+        return (new AssetFolder)->container($this)->path($path);
     }
 
     /**

--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -8,8 +8,6 @@ use Statamic\Events\AssetFolderDeleted;
 use Statamic\Events\AssetFolderSaved;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Path;
-use Statamic\Facades\YAML;
-use Statamic\Support\Arr;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class AssetFolder implements Contract, Arrayable
@@ -43,17 +41,7 @@ class AssetFolder implements Contract, Arrayable
         return pathinfo($this->path(), PATHINFO_BASENAME);
     }
 
-    public function title($title = null)
-    {
-        return $this
-            ->fluentlyGetOrSet('title')
-            ->getter(function ($title) {
-                return $title ?? $this->computedTitle();
-            })
-            ->args(func_get_args());
-    }
-
-    protected function computedTitle()
+    public function title()
     {
         return pathinfo($this->path(), PATHINFO_FILENAME);
     }
@@ -109,21 +97,7 @@ class AssetFolder implements Contract, Arrayable
 
     public function save()
     {
-        $path = $this->path().'/folder.yaml';
-
-        if ($this->title === $this->computedTitle()) {
-            $this->disk()->delete($path);
-
-            return $this;
-        }
-
         $this->disk()->makeDirectory($this->path());
-
-        $arr = Arr::removeNullValues(['title' => $this->title]);
-
-        if (! empty($arr)) {
-            $this->disk()->put($path, YAML::dump($arr));
-        }
 
         AssetFolderSaved::dispatch($this);
 

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -369,11 +369,6 @@ class AssetContainerTest extends TestCase
         $this->assertEquals('foo', $folder->title());
         $this->assertEquals('foo', $folder->path());
         $this->assertEquals($container, $folder->container());
-
-        Storage::disk('test')->put('foo/folder.yaml', "title: 'Test Folder'");
-        $folder = $container->assetFolder('foo');
-
-        $this->assertEquals('Test Folder', $folder->title());
     }
 
     private function containerWithDisk()


### PR DESCRIPTION
Part one of many to fix #3216

Back in the 3.0 beta, we decided to remove the folder.yaml "title" field. (#281) While we removed the UI and some other spots, the code to read from the `folder.yaml` files stayed around.

There are a number of bottlenecks when using an S3 asset container because there are so many API calls. One of the bottlenecks was due to looking at each folder's `folder.yaml` every time.

We're doing pretty much absolutely nothing with it, so there was overhead for no reason.

I've removed it in this PR.

When viewing a directory with 25 subdirectories and 11 assets (completely arbitrary numbers - it's just what I had in there at the time) **the number of API requests went from 167 down to 14. Or about 10 seconds down to 1.2 seconds.**

I'm targeting master as it's a little breaking change. You can no longer set an asset folder's `title`. It's now just a getter that returns the folder name. The only time the title would be set is if an addon was doing it or if you manually created folder.yaml files. You haven't been able to set a folder title through the CP in any v3 release.
