### PR TITLE
Rely on exception rather than separate exists call to reduce api calls

### DIFF
--- a/src/Filesystem/AbstractAdapter.php
+++ b/src/Filesystem/AbstractAdapter.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Filesystem;
 
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Statamic\Support\FileCollection;
 use Statamic\Support\Str;
 
@@ -9,11 +10,11 @@ abstract class AbstractAdapter implements Filesystem
 {
     public function get($path, $fallback = null)
     {
-        if (! $this->exists($path)) {
+        try {
+            return $this->filesystem->get($this->normalizePath($path)) ?: $fallback;
+        } catch (FileNotFoundException $e) {
             return $fallback;
         }
-
-        return $this->filesystem->get($this->normalizePath($path));
     }
 
     public function exists($path = null)

--- a/tests/Filesystem/FlysystemAdapterTest.php
+++ b/tests/Filesystem/FlysystemAdapterTest.php
@@ -41,6 +41,14 @@ class FlysystemAdapterTest extends TestCase
     }
 
     /** @test */
+    public function gets_fallback_if_a_file_doesnt_exist_and_asserts_are_disabled()
+    {
+        $this->filesystem->getConfig()->set('disable_asserts', true);
+
+        $this->assertEquals('Hello World', $this->adapter->get('filename.txt', 'Hello World'));
+    }
+
+    /** @test */
     public function it_normalizes_relative_paths()
     {
         $this->assertEquals('bar.txt', $this->adapter->normalizePath('bar.txt'));


### PR DESCRIPTION
This PR removes the additional "exists" check when "getting" a file's contents.

Part 2 of who knows to fix #3216 

It's an improvement on #3330 which would break the fallbacks if you've disabled asserts on the filesystem disk. That's Flysystem's own performance feature that will prevent throwing the exception if the file exists. If the file doesn't exist, it'll return `false`. So, we'll just check for that.

For benchmarking I looked at the ajax request performed in the CP when you edit an asset.
I have the same setup as described in #3353 - 25 subdirectories and 11 assets.
Before this, there were 52 API calls taking 3.5 seconds.
After, there were 27 calls taking 2 seconds. Good improvement.
When combining with the changes in #3353 it dropped to 2 calls in 450ms. Better.

Closes #3330 