### PR TITLE
Optimize the asset exists check

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -130,6 +130,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Cache Directory Listings
+    |--------------------------------------------------------------------------
+    |
+    | When retrieving the contents of a particular directory, Statamic will
+    | read from disk which will provide the most up to date listings. You
+    | can choose to cache these to reduce overhead, but you will need
+    | to either update the cache manually or use the Control Panel.
+    |
+    | https://statamic.dev/knowledge-base/caching-asset-directory-listings
+    |
+    */
+
+    'cache_listings' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Focal Point Editor
     |--------------------------------------------------------------------------
     |

--- a/config/assets.php
+++ b/config/assets.php
@@ -142,7 +142,7 @@ return [
     |
     */
 
-    'cache_listings' => false,
+    'cache_listings' => env('STATAMIC_CACHE_ASSET_LISTINGS'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -421,19 +421,22 @@ class Asset implements AssetContract, Augmentable
      */
     private function clearCaches()
     {
+        $container = $this->container();
+
+        $keys = [
+            $container->filesCacheKey('/', true),
+            $container->filesCacheKey('/', false),
+            $container->filesCacheKey($this->folder(), true),
+            $container->filesCacheKey($this->folder(), false),
+        ];
+
+        foreach ($keys as $key) {
+            Cache::forget($key);
+            Blink::forget($key);
+        }
+
         $this->meta = null;
-
         Cache::forget($this->metaCacheKey());
-
-        Cache::forget($this->container()->filesCacheKey('/', true));
-        Cache::forget($this->container()->filesCacheKey('/', false));
-        Cache::forget($this->container()->filesCacheKey($this->folder(), true));
-        Cache::forget($this->container()->filesCacheKey($this->folder(), false));
-
-        Blink::forget($this->container()->filesCacheKey('/', true));
-        Blink::forget($this->container()->filesCacheKey('/', false));
-        Blink::forget($this->container()->filesCacheKey($this->folder(), true));
-        Blink::forget($this->container()->filesCacheKey($this->folder(), false));
     }
 
     /**

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -426,8 +426,16 @@ class Asset implements AssetContract, Augmentable
         $this->meta = null;
 
         Cache::forget($this->metaCacheKey());
-        Cache::forget($this->container()->filesCacheKey());
-        Cache::forget($this->container()->filesCacheKey($this->folder()));
+
+        Cache::forget($this->container()->filesCacheKey('/', true));
+        Cache::forget($this->container()->filesCacheKey('/', false));
+        Cache::forget($this->container()->filesCacheKey($this->folder(), true));
+        Cache::forget($this->container()->filesCacheKey($this->folder(), false));
+
+        Blink::forget($this->container()->filesCacheKey('/', true));
+        Blink::forget($this->container()->filesCacheKey('/', false));
+        Blink::forget($this->container()->filesCacheKey($this->folder(), true));
+        Blink::forget($this->container()->filesCacheKey($this->folder(), false));
     }
 
     /**

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -111,7 +111,7 @@ class Asset implements AssetContract, Augmentable
             return false;
         }
 
-        return Blink::once('disk-paths-'.$this->containerHandle(), function () {
+        return Blink::once($this->container()->pathsCacheKey(), function () {
             return $this->disk()->getFilesRecursively('/');
         })->contains($path);
     }
@@ -489,7 +489,7 @@ class Asset implements AssetContract, Augmentable
     public function move($folder, $filename = null)
     {
         Cache::forget($this->container()->filesCacheKey($this->folder()));
-        Blink::forget('disk-paths-'.$this->containerHandle());
+        Blink::forget($this->container()->pathsCacheKey());
 
         $filename = $filename ?: $this->filename();
         $oldPath = $this->path();

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -111,9 +111,7 @@ class Asset implements AssetContract, Augmentable
             return false;
         }
 
-        return Blink::once($this->container()->pathsCacheKey(), function () {
-            return $this->disk()->getFilesRecursively('/');
-        })->contains($path);
+        return $this->container()->files()->contains($path);
     }
 
     public function meta($key = null)
@@ -497,7 +495,6 @@ class Asset implements AssetContract, Augmentable
     public function move($folder, $filename = null)
     {
         Cache::forget($this->container()->filesCacheKey($this->folder()));
-        Blink::forget($this->container()->pathsCacheKey());
 
         $filename = $filename ?: $this->filename();
         $oldPath = $this->path();

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -220,16 +220,16 @@ class AssetContainer implements AssetContainerContract, Augmentable
      * @param bool $recursive
      * @return \Illuminate\Support\Collection
      */
-    public function files($folder = null, $recursive = false)
+    public function files($folder = '/', $recursive = false)
     {
         // When requesting files() as-is, we want all of them.
-        if ($folder == null) {
+        if (func_num_args() === 0) {
             $recursive = true;
         }
 
         $cacheFor = config('statamic.assets.file_listing_cache_length', 60);
 
-        return Cache::remember($this->filesCacheKey($folder), $cacheFor, function () use ($folder, $recursive) {
+        return Cache::remember($this->filesCacheKey($folder, $recursive), $cacheFor, function () use ($folder, $recursive) {
             $files = collect($this->disk()->getFiles($folder, $recursive));
 
             // Get rid of files we never want to show up.
@@ -243,9 +243,11 @@ class AssetContainer implements AssetContainerContract, Augmentable
         });
     }
 
-    public function filesCacheKey($folder = '/')
+    public function filesCacheKey($folder = '/', $recursive = false)
     {
-        return 'asset-files-'.$this->handle().'-'.$folder;
+        $rec = $recursive ? '-recursive' : '';
+
+        return 'asset-files-'.$this->handle().'-'.$folder.$rec;
     }
 
     public function pathsCacheKey()

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -325,7 +325,7 @@ class AssetContainer implements AssetContainerContract, Augmentable
     {
         $asset = Facades\Asset::make()->container($this)->path($path);
 
-        if (! $asset->disk()->exists($asset->path())) {
+        if (! $asset->exists()) {
             return null;
         }
 

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -248,6 +248,11 @@ class AssetContainer implements AssetContainerContract, Augmentable
         return 'asset-files-'.$this->handle().'-'.$folder;
     }
 
+    public function pathsCacheKey()
+    {
+        return 'asset-paths-'.$this->handle();
+    }
+
     /**
      * Get all the subfolders in this container.
      *

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -263,11 +263,6 @@ class AssetContainer implements AssetContainerContract, Augmentable
         return 'asset-folders-'.$this->handle().'-'.$folder.$rec;
     }
 
-    public function pathsCacheKey()
-    {
-        return 'asset-paths-'.$this->handle();
-    }
-
     /**
      * Get all the subfolders in this container.
      *

--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -133,14 +133,19 @@ class AssetFolder implements Contract, Arrayable
 
     private function clearCaches()
     {
-        Cache::forget($this->container()->foldersCacheKey('/', true));
-        Cache::forget($this->container()->foldersCacheKey('/', false));
-        Cache::forget($this->container()->foldersCacheKey($this->path(), true));
-        Cache::forget($this->container()->foldersCacheKey($this->path(), false));
-        Blink::forget($this->container()->foldersCacheKey('/', true));
-        Blink::forget($this->container()->foldersCacheKey('/', false));
-        Blink::forget($this->container()->foldersCacheKey($this->path(), true));
-        Blink::forget($this->container()->foldersCacheKey($this->path(), false));
+        $container = $this->container();
+
+        $keys = [
+            $container->foldersCacheKey('/', true),
+            $container->foldersCacheKey('/', false),
+            $container->foldersCacheKey($this->path(), true),
+            $container->foldersCacheKey($this->path(), false),
+        ];
+
+        foreach ($keys as $key) {
+            Cache::forget($key);
+            Blink::forget($key);
+        }
     }
 
     /**

--- a/src/Assets/QueryBuilder.php
+++ b/src/Assets/QueryBuilder.php
@@ -77,6 +77,7 @@ class QueryBuilder extends BaseQueryBuilder implements Contract
         if ($this->hasAnyNulls($items) && $this->limit) {
             Cache::forget($this->container->filesCacheKey());
             Cache::forget($this->container->filesCacheKey($this->folder));
+            \Statamic\Facades\Blink::forget('disk-paths-'.$this->container->handle());
 
             return $this->get($columns);
         }

--- a/src/Assets/QueryBuilder.php
+++ b/src/Assets/QueryBuilder.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Cache;
 use Statamic\Contracts\Assets\AssetContainer;
 use Statamic\Contracts\Assets\QueryBuilder as Contract;
 use Statamic\Facades;
+use Statamic\Facades\Blink;
 use Statamic\Query\IteratorBuilder as BaseQueryBuilder;
 
 class QueryBuilder extends BaseQueryBuilder implements Contract
@@ -77,7 +78,7 @@ class QueryBuilder extends BaseQueryBuilder implements Contract
         if ($this->hasAnyNulls($items) && $this->limit) {
             Cache::forget($this->container->filesCacheKey());
             Cache::forget($this->container->filesCacheKey($this->folder));
-            \Statamic\Facades\Blink::forget('disk-paths-'.$this->container->handle());
+            Blink::forget($this->container->pathsCacheKey());
 
             return $this->get($columns);
         }

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -12,6 +12,7 @@ use Statamic\Assets\AssetContainer;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\AssetFolder;
 use Statamic\Facades;
+use Statamic\Facades\Blink;
 use Statamic\Facades\File;
 use Statamic\Fields\Blueprint;
 use Statamic\Filesystem\Filesystem;
@@ -299,6 +300,7 @@ class AssetContainerTest extends TestCase
         File::shouldReceive('disk')->with('test')->andReturn($disk);
 
         $this->assertFalse(Cache::has($cacheKey = 'asset-files-test-/-recursive'));
+        $this->assertFalse(Blink::has($cacheKey));
 
         $container = (new AssetContainer)->handle('test')->disk('test');
 
@@ -309,11 +311,14 @@ class AssetContainerTest extends TestCase
         $this->assertEquals($expected, $first->all());
         $this->assertEquals($expected, $second->all());
         $this->assertTrue(Cache::has($cacheKey));
+        $this->assertTrue(Blink::has($cacheKey));
 
         Carbon::setTestNow(now()->addSeconds(60));
         $this->assertTrue(Cache::has($cacheKey));
+        $this->assertTrue(Blink::has($cacheKey));
         Carbon::setTestNow(now()->addSeconds(1));
         $this->assertFalse(Cache::has($cacheKey));
+        $this->assertTrue(Blink::has($cacheKey));
     }
 
     /** @test */

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -283,6 +283,7 @@ class AssetContainerTest extends TestCase
     /** @test */
     public function it_gets_the_files_from_the_filesystem_only_once()
     {
+        config(['statamic.assets.cache_listings' => 60]);
         Carbon::setTestNow(now()->startOfMinute());
 
         $disk = $this->mock(Filesystem::class);
@@ -324,6 +325,7 @@ class AssetContainerTest extends TestCase
     /** @test */
     public function it_gets_the_folders_from_the_filesystem_only_once()
     {
+        config(['statamic.assets.cache_listings' => 60]);
         Carbon::setTestNow(now()->startOfMinute());
 
         $disk = $this->mock(Filesystem::class);

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -3,14 +3,18 @@
 namespace Tests\Assets;
 
 use Facades\Statamic\Fields\BlueprintRepository;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Statamic\Assets\Asset;
 use Statamic\Assets\AssetContainer;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\AssetFolder;
 use Statamic\Facades;
+use Statamic\Facades\File;
 use Statamic\Fields\Blueprint;
+use Statamic\Filesystem\Filesystem;
 use Statamic\Filesystem\FlysystemAdapter;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -273,6 +277,48 @@ class AssetContainerTest extends TestCase
         $this->assertEquals([
             'nested/double-nested',
         ], $this->containerWithDisk()->folders('nested', true)->all());
+    }
+
+    /** @test */
+    public function it_gets_the_files_from_the_filesystem_only_once()
+    {
+        Carbon::setTestNow(now()->startOfMinute());
+
+        $disk = $this->mock(Filesystem::class);
+        $disk->shouldReceive('getFiles')
+            ->with('/', true)
+            ->once()
+            ->andReturn(collect([
+                '.meta/one.jpg.yaml',
+                '.DS_Store',
+                '.gitignore',
+                'one.jpg',
+                'two.jpg',
+            ]));
+
+        File::shouldReceive('disk')->with('test')->andReturn($disk);
+
+        $this->assertFalse(Cache::has($cacheKey = 'asset-files-test-/-recursive'));
+
+        $container = (new AssetContainer)->handle('test')->disk('test');
+
+        $first = $container->files();
+        $second = $container->files();
+
+        $expected = ['one.jpg', 'two.jpg'];
+        $this->assertEquals($expected, $first->all());
+        $this->assertEquals($expected, $second->all());
+        $this->assertTrue(Cache::has($cacheKey));
+
+        Carbon::setTestNow(now()->addSeconds(60));
+        $this->assertTrue(Cache::has($cacheKey));
+        Carbon::setTestNow(now()->addSeconds(1));
+        $this->assertFalse(Cache::has($cacheKey));
+    }
+
+    /** @test */
+    public function it_gets_the_folders_from_the_filesystem_only_once()
+    {
     }
 
     /** @test */

--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -152,6 +152,7 @@ class AssetFolderTest extends TestCase
 
         $container = $this->mock(AssetContainer::class);
         $container->shouldReceive('disk')->andReturn($disk = Storage::disk('local'));
+        $container->shouldReceive('foldersCacheKey')->andReturn('irrelevant for test');
 
         $folder = (new Folder)
             ->container($container)

--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -229,6 +229,15 @@ EOT;
         $disk->put('path/to/sub/folder/subdirectory/five.txt', '');
         $this->assertCount(6, $disk->allFiles());
 
+        $this->assertEquals([
+            'path',
+            'path/to',
+            'path/to/folder',
+            'path/to/sub',
+            'path/to/sub/folder',
+            'path/to/sub/folder/subdirectory',
+        ], $container->folders()->all());
+
         $folder = (new Folder)
             ->container($container)
             ->path('path/to/sub/folder');
@@ -237,6 +246,13 @@ EOT;
 
         $this->assertEquals($folder, $return);
         $this->assertEquals(['path/to/folder/one.txt'], $disk->allFiles());
+
+        $this->assertEquals([
+            'path',
+            'path/to',
+            'path/to/folder',
+            'path/to/sub',
+        ], $container->folders()->all());
 
         // TODO: assert about event
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -107,6 +107,10 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             'driver' => 'file',
             'path' => storage_path('framework/cache/outpost-data'),
         ]);
+
+        // It's disabled by default, but we want it enabled in tests so we can make
+        // sure all the moving parts throughout the app still work with it on.
+        $app['config']->set('statamic.assets.cache_listings', true);
     }
 
     protected function assertEveryItem($items, $callback)


### PR DESCRIPTION
Part 4, I think, of multiple, to fix #3216 

This PR aims to reduce S3 API calls when checking for file existence.

Story time.

We check an asset's underlying file exists in order to prevent a situation where you may have requested one that has been deleted or moved.

For example, if you have an `assets` field in an entry, and you pick a few assets, you'll get yaml like this:

```
images:
  - one.jpg
  - two.jpg
  - three
```

If you delete or move two.jpg using the filesystem or the asset browser, the entry doesn't get updated, and will reference an outdated path. When Statamic converts those paths to assets, it will fail on two.jpg. We solved this by checking that each path existed, and filtered it out if it didn't. This came at the cost of API requests on S3.

This PR improves the `$asset->exists()` calls by checking if a path exists in the entire file listing of the container.
This boils down to a single API request to get the directory contents, and no additional ones for each subsequent `exists` check. For the record this idea was @jesseleite 's.

However, when you're dealing with a container with thousands of files, that directory listing API call can still be a few seconds.
So! This PR also adds caching to those listings. It'll cache them for a specified length of time - or forever. That long API call will only happen once. When you do stuff programmatically or within the CP, it'll handle busting those caches. 

```env
STATAMIC_CACHE_ASSET_LISTINGS=false # or a number of seconds, or true for forever
```

The caching is disabled by default so when you're working locally, you can mess with files by hand, but it's potentially a bit slower. Local driver isn't really an issue though. If you're using S3, you can crank up the caching. If you're touching files in s3 manually (for some reason?) then you'll need to bust the cache manually.