### PR TITLE
Add mime type to asset meta

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -28,6 +28,7 @@ use Statamic\Support\Str;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 use Stringy\Stringy;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Mime\MimeTypes;
 
 class Asset implements AssetContract, Augmentable
 {
@@ -166,6 +167,7 @@ class Asset implements AssetContract, Augmentable
                 'last_modified' => $this->disk()->lastModified($this->path()),
                 'width' => $dimensions[0],
                 'height' => $dimensions[1],
+                'mime_type' => $this->disk()->mimeType($this->path()),
             ]);
         }
 
@@ -371,6 +373,26 @@ class Asset implements AssetContract, Augmentable
     public function extension()
     {
         return Path::extension($this->path());
+    }
+
+    /**
+     * Get the extension based on the mime type.
+     *
+     * @return string|null The guessed extension or null if it cannot be guessed
+     */
+    public function guessedExtension()
+    {
+        return MimeTypes::getDefault()->getExtensions($this->mimeType())[0] ?? null;
+    }
+
+    /**
+     * Get the mime type.
+     *
+     * @return string
+     */
+    public function mimeType()
+    {
+        return $this->meta('mime_type');
     }
 
     /**

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -178,7 +178,7 @@ class ImageGenerator
     {
         if ($this->asset) {
             $path = $this->asset->path();
-            $mime = $this->asset->disk()->mimeType($path);
+            $mime = $this->asset->mimeType();
         } else {
             $path = $this->path;
             $mime = File::mimeType(public_path($this->path));

--- a/tests/Assets/AssetRepositoryTest.php
+++ b/tests/Assets/AssetRepositoryTest.php
@@ -35,6 +35,7 @@ size: 723
 last_modified: $timestamp
 width: 30
 height: 60
+mime_type: image/jpeg
 
 EOT;
         $this->assertEquals($contents, $disk->get($path));

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -192,14 +192,6 @@ class AssetTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_the_extension()
-    {
-        $this->assertEquals('jpg', (new Asset)->path('asset.jpg')->extension());
-        $this->assertEquals('txt', (new Asset)->path('asset.txt')->extension());
-        $this->assertNull((new Asset)->path('asset')->extension());
-    }
-
-    /** @test */
     public function it_checks_if_an_extension_matches()
     {
         $asset = (new Asset)->path('asset.jpg');
@@ -207,6 +199,21 @@ class AssetTest extends TestCase
         $this->assertTrue($asset->extensionIsOneof(['jpg']));
         $this->assertTrue($asset->extensionIsOneof(['jpg', 'txt']));
         $this->assertFalse($asset->extensionIsOneof(['txt', 'mp3']));
+    }
+
+    /** @test */
+    public function it_gets_the_extension_guessed_extension_and_mime_type()
+    {
+        Storage::fake('test');
+        Storage::disk('test')->put('.meta/foo.jpeg.yaml', YAML::dump(['mime_type' => 'image/jpeg']));
+
+        $container = Facades\AssetContainer::make('test')->disk('test');
+
+        $asset = (new Asset)->container($container)->path('foo.jpeg');
+
+        $this->assertEquals('image/jpeg', $asset->mimeType());
+        $this->assertEquals('jpg', $asset->guessedExtension());
+        $this->assertEquals('jpeg', $asset->extension());
     }
 
     /** @test */
@@ -348,6 +355,7 @@ class AssetTest extends TestCase
             'last_modified' => Carbon::parse('2012-01-02 4:57pm')->timestamp,
             'width' => 30,
             'height' => 60,
+            'mime_type' => 'image/jpeg',
         ];
 
         $metaWithData = [
@@ -356,6 +364,7 @@ class AssetTest extends TestCase
             'last_modified' => Carbon::parse('2012-01-02 4:57pm')->timestamp,
             'width' => 30,
             'height' => 60,
+            'mime_type' => 'image/jpeg',
         ];
 
         // The meta that's saved to file will also be cached, but will not include in-memory data...
@@ -399,6 +408,7 @@ class AssetTest extends TestCase
             'last_modified' => $timestamp,
             'width' => 30,
             'height' => 60,
+            'mime_type' => 'image/jpeg',
         ];
 
         Storage::disk('test')->put('foo/.meta/image.jpg.yaml', YAML::dump($incompleteMeta));

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -205,15 +205,15 @@ class AssetTest extends TestCase
     public function it_gets_the_extension_guessed_extension_and_mime_type()
     {
         Storage::fake('test');
-        Storage::disk('test')->put('.meta/foo.jpeg.yaml', YAML::dump(['mime_type' => 'image/jpeg']));
+        Storage::disk('test')->put('.meta/foo.m3a.yaml', YAML::dump(['mime_type' => 'audio/mpeg']));
 
         $container = Facades\AssetContainer::make('test')->disk('test');
 
-        $asset = (new Asset)->container($container)->path('foo.jpeg');
+        $asset = (new Asset)->container($container)->path('foo.m3a');
 
-        $this->assertEquals('image/jpeg', $asset->mimeType());
-        $this->assertEquals('jpg', $asset->guessedExtension());
-        $this->assertEquals('jpeg', $asset->extension());
+        $this->assertEquals('audio/mpeg', $asset->mimeType());
+        $this->assertEquals('mp3', $asset->guessedExtension());
+        $this->assertEquals('m3a', $asset->extension());
     }
 
     /** @test */

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -205,15 +205,15 @@ class AssetTest extends TestCase
     public function it_gets_the_extension_guessed_extension_and_mime_type()
     {
         Storage::fake('test');
-        Storage::disk('test')->put('.meta/foo.m3a.yaml', YAML::dump(['mime_type' => 'audio/mpeg']));
+        Storage::disk('test')->put('.meta/foo.mp4a.yaml', YAML::dump(['mime_type' => 'audio/mp4']));
 
         $container = Facades\AssetContainer::make('test')->disk('test');
 
-        $asset = (new Asset)->container($container)->path('foo.m3a');
+        $asset = (new Asset)->container($container)->path('foo.mp4a');
 
-        $this->assertEquals('audio/mpeg', $asset->mimeType());
-        $this->assertEquals('mp3', $asset->guessedExtension());
-        $this->assertEquals('m3a', $asset->extension());
+        $this->assertEquals('audio/mp4', $asset->mimeType());
+        $this->assertEquals('m4a', $asset->guessedExtension());
+        $this->assertEquals('mp4a', $asset->extension());
     }
 
     /** @test */


### PR DESCRIPTION
This PR is another in the #3216 saga.

This adds a `mimeType` method to the Asset class which will read it from the meta instead of needing to read it directly from the file every time.

Because #3280 was implemented, this will lazily insert the mime type into the meta file for existing assets.

Also, for security, we check the mime type before sending an image to Glide. This would be an extra API call to S3 every time. Now that it uses the mimeType method, that API will only be needed once when the meta file is written.