### PR TITLE
Assets + Stache

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -130,22 +130,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Cache Directory Listings
-    |--------------------------------------------------------------------------
-    |
-    | When retrieving the contents of a particular directory, Statamic will
-    | read from disk which will provide the most up to date listings. You
-    | can choose to cache these to reduce overhead, but you will need
-    | to either update the cache manually or use the Control Panel.
-    |
-    | https://statamic.dev/knowledge-base/caching-asset-directory-listings
-    |
-    */
-
-    'cache_listings' => env('STATAMIC_CACHE_ASSET_LISTINGS'),
-
-    /*
-    |--------------------------------------------------------------------------
     | Focal Point Editor
     |--------------------------------------------------------------------------
     |

--- a/config/stache.php
+++ b/config/stache.php
@@ -73,6 +73,10 @@ return [
             'directory' => base_path('content/assets'),
         ],
 
+        'assets' => [
+            'class' => Stores\AssetsStore::class,
+        ],
+
         'users' => [
             'class' => Stores\UsersStore::class,
             'directory' => base_path('users'),

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -747,6 +747,11 @@ class Asset implements AssetContract, Augmentable
         return new AugmentedAsset($this);
     }
 
+    public function defaultAugmentedArrayKeys()
+    {
+        return $this->selectedQueryColumns;
+    }
+
     protected function shallowAugmentedArrayKeys()
     {
         return ['id', 'url', 'permalink', 'api_url'];

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -129,8 +129,8 @@ class Asset implements AssetContract, Augmentable
         }
 
         return $this->meta = Cache::rememberForever($this->metaCacheKey(), function () {
-            if ($this->disk()->exists($path = $this->metaPath())) {
-                return YAML::parse($this->disk()->get($path));
+            if ($contents = $this->disk()->get($this->metaPath())) {
+                return YAML::parse($contents);
             }
 
             $this->writeMeta($meta = $this->generateMeta());

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -11,12 +11,12 @@ use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Data\ContainsData;
 use Statamic\Data\HasAugmentedInstance;
+use Statamic\Data\TracksQueriedColumns;
 use Statamic\Events\AssetDeleted;
 use Statamic\Events\AssetSaved;
 use Statamic\Events\AssetUploaded;
 use Statamic\Facades;
 use Statamic\Facades\AssetContainer as AssetContainerAPI;
-use Statamic\Facades\Blink;
 use Statamic\Facades\Image;
 use Statamic\Facades\Path;
 use Statamic\Facades\URL;
@@ -31,7 +31,7 @@ use Symfony\Component\Mime\MimeTypes;
 
 class Asset implements AssetContract, Augmentable
 {
-    use HasAugmentedInstance, FluentlyGetsAndSets, ContainsData {
+    use HasAugmentedInstance, FluentlyGetsAndSets, TracksQueriedColumns, ContainsData {
         set as traitSet;
         get as traitGet;
         remove as traitRemove;
@@ -41,6 +41,7 @@ class Asset implements AssetContract, Augmentable
     protected $container;
     protected $path;
     protected $meta;
+    protected $original;
 
     public function __construct()
     {
@@ -227,7 +228,9 @@ class Asset implements AssetContract, Augmentable
      */
     public function folder()
     {
-        return pathinfo($this->path())['dirname'];
+        $dirname = pathinfo($this->path())['dirname'];
+
+        return $dirname === '.' ? '/' : $dirname;
     }
 
     /**
@@ -430,6 +433,8 @@ class Asset implements AssetContract, Augmentable
         $this->disk()->delete($this->path());
         $this->disk()->delete($this->metaPath());
 
+        Facades\Asset::delete($this);
+
         $this->clearCaches();
 
         AssetDeleted::dispatch($this);
@@ -442,20 +447,6 @@ class Asset implements AssetContract, Augmentable
      */
     private function clearCaches()
     {
-        $container = $this->container();
-
-        $keys = [
-            $container->filesCacheKey('/', true),
-            $container->filesCacheKey('/', false),
-            $container->filesCacheKey($this->folder(), true),
-            $container->filesCacheKey($this->folder(), false),
-        ];
-
-        foreach ($keys as $key) {
-            Cache::forget($key);
-            Blink::forget($key);
-        }
-
         $this->meta = null;
         Cache::forget($this->metaCacheKey());
     }
@@ -518,8 +509,6 @@ class Asset implements AssetContract, Augmentable
      */
     public function move($folder, $filename = null)
     {
-        Cache::forget($this->container()->filesCacheKey($this->folder()));
-
         $filename = $filename ?: $this->filename();
         $oldPath = $this->path();
         $oldMetaPath = $this->metaPath();
@@ -761,5 +750,19 @@ class Asset implements AssetContract, Augmentable
     protected function shallowAugmentedArrayKeys()
     {
         return ['id', 'url', 'permalink', 'api_url'];
+    }
+
+    public function syncOriginal()
+    {
+        $this->original = [
+            'path' => $this->path,
+        ];
+
+        return $this;
+    }
+
+    public function getOriginal($key = null, $fallback = null)
+    {
+        return Arr::get($this->original, $key, $fallback);
     }
 }

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Statamic\Assets;
+
+use Illuminate\Support\Facades\Cache;
+use League\Flysystem\Util;
+
+class AssetContainerContents
+{
+    protected $container;
+    protected $files;
+
+    public function __construct($container)
+    {
+        $this->container = $container;
+    }
+
+    public function all()
+    {
+        return $this->files = $this->files
+            ?? Cache::remember($this->key(), $this->ttl(), function () {
+                // Use Flysystem directly because it gives us type, timestamps, dirname
+                // and will let us perform more efficient filtering and caching.
+                $files = $this->filesystem()->listContents('/', true);
+
+                return collect($files)->keyBy('path');
+            });
+    }
+
+    public function cached()
+    {
+        return Cache::get($this->key());
+    }
+
+    public function files()
+    {
+        return $this->all()->where('type', 'file');
+    }
+
+    public function directories()
+    {
+        return $this->all()->where('type', 'dir');
+    }
+
+    private function filesystem()
+    {
+        return $this->container->disk()->filesystem()->getDriver();
+    }
+
+    public function save()
+    {
+        Cache::put($this->key(), $this->all(), $this->ttl());
+    }
+
+    public function forget($path)
+    {
+        $this->files = $this->all()->forget($path);
+
+        return $this;
+    }
+
+    public function add($path)
+    {
+        try {
+            // If the file doesn't exist, this will either throw an exception or return
+            // false depending on the adapter and whether or not asserts are enabled.
+            if (! $metadata = $this->filesystem()->getMetadata($path)) {
+                return $this;
+            }
+
+            // Add parent directories
+            if (($dir = dirname($path)) !== '.') {
+                $this->add($dir);
+            }
+
+            $this->files->put($path, $metadata + Util::pathinfo($path));
+        } finally {
+            return $this;
+        }
+    }
+
+    private function key()
+    {
+        return 'asset-list-contents-'.$this->container->handle();
+    }
+
+    private function ttl()
+    {
+        // @deprecated
+        $ttl = config('statamic.assets.file_listing_cache_length', false);
+
+        if (! $ttl) {
+            $ttl = config('statamic.assets.cache_listings', false);
+        }
+
+        if (! $ttl) {
+            return 0;
+        }
+
+        if ($ttl === true) {
+            return null;
+        }
+
+        return $ttl;
+    }
+}

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -86,21 +86,6 @@ class AssetContainerContents
 
     private function ttl()
     {
-        // @deprecated
-        $ttl = config('statamic.assets.file_listing_cache_length', false);
-
-        if (! $ttl) {
-            $ttl = config('statamic.assets.cache_listings', false);
-        }
-
-        if (! $ttl) {
-            return 0;
-        }
-
-        if ($ttl === true) {
-            return null;
-        }
-
-        return $ttl;
+        return config('statamic.stache.watcher') ? 0 : null;
     }
 }

--- a/src/Stache/Indexes/Value.php
+++ b/src/Stache/Indexes/Value.php
@@ -25,8 +25,14 @@ class Value extends Index
             return $item->entriesCount();
         }
 
-        return method_exists($item, $method)
-            ? $item->{$method}()
-            : $item->value($this->name);
+        if (method_exists($item, $method)) {
+            return $item->{$method}();
+        }
+
+        if (method_exists($item, 'value')) {
+            return $item->value($this->name);
+        }
+
+        return $item->get($this->name);
     }
 }

--- a/src/Stache/ServiceProvider.php
+++ b/src/Stache/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Statamic\Stache;
 
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
+use Statamic\Assets\QueryBuilder as AssetQueryBuilder;
 use Statamic\Facades\File;
 use Statamic\Facades\Site;
 use Statamic\Stache\Query\EntryQueryBuilder;
@@ -25,6 +26,10 @@ class ServiceProvider extends LaravelServiceProvider
 
         $this->app->bind(EntryQueryBuilder::class, function () {
             return new EntryQueryBuilder($this->app->make(Stache::class)->store('entries'));
+        });
+
+        $this->app->bind(AssetQueryBuilder::class, function () {
+            return new AssetQueryBuilder($this->app->make(Stache::class)->store('assets'));
         });
     }
 
@@ -53,7 +58,7 @@ class ServiceProvider extends LaravelServiceProvider
         $stores = $nativeStores->merge(collect($published)->diffKeys($nativeStores));
 
         $stores = $stores->map(function ($config) {
-            return app($config['class'])->directory($config['directory']);
+            return app($config['class'])->directory($config['directory'] ?? null);
         });
 
         $stache->registerStores($stores->all());

--- a/src/Stache/Stores/AssetsStore.php
+++ b/src/Stache/Stores/AssetsStore.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Statamic\Stache\Stores;
+
+use Statamic\Facades\AssetContainer;
+
+class AssetsStore extends AggregateStore
+{
+    protected $childStore = ContainerAssetsStore::class;
+
+    public function key()
+    {
+        return 'assets';
+    }
+
+    public function discoverStores()
+    {
+        return AssetContainer::all()->map->handle()->map(function ($handle) {
+            return $this->store($handle);
+        });
+    }
+}

--- a/src/Stache/Stores/BasicStore.php
+++ b/src/Stache/Stores/BasicStore.php
@@ -97,7 +97,7 @@ abstract class BasicStore extends Store
 
     public function delete($item)
     {
-        $item->deleteFile();
+        $this->deleteItemFromDisk($item);
 
         $key = $this->getItemKey($item);
 
@@ -111,5 +111,10 @@ abstract class BasicStore extends Store
     protected function writeItemToDisk($item)
     {
         $item->writeFile();
+    }
+
+    protected function deleteItemFromDisk($item)
+    {
+        $item->deleteFile();
     }
 }

--- a/src/Stache/Stores/ContainerAssetsStore.php
+++ b/src/Stache/Stores/ContainerAssetsStore.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Statamic\Stache\Stores;
+
+use Illuminate\Support\Facades\Cache;
+use Statamic\Facades\AssetContainer;
+use Statamic\Support\Str;
+
+class ContainerAssetsStore extends ChildStore
+{
+    private $container;
+
+    private function container()
+    {
+        return $this->container = $this->container ?? AssetContainer::findByHandle($this->childKey());
+    }
+
+    public function handleFileChanges()
+    {
+        //
+    }
+
+    public function getItem($key)
+    {
+        $path = Str::after($key, '::');
+
+        $asset = $this->container()->makeAsset($path);
+
+        return $asset;
+    }
+
+    public function getItemsFromFiles()
+    {
+        if ($this->shouldCacheFileItems && $this->fileItems) {
+            return $this->fileItems;
+        }
+
+        return $this->fileItems = $this->paths()->map(function ($path) {
+            return $this->getItem($path);
+        });
+    }
+
+    public function paths()
+    {
+        if ($this->paths) {
+            return $this->paths;
+        }
+
+        if ($paths = Cache::get($this->pathsCacheKey())) {
+            return $this->paths = collect($paths);
+        }
+
+        $container = $this->container();
+        $handle = $container->handle();
+
+        $files = $this->getFiles();
+
+        $paths = $files->mapWithKeys(function ($file) use ($handle) {
+            $path = $file['path'];
+
+            return ["$handle::$path" => $path];
+        });
+
+        $this->cachePaths($paths);
+
+        return $paths;
+    }
+
+    private function getFiles()
+    {
+        return $this->container()->listContents()->reject(function ($file) {
+            return $file['type'] !== 'file'
+                || $file['dirname'] === '.meta'
+                || Str::contains($file['path'], '/.meta/')
+                || in_array($file['basename'], ['.gitignore', '.gitkeep', '.DS_Store']);
+        });
+    }
+
+    protected function writeItemToDisk($item)
+    {
+        //
+    }
+
+    protected function deleteItemFromDisk($item)
+    {
+        //
+    }
+}

--- a/src/Stache/Stores/ContainerAssetsStore.php
+++ b/src/Stache/Stores/ContainerAssetsStore.php
@@ -17,7 +17,18 @@ class ContainerAssetsStore extends ChildStore
 
     public function handleFileChanges()
     {
-        //
+        // We only want to act on any file changes one time per store.
+        if ($this->fileChangesHandled) {
+            return;
+        }
+
+        $this->fileChangesHandled = true;
+
+        if (! config('statamic.stache.watcher')) {
+            return;
+        }
+
+        $this->clear();
     }
 
     public function getItem($key)

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\File;
 use Statamic\Facades\Path;
 use Statamic\Stache\Indexes;
+use Statamic\Stache\Indexes\Index;
 
 abstract class Store
 {
@@ -24,7 +25,7 @@ abstract class Store
 
     public function directory($directory = null)
     {
-        if ($directory === null) {
+        if (func_num_args() === 0) {
             return $this->directory;
         }
 

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -99,9 +99,11 @@ abstract class Store
 
     public function cacheIndexUsage($index)
     {
+        $index = $index instanceof Index ? $index->name() : $index;
+
         $indexes = $this->indexUsage();
 
-        if ($indexes->contains($index = $index->name())) {
+        if ($indexes->contains($index)) {
             $this->usedIndexes = $indexes;
 
             return;
@@ -357,6 +359,8 @@ abstract class Store
         Cache::forever($this->pathsCacheKey(), $paths->all());
 
         $this->paths = $paths;
+
+        $this->cacheIndexUsage('path');
     }
 
     protected function clearCachedPaths()
@@ -367,7 +371,7 @@ abstract class Store
 
     protected function pathsCacheKey()
     {
-        return "stache::indexes::{$this->key()}::_paths";
+        return "stache::indexes::{$this->key()}::path";
     }
 
     public function clear()

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -285,7 +285,6 @@ class AssetContainerTest extends TestCase
     /** @test */
     public function it_gets_the_files_from_the_filesystem_only_once()
     {
-        config(['statamic.assets.cache_listings' => 60]);
         Carbon::setTestNow(now()->startOfMinute());
 
         $disk = $this->mock(Filesystem::class);
@@ -315,10 +314,8 @@ class AssetContainerTest extends TestCase
         $this->assertEquals($expected, $second->all());
         $this->assertTrue(Cache::has($cacheKey));
 
-        Carbon::setTestNow(now()->addSeconds(60));
+        Carbon::setTestNow(now()->addYears(5)); // i.e. forever.
         $this->assertTrue(Cache::has($cacheKey));
-        Carbon::setTestNow(now()->addSeconds(1));
-        $this->assertFalse(Cache::has($cacheKey));
     }
 
     /** @test */
@@ -353,7 +350,6 @@ class AssetContainerTest extends TestCase
     /** @test */
     public function it_gets_the_folders_from_the_filesystem_only_once()
     {
-        config(['statamic.assets.cache_listings' => 60]);
         Carbon::setTestNow(now()->startOfMinute());
 
         $disk = $this->mock(Filesystem::class);
@@ -382,10 +378,8 @@ class AssetContainerTest extends TestCase
         $this->assertEquals($expected, $second->all());
         $this->assertTrue(Cache::has($cacheKey));
 
-        Carbon::setTestNow(now()->addSeconds(60));
+        Carbon::setTestNow(now()->addYears(5)); // i.e. forever.
         $this->assertTrue(Cache::has($cacheKey));
-        Carbon::setTestNow(now()->addSeconds(1));
-        $this->assertFalse(Cache::has($cacheKey));
     }
 
     /** @test */

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -335,7 +335,7 @@ class AssetContainerTest extends TestCase
         ]));
 
         $cacheHits = 0;
-        Event::listen(function (CacheHit $event) use (&$cacheHits, $cacheKey) {
+        Event::listen(CacheHit::class, function ($event) use (&$cacheHits, $cacheKey) {
             if ($event->key === $cacheKey) {
                 $cacheHits++;
             }
@@ -401,7 +401,7 @@ class AssetContainerTest extends TestCase
         ]));
 
         $cacheHits = 0;
-        Event::listen(function (CacheHit $event) use (&$cacheHits, $cacheKey) {
+        Event::listen(CacheHit::class, function ($event) use (&$cacheHits, $cacheKey) {
             if ($event->key === $cacheKey) {
                 $cacheHits++;
             }

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Assets;
 
 use Facades\Statamic\Fields\BlueprintRepository;
+use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Statamic\Assets\Asset;
 use Statamic\Assets\AssetContainer;
@@ -287,20 +289,20 @@ class AssetContainerTest extends TestCase
         Carbon::setTestNow(now()->startOfMinute());
 
         $disk = $this->mock(Filesystem::class);
-        $disk->shouldReceive('getFiles')
+        $disk->shouldReceive('filesystem->getDriver->listContents')
             ->with('/', true)
             ->once()
-            ->andReturn(collect([
-                '.meta/one.jpg.yaml',
-                '.DS_Store',
-                '.gitignore',
-                'one.jpg',
-                'two.jpg',
-            ]));
+            ->andReturn([
+                '.meta/one.jpg.yaml' => ['type' => 'file', 'path' => '.meta/one.jpg.yaml', 'basename' => 'one.jpg.yaml'],
+                '.DS_Store' => ['type' => 'file', 'path' => '.DS_Store', 'basename' => '.DS_Store'],
+                '.gitignore' => ['type' => 'file', 'path' => '.gitignore', 'basename' => '.gitignore'],
+                'one.jpg' => ['type' => 'file', 'path' => 'one.jpg', 'basename' => 'one.jpg'],
+                'two.jpg' => ['type' => 'file', 'path' => 'two.jpg', 'basename' => 'two.jpg'],
+            ]);
 
         File::shouldReceive('disk')->with('test')->andReturn($disk);
 
-        $this->assertFalse(Cache::has($cacheKey = 'asset-files-test-/-recursive'));
+        $this->assertFalse(Cache::has($cacheKey = 'asset-list-contents-test'));
         $this->assertFalse(Blink::has($cacheKey));
 
         $container = (new AssetContainer)->handle('test')->disk('test');
@@ -312,14 +314,40 @@ class AssetContainerTest extends TestCase
         $this->assertEquals($expected, $first->all());
         $this->assertEquals($expected, $second->all());
         $this->assertTrue(Cache::has($cacheKey));
-        $this->assertTrue(Blink::has($cacheKey));
 
         Carbon::setTestNow(now()->addSeconds(60));
         $this->assertTrue(Cache::has($cacheKey));
-        $this->assertTrue(Blink::has($cacheKey));
         Carbon::setTestNow(now()->addSeconds(1));
         $this->assertFalse(Cache::has($cacheKey));
-        $this->assertTrue(Blink::has($cacheKey));
+    }
+
+    /** @test */
+    public function it_gets_the_files_from_the_cache_only_once()
+    {
+        $cacheKey = 'asset-list-contents-test';
+
+        Cache::put($cacheKey, collect([
+            '.meta/one.jpg.yaml' => ['type' => 'file', 'path' => '.meta/one.jpg.yaml', 'basename' => 'one.jpg.yaml'],
+            '.DS_Store' => ['type' => 'file', 'path' => '.DS_Store', 'basename' => '.DS_Store'],
+            '.gitignore' => ['type' => 'file', 'path' => '.gitignore', 'basename' => '.gitignore'],
+            'one.jpg' => ['type' => 'file', 'path' => 'one.jpg', 'basename' => 'one.jpg'],
+            'two.jpg' => ['type' => 'file', 'path' => 'two.jpg', 'basename' => 'two.jpg'],
+        ]));
+
+        $cacheHits = 0;
+        Event::listen(function (CacheHit $event) use (&$cacheHits, $cacheKey) {
+            if ($event->key === $cacheKey) {
+                $cacheHits++;
+            }
+        });
+
+        $container = (new AssetContainer)->handle('test')->disk('test');
+
+        $expected = ['one.jpg', 'two.jpg'];
+        $this->assertEquals($expected, $container->files()->all());
+        $this->assertEquals(1, $cacheHits);
+        $this->assertEquals($expected, $container->files()->all());
+        $this->assertEquals(1, $cacheHits);
     }
 
     /** @test */
@@ -329,19 +357,19 @@ class AssetContainerTest extends TestCase
         Carbon::setTestNow(now()->startOfMinute());
 
         $disk = $this->mock(Filesystem::class);
-        $disk->shouldReceive('getFolders')
+        $disk->shouldReceive('filesystem->getDriver->listContents')
             ->with('/', true)
             ->once()
-            ->andReturn(collect([
-                '.meta',
-                'one',
-                'one/.meta',
-                'two',
-            ]));
+            ->andReturn([
+                '.meta' => ['type' => 'dir', 'path' => '.meta', 'basename' => '.meta'],
+                'one' => ['type' => 'dir', 'path' => 'one', 'basename' => 'one'],
+                'one/.meta' => ['type' => 'dir', 'path' => 'one/.meta', 'basename' => '.meta'],
+                'two' => ['type' => 'dir', 'path' => 'two', 'basename' => 'two'],
+            ]);
 
         File::shouldReceive('disk')->with('test')->andReturn($disk);
 
-        $this->assertFalse(Cache::has($cacheKey = 'asset-folders-test-/-recursive'));
+        $this->assertFalse(Cache::has($cacheKey = 'asset-list-contents-test'));
         $this->assertFalse(Blink::has($cacheKey));
 
         $container = (new AssetContainer)->handle('test')->disk('test');
@@ -353,14 +381,45 @@ class AssetContainerTest extends TestCase
         $this->assertEquals($expected, $first->all());
         $this->assertEquals($expected, $second->all());
         $this->assertTrue(Cache::has($cacheKey));
-        $this->assertTrue(Blink::has($cacheKey));
 
         Carbon::setTestNow(now()->addSeconds(60));
         $this->assertTrue(Cache::has($cacheKey));
-        $this->assertTrue(Blink::has($cacheKey));
         Carbon::setTestNow(now()->addSeconds(1));
         $this->assertFalse(Cache::has($cacheKey));
-        $this->assertTrue(Blink::has($cacheKey));
+    }
+
+    /** @test */
+    public function it_gets_the_folders_from_the_cache_and_blink_only_once()
+    {
+        $cacheKey = 'asset-list-contents-test';
+
+        Cache::put($cacheKey, collect([
+            '.meta' => ['type' => 'dir', 'path' => '.meta', 'basename' => '.meta'],
+            'one' => ['type' => 'dir', 'path' => 'one', 'basename' => 'one'],
+            'one/.meta' => ['type' => 'dir', 'path' => 'one/.meta', 'basename' => '.meta'],
+            'two' => ['type' => 'dir', 'path' => 'two', 'basename' => 'two'],
+        ]));
+
+        $cacheHits = 0;
+        Event::listen(function (CacheHit $event) use (&$cacheHits, $cacheKey) {
+            if ($event->key === $cacheKey) {
+                $cacheHits++;
+            }
+        });
+
+        $container = (new AssetContainer)->handle('test')->disk('test');
+
+        $expected = ['one', 'two'];
+        $this->assertEquals($expected, $container->folders()->all());
+        $this->assertEquals(1, $cacheHits);
+        $this->assertEquals($expected, $container->folders()->all());
+        $this->assertEquals(1, $cacheHits);
+
+        // This checks that we're using blink to persist across instances in case the container
+        // was newed up again. If wouldn't persist if we simply put the cache into a property.
+        $anotherInstanceOfTheContainer = (new AssetContainer)->handle('test')->disk('test');
+        $this->assertEquals($expected, $anotherInstanceOfTheContainer->folders()->all());
+        $this->assertEquals(1, $cacheHits);
     }
 
     /** @test */
@@ -466,6 +525,10 @@ class AssetContainerTest extends TestCase
             'root' => __DIR__.'/__fixtures__/container',
         ]]);
 
-        return (new AssetContainer)->handle('test')->disk('test');
+        $container = (new AssetContainer)->handle('test')->disk('test');
+
+        Facades\AssetContainer::shouldReceive('findByHandle')->andReturn($container);
+
+        return $container;
     }
 }

--- a/tests/Assets/AssetRepositoryTest.php
+++ b/tests/Assets/AssetRepositoryTest.php
@@ -6,12 +6,14 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 use Statamic\Assets\AssetRepository;
-use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
+use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class AssetRepositoryTest extends TestCase
 {
+    use PreventSavingStacheItemsToDisk;
+
     /** @test */
     public function it_saves_the_meta_file_to_disk()
     {
@@ -22,8 +24,8 @@ class AssetRepositoryTest extends TestCase
         $realFilePath = Storage::disk('test')->getAdapter()->getPathPrefix().'foo/image.jpg';
         touch($realFilePath, $timestamp = Carbon::now()->subMinutes(3)->timestamp);
 
-        $container = AssetContainer::make('test')->disk('test');
-        $asset = Asset::make()->container($container)->path('foo/image.jpg');
+        $container = tap(AssetContainer::make('test')->disk('test'))->save();
+        $asset = $container->makeAsset('foo/image.jpg');
         $disk->assertMissing('foo/.meta/image.jpg.yaml');
 
         (new AssetRepository)->save($asset);

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -783,7 +783,6 @@ class AssetTest extends TestCase
     /** @test */
     public function it_can_upload_a_file()
     {
-        ray()->clearAll();
         Event::fake();
         $asset = (new Asset)->container($this->container)->path('path/to/asset.jpg');
         Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -12,6 +12,7 @@ use Statamic\Assets\AssetContainer;
 use Statamic\Events\AssetSaved;
 use Statamic\Events\AssetUploaded;
 use Statamic\Facades;
+use Statamic\Facades\File;
 use Statamic\Facades\YAML;
 use Statamic\Fields\Blueprint;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -24,6 +25,11 @@ class AssetTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        // use the file cache driver so we can test that the cached file listings
+        // are coming from the cache and not just the in-memory collection
+        config(['cache.default' => 'file']);
+        Cache::clear();
 
         config(['filesystems.disks.test' => [
             'driver' => 'local',
@@ -177,6 +183,7 @@ class AssetTest extends TestCase
     /** @test */
     public function it_gets_the_folder_name()
     {
+        $this->assertEquals('/', (new Asset)->path('asset.jpg')->folder());
         $this->assertEquals('path/to', (new Asset)->path('path/to/asset.jpg')->folder());
     }
 
@@ -285,7 +292,7 @@ class AssetTest extends TestCase
     }
 
     /** @test */
-    public function it_generates_and_clears_meta_and_filesystem_listing_caches()
+    public function it_generates_and_clears_meta_caches()
     {
         Storage::fake('test');
         Storage::disk('test')->put('foo/test.txt', '');
@@ -294,24 +301,19 @@ class AssetTest extends TestCase
             'size' => 123,
         ]));
 
-        $container = Facades\AssetContainer::make('test')->disk('test');
+        $container = tap(Facades\AssetContainer::make('test')->disk('test'))->save();
         $asset = (new Asset)->container($container)->path('foo/test.txt');
 
         // Caches shouldn't be generated until asked for...
         $this->assertFalse(Cache::has($asset->metaCacheKey()));
-        $this->assertFalse(Cache::has($container->filesCacheKey('foo')));
 
-        // Ask for meta and files to generate caches...
+        // Asking for meta results in it being cached
         $asset->meta();
-        $container->files('foo');
         $this->assertTrue(Cache::has($asset->metaCacheKey()));
-        $this->assertTrue(Cache::has($container->filesCacheKey('foo')));
 
-        // Deleting asset and container should clear caches...
+        // Deleting asset should clear cache
         $asset->delete();
-        $container->delete();
         $this->assertFalse(Cache::has($asset->metaCacheKey()));
-        $this->assertFalse(Cache::has($container->filesCacheKey('foo')));
     }
 
     /** @test */
@@ -347,7 +349,8 @@ class AssetTest extends TestCase
         touch($realFilePath, Carbon::now()->subMinutes(3)->timestamp);
 
         $container = Facades\AssetContainer::make('test')->disk('test');
-        $asset = (new Asset)->container($container)->path('foo/image.jpg')->set('foo', 'bar');
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test')->andReturn($container);
+        $asset = $container->makeAsset('foo/image.jpg')->set('foo', 'bar');
 
         $metaWithoutData = [
             'data' => [],
@@ -452,20 +455,97 @@ class AssetTest extends TestCase
     }
 
     /** @test */
+    public function it_doesnt_add_path_to_container_listing_if_it_doesnt_exist()
+    {
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
+
+        $this->container->makeAsset('one/two/foo.jpg')->save();
+
+        $this->assertEquals([], $this->container->contents()->cached()->keys()->all());
+    }
+
+    /** @test */
+    public function it_doesnt_add_path_to_container_listing_if_it_doesnt_exist_with_asserts_disabled_and_using_local()
+    {
+        // the local adapter doesn't really matter. its just checking that if getMetadata
+        // with asserts disabled returns throws an exception (which local does, but not s3).
+
+        $this->container->disk()->filesystem()->getConfig()->set('disable_asserts', true);
+
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
+
+        $this->container->makeAsset('one/two/foo.jpg')->save();
+
+        $this->assertEquals([], $this->container->contents()->cached()->keys()->all());
+    }
+
+    /** @test */
+    public function it_doesnt_add_path_to_container_listing_if_it_doesnt_exist_with_asserts_disabled_and_using_s3()
+    {
+        // the s3 adapter doesn't really matter. its just checking that if getMetadata
+        // with asserts disabled returns false (which s3 does, but local doesn't).
+
+        // these mocks are ugly but it was simpler than setting up an s3 driver.
+        // we just want to make sure getMetadata returns false.
+        $driver = $this->mock(\League\Flysystem\Filesystem::class);
+        $driver->shouldReceive('listContents')->andReturn([]);
+        $driver->shouldReceive('getMetadata')->andReturnFalse(); // this is the meaningful line
+        $filesystem = $this->mock(\Illuminate\Filesystem\FilesystemAdapter::class);
+        $filesystem->shouldReceive('getDriver')->andReturn($driver);
+        $disk = $this->mock(\Statamic\Filesystem\Filesystem::class);
+        $disk->shouldReceive('filesystem')->andReturn($filesystem);
+        $disk->shouldReceive('put');
+
+        File::shouldReceive('disk')->with('test')->andReturn($disk);
+
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
+
+        $this->container->makeAsset('one/two/foo.jpg')->save();
+
+        $this->assertEquals([], $this->container->contents()->cached()->keys()->all());
+    }
+
+    /** @test */
     public function it_deletes()
     {
         Storage::fake('local');
         $disk = Storage::disk('local');
         $disk->put('path/to/asset.txt', '');
+        $disk->put('path/to/another-asset.txt', '');
         $container = Facades\AssetContainer::make('test')->disk('local');
         Facades\AssetContainer::shouldReceive('save')->with($container);
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test')->andReturn($container);
         $asset = (new Asset)->container($container)->path('path/to/asset.txt');
         $disk->assertExists('path/to/asset.txt');
+        $this->assertEquals([
+            'path/to/another-asset.txt',
+            'path/to/asset.txt',
+        ], $container->files()->all());
+        $this->assertEquals([
+            'path/to/asset.txt' => [],
+            'path/to/another-asset.txt' => [],
+        ], $container->assets('/', true)->keyBy->path()->map(function ($item) {
+            return $item->data()->all();
+        })->all());
 
         $return = $asset->delete();
 
         $this->assertEquals($asset, $return);
         $disk->assertMissing('path/to/asset.txt');
+        $this->assertEquals([
+            'path/to/another-asset.txt',
+        ], $container->files()->all());
+        $this->assertEquals([
+            'path/to/another-asset.txt' => [],
+        ], $container->assets('/', true)->keyBy->path()->map(function ($item) {
+            return $item->data()->all();
+        })->all());
+
+        $this->assertEquals([
+            'path',
+            'path/to',
+            'path/to/another-asset.txt',
+        ], $container->contents()->cached()->keys()->all());
 
         // TODO: Assert about event, or convert to a callback
     }
@@ -479,10 +559,14 @@ class AssetTest extends TestCase
         $disk->put('old/asset.txt', 'The asset contents');
         $container = Facades\AssetContainer::make('test')->disk('local');
         Facades\AssetContainer::shouldReceive('save')->with($container);
-        $asset = (new Asset)->container($container)->path('old/asset.txt')->data(['foo' => 'bar']);
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test')->andReturn($container);
+        $asset = $container->makeAsset('old/asset.txt')->data(['foo' => 'bar']);
         $asset->save();
         $disk->assertExists('old/asset.txt');
         $disk->assertExists('old/.meta/asset.txt.yaml');
+        $this->assertEquals([
+            'old/asset.txt',
+        ], $container->files()->all());
         $this->assertEquals([
             'old/asset.txt' => ['foo' => 'bar'],
         ], $container->assets('/', true)->keyBy->path()->map(function ($item) {
@@ -497,10 +581,18 @@ class AssetTest extends TestCase
         $disk->assertExists('new/asset.txt');
         $disk->assertExists('new/.meta/asset.txt.yaml');
         $this->assertEquals([
+            'new/asset.txt',
+        ], $container->files()->all());
+        $this->assertEquals([
             'new/asset.txt' => ['foo' => 'bar'],
         ], $container->assets('/', true)->keyBy->path()->map(function ($item) {
             return $item->data()->all();
         })->all());
+        $this->assertEquals([
+            'old', // the empty directory doesnt actually get deleted
+            'new',
+            'new/asset.txt',
+        ], $container->contents()->cached()->keys()->all());
         Event::assertDispatched(AssetSaved::class);
     }
 
@@ -512,7 +604,8 @@ class AssetTest extends TestCase
         $disk->put('old/asset.txt', 'The asset contents');
         $container = Facades\AssetContainer::make('test')->disk('local');
         Facades\AssetContainer::shouldReceive('save')->with($container);
-        $asset = (new Asset)->container($container)->path('old/asset.txt')->data(['foo' => 'bar']);
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test')->andReturn($container);
+        $asset = $container->makeAsset('old/asset.txt')->data(['foo' => 'bar']);
         $asset->save();
         $disk->assertExists('old/asset.txt');
         $disk->assertExists('old/.meta/asset.txt.yaml');
@@ -534,6 +627,11 @@ class AssetTest extends TestCase
         ], $container->assets('/', true)->keyBy->path()->map(function ($item) {
             return $item->data()->all();
         })->all());
+        $this->assertEquals([
+            'old', // the empty directory doesnt actually get deleted
+            'new',
+            'new/newfilename.txt',
+        ], $container->contents()->cached()->keys()->all());
     }
 
     /** @test */
@@ -544,10 +642,14 @@ class AssetTest extends TestCase
         $disk->put('old/asset.txt', 'The asset contents');
         $container = Facades\AssetContainer::make('test')->disk('local');
         Facades\AssetContainer::shouldReceive('save')->with($container);
-        $asset = (new Asset)->container($container)->path('old/asset.txt')->data(['foo' => 'bar']);
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test')->andReturn($container);
+        $asset = $container->makeAsset('old/asset.txt')->data(['foo' => 'bar']);
         $asset->save();
         $disk->assertExists('old/asset.txt');
         $disk->assertExists('old/.meta/asset.txt.yaml');
+        $this->assertEquals([
+            'old/asset.txt',
+        ], $container->files()->all());
         $this->assertEquals([
             'old/asset.txt' => ['foo' => 'bar'],
         ], $container->assets('/', true)->keyBy->path()->map(function ($item) {
@@ -562,10 +664,17 @@ class AssetTest extends TestCase
         $disk->assertExists('old/newfilename.txt');
         $disk->assertExists('old/.meta/newfilename.txt.yaml');
         $this->assertEquals([
+            'old/newfilename.txt',
+        ], $container->files()->all());
+        $this->assertEquals([
             'old/newfilename.txt' => ['foo' => 'bar'],
         ], $container->assets('/', true)->keyBy->path()->map(function ($item) {
             return $item->data()->all();
         })->all());
+        $this->assertEquals([
+            'old',
+            'old/newfilename.txt',
+        ], $container->contents()->cached()->keys()->all());
         Event::assertDispatched(AssetSaved::class);
     }
 
@@ -674,15 +783,37 @@ class AssetTest extends TestCase
     /** @test */
     public function it_can_upload_a_file()
     {
+        ray()->clearAll();
         Event::fake();
         $asset = (new Asset)->container($this->container)->path('path/to/asset.jpg');
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
         Storage::disk('test')->assertMissing('path/to/asset.jpg');
+
+        $this->assertEquals([
+        ], $this->container->files()->all());
+        $this->assertEquals([
+        ], $this->container->assets('/', true)->keyBy->path()->map(function ($item) {
+            return $item->data()->all();
+        })->all());
 
         $return = $asset->upload(UploadedFile::fake()->image('asset.jpg'));
 
         $this->assertEquals($asset, $return);
         Storage::disk('test')->assertExists('path/to/asset.jpg');
         $this->assertEquals('path/to/asset.jpg', $asset->path());
+        $this->assertEquals([
+            'path/to/asset.jpg',
+        ], $this->container->files()->all());
+        $this->assertEquals([
+            'path/to/asset.jpg' => [],
+        ], $this->container->assets('/', true)->keyBy->path()->map(function ($item) {
+            return $item->data()->all();
+        })->all());
+        $this->assertEquals([
+            'path',
+            'path/to',
+            'path/to/asset.jpg',
+        ], Cache::get('asset-list-contents-test_container')->keys()->all());
         Event::assertDispatched(AssetUploaded::class, function ($event) use ($asset) {
             return $event->asset = $asset;
         });
@@ -694,7 +825,8 @@ class AssetTest extends TestCase
     {
         Event::fake();
         Carbon::setTestNow(Carbon::createFromTimestamp(1549914700));
-        $asset = (new Asset)->container($this->container)->path('path/to/asset.jpg');
+        $asset = $this->container->makeAsset('path/to/asset.jpg');
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
         Storage::disk('test')->put('path/to/asset.jpg', '');
         Storage::disk('test')->assertExists('path/to/asset.jpg');
 

--- a/tests/Stache/Stores/AssetContainersStoreTest.php
+++ b/tests/Stache/Stores/AssetContainersStoreTest.php
@@ -67,6 +67,9 @@ blueprint: test
 EOL;
         $item = $this->store->makeItemFromFile($this->tempDir.'/example.yaml', $contents);
 
+        // When assets are queried below, it looks for the container.
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('example')->andReturn($item);
+
         $this->assertInstanceOf(AssetContainer::class, $item);
         $this->assertEquals(File::disk('test'), $item->disk());
         $this->assertEquals('example', $item->handle());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -107,10 +107,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             'driver' => 'file',
             'path' => storage_path('framework/cache/outpost-data'),
         ]);
-
-        // It's disabled by default, but we want it enabled in tests so we can make
-        // sure all the moving parts throughout the app still work with it on.
-        $app['config']->set('statamic.assets.cache_listings', true);
     }
 
     protected function assertEveryItem($items, $callback)


### PR DESCRIPTION
Another one to fix #3216 

In #3359 we made the `exists` checks better by instead of actually checking the file for existence, it would grab the directory listing and see if the path was in there. We cached those listings, so every existence check wouldn't result in another API call on S3.

That was good, but it fell apart when uploading assets. The caches are invalidated when you save an asset, so it would cause those listings to be blown away and rebuilt over way too many times and would be slow.

What needed to happen is that when updating an asset, it should update that item in the cache rather than blow the whole thing away.

That's pretty much what the Stache does, so this PR piggybacks off that.

In this PR:
- Adds an assets stache store
- Values get indexed in the stache so better querying can happen - and much faster.
- Added a class that'll track and cache the directory listing
- Asset's folder() method will return / instead of . when they live in the root. Closes #3213 
- Stache paths are stored as if they were an index, which prevents asset meta needing to be loaded for the initial cache build. It also makes all the other stache stores like entries etc just a tad faster.
- Assets search in the CP is snappy.
- Cut down meta file api calls by half. (Just attempt to read the file rather than check it exists first)

It's worth noting that any asset queries that would require the meta file to be loaded (like width, etc) would mean that all the meta files would need to be retrieved. This is still slow (initially). But there's nowhere in the Control Panel that happens yet anyway.