### PR TITLE
Fixes is_external using wrong URL method

### DIFF
--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -64,7 +64,7 @@ class Structure extends Tags
                 'depth'       => $depth,
                 'is_current'  => rtrim(URL::getCurrent(), '/') == rtrim($page->url(), '/'),
                 'is_parent'   => Site::current()->url() === $page->url() ? false : URL::isAncestorOf(URL::getCurrent(), $page->url()),
-                'is_external' => URL::isExternal($page->absoluteUrl()),
+                'is_external' => URL::isExternal($page->url()),
             ]);
         })->filter()->values()->all();
     }


### PR DESCRIPTION
Quick patch, somewhat related to #2825. In Structure.php, I'm 99% sure that `absoluteUrl` is the wrong method to use when determining whether or not a nav entry `is_external`—it will always return true. This PR updates Structure.php to call the `url` method instead. Example below, where _Home_, _About_ and _Contact_ are pages, while _Merch_ is an external link.


```blade
{{ if is_external }} <i class="ml-2 fal fa-external-link"></i> {{ /if }}
```


**Before:**
![image](https://user-images.githubusercontent.com/13950848/111039861-ef4d9f80-83f5-11eb-8797-8db9b5e90017.png)

**After:**
![image](https://user-images.githubusercontent.com/13950848/111039843-d2b16780-83f5-11eb-92cc-8efdd81fb929.png)