### PR TITLE
Fix markdown modifier with custom parser

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1233,7 +1233,7 @@ class CoreModifiers extends Modifier
 
         $parser = $params[0] ?? 'default';
 
-        if (in_array($parser, [true, 'true', ''])) {
+        if (in_array($parser, [true, 'true', ''], true)) {
             $parser = 'default';
         }
 

--- a/tests/Modifiers/MarkdownTest.php
+++ b/tests/Modifiers/MarkdownTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Facades\Markdown;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class MarkdownTest extends TestCase
+{
+    /** @test */
+    public function it_converts_to_markdown()
+    {
+        $markdown = '**bold** ~~strike~~';
+
+        Markdown::extend('custom', function ($parser) {
+            return $parser;
+        });
+
+        // the default parser includes support for strikethrough
+        $this->assertEquals("<p><strong>bold</strong> <del>strike</del></p>\n", $this->modify($markdown));
+        $this->assertEquals("<p><strong>bold</strong> <del>strike</del></p>\n", $this->modify($markdown, 'default'));
+
+        // the custom one doesnt
+        $this->assertEquals("<p><strong>bold</strong> ~~strike~~</p>\n", $this->modify($markdown, 'custom'));
+    }
+
+    /** @test */
+    public function using_an_unknown_parser_throws_exception()
+    {
+        $this->expectExceptionMessage('Markdown parser [foo] is not defined.');
+
+        $this->modify('**words**', 'foo');
+    }
+
+    public function modify($value, $params = [])
+    {
+        return Modify::value($value)->markdown($params)->fetch();
+    }
+}


### PR DESCRIPTION
Hi there 👋 

Just a quick little bug I've noticed.

When creating a custom parser as per the documentation:


```php
Markdown::extend('special', function ($parser) {
    return $parser
        ->withStatamicDefaults()
        ->addExtensions(...);
});
```

And then using this custom parser via the `markdown` modifier:

```html
{{ text | markdown:special }}
```

It always uses the `default` markdown parser no matter what option we provide.

A quick check at the source code and I found that this check:

```php
in_array($parser, [true, 'true', ''])
```

always returns `true` since it does not use strict comparison and `"any_non_empty_string" == true`.

This tiny PR fixes this by making the `in_array` strict.