### PR TITLE
Remove method call on array

### DIFF
--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -106,7 +106,7 @@ class Term implements TermContract
                 return Arr::removeNullValues($item->all());
             })->all();
         }
-        
+
         if (is_array($array)) {
             return $array;
         }

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -106,8 +106,12 @@ class Term implements TermContract
                 return Arr::removeNullValues($item->all());
             })->all();
         }
+        
+        if (is_array($array)) {
+            return $array;
+        }
 
-        return $array;
+        return $array->all();
     }
 
     public function in($site)

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -107,7 +107,7 @@ class Term implements TermContract
             })->all();
         }
 
-        return $array->all();
+        return $array;
     }
 
     public function in($site)


### PR DESCRIPTION
This pull request fixes #3364. 

For some reason, the `all()` method was being called on the `$array` variable (which is an array). I've added some code to check if `$array` is actually an array, if it is, then it will return normally, otherwise it will continue with the `->all()` code.