### PR TITLE
Add option to set custom path to git binary

### DIFF
--- a/config/git.php
+++ b/config/git.php
@@ -22,7 +22,7 @@ return [
     | Git Binary
     |--------------------------------------------------------------------------
     |
-    | By default, Statamic will try to use the "git" command, but you can set 
+    | By default, Statamic will try to use the "git" command, but you can set
     | an absolute path to the git binary if necessary for your environment.
     |
     */

--- a/config/git.php
+++ b/config/git.php
@@ -19,6 +19,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Git Binary
+    |--------------------------------------------------------------------------
+    |
+    | The path to the git binary. By default Statamic will try to use the git
+    | command, but you can set an absolute path to the git binary, if the
+    | command is not available in the php environment.
+    |
+    */
+
+    'binary' => env('STATAMIC_GIT_BINARY', 'git'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Automatically Run
     |--------------------------------------------------------------------------
     |

--- a/config/git.php
+++ b/config/git.php
@@ -22,9 +22,8 @@ return [
     | Git Binary
     |--------------------------------------------------------------------------
     |
-    | The path to the git binary. By default Statamic will try to use the git
-    | command, but you can set an absolute path to the git binary, if the
-    | command is not available in the php environment.
+    | By default, Statamic will try to use the "git" command, but you can set 
+    | an absolute path to the git binary if necessary for your environment.
     |
     */
 

--- a/config/git.php
+++ b/config/git.php
@@ -19,18 +19,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Git Binary
-    |--------------------------------------------------------------------------
-    |
-    | By default, Statamic will try to use the "git" command, but you can set
-    | an absolute path to the git binary if necessary for your environment.
-    |
-    */
-
-    'binary' => env('STATAMIC_GIT_BINARY', 'git'),
-
-    /*
-    |--------------------------------------------------------------------------
     | Automatically Run
     |--------------------------------------------------------------------------
     |
@@ -97,6 +85,18 @@ return [
         resource_path('users'),
         storage_path('forms'),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Git Binary
+    |--------------------------------------------------------------------------
+    |
+    | By default, Statamic will try to use the "git" command, but you can set
+    | an absolute path to the git binary if necessary for your environment.
+    |
+    */
+
+    'binary' => env('STATAMIC_GIT_BINARY', 'git'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Console/Processes/Git.php
+++ b/src/Console/Processes/Git.php
@@ -54,7 +54,7 @@ class Git extends Process
      */
     private function prepareProcessArguments($parts)
     {
-        return collect(['git'])
+        return collect([config('statamic.git.binary')])
             ->merge($parts)
             ->flatten()
             ->reject(function ($part) {


### PR DESCRIPTION
Closes #3392

This is an idea to fix #3392 by making the path to the git binary configurable for a case where the `git` command is not directly available in the environment. Sorry for my bad english in the code comment 🙈 