### PR TITLE
[3.1] Use the config to get the broadcast url rather than a route ...

### DIFF
--- a/src/Providers/BroadcastServiceProvider.php
+++ b/src/Providers/BroadcastServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Providers;
 
-use Illuminate\Broadcasting\BroadcastController;
 use Illuminate\Support\ServiceProvider;
 use Statamic\Statamic;
 
@@ -39,6 +38,6 @@ class BroadcastServiceProvider extends ServiceProvider
 
     protected function authEndpoint()
     {
-        return $this->app['url']->action([BroadcastController::class, 'authenticate']);
+        return config('broadcasting.auth_endpoint', url('/broadcasting/auth'));
     }
 }


### PR DESCRIPTION
If you cache your routes, they get loaded after our broadcast service provider. Closes #3021

We'll use the default hardcoded route of `/broadcasting/auth` which Laravel's `Broadcast::routes()` creates.
If you go custom, you can drop the url into `auth_endpoint` in `config/broadcasting.php`.