### PR TITLE
Improve URL::isExternal()

### DIFF
--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -6,6 +6,7 @@ use Statamic\Data\Services\ContentService;
 use Statamic\Facades\Config;
 use Statamic\Facades\Path;
 use Statamic\Facades\Pattern;
+use Statamic\Facades\Site;
 use Statamic\Support\Str;
 
 /**
@@ -219,9 +220,13 @@ class URL
      */
     public function isExternal($url)
     {
+        if (Str::startsWith($url, '/')) {
+            return false;
+        }
+
         return ! Pattern::startsWith(
             Str::ensureRight($url, '/'),
-            self::prependSiteUrl('/')
+            Site::current()->absoluteUrl()
         );
     }
 

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -8,6 +8,13 @@ use Tests\TestCase;
 
 class UrlTest extends TestCase
 {
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        $app['config']->set('app.url', 'http://absolute-url-resolved-from-request.com');
+    }
+
     public function testBuildsUrl()
     {
         $url = URL::buildFromPath('pages/about/index.md');
@@ -80,6 +87,19 @@ class UrlTest extends TestCase
         $this->assertFalse(URL::isExternal('http://this-site.com'));
         $this->assertFalse(URL::isExternal('http://this-site.com/'));
         $this->assertFalse(URL::isExternal('http://this-site.com/some-slug'));
+        $this->assertFalse(URL::isExternal('/foo'));
+    }
+
+    public function testDeterminesExternalUrlWhenUsingRelativeInConfig()
+    {
+        Site::setConfig('sites.en.url', '/');
+        $this->assertTrue(URL::isExternal('http://that-site.com'));
+        $this->assertTrue(URL::isExternal('http://that-site.com/'));
+        $this->assertTrue(URL::isExternal('http://that-site.com/some-slug'));
+        $this->assertFalse(URL::isExternal('http://absolute-url-resolved-from-request.com'));
+        $this->assertFalse(URL::isExternal('http://absolute-url-resolved-from-request.com/'));
+        $this->assertFalse(URL::isExternal('http://absolute-url-resolved-from-request.com/some-slug'));
+        $this->assertFalse(URL::isExternal('/foo'));
     }
 
     /**


### PR DESCRIPTION
Same as #3397 but retargeted to the 3.0 branch.

- Handle situation when the site url is relative.
- Handle situation where the passed url is relative. If it's relative, it can't be external.

Fixes #2825