### PR TITLE
[3.1] Fix custom logo when using arrays with null

### DIFF
--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -5,8 +5,8 @@
         <button class="nav-toggle md:hidden ml-sm flex-shrink-0" @click="toggleMobileNav" v-else v-cloak aria-label="{{ __('Toggle Mobile Nav') }}">@cp_svg('close')</button>
         <a href="{{ route('statamic.cp.index') }}" class="flex items-end">
             <div v-tooltip="version" class="hidden md:block flex-shrink-0">
-                @if (Statamic::pro() && config('statamic.cp.custom_logo_url'))
-                    <img src="{{ config('statamic.cp.custom_logo_url.nav') ?? config('statamic.cp.custom_logo_url') }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo">
+                @if ($customLogo)
+                    <img src="{{ $customLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo">
                 @else
                     @cp_svg('statamic-wordmark')
                     @if (Statamic::pro())<span class="font-bold text-4xs align-top">PRO</span>@endif

--- a/resources/views/partials/outside-logo.blade.php
+++ b/resources/views/partials/outside-logo.blade.php
@@ -1,6 +1,6 @@
 <div class="logo pt-7">
-    @if (Statamic::pro() && config('statamic.cp.custom_logo_url'))
-        <img src="{{ config('statamic.cp.custom_logo_url.outside') ?? config('statamic.cp.custom_logo_url') }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo">
+    @if ($customLogo)
+        <img src="{{ $customLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo">
     @else
         @cp_svg('statamic-wordmark')
     @endif

--- a/src/Http/View/Composers/CustomLogoComposer.php
+++ b/src/Http/View/Composers/CustomLogoComposer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Statamic\Http\View\Composers;
+
+use Illuminate\View\View;
+use Statamic\Statamic;
+use Statamic\Support\Arr;
+
+class CustomLogoComposer
+{
+    const VIEWS = [
+        'statamic::partials.global-header',
+        'statamic::partials.outside-logo',
+    ];
+
+    public function compose(View $view)
+    {
+        $view->with('customLogo', $this->customLogo($view));
+    }
+
+    protected function customLogo($view)
+    {
+        if (! Statamic::pro()) {
+            return false;
+        }
+
+        $config = config('statamic.cp.custom_logo_url');
+
+        switch ($view->name()) {
+            case 'statamic::partials.outside-logo':
+                $type = 'outside';
+                break;
+            case 'statamic::partials.global-header':
+                $type = 'nav';
+                break;
+            default:
+                $type = 'other';
+        }
+
+        if ($logo = Arr::get($config, $type)) {
+            return $logo;
+        }
+
+        if (! is_array($config)) {
+            return $config;
+        }
+
+        return false;
+    }
+}

--- a/src/Providers/CpServiceProvider.php
+++ b/src/Providers/CpServiceProvider.php
@@ -11,6 +11,7 @@ use Statamic\CP\Utilities\UtilityRepository;
 use Statamic\Extensions\Translation\Loader;
 use Statamic\Extensions\Translation\Translator;
 use Statamic\Facades\User;
+use Statamic\Http\View\Composers\CustomLogoComposer;
 use Statamic\Http\View\Composers\FieldComposer;
 use Statamic\Http\View\Composers\JavascriptComposer;
 use Statamic\Http\View\Composers\NavComposer;
@@ -30,6 +31,7 @@ class CpServiceProvider extends ServiceProvider
         View::composer(SessionExpiryComposer::VIEWS, SessionExpiryComposer::class);
         View::composer(JavascriptComposer::VIEWS, JavascriptComposer::class);
         View::composer(NavComposer::VIEWS, NavComposer::class);
+        View::composer(CustomLogoComposer::VIEWS, CustomLogoComposer::class);
 
         CoreUtilities::boot();
 


### PR DESCRIPTION
Fixes #3394 

Move the now more complicated logic for determining the logo url into a composer, and share it between the two views that need it.