### PR TITLE
Ability to use the same slug in different parts in a structure

### DIFF
--- a/src/Contracts/Entries/EntryRepository.php
+++ b/src/Contracts/Entries/EntryRepository.php
@@ -24,7 +24,7 @@ interface EntryRepository
 
     public function delete($entry);
 
-    public function createRules($collection, $site);
+    public function createRules($collection, $site, $uri, $slug);
 
     public function updateRules($collection, $entry);
 }

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -339,12 +339,13 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
             $prefix = $this->date->format($this->hasTime() ? 'Y-m-d-Hi' : 'Y-m-d').'.';
         }
 
-        return vsprintf('%s/%s/%s%s%s.%s', [
+        return vsprintf('%s/%s/%s%s%s.%s.%s', [
             rtrim(Stache::store('entries')->directory(), '/'),
             $this->collectionHandle(),
             Site::hasMultiple() ? $this->locale().'/' : '',
             $prefix,
             $this->slug(),
+            $this->id(),
             $this->fileExtension(),
         ]);
     }

--- a/src/Facades/Entry.php
+++ b/src/Facades/Entry.php
@@ -16,7 +16,7 @@ use Statamic\Contracts\Entries\EntryRepository;
  * @method static \Statamic\Contracts\Entries\QueryBuilder query()
  * @method static void save($entry)
  * @method static void delete($entry)
- * @method static array createRules($collection, $site)
+ * @method static array createRules($collection, $site, $uri, $slug)
  * @method static array updateRules($collection, $entry)
  *
  * @see \Statamic\Stache\Repositories\EntryRepository

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -302,7 +302,11 @@ class EntriesController extends CpController
 
         $fields = $blueprint->fields()->addValues($data);
 
-        $fields->validate(Entry::createRules($collection, $site));
+        $parentEntryUri = isset($data['parent'][0])
+            ? Entry::find($data['parent'][0])->uri()
+            : null;
+
+        $fields->validate(Entry::createRules($collection, $site, $parentEntryUri, $data['slug']));
 
         $values = $fields->process()->values()->except(['slug', 'date', 'blueprint']);
 

--- a/src/Stache/Repositories/EntryRepository.php
+++ b/src/Stache/Repositories/EntryRepository.php
@@ -99,11 +99,11 @@ class EntryRepository implements RepositoryContract
         });
     }
 
-    public function createRules($collection, $site)
+    public function createRules($collection, $site, $uri, $slug)
     {
         return [
             'title' => 'required',
-            'slug' => 'required|unique_entry_value:'.$collection->handle().',null,'.$site->handle(),
+            'slug' => 'required|unique_entry_value:'.$collection->handle().',null,'.$site->handle().','.$uri.','.$slug,
         ];
     }
 
@@ -111,7 +111,7 @@ class EntryRepository implements RepositoryContract
     {
         return [
             'title' => 'required',
-            'slug' => 'required|alpha_dash|unique_entry_value:'.$collection->handle().','.$entry->id().','.$entry->locale(),
+            'slug' => 'required|alpha_dash|unique_entry_value:'.$collection->handle().','.$entry->id().','.$entry->locale().','.$entry->uri().','.$entry->slug(),
         ];
     }
 

--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -64,6 +64,10 @@ class CollectionEntriesStore extends ChildStore
 
         $slug = pathinfo(Path::clean($path), PATHINFO_FILENAME);
 
+        if (isset($idGenerated) && str_contains($slug, $id)) {
+            $slug = str_replace(".{$id}", '', $slug);
+        }
+
         if ($origin = array_pull($data, 'origin')) {
             $entry->origin($origin);
         }

--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -64,7 +64,7 @@ class CollectionEntriesStore extends ChildStore
 
         $slug = pathinfo(Path::clean($path), PATHINFO_FILENAME);
 
-        if (isset($idGenerated) && str_contains($slug, $id)) {
+        if (isset($id) && str_contains($slug, $id)) {
             $slug = str_replace(".{$id}", '', $slug);
         }
 

--- a/src/Validation/UniqueEntryValue.php
+++ b/src/Validation/UniqueEntryValue.php
@@ -8,7 +8,7 @@ class UniqueEntryValue
 {
     public function validate($attribute, $value, $parameters, $validator)
     {
-        [$collection, $except, $site] = array_pad($parameters, 3, null);
+        [$collection, $except, $site, $uri, $slug] = array_pad($parameters, 5, null);
 
         $query = Entry::query();
 
@@ -18,6 +18,10 @@ class UniqueEntryValue
 
         if ($site) {
             $query->where('site', $site);
+        }
+
+        if ($uri) {
+            $query->where('uri', str_replace($slug, '', $uri));
         }
 
         $existing = $query

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -377,9 +377,9 @@ class EntryTest extends TestCase
         ]]);
 
         $collection = (new Collection)->handle('blog');
-        $entry = (new Entry)->collection($collection)->locale('en')->slug('post');
+        $entry = (new Entry)->id('foo-bar-baz')->collection($collection)->locale('en')->slug('post');
 
-        $this->assertEquals($this->fakeStacheDirectory.'/content/collections/blog/post.md', $entry->path());
+        $this->assertEquals($this->fakeStacheDirectory.'/content/collections/blog/post.foo-bar-baz.md', $entry->path());
         $this->assertEquals($this->fakeStacheDirectory.'/content/collections/blog/2018-01-02.post.md', $entry->date('2018-01-02')->path());
     }
 
@@ -392,9 +392,9 @@ class EntryTest extends TestCase
         ]]);
 
         $collection = (new Collection)->handle('blog');
-        $entry = (new Entry)->collection($collection)->locale('en')->slug('post');
+        $entry = (new Entry)->id('foo-bar-baz')->collection($collection)->locale('en')->slug('post');
 
-        $this->assertEquals($this->fakeStacheDirectory.'/content/collections/blog/en/post.md', $entry->path());
+        $this->assertEquals($this->fakeStacheDirectory.'/content/collections/blog/en/post.foo-bar-baz.md', $entry->path());
         $this->assertEquals($this->fakeStacheDirectory.'/content/collections/blog/en/2018-01-02.post.md', $entry->date('2018-01-02')->path());
     }
 

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -380,7 +380,7 @@ class EntryTest extends TestCase
         $entry = (new Entry)->id('foo-bar-baz')->collection($collection)->locale('en')->slug('post');
 
         $this->assertEquals($this->fakeStacheDirectory.'/content/collections/blog/post.foo-bar-baz.md', $entry->path());
-        $this->assertEquals($this->fakeStacheDirectory.'/content/collections/blog/2018-01-02.post.md', $entry->date('2018-01-02')->path());
+        $this->assertEquals($this->fakeStacheDirectory.'/content/collections/blog/2018-01-02.post.foo-bar-baz.md', $entry->date('2018-01-02')->path());
     }
 
     /** @test */
@@ -395,7 +395,7 @@ class EntryTest extends TestCase
         $entry = (new Entry)->id('foo-bar-baz')->collection($collection)->locale('en')->slug('post');
 
         $this->assertEquals($this->fakeStacheDirectory.'/content/collections/blog/en/post.foo-bar-baz.md', $entry->path());
-        $this->assertEquals($this->fakeStacheDirectory.'/content/collections/blog/en/2018-01-02.post.md', $entry->date('2018-01-02')->path());
+        $this->assertEquals($this->fakeStacheDirectory.'/content/collections/blog/en/2018-01-02.post.foo-bar-baz.md', $entry->date('2018-01-02')->path());
     }
 
     /** @test */

--- a/tests/Feature/Entries/EntryRevisionsTest.php
+++ b/tests/Feature/Entries/EntryRevisionsTest.php
@@ -297,6 +297,7 @@ class EntryRevisionsTest extends TestCase
             ->slug('test')
             ->collection('blog')
             ->published(false)
+            ->date(Carbon::createFromTimestamp('1553546421'))
             ->data([
                 'blueprint' => 'test',
                 'title' => 'Title',

--- a/tests/Stache/FeatureTest.php
+++ b/tests/Stache/FeatureTest.php
@@ -282,7 +282,7 @@ class FeatureTest extends TestCase
             ->data(['title' => 'Test Entry', 'foo' => 'bar'])
         )->save();
 
-        $this->assertFileExists(__DIR__.'/__fixtures__/content/collections/blog/2017-07-04.test-entry.md');
+        $this->assertFileExists(__DIR__.'/__fixtures__/content/collections/blog/2017-07-04.test-entry.123.md');
 
         $entry->delete();
     }

--- a/tests/Stache/Repositories/EntryRepositoryTest.php
+++ b/tests/Stache/Repositories/EntryRepositoryTest.php
@@ -176,7 +176,7 @@ class EntryRepositoryTest extends TestCase
             ->date('2017-07-04')
             ->data(['foo' => 'bar']);
 
-        $this->unlinkAfter($path = $this->directory.'/blog/2017-07-04.test.md');
+        $this->unlinkAfter($path = $this->directory.'/blog/2017-07-04.test.test-blog-entry.md');
 
         $this->assertCount(14, $this->repo->all());
         $this->assertNull($this->repo->find('test-blog-entry'));

--- a/tests/Stache/Repositories/EntryRepositoryTest.php
+++ b/tests/Stache/Repositories/EntryRepositoryTest.php
@@ -202,7 +202,7 @@ class EntryRepositoryTest extends TestCase
             ->date('2017-07-04')
             ->data(['foo' => 'bar']);
 
-        $this->unlinkAfter($path = $this->directory.'/blog/2017-07-04.test.md');
+        $this->unlinkAfter($path = $this->directory.'/blog/2017-07-04.test.test-blog-entry.md');
 
         $this->assertCount(14, $this->repo->all());
         $this->assertNull($this->repo->find('test-blog-entry'));

--- a/tests/Stache/Stores/EntriesStoreTest.php
+++ b/tests/Stache/Stores/EntriesStoreTest.php
@@ -123,7 +123,7 @@ class EntriesStoreTest extends TestCase
 
         $this->parent->store('blog')->save($entry);
 
-        $this->assertFileEqualsString($path = $this->directory.'/blog/2017-07-04.test.md', $entry->fileContents());
+        $this->assertFileEqualsString($path = $this->directory.'/blog/2017-07-04.test.123.md', $entry->fileContents());
         @unlink($path);
         $this->assertFileNotExists($path);
 


### PR DESCRIPTION
This pull request allows for slugs to be the same in different parts of the structure.

The first thing this PR does is appends the entry's ID to the end of the entry filename, eg. `about.c3c9ebc5-4324-4fa2-8871-0b1b9c87ba19.md`. This was a solution pointed out on the original issue (which is linked below). 

However, the only difference is this PR uses the existing ID, instead of a random set of characters like `abc`.

The second thing this PR does is updates the `UniqueEntryValue` validation rule which checks the slug of the entry is unique. Previously it would check the slug against any entries in the collection & site. Now it will check the slug against the collection, site and the URI of where the entry is inside of the structure tree.

I had to add two extra parameters to the `createRules` method so I could pass in the `uri` and `slug` of the newly created entry. This isn't needed for the `updateRules` as it seems already possible to do.

I've tested this PR a bit myself with some use cases I came up but I might have missed something. Feel free to close this if this isn't the way you'd prefer for this to be fixed or if I've overlooked something 😆 

---

Closes #714.