### PR TITLE
`form:create` action and method params

### DIFF
--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -69,8 +69,9 @@ class Tags extends BaseTags
         $knownParams = array_merge(static::HANDLE_PARAM, ['redirect', 'error_redirect', 'allow_request_redirect', 'files']);
 
         $action = $this->params->get('action', route('statamic.forms.submit', $formHandle));
+        $method = $this->params->get('method', 'POST');
 
-        $html = $this->formOpen($action, 'POST', $knownParams);
+        $html = $this->formOpen($action, $method, $knownParams);
 
         $params = [];
 

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -68,7 +68,9 @@ class Tags extends BaseTags
 
         $knownParams = array_merge(static::HANDLE_PARAM, ['redirect', 'error_redirect', 'allow_request_redirect', 'files']);
 
-        $html = $this->formOpen(route('statamic.forms.submit', $formHandle), 'POST', $knownParams);
+        $action = $this->params->get('action', route('statamic.forms.submit', $formHandle));
+
+        $html = $this->formOpen($action, 'POST', $knownParams);
 
         $params = [];
 


### PR DESCRIPTION
Add `action` and method params to `form:create` tag. This is useful for people who want to generate forms off blueprints, but submit to an external form handler, say in the case of an SSG site on netlify, vercel, etc.