### PR TITLE
get defaultPerPageSize from config for Query Builder

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -50,7 +50,7 @@ abstract class Builder implements Contract
 
     protected function defaultPerPageSize()
     {
-        return 15; // TODO get from config.
+        return config('statamic.cp.pagination_size');
     }
 
     public function orderBy($column, $direction = 'asc')


### PR DESCRIPTION
Closing a TODO -- ought to be the right method (testing locally worked as expected) 

Main fix is when using a PageSelector or other relational field type -- the limit is set to 15 which can be hard to use when there are lots of entries to try and select from! 