### PR TITLE
Add markdown option to render form emails

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -77,6 +77,7 @@ return [
     'form_configure_blueprint_instructions' => 'Choose from existing Blueprints or create a new one.',
     'form_configure_email_from_instructions' => 'Leave blank to fall back to the site default',
     'form_configure_email_html_instructions' => 'The view for the html version of this email.',
+    'form_configure_email_markdown_instructions' => 'Render the HTML version of this email using markdown.',
     'form_configure_email_instructions' => 'Configure emails to be sent when new form submission are received.',
     'form_configure_email_reply_to_instructions' => 'Leave blank to fall back to sender.',
     'form_configure_email_subject_instructions' => 'Email subject line.',

--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -74,7 +74,8 @@ class Email extends Mailable
         }
 
         if ($html) {
-            $this->view($html);
+            $method = array_get($this->config, 'markdown') ? 'markdown' : 'view';
+            $this->$method($html);
         }
 
         return $this;

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -147,6 +147,8 @@ class Form implements FormContract, Augmentable
             'title' => $this->title,
             'honeypot' => $this->honeypot,
             'email' => collect($this->email)->map(function ($email) {
+                $email['markdown'] = $email['markdown'] ?: null;
+
                 return Arr::removeNullValues($email);
             })->all(),
             'metrics' => $this->metrics,

--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -256,6 +256,14 @@ class FormsController extends CpController
                                 ],
                             ],
                             [
+                                'handle' => 'markdown',
+                                'field' => [
+                                    'type' => 'toggle',
+                                    'display' => __('Use markdown'),
+                                    'instructions' => __('statamic::messages.form_configure_email_markdown_instructions'),
+                                ],
+                            ],
+                            [
                                 'handle' => 'text',
                                 'field' => [
                                     'type' => 'template',

--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -256,19 +256,19 @@ class FormsController extends CpController
                                 ],
                             ],
                             [
-                                'handle' => 'markdown',
-                                'field' => [
-                                    'type' => 'toggle',
-                                    'display' => __('Use markdown'),
-                                    'instructions' => __('statamic::messages.form_configure_email_markdown_instructions'),
-                                ],
-                            ],
-                            [
                                 'handle' => 'text',
                                 'field' => [
                                     'type' => 'template',
                                     'display' => __('Text view'),
                                     'instructions' => __('statamic::messages.form_configure_email_text_instructions'),
+                                ],
+                            ],
+                            [
+                                'handle' => 'markdown',
+                                'field' => [
+                                    'type' => 'toggle',
+                                    'display' => __('Markdown'),
+                                    'instructions' => __('statamic::messages.form_configure_email_markdown_instructions'),
                                 ],
                             ],
                         ],

--- a/tests/Feature/Forms/UpdateFormTest.php
+++ b/tests/Feature/Forms/UpdateFormTest.php
@@ -68,12 +68,14 @@ class UpdateFormTest extends TestCase
             [
                 'to' => 'john@example.com',
                 'from' => 'jane@example.com',
+                'markdown' => false,
             ],
             [
                 'to' => 'foo@example.com',
                 'from' => 'bar@example.com',
                 'text' => 'emails.contact.text',
                 'html' => 'emails.contact.html',
+                'markdown' => false,
             ],
         ];
 

--- a/tests/Feature/Forms/UpdateFormTest.php
+++ b/tests/Feature/Forms/UpdateFormTest.php
@@ -68,14 +68,12 @@ class UpdateFormTest extends TestCase
             [
                 'to' => 'john@example.com',
                 'from' => 'jane@example.com',
-                'markdown' => false,
             ],
             [
                 'to' => 'foo@example.com',
                 'from' => 'bar@example.com',
                 'text' => 'emails.contact.text',
                 'html' => 'emails.contact.html',
-                'markdown' => false,
             ],
         ];
 


### PR DESCRIPTION
Currently, if you set up a form submission email to use a markdown template, there's no way to indicate that you're using markdown. Through [the mailable's `build` method](https://github.com/statamic/cms/blob/fc4d56dfd426e0d4be42a243743b23450862cc08/src/Forms/Email.php#L30) (and then the `addViews` method), `view` is called instead of `markdown`, which throws an error:

`InvalidArgumentException
No hint path defined for [mail]. (View: C:\xampp\htdocs\statamic-site\resources\views\emails\form-submission.blade.php)`

This PR adds a toggle field in the CP, allowing a user to indicate the HTML template should be rendered using markdown. If the toggle is on, `addViews` will call the `markdown` method. Otherwise, it falls back to the standard `view` method.

This is (very loosely) related to [a small bug I stumbled onto with markdown mail failing to inline styles](https://github.com/statamic/cms/issues/2747#issuecomment-770422141), when there's a naming conflict on the `default.antlers.html` view file.

I realize this PR is 100% unsolicited, so no worries if you decide to scrap this. Seemed to be pretty low-hanging fruit, however, and I thought other folks might want to use markdown for their email notifications. Let me know if you'd like to see any changes, and thanks for your work on a great CMS! 👍 _Replaces #3180, to allow edits by maintainers_ 