### PR TITLE
Add `utf8btoa` to encode utf8 strings

### DIFF
--- a/resources/js/bootstrap/globals.js
+++ b/resources/js/bootstrap/globals.js
@@ -69,3 +69,12 @@ global.__ = function (string, replacements) {
 global.__n = function (string, number, replacements) {
     return translateChoice(string, number, replacements);
 }
+
+global.utf8btoa = function (stringToEncode) {
+    // first we convert it to utf-8
+    const utf8String = encodeURIComponent(stringToEncode)
+      .replace(/%([0-9A-F]{2})/g, (_, code) => String.fromCharCode(`0x${code}`));
+
+    // return base64 encoded string
+    return btoa(utf8String);
+}

--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -52,7 +52,7 @@ export default {
         },
 
         activeFilterParameters() {
-            return btoa(JSON.stringify(this.activeFilters));
+            return utf8btoa(JSON.stringify(this.activeFilters));
         },
 
         additionalParameters() {

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -273,7 +273,7 @@ export default {
         load() {
             this.loading = true;
 
-            const url = cp_url(`assets/${btoa(this.id)}`);
+            const url = cp_url(`assets/${utf8btoa(this.id)}`);
 
             this.$axios.get(url).then(response => {
                 const data = response.data.data;
@@ -321,7 +321,7 @@ export default {
          */
         save() {
             this.saving = true;
-            const url = cp_url(`assets/${btoa(this.id)}`);
+            const url = cp_url(`assets/${utf8btoa(this.id)}`);
 
             this.$axios.patch(url, this.values).then(response => {
                 this.$emit('saved', response.data.asset);

--- a/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
+++ b/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
@@ -85,7 +85,7 @@ export default {
         },
 
         configParameter() {
-            return btoa(JSON.stringify(this.config));
+            return utf8btoa(JSON.stringify(this.config));
         },
 
         site() {

--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -144,7 +144,7 @@ export default {
                 page: this.page,
                 site: this.site,
                 exclusions: this.exclusions,
-                filters: btoa(JSON.stringify(this.activeFilters)),
+                filters: utf8btoa(JSON.stringify(this.activeFilters)),
             }
         },
 

--- a/resources/js/components/publish/FieldMeta.vue
+++ b/resources/js/components/publish/FieldMeta.vue
@@ -58,7 +58,7 @@ export default {
             this.loading = true;
 
             const params = {
-                config: btoa(JSON.stringify(this.config)),
+                config: utf8btoa(JSON.stringify(this.config)),
                 value: this.value,
             };
 

--- a/resources/js/components/structures/PageSelector.vue
+++ b/resources/js/components/structures/PageSelector.vue
@@ -65,7 +65,7 @@ export default {
         },
 
         configParameter() {
-            return btoa(JSON.stringify(this.config));
+            return utf8btoa(JSON.stringify(this.config));
         }
 
     },

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -29,7 +29,7 @@ class AssetsController extends CpController
 
     public function show($asset)
     {
-        $asset = Asset::find(utf8_encode(base64_decode($asset)));
+        $asset = Asset::find(base64_decode($asset));
 
         // TODO: Auth
 
@@ -38,7 +38,7 @@ class AssetsController extends CpController
 
     public function update(Request $request, $asset)
     {
-        $asset = Asset::find(utf8_encode(base64_decode($asset)));
+        $asset = Asset::find(base64_decode($asset));
 
         $this->authorize('edit', $asset);
 


### PR DESCRIPTION
Fixes #1931 
Fixes #2175 
Fixes #2009 

Apparently, [a string in JavaScript is representing in UTF-16 and converting a non-ASCII character using `btoa` will resulting error.](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa#unicode_strings)

There are many places in statamic using `btoa` to encode strings and passing it to the backend.

For example, the field relationship contains following code:
https://github.com/statamic/cms/blob/de8b1847243ca3ccb46f7b98d54ce82aa78ff309/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue#L87-L89

If there are any non-ASCII character in `this.config`, for example, someone might decide to use a fancy Emoji inside their field name, the field will just stop working.


![CleanShot 2021-03-25 at 05 14 19](https://user-images.githubusercontent.com/67255597/112384128-001ce000-8d29-11eb-852c-d8cf328124bc.png)

AFAIK, these encoded string will be (and only be) decoded by the backend, which is using `base64_decode` in PHP. To be able to decode on the PHP side, we can just convert the string into UTF-8.

Reference: https://stackoverflow.com/a/30106551