### PR TITLE
Replace `_` to `-` in locale for vCalendar

### DIFF
--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -23,7 +23,7 @@
                     :popover="{ visibility: 'click' }"
                     :class="{'input-text border border-grey-50 border-l-0': !config.inline }"
                     :attributes="attrs"
-                    :locale="$config.get('locale')"
+                    :locale="$config.get('locale').replace('_', '-')"
                     :formats="formats"
                     :mode="config.mode"
                     :input="value"


### PR DESCRIPTION
[vCalendar is using `-` instead of `_` in their locale](https://github.com/nathanreyes/v-calendar/blob/07e676e0ee5e08f5c10addabd85decb7aaa3b313/src/utils/defaults/locales.js)

People using `de_CH` and `zh_TW` will be affected. They won't be able to see the date picker.