### PR TITLE
Reset the callbacks after running them ...

### DIFF
--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -261,6 +261,8 @@ class Statamic
         foreach (static::$bootedCallbacks as $callback) {
             $callback();
         }
+
+        static::$bootedCallbacks = [];
     }
 
     public static function afterInstalled(Closure $callback)
@@ -273,6 +275,8 @@ class Statamic
         foreach (static::$afterInstalledCallbacks as $callback) {
             $callback($command);
         }
+
+        static::$afterInstalledCallbacks = [];
     }
 
     public static function repository($abstract, $concrete)


### PR DESCRIPTION
When running tests, they stack up between each test, causing an "Target class [config] does not exist" error when using addons.

This should probably be moved from static arrays to something in the container, but this will do for now.