### PR TITLE
Action routes and glide should not be disabled

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -30,8 +30,6 @@ if (config('statamic.cp.enabled')) {
     });
 }
 
-if (config('statamic.routes.enabled')) {
-    Route::middleware(config('statamic.routes.middleware', 'web'))
-        ->namespace('Statamic\Http\Controllers')
-        ->group(__DIR__.'/web.php');
-}
+Route::middleware(config('statamic.routes.middleware', 'web'))
+    ->namespace('Statamic\Http\Controllers')
+    ->group(__DIR__.'/web.php');

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,12 +53,14 @@ Route::name('statamic.')->group(function () {
     }
 });
 
-Statamic::additionalWebRoutes();
+if (config('statamic.routes.enabled')) {
+    Statamic::additionalWebRoutes();
 
-/**
- * Front-end
- * All front-end website requests go through a single controller method.
- */
-Route::any('/{segments?}', 'FrontendController@index')
-    ->where('segments', '.*')
-    ->name('statamic.site');
+    /*
+     * Front-end
+     * All front-end website requests go through a single controller method.
+     */
+    Route::any('/{segments?}', 'FrontendController@index')
+        ->where('segments', '.*')
+        ->name('statamic.site');
+}


### PR DESCRIPTION
When setting `'enabled' => false` in `config/statamic/routes.php` to enable "headless" mode, we were preventing all non-cp routes from being loaded.

This PR changes it so that only the real "web" routes are disabled.

Action routes (necessary for non-CP functionality like password resets, and form submissions) and Glide routes will remain enabled.

Fixes #3444