### PR TITLE
Adjust taxonomy uri, url, and supplemental data.

### DIFF
--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -237,7 +237,12 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
 
     public function url()
     {
-        return URL::tidy(Site::current()->url().$this->uri());
+        return URL::makeRelative($this->absoluteUrl());
+    }
+
+    public function absoluteUrl()
+    {
+        return URL::tidy(Site::current()->absoluteUrl().$this->uri());
     }
 
     public function uri()
@@ -245,6 +250,11 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
         $site = Site::current();
 
         $prefix = $this->collection() ? $this->collection()->uri($site->handle()) : $site->url();
+
+        // If the site's url was defined absolutely, it'll be absolute.
+        // We need it relative. Perhaps the url method should return
+        // a relative url already, but that's a problem for later.
+        $prefix = URL::makeRelative($prefix);
 
         return URL::tidy($prefix.str_replace('_', '-', '/'.$this->handle));
     }
@@ -332,6 +342,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
             'handle' => $this->handle(),
             'uri' => $this->uri(),
             'url' => $this->url(),
+            'permalink' => $this->absoluteUrl(),
         ], $this->supplements->all());
     }
 }

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Statamic\Contracts\Data\Augmentable as AugmentableContract;
 use Statamic\Contracts\Taxonomies\Taxonomy as Contract;
 use Statamic\Data\ContainsCascadingData;
+use Statamic\Data\ContainsSupplementalData;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Data\HasAugmentedData;
 use Statamic\Events\TaxonomyDeleted;
@@ -17,12 +18,13 @@ use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
+use Statamic\Facades\URL;
 use Statamic\Statamic;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class Taxonomy implements Contract, Responsable, AugmentableContract
 {
-    use FluentlyGetsAndSets, ExistsAsFile, HasAugmentedData, ContainsCascadingData;
+    use FluentlyGetsAndSets, ExistsAsFile, HasAugmentedData, ContainsCascadingData, ContainsSupplementalData;
 
     protected $handle;
     protected $title;
@@ -36,6 +38,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
     public function __construct()
     {
         $this->cascade = collect();
+        $this->supplements = collect();
     }
 
     public function id()
@@ -232,9 +235,18 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
             ->args(func_get_args());
     }
 
+    public function url()
+    {
+        return URL::tidy(Site::current()->url().$this->uri());
+    }
+
     public function uri()
     {
-        return str_replace('_', '-', '/'.$this->handle);
+        $site = Site::current();
+
+        $prefix = $this->collection() ? $this->collection()->uri($site->handle()) : $site->url();
+
+        return URL::tidy($prefix.str_replace('_', '-', '/'.$this->handle));
     }
 
     public function collection($collection = null)
@@ -315,9 +327,11 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
 
     public function augmentedArrayData()
     {
-        return [
+        return array_merge([
             'title' => $this->title(),
             'handle' => $this->handle(),
-        ];
+            'uri' => $this->uri(),
+            'url' => $this->url(),
+        ], $this->supplements->all());
     }
 }

--- a/tests/Data/Taxonomies/TaxonomyTest.php
+++ b/tests/Data/Taxonomies/TaxonomyTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Data\Taxonomies;
 
 use Facades\Statamic\Fields\BlueprintRepository;
+use Statamic\Contracts\Entries\Entry as EntryContract;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
 use Statamic\Fields\Blueprint;
 use Statamic\Taxonomies\Taxonomy;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -96,5 +99,32 @@ class TaxonomyTest extends TestCase
 
         $this->assertEquals($blueprint, $taxonomy->termBlueprint('tags'));
         $this->assertNull($taxonomy->termBlueprint('two'));
+    }
+
+    /** @test */
+    public function it_gets_the_url()
+    {
+        $taxonomy = (new Taxonomy)->handle('tags');
+
+        $this->assertEquals('/tags', $taxonomy->uri());
+        $this->assertEquals('/tags', $taxonomy->url());
+        $this->assertEquals('http://localhost/tags', $taxonomy->absoluteUrl());
+    }
+
+    /** @test */
+    public function it_gets_the_url_with_a_collection()
+    {
+        $entry = $this->mock(EntryContract::class);
+        $entry->shouldReceive('in')->andReturnSelf();
+        $entry->shouldReceive('uri')->andReturn('/blog');
+        Entry::shouldReceive('find')->with('blog-page')->andReturn($entry);
+
+        $collection = tap(Collection::make('blog')->mount('blog-page'))->save();
+
+        $taxonomy = (new Taxonomy)->handle('tags')->collection($collection);
+
+        $this->assertEquals('/blog/tags', $taxonomy->uri());
+        $this->assertEquals('/blog/tags', $taxonomy->url());
+        $this->assertEquals('http://localhost/blog/tags', $taxonomy->absoluteUrl());
     }
 }

--- a/tests/Stache/Repositories/EntryRepositoryTest.php
+++ b/tests/Stache/Repositories/EntryRepositoryTest.php
@@ -12,6 +12,7 @@ use Statamic\Stache\Stores\CollectionsStore;
 use Statamic\Stache\Stores\CollectionTreeStore;
 use Statamic\Stache\Stores\EntriesStore;
 use Statamic\Stache\Stores\NavigationStore;
+use Statamic\Stache\Stores\TaxonomiesStore;
 use Tests\TestCase;
 use Tests\UnlinksPaths;
 
@@ -31,6 +32,7 @@ class EntryRepositoryTest extends TestCase
             (new EntriesStore($this->stache, app('files')))->directory($this->directory),
             (new NavigationStore($this->stache, app('files')))->directory(__DIR__.'/../__fixtures__/content/navigation'),
             (new CollectionTreeStore($this->stache, app('files')))->directory(__DIR__.'/../__fixtures__/content/structures/collections'),
+            (new TaxonomiesStore($this->stache, app('files')))->directory(__DIR__.'/../__fixtures__/content/taxonomies'),
         ]);
 
         $this->repo = new EntryRepository($this->stache);

--- a/tests/Stache/__fixtures__/content/collections/blog.yaml
+++ b/tests/Stache/__fixtures__/content/collections/blog.yaml
@@ -1,2 +1,4 @@
 title: Blog
 date: true
+taxonomies:
+  - tags


### PR DESCRIPTION
This PR adds support for a taxonomy instance to have a url and supplemental data.
Both are needed in order for the nav:breadcrumbs tag to work on a taxonomy's url as outlined in #1776.

It also makes the uri/url adjust itself based on whether the instance is connected to a collection.
e.g. `/tags` vs. `/blog/tags`

Fixes #1776 