### PR TITLE
GlideController now returns 404 for non-existing images

### DIFF
--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -115,7 +115,7 @@ class GlideController extends Controller
         try {
             return $this->generator->$method($item, $this->request->all());
         } catch (FileNotFoundException $e) {
-            abort(404);
+            throw new NotFoundHttpException;
         }
     }
 

--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -7,6 +7,7 @@ use League\Flysystem\FileNotFoundException;
 use League\Glide\Server;
 use League\Glide\Signatures\SignatureException;
 use League\Glide\Signatures\SignatureFactory;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Config;
@@ -97,6 +98,8 @@ class GlideController extends Controller
         [$container, $path] = explode('/', $decoded, 2);
 
         $asset = AssetContainer::find($container)->asset($path);
+
+        throw_unless($asset, new NotFoundHttpException);
 
         return $this->createResponse($this->generateBy('asset', $asset));
     }

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -4,6 +4,7 @@ namespace Statamic\Imaging;
 
 use GuzzleHttp\Client;
 use League\Flysystem\Adapter\Local;
+use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Filesystem;
 use League\Glide\Server;
 use Statamic\Events\GlideImageGenerated;
@@ -181,7 +182,11 @@ class ImageGenerator
             $mime = $this->asset->mimeType();
         } else {
             $path = $this->path;
-            $mime = File::mimeType(public_path($this->path));
+            try {
+                $mime = File::mimeType(public_path($this->path));
+            } catch (\Exception $e) {
+                throw new FileNotFoundException($path);
+            }
         }
 
         if ($mime !== null && strncmp($mime, 'image/', 6) !== 0) {

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -4,7 +4,7 @@ namespace Statamic\Imaging;
 
 use GuzzleHttp\Client;
 use League\Flysystem\Adapter\Local;
-use League\Flysystem\FileNotFoundException;
+use League\Flysystem\FileNotFoundException as FlysystemFileNotFoundException;
 use League\Flysystem\Filesystem;
 use League\Glide\Server;
 use Statamic\Events\GlideImageGenerated;
@@ -182,11 +182,8 @@ class ImageGenerator
             $mime = $this->asset->mimeType();
         } else {
             $path = $this->path;
-            try {
-                $mime = File::mimeType(public_path($this->path));
-            } catch (\Exception $e) {
-                throw new FileNotFoundException($path);
-            }
+            throw_unless(File::exists($path), new FlysystemFileNotFoundException($path));
+            $mime = File::mimeType(public_path($this->path));
         }
 
         if ($mime !== null && strncmp($mime, 'image/', 6) !== 0) {

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -6,8 +6,10 @@ use GuzzleHttp\Client;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\FileNotFoundException as FlysystemFileNotFoundException;
 use League\Flysystem\Filesystem;
+use League\Glide\Filesystem\FileNotFoundException as GlideFileNotFoundException;
 use League\Glide\Server;
 use Statamic\Events\GlideImageGenerated;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Config;
 use Statamic\Facades\File;
 
@@ -144,7 +146,11 @@ class ImageGenerator
             $this->validateImage();
         }
 
-        $path = $this->server->makeImage($image, $this->params);
+        try {
+            $path = $this->server->makeImage($image, $this->params);
+        } catch (GlideFileNotFoundException $e) {
+            throw new NotFoundHttpException;
+        }
 
         GlideImageGenerated::dispatch($path, $this->params);
 


### PR DESCRIPTION
Fixes #3070.

I used a `try/catch` here instead of a `File::exists()` call for performance reasons.
