### PR TITLE
Recognise tag pairs correctly for a collection alias

### DIFF
--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -79,7 +79,7 @@ class Parser
         $this->variableTagRegex = '/{{\s*('.$this->looseVariableRegex.')\s*}}/m';
 
         // Matches the callback handle for a matching tag pair, captures the contents, and ignores the parameters.
-        // We assume it's a callback because the of the matching tag pair, no modifiers and lack of "?" in the expression.
+        // We assume it's a callback because the of the matching tag pair, no pipe modifiers, and lack of "?" in the expression.
         $this->callbackBlockRegex = '/{{\s*('.$this->variableRegex.')(?!\s*\|)(?:\s([^?]*?))}}(.*?){{\s*\/\1\s*}}/ms';
 
         // Matches a recursive children loop.

--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -79,8 +79,8 @@ class Parser
         $this->variableTagRegex = '/{{\s*('.$this->looseVariableRegex.')\s*}}/m';
 
         // Matches the callback handle for a matching tag pair, captures the contents, and ignores the parameters.
-        // We assume it's a callback because the of the matching tag pair and lack of "?" in the expression.
-        $this->callbackBlockRegex = '/{{\s*('.$this->variableRegex.')(?:\s([^?]*?))}}(.*?){{\s*\/\1\s*}}/ms';
+        // We assume it's a callback because the of the matching tag pair, no modifiers and lack of "?" in the expression.
+        $this->callbackBlockRegex = '/{{\s*('.$this->variableRegex.')(?!\s*\|)(?:\s([^?]*?))}}(.*?){{\s*\/\1\s*}}/ms';
 
         // Matches a recursive children loop.
         $this->recursiveRegex = '/{{\s*\*recursive\s*('.$this->variableRegex.')\*\s*}}/ms';

--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -2020,6 +2020,18 @@ EOT;
             'test' => 'price:desc',
         ]));
     }
+
+    /**
+     * @test
+     * @see https://github.com/statamic/cms/issues/3374
+     **/
+    public function it_parses_single_and_tag_pairs_with_modifiers()
+    {
+        $data = ['items' => ['one', 'two', 'three']];
+
+        $this->assertEquals('<one><two>3', $this->parse('{{ items limit="2" }}<{{ value }}>{{ /items }}{{ items | count }}', $data));
+        $this->assertEquals('3<one><two>', $this->parse('{{ items | count }}{{ items limit="2" }}<{{ value }}>{{ /items }}', $data));
+    }
 }
 
 class NonArrayableObject


### PR DESCRIPTION
Fixes #3374.

See [this comment](https://github.com/statamic/cms/issues/3374#issuecomment-811447899) for the rationale behind it.