### PR TITLE
Don’t delete extractions after use

### DIFF
--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -1140,7 +1140,6 @@ class Parser
             foreach ($this->extractions[$type] as $hash => $replacement) {
                 if (strpos($text, "{$type}_{$hash}") !== false) {
                     $text = str_replace("{$type}_{$hash}", $replacement, $text);
-                    unset($this->extractions[$type][$hash]);
                 }
             }
         }


### PR DESCRIPTION
Trying to fix #3381 here.

Right now this PR would fix cases like the first example in the issue, where a tag is used twice in a condition:

```{{ if collection:handle === "news" || collection:handle === "services" }}```

It does so by remembering the 'extractions' after use (they we're deleted for performance reasons I guess).

The recommended syntax is still not working though:

```{{ if {collection:handle} === "news" }}```

And this is also still failing:

```{{ if collection:handle === "news" || collection:title === "services" }}```