### PR TITLE
Honeypot

### DIFF
--- a/src/Forms/AugmentedForm.php
+++ b/src/Forms/AugmentedForm.php
@@ -3,11 +3,18 @@
 namespace Statamic\Forms;
 
 use Statamic\Data\AbstractAugmented;
+use Statamic\Statamic;
 
 class AugmentedForm extends AbstractAugmented
 {
     public function keys()
     {
-        return ['handle', 'title', 'fields', 'api_url'];
+        $keys = ['handle', 'title', 'fields', 'api_url'];
+
+        if (! Statamic::isApiRoute()) {
+            $keys[] = 'honeypot';
+        }
+
+        return $keys;
     }
 }

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -59,6 +59,7 @@ class Tags extends BaseTags
 
         $data = $this->getFormSession($sessionHandle);
         $data['fields'] = $this->getFields($sessionHandle);
+        $data['honeypot'] = $form->honeypot();
 
         $this->addToDebugBar($data, $formHandle);
 


### PR DESCRIPTION
This PR adds the `honeypot` variable inside `form:create` tags so you can do this:

```
{{ form:create in="contact" }}
   ...
   {{ honeypot }} // outputs honeypot, fax, url - whatever you've defined.
   ...
{{ /form:create }}
```

as well as inside the augmented form object:

``` yaml
myform: contact
```

```
{{ myform }}
  {{ handle }}
  {{ honeypot }}
{{ /myform }}
```

and with the shorthand:

```
{{ myform:honeypot }}
```

It will **not** add it to API responses.

Closes #3449 