### PR TITLE
Fix symfony/var-exporter allowed versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "statamic/stringy": "^3.1",
         "symfony/http-foundation": "^4.3.3 || ^5.1.4",
         "symfony/lock": "^5.1",
-        "symfony/var-exporter": "^4.3",
+        "symfony/var-exporter": "^4.3 || ^5.1",
         "symfony/yaml": "^4.1 || ^5.1",
         "ueberdosis/html-to-prosemirror": "^1.3",
         "ueberdosis/prosemirror-to-html": "^2.2",


### PR DESCRIPTION
This one fixes the problem with the version of `symfony/var-exporter` dependency which occurs when you try to install in a project that has that package on version > 5.

See this composer error for more information:
```
Problem 1
    - statamic/cms[v3.1.0-alpha.1, ..., 3.1.x-dev] require symfony/var-exporter
^4.3 -> found symfony/var-exporter[v4.3.0-BETA1, ..., 4.4.x-dev] but the package
 is fixed to v5.2.3 (lock file version) by a partial update and that version doe
s not match. Make sure you list it as an argument for the update command.
```

Fixes #2263.