### PR TITLE
Bard links

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -76,7 +76,7 @@
             </editor-floating-menu>
 
             <editor-content :editor="editor" v-show="!showSource" :id="fieldId" />
-            <bard-source :html="html" v-if="showSource" />
+            <bard-source :html="htmlWithReplacedLinks" v-if="showSource" />
         </div>
         <div class="bard-footer-toolbar" v-if="config.reading_time">
             {{ readingTime }} {{ __('Reading Time') }}
@@ -219,6 +219,12 @@ export default {
 
             return this.$store.state.publish[this.storeName].site;
         },
+
+        htmlWithReplacedLinks() {
+            return this.html.replaceAll(/\"statamic:\/\/(.*)\"/g, (match, ref) => {
+                return `"${this.meta.linkData[ref].permalink}"`;
+            });
+        }
 
     },
 

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -212,7 +212,13 @@ export default {
             });
 
             return indexes;
-        }
+        },
+
+        site() {
+            if (! this.storeName) return this.$config.get('selectedSite');
+
+            return this.$store.state.publish[this.storeName].site;
+        },
 
     },
 

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -35,6 +35,7 @@
                     :filters-url="filtersUrl"
                     :columns="[{ label: __('Title'), field: 'title' }]"
                     :max-items="1"
+                    :site="bard.site"
                     @item-data-updated="relationshipItemDataUpdated"
                 />
                 <button @click="edit" v-tooltip="__('Edit Link')" v-show="!isEditing">

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -158,6 +158,11 @@ export default {
         this.bard.$on('link-deselected', () => this.$emit('deselected'));
     },
 
+    beforeDestroy() {
+        this.bard.$off('link-selected');
+        this.bard.$off('link-deselected');
+    },
+
     methods: {
 
         edit() {

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -25,7 +25,7 @@
                     <div
                         v-show="isInternalLink"
                         v-text="actualLinkText"
-                        class="flex-1 input h-auto cursor-not-allowed"
+                        class="flex-1 input whitespace-no-wrap overflow-hidden text-overflow-ellipsis h-auto cursor-not-allowed"
                     />
                 </div>
             </div>

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -58,9 +58,9 @@
                 </button>
             </div>
         </div>
-        <div class="p-sm pt-1 border-t border-faint-white" v-show="isEditing">
-            <label class="text-2xs text-white flex items-center">
-                <input class="checkbox mr-1 -mt-sm" type="checkbox" v-model="targetBlank">
+        <div class="p-sm pt-1 border-t" v-show="isEditing">
+            <label class="text-2xs flex items-center">
+                <input class="checkbox mr-1" type="checkbox" v-model="targetBlank">
                 {{ __('Open in new window') }}
             </label>
         </div>

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -133,7 +133,7 @@ export default {
         },
 
         collections() {
-            return this.bard.meta.link_collections;
+            return this.bard.meta.linkCollections;
         }
 
     },

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -24,8 +24,24 @@
                 </div>
             </div>
             <div class="bard-link-toolbar-buttons">
+                <relationship-input
+                    class="hidden"
+                    ref="relationshipInput"
+                    name="link"
+                    :value="[]"
+                    :config="relationshipConfig"
+                    :item-data-url="itemDataUrl"
+                    :selections-url="selectionsUrl"
+                    :filters-url="filtersUrl"
+                    :columns="[{ label: __('Title'), field: 'title' }]"
+                    :max-items="1"
+                    @item-data-updated="relationshipItemDataUpdated"
+                />
                 <button @click="edit" v-tooltip="__('Edit Link')" v-show="!isEditing">
                     <span class="icon icon-pencil" />
+                </button>
+                <button @click="openSelector" v-tooltip="`${__('Browse')}...`" v-show="isEditing">
+                    <span class="icon icon-magnifying-glass" />
                 </button>
                 <button @click="remove" v-tooltip="__('Remove Link')" v-show="hasLink && isEditing">
                     <span class="icon icon-trash" />
@@ -46,6 +62,8 @@
 </template>
 
 <script>
+import qs from 'qs';
+
 export default {
 
     props: {
@@ -80,6 +98,42 @@ export default {
         actualLinkText() {
             return this.isInternalLink ? this.internalLink.text : this.linkAttrs.href;
         },
+
+        relationshipConfig() {
+            return {
+                type: 'entries',
+                collections: this.collections,
+                max_items: 1,
+            };
+        },
+
+        itemDataUrl() {
+            return cp_url('fieldtypes/relationship/data') + '?' + qs.stringify({
+                config: this.configParameter
+            });
+        },
+
+        selectionsUrl() {
+            return cp_url('fieldtypes/relationship') + '?' + qs.stringify({
+                config: this.configParameter,
+                collections: this.collections,
+            });
+        },
+
+        filtersUrl() {
+            return cp_url('fieldtypes/relationship/filters') + '?' + qs.stringify({
+                config: this.configParameter,
+                collections: this.collections,
+            });
+        },
+
+        configParameter() {
+            return utf8btoa(JSON.stringify(this.relationshipConfig));
+        },
+
+        collections() {
+            return ['pages'];
+        }
 
     },
 
@@ -140,6 +194,18 @@ export default {
                         'https://' + str :
                             str;
         },
+
+        openSelector() {
+            this.$refs.relationshipInput.$refs.existing.click();
+        },
+
+        relationshipItemDataUpdated(data) {
+            if (! data.length) return;
+
+            this.linkInput = 'statamic://entry::'+data[0].id;
+
+            this.commit();
+        }
 
     }
 

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -132,7 +132,7 @@ export default {
         },
 
         collections() {
-            return ['pages'];
+            return this.bard.meta.link_collections;
         }
 
     },

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -19,6 +19,7 @@ return [
     'bard.config.enable_input_rules' => 'Enables Markdown-style shortcuts when typing content.',
     'bard.config.enable_paste_rules' => 'Enables Markdown-style shortcuts when pasting content.',
     'bard.config.fullscreen' => 'Enable to toggle into fullscreen mode',
+    'bard.config.link_collections' => 'Entries from these collections will be available in the link selector. Leaving this empty will make all entries available.',
     'bard.config.link_noopener' => 'Set `rel="noopener` on all links.',
     'bard.config.link_noreferrer' => 'Set `rel="noreferrer` on all links.',
     'bard.config.reading_time' => 'Show estimated reading time at the bottom of the field.',

--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -100,9 +100,9 @@
 // Responive Wangjangling
 @screen md {
     // Fixed toolbar below fixed global header
-    .bard-fixed-toolbar { top: 52px; } 
-    .bard-fieldtype .bard-fieldtype .bard-fixed-toolbar { top: 92px; } 
-    
+    .bard-fixed-toolbar { top: 52px; }
+    .bard-fieldtype .bard-fieldtype .bard-fixed-toolbar { top: 92px; }
+
     // Fixed toolbar inside the live preview
     .live-preview-fields .bard-fixed-toolbar { top: -24px; }
     .live-preview-fields .bard-fieldtype .bard-fieldtype .bard-fixed-toolbar { top: 16px; }
@@ -427,7 +427,7 @@
   ========================================================================== */
 
   .bard-link-toolbar {
-    @apply bg-black rounded absolute leading-none shadow mt-1;
+    @apply bg-white rounded absolute leading-none shadow mt-1;
     z-index: 100;
     width: 300px;
     top: 100%;
@@ -435,25 +435,25 @@
     &:before {
         content: '';
         border: 6px solid transparent;
-        border-bottom-color: black;
+        border-bottom-color: white;
         position: absolute;
         bottom: 100%;
         left: 10px;
     }
 
     .link-container {
-        @apply w-full overflow-hidden text-white leading-normal;
+        @apply w-full overflow-hidden leading-normal;
         text-overflow: ellipsis;
     }
 
     .link {
-        @apply text-xs text-white whitespace-no-wrap;
+        @apply text-xs whitespace-no-wrap;
 
         &:hover { @apply text-blue }
     }
 
     .input {
-        @apply p-0 text-xs text-white h-8 bg-transparent shadow-none border-none;
+        @apply p-0 text-xs h-8 bg-transparent shadow-none border-none;
         width: 240px;
         outline: none;
     }
@@ -463,11 +463,11 @@
     }
 
     button {
-        @apply p-0 text-grey-20 h-10 ml-1;
+        @apply p-0 text-grey-70 h-10 ml-1 outline-none;
         font-size: 16px;
 
         &:hover {
-            @apply text-white;
+            @apply text-grey-90;
         }
     }
 

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -3,6 +3,7 @@
 namespace Statamic\Fieldtypes;
 
 use ProseMirrorToHtml\Renderer;
+use Statamic\Facades\Collection;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fields;
 use Statamic\Fieldtypes\Bard\Augmentor;
@@ -363,6 +364,7 @@ class Bard extends Replicator
             'collapsed' => [],
             'previews' => $previews,
             '__collaboration' => ['existing'],
+            'link_collections' => empty($collections = $this->config('link_collections')) ? Collection::handles()->all() : $collections,
         ];
     }
 

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -4,6 +4,7 @@ namespace Statamic\Fieldtypes;
 
 use ProseMirrorToHtml\Renderer;
 use Statamic\Facades\Collection;
+use Statamic\Facades\Data;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fields;
 use Statamic\Fieldtypes\Bard\Augmentor;
@@ -12,6 +13,7 @@ use Statamic\GraphQL\Types\BardTextType;
 use Statamic\GraphQL\Types\ReplicatorSetType;
 use Statamic\Query\Scopes\Filters\Fields\Bard as BardFilter;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class Bard extends Replicator
 {
@@ -365,6 +367,7 @@ class Bard extends Replicator
             'previews' => $previews,
             '__collaboration' => ['existing'],
             'linkCollections' => empty($collections = $this->config('link_collections')) ? Collection::handles()->all() : $collections,
+            'linkData' => $this->getLinkData($value),
         ];
     }
 
@@ -431,5 +434,39 @@ class Bard extends Replicator
         $union = new BardSetsType($this, $this->gqlSetsTypeName(), $types);
 
         GraphQL::addType($union);
+    }
+
+    public function getLinkData($value)
+    {
+        return collect($value)->mapWithKeys(function ($node) {
+            return $this->extractLinkDataFromNode($node);
+        })->all();
+    }
+
+    private function extractLinkDataFromNode($node)
+    {
+        $data = collect();
+
+        if ($node['type'] === 'link') {
+            $href = $node['attrs']['href'] ?? null;
+
+            if (Str::startsWith($href, 'statamic://')) {
+                $ref = Str::after($href, 'statamic://');
+                $item = Data::find($ref);
+                $data[$ref] = [
+                    'title' => $item->value('title'),
+                    'permalink' => $item->absoluteUrl(),
+                ];
+            }
+        }
+
+        $childData = collect()
+            ->merge($node['content'] ?? [])
+            ->merge($node['marks'] ?? [])
+            ->mapWithKeys(function ($node) {
+                return $this->extractLinkDataFromNode($node);
+            });
+
+        return $data->merge($childData);
     }
 }

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -364,7 +364,7 @@ class Bard extends Replicator
             'collapsed' => [],
             'previews' => $previews,
             '__collaboration' => ['existing'],
-            'link_collections' => empty($collections = $this->config('link_collections')) ? Collection::handles()->all() : $collections,
+            'linkCollections' => empty($collections = $this->config('link_collections')) ? Collection::handles()->all() : $collections,
         ];
     }
 

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -100,6 +100,12 @@ class Bard extends Replicator
                 'width' => 50,
                 'instructions' => __('statamic::fieldtypes.bard.config.target_blank'),
             ],
+            'link_collections' => [
+                'display' => __('Link Collections'),
+                'instructions' => __('statamic::fieldtypes.bard.config.link_collections'),
+                'type' => 'collections',
+                'mode' => 'select',
+            ],
             'reading_time' => [
                 'display' => __('Show Reading Time'),
                 'instructions' => __('statamic::fieldtypes.bard.config.reading_time'),

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -2,11 +2,13 @@
 
 namespace Statamic\Fieldtypes\Bard;
 
+use ProseMirrorToHtml\Marks\Link as DefaultLinkMark;
 use ProseMirrorToHtml\Nodes\Image as DefaultImageNode;
 use ProseMirrorToHtml\Renderer;
 use Statamic\Fields\Field;
 use Statamic\Fields\Value;
 use Statamic\Fieldtypes\Bard\ImageNode as CustomImageNode;
+use Statamic\Fieldtypes\Bard\LinkMark as CustomLinkMark;
 use Statamic\Fieldtypes\Text;
 use Statamic\Support\Arr;
 
@@ -94,6 +96,7 @@ class Augmentor
     {
         return (new Renderer)
             ->replaceNode(DefaultImageNode::class, CustomImageNode::class)
+            ->replaceMark(DefaultLinkMark::class, CustomLinkMark::class)
             ->addNode(SetNode::class)
             ->addNodes(static::$customNodes)
             ->addMarks(static::$customMarks)

--- a/src/Fieldtypes/Bard/LinkMark.php
+++ b/src/Fieldtypes/Bard/LinkMark.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Statamic\Fieldtypes\Bard;
+
+use ProseMirrorToHtml\Marks\Link;
+use Statamic\Facades\Data;
+use Statamic\Support\Str;
+
+class LinkMark extends Link
+{
+    public function tag()
+    {
+        $tag = parent::tag();
+
+        $tag[0]['attrs']['href'] = $this->convertHref($tag[0]['attrs']['href']);
+
+        return $tag;
+    }
+
+    private function convertHref($href)
+    {
+        if (! Str::startsWith($href, 'statamic://')) {
+            return $href;
+        }
+
+        $ref = Str::after($href, 'statamic://');
+
+        if (! $item = Data::find($ref)) {
+            return '';
+        }
+
+        return $item->url();
+    }
+}


### PR DESCRIPTION
This PR adds the link picker to Bard.

Rather than the `{{ link:id-of-thing }}` syntax that v2 used, I think we're better off with a `statamic://id-of-thing` syntax.

The prosemirror-to-html renderer would handle this, so it could be usable from anywhere: Antlers, API, GraphQL, etc.
The v2 way required Antlers for it to convert to a url.

Todo:
- [x] The picker
- [x] The renderer
- [x] UI Polish

Closes #801 