### PR TITLE
Add max_depth and show_hidden parameters to Nav tag

### DIFF
--- a/src/Structures/TreeBuilder.php
+++ b/src/Structures/TreeBuilder.php
@@ -48,15 +48,22 @@ class TreeBuilder
         $maxDepth = $params['max_depth'] ?? null;
         $fields = $params['fields'] ?? null;
         $showUnpublished = $params['show_unpublished'] ?? true;
+        $showHidden = $params['show_hidden'] ?? true;
 
         if ($maxDepth && $depth > $maxDepth) {
             return [];
         }
 
-        return $pages->map(function ($page) use ($fields, $params, $depth, $showUnpublished) {
+        return $pages->map(function ($page) use ($fields, $params, $depth, $showUnpublished, $showHidden) {
             if ($page->reference() && ! $page->referenceExists()) {
                 return null;
-            } elseif (! $showUnpublished && $page->entry() && $page->entry()->status() !== 'published') {
+            }
+
+            if (! $showUnpublished && $page->entry() && $page->entry()->status() !== 'published') {
+                return null;
+            }
+
+            if (! $showHidden && $page->entry() && $page->entry()->get('is_hidden')) {
                 return null;
             }
 

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -36,8 +36,10 @@ class Structure extends Tags
             'structure' => $handle,
             'include_home' => $this->params->get('include_home'),
             'show_unpublished' => $this->params->get('show_unpublished', false),
+            'show_hidden' => $this->params->get('show_hidden', false),
             'site' => $this->params->get('site', Site::current()->handle()),
             'from' => $this->params->get('from'),
+            'max_depth' => $this->params->get('max_depth'),
         ]);
 
         return $this->toArray($tree);


### PR DESCRIPTION
Inspired by #2286.

This adds the much-coveted support for hiding pages from the nav, using the `is_hidden` field. It also adds a `max_depth` parameter. I think these were the most important missing tools for filtering a nav in practice.

* This doesn't implement the requested fully fledged filter functionality. I wouldn't know where to start actually without some sort of query present.
* Just like `show_unpublished` the `show_hidden` parameter defaults to false. Seemed like the most natural behaviour. So if you have pages/entries in your site that already have an is_hidden field, the nav tag behaviour may change. Might be considered a breaking change?