### PR TITLE
Fix autofocus issues in Safari and Firefox

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -185,9 +185,11 @@ Statamic.app({
         }
 
         // Set moment locale
-        window.moment.locale(Statamic.$config.get('locale'))
-        Vue.moment.locale(Statamic.$config.get('locale'))
-        Vue.prototype.$moment.locale(Statamic.$config.get('locale'))
+        window.moment.locale(Statamic.$config.get('locale'));
+        Vue.moment.locale(Statamic.$config.get('locale'));
+        Vue.prototype.$moment.locale(Statamic.$config.get('locale'));
+        
+        this.fixAutofocus();
     },
 
     created() {
@@ -215,6 +217,17 @@ Statamic.app({
 
         hideBanner() {
             this.showBanner = false;
+        },
+
+        fixAutofocus() {
+            // Fix autofocus issues in Safari and Firefox
+            setTimeout(() => {
+                const inputs = document.querySelectorAll('input[autofocus]');
+                for (let input of inputs) {
+                    input.blur();
+                    input.focus();    
+                }
+            }, 0);
         }
     }
 

--- a/resources/js/components/inputs/Text.vue
+++ b/resources/js/components/inputs/Text.vue
@@ -51,8 +51,6 @@ export default {
     mounted() {
         if (this.autoselect) {
             this.$refs.input.select();
-        } else if (this.autofocus) {
-            this.$refs.input.focus();
         }
     }
 }


### PR DESCRIPTION
Fixes #3396.

I've sent quite some characters into the void myself too because of this one 😁

* The issue is not limited to creating a new entry though, it concerns all text inputs with autofocus. So it needed solving on the DOM-level.
* It seems a fix was attempted for this in Text.vue, but it doesn't do anything (this.autofocus doesn't exist) so I removed it.
* Yes, the blur() is necessary.
* Yes, the setTimeout() is necessary.
* No, $nextTick() doesn't work.
* Yes, it looks a bit ugly 😜

