### PR TITLE
Include search score in search results ‘with data’

### DIFF
--- a/src/Search/Algolia/Index.php
+++ b/src/Search/Algolia/Index.php
@@ -80,7 +80,7 @@ class Index extends BaseIndex
         }
 
         return collect($response['hits'])->map(function ($hit) {
-            $hit['id'] = $hit['objectID'];
+            $hit['reference'] = $hit['objectID'];
 
             return $hit;
         });

--- a/src/Search/Comb/Index.php
+++ b/src/Search/Comb/Index.php
@@ -19,8 +19,8 @@ class Index extends BaseIndex
 
     public function lookup($query)
     {
-        $data = $this->data()->map(function ($item, $id) {
-            return $item + ['id' => $id];
+        $data = $this->data()->map(function ($item, $reference) {
+            return $item + ['reference' => $reference];
         })->values()->toArray();
 
         $comb = new Comb($data, $this->settings());

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -47,7 +47,7 @@ abstract class QueryBuilder extends BaseQueryBuilder
         }
 
         return $this->collect($results)->map(function ($result) {
-            if ($data = Data::find($result['id'])) {
+            if ($data = Data::find($result['reference'])) {
                 $data->setSupplement('search_score', $result['search_score'] ?? null);
             }
 

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -50,6 +50,7 @@ abstract class QueryBuilder extends BaseQueryBuilder
             if ($data = Data::find($result['id'])) {
                 $data->set('search_score', $result['search_score'] ?? null);
             }
+
             return $data;
         })->filter()->values();
     }

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -48,7 +48,7 @@ abstract class QueryBuilder extends BaseQueryBuilder
 
         return $this->collect($results)->map(function ($result) {
             if ($data = Data::find($result['id'])) {
-                $data->set('search_score', $result['search_score'] ?? null);
+                $data->setSupplement('search_score', $result['search_score'] ?? null);
             }
 
             return $data;

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -47,7 +47,10 @@ abstract class QueryBuilder extends BaseQueryBuilder
         }
 
         return $this->collect($results)->map(function ($result) {
-            return Data::find($result['id']);
+            if ($data = Data::find($result['id'])) {
+                $data->set('search_score', $result['search_score'] ?? null);
+            }
+            return $data;
         })->filter()->values();
     }
 

--- a/src/Search/Tags.php
+++ b/src/Search/Tags.php
@@ -25,10 +25,12 @@ class Tags extends BaseTags
             return $this->parseNoResults();
         }
 
+        $supplementData = $this->params->get('supplement_data', true);
+
         $builder = Search::index($this->params->get('index'))
             ->ensureExists()
             ->search($query)
-            ->withData($this->params->get('supplement_data', true))
+            ->withData($supplementData)
             ->limit($this->params->get('limit'))
             ->offset($this->params->get('offset'));
 
@@ -39,7 +41,10 @@ class Tags extends BaseTags
         $this->queryOrderBys($builder);
 
         $results = $this->getQueryResults($builder);
-        $results = $this->addResultTypes($results);
+
+        if ($supplementData) {
+            $results = $this->addResultTypes($results);
+        }
 
         return $this->output($results);
     }

--- a/src/Search/Tags.php
+++ b/src/Search/Tags.php
@@ -41,28 +41,25 @@ class Tags extends BaseTags
         $this->queryOrderBys($builder);
 
         $results = $this->getQueryResults($builder);
-
-        if ($supplementData) {
-            $results = $this->addResultTypes($results);
-        }
+        $results = $this->addResultTypes($results);
 
         return $this->output($results);
     }
 
     protected function addResultTypes($results)
     {
-        return $results->supplement('result_type', function ($result) {
-            $type = null;
+        return $results->map(function ($result) {
+            $reference = is_array($result) ? $result['reference'] : $result->reference();
 
-            if ($result instanceof \Statamic\Contracts\Entries\Entry) {
-                $type = 'entry';
-            } elseif ($result instanceof \Statamic\Contracts\Taxonomies\Term) {
-                $type = 'term';
-            } elseif ($result instanceof \Statamic\Contracts\Assets\Asset) {
-                $type = 'asset';
+            [$type, $id] = explode('::', $reference, 2);
+
+            if (is_array($result)) {
+                $result['result_type'] = $type;
+            } else {
+                $result->setSupplement('result_type', $type);
             }
 
-            return $type;
+            return $result;
         });
     }
 


### PR DESCRIPTION
This would fix #2728. And it fixes #3480.

I'm not that happy about injecting the search_score into the data, but there your are. It is the best I could think of without changing the return type. And the fact that this is a QueryBuilder for searching specifically might justify it.