### PR TITLE
Use public_path in exists check

### DIFF
--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -187,9 +187,9 @@ class ImageGenerator
             $path = $this->asset->path();
             $mime = $this->asset->mimeType();
         } else {
-            $path = $this->path;
+            $path = public_path($this->path);
             throw_unless(File::exists($path), new FlysystemFileNotFoundException($path));
-            $mime = File::mimeType(public_path($this->path));
+            $mime = File::mimeType($path);
         }
 
         if ($mime !== null && strncmp($mime, 'image/', 6) !== 0) {


### PR DESCRIPTION
This fixes an issue introduced in 3.1.3 where if you use Glide with a file in your `public` directory, it would always fail.

```
{{ glide src="something/in/public.jpg" }}
```

The `$path` passed to the `File::exists()` check didn't have the `public_path()` wrapped around it.