### PR TITLE
Clear the used indexes property when clearing

### DIFF
--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -386,6 +386,7 @@ abstract class Store
             app('stache.indexes')->forget("{$this->key()}.{$index->name()}");
         });
 
+        $this->usedIndexes = collect();
         Cache::forget($this->indexUsageCacheKey());
 
         $this->clearCachedPaths();


### PR DESCRIPTION
Closes #3476 

In the asset store, we just clear it every request, which is different from all the others.

Since the `path` index was still tracked on the property, this line of code returned early, before the array could be cached.

https://github.com/statamic/cms/blob/7ecfffaad53111390f810f2693297696c371d811/src/Stache/Stores/Store.php#L107-L111