### PR TITLE
Make the `assets:generate-presets` command queue friendly

### DIFF
--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -45,7 +45,7 @@ class AssetsGeneratePresets extends Command
         $this->shouldQueue = $this->option('queue');
 
         if ($this->shouldQueue && config('queue.default') === 'sync') {
-            $this->error('The queue driver is set to "sync". Queueing will be disabled.');
+            $this->error('The queue connection is set to "sync". Queueing will be disabled.');
             $this->shouldQueue = false;
         }
 

--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -7,7 +7,7 @@ use Statamic\Console\RunsInPlease;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Config;
 use Statamic\Facades\Image;
-use Statamic\Imaging\PresetGenerator;
+use Statamic\Jobs\GeneratePresetImageManipulation;
 
 class AssetsGeneratePresets extends Command
 {
@@ -18,7 +18,7 @@ class AssetsGeneratePresets extends Command
      *
      * @var string
      */
-    protected $signature = 'statamic:assets:generate-presets';
+    protected $signature = 'statamic:assets:generate-presets {--queue : Queue the image generation.}';
 
     /**
      * The console command description.
@@ -28,26 +28,22 @@ class AssetsGeneratePresets extends Command
     protected $description = 'Generate asset preset manipulations.';
 
     /**
-     * @var PresetGenerator
-     */
-    protected $generator;
-
-    /**
      * @var \Statamic\Assets\AssetCollection
      */
     protected $imageAssets;
 
-    public function __construct(PresetGenerator $generator)
-    {
-        $this->generator = $generator;
-        parent::__construct();
-    }
+    /**
+     * @var bool
+     */
+    protected $shouldQueue = false;
 
     /**
      * Execute the console command.
      */
     public function handle()
     {
+        $this->shouldQueue = $this->option('queue');
+
         $this->imageAssets = Asset::all()->filter(function ($asset) {
             return $asset->isImage();
         });
@@ -97,15 +93,22 @@ class AssetsGeneratePresets extends Command
     {
         foreach ($presets as $preset => $params) {
             $bar = $this->output->createProgressBar($this->imageAssets->count());
-            $bar->setFormat("[%current%/%max%] Generating <comment>$preset</comment>... %filename%");
+
+            $verb = $this->shouldQueue ? 'Queueing' : 'Generating';
+            $bar->setFormat("[%current%/%max%] $verb <comment>$preset</comment>... %filename%");
 
             foreach ($this->imageAssets as $asset) {
                 $bar->setMessage($asset->basename(), 'filename');
-                $this->generator->generate($asset, $preset);
+
+                $dispatchMethod = $this->shouldQueue ? 'dispatch' : 'dispatchSync';
+                GeneratePresetImageManipulation::$dispatchMethod($asset, $preset);
+
                 $bar->advance();
             }
 
-            $bar->setFormat("<info>[✓] Images generated for <comment>$preset</comment>.</info>");
+            $verb = $this->shouldQueue ? 'queued' : 'generated';
+            $bar->setFormat("<info>[✓] Images $verb for <comment>$preset</comment>.</info>");
+
             $bar->finish();
 
             $this->output->newLine();

--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -44,6 +44,11 @@ class AssetsGeneratePresets extends Command
     {
         $this->shouldQueue = $this->option('queue');
 
+        if ($this->shouldQueue && config('queue.default') === 'sync') {
+            $this->error('The queue driver is set to "sync". Queueing will be disabled.');
+            $this->shouldQueue = false;
+        }
+
         $this->imageAssets = Asset::all()->filter(function ($asset) {
             return $asset->isImage();
         });

--- a/src/Jobs/GeneratePresetImageManipulation.php
+++ b/src/Jobs/GeneratePresetImageManipulation.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Statamic\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Statamic\Contracts\Assets\Asset;
+use Statamic\Imaging\PresetGenerator;
+
+class GeneratePresetImageManipulation implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public $asset;
+    public $preset;
+
+    public function __construct(Asset $asset, $preset)
+    {
+        $this->asset = $asset;
+        $this->preset = $preset;
+    }
+
+    public function handle(PresetGenerator $generator)
+    {
+        $generator->generate($this->asset, $this->preset);
+    }
+}


### PR DESCRIPTION
This PR adds a `queue` option to the command.

```
php please assets:generate-presets --queue
```

You must have a queue connection set up.

![image](https://user-images.githubusercontent.com/105211/113886393-a38cdc80-978e-11eb-8ac7-6a03b9ef689f.png)

If you don't (i.e. it's set to `sync`) then it'll tell you, and just generate them without a queue.

![image](https://user-images.githubusercontent.com/105211/113886298-907a0c80-978e-11eb-8e29-7c618902a352.png)

Closes statamic/ideas#480