### PR TITLE
Fix 404 error when URLs have both ending slash and query parameters

### DIFF
--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -45,6 +45,10 @@ class FrontendController extends Controller
             $url = substr($url, 0, strpos($url, '?'));
         }
 
+        if (Str::endsWith($url, '/')) {
+            $url = rtrim($url, '/');
+        }
+
         if ($data = Data::findByUri($url, Site::current()->handle())) {
             return $data;
         }

--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -29,7 +29,9 @@ class FrontendController extends Controller
      */
     public function index(Request $request)
     {
-        $url = Site::current()->relativePath($request->getUri());
+        $url = Site::current()->relativePath(
+            str_finish($request->getUri(), '/')
+        );
 
         if ($url === '') {
             $url = '/';
@@ -41,6 +43,10 @@ class FrontendController extends Controller
 
         if (Str::contains($url, '?')) {
             $url = substr($url, 0, strpos($url, '?'));
+        }
+
+        if (Str::endsWith($url, '/') && Str::length($url) > 1) {
+            $url = rtrim($url, '/');
         }
 
         if ($data = Data::findByUri($url, Site::current()->handle())) {

--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -29,9 +29,7 @@ class FrontendController extends Controller
      */
     public function index(Request $request)
     {
-        $url = Site::current()->relativePath(
-            str_finish($request->getUri(), '/')
-        );
+        $url = Site::current()->relativePath($request->getUri());
 
         if ($url === '') {
             $url = '/';
@@ -43,10 +41,6 @@ class FrontendController extends Controller
 
         if (Str::contains($url, '?')) {
             $url = substr($url, 0, strpos($url, '?'));
-        }
-
-        if (Str::endsWith($url, '/') && Str::length($url) > 1) {
-            $url = rtrim($url, '/');
         }
 
         if ($data = Data::findByUri($url, Site::current()->handle())) {

--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -45,7 +45,7 @@ class FrontendController extends Controller
             $url = substr($url, 0, strpos($url, '?'));
         }
 
-        if (Str::endsWith($url, '/')) {
+        if (Str::endsWith($url, '/') && Str::length($url) > 1) {
             $url = rtrim($url, '/');
         }
 

--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -29,13 +29,7 @@ class FrontendController extends Controller
      */
     public function index(Request $request)
     {
-        $url = Site::current()->relativePath(
-            str_finish($request->getUri(), '/')
-        );
-
-        if ($url === '') {
-            $url = '/';
-        }
+        $url = Site::current()->relativePath($request->getUri());
 
         if (Statamic::isAmpRequest()) {
             $url = str_after($url, '/'.config('statamic.amp.route'));

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -77,6 +77,27 @@ class FrontendTest extends TestCase
     }
 
     /** @test */
+    public function page_is_displayed_with_ending_slash()
+    {
+        $this->withStandardBlueprints();
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('some_template', '<h1>{{ title }}</h1> <p>{{ content }}</p>');
+
+        $page = $this->createPage('about', [
+            'with' => [
+                'title' => 'The About Page',
+                'content' => 'This is the about page.',
+                'template' => 'some_template',
+            ],
+        ]);
+
+        $response = $this->get('/about/')->assertStatus(200);
+
+        $this->assertEquals('<h1>The About Page</h1> <p>This is the about page.</p>', trim($response->content()));
+    }
+
+    /** @test */
     public function page_is_displayed_with_query_string_and_ending_slash()
     {
         $this->withStandardBlueprints();
@@ -95,6 +116,81 @@ class FrontendTest extends TestCase
         $response = $this->get('/about/?some=querystring')->assertStatus(200);
 
         $this->assertEquals('<h1>The About Page</h1> <p>This is the about page.</p>', trim($response->content()));
+    }
+
+    /** @test */
+    public function home_page_on_second_subdirectory_based_site_is_displayed()
+    {
+        Site::setConfig(['sites' => [
+            'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'french' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+        ]]);
+
+        $this->createHomePagesForTwoSites();
+
+        $response = $this->get('/fr')->assertStatus(200);
+
+        $this->assertEquals('French Home', trim($response->content()));
+    }
+
+    /** @test */
+    public function home_page_on_second_subdirectory_based_site_is_displayed_with_ending_slash()
+    {
+        Site::setConfig(['sites' => [
+            'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'french' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+        ]]);
+
+        $this->createHomePagesForTwoSites();
+
+        $response = $this->get('/fr/')->assertStatus(200);
+
+        $this->assertEquals('French Home', trim($response->content()));
+    }
+
+    /** @test */
+    public function home_page_on_second_domain_site_is_displayed()
+    {
+        Site::setConfig(['sites' => [
+            'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'french' => ['url' => 'http://anotherhost.com/', 'locale' => 'fr'],
+        ]]);
+
+        $this->createHomePagesForTwoSites();
+
+        $response = $this->get('http://anotherhost.com')->assertStatus(200);
+
+        $this->assertEquals('French Home', trim($response->content()));
+    }
+
+    /** @test */
+    public function home_page_on_second_domain_site_is_displayed_with_ending_slash()
+    {
+        Site::setConfig(['sites' => [
+            'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'french' => ['url' => 'http://anotherhost.com/', 'locale' => 'fr'],
+        ]]);
+
+        $this->createHomePagesForTwoSites();
+
+        $response = $this->get('http://anotherhost.com/')->assertStatus(200);
+
+        $this->assertEquals('French Home', trim($response->content()));
+    }
+
+    private function createHomePagesForTwoSites()
+    {
+        $this->withStandardBlueprints();
+        $this->withoutExceptionHandling();
+        $this->withStandardFakeViews();
+
+        $c = tap(Collection::make('pages')->sites(['english', 'french'])->routes('{slug}')->structureContents(['root' => true]))->save();
+
+        EntryFactory::id('1')->locale('english')->slug('home')->collection('pages')->data(['content' => 'Home'])->create();
+        EntryFactory::id('2')->locale('french')->slug('french-home')->collection('pages')->data(['content' => 'French Home'])->create();
+
+        $c->structure()->in('english')->tree([['entry' => '1']])->save();
+        $c->structure()->in('french')->tree([['entry' => '2']])->save();
     }
 
     /** @test */

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -77,6 +77,27 @@ class FrontendTest extends TestCase
     }
 
     /** @test */
+    public function page_is_displayed_with_query_string_and_ending_slash()
+    {
+        $this->withStandardBlueprints();
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('some_template', '<h1>{{ title }}</h1> <p>{{ content }}</p>');
+
+        $page = $this->createPage('about', [
+            'with' => [
+                'title' => 'The About Page',
+                'content' => 'This is the about page.',
+                'template' => 'some_template',
+            ],
+        ]);
+
+        $response = $this->get('/about/?some=querystring')->assertStatus(200);
+
+        $this->assertEquals('<h1>The About Page</h1> <p>This is the about page.</p>', trim($response->content()));
+    }
+
+    /** @test */
     public function drafts_are_not_visible()
     {
         $this->withStandardFakeErrorViews();


### PR DESCRIPTION
This PR fixes #3469, where you visiting a page with a URL like this would simply 404, `/about/?ref=smth`.