### PR TITLE
Update Browser.vue

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -453,7 +453,7 @@ export default {
 
             const url = this.searchQuery
                 ? cp_url(`assets/browse/search/${this.container.id}`)
-                : cp_url(`assets/browse/folders/${this.container.id}/${this.path || ''}`.trim('/'));
+                : cp_url(`assets/browse/folders/${this.container.id}/${this.path || ''}`).replace(/\/$/, '');
 
             this.$axios.get(url, { params: this.parameters }).then(response => {
                 const data = response.data;


### PR DESCRIPTION
Incorrect intended use of trim, it will not remove the trailing slash, using replace instead to remove trailing slash. It also matters when try to remove the trailing slash, function cp_url() returns a URL with trailing slash because global.tidy_url() does it.

this resolves [3495](https://github.com/statamic/cms/issues/3495)