### PR TITLE
Fix taxonomy routes using localization

### DIFF
--- a/src/Stache/Repositories/TaxonomyRepository.php
+++ b/src/Stache/Repositories/TaxonomyRepository.php
@@ -62,8 +62,8 @@ class TaxonomyRepository implements RepositoryContract
     public function findByUri(string $uri, string $site = null): ?Taxonomy
     {
         $collection = Facades\Collection::all()
-            ->first(function ($collection) use ($uri) {
-                if (Str::startsWith($uri, $collection->url())) {
+            ->first(function ($collection) use ($uri, $site) {
+                if (Str::startsWith($uri, $collection->uri($site))) {
                     return true;
                 }
 
@@ -71,7 +71,7 @@ class TaxonomyRepository implements RepositoryContract
             });
 
         if ($collection) {
-            $uri = Str::after($uri, $collection->url() ?? $collection->handle());
+            $uri = Str::after($uri, $collection->uri($site) ?? $collection->handle());
         }
 
         // If the collection is mounted to the home page, the uri would have

--- a/src/Stache/Repositories/TaxonomyRepository.php
+++ b/src/Stache/Repositories/TaxonomyRepository.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Collection;
 use Statamic\Contracts\Taxonomies\Taxonomy;
 use Statamic\Contracts\Taxonomies\TaxonomyRepository as RepositoryContract;
 use Statamic\Facades;
-use Statamic\Facades\Site;
 use Statamic\Stache\Stache;
 use Statamic\Support\Str;
 
@@ -67,7 +66,7 @@ class TaxonomyRepository implements RepositoryContract
                     return true;
                 }
 
-                return Site::hasMultiple() ? false : Str::startsWith($uri, '/'.$collection->handle());
+                return Str::startsWith($uri, '/'.$collection->handle());
             });
 
         if ($collection) {

--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -46,8 +46,8 @@ class TermRepository implements RepositoryContract
     public function findByUri(string $uri, string $site = null): ?Term
     {
         $collection = Collection::all()
-            ->first(function ($collection) use ($uri) {
-                if (Str::startsWith($uri, $collection->url())) {
+            ->first(function ($collection) use ($uri, $site) {
+                if (Str::startsWith($uri, $collection->uri($site))) {
                     return true;
                 }
 
@@ -55,7 +55,7 @@ class TermRepository implements RepositoryContract
             });
 
         if ($collection) {
-            $uri = Str::after($uri, $collection->url() ?? $collection->handle());
+            $uri = Str::after($uri, $collection->uri($site) ?? $collection->handle());
         }
 
         $uri = Str::removeLeft($uri, '/');

--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -5,7 +5,6 @@ namespace Statamic\Stache\Repositories;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Contracts\Taxonomies\TermRepository as RepositoryContract;
 use Statamic\Facades\Collection;
-use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
 use Statamic\Stache\Query\TermQueryBuilder;
 use Statamic\Stache\Stache;
@@ -51,7 +50,7 @@ class TermRepository implements RepositoryContract
                     return true;
                 }
 
-                return Site::hasMultiple() ? false : Str::startsWith($uri, '/'.$collection->handle());
+                return Str::startsWith($uri, '/'.$collection->handle());
             });
 
         if ($collection) {

--- a/tests/Data/Taxonomies/ViewsTest.php
+++ b/tests/Data/Taxonomies/ViewsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Data\Taxonomies;
+
+use Facades\Tests\Factories\EntryFactory;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Site;
+use Statamic\Facades\Taxonomy;
+use Statamic\Facades\Term;
+use Tests\FakesViews;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ViewsTest extends TestCase
+{
+    use FakesViews;
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Site::setConfig(['sites' => [
+            'en' => ['url' => '/', 'locale' => 'en'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr'],
+        ]]);
+
+        $this->withStandardFakeViews();
+
+        Collection::make('pages')->routes('{slug}')->sites(['en', 'fr'])->save();
+        $blog = EntryFactory::collection('pages')->locale('en')->slug('the-blog')->create();
+        $frenchBlog = EntryFactory::collection('pages')->locale('fr')->slug('le-blog')->origin($blog->id())->create();
+
+        Collection::make('blog')->sites(['en', 'fr'])->mount($blog->id())->taxonomies(['tags'])->save();
+
+        Taxonomy::make('tags')->sites(['en', 'fr'])->title('Tags')->save();
+
+        tap(Term::make('test')->taxonomy('tags'), function ($term) {
+            $term->in('en')->slug('test')->set('title', 'Test');
+            $term->in('fr')->slug('le-test')->set('title', 'Le Test');
+        })->save();
+    }
+
+    /** @test */
+    public function the_taxonomy_url_404s_if_the_view_doesnt_exist()
+    {
+        $this->get('/tags')->assertNotFound();
+    }
+
+    /** @test */
+    public function it_loads_the_taxonomy_url_if_the_view_exists()
+    {
+        $this->viewShouldReturnRaw('tags.index', '{{ title }} index');
+
+        $this->get('/tags')->assertOk()->assertSee('Tags index');
+    }
+
+    /** @test */
+    public function the_term_url_404s_if_the_view_doesnt_exist()
+    {
+        $this->get('/tags/test')->assertNotFound();
+    }
+
+    /** @test */
+    public function it_loads_the_term_url_if_the_view_exists()
+    {
+        $this->viewShouldReturnRaw('tags.show', 'showing {{ title }}');
+
+        $this->get('/tags/test')->assertOk()->assertSeeText('showing Test');
+    }
+
+    /** @test */
+    public function it_loads_the_localized_term_url_if_the_view_exists()
+    {
+        $this->viewShouldReturnRaw('tags.show', 'showing {{ title }}');
+
+        $this->get('/fr/tags/le-test')->assertOk()->assertSee('showing Le Test');
+    }
+
+    /** @test */
+    public function the_collection_specific_taxonomy_url_404s_if_the_view_doesnt_exist()
+    {
+        $this->get('/tags/test')->assertNotFound();
+    }
+
+    /** @test */
+    public function it_loads_the_collection_specific_taxonomy_url_if_the_view_exists()
+    {
+        $this->viewShouldReturnRaw('blog.tags.index', '{{ title }} index');
+
+        $this->get('/the-blog/tags')->assertOk()->assertSee('Tags index');
+    }
+
+    /** @test */
+    public function the_collection_specific_term_url_404s_if_the_view_doesnt_exist()
+    {
+        $this->get('/the-blog/tags/test')->assertNotFound();
+    }
+
+    /** @test */
+    public function it_loads_the_collection_specific_term_url_if_the_view_exists()
+    {
+        $this->viewShouldReturnRaw('blog.tags.show', 'showing {{ title }}');
+
+        $this->get('/the-blog/tags/test')->assertOk()->assertSee('showing Test');
+    }
+
+    /** @test */
+    public function it_loads_the_localized_collection_specific_taxonomy_url_if_the_view_exists()
+    {
+        $this->viewShouldReturnRaw('blog.tags.index', '{{ title }} index');
+
+        $this->get('/fr/le-blog/tags')->assertOk()->assertSee('Tags index');
+    }
+
+    /** @test */
+    public function it_loads_the_localized_collection_specific_term_url_if_the_view_exists()
+    {
+        $this->viewShouldReturnRaw('blog.tags.show', 'showing {{ title }}');
+
+        $this->get('/fr/le-blog/tags/le-test')->assertOk()->assertSee('showing Le Test');
+    }
+}

--- a/tests/Data/Taxonomies/ViewsTest.php
+++ b/tests/Data/Taxonomies/ViewsTest.php
@@ -80,7 +80,7 @@ class ViewsTest extends TestCase
     /** @test */
     public function the_collection_specific_taxonomy_url_404s_if_the_view_doesnt_exist()
     {
-        $this->get('/tags/test')->assertNotFound();
+        $this->get('/the-blog/tags/test')->assertNotFound();
     }
 
     /** @test */


### PR DESCRIPTION
This fixes #3159

It adds tests for all of our automatic view-based taxonomy/term routes, with and without localized slugs.

This PR also makes the collection based routes work without needing to mount them, on multisite.
For some reason, we only made that work when using a single site.