### PR TITLE
Improve YAML exception handling

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -130,8 +130,8 @@ class Asset implements AssetContract, Augmentable
         }
 
         return $this->meta = Cache::rememberForever($this->metaCacheKey(), function () {
-            if ($contents = $this->disk()->get($this->metaPath())) {
-                return YAML::parse($contents);
+            if ($contents = $this->disk()->get($path = $this->metaPath())) {
+                return YAML::file($path)->parse($contents);
             }
 
             $this->writeMeta($meta = $this->generateMeta());

--- a/src/Yaml/Yaml.php
+++ b/src/Yaml/Yaml.php
@@ -113,7 +113,11 @@ class Yaml
 
     protected function viewException($e, $str, $line = null)
     {
-        $path = $this->file ?? $this->createTemporaryExceptionFile($str);
+        if ($this->file && File::exists($this->file)) {
+            $path = $this->file;
+        } else {
+            $path = $this->createTemporaryExceptionFile($str, $this->file);
+        }
 
         $args = [
             $e->getMessage(), 0, 1, $path,
@@ -137,9 +141,9 @@ class Yaml
         return $exception;
     }
 
-    protected function createTemporaryExceptionFile($string)
+    protected function createTemporaryExceptionFile($string, $path = null)
     {
-        $path = storage_path('statamic/tmp/yaml-'.md5($string));
+        $path = storage_path('statamic/tmp/yaml/'.($path ?? md5($string)));
 
         File::put($path, $string);
 

--- a/src/Yaml/Yaml.php
+++ b/src/Yaml/Yaml.php
@@ -43,6 +43,8 @@ class Yaml
         }
 
         if (empty($str)) {
+            $this->file = null;
+
             return [];
         }
 
@@ -64,6 +66,8 @@ class Yaml
 
         $this->validateString($yaml, $str);
         $this->validateDocumentContent($yaml, $content, $originalStr);
+
+        $this->file = null;
 
         return isset($content)
             ? $yaml + ['content' => $content]

--- a/tests/Yaml/YamlTest.php
+++ b/tests/Yaml/YamlTest.php
@@ -275,6 +275,60 @@ EOT;
     }
 
     /** @test */
+    public function it_doesnt_maintain_files_across_uses()
+    {
+        YAML::file('path/to/file/previously/used.yaml')->parse('foo: bar');
+
+        $yaml = <<<'EOT'
+---
+foo: 'bar
+baz: 'qux'
+---
+some content
+EOT;
+
+        try {
+            YAML::parse($yaml);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(ParseException::class, $e);
+            $this->assertEquals('Unexpected characters near "qux\'" at line 3 (near "baz: \'qux\'").', $e->getMessage());
+            $path = storage_path('statamic/tmp/yaml-'.md5("---\nfoo: 'bar\nbaz: 'qux'"));
+            $this->assertEquals($path, $e->getFile());
+
+            return;
+        }
+
+        $this->fail('Exception was not thrown.');
+    }
+
+    /** @test */
+    public function it_doesnt_maintain_files_across_uses_when_previous_call_had_no_yaml()
+    {
+        YAML::file('path/to/file/previously/used.yaml')->parse('');
+
+        $yaml = <<<'EOT'
+---
+foo: 'bar
+baz: 'qux'
+---
+some content
+EOT;
+
+        try {
+            YAML::parse($yaml);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(ParseException::class, $e);
+            $this->assertEquals('Unexpected characters near "qux\'" at line 3 (near "baz: \'qux\'").', $e->getMessage());
+            $path = storage_path('statamic/tmp/yaml-'.md5("---\nfoo: 'bar\nbaz: 'qux'"));
+            $this->assertEquals($path, $e->getFile());
+
+            return;
+        }
+
+        $this->fail('Exception was not thrown.');
+    }
+
+    /** @test */
     public function it_throws_an_exception_when_an_array_cannot_be_returned()
     {
         $string = <<<'EOT'

--- a/tests/Yaml/YamlTest.php
+++ b/tests/Yaml/YamlTest.php
@@ -241,7 +241,7 @@ EOT;
         } catch (Exception $e) {
             $this->assertInstanceOf(ParseException::class, $e);
             $this->assertEquals('Unexpected characters near "qux\'" at line 3 (near "baz: \'qux\'").', $e->getMessage());
-            $path = storage_path('statamic/tmp/yaml-'.md5("---\nfoo: 'bar\nbaz: 'qux'"));
+            $path = storage_path('statamic/tmp/yaml/'.md5("---\nfoo: 'bar\nbaz: 'qux'"));
             $this->assertEquals($path, $e->getFile());
 
             return;
@@ -251,7 +251,34 @@ EOT;
     }
 
     /** @test */
-    public function it_creates_parse_exception_pointing_to_actual_file_when_file_is_provided()
+    public function it_creates_parse_exception_pointing_to_actual_file_when_file_is_provided_and_it_exists()
+    {
+        $yaml = <<<'EOT'
+---
+foo: 'bar
+baz: 'qux'
+---
+some content
+EOT;
+
+        file_put_contents($path = __DIR__.'/test.yaml', $yaml);
+
+        try {
+            YAML::file($path)->parse($yaml);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(ParseException::class, $e);
+            $this->assertEquals('Unexpected characters near "qux\'" at line 3 (near "baz: \'qux\'").', $e->getMessage());
+            $this->assertEquals($path, $e->getFile());
+            @unlink($path);
+
+            return;
+        }
+
+        $this->fail('Exception was not thrown.');
+    }
+
+    /** @test */
+    public function it_creates_parse_exception_pointing_to_temporary_file_with_similar_path_when_file_is_provided_but_doesnt_exist()
     {
         $yaml = <<<'EOT'
 ---
@@ -266,7 +293,7 @@ EOT;
         } catch (Exception $e) {
             $this->assertInstanceOf(ParseException::class, $e);
             $this->assertEquals('Unexpected characters near "qux\'" at line 3 (near "baz: \'qux\'").', $e->getMessage());
-            $this->assertEquals('path/to/file.yaml', $e->getFile());
+            $this->assertEquals(storage_path('statamic/tmp/yaml/path/to/file.yaml'), $e->getFile());
 
             return;
         }
@@ -292,7 +319,7 @@ EOT;
         } catch (Exception $e) {
             $this->assertInstanceOf(ParseException::class, $e);
             $this->assertEquals('Unexpected characters near "qux\'" at line 3 (near "baz: \'qux\'").', $e->getMessage());
-            $path = storage_path('statamic/tmp/yaml-'.md5("---\nfoo: 'bar\nbaz: 'qux'"));
+            $path = storage_path('statamic/tmp/yaml/'.md5("---\nfoo: 'bar\nbaz: 'qux'"));
             $this->assertEquals($path, $e->getFile());
 
             return;
@@ -319,7 +346,7 @@ EOT;
         } catch (Exception $e) {
             $this->assertInstanceOf(ParseException::class, $e);
             $this->assertEquals('Unexpected characters near "qux\'" at line 3 (near "baz: \'qux\'").', $e->getMessage());
-            $path = storage_path('statamic/tmp/yaml-'.md5("---\nfoo: 'bar\nbaz: 'qux'"));
+            $path = storage_path('statamic/tmp/yaml/'.md5("---\nfoo: 'bar\nbaz: 'qux'"));
             $this->assertEquals($path, $e->getFile());
 
             return;


### PR DESCRIPTION
You can tell the YAML parser which file is being parsed by doing `YAML::file($path)->parse()`.
You can also choose to _not_ pass the path, if you're just parsing a string of YAML: `YAML::parse($string)`.

The filename was being stored as a property on the yaml parser, and would be remembered if you do those two things in order.

```
YAML::file($path)->parse();

YAML::parse($str);
```

If the second one threw an exception, it would use the file you provided in the first call. This would send the user on a wild goose chase, looking in the wrong YAML file.

This PR fixes that.

---

Also, if you provide a non-existent path (or one that's not on the local filesystem)  for the purpose of a nicer exception (i.e. the asset meta file change in this PR), then the exception would be empty. Ignition would look for that file, not find it, and just render nothing.

This PR fixes that by creating the temporary file, and uses a more readable path instead of just the hash of the contents.

You can see here that it says `storage/statamic/tmp/yaml/{path to file}`. It's obviously not the 100% correct filename, but it should help with debugging. Previously it would be `storage/statamic/tmp/yaml-6d6932` which isn't really helpful.

We can't provide the actual path to the file in some cases because they might be stored outside the filesystem, for example meta data might be on Amazon S3. Ignition/Flare expects the file to be local. It is what it is.

![image](https://user-images.githubusercontent.com/105211/114448634-cc074300-9ba1-11eb-885b-6336514ef016.png)

