### PR TITLE
Add ability to set a date field’s display format

### DIFF
--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -41,6 +41,7 @@ return [
     'date.config.columns' => 'Show multiple months at one time, in rows and columns',
     'date.config.earliest_date' => 'Set the earliest selectable date.',
     'date.config.format' => 'Optionally format the date string using [moment.js](https://momentjs.com/docs/#/displaying/format/).',
+    'date.config.display_format' => 'Optionally format the date string using [moment.js](https://momentjs.com/docs/#/displaying/format/).',
     'date.config.full_width' => 'Stretch the calendar to use up the full width.',
     'date.config.inline' => 'Skip the dropdown input field and show the calendar directly.',
     'date.config.mode' => 'Choose between single or range mode (range disables time picker).',

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -53,6 +53,7 @@ class Date extends Fieldtype
                 'instructions' => __('statamic::fieldtypes.date.config.format'),
                 'type' => 'text',
                 'width' => 50,
+            ],
             'display_format' => [
                 'display' => __('Display Format'),
                 'instructions' => __('statamic::fieldtypes.date.config.display_format'),

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -53,6 +53,11 @@ class Date extends Fieldtype
                 'instructions' => __('statamic::fieldtypes.date.config.format'),
                 'type' => 'text',
                 'width' => 50,
+            'display_format' => [
+                'display' => __('Display Format'),
+                'instructions' => __('statamic::fieldtypes.date.config.display_format'),
+                'type' => 'text',
+                'width' => 50,
             ],
             'full_width' => [
                 'display' => __('Full Width'),
@@ -134,14 +139,16 @@ class Date extends Fieldtype
             return;
         }
 
+        $format = $this->config('display_format') ?? config('statamic.cp.date_format');
+
         if ($this->config('mode') === 'range') {
-            $start = Carbon::parse($data['start'])->format(config('statamic.cp.date_format'));
-            $end = Carbon::parse($data['end'])->format(config('statamic.cp.date_format'));
+            $start = Carbon::parse($data['start'])->format($format);
+            $end = Carbon::parse($data['end'])->format($format);
 
             return $start.' - '.$end;
         }
 
-        return Carbon::parse($data)->format(config('statamic.cp.date_format'));
+        return Carbon::parse($data)->format($format);
     }
 
     private function dateFormat($date)


### PR DESCRIPTION
This PR fixes issue #3516. 

You can now set a date field's display format for the collection overview page using `display_format` in the blueprint, eg. `display_format: Y-m-d H:i`.