### PR TITLE
Fix localizable grid in stacked mode

### DIFF
--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -16,7 +16,7 @@
                 v-for="field in fields"
                 v-show="showField(field)"
                 :key="field.handle"
-                :config="field"
+                :config="{...field, localizable: grid.config.localizable}"
                 :value="values[field.handle]"
                 :meta="meta[field.handle]"
                 :read-only="grid.isReadOnly"


### PR DESCRIPTION
Fixes #3498.

Since only top-level fields can be localizable, the `stacked-row` overrides the grid subfield's localizable setting in the config just before handing it to the `publish-field`.