### PR TITLE
Nav and url handling improvements

### DIFF
--- a/src/Routing/Routable.php
+++ b/src/Routing/Routable.php
@@ -36,7 +36,12 @@ trait Routable
             return $this->redirectUrl();
         }
 
-        return URL::makeRelative($this->absoluteUrl());
+        return $this->urlWithoutRedirect();
+    }
+
+    public function urlWithoutRedirect()
+    {
+        return URL::makeRelative($this->absoluteUrlWithoutRedirect());
     }
 
     public function absoluteUrl()
@@ -45,6 +50,11 @@ trait Routable
             return $this->redirectUrl();
         }
 
+        return $this->absoluteUrlWithoutRedirect();
+    }
+
+    public function absoluteUrlWithoutRedirect()
+    {
         $url = vsprintf('%s/%s', [
             rtrim($this->site()->absoluteUrl(), '/'),
             ltrim($this->uri(), '/'),

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -46,18 +46,21 @@ class Page implements Entry, Augmentable, Responsable, Protectable, JsonSerializ
             return $this->url;
         }
 
-        if ($this->isRedirect()) {
-            return $this->redirectUrl();
+        return optional($this->entry())->url();
+    }
+
+    public function urlWithoutRedirect()
+    {
+        if ($this->url) {
+            return $this->url;
         }
 
-        if ($this->reference && $this->referenceExists()) {
-            return URL::makeRelative($this->absoluteUrl());
-        }
+        return optional($this->entry())->urlWithoutRedirect();
     }
 
     public function isRedirect()
     {
-        return optional($this->entry())->isRedirect();
+        return optional($this->entry())->isRedirect() ?? false;
     }
 
     public function setDepth($depth)
@@ -157,8 +160,12 @@ class Page implements Entry, Augmentable, Responsable, Protectable, JsonSerializ
 
     public function uri()
     {
+        if ($this->url) {
+            return $this->url();
+        }
+
         if (! $this->reference) {
-            return optional($this->parent)->uri();
+            return null;
         }
 
         $uris = Blink::store('structure-uris');
@@ -185,21 +192,19 @@ class Page implements Entry, Augmentable, Responsable, Protectable, JsonSerializ
     public function absoluteUrl()
     {
         if ($this->url) {
-            return $this->url;
+            return URL::makeAbsolute($this->url);
         }
 
-        if ($this->isRedirect()) {
-            return $this->redirectUrl();
+        return optional($this->entry())->absoluteUrl();
+    }
+
+    public function absoluteUrlWithoutRedirect()
+    {
+        if ($this->url) {
+            return $this->absoluteUrl();
         }
 
-        if ($this->reference && $this->referenceExists()) {
-            $url = vsprintf('%s/%s', [
-                rtrim($this->site()->absoluteUrl(), '/'),
-                ltrim($this->uri(), '/'),
-            ]);
-
-            return $url === '/' ? $url : rtrim($url, '/');
-        }
+        return optional($this->entry())->absoluteUrlWithoutRedirect();
     }
 
     public function isRoot()

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -42,20 +42,12 @@ class Page implements Entry, Augmentable, Responsable, Protectable, JsonSerializ
 
     public function url()
     {
-        if ($this->url) {
-            return $this->url;
-        }
-
-        return optional($this->entry())->url();
+        return $this->url ?? optional($this->entry())->url();
     }
 
     public function urlWithoutRedirect()
     {
-        if ($this->url) {
-            return $this->url;
-        }
-
-        return optional($this->entry())->urlWithoutRedirect();
+        return $this->url ?? optional($this->entry())->urlWithoutRedirect();
     }
 
     public function isRedirect()

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -56,7 +56,7 @@ class Structure extends Tags
                 'parent'      => $parent,
                 'depth'       => $depth,
                 'is_current'  => rtrim(URL::getCurrent(), '/') == rtrim($page->url(), '/'),
-                'is_parent'   => Site::current()->url() === $page->url() ? false : URL::isAncestorOf(URL::getCurrent(), $page->url()),
+                'is_parent'   => Site::current()->url() === $page->url() ? false : URL::isAncestorOf(URL::getCurrent(), $page->urlWithoutRedirect()),
                 'is_external' => URL::isExternal($page->absoluteUrl()),
             ]);
         })->filter()->values()->all();

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -204,31 +204,41 @@ class EntryTest extends TestCase
 
         $this->assertEquals('/blog/foo', $entryEn->uri());
         $this->assertEquals('/blog/foo', $entryEn->url());
+        $this->assertEquals('/blog/foo', $entryEn->urlWithoutRedirect());
         $this->assertEquals('http://domain.com/blog/foo', $entryEn->absoluteUrl());
+        $this->assertEquals('http://domain.com/blog/foo', $entryEn->absoluteUrlWithoutRedirect());
         $this->assertEquals('http://domain.com/amp/blog/foo', $entryEn->ampUrl());
         $this->assertNull($entryEn->redirectUrl());
 
         $this->assertEquals('/le-blog/le-foo', $entryFr->uri());
         $this->assertEquals('/fr/le-blog/le-foo', $entryFr->url());
+        $this->assertEquals('/fr/le-blog/le-foo', $entryFr->urlWithoutRedirect());
         $this->assertEquals('http://domain.com/fr/le-blog/le-foo', $entryFr->absoluteUrl());
+        $this->assertEquals('http://domain.com/fr/le-blog/le-foo', $entryFr->absoluteUrlWithoutRedirect());
         $this->assertEquals('http://domain.com/fr/amp/le-blog/le-foo', $entryFr->ampUrl());
         $this->assertNull($entryFr->redirectUrl());
 
         $this->assertEquals('/das-blog/das-foo', $entryDe->uri());
         $this->assertEquals('/das-blog/das-foo', $entryDe->url());
+        $this->assertEquals('/das-blog/das-foo', $entryDe->urlWithoutRedirect());
         $this->assertEquals('http://domain.de/das-blog/das-foo', $entryDe->absoluteUrl());
+        $this->assertEquals('http://domain.de/das-blog/das-foo', $entryDe->absoluteUrlWithoutRedirect());
         $this->assertEquals('http://domain.de/amp/das-blog/das-foo', $entryDe->ampUrl());
         $this->assertNull($entryDe->redirectUrl());
 
         $this->assertEquals('/blog/redirected', $redirectEntry->uri());
         $this->assertEquals('http://example.com/page', $redirectEntry->url());
+        $this->assertEquals('/blog/redirected', $redirectEntry->urlWithoutRedirect());
         $this->assertEquals('http://example.com/page', $redirectEntry->absoluteUrl());
+        $this->assertEquals('http://domain.com/blog/redirected', $redirectEntry->absoluteUrlWithoutRedirect());
         $this->assertNull($redirectEntry->ampUrl());
         $this->assertEquals('http://example.com/page', $redirectEntry->redirectUrl());
 
         $this->assertEquals('/blog/redirect-404', $redirect404Entry->uri());
         $this->assertEquals('/blog/redirect-404', $redirect404Entry->url());
+        $this->assertEquals('/blog/redirect-404', $redirect404Entry->urlWithoutRedirect());
         $this->assertEquals('http://domain.com/blog/redirect-404', $redirect404Entry->absoluteUrl());
+        $this->assertEquals('http://domain.com/blog/redirect-404', $redirect404Entry->absoluteUrlWithoutRedirect());
         $this->assertEquals('http://domain.com/amp/blog/redirect-404', $redirect404Entry->ampUrl());
         $this->assertEquals(404, $redirect404Entry->redirectUrl());
     }
@@ -274,14 +284,17 @@ class EntryTest extends TestCase
 
         $this->assertEquals('/parent', $parent->uri());
         $this->assertEquals('/parent/child', $parent->url());
+        $this->assertEquals('/parent', $parent->urlWithoutRedirect());
         $this->assertEquals('/parent/child', $parent->redirectUrl());
 
         $this->assertEquals('/parent/child', $child->uri());
         $this->assertEquals('/parent/child', $child->url());
+        $this->assertEquals('/parent/child', $child->urlWithoutRedirect());
         $this->assertNull($child->redirectUrl());
 
         $this->assertEquals('/nochildren', $noChildren->uri());
         $this->assertEquals('/nochildren', $noChildren->url());
+        $this->assertEquals('/nochildren', $noChildren->urlWithoutRedirect());
         $this->assertEquals(404, $noChildren->redirectUrl());
     }
 

--- a/tests/Data/Structures/PageTest.php
+++ b/tests/Data/Structures/PageTest.php
@@ -148,7 +148,9 @@ class PageTest extends TestCase
 
         $this->assertEquals('/the/actual/entry/uri', $page->uri());
         $this->assertEquals('/the/actual/entry/uri', $page->url());
+        $this->assertEquals('/the/actual/entry/uri', $page->urlWithoutRedirect());
         $this->assertEquals('http://localhost/the/actual/entry/uri', $page->absoluteUrl());
+        $this->assertEquals('http://localhost/the/actual/entry/uri', $page->absoluteUrlWithoutRedirect());
         $this->assertFalse($page->isRedirect());
     }
 
@@ -171,8 +173,67 @@ class PageTest extends TestCase
 
         $this->assertEquals('/the/actual/entry/uri', $page->uri());
         $this->assertEquals('http://example.com/page', $page->url());
+        $this->assertEquals('/the/actual/entry/uri', $page->urlWithoutRedirect());
         $this->assertEquals('http://example.com/page', $page->absoluteUrl());
+        $this->assertEquals('http://localhost/the/actual/entry/uri', $page->absoluteUrlWithoutRedirect());
         $this->assertTrue($page->isRedirect());
+    }
+
+    /** @test */
+    public function it_gets_the_uri_of_a_hardcoded_relative_link()
+    {
+        $tree = $this->newTree()->setStructure(
+            $this->mock(Nav::class)
+        );
+
+        $page = (new Page)
+            ->setTree($tree)
+            ->setUrl('/blog');
+
+        $this->assertEquals('/blog', $page->uri());
+        $this->assertEquals('/blog', $page->url());
+        $this->assertEquals('/blog', $page->urlWithoutRedirect());
+        $this->assertEquals('http://localhost/blog', $page->absoluteUrl());
+        $this->assertEquals('http://localhost/blog', $page->absoluteUrlWithoutRedirect());
+        $this->assertFalse($page->isRedirect());
+    }
+
+    /** @test */
+    public function it_gets_the_uri_of_a_hardcoded_absolute_link()
+    {
+        $tree = $this->newTree()->setStructure(
+            $this->mock(Nav::class)
+        );
+
+        $page = (new Page)
+            ->setTree($tree)
+            ->setUrl('https://google.com');
+
+        $this->assertEquals('https://google.com', $page->uri());
+        $this->assertEquals('https://google.com', $page->url());
+        $this->assertEquals('https://google.com', $page->urlWithoutRedirect());
+        $this->assertEquals('https://google.com', $page->absoluteUrl());
+        $this->assertEquals('https://google.com', $page->absoluteUrlWithoutRedirect());
+        $this->assertFalse($page->isRedirect());
+    }
+
+    /** @test */
+    public function it_gets_the_uri_of_a_hardcoded_text_only_page()
+    {
+        $tree = $this->newTree()->setStructure(
+            $this->mock(Nav::class)
+        );
+
+        $page = (new Page)
+            ->setTree($tree)
+            ->setTitle('Test');
+
+        $this->assertNull($page->uri());
+        $this->assertNull($page->url());
+        $this->assertNull($page->urlWithoutRedirect());
+        $this->assertNull($page->absoluteUrl());
+        $this->assertNull($page->absoluteUrlWithoutRedirect());
+        $this->assertFalse($page->isRedirect());
     }
 
     /** @test */


### PR DESCRIPTION
In this PR:
- Add `urlWithoutRedirect` and `absoluteUrlWithoutRedirect` methods to the `Routable` trait. (Which means `Entry`, etc) I didn't want to add arguments to `url` and `absoluteUrl`, which #3234 was doing.
- Fixes #2359 by using the new redirect-less urls in the ancestor comparison in the nav/structure tag.
- Removed redundant `url` and `absoluteUrl` logic inside `Page`. Let it delegate to the entry.
- Adds test coverage for nav items with hardcoded urls, or url-less ones.
- Fixes `absoluteUrl` / `{{ permalink }}` for nav items with hardcoded urls. Previously they would simply output whatever was input. It wouldn't convert it to absolute.
- Removes code introduced in 17b7978 which is no longer relevant since #1445
