### PR TITLE
Force reload of javascript modules in Live Preview

### DIFF
--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Responses;
 
 use Facades\Statamic\View\Cascade;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Str;
 use Statamic\Auth\Protect\Protection;
 use Statamic\Events\ResponseCreated;
 use Statamic\Exceptions\NotFoundHttpException;
@@ -136,12 +137,18 @@ class DataResponse implements Responsable
 
     protected function contents()
     {
-        return (new View)
+        $contents = (new View)
             ->template($this->data->template())
             ->layout($this->data->layout())
             ->with($this->with)
             ->cascadeContent($this->data)
             ->render();
+
+        if ($this->isLivePreview()) {
+           $contents = $this->versionJavascriptModules($contents);
+        }
+
+        return $contents;
     }
 
     protected function cascade()
@@ -179,6 +186,26 @@ class DataResponse implements Responsable
     protected function isLivePreview()
     {
         return $this->request->headers->get('X-Statamic-Live-Preview');
+    }
+
+    protected function versionJavascriptModules($contents)
+    {
+        $sufix = 't='.(microtime(true) * 10000);
+
+        return preg_replace_callback('~<script[^>]*type=("|\')module\1[^>]*>~i', function($scriptMatches) use ($sufix) {
+            return preg_replace_callback('~src=("|\')(.*?)\1~i', function($matches) use ($sufix) {
+                $quote = $matches[1];
+                $url = $matches[2];
+
+                if (Str::contains($url, '?')) {
+                    $url = str_replace('?', "?$sufix&", $url);
+                } else {
+                    $url .= "?$sufix";
+                }
+
+                return 'src='.$quote.$url.$quote;
+            }, $scriptMatches[0]);
+        }, $contents);
     }
 
     public static function contentType($type)

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -145,7 +145,7 @@ class DataResponse implements Responsable
             ->render();
 
         if ($this->isLivePreview()) {
-           $contents = $this->versionJavascriptModules($contents);
+            $contents = $this->versionJavascriptModules($contents);
         }
 
         return $contents;
@@ -192,8 +192,8 @@ class DataResponse implements Responsable
     {
         $sufix = 't='.(microtime(true) * 10000);
 
-        return preg_replace_callback('~<script[^>]*type=("|\')module\1[^>]*>~i', function($scriptMatches) use ($sufix) {
-            return preg_replace_callback('~src=("|\')(.*?)\1~i', function($matches) use ($sufix) {
+        return preg_replace_callback('~<script[^>]*type=("|\')module\1[^>]*>~i', function ($scriptMatches) use ($sufix) {
+            return preg_replace_callback('~src=("|\')(.*?)\1~i', function ($matches) use ($sufix) {
                 $quote = $matches[1];
                 $url = $matches[2];
 

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -190,17 +190,17 @@ class DataResponse implements Responsable
 
     protected function versionJavascriptModules($contents)
     {
-        $sufix = 't='.(microtime(true) * 10000);
-
-        return preg_replace_callback('~<script[^>]*type=("|\')module\1[^>]*>~i', function ($scriptMatches) use ($sufix) {
-            return preg_replace_callback('~src=("|\')(.*?)\1~i', function ($matches) use ($sufix) {
+        return preg_replace_callback('~<script[^>]*type=("|\')module\1[^>]*>~i', function ($scriptMatches) {
+            return preg_replace_callback('~src=("|\')(.*?)\1~i', function ($matches) {
                 $quote = $matches[1];
                 $url = $matches[2];
 
+                $parameter = 't='.(microtime(true) * 10000);
+
                 if (Str::contains($url, '?')) {
-                    $url = str_replace('?', "?$sufix&", $url);
+                    $url = str_replace('?', "?$parameter&", $url);
                 } else {
-                    $url .= "?$sufix";
+                    $url .= "?$parameter";
                 }
 
                 return 'src='.$quote.$url.$quote;


### PR DESCRIPTION
Fixes #3287.

I tried several solutions on the Javascript level, but to no avail. This forces the reload by adding a changing parameter to the `src` attribute of the `script` tag.