### PR TITLE
Add border to selected non-image thumbnails in the asset browser

### DIFF
--- a/resources/js/components/assets/Browser/Breadcrumbs.vue
+++ b/resources/js/components/assets/Browser/Breadcrumbs.vue
@@ -8,7 +8,7 @@
             class="mr-1 group"
         >
             <span v-if="index !== 0" class="px-sm text-grey-70">></span>
-            <span class="icon icon-folder  text-blue-lighter group-hover:text-blue" />
+            <span class="icon icon-folder text-blue-lighter group-hover:text-blue" />
             <span class="text-grey-70 group-hover:text-grey-80">{{ part }}</span>
         </a>
     </div>

--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -103,8 +103,8 @@
                                     <tr v-if="folder && folder.parent_path && !restrictFolderNavigation">
                                         <td />
                                         <td @click="selectFolder(folder.parent_path)">
-                                            <a class="flex items-center cursor-pointer">
-                                                <file-icon extension="folder" class="w-8 h-8 mr-1 inline-block text-blue-lighter hover:text-blue"></file-icon>
+                                            <a class="flex items-center cursor-pointer group">
+                                                <file-icon extension="folder" class="w-8 h-8 mr-1 inline-block text-blue-lighter group-hover:text-blue"></file-icon>
                                                 ..
                                             </a>
                                         </td>
@@ -113,8 +113,8 @@
                                     <tr v-for="(folder, i) in folders" :key="folder.path" v-if="!restrictFolderNavigation">
                                         <td />
                                         <td @click="selectFolder(folder.path)">
-                                            <a class="flex items-center cursor-pointer">
-                                                <file-icon extension="folder" class="w-8 h-8 mr-1 inline-block text-blue-lighter hover:text-blue"></file-icon>
+                                            <a class="flex items-center cursor-pointer group">
+                                                <file-icon extension="folder" class="w-8 h-8 mr-1 inline-block text-blue-lighter group-hover:text-blue"></file-icon>
                                                 {{ folder.basename }}
                                             </a>
                                         </td>

--- a/resources/js/components/assets/Browser/Thumbnail.vue
+++ b/resources/js/components/assets/Browser/Thumbnail.vue
@@ -14,7 +14,7 @@
                 class="asset-thumbnail max-h-full max-w-full mx-auto rounded lazyload"
                 :class="{'w-8 h-8 fit-cover': square}"
                 />
-            <file-icon v-else :extension="asset.extension" class="h-full w-full p-1"></file-icon>
+            <file-icon v-else :extension="asset.extension" class="asset-thumbnail w-full h-full p-1 rounded"></file-icon>
         </template>
 
     </div>


### PR DESCRIPTION
Fixes #3521.

Also groups the hover on the folders in the regular view.