### PR TITLE
Fix N+1 queries from `all` method on User Roles & User Groups classes

### DIFF
--- a/src/Auth/Eloquent/Roles.php
+++ b/src/Auth/Eloquent/Roles.php
@@ -4,6 +4,7 @@ namespace Statamic\Auth\Eloquent;
 
 use Illuminate\Support\Facades\DB;
 use Statamic\Contracts\Auth\User as UserContract;
+use Statamic\Facades\Blink;
 
 class Roles
 {
@@ -27,13 +28,15 @@ class Roles
      */
     public function all()
     {
-        $roles = collect($this->table()->where('user_id', $this->user->id())->get());
+        return Blink::once("eloquent-user-roles-{$this->user->id()}", function () {
+            $roles = collect($this->table()->where('user_id', $this->user->id())->get());
 
-        if ($roles->isEmpty()) {
-            return collect();
-        }
+            if ($roles->isEmpty()) {
+                return collect();
+            }
 
-        return $roles; // todo: groups
+            return $roles; // todo: groups
+        });
     }
 
     /**

--- a/src/Auth/Eloquent/UserGroups.php
+++ b/src/Auth/Eloquent/UserGroups.php
@@ -4,6 +4,7 @@ namespace Statamic\Auth\Eloquent;
 
 use Illuminate\Support\Facades\DB;
 use Statamic\Contracts\Auth\User as UserContract;
+use Statamic\Facades\Blink;
 
 class UserGroups
 {
@@ -27,13 +28,15 @@ class UserGroups
      */
     public function all()
     {
-        $groups = collect($this->table()->where('user_id', $this->user->id())->get());
+        return Blink::once("eloquent-user-groups-{$this->user->id()}", function () {
+            $groups = collect($this->table()->where('user_id', $this->user->id())->get());
 
-        if ($groups->isEmpty()) {
-            return collect();
-        }
+            if ($groups->isEmpty()) {
+                return collect();
+            }
 
-        return $groups;
+            return $groups;
+        });
     }
 
     /**


### PR DESCRIPTION
We've just had a staging site become really slow.

We did some discovery and it turns out it is mostly down to Statamic making N+1 queries on the `all` method of the  Role & Group classes. 

Here's the kind of things we were seeing:

![image](https://user-images.githubusercontent.com/19637309/114700904-0b589f80-9d1a-11eb-931a-85c944c355e3.png)
![image](https://user-images.githubusercontent.com/19637309/114700950-18758e80-9d1a-11eb-8c5a-583fbb10490e.png)

This PR fixes the issue by wrapping the `all` code in a `Blink` closure, meaning it will be cached for the request.

I'm sure there was an issue for this at some point, not sure where it's gone. I fixed a similar issue for the `users` table I think a couple months back.

Let me know if you need any changes. I'd be happy to make them. This is a fairly big issue for us at the moment 😅 