### PR TITLE
Let the link and path tags output data urls

### DIFF
--- a/src/Tags/Link.php
+++ b/src/Tags/Link.php
@@ -10,9 +10,9 @@ class Link extends Path
     public function wildcard($method)
     {
         if ($data = Data::find($method)) {
-            return $data
-                ->in($this->params->get('in', Site::current()->handle()))
-                ->absoluteUrl();
+            $data = $data->in($this->params->get('in', Site::current()->handle()));
+
+            return $this->params->bool('absolute', false) ? $data->absoluteUrl() : $data->url();
         }
     }
 }

--- a/src/Tags/Link.php
+++ b/src/Tags/Link.php
@@ -2,7 +2,17 @@
 
 namespace Statamic\Tags;
 
+use Statamic\Facades\Data;
+use Statamic\Facades\Site;
+
 class Link extends Path
 {
-    //
+    public function wildcard($method)
+    {
+        if ($data = Data::find($method)) {
+            return $data
+                ->in($this->params->get('in', Site::current()->handle()))
+                ->absoluteUrl();
+        }
+    }
 }

--- a/src/Tags/Path.php
+++ b/src/Tags/Path.php
@@ -3,8 +3,10 @@
 namespace Statamic\Tags;
 
 use Statamic\Facades;
+use Statamic\Facades\Data;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
+use Statamic\Support\Str;
 
 class Path extends Tags
 {
@@ -21,6 +23,12 @@ class Path extends Tags
         }
 
         $site = Site::current();
+
+        if (! Str::isUrl($src) && ($data = Data::find($src))) {
+            return $data
+                ->in($this->params->get('in', $site->handle()))
+                ->absoluteUrl();
+        }
 
         $url = $this->params->bool('absolute', false)
             ? $site->absoluteUrl().'/'.$src

--- a/src/Tags/Path.php
+++ b/src/Tags/Path.php
@@ -23,14 +23,15 @@ class Path extends Tags
         }
 
         $site = Site::current();
+        $absolute = $this->params->bool('absolute', false);
 
         if (! Str::isUrl($src) && ($data = Data::find($src))) {
-            return $data
-                ->in($this->params->get('in', $site->handle()))
-                ->absoluteUrl();
+            $data = $data->in($this->params->get('in', $site->handle()));
+
+            return $absolute ? $data->absoluteUrl() : $data->url();
         }
 
-        $url = $this->params->bool('absolute', false)
+        $url = $absolute
             ? $site->absoluteUrl().'/'.$src
             : URL::makeRelative($site->url()).'/'.$src;
 

--- a/tests/Tags/LinkTest.php
+++ b/tests/Tags/LinkTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Tags;
+
+use Statamic\Facades\Data;
+use Statamic\Facades\Parse;
+use Tests\TestCase;
+
+class LinkTest extends TestCase
+{
+    private function tag($tag, $data = [])
+    {
+        return (string) Parse::template($tag, $data);
+    }
+
+    /** @test */
+    public function it_outputs_datas_absolute_url_if_not_providing_a_url()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('en')->andReturnSelf();
+        $entry->shouldReceive('absoluteUrl')->andReturn('http://example.com/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('http://example.com/test', $this->tag('{{ link:123 }}'));
+    }
+
+    /** @test */
+    public function it_outputs_datas_absolute_url_for_a_specific_site_if_not_providing_a_url()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnSelf();
+        $entry->shouldReceive('absoluteUrl')->andReturn('http://example.com/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('http://example.com/test', $this->tag('{{ link:123 in="fr" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_nothing_if_data_doesnt_exist()
+    {
+        Data::shouldReceive('find')->with('123')->andReturnNull();
+
+        $this->assertEquals('', $this->tag('{{ link:123 }}'));
+    }
+}

--- a/tests/Tags/LinkTest.php
+++ b/tests/Tags/LinkTest.php
@@ -14,6 +14,32 @@ class LinkTest extends TestCase
     }
 
     /** @test */
+    public function it_outputs_datas_url_if_not_providing_a_url()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('en')->andReturnSelf();
+        $entry->shouldReceive('url')->andReturn('/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('/test', $this->tag('{{ link:123 }}'));
+        $this->assertEquals('/test', $this->tag('{{ link:123 absolute="false" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_datas_url_for_a_specific_site_if_not_providing_a_url()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnSelf();
+        $entry->shouldReceive('url')->andReturn('/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('/test', $this->tag('{{ link:123 in="fr" }}'));
+        $this->assertEquals('/test', $this->tag('{{ link:123 in="fr" absolute="false" }}'));
+    }
+
+    /** @test */
     public function it_outputs_datas_absolute_url_if_not_providing_a_url()
     {
         $entry = $this->mock(Entry::class);
@@ -22,7 +48,7 @@ class LinkTest extends TestCase
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);
 
-        $this->assertEquals('http://example.com/test', $this->tag('{{ link:123 }}'));
+        $this->assertEquals('http://example.com/test', $this->tag('{{ link:123 absolute="true" }}'));
     }
 
     /** @test */
@@ -34,7 +60,7 @@ class LinkTest extends TestCase
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);
 
-        $this->assertEquals('http://example.com/test', $this->tag('{{ link:123 in="fr" }}'));
+        $this->assertEquals('http://example.com/test', $this->tag('{{ link:123 in="fr" absolute="true" }}'));
     }
 
     /** @test */

--- a/tests/Tags/PathTest.php
+++ b/tests/Tags/PathTest.php
@@ -170,6 +170,32 @@ class PathTest extends TestCase
     }
 
     /** @test */
+    public function it_outputs_datas_url_if_not_providing_a_url()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('en')->andReturnSelf();
+        $entry->shouldReceive('url')->andReturn('/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('/test', $this->tag('{{ path to="123" }}'));
+        $this->assertEquals('/test', $this->tag('{{ path to="123" absolute="false" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_datas_url_for_a_specific_site_if_not_providing_a_url()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnSelf();
+        $entry->shouldReceive('url')->andReturn('/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('/test', $this->tag('{{ path to="123" in="fr" }}'));
+        $this->assertEquals('/test', $this->tag('{{ path to="123" in="fr" absolute="false" }}'));
+    }
+
+    /** @test */
     public function it_outputs_datas_absolute_url_if_not_providing_a_url()
     {
         $entry = $this->mock(Entry::class);
@@ -178,7 +204,7 @@ class PathTest extends TestCase
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);
 
-        $this->assertEquals('http://example.com/test', $this->tag('{{ path to="123" }}'));
+        $this->assertEquals('http://example.com/test', $this->tag('{{ path to="123" absolute="true" }}'));
     }
 
     /** @test */
@@ -190,6 +216,6 @@ class PathTest extends TestCase
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);
 
-        $this->assertEquals('http://example.com/test', $this->tag('{{ path to="123" in="fr" }}'));
+        $this->assertEquals('http://example.com/test', $this->tag('{{ path to="123" in="fr" absolute="true" }}'));
     }
 }

--- a/tests/Tags/PathTest.php
+++ b/tests/Tags/PathTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Tags;
 
+use Statamic\Facades\Data;
 use Statamic\Facades\Parse;
 use Statamic\Facades\Site;
 use Tests\TestCase;
@@ -166,5 +167,29 @@ class PathTest extends TestCase
         $this->setSiteUrl('http://example.com/sub/');
         $this->assertEquals('/sub/the/path', $this->tag('{{ path to="the/path" absolute="false" }}'));
         $this->assertEquals('/sub/the/path', $this->tag('{{ path to="/the/path" absolute="false" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_datas_absolute_url_if_not_providing_a_url()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('en')->andReturnSelf();
+        $entry->shouldReceive('absoluteUrl')->andReturn('http://example.com/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('http://example.com/test', $this->tag('{{ path to="123" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_datas_absolute_url_for_a_specific_site_if_not_providing_a_url()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnSelf();
+        $entry->shouldReceive('absoluteUrl')->andReturn('http://example.com/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('http://example.com/test', $this->tag('{{ path to="123" in="fr" }}'));
     }
 }


### PR DESCRIPTION
This PR adds data fetching to the link and path tags. We had this in v2.

Fixes #3529 

```
{{ link to="this-is-an-id" }}
{{ path to="this-is-an-id" }}
```

It'll output that entry for the current site. You can ask for it in a specific one:

```
{{ link to="this-is-an-id" in="site_two" }}
{{ path to="this-is-an-id" in="site_two" }}
```

There's also the shorthand version when using the `link` tag:

```
{{ link:this-is-an-id }}
{{ link:this-is-an-id in="site_two" }}
```