### PR TITLE
Allow localized entries to have empty values

### DIFF
--- a/src/Data/ExistsAsFile.php
+++ b/src/Data/ExistsAsFile.php
@@ -47,9 +47,15 @@ trait ExistsAsFile
             return YAML::dump($data);
         }
 
-        $content = array_pull($data, 'content');
+        if (! Arr::has($data, 'content')) {
+            return YAML::dumpFrontMatter($data);
+        }
 
-        return YAML::dumpFrontMatter($data, $content);
+        $content = $data['content'];
+
+        return $content === null
+            ? YAML::dump($data)
+            : YAML::dumpFrontMatter(Arr::except($data, 'content'), $content);
     }
 
     protected function shouldRemoveNullsFromFileData()

--- a/src/Data/ExistsAsFile.php
+++ b/src/Data/ExistsAsFile.php
@@ -37,7 +37,11 @@ trait ExistsAsFile
         // file type used. Right now it's assuming markdown. Maybe you'll want to
         // save JSON, etc. TODO: Make it smarter when the time is right.
 
-        $data = Arr::removeNullValues($this->fileData());
+        $data = $this->fileData();
+
+        if ($this->shouldRemoveNullsFromFileData()) {
+            $data = Arr::removeNullValues($data);
+        }
 
         if ($this->fileExtension() === 'yaml') {
             return YAML::dump($data);
@@ -46,6 +50,11 @@ trait ExistsAsFile
         $content = array_pull($data, 'content');
 
         return YAML::dumpFrontMatter($data, $content);
+    }
+
+    protected function shouldRemoveNullsFromFileData()
+    {
+        return true;
     }
 
     public function fileLastModified()

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -435,7 +435,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
 
     public function fileData()
     {
-        $array = $this->data()->merge([
+        $array = Arr::removeNullValues([
             'id' => $this->id(),
             'origin' => optional($this->origin())->id(),
             'published' => $this->published === false ? false : null,
@@ -445,7 +445,18 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
             $array['blueprint'] = $this->blueprint;
         }
 
-        return $array->all();
+        $data = $this->data()->all();
+
+        if ($this->isRoot()) {
+            $data = Arr::removeNullValues($data);
+        }
+
+        return array_merge($array, $data);
+    }
+
+    protected function shouldRemoveNullsFromFileData()
+    {
+        return false;
     }
 
     public function ampable()

--- a/tests/Data/ExistsAsFileTest.php
+++ b/tests/Data/ExistsAsFileTest.php
@@ -10,25 +10,14 @@ class ExistsAsFileTest extends TestCase
     /** @test */
     public function it_dumps_yaml_without_front_matter_when_the_file_extension_is_yaml()
     {
-        $item = new class extends ExistsAsFileItem {
-            public function fileExtension()
-            {
-                return 'yaml';
-            }
-
-            public function shouldRemoveNullsFromFileData()
-            {
-                return false;
-            }
-
-            public function fileData()
-            {
-                return [
-                    'foo' => 'bar',
-                    'content' => 'the content',
-                ];
-            }
-        };
+        $item = $this->makeItem([
+            'extension' => 'yaml',
+            'removeNulls' => false,
+            'data' => [
+                'foo' => 'bar',
+                'content' => 'the content',
+            ],
+        ]);
 
         $expected = <<<'EOT'
 foo: bar
@@ -41,25 +30,14 @@ EOT;
     /** @test */
     public function it_dumps_yaml_with_front_matter_when_theres_content()
     {
-        $item = new class extends ExistsAsFileItem {
-            public function fileExtension()
-            {
-                return 'md';
-            }
-
-            public function shouldRemoveNullsFromFileData()
-            {
-                return false;
-            }
-
-            public function fileData()
-            {
-                return [
-                    'foo' => 'bar',
-                    'content' => 'the content',
-                ];
-            }
-        };
+        $item = $this->makeItem([
+            'extension' => 'md',
+            'removeNulls' => false,
+            'data' => [
+                'foo' => 'bar',
+                'content' => 'the content',
+            ],
+        ]);
 
         $expected = <<<'EOT'
 ---
@@ -74,24 +52,13 @@ EOT;
     /** @test */
     public function it_dumps_yaml_with_front_matter_when_content_is_missing()
     {
-        $item = new class extends ExistsAsFileItem {
-            public function fileExtension()
-            {
-                return 'md';
-            }
-
-            public function shouldRemoveNullsFromFileData()
-            {
-                return false;
-            }
-
-            public function fileData()
-            {
-                return [
-                    'foo' => 'bar',
-                ];
-            }
-        };
+        $item = $this->makeItem([
+            'extension' => 'md',
+            'removeNulls' => false,
+            'data' => [
+                'foo' => 'bar',
+            ],
+        ]);
 
         $expected = <<<'EOT'
 ---
@@ -105,25 +72,14 @@ EOT;
     /** @test */
     public function it_dumps_yaml_without_front_matter_when_content_is_literally_null()
     {
-        $item = new class extends ExistsAsFileItem {
-            public function fileExtension()
-            {
-                return 'md';
-            }
-
-            public function shouldRemoveNullsFromFileData()
-            {
-                return false;
-            }
-
-            public function fileData()
-            {
-                return [
-                    'foo' => 'bar',
-                    'content' => null,
-                ];
-            }
-        };
+        $item = $this->makeItem([
+            'extension' => 'md',
+            'removeNulls' => false,
+            'data' => [
+                'foo' => 'bar',
+                'content' => null,
+            ],
+        ]);
 
         $expected = <<<'EOT'
 foo: bar
@@ -132,14 +88,42 @@ EOT;
 
         $this->assertEquals($expected, trim($item->fileContents()));
     }
-}
 
-class ExistsAsFileItem
-{
-    use ExistsAsFile;
-
-    public function path()
+    private function makeItem($args)
     {
-        //
+        return new class($args['extension'] ?? 'yaml', $args['removeNulls'] ?? true, $args['data'] ?? []) {
+            use ExistsAsFile;
+
+            protected $extension;
+            protected $shouldRemoveNulls;
+            protected $fileData;
+
+            public function __construct($extension, $shouldRemoveNulls, $fileData)
+            {
+                $this->extension = $extension;
+                $this->shouldRemoveNulls = $shouldRemoveNulls;
+                $this->fileData = $fileData;
+            }
+
+            public function path()
+            {
+                //
+            }
+
+            public function fileExtension()
+            {
+                return $this->extension;
+            }
+
+            public function shouldRemoveNullsFromFileData()
+            {
+                return $this->shouldRemoveNulls;
+            }
+
+            public function fileData()
+            {
+                return $this->fileData;
+            }
+        };
     }
 }

--- a/tests/Data/ExistsAsFileTest.php
+++ b/tests/Data/ExistsAsFileTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Data;
+
+use Statamic\Data\ExistsAsFile;
+use Tests\TestCase;
+
+class ExistsAsFileTest extends TestCase
+{
+    /** @test */
+    public function it_dumps_yaml_without_front_matter_when_the_file_extension_is_yaml()
+    {
+        $item = new class extends ExistsAsFileItem {
+            public function fileExtension()
+            {
+                return 'yaml';
+            }
+
+            public function shouldRemoveNullsFromFileData()
+            {
+                return false;
+            }
+
+            public function fileData()
+            {
+                return [
+                    'foo' => 'bar',
+                    'content' => 'the content',
+                ];
+            }
+        };
+
+        $expected = <<<'EOT'
+foo: bar
+content: 'the content'
+EOT;
+
+        $this->assertEquals($expected, trim($item->fileContents()));
+    }
+
+    /** @test */
+    public function it_dumps_yaml_with_front_matter_when_theres_content()
+    {
+        $item = new class extends ExistsAsFileItem {
+            public function fileExtension()
+            {
+                return 'md';
+            }
+
+            public function shouldRemoveNullsFromFileData()
+            {
+                return false;
+            }
+
+            public function fileData()
+            {
+                return [
+                    'foo' => 'bar',
+                    'content' => 'the content',
+                ];
+            }
+        };
+
+        $expected = <<<'EOT'
+---
+foo: bar
+---
+the content
+EOT;
+
+        $this->assertEquals($expected, trim($item->fileContents()));
+    }
+
+    /** @test */
+    public function it_dumps_yaml_with_front_matter_when_content_is_missing()
+    {
+        $item = new class extends ExistsAsFileItem {
+            public function fileExtension()
+            {
+                return 'md';
+            }
+
+            public function shouldRemoveNullsFromFileData()
+            {
+                return false;
+            }
+
+            public function fileData()
+            {
+                return [
+                    'foo' => 'bar',
+                ];
+            }
+        };
+
+        $expected = <<<'EOT'
+---
+foo: bar
+---
+EOT;
+
+        $this->assertEquals($expected, trim($item->fileContents()));
+    }
+
+    /** @test */
+    public function it_dumps_yaml_without_front_matter_when_content_is_literally_null()
+    {
+        $item = new class extends ExistsAsFileItem {
+            public function fileExtension()
+            {
+                return 'md';
+            }
+
+            public function shouldRemoveNullsFromFileData()
+            {
+                return false;
+            }
+
+            public function fileData()
+            {
+                return [
+                    'foo' => 'bar',
+                    'content' => null,
+                ];
+            }
+        };
+
+        $expected = <<<'EOT'
+foo: bar
+content: null
+EOT;
+
+        $this->assertEquals($expected, trim($item->fileContents()));
+    }
+}
+
+class ExistsAsFileItem
+{
+    use ExistsAsFile;
+
+    public function path()
+    {
+        //
+    }
+}


### PR DESCRIPTION
Fixes #3406 

Until now, Statamic would strip out any nulls, empty strings, and empty arrays from the YAML before writing files. This was mainly to keep the files tidy.

Statamic's localization worked in such a way that if a localized entry didn't have a key in the YAML, it would fall back to whatever was in the origin.

Combine these two things, and you are left with the issue explained in #3406. Intentionally emptying out a field that would result in null would mean that it wouldn't be in the file, so always fell back to the originating entry's value.

This PR fixes that by preventing the nulls from being stripped out of localized entries.

Rather than preventing a huge change by preventing this in _all_ files (objects that use the `ExistsAsFile` trait) - it's selectively done to entries. The trait gets a new `shouldRemoveNullsFromFileData` method that defaults to `true`. The `Entry` class overrides it. In the future if other items should get this treatment, they can override the method too.

It's worth noting that while editing a localized entry in the CP, if you click the "sync field" button, it will _not_ save a null value to file. It just won't save anything to file, which keeps the fallback behavior in place.