### PR TITLE
Show private pages in Live Preview (and don’t cache them)

### DIFF
--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -112,13 +112,13 @@ class DataResponse implements Responsable
             return $this;
         }
 
-        if (! $this->isLivePreview() && ! $this->data->published()) {
-            throw new NotFoundHttpException;
+        if ($this->data->published()) {
+            return $this;
         }
 
-        if ($this->isLivePreview()) {
-            $this->headers['X-Statamic-Draft'] = true;
-        }
+        throw_unless($this->isLivePreview(), new NotFoundHttpException);
+
+        $this->headers['X-Statamic-Draft'] = true;
 
         return $this;
     }
@@ -129,13 +129,13 @@ class DataResponse implements Responsable
             return $this;
         }
 
-        if (! $this->isLivePreview() && $this->data->private()) {
-            throw new NotFoundHttpException;
+        if (! $this->data->private()) {
+            return $this;
         }
 
-        if ($this->isLivePreview()) {
-            $this->headers['X-Statamic-Private'] = true;
-        }
+        throw_unless($this->isLivePreview(), new NotFoundHttpException);
+
+        $this->headers['X-Statamic-Private'] = true;
 
         return $this;
     }

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -129,7 +129,13 @@ class DataResponse implements Responsable
             return $this;
         }
 
-        throw_if($this->data->private(), new NotFoundHttpException);
+        if (! $this->isLivePreview() && $this->data->private()) {
+            throw new NotFoundHttpException;
+        }
+
+        if ($this->isLivePreview()) {
+            $this->headers['X-Statamic-Private'] = true;
+        }
 
         return $this;
     }

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -62,8 +62,8 @@ class Cache
             return false;
         }
 
-        // Draft pages should not be cached.
-        if ($response->headers->has('X-Statamic-Draft')) {
+        // Draft and private pages should not be cached.
+        if ($response->headers->has('X-Statamic-Draft') || $response->headers->has('X-Statamic-Private')) {
             return false;
         }
 

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -250,6 +250,29 @@ class FrontendTest extends TestCase
     }
 
     /** @test */
+    public function future_private_entries_viewable_in_live_preview()
+    {
+        Carbon::setTestNow(Carbon::parse('2019-01-01'));
+        $this->withStandardFakeErrorViews();
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRendered('default', 'The template contents');
+
+        tap($this->makeCollection()->dated(true)->futureDateBehavior('private'))->save();
+        tap($this->makePage('about')->date('2019-01-02'))->save();
+
+        $this
+            ->get('/about', ['X-Statamic-Live-Preview' => true])
+            ->assertStatus(200)
+            ->assertHeader('X-Statamic-Private', true);
+    }
+
+    /** @test */
+    public function future_private_entries_dont_get_statically_cached()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /** @test */
     public function past_private_entries_are_not_viewable()
     {
         Carbon::setTestNow(Carbon::parse('2019-01-01'));
@@ -270,6 +293,29 @@ class FrontendTest extends TestCase
         $this
             ->get('/about')
             ->assertStatus(404);
+    }
+
+    /** @test */
+    public function past_private_entries_are_viewable_in_live_preview()
+    {
+        Carbon::setTestNow(Carbon::parse('2019-01-01'));
+        $this->withStandardFakeErrorViews();
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRendered('default', 'The template contents');
+
+        tap($this->makeCollection()->dated(true)->pastDateBehavior('private'))->save();
+        tap($this->makePage('about')->date('2018-01-01'))->save();
+
+        $this
+            ->get('/about', ['X-Statamic-Live-Preview' => true])
+            ->assertStatus(200)
+            ->assertHeader('X-Statamic-Private', true);
+    }
+
+    /** @test */
+    public function past_private_entries_dont_get_statically_cached()
+    {
+        $this->markTestIncomplete();
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #3113.