### PR TITLE
Fix taxonomy not loading when using site subdirectory

### DIFF
--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -249,12 +249,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
     {
         $site = Site::current();
 
-        $prefix = $this->collection() ? $this->collection()->uri($site->handle()) : $site->url();
-
-        // If the site's url was defined absolutely, it'll be absolute.
-        // We need it relative. Perhaps the url method should return
-        // a relative url already, but that's a problem for later.
-        $prefix = URL::makeRelative($prefix);
+        $prefix = $this->collection() ? $this->collection()->uri($site->handle()) : '/';
 
         return URL::tidy($prefix.str_replace('_', '-', '/'.$this->handle));
     }

--- a/tests/Data/Taxonomies/TaxonomyTest.php
+++ b/tests/Data/Taxonomies/TaxonomyTest.php
@@ -6,7 +6,9 @@ use Facades\Statamic\Fields\BlueprintRepository;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
+use Statamic\Facades\Site;
 use Statamic\Fields\Blueprint;
+use Statamic\Support\Arr;
 use Statamic\Taxonomies\Taxonomy;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -109,6 +111,20 @@ class TaxonomyTest extends TestCase
         $this->assertEquals('/tags', $taxonomy->uri());
         $this->assertEquals('/tags', $taxonomy->url());
         $this->assertEquals('http://localhost/tags', $taxonomy->absoluteUrl());
+    }
+
+    /** @test */
+    public function it_gets_the_url_when_the_site_is_using_a_subdirectory()
+    {
+        $config = config('statamic.sites');
+        Arr::set($config, 'sites.en.url', '/subdirectory/');
+        Site::setConfig($config);
+
+        $taxonomy = (new Taxonomy)->handle('tags');
+
+        $this->assertEquals('/tags', $taxonomy->uri());
+        $this->assertEquals('/subdirectory/tags', $taxonomy->url());
+        $this->assertEquals('http://localhost/subdirectory/tags', $taxonomy->absoluteUrl());
     }
 
     /** @test */


### PR DESCRIPTION
If you have a site that uses a subdirectory (like `/subdirectory/` or `/blog/` or `/statamic/`) then it would incorrectly prefix that to the taxonomy's `uri`, which should be relative to the site root.

When you visit `/subdirectory/tags`, it would look for a taxonomy with a uri of `/tags`, which doesn't match what Statamic thinks the taxonomy's uri is. This results in a 404. A similar thing happens for the term url.

The taxonomy `url` would also have the double prefix. e.g. `/subdirectory/subdirectory/tags`.