### PR TITLE
Disable FLoC by default

### DIFF
--- a/src/Http/Middleware/DisableFloc.php
+++ b/src/Http/Middleware/DisableFloc.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Statamic\Http\Middleware;
+
+use Closure;
+
+class DisableFloc
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        if (config('statamic.system.disable_floc', true)) {
+            $response->headers->set('Permissions-Policy', 'interest-cohort=()');
+        }
+
+        return $response;
+    }
+}

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -30,7 +30,8 @@ class AppServiceProvider extends ServiceProvider
         $this->app[\Illuminate\Contracts\Http\Kernel::class]
             ->pushMiddleware(\Statamic\Http\Middleware\PoweredByHeader::class)
             ->pushMiddleware(\Statamic\Http\Middleware\CheckComposerJsonScripts::class)
-            ->pushMiddleware(\Statamic\Http\Middleware\CheckMultisite::class);
+            ->pushMiddleware(\Statamic\Http\Middleware\CheckMultisite::class)
+            ->pushMiddleware(\Statamic\Http\Middleware\DisableFloc::class);
 
         $this->loadViewsFrom("{$this->root}/resources/views", 'statamic');
 

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -413,6 +413,23 @@ class FrontendTest extends TestCase
     }
 
     /** @test */
+    public function disables_floc_through_header_by_default()
+    {
+        $this->createPage('about');
+
+        $this->get('about')->assertHeader('Permissions-Policy', 'interest-cohort=()');
+    }
+
+    /** @test */
+    public function doesnt_disable_floc_through_header_if_disabled()
+    {
+        config(['statamic.system.disable_floc' => false]);
+        $this->createPage('about');
+
+        $this->get('about')->assertHeaderMissing('Permissions-Policy', 'interest-cohort=()');
+    }
+
+    /** @test */
     public function headers_can_be_set_in_content()
     {
         $page = $this->createPage('about', ['with' => [


### PR DESCRIPTION
This PR adds a middleware that disables Google's FLoC by default. No action will be necessary from the user. Upgrade Statamic and it'll be disabled.

If you want to enable it, you can flick the switch in `config/statamic/system.php`.

```php
'disable_floc' => false,
```

Closes #3520 

(I'm still just working on the assumption that this header is enough to stop whatever it does. I don't know what I'm supposed to do to confirm it. The header is definitely there though.)