### PR TITLE
Register core permissions after Localize middleware

### DIFF
--- a/src/Http/Middleware/CP/RegisterCorePermissions.php
+++ b/src/Http/Middleware/CP/RegisterCorePermissions.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Statamic\Http\Middleware\CP;
+
+use Closure;
+use Facades\Statamic\Auth\CorePermissions;
+
+class RegisterCorePermissions
+{
+    public function handle($request, Closure $next)
+    {
+        CorePermissions::boot();
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/RegisterCorePermissions.php
+++ b/src/Http/Middleware/RegisterCorePermissions.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Statamic\Http\Middleware;
+
+use Closure;
+use Facades\Statamic\Auth\CorePermissions;
+
+class RegisterCorePermissions
+{
+    public function handle($request, Closure $next)
+    {
+        CorePermissions::boot();
+
+        return $next($request);
+    }
+}

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -133,6 +133,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->make(Router::class)->middlewareGroup('statamic.web', [
             \Statamic\Http\Middleware\StacheLock::class,
             \Statamic\Http\Middleware\Localize::class,
+            \Statamic\Http\Middleware\RegisterCorePermissions::class,
             \Statamic\Http\Middleware\AuthGuard::class,
             \Statamic\StaticCaching\Middleware\Cache::class,
         ]);

--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Providers;
 
-use Facades\Statamic\Auth\CorePermissions;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;

--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -81,10 +81,6 @@ class AuthServiceProvider extends ServiceProvider
             return optional(User::fromUser($user))->hasPermission($ability) === true ? true : null;
         });
 
-        $this->app->booted(function () {
-            CorePermissions::boot();
-        });
-
         foreach ($this->policies as $key => $policy) {
             Gate::policy($key, $policy);
         }

--- a/src/Providers/CpServiceProvider.php
+++ b/src/Providers/CpServiceProvider.php
@@ -82,6 +82,7 @@ class CpServiceProvider extends ServiceProvider
         $router->middlewareGroup('statamic.cp.authenticated', [
             \Statamic\Http\Middleware\CP\Authorize::class,
             \Statamic\Http\Middleware\CP\Localize::class,
+            \Statamic\Http\Middleware\CP\RegisterCorePermissions::class,
             \Statamic\Http\Middleware\CP\CountUsers::class,
         ]);
     }


### PR DESCRIPTION
Fixes #3467.

The `CorePermissions::boot()` method registers and translates the permissions. The locale is set in the `Localize` middleware, using the user's locale and falling back the app locale. The `CorePermissions::boot()` should run after the `Localize` middleware to use the right locale for its translations. That is what this PR does.

Issue #2041 is similar, but it is not solved by this PR.