### PR TITLE
PublishContainer: deep compare before and after values in watch handler

### DIFF
--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -217,7 +217,7 @@ export default {
         values: {
             deep: true,
             handler(after, before) {
-                if (before === after) return;
+                if (_.isEqual(before, after)) return;
                 this.$store.commit(`publish/${this.name}/setValues`, after);
             }
         },
@@ -225,7 +225,7 @@ export default {
         meta: {
             deep: true,
             handler(after, before) {
-                if (before === after) return;
+                if (_.isEqual(before, after)) return;
                 this.$store.commit(`publish/${this.name}/setMeta`, after);
             }
         },


### PR DESCRIPTION
This fixes #3537.

The meta object is deeply nested, so the `===` operator didn't cut it. 