### PR TITLE
Read-only asset editor

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -158,7 +158,7 @@
 
                                 <template slot="actions" slot-scope="{ row: asset }">
                                     <dropdown-list>
-                                        <dropdown-item :text="__('Edit')" @click="edit(asset.id)" />
+                                        <dropdown-item :text="__(canEdit ? 'Edit' : 'View')" @click="edit(asset.id)" />
                                         <div class="divider" v-if="asset.actions.length" />
                                         <data-list-inline-actions
                                             :item="asset.id"
@@ -225,6 +225,7 @@
         <asset-editor
             v-if="showAssetEditor"
             :id="editedAssetId"
+            :read-only="! canEdit"
             @closed="closeAssetEditor"
             @saved="assetSaved"
         />
@@ -331,9 +332,7 @@ export default {
         },
 
         canEdit() {
-            return true;
-            // TODO
-            // return this.can('assets:'+ this.container.id +':edit')
+            return this.can('assets:'+ this.container.id +':edit')
         },
 
         canUpload() {
@@ -502,9 +501,7 @@ export default {
         },
 
         edit(id) {
-            if (this.canEdit) {
-                this.editedAssetId = id;
-            }
+            this.editedAssetId = id;
         },
 
         closeAssetEditor() {

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -91,7 +91,7 @@
                         <iframe class="h-full w-full" frameborder="0" :src="'https://docs.google.com/gview?url=' + asset.permalink + '&embedded=true'"></iframe>
                     </div>
 
-                    <div class="editor-file-actions">
+                    <div class="editor-file-actions" v-if="!readOnly">
                         <button v-if="isImage && isFocalPointEditorEnabled" type="button" class="btn" @click.prevent="openFocalPointEditor">
                             {{ __('Set Focal Point') }}
                         </button>
@@ -131,10 +131,15 @@
 
                         <div class="editor-form-fields">
                             <div v-if="error" class="bg-red text-white p-2 shadow mb-2" v-text="error" />
-                            <publish-fields :fields="fields" @updated="setFieldValue" @meta-updated="setFieldMeta" />
+                            <publish-fields 
+                                :fields="fields"
+                                :read-only="readOnly"
+                                @updated="setFieldValue"
+                                @meta-updated="setFieldMeta"
+                            />
                         </div>
 
-                        <div class="editor-form-actions text-right">
+                        <div class="editor-form-actions text-right" v-if="!readOnly">
                             <button v-if="allowDeleting && canRunAction('delete')" type="button" class="btn-danger mr-1" @click="runAction('delete')">
                                 {{ __('Delete') }}
                             </button>
@@ -191,6 +196,9 @@ export default {
     props: {
         id: {
             required: true
+        },
+        readOnly: {
+            type: Boolean,
         },
         allowDeleting: {
             type: Boolean,

--- a/resources/sass/components/assets.scss
+++ b/resources/sass/components/assets.scss
@@ -248,6 +248,7 @@
 
     .editor-preview {
         flex-basis: 64%;
+        flex-grow: 1;
     }
 
     .editor-form {
@@ -298,12 +299,11 @@
 }
 
 .asset-editor .editor-preview {
-	@apply bg-grey-80 flex flex-col justify-between relative;
+	@apply bg-grey-80 flex flex-col justify-between;
 
     .editor-preview-image {
-        flex-grow: 1;
-        padding: 30px 30px 90px; // bottom padding accounts for action button bar.
-        height: 100%;
+        flex: 1;
+        padding: 30px;
         display: flex;
         flex-direction: column;
     }
@@ -335,7 +335,7 @@
     }
 
     .editor-file-actions {
-		@apply absolute bottom-0 inset-x-0 bg-grey-90 p-2 text-center h-16;
+		@apply bg-grey-90 p-2 text-center h-16;
 
         button {
             @apply mx-sm;


### PR DESCRIPTION
Fixes #930.

* No editing buttons below the image (full-height image preview)
* Read Only data fields (if any)
* No save / delete buttons

