### PR TITLE
Don’t scroll to top when using pagination in collection widget

### DIFF
--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -61,6 +61,10 @@ export default {
         resourceMeta: {
             type: Object,
             required: true
+        },
+        scrollToTop: {
+            type: Boolean,
+            default: true,
         }
     },
 
@@ -153,7 +157,9 @@ export default {
 
             this.$emit('page-selected', page);
 
-            window.scrollTo(0, 0);
+            if (this.scrollToTop) {
+                window.scrollTo(0, 0);
+            }
         },
 
         selectPreviousPage() {

--- a/resources/js/components/entries/Widget.vue
+++ b/resources/js/components/entries/Widget.vue
@@ -26,6 +26,7 @@
                     class="py-1 border-t bg-grey-20 rounded-b-lg text-sm"
                     :resource-meta="meta"
                     @page-selected="selectPage"
+                    :scroll-to-top="false"
                 />
             </div>
         </data-list>


### PR DESCRIPTION
Fixes #2264.