### PR TITLE
Bard: make first line after image editable

### DIFF
--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -1,9 +1,9 @@
 <template>
 
     <div class="bard-inline-image-container">
-        <div ref="content" />
         <div v-if="src">
             <div class="p-1 text-center">
+                <div ref="content" hidden />
                 <img :src="src" class="block mx-auto" data-drag-handle />
             </div>
 


### PR DESCRIPTION
Fixes #1069.

The obligatory `ref="content"` [thingy](https://github.com/ueberdosis/tiptap/blob/2466d3398f3cd1c64aa9a6211860a69bc253cb91/examples/Components/Routes/DragHandle/DragItem.js#L20) was causing the problem. I moved it to another place, problem gone.

By the way I don't see any custom drag handle, before or after this change. The `<div ref="content" .. />` can even be removed, together with the `data-drag-handle` attribute and dragging still works.