### PR TITLE
Turn off automatic hyphenation in Bard

### DIFF
--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -14,7 +14,6 @@
 
 .bard-editor .ProseMirror {
     @apply p-1 min-h-48;
-    hyphens: auto;
 }
 
 // Modes


### PR DESCRIPTION
This fixes #3438. See the comments in the issue.

