### PR TITLE
Turn off automatic hyphenation in Bard

### DIFF
--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -14,7 +14,6 @@
 
 .bard-editor .ProseMirror {
     @apply p-1 min-h-48;
-    hyphens: auto;
 }
 
 // Modes

--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -248,7 +248,8 @@
 .bard-fieldtype .ProseMirror > {
     p {
         @apply text-grey-80;
-        word-wrap: break-word;
+        word-break: break-all;
+        word-break: break-word;
 
         line-height: 1.7;
         text-size-adjust: 100%;


### PR DESCRIPTION
This fixes #3438. See the comments in the issue.

This is a continuation of #3557, I closed that one by accident.

@jasonvarga Good catch, the fix broke #3115 again. This time I fixed #3115 again, and not by using `hyphens: auto;` (which causes #3438). This css puts words that don't fit anymore on the next line. And very long words, longer than a single line, just get cut off at the end of the line.