### PR TITLE
Always show an error when an asset upload fails

### DIFF
--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -132,9 +132,9 @@ export default {
 
                     if (! errMsg) {
                         if (response.status === 413) {
-                            errMsg = __('File is too large');
+                            errMsg = __('Upload failed. The file is larger than is allowed by your server.');
                         } else {
-                            errMsg = __('Something went wrong');    
+                            errMsg = __('Upload failed. The file might be larger than is allowed by your server.');
                         }
                     }
 

--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -128,6 +128,14 @@ export default {
 
                     if (response.responseJSON) {
                         errMsg = response.responseJSON.message;
+                    } 
+
+                    if (! errMsg) {
+                        if (response.status === 413) {
+                            errMsg = __('File is too large');
+                        } else {
+                            errMsg = __('Something went wrong');    
+                        }
                     }
 
                     upload.errorMessage = errMsg;


### PR DESCRIPTION
Fixes #3558.

This uses a new string `'File is too large'`, which should be added to the translations.