### PR TITLE
Fix bugs in Link and Path tags

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -9,6 +9,7 @@ use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
+use Statamic\Contracts\Data\Linkable;
 use Statamic\Data\ContainsData;
 use Statamic\Data\HasAugmentedInstance;
 use Statamic\Data\TracksQueriedColumns;
@@ -29,7 +30,7 @@ use Stringy\Stringy;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Mime\MimeTypes;
 
-class Asset implements AssetContract, Augmentable
+class Asset implements AssetContract, Augmentable, Linkable
 {
     use HasAugmentedInstance, FluentlyGetsAndSets, TracksQueriedColumns, ContainsData {
         set as traitSet;

--- a/src/Contracts/Data/Linkable.php
+++ b/src/Contracts/Data/Linkable.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Statamic\Contracts\Data;
+
+interface Linkable
+{
+}

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -3,6 +3,7 @@
 namespace Statamic\Entries;
 
 use Statamic\Contracts\Data\Augmentable as AugmentableContract;
+use Statamic\Contracts\Data\Linkable;
 use Statamic\Contracts\Entries\Collection as Contract;
 use Statamic\Data\ContainsCascadingData;
 use Statamic\Data\ExistsAsFile;
@@ -20,12 +21,13 @@ use Statamic\Facades\Search;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
 use Statamic\Facades\Taxonomy;
+use Statamic\Facades\URL;
 use Statamic\Statamic;
 use Statamic\Structures\CollectionStructure;
 use Statamic\Support\Arr;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Collection implements Contract, AugmentableContract
+class Collection implements Contract, AugmentableContract, Linkable
 {
     use FluentlyGetsAndSets, ExistsAsFile, HasAugmentedData, ContainsCascadingData;
 
@@ -180,6 +182,17 @@ class Collection implements Contract, AugmentableContract
         $site = $site ?? $this->sites()->first();
 
         return optional($mount->in($site))->uri();
+    }
+
+    public function absoluteUrl($site = null)
+    {
+        if (! $uri = $this->uri($site)) {
+            return null;
+        }
+
+        $site = $site ?? $this->sites()->first();
+
+        return URL::tidy(Site::get($site)->absoluteUrl().$uri);
     }
 
     public function showUrl()

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Carbon;
 use Statamic\Contracts\Auth\Protect\Protectable;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
+use Statamic\Contracts\Data\Linkable;
 use Statamic\Contracts\Data\Localization;
 use Statamic\Contracts\Entries\Entry as Contract;
 use Statamic\Contracts\GraphQL\ResolvesValues as ResolvesValuesContract;
@@ -34,7 +35,7 @@ use Statamic\Statamic;
 use Statamic\Support\Arr;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Entry implements Contract, Augmentable, Responsable, Localization, Protectable, ResolvesValuesContract
+class Entry implements Contract, Augmentable, Responsable, Localization, Protectable, ResolvesValuesContract, Linkable
 {
     use Routable {
         uri as routableUri;

--- a/src/Tags/Link.php
+++ b/src/Tags/Link.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Tags;
 
+use Statamic\Contracts\Data\Linkable;
+use Statamic\Contracts\Data\Localizable;
 use Statamic\Facades\Data;
 use Statamic\Facades\Site;
 
@@ -9,8 +11,10 @@ class Link extends Path
 {
     public function wildcard($method)
     {
-        if ($data = Data::find($method)) {
-            $data = $data->in($this->params->get('in', Site::current()->handle()));
+        if (($data = Data::find($method)) && $data instanceof Linkable) {
+            if ($data instanceof Localizable) {
+                $data = $data->in($this->params->get('in', Site::current()->handle()));
+            }
 
             return $this->params->bool('absolute', false) ? $data->absoluteUrl() : $data->url();
         }

--- a/src/Tags/Path.php
+++ b/src/Tags/Path.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Tags;
 
+use Statamic\Contracts\Data\Linkable;
+use Statamic\Contracts\Data\Localizable;
 use Statamic\Facades;
 use Statamic\Facades\Data;
 use Statamic\Facades\Site;
@@ -25,8 +27,10 @@ class Path extends Tags
         $site = Site::current();
         $absolute = $this->params->bool('absolute', false);
 
-        if (! Str::isUrl($src) && ($data = Data::find($src))) {
-            $data = $data->in($this->params->get('in', $site->handle()));
+        if (! Str::isUrl($src) && ($data = Data::find($src)) && $data instanceof Linkable) {
+            if ($data instanceof Localizable) {
+                $data = $data->in($this->params->get('in', $site->handle()));
+            }
 
             return $absolute ? $data->absoluteUrl() : $data->url();
         }

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Carbon;
 use Statamic\Contracts\Auth\Protect\Protectable;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
+use Statamic\Contracts\Data\Linkable;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Data\ContainsSupplementalData;
 use Statamic\Data\HasAugmentedInstance;
@@ -21,7 +22,7 @@ use Statamic\Revisions\Revisable;
 use Statamic\Routing\Routable;
 use Statamic\Statamic;
 
-class LocalizedTerm implements Term, Responsable, Augmentable, Protectable
+class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, Linkable
 {
     use Revisable, Routable, Publishable, HasAugmentedInstance, TracksQueriedColumns, TracksLastModified, ContainsSupplementalData;
 

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -4,6 +4,7 @@ namespace Statamic\Taxonomies;
 
 use Illuminate\Contracts\Support\Responsable;
 use Statamic\Contracts\Data\Augmentable as AugmentableContract;
+use Statamic\Contracts\Data\Linkable;
 use Statamic\Contracts\Taxonomies\Taxonomy as Contract;
 use Statamic\Data\ContainsCascadingData;
 use Statamic\Data\ContainsSupplementalData;
@@ -22,7 +23,7 @@ use Statamic\Facades\URL;
 use Statamic\Statamic;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Taxonomy implements Contract, Responsable, AugmentableContract
+class Taxonomy implements Contract, Responsable, AugmentableContract, Linkable
 {
     use FluentlyGetsAndSets, ExistsAsFile, HasAugmentedData, ContainsCascadingData, ContainsSupplementalData;
 

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -504,6 +504,11 @@ class CollectionTest extends TestCase
     /** @test */
     public function it_gets_the_uri_and_url_from_the_mounted_entry()
     {
+        Site::setConfig(['sites' => [
+            'en' => ['url' => 'http://domain.com/en/'],
+            'fr' => ['url' => 'http://domain.com/fr/'],
+        ]]);
+
         $mount = $this->mock(Entry::class);
         $frenchMount = $this->mock(Entry::class);
         $mount->shouldReceive('in')->with('en')->andReturnSelf();
@@ -519,19 +524,25 @@ class CollectionTest extends TestCase
 
         $this->assertNull($collection->uri());
         $this->assertNull($collection->url());
+        $this->assertNull($collection->absoluteUrl());
         $this->assertNull($collection->uri('en'));
         $this->assertNull($collection->url('en'));
+        $this->assertNull($collection->absoluteUrl('en'));
         $this->assertNull($collection->uri('fr'));
         $this->assertNull($collection->url('fr'));
+        $this->assertNull($collection->absoluteUrl('fr'));
 
         $collection->mount('mounted');
 
         $this->assertEquals('/blog', $collection->uri());
         $this->assertEquals('/en/blog', $collection->url());
+        $this->assertEquals('http://domain.com/en/blog', $collection->absoluteUrl());
         $this->assertEquals('/blog', $collection->uri('en'));
         $this->assertEquals('/en/blog', $collection->url('en'));
+        $this->assertEquals('http://domain.com/en/blog', $collection->absoluteUrl('en'));
         $this->assertEquals('/le-blog', $collection->uri('fr'));
         $this->assertEquals('/fr/le-blog', $collection->url('fr'));
+        $this->assertEquals('http://domain.com/fr/le-blog', $collection->absoluteUrl('fr'));
     }
 
     /** @test */

--- a/tests/Tags/LinkTest.php
+++ b/tests/Tags/LinkTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Tags;
 
+use Statamic\Entries\Entry;
 use Statamic\Facades\Data;
 use Statamic\Facades\Parse;
 use Tests\TestCase;

--- a/tests/Tags/PathTest.php
+++ b/tests/Tags/PathTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Tags;
 
+use Statamic\Entries\Entry;
 use Statamic\Facades\Data;
 use Statamic\Facades\Parse;
 use Statamic\Facades\Site;


### PR DESCRIPTION
Fixes #3548.

* Checks `instanceof Localizable` before calling `->in($site)`
* Checks `instanceof Linkable`\* before calling `->url()` or `->absoluteUrl()`
* Adds `absoluteUrl()` method to `Collection`

\* The `Linkable` interface was added. Not sure if that is the preferred name, it is easy to rename right now.
