### PR TITLE
Add a red asterisk to required fields in a set

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Field.vue
+++ b/resources/js/components/fieldtypes/replicator/Field.vue
@@ -4,6 +4,7 @@
 
         <label class="block">
             {{ display }}
+            <i class="required" v-if="field.required">*</i>
             <span v-if="isReadOnly" class="text-grey-50 font-normal text-2xs mx-sm" v-text="__('Read Only')" />
         </label>
 


### PR DESCRIPTION
Fixes #2274. 

Fixes it for Replicators too, because Bard and Replicators use the same set component.