### PR TITLE
Make Statamic Stores configurable via env file

### DIFF
--- a/config/stache.php
+++ b/config/stache.php
@@ -30,47 +30,47 @@ return [
 
         'taxonomies' => [
             'class' => Stores\TaxonomiesStore::class,
-            'directory' => base_path('content/taxonomies'),
+            'directory' => base_path(env('STATAMIC_STORE_TAXONOMIES', 'content/taxonomies')),
         ],
 
         'terms' => [
             'class' => Stores\TermsStore::class,
-            'directory' => base_path('content/taxonomies'),
+            'directory' => base_path(env('STATAMIC_STORE_TERMS', 'content/taxonomies')),
         ],
 
         'collections' => [
             'class' => Stores\CollectionsStore::class,
-            'directory' => base_path('content/collections'),
+            'directory' => base_path(env('STATAMIC_STORE_COLLECTIONS', 'content/collections')),
         ],
 
         'entries' => [
             'class' => Stores\EntriesStore::class,
-            'directory' => base_path('content/collections'),
+            'directory' => base_path(env('STATAMIC_STORE_ENTRIES', 'content/collections')),
         ],
 
         'navigation' => [
             'class' => Stores\NavigationStore::class,
-            'directory' => base_path('content/navigation'),
+            'directory' => base_path(env('STATAMIC_STORE_NAVIGATION','content/navigation')),
         ],
 
         'collection-trees' => [
             'class' => Stores\CollectionTreeStore::class,
-            'directory' => base_path('content/trees/collections'),
+            'directory' => base_path(env('STATAMIC_STORE_COLLECTION_TREES','content/trees/collections')),
         ],
 
         'nav-trees' => [
             'class' => Stores\NavTreeStore::class,
-            'directory' => base_path('content/trees/navigation'),
+            'directory' => base_path(env('STATAMIC_STORE_NAVIGATION_TREES','content/trees/navigation')),
         ],
 
         'globals' => [
             'class' => Stores\GlobalsStore::class,
-            'directory' => base_path('content/globals'),
+            'directory' => base_path(env('STATAMIC_STORE_GLOBALS','content/globals')),
         ],
 
         'asset-containers' => [
             'class' => Stores\AssetContainersStore::class,
-            'directory' => base_path('content/assets'),
+            'directory' => base_path(env('STATAMIC_STORE_ASSET_CONTAINERS','content/assets')),
         ],
 
         'assets' => [
@@ -79,7 +79,7 @@ return [
 
         'users' => [
             'class' => Stores\UsersStore::class,
-            'directory' => base_path('users'),
+            'directory' => base_path(env('STATAMIC_STORE_USERS','users')),
         ],
 
     ],

--- a/config/stache.php
+++ b/config/stache.php
@@ -50,27 +50,27 @@ return [
 
         'navigation' => [
             'class' => Stores\NavigationStore::class,
-            'directory' => base_path(env('STATAMIC_STORE_NAVIGATION','content/navigation')),
+            'directory' => base_path(env('STATAMIC_STORE_NAVIGATION', 'content/navigation')),
         ],
 
         'collection-trees' => [
             'class' => Stores\CollectionTreeStore::class,
-            'directory' => base_path(env('STATAMIC_STORE_COLLECTION_TREES','content/trees/collections')),
+            'directory' => base_path(env('STATAMIC_STORE_COLLECTION_TREES', 'content/trees/collections')),
         ],
 
         'nav-trees' => [
             'class' => Stores\NavTreeStore::class,
-            'directory' => base_path(env('STATAMIC_STORE_NAVIGATION_TREES','content/trees/navigation')),
+            'directory' => base_path(env('STATAMIC_STORE_NAVIGATION_TREES', 'content/trees/navigation')),
         ],
 
         'globals' => [
             'class' => Stores\GlobalsStore::class,
-            'directory' => base_path(env('STATAMIC_STORE_GLOBALS','content/globals')),
+            'directory' => base_path(env('STATAMIC_STORE_GLOBALS', 'content/globals')),
         ],
 
         'asset-containers' => [
             'class' => Stores\AssetContainersStore::class,
-            'directory' => base_path(env('STATAMIC_STORE_ASSET_CONTAINERS','content/assets')),
+            'directory' => base_path(env('STATAMIC_STORE_ASSET_CONTAINERS', 'content/assets')),
         ],
 
         'assets' => [
@@ -79,7 +79,7 @@ return [
 
         'users' => [
             'class' => Stores\UsersStore::class,
-            'directory' => base_path(env('STATAMIC_STORE_USERS','users')),
+            'directory' => base_path(env('STATAMIC_STORE_USERS', 'users')),
         ],
 
     ],


### PR DESCRIPTION
There are cases, where you want to change the storage path per environment. This PR will make it possible by default.

**One example Usecase**
In a current Projekt, we do have 3 stages:
- Local (Development)
- Dev (Dev Stage for User Acceptance tests)
- Live System (Well ...)

We do use different places to store the  »content« like collections, taxonomies, terms, entries etc to separate the Statamic code from the content. Content Backups can be done easily, without the need to store the Statamic code. We got Version-Control for this stuff.  
Having everything in one Git is really useful, but not for page with multiple hundred edits per day. This would get really messy in a git. 

On the other side, we are using the same directory for user information. Once a user has been created, this user can login into both systems.
Locally the user's directory will be the Statamic default though. 

Our use case might be special, but I can imagine that it will be really handy for others to have the possibility to change those paths per environment. This is really helpful if working with different stages.