### PR TITLE
Link tag ID lookup only when using id param

### DIFF
--- a/src/Tags/Link.php
+++ b/src/Tags/Link.php
@@ -2,17 +2,10 @@
 
 namespace Statamic\Tags;
 
-use Statamic\Facades\Data;
-use Statamic\Facades\Site;
-
 class Link extends Path
 {
     public function wildcard($method)
     {
-        if ($data = Data::find($method)) {
-            $data = $data->in($this->params->get('in', Site::current()->handle()));
-
-            return $this->params->bool('absolute', false) ? $data->absoluteUrl() : $data->url();
-        }
+        return $this->getUrlFromId($method);
     }
 }

--- a/src/Tags/Path.php
+++ b/src/Tags/Path.php
@@ -6,7 +6,6 @@ use Statamic\Facades;
 use Statamic\Facades\Data;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
-use Statamic\Support\Str;
 
 class Path extends Tags
 {
@@ -18,23 +17,48 @@ class Path extends Tags
     public function index()
     {
         // If no src param was used, we will treat this as a regular `path` variable.
-        if (! $src = $this->params->get(['src', 'to'])) {
+        if (! $this->params->hasAny(['src', 'to', 'id'])) {
             return $this->context->get('path');
         }
 
-        $site = Site::current();
-        $absolute = $this->params->bool('absolute', false);
-
-        if (! Str::isUrl($src) && ($data = Data::find($src))) {
-            $data = $data->in($this->params->get('in', $site->handle()));
-
-            return $absolute ? $data->absoluteUrl() : $data->url();
+        if ($id = $this->params->get('id')) {
+            return $this->getUrlFromId($id);
         }
 
-        $url = $absolute
-            ? $site->absoluteUrl().'/'.$src
-            : URL::makeRelative($site->url()).'/'.$src;
+        if ($path = $this->params->get(['src', 'to'])) {
+            return $this->getUrlFromPath($path);
+        }
+    }
+
+    protected function getUrlFromId($id)
+    {
+        if (! $data = Data::find($id)) {
+            return;
+        }
+
+        $data = $data->in($this->targetSite()->handle());
+
+        return $this->wantsAbsoluteUrl() ? $data->absoluteUrl() : $data->url();
+    }
+
+    protected function getUrlFromPath($path)
+    {
+        $site = $this->targetSite();
+
+        $url = $this->wantsAbsoluteUrl()
+            ? $site->absoluteUrl().'/'.$path
+            : URL::makeRelative($site->url()).'/'.$path;
 
         return Facades\Path::tidy($url);
+    }
+
+    protected function targetSite()
+    {
+        return Site::get($this->params->get('in', Site::current()->handle()));
+    }
+
+    protected function wantsAbsoluteUrl()
+    {
+        return $this->params->bool('absolute', false);
     }
 }

--- a/tests/Tags/LinkTest.php
+++ b/tests/Tags/LinkTest.php
@@ -4,17 +4,28 @@ namespace Tests\Tags;
 
 use Statamic\Facades\Data;
 use Statamic\Facades\Parse;
+use Statamic\Facades\Site;
 use Tests\TestCase;
 
 class LinkTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Site::setConfig(['sites' => [
+            'en' => ['url' => '/'],
+            'fr' => ['url' => '/fr'],
+        ]]);
+    }
+
     private function tag($tag, $data = [])
     {
         return (string) Parse::template($tag, $data);
     }
 
     /** @test */
-    public function it_outputs_datas_url_if_not_providing_a_url()
+    public function it_outputs_datas_url()
     {
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('en')->andReturnSelf();
@@ -27,7 +38,7 @@ class LinkTest extends TestCase
     }
 
     /** @test */
-    public function it_outputs_datas_url_for_a_specific_site_if_not_providing_a_url()
+    public function it_outputs_datas_url_for_a_specific_site()
     {
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('fr')->andReturnSelf();
@@ -40,7 +51,7 @@ class LinkTest extends TestCase
     }
 
     /** @test */
-    public function it_outputs_datas_absolute_url_if_not_providing_a_url()
+    public function it_outputs_datas_absolute_url()
     {
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('en')->andReturnSelf();
@@ -52,7 +63,7 @@ class LinkTest extends TestCase
     }
 
     /** @test */
-    public function it_outputs_datas_absolute_url_for_a_specific_site_if_not_providing_a_url()
+    public function it_outputs_datas_absolute_url_for_a_specific_site()
     {
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('fr')->andReturnSelf();

--- a/tests/Tags/PathTest.php
+++ b/tests/Tags/PathTest.php
@@ -9,6 +9,16 @@ use Tests\TestCase;
 
 class PathTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Site::setConfig(['sites' => [
+            'en' => ['url' => '/'],
+            'fr' => ['url' => '/fr'],
+        ]]);
+    }
+
     private function tag($tag, $data = [])
     {
         return (string) Parse::template($tag, $data);
@@ -170,7 +180,7 @@ class PathTest extends TestCase
     }
 
     /** @test */
-    public function it_outputs_datas_url_if_not_providing_a_url()
+    public function it_outputs_datas_url()
     {
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('en')->andReturnSelf();
@@ -178,12 +188,12 @@ class PathTest extends TestCase
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);
 
-        $this->assertEquals('/test', $this->tag('{{ path to="123" }}'));
-        $this->assertEquals('/test', $this->tag('{{ path to="123" absolute="false" }}'));
+        $this->assertEquals('/test', $this->tag('{{ path id="123" }}'));
+        $this->assertEquals('/test', $this->tag('{{ path id="123" absolute="false" }}'));
     }
 
     /** @test */
-    public function it_outputs_datas_url_for_a_specific_site_if_not_providing_a_url()
+    public function it_outputs_datas_url_for_a_specific_site()
     {
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('fr')->andReturnSelf();
@@ -191,12 +201,12 @@ class PathTest extends TestCase
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);
 
-        $this->assertEquals('/test', $this->tag('{{ path to="123" in="fr" }}'));
-        $this->assertEquals('/test', $this->tag('{{ path to="123" in="fr" absolute="false" }}'));
+        $this->assertEquals('/test', $this->tag('{{ path id="123" in="fr" }}'));
+        $this->assertEquals('/test', $this->tag('{{ path id="123" in="fr" absolute="false" }}'));
     }
 
     /** @test */
-    public function it_outputs_datas_absolute_url_if_not_providing_a_url()
+    public function it_outputs_datas_absolute_url()
     {
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('en')->andReturnSelf();
@@ -204,11 +214,11 @@ class PathTest extends TestCase
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);
 
-        $this->assertEquals('http://example.com/test', $this->tag('{{ path to="123" absolute="true" }}'));
+        $this->assertEquals('http://example.com/test', $this->tag('{{ path id="123" absolute="true" }}'));
     }
 
     /** @test */
-    public function it_outputs_datas_absolute_url_for_a_specific_site_if_not_providing_a_url()
+    public function it_outputs_datas_absolute_url_for_a_specific_site()
     {
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('fr')->andReturnSelf();
@@ -216,6 +226,6 @@ class PathTest extends TestCase
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);
 
-        $this->assertEquals('http://example.com/test', $this->tag('{{ path to="123" in="fr" absolute="true" }}'));
+        $this->assertEquals('http://example.com/test', $this->tag('{{ path id="123" in="fr" absolute="true" }}'));
     }
 }


### PR DESCRIPTION
In #3530 I added support for entries to be retrieved by ID using the `link to="id"` syntax.

It doesn't just get entries though. It gets anything by ID. Assets, collections, whatever.

There was a conflict pointed out in #3548

This PR makes the ID functionality only happen if you use an `id` param.

```
{{ link to="path" }} outputs "/path"
{{ link id="123" }} outputs url of item with id 123
```

The shorthand still expects ids, though.

```
{{ link:123 }}
```

Fixes #3548 