### PR TITLE
Use the original item's url if doesnt exist in the target site

### DIFF
--- a/src/Tags/Path.php
+++ b/src/Tags/Path.php
@@ -38,6 +38,8 @@ class Path extends Tags
 
         if ($localized = $data->in($this->targetSite()->handle())) {
             $data = $localized;
+        } elseif ($this->wantsSpecificSite()) {
+            return;
         }
 
         return $this->wantsAbsoluteUrl() ? $data->absoluteUrl() : $data->url();
@@ -57,6 +59,11 @@ class Path extends Tags
     protected function targetSite()
     {
         return Site::get($this->params->get('in', Site::current()->handle()));
+    }
+
+    protected function wantsSpecificSite()
+    {
+        return $this->params->has('in');
     }
 
     protected function wantsAbsoluteUrl()

--- a/src/Tags/Path.php
+++ b/src/Tags/Path.php
@@ -36,7 +36,9 @@ class Path extends Tags
             return;
         }
 
-        $data = $data->in($this->targetSite()->handle());
+        if ($localized = $data->in($this->targetSite()->handle())) {
+            $data = $localized;
+        }
 
         return $this->wantsAbsoluteUrl() ? $data->absoluteUrl() : $data->url();
     }

--- a/tests/Tags/LinkTest.php
+++ b/tests/Tags/LinkTest.php
@@ -51,6 +51,19 @@ class LinkTest extends TestCase
     }
 
     /** @test */
+    public function it_outputs_datas_url_for_the_original_site_if_it_doesnt_exist_in_the_requested_one()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnNull();
+        $entry->shouldReceive('url')->andReturn('/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('/test', $this->tag('{{ link:123 in="fr" }}'));
+        $this->assertEquals('/test', $this->tag('{{ link:123 in="fr" absolute="false" }}'));
+    }
+
+    /** @test */
     public function it_outputs_datas_absolute_url()
     {
         $entry = $this->mock(Entry::class);
@@ -67,6 +80,18 @@ class LinkTest extends TestCase
     {
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('fr')->andReturnSelf();
+        $entry->shouldReceive('absoluteUrl')->andReturn('http://example.com/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('http://example.com/test', $this->tag('{{ link:123 in="fr" absolute="true" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_datas_absolute_url_for_the_original_site_if_it_doesnt_exist_in_the_requested_one()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnNull();
         $entry->shouldReceive('absoluteUrl')->andReturn('http://example.com/test');
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);

--- a/tests/Tags/LinkTest.php
+++ b/tests/Tags/LinkTest.php
@@ -51,16 +51,44 @@ class LinkTest extends TestCase
     }
 
     /** @test */
-    public function it_outputs_datas_url_for_the_original_site_if_it_doesnt_exist_in_the_requested_one()
+    public function it_outputs_datas_url_for_the_current_site()
     {
+        Site::setCurrent('fr');
+
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnSelf();
+        $entry->shouldReceive('url')->andReturn('/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('/test', $this->tag('{{ link:123 }}'));
+        $this->assertEquals('/test', $this->tag('{{ link:123 absolute="false" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_datas_url_for_the_original_site_if_it_doesnt_exist_in_the_current_one()
+    {
+        Site::setCurrent('fr');
+
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('fr')->andReturnNull();
         $entry->shouldReceive('url')->andReturn('/test');
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);
 
-        $this->assertEquals('/test', $this->tag('{{ link:123 in="fr" }}'));
-        $this->assertEquals('/test', $this->tag('{{ link:123 in="fr" absolute="false" }}'));
+        $this->assertEquals('/test', $this->tag('{{ link:123 }}'));
+        $this->assertEquals('/test', $this->tag('{{ link:123 absolute="false" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_nothing_if_it_doesnt_exist_in_the_requested_site()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnNull();
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('', $this->tag('{{ link:123 in="fr" }}'));
     }
 
     /** @test */
@@ -88,15 +116,31 @@ class LinkTest extends TestCase
     }
 
     /** @test */
-    public function it_outputs_datas_absolute_url_for_the_original_site_if_it_doesnt_exist_in_the_requested_one()
+    public function it_outputs_datas_absolute_url_for_the_current_site()
     {
+        Site::setCurrent('fr');
+
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnSelf();
+        $entry->shouldReceive('absoluteUrl')->andReturn('http://example.com/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('http://example.com/test', $this->tag('{{ link:123 absolute="true" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_datas_absolute_url_for_the_original_site_if_it_doesnt_exist_in_the_current_one()
+    {
+        Site::setCurrent('fr');
+
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('fr')->andReturnNull();
         $entry->shouldReceive('absoluteUrl')->andReturn('http://example.com/test');
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);
 
-        $this->assertEquals('http://example.com/test', $this->tag('{{ link:123 in="fr" absolute="true" }}'));
+        $this->assertEquals('http://example.com/test', $this->tag('{{ link:123 absolute="true" }}'));
     }
 
     /** @test */

--- a/tests/Tags/PathTest.php
+++ b/tests/Tags/PathTest.php
@@ -206,16 +206,44 @@ class PathTest extends TestCase
     }
 
     /** @test */
-    public function it_outputs_datas_url_for_the_original_site_if_it_doesnt_exist_in_the_requested_one()
+    public function it_outputs_datas_url_for_the_current_site()
     {
+        Site::setCurrent('fr');
+
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnSelf();
+        $entry->shouldReceive('url')->andReturn('/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('/test', $this->tag('{{ path id="123" }}'));
+        $this->assertEquals('/test', $this->tag('{{ path id="123" absolute="false" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_datas_url_for_the_original_site_if_it_doesnt_exist_in_the_current_one()
+    {
+        Site::setCurrent('fr');
+
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('fr')->andReturnNull();
         $entry->shouldReceive('url')->andReturn('/test');
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);
 
-        $this->assertEquals('/test', $this->tag('{{ path id="123" in="fr" }}'));
-        $this->assertEquals('/test', $this->tag('{{ path id="123" in="fr" absolute="false" }}'));
+        $this->assertEquals('/test', $this->tag('{{ path id="123" }}'));
+        $this->assertEquals('/test', $this->tag('{{ path id="123" absolute="false" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_nothing_if_it_doesnt_exist_in_the_requested_site()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnNull();
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('', $this->tag('{{ path id="123" in="fr" }}'));
     }
 
     /** @test */
@@ -243,14 +271,30 @@ class PathTest extends TestCase
     }
 
     /** @test */
-    public function it_outputs_datas_absolute_url_for_the_original_site_if_it_doesnt_exist_in_the_requested_one()
+    public function it_outputs_datas_absolute_url_for_the_current_site()
     {
+        Site::setCurrent('fr');
+
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnSelf();
+        $entry->shouldReceive('absoluteUrl')->andReturn('http://example.com/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('http://example.com/test', $this->tag('{{ path id="123" absolute="true" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_datas_absolute_url_for_the_original_site_if_it_doesnt_exist_in_the_current_one()
+    {
+        Site::setCurrent('fr');
+
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('fr')->andReturnNull();
         $entry->shouldReceive('absoluteUrl')->andReturn('http://example.com/test');
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);
 
-        $this->assertEquals('http://example.com/test', $this->tag('{{ path id="123" in="fr" absolute="true" }}'));
+        $this->assertEquals('http://example.com/test', $this->tag('{{ path id="123" absolute="true" }}'));
     }
 }

--- a/tests/Tags/PathTest.php
+++ b/tests/Tags/PathTest.php
@@ -206,6 +206,19 @@ class PathTest extends TestCase
     }
 
     /** @test */
+    public function it_outputs_datas_url_for_the_original_site_if_it_doesnt_exist_in_the_requested_one()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnNull();
+        $entry->shouldReceive('url')->andReturn('/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('/test', $this->tag('{{ path id="123" in="fr" }}'));
+        $this->assertEquals('/test', $this->tag('{{ path id="123" in="fr" absolute="false" }}'));
+    }
+
+    /** @test */
     public function it_outputs_datas_absolute_url()
     {
         $entry = $this->mock(Entry::class);
@@ -222,6 +235,18 @@ class PathTest extends TestCase
     {
         $entry = $this->mock(Entry::class);
         $entry->shouldReceive('in')->with('fr')->andReturnSelf();
+        $entry->shouldReceive('absoluteUrl')->andReturn('http://example.com/test');
+
+        Data::shouldReceive('find')->with('123')->andReturn($entry);
+
+        $this->assertEquals('http://example.com/test', $this->tag('{{ path id="123" in="fr" absolute="true" }}'));
+    }
+
+    /** @test */
+    public function it_outputs_datas_absolute_url_for_the_original_site_if_it_doesnt_exist_in_the_requested_one()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('in')->with('fr')->andReturnNull();
         $entry->shouldReceive('absoluteUrl')->andReturn('http://example.com/test');
 
         Data::shouldReceive('find')->with('123')->andReturn($entry);


### PR DESCRIPTION
This fixes the issue outlined in [this comment](https://github.com/statamic/cms/pull/3576#issuecomment-825613525)

If you use the link tag to point to an entry, and the entry doesn't exist in the target locale, it'll use the url of the original entry.