### PR TITLE
Bard: fix link data problems

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -227,8 +227,14 @@ export default {
         },
 
         htmlWithReplacedLinks() {
-            return this.html.replaceAll(/\"statamic:\/\/(.*)\"/g, (match, ref) => {
-                return `"${this.meta.linkData[ref].permalink}"`;
+            return this.html.replaceAll(/\"statamic:\/\/(.*?)\"/g, (match, ref) => {
+                const linkData = this.meta.linkData[ref];
+                if (! linkData) {
+                    this.$toast.error(`${__('No link data found for')} ${ref}`);
+                    return '""';
+                }
+
+                return `"${linkData.permalink}"`;
             });
         }
 

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -373,7 +373,7 @@ class Bard extends Replicator
             'previews' => $previews,
             '__collaboration' => ['existing'],
             'linkCollections' => empty($collections = $this->config('link_collections')) ? Collection::handles()->all() : $collections,
-            'linkData' => $this->getLinkData($value),
+            'linkData' => (object) $this->getLinkData($value),
         ];
     }
 


### PR DESCRIPTION
Fixes #3567.

* `Bard.php`: The `linkData` is cast to an object now. It is an associative array, which converts to a javascript object (expected on the frontend). When empty though, the array would stay an array in javascript (frontend tried to update an array by key and failed silently). This might have caused #3567 also.
* `BardFieldtype.vue`: Made the link regex url matcher lazy. Before it was greedy, and could match way beyond the end quote when there was a quote further on in the html. This caused #3567.
* And then handle any (other) errors gracefully.