### PR TITLE
Allow for other implementations of Submission Storage

### DIFF
--- a/src/Forms/SendEmails.php
+++ b/src/Forms/SendEmails.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Mail;
 use Statamic\Contracts\Forms\Submission;
 use Statamic\Facades\Antlers;
 use Statamic\Sites\Site;
+use Statamic\Contracts\Forms\Submission as SubmissionContract;
 
 class SendEmails implements ShouldQueue
 {
@@ -19,7 +20,7 @@ class SendEmails implements ShouldQueue
     protected $submission;
     protected $site;
 
-    public function __construct(Submission $submission, Site $site)
+    public function __construct(SubmissionContract $submission, Site $site)
     {
         $this->submission = $submission;
         $this->site = $site;

--- a/src/Forms/SendEmails.php
+++ b/src/Forms/SendEmails.php
@@ -9,9 +9,9 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Mail;
 use Statamic\Contracts\Forms\Submission;
+use Statamic\Contracts\Forms\Submission as SubmissionContract;
 use Statamic\Facades\Antlers;
 use Statamic\Sites\Site;
-use Statamic\Contracts\Forms\Submission as SubmissionContract;
 
 class SendEmails implements ShouldQueue
 {


### PR DESCRIPTION
This change allows other implementations of the submission storage (database).

It is currently not possible to store submissions in the db without creating a new class that replaces `Statamic\Forms\Submission`. This is the only change needed to implement a DB submission storage.