### PR TITLE
Allow for other implementations of Submission Storage

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -5,6 +5,7 @@ namespace Statamic\Forms;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Statamic\Contracts\Forms\Submission as SubmissionContract;
 use Statamic\Facades\Config;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Parse;
@@ -20,7 +21,7 @@ class Email extends Mailable
     protected $config;
     protected $site;
 
-    public function __construct(Submission $submission, array $config, Site $site)
+    public function __construct(SubmissionContract $submission, array $config, Site $site)
     {
         $this->submission = $submission;
         $this->config = $this->parseConfig($config);

--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -5,7 +5,7 @@ namespace Statamic\Forms;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
-use Statamic\Contracts\Forms\Submission as SubmissionContract;
+use Statamic\Contracts\Forms\Submission;
 use Statamic\Facades\Config;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Parse;
@@ -21,7 +21,7 @@ class Email extends Mailable
     protected $config;
     protected $site;
 
-    public function __construct(SubmissionContract $submission, array $config, Site $site)
+    public function __construct(Submission $submission, array $config, Site $site)
     {
         $this->submission = $submission;
         $this->config = $this->parseConfig($config);


### PR DESCRIPTION
This change allows other implementations of the submission storage (database).

It is currently not possible to store submissions in the db without creating a new class that replaces Statamic\Forms\Submission. This is the only change needed to implement a DB submission storage.

Sorry for the wrong PR before, I need to find a better way to create these.