### PR TITLE
Handle custom authors field

### DIFF
--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -69,4 +69,9 @@ class AugmentedEntry extends AbstractAugmented
     {
         return $this->data->value('mount') ?? Collection::findByMount($this->data);
     }
+
+    public function authors()
+    {
+        return $this->data->value('authors') ?? $this->data->authors();
+    }
 }


### PR DESCRIPTION
Fixes #3597 

In 3.1, we added the entry author permissions feature.

You defined the authors by adding user IDs to an `author` (singular) field. You could put multiple authors in there if you want, but it would still go in the singular `author` field. We did this because if people were already using their own author based thing, there was a pretty high chance they were already calling the field `author`.

In the code though, we used the `authors()` method (plural). We did this because there _could_ be multiple.

Then, with the way augmentation works, if there's a method on the entry, it'll use that. Thats the conflict that was happening in #3597.

This PR makes it so that if you have an `authors` value, it'll favor that over the method.