### PR TITLE
Autoselect uploaded asset in selector

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -273,14 +273,15 @@ export default {
         selectedAssets: Array,
         maxFiles: Number,
         initialEditingAssetId: String,
+        autoselectUploads: Boolean,
     },
 
     data() {
         return {
             columns: [
-                { label: __('File'), field: 'basename', visible: true },
-                { label: __('Size'), field: 'size', value: 'size_formatted', visible: true },
-                { label: __('Last Modified'), field: 'last_modified', value: 'last_modified_relative', visible: true },
+                { label: __('File'), field: 'basename', visible: true, sortable: true },
+                { label: __('Size'), field: 'size', value: 'size_formatted', visible: true, sortable: true },
+                { label: __('Last Modified'), field: 'last_modified', value: 'last_modified_relative', visible: true, sortable: true },
             ],
             containers: [],
             container: {},
@@ -523,6 +524,14 @@ export default {
         },
 
         uploadCompleted(asset) {
+            if (this.autoselectUploads) {
+                this.sortColumn = 'last_modified';
+                this.sortDirection = 'desc';
+
+                this.selectedAssets.push(asset.id);
+                this.$emit('selections-updated', this.selectedAssets);
+            }
+
             this.loadAssets();
             this.$toast.success(__(':file uploaded', { file: asset.basename }));
         },

--- a/resources/js/components/assets/Selector.vue
+++ b/resources/js/components/assets/Selector.vue
@@ -10,6 +10,7 @@
                     :restrict-container-navigation="restrictContainerNavigation"
                     :restrict-folder-navigation="restrictFolderNavigation"
                     :max-files="maxFiles"
+                    :autoselect-uploads="true"
                     @selections-updated="selectionsUpdated"
                     @asset-doubleclicked="select">
 

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -71,7 +71,9 @@ class BrowserController extends CpController
 
         $folder = $container->assetFolder($path);
 
-        $assets = $folder->queryAssets()->paginate(30);
+        $assets = $folder->queryAssets()
+            ->orderBy($request->sort ?? 'basename', $request->order ?? 'asc')
+            ->paginate(30);
 
         return (new FolderAssetsCollection($assets))->folder($folder);
     }

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -71,9 +71,13 @@ class BrowserController extends CpController
 
         $folder = $container->assetFolder($path);
 
-        $assets = $folder->queryAssets()
-            ->orderBy($request->sort ?? 'basename', $request->order ?? 'asc')
-            ->paginate(30);
+        $query = $folder->queryAssets();
+
+        if ($request->sort) {
+            $query->orderBy($request->sort, $request->order ?? 'asc');
+        }
+
+        $assets = $query->paginate(30);
 
         return (new FolderAssetsCollection($assets))->folder($folder);
     }


### PR DESCRIPTION
Fixes #3602.

* Automatically adds the uploaded asset to the selection. And sorts by last modified, most recent first.
* Enables sortable columns in the Asset Browser.
