### PR TITLE
Use npm ci instead of install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Compile assets
         run: npm run production


### PR DESCRIPTION
`npm ci` will install all dependencies based on the package-lock.json.

`npm install` is kind of the same as `composer update` for PHP.

Just a few minutes ago, I finished a small article about it, which might explain a little better:
https://dev.to/visuellverstehen/why-to-use-npm-ci-instead-of-npm-install-mfd 