### PR TITLE
Prevent regenerating asset meta file for non-images

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -533,6 +533,10 @@ class Asset implements AssetContract, Augmentable
      */
     public function dimensions()
     {
+        if (! $this->isImage()) {
+            return [null, null];
+        }
+
         return [$this->meta('width'), $this->meta('height')];
     }
 

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -691,6 +691,28 @@ class AssetTest extends TestCase
     }
 
     /** @test */
+    public function it_gets_no_dimensions_for_non_images()
+    {
+        $file = UploadedFile::fake()->create('file.txt');
+        Storage::fake('test')->putFileAs('foo', $file, 'file.txt');
+        $asset = (new Asset)->path('foo/file.txt')->container($this->container);
+
+        $this->assertEquals([null, null], $asset->dimensions());
+        $this->assertEquals(null, $asset->width());
+        $this->assertEquals(null, $asset->height());
+    }
+
+    /** @test */
+    public function it_doesnt_regenerate_the_meta_file_when_getting_non_image_dimensions()
+    {
+        $asset = $this->partialMock(Asset::class);
+
+        $asset->shouldReceive('meta')->times(0);
+
+        $this->assertEquals([null, null], $asset->dimensions());
+    }
+
+    /** @test */
     public function it_gets_file_size_in_bytes()
     {
         $container = $this->container;


### PR DESCRIPTION
In [this comment on the static site generator](https://github.com/statamic/ssg/issues/16#issuecomment-828407480) @tao was finding pages with mp3 assets taking a bonkers amount of time.

Turns out it was because when `width` was being requested somewhere in augmentation. Width comes from dimensions, dimensions looks in the meta data. If there's a null value in the meta data, it assumes its just missing or invalid and regenerates it.

His asset container had a ton of mp3 files, on s3, and would regenerate the meta file for each of them on every page load.

It's an mp3 so the dimensions _should_ be null. This PR adds that short circuit.

The page flies now.