### PR TITLE
Only remove items from indexes that have been cached

### DIFF
--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -94,6 +94,11 @@ abstract class Index
         return $this;
     }
 
+    public function isCached()
+    {
+        return Cache::has($this->cacheKey());
+    }
+
     public function cache()
     {
         Cache::forever($this->cacheKey(), $this->items);

--- a/src/Stache/Stores/BasicStore.php
+++ b/src/Stache/Stores/BasicStore.php
@@ -105,7 +105,7 @@ abstract class BasicStore extends Store
 
         $this->forgetPath($key);
 
-        $this->resolveIndexes()->each->forgetItem($key);
+        $this->resolveIndexes()->filter->isCached()->each->forgetItem($key);
     }
 
     protected function writeItemToDisk($item)


### PR DESCRIPTION
Fixes #3600 

When you delete an entry, the Stache will loop through the indexes and remove that entry from each of them.
If an index hasn't been cached already, it creates it. 

In #3600, if the `uri` index didn't already exist, it would create it. It's in here that the error happened. It has to query the structure to build the uri. The file was deleted at that point so it couldn't work it out. If the uri index already existed, it wouldn't try to rebuild it and you wouldn't get the error.

There's no point to create an index just to remove an item from it. In this PR, it will only try to update indexes that already exist.