### PR TITLE
Favor authors value in Stache index

### DIFF
--- a/src/Stache/Indexes/Value.php
+++ b/src/Stache/Indexes/Value.php
@@ -25,6 +25,10 @@ class Value extends Index
             return $item->entriesCount();
         }
 
+        if ($method === 'authors') {
+            return $item->value('authors') ?? $item->authors();
+        }
+
         if (method_exists($item, $method)) {
             return $item->{$method}();
         }


### PR DESCRIPTION
Fixes the issue in [this comment](https://github.com/statamic/cms/issues/3597#issuecomment-829256092) in #3597

Mimics the behavior of #3599 

The `authors` case is kinda special, but a guard here feels a little silly. It'll do until the refactor for #1759 happens.