### PR TITLE
Dispatch and listen for duplicate ID regeneration event

### DIFF
--- a/src/Events/Concerns/ListensForContentEvents.php
+++ b/src/Events/Concerns/ListensForContentEvents.php
@@ -46,5 +46,6 @@ trait ListensForContentEvents
         \Statamic\Events\UserGroupDeleted::class,
         \Statamic\Events\UserGroupSaved::class,
         \Statamic\Events\UserSaved::class,
+        \Statamic\Events\DuplicateIdRegenerated::class,
     ];
 }

--- a/src/Events/DuplicateIdRegenerated.php
+++ b/src/Events/DuplicateIdRegenerated.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Events;
+
+use Statamic\Contracts\Git\ProvidesCommitMessage;
+
+class DuplicateIdRegenerated extends Event implements ProvidesCommitMessage
+{
+    public function commitMessage()
+    {
+        return __('Duplicate ID Regenerated', [], config('statamic.git.locale'));
+    }
+}

--- a/src/Http/Controllers/CP/DuplicatesController.php
+++ b/src/Http/Controllers/CP/DuplicatesController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\CP;
 
 use Illuminate\Http\Request;
+use Statamic\Events\DuplicateIdRegenerated;
 use Statamic\Facades\File;
 use Statamic\Facades\Stache;
 use Statamic\Support\Str;
@@ -46,6 +47,8 @@ class DuplicatesController extends CpController
         $item->writeFile();
 
         Stache::clear();
+
+        DuplicateIdRegenerated::dispatch();
 
         return back()->with('success', __('ID regenerated and Stache cleared'));
     }


### PR DESCRIPTION
When you regenerate an ID as per #3619, it'll dispatch an event and trigger:

- A Git commit (if using the integration)
- GraphQL cache to be cleared
- REST API cache to be cleared