### PR TITLE
Support replacing the built in ProseMirror nodes and marks with custom nodes and marks

### DIFF
--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -99,9 +99,11 @@ class Augmentor
             ->addNode(SetNode::class)
             ->addNodes(static::$customNodes)
             ->addMarks(static::$customMarks);
+
         foreach (static::$replaceNodes as $searchNode => $replaceNode) {
             $renderer->replaceNode($searchNode, $replaceNode);
         }
+
         foreach (static::$replaceMarks as $searchMark => $replaceMark) {
             $renderer->replaceMark($searchMark, $replaceMark);
         }

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -98,14 +98,14 @@ class Augmentor
             ->replaceNode(DefaultImageNode::class, CustomImageNode::class)
             ->addNode(SetNode::class)
             ->addNodes(static::$customNodes)
-            ->addMarks(static::$customMarks)
-            ;
+            ->addMarks(static::$customMarks);
         foreach (static::$replaceNodes as $searchNode => $replaceNode) {
             $renderer->replaceNode($searchNode, $replaceNode);
         }
         foreach (static::$replaceMarks as $searchMark => $replaceMark) {
             $renderer->replaceMark($searchMark, $replaceMark);
         }
+
         return $renderer->render(['type' => 'doc', 'content' => $value]);
     }
 

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -19,6 +19,8 @@ class Augmentor
 
     protected static $customMarks = [];
     protected static $customNodes = [];
+    protected static $replaceMarks = [];
+    protected static $replaceNodes = [];
 
     public function __construct($fieldtype)
     {
@@ -92,12 +94,19 @@ class Augmentor
 
     public function convertToHtml($value)
     {
-        return (new Renderer)
+        $renderer = (new Renderer)
             ->replaceNode(DefaultImageNode::class, CustomImageNode::class)
             ->addNode(SetNode::class)
             ->addNodes(static::$customNodes)
             ->addMarks(static::$customMarks)
-            ->render(['type' => 'doc', 'content' => $value]);
+            ;
+        foreach (static::$replaceNodes as $searchNode => $replaceNode) {
+            $renderer->replaceNode($searchNode, $replaceNode);
+        }
+        foreach (static::$replaceMarks as $searchMark => $replaceMark) {
+            $renderer->replaceMark($searchMark, $replaceMark);
+        }
+        return $renderer->render(['type' => 'doc', 'content' => $value]);
     }
 
     public static function addNode($node)
@@ -108,6 +117,16 @@ class Augmentor
     public static function addMark($mark)
     {
         static::$customMarks[] = $mark;
+    }
+
+    public static function replaceNode($searchNode, $replaceNode)
+    {
+        static::$replaceNodes[$searchNode] = $replaceNode;
+    }
+
+    public static function replaceMark($searchMark, $replaceMark)
+    {
+        static::$replaceMarks[$searchMark] = $replaceMark;
     }
 
     protected function convertToSets($html)


### PR DESCRIPTION
I've been looking into extending the Paragraph and Heading nodes to allow the addition of extra attributes. While it is currently possible to add new node types to the ProseMirror renderer, it is not possible to replace the built in ones. This functionality exists in the ProseMirror Renderer (Statamic is already using it to replace the Image node), but the Augmentor class does not expose a way for addons etc. to access it. This commit adds that ability.