### PR TITLE
Add bard node extension helper function

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -131,6 +131,7 @@ import css from 'highlight.js/lib/languages/css'
 import hljs from 'highlight.js/lib/highlight';
 import 'highlight.js/styles/github.css';
 import mark from './Mark';
+import node from './Node';
 
 export default {
 
@@ -528,7 +529,7 @@ export default {
             }
 
             this.$bard.extensionCallbacks.forEach(callback => {
-                let returned = callback({ bard: this, mark });
+                let returned = callback({ bard: this, mark, node });
                 exts = exts.concat(
                     Array.isArray(returned) ? returned : [returned]
                 );

--- a/resources/js/components/fieldtypes/bard/Node.js
+++ b/resources/js/components/fieldtypes/bard/Node.js
@@ -1,5 +1,5 @@
 import { Node, Plugin } from 'tiptap';
-import { pasteRule } from 'tiptap-commands';
+import { pasteRule, toggleBlockType } from 'tiptap-commands';
 
 export default function (extension) {
     return new class extends Node {
@@ -12,7 +12,7 @@ export default function (extension) {
         }
 
         commands(args) {
-            return extension.commands({...args });
+            return extension.commands({...args, toggleBlockType });
         }
 
         pasteRules(args) {

--- a/resources/js/components/fieldtypes/bard/Node.js
+++ b/resources/js/components/fieldtypes/bard/Node.js
@@ -1,0 +1,26 @@
+import { Node, Plugin } from 'tiptap';
+import { pasteRule } from 'tiptap-commands';
+
+export default function (extension) {
+    return new class extends Node {
+        get name() {
+            return extension.name();
+        }
+
+        get schema() {
+            return extension.schema();
+        }
+
+        commands(args) {
+            return extension.commands({...args });
+        }
+
+        pasteRules(args) {
+            return extension.pasteRules({...args, pasteRule});
+        }
+
+        get plugins() {
+            return extension.plugins().map(plugin => new Plugin(plugin));
+        }
+    }
+}


### PR DESCRIPTION
Statamic includes a helper function for creating bard mark extensions. This PR adds the same functionality for node extensions.