### PR TITLE
Fix yaml fence when dumping multiline string as last key

### DIFF
--- a/src/Yaml/Yaml.php
+++ b/src/Yaml/Yaml.php
@@ -108,7 +108,7 @@ class Yaml
             $content = '';
         }
 
-        return '---'.PHP_EOL.$this->dump($data).'---'.PHP_EOL.$content;
+        return '---'.PHP_EOL.rtrim($this->dump($data)).PHP_EOL.'---'.PHP_EOL.$content;
     }
 
     protected function viewException($e, $str, $line = null)

--- a/tests/Yaml/YamlTest.php
+++ b/tests/Yaml/YamlTest.php
@@ -126,6 +126,28 @@ EOT;
         $this->assertEqualsIgnoringLineEndings($expected, YAML::dumpFrontMatter(['foo' => 'bar']));
     }
 
+    /**
+     * @test
+     * @see https://github.com/statamic/cms/issues/3612
+     **/
+    public function it_dumps_front_matter_properly_when_a_multiline_string_is_the_last_key()
+    {
+        $expectedWithFrontMatter = <<<'EOT'
+---
+foo: bar
+baz: |-
+  first line
+  second line
+---
+content
+EOT;
+
+        $this->assertEqualsIgnoringLineEndings($expectedWithFrontMatter, YAML::dumpFrontMatter([
+            'foo' => 'bar',
+            'baz' => "first line\nsecond line", // the multiline string *must* be last for this bug
+        ], 'content'));
+    }
+
     /** @test */
     public function it_parses_a_string_of_yaml()
     {

--- a/tests/Yaml/YamlTest.php
+++ b/tests/Yaml/YamlTest.php
@@ -130,22 +130,38 @@ EOT;
      * @test
      * @see https://github.com/statamic/cms/issues/3612
      **/
-    public function it_dumps_front_matter_properly_when_a_multiline_string_is_the_last_key()
+    public function it_dumps_front_matter_properly_when_symfony_yaml_dumper_doesnt_end_with_a_line_break()
     {
-        $expectedWithFrontMatter = <<<'EOT'
+        $array = [
+            'foo' => 'bar',
+            'baz' => "first line\nsecond line", // the multiline string *must* be last for this bug
+        ];
+
+        // We mock symfony because the multiline character is different depending on the version installed.
+        // It will be | on early versions. It will be |- on later versions.
+        // The |- character means trim trailing newlines, and is the default when dumping multiline strings.
+        $symfonyYaml = $this->mock(SymfonyYaml::class)
+            ->shouldReceive('dump')
+            ->with($array, 100, 2, SymfonyYaml::DUMP_MULTI_LINE_LITERAL_BLOCK)
+            ->once()
+            ->andReturn($symfonyDumpedYaml = "foo: bar\nbaz: |-\n  first line\n  second line")
+            ->getMock();
+
+        $this->app->instance(StatamicYaml::class, new StatamicYaml($symfonyYaml));
+
+        // Without the bug fix, the --- would come immediately after the "second line". Like this:
+        // baz: |-
+        //   first line
+        //   second line---
+        // content
+        $expected = <<<EOT
 ---
-foo: bar
-baz: |-
-  first line
-  second line
+$symfonyDumpedYaml
 ---
 content
 EOT;
 
-        $this->assertEqualsIgnoringLineEndings($expectedWithFrontMatter, YAML::dumpFrontMatter([
-            'foo' => 'bar',
-            'baz' => "first line\nsecond line", // the multiline string *must* be last for this bug
-        ], 'content'));
+        $this->assertEqualsIgnoringLineEndings($expected, YAML::dumpFrontMatter($array, 'content'));
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #3612 

There wasn't a line break at the end if the last key was a multiline string.
Trim the dump first to prevent two line breaks, if there was one.