### PR TITLE
Bard: only show entries for collection with a route

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -4,9 +4,11 @@ namespace Statamic\Fieldtypes;
 
 use ProseMirrorToHtml\Renderer;
 use Statamic\Facades\Asset;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\GraphQL;
+use Statamic\Facades\Site;
 use Statamic\Fields\Fields;
 use Statamic\Fieldtypes\Bard\Augmentor;
 use Statamic\GraphQL\Types\BardSetsType;
@@ -366,6 +368,18 @@ class Bard extends Replicator
             })->all();
         })->all();
 
+        $linkCollections = $this->config('link_collections');
+
+        if (empty($linkCollections)) {
+            $site = Site::current()->handle();
+
+            $linkCollections = Blink::once('routable-collection-handles'.$site, function () use ($site) {
+                return Collection::all()->reject(function ($collection) use ($site) {
+                    return is_null($collection->route($site));
+                })->map->handle();
+            });
+        }
+
         return [
             'existing' => $existing,
             'new' => $new,
@@ -373,7 +387,7 @@ class Bard extends Replicator
             'collapsed' => [],
             'previews' => $previews,
             '__collaboration' => ['existing'],
-            'linkCollections' => empty($collections = $this->config('link_collections')) ? Collection::handles()->all() : $collections,
+            'linkCollections' => $linkCollections,
             'linkData' => (object) $this->getLinkData($value),
         ];
     }

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -373,7 +373,7 @@ class Bard extends Replicator
         if (empty($linkCollections)) {
             $site = Site::current()->handle();
 
-            $linkCollections = Blink::once('routable-collection-handles'.$site, function () use ($site) {
+            $linkCollections = Blink::once('routable-collection-handles-'.$site, function () use ($site) {
                 return Collection::all()->reject(function ($collection) use ($site) {
                     return is_null($collection->route($site));
                 })->map->handle();


### PR DESCRIPTION
Fixes #3668.

Filters out the collections without a route when no collections have been selected. When the user decides to select specific collections in the Bard config, the responsibility for picking suitable ones is left to the user.