### PR TITLE
Update tracked keys when saving and deleting

### DIFF
--- a/src/Stache/Stores/Keys.php
+++ b/src/Stache/Stores/Keys.php
@@ -59,6 +59,20 @@ class Keys
             throw new DuplicateKeyException($key, $path);
         }
 
+        $this->set($key, $path);
+    }
+
+    public function forget($key)
+    {
+        unset($this->keys[$key]);
+
+        return $this;
+    }
+
+    public function set($key, $path)
+    {
         $this->keys[$key] = $path;
+
+        return $this;
     }
 }

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -359,6 +359,8 @@ abstract class Store
         unset($paths[$key]);
 
         $this->cachePaths($paths);
+
+        $this->keys()->forget($key)->cache();
     }
 
     protected function setPath($key, $path)
@@ -368,6 +370,8 @@ abstract class Store
         $paths[$key] = $path;
 
         $this->cachePaths($paths);
+
+        $this->keys()->set($key, $path)->cache();
     }
 
     protected function cachePaths($paths)

--- a/tests/Stache/Stores/KeysTest.php
+++ b/tests/Stache/Stores/KeysTest.php
@@ -98,4 +98,41 @@ class KeysTest extends TestCase
 
         $this->assertNull(Cache::get('stache::keys/test-store'));
     }
+
+    /** @test */
+    public function it_forgets_a_key()
+    {
+        $store = $this->mock(Store::class);
+        $store->shouldReceive('key')->andReturn('test-store');
+
+        $keys = (new Keys($store))->setKeys([
+            '123' => 'original.md',
+            '456' => 'another.md',
+        ]);
+
+        $return = $keys->forget('123');
+
+        $this->assertEquals($keys, $return);
+        $this->assertEquals(['456' => 'another.md'], $keys->all());
+    }
+
+    /** @test */
+    public function it_sets_the_path_of_a_key()
+    {
+        $store = $this->mock(Store::class);
+        $store->shouldReceive('key')->andReturn('test-store');
+
+        $keys = (new Keys($store))->setKeys([
+            '123' => 'original.md',
+            '456' => 'another.md',
+        ]);
+
+        $return = $keys->set('123', 'changed.md');
+
+        $this->assertEquals($keys, $return);
+        $this->assertEquals([
+            '123' => 'changed.md',
+            '456' => 'another.md',
+        ], $keys->all());
+    }
 }


### PR DESCRIPTION
Fixes #3683 

They ID/key tracking that was added in #3619 left out some logic for updating them when you deleted or renamed files in some spots.