### PR TITLE
Validation replacements

### DIFF
--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -47,7 +47,7 @@
                     />
                 </template>
                 <template #option="{ value, display }">
-                    {{ display }} <code class="ml-1">{{ value.replace(':', '') }}</code>
+                    {{ display }} <code class="ml-1">{{ valueWithoutTrailingColon(value) }}</code>
                 </template>
                 <template #no-options="{ search }">
                     <div class="vs__dropdown-option text-left">{{ __('Add') }} <code class="ml-1">{{ search }}</code></div>
@@ -252,6 +252,10 @@ export default {
         updated(rules) {
             this.rules = rules;
         },
+
+        valueWithoutTrailingColon(value) {
+            return this.hasUnfinishedParameters(value) ? value.replace(':', '') : value;
+        }
 
     }
 }

--- a/resources/js/components/field-validation/Rules.js
+++ b/resources/js/components/field-validation/Rules.js
@@ -287,6 +287,10 @@ export default [
     //     example: 'unique:table,column,except,idColumn'
     // },
     {
+        label: 'Unique Entry Value',
+        value: 'unique_entry_value:{collection},{id},{site}',
+    },
+    {
         label: 'URL',
         value: 'url'
     },

--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -4,11 +4,13 @@ namespace Statamic\Fields;
 
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Validator as LaravelValidator;
+use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class Validator
 {
     protected $fields;
-    protected $data = [];
+    protected $replacements = [];
     protected $extraRules = [];
 
     public function make()
@@ -34,7 +36,11 @@ class Validator
     {
         return $this
             ->merge($this->fieldRules(), $this->extraRules)
-            ->all();
+            ->map(function ($rules) {
+                return collect($rules)->map(function ($rule) {
+                    return $this->parse($rule);
+                })->all();
+            })->all();
     }
 
     private function fieldRules()
@@ -65,6 +71,13 @@ class Validator
         return collect($original);
     }
 
+    public function withReplacements($replacements)
+    {
+        $this->replacements = $replacements;
+
+        return $this;
+    }
+
     public function validate()
     {
         return LaravelValidator::validate(
@@ -82,6 +95,17 @@ class Validator
 
             return Lang::has($handle) ? Lang::get($handle) : $field->display();
         })->all();
+    }
+
+    private function parse($rule)
+    {
+        if (! Str::contains($rule, '{')) {
+            return $rule;
+        }
+
+        return preg_replace_callback('/{\s*([a-zA-Z0-9_\-]+)\s*}/', function ($match) {
+            return Arr::get($this->replacements, $match[1], 'NULL');
+        }, $rule);
     }
 
     public static function explodeRules($rules)

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -164,7 +164,14 @@ class EntriesController extends CpController
 
         $fields = $entry->blueprint()->fields()->addValues($data);
 
-        $fields->validate(Entry::updateRules($collection, $entry));
+        $fields
+            ->validator()
+            ->withRules(Entry::updateRules($collection, $entry))
+            ->withReplacements([
+                'id' => $entry->id(),
+                'collection' => $collection->handle(),
+                'site' => $entry->locale(),
+            ])->validate();
 
         $values = $fields->process()->values();
 
@@ -302,7 +309,13 @@ class EntriesController extends CpController
 
         $fields = $blueprint->fields()->addValues($data);
 
-        $fields->validate(Entry::createRules($collection, $site));
+        $fields
+            ->validator()
+            ->withRules(Entry::createRules($collection, $site))
+            ->withReplacements([
+                'collection' => $collection->handle(),
+                'site' => $site->handle(),
+            ])->validate();
 
         $values = $fields->process()->values()->except(['slug', 'date', 'blueprint']);
 


### PR DESCRIPTION
In #3671, I'm moving the unique slug validation into the `slug` field of the blueprint, instead of being dynamically added.

When doing that, I noticed we don't really have any way to have different rules for updating vs creating within a blueprint.

If you've ever tried to use the `unique` validation rule in a Laravel app, you would have probably found yourself trying to exclude the current model from the rule. That's what I'm talking about here.

Since you can't do PHP stuff from inside the blueprint, I've introduced a concept of replacements (like in routes, or translations) that'll let you inject data from the entry.

```yaml
field:
  type: text
  validate:
    - "rule_with_params:{id}"
```

This would become `rule_with_params:123` where `123` is the ID of the entry. Or `NULL` if on the "create" form since there's no ID yet.

The main intended usage would be for unique value/slug validation, which expects a rule like:

```
unique_entry_value:blog,123,en
```

Using replacements, you'd plop this into your blueprint:

```
unique_entry_value:{collection},{id},{site}
```

The validation builder will do it for you:

![image](https://user-images.githubusercontent.com/105211/117883908-fec45a00-b279-11eb-970e-043a81cbe084.gif)
