### PR TITLE
Leverage Laravel to determine secure connection

### DIFF
--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -240,7 +240,7 @@ class URL
             return config('app.url');
         }
 
-        $protocol = (! empty(request()->server('HTTPS')) && request()->server('HTTPS') !== 'off' || request()->server('SERVER_PORT') == 443)
+        $protocol = app('request')->isSecure()
             ? 'https://'
             : 'http://';
 

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -242,7 +242,7 @@ class URL
         
         $rootUrl = app('request')->root();
 
-        return Str::ensureRight($rootUrl);
+        return Str::ensureRight($rootUrl, '/');
     }
 
     /**

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -239,7 +239,7 @@ class URL
         if (app()->runningInConsole()) {
             return config('app.url');
         }
-        
+
         $rootUrl = app('request')->root();
 
         return Str::ensureRight($rootUrl, '/');

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -239,8 +239,10 @@ class URL
         if (app()->runningInConsole()) {
             return config('app.url');
         }
+        
+        $rootUrl = app('request')->root();
 
-        return app('request')->root();
+        return Str::ensureRight($rootUrl);
     }
 
     /**

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -240,13 +240,7 @@ class URL
             return config('app.url');
         }
 
-        $protocol = app('request')->isSecure()
-            ? 'https://'
-            : 'http://';
-
-        $domain_name = request()->server('HTTP_HOST').'/';
-
-        return $protocol.$domain_name;
+        return app('request')->root();
     }
 
     /**


### PR DESCRIPTION
We are running statamic behind reverse a reverse proxy to terminate SSL for us before our docker container handles the request.
Currently this makes the URL Facade return a rather useless URL when calling `getSiteUrl`.

Instead of writing custom logic to determine if the original request was https (X-Forwarded-Proto or similar) I think it would make sense to just use Laravels request class to determine this.

Fixes #3696 