### PR TITLE
Explicitly use Stringy for `Str::replace()`

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -258,4 +258,9 @@ class Str extends \Illuminate\Support\Str
     {
         return ! in_array(strtolower($value), ['no', 'false', '0', '', '-1']);
     }
+
+    public static function replace($string, $search, $replace)
+    {
+        return StaticStringy::replace($string, $search, $replace);
+    }
 }

--- a/tests/Support/StrTest.php
+++ b/tests/Support/StrTest.php
@@ -170,4 +170,13 @@ class StrTest extends TestCase
         $this->assertFalse(Str::toBool(''));
         $this->assertFalse(Str::toBool('-1'));
     }
+
+    /**
+     * @test
+     * @see https://github.com/statamic/cms/issues/3697
+     **/
+    public function it_replaces_strings()
+    {
+        $this->assertEquals('FÒÔ bàř', Str::replace('fòô bàř', 'fòô', 'FÒÔ'));
+    }
 }

--- a/tests/Support/StrTest.php
+++ b/tests/Support/StrTest.php
@@ -173,7 +173,7 @@ class StrTest extends TestCase
 
     /**
      * @test
-     * @see https://github.com/statamic/cms/issues/3697
+     * @see https://github.com/statamic/cms/pull/3698
      **/
     public function it_replaces_strings()
     {


### PR DESCRIPTION
Our `Statamic\Support\Str` class extends `Illuminate\Support\Str` and offloads any undefined methods to `Stringy`.

When you would call `Statamic\Support\Str::replace()`, it would use `Stringy::replace()`.

[Laravel 8.41.0](https://github.com/laravel/framework/pull/37186) introduced `Str::replace()` with a different method signature than Stringy's `Str::replace()`. Since our class extends this, their new method will be favored.

This PR adds a `replace` method that explicitly uses Stringy's, so that it continues working like it used to.

Fixes #3697 