### PR TITLE
Fix SVG Dimensions

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -585,7 +585,7 @@ class Asset implements AssetContract, Augmentable
      */
     public function ratio()
     {
-        if (! $this->isImage()) {
+        if (! $this->isImage() && ! $this->isSvg()) {
             return null;
         }
 

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -533,7 +533,7 @@ class Asset implements AssetContract, Augmentable
      */
     public function dimensions()
     {
-        if (! $this->isImage()) {
+        if (! $this->isImage() && ! $this->isSvg()) {
             return [null, null];
         }
 

--- a/src/Assets/Dimensions.php
+++ b/src/Assets/Dimensions.php
@@ -129,7 +129,7 @@ class Dimensions
             return [$viewBox[2], $viewBox[3]];
         }
 
-        return [null, null];
+        return [300, 150];
     }
 
     private function getCacheFlysystem()

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -691,6 +691,17 @@ class AssetTest extends TestCase
     }
 
     /** @test */
+    public function it_gets_dimensions_for_svgs()
+    {
+        Storage::fake('test')->put('foo/image.svg', '<svg width="30" height="60"></svg>');
+        $asset = (new Asset)->path('foo/image.svg')->container($this->container);
+
+        $this->assertEquals([30, 60], $asset->dimensions());
+        $this->assertEquals(30, $asset->width());
+        $this->assertEquals(60, $asset->height());
+    }
+
+    /** @test */
     public function it_gets_no_dimensions_for_non_images()
     {
         $file = UploadedFile::fake()->create('file.txt');

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -688,6 +688,7 @@ class AssetTest extends TestCase
         $this->assertEquals([30, 60], $asset->dimensions());
         $this->assertEquals(30, $asset->width());
         $this->assertEquals(60, $asset->height());
+        $this->assertEquals(0.5, $asset->ratio());
     }
 
     /** @test */
@@ -699,6 +700,7 @@ class AssetTest extends TestCase
         $this->assertEquals([30, 60], $asset->dimensions());
         $this->assertEquals(30, $asset->width());
         $this->assertEquals(60, $asset->height());
+        $this->assertEquals(0.5, $asset->ratio());
     }
 
     /** @test */
@@ -711,6 +713,7 @@ class AssetTest extends TestCase
         $this->assertEquals([null, null], $asset->dimensions());
         $this->assertEquals(null, $asset->width());
         $this->assertEquals(null, $asset->height());
+        $this->assertEquals(null, $asset->ratio());
     }
 
     /** @test */

--- a/tests/Assets/DimensionsTest.php
+++ b/tests/Assets/DimensionsTest.php
@@ -98,6 +98,14 @@ class DimensionsTest extends TestCase
         $this->assertEquals([300, 600], $this->dimensions->asset($asset)->get());
     }
 
+    /** @test */
+    public function it_uses_default_dimensions_if_the_svg_has_no_viewbox_and_is_missing_either_or_both_dimensions()
+    {
+        $this->assertEquals([300, 150], $this->dimensions->asset($this->svgAsset('<svg></svg>'))->get());
+        $this->assertEquals([300, 150], $this->dimensions->asset($this->svgAsset('<svg width="100"></svg>'))->get());
+        $this->assertEquals([300, 150], $this->dimensions->asset($this->svgAsset('<svg height="100"></svg>'))->get());
+    }
+
     private function svgAsset($svg)
     {
         $asset = (new Asset)


### PR DESCRIPTION
Fixes #3700 

As pointed out, in #3609 dimensions were unintentionally removed for SVGs. Now it'll generate them for SVGs again.

However, since it was possible that if your svg didn't have any `width`, `height`, or `viewBox`, that it'd output `null`x`null` dimensions, which would cause what #3609 was fixing.

So instead of outputting `null`s, SVG dimensions now fall back to `300`x`150` which is apparently what browsers do. It's in the [CSS spec](https://www.w3.org/TR/CSS2/visudet.html#inline-replaced-width) and explained [in this article](https://thatemil.com/blog/2014/04/06/intrinsic-sizing-of-svg-in-responsive-web-design/). It's also done in [this SVG library](https://github.com/contao/imagine-svg/blob/08eb302552dc83ffc7d0f3b1b79f53207094cfa4/src/SvgBox.php#L44).