### PR TITLE
don't rely on array index when showing first collection

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -376,7 +376,7 @@ class Bard extends Replicator
             $linkCollections = Blink::once('routable-collection-handles-'.$site, function () use ($site) {
                 return Collection::all()->reject(function ($collection) use ($site) {
                     return is_null($collection->route($site));
-                })->map->handle();
+                })->map->handle()->values();
             });
         }
 

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -104,7 +104,7 @@ class Entries extends Relationship
             $collections = $this->getConfiguredCollections();
         }
 
-        return Collection::findByHandle($collections[0]);
+        return Collection::findByHandle(collect($collections)->first());
     }
 
     public function getSortColumn($request)

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -104,7 +104,7 @@ class Entries extends Relationship
             $collections = $this->getConfiguredCollections();
         }
 
-        return Collection::findByHandle(collect($collections)->first());
+        return Collection::findByHandle($collections[0]);
     }
 
     public function getSortColumn($request)


### PR DESCRIPTION
This function assumes the `$collections` array contains the index `0`:

https://github.com/statamic/cms/blob/feeffbcd60c4ecd623c0175827de30b1d5210bbc/src/Fieldtypes/Entries.php#L97-L107

`$collections` has been filtered and doesn't necessarily contain the `0` index; after manipulating Collections, there may be "holes" in the indexes:

https://github.com/statamic/cms/blob/feeffbcd60c4ecd623c0175827de30b1d5210bbc/src/Fieldtypes/Bard.php#L376-L380

If the first collection has been filtered out because it doesn't have a route, the app crashes with `Undefined array key 0`.

Please tell me if you prefer another way to solve this.

The bug was introduced in https://github.com/statamic/cms/pull/3679. Pinging @arthurperton in case he has some opinions:)