### PR TITLE
Resolve GraphQL values in globals and terms

### DIFF
--- a/src/Globals/Variables.php
+++ b/src/Globals/Variables.php
@@ -6,6 +6,7 @@ use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Contracts\Data\Localization;
 use Statamic\Contracts\Globals\Variables as Contract;
+use Statamic\Contracts\GraphQL\ResolvesValues as ResolvesValuesContract;
 use Statamic\Data\ContainsData;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Data\HasAugmentedInstance;
@@ -13,11 +14,12 @@ use Statamic\Data\HasOrigin;
 use Statamic\Events\GlobalVariablesBlueprintFound;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
+use Statamic\GraphQL\ResolvesValues;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Variables implements Contract, Localization, Augmentable
+class Variables implements Contract, Localization, Augmentable, ResolvesValuesContract
 {
-    use ExistsAsFile, ContainsData, HasAugmentedInstance, HasOrigin, FluentlyGetsAndSets;
+    use ExistsAsFile, ContainsData, HasAugmentedInstance, HasOrigin, FluentlyGetsAndSets, ResolvesValues;
 
     protected $set;
     protected $locale;

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Carbon;
 use Statamic\Contracts\Auth\Protect\Protectable;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
+use Statamic\Contracts\GraphQL\ResolvesValues as ResolvesValuesContract;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Data\ContainsSupplementalData;
 use Statamic\Data\HasAugmentedInstance;
@@ -16,14 +17,15 @@ use Statamic\Data\TracksLastModified;
 use Statamic\Data\TracksQueriedColumns;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Site;
+use Statamic\GraphQL\ResolvesValues;
 use Statamic\Http\Responses\DataResponse;
 use Statamic\Revisions\Revisable;
 use Statamic\Routing\Routable;
 use Statamic\Statamic;
 
-class LocalizedTerm implements Term, Responsable, Augmentable, Protectable
+class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, ResolvesValuesContract
 {
-    use Revisable, Routable, Publishable, HasAugmentedInstance, TracksQueriedColumns, TracksLastModified, ContainsSupplementalData;
+    use Revisable, Routable, Publishable, HasAugmentedInstance, TracksQueriedColumns, TracksLastModified, ContainsSupplementalData, ResolvesValues;
 
     protected $locale;
     protected $term;

--- a/tests/Feature/GraphQL/ResolvesValuesTest.php
+++ b/tests/Feature/GraphQL/ResolvesValuesTest.php
@@ -23,7 +23,8 @@ class ResolvesValuesTest extends TestCase
     {
         parent::setUp();
 
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             public function augment($value)
             {
                 return strtoupper($value);

--- a/tests/Feature/GraphQL/ResolvesValuesTest.php
+++ b/tests/Feature/GraphQL/ResolvesValuesTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use Facades\Statamic\Fields\BlueprintRepository;
+use Facades\Statamic\Fields\FieldtypeRepository;
+use Facades\Tests\Factories\EntryFactory;
+use Facades\Tests\Factories\GlobalFactory;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Taxonomy;
+use Statamic\Facades\Term;
+use Statamic\Facades\User;
+use Statamic\Fields\Fieldtype;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+/** @group graphql */
+class ResolvesValuesTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $fieldtype = new class extends Fieldtype {
+            public function augment($value)
+            {
+                return strtoupper($value);
+            }
+        };
+
+        FieldtypeRepository::shouldReceive('find')->with('example')->andReturn($fieldtype);
+
+        $this->blueprint = Blueprint::makeFromFields(['foo' => ['type' => 'example']]);
+    }
+
+    /** @test */
+    public function it_resolves_values_in_entries()
+    {
+        BlueprintRepository::shouldReceive('in')->with('collections/test')->andReturn(collect([
+            'test' => $this->blueprint->setHandle('test'),
+        ]));
+
+        $entry = EntryFactory::id('test')->slug('test')->collection('test')->data(['foo' => 'bar'])->create();
+
+        $this->assertEquals('bar', $entry->value('foo'));
+        $this->assertEquals('BAR', $entry->resolveGqlValue('foo'));
+        $this->assertEquals('bar', $entry->resolveRawGqlValue('foo'));
+    }
+
+    /** @test */
+    public function it_resolves_values_in_terms()
+    {
+        BlueprintRepository::shouldReceive('in')->with('taxonomies/test')->andReturn(collect([
+            'test' => $this->blueprint->setHandle('test'),
+        ]));
+
+        Taxonomy::make('test')->save();
+
+        $term = tap(Term::make('test')->taxonomy('test')->data(['foo' => 'bar']))->save();
+        $term = $term->in('en');
+
+        $this->assertEquals('bar', $term->value('foo'));
+        $this->assertEquals('BAR', $term->resolveGqlValue('foo'));
+        $this->assertEquals('bar', $term->resolveRawGqlValue('foo'));
+    }
+
+    /** @test */
+    public function it_resolves_values_in_users()
+    {
+        BlueprintRepository::shouldReceive('find')->with('user')->andReturn($this->blueprint);
+
+        $user = User::make()->data(['foo' => 'bar']);
+
+        $this->assertEquals('bar', $user->value('foo'));
+        $this->assertEquals('BAR', $user->resolveGqlValue('foo'));
+        $this->assertEquals('bar', $user->resolveRawGqlValue('foo'));
+    }
+
+    /** @test */
+    public function it_resolves_values_in_globals()
+    {
+        BlueprintRepository::shouldReceive('find')->with('globals.test')->andReturn($this->blueprint);
+
+        $set = GlobalFactory::handle('test')->data(['foo' => 'bar'])->create();
+        $vars = $set->in('en');
+
+        $this->assertEquals('bar', $vars->get('foo'));
+        $this->assertEquals('BAR', $vars->resolveGqlValue('foo'));
+        $this->assertEquals('bar', $vars->resolveRawGqlValue('foo'));
+    }
+}

--- a/tests/Feature/GraphQL/ResolvesValuesTest.php
+++ b/tests/Feature/GraphQL/ResolvesValuesTest.php
@@ -86,7 +86,7 @@ class ResolvesValuesTest extends TestCase
         $set = GlobalFactory::handle('test')->data(['foo' => 'bar'])->create();
         $vars = $set->in('en');
 
-        $this->assertEquals('bar', $vars->get('foo'));
+        $this->assertEquals('bar', $vars->value('foo'));
         $this->assertEquals('BAR', $vars->resolveGqlValue('foo'));
         $this->assertEquals('bar', $vars->resolveRawGqlValue('foo'));
     }


### PR DESCRIPTION
Fixes #3658 

There are tests for values being returned appropriately (i.e. CodeFieldtypeTest and CheckboxesFieldtypeTest) but they use entries. The implementation will call the same methods on terms, globals, users, whatever. This PR adds tests that ensure the methods exists in those classes and work as expected.