### PR TITLE
Make titles translateable

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -142,12 +142,14 @@ class Collection implements Contract, AugmentableContract
 
     public function title($title = null)
     {
-        return $this
+        $name = $this
             ->fluentlyGetOrSet('title')
             ->getter(function ($title) {
                 return $title ?? ucfirst($this->handle);
             })
             ->args(func_get_args());
+
+        return trans($name);
     }
 
     public function ampable($ampable = null)


### PR DESCRIPTION
This PR adds more uses of the `__()` helper for titles from `collections`, `navigations`, `roles`, `forms`, etc. within views.

---
Closes: #3638 