### PR TITLE
Change $id from a private to public method

### DIFF
--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -22,7 +22,7 @@ class Submission implements SubmissionContract, Augmentable
     /**
      * @var string
      */
-    private $id;
+    public $id;
 
     /**
      * @var Form


### PR DESCRIPTION
Because of our setup, we're swapping out the `Submission` and `Form` classes for our own so we can save the submissions in Amazon S3 instead.

When doing that, I was running into issues where because the `$id` was `private`, the 'submission view' page would throw a 404, instead of showing the submission details.

If needed, I can provide the code for the custom classes if you need to test this but it's a really simple fix.