### PR TITLE
Allow addons to register/provide fieldsets

### DIFF
--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -16,7 +16,7 @@ class Fieldset
     /** @var bool */
     protected $isAddonFieldset = false;
 
-    public function setHandle(string $handle)
+    public function setHandle(string $handle): self
     {
         $this->handle = $handle;
 
@@ -28,7 +28,7 @@ class Fieldset
         return $this->handle;
     }
 
-    public function setIsAddonFieldset(bool $isAddonFieldset)
+    public function setIsAddonFieldset(bool $isAddonFieldset): self
     {
         $this->isAddonFieldset = $isAddonFieldset;
 
@@ -40,7 +40,7 @@ class Fieldset
         return $this->isAddonFieldset;
     }
 
-    public function setContents(array $contents)
+    public function setContents(array $contents): self
     {
         $fields = array_get($contents, 'fields', []);
 

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -13,7 +13,8 @@ class Fieldset
     protected $contents = [];
     protected $handle;
 
-    protected string $path;
+    /** @var bool */
+    protected $isAddonFieldset = false;
 
     public function setHandle(string $handle)
     {
@@ -27,16 +28,16 @@ class Fieldset
         return $this->handle;
     }
 
-    public function setPath(string $path)
+    public function setIsAddonFieldset(bool $isAddonFieldset)
     {
-        $this->path = $path;
+        $this->isAddonFieldset = $isAddonFieldset;
 
         return $this;
     }
 
-    public function path(): ?string
+    public function isAddonFieldset(): bool
     {
-        return $this->path;
+        return $this->isAddonFieldset;
     }
 
     public function setContents(array $contents)

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -10,8 +10,10 @@ use Statamic\Support\Str;
 
 class Fieldset
 {
-    protected $handle;
     protected $contents = [];
+    protected $handle;
+
+    protected string $path;
 
     public function setHandle(string $handle)
     {
@@ -23,6 +25,18 @@ class Fieldset
     public function handle(): ?string
     {
         return $this->handle;
+    }
+
+    public function setPath(string $path)
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function path(): ?string
+    {
+        return $this->path;
     }
 
     public function setContents(array $contents)

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -14,7 +14,7 @@ class Fieldset
     protected $handle;
 
     /** @var bool */
-    protected $isAddonFieldset = false;
+    protected $isExternalFieldset = false;
 
     public function setHandle(string $handle): self
     {
@@ -28,16 +28,16 @@ class Fieldset
         return $this->handle;
     }
 
-    public function setIsAddonFieldset(bool $isAddonFieldset): self
+    public function setIsExternalFieldset(bool $isExternalFieldset): self
     {
-        $this->isAddonFieldset = $isAddonFieldset;
+        $this->isExternalFieldset = $isExternalFieldset;
 
         return $this;
     }
 
-    public function isAddonFieldset(): bool
+    public function isExternalFieldset(): bool
     {
-        return $this->isAddonFieldset;
+        return $this->isExternalFieldset;
     }
 
     public function setContents(array $contents): self

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -115,7 +115,7 @@ class FieldsetRepository
 
                 return (new Fieldset)
                     ->setHandle($handle)
-                    ->setIsAddonFieldset(Str::startsWith($directory, resource_path()))
+                    ->setIsAddonFieldset(! Str::startsWith($directory, resource_path()))
                     ->setContents(YAML::file($file)->parse());
             })
             ->keyBy->handle();

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -40,7 +40,7 @@ class FieldsetRepository
 
         $fieldset = (new Fieldset)
             ->setHandle($handle)
-            ->setIsAddonFieldset(Str::startsWith($directory, resource_path()))
+            ->setIsAddonFieldset(! Str::startsWith($directory, resource_path()))
             ->setContents(YAML::file("{$directory}/{$path}.yaml")->parse());
 
         $this->fieldsets[$handle] = $fieldset;

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -26,17 +26,16 @@ class FieldsetRepository
             return $cached;
         }
 
-        // I don't understand why this is done
         $handle = str_replace('/', '.', $handle);
         $path = str_replace('.', '/', $handle);
-
-        if (! $this->exists($handle)) {
-            return null;
-        }
 
         $directory = $this->directories()->first(function ($directory) use ($path) {
             return File::exists("{$directory}/{$path}.yaml");
         });
+
+        if (! $directory) {
+            return null;
+        }
 
         $fieldset = (new Fieldset)
             ->setHandle($handle)
@@ -49,7 +48,6 @@ class FieldsetRepository
 
     public function exists(string $handle): bool
     {
-        // I don't understand why this is done
         $handle = str_replace('/', '.', $handle);
         $path = str_replace('.', '/', $handle);
 
@@ -65,7 +63,7 @@ class FieldsetRepository
 
     public function all(): Collection
     {
-        $fieldsets = $this->directories
+        $fieldsets = $this->directories()
             ->flatMap(function (string $directory) {
                 return File::withAbsolutePaths()
                     ->getFilesByTypeRecursively($directory, 'yaml')

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -70,7 +70,6 @@ class FieldsetRepository
                 return $this->getFieldsetsByDirectory($directory);
             });
 
-        dd($fieldsets);
         if ($fieldsets->isEmpty()) {
             return collect();
         }

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -12,7 +12,7 @@ class FieldsetRepository
 {
     protected $fieldsets = [];
     protected $directory;
-    protected $addonDirectories = [];
+    protected $fieldsetDirectories = [];
 
     public function setDirectory($directory)
     {
@@ -40,7 +40,7 @@ class FieldsetRepository
 
         $fieldset = (new Fieldset)
             ->setHandle($handle)
-            ->setIsAddonFieldset(! Str::startsWith($directory, resource_path()))
+            ->setIsExternalFieldset(! Str::startsWith($directory, resource_path()))
             ->setContents(YAML::file("{$directory}/{$path}.yaml")->parse());
 
         $this->fieldsets[$handle] = $fieldset;
@@ -96,12 +96,12 @@ class FieldsetRepository
 
     public function addDirectory(string $directory): void
     {
-        $this->addonDirectories[] = $directory;
+        $this->fieldsetDirectories[] = $directory;
     }
 
     public function directories(): Collection
     {
-        return collect($this->addonDirectories)->merge($this->directory);
+        return collect($this->fieldsetDirectories)->merge($this->directory);
     }
 
     private function getFieldsetsByDirectory(string $directory): Collection
@@ -115,7 +115,7 @@ class FieldsetRepository
 
                 return (new Fieldset)
                     ->setHandle($handle)
-                    ->setIsAddonFieldset(! Str::startsWith($directory, resource_path()))
+                    ->setIsExternalFieldset(! Str::startsWith($directory, resource_path()))
                     ->setContents(YAML::file($file)->parse());
             })
             ->keyBy->handle();

--- a/src/Http/Controllers/CP/Fields/FieldsetController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsetController.php
@@ -20,7 +20,7 @@ class FieldsetController extends CpController
     {
         $fieldsets = Facades\Fieldset::all()
             ->reject(function (Fieldset $fieldset) {
-                return $fieldset->isAddonFieldset();
+                return $fieldset->isExternalFieldset();
             })->map(function (Fieldset $fieldset) {
                 return [
                     'id' => $fieldset->handle(),

--- a/src/Http/Controllers/CP/Fields/FieldsetController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsetController.php
@@ -8,6 +8,7 @@ use Statamic\Fields\Fieldset;
 use Statamic\Fields\FieldTransformer;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class FieldsetController extends CpController
 {
@@ -18,16 +19,19 @@ class FieldsetController extends CpController
 
     public function index(Request $request)
     {
-        $fieldsets = Facades\Fieldset::all()->map(function ($fieldset) {
-            return [
-                'id' => $fieldset->handle(),
-                'handle' => $fieldset->handle(),
-                'title' => $fieldset->title(),
-                'fields' => $fieldset->fields()->all()->count(),
-                'edit_url' => $fieldset->editUrl(),
-                'delete_url' => $fieldset->deleteUrl(),
-            ];
-        })->values();
+        $fieldsets = Facades\Fieldset::all()
+            ->filter(function (Fieldset $fieldset) {
+                return Str::startsWith($fieldset->path(), resource_path());
+            })->map(function ($fieldset) {
+                return [
+                    'id' => $fieldset->handle(),
+                    'handle' => $fieldset->handle(),
+                    'title' => $fieldset->title(),
+                    'fields' => $fieldset->fields()->all()->count(),
+                    'edit_url' => $fieldset->editUrl(),
+                    'delete_url' => $fieldset->deleteUrl(),
+                ];
+            })->values();
 
         if ($request->wantsJson()) {
             return $fieldsets;

--- a/src/Http/Controllers/CP/Fields/FieldsetController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsetController.php
@@ -8,7 +8,6 @@ use Statamic\Fields\Fieldset;
 use Statamic\Fields\FieldTransformer;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Support\Arr;
-use Statamic\Support\Str;
 
 class FieldsetController extends CpController
 {
@@ -20,9 +19,9 @@ class FieldsetController extends CpController
     public function index(Request $request)
     {
         $fieldsets = Facades\Fieldset::all()
-            ->filter(function (Fieldset $fieldset) {
-                return Str::startsWith($fieldset->path(), resource_path());
-            })->map(function ($fieldset) {
+            ->reject(function (Fieldset $fieldset) {
+                return $fieldset->isAddonFieldset();
+            })->map(function (Fieldset $fieldset) {
                 return [
                     'id' => $fieldset->handle(),
                     'handle' => $fieldset->handle(),

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -123,7 +123,7 @@ class AppServiceProvider extends ServiceProvider
                 });
         });
 
-        $this->app->bind(\Statamic\Fields\FieldsetRepository::class, function () {
+        $this->app->singleton(\Statamic\Fields\FieldsetRepository::class, function () {
             return (new \Statamic\Fields\FieldsetRepository)
                 ->setDirectory(resource_path('fieldsets'));
         });

--- a/tests/Feature/Fieldsets/ViewFieldsetListingTest.php
+++ b/tests/Feature/Fieldsets/ViewFieldsetListingTest.php
@@ -49,6 +49,33 @@ class ViewFieldsetListingTest extends TestCase
     }
 
     /** @test */
+    public function it_shows_a_list_of_non_addon_fieldsets()
+    {
+        Facades\Fieldset::shouldReceive('all')->andReturn(collect([
+            'foo' => $fieldsetA = $this->createfieldset('foo'),
+            'bar' => $fieldsetB = $this->createFieldset('bar')->setIsAddonFieldset(true),
+        ]));
+
+        $user = Facades\User::make()->makeSuper()->save();
+
+        $response = $this
+            ->actingAs($user)
+            ->get(cp_route('fieldsets.index'))
+            ->assertSuccessful()
+            ->assertViewHas('fieldsets', collect([
+                [
+                    'id' => 'foo',
+                    'handle' => 'foo',
+                    'title' => 'Foo',
+                    'fields' => 0,
+                    'edit_url' => 'http://localhost/cp/fields/fieldsets/foo/edit',
+                    'delete_url' => 'http://localhost/cp/fields/fieldsets/foo',
+                ],
+            ]))
+            ->assertDontSee('no-results');
+    }
+
+    /** @test */
     public function it_denies_access_if_you_dont_have_permission()
     {
         $this->setTestRoles(['test' => ['access cp']]);
@@ -61,7 +88,7 @@ class ViewFieldsetListingTest extends TestCase
             ->assertRedirect('/cp/original');
     }
 
-    private function createFieldset($handle)
+    private function createFieldset($handle): Fieldset
     {
         return tap(new Fieldset)->setHandle($handle);
     }

--- a/tests/Feature/Fieldsets/ViewFieldsetListingTest.php
+++ b/tests/Feature/Fieldsets/ViewFieldsetListingTest.php
@@ -53,7 +53,7 @@ class ViewFieldsetListingTest extends TestCase
     {
         Facades\Fieldset::shouldReceive('all')->andReturn(collect([
             'foo' => $fieldsetA = $this->createfieldset('foo'),
-            'bar' => $fieldsetB = $this->createFieldset('bar')->setIsAddonFieldset(true),
+            'bar' => $fieldsetB = $this->createFieldset('bar')->setIsExternalFieldset(true),
         ]));
 
         $user = Facades\User::make()->makeSuper()->save();

--- a/tests/Fields/FieldsetRepositoryTest.php
+++ b/tests/Fields/FieldsetRepositoryTest.php
@@ -112,7 +112,6 @@ fields:
 EOT;
 
         File::shouldReceive('withAbsolutePaths')->once()->andReturnSelf();
-        File::shouldReceive('exists')->with('/path/to/resources/fieldsets')->once()->andReturnTrue();
         File::shouldReceive('getFilesByTypeRecursively')->with('/path/to/resources/fieldsets', 'yaml')->once()->andReturn(new FileCollection([
             '/path/to/resources/fieldsets/first.yaml',
             '/path/to/resources/fieldsets/second.yaml',
@@ -135,8 +134,6 @@ EOT;
     /** @test */
     public function it_returns_empty_collection_if_fieldset_directory_doesnt_exist()
     {
-        File::shouldReceive('exists')->with('/path/to/resources/fieldsets')->once()->andReturnFalse();
-
         $all = $this->repo->all();
 
         $this->assertInstanceOf(Collection::class, $all);

--- a/tests/Fields/FieldsetRepositoryTest.php
+++ b/tests/Fields/FieldsetRepositoryTest.php
@@ -169,4 +169,67 @@ EOT;
 
         $this->repo->save($fieldset);
     }
+
+    /** @test  */
+    public function it_gets_a_fieldset_in_a_an_addon_directory()
+    {
+        $contents = <<<'EOT'
+title: Test Fieldset
+fields: []
+EOT;
+        $this->repo->addDirectory('/vendor/foo/resources/fieldsets');
+        File::shouldReceive('exists')->with('/vendor/foo/resources/fieldsets/test.yaml')->once()->andReturnTrue();
+        File::shouldReceive('get')->with('/vendor/foo/resources/fieldsets/test.yaml')->once()->andReturn($contents);
+
+        $fieldset = $this->repo->find('test');
+
+        $this->assertInstanceOf(Fieldset::class, $fieldset);
+        $this->assertEquals('Test Fieldset', $fieldset->title());
+        $this->assertEquals('test', $fieldset->handle());
+    }
+
+    /** @test */
+    public function it_gets_all_fieldsets_including_addon_ones()
+    {
+        $firstContents = <<<'EOT'
+title: First Fieldset
+fields:
+  one:
+    type: text
+    display: First Field
+EOT;
+        $secondContents = <<<'EOT'
+title: Second Fieldset
+fields:
+  two:
+    type: text
+    display: Second Field
+EOT;
+        $thirdContents = <<<'EOT'
+title: Third Fieldset
+fields:
+  three:
+    type: text
+    display: Third Field
+EOT;
+
+        File::shouldReceive('withAbsolutePaths')->once()->andReturnSelf();
+        File::shouldReceive('getFilesByTypeRecursively')->with('/path/to/resources/fieldsets', 'yaml')->once()->andReturn(new FileCollection([
+            '/path/to/resources/fieldsets/first.yaml',
+            '/path/to/resources/fieldsets/second.yaml',
+            '/path/to/resources/fieldsets/sub/third.yaml',
+        ]));
+        File::shouldReceive('get')->with('/path/to/resources/fieldsets/first.yaml')->once()->andReturn($firstContents);
+        File::shouldReceive('get')->with('/path/to/resources/fieldsets/second.yaml')->once()->andReturn($secondContents);
+        File::shouldReceive('get')->with('/path/to/resources/fieldsets/sub/third.yaml')->once()->andReturn($thirdContents);
+
+        $all = $this->repo->all();
+
+        $this->assertInstanceOf(Collection::class, $all);
+        $this->assertCount(3, $all);
+        $this->assertEveryItemIsInstanceOf(Fieldset::class, $all);
+        $this->assertEquals(['first', 'second', 'sub.third'], $all->keys()->all());
+        $this->assertEquals(['first', 'second', 'sub.third'], $all->map->handle()->values()->all());
+        $this->assertEquals(['First Fieldset', 'Second Fieldset', 'Third Fieldset'], $all->map->title()->values()->all());
+    }
 }


### PR DESCRIPTION
Closes: https://github.com/statamic/ideas/issues/546

Adds the ability for addons to provide non-editable fieldsets that can be used.

They won't be listed in the fieldset listing, but will be selectable in the blueprints.