### PR TITLE
Don't allow mounting collection on entries within that same collection

### DIFF
--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -437,6 +437,9 @@ class CollectionsController extends CpController
                         'type' => 'entries',
                         'max_items' => 1,
                         'create' => false,
+                        'collections' => Collection::all()->map->handle()->reject(function ($collectionHandle) use ($collection) {
+                            return $collectionHandle === $collection->handle();
+                        })->toArray(),
                     ],
                     'amp' => [
                         'display' => __('Enable AMP'),

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -439,7 +439,7 @@ class CollectionsController extends CpController
                         'create' => false,
                         'collections' => Collection::all()->map->handle()->reject(function ($collectionHandle) use ($collection) {
                             return $collectionHandle === $collection->handle();
-                        })->toArray(),
+                        })->all(),
                     ],
                     'amp' => [
                         'display' => __('Enable AMP'),


### PR DESCRIPTION
This pull request closes #3720 by ensuring that the only collections that entries come from in the `mount` field is any collection *but* the current one.