### PR TITLE
Allow configuration of additional password validations

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -64,6 +64,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Password Requirements
+    |--------------------------------------------------------------------------
+    |
+    | When setting a new password the password will be validated against
+    | these additional rules to prevent any weak passwords for users.
+    |
+    */
+
+    'password_validation' => [],
+
+    /*
+    |--------------------------------------------------------------------------
     | Password Brokers
     |--------------------------------------------------------------------------
     |

--- a/src/Auth/ResetsPasswords.php
+++ b/src/Auth/ResetsPasswords.php
@@ -75,7 +75,7 @@ trait ResetsPasswords
         return [
             'token' => 'required',
             'email' => 'required|email',
-            'password' => 'required|confirmed|min:8',
+            'password' => array_merge(['required', 'confirmed'], config('statamic.users.password_validation', [])),
         ];
     }
 

--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -121,6 +121,10 @@ class MakeUser extends Command
     {
         $this->data['password'] = $this->secret('Password (Your input will be hidden)');
 
+        if ($this->passwordValidationFails()) {
+            return $this->promptPassword();
+        }
+
         return $this;
     }
 
@@ -162,6 +166,19 @@ class MakeUser extends Command
     protected function emailValidationFails()
     {
         return $this->validationFails($this->email, ['required', new EmailAvailable, 'email']);
+    }
+
+    /**
+     * Check if password validation fails.
+     *
+     * @return bool
+     */
+    protected function passwordValidationFails()
+    {
+        return $this->validationFails(
+            $this->data['password'],
+            array_merge(['required'], config('statamic.users.password_validation', []))
+        );
     }
 
     /**

--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -16,7 +16,7 @@ class PasswordController extends CpController
         $this->authorize('editPassword', $user);
 
         $request->validate([
-            'password' => 'required|confirmed',
+            'password' => array_merge(['required', 'confirmed'], config('statamic.users.password_validation', [])),
         ]);
 
         $user->password($request->password)->save();

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -49,7 +49,7 @@ class UserController extends Controller
 
         $fieldRules = $fields->validator()->withRules([
             'email' => 'required|email|unique_user_value',
-            'password' => 'required|confirmed',
+            'password' => array_merge(['required', 'confirmed'], config('statamic.users.password_validation', [])),
         ])->rules();
 
         $validator = Validator::make($request->all(), $fieldRules);


### PR DESCRIPTION
This is a basic implementation of custom validation rules for user passwords discussed in https://github.com/statamic/ideas/issues/422
We need this to satisfy a government customer requiring more strict password rules

I replaced all occurrences of `required|confirmed` on password validations, please check if all three are ok.

It allows to add any validation to the optional config parameter
``` php
'password_validation' => ['min:8'],
```

I did my best writing a description matching the pattern, feel free to give feedback on naming.

---

Edit: I additionally added the password validation to the MakeUser command, before the password was not validated at all. An empty password could be entered (did not work to login!)