### PR TITLE
Pass ENV to SymfonyProcess via getenv() call.

### DIFF
--- a/src/Console/Processes/Process.php
+++ b/src/Console/Processes/Process.php
@@ -269,8 +269,8 @@ class Process
 
         // Handle both string and array command formats.
         $process = is_string($command) && method_exists(SymfonyProcess::class, 'fromShellCommandLine')
-            ? SymfonyProcess::fromShellCommandline($command, $path ?? $this->basePath, getenv())
-            : new SymfonyProcess($command, $path ?? $this->basePath, getenv());
+            ? SymfonyProcess::fromShellCommandline($command, $path ?? $this->basePath, ['HOME' => getenv('HOME')])
+            : new SymfonyProcess($command, $path ?? $this->basePath, ['HOME' => getenv('HOME')]);
 
         $process->setTimeout(null);
 

--- a/src/Console/Processes/Process.php
+++ b/src/Console/Processes/Process.php
@@ -269,8 +269,8 @@ class Process
 
         // Handle both string and array command formats.
         $process = is_string($command) && method_exists(SymfonyProcess::class, 'fromShellCommandLine')
-            ? SymfonyProcess::fromShellCommandline($command, $path ?? $this->basePath)
-            : new SymfonyProcess($command, $path ?? $this->basePath);
+            ? SymfonyProcess::fromShellCommandline($command, $path ?? $this->basePath, getenv())
+            : new SymfonyProcess($command, $path ?? $this->basePath, getenv());
 
         $process->setTimeout(null);
 


### PR DESCRIPTION
Aim's to fix issue with installing/updating Addons or Statamic via the Statamic Control Panel.

For those who get the error:

```
In Factory.php line 677:
                                                                               
  The HOME or COMPOSER_HOME environment variable must be set for composer to   
  run correctly   
```

As referenced in https://github.com/statamic/cms/issues/3383

Addon installation is currently now working.
However there are issues with the Statamic Core updates, which appear to remove the contents of vendor/statamic/cms

I'm not sure where to start in regards to the removal issue, so feel free to chime in.

Thanks.
