### PR TITLE
Make blueprint be extendable temporarily

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -28,7 +28,7 @@ class Blueprint implements Augmentable
     protected $order;
     protected $hidden = false;
     protected $initialPath;
-    protected $contents;
+    protected $contents = [];
     protected $extendedContents = [];
     protected $fieldsCache;
     protected $parent;
@@ -150,7 +150,10 @@ class Blueprint implements Augmentable
      */
     private function getContents($withExtends = true)
     {
-        $contents = $withExtends ? array_merge_recursive($this->contents, $this->extendedContents) : $this->contents;
+        $contents = array_merge_recursive(
+            $this->contents,
+            $withExtends ? $this->extendedContents : []
+        );
 
         $contents['sections'] = $contents['sections'] ?? [
             'main' => ['fields' => []],

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -1035,4 +1035,35 @@ class BlueprintTest extends TestCase
 
         $this->assertEquals('test Test', Facades\Antlers::parse('{{ blueprint }}{{ handle }} {{ title }}{{ /blueprint }}', ['blueprint' => $blueprint]));
     }
+
+    /** @test */
+    public function it_save_the_correct_file_data_and_outputs_extended_contents() {
+        $contents_one = [
+            'sections' => [
+                'one' => [
+                    'fields' => [
+                        ['handle' => 'two', 'field' => ['type' => 'text']],
+                    ],
+                ]
+            ]
+        ];
+
+        $contents_two = [
+            'sections' => [
+                'two' => [
+                    'fields' => [
+                        ['handle' => 'two', 'field' => ['type' => 'text']],
+                    ],
+                ]
+            ]
+        ];
+
+        $blueprint = (new Blueprint)->setHandle('test')->setContents($contents_one);
+        $blueprint->extendWith($contents_two);
+
+        $this->assertEquals($contents_one, $blueprint->fileData());
+
+        $this->assertArraySubset($contents_one, $blueprint->contents());
+        $this->assertArraySubset($contents_two, $blueprint->contents());
+    }
 }


### PR DESCRIPTION
Closes: https://github.com/statamic/ideas/issues/550

This PR makes the blueprint be extendable temporarily without the changes or additions being written to the blueprint file. Also, they won't be visible in the blueprint editor.

You can use the simple API

```php
$blueprint->extendBlueprint(Blueprint::makeFromSections([...]));
```

to add new fields.