### PR TITLE
Fix permission name style on asset Browser canEdit method

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -333,7 +333,7 @@ export default {
         },
 
         canEdit() {
-            return this.can('assets:'+ this.container.id +':edit')
+            return this.can('edit '+ this.container.id +' assets')
         },
 
         canUpload() {


### PR DESCRIPTION
Fixes #3742