### PR TITLE
Bail out of Data::find() early if null is passed

### DIFF
--- a/src/Data/DataRepository.php
+++ b/src/Data/DataRepository.php
@@ -17,6 +17,10 @@ class DataRepository
 
     public function find($reference)
     {
+        if (! $reference) {
+            return null;
+        }
+
         [$handle, $id] = $this->splitReference($reference);
 
         if (! $handle) {

--- a/tests/Data/DataRepositoryTest.php
+++ b/tests/Data/DataRepositoryTest.php
@@ -62,6 +62,18 @@ class DataRepositoryTest extends TestCase
     }
 
     /** @test */
+    public function it_bails_early_when_finding_null()
+    {
+        $this->app->instance('FooRepository', Mockery::mock('FooRepository', function ($m) {
+            $m->shouldNotReceive('find');
+        }));
+
+        $this->data->setRepository('foo', 'FooRepository');
+
+        $this->assertNull($this->data->find(null));
+    }
+
+    /** @test */
     public function when_a_repository_key_isnt_provided_it_will_loop_through_repositories()
     {
         $this->app->instance('FooRepository', Mockery::mock('FooRepository', function ($m) {


### PR DESCRIPTION
Fixes #3752 

Prevents the overhead of looping through all the repositories since we know it's going to return null anyway.