### PR TITLE
Add AssetMoved event

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -13,6 +13,7 @@ use Statamic\Data\ContainsData;
 use Statamic\Data\HasAugmentedInstance;
 use Statamic\Data\TracksQueriedColumns;
 use Statamic\Events\AssetDeleted;
+use Statamic\Events\AssetMoved;
 use Statamic\Events\AssetSaved;
 use Statamic\Events\AssetUploaded;
 use Statamic\Facades;
@@ -522,6 +523,8 @@ class Asset implements AssetContract, Augmentable
         $this->path($newPath);
         $this->disk()->rename($oldMetaPath, $this->metaPath());
         $this->save();
+
+        AssetMoved::dispatch($this, $oldPath);
 
         return $this;
     }

--- a/src/Events/AssetMoved.php
+++ b/src/Events/AssetMoved.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Statamic\Events;
+
+use Statamic\Assets\Asset;
+
+class AssetMoved extends Event
+{
+    /**
+     * @var Asset
+     */
+    public $asset;
+
+    /**
+     * @var string
+     */
+    public $oldPath;
+
+    /**
+     * @param Asset $asset
+     * @param string $oldPath
+     */
+    public function __construct($asset, $oldPath)
+    {
+        $this->asset = $asset;
+        $this->oldPath = $oldPath;
+    }
+}

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Statamic\Assets\Asset;
 use Statamic\Assets\AssetContainer;
+use Statamic\Events\AssetMoved;
 use Statamic\Events\AssetSaved;
 use Statamic\Events\AssetUploaded;
 use Statamic\Facades;
@@ -676,6 +677,9 @@ class AssetTest extends TestCase
             'old/newfilename.txt',
         ], $container->contents()->cached()->keys()->all());
         Event::assertDispatched(AssetSaved::class);
+        Event::assertDispatched(AssetMoved::class, function ($event) use ($asset) {
+            return $event->asset === $asset && $event->oldPath === 'old/asset.txt';
+        });
     }
 
     /** @test */


### PR DESCRIPTION
Adds a new AssetMoved event because it's not possible to tell if an asset has been moved/renamed by the time AssetSaved is fired.

