### PR TITLE
Update 2020 to 2021 for change log dates that should be 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Release Notes
 
+## 3.1.16 (2021-05-20)
+
+### What's fixed
+- Reverted the lodash and underscore upgrades from 3.1.15 temporarily. [#3750](https://github.com/statamic/cms/issues/3750)
+
+
+
+## 3.1.15 (2021-05-20)
+
+### What's new
+- You can programmatically get and set a user's preferred locale more easily. [#3725](https://github.com/statamic/cms/issues/3725)
+- You can customize a Collection's "Create Entry" text. [#3586](https://github.com/statamic/cms/issues/3586)
+
+### What's improved
+- The Bard link picker will autofocus the URL input. [#3741](https://github.com/statamic/cms/issues/3741)
+- Updated French translations [#3718](https://github.com/statamic/cms/issues/3718) [#3716](https://github.com/statamic/cms/issues/3716)
+
+### What's fixed
+- Fix issue where the site URL sometimes would be incorrect, causing incorrect behavior in the `nav:breadcrumbs` tag, and likely other places. [#3695](https://github.com/statamic/cms/issues/3695)
+- Fix the `locales` tag only working for entries. [#3689](https://github.com/statamic/cms/issues/3689)
+- Fix asset editor not being editable even if you have permission. [#3743](https://github.com/statamic/cms/issues/3743)
+- Prevent mounting an entry from the same collection onto itself. [#3731](https://github.com/statamic/cms/issues/3731)
+- The `entries` fieldtype filters out unpublished entries when augmenting. [#3544](https://github.com/statamic/cms/issues/3544)
+- Typehint the Submission interface in the form email class so custom implementations can be used. [#3596](https://github.com/statamic/cms/issues/3596)
+- Bump underscore from 1.9.2 to 1.12.1 [#3662](https://github.com/statamic/cms/issues/3662)
+- Bump lodash from 4.17.19 to 4.17.21 [#3672](https://github.com/statamic/cms/issues/3672)
+
+
+
 ## 3.1.14 (2021-05-14)
 
 ### What's new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## 3.1.14 (2020-05-14)
+## 3.1.14 (2021-05-14)
 
 ### What's new
 - Add Bard node extension helper. [#3657](https://github.com/statamic/cms/issues/3657)
@@ -23,7 +23,7 @@
 
 
 
-## 3.1.13 (2020-05-10)
+## 3.1.13 (2021-05-10)
 
 ### What's improved
 - In Bard, display the asset container option when using the link or image buttons. [#3665](https://github.com/statamic/cms/issues/3665)
@@ -41,7 +41,7 @@
 
 
 
-## 3.1.12 (2020-05-06)
+## 3.1.12 (2021-05-06)
 
 ### What's new
 - Added Duplicate ID tracking with Control Panel and CLI reviewing options. [#3619](https://github.com/statamic/cms/issues/3619)
@@ -63,7 +63,7 @@
 
 
 
-## 3.1.11 (2020-04-28)
+## 3.1.11 (2021-04-28)
 
 ### What's improved
 - Assets uploaded in the selector stack will be automatically selected. [#3604](https://github.com/statamic/cms/issues/3604)
@@ -82,7 +82,7 @@
 
 
 
-## 3.1.10 (2020-04-23)
+## 3.1.10 (2021-04-23)
 
 ### What's improved
 - Improve Laravel Nova compatibility by avoiding conflicting routes. [#3543](https://github.com/statamic/cms/issues/3543)
@@ -106,14 +106,14 @@
 
 
 
-## 3.1.9 (2020-04-19)
+## 3.1.9 (2021-04-19)
 
 ### What's improved
 - Added header to disable Google's FLoC tracking by default. [#3545](https://github.com/statamic/cms/issues/3545)
 
 
 
-## 3.1.8 (2020-04-16)
+## 3.1.8 (2021-04-16)
 
 ### What's fixed
 - Fix n+1 user group and role queries when storing users in the database. [#3527](https://github.com/statamic/cms/issues/3527)
@@ -121,7 +121,7 @@
 
 
 
-## 3.1.7 (2020-04-15)
+## 3.1.7 (2021-04-15)
 
 ### What's new
 - The `link` and `path` tags can output URLs for entries, terms, etc. [#3530](https://github.com/statamic/cms/issues/3530)
@@ -145,7 +145,7 @@
 
 
 
-## 3.1.6 (2020-04-12)
+## 3.1.6 (2021-04-12)
 
 ### What's new
 - Added a `pluck` modifier. [#3502](https://github.com/statamic/cms/issues/3502)
@@ -168,7 +168,7 @@
 - Fix NaN and other glitches in the `time` fieldtype. [#3496](https://github.com/statamic/cms/issues/3496)
 
 
-## 3.1.5 (2020-04-07)
+## 3.1.5 (2021-04-07)
 
 ### What's new
 - The Bard link toolbar allows you to browse for entries. [#3466](https://github.com/statamic/cms/issues/3466)
@@ -183,7 +183,7 @@
 
 
 
-## 3.1.4 (2020-04-06)
+## 3.1.4 (2021-04-06)
 
 ### What's new
 - Ability to push queries and middleware into GraphQL. [#3385](https://github.com/statamic/cms/issues/3385)
@@ -201,7 +201,7 @@
 
 
 
-## 3.1.3 (2020-04-02)
+## 3.1.3 (2021-04-02)
 
 ### What's new
 - Status icons are shown in collections' tree views. [#3461](https://github.com/statamic/cms/issues/3461)
@@ -218,7 +218,7 @@
 
 
 
-## 3.1.2 (2020-03-30)
+## 3.1.2 (2021-03-30)
 
 ### What's improved
 - Prevent the need to hit enter to add a validation rule. [bdf9e03a5](https://github.com/statamic/cms/commit/bdf9e03a5)
@@ -232,7 +232,7 @@
 
 
 
-## 3.1.1 (2020-03-25)
+## 3.1.1 (2021-03-25)
 
 ### What's improved
 - French translations. [#3429](https://github.com/statamic/cms/issues/3429)
@@ -249,14 +249,14 @@
 
 
 
-## 3.1.0 (2020-03-24)
+## 3.1.0 (2021-03-24)
 
 ### What's new
 - Official 3.1 release. 🎉
 
 
 
-## 3.1.0-beta.3 (2020-03-24)
+## 3.1.0-beta.3 (2021-03-24)
 
 ### What's new
 - `form:create` action and method params. [#3411](https://github.com/statamic/cms/issues/3411)
@@ -270,7 +270,7 @@
 
 
 
-## 3.1.0-beta.2 (2020-03-22)
+## 3.1.0-beta.2 (2021-03-22)
 
 ### What's new
 - Added option to set a custom path to git binary. [#3393](https://github.com/statamic/cms/issues/3393)
@@ -296,7 +296,7 @@
 
 
 
-## 3.1.0-beta.1 (2020-03-15)
+## 3.1.0-beta.1 (2021-03-15)
 
 ### What's new
 - You can configure Statamic to use separate authentication from the rest of your app. [#3143](https://github.com/statamic/cms/issues/3143) 
@@ -314,7 +314,7 @@
 
 
 
-## 3.1.0-alpha.4 (2020-03-08)
+## 3.1.0-alpha.4 (2021-03-08)
 
 ### What's new
 - Collection and Nav Trees are now stored separately from their config. [#2768](https://github.com/statamic/cms/issues/2768)
@@ -341,7 +341,7 @@
 
 
 
-## 3.1.0-alpha.3 (2020-02-11)
+## 3.1.0-alpha.3 (2021-02-11)
 
 ### What's new
 - Add site and locale to entries. [#3205](https://github.com/statamic/cms/issues/3205)
@@ -357,7 +357,7 @@
 
 
 
-## 3.1.0-alpha.2 (2020-02-04)
+## 3.1.0-alpha.2 (2021-02-04)
 
 ### What's new
 - Ability to query an entry by slug or URI in GraphQL. [#3193](https://github.com/statamic/cms/issues/3193)
@@ -369,7 +369,7 @@
 
 
 
-## 3.1.0-alpha.1 (2020-02-01)
+## 3.1.0-alpha.1 (2021-02-01)
 
 ### What's new
 - GraphQL [#2982](https://github.com/statamic/cms/issues/2982)
@@ -384,7 +384,7 @@
 
 
 
-## 3.0.49 (2020-03-24)
+## 3.0.49 (2021-03-24)
 
 ### What's new
 - Add markdown option to render form emails. [#3414](https://github.com/statamic/cms/issues/3414)
@@ -396,7 +396,7 @@
 
 
 
-## 3.0.48 (2020-03-22)
+## 3.0.48 (2021-03-22)
 
 ### What's new
 - The Git integration can use a custom queue connection. [#3305](https://github.com/statamic/cms/issues/3305)
@@ -412,7 +412,7 @@
 
 
 
-## 3.0.47 (2020-03-15)
+## 3.0.47 (2021-03-15)
 
 ### What's new
 - Added a `route` param to `redirect` tag. [#3308](https://github.com/statamic/cms/issues/3308)
@@ -428,7 +428,7 @@
 
 
 
-## 3.0.46 (2020-03-05)
+## 3.0.46 (2021-03-05)
 
 ### What's new
 - You can get a user's email via a property. [#3331](https://github.com/statamic/cms/issues/3331)
@@ -440,7 +440,7 @@
 
 
 
-## 3.0.45 (2020-02-22)
+## 3.0.45 (2021-02-22)
 
 ### What's new
 - Add new `chunk` modifier. [849ae0ccb](https://github.com/statamic/cms/commit/849ae0ccb)
@@ -467,7 +467,7 @@
 
 
 
-## 3.0.44 (2020-02-17)
+## 3.0.44 (2021-02-17)
 
 ### What's fixed
 - Allow `view` data to be passed into tags parameters. [#3252](https://github.com/statamic/cms/issues/3252)
@@ -475,7 +475,7 @@
 
 
 
-## 3.0.43 (2020-02-11)
+## 3.0.43 (2021-02-11)
 
 ### What's new
 - Added an `EntryCreated` event. [#3078](https://github.com/statamic/cms/issues/3078)


### PR DESCRIPTION
Update 2020 to 2021 for change log dates that should be 2021.