### PR TITLE
Fix Terms issue from #3739

### DIFF
--- a/src/Stache/Indexes/Terms/Path.php
+++ b/src/Stache/Indexes/Terms/Path.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Statamic\Stache\Indexes\Terms;
+
+class Path extends Value
+{
+    public function getItemValue($item)
+    {
+        return $item->locale().'::'.$item->path();
+    }
+}

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -15,7 +15,6 @@ abstract class Store
 {
     protected $directory;
     protected $valueIndex = Indexes\Value::class;
-    protected $customIndexes = [];
     protected $defaultIndexes = ['id', 'path'];
     protected $storeIndexes = [];
     protected $usedIndexes;

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -134,7 +134,7 @@ abstract class Store
             $rekey(config('statamic.stache.indexes', [])),
             $rekey(config("statamic.stache.stores.{$storeIndexConfigKey}.indexes", [])),
             $rekey($this->defaultIndexes),
-            $rekey($this->storeIndexes()),
+            $rekey($this->storeIndexes())
         ));
     }
 

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -123,10 +123,10 @@ abstract class Store
         $storeIndexConfigKey = $this instanceof ChildStore ? $this->parent->key() : $this->key();
 
         return collect([
+            $this->defaultIndexes,
             ($withUsages) ? $this->indexUsage()->all() : [],
             config('statamic.stache.indexes', []),
             config("statamic.stache.stores.{$storeIndexConfigKey}.indexes", []),
-            $this->defaultIndexes,
             $this->storeIndexes(),
         ])->reduce(function ($carry, $item) {
             return $carry->merge(collect($item)->mapWithKeys(function ($value, $key) {

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -24,6 +24,7 @@ class TaxonomyTermsStore extends ChildStore
         'taxonomy',
         'associations' => Indexes\Terms\Associations::class,
         'site' => Indexes\Terms\Site::class,
+        'path' => Indexes\Terms\Path::class,
     ];
 
     public function getFileFilter(SplFileInfo $file)

--- a/tests/Stache/StoreTest.php
+++ b/tests/Stache/StoreTest.php
@@ -51,7 +51,8 @@ class StoreTest extends TestCase
             'golf',
         ]]);
 
-        $store = new class extends Store {
+        $store = new class extends Store
+        {
             protected $valueIndex = 'TestValueIndex';
             protected $storeIndexes = [
                 'alfa',

--- a/tests/Stache/StoreTest.php
+++ b/tests/Stache/StoreTest.php
@@ -74,6 +74,8 @@ class StoreTest extends TestCase
         Cache::forever('stache::indexes::test::_indexes', ['alfa', 'bravo', 'zulu']);
 
         $this->assertSame([
+            'id' => 'TestValueIndex', // default
+            'path' => 'TestValueIndex', // default
             'alfa' => 'TestValueIndex', // usage
             'bravo' => 'CustomBravoIndex', // usage, overridden by store index
             'zulu' => 'TestValueIndex', // usage
@@ -82,21 +84,19 @@ class StoreTest extends TestCase
             'romeo' => 'TestValueIndex', // indexes config
             'yankee' => 'TestValueIndex', // store indexes config
             'golf' => 'TestValueIndex', // store indexes config
-            'id' => 'TestValueIndex', // default
-            'path' => 'TestValueIndex', // default
             'tango' => 'CustomTangoIndex', // store
             'victor' => 'TestValueIndex', // store
         ], $store->indexes()->all());
 
         $this->assertSame([
+            'id' => 'TestValueIndex', // default
+            'path' => 'TestValueIndex', // default
             'bravo' => 'CustomBravoIndex', // indexes config, overridden by store index
             'kilo' => 'StoreCustomKiloIndex', // indexes config, overridden class from store indexes config
             'lima' => 'CustomLimaIndex', // indexes config
             'romeo' => 'TestValueIndex', // indexes config
             'yankee' => 'TestValueIndex', // store indexes config
             'golf' => 'TestValueIndex', // store indexes config
-            'id' => 'TestValueIndex', // default
-            'path' => 'TestValueIndex', // default
             'alfa' => 'TestValueIndex', // store
             'tango' => 'CustomTangoIndex', // store
             'victor' => 'TestValueIndex', // store


### PR DESCRIPTION
I was about to open this PR to fix #3739 when I realized it was really not what was needed.

I'm going to scrap this and fix it differently. But, I'm going to open this anyway and close it just in case I need to reference it in the future.

This was going to introduce a custom "path" index just for terms, which I thought it would need the paths saved with the site prefix. In order to do that I needed to fix an issue where if a Stache store has a custom class for an index, that it wouldn't get overridden correctly.

Since the Stache thing isn't really needed now, I'll avoid adding code for no real reason.