### PR TITLE
Improve Stache path handling

### DIFF
--- a/src/Stache/Stores/BasicStore.php
+++ b/src/Stache/Stores/BasicStore.php
@@ -39,11 +39,6 @@ abstract class BasicStore extends Store
         return $item;
     }
 
-    public function getItemByPath($path)
-    {
-        return $this->getItem($this->getKeyFromPath($path));
-    }
-
     protected function getCachedItem($key)
     {
         $cacheKey = $this->getItemCacheKey($key);

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -337,10 +337,6 @@ abstract class Store
             return $isDuplicate ?? false;
         });
 
-        $items->each(function ($item) {
-            $this->cacheItem($item['item']);
-        });
-
         $paths = $items->pluck('path', 'key');
 
         $this->cachePaths($paths);

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -213,12 +213,12 @@ abstract class Store
 
         // Flush cached instances of deleted items.
         $deleted->each(function ($path) {
-            if ($key = $this->getKeyFromPath($path)) {
+            collect(Arr::wrap($this->getKeyFromPath($path)))->each(function ($key) use ($path) {
                 $this->forgetItem($key);
                 $this->forgetPath($key);
                 $this->resolveIndexes()->filter->isCached()->each->forgetItem($key);
                 $this->handleDeletedItem($path, $key);
-            }
+            });
         });
 
         // Get items from every file that was modified.

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -210,9 +210,6 @@ abstract class Store
             return;
         }
 
-        // Get a path to key mapping, so we can easily get the keys of existing files.
-        $pathMap = $this->paths()->flip();
-
         // Flush cached instances of deleted items.
         $deleted->each(function ($path) {
             if ($key = $this->getKeyFromPath($path)) {
@@ -222,12 +219,6 @@ abstract class Store
                 $this->handleDeletedItem($path, $key);
             }
         });
-
-        // Clear cached paths so we're free to deal with the latest ones. We do this after
-        // forgetting deleted files, otherwise they wouldn't be available in the array.
-        // TODO: It may be more performant to keep the paths instead of clearing them
-        // all, then manually create any added files, and delete any deleted files.
-        $this->clearCachedPaths();
 
         // Get items from every file that was modified.
         $modified = $modified->flatMap(function ($timestamp, $path) {

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -213,7 +213,7 @@ abstract class Store
 
         // Flush cached instances of deleted items.
         $deleted->each(function ($path) {
-            collect(Arr::wrap($this->getKeyFromPath($path)))->each(function ($key) use ($path) {
+            collect($this->getKeyFromPath($path))->each(function ($key) use ($path) {
                 $this->forgetItem($key);
                 $this->forgetPath($key);
                 $this->resolveIndexes()->filter->isCached()->each->forgetItem($key);

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -233,8 +233,14 @@ abstract class Store
         $this->clearCachedPaths();
 
         // Get items from every file that was modified.
-        $modified = $modified->map(function ($timestamp, $path) use ($pathMap) {
-            return $this->getItemFromModifiedPath($path, $pathMap);
+        $modified = $modified->flatMap(function ($timestamp, $path) {
+            $items = $this->getItemFromModifiedPath($path);
+
+            if (! is_array($items)) {
+                $items = [$items];
+            }
+
+            return $items;
         });
 
         // Remove items with duplicate IDs/keys
@@ -295,12 +301,8 @@ abstract class Store
         return $paths;
     }
 
-    protected function getItemFromModifiedPath($path, $pathMap)
+    protected function getItemFromModifiedPath($path)
     {
-        if ($key = $pathMap->get($path)) {
-            return $this->getItem($key);
-        }
-
         return $this->makeItemFromFile($path, File::get($path));
     }
 

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -10,6 +10,7 @@ use Statamic\Facades\Stache;
 use Statamic\Stache\Exceptions\DuplicateKeyException;
 use Statamic\Stache\Indexes;
 use Statamic\Stache\Indexes\Index;
+use Statamic\Support\Arr;
 
 abstract class Store
 {
@@ -222,13 +223,7 @@ abstract class Store
 
         // Get items from every file that was modified.
         $modified = $modified->flatMap(function ($timestamp, $path) {
-            $items = $this->getItemFromModifiedPath($path);
-
-            if (! is_array($items)) {
-                $items = [$items];
-            }
-
-            return $items;
+            return Arr::wrap($this->getItemFromModifiedPath($path));
         });
 
         // Remove items with duplicate IDs/keys

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -210,9 +210,6 @@ abstract class Store
             return;
         }
 
-        $modified = $this->adjustModifiedPaths($modified);
-        $deleted = $this->adjustDeletedPaths($deleted);
-
         // Get a path to key mapping, so we can easily get the keys of existing files.
         $pathMap = $this->paths()->flip();
 
@@ -289,16 +286,6 @@ abstract class Store
     protected function handleDeletedItem($item, $key)
     {
         //
-    }
-
-    protected function adjustModifiedPaths($paths)
-    {
-        return $paths;
-    }
-
-    protected function adjustDeletedPaths($paths)
-    {
-        return $paths;
     }
 
     protected function getItemFromModifiedPath($path)

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -175,7 +175,7 @@ class TaxonomyTermsStore extends ChildStore
     {
         return $this->paths()->filter(function ($p) use ($path) {
             return \Statamic\Support\Str::endsWith($p, $path);
-        })->keys()->all();
+        })->keys();
     }
 
     public function save($term)

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -180,7 +180,7 @@ class TaxonomyTermsStore extends ChildStore
 
             $this->forgetItem($key);
 
-            $this->setPath($key, $item->locale().'::'.$item->path());
+            $this->setPath($key, $item->path());
 
             $this->resolveIndexes()->each->updateItem($item);
 

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -188,34 +188,8 @@ class TaxonomyTermsStore extends ChildStore
         }
     }
 
-    protected function adjustModifiedPaths($paths)
+    protected function getItemFromModifiedPath($path)
     {
-        $sites = Taxonomy::find($this->childKey())->sites();
-
-        return $paths->flatMap(function ($timestamp, $path) use ($sites) {
-            return $sites->mapWithKeys(function ($site) use ($timestamp, $path) {
-                return [$site.'::'.$path => $timestamp];
-            });
-        });
-    }
-
-    protected function adjustDeletedPaths($paths)
-    {
-        return $this->adjustModifiedPaths($paths);
-    }
-
-    protected function getItemFromModifiedPath($path, $pathMap)
-    {
-        if ($key = $pathMap->get($path)) {
-            return $this->getItem($key);
-        }
-
-        $site = explode('::', $key)[0];
-
-        $item = $this->makeItemFromFile($path, File::get($path))->in($site);
-
-        $this->cacheItem($item);
-
-        return $item;
+        return parent::getItemFromModifiedPath($path)->localizations()->all();
     }
 }

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -171,6 +171,13 @@ class TaxonomyTermsStore extends ChildStore
         return $paths;
     }
 
+    protected function getKeyFromPath($path)
+    {
+        return $this->paths()->filter(function ($p) use ($path) {
+            return \Statamic\Support\Str::endsWith($p, $path);
+        })->keys()->all();
+    }
+
     public function save($term)
     {
         $this->writeItemToDisk($term);

--- a/tests/Feature/GraphQL/TermsTest.php
+++ b/tests/Feature/GraphQL/TermsTest.php
@@ -93,8 +93,8 @@ GQL;
                 ['id' => 'tags::bravo', 'title' => 'Tag Bravo'],
                 ['id' => 'categories::alpha', 'title' => 'Category Alpha'],
                 ['id' => 'categories::bravo', 'title' => 'Category Bravo'],
-                ['id' => 'sizes::large', 'title' => 'Size Large'],
                 ['id' => 'sizes::small', 'title' => 'Size Small'],
+                ['id' => 'sizes::large', 'title' => 'Size Large'],
             ]]]]);
     }
 
@@ -197,8 +197,8 @@ GQL;
             ->assertExactJson(['data' => ['terms' => ['data' => [
                 ['id' => 'categories::alpha', 'title' => 'Category Alpha'],
                 ['id' => 'categories::bravo', 'title' => 'Category Bravo'],
-                ['id' => 'sizes::large', 'title' => 'Size Large'],
                 ['id' => 'sizes::small', 'title' => 'Size Small'],
+                ['id' => 'sizes::large', 'title' => 'Size Large'],
             ]]]]);
     }
 
@@ -252,8 +252,8 @@ GQL;
             ->assertExactJson(['data' => ['terms' => ['data' => [
                 ['id' => 'tags::alpha', 'foo' => 'FOO!'],
                 ['id' => 'tags::bravo', 'bar' => 'BAR!'],
-                ['id' => 'sizes::large', 'shorthand' => 'lg'],
                 ['id' => 'sizes::small', 'shorthand' => 'sm'],
+                ['id' => 'sizes::large', 'shorthand' => 'lg'],
             ]]]]);
     }
 

--- a/tests/Stache/Stores/TermsStoreTest.php
+++ b/tests/Stache/Stores/TermsStoreTest.php
@@ -37,6 +37,6 @@ class TermsStoreTest extends TestCase
         @unlink($path);
         $this->assertFileNotExists($path);
 
-        $this->assertEquals('en::'.$path, $this->parent->store('tags')->paths()->get('en::test'));
+        $this->assertEquals($path, $this->parent->store('tags')->paths()->get('en::test'));
     }
 }


### PR DESCRIPTION
In #3369, there was a changed made to how paths were stored in the Stache:

> Stache paths are stored as if they were an index, which prevents asset meta needing to be loaded for the initial cache build. It also makes all the other stache stores like entries etc just a tad faster.

Terms were handled a little differently, and the change introduced in that PR didn't take it into account and caused #3739 and #3775.

---

Since localized versions of terms exist in the same file, we would previously wangjangle the list of paths so that there would be multiple of the same path. We'd prefix the path with the site. Like `siteone::/path/to/term.yaml`. We did that so if we needed to `array_flip()` the paths, the dupes wouldn't disappear and we'd be able to quickly grab the key.

Now, we'll just use the regular paths like everywhere else in the Stache. We'd avoid the deduping path issue by avoiding the need to flip the array. Instead, the `getItemFromModifiedPath()` in the Stache will now allow multiple items. We spit back all the localized terms in there.

Fixes #3739
Fixes #3775 

---

The watcher would loop through any deleted paths and invalidate the cache for those items appropriately.
For terms, multiple items would share the same key so the `getKeyFromPath` method would only return one key. When one localization would get the deleted, the others remained.

Now it'll allow an array of keys.

Fixes #1569

---

Also, the stores' `paths()` method was caching all of the items. It didn't need to do that, and was causing excess overhead.
When the Stache noticed a file change, it would re-cache all the items in that store. i.e. edit one entry in a collection, and it'd re-cache all of that collection's entries.

Now the watcher will re-cache only the modified items.

---

Other minor housekeeping:

- The `getItemFromModifiedPath` method gets from the file rather than the cache. It's been modified so it should definitely get the most up to date version anyway.
- Needed to fix a GraphQL test that is affected by the alphabetical nature of how paths are stored.
- Removed now unused methods in the Stache