### PR TITLE
Allow Addon FieldTypes to be usable on Forms

### DIFF
--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -138,7 +138,6 @@ abstract class Fieldtype implements Arrayable
             'validatable' => $this->validatable(),
             'defaultable' => $this->defaultable(),
             'selectable'  => $this->selectable(),
-            'supportedInForms' => $this->supportedInForms(),
             'categories' => $this->categories(),
             'icon' => $this->icon(),
             'config' => $this->configFields()->toPublishArray(),

--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -24,6 +24,7 @@ abstract class Fieldtype implements Arrayable
     protected $validatable = true;
     protected $defaultable = true;
     protected $selectable = true;
+    protected $supportedInForms = false;
     protected $categories = ['text'];
     protected $rules = [];
     protected $extraRules = [];
@@ -76,6 +77,11 @@ abstract class Fieldtype implements Arrayable
     public function selectable(): bool
     {
         return $this->selectable;
+    }
+
+    public function supportedInForms(): bool
+    {
+        return $this->supportedInForms;
     }
 
     public function categories(): array
@@ -132,6 +138,7 @@ abstract class Fieldtype implements Arrayable
             'validatable' => $this->validatable(),
             'defaultable' => $this->defaultable(),
             'selectable'  => $this->selectable(),
+            'supportedInForms' => $this->supportedInForms(),
             'categories' => $this->categories(),
             'icon' => $this->icon(),
             'config' => $this->configFields()->toPublishArray(),

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -15,6 +15,7 @@ class Assets extends Fieldtype
 {
     protected $categories = ['media', 'relationship'];
     protected $defaultValue = [];
+    protected $supportedInForms = true;
 
     protected function configFieldItems(): array
     {

--- a/src/Fieldtypes/Checkboxes.php
+++ b/src/Fieldtypes/Checkboxes.php
@@ -9,6 +9,8 @@ use Statamic\GraphQL\Types\LabeledValueType;
 
 class Checkboxes extends Fieldtype
 {
+    protected $supportedInForms = true;
+
     protected function configFieldItems(): array
     {
         return [

--- a/src/Fieldtypes/Integer.php
+++ b/src/Fieldtypes/Integer.php
@@ -8,6 +8,7 @@ use Statamic\Fields\Fieldtype;
 class Integer extends Fieldtype
 {
     protected $rules = ['integer'];
+    protected $supportedInForms = true;
 
     public function preProcess($data)
     {

--- a/src/Fieldtypes/Radio.php
+++ b/src/Fieldtypes/Radio.php
@@ -9,6 +9,8 @@ use Statamic\GraphQL\Types\LabeledValueType;
 
 class Radio extends Fieldtype
 {
+    protected $supportedInForms = true;
+
     protected function configFieldItems(): array
     {
         return [

--- a/src/Fieldtypes/Select.php
+++ b/src/Fieldtypes/Select.php
@@ -10,6 +10,8 @@ use Statamic\Support\Arr;
 
 class Select extends Fieldtype
 {
+    protected $supportedInForms = true;
+
     protected function configFieldItems(): array
     {
         return [

--- a/src/Fieldtypes/Text.php
+++ b/src/Fieldtypes/Text.php
@@ -7,6 +7,8 @@ use Statamic\Support\Str;
 
 class Text extends Fieldtype
 {
+    protected $supportedInForms = true;
+
     protected function configFieldItems(): array
     {
         return [

--- a/src/Fieldtypes/Textarea.php
+++ b/src/Fieldtypes/Textarea.php
@@ -7,6 +7,8 @@ use Statamic\Query\Scopes\Filters\Fields\Textarea as TextareaFilter;
 
 class Textarea extends Fieldtype
 {
+    protected $supportedInForms = true;
+
     protected function configFieldItems(): array
     {
         return [

--- a/src/Http/Controllers/CP/Fields/FieldtypesController.php
+++ b/src/Http/Controllers/CP/Fields/FieldtypesController.php
@@ -16,7 +16,7 @@ class FieldtypesController extends CpController
                 $arr = $fieldtype->toArray();
 
                 if ($request->forms) {
-                    $arr['selectable'] = $arr['supportedInForms'] ?: $this->supportedInForms($fieldtype->handle());
+                    $arr['selectable'] = $fieldtype->supportedInForms();
                 }
 
                 return $arr;
@@ -31,18 +31,5 @@ class FieldtypesController extends CpController
         // TODO: Make sure the configs get preprocessed.
 
         return $fieldtypes->values();
-    }
-
-    private function supportedInForms($fieldtype)
-    {
-        return in_array($fieldtype, [
-            'assets',
-            'checkboxes',
-            'integer',
-            'radio',
-            'select',
-            'text',
-            'textarea',
-        ]);
     }
 }

--- a/src/Http/Controllers/CP/Fields/FieldtypesController.php
+++ b/src/Http/Controllers/CP/Fields/FieldtypesController.php
@@ -16,7 +16,7 @@ class FieldtypesController extends CpController
                 $arr = $fieldtype->toArray();
 
                 if ($request->forms) {
-                    $arr['selectable'] = $this->supportedInForms($fieldtype->handle());
+                    $arr['selectable'] = $arr['supportedInForms'] ?: $this->supportedInForms($fieldtype->handle());
                 }
 
                 return $arr;

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -152,7 +152,6 @@ class FieldtypeTest extends TestCase
             'validatable' => true,
             'defaultable' => true,
             'selectable' => true,
-            'supportedInForms' => false,
             'categories' => ['text'],
             'icon' => 'test',
             'config' => [],

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -42,7 +42,7 @@ class FieldtypeTest extends TestCase
     /** @test */
     public function handle_can_be_defined_as_a_property()
     {
-        $fieldtype = new class extends Fieldtype 
+        $fieldtype = new class extends Fieldtype
         {
             protected static $handle = 'example';
         };
@@ -67,7 +67,7 @@ class FieldtypeTest extends TestCase
     /** @test */
     public function title_can_be_defined_as_a_property()
     {
-        $fieldtype = new class extends Fieldtype 
+        $fieldtype = new class extends Fieldtype
         {
             protected static $title = 'Super Cool Example';
         };
@@ -80,7 +80,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertTrue((new TestFieldtype)->localizable());
 
-        $fieldtype = new class extends Fieldtype 
+        $fieldtype = new class extends Fieldtype
         {
             protected $localizable = false;
         };
@@ -93,7 +93,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertTrue((new TestFieldtype)->validatable());
 
-        $fieldtype = new class extends Fieldtype 
+        $fieldtype = new class extends Fieldtype
         {
             protected $validatable = false;
         };
@@ -106,7 +106,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertTrue((new TestFieldtype)->defaultable());
 
-        $fieldtype = new class extends Fieldtype 
+        $fieldtype = new class extends Fieldtype
         {
             protected $defaultable = false;
         };
@@ -119,7 +119,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertEquals(['text'], (new TestFieldtype)->categories());
 
-        $fieldtype = new class extends Fieldtype 
+        $fieldtype = new class extends Fieldtype
         {
             protected $categories = ['foo', 'bar'];
         };
@@ -132,7 +132,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertTrue((new TestFieldtype)->selectable());
 
-        $fieldtype = new class extends Fieldtype 
+        $fieldtype = new class extends Fieldtype
         {
             protected $selectable = false;
         };
@@ -190,13 +190,13 @@ class FieldtypeTest extends TestCase
     {
         $this->assertEquals([], (new TestFieldtype)->rules());
 
-        $arrayDefined = new class extends Fieldtype 
+        $arrayDefined = new class extends Fieldtype
         {
             protected $rules = ['required', 'min:2'];
         };
         $this->assertEquals(['required', 'min:2'], $arrayDefined->rules());
 
-        $stringDefined = new class extends Fieldtype 
+        $stringDefined = new class extends Fieldtype
         {
             protected $rules = 'required|min:2';
         };
@@ -208,7 +208,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertEquals([], (new TestFieldtype)->rules());
 
-        $arrayDefined = new class extends Fieldtype 
+        $arrayDefined = new class extends Fieldtype
         {
             protected $extraRules = [
                 'extra.one' => ['required', 'min:2'],
@@ -220,7 +220,7 @@ class FieldtypeTest extends TestCase
             'extra.two' => ['array'],
         ], $arrayDefined->extraRules());
 
-        $stringDefined = new class extends Fieldtype 
+        $stringDefined = new class extends Fieldtype
         {
             protected $extraRules = [
                 'extra.one' => 'required|min:2',
@@ -238,7 +238,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertNull((new TestFieldtype)->defaultValue());
 
-        $fieldtype = new class extends Fieldtype 
+        $fieldtype = new class extends Fieldtype
         {
             protected $defaultValue = 'test';
         };
@@ -255,7 +255,7 @@ class FieldtypeTest extends TestCase
             $this->assertCount(0, $fields->all());
         });
 
-        $fieldtype = new class extends Fieldtype 
+        $fieldtype = new class extends Fieldtype
         {
             protected $configFields = [
                 'foo' => ['type' => 'textarea'],
@@ -279,14 +279,14 @@ class FieldtypeTest extends TestCase
     {
         $this->assertEquals('test', (new TestFieldtype)->icon());
 
-        $customHandle = new class extends Fieldtype 
+        $customHandle = new class extends Fieldtype
         {
             protected static $handle = 'custom_handle';
         };
 
         $this->assertEquals('custom_handle', $customHandle->icon());
 
-        $customIcon = new class extends Fieldtype 
+        $customIcon = new class extends Fieldtype
         {
             protected $icon = 'foo';
         };

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -165,7 +165,8 @@ class FieldtypeTest extends TestCase
         $fields = Mockery::mock(Fields::class);
         $fields->shouldReceive('toPublishArray')->once()->andReturn(['example', 'publish', 'array']);
 
-        $fieldtype = new class($fields) extends Fieldtype {
+        $fieldtype = new class($fields) extends Fieldtype
+        {
             protected $mock;
             protected static $handle = 'test';
 

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -42,8 +42,7 @@ class FieldtypeTest extends TestCase
     /** @test */
     public function handle_can_be_defined_as_a_property()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected static $handle = 'example';
         };
 
@@ -67,8 +66,7 @@ class FieldtypeTest extends TestCase
     /** @test */
     public function title_can_be_defined_as_a_property()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected static $title = 'Super Cool Example';
         };
 
@@ -80,8 +78,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertTrue((new TestFieldtype)->localizable());
 
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $localizable = false;
         };
 
@@ -93,8 +90,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertTrue((new TestFieldtype)->validatable());
 
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $validatable = false;
         };
 
@@ -106,8 +102,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertTrue((new TestFieldtype)->defaultable());
 
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $defaultable = false;
         };
 
@@ -119,8 +114,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertEquals(['text'], (new TestFieldtype)->categories());
 
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $categories = ['foo', 'bar'];
         };
 
@@ -132,8 +126,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertTrue((new TestFieldtype)->selectable());
 
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $selectable = false;
         };
 
@@ -152,6 +145,7 @@ class FieldtypeTest extends TestCase
             'validatable' => true,
             'defaultable' => true,
             'selectable' => true,
+            'supportedInForms' => false,
             'categories' => ['text'],
             'icon' => 'test',
             'config' => [],
@@ -164,8 +158,7 @@ class FieldtypeTest extends TestCase
         $fields = Mockery::mock(Fields::class);
         $fields->shouldReceive('toPublishArray')->once()->andReturn(['example', 'publish', 'array']);
 
-        $fieldtype = new class($fields) extends Fieldtype
-        {
+        $fieldtype = new class($fields) extends Fieldtype {
             protected $mock;
             protected static $handle = 'test';
 
@@ -190,14 +183,12 @@ class FieldtypeTest extends TestCase
     {
         $this->assertEquals([], (new TestFieldtype)->rules());
 
-        $arrayDefined = new class extends Fieldtype
-        {
+        $arrayDefined = new class extends Fieldtype {
             protected $rules = ['required', 'min:2'];
         };
         $this->assertEquals(['required', 'min:2'], $arrayDefined->rules());
 
-        $stringDefined = new class extends Fieldtype
-        {
+        $stringDefined = new class extends Fieldtype {
             protected $rules = 'required|min:2';
         };
         $this->assertEquals(['required', 'min:2'], $stringDefined->rules());
@@ -208,8 +199,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertEquals([], (new TestFieldtype)->rules());
 
-        $arrayDefined = new class extends Fieldtype
-        {
+        $arrayDefined = new class extends Fieldtype {
             protected $extraRules = [
                 'extra.one' => ['required', 'min:2'],
                 'extra.two' => ['array'],
@@ -220,8 +210,7 @@ class FieldtypeTest extends TestCase
             'extra.two' => ['array'],
         ], $arrayDefined->extraRules());
 
-        $stringDefined = new class extends Fieldtype
-        {
+        $stringDefined = new class extends Fieldtype {
             protected $extraRules = [
                 'extra.one' => 'required|min:2',
                 'extra.two' => 'array',
@@ -238,8 +227,7 @@ class FieldtypeTest extends TestCase
     {
         $this->assertNull((new TestFieldtype)->defaultValue());
 
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $defaultValue = 'test';
         };
 
@@ -255,8 +243,7 @@ class FieldtypeTest extends TestCase
             $this->assertCount(0, $fields->all());
         });
 
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $configFields = [
                 'foo' => ['type' => 'textarea'],
                 'max_items' => ['type' => 'integer'],
@@ -279,15 +266,13 @@ class FieldtypeTest extends TestCase
     {
         $this->assertEquals('test', (new TestFieldtype)->icon());
 
-        $customHandle = new class extends Fieldtype
-        {
+        $customHandle = new class extends Fieldtype {
             protected static $handle = 'custom_handle';
         };
 
         $this->assertEquals('custom_handle', $customHandle->icon());
 
-        $customIcon = new class extends Fieldtype
-        {
+        $customIcon = new class extends Fieldtype {
             protected $icon = 'foo';
         };
 

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -42,7 +42,8 @@ class FieldtypeTest extends TestCase
     /** @test */
     public function handle_can_be_defined_as_a_property()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype 
+        {
             protected static $handle = 'example';
         };
 
@@ -66,7 +67,8 @@ class FieldtypeTest extends TestCase
     /** @test */
     public function title_can_be_defined_as_a_property()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype 
+        {
             protected static $title = 'Super Cool Example';
         };
 
@@ -78,7 +80,8 @@ class FieldtypeTest extends TestCase
     {
         $this->assertTrue((new TestFieldtype)->localizable());
 
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype 
+        {
             protected $localizable = false;
         };
 
@@ -90,7 +93,8 @@ class FieldtypeTest extends TestCase
     {
         $this->assertTrue((new TestFieldtype)->validatable());
 
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype 
+        {
             protected $validatable = false;
         };
 
@@ -102,7 +106,8 @@ class FieldtypeTest extends TestCase
     {
         $this->assertTrue((new TestFieldtype)->defaultable());
 
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype 
+        {
             protected $defaultable = false;
         };
 
@@ -114,7 +119,8 @@ class FieldtypeTest extends TestCase
     {
         $this->assertEquals(['text'], (new TestFieldtype)->categories());
 
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype 
+        {
             protected $categories = ['foo', 'bar'];
         };
 
@@ -126,7 +132,8 @@ class FieldtypeTest extends TestCase
     {
         $this->assertTrue((new TestFieldtype)->selectable());
 
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype 
+        {
             protected $selectable = false;
         };
 
@@ -183,12 +190,14 @@ class FieldtypeTest extends TestCase
     {
         $this->assertEquals([], (new TestFieldtype)->rules());
 
-        $arrayDefined = new class extends Fieldtype {
+        $arrayDefined = new class extends Fieldtype 
+        {
             protected $rules = ['required', 'min:2'];
         };
         $this->assertEquals(['required', 'min:2'], $arrayDefined->rules());
 
-        $stringDefined = new class extends Fieldtype {
+        $stringDefined = new class extends Fieldtype 
+        {
             protected $rules = 'required|min:2';
         };
         $this->assertEquals(['required', 'min:2'], $stringDefined->rules());
@@ -199,7 +208,8 @@ class FieldtypeTest extends TestCase
     {
         $this->assertEquals([], (new TestFieldtype)->rules());
 
-        $arrayDefined = new class extends Fieldtype {
+        $arrayDefined = new class extends Fieldtype 
+        {
             protected $extraRules = [
                 'extra.one' => ['required', 'min:2'],
                 'extra.two' => ['array'],
@@ -210,7 +220,8 @@ class FieldtypeTest extends TestCase
             'extra.two' => ['array'],
         ], $arrayDefined->extraRules());
 
-        $stringDefined = new class extends Fieldtype {
+        $stringDefined = new class extends Fieldtype 
+        {
             protected $extraRules = [
                 'extra.one' => 'required|min:2',
                 'extra.two' => 'array',
@@ -227,7 +238,8 @@ class FieldtypeTest extends TestCase
     {
         $this->assertNull((new TestFieldtype)->defaultValue());
 
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype 
+        {
             protected $defaultValue = 'test';
         };
 
@@ -243,7 +255,8 @@ class FieldtypeTest extends TestCase
             $this->assertCount(0, $fields->all());
         });
 
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype 
+        {
             protected $configFields = [
                 'foo' => ['type' => 'textarea'],
                 'max_items' => ['type' => 'integer'],
@@ -266,13 +279,15 @@ class FieldtypeTest extends TestCase
     {
         $this->assertEquals('test', (new TestFieldtype)->icon());
 
-        $customHandle = new class extends Fieldtype {
+        $customHandle = new class extends Fieldtype 
+        {
             protected static $handle = 'custom_handle';
         };
 
         $this->assertEquals('custom_handle', $customHandle->icon());
 
-        $customIcon = new class extends Fieldtype {
+        $customIcon = new class extends Fieldtype 
+        {
             protected $icon = 'foo';
         };
 


### PR DESCRIPTION
Hey there,

This aims to allow FieldTypes to use a parameter or method to specify that they can be used on Forms.
This way addon's can be created to add FieldTypes that can be used on Form Blueprints.

An addon FieldType could then appear as a selectable field when editing a form's blueprint, either by using one of the below methods.

```php
class MyAwesomeField extends Fieldtype
{
    protected $supportedInForms = true;
```

```php
class MyAwesomeField extends Fieldtype
{
    protected function supportedInForms(){
       return true; // Or various logic.
   }
```

Frontend output would need to be handled by either the end developer or the addon developer, but that is to be expected I suppose?

Open to ideas, let me know what you think.

Thanks.