### PR TITLE
Pass preProcessed values into Replicator's 'new' meta

### DIFF
--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -135,8 +135,8 @@ class Grid extends Fieldtype
     public function preload()
     {
         return [
-            'defaults' => $this->defaultRowData(),
-            'new' => $this->fields()->meta(),
+            'defaults' => $this->defaultRowData()->all(),
+            'new' => $this->fields()->meta()->all(),
             'existing' => collect($this->field->value())->mapWithKeys(function ($row) {
                 return [$row['_id'] => $this->fields()->addValues($row)->meta()];
             })->toArray(),

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -156,7 +156,7 @@ class Replicator extends Fieldtype
                 return [$set['_id'] => (new Fields($config))->addValues($set)->meta()->put('_', '_')];
             })->toArray(),
             'new' => collect($this->config('sets'))->map(function ($set, $handle) {
-                return (new Fields($set['fields']))->meta()->put('_', '_');
+                return (new Fields($set['fields']))->preProcess()->meta()->put('_', '_');
             })->toArray(),
             'defaults' => collect($this->config('sets'))->map(function ($set) {
                 return (new Fields($set['fields']))->all()->map(function ($field) {

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -149,26 +149,34 @@ class Replicator extends Fieldtype
 
     public function preload()
     {
-        return [
-            'existing' => $existing = collect($this->field->value())->mapWithKeys(function ($set) {
-                $config = $this->config("sets.{$set['type']}.fields", []);
+        $existing = collect($this->field->value())->mapWithKeys(function ($set) {
+            $config = $this->config("sets.{$set['type']}.fields", []);
 
-                return [$set['_id'] => (new Fields($config))->addValues($set)->meta()->put('_', '_')];
-            })->toArray(),
-            'new' => collect($this->config('sets'))->map(function ($set, $handle) {
-                return (new Fields($set['fields']))->preProcess()->meta()->put('_', '_');
-            })->toArray(),
-            'defaults' => collect($this->config('sets'))->map(function ($set) {
-                return (new Fields($set['fields']))->all()->map(function ($field) {
-                    return $field->fieldtype()->preProcess($field->defaultValue());
-                });
-            })->all(),
+            return [$set['_id'] => (new Fields($config))->addValues($set)->meta()->put('_', '_')];
+        })->toArray();
+
+        $defaults = collect($this->config('sets'))->map(function ($set) {
+            return (new Fields($set['fields']))->all()->map(function ($field) {
+                return $field->fieldtype()->preProcess($field->defaultValue());
+            })->all();
+        })->all();
+
+        $new = collect($this->config('sets'))->map(function ($set, $handle) use ($defaults) {
+            return (new Fields($set['fields']))->addValues($defaults[$handle])->meta()->put('_', '_');
+        })->toArray();
+
+        $previews = collect($existing)->map(function ($fields) {
+            return collect($fields)->map(function () {
+                return null;
+            })->all();
+        })->all();
+
+        return [
+            'existing' => $existing,
+            'new' => $new,
+            'defaults' => $defaults,
             'collapsed' => [],
-            'previews' => collect($existing)->map(function ($fields) {
-                return collect($fields)->map(function () {
-                    return null;
-                })->all();
-            })->all(),
+            'previews' => $previews,
         ];
     }
 

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -372,6 +372,53 @@ class BardTest extends TestCase
     }
 
     /** @test */
+    public function it_preloads_new_meta_with_preprocessed_values()
+    {
+        // For this test, use a grid field with min_rows.
+        // It doesn't have to be, but it's a fieldtype that would
+        // require preprocessed values to be provided down the line.
+        // https://github.com/statamic/cms/issues/3481
+
+        $field = (new Field('test', [
+            'type' => 'bard',
+            'sets' => [
+                'main' => [
+                    'fields' => [
+                        [
+                            'handle' => 'things',
+                            'field' => [
+                                'type' => 'grid',
+                                'min_rows' => 2,
+                                'fields' => [
+                                    ['handle' => 'one', 'field' => ['type' => 'text']],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+
+        $expected = [
+            '_' => '_',
+            'things' => [ // this array is the preloaded meta for the grid field
+                'defaults' => [
+                    'one' => null, // default value for the text field
+                ],
+                'new' => [
+                    'one' => null, // meta for the text field
+                ],
+                'existing' => [
+                    'row-0' => ['one' => null],
+                    'row-1' => ['one' => null],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $field->fieldtype()->preload()['new']['main']);
+    }
+
+    /** @test */
     public function it_gets_link_data()
     {
         tap(Collection::make('pages')->routes('/{slug}'))->save();

--- a/tests/Fieldtypes/GridTest.php
+++ b/tests/Fieldtypes/GridTest.php
@@ -313,6 +313,6 @@ class GridTest extends TestCase
             'things' => [],
         ];
 
-        $this->assertSame($expected, $field->fieldtype()->preload()['defaults']->all());
+        $this->assertSame($expected, $field->fieldtype()->preload()['defaults']);
     }
 }

--- a/tests/Fieldtypes/ReplicatorTest.php
+++ b/tests/Fieldtypes/ReplicatorTest.php
@@ -281,7 +281,7 @@ class ReplicatorTest extends TestCase
             'things' => [],
         ];
 
-        $this->assertEquals($expected, $field->fieldtype()->preload()['defaults']['main']->all());
+        $this->assertEquals($expected, $field->fieldtype()->preload()['defaults']['main']);
     }
 
     /** @test */

--- a/tests/Fieldtypes/ReplicatorTest.php
+++ b/tests/Fieldtypes/ReplicatorTest.php
@@ -283,4 +283,51 @@ class ReplicatorTest extends TestCase
 
         $this->assertEquals($expected, $field->fieldtype()->preload()['defaults']['main']->all());
     }
+
+    /** @test */
+    public function it_preloads_new_meta_with_preprocessed_values()
+    {
+        // For this test, use a grid field with min_rows.
+        // It doesn't have to be, but it's a fieldtype that would
+        // require preprocessed values to be provided down the line.
+        // https://github.com/statamic/cms/issues/3481
+
+        $field = (new Field('test', [
+            'type' => 'replicator',
+            'sets' => [
+                'main' => [
+                    'fields' => [
+                        [
+                            'handle' => 'things',
+                            'field' => [
+                                'type' => 'grid',
+                                'min_rows' => 2,
+                                'fields' => [
+                                    ['handle' => 'one', 'field' => ['type' => 'text']],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+
+        $expected = [
+            '_' => '_',
+            'things' => [ // this array is the preloaded meta for the grid field
+                'defaults' => [
+                    'one' => null, // default value for the text field
+                ],
+                'new' => [
+                    'one' => null, // meta for the text field
+                ],
+                'existing' => [
+                    'row-0' => ['one' => null],
+                    'row-1' => ['one' => null],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $field->fieldtype()->preload()['new']['main']);
+    }
 }


### PR DESCRIPTION
Fixes #3481 

The meta for sub fields wasn't being appropriately passed along through Replicator.

The data wasn't preprocessed, so when you had `min_rows` in a Grid field, it was missing those dynamically added rows, and JS would 💩 itself.

The change looks bigger than it actually is. I changed the formatting of the `preload` method to match Bard's.
The real change is only a single method call. [In this commit](https://github.com/statamic/cms/pull/3782/commits/fd36172c840c1b6832e0fbd48aae679a1541d896).