### PR TITLE
Fix `@{{ }}` noparse tags with nested braces

### DIFF
--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -89,7 +89,7 @@ class Parser
         $this->noparseRegex = '/{{\s*noparse\s*}}(.*?){{\s*\/noparse\s*}}/ms';
 
         // Matches an ignored tag as indicated by a prefixed @ symbol: @{{ }}
-        $this->ignoreRegex = '/@{{[^}]*}}/';
+        $this->ignoreRegex = '/@{{(?:(?!}}).)*}}/';
 
         // Matches the logic operator tags
         $this->conditionalRegex = '/{{\s*(if|unless|elseif|elseunless)\s+((?:\()?(.*?)(?:\))?)\s*}}/ms';

--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -825,6 +825,54 @@ EOT;
     }
 
     /** @test */
+    public function it_doesnt_parse_tags_prefixed_with_an_at_symbol()
+    {
+        $this->assertEquals('foo {{ bar }} baz', $this->parse('foo @{{ bar }} baz'));
+    }
+
+    /** @test */
+    public function it_doesnt_parse_tags_prefixed_with_an_at_symbol_over_multiple_lines()
+    {
+        $template = <<<'EOT'
+@{{ foo }}
+bar
+{{ baz }}
+EOT;
+
+        $expected = <<<'EOT'
+{{ foo }}
+bar
+BAZ
+EOT;
+
+        $this->assertEquals($expected, $this->parse($template, ['baz' => 'BAZ']));
+    }
+
+    /** @test */
+    public function it_doesnt_parse_tags_prefixed_with_an_at_symbol_over_tags_in_multiple_lines()
+    {
+        $template = <<<'EOT'
+@{{ foo }} {{ qux }}
+bar
+{{ baz }}
+EOT;
+
+        $expected = <<<'EOT'
+{{ foo }} QUX
+bar
+BAZ
+EOT;
+
+        $this->assertEquals($expected, $this->parse($template, ['baz' => 'BAZ', 'qux' => 'QUX']));
+    }
+
+    /** @test */
+    public function it_doesnt_parse_tags_prefixed_with_an_at_symbol_containing_nested_tags()
+    {
+        $this->assertEquals('{{ foo bar="{baz}" }}', $this->parse('@{{ foo bar="{baz}" }}'));
+    }
+
+    /** @test */
     public function it_accepts_an_arrayable_object()
     {
         $this->assertEquals(


### PR DESCRIPTION
There was an issue where noparse tags would still be parsed when they would contain nested tags.

Like this:

```
@{{ nav from="{foo}" }}
```

Because of the `{` inside the parameter, the regex the parser uses to escape that whole tag was not catching it. So, the nav tag would actually be evaluated.

I went through the history of the `ignoreRegex` and added tests for the problems each iteration was fixing.

It seems that the most recent change to it was just tidying it up, but actually broke this edge case. I've reverted it.