### PR TITLE
Handle multiline`@{{ }}` noparse tags

### DIFF
--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -89,7 +89,7 @@ class Parser
         $this->noparseRegex = '/{{\s*noparse\s*}}(.*?){{\s*\/noparse\s*}}/ms';
 
         // Matches an ignored tag as indicated by a prefixed @ symbol: @{{ }}
-        $this->ignoreRegex = '/@{{(?:(?!}}).)*}}/';
+        $this->ignoreRegex = '/@{{(?:(?!}}).)*}}/s';
 
         // Matches the logic operator tags
         $this->conditionalRegex = '/{{\s*(if|unless|elseif|elseunless)\s+((?:\()?(.*?)(?:\))?)\s*}}/ms';

--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -873,7 +873,6 @@ EOT;
 @{{ foo
   bar:baz="qux"
 }} {{ qux }}
-@{{ another }}
 bar
 {{ baz }}
 EOT;
@@ -882,7 +881,6 @@ EOT;
 {{ foo
   bar:baz="qux"
 }} QUX
-{{ another }}
 bar
 BAZ
 EOT;

--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -867,6 +867,30 @@ EOT;
     }
 
     /** @test */
+    public function it_doesnt_parse_multiline_tags_prefixed_with_an_at_symbol_over_tags_in_multiple_lines()
+    {
+        $template = <<<'EOT'
+@{{ foo
+  bar:baz="qux"
+}} {{ qux }}
+@{{ another }}
+bar
+{{ baz }}
+EOT;
+
+        $expected = <<<'EOT'
+{{ foo
+  bar:baz="qux"
+}} QUX
+{{ another }}
+bar
+BAZ
+EOT;
+
+        $this->assertEquals($expected, $this->parse($template, ['baz' => 'BAZ', 'qux' => 'QUX']));
+    }
+
+    /** @test */
     public function it_doesnt_parse_tags_prefixed_with_an_at_symbol_containing_nested_tags()
     {
         $this->assertEquals('{{ foo bar="{baz}" }}', $this->parse('@{{ foo bar="{baz}" }}'));


### PR DESCRIPTION
Similar to #3784, this one handles single tags that span multiple lines.

Like this example that the docs was using:

```
@{{ collection:blog
   title:contains="awesome"
   title:contains="thing"
   author:is="joe"
}}
```