### PR TITLE
Always save the blueprint

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -442,11 +442,8 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
             'id' => $this->id(),
             'origin' => optional($this->origin())->id(),
             'published' => $this->published === false ? false : null,
+            'blueprint' => $this->blueprint ?? $this->collection()->entryBlueprint()->handle(),
         ]);
-
-        if ($this->blueprint && $this->collection()->entryBlueprints()->count() > 1) {
-            $array['blueprint'] = $this->blueprint;
-        }
 
         $data = $this->data()->all();
 


### PR DESCRIPTION
Fixes #3783 

Now the `blueprint` key will always be saved to the entry's markdown file, even if the collection only has one blueprint.

This solves the following situation:

- Your collection has a single blueprint.
- You create an entry.
- You create a blueprint.
- You make that new blueprint the default.
- The entry you created before will now use the new default, which is wrong.