### PR TITLE
Add “form” to Submission array

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -88,7 +88,7 @@ class Email extends Mailable
 
         $data = array_merge($augmented, $this->getGlobalsData(), [
             'config'     => config()->all(),
-            'fields'     => $this->getRenderableFieldData(Arr::except($augmented, ['id', 'date'])),
+            'fields'     => $this->getRenderableFieldData(Arr::except($augmented, ['id', 'date', 'form'])),
             'site_url'   => Config::getSiteUrl(),
             'date'       => now(),
             'now'        => now(),

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -220,7 +220,7 @@ class Submission implements SubmissionContract, Augmentable
             ->merge([
                 'id' => $this->id(),
                 'date' => $this->date(),
-                'form' => $this->form()
+                'form' => $this->form(),
             ])
             ->all();
     }

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -212,7 +212,7 @@ class Submission implements SubmissionContract, Augmentable
 
         return $this->form()->fields()->keys()->flip()
             ->reject(function ($field, $key) {
-                return in_array($key, ['id', 'date']);
+                return in_array($key, ['id', 'date', 'form']);
             })
             ->map(function ($field, $key) use ($data) {
                 return $data[$key] ?? null;
@@ -220,6 +220,7 @@ class Submission implements SubmissionContract, Augmentable
             ->merge([
                 'id' => $this->id(),
                 'date' => $this->date(),
+                'form' => $this->form()
             ])
             ->all();
     }

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -220,14 +220,15 @@ class Submission implements SubmissionContract, Augmentable
             ->merge([
                 'id' => $this->id(),
                 'date' => $this->date(),
-                'form' => $this->form(),
             ])
             ->all();
     }
 
     public function augmentedArrayData()
     {
-        return $this->toArray();
+        return array_merge($this->toArray(), [
+            'form' => $this->form,
+        ]);
     }
 
     public function blueprint()


### PR DESCRIPTION
When creating templates (HTML or Text) for use when sending emails, there are times when you just want a single template that any form on the site can use. However, I could not see a way to reference the form from within the template antler files, or in the data that was passed.

This pull request adds the Form to the Submission array that will be passed to the Email template.

You can then get the Form's title in your email templates using:
```{{ form:title }}```

This means that you can create a standard email template for your Forms, and the template itself can include a reference to Form details - such as the Form Name. This is really useful when your template loops over the ``{{ fields }}`` in the submission to output them as it makes the template more generic in nature.

The one concern/consideration I have is that it uses the key "form" which is an antlers tag itself - so not sure if "form" is the best-practice name, or even if the entire form object needs to be included (and could just be the form name instead). The name especially is really handy to have at the template level.