### PR TITLE
Pass route params to `redirect` tag

### DIFF
--- a/src/Tags/Redirect.php
+++ b/src/Tags/Redirect.php
@@ -17,7 +17,10 @@ class Redirect extends Tags
     public function index()
     {
         if ($route = $this->params->get('route')) {
-            return $this->redirect(route($route));
+            return $this->redirect(route(
+                $route,
+                $this->params->forget('route')->all()
+            ));
         }
 
         return $this->redirect(

--- a/tests/Tags/RedirectTest.php
+++ b/tests/Tags/RedirectTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Tags;
+
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Route;
+use Statamic\Facades\Parse;
+use Statamic\Facades\Site;
+use Tests\TestCase;
+
+class RedirectTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Site::setConfig(['sites' => [
+            'en' => ['url' => '/'],
+            'fr' => ['url' => '/fr'],
+        ]]);
+    }
+
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        $app->booted(function () {
+            Route::statamic('/named-route', 'test')->name('named-route');
+
+            Route::statamic('/route-with-params/{foo}/baz', 'test')->name('param-route');
+        });
+    }
+
+    private function tag($tag, $data = [])
+    {
+        return (string) Parse::template($tag, $data);
+    }
+
+    /** @test */
+    public function it_throws_http_response_exception()
+    {
+        $this->expectException(HttpResponseException::class);
+        $this->tag('{{ redirect to="/foo" }}');
+    }
+
+    /** @test */
+    public function it_redirects_to()
+    {
+        try {
+            $this->tag('{{ redirect to="/foo" }}');
+        } catch (HttpResponseException $e) {
+            $response = $e->getResponse();
+            $this->assertInstanceOf(RedirectResponse::class, $response);
+            $this->assertEquals('http://localhost/foo', $response->getTargetUrl());
+        }
+    }
+
+    /** @test */
+    public function it_redirects_to_route()
+    {
+        try {
+            $this->tag('{{ redirect route="named-route" }}');
+        } catch (HttpResponseException $e) {
+            $response = $e->getResponse();
+            $this->assertEquals('http://localhost/named-route', $response->getTargetUrl());
+        }
+    }
+
+    /** @test */
+    public function it_redirects_to_route_with_query_params()
+    {
+        try {
+            $this->tag('{{ redirect route="param-route" foo="bar" }}');
+        } catch (HttpResponseException $e) {
+            $response = $e->getResponse();
+            $this->assertEquals('http://localhost/route-with-params/bar/baz', $response->getTargetUrl());
+        }
+    }
+}


### PR DESCRIPTION
Recently had the need to pass route params to the `redirect` tag and discovered it wasn't supported.

This adds that ability. All params except `route` are passed to the `route()` helper.

Tests added.