### PR TITLE
Prevent an infinite loop when you create an entry without an id

### DIFF
--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -88,7 +88,7 @@ class CollectionEntriesStore extends ChildStore
         }
 
         if (isset($idGenerated) || isset($positionGenerated)) {
-            $entry->save();
+            $this->writeItemToDiskWithoutIncrementing($entry);
         }
 
         return $entry;
@@ -168,12 +168,17 @@ class CollectionEntriesStore extends ChildStore
         )->all();
     }
 
+    protected function writeItemToDiskWithoutIncrementing($item)
+    {
+        $item->writeFile($item->path());
+    }
+
     protected function writeItemToDisk($item)
     {
         $basePath = $item->buildPath();
 
         if ($basePath !== $item->path()) {
-            return $item->writeFile($item->path());
+            return $this->writeItemToDiskWithoutIncrementing($item);
         }
 
         $num = 0;


### PR DESCRIPTION
If you manually create an entry file without an ID, one gets added automatically.

Since #3671, the part where the filename gets incremented looks for an id.

Combine those two, and there was an infinite loop when you added an entry without an id.

Also, this now just writes the file. It doesn't "save" it, which avoids events and whatever other overhead is involved.