### PR TITLE
Validate uri uniqueness per site

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -443,7 +443,7 @@ class EntriesController extends CpController
             return;
         }
 
-        $existing = Entry::findByUri($uri);
+        $existing = Entry::findByUri($uri, $entry->locale());
 
         if (! $existing || $existing->id() === $entry->id()) {
             return;


### PR DESCRIPTION
When submitting an entry, it'll check for URI uniqueness.

This PR fixes it so that it'll validate it for the given site.
It's fine to have two entries with the same URI if they're on different sites, because their URLs will be different.