### PR TITLE
Proposal: Direction in site config to support rtl layouts

### DIFF
--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -52,11 +52,7 @@ class Site implements Augmentable
 
     public function direction()
     {
-        if (! isset($this->config['direction'])) {
-            return 'ltr';
-        }
-
-        return $this->config['direction'];
+        return $this->config['direction'] ?? 'ltr';
     }
 
     public function absoluteUrl()

--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -50,6 +50,15 @@ class Site implements Augmentable
         return Str::removeRight($url, '/');
     }
 
+    public function direction()
+    {
+        if (! isset($this->config['direction'])) {
+            return 'ltr';
+        }
+
+        return $this->config['direction'];
+    }
+
     public function absoluteUrl()
     {
         if (Str::startsWith($url = $this->url(), '/')) {
@@ -85,6 +94,7 @@ class Site implements Augmentable
             'locale' => $this->locale(),
             'short_locale' => $this->shortLocale(),
             'url' => $this->url(),
+            'direction' => $this->direction(),
         ];
     }
 

--- a/tests/Sites/SiteTest.php
+++ b/tests/Sites/SiteTest.php
@@ -236,6 +236,7 @@ class SiteTest extends TestCase
             'locale' => 'en_US',
             'short_locale' => 'en',
             'url' => 'http://test.com',
+            'direction' => 'ltr',
         ], $values->all());
 
         $this->assertEquals(
@@ -255,5 +256,21 @@ class SiteTest extends TestCase
 
         $this->assertSame('test', (string) $site);
         $this->assertEquals('test', Antlers::parse('{{ site }}', ['site' => $site]));
+    }
+
+    /** @test */
+    public function gets_direction()
+    {
+        $site = new Site('ar', ['locale' => 'ar_SA', 'direction' => 'rtl']);
+
+        $this->assertEquals('rtl', $site->direction());
+    }
+
+    /** @test */
+    public function gets_direction_with_fallback()
+    {
+        $site = new Site('en', ['locale' => 'en_US']);
+
+        $this->assertEquals('ltr', $site->direction());
     }
 }


### PR DESCRIPTION
Proposal to add a `direction` to the site config allowing RTL configruations.

In the site config a optional parameter `direction` would be added.
The default value is `ltr` but can be set to `rtl`

``` php
    'sites' => [
        'default' => [
            'name' => config('app.name'),
            'locale' => 'ar_SA',
            'url' => '/',
            'direction' => 'rtl', // optionals: fallsback to ltr
        ],
    ],
```

In the layout it is usable from the site config
``` html
<html lang="{{ site:short_locale }}" dir="{{ site:direction }}">
```

This would be only for the frontend, I don't have any plans to change anything in the CP

---

Relates: [Ideas #248](https://github.com/statamic/ideas/issues/248)