### PR TITLE
Improve action responses

### DIFF
--- a/resources/js/components/data-list/Actions.js
+++ b/resources/js/components/data-list/Actions.js
@@ -53,20 +53,16 @@ export default {
                     response.data.text().then(data => {
                         data = JSON.parse(data);
                         if (data.redirect) window.location = data.redirect;
+                        this.$emit('completed', true, data);
                     });
                 }
-
-                this.$emit('completed');
             }).catch(error => {
                 error.response.data.text().then(data => {
                     data = JSON.parse(data);
-
                     this.$toast.error(data.message);
-
                     if (error.response.status == 422) this.errors = data.errors;
+                    this.$emit('completed', false, data)
                 });
-
-                this.$emit('completed', false)
             });
         },
 

--- a/resources/js/components/data-list/HasActions.js
+++ b/resources/js/components/data-list/HasActions.js
@@ -11,7 +11,7 @@ export default {
             this.loading = true;
         },
 
-        actionCompleted(successful=null) {
+        actionCompleted(successful=null, response) {
             this.loading = false;
 
             if (successful === false) return;
@@ -19,7 +19,7 @@ export default {
             this.$events.$emit('clear-selections');
             this.$events.$emit('reset-action-modals');
 
-            this.$toast.success(__('Action completed'));
+            this.$toast.success(response.message || __('Action completed'));
 
             this.request();
         }

--- a/src/Http/Controllers/CP/ActionController.php
+++ b/src/Http/Controllers/CP/ActionController.php
@@ -33,7 +33,7 @@ abstract class ActionController extends CpController
 
         abort_unless($unauthorized->isEmpty(), 403, __('You are not authorized to run this action.'));
 
-        $action->run($items, $values = $request->all());
+        $response = $action->run($items, $values = $request->all());
 
         if ($redirect = $action->redirect($items, $values)) {
             return ['redirect' => $redirect];
@@ -41,7 +41,11 @@ abstract class ActionController extends CpController
             return $download instanceof Response ? $download : response()->download($download);
         }
 
-        return [];
+        if (is_string($response)) {
+            return ['message' => $response];
+        }
+
+        return $response ?: [];
     }
 
     public function bulkActions(Request $request)


### PR DESCRIPTION
Closes statamic/ideas#549
Related to #3719 

This PR lets action classes provide their toast message, rather than just the "Action Completed" that you currently get.

```php
public function run($entries, $values)
{
    $entries->each->whatever();

    return 'This will be in the toast.';
}
```

![image](https://user-images.githubusercontent.com/105211/121424256-23762500-c93f-11eb-914f-4f90db23f27f.png)

Of course, you should probably be using translations:

```php
return trans_choice('Did whatever to an entry.|Did whatever to :count entries.', $entries);
```

![image](https://user-images.githubusercontent.com/105211/121425067-055cf480-c940-11eb-950a-7d1151690e87.png)

If you don't return anything (like actions currently do), you'll continue to see the basic "Action Completed" message.

You may either return a string as shown above, or you can return an array with a `message` key.

```php
return [
  'message' => 'This will be in the toast.',
  'foo' => 'bar',
];
```

The array could be useful if you are creating your own listing component and you have a custom event handler.

```vue
<data-list-bulk-actions ... @completed="completed" />
```
```js
completed(success, response) {
  this.$toast.success(response.message);
  this.doSomethingWithFoo(response.foo); // 🤷‍♂️
}
```