### PR TITLE
Add support for Laravel 8.x's Default Password Rules

### DIFF
--- a/src/Auth/Passwords/PasswordDefaults.php
+++ b/src/Auth/Passwords/PasswordDefaults.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Statamic\Auth\Passwords;
+use Illuminate\Validation\Rules\Password;
+
+class PasswordDefaults
+{
+    /**
+     * @return Password|string
+     */
+    public static function rules() {
+        if (version_compare(app()->version(), '8.43.0', '<') ) {
+            // Return the old password rules
+            return 'min:8';
+        }
+
+        return Password::default();
+    }
+}

--- a/src/Auth/Passwords/PasswordDefaults.php
+++ b/src/Auth/Passwords/PasswordDefaults.php
@@ -9,8 +9,9 @@ class PasswordDefaults
     /**
      * @return Password|string
      */
-    public static function rules() {
-        if (version_compare(app()->version(), '8.43.0', '<') ) {
+    public static function rules()
+    {
+        if (version_compare(app()->version(), '8.43.0', '<')) {
             // Return the old password rules
             return 'min:8';
         }

--- a/src/Auth/Passwords/PasswordDefaults.php
+++ b/src/Auth/Passwords/PasswordDefaults.php
@@ -1,7 +1,7 @@
 <?php
 
-
 namespace Statamic\Auth\Passwords;
+
 use Illuminate\Validation\Rules\Password;
 
 class PasswordDefaults

--- a/src/Auth/ResetsPasswords.php
+++ b/src/Auth/ResetsPasswords.php
@@ -75,7 +75,7 @@ trait ResetsPasswords
     {
         return [
             'token' => 'required',
-            'email' => ['required','email'],
+            'email' => ['required', 'email'],
             'password' => ['required', 'confirmed', PasswordDefaults::rules()],
         ];
     }

--- a/src/Auth/ResetsPasswords.php
+++ b/src/Auth/ResetsPasswords.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
+use Statamic\Auth\Passwords\PasswordDefaults;
 
 /**
  * A copy of Illuminate\Auth\ResetsPasswords.
@@ -74,8 +75,8 @@ trait ResetsPasswords
     {
         return [
             'token' => 'required',
-            'email' => 'required|email',
-            'password' => 'required|confirmed|min:8',
+            'email' => ['required','email'],
+            'password' => ['required', 'confirmed', PasswordDefaults::rules()],
         ];
     }
 

--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -178,7 +178,7 @@ class MakeUser extends Command
     {
         return $this->validationFails(
             $this->data['password'],
-            ['required', PasswordDefaults::rules()],
+            ['required', PasswordDefaults::rules()]
         );
     }
 

--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -3,6 +3,7 @@
 namespace Statamic\Console\Commands;
 
 use Illuminate\Console\Command;
+use Statamic\Auth\Passwords\PasswordDefaults;
 use Statamic\Console\RunsInPlease;
 use Statamic\Console\ValidatesInput;
 use Statamic\Facades\User;
@@ -121,6 +122,10 @@ class MakeUser extends Command
     {
         $this->data['password'] = $this->secret('Password (Your input will be hidden)');
 
+        if ($this->passwordValidationFails()) {
+            return $this->promptPassword();
+        }
+
         return $this;
     }
 
@@ -162,6 +167,19 @@ class MakeUser extends Command
     protected function emailValidationFails()
     {
         return $this->validationFails($this->email, ['required', new EmailAvailable, 'email']);
+    }
+
+    /**
+     * Check if password validation fails.
+     *
+     * @return bool
+     */
+    protected function passwordValidationFails()
+    {
+        return $this->validationFails(
+            $this->data['password'],
+            ['required', PasswordDefaults::rules()],
+        );
     }
 
     /**

--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\CP\Users;
 
 use Illuminate\Http\Request;
+use Statamic\Auth\Passwords\PasswordDefaults;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
@@ -16,7 +17,7 @@ class PasswordController extends CpController
         $this->authorize('editPassword', $user);
 
         $request->validate([
-            'password' => 'required|confirmed',
+            'password' => ['required','confirmed', PasswordDefaults::rules()],
         ]);
 
         $user->password($request->password)->save();

--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -17,7 +17,7 @@ class PasswordController extends CpController
         $this->authorize('editPassword', $user);
 
         $request->validate([
-            'password' => ['required','confirmed', PasswordDefaults::rules()],
+            'password' => ['required', 'confirmed', PasswordDefaults::rules()],
         ]);
 
         $user->password($request->password)->save();

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -49,8 +49,8 @@ class UserController extends Controller
         $fields = $blueprint->fields()->addValues($request->all());
 
         $fieldRules = $fields->validator()->withRules([
-            'email' => ['required','email','unique_user_value'],
-            'password' => ['required','confirmed', PasswordDefaults::rules()],
+            'email' => ['required', 'email', 'unique_user_value'],
+            'password' => ['required', 'confirmed', PasswordDefaults::rules()],
         ])->rules();
 
         $validator = Validator::make($request->all(), $fieldRules);

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
+use Statamic\Auth\Passwords\PasswordDefaults;
 use Statamic\Events\UserRegistered;
 use Statamic\Events\UserRegistering;
 use Statamic\Exceptions\SilentFormFailureException;
@@ -48,8 +49,8 @@ class UserController extends Controller
         $fields = $blueprint->fields()->addValues($request->all());
 
         $fieldRules = $fields->validator()->withRules([
-            'email' => 'required|email|unique_user_value',
-            'password' => 'required|confirmed',
+            'email' => ['required','email','unique_user_value'],
+            'password' => ['required','confirmed', PasswordDefaults::rules()],
         ])->rules();
 
         $validator = Validator::make($request->all(), $fieldRules);

--- a/tests/Tags/User/RegisterFormTest.php
+++ b/tests/Tags/User/RegisterFormTest.php
@@ -210,8 +210,8 @@ EOT
         $this
             ->post('/!/auth/register', [
                 'email' => 'san@holo.com',
-                'password' => 'chewy',
-                'password_confirmation' => 'chewy',
+                'password' => 'chewbacca',
+                'password_confirmation' => 'chewbacca',
             ])
             ->assertSessionHasNoErrors()
             ->assertLocation('/');
@@ -251,8 +251,8 @@ EOT
         $this
             ->post('/!/auth/register', [
                 'email' => 'san@holo.com',
-                'password' => 'chewy',
-                'password_confirmation' => 'chewy',
+                'password' => 'chewbacca',
+                'password_confirmation' => 'chewbacca',
                 '_redirect' => '/registration-successful',
             ])
             ->assertSessionHasNoErrors()


### PR DESCRIPTION
An updated version of #3732 utilising the suggestions from @jasonvarga 

Props to @rrelmy  for much of the code / work on this one, I believe with time #3732 would have got there I just have a client waiting for this so I'm impatient!

Really the only thing I'm unsure of is if it was the right move to make the PasswordDefaults class - possibly that function could have lived off something else, but this keeps it explicit, it seems like it's in an appropriate namespace etc

Most users will need to upgrade their underlying Laravel framework version to use this - 8.43.0 only dropped 2 weeks ago.

- Opens up support for utilising Laravel's Password::defaults() function
- Checks for the minimum framework version (8.43.0)
- Behaviour is exactly the same for users on older versions
- Behaviour is exactly the same for users who do not utilise this feature

Closes https://github.com/statamic/ideas/issues/422