### PR TITLE
Don't assume the first collection has array key 0.

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -12,6 +12,7 @@ use Statamic\Facades\Site;
 use Statamic\Http\Resources\CP\Entries\Entries as EntriesResource;
 use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
+use Statamic\Support\Arr;
 
 class Entries extends Relationship
 {
@@ -104,7 +105,7 @@ class Entries extends Relationship
             $collections = $this->getConfiguredCollections();
         }
 
-        return Collection::findByHandle($collections[0]);
+        return Collection::findByHandle(Arr::first($collections));
     }
 
     public function getSortColumn($request)


### PR DESCRIPTION
Closes #3844

Like I said in the issue, I'm not entirely sure what causes the config to sometimes not have a collection with the array key `0`. It _might_ be because I'm configuring the first alphabetical collection, and I'm not allowed to mount on an entry in that collection, or because that collection doesn't have any entries. 

Either way, I don't think there's an issue with this solution since it's fully backwards compatible and solves my issue.