### PR TITLE
Adjust asset list svg dimensions

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -3,7 +3,7 @@
     <tr class="cursor-grab bg-white hover:bg-grey-10">
         <td class="flex items-center">
             <div v-if="canShowSvg"
-                 class="img svg-img mr-1 h-5 w-5 bg-no-repeat bg-center bg-cover"
+                 class="img svg-img mr-1 h-8 w-8 bg-no-repeat bg-center bg-cover"
                  :style="'background-image:url('+asset.url+')'">
             </div>
             <div class="w-8 h-8 mr-1 cursor-pointer whitespace-no-wrap" v-else>


### PR DESCRIPTION
SVG thumbnails are smaller than raster thumbnails when using the asset fieldtype in list mode.

![Screen Shot 2021-06-15 at 10 20 01](https://user-images.githubusercontent.com/2236267/122097441-87c43900-cdc4-11eb-94c7-a4d6e58788ec.jpg)

This PR updates the Tailwind classes so the thumbnails are consistent.

![Screen Shot 2021-06-15 at 10 20 16](https://user-images.githubusercontent.com/2236267/122097487-9579be80-cdc4-11eb-9017-a644e8f9b430.jpg)
