### PR TITLE
Antlers XML views

### DIFF
--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -59,15 +59,19 @@ class FrontendController extends Controller
 
         $this->addViewPaths();
 
-        $contents = (new View)
+        $view = (new View)
             ->template($view)
             ->layout(Arr::get($data, 'layout', 'layout'))
             ->with($data)
-            ->cascadeContent($this->getLoadedRouteItem($data))
-            ->render();
+            ->cascadeContent($this->getLoadedRouteItem($data));
 
-        return response($contents, 200, [
-            'Content-Type' => DataResponse::contentType($data['content_type'] ?? 'html'),
+        $contentType = DataResponse::contentType(
+            $data['content_type']
+            ?? ($view->wantsXmlResponse() ? 'xml' : 'html')
+        );
+
+        return response($view->render(), 200, [
+            'Content-Type' => $contentType,
         ]);
     }
 

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -141,14 +141,18 @@ class DataResponse implements Responsable
         return $this;
     }
 
-    protected function contents()
+    protected function view()
     {
-        $contents = (new View)
+        return (new View)
             ->template($this->data->template())
             ->layout($this->data->layout())
             ->with($this->with)
-            ->cascadeContent($this->data)
-            ->render();
+            ->cascadeContent($this->data);
+    }
+
+    protected function contents()
+    {
+        $contents = $this->view()->render();
 
         if ($this->isLivePreview()) {
             $contents = $this->versionJavascriptModules($contents);
@@ -164,7 +168,10 @@ class DataResponse implements Responsable
 
     protected function adjustResponseType()
     {
-        $contentType = $this->data->get('content_type', 'html');
+        $contentType = $this->data->get(
+            'content_type',
+            $this->view()->wantsXmlResponse() ? 'xml' : 'html'
+        );
 
         if ($contentType !== 'html') {
             $this->headers['Content-Type'] = self::contentType($contentType);

--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -46,13 +46,11 @@ class ViewServiceProvider extends ServiceProvider
             return $this;
         });
 
-        tap($this->app['view'], function ($view) {
-            $resolver = function () {
+        foreach (Engine::EXTENSIONS as $extension) {
+            $this->app['view']->addExtension($extension, 'antlers', function () {
                 return $this->app[Engine::class];
-            };
-            $view->addExtension('antlers.html', 'antlers', $resolver);
-            $view->addExtension('antlers.php', 'antlers', $resolver);
-        });
+            });
+        }
 
         ini_set('pcre.backtrack_limit', config('statamic.system.pcre_backtrack_limit', -1));
     }

--- a/src/View/Antlers/Engine.php
+++ b/src/View/Antlers/Engine.php
@@ -17,6 +17,12 @@ use Statamic\Tags\TagNotFoundException;
 
 class Engine implements EngineInterface
 {
+    const EXTENSIONS = [
+        'antlers.html',
+        'antlers.php',
+        'antlers.xml',
+    ];
+
     /**
      * The Antlers Parser.
      *

--- a/src/View/Antlers/Engine.php
+++ b/src/View/Antlers/Engine.php
@@ -189,13 +189,4 @@ class Engine implements EngineInterface
             debugbar()->stopMeasure($tag_measure);
         }
     }
-
-    public static function supportsPath($path)
-    {
-        $extensions = collect(self::EXTENSIONS)->map(function ($extension) {
-            return '.'.$extension;
-        })->all();
-
-        return Str::endsWith($path, $extensions);
-    }
 }

--- a/src/View/Antlers/Engine.php
+++ b/src/View/Antlers/Engine.php
@@ -189,4 +189,13 @@ class Engine implements EngineInterface
             debugbar()->stopMeasure($tag_measure);
         }
     }
+
+    public static function supportsPath($path)
+    {
+        $extensions = collect(self::EXTENSIONS)->map(function ($extension) {
+            return '.'.$extension;
+        })->all();
+
+        return Str::endsWith($path, $extensions);
+    }
 }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -4,6 +4,7 @@ namespace Statamic\View;
 
 use Facades\Statamic\View\Cascade;
 use Statamic\Support\Str;
+use Statamic\View\Antlers\Engine as AntlersEngine;
 use Statamic\View\Events\ViewRendered;
 
 class View
@@ -69,10 +70,7 @@ class View
 
         $contents = view($this->templateViewName(), $cascade);
 
-        // We only want the template-in-a-layout behavior if the template is Antlers.
-        $isAntlers = Str::endsWith($contents->getPath(), ['.antlers.html', '.antlers.php']);
-
-        if ($this->layout && $isAntlers) {
+        if ($this->shouldUseLayout()) {
             $contents = view($this->layoutViewName(), array_merge($cascade, [
                 'template_content' => $contents->withoutExtractions()->render(),
             ]));
@@ -81,6 +79,59 @@ class View
         ViewRendered::dispatch($this);
 
         return $contents->render();
+    }
+
+    private function shouldUseLayout()
+    {
+        if (! $this->layout) {
+            return false;
+        }
+
+        if (! $this->isUsingAntlersTemplate()) {
+            return false;
+        }
+
+        if ($this->isUsingXmlTemplate() && ! $this->isUsingXmlLayout()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function wantsXmlResponse()
+    {
+        if (! $this->isUsingAntlersTemplate()) {
+            return false;
+        }
+
+        return $this->isUsingXmlTemplate() || $this->isUsingXmlLayout();
+    }
+
+    private function isUsingAntlersTemplate()
+    {
+        return Str::endsWith($this->templateViewPath(), collect(AntlersEngine::EXTENSIONS)->map(function ($extension) {
+            return '.'.$extension;
+        })->all());
+    }
+
+    private function isUsingXmlTemplate()
+    {
+        return Str::endsWith($this->templateViewPath(), '.xml');
+    }
+
+    private function isUsingXmlLayout()
+    {
+        return Str::endsWith($this->layoutViewPath(), '.xml');
+    }
+
+    private function templateViewPath()
+    {
+        return view($this->templateViewName())->getPath();
+    }
+
+    private function layoutViewPath()
+    {
+        return view($this->layoutViewName())->getPath();
     }
 
     protected function cascade()
@@ -107,7 +158,7 @@ class View
         return $this->render();
     }
 
-    protected function layoutViewName()
+    private function layoutViewName()
     {
         $view = $this->layout;
 
@@ -118,7 +169,7 @@ class View
         return $view;
     }
 
-    protected function templateViewName()
+    private function templateViewName()
     {
         $view = $this->template;
 

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -395,6 +395,81 @@ class FrontendTest extends TestCase
     }
 
     /** @test */
+    public function xml_antlers_template_with_xml_layout_will_use_both_and_change_the_content_type()
+    {
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '<?xml ?>{{ template_content }}', 'antlers.xml');
+        $this->viewShouldReturnRaw('feed', '<foo></foo>', 'antlers.xml');
+        $this->createPage('about', ['with' => ['template' => 'feed']]);
+
+        $response = $this
+            ->get('about')
+            ->assertHeader('Content-Type', 'text/xml; charset=UTF-8');
+
+        $this->assertEquals('<?xml ?><foo></foo>', $response->getContent());
+    }
+
+    /** @test */
+    public function xml_antlers_template_with_non_xml_layout_will_change_content_type_but_avoid_using_the_layout()
+    {
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '<html>{{ template_content }}</html>', 'antlers.html');
+        $this->viewShouldReturnRaw('feed', '<foo></foo>', 'antlers.xml');
+        $this->createPage('about', ['with' => ['template' => 'feed']]);
+
+        $response = $this
+            ->get('about')
+            ->assertHeader('Content-Type', 'text/xml; charset=UTF-8');
+
+        $this->assertEquals('<foo></foo>', $response->getContent());
+    }
+
+    /** @test */
+    public function xml_antlers_layout_will_change_the_content_type()
+    {
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '<?xml ?>{{ template_content }}', 'antlers.xml');
+        $this->viewShouldReturnRaw('feed', '<foo></foo>', 'antlers.html');
+        $this->createPage('about', ['with' => ['template' => 'feed']]);
+
+        $response = $this
+            ->get('about')
+            ->assertHeader('Content-Type', 'text/xml; charset=UTF-8');
+
+        $this->assertEquals('<?xml ?><foo></foo>', $response->getContent());
+    }
+
+    /** @test */
+    public function xml_blade_template_will_not_change_content_type()
+    {
+        // Blade doesnt support xml files, but even if it did,
+        // we only want it to happen when using Antlers.
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('feed', '<foo></foo>', 'blade.xml');
+        $this->createPage('about', ['with' => ['template' => 'feed']]);
+
+        $response = $this
+            ->get('about')
+            ->assertHeader('Content-Type', 'text/html; charset=UTF-8');
+
+        $this->assertEquals('<foo></foo>', $response->getContent());
+    }
+
+    /** @test */
+    public function xml_template_with_custom_content_type_does_not_change_to_xml()
+    {
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '<?xml ?>{{ template_content }}', 'antlers.xml');
+        $this->viewShouldReturnRaw('feed', '<foo></foo>', 'antlers.xml');
+        $this->createPage('about', ['with' => ['template' => 'feed', 'content_type' => 'json']]);
+
+        $this
+            ->get('about')
+            ->assertHeader('Content-Type', 'application/json');
+    }
+
+    /** @test */
     public function sends_powered_by_header_if_enabled()
     {
         config(['statamic.system.send_powered_by_header' => true]);


### PR DESCRIPTION
This PR provides some enhancements for dealing with XML - for sitemaps, RSS feeds, etc.

The `.antlers.xml` extension is now supported.

## XML templates change content type

If your template uses `.antlers.xml`, then the content type will automatically be set to `text/xml`. There's no need to manually set `content_type: xml` anywhere.

This applies to content (e.g. entries):

```yaml
---
title: Sitemap
template: sitemap  # sitemap.antlers.xml
---
```

or routes:

```php
Route::statamic('/sitemap', 'sitemap');
```

## XML layouts 

If your layout uses `.antlers.xml`, it'll set the content type to `text/xml`, and it'll inject the template into it like you're used to. It'll do it regardless of whether your template is xml or not. This is useful if you intentionally want to have a wrapper layout.

```yaml
title: Sitemap
template: sitemap
layout: base_xml
```

```xml
<!-- base_xml.antlers.xml -->
<?xml version="1.0" encoding="UTF-8"?>
{{ template_content }}
```

```xml
<!-- sitemap.antlers.html or sitemap.antlers.xml - either would work. -->
{{ collection:articles }}
  <url> ... </url>
{{ /collection:articles }}
```

## Non-XML layouts get discarded

If your template uses `.antlers.xml`, but your layout doesn't, the layout just won't be used. This is handy if you don't explicitly provide a layout, since it would fall back to `layout`, which is probably an `html` file.