### PR TITLE
Render markdown preview on the server

### DIFF
--- a/resources/js/components/fieldtypes/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/MarkdownFieldtype.vue
@@ -173,6 +173,7 @@ export default {
             uploads: [],
             count: {},
             escBinding: null,
+            markdownPreviewText: null
         };
     },
 
@@ -191,6 +192,10 @@ export default {
                     document.body.style.removeProperty("overflow")
                 }
             }
+        },
+
+        mode(mode) {
+            if (mode === 'preview') this.updateMarkdownPreview();
         }
 
     },
@@ -540,14 +545,17 @@ export default {
             return this.config.restrict_assets || false;
         },
 
-        markdownPreviewText() {
-            return markdown(this.data);
-        },
-
         replicatorPreview() {
             return marked(this.data || '', { renderer: new PlainTextRenderer })
                 .replace(/<\/?[^>]+(>|$)/g, "");
         },
+
+        updateMarkdownPreview() {
+            this.$axios
+                .post(this.meta.previewUrl, { value: this.data, config: this.config })
+                .then(response => this.markdownPreviewText = response.data)
+                .catch(e => this.$toast.error(e.response ? e.response.data.message : __('Something went wrong')));
+        }
     },
 
     mounted() {

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -207,6 +207,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::get('relationship', 'RelationshipFieldtypeController@index')->name('relationship.index');
         Route::get('relationship/data', 'RelationshipFieldtypeController@data')->name('relationship.data');
         Route::get('relationship/filters', 'RelationshipFieldtypeController@filters')->name('relationship.filters');
+        Route::post('markdown', 'MarkdownFieldtypeController@preview')->name('markdown.preview');
     });
 
     Route::group(['prefix' => 'api', 'as' => 'api.', 'namespace' => 'API'], function () {

--- a/src/Fieldtypes/Markdown.php
+++ b/src/Fieldtypes/Markdown.php
@@ -134,4 +134,11 @@ class Markdown extends Fieldtype
             },
         ];
     }
+
+    public function preload()
+    {
+        return [
+            'previewUrl' => cp_route('markdown.preview'),
+        ];
+    }
 }

--- a/src/Http/Controllers/CP/Fieldtypes/MarkdownFieldtypeController.php
+++ b/src/Http/Controllers/CP/Fieldtypes/MarkdownFieldtypeController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Statamic\Http\Controllers\CP\Fieldtypes;
+
+use Facades\Statamic\Fields\FieldtypeRepository as Fieldtype;
+use Illuminate\Http\Request;
+use Statamic\Fields\Field;
+use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Support\Arr;
+
+class MarkdownFieldtypeController extends CpController
+{
+    public function preview(Request $request)
+    {
+        return $this->fieldtype($request->config)->augment($request->value);
+    }
+
+    protected function fieldtype($config)
+    {
+        return Fieldtype::find($config['type'])->setField(
+            new Field('markdown', Arr::removeNullValues($config))
+        );
+    }
+}


### PR DESCRIPTION
Instead of using the `marked` JS library to generate the `markdown` fieldtype's preview, it'll now use an AJAX request to generate the preview on the server.

This lets us preview using any custom markdown parsers, which is more accurate with what you'd see on the frontend. (Closes https://github.com/statamic/ideas/issues/442)

It's also going to be necessary in #3850 which is going to add support for ID-based `statamic://` image URLs. If we continued to a JS preview, those would 404 since they wouldn't be the actual image URLs.