### PR TITLE
Static caching fallback for long query strings

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -44,10 +44,6 @@ class FileCacher extends AbstractCacher
 
         $path = $this->getFilePath($request->getUri());
 
-        if (strlen(pathinfo($path, PATHINFO_BASENAME)) > $this->config('max_filename_length')) {
-            return Log::debug("Could not write static cache file. File name too long. $path");
-        }
-
         if (! $this->writer->write($path, $content, $this->config('lock_hold_length'))) {
             return;
         }

--- a/src/StaticCaching/StaticCacheManager.php
+++ b/src/StaticCaching/StaticCacheManager.php
@@ -48,7 +48,6 @@ class StaticCacheManager extends Manager
             'ignore_query_strings' => $this->app['config']['statamic.static_caching.ignore_query_strings'] ?? false,
             'base_url' => $this->app['request']->root(),
             'locale' => Site::current()->handle(),
-            'max_filename_length' => 255,
         ]);
     }
 }

--- a/src/StaticCaching/StaticCacheManager.php
+++ b/src/StaticCaching/StaticCacheManager.php
@@ -48,6 +48,7 @@ class StaticCacheManager extends Manager
             'ignore_query_strings' => $this->app['config']['statamic.static_caching.ignore_query_strings'] ?? false,
             'base_url' => $this->app['request']->root(),
             'locale' => Site::current()->handle(),
+            'max_filename_length' => 255,
         ]);
     }
 }

--- a/tests/StaticCaching/FileCacherTest.php
+++ b/tests/StaticCaching/FileCacherTest.php
@@ -53,11 +53,12 @@ class FileCacherTest extends TestCase
     {
         $cacher = $this->fileCacher([
             'path' => 'test/path',
+            'max_filename_length' => 16,
         ]);
 
         $this->assertEquals(
-            'test/path/foo/bar_baz=qux&one=two.html',
-            $cacher->getFilePath('http://domain.com/foo/bar?baz=qux&one=two')
+            'test/path/foo/bar/baz/qux_a=b&c=d.html',
+            $cacher->getFilePath('http://domain.com/foo/bar/baz/qux?a=b&c=d')
         );
 
         $this->assertEquals(
@@ -77,7 +78,7 @@ class FileCacherTest extends TestCase
         $query = 'baz=qux&one=two&three=four&five=six';
 
         $this->assertEquals(
-            'test/path/foo/bar_'.md5($query).'.html',
+            'test/path/foo/bar_lqs_'.md5($query).'.html',
             $cacher->getFilePath('http://domain.com/foo/bar?'.$query)
         );
     }
@@ -168,6 +169,6 @@ class FileCacherTest extends TestCase
     {
         $writer = $writer ?: \Mockery::mock(Writer::class);
 
-        return new FileCacher($writer, app(Repository::class), array_replace(['max_filename_length' => 255], $config));
+        return new FileCacher($writer, app(Repository::class), $config);
     }
 }

--- a/tests/StaticCaching/FileCacherTest.php
+++ b/tests/StaticCaching/FileCacherTest.php
@@ -67,6 +67,22 @@ class FileCacherTest extends TestCase
     }
 
     /** @test */
+    public function gets_file_path_from_url_and_hashes_long_query_strings()
+    {
+        $cacher = $this->fileCacher([
+            'path' => 'test/path',
+            'max_filename_length' => 30,
+        ]);
+
+        $query = 'baz=qux&one=two&three=four&five=six';
+
+        $this->assertEquals(
+            'test/path/foo/bar_'.md5($query).'.html',
+            $cacher->getFilePath('http://domain.com/foo/bar?'.$query)
+        );
+    }
+
+    /** @test */
     public function gets_file_path_from_url_and_ignores_query_strings()
     {
         $cacher = $this->fileCacher([
@@ -152,6 +168,6 @@ class FileCacherTest extends TestCase
     {
         $writer = $writer ?: \Mockery::mock(Writer::class);
 
-        return new FileCacher($writer, app(Repository::class), $config);
+        return new FileCacher($writer, app(Repository::class), array_replace(['max_filename_length' => 255], $config));
     }
 }


### PR DESCRIPTION
I've been following #3210 and #3860. 

This PR adds a **fallback** for requests with long query strings by hashing them. 

The retrieval of the related responses from the cache will be slower than for regular requests, because Statamic needs to be fired up. I guess the performance is comparable to half measure static caching. Still beats not caching the response at all though.

I also made `max_filename_length` configurable for those who know what they're doing and want to tweak things to the max.