### PR TITLE
Only set up Static Caching invalidation when enabled

### DIFF
--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -33,6 +33,8 @@ class ServiceProvider extends LaravelServiceProvider
 
     public function boot()
     {
-        Event::subscribe(Invalidate::class);
+        if (config('statamic.static_caching.strategy')) {
+            Event::subscribe(Invalidate::class);
+        }
     }
 }


### PR DESCRIPTION
Fixes #3868 

Nothing was broken, but this avoids generating jobs that basically do nothing.