### PR TITLE
Fix filtering taxonomy terms by collection

### DIFF
--- a/src/Stache/Indexes/Terms/Associations.php
+++ b/src/Stache/Indexes/Terms/Associations.php
@@ -23,6 +23,7 @@ class Associations extends Index
                                     'value' => $value,
                                     'slug' => Str::slug($value),
                                     'entry' => $entry->id(),
+                                    'collection' => $entry->collectionHandle(),
                                     'site' => $entry->locale(),
                                 ];
                             });

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -111,6 +111,7 @@ class TaxonomyTermsStore extends ChildStore
                 'value' => $value,
                 'slug' => $slug,
                 'entry' => $entry->id(),
+                'collection' => $entry->collectionHandle(),
                 'site' => $entry->locale(),
             ]);
         }

--- a/tests/Data/Taxonomies/TermQueryBuilderTest.php
+++ b/tests/Data/Taxonomies/TermQueryBuilderTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Data\Taxonomies;
+
+use Statamic\Facades\Taxonomy;
+use Statamic\Facades\Term;
+use Statamic\Taxonomies\LocalizedTerm;
+use Statamic\Taxonomies\TermCollection;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class TermQueryBuilderTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    /** @test */
+    public function it_gets_terms()
+    {
+        Taxonomy::make('tags')->save();
+        Term::make('a')->taxonomy('tags')->data([])->save();
+        Term::make('b')->taxonomy('tags')->data([])->save();
+        Term::make('c')->taxonomy('tags')->data([])->save();
+
+        $terms = Term::query()->get();
+        $this->assertInstanceOf(TermCollection::class, $terms);
+        $this->assertEveryItemIsInstanceOf(LocalizedTerm::class, $terms);
+    }
+
+    /** @test */
+    public function it_filters_using_wheres()
+    {
+        Taxonomy::make('tags')->save();
+        Term::make('a')->taxonomy('tags')->data(['test' => 'foo'])->save();
+        Term::make('b')->taxonomy('tags')->data(['test' => 'bar'])->save();
+        Term::make('c')->taxonomy('tags')->data(['test' => 'foo'])->save();
+
+        $terms = Term::query()->where('test', 'foo')->get();
+        $this->assertEquals(['a', 'c'], $terms->map->slug()->sort()->values()->all());
+    }
+
+    /** @test */
+    public function it_filters_by_taxonomy()
+    {
+        Taxonomy::make('tags')->save();
+        Taxonomy::make('categories')->save();
+        Term::make('a')->taxonomy('tags')->data([])->save();
+        Term::make('b')->taxonomy('categories')->data([])->save();
+        Term::make('c')->taxonomy('tags')->data([])->save();
+
+        $terms = Term::query()->where('taxonomy', 'tags')->get();
+        $this->assertEquals(['a', 'c'], $terms->map->slug()->sort()->values()->all());
+    }
+
+    /** @test */
+    public function it_filters_by_multiple_taxonomies()
+    {
+        Taxonomy::make('tags')->save();
+        Taxonomy::make('categories')->save();
+        Taxonomy::make('colors')->save();
+        Term::make('a')->taxonomy('tags')->data([])->save();
+        Term::make('b')->taxonomy('categories')->data([])->save();
+        Term::make('c')->taxonomy('colors')->data([])->save();
+        Term::make('d')->taxonomy('tags')->data([])->save();
+
+        $terms = Term::query()->whereIn('taxonomy', ['tags', 'categories'])->get();
+        $this->assertEquals(['a', 'b', 'd'], $terms->map->slug()->sort()->values()->all());
+    }
+
+    /** @test */
+    public function it_sorts()
+    {
+        Taxonomy::make('tags')->save();
+        Term::make('a')->taxonomy('tags')->data(['test' => 4])->save();
+        Term::make('b')->taxonomy('tags')->data(['test' => 2])->save();
+        Term::make('c')->taxonomy('tags')->data(['test' => 1])->save();
+        Term::make('d')->taxonomy('tags')->data(['test' => 5])->save();
+        Term::make('e')->taxonomy('tags')->data(['test' => 3])->save();
+
+        $terms = Term::query()->orderBy('test')->get();
+        $this->assertEquals(['c', 'b', 'e', 'a', 'd'], $terms->map->slug()->all());
+    }
+}


### PR DESCRIPTION
Fixes #1993 
Fixes #1684 

Whether you use the taxonomy tag like this:

```
{{ taxonomy:tags collection="blog" }} ... {{ /taxonomy:tags }}
```

Or through the query builder like this (which is basically what the tag is doing):

```php
Term::query()->where('taxonomy', 'tags')->where('collection', 'blog')->get()
```

It's supposed to filter down the terms to ones being used within that collection. It doesn't.

Looks like [a refactor a while ago](e23065f8acbb2328f6f529a83e1cef411e6bb476) removed this and it never made it back in.

This PR brings it back, and adds some general term querying tests.