### PR TITLE
Hide breadcrumbs in asset browser when navigation is restricted

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -73,7 +73,7 @@
 
                                 </div>
 
-                                <breadcrumbs :path="path" @navigated="selectFolder" />
+                                <breadcrumbs v-if="!restrictFolderNavigation" :path="path" @navigated="selectFolder" />
 
                                 <data-list-bulk-actions
                                     :url="actionUrl"


### PR DESCRIPTION
Fixes #3824.