### PR TITLE
Apply field config ‘classes’ to grid fields too

### DIFF
--- a/resources/js/components/fieldtypes/grid/Cell.vue
+++ b/resources/js/components/fieldtypes/grid/Cell.vue
@@ -1,6 +1,6 @@
 <template>
 
-    <td class="grid-cell" :class="fieldtypeComponent" :width="width">
+    <td class="grid-cell" :class="classes" :width="width">
         <div v-show="showInner">
             <component
                 :is="fieldtypeComponent"
@@ -68,6 +68,10 @@ export default {
     inject: ['grid'],
 
     computed: {
+
+        classes() {
+            return [this.fieldtypeComponent, this.field.classes];
+        },
 
         fieldtypeComponent() {
             return `${this.field.component || this.field.type}-fieldtype`;


### PR DESCRIPTION
Fixes #3721 by applying the classes to the grid table cell.

**Rationale**
For regular fields (i.e. outside a grid) the field config's `classes` are already applied to the `form-group` wrapper, which also carries the `xxx-fieldtype` class. The equivalent to that wrapper in a grid table is the `td`. That element carries the `xxx-fieldtype` class too.

So the classes are always applied to the wrapper. In addition to that the classes are (already) only ever applied to the actual input for text fields.