### PR TITLE
Include title in Bard link mark

### DIFF
--- a/src/Fieldtypes/Bard/LinkMark.php
+++ b/src/Fieldtypes/Bard/LinkMark.php
@@ -14,6 +14,10 @@ class LinkMark extends Link
 
         $tag[0]['attrs']['href'] = $this->convertHref($tag[0]['attrs']['href']);
 
+        if (isset($this->mark->attrs->title)) {
+            $tag[0]['attrs']['title'] = $this->mark->attrs->title;
+        }
+
         return $tag;
     }
 


### PR DESCRIPTION
This fixes #3686.

The `href` is allright, see the discussion over there.