### PR TITLE
don't add the Variables more than once

### DIFF
--- a/src/View/Debugbar/AddVariables.php
+++ b/src/View/Debugbar/AddVariables.php
@@ -22,6 +22,8 @@ class AddVariables
 
         ksort($variables);
 
-        debugbar()->addCollector(new VariableCollector($variables, 'Variables'));
+        if (! debugbar()->hasCollector('Variables')) {
+            debugbar()->addCollector(new VariableCollector($variables, 'Variables'));
+        }
     }
 }


### PR DESCRIPTION
If a view threw an except AND you had a custom handler for that exception that returned a view AND you're running the debugbar, you'd get an error about `Variables` collector already existing.

Check to see if it's there first.