### PR TITLE
Get page collection for unmounted collections too

### DIFF
--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -319,7 +319,7 @@ class Page implements Entry, Augmentable, Responsable, Protectable, JsonSerializ
 
     public function collection()
     {
-        return Collection::findByMount($this);
+        return Collection::findByHandle($this->tree->handle());
     }
 
     public function getProtectionScheme()

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -319,7 +319,11 @@ class Page implements Entry, Augmentable, Responsable, Protectable, JsonSerializ
 
     public function collection()
     {
-        return Collection::findByHandle($this->tree->handle());
+        if ($this->reference && $this->referenceExists()) {
+            return $this->entry()->collection();
+        }
+
+        return Collection::findByMount($this);
     }
 
     public function getProtectionScheme()


### PR DESCRIPTION
Fixes #3853.

I changed the way the collection for a `Page` is looked up. Before its `->collection()` method used `Collection::findByMount()` and would only work for mounted collections. It is done via the `tree` property now which has the collection's handle, so you can do a `Collection::findByHandle()`.