### PR TITLE
Handle entries with layout false and routes with layout false or null

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -135,6 +135,10 @@ class View
 
     private function isUsingXmlLayout()
     {
+        if (! $this->layout) {
+            return false;
+        }
+
         return Str::endsWith($this->layoutViewPath(), '.xml');
     }
 

--- a/tests/FakesViews.php
+++ b/tests/FakesViews.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Illuminate\View\Factory;
 use Illuminate\View\View;
+use InvalidArgumentException;
 
 trait FakesViews
 {
@@ -56,6 +57,10 @@ class FakeViewFactory extends Factory
     {
         $engine = app('FakeViewEngine');
         $ext = $this->extensions[$view] ?? 'antlers.html';
+
+        if (! $engine->exists($view)) {
+            throw new InvalidArgumentException("View [{$view}] not found.");
+        }
 
         return new View($this, $engine, $view, "{$view}.{$ext}", $data);
     }

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -118,6 +118,30 @@ class FrontendTest extends TestCase
     }
 
     /** @test */
+    public function page_with_no_explicit_layout_will_not_use_a_layout()
+    {
+        $this->withStandardBlueprints();
+        $this->withoutExceptionHandling();
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', 'Layout {{ template_content }}');
+        $this->viewShouldReturnRaw('some_template', '<h1>{{ title }}</h1> <p>{{ content }}</p>');
+
+        $page = $this->createPage('about', [
+            'with' => [
+                'title' => 'The About Page',
+                'content' => 'This is the about page.',
+                'template' => 'some_template',
+                'layout' => false,
+            ],
+        ]);
+
+        $response = $this->get('/about')->assertStatus(200);
+
+        $this->assertEquals('<h1>The About Page</h1> <p>This is the about page.</p>', trim($response->content()));
+        $response->assertDontSee('Layout');
+    }
+
+    /** @test */
     public function home_page_on_second_subdirectory_based_site_is_displayed()
     {
         Site::setConfig(['sites' => [

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -39,6 +39,16 @@ class RoutesTest extends TestCase
                 'hello' => 'world',
             ]);
 
+            Route::statamic('/route-with-null-layout', 'test', [
+                'layout' => null,
+                'hello' => 'world',
+            ]);
+
+            Route::statamic('/route-with-false-layout', 'test', [
+                'layout' => false,
+                'hello' => 'world',
+            ]);
+
             Route::statamic('/route-with-loaded-entry', 'test', [
                 'hello' => 'world',
                 'load' => 'pages-blog',
@@ -109,6 +119,30 @@ class RoutesTest extends TestCase
         $this->get('/route-with-custom-layout')
             ->assertOk()
             ->assertSee('Custom layout Hello world');
+    }
+
+    /**
+     * @test
+     * @dataProvider undefinedLayoutRouteProvider
+     **/
+    public function it_renders_a_view_without_a_layout($route)
+    {
+        $this->withoutExceptionHandling();
+        $this->viewShouldReturnRaw('layout', 'The layout {{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        $this->get($route)
+            ->assertOk()
+            ->assertSee('Hello world')
+            ->assertDontSee('The layout');
+    }
+
+    public function undefinedLayoutRouteProvider()
+    {
+        return [
+            'null' => ['route-with-null-layout'],
+            'false' => ['route-with-false-layout'],
+        ];
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #3892 

Routes could set a `null` layout.

```php
Route::statamic('/page', 'page', ['layout' => null]);
```

Entries though, `null` didn't do anything, but `false` would prevent the layout.

```yaml
title: My Page
layout: false
```

It'd probably be nice for null to work, but since it wasn't like that before, it would arguably be a breaking change, so I'm not going to change that.

This also makes our view fake throw an exception when you request a null view. The error would happen in the browser but not during tests.