### PR TITLE
Search tag pagination

### DIFF
--- a/src/Search/Tags.php
+++ b/src/Search/Tags.php
@@ -41,9 +41,23 @@ class Tags extends BaseTags
         $this->queryOrderBys($builder);
 
         $results = $this->getQueryResults($builder);
-        $results = $this->addResultTypes($results);
 
-        return $this->output($results);
+        $results = $this->output($results);
+
+        return $this->addResultTypesToOutput($results);
+    }
+
+    protected function addResultTypesToOutput($output)
+    {
+        if (! $this->params->get('paginate')) {
+            return $this->addResultTypes($output);
+        }
+
+        $as = $this->getPaginationResultsKey();
+
+        $output[$as] = $this->addResultTypes($output[$as]);
+
+        return $output;
     }
 
     protected function addResultTypes($results)

--- a/src/Search/Tags.php
+++ b/src/Search/Tags.php
@@ -42,6 +42,11 @@ class Tags extends BaseTags
 
         $results = $this->getQueryResults($builder);
 
+        // Backwards compatibility. This can be removed in 3.2.
+        if (! $this->params->get('as')) {
+            return $this->output($this->addResultTypes($results));
+        }
+
         $results = $this->output($results);
 
         return $this->addResultTypesToOutput($results);

--- a/src/Tags/Concerns/OutputsItems.php
+++ b/src/Tags/Concerns/OutputsItems.php
@@ -35,13 +35,18 @@ trait OutputsItems
     protected function paginatedOutput($paginator)
     {
         $paginator->withQueryString();
-        $as = $this->params->get('as', $this->defaultAsKey ?? 'results');
+        $as = $this->getPaginationResultsKey();
         $items = $paginator->getCollection()->supplement('total_results', $paginator->total());
 
         return array_merge([
             $as => $items,
             'paginate' => $this->getPaginationData($paginator),
         ], $this->extraOutput($items));
+    }
+
+    protected function getPaginationResultsKey()
+    {
+        return $this->params->get('as', $this->defaultAsKey ?? 'results');
     }
 
     protected function getPaginationData($paginator)


### PR DESCRIPTION
Fixes #3682 

In order to use pagination with search and get the `pagination` array, you **need** to opt into it by using the `as=""` parameter.

I've done it this way to prevent it from being a breaking change. Normally you wouldn't _need_ the `as` parameter, and it'd default to the `results` array.

You use the same Antlers templating described on the collection tag. You need that inner loop over the results.

```mustache
{{ search:results paginate="5" as="results" }}

    {{ results }}
        {{ title }} {{ result_type }} <br>
    {{ /results }}

    {{ paginate }}
        <a href="{{ prev_page }}">Previous</a>
        <a href="{{ next_page }}">Next</a>
    {{ /paginate }}

{{ /search:results }}
```

If you were using pagination as it was introduced in 3.0.30, you'd probably have done this:

```mustache
{{ search:results paginate="5" }}
  {{ title }}
{{ /search:results }}
```

If I'd made the change without you opting into it, this loop would now output the wrong stuff until you updated your templates.