### PR TITLE
Delete trees when setting a collection to not orderable

### DIFF
--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -223,6 +223,9 @@ class CollectionsController extends CpController
         }
 
         if (! $values['structured']) {
+            if ($structure = $collection->structure()) {
+                $structure->trees()->each->delete();
+            }
             $collection->structure(null);
         } else {
             $collection->structure($this->makeStructure($collection, $values['max_depth'], $values['expects_root'], $values['sites'] ?? null));


### PR DESCRIPTION
Together with #3889 this should fix #3478.

(#3889 deletes the tree file when deleting the collection)
