### PR TITLE
Multi-select DataList rows and Assets with shift key

### DIFF
--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -234,7 +234,6 @@ export default {
         checkboxClicked($event, index) {
             this.$refs.table.focus();
             if ($event.shiftKey && this.lastItemClicked !== null) {
-                console.log('should not do')
                 this.selectRange(
                     Math.min(this.lastItemClicked, index),
                     Math.max(this.lastItemClicked, index)

--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -1,5 +1,5 @@
 <template>
-    <table class="data-table" :class="{ 'opacity-50': loading }">
+    <table ref="table" tabindex="0" class="data-table" :class="{ 'opacity-50': loading, 'select-none' : shifting }" @keydown.shift="shiftDown" @keyup="clearShift">
         <thead v-if="allowBulkActions || allowColumnPicker || visibleColumns.length > 1">
             <tr>
                 <th class="checkbox-column" v-if="allowBulkActions || reorderable">
@@ -40,13 +40,14 @@
                     <input
                         v-if="!reorderable"
                         type="checkbox"
-                        :value="row.id"
                         v-model="sharedState.selections"
                         :disabled="reachedSelectionLimit && !sharedState.selections.includes(row.id)"
                         :id="`checkbox-${row.id}`"
+                        :value="row.id"
+                        @click="checkboxClicked($event, index)"
                     />
                 </td>
-                <td v-for="column in visibleColumns" :key="column.field" @click="rowClicked(row)" :width="column.width">
+                <td v-for="column in visibleColumns" :key="column.field" @click="rowClicked(row, index, $event)" :width="column.width">
                     <slot
                         :name="`cell-${column.field}`"
                         :value="row[column.value || column.field]"
@@ -82,6 +83,13 @@ export default {
     components: {
         TableField,
         SortableList,
+    },
+
+    data() {
+        return {
+            shifting: false,
+            lastItemClicked: null
+        }
     },
 
     props: {
@@ -146,7 +154,6 @@ export default {
     },
 
     methods: {
-
         changeSortColumn(column) {
             if (!this.sortable) return;
 
@@ -185,13 +192,28 @@ export default {
             return _.findIndex(this.sharedState.originalRows, row);
         },
 
-        rowClicked(row, i) {
-            if (this.toggleSelectionOnRowClick) {
-                this.toggleSelection(row.id);
+        rowClicked(row, index, $event) {
+            if ($event.shiftKey && this.lastItemClicked !== null) {
+                this.selectRange(
+                    Math.min(this.lastItemClicked, index),
+                    Math.max(this.lastItemClicked, index)
+                );
+            } else if (this.toggleSelectionOnRowClick) {
+                this.toggleSelection(row.id, index);
             }
+            this.lastItemClicked = index;
         },
 
-        toggleSelection(id) {
+        selectRange(from, to) {
+            for (var i = from; i <= to; i++ ) {
+                let row = this.sharedState.rows[i].id;
+                if (! this.sharedState.selections.includes(row) && ! this.reachedSelectionLimit) {
+                    this.sharedState.selections.push(row);
+                }
+            };
+        },
+
+        toggleSelection(id, index) {
             const i = this.sharedState.selections.indexOf(id);
 
             if (i != -1) {
@@ -199,8 +221,30 @@ export default {
             } else if (! this.reachedSelectionLimit) {
                 this.sharedState.selections.push(id);
             }
-        }
+        },
 
-    }
+        shiftDown() {
+            this.shifting = true
+        },
+
+        clearShift() {
+            this.shifting = false
+        },
+
+        checkboxClicked($event, index) {
+            this.$refs.table.focus();
+            if ($event.shiftKey && this.lastItemClicked !== null) {
+                console.log('should do')
+                this.selectRange(
+                    Math.min(this.lastItemClicked, index),
+                    Math.max(this.lastItemClicked, index)
+                );
+            }
+
+            if ($event.target.checked) {
+                this.lastItemClicked = index
+            }
+        }
+    },
 }
 </script>

--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -234,7 +234,7 @@ export default {
         checkboxClicked($event, index) {
             this.$refs.table.focus();
             if ($event.shiftKey && this.lastItemClicked !== null) {
-                console.log('should do')
+                console.log('should not do')
                 this.selectRange(
                     Math.min(this.lastItemClicked, index),
                     Math.max(this.lastItemClicked, index)


### PR DESCRIPTION
It's completely additive, in that it's only designed to SELECT items, not deselect. Works in all directions (up to down, down to up, etc).

It also prevents users from selecting text while holding down shift so you don't get a derpy looking UI after the interaction.