### PR TITLE
Multisite: Use current site locale as fallback locale in the `trans` tag

### DIFF
--- a/src/Tags/Trans.php
+++ b/src/Tags/Trans.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Tags;
 
+use Statamic\Facades\Site;
+
 class Trans extends Tags
 {
     /**
@@ -12,7 +14,9 @@ class Trans extends Tags
     public function wildcard($tag)
     {
         $key = $this->params->get('key', $tag);
-        $locale = $this->params->pull('locale') ?? $this->params->pull('site');
+        $locale = $this->params->pull('locale')
+            ?? $this->params->pull('site')
+            ?? Site::current()->shortLocale();
         $params = $this->params->all();
 
         return __($key, $params, $locale);


### PR DESCRIPTION
This PR fixes a small bug in the `trans` tag when no site is previously selected and a not found page is visited.

## Test Case

In a multisite installation where the locale of the default site does not match the `app.fallback_locale`, and a user lands on a non-existent page (without visiting any entry before), if the `404.antlers.html` template uses the `trans` tag somewhere, the tag will display the `app.fallback_locale` translation.

Explicitly setting `Site::current()->shortLocale()` as the locale on `__()` if no `$this->params->pull('locale')` or `$this->params->pull('site')` is found seems to mitigate this issue (which could mean that `app.locale` is not set in 404s).