### PR TITLE
Use partial mock to fix breadcrumbs test

### DIFF
--- a/tests/CP/BreadcrumbsTest.php
+++ b/tests/CP/BreadcrumbsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\CP;
 
 use Illuminate\Contracts\Translation\Translator;
+use Mockery;
 use Statamic\CP\Breadcrumbs;
 use Tests\TestCase;
 
@@ -37,11 +38,13 @@ class BreadcrumbsTest extends TestCase
     /** @test */
     public function it_pushes_a_crumb_into_the_title()
     {
-        app()->instance('translator', $this->mock(Translator::class)
+        $translator = Mockery::mock(app(Translator::class))
+            ->makePartial()
             ->shouldReceive('get')->with('The title', [], null)->once()
             ->andReturn('The translated title')
-            ->getMock()
-        );
+            ->getMock();
+
+        app()->instance('translator', $translator);
 
         $bc = new Breadcrumbs($array = [
             ['text' => 'First', 'url' => '/first'],


### PR DESCRIPTION
Something in laravel/framework 8.48.2 broke our `BreadcrumbsTest`.

Looks like https://github.com/laravel/framework/issues/37789

Grabbing the instance out of the container, making it a partial mock, and putting it back into the container fixes it.