### PR TITLE
Make column squeezing css rules more specific

### DIFF
--- a/resources/sass/components/fieldtypes/button-group.scss
+++ b/resources/sass/components/fieldtypes/button-group.scss
@@ -1,6 +1,6 @@
 /* Inside a Grid field
   ========================================================================== */
 
-.grid-table .button_group-fieldtype {
+.grid-table td.button_group-fieldtype {
     width: 1%;
 }

--- a/resources/sass/components/fieldtypes/time.scss
+++ b/resources/sass/components/fieldtypes/time.scss
@@ -1,6 +1,6 @@
 /* Inside a Grid field
   ========================================================================== */
 
-.grid-table .time-fieldtype {
+.grid-table td.time-fieldtype {
     width: 1%;
 }

--- a/resources/sass/components/toggle.scss
+++ b/resources/sass/components/toggle.scss
@@ -107,7 +107,7 @@ $toggle_radius: 20px;
 /* Inside a Grid field
   ========================================================================== */
 
-.grid-table .toggle-fieldtype {
+.grid-table td.toggle-fieldtype {
     width: 1%;
     padding-top: 14px;
 }


### PR DESCRIPTION
Fixes #3897.

Because the rules were too generic, they were unintentionally applied to some other elements. They should only apply to the table cell.