### PR TITLE
Filter out import fields

### DIFF
--- a/resources/js/components/blueprints/LinkFields.vue
+++ b/resources/js/components/blueprints/LinkFields.vue
@@ -111,7 +111,9 @@ export default {
             reference: null,
             fieldset: null,
             importPrefix: null,
-            fieldSuggestions: fieldsets.flatMap(fieldset => fieldset.fields.map(field => ({
+            fieldSuggestions: fieldsets.flatMap(fieldset => fieldset.fields.filter(field => {
+                return field.type !== 'import';
+            }).map(field => ({
                 value: `${fieldset.handle}.${field.handle}`,
                 label: field.config.display,
                 fieldset: fieldset.title,

--- a/resources/js/components/blueprints/LinkFields.vue
+++ b/resources/js/components/blueprints/LinkFields.vue
@@ -106,18 +106,22 @@ export default {
             )
         ));
 
+        const fieldSuggestions = fieldsets.flatMap(fieldset => {
+            return fieldset.fields
+                .filter(field => field.type !== 'import')
+                .map(field => ({
+                    value: `${fieldset.handle}.${field.handle}`,
+                    label: field.config.display,
+                    fieldset: fieldset.title,
+                }));
+        });
+
         return {
             open: false,
             reference: null,
             fieldset: null,
             importPrefix: null,
-            fieldSuggestions: fieldsets.flatMap(fieldset => fieldset.fields.filter(field => {
-                return field.type !== 'import';
-            }).map(field => ({
-                value: `${fieldset.handle}.${field.handle}`,
-                label: field.config.display,
-                fieldset: fieldset.title,
-            }))),
+            fieldSuggestions,
             fieldsetSuggestions: fieldsets.map(fieldset => ({
                 value: fieldset.handle,
                 label: fieldset.title,


### PR DESCRIPTION
This will filter out `import` fields from the field suggestions you see when you click "Link Existing".

The lack of a `config` was causing an error. You shouldn't be referencing `import` fields anyway. You can just import a fieldset.

Fixes #3904 

This PR is really just adding `.filter(field => field.type !== 'import')`. The diff is bigger because it's been moved out to a variable for readability.