### PR TITLE
Allow setting more Pusher options like host and port

### DIFF
--- a/resources/js/components/Echo.js
+++ b/resources/js/components/Echo.js
@@ -19,7 +19,17 @@ class Echo {
             encrypted: Statamic.$config.get('broadcasting.pusher.encrypted'),
             csrfToken: Statamic.$config.get('csrfToken'),
             authEndpoint: Statamic.$config.get('broadcasting.endpoint'),
+            disableStats: Statamic.$config.get('broadcasting.pusher.disableStats'),
         };
+        const pusherHost = Statamic.$config.get('broadcasting.pusher.host'),
+        if(pusherHost) {
+            config.wsHost = pusherHost;
+        }
+
+        const pusherPort = Statamic.$config.get('broadcasting.pusher.port'),
+        if(pusherPort) {
+            config.wsPort = pusherPort;
+        }
 
         this.echo = new LaravelEcho(config);
 

--- a/src/Providers/BroadcastServiceProvider.php
+++ b/src/Providers/BroadcastServiceProvider.php
@@ -23,6 +23,9 @@ class BroadcastServiceProvider extends ServiceProvider
             'endpoint' => $this->authEndpoint(),
             'pusher' => [
                 'key' => config('broadcasting.connections.pusher.key'),
+                'host' => config('broadcasting.connections.pusher.options.host'),
+                'port' => config('broadcasting.connections.pusher.options.port', 443),
+                'disableStats' => config('broadcasting.connections.pusher.options.disableStats', false),
                 'cluster' => config('broadcasting.connections.pusher.options.cluster'),
                 'encrypted' => config('broadcasting.connections.pusher.options.encrypted'),
             ],


### PR DESCRIPTION
Hi,

We'd like to use a custom pusher server hosted with https://github.com/beyondcode/laravel-websockets. For Example, to use https://statamic.com/addons/statamic/collaboration. 

To allow this, more pusher options are required to configure the Statamic Pusher instance.

This PR adds the ability to also configure the options `host`, `port` and `disableStats`.