### PR TITLE
Update a Stache index only when it hasn't been cached

### DIFF
--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -70,7 +70,7 @@ abstract class Index
 
         $this->items = Cache::get($this->cacheKey());
 
-        if (! $this->items) {
+        if ($this->items === null) {
             $this->update();
         }
 


### PR DESCRIPTION
This fixes an issue where if an index's cached items are empty, then the index will be updated and cached again on every request, regardless of whether it's already been cached.