### PR TITLE
Keep all the asset rule logic in the class

### DIFF
--- a/src/Fieldtypes/Assets/AssetRule.php
+++ b/src/Fieldtypes/Assets/AssetRule.php
@@ -15,12 +15,17 @@ class AssetRule implements Rule
 
     protected $name;
     protected $parameters;
-    protected $message;
 
-    public function __construct($name, $message, $parameters = null)
+    protected static $rules = [
+        'image',
+        'dimensions',
+        'mimes',
+        'mimetypes',
+    ];
+
+    public function __construct($name, $parameters = null)
     {
         $this->name = $name;
-        $this->message = $message;
         $this->parameters = $parameters;
     }
 
@@ -55,6 +60,32 @@ class AssetRule implements Rule
      */
     public function message()
     {
-        return $this->message;
+        $key = 'statamic::validation.'.$this->name;
+
+        if (in_array($this->name, ['mimes', 'mimetypes'])) {
+            $replace = ['values' => join(', ', $this->parameters)];
+        }
+
+        return __($key, $replace ?? []);
+    }
+
+    /**
+     * Make an AssetRule instance if it's a supported rule, or return itself.
+     *
+     * @return self|string
+     */
+    public static function makeFromRule($rule)
+    {
+        $name = Str::before($rule, ':');
+
+        if (! in_array($name, static::$rules)) {
+            return $rule;
+        }
+
+        $parameters = Str::contains($rule, ':')
+            ? explode(',', Str::after($rule, ':'))
+            : null;
+
+        return new AssetRule($name, $parameters);
     }
 }

--- a/src/Fieldtypes/Assets/AssetRule.php
+++ b/src/Fieldtypes/Assets/AssetRule.php
@@ -70,7 +70,7 @@ class AssetRule implements Rule
     }
 
     /**
-     * Make an AssetRule instance if it's a supported rule, or return itself.
+     * Make an AssetRule instance if it's a supported rule, or return what was passed in.
      *
      * @return self|string
      */

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -173,23 +173,7 @@ class Assets extends Fieldtype
     public function fieldRules()
     {
         return collect(parent::fieldRules())->map(function ($rule) {
-            $name = Str::before($rule, ':');
-
-            $parameters = Str::contains($rule, ':')
-                ? explode(',', Str::after($rule, ':'))
-                : null;
-
-            if ($name === 'dimensions') {
-                $message = __('statamic::validation.dimensions');
-            } elseif ($name === 'image') {
-                $message = __('statamic::validation.image');
-            } elseif ($name === 'mimes') {
-                $message = str_replace(':values', join(', ', $parameters), __('statamic::validation.mimes'));
-            } elseif ($name === 'mimetypes') {
-                $message = str_replace(':values', join(', ', $parameters), __('statamic::validation.mimetypes'));
-            }
-
-            return $message ? new AssetRule($name, $message, $parameters) : $rule;
+            return AssetRule::makeFromRule($rule);
         })->all();
     }
 

--- a/tests/Fieldtypes/AssetsTest.php
+++ b/tests/Fieldtypes/AssetsTest.php
@@ -94,6 +94,7 @@ class AssetsTest extends TestCase
         $this->assertIsArray($replaced);
         $this->assertCount(1, $replaced);
         $this->assertInstanceOf(AssetRule::class, $replaced[0]);
+        $this->assertEquals(__('statamic::validation.dimensions'), $replaced[0]->message());
     }
 
     /** @test */
@@ -104,6 +105,7 @@ class AssetsTest extends TestCase
         $this->assertIsArray($replaced);
         $this->assertCount(1, $replaced);
         $this->assertInstanceOf(AssetRule::class, $replaced[0]);
+        $this->assertEquals(__('statamic::validation.image'), $replaced[0]->message());
     }
 
     /** @test */
@@ -114,6 +116,7 @@ class AssetsTest extends TestCase
         $this->assertIsArray($replaced);
         $this->assertCount(1, $replaced);
         $this->assertInstanceOf(AssetRule::class, $replaced[0]);
+        $this->assertEquals(__('statamic::validation.mimes', ['values' => 'jpg, png']), $replaced[0]->message());
     }
 
     /** @test */
@@ -124,6 +127,17 @@ class AssetsTest extends TestCase
         $this->assertIsArray($replaced);
         $this->assertCount(1, $replaced);
         $this->assertInstanceOf(AssetRule::class, $replaced[0]);
+        $this->assertEquals(__('statamic::validation.mimetypes', ['values' => 'image/jpg, image/png']), $replaced[0]->message());
+    }
+
+    /** @test */
+    public function it_doesnt_replace_non_image_related_rule()
+    {
+        $replaced = $this->fieldtype(['validate' => ['min:3']])->fieldRules();
+
+        $this->assertIsArray($replaced);
+        $this->assertCount(1, $replaced);
+        $this->assertEquals('min:3', $replaced[0]);
     }
 
     public function fieldtype($config = [])


### PR DESCRIPTION
Just a small refactor of #3922 

Instead of passing in the validation message, it'll know how to work itself out.