### PR TITLE
Fix dimensions for zero byte image

### DIFF
--- a/src/Assets/Dimensions.php
+++ b/src/Assets/Dimensions.php
@@ -89,12 +89,12 @@ class Dimensions
         try {
             $size = getimagesize($cache->getAdapter()->getPathPrefix().$cachePath);
         } catch (\Exception $e) {
-            $size = [null, null];
+            $size = [0, 0];
         } finally {
             $cache->delete($cachePath);
         }
 
-        return $size ? array_splice($size, 0, 2) : [null, null];
+        return $size ? array_splice($size, 0, 2) : [0, 0];
     }
 
     /**

--- a/src/Assets/Dimensions.php
+++ b/src/Assets/Dimensions.php
@@ -86,9 +86,13 @@ class Dimensions
 
         $manager->copy("source://{$this->asset->path()}", $destination);
 
-        $size = getimagesize($cache->getAdapter()->getPathPrefix().$cachePath);
-
-        $cache->delete($cachePath);
+        try {
+            $size = getimagesize($cache->getAdapter()->getPathPrefix().$cachePath);
+        } catch (\Exception $e) {
+            $size = [null, null];
+        } finally {
+            $cache->delete($cachePath);
+        }
 
         return $size ? array_splice($size, 0, 2) : [null, null];
     }


### PR DESCRIPTION
Fixes #3932 

Apparently sometimes a failure just returns false, and sometimes it throws an exception.

Also changes the null dimensions to zeroes. If they're nulls, it'll continuously try to grab new dimensions.