### PR TITLE
Use Request facade to get base URL in AbstractCacher instead of StaticCacheManager if not set in config.

### DIFF
--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -5,6 +5,7 @@ namespace Statamic\StaticCaching\Cachers;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Request as RequestFacade;
 use Statamic\StaticCaching\Cacher;
 use Statamic\Support\Str;
 
@@ -48,7 +49,7 @@ abstract class AbstractCacher implements Cacher
      */
     public function getBaseUrl()
     {
-        return $this->config('base_url');
+        return $this->config('base_url') ?? RequestFacade::root();
     }
 
     /**

--- a/src/StaticCaching/StaticCacheManager.php
+++ b/src/StaticCaching/StaticCacheManager.php
@@ -46,7 +46,6 @@ class StaticCacheManager extends Manager
         return array_merge($config, [
             'exclude' => $this->app['config']['statamic.static_caching.exclude'] ?? [],
             'ignore_query_strings' => $this->app['config']['statamic.static_caching.ignore_query_strings'] ?? false,
-            'base_url' => $this->app['request']->root(),
             'locale' => Site::current()->handle(),
         ]);
     }


### PR DESCRIPTION
The StaticCacheManager is run before the TrustedProxy class. If TrustedProxy promotes your request to https, the StaticCache config thinks it's still on http, due to the config being set earlier in the request. Seen as though the string which is used to generate the hash which is used to store/get the page from cache (responses:<HASH>) is created using the request class directly, it (correctly) contains https://, but when the config is used (during invalidation for example), it contains http://, due to TrustedProxies not yet being evaluated when it's set.

This PR stops the base_url config from always being set, and instead uses the Request facade if it's not set.

<img width="2559" alt="Screenshot 2021-07-01 at 13 06 17" src="https://user-images.githubusercontent.com/25618897/124123767-96227e00-da6f-11eb-96d2-6be185a6dfb7.png">