### PR TITLE
Fix site specific views not loading

### DIFF
--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -37,9 +37,9 @@ class DataResponse implements Responsable
             ->protect()
             ->handleDraft()
             ->handlePrivateEntries()
+            ->addViewPaths()
             ->adjustResponseType()
             ->addContentHeaders()
-            ->addViewPaths()
             ->handleAmp();
 
         $response = response()


### PR DESCRIPTION
Site specific views stopped working in 3.1.25 when the XML templates were introduced.

This is because we interacted with the view before the extra view paths were added. This PR just adds them earlier.﻿

Fixes #3945 