### PR TITLE
Handle numeric prefixes

### DIFF
--- a/src/Entries/GetSlugFromPath.php
+++ b/src/Entries/GetSlugFromPath.php
@@ -14,7 +14,7 @@ class GetSlugFromPath
 
         $segments = explode('.', $path);
 
-        if ($this->isDate($segments[0]) || $this->isNumeric($segments[0])) {
+        if ($this->isDate($segments[0]) || is_numeric($segments[0])) {
             return $segments[1];
         }
 
@@ -24,10 +24,5 @@ class GetSlugFromPath
     private function isDate($str)
     {
         return preg_match('/^\d{4}-\d{2}-\d{2}(-\d{4})?$/', $str);
-    }
-
-    private function isNumeric($str)
-    {
-        return $str == (int) $str;
     }
 }

--- a/src/Entries/GetSlugFromPath.php
+++ b/src/Entries/GetSlugFromPath.php
@@ -14,7 +14,7 @@ class GetSlugFromPath
 
         $segments = explode('.', $path);
 
-        if ($this->isDate($segments[0])) {
+        if ($this->isDate($segments[0]) || $this->isNumeric($segments[0])) {
             return $segments[1];
         }
 
@@ -24,5 +24,10 @@ class GetSlugFromPath
     private function isDate($str)
     {
         return preg_match('/^\d{4}-\d{2}-\d{2}(-\d{4})?$/', $str);
+    }
+
+    private function isNumeric($str)
+    {
+        return $str == (int) $str;
     }
 }

--- a/src/Entries/GetSuffixFromPath.php
+++ b/src/Entries/GetSuffixFromPath.php
@@ -14,7 +14,7 @@ class GetSuffixFromPath
 
         $segments = explode('.', pathinfo($path, PATHINFO_FILENAME));
 
-        if ($this->isDate($segments[0])) {
+        if ($this->isDate($segments[0]) || $this->isNumeric($segments[0])) {
             return $segments[2] ?? null;
         }
 
@@ -24,5 +24,10 @@ class GetSuffixFromPath
     private function isDate($str)
     {
         return preg_match('/^\d{4}-\d{2}-\d{2}(-\d{4})?$/', $str);
+    }
+
+    private function isNumeric($str)
+    {
+        return $str == (int) $str;
     }
 }

--- a/src/Entries/GetSuffixFromPath.php
+++ b/src/Entries/GetSuffixFromPath.php
@@ -14,7 +14,7 @@ class GetSuffixFromPath
 
         $segments = explode('.', pathinfo($path, PATHINFO_FILENAME));
 
-        if ($this->isDate($segments[0]) || $this->isNumeric($segments[0])) {
+        if ($this->isDate($segments[0]) || is_numeric($segments[0])) {
             return $segments[2] ?? null;
         }
 
@@ -24,10 +24,5 @@ class GetSuffixFromPath
     private function isDate($str)
     {
         return preg_match('/^\d{4}-\d{2}-\d{2}(-\d{4})?$/', $str);
-    }
-
-    private function isNumeric($str)
-    {
-        return $str == (int) $str;
     }
 }

--- a/tests/Data/Entries/GetDateFromPathTest.php
+++ b/tests/Data/Entries/GetDateFromPathTest.php
@@ -23,11 +23,13 @@ class GetDateFromPathTest extends TestCase
             'time' => ['2015-01-01-1300', 'path/to/2015-01-01-1300.post.md'],
             'no date' => [null, 'path/to/post.md'],
             'no date but slug with number' => [null, 'path/to/2nd-post.md'],
+            'numeric prefix' => [null, 'path/to/13.post.md'],
 
             'date with id suffix' => ['2015-01-01', 'path/to/2015-01-01.post.id-suffix.md'],
             'time with id suffix' => ['2015-01-01-1300', 'path/to/2015-01-01-1300.post.id-suffix.md'],
             'no date with id suffix' => [null, 'path/to/post.id-suffix.md'],
             'no date but slug with number with id suffix' => [null, 'path/to/2nd-post.id-suffix.md'],
+            'numeric prefix with id suffix' => [null, 'path/to/13.post.id-suffix.md'],
         ];
     }
 }

--- a/tests/Data/Entries/GetSlugFromPathTest.php
+++ b/tests/Data/Entries/GetSlugFromPathTest.php
@@ -24,12 +24,14 @@ class GetSlugFromPathTest extends TestCase
             'no date' => ['post', 'post.md'],
             'no date but slug thats a number' => ['404', '404.md'],
             'no date but slug with number' => ['2nd-post', '2nd-post.md'],
+            'numeric prefix' => ['post', '13.post.md'],
 
             'date with id suffix' => ['post', '2015-01-01.post.id-suffix.md'],
             'time with id suffix' => ['post', '2015-01-01-1300.post.id-suffix.md'],
             'no date with id suffix' => ['post', 'post.id-suffix.md'],
             'no date but slug thats a number' => ['404', '404.md'],
             'no date but slug with number with id suffix' => ['2nd-post', '2nd-post.id-suffix.md'],
+            'numeric prefix with suffix' => ['post', '13.post.id-suffix.md'],
         ];
     }
 }

--- a/tests/Data/Entries/GetSuffixFromPathTest.php
+++ b/tests/Data/Entries/GetSuffixFromPathTest.php
@@ -23,11 +23,13 @@ class GetSuffixFromPathTest extends TestCase
             'time' => [null, 'path/to/2015-01-01-1300.post.md'],
             'no date' => [null, 'path/to/post.md'],
             'no date but slug with number' => [null, 'path/to/2nd-post.md'],
+            'numeric prefix' => [null, 'path/to/13.post.md'],
 
             'date with id suffix' => ['id-suffix', 'path/to/2015-01-01.post.id-suffix.md'],
             'time with id suffix' => ['id-suffix', 'path/to/2015-01-01-1300.post.id-suffix.md'],
             'no date with id suffix' => ['id-suffix', 'path/to/post.id-suffix.md'],
             'no date but slug with number with id suffix' => ['id-suffix', 'path/to/2nd-post.id-suffix.md'],
+            'numeric prefix with id suffix' => ['id-suffix', 'path/to/13.post.id-suffix.md'],
         ];
     }
 }

--- a/tests/Data/Entries/RemoveSuffixFromPathTest.php
+++ b/tests/Data/Entries/RemoveSuffixFromPathTest.php
@@ -23,11 +23,13 @@ class RemoveSuffixFromPathTest extends TestCase
             'time' => ['path/to/2015-01-01-1300.post.md', 'path/to/2015-01-01-1300.post.md'],
             'no date' => ['path/to/post.md', 'path/to/post.md'],
             'no date but slug with number' => ['path/to/2nd-post.md', 'path/to/2nd-post.md'],
+            'numeric prefix' => ['path/to/13.post.md', 'path/to/13.post.md'],
 
             'date with id suffix' => ['path/to/2015-01-01.post.md', 'path/to/2015-01-01.post.id-suffix.md'],
             'time with id suffix' => ['path/to/2015-01-01-1300.post.md', 'path/to/2015-01-01-1300.post.id-suffix.md'],
             'no date with id suffix' => ['path/to/post.md', 'path/to/post.id-suffix.md'],
             'no date but slug with number with id suffix' => ['path/to/2nd-post.md', 'path/to/2nd-post.id-suffix.md'],
+            'numeric prefix with id suffix' => ['path/to/13.post.md', 'path/to/13.post.id-suffix.md'],
 
             'date with id suffix but suffix is also in the date' => ['path/to/2015-01-01.post.md', 'path/to/2015-01-01.post.1.md'],
         ];


### PR DESCRIPTION
Fixes #3946 

Entries with numeric prefixes all of a sudden assumed that the prefix is the slug and the slug is the suffix.

You can't have entries with numeric prefixes in v3, I don't think you ever could, but if you did it would work anyway. This PR helps to keep things just working, even though it wasn't really supported.