### PR TITLE
Change group:: to UserGroup:: in removeFromGroup method.

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -206,7 +206,7 @@ class User extends BaseUser
     public function removeFromGroup($group)
     {
         $groups = collect(array_wrap($group))->map(function ($group) {
-            return is_string($group) ? group::find($group) : $group;
+            return is_string($group) ? UserGroup::find($group) : $group;
         })->filter();
 
         $groups->each(function ($group) {


### PR DESCRIPTION
Changed 

```php
    public function removeFromGroup($group)
    {
        $groups = collect(array_wrap($group))->map(function ($group) {
            return is_string($group) ? group::find($group) : $group;
        })->filter();

        $groups->each(function ($group) {
            $this->groups->forget($group->id());
        });

        return $this;
    }
```

To

```php
    public function removeFromGroup($group)
    {
        $groups = collect(array_wrap($group))->map(function ($group) {
            return is_string($group) ? UserGroup::find($group) : $group;
        })->filter();

        $groups->each(function ($group) {
            $this->groups->forget($group->id());
        });

        return $this;
    }
```