### PR TITLE
Fix issue with Code and Textarea fieldtypes in inactive tabs

### DIFF
--- a/resources/js/components/fieldtypes/CodeFieldtype.vue
+++ b/resources/js/components/fieldtypes/CodeFieldtype.vue
@@ -89,11 +89,13 @@ export default {
         this.codemirror.on('focus', () => this.$emit('focus'));
         this.codemirror.on('blur', () => this.$emit('blur'));
 
-        // Refresh to ensure proper size
-        // Most applicable when loaded by another field like Bard, etc
-        this.$nextTick(function() {
-            this.codemirror.refresh();
-        })
+
+        // Refresh to ensure CodeMirror visible and the proper size
+        // Most applicable when loaded by another field like Bard
+        this.refresh();
+
+        // CodeMirror also needs to be manually refreshed when made visible in the DOM
+        this.$events.$on('tab-switched', this.refresh);
     },
 
     watch: {
@@ -101,7 +103,6 @@ export default {
             if (value == this.codemirror.doc.getValue()) return;
             this.codemirror.doc.setValue(value);
         },
-
         readOnlyOption(val) {
             this.codemirror.setOption('readOnly', val);
         }
@@ -110,8 +111,12 @@ export default {
     methods: {
         focus() {
             this.codemirror.focus();
+        },
+        refresh() {
+            this.$nextTick(function() {
+                this.codemirror.refresh();
+            })
         }
     }
-
 };
 </script>

--- a/resources/js/components/inputs/Textarea.vue
+++ b/resources/js/components/inputs/Textarea.vue
@@ -2,6 +2,7 @@
     <div>
         <textarea
             class="input-text"
+            ref="textarea"
             :value="value"
             :id="id"
             :disabled="disabled"
@@ -11,7 +12,6 @@
             @input="$emit('input', $event.target.value)"
             @focus="$emit('focus')"
             @blur="$emit('blur')"
-            v-elastic
         />
         <div class="text-right text-xs" :class="limitIndicatorColor" v-if="limit">
             <span v-text="currentLength"></span>/<span v-text="limit"></span>
@@ -22,9 +22,11 @@
 
 <script>
 import LengthLimiter from '../LengthLimiter.vue'
+import autosize from 'autosize';
 
 export default {
     mixins: [LengthLimiter],
+
     props: {
         disabled: { default: false },
         isReadOnly: { type: Boolean, default: false },
@@ -32,6 +34,19 @@ export default {
         value: { required: true },
         id: { default: null },
         focus: { type: Boolean, default: false }
+
+    },
+    mounted() {
+        autosize(this.$refs.textarea)
+        this.$events.$on('tab-switched', this.updateSize);
+    },
+
+    methods: {
+        updateSize() {
+            this.$nextTick(function() {
+                autosize.update(this.$refs.textarea)
+            })
+        }
     }
 }
 </script>

--- a/resources/js/components/publish/Sections.vue
+++ b/resources/js/components/publish/Sections.vue
@@ -10,7 +10,7 @@
                     'active': section.handle == active,
                     'has-error': sectionHasError(section.handle)
                 }"
-                @click.prevent="active = section.handle"
+                @click.prevent="setActive(section.handle)"
                 v-text="section.display || `${section.handle[0].toUpperCase()}${section.handle.slice(1)}`"
             ></a>
         </div>
@@ -155,6 +155,11 @@ export default {
 
         sectionHasError(handle) {
             return _.chain(this.sectionErrors).values().contains(handle).value();
+        },
+
+        setActive(tab) {
+            this.active = tab;
+            this.$events.$emit('tab-switched', tab);
         }
 
     }


### PR DESCRIPTION
Apparently this is a design "decision" from CodeMirror (https://github.com/codemirror/CodeMirror/issues/2469). Upside, we now have a new event when tabs are switched.

Also, I manually bound the autosize helper on the textarea component instead of using a directive as it doesn't handle all the events necessary to trigger the proper update.

Closes #3391 and #1952. Apologies for the branch name, didn't realize I could kill two issues with one PR at first.