### PR TITLE
Add 'has' method to Session Tag

### DIFF
--- a/src/Tags/Session.php
+++ b/src/Tags/Session.php
@@ -68,7 +68,7 @@ class Session extends Tags
     {
         return session()->has($this->params->get('key'));
     }
-    
+
     protected function returnableSession()
     {
         if (! $this->isPair) {

--- a/src/Tags/Session.php
+++ b/src/Tags/Session.php
@@ -64,6 +64,11 @@ class Session extends Tags
         return $this->returnableSession();
     }
 
+    public function has()
+    {
+        return session()->has($this->params->get('key'));
+    }
+    
     protected function returnableSession()
     {
         if (! $this->isPair) {


### PR DESCRIPTION
This pull request adds a helpful `has` method to the [Session](https://statamic.dev/tags/session#content) tag.

## Usage

This could be used to check if something exists in the users' session.

```
{{ if {session:has key="cart"} === false }}
    No cart around here...
{{ /if }}
```

## Alternative

Without this tag, you can just do something like this instead.

```
{{ if {session:cart} === null }}
    No cart around here...
{{ /if }}
```

---

I know this PR wasn't really asked for anywhere but just came across it while working on a site. Feel free to shoot it down, the alternative is a fine workaround.