### PR TITLE
Control Panel: Customize the notification for saving entries

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -472,7 +472,8 @@ export default {
                     document.title = this.title + ' ‹ ' + this.breadcrumbs[1].text + ' ‹ ' + this.breadcrumbs[0].text + ' ‹ Statamic';
                 }
                 if (!this.revisionsEnabled) this.permalink = response.data.data.permalink;
-                if (!this.isCreating) this.$toast.success(__('Saved'));
+                const successMessage = response.data.data.cp_message_success
+                if (!this.isCreating) this.$toast.success(successMessage);
                 this.$refs.container.saved();
                 this.runAfterSaveHook(response);
             }).catch(error => this.handleAxiosError(error));

--- a/src/Events/EntrySaving.php
+++ b/src/Events/EntrySaving.php
@@ -2,12 +2,14 @@
 
 namespace Statamic\Events;
 
+use Statamic\Entries\Entry;
+
 class EntrySaving extends Event
 {
     public $entry;
     private $messageStore;
 
-    public function __construct($entry)
+    public function __construct(Entry $entry)
     {
         $this->entry = $entry;
         $this->messageStore = app(EntrySavingMessageStore::class);

--- a/src/Events/EntrySaving.php
+++ b/src/Events/EntrySaving.php
@@ -5,10 +5,22 @@ namespace Statamic\Events;
 class EntrySaving extends Event
 {
     public $entry;
+    private $messageStore;
 
     public function __construct($entry)
     {
         $this->entry = $entry;
+        $this->messageStore = app(EntrySavingMessageStore::class);
+    }
+
+    public function addSuccessMessage(string $message)
+    {
+        $this->messageStore->addSuccessMessage($message);
+    }
+
+    public function successMessages(): array
+    {
+        return $this->messageStore->successMessages;
     }
 
     /**

--- a/src/Events/EntrySavingMessageStore.php
+++ b/src/Events/EntrySavingMessageStore.php
@@ -15,4 +15,14 @@ class EntrySavingMessageStore
     {
         return $this->successMessages;
     }
+
+    public function getMessage(): string
+    {
+        $successMessages = $this->successMessages();
+        if (empty($successMessages)) {
+            return __('Saved');
+        } else {
+            return join(PHP_EOL, $successMessages);
+        }
+    }
 }

--- a/src/Events/EntrySavingMessageStore.php
+++ b/src/Events/EntrySavingMessageStore.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Statamic\Events;
+
+class EntrySavingMessageStore
+{
+    protected $successMessages = [];
+
+    public function addSuccessMessage(string $message)
+    {
+        $this->successMessages[] = $message;
+    }
+
+    public function successMessages(): array
+    {
+        return $this->successMessages;
+    }
+}

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\CP\Breadcrumbs;
+use Statamic\Events\EntrySavingMessageStore;
 use Statamic\Exceptions\BlueprintNotFoundException;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Entry;
@@ -231,7 +232,9 @@ class EntriesController extends CpController
             $entry->updateLastModified(User::current())->save();
         }
 
-        return new EntryResource($entry->fresh());
+        $successMessage = $this->getEntrySavingSuccessMessage();
+
+        return new EntryResource($entry, $successMessage);
     }
 
     public function create(Request $request, $collection, $site)
@@ -360,7 +363,9 @@ class EntriesController extends CpController
             $entry->updateLastModified(User::current())->save();
         }
 
-        return new EntryResource($entry);
+        $successMessage = $this->getEntrySavingSuccessMessage();
+
+        return new EntryResource($entry, $successMessage);
     }
 
     public function destroy($collection, $entry)
@@ -441,6 +446,13 @@ class EntriesController extends CpController
         }
 
         return $date;
+    }
+
+    protected function getEntrySavingSuccessMessage(): string
+    {
+        $messageStore = app(EntrySavingMessageStore::class);
+
+        return $messageStore->getMessage();
     }
 
     private function validateUniqueUri($entry, $tree, $parent)

--- a/src/Http/Resources/CP/Entries/Entry.php
+++ b/src/Http/Resources/CP/Entries/Entry.php
@@ -6,6 +6,14 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class Entry extends JsonResource
 {
+    private $successMessage;
+
+    public function __construct($resource, string $successMessage = null)
+    {
+        parent::__construct($resource);
+        $this->successMessage = $successMessage;
+    }
+
     public function toArray($request)
     {
         return [
@@ -20,6 +28,7 @@ class Entry extends JsonResource
                 'title' => $this->resource->collection()->title(),
                 'handle' => $this->resource->collection()->handle(),
             ],
+            'cp_message_success' => $this->successMessage,
         ];
     }
 }

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -125,6 +125,10 @@ class AppServiceProvider extends ServiceProvider
             return (new \Statamic\Fields\FieldsetRepository)
                 ->setDirectory(resource_path('fieldsets'));
         });
+
+        $this->app->singleton(Statamic\Events\EntrySavingMessageStore::class, function () {
+            return new Statamic\Events\EntrySavingMessageStore();
+        });
     }
 
     protected function registerMiddlewareGroup()

--- a/tests/Events/EntrySavingMessageStoreTest.php
+++ b/tests/Events/EntrySavingMessageStoreTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Events;
+
+use Statamic\Events\EntrySavingMessageStore;
+use Tests\TestCase;
+
+class EntrySavingMessageStoreTest extends TestCase
+{
+    private $store;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->store = new EntrySavingMessageStore();
+    }
+
+    /** @test */
+    public function it_provides_a_generic_message_if_no_custom_message_is_specified()
+    {
+        $genericMessage = __('Saved');
+
+        $this->assertMessageIs($genericMessage);
+    }
+
+    /** @test */
+    public function it_provides_an_empty_message_if_an_empty_message_is_specified()
+    {
+        $empty = '';
+
+        $this->store->addSuccessMessage($empty);
+
+        $this->assertMessageIs($empty);
+    }
+
+    /** @test */
+    public function it_provides_a_single_specified_message()
+    {
+        $customMessage = 'Changes applied!';
+
+        $this->store->addSuccessMessage($customMessage);
+
+        $this->assertMessageIs($customMessage);
+    }
+
+    /** @test */
+    public function it_provides_multiple_specified_messages()
+    {
+        $firstMessage = 'Changes applied';
+        $secondMessage = 'Notification sent';
+
+        $this->store->addSuccessMessage($firstMessage);
+        $this->store->addSuccessMessage($secondMessage);
+
+        $eol = PHP_EOL;
+        $this->assertMessageIs("$firstMessage$eol$secondMessage");
+    }
+
+    private function assertMessageIs($expected): void
+    {
+        $this->assertEquals(
+            $expected,
+            $this->store->getMessage()
+        );
+    }
+}


### PR DESCRIPTION
Closes idea [#592](https://github.com/statamic/ideas/issues/592).

Obviously stuff is still missing, but this is the basic idea of how I would like to solve this. As someone using Statamic, you can set the success message by calling `addSuccessMessage` to the event:

```php
function handle(EntrySaving $event)
{
    $event->addSuccessMessage('This is a custom message');
}
```

This message gets stored within the event and extracted later by `EntriesController`, which returns it as part of the http response as `cp_message_success`. In the frontend, this message is then simply displayed.

Right now, only the last success message that was set is displayed, but this behavior can be changed easily in `EntriesController::getSuccessMessageFrom`.

Do you have any suggestions for improvements? It I admit that this is a little bit hacky, but I had a hard time coming up with a less intrusive way.

Things that still need to be done:
- [x] Tests
- [x] Allow custom error message also when an entry is newly created.
- [x] Remove docker (I will drop the commit, I just added it for convenience).