### PR TITLE
Support Array fieldtype in GraphQL

### DIFF
--- a/src/Fieldtypes/Arr.php
+++ b/src/Fieldtypes/Arr.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Fieldtypes;
 
+use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
+use Statamic\GraphQL\Types\ArrayType;
 
 class Arr extends Fieldtype
 {
@@ -65,5 +67,10 @@ class Arr extends Fieldtype
                 return null;
             })
             ->all();
+    }
+
+    public function toGqlType()
+    {
+        return GraphQL::type(ArrayType::NAME);
     }
 }

--- a/src/GraphQL/TypeRegistrar.php
+++ b/src/GraphQL/TypeRegistrar.php
@@ -3,6 +3,7 @@
 namespace Statamic\GraphQL;
 
 use Statamic\Facades\GraphQL;
+use Statamic\GraphQL\Types\ArrayType;
 use Statamic\GraphQL\Types\AssetContainerType;
 use Statamic\GraphQL\Types\AssetInterface;
 use Statamic\GraphQL\Types\CollectionStructureType;
@@ -33,6 +34,7 @@ class TypeRegistrar
             return;
         }
 
+        GraphQL::addType(ArrayType::class);
         GraphQL::addType(JsonArgument::class);
         GraphQL::addType(DateRangeType::class);
         GraphQL::addType(SiteType::class);

--- a/src/GraphQL/Types/ArrayType.php
+++ b/src/GraphQL/Types/ArrayType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Statamic\GraphQL\Types;
+
+use GraphQL\Language\AST\Node;
+use GraphQL\Type\Definition\ScalarType;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Contracts\TypeConvertible;
+
+class ArrayType extends ScalarType implements TypeConvertible
+{
+    const NAME = 'Array';
+
+    public function serialize($value)
+    {
+        return $value;
+    }
+
+    public function parseValue($value)
+    {
+        return $value;
+    }
+
+    public function parseLiteral(Node $valueNode, ?array $variables = null)
+    {
+        return $valueNode->value;
+    }
+
+    public function toType(): Type
+    {
+        return new static();
+    }
+}

--- a/tests/Feature/GraphQL/Fieldtypes/ArrFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/ArrFieldtypeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\GraphQL\Fieldtypes;
+
+/** @group graphql */
+class ArrFieldtypeTest extends FieldtypeTestCase
+{
+    /** @test */
+    public function it_gets_arrays()
+    {
+        $keyedConfig = ['type' => 'array', 'keys' => ['foo' => 'Foo', 'bar' => 'Bar']];
+        $dynamicConfig = ['type' => 'array'];
+
+        $this->createEntryWithFields([
+            'keyed' => [
+                'value' => ['foo' => 'bar', 'baz' => 'qux'],
+                'field' => $keyedConfig,
+            ],
+            'keyed_incomplete' => [
+                'value' => ['foo' => 'bar'],
+                'field' => $keyedConfig,
+            ],
+            'keyed_undefined' => [
+                'value' => null,
+                'field' => $keyedConfig,
+            ],
+            'dynamic' => [
+                'value' => ['alfa' => 'bravo', 'charlie' => 'delta'],
+                'field' => $dynamicConfig,
+            ],
+            'dynamic_undefined' => [
+                'value' => null,
+                'field' => $dynamicConfig,
+            ],
+        ]);
+
+        $this->assertGqlEntryHas('keyed, keyed_incomplete, keyed_undefined, dynamic, dynamic_undefined', [
+            'keyed' => ['foo' => 'bar', 'baz' => 'qux'],
+            'keyed_incomplete' => ['foo' => 'bar'],
+            'keyed_undefined' => null,
+            'dynamic' => ['alfa' => 'bravo', 'charlie' => 'delta'],
+            'dynamic_undefined' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
This fixes #3961 for both dynamic and keyed arrays. It just outputs them as is:

<img width="725" alt="Screen Shot 2021-07-08 at 11 50 04" src="https://user-images.githubusercontent.com/4067531/124901824-a643db80-dfe2-11eb-8da3-56e05a22f9d6.png">
