### PR TITLE
Make Link fieldtype collections configurable

### DIFF
--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -55,7 +55,7 @@ return [
     'grid.config.min_rows' => 'Set a minimum number of creatable rows.',
     'grid.config.mode' => 'Choose your preferred layout style.',
     'grid.config.reorderable' => 'Enable to allow row reordering.',
-    'link.config.collections' => 'Entries from these collections will be available. Leaving this empty will make all entries from routable collections available.',
+    'link.config.collections' => 'Entries from these collections will be available. Leaving this empty will make entries from routable collections available.',
     'markdown.config.automatic_line_breaks' => 'Enables automatic line breaks.',
     'markdown.config.automatic_links' => 'Enables automatic linking of any URLs.',
     'markdown.config.container' => 'Choose which asset container to use for this field.',

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -55,6 +55,7 @@ return [
     'grid.config.min_rows' => 'Set a minimum number of creatable rows.',
     'grid.config.mode' => 'Choose your preferred layout style.',
     'grid.config.reorderable' => 'Enable to allow row reordering.',
+    'link.config.collections' => 'Entries from these collections will be available. Leaving this empty will make all entries from mounted collections available.',
     'markdown.config.automatic_line_breaks' => 'Enables automatic line breaks.',
     'markdown.config.automatic_links' => 'Enables automatic linking of any URLs.',
     'markdown.config.container' => 'Choose which asset container to use for this field.',

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -55,7 +55,7 @@ return [
     'grid.config.min_rows' => 'Set a minimum number of creatable rows.',
     'grid.config.mode' => 'Choose your preferred layout style.',
     'grid.config.reorderable' => 'Enable to allow row reordering.',
-    'link.config.collections' => 'Entries from these collections will be available. Leaving this empty will make all entries from mounted collections available.',
+    'link.config.collections' => 'Entries from these collections will be available. Leaving this empty will make all entries from routable collections available.',
     'markdown.config.automatic_line_breaks' => 'Enables automatic line breaks.',
     'markdown.config.automatic_links' => 'Enables automatic linking of any URLs.',
     'markdown.config.container' => 'Choose which asset container to use for this field.',


### PR DESCRIPTION
Fixes #3805. Makes the collections configurable and defaults to all mounted collections.

Part of the code is copied from a recent addition to `Fieldtypes/Bard.php`. It would be nice to add something like a `whereMounted()` method to the `Collection` facade and have this logic in one single place, but that would mean a breaking change I guess.