### PR TITLE
Make sure media previews don’t overflow in the asset editor

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -49,45 +49,46 @@
 
                 <div class="editor-preview">
 
-                    <div class="editor-preview-image" v-if="isImage">
+                    <div 
+                        v-if="asset.isImage || asset.isSvg || asset.isAudo || asset.isVideo"
+                        class="editor-preview-image"
+                    >
                         <div class="image-wrapper">
-                            <img :src="asset.preview" class="asset-thumb" />
+                            <!-- Image -->
+                            <img v-if="asset.isImage" :src="asset.preview" class="asset-thumb" />
+
+                            <!-- SVG --> 
+                            <div v-else-if="asset.isSvg" class="bg-checkerboard h-full w-full flex flex-col">
+                                <div class="flex border-b-2 border-grey-90">
+                                    <div class="flex-1 order-r p-2 border-grey-90 flex items-center justify-center">
+                                        <img :src="asset.url" class="asset-thumb w-4 h-4" />
+                                    </div>
+                                    <div class="flex-1 border-l border-r p-2 border-grey-90 flex items-center justify-center">
+                                        <img :src="asset.url" class="asset-thumb w-12 h-12" />
+                                    </div>
+                                    <div class="flex-1 border-l p-2 border-grey-90 flex items-center justify-center">
+                                        <img :src="asset.url" class="asset-thumb w-24 h-24" />
+                                    </div>
+                                </div>
+                                <div class="min-h-0 p-2 flex items-center justify-center">
+                                    <img :src="asset.url" class="asset-thumb w-2/3 max-w-full max-h-full" />
+                                </div>
+                            </div>
+
+                            <!-- Audio -->
+                            <audio v-else-if="asset.isAudio" :src="asset.url" controls preload="auto"></audio>
+
+                            <!-- Video -->
+                            <video v-else-if="asset.isVideo" :src="asset.url" controls></video>
                         </div>
                     </div>
 
-                    <div class="editor-preview-image" v-if="asset.isSvg">
-                        <div class="bg-checkerboard h-full w-full">
-                            <div class="hidden md:grid md:grid-cols-3 border-b-2 border-grey-90">
-                                <div class="border-r p-2 border-grey-90 flex items-center justify-center">
-                                    <img :src="asset.url" class="asset-thumb w-4 h-4" />
-                                </div>
-                                <div class="border-l border-r p-2 border-grey-90 flex items-center justify-center">
-                                    <img :src="asset.url" class="asset-thumb w-12 h-12" />
-                                </div>
-                                <div class="border-l p-2 border-grey-90 flex items-center justify-center">
-                                    <img :src="asset.url" class="asset-thumb w-24 h-24" />
-                                </div>
-                            </div>
-                            <div class="h-full flex items-center justify-center">
-                                <img :src="asset.url" class="asset-thumb w-2/3 max-h-screen-1/2 relative md:-top-6" />
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="audio-wrapper" v-if="asset.isAudio">
-                        <audio :src="asset.url" controls preload="auto"></audio>
-                    </div>
-
-                    <div class="video-wrapper" v-if="asset.isVideo">
-                        <video :src="asset.url" controls></video>
-                    </div>
-
-                    <div class="h-full" v-if="asset.extension == 'pdf'">
+                    <div class="h-full" v-else-if="asset.extension == 'pdf'">
                         <object :data="asset.url" type="application/pdf" width="100%" height="100%">
                         </object>
                     </div>
 
-                    <div class="h-full" v-if="asset.isPreviewable && canUseGoogleDocsViewer">
+                    <div class="h-full" v-else-if="asset.isPreviewable && canUseGoogleDocsViewer">
                         <iframe class="h-full w-full" frameborder="0" :src="'https://docs.google.com/gview?url=' + asset.permalink + '&embedded=true'"></iframe>
                     </div>
 

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -49,7 +49,7 @@
 
                 <div class="editor-preview">
 
-                    <div 
+                    <div
                         v-if="asset.isImage || asset.isSvg || asset.isAudo || asset.isVideo"
                         class="editor-preview-image"
                     >
@@ -57,7 +57,7 @@
                             <!-- Image -->
                             <img v-if="asset.isImage" :src="asset.preview" class="asset-thumb" />
 
-                            <!-- SVG --> 
+                            <!-- SVG -->
                             <div v-else-if="asset.isSvg" class="bg-checkerboard h-full w-full flex flex-col">
                                 <div class="flex border-b-2 border-grey-90">
                                     <div class="flex-1 order-r p-2 border-grey-90 flex items-center justify-center">
@@ -132,7 +132,7 @@
 
                         <div class="editor-form-fields">
                             <div v-if="error" class="bg-red text-white p-2 shadow mb-2" v-text="error" />
-                            <publish-fields 
+                            <publish-fields
                                 :fields="fields"
                                 :read-only="readOnly"
                                 @updated="setFieldValue"

--- a/resources/sass/components/assets.scss
+++ b/resources/sass/components/assets.scss
@@ -309,16 +309,8 @@
     }
 
     .image-wrapper {
-        flex: 1 1 auto;
-        position: relative;
-
-        > * {
-			@apply absolute w-auto h-auto max-w-full max-h-full;
-			box-shadow: 0 0 32px rgba(0, 0, 0, .35);
-            left: 50%;
-            top: 50%;
-            transform: translate(-50%, -50%);
-        }
+        @apply flex items-center justify-center max-w-full max-h-full h-full overflow-hidden;
+        > * { box-shadow: 0 0 32px rgba(0, 0, 0, .35); }
     }
 
     .editor-file-actions {

--- a/resources/sass/components/assets.scss
+++ b/resources/sass/components/assets.scss
@@ -308,24 +308,11 @@
         flex-direction: column;
     }
 
-    .audio-wrapper,
-    .video-wrapper {
-        align-items: center;
-        display: flex;
-        height: 100%;
-        padding: 30px;
-        audio, video {
-            box-shadow: 0 0 30px rgba(black, .35);
-            text-align: center;
-            width: 100%;
-        }
-    }
-
     .image-wrapper {
         flex: 1 1 auto;
         position: relative;
 
-        img {
+        > * {
 			@apply absolute w-auto h-auto max-w-full max-h-full;
 			box-shadow: 0 0 32px rgba(0, 0, 0, .35);
             left: 50%;

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -364,7 +364,7 @@ class Asset implements AssetContract, Augmentable
      */
     public function isVideo()
     {
-        return $this->extensionIsOneOf(['h264', 'mp4', 'm4v', 'ogv', 'webm']);
+        return $this->extensionIsOneOf(['h264', 'mp4', 'm4v', 'ogv', 'webm', 'mov']);
     }
 
     /**


### PR DESCRIPTION
Fixes #3962.

Took the new approach for image previews and applied it to SVG, audio en video previews too.