### PR TITLE
Throw a helpful exception if a referenced blueprint does not exist

### DIFF
--- a/src/Exceptions/BlueprintDoesNotExistException.php
+++ b/src/Exceptions/BlueprintDoesNotExistException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Statamic\Exceptions;
+
+class BlueprintDoesNotExistException extends \Exception
+{}

--- a/src/Exceptions/BlueprintDoesNotExistException.php
+++ b/src/Exceptions/BlueprintDoesNotExistException.php
@@ -2,5 +2,43 @@
 
 namespace Statamic\Exceptions;
 
-class BlueprintDoesNotExistException extends \Exception
-{}
+use Exception;
+use Facade\Ignition\Support\StringComparator;
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\IgnitionContracts\ProvidesSolution;
+use Facade\IgnitionContracts\Solution;
+use Statamic\Facades\Blueprint;
+use Statamic\Statamic;
+
+class BlueprintDoesNotExistException extends Exception implements ProvidesSolution
+{
+    protected $blueprintHandle;
+
+    public function __construct($blueprintHandle)
+    {
+        parent::__construct("Blueprint [{$blueprintHandle}] not found");
+
+        $this->blueprintHandle = $blueprintHandle;
+    }
+
+    public function getSolution(): Solution
+    {
+        $description = ($suggestedCollection = $this->getSuggestedCollection())
+            ? "Did you mean `$suggestedCollection`?"
+            : 'Are you sure the blueprint exists?';
+
+        return BaseSolution::create("The {$this->blueprintHandle} blueprint was not found.")
+            ->setSolutionDescription($description)
+            ->setDocumentationLinks([
+                'Read the blueprints guide' => Statamic::docsUrl('/blueprints'),
+            ]);
+    }
+
+    protected function getSuggestedCollection()
+    {
+        return StringComparator::findClosestMatch(
+            Blueprint::in('.')->map->handle()->flatten()->all(),
+            $this->blueprintHandle
+        );
+    }
+}

--- a/src/Exceptions/BlueprintNotFoundException.php
+++ b/src/Exceptions/BlueprintNotFoundException.php
@@ -13,6 +13,7 @@ use Statamic\Statamic;
 class BlueprintNotFoundException extends Exception implements ProvidesSolution
 {
     protected $blueprintHandle;
+    protected $namespace;
 
     public function __construct($blueprintHandle, $namespace = null)
     {

--- a/src/Exceptions/BlueprintNotFoundException.php
+++ b/src/Exceptions/BlueprintNotFoundException.php
@@ -10,7 +10,7 @@ use Facade\IgnitionContracts\Solution;
 use Statamic\Facades\Blueprint;
 use Statamic\Statamic;
 
-class BlueprintDoesNotExistException extends Exception implements ProvidesSolution
+class BlueprintNotFoundException extends Exception implements ProvidesSolution
 {
     protected $blueprintHandle;
 

--- a/src/Exceptions/BlueprintNotFoundException.php
+++ b/src/Exceptions/BlueprintNotFoundException.php
@@ -42,7 +42,7 @@ class BlueprintNotFoundException extends Exception implements ProvidesSolution
         }
 
         return StringComparator::findClosestMatch(
-            Blueprint::in($this->namespace)->map->handle()->flatten()->all(),
+            Blueprint::in($this->namespace)->map->handle()->values()->all(),
             $this->blueprintHandle
         );
     }

--- a/src/Exceptions/BlueprintNotFoundException.php
+++ b/src/Exceptions/BlueprintNotFoundException.php
@@ -23,7 +23,7 @@ class BlueprintNotFoundException extends Exception implements ProvidesSolution
 
     public function getSolution(): Solution
     {
-        $description = ($suggestedCollection = $this->getSuggestedCollection())
+        $description = ($suggestedCollection = $this->getSuggestedBlueprint())
             ? "Did you mean `$suggestedCollection`?"
             : 'Are you sure the blueprint exists?';
 
@@ -34,7 +34,7 @@ class BlueprintNotFoundException extends Exception implements ProvidesSolution
             ]);
     }
 
-    protected function getSuggestedCollection()
+    protected function getSuggestedBlueprint()
     {
         return StringComparator::findClosestMatch(
             Blueprint::in('.')->map->handle()->flatten()->all(),

--- a/src/Exceptions/BlueprintNotFoundException.php
+++ b/src/Exceptions/BlueprintNotFoundException.php
@@ -23,8 +23,8 @@ class BlueprintNotFoundException extends Exception implements ProvidesSolution
 
     public function getSolution(): Solution
     {
-        $description = ($suggestedCollection = $this->getSuggestedBlueprint())
-            ? "Did you mean `$suggestedCollection`?"
+        $description = ($suggestedBlueprint = $this->getSuggestedBlueprint())
+            ? "Did you mean `$suggestedBlueprint`?"
             : 'Are you sure the blueprint exists?';
 
         return BaseSolution::create("The {$this->blueprintHandle} blueprint was not found.")

--- a/src/Exceptions/BlueprintNotFoundException.php
+++ b/src/Exceptions/BlueprintNotFoundException.php
@@ -14,11 +14,12 @@ class BlueprintNotFoundException extends Exception implements ProvidesSolution
 {
     protected $blueprintHandle;
 
-    public function __construct($blueprintHandle)
+    public function __construct($blueprintHandle, $namespace = null)
     {
         parent::__construct("Blueprint [{$blueprintHandle}] not found");
 
         $this->blueprintHandle = $blueprintHandle;
+        $this->namespace = $namespace;
     }
 
     public function getSolution(): Solution
@@ -36,8 +37,12 @@ class BlueprintNotFoundException extends Exception implements ProvidesSolution
 
     protected function getSuggestedBlueprint()
     {
+        if (! $this->namespace) {
+            return null;
+        }
+
         return StringComparator::findClosestMatch(
-            Blueprint::in('.')->map->handle()->flatten()->all(),
+            Blueprint::in($this->namespace)->map->handle()->flatten()->all(),
             $this->blueprintHandle
         );
     }

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\CP\Breadcrumbs;
+use Statamic\Exceptions\BlueprintDoesNotExistException;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
@@ -75,6 +76,10 @@ class EntriesController extends CpController
         $entry = $entry->fromWorkingCopy();
 
         $blueprint = $entry->blueprint();
+
+        if (! $blueprint) {
+            throw new BlueprintDoesNotExistException("Blueprint [{$entry->get('blueprint')}] does not exist. It may have been renamed or deleted.");
+        }
 
         if (User::current()->cant('edit-other-authors-entries', [EntryContract::class, $collection, $blueprint])) {
             $blueprint->ensureFieldHasConfig('author', ['read_only' => true]);

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -78,7 +78,7 @@ class EntriesController extends CpController
         $blueprint = $entry->blueprint();
 
         if (! $blueprint) {
-            throw new BlueprintNotFoundException($entry->value('blueprint'));
+            throw new BlueprintNotFoundException($entry->value('blueprint'), 'collections/'.$collection->handle());
         }
 
         if (User::current()->cant('edit-other-authors-entries', [EntryContract::class, $collection, $blueprint])) {

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -78,7 +78,7 @@ class EntriesController extends CpController
         $blueprint = $entry->blueprint();
 
         if (! $blueprint) {
-            throw new BlueprintNotFoundException($entry->get('blueprint'));
+            throw new BlueprintNotFoundException($entry->value('blueprint'));
         }
 
         if (User::current()->cant('edit-other-authors-entries', [EntryContract::class, $collection, $blueprint])) {

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\CP\Breadcrumbs;
-use Statamic\Exceptions\BlueprintDoesNotExistException;
+use Statamic\Exceptions\BlueprintNotFoundException;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
@@ -78,7 +78,7 @@ class EntriesController extends CpController
         $blueprint = $entry->blueprint();
 
         if (! $blueprint) {
-            throw new BlueprintDoesNotExistException($entry->get('blueprint'));
+            throw new BlueprintNotFoundException($entry->get('blueprint'));
         }
 
         if (User::current()->cant('edit-other-authors-entries', [EntryContract::class, $collection, $blueprint])) {

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -78,7 +78,7 @@ class EntriesController extends CpController
         $blueprint = $entry->blueprint();
 
         if (! $blueprint) {
-            throw new BlueprintDoesNotExistException("Blueprint [{$entry->get('blueprint')}] does not exist. It may have been renamed or deleted.");
+            throw new BlueprintDoesNotExistException($entry->get('blueprint'));
         }
 
         if (User::current()->cant('edit-other-authors-entries', [EntryContract::class, $collection, $blueprint])) {


### PR DESCRIPTION
This pull request adds a helpful exception that'll be thrown if a specified blueprint does not exist. I've added an Ignition solution to the exception that'll suggest any blueprints close _ish_ to the specified one (done the same way as in the [`CollectionNotFoundException`](https://github.com/statamic/cms/blob/3.1/src/Exceptions/CollectionNotFoundException.php))

Closes #3920

## Ignition Exception

![image](https://user-images.githubusercontent.com/19637309/124981388-6b1aca00-e02d-11eb-9805-3babbda3cfe8.png)
