### PR TITLE
Stop iframe from killing Vue in Safari

### DIFF
--- a/resources/js/components/fieldtypes/VideoFieldtype.vue
+++ b/resources/js/components/fieldtypes/VideoFieldtype.vue
@@ -44,7 +44,7 @@ export default {
 
         value(value) {
             this.data = value;
-        },
+        }
 
     },
 
@@ -54,7 +54,6 @@ export default {
     },
 
     computed: {
-
         embed() {
             if (this.data.includes('youtube')) {
                 return this.data.replace('watch?v=', 'embed/');
@@ -88,9 +87,7 @@ export default {
                 this.data.includes('.mov') ||
                 this.data.includes('.webm')
             )
-        },
-
+        }
     },
-
 };
 </script>

--- a/resources/js/components/fieldtypes/VideoFieldtype.vue
+++ b/resources/js/components/fieldtypes/VideoFieldtype.vue
@@ -17,7 +17,7 @@
 
         <div class="video-preview-wrapper" v-if="isEmbeddable || isVideo">
             <div class="video-preview">
-                <iframe v-if="isEmbeddable" width="560" height="315" :src="embed" frameborder="0"></iframe>
+                <iframe v-if="isEmbeddable && canShowIframe" width="560" height="315" :src="embed" frameborder="0" allow="fullscreen"></iframe>
                 <video controls v-if="isVideo" :src="embed" width="560" height="315"></video>
             </div>
         </div>
@@ -31,7 +31,8 @@ export default {
 
     data() {
         return {
-            data: this.value || ''
+            data: this.value || '',
+            canShowIframe: false,
         }
     },
 
@@ -43,11 +44,17 @@ export default {
 
         value(value) {
             this.data = value;
-        }
+        },
 
     },
 
+    mounted() {
+        // Showing the iframe right away causes Vue to stop in Safari.
+        this.canShowIframe = true;
+    },
+
     computed: {
+
         embed() {
             if (this.data.includes('youtube')) {
                 return this.data.replace('watch?v=', 'embed/');
@@ -81,7 +88,9 @@ export default {
                 this.data.includes('.mov') ||
                 this.data.includes('.webm')
             )
-        }
+        },
+
     },
+
 };
 </script>


### PR DESCRIPTION
Fixes #3744 in the most peculiar way.

The iframe with the video caused Vue / Javascript to completely stop working in Safari. Now it doesn't anymore.