### PR TITLE
Prevent using reserved words as field handles

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -63,7 +63,6 @@ return [
     'fields_display_instructions' => 'The field\'s label shown in the Control Panel.',
     'fields_fieldsets_description' => 'Fieldsets are simple, flexible, and completely optional groupings of fields that help to organize reusable, pre-configured fields.',
     'fields_handle_instructions' => 'The field\'s template variable.',
-    'fields_handle_reserved' => 'You can\'t use \':input\' as a handle because it is a reserverd word.',
     'fields_instructions_instructions' => 'Shown under the field\'s display label, like this very text. Markdown is supported.',
     'fields_listable_instructions' => 'Control the column visibility of this field.',
     'fieldset_import_fieldset_instructions' => 'The fieldset to be imported.',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -63,6 +63,7 @@ return [
     'fields_display_instructions' => 'The field\'s label shown in the Control Panel.',
     'fields_fieldsets_description' => 'Fieldsets are simple, flexible, and completely optional groupings of fields that help to organize reusable, pre-configured fields.',
     'fields_handle_instructions' => 'The field\'s template variable.',
+    'fields_handle_reserved' => 'You can\'t use \':input\' as a handle because it is a reserverd word.',
     'fields_instructions_instructions' => 'Shown under the field\'s display label, like this very text. Markdown is supported.',
     'fields_listable_instructions' => 'Control the column visibility of this field.',
     'fieldset_import_fieldset_instructions' => 'The fieldset to be imported.',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -130,6 +130,7 @@ return [
     'origin_cannot_be_disabled' => 'Cannot select a disabled origin.',
     'unique_uri' => 'This URI has already been taken.',
     'duplicate_uri' => 'Duplicate URI :value',
+    'reserved' => 'This is a reserved word.',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -260,9 +260,9 @@ class Fields
         return Validator::make()->fields($this);
     }
 
-    public function validate($extraRules = [])
+    public function validate($extraRules = [], $customMessages = [])
     {
-        return $this->validator()->withRules($extraRules)->validate();
+        return $this->validator()->withRules($extraRules)->withMessages($customMessages)->validate();
     }
 
     public function toGql()

--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -12,6 +12,7 @@ class Validator
     protected $fields;
     protected $replacements = [];
     protected $extraRules = [];
+    protected $customMessages = [];
 
     public function make()
     {
@@ -28,6 +29,13 @@ class Validator
     public function withRules($rules)
     {
         $this->extraRules = $rules;
+
+        return $this;
+    }
+
+    public function withMessages($messages)
+    {
+        $this->customMessages = $messages;
 
         return $this;
     }
@@ -83,7 +91,7 @@ class Validator
         return LaravelValidator::validate(
             $this->fields->preProcessValidatables()->values()->all(),
             $this->rules(),
-            [],
+            $this->customMessages,
             $this->fieldAttributes()
         );
     }

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -70,16 +70,16 @@ class FieldsController extends CpController
     protected function blueprint($blueprint)
     {
         $reserverd = [
+            'content_type',
             'elseif',
             'endif',
             'endunless',
             'if',
+            'length',
             'reference',
             'resource',
             'unless',
             'value',
-            'content_type',
-            'length',
         ];
 
         $prepends = collect([

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -8,6 +8,12 @@ use Statamic\Http\Controllers\CP\CpController;
 
 class FieldsController extends CpController
 {
+    protected $reserverd = [
+        'content_type',
+        'length',
+        'slug',
+    ];
+
     public function __construct()
     {
         $this->middleware(\Illuminate\Auth\Middleware\Authorize::class.':configure fields');
@@ -58,6 +64,10 @@ class FieldsController extends CpController
             ->addValues($request->values)
             ->process();
 
+        $fields->validate([], [
+            'handle.not_in' => __('statamic::messages.fields_handle_reserved'),
+        ]);
+
         $values = array_merge($request->values, $fields->values()->all());
 
         return $values;
@@ -76,6 +86,7 @@ class FieldsController extends CpController
                 'display' => __('Handle'),
                 'instructions' => __('statamic::messages.fields_handle_instructions'),
                 'type' => 'text',
+                'validate' => 'required|not_in:'.join(',', $this->reserverd),
                 'width' => 50,
             ],
             'instructions' => [

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -8,12 +8,6 @@ use Statamic\Http\Controllers\CP\CpController;
 
 class FieldsController extends CpController
 {
-    protected $reserverd = [
-        'content_type',
-        'length',
-        'slug',
-    ];
-
     public function __construct()
     {
         $this->middleware(\Illuminate\Auth\Middleware\Authorize::class.':configure fields');
@@ -75,6 +69,19 @@ class FieldsController extends CpController
 
     protected function blueprint($blueprint)
     {
+        $reserverd = [
+            'elseif',
+            'endif',
+            'endunless',
+            'if',
+            'reference',
+            'resource',
+            'unless',
+            'value',
+            'content_type',
+            'length',
+        ];
+
         $prepends = collect([
             'display' => [
                 'display' => __('Display'),
@@ -86,7 +93,7 @@ class FieldsController extends CpController
                 'display' => __('Handle'),
                 'instructions' => __('statamic::messages.fields_handle_instructions'),
                 'type' => 'text',
-                'validate' => 'required|not_in:'.join(',', $this->reserverd),
+                'validate' => 'required|not_in:'.join(',', $reserverd),
                 'width' => 50,
             ],
             'instructions' => [

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -59,7 +59,7 @@ class FieldsController extends CpController
             ->process();
 
         $fields->validate([], [
-            'handle.not_in' => __('statamic::messages.fields_handle_reserved'),
+            'handle.not_in' => __('statamic::validation.reserved'),
         ]);
 
         $values = array_merge($request->values, $fields->values()->all());

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -69,7 +69,7 @@ class FieldsController extends CpController
 
     protected function blueprint($blueprint)
     {
-        $reserverd = [
+        $reserved = [
             'content_type',
             'elseif',
             'endif',
@@ -93,7 +93,7 @@ class FieldsController extends CpController
                 'display' => __('Handle'),
                 'instructions' => __('statamic::messages.fields_handle_instructions'),
                 'type' => 'text',
-                'validate' => 'required|not_in:'.join(',', $reserverd),
+                'validate' => 'required|not_in:'.implode(',', $reserved),
                 'width' => 50,
             ],
             'instructions' => [

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -79,7 +79,7 @@ class FieldsController extends CpController
             'reference',
             'resource',
             'unless',
-            'value',
+            'value', // todo: can be removed when https://github.com/statamic/cms/issues/2495 is resolved
         ];
 
         $prepends = collect([

--- a/tests/Fields/FieldsTest.php
+++ b/tests/Fields/FieldsTest.php
@@ -738,6 +738,7 @@ class FieldsTest extends TestCase
         Validator::shouldReceive('make')->once()->andReturnSelf();
         Validator::shouldReceive('fields')->once()->andReturnSelf();
         Validator::shouldReceive('withRules')->with([])->once()->andReturnSelf();
+        Validator::shouldReceive('withMessages')->with([])->once()->andReturnSelf();
         Validator::shouldReceive('validate')->once();
 
         $fields->validate();
@@ -750,6 +751,7 @@ class FieldsTest extends TestCase
         Validator::shouldReceive('make')->once()->andReturnSelf();
         Validator::shouldReceive('fields')->once()->andReturnSelf();
         Validator::shouldReceive('withRules')->with(['foo' => 'bar'])->once()->andReturnSelf();
+        Validator::shouldReceive('withMessages')->with([])->once()->andReturnSelf();
         Validator::shouldReceive('validate')->once();
 
         $fields->validate(['foo' => 'bar']);


### PR DESCRIPTION
This is an implementation for [idea #46](https://github.com/statamic/ideas/issues/46) and a partial fix for #3956.

It adds the mechanics for checking for reserved words and notifying the user in a meaningful way. The list of reserved words can (and probably should) be extended in the future of course.