### PR TITLE
feat: add attributes to the Site config

### DIFF
--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -55,6 +55,11 @@ class Site implements Augmentable
         return $this->config['direction'] ?? 'ltr';
     }
 
+    public function attributes()
+    {
+        return $this->config['attributes'] ?? [];
+    }
+
     public function absoluteUrl()
     {
         if (Str::startsWith($url = $this->url(), '/')) {
@@ -91,6 +96,7 @@ class Site implements Augmentable
             'short_locale' => $this->shortLocale(),
             'url' => $this->url(),
             'direction' => $this->direction(),
+            'attributes' => $this->attributes(),
         ];
     }
 

--- a/tests/Sites/SiteTest.php
+++ b/tests/Sites/SiteTest.php
@@ -237,6 +237,7 @@ class SiteTest extends TestCase
             'short_locale' => 'en',
             'url' => 'http://test.com',
             'direction' => 'ltr',
+            'attributes' => [],
         ], $values->all());
 
         $this->assertEquals(


### PR DESCRIPTION
Closes https://github.com/statamic/ideas/issues/602

If this is accepted, I can also update the docs before it will be merged.

now you can define site-specific `attributes` in your `config/statamic/sites.php`
This is useful if you want to define different themes per site for example.

```php
<?php

return [
    'sites' => [
        'default' => [
            'name' => config('app.name'),
            'locale' => 'en_US',
            'url' => '/',

            'attributes' => [
                'theme' => 'default',
            ],
        ]
    ]
];
```

This can now be used to set a class:
```html
<body class="theme-{{ site:attributes:theme }}">
    <!-- [...] -->
</body>
```