### PR TITLE
Consolidate Stache's `getItemFilter` and `getFileFilter`

### DIFF
--- a/src/Stache/Stores/BasicStore.php
+++ b/src/Stache/Stores/BasicStore.php
@@ -8,14 +8,9 @@ use Symfony\Component\Finder\SplFileInfo;
 
 abstract class BasicStore extends Store
 {
-    public function getFileFilter(SplFileInfo $file)
-    {
-        return $file->getExtension() === 'yaml';
-    }
-
     public function getItemFilter(SplFileInfo $file)
     {
-        return $this->getFileFilter($file);
+        return $file->getExtension() === 'yaml';
     }
 
     abstract public function makeItemFromFile($path, $contents);

--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -25,7 +25,7 @@ class CollectionEntriesStore extends ChildStore
         return $this->collection ?? Collection::findByHandle($this->childKey);
     }
 
-    public function getFileFilter(SplFileInfo $file)
+    public function getItemFilter(SplFileInfo $file)
     {
         $dir = str_finish($this->directory(), '/');
         $relative = Path::tidy($file->getPathname());

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -21,7 +21,7 @@ class CollectionsStore extends BasicStore
         return $item->handle();
     }
 
-    public function getFileFilter(SplFileInfo $file)
+    public function getItemFilter(SplFileInfo $file)
     {
         $dir = str_finish($this->directory, '/');
         $relative = str_after(Path::tidy($file->getPathname()), $dir);

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -179,7 +179,7 @@ abstract class Store
         $existing = collect(Cache::get($cacheKey, []));
 
         // Get the files and timestamps from the filesystem right now.
-        $files = Traverser::filter([$this, 'getFileFilter'])->traverse($this);
+        $files = Traverser::filter([$this, 'getItemFilter'])->traverse($this);
 
         // Cache the files and timestamps, ready for comparisons on the next request.
         // We'll do it now since there are multiple early returns coming up.

--- a/src/Stache/Stores/TaxonomiesStore.php
+++ b/src/Stache/Stores/TaxonomiesStore.php
@@ -24,7 +24,7 @@ class TaxonomiesStore extends BasicStore
         return $item->handle();
     }
 
-    public function getFileFilter(SplFileInfo $file)
+    public function getItemFilter(SplFileInfo $file)
     {
         $filename = str_after(Path::tidy($file->getPathName()), $this->directory);
 

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -26,7 +26,7 @@ class TaxonomyTermsStore extends ChildStore
         'site' => Indexes\Terms\Site::class,
     ];
 
-    public function getFileFilter(SplFileInfo $file)
+    public function getItemFilter(SplFileInfo $file)
     {
         $dir = str_finish($this->directory(), '/');
         $relative = $file->getPathname();

--- a/src/Stache/Stores/UsersStore.php
+++ b/src/Stache/Stores/UsersStore.php
@@ -6,7 +6,6 @@ use Statamic\Facades\User;
 use Statamic\Facades\UserGroup;
 use Statamic\Facades\YAML;
 use Statamic\Stache\Indexes\Users\Group;
-use Symfony\Component\Finder\SplFileInfo;
 
 class UsersStore extends BasicStore
 {
@@ -49,10 +48,5 @@ class UsersStore extends BasicStore
         // $this->queueGroups($user);
 
         return $user;
-    }
-
-    public function filter(SplFileInfo $file)
-    {
-        return $file->getExtension() === 'yaml';
     }
 }


### PR DESCRIPTION
These two methods were doing essentially exactly the same thing.

Maybe once upon a time they were doing different things, but right now it's the same.
It takes a file and checks whether its applicable to a respective Stache store. (e.g. ignore non-yaml files in the globals directory)

When the cache gets built, it was using `getItemFilter`, but in the file change handler (where it detects if you've manually saved files) it was using `getFileFilter`.
While reviewing #3948 I noticed that I was still getting the error when I'd manually save a tree yaml file, but it would work fine on a fresh cache. That's why.

Then there's the poor `filter` method on the `UsersStore` who hasn't done anything for even longer. It wasn't renamed to `getItemFilter` whenever that happened everywhere else.