### PR TITLE
Support collections in the `reverse` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1714,6 +1714,10 @@ class CoreModifiers extends Modifier
      */
     public function reverse($value)
     {
+        if ($value instanceof Collection) {
+            return $value->reverse();
+        }
+
         if (is_array($value)) {
             return array_reverse($value);
         }


### PR DESCRIPTION
The modifier isn't able to handle collections which is what arrays get augmented into when passed to the view. This PR adds support for the augmented collection.