### PR TITLE
Allow static cache bypass for logged in users, or when user has role.

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -31,12 +31,24 @@ return [
         'half' => [
             'driver' => 'application',
             'expiry' => null,
+            'bypass' => [
+                'logged_in' => false,
+                'roles' => [
+                    //
+                ],
+            ],
         ],
 
         'full' => [
             'driver' => 'file',
             'path' => public_path('static'),
             'lock_hold_length' => 0,
+            'bypass' => [
+                'logged_in' => false,
+                'roles' => [
+                    //
+                ],
+            ],
         ],
 
     ],


### PR DESCRIPTION
Allows the Static Cache to be bypassed under certain conditions.
I have allowed the following options:
* Bypass if the User is logged in or Bypass if the User has a particular role.
* Role bypasses take priority over user logged in bypasses.

To enable it, the `static_cache.php` config file will need to be updated with one of the below examples.

`Bypass if user has role`
```php
    'strategies' => [

        'half' => [
            'driver' => 'application',
            'expiry' => null,
            'bypass' => [
                'logged_in' => false,
                'roles' => [
                    'bypass_cache_role'
                ],
            ],
        ],
```

`Bypass for logged in users`
```php
    'strategies' => [

        'half' => [
            'driver' => 'application',
            'expiry' => null,
            'bypass' => [
                'logged_in' => true,
                'roles' => [
                    //
                ],
            ],
        ],
```

This could probably be expanded to include cookies or such, which might make it possible to use the full cache for guests but no cache or possibly half cache for logged in users.

I'd imagine this could be done by using something like (untested/unconfirmed).

`nginx`
```nginx
if ($http_cookie ~* "statamic_session") {
    location / {
        try_files $uri $uri/ /index.php?$query_string;
    }
}

location / {
  try_files /static${uri}_${args}.html $uri /index.php?$args;
}
```

`htaccess`
```htaccess
<IfModule mod_rewrite.c>
    <IfModule mod_negotiation.c>
        Options -MultiViews -Indexes
    </IfModule>

    RewriteEngine On

    # Handle Authorization Header
    RewriteCond %{HTTP:Authorization} .
    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]

    # Redirect Trailing Slashes If Not A Folder...
    RewriteCond %{REQUEST_FILENAME} !-d
    RewriteCond %{REQUEST_URI} (.+)/$
    RewriteRule ^ %1 [L,R=301]
    
    # Bypass Cache if Cookie exists
    RewriteCond %{HTTP_COOKIE} !statamic_session=
    RewriteCond %{DOCUMENT_ROOT}/static/%{REQUEST_URI}_%{QUERY_STRING}\.html -s
    RewriteCond %{REQUEST_METHOD} GET
    RewriteRule .* static/%{REQUEST_URI}_%{QUERY_STRING}\.html [L,T=text/html]

    # Send Requests To Front Controller...
    RewriteCond %{REQUEST_FILENAME} !-d
    RewriteCond %{REQUEST_FILENAME} !-f
    RewriteRule ^ index.php [L]
</IfModule>
```

Open to ideas and hopeful expansion upon this.

Thanks. 