### PR TITLE
Enhance foreach tag to support dynamic variables 

### DIFF
--- a/src/Tags/Iterate.php
+++ b/src/Tags/Iterate.php
@@ -13,7 +13,7 @@ class Iterate extends Tags
      */
     public function index()
     {
-        return $this->wildcard($this->params->get('array'));
+        return $this->iterate($this->params->get('array'));
     }
 
     /**
@@ -26,11 +26,14 @@ class Iterate extends Tags
      */
     public function wildcard($tag)
     {
+        return $this->iterate($this->context->get($tag));
+    }
+
+    protected function iterate($items)
+    {
         [$keyKey, $valueKey] = $this->getKeyNames();
 
-        $tag = $this->context->get($tag) ?? $tag;
-
-        $items = collect($tag)
+        $items = collect($items)
             ->map(function ($value, $key) use ($keyKey, $valueKey) {
                 return [$keyKey => $key, $valueKey => $value];
             });

--- a/src/Tags/Iterate.php
+++ b/src/Tags/Iterate.php
@@ -7,6 +7,16 @@ class Iterate extends Tags
     protected static $aliases = ['foreach'];
 
     /**
+     * Maps to the {{ iterate }} tag.
+     *
+     * @return mixed
+     */
+    public function index()
+    {
+        return $this->wildcard($this->params->get('array'));
+    }
+
+    /**
      * Maps to the {{ iterate:fieldname }} tag.
      *
      * Also maps to {{ foreach:fieldname }}.
@@ -18,7 +28,9 @@ class Iterate extends Tags
     {
         [$keyKey, $valueKey] = $this->getKeyNames();
 
-        $items = collect($this->context->get($tag))
+        $tag = $this->context->get($tag) ?? $tag;
+
+        $items = collect($tag)
             ->map(function ($value, $key) use ($keyKey, $valueKey) {
                 return [$keyKey => $key, $valueKey => $value];
             });


### PR DESCRIPTION
This PR adds the option to pass a variable by parameter. This makes it possible use dynamic variables:

```html
{{ foreach :array="fields[field].options" }}
    ...
{{ /foreach }}
```