### PR TITLE
Fix validation on blueprint editor

### DIFF
--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -55,14 +55,13 @@ class FieldsController extends CpController
 
         $fields = $blueprint
             ->fields()
-            ->addValues($request->values)
-            ->process();
+            ->addValues($request->values);
 
         $fields->validate([], [
             'handle.not_in' => __('statamic::validation.reserved'),
         ]);
 
-        $values = array_merge($request->values, $fields->values()->all());
+        $values = array_merge($request->values, $fields->process()->values()->all());
 
         return $values;
     }


### PR DESCRIPTION
Fixes #4007

By calling process() _before_ validate(), it was using the processed values for validation. It shouldn't.
In the case of #4007, that meant it would convert the array into a string because the field had max_files: 1. Then the validation would fail because it was expecting an array.
