### PR TITLE
Command to warm the static cache

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Statamic\Console\Commands;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Pool;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Console\Command;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Collection;
+use Statamic\Console\EnhancesCommands;
+use Statamic\Console\RunsInPlease;
+use Statamic\Entries\Collection as EntriesCollection;
+use Statamic\Entries\Entry as Entry;
+use Statamic\Facades;
+use Statamic\Facades\URL;
+use Statamic\Http\Controllers\FrontendController;
+use Statamic\Support\Str;
+use Statamic\Taxonomies\Taxonomy;
+
+class StaticWarm extends Command
+{
+    use RunsInPlease;
+    use EnhancesCommands;
+
+    protected $name = 'statamic:static:warm';
+    protected $description = "Warms the static cache by visiting all URL's.";
+
+    public function handle()
+    {
+        $this->info('Warming the static cache.');
+
+        $this->warm();
+
+        return 0;
+    }
+
+    private function warm(): void
+    {
+        $client = new Client();
+
+        $uris = $this->uris();
+
+        $pool = new Pool($client, $this->requests(), [
+            'fulfilled' => function (Response $response, $index) use ($uris) {
+                $this->checkLine($uris->get($index));
+            },
+            'rejected' => function (RequestException $e, $index) use ($uris) {
+                $this->crossLine($uris->get($index));
+            },
+        ]);
+
+        $promise = $pool->promise();
+
+        $promise->wait();
+    }
+
+    private function requests(): array
+    {
+        return $this->uris()->map(function ($uri) {
+            return new Request('GET', $uri);
+        })->all();
+    }
+
+    private function uris(): Collection
+    {
+        return collect()
+            ->merge($this->customRoutes())
+            ->merge($this->entries())
+            ->merge($this->terms())
+            ->merge($this->scopedTerms()) // TODO obsolete?
+            ->unique()
+            ->values();
+    }
+
+    protected function customRoutes(): Collection
+    {
+        // TODO test
+        return collect(app('router')->getRoutes()->getRoutes())
+            ->filter(function ($route) {
+                return $route->getActionName() === FrontendController::class . '@route'
+                    && !Str::contains($route->uri(), '{');
+            })
+            ->map(function (Route $route) {
+                return URL::tidy(Str::start($route->uri(), config('app.url') . '/'));
+            });
+    }
+
+    protected function entries(): Collection
+    {
+        return Facades\Entry::all()
+            ->reject(function (Entry $entry) {
+                return is_null($entry->uri());
+            })
+            ->filter(function (Entry $entry) {
+                return $entry->published();
+            })
+            ->map->absoluteUrl();
+    }
+
+    protected function terms(): Collection
+    {
+        return Facades\Term::all()
+            ->map->absoluteUrl();
+    }
+
+    // TODO Obsolete?
+    protected function scopedTerms(): Collection
+    {
+        return Facades\Collection::all()
+            ->flatMap(function (EntriesCollection $collection) {
+                return $this->getCollectionTerms($collection);
+            })
+            ->map->absoluteUrl();
+    }
+
+    // TODO Obsolete?
+    protected function getCollectionTerms($collection)
+    {
+        return $collection->taxonomies()
+            ->flatMap(function (Taxonomy $taxonomy) {
+                return $taxonomy->queryTerms()->get();
+            })
+            ->map->collection($collection);
+    }
+}

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -81,7 +81,7 @@ class StaticWarm extends Command
         return collect(app('router')->getRoutes()->getRoutes())
             ->filter(function ($route) {
                 return $route->getActionName() === FrontendController::class.'@route'
-                    && !Str::contains($route->uri(), '{');
+                    && ! Str::contains($route->uri(), '{');
             })
             ->map(function (Route $route) {
                 return URL::tidy(Str::start($route->uri(), config('app.url').'/'));

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -39,9 +39,11 @@ class StaticWarm extends Command
             return 1;
         }
 
-        $this->info('Warming the static cache.');
+        $this->line('Warming the static cache...');
 
         $this->warm();
+
+        $this->info('The static cache has been warmed.');
 
         return 0;
     }

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -80,11 +80,11 @@ class StaticWarm extends Command
         // TODO test
         return collect(app('router')->getRoutes()->getRoutes())
             ->filter(function ($route) {
-                return $route->getActionName() === FrontendController::class . '@route'
+                return $route->getActionName() === FrontendController::class.'@route'
                     && !Str::contains($route->uri(), '{');
             })
             ->map(function (Route $route) {
-                return URL::tidy(Str::start($route->uri(), config('app.url') . '/'));
+                return URL::tidy(Str::start($route->uri(), config('app.url').'/'));
             });
     }
 

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -64,6 +64,8 @@ class StaticWarm extends Command
 
     private function outputResponseLine(string $uri, Response $response): void
     {
+        $uri = Str::start(Str::after($uri, config('app.url')), '/');
+
         $response->ok() ? $this->checkLine($uri) : $this->crossLine($uri);
     }
 

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -33,6 +33,12 @@ class StaticWarm extends Command
             return 1;
         }
 
+        if (! config('statamic.static_caching.strategy')) {
+            $this->error('Static caching is not enabled.');
+
+            return 1;
+        }
+
         $this->info('Warming the static cache.');
 
         $this->warm();

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -70,7 +70,7 @@ class StaticWarm extends Command
             ->merge($this->customRoutes())
             ->merge($this->entries())
             ->merge($this->terms())
-            ->merge($this->scopedTerms()) // TODO obsolete?
+            ->merge($this->scopedTerms()) // TODO Obsolete now that all terms have are saved as a file?
             ->unique()
             ->values();
     }

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -23,7 +23,7 @@ class StaticWarm extends Command
     use EnhancesCommands;
 
     protected $name = 'statamic:static:warm';
-    protected $description = "Warms the static cache by visiting all URL's.";
+    protected $description = 'Warms the static cache by visiting all URLs.';
 
     public function handle()
     {

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -27,6 +27,12 @@ class StaticWarm extends Command
 
     public function handle()
     {
+        if (version_compare(app()->version(), '8', '<')) {
+            $this->error('Laravel version must be at least 8.0.0 to use this command.');
+
+            return 1;
+        }
+
         $this->info('Warming the static cache.');
 
         $this->warm();

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -30,6 +30,7 @@ class ConsoleServiceProvider extends ServiceProvider
         Commands\StacheWarm::class,
         Commands\StacheDoctor::class,
         Commands\StaticClear::class,
+        Commands\StaticWarm::class,
         // Commands\MakeUserMigration::class,
         Commands\SupportDetails::class,
         Commands\AuthMigration::class,


### PR DESCRIPTION
This is a continuation of #3745 by @edalzell, which was closed 25 days ago. I think this command will be a very welcome addition to the toolbox and Erin was okay with me taking over. So here we go.

- [x] Revive the original code
- [x] Make it compatible with older Laravel versions (< 8) by using `GuzzleHttp\Pool` instead of `Illuminate\Http\Client\Pool`
- [x] Make it compatible with PHP 7.2.5+ (instead of 7.4+) by (sadly) dropping the arrow notation for anonymous functions
- [x] Test properly and check for completeness 