### PR TITLE
CollectionTreeStore should use relative path name

### DIFF
--- a/src/Stache/Stores/CollectionTreeStore.php
+++ b/src/Stache/Stores/CollectionTreeStore.php
@@ -19,7 +19,7 @@ class CollectionTreeStore extends NavTreeStore
             return false;
         }
 
-        [, $handle] = $this->parseTreePath($file->getPathname());
+        [, $handle] = $this->parseTreePath($file->getRelativePathname());
 
         if (! ($collection = Collection::findByHandle($handle))) {
             return false;


### PR DESCRIPTION
Fixes issue with returning a full path on Windows - #4018