### PR TITLE
Tidy tree path before parsing

### DIFF
--- a/src/Stache/Stores/CollectionTreeStore.php
+++ b/src/Stache/Stores/CollectionTreeStore.php
@@ -3,6 +3,7 @@
 namespace Statamic\Stache\Stores;
 
 use Statamic\Facades\Collection;
+use Statamic\Facades\Path;
 use Statamic\Structures\CollectionTree;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -19,7 +20,7 @@ class CollectionTreeStore extends NavTreeStore
             return false;
         }
 
-        [, $handle] = $this->parseTreePath($file->getPathname());
+        [, $handle] = $this->parseTreePath(Path::tidy($file->getPathname()));
 
         if (! ($collection = Collection::findByHandle($handle))) {
             return false;


### PR DESCRIPTION
Fixes #4018.

I ended up with tidying the path on the spot, using the same approach as in `Statamic\Stache\Traverser->traverse()`. No need to worry what kind of (mix of) (back)slashes any specific `SplInfo` method returns.