### PR TITLE
HOME or COMPOSER_HOME environment variable - continued

### DIFF
--- a/config/system.php
+++ b/config/system.php
@@ -112,21 +112,4 @@ return [
     'ajax_timeout' => '600000',
     'pcre_backtrack_limit' => '-1',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Process Environment Variables
-    |--------------------------------------------------------------------------
-    |
-    | External processes (e.g. Composer) may require additional environment
-    | variables to be explicitly made available. Here you may add a list
-    | of vars that you would like to be passed along from Statamic.
-    |
-    */
-
-    'process_environment_variables' => [
-        // 'HOME',
-        // 'COMPOSER_HOME',
-        // 'COMPOSER_AUTH',
-    ],
-
 ];

--- a/config/system.php
+++ b/config/system.php
@@ -112,4 +112,21 @@ return [
     'ajax_timeout' => '600000',
     'pcre_backtrack_limit' => '-1',
 
+    /*
+    |--------------------------------------------------------------------------
+    | System Environment Variables
+    |--------------------------------------------------------------------------
+    |
+    | Sometimes external processes `Composer` require additional environment variables.
+    | Here you can add any variables from getenv() that you would like to pass from Statamic.
+    | Simply specifiy the environment variable by name, example: 'HOME' will return the value of getenv('HOME')
+    |
+    | HOME and LARAVEL_SAIL will automatically attempt to be passed to the process.
+    */
+    'system_environment_variables' => [
+        // 'HOME',
+        // 'COMPOSER_HOME',
+        // 'COMPOSER_AUTH',
+    ],
+
 ];

--- a/config/system.php
+++ b/config/system.php
@@ -114,16 +114,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | System Environment Variables
+    | Process Environment Variables
     |--------------------------------------------------------------------------
     |
-    | Sometimes external processes `Composer` require additional environment variables.
-    | Here you can add any variables from getenv() that you would like to pass from Statamic.
-    | Simply specifiy the environment variable by name, example: 'HOME' will return the value of getenv('HOME')
+    | External processes (e.g. Composer) may require additional environment
+    | variables to be explicitly made available. Here you may add a list
+    | of vars that you would like to be passed along from Statamic.
     |
-    | HOME and LARAVEL_SAIL will automatically attempt to be passed to the process.
     */
-    'system_environment_variables' => [
+
+    'process_environment_variables' => [
         // 'HOME',
         // 'COMPOSER_HOME',
         // 'COMPOSER_AUTH',

--- a/src/Console/Processes/Process.php
+++ b/src/Console/Processes/Process.php
@@ -65,21 +65,11 @@ class Process
     {
         $env = collect(getenv())->only(['HOME', 'LARAVEL_SAIL']);
 
-        if (! $env->has('HOME') && $this->isRunningInSail()) {
+        if (! $env->has('HOME') && $env->get('LARAVEL_SAIL') === '1') {
             $env['HOME'] = '/home/sail';
         }
 
         return $env->all();
-    }
-
-    /**
-     * Check to see if Statamic is running in Laravel Sail.
-     *
-     * @return bool
-     */
-    protected function isRunningInSail(): bool
-    {
-        return isset($this->env['LARAVEL_SAIL']) && $this->env['LARAVEL_SAIL'] === '1';
     }
 
     /**

--- a/src/Console/Processes/Process.php
+++ b/src/Console/Processes/Process.php
@@ -3,6 +3,7 @@
 namespace Statamic\Console\Processes;
 
 use Closure;
+use Composer\Util\Platform;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Statamic\Support\Arr;
@@ -315,10 +316,23 @@ class Process
             $command = (string) $command;
         }
 
+        $composerEnv = [
+            'HOME' => getenv('HOME'),
+            // 'COMPOSER_HOME' => getenv('COMPOSER_HOME'),
+            // 'COMPOSER_CACHE_DIR' => getenv('COMPOSER_CACHE_DIR'),
+            // 'COMPOSER_AUTH' => getenv('COMPOSER_AUTH'),
+            // 'USERPROFILE' => getenv('USERPROFILE'),
+        ];
+
+        // if (Platform::isWindows()) {
+        //     $composerEnv['APPDATA'] = getenv('APPDATA');
+        //     $composerEnv['LOCALAPPDATA'] = getenv('LOCALAPPDATA');
+        // }
+
         // Handle both string and array command formats.
         $process = is_string($command) && method_exists(SymfonyProcess::class, 'fromShellCommandLine')
-            ? SymfonyProcess::fromShellCommandline($command, $path ?? $this->basePath, ['HOME' => getenv('HOME')])
-            : new SymfonyProcess($command, $path ?? $this->basePath, ['HOME' => getenv('HOME')]);
+            ? SymfonyProcess::fromShellCommandline($command, $path ?? $this->basePath, $composerEnv)
+            : new SymfonyProcess($command, $path ?? $this->basePath, $composerEnv);
 
         $process->setTimeout(null);
 

--- a/src/Console/Processes/Process.php
+++ b/src/Console/Processes/Process.php
@@ -63,14 +63,12 @@ class Process
      */
     protected function constructEnv()
     {
-        $filteredEnv = array_merge([
+        $keys = array_merge([
             'HOME',
             'LARAVEL_SAIL',
-        ], config('statamic.system.system_environment_variables', []));
+        ], config('statamic.system.process_environment_variables', []));
 
-        $this->env = collect(getenv())
-            ->only($filteredEnv)
-            ->toArray();
+        $this->env = collect(getenv())->only($keys)->all();
 
         if ($this->isRunningInSail() && ! isset($this->env['HOME'])) {
             $this->env['HOME'] = '/home/sail';

--- a/src/Console/Processes/Process.php
+++ b/src/Console/Processes/Process.php
@@ -53,26 +53,23 @@ class Process
     {
         $this->basePath = str_finish($basePath ?? base_path(), '/');
 
-        $this->constructEnv();
+        $this->env = $this->constructEnv();
     }
 
     /**
      * Construct the environment variables that will be passed to the process.
      *
-     * @return void
+     * @return array
      */
     protected function constructEnv()
     {
-        $keys = array_merge([
-            'HOME',
-            'LARAVEL_SAIL',
-        ], config('statamic.system.process_environment_variables', []));
+        $env = collect(getenv())->only(['HOME', 'LARAVEL_SAIL']);
 
-        $this->env = collect(getenv())->only($keys)->all();
-
-        if ($this->isRunningInSail() && ! isset($this->env['HOME'])) {
-            $this->env['HOME'] = '/home/sail';
+        if (! $env->has('HOME') && $this->isRunningInSail()) {
+            $env['HOME'] = '/home/sail';
         }
+
+        return $env->all();
     }
 
     /**


### PR DESCRIPTION
It appears that a few people are still having issues with
```
In Factory.php line 677:
                                                                               
  The HOME or COMPOSER_HOME environment variable must be set for composer to   
  run correctly 
```
There might be more ENV needed to expand upon https://github.com/statamic/cms/pull/3734 

Pending the results of https://github.com/statamic/cms/issues/3383 