### PR TITLE
Filter available globals for selected site (fix #1636, #2319, #3883)

### DIFF
--- a/src/CP/Navigation/CoreNav.php
+++ b/src/CP/Navigation/CoreNav.php
@@ -121,7 +121,9 @@ class CoreNav
             ->icon('earth')
             ->can('index', GlobalSet::class)
             ->children(function () {
-                return GlobalSetAPI::all()->sortBy->title()->map(function ($globalSet) {
+                return GlobalSetAPI::all()->filter(function ($globalSet) {
+                    return $globalSet->in(Site::selected()->handle()) !== null;
+                })->sortBy->title()->map(function ($globalSet) {
                     $globalSet = $globalSet->in(Site::selected()->handle());
 
                     return Nav::item($globalSet->title())

--- a/src/Http/Controllers/CP/Globals/GlobalsController.php
+++ b/src/Http/Controllers/CP/Globals/GlobalsController.php
@@ -18,6 +18,8 @@ class GlobalsController extends CpController
     {
         $globals = GlobalSet::all()->filter(function ($set) {
             return User::current()->can('view', $set);
+        })->filter(function ($set) {
+            return $set->in(Site::selected()->handle()) !== null;
         })->tap(function ($globals) {
             $this->authorizeIf($globals->isEmpty(), 'create', GlobalSetContract::class);
         })->map(function ($set) {


### PR DESCRIPTION
This fixes the errors described in the mentioned bugs (#1636, #2319, #3883) by only showing the globals available for the selected site in a multisite setup.