### PR TITLE
Fix explicit `'fit' => 'crop_focal'` in configured glide presets.

### DIFF
--- a/src/Imaging/Manager.php
+++ b/src/Imaging/Manager.php
@@ -3,6 +3,7 @@
 namespace Statamic\Imaging;
 
 use Statamic\Contracts\Imaging\ImageManipulator;
+use Statamic\Support\Arr;
 
 class Manager
 {
@@ -63,7 +64,11 @@ class Manager
      */
     public function userManipulationPresets()
     {
-        return config('statamic.assets.image_manipulation.presets', []);
+        return collect(config('statamic.assets.image_manipulation.presets', []))
+            ->map(function ($preset) {
+                return $this->normalizePreset($preset);
+            })
+            ->all();
     }
 
     /**
@@ -86,5 +91,23 @@ class Manager
     public function getCpImageManipulationPresets()
     {
         return $this->cpManipulationPresets();
+    }
+
+    /**
+     * Normalize preset.
+     *
+     * @param array $preset
+     * @return array
+     */
+    protected function normalizePreset($preset)
+    {
+        // When explicitly setting `crop_focal` in a preset, it breaks cropping
+        // altogether. Statamic's glide tag will automatically respect focal
+        // points though, so we can remove this parameter from the preset.
+        if (Arr::get($preset, 'fit') === 'crop_focal') {
+            Arr::forget($preset, 'fit');
+        }
+
+        return $preset;
     }
 }


### PR DESCRIPTION
This works fine (and crops while respecting the image's focal point):

```php
'presets' => [
    'small' => ['w' => 80, 'h' => 80, 'q' => 75],
],
```

But explicitly defining `crop_focal` breaks cropping altogether:

```php
'presets' => [
    'small' => ['w' => 80, 'h' => 80, 'q' => 75, 'fit' => 'crop_focal'],
],
```

That said, `crop_focal` is essentially the default behaviour, so we can just filter this out of the user's preset.

Closes #1431.