### PR TITLE
Add object to augmented array

### DIFF
--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -94,4 +94,9 @@ abstract class AbstractAugmented implements Augmented
             ? $blueprint->fields()->all()
             : collect();
     }
+
+    protected function self()
+    {
+        return $this->data;
+    }
 }

--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -39,6 +39,7 @@ class AugmentedEntry extends AbstractAugmented
             'last_modified',
             'updated_at',
             'updated_by',
+            'self',
         ];
     }
 

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -141,6 +141,10 @@ class Locales extends Tags
             return $this->data;
         }
 
+        if ($self = $this->context->get('self')) {
+            return $this->data = $self;
+        }
+
         $id = $this->params->get('id', $this->context->get('id'));
 
         return $this->data = Data::find($id);

--- a/src/Taxonomies/AugmentedTerm.php
+++ b/src/Taxonomies/AugmentedTerm.php
@@ -32,6 +32,7 @@ class AugmentedTerm extends AbstractAugmented
             'edit_url',
             'updated_at',
             'updated_by',
+            'self',
         ];
     }
 


### PR DESCRIPTION
This PR adds the item itself to its augmented output so within templates, you can grab it using `{{ self }}`.

The `locales` tag will try to find the object through `self` instead of doing a lookup using `id`. Then it'll be able to maintain the associated `collection`. Fixes #3833.

I'm not quite sold on the name `self`. Maybe.

Also, it needs to not be in the API output since it's pretty useless.

- [ ] Add to all the AugmentedThing classes
- [ ] Remove from REST API output
- [ ] Remove from GraphQL output
