### PR TITLE
Fix `live_preview` variable not available in views

### DIFF
--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -79,7 +79,6 @@ class Cascade
 
     public function hydrate()
     {
-        $this->data([]);
         $this->sections = collect();
 
         return $this


### PR DESCRIPTION
This PR fixes an issue where the `live_preview` variable was not available inside views. 

In #3562, a change was introduced that cleared all of the view's cascade data before hydrating it again. This change was made as part of improvements to the SSG. I'm not entirely sure if removing this line here will break/slow things down when using the SSG. I've not tested that aspect of it (and don't really have a big enough site to test it with).

Fixes #4013