### PR TITLE
Fix updating of entry's `author` field

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -16,6 +16,7 @@ use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Http\Resources\CP\Entries\Entries;
 use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
+use Statamic\Support\Arr;
 
 class EntriesController extends CpController
 {
@@ -165,7 +166,7 @@ class EntriesController extends CpController
         $data = $request->except('id');
 
         if (User::current()->cant('edit-other-authors-entries', [EntryContract::class, $collection, $blueprint])) {
-            $data['author'] = $entry->value('author');
+            $data['author'] = Arr::wrap($entry->value('author'));
         }
 
         $fields = $entry->blueprint()->fields()->addValues($data);


### PR DESCRIPTION
Fix updating of entry's `author` field when user doesn't have permission to edit other authors. This would even break when trying to save the author's own entry.

Closes #3677.