### PR TITLE
Use `urlWithoutRedirect` to determine `is_current`

### DIFF
--- a/src/Tags/Nav.php
+++ b/src/Tags/Nav.php
@@ -46,7 +46,7 @@ class Nav extends Structure
         }
 
         $crumbs = $crumbs->values()->map(function ($crumb) {
-            $crumb->setSupplement('is_current', URL::getCurrent() === $crumb->url());
+            $crumb->setSupplement('is_current', URL::getCurrent() === $crumb->urlWithoutRedirect());
 
             return $crumb;
         });

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -55,7 +55,7 @@ class Structure extends Tags
                 'children'    => $children,
                 'parent'      => $parent,
                 'depth'       => $depth,
-                'is_current'  => rtrim(URL::getCurrent(), '/') == rtrim($page->url(), '/'),
+                'is_current'  => rtrim(URL::getCurrent(), '/') == rtrim($page->urlWithoutRedirect(), '/'),
                 'is_parent'   => Site::current()->absoluteUrl() === $page->absoluteUrl() ? false : URL::isAncestorOf(URL::getCurrent(), $page->urlWithoutRedirect()),
                 'is_external' => URL::isExternal($page->absoluteUrl()),
             ]);


### PR DESCRIPTION
Entries with redirects use the redirect url, not the entry url, to determine `is_current`. All redirected pages are current when the target of the redirect(s) is current. A simple sidebar navigation to illustrate the problem:

Original

![CleanShot-2021-07-27-at-15 21 45](https://user-images.githubusercontent.com/2236267/127236397-bb2a9885-d19d-4938-a34b-7c95008e980f.jpg)

Fixed

![CleanShot-2021-07-27-at-15 28 02](https://user-images.githubusercontent.com/2236267/127236414-45f798e9-b652-4620-adc2-5af738a600d9.jpg)