### PR TITLE
Revert "Generate asset meta after updating the container contents (#3964)"

### DIFF
--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -116,6 +116,8 @@ class AssetRepository implements Contract
 
     public function save($asset)
     {
+        $asset->writeMeta($asset->generateMeta());
+
         $store = Stache::store('assets::'.$asset->containerHandle());
 
         $cache = $asset->container()->contents();
@@ -129,8 +131,6 @@ class AssetRepository implements Contract
         }
 
         $cache->save();
-
-        $asset->writeMeta($asset->generateMeta());
 
         $store->save($asset);
     }


### PR DESCRIPTION
This reverts #3964, which would reopen #3896.
Fixes #4048 