### PR TITLE
🐛 config stubs updated to match config files

### DIFF
--- a/src/Console/Commands/stubs/config/stache.php.stub
+++ b/src/Console/Commands/stubs/config/stache.php.stub
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'watcher' => true,
+    'watcher' => env('STATAMIC_STACHE_WATCHER', true),
 
     /*
     |--------------------------------------------------------------------------
@@ -83,6 +83,24 @@ return [
 
     'indexes' => [
         //
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Locking
+    |--------------------------------------------------------------------------
+    |
+    | In order to prevent concurrent requests from updating the Stache at
+    | the same and wasting resources, it will be "locked" so subsequent
+    | requests will have to wait until the first has been completed.
+    |
+    | https://statamic.dev/stache#locks
+    |
+    */
+
+    'lock' => [
+        'enabled' => true,
+        'timeout' => 30,
     ],
 
 ];

--- a/src/Console/Commands/stubs/config/users.php.stub
+++ b/src/Console/Commands/stubs/config/users.php.stub
@@ -74,8 +74,41 @@ return [
     */
 
     'passwords' => [
-        'resets' => 'resets',
-        'activations' => 'activations',
+        'resets' => config('auth.defaults.passwords'),
+        'activations' => config('auth.defaults.passwords'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Database
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the database connection and its table names.
+    |
+    */
+
+    'database' => config('database.default'),
+
+    'tables' => [
+        'users' => 'users',
+        'role_user' => 'role_user',
+        'group_user' => 'group_user',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Guards
+    |--------------------------------------------------------------------------
+    |
+    | By default, Statamic will use the `web` authentication guard. However,
+    | if you want to run Statamic alongside the default Laravel auth
+    | guard, you can configure that for your cp and/or frontend.
+    |
+    */
+
+    'guards' => [
+        'cp' => 'web',
+        'web' => 'web',
     ],
 
 ];


### PR DESCRIPTION
Noticed when running the migrator, that the stub was being used to create the config files for `stache` & `user` -- and that they are slightly different than what is current

https://github.com/statamic/migrator/blob/master/src/SettingsMigrator.php#L213 

This just updates the stubs to reflect those updated config files! 


NB. the default `user.php` config sets the repository to `eloquent` but I left it set to `file` which I believe is the more expected behavior when installing a new site. 

