### PR TITLE
Fix git integration symlinked paths

### DIFF
--- a/src/Console/Processes/Process.php
+++ b/src/Console/Processes/Process.php
@@ -5,6 +5,7 @@ namespace Statamic\Console\Processes;
 use Closure;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Statamic\Facades\Path;
 use Statamic\Support\Arr;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -323,5 +324,29 @@ class Process
         $process->setTimeout(null);
 
         return $process;
+    }
+
+    /**
+     * Get process base path.
+     *
+     * @return string
+     */
+    public function getBasePath()
+    {
+        return preg_replace('/(.*)\/$/', '$1', $this->basePath);
+    }
+
+    /**
+     * Clone process from parent relative to base path.
+     *
+     * @return Process
+     */
+    public function fromParent()
+    {
+        $that = clone $this;
+
+        $that->basePath = str_finish(Path::resolve($this->basePath.'/../'), '/');
+
+        return $that;
     }
 }

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -130,14 +130,27 @@ class Git
                 return app(Filesystem::class)->exists($path);
             })
             ->filter(function ($path) {
-                return GitProcess::create($path)->isRepo();
+                return $this->gitProcessForPath($path)->isRepo();
             })
             ->filter(function ($path) {
-                return GitProcess::create($path)->status();
+                return $this->gitProcessForPath($path)->status();
             })
             ->groupBy(function ($path) {
-                return GitProcess::create($path)->root();
+                return $this->gitProcessForPath($path)->root();
             });
+    }
+
+    /**
+     * Get git process for content path.
+     *
+     * @param string $path
+     * @return GitProcess
+     */
+    protected function gitProcessForPath($path)
+    {
+        return is_link($path)
+            ? GitProcess::create($path)->fromParent()
+            : GitProcess::create($path);
     }
 
     /**

--- a/tests/Console/ProcessTest.php
+++ b/tests/Console/ProcessTest.php
@@ -99,4 +99,18 @@ class ProcessTest extends TestCase
         $this->assertTrue($process->hasErrorOutput());
         $this->assertStringContainsString('not found', $output);
     }
+
+    /** @test */
+    public function it_can_get_cloned_process_for_running_commands_from_parent_path()
+    {
+        $this->assertEquals(
+            Path::resolve(resource_path()),
+            Process::create(resource_path())->getBasePath()
+        );
+
+        $this->assertEquals(
+            Path::resolve(base_path()),
+            Process::create(resource_path())->fromParent()->getBasePath()
+        );
+    }
 }

--- a/tests/Git/GitTest.php
+++ b/tests/Git/GitTest.php
@@ -157,6 +157,23 @@ EOT;
         $this->assertEquals(1, $status->addedCount);
         $this->assertEquals(0, $status->modifiedCount);
         $this->assertEquals(0, $status->deletedCount);
+
+        Git::commit();
+
+        $this->files->put($externalPath.'/statement.txt', 'Change statement again.');
+
+        $status = Git::statuses()->get(Path::resolve(base_path('content')));
+
+        $expectedStatus = <<<'EOT'
+ M assets-linked/statement.txt
+EOT;
+
+        $this->assertEquals($expectedStatus, $status->status);
+
+        $this->assertEquals(1, $status->totalCount);
+        $this->assertEquals(0, $status->addedCount);
+        $this->assertEquals(1, $status->modifiedCount);
+        $this->assertEquals(0, $status->deletedCount);
     }
 
     /** @test */

--- a/tests/Git/GitTest.php
+++ b/tests/Git/GitTest.php
@@ -132,7 +132,7 @@ EOT;
     }
 
     /** @test */
-    public function it_can_run_git_commands_from_symlinked_repo_folders()
+    public function it_can_handle_configured_paths_that_are_symlinks()
     {
         $externalPath = Path::resolve(base_path('../assets-external'));
         $symlinkPath = base_path('content/assets-linked');
@@ -156,23 +156,6 @@ EOT;
         $this->assertEquals(1, $status->totalCount);
         $this->assertEquals(1, $status->addedCount);
         $this->assertEquals(0, $status->modifiedCount);
-        $this->assertEquals(0, $status->deletedCount);
-
-        Git::commit();
-
-        $this->files->put($externalPath.'/statement.txt', 'Change statement again.');
-
-        $status = Git::statuses()->get(Path::resolve(base_path('content')));
-
-        $expectedStatus = <<<'EOT'
- M assets-linked/statement.txt
-EOT;
-
-        $this->assertEquals($expectedStatus, $status->status);
-
-        $this->assertEquals(1, $status->totalCount);
-        $this->assertEquals(0, $status->addedCount);
-        $this->assertEquals(1, $status->modifiedCount);
         $this->assertEquals(0, $status->deletedCount);
     }
 

--- a/tests/Git/GitTest.php
+++ b/tests/Git/GitTest.php
@@ -26,6 +26,7 @@ class GitTest extends TestCase
         $this->files->copyDirectory($this->basePath('assets'), $this->basePath('temp/assets'));
         $this->createTempRepo(base_path('content'));
         $this->createTempRepo($this->basePath('temp/assets'));
+        $this->files->copyDirectory($this->basePath('assets'), base_path('../assets-external'));
 
         $defaultConfig = include __DIR__.'/../../config/git.php';
 
@@ -42,6 +43,8 @@ class GitTest extends TestCase
     {
         $this->deleteTempDirectory(base_path('content'));
         $this->deleteTempDirectory($this->basePath('temp'));
+        $this->deleteTempDirectory(base_path('../assets-external'));
+        $this->deleteTempDirectory(base_path('content/assets-linked'));
 
         parent::tearDown();
     }
@@ -100,7 +103,6 @@ EOT;
     /** @test */
     public function it_filters_out_external_paths_that_are_not_separate_repos()
     {
-        // If a user symlinks an assets folder for example, this will fail if not a repo itself.
         $notARepoPath = Path::resolve(base_path('../../../../..'));
 
         Config::set('statamic.git.paths', [
@@ -127,6 +129,34 @@ EOT;
         $this->assertEquals(1, $contentStatus->addedCount);
         $this->assertEquals(1, $contentStatus->modifiedCount);
         $this->assertEquals(0, $contentStatus->deletedCount);
+    }
+
+    /** @test */
+    public function it_can_run_git_commands_from_symlinked_repo_folders()
+    {
+        $externalPath = Path::resolve(base_path('../assets-external'));
+        $symlinkPath = base_path('content/assets-linked');
+
+        @symlink($externalPath, $symlinkPath);
+
+        $this->files->put($externalPath.'/statement.txt', 'Change statement.');
+
+        Config::set('statamic.git.paths', [
+            $symlinkPath,
+        ]);
+
+        $status = Git::statuses()->get(Path::resolve(base_path('content')));
+
+        $expectedStatus = <<<'EOT'
+?? assets-linked
+EOT;
+
+        $this->assertEquals($expectedStatus, $status->status);
+
+        $this->assertEquals(1, $status->totalCount);
+        $this->assertEquals(1, $status->addedCount);
+        $this->assertEquals(0, $status->modifiedCount);
+        $this->assertEquals(0, $status->deletedCount);
     }
 
     /** @test */


### PR DESCRIPTION
Fix an error that prevents git commit and push when one of the paths is a symlink.

Note: More on how git deals with symlinks here: http://tdongsi.github.io/blog/2016/02/20/symlinks-in-git/

References #4045.