### PR TITLE
Prevent 500 error when users move or rename assets

### DIFF
--- a/src/Fieldtypes/Bard/ImageNode.php
+++ b/src/Fieldtypes/Bard/ImageNode.php
@@ -24,7 +24,7 @@ class ImageNode extends Node
 
         if (Str::startsWith($attrs->src, 'asset::')) {
             $id = Str::after($attrs->src, 'asset::');
-            $asset =Asset::find($id);
+            $asset = Asset::find($id);
             $attrs->src = $asset ? $asset->url() : '';
         }
 

--- a/src/Fieldtypes/Bard/ImageNode.php
+++ b/src/Fieldtypes/Bard/ImageNode.php
@@ -24,7 +24,7 @@ class ImageNode extends Node
 
         if (Str::startsWith($attrs->src, 'asset::')) {
             $id = Str::after($attrs->src, 'asset::');
-            $attrs->src = $this->getUrl();
+            $attrs->src = $this->getUrl($id);
         }
 
         return [

--- a/src/Fieldtypes/Bard/ImageNode.php
+++ b/src/Fieldtypes/Bard/ImageNode.php
@@ -24,8 +24,7 @@ class ImageNode extends Node
 
         if (Str::startsWith($attrs->src, 'asset::')) {
             $id = Str::after($attrs->src, 'asset::');
-            $asset = Asset::find($id);
-            $attrs->src = $asset ? $asset->url() : '';
+            $attrs->src = $this->getUrl();
         }
 
         return [
@@ -38,6 +37,6 @@ class ImageNode extends Node
 
     protected function getUrl($id)
     {
-        return Asset::find($id)->url();
+        return optional(Asset::find($id))->url();
     }
 }

--- a/src/Fieldtypes/Bard/ImageNode.php
+++ b/src/Fieldtypes/Bard/ImageNode.php
@@ -24,7 +24,8 @@ class ImageNode extends Node
 
         if (Str::startsWith($attrs->src, 'asset::')) {
             $id = Str::after($attrs->src, 'asset::');
-            $attrs->src = $this->getUrl($id);
+            $asset =Asset::find($id);
+            $attrs->src = $asset ? $asset->url() : '';
         }
 
         return [


### PR DESCRIPTION
A client renamed a folder today. Seems like when URLs in the bard field are changed it's not handled gracefully.

This is a quick PR and seemed to work on my machine. Sorry I did not have time to do more extensive investigation and testing and PHP is not my main language... what I am trying to say is feel free to make changes!