### PR TITLE
Check permissions for Telescope

### DIFF
--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -31,7 +31,7 @@
         <favorite-creator class="hidden md:block"></favorite-creator>
 
         @if (Route::has('telescope') && $user->can('viewTelescope'))
-            <a class="hidden md:block h-6 w-6 p-sm text-grey ml-2 hover:text-grey-80" href="/{{ route('telescope') }}" target="_blank" v-tooltip="'Laravel Telescope'">
+            <a class="hidden md:block h-6 w-6 p-sm text-grey ml-2 hover:text-grey-80" href="{{ route('telescope') }}" target="_blank" v-tooltip="'Laravel Telescope'">
                 @cp_svg('telescope')
             </a>
         @endif

--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -30,8 +30,8 @@
 
         <favorite-creator class="hidden md:block"></favorite-creator>
 
-        @if (config('telescope.enabled'))
-            <a class="hidden md:block h-6 w-6 p-sm text-grey ml-2 hover:text-grey-80" href="/{{ config('telescope.path') }}" target="_blank" v-tooltip="'Laravel Telescope'">
+        @if (Route::has('telescope') && $user->can('viewTelescope'))
+            <a class="hidden md:block h-6 w-6 p-sm text-grey ml-2 hover:text-grey-80" href="/{{ route('telescope') }}" target="_blank" v-tooltip="'Laravel Telescope'">
                 @cp_svg('telescope')
             </a>
         @endif

--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -30,7 +30,7 @@
 
         <favorite-creator class="hidden md:block"></favorite-creator>
 
-        @if (Route::has('telescope') && $user->can('viewTelescope'))
+        @if (Route::has('telescope') && \Laravel\Telescope\Telescope::check(request()))
             <a class="hidden md:block h-6 w-6 p-sm text-grey ml-2 hover:text-grey-80" href="{{ route('telescope') }}" target="_blank" v-tooltip="'Laravel Telescope'">
                 @cp_svg('telescope')
             </a>


### PR DESCRIPTION
Checks if the user can access Telescope, will only add the link if they can.
Also changes the check from telescope.enabled to instead look for the existance of the route and changes the link to be returned from route('telescope'), so that it is functionally the same as https://github.com/statamic/cms/pull/4074