### PR TITLE
Date Fieldtype: Add possiblity to define dynamic default dates

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -113,7 +113,7 @@ class Date extends Fieldtype
             $value = $value['start'];
         }
 
-        $date = Carbon::createFromFormat($this->saveFormat($value), $value);
+        $date = $this->config('parse_from_format', true) ? Carbon::createFromFormat($this->saveFormat($value), $value) : Carbon::parse($value);
 
         return $date->format($vueFormat);
     }


### PR DESCRIPTION
This pull request makes it possible to define more advanced (& dynamic) default dates.

Make sure to disable `parse_from_format`. It is enabled by default.

## Examples
```yaml
fields:
      -
        handle: date
        field:
          type: date
          mode: single
          time_enabled: false
          parse_from_format: false
          default: 'tomorrow'
      -
        handle: another_date
        field:
          type: date
          mode: single
          time_enabled: false
          parse_from_format: false
          default: 'next tuesday'
      -
        handle: date_time
        field:
          type: date
          mode: single
          time_enabled: true
          parse_from_format: false
          default: 'previous wednesday 12:00'
      -
        handle: another_date_time
        field:
          type: date
          mode: single
          time_enabled: true
          parse_from_format: false
          default: 'now +3 days 17:00'
```

Any feedback is welcome ☺️