### PR TITLE
Improve Form tags

### DIFF
--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -54,14 +54,13 @@ class Tags extends BaseTags
     public function create()
     {
         $formHandle = $this->getForm();
-        $form = Form::find($formHandle);
-        $sessionHandle = "form.{$formHandle}";
+        $form = $this->form();
 
         $data = array_merge(
             $form->toArray(),
-            ['fields' => $this->getFields($sessionHandle)],
-            $this->getFormSession($sessionHandle),
+            $this->getFormSession($this->sessionHandle()),
         );
+        $data['fields'] = $this->getFields($this->sessionHandle());
 
         $this->addToDebugBar($data, $formHandle);
 
@@ -102,29 +101,20 @@ class Tags extends BaseTags
      */
     public function errors()
     {
-        if (! $handle = $this->getForm()) {
+        if (! $sessionHandle = $this->sessionHandle()) {
             return false;
         }
 
-        // TODO: Refactor this method to use GetsFormSession `getFormSession()` trait method.
+        $errors = $this->getFormSession($sessionHandle)['errors'];
 
-        $formHasErrors = session()->has('errors')
-            ? $this->getFormSession($handle)['errors']
-            : false;
-
-        if (! $formHasErrors) {
-            return false;
+        // If this is a single tag just output a boolean.
+        if ($this->content === '') {
+            return ! empty($errors);
         }
 
-        $errors = [];
-
-        foreach (session('errors')->getBag('form.'.$formset)->all() as $error) {
-            $errors[]['value'] = $error;
-        }
-
-        return ($this->content === '')    // If this is a single tag...
-            ? ! empty($errors)             // just output a boolean.
-            : $this->parseLoop($errors);  // Otherwise, parse the content loop.
+        return $this->parseLoop(collect($errors)->map(function ($error) {
+            return ['value' => $error];
+        }));
     }
 
     /**
@@ -134,14 +124,12 @@ class Tags extends BaseTags
      */
     public function success()
     {
-        if (! $formset = $this->getForm()) {
+        if (! $sessionHandle = $this->sessionHandle()) {
             return false;
         }
 
-        // TODO: Refactor this method to use GetsFormSession `getFormSession()` trait method.
-        // Also should probably output success string instead of `true` boolean for consistency.
-
-        return session()->has("form.{$formset}.success");
+        // TODO: Should probably output success string instead of `true` boolean for consistency.
+        return $this->getFromFormSession($sessionHandle, 'success');
     }
 
     /**
@@ -163,7 +151,7 @@ class Tags extends BaseTags
      */
     public function submissions()
     {
-        $submissions = Form::find($this->getForm())->submissions();
+        $submissions = $this->form()->submissions();
 
         return $this->output($submissions);
     }
@@ -185,15 +173,15 @@ class Tags extends BaseTags
      */
     protected function getForm()
     {
-        if (! $form = $this->params->get(static::HANDLE_PARAM, Arr::get($this->context, 'form'))) {
+        if (! $handle = $this->formHandle()) {
             throw new \Exception('A form handle is required on Form tags. Please refer to the docs for more information.');
         }
 
-        if (! Form::find($form)) {
-            throw new \Exception("Form with handle [$form] cannot be found.");
+        if (! $this->form()) {
+            throw new \Exception("Form with handle [$handle] cannot be found.");
         }
 
-        return $form;
+        return $handle;
     }
 
     /**
@@ -204,7 +192,7 @@ class Tags extends BaseTags
      */
     protected function getFields($sessionHandle)
     {
-        return Form::find($this->getForm())->fields()
+        return $this->form()->fields()
             ->map(function ($field) use ($sessionHandle) {
                 return $this->getRenderableField($field, $sessionHandle);
             })
@@ -239,6 +227,25 @@ class Tags extends BaseTags
             // Collector doesn't exist yet. We'll create it.
             debugbar()->addCollector(new ConfigCollector($debug, 'Forms'));
         }
+    }
+
+    protected function sessionHandle()
+    {
+        return 'form.'.$this->getForm();
+    }
+
+    protected function form()
+    {
+        $handle = $this->formHandle();
+
+        return Blink::once("form-$handle", function () use ($handle) {
+            return Form::find($handle);
+        });
+    }
+
+    protected function formHandle()
+    {
+        return $this->params->get(static::HANDLE_PARAM, Arr::get($this->context, 'form'));
     }
 
     public function eventUrl($url, $relative = true)

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -57,9 +57,11 @@ class Tags extends BaseTags
         $form = Form::find($formHandle);
         $sessionHandle = "form.{$formHandle}";
 
-        $data = $this->getFormSession($sessionHandle);
-        $data['fields'] = $this->getFields($sessionHandle);
-        $data['honeypot'] = $form->honeypot();
+        $data = array_merge(
+            $form->toArray(),
+            ['fields' => $this->getFields($sessionHandle)],
+            $this->getFormSession($sessionHandle),
+        );
 
         $this->addToDebugBar($data, $formHandle);
 

--- a/tests/Tags/Form/FormCreateTest.php
+++ b/tests/Tags/Form/FormCreateTest.php
@@ -2,38 +2,10 @@
 
 namespace Tests\Tags\Form;
 
-use Statamic\Facades\Blueprint;
 use Statamic\Facades\Form;
-use Statamic\Facades\Parse;
-use Statamic\Support\Arr;
-use Tests\NormalizesHtml;
-use Tests\PreventSavingStacheItemsToDisk;
-use Tests\TestCase;
 
-class FormCreateTest extends TestCase
+class FormCreateTest extends FormTestCase
 {
-    use PreventSavingStacheItemsToDisk, NormalizesHtml;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->createContactForm();
-        $this->clearSubmissions();
-    }
-
-    public function tearDown(): void
-    {
-        $this->clearSubmissions();
-
-        parent::tearDown();
-    }
-
-    private function tag($tag)
-    {
-        return Parse::template($tag, []);
-    }
-
     /** @test */
     public function it_renders_form()
     {
@@ -711,89 +683,5 @@ EOT
 
         $this->assertEquals($expected, $errors[1]);
         $this->assertEquals($expectedInline, $inlineErrors[1]);
-    }
-
-    private function createContactForm($fields = null)
-    {
-        $defaultFields = [
-            [
-                'handle' => 'name',
-                'field' => [
-                    'type' => 'text',
-                    'display' => 'Full Name',
-                    'validate' => 'min:3|alpha_num',
-                ],
-            ],
-            [
-                'handle' => 'email',
-                'field' => [
-                    'type' => 'text',
-                    'input_type' => 'email',
-                    'display' => 'Email Address',
-                    'validate' => 'required|email',
-                ],
-            ],
-            [
-                'handle' => 'message',
-                'field' => [
-                    'type' => 'textarea',
-                    'display' => 'Message',
-                    'validate' => 'required',
-                ],
-            ],
-        ];
-
-        $blueprint = Blueprint::make()->setContents([
-            'fields' => $fields ?? $defaultFields,
-        ]);
-
-        $handle = $fields ? $this->customFieldBlueprintHandle : 'contact';
-
-        Blueprint::shouldReceive('find')->with("forms.{$handle}")->andReturn($blueprint);
-        Blueprint::makePartial();
-
-        $form = Form::make()->handle($handle)->honeypot('winnie');
-
-        Form::shouldReceive('find')->with($handle)->andReturn($form);
-        Form::makePartial();
-    }
-
-    private function assertFieldRendersHtml($expectedHtmlParts, $fieldConfig, $oldData = [])
-    {
-        $randomString = str_shuffle('nobodymesseswiththehoff');
-
-        $this->customFieldBlueprintHandle = $handle = $fieldConfig['handle'].'_'.$randomString;
-
-        $fields = $oldData
-            ? array_merge([['handle' => 'failing_field', 'field' => ['type' => 'text', 'validate' => 'required']]], [$fieldConfig])
-            : [$fieldConfig];
-
-        $this->createContactForm($fields);
-
-        if ($oldData) {
-            $this->post('/!/forms/'.$handle, $oldData)
-                ->assertSessionHasErrors(['failing_field'], null, "form.{$handle}")
-                ->assertLocation('/');
-        }
-
-        $output = $this->normalizeHtml(
-            $this->tag("{{ form:{$handle} }}{{ fields }}{{ field}}{{ /fields }}{{ /form:{$handle} }}", $oldData)
-        );
-
-        $expected = collect(Arr::wrap($expectedHtmlParts))->implode('');
-
-        $this->assertStringContainsString($expected, $output);
-    }
-
-    public function post($uri, array $data = [], array $headers = [])
-    {
-        return parent::post($uri, $data, array_merge([
-            'Content-Type' => 'multipart/form-data',
-        ], $headers));
-    }
-
-    private function clearSubmissions()
-    {
-        Form::find('contact')->submissions()->each->delete();
     }
 }

--- a/tests/Tags/Form/FormErrorsTest.php
+++ b/tests/Tags/Form/FormErrorsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Tags\Form;
+
+class FormErrorsTest extends FormTestCase
+{
+    /** @test */
+    public function it_renders_errors()
+    {
+        $this
+            ->post('/!/forms/contact')
+            ->assertSessionHasErrors(['email', 'message'], null, 'form.contact')
+            ->assertLocation('/');
+            
+        $output = $this->tag(<<<'EOT'
+{{ form:errors in="contact" }}
+    <p class="error">{{ value }}</p>
+{{ /form:errors }}
+EOT
+        );
+
+        preg_match_all('/<p class="error">(.+)<\/p>/U', $output, $errors);
+
+        $expected = [
+            'The Email Address field is required.',
+            'The Message field is required.',
+        ];
+
+        $this->assertEquals($expected, $errors[1]);
+    }
+}

--- a/tests/Tags/Form/FormTestCase.php
+++ b/tests/Tags/Form/FormTestCase.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Tags\Form;
+
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Form;
+use Statamic\Facades\Parse;
+use Statamic\Support\Arr;
+use Tests\NormalizesHtml;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+abstract class FormTestCase extends TestCase
+{
+    use PreventSavingStacheItemsToDisk, NormalizesHtml;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createContactForm();
+        $this->clearSubmissions();
+    }
+
+    public function tearDown(): void
+    {
+        $this->clearSubmissions();
+
+        parent::tearDown();
+    }
+
+    public function post($uri, array $data = [], array $headers = [])
+    {
+        return parent::post($uri, $data, array_merge([
+            'Content-Type' => 'multipart/form-data',
+        ], $headers));
+    }
+
+    protected function tag($tag)
+    {
+        return Parse::template($tag, []);
+    }
+
+    protected function createContactForm($fields = null)
+    {
+        $defaultFields = [
+            [
+                'handle' => 'name',
+                'field' => [
+                    'type' => 'text',
+                    'display' => 'Full Name',
+                    'validate' => 'min:3|alpha_num',
+                ],
+            ],
+            [
+                'handle' => 'email',
+                'field' => [
+                    'type' => 'text',
+                    'input_type' => 'email',
+                    'display' => 'Email Address',
+                    'validate' => 'required|email',
+                ],
+            ],
+            [
+                'handle' => 'message',
+                'field' => [
+                    'type' => 'textarea',
+                    'display' => 'Message',
+                    'validate' => 'required',
+                ],
+            ],
+        ];
+
+        $blueprint = Blueprint::make()->setContents([
+            'fields' => $fields ?? $defaultFields,
+        ]);
+
+        $handle = $fields ? $this->customFieldBlueprintHandle : 'contact';
+
+        Blueprint::shouldReceive('find')->with("forms.{$handle}")->andReturn($blueprint);
+        Blueprint::makePartial();
+
+        $form = Form::make()->handle($handle)->honeypot('winnie');
+
+        Form::shouldReceive('find')->with($handle)->andReturn($form);
+        Form::makePartial();
+    }
+
+    protected function assertFieldRendersHtml($expectedHtmlParts, $fieldConfig, $oldData = [])
+    {
+        $randomString = str_shuffle('nobodymesseswiththehoff');
+
+        $this->customFieldBlueprintHandle = $handle = $fieldConfig['handle'].'_'.$randomString;
+
+        $fields = $oldData
+            ? array_merge([['handle' => 'failing_field', 'field' => ['type' => 'text', 'validate' => 'required']]], [$fieldConfig])
+            : [$fieldConfig];
+
+        $this->createContactForm($fields);
+
+        if ($oldData) {
+            $this->post('/!/forms/'.$handle, $oldData)
+                ->assertSessionHasErrors(['failing_field'], null, "form.{$handle}")
+                ->assertLocation('/');
+        }
+
+        $output = $this->normalizeHtml(
+            $this->tag("{{ form:{$handle} }}{{ fields }}{{ field}}{{ /fields }}{{ /form:{$handle} }}", $oldData)
+        );
+
+        $expected = collect(Arr::wrap($expectedHtmlParts))->implode('');
+
+        $this->assertStringContainsString($expected, $output);
+    }
+
+    protected function clearSubmissions()
+    {
+        Form::find('contact')->submissions()->each->delete();
+    }
+}


### PR DESCRIPTION
I was using the `{{ form:create }}` tag and found that the `{{ title }}` wasn't available, so I created a PR to fix that. While doing so I found and fixed some other things too:

- Make form properties (like `title` and `handle`) available inside the `{{ form:create }}` tags
- Add a test for the `{{ form:errors }}` tag
- Actually output any validation errors in the `{{ form:errors }}` tag (fixes #4094)
- Use `GetsFormSession` trait everywhere as suggested by the TODOs in the comments
- Use `Blink` to cache the `Form` object. 