### PR TITLE
Add more assertions for ternary conditions inside tag parameters

### DIFF
--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -35,6 +35,9 @@ class ParserTest extends TestCase
             'default_key' => 'two',
             'first_key' => 'three',
             'second_key' => 'deep',
+            'good' => true,
+            'bad' => false,
+            'unknown' => null,
             'string' => 'Hello wilderness',
             'simple' => ['one', 'two', 'three'],
             'complex' => [
@@ -389,9 +392,25 @@ EOT;
     {
         $this->app['statamic.tags']['test'] = \Tests\Fixtures\Addon\Tags\Test::class;
 
-        $template = "{{ test variable='{{ true ? 'Hello wilderness' : 'fail' }}' }}";
+        $this->assertEquals('yes', $this->parse(
+            "{{ test variable='{{ good ? 'yes' : 'fail' }}' }}",
+            $this->variables
+        ));
 
-        $this->assertEquals('Hello wilderness', $this->parse($template, $this->variables));
+        $this->assertEquals('fail', $this->parse(
+            "{{ test variable='{{ bad ? 'yes' : 'fail' }}' }}",
+            $this->variables
+        ));
+
+        $this->assertEquals('fail', $this->parse(
+            "{{ test variable='{{ unknown ?? 'fail' }}' }}",
+            $this->variables
+        ));
+
+        $this->assertEquals('yes', $this->parse(
+            "{{ test variable='{{ !unknown ? 'yes' : 'fail' }}' }}",
+            $this->variables
+        ));
     }
 
     public function testNullCoalescence()


### PR DESCRIPTION
This PR adds some assertions to the ParserTest to check some more cases when using ternary conditions inside a tag parameter. I did not find this syntax in the docs so I'm not sure how official it is or if it hasn't just been mentioned yet in https://statamic.dev/antlers#tags 🤷‍♂️ It would be awesome if someone could add this syntax to the docs!

I use this syntax to achieve the following:

```
{{ collection:events show_past="{{ show_past ? 'true' : 'false' }}" show_future="{{ show_past ? 'false' : 'true' }}" }}
```

`show_past` can be `true`, `false`, or `null`, so I want to make sure that only a boolean is passed.