### PR TITLE
Fix QueriesConditionTest

### DIFF
--- a/tests/Tags/Concerns/QueriesConditionsTest.php
+++ b/tests/Tags/Concerns/QueriesConditionsTest.php
@@ -550,7 +550,7 @@ class QueriesConditionsTest extends TestCase
 
             public function __construct($values)
             {
-                $this->params = new Parameters(['somefield:is_in' => $values]);
+                $this->params = new Parameters(['somefield:in' => $values]);
             }
 
             public function query($query)
@@ -583,7 +583,7 @@ class QueriesConditionsTest extends TestCase
 
             public function __construct($values)
             {
-                $this->params = new Parameters(['somefield:is_in' => $values]);
+                $this->params = new Parameters(['somefield:in' => $values]);
             }
 
             public function query($query)

--- a/tests/Tags/Concerns/QueriesConditionsTest.php
+++ b/tests/Tags/Concerns/QueriesConditionsTest.php
@@ -527,7 +527,7 @@ class QueriesConditionsTest extends TestCase
         };
 
         $query = $this->mock(Builder::class);
-        $query->shouldReceive('where')->with('somefield', 'somevalue');
+        $query->shouldReceive('where')->with('somefield', 'somevalue')->once();
 
         $class->query($query);
     }
@@ -560,7 +560,7 @@ class QueriesConditionsTest extends TestCase
         };
 
         $query = $this->mock(Builder::class);
-        $query->shouldReceive('whereIn')->with('somefield', ['somevalue']);
+        $query->shouldReceive('whereIn')->with('somefield', ['somevalue'])->once();
 
         $class->query($query);
     }
@@ -593,7 +593,7 @@ class QueriesConditionsTest extends TestCase
         };
 
         $query = $this->mock(Builder::class);
-        $query->shouldReceive('whereIn')->with('somefield', ['somevalue']);
+        $query->shouldReceive('whereIn')->with('somefield', ['somevalue'])->once();
 
         $class->query($query);
     }
@@ -620,7 +620,7 @@ class QueriesConditionsTest extends TestCase
         };
 
         $query = $this->mock(Builder::class);
-        $query->shouldReceive('where')->with('somefield', 'foo');
+        $query->shouldReceive('where')->with('somefield', 'foo')->once();
 
         $class->query($query);
     }
@@ -649,7 +649,7 @@ class QueriesConditionsTest extends TestCase
         };
 
         $query = $this->mock(Builder::class);
-        $query->shouldReceive('where')->with('somefield', 'somevalue');
+        $query->shouldReceive('where')->never();
 
         $class->query($query);
     }


### PR DESCRIPTION
While testing #3976 I suspected it would conflict with existing query code and maybe even fail the tests. I notice the tests were written in a way that they should have been failing, but weren't.

- Add expectation counts so the test would fail if the method wasn't called as expected.
- There was a test for an `is_in` condition, which should have failed because it's actually just `in`.
