### PR TITLE
Align command descriptions

### DIFF
--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -25,7 +25,7 @@ class AssetsGeneratePresets extends Command
      *
      * @var string
      */
-    protected $description = 'Generate asset preset manipulations.';
+    protected $description = 'Generate asset preset manipulations';
 
     /**
      * @var \Statamic\Assets\AssetCollection

--- a/src/Console/Commands/Multisite.php
+++ b/src/Console/Commands/Multisite.php
@@ -21,7 +21,7 @@ class Multisite extends Command
     use RunsInPlease, EnhancesCommands;
 
     protected $name = 'statamic:multisite';
-    protected $description = 'Converts from a single to multisite installation.';
+    protected $description = 'Converts from a single to multisite installation';
 
     protected $sites;
     protected $newSiteConfigs;

--- a/src/Console/Commands/StacheDoctor.php
+++ b/src/Console/Commands/StacheDoctor.php
@@ -14,7 +14,7 @@ class StacheDoctor extends Command
     use RunsInPlease, EnhancesCommands;
 
     protected $signature = 'statamic:stache:doctor';
-    protected $description = 'Diagnose any problems with the Stache.';
+    protected $description = 'Diagnose any problems with the Stache';
     protected $stores;
     protected $hasDuplicateIds = false;
 

--- a/src/Console/Commands/StacheWarm.php
+++ b/src/Console/Commands/StacheWarm.php
@@ -22,6 +22,6 @@ class StacheWarm extends Command
 
         Stache::warm();
 
-        $this->info('You have poured oil over the Stache and polished it until it shines. It is warm and ready.');
+        $this->info('You have poured oil over the Stache and polished it until it shines. It is warm and ready');
     }
 }

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -23,7 +23,7 @@ class StaticWarm extends Command
     use EnhancesCommands;
 
     protected $name = 'statamic:static:warm';
-    protected $description = 'Warms the static cache by visiting all URLs.';
+    protected $description = 'Warms the static cache by visiting all URLs';
 
     public function handle()
     {

--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -13,7 +13,7 @@ class SupportDetails extends Command
     use RunsInPlease;
 
     protected $signature = 'statamic:support:details';
-    protected $description = 'Outputs details helpful for support requests.';
+    protected $description = 'Outputs details helpful for support requests';
 
     public function handle()
     {

--- a/src/Git/CommitCommand.php
+++ b/src/Git/CommitCommand.php
@@ -22,7 +22,7 @@ class CommitCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Git add and commit tracked content.';
+    protected $description = 'Git add and commit tracked content';
 
     /**
      * Execute the console command.


### PR DESCRIPTION
Some commands descriptions do use a dot at the end and others don't. 

This PR does align the syntax as used by Laravel. 

<img width="807" alt="Screenshot 2021-08-15 at 12 21 51" src="https://user-images.githubusercontent.com/38906163/129475550-617f81fc-8adf-4247-8500-8983a8954469.png">
