### PR TITLE
Fix failing / missing requests in Static Warm command

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -69,9 +69,9 @@ class StaticWarm extends Command
 
         if ($reason->hasResponse()) {
             $response = $reason->getResponse();
-            
+
             $message = $response->getStatusCode().' '.$response->getReasonPhrase();
-            
+
             if ($response->getStatusCode() == 500) {
                 $message .= "\n".Message::bodySummary($response, 500);
             }

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -34,6 +34,12 @@ class StaticWarm extends Command
 
     public function handle()
     {
+        if (! config('statamic.static_caching.strategy')) {
+            $this->error('Static caching is not enabled.');
+
+            return 1;
+        }
+
         $this->comment('Please wait. This may take a while if you have a lot of content.');
 
         $this->warm();

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Psr7\Response;
 use Illuminate\Console\Command;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Collection;
+use Psr\Http\Client\ClientExceptionInterface;
 use Statamic\Console\EnhancesCommands;
 use Statamic\Console\RunsInPlease;
 use Statamic\Entries\Collection as EntriesCollection;
@@ -63,11 +64,11 @@ class StaticWarm extends Command
         $this->checkLine($this->getRelativeUri($index));
     }
 
-    public function outputFailureLine(RequestException $exception, $index): void
+    public function outputFailureLine(ClientExceptionInterface $exception, $index): void
     {
         $uri = $this->getRelativeUri($index);
 
-        if ($exception->hasResponse()) {
+        if ($exception instanceof RequestException && $exception->hasResponse()) {
             $response = $exception->getResponse();
 
             $message = $response->getStatusCode().' '.$response->getReasonPhrase();

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -46,7 +46,7 @@ class StaticWarm extends Command
         $pool = new Pool($client, $this->requests(), [
             'fulfilled' => [$this, 'outputSuccessLine'],
             'rejected' => [$this, 'outputFailureLine'],
-        ],);
+        ]);
 
         $promise = $pool->promise();
 

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -102,17 +102,17 @@ class StaticWarm extends Command
 
     private function uris(): Collection
     {
-        if (! $this->uris) {
-            $this->uris = collect()
-                ->merge($this->entries())
-                ->merge($this->terms())
-                ->merge($this->customRoutes())
-                ->unique()
-                ->sort()
-                ->values();
+        if ($this->uris) {
+            return $this->uris;
         }
 
-        return $this->uris;
+        return $this->uris = collect()
+            ->merge($this->entries())
+            ->merge($this->terms())
+            ->merge($this->customRoutes())
+            ->unique()
+            ->sort()
+            ->values();
     }
 
     protected function entries(): Collection

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -5,6 +5,7 @@ namespace Statamic\Console\Commands;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Pool;
+use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Console\Command;
@@ -68,7 +69,12 @@ class StaticWarm extends Command
 
         if ($reason->hasResponse()) {
             $response = $reason->getResponse();
+            
             $message = $response->getStatusCode().' '.$response->getReasonPhrase();
+            
+            if ($response->getStatusCode() == 500) {
+                $message .= "\n".Message::bodySummary($response, 500);
+            }
         } else {
             $message = $reason->getMessage();
         }

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -63,12 +63,12 @@ class StaticWarm extends Command
         $this->checkLine($this->getRelativeUri($index));
     }
 
-    public function outputFailureLine(RequestException $reason, $index): void
+    public function outputFailureLine(RequestException $exception, $index): void
     {
         $uri = $this->getRelativeUri($index);
 
-        if ($reason->hasResponse()) {
-            $response = $reason->getResponse();
+        if ($exception->hasResponse()) {
+            $response = $exception->getResponse();
 
             $message = $response->getStatusCode().' '.$response->getReasonPhrase();
 
@@ -76,7 +76,7 @@ class StaticWarm extends Command
                 $message .= "\n".Message::bodySummary($response, 500);
             }
         } else {
-            $message = $reason->getMessage();
+            $message = $exception->getMessage();
         }
 
         $this->crossLine("$uri → <comment>$message</comment>");


### PR DESCRIPTION
From what I experience locally, this should fix #4082. In addition it also outputs errors for failed requests now.

@jasonvarga I remember you had a preference for the Laravel HTTP Client, but it has these issues that I'm not able to solve and that don't occur when using Guzzle directly (see discussion in #4082).

@edalzell I added your `->sort()` addition from your PR #4124 here for convenience. That PR can be closed if this one gets merged. Bear in mind that, since we're using concurrent requests, the responses might still come back in a different order.

@edalzell I am really curious if this solves the problems for your specific site and setup. Would be great if you're able to test this.