### PR TITLE
Add "markalpha" support to the Glide tag

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -69,20 +69,20 @@ return [
         'presets' => [
             // 'small' => ['w' => 200, 'h' => 200, 'q' => 75, 'fit' => 'crop'],
         ],
-        
+
         /*
         |--------------------------------------------------------------------------
         | Watermarks base path
         |--------------------------------------------------------------------------
         |
         | To help make it easier in your Glide tags to reference your watermark
-        | assets without needing to pass the entire asset path, you can provide 
-        | the base path to the folder containing your watermark. This will be the 
+        | assets without needing to pass the entire asset path, you can provide
+        | the base path to the folder containing your watermark. This will be the
         | prefix for the "mark" attribute in your Glide tag.
         |
         */
 
-        'watermarks_path' => public_path('assets')
+        'watermarks_path' => public_path('assets'),
     ],
 
     /*

--- a/config/assets.php
+++ b/config/assets.php
@@ -69,7 +69,20 @@ return [
         'presets' => [
             // 'small' => ['w' => 200, 'h' => 200, 'q' => 75, 'fit' => 'crop'],
         ],
+        
+        /*
+        |--------------------------------------------------------------------------
+        | Watermarks base path
+        |--------------------------------------------------------------------------
+        |
+        | To help make it easier in your Glide tags to reference your watermark
+        | assets without needing to pass the entire asset path, you can provide 
+        | the base path to the folder containing your watermark. This will be the 
+        | prefix for the "mark" attribute in your Glide tag.
+        |
+        */
 
+        'watermarks_path' => public_path('assets')
     ],
 
     /*

--- a/src/Imaging/GlideImageManipulator.php
+++ b/src/Imaging/GlideImageManipulator.php
@@ -45,7 +45,7 @@ class GlideImageManipulator implements ImageManipulator
      */
     private $api = [
         'or', 'crop', 'w', 'h', 'fit', 'dpr', 'bri', 'con', 'gam', 'sharp', 'blur', 'pixel', 'filt',
-        'mark', 'markw', 'markx', 'marky', 'markpad', 'markpos', 'markalpha', 'bg', 'border', 'q', 'fm', 'p',
+        'mark', 'markw', 'markh', 'markx', 'marky', 'markfit', 'markpad', 'markpos', 'markalpha', 'bg', 'border', 'q', 'fm', 'p',
     ];
 
     /**

--- a/src/Imaging/GlideImageManipulator.php
+++ b/src/Imaging/GlideImageManipulator.php
@@ -45,7 +45,7 @@ class GlideImageManipulator implements ImageManipulator
      */
     private $api = [
         'or', 'crop', 'w', 'h', 'fit', 'dpr', 'bri', 'con', 'gam', 'sharp', 'blur', 'pixel', 'filt',
-        'mark', 'markw', 'markx', 'marky', 'markpad', 'markpos', 'bg', 'border', 'q', 'fm', 'p',
+        'mark', 'markw', 'markx', 'marky', 'markpad', 'markpos', 'markalpha', 'bg', 'border', 'q', 'fm', 'p',
     ];
 
     /**

--- a/src/Imaging/GlideServer.php
+++ b/src/Imaging/GlideServer.php
@@ -23,6 +23,7 @@ class GlideServer
             'driver'   => Config::get('statamic.assets.image_manipulation.driver'),
             'cache_with_file_extensions' => true,
             'presets' => Image::manipulationPresets(),
+            'watermarks' => $this->watermarksPath()
         ]);
     }
 
@@ -36,5 +37,18 @@ class GlideServer
         return Config::get('statamic.assets.image_manipulation.cache')
             ? Config::get('statamic.assets.image_manipulation.cache_path')
             : storage_path('statamic/glide');
+    }
+    
+    
+    /**
+     * Get glide watermarks path
+     *
+     * @return string
+     */
+    public function watermarksPath()
+    {
+        return Config::get('statamic.assets.image_manipulation.watermarks_path')
+            ? Config::get('statamic.assets.image_manipulation.watermarks_path')
+            : public_path();
     }
 }

--- a/src/Imaging/GlideServer.php
+++ b/src/Imaging/GlideServer.php
@@ -23,7 +23,7 @@ class GlideServer
             'driver'   => Config::get('statamic.assets.image_manipulation.driver'),
             'cache_with_file_extensions' => true,
             'presets' => Image::manipulationPresets(),
-            'watermarks' => $this->watermarksPath()
+            'watermarks' => $this->watermarksPath(),
         ]);
     }
 
@@ -38,10 +38,9 @@ class GlideServer
             ? Config::get('statamic.assets.image_manipulation.cache_path')
             : storage_path('statamic/glide');
     }
-    
-    
+
     /**
-     * Get glide watermarks path
+     * Get glide watermarks path.
      *
      * @return string
      */


### PR DESCRIPTION
Looking through the Statamic source, I can see that the Glide 'mark' attributes are allowed - but 'markalpha' is missing. When used, a Glide URL exception was thrown. Adding the attribute to the allowed list resolves the exception, however means the watermark is never shown.

The Watermark manipulator `League\Glide\Manipulators\Watermark.php` was returning null at getImage, because there was no watermarks FilesystemInterface provided. Rather than just setting the public_path at the GlideServer, I added a config option to allow the developer to change the path as they need - and in turn this can shortcut the code needed to use the 'mark' attribute.

When `public_path()` is used, the full 'mark' path must be provided:
`<img src="{{ glide:image mark="/public/path/to/assets/watermark.png" }}">`

When `watermarks_path` is set to `public_path('public/path/to/assets')`, the 'mark' becomes easier to use (i.e. cleaner to read) in your template:
`<img src="{{ glide:image mark="watermark.png" }}">`

This pull request adds the 'markalpha' attribute, plus a config option to define the watermarks source for GlideServer:
- 'markalpha' as a valid Glide API option
- a configurable 'watermarks' path for the GlideServer
- a config option in assets.php to shortcut the path needed for the 'mark' attribute
