### PR TITLE
`alias` modifier works with collections

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -94,7 +94,7 @@ class CoreModifiers extends Modifier
      */
     public function alias($value, $params)
     {
-        if (! is_array($value)) {
+        if (! (is_array($value) || $value instanceof Collection)) {
             return;
         }
 

--- a/tests/Modifiers/AliasTest.php
+++ b/tests/Modifiers/AliasTest.php
@@ -23,8 +23,8 @@ class AliasTest extends TestCase
         $this->assertEquals(['as' => $collection], $this->modify($collection, 'as'));
     }
 
-    public function modify($arr, $limit)
+    public function modify($arr, $as)
     {
-        return Modify::value($arr)->alias($limit)->fetch();
+        return Modify::value($arr)->alias($as)->fetch();
     }
 }

--- a/tests/Modifiers/AliasTest.php
+++ b/tests/Modifiers/AliasTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class AliasTest extends TestCase
+{
+    /** @test */
+    public function it_aliases_arrays()
+    {
+        $arr = ['one', 'two'];
+
+        $this->assertEquals(['as' => ['one', 'two']], $this->modify($arr, 'as'));
+    }
+
+    /** @test */
+    public function it_aliases_collections()
+    {
+        $collection = collect(['one', 'two']);
+
+        $this->assertEquals(['as' => $collection], $this->modify($collection, 'as'));
+    }
+
+    public function modify($arr, $limit)
+    {
+        return Modify::value($arr)->alias($limit)->fetch();
+    }
+}


### PR DESCRIPTION
Much Statamic data, augmented, is now a collection and not an array. The `as` modifier was expecting an array.