### PR TITLE
Prevent clearing the default disks

### DIFF
--- a/src/Console/Commands/SiteClear.php
+++ b/src/Console/Commands/SiteClear.php
@@ -153,6 +153,11 @@ class SiteClear extends Command
             return;
         }
 
+        // Don't remove the extra disk provided with statamic/statamic
+        if ($disk === 'assets') {
+            return;
+        }
+
         // TODO: Maybe we can eventually bring in and extract this to statamic/migrator's Configurator class...
         $filesystemsPath = config_path('filesystems.php');
         $config = $this->files->get($filesystemsPath);

--- a/src/Console/Commands/SiteClear.php
+++ b/src/Console/Commands/SiteClear.php
@@ -153,8 +153,8 @@ class SiteClear extends Command
             return;
         }
 
-        // Don't remove the extra disk provided with statamic/statamic
-        if ($disk === 'assets') {
+        // Don't remove any of the default disks.
+        if (in_array($disk, ['local', 'public', 's3', 'assets'])) {
             return;
         }
 


### PR DESCRIPTION
When running `php please site:clear`, it removes any filesystem disks that are being used by asset container.

So if you create a container, you probably also create a disk in `config/filesystems.php`. It'll reset that. Great, that's handy.

But not always. If you're using the `assets` disk that we've added to `statamic/statamic`, it'll remove that too. Starter kits in 3.2 assume the clear slate is what you get on `statamic/statamic`. If we remove the `assets` disk (or any other default ones) it may be broken if they're relying them being there.

This PR prevents removal of the disks that you'd find in `statamic/statamic`.