### PR TITLE
Remove warning about renaming assets

### DIFF
--- a/resources/lang/da/messages.php
+++ b/resources/lang/da/messages.php
@@ -134,7 +134,6 @@ return [
     'publish_actions_publish' => 'Ændringer i arbejdskopien anvendes og den offentliggøres straks.',
     'publish_actions_schedule' => 'Ændringer i arbejdskopien anvendes og den vises offentliggjort på den valgte dato.',
     'publish_actions_unpublish' => 'Den aktuelle revision vil ikke blive offentliggjort.',
-    'rename_asset_warning' => 'Omdøbning af et aktiv opdaterer ikke nogen referencer til det, hvilket kan resultere i ødelagte links på dit websted.',
     'reset_password_notification_body' => 'Du modtager denne e-mail, fordi vi modtog en anmodning om nulstilling af adgangskode til din konto.',
     'reset_password_notification_no_action' => 'Hvis du ikke anmodede om nulstilling af adgangskode, er der ikke behov for yderligere handling.',
     'reset_password_notification_subject' => 'Nulstil adgangskode besked',

--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -137,7 +137,6 @@ return [
     'publish_actions_publish' => 'Die Änderungen in der Arbeitskopie werden auf den Eintrag angewendet und dieser wird sofort veröffentlicht.',
     'publish_actions_schedule' => 'Die Änderungen in der Arbeitskopie werden auf den Eintrag angewendet und dieser wird am gewünschten Datum veröffentlicht.',
     'publish_actions_unpublish' => 'Die aktuelle Überarbeitung wird nicht veröffentlicht.',
-    'rename_asset_warning' => 'Beim Umbenennen einer Datei werden keine Verweise darauf aktualisiert, was zu fehlerhaften Links auf deiner Website führen kann.',
     'reset_password_notification_body' => 'Du bekommst diese E-Mail, weil wir für dein Konto eine Anfrage zum Zurücksetzen des Passworts erhalten haben.',
     'reset_password_notification_no_action' => 'Sollte die Anfrage zum Zurücksetzen des Passwortes nicht von dir stammen, sind keine weiteren Maßnahmen erforderlich.',
     'reset_password_notification_subject' => 'Passwort zurücksetzen',

--- a/resources/lang/de_CH/messages.php
+++ b/resources/lang/de_CH/messages.php
@@ -137,7 +137,6 @@ return [
     'publish_actions_publish' => 'Die Änderungen in der Arbeitskopie werden auf den Eintrag angewendet und dieser wird sofort veröffentlicht.',
     'publish_actions_schedule' => 'Die Änderungen in der Arbeitskopie werden auf den Eintrag angewendet und dieser wird am gewünschten Datum veröffentlicht.',
     'publish_actions_unpublish' => 'Die aktuelle Überarbeitung wird nicht veröffentlicht.',
-    'rename_asset_warning' => 'Beim Umbenennen einer Datei werden keine Verweise darauf aktualisiert, was zu fehlerhaften Links auf deiner Website führen kann.',
     'reset_password_notification_body' => 'Du bekommst dieses E-Mail, weil wir für dein Konto eine Anfrage zum Zurücksetzen des Passworts erhalten haben.',
     'reset_password_notification_no_action' => 'Sollte die Anfrage zum Zurücksetzen des Passworts nicht von dir stammen, kannst du dieses E-Mail ignorieren.',
     'reset_password_notification_subject' => 'Passwort zurücksetzen',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -137,7 +137,6 @@ return [
     'publish_actions_publish' => 'Changes to the working copy will applied to the entry and it will be published immediately.',
     'publish_actions_schedule' => 'Changes to the working copy will applied to the entry and it will be appear published on the selected date.',
     'publish_actions_unpublish' => 'The current revision will be unpublished.',
-    'rename_asset_warning' => 'Renaming an asset will not update any references to it, which may result in broken links in your site.',
     'reset_password_notification_body' => 'You are receiving this email because we received a password reset request for your account.',
     'reset_password_notification_no_action' => 'If you did not request a password reset, no further action is required.',
     'reset_password_notification_subject' => 'Reset Password Notification',

--- a/resources/lang/es/messages.php
+++ b/resources/lang/es/messages.php
@@ -135,7 +135,6 @@ return [
     'publish_actions_publish' => 'Los cambios en la copia de trabajo se aplicarán a la entrada y se publicarán de inmediato.',
     'publish_actions_schedule' => 'Los cambios en la copia de trabajo se aplicarán a la entrada y aparecerá publicada en la fecha seleccionada.',
     'publish_actions_unpublish' => 'La revisión actual se ocultará.',
-    'rename_asset_warning' => 'Cambiar el nombre de un medio no actualizará ninguna referencia a él, lo que puede resultar en enlaces rotos dentro de tu sitio.',
     'reset_password_notification_body' => 'Te enviamos este correo electrónico porque recibimos una solicitud de restablecimiento de contraseña para tu cuenta.',
     'reset_password_notification_no_action' => 'Si no solicitaste un restablecimiento de contraseña, tienes que hacer nada más.',
     'reset_password_notification_subject' => 'Notificación de restablecimiento de contraseña',

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -137,7 +137,6 @@ return [
     'publish_actions_publish' => 'Les modifications apportées à la copie de travail s’appliqueront à l’entrée et celle-ci sera publiée immédiatement.',
     'publish_actions_schedule' => 'Les modifications apportées à la copie de travail s’appliqueront à l’entrée et celle-ci paraîtra publiée à la date sélectionnée.',
     'publish_actions_unpublish' => 'La révision actuelle sera dépubliée.',
-    'rename_asset_warning' => 'Renommer une ressource ne mettra à jour aucune des références qui pointent vers elle, ce qui pourrait entraîner l’apparition de liens brisés sur votre site.',
     'reset_password_notification_body' => 'Vous recevez cet email car nous avons reçu une demande de réinitialisation du mot de passe pour votre compte.',
     'reset_password_notification_no_action' => 'Si vous n’avez pas demandé de réinitialisation de mot de passe, aucune autre action n’est requise.',
     'reset_password_notification_subject' => 'Notification de réinitialisation du mot de passe',

--- a/resources/lang/id/messages.php
+++ b/resources/lang/id/messages.php
@@ -133,7 +133,6 @@ return [
     'publish_actions_publish' => 'Perubahan pada salinan pekerjaan akan diterapkan ke entri dan akan segera diterbitkan.',
     'publish_actions_schedule' => 'Perubahan pada salinan pekerjaan akan diterapkan ke entri dan itu akan muncul diterbitkan pada tanggal yang dipilih.',
     'publish_actions_unpublish' => 'Revisi saat ini tidak akan dipublikasikan.',
-    'rename_asset_warning' => 'Mengganti nama aset tidak akan memperbarui referensi apa pun ke aset tersebut, yang dapat mengakibatkan tautan rusak di situs Anda.',
     'reset_password_notification_body' => 'Anda menerima email ini karena kami menerima permintaan pengaturan ulang kata sandi untuk akun Anda.',
     'reset_password_notification_no_action' => 'Jika Anda tidak meminta pengaturan ulang kata sandi, tidak ada tindakan lebih lanjut yang diperlukan.',
     'reset_password_notification_subject' => 'Atur Ulang Pemberitahuan Kata Sandi',

--- a/resources/lang/it/messages.php
+++ b/resources/lang/it/messages.php
@@ -133,7 +133,6 @@ return [
     'publish_actions_publish' => 'Le modifiche alla copia di lavoro verranno applicate alla voce e sarà pubblicata immediatamente.',
     'publish_actions_schedule' => 'Le modifiche alla copia di lavoro verranno applicate alla voce ed apparirà pubblicata nella data selezionata.',
     'publish_actions_unpublish' => 'L\'attuale revisione non sarà pubblicata.',
-    'rename_asset_warning' => 'La ridenominazione di una risorsa non aggiorna alcun riferimento ad essa, il che potrebbe causare collegamenti interrotti nel tuo sito.',
     'reset_password_notification_body' => 'Ricevi questa mail perché abbiamo ricevuto una richiesta di reimpostazione della password per il tuo account.',
     'reset_password_notification_no_action' => 'Se non hai richiesto la reimpostazione della password, non sono necessarie ulteriori azioni.',
     'reset_password_notification_subject' => 'Reimposta la password',

--- a/resources/lang/nl/messages.php
+++ b/resources/lang/nl/messages.php
@@ -136,7 +136,6 @@ return [
     'publish_actions_publish' => 'Aanpassingen aan de werkkopie worden toegepast op de entry en onmiddelijk gepubliceerd.',
     'publish_actions_schedule' => 'Aanpassingen aan de werkkopie worden toegepast op de entry en gepubliceerd op de publicatiedatum.',
     'publish_actions_unpublish' => 'De huidige revisie wordt gedepubliceerd.',
-    'rename_asset_warning' => 'Het hernoemen van een item werkt geen verwijzingen ernaar bij, wat kan resulteren in verbroken links op je site.',
     'reset_password_notification_body' => 'Je ontvangt deze e-mail, omdat we een verzoek hebben gekregen om je wachtwoord te resetten.',
     'reset_password_notification_no_action' => 'Als je geen verzoek hebt gedaan om je wachtwoord te resetten dan hoef je verder niets te doen.',
     'reset_password_notification_subject' => 'Wachtwoordresetnotificatie',

--- a/resources/lang/pt/messages.php
+++ b/resources/lang/pt/messages.php
@@ -133,7 +133,6 @@ return [
     'publish_actions_publish' => 'As alterações na cópia de trabalho serão aplicadas à entrada e serão publicadas imediatamente.',
     'publish_actions_schedule' => 'As alterações na cópia de trabalho serão aplicadas à entrada e aparecerão publicadas na data seleccionada.',
     'publish_actions_unpublish' => 'A revisão actual não será publicada.',
-    'rename_asset_warning' => 'Renomear um arquivo não actualizará quaisquer referências ao mesmo, o que pode resultar em links quebrados no seu website.',
     'reset_password_notification_body' => 'Recebeu este email porque foi feita uma solicitação de redefinição de senha para sua conta.',
     'reset_password_notification_no_action' => 'Se não solicitou uma redefinição de senha, nenhuma acção adicional será necessária.',
     'reset_password_notification_subject' => 'Redefinir notificação de senha',

--- a/resources/lang/sl/messages.php
+++ b/resources/lang/sl/messages.php
@@ -133,7 +133,6 @@ return [
     'publish_actions_publish' => 'Spremembe delovne kopije bodo veljale za vnos in bo takoj objavljena.',
     'publish_actions_schedule' => 'Spremembe delovne kopije bodo veljale za vnos in bo objavljena na izbrani datum.',
     'publish_actions_unpublish' => 'Trenutna revizija ne bo objavljena.',
-    'rename_asset_warning' => 'S preimenovanjem sredstva ne boste posodobili nobenih sklicev nanj, kar lahko povzroči nepravilne povezave na vašem spletnem mestu.',
     'reset_password_notification_body' => 'To e-poštno sporočilo ste prejeli, ker smo za vaš račun prejeli zahtevo za ponastavitev gesla.',
     'reset_password_notification_no_action' => 'Če niste zahtevali ponastavitve gesla, nadaljnja dejanja niso potrebna.',
     'reset_password_notification_subject' => 'Ponastavi obvestilo o geslu',

--- a/resources/lang/zh_TW/messages.php
+++ b/resources/lang/zh_TW/messages.php
@@ -135,7 +135,6 @@ return [
     'publish_actions_publish' => '對該工作複本做出的更改將套用至該條目，且將立即發佈。',
     'publish_actions_schedule' => '對該工作複本做出的更改將套用至該條目，且將在所選日期顯示為已發佈。',
     'publish_actions_unpublish' => '目前的修訂版將不發佈。',
-    'rename_asset_warning' => '重新命名素材將不會更新所有該素材的參照，將導致網站內出現中斷的連結。',
     'reset_password_notification_body' => '你會收到此電子郵件時因為我們收到了重設密碼的請求。',
     'reset_password_notification_no_action' => '若你未要求重設密碼，則不需進一步操作。',
     'reset_password_notification_subject' => '重設密碼通知',

--- a/src/Actions/RenameAsset.php
+++ b/src/Actions/RenameAsset.php
@@ -33,12 +33,6 @@ class RenameAsset extends Action
         return 'Are you sure you want to rename this asset?|Are you sure you want to rename these :count assets?';
     }
 
-    public function warningText()
-    {
-        /** @translation */
-        return 'messages.rename_asset_warning';
-    }
-
     public function run($assets, $values)
     {
         return $assets->each->rename($values['filename'], true);


### PR DESCRIPTION
It's now not true - references _will_ be updated.

Closes #4137 