### PR TITLE
Fix nav item editor stack instructions

### DIFF
--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -121,7 +121,7 @@ export default {
                     handle: 'url',
                     type: 'text',
                     display: __('URL'),
-                    instructions: __('Enter any internal or external URL. Leave blank for a text-only item.'),
+                    instructions: __('Enter any internal or external URL.'),
                 });
             }
 
@@ -135,8 +135,7 @@ export default {
                 fields.unshift({
                     handle: 'title',
                     type: 'text',
-                    display: __('Title'),
-                    instructions: __('Link display text. Leave blank to use the URL.'),
+                    display: __('Title')
                 });
             }
 

--- a/resources/lang/da.json
+++ b/resources/lang/da.json
@@ -277,7 +277,7 @@
     "Enable Pro Mode": "Aktivér Pro-tilstand",
     "Enable Publish Dates": "Aktivér publiceringsdatoer",
     "Encryption": "Kryptering",
-    "Enter any internal or external URL. Leave blank for a text-only item.": "Indtast enhver intern eller ekstern URL. Lad det være tomt for et tekstelement.",
+    "Enter any internal or external URL.": "Indtast enhver intern eller ekstern URL.",
     "Enter URL": "Indtast URL",
     "Entries": "Indlæg",
     "Entries successfully reordered": "Indlæg sorteret",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -291,7 +291,7 @@
     "Enable Pro Mode": "Pro-Modus aktivieren",
     "Enable Publish Dates": "Erscheinungsdaten aktivieren",
     "Encryption": "Verschlüsselung",
-    "Enter any internal or external URL. Leave blank for a text-only item.": "Beliebige interne oder externe URL eingeben. Für einen reinen Texteintrag Feld leer lassen.",
+    "Enter any internal or external URL.": "Beliebige interne oder externe URL eingeben.",
     "Enter URL": "URL eingeben",
     "Entries": "Einträge",
     "Entries successfully reordered": "Einträge erfolgreich umsortiert",

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -291,7 +291,7 @@
     "Enable Pro Mode": "Pro-Modus aktivieren",
     "Enable Publish Dates": "Erscheinungsdaten aktivieren",
     "Encryption": "Verschlüsselung",
-    "Enter any internal or external URL. Leave blank for a text-only item.": "Beliebige interne oder externe URL eingeben. Für einen reinen Texteintrag Feld leer lassen.",
+    "Enter any internal or external URL.": "Beliebige interne oder externe URL eingeben.",
     "Enter URL": "URL eingeben",
     "Entries": "Einträge",
     "Entries successfully reordered": "Einträge erfolgreich umsortiert",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -277,7 +277,7 @@
     "Enable Pro Mode": "Habilitar el modo Pro",
     "Enable Publish Dates": "Habilitar fechas de publicación",
     "Encryption": "Encripción",
-    "Enter any internal or external URL. Leave blank for a text-only item.": "Ingresa cualquier URL interna o externa. Déjalo en blanco para un elemento de solo texto.",
+    "Enter any internal or external URL.": "Ingresa cualquier URL interna o externa.",
     "Enter URL": "Introducir URL",
     "Entries": "Entradas",
     "Entries successfully reordered": "Entradas reordenadas correctamente",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -290,7 +290,7 @@
     "Enable Pro Mode": "Activer le mode Pro",
     "Enable Publish Dates": "Activer les dates de publication",
     "Encryption": "Chiffrement",
-    "Enter any internal or external URL. Leave blank for a text-only item.": "Renseigner n'importe quel lien URL interne ou externe. Laissez vide pour un élément texte uniquement. ",
+    "Enter any internal or external URL.": "Renseigner n'importe quel lien URL interne ou externe.",
     "Enter URL": "Renseigner l'URL",
     "Entries": "Entrées",
     "Entries successfully reordered": "Entrées réorganisées avec succès",

--- a/resources/lang/id.json
+++ b/resources/lang/id.json
@@ -277,7 +277,7 @@
     "Enable Pro Mode": "Aktifkan Mode Pro",
     "Enable Publish Dates": "Aktifkan Tanggal Publikasi",
     "Encryption": "Enkripsi",
-    "Enter any internal or external URL. Leave blank for a text-only item.": "Masukkan URL internal atau eksternal apa pun. Biarkan kosong untuk item teks saja.",
+    "Enter any internal or external URL.": "Masukkan URL internal atau eksternal apa pun.",
     "Enter URL": "Masukkan URL",
     "Entries": "Entri",
     "Entries successfully reordered": "Entri berhasil disusun ulang",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -277,7 +277,7 @@
     "Enable Pro Mode": "Abilita la modalità Pro",
     "Enable Publish Dates": "Abilita date di pubblicazione",
     "Encryption": "Crittografia",
-    "Enter any internal or external URL. Leave blank for a text-only item.": "Inserisci qualsiasi URL interno o esterno. Lascia vuoto per un elemento di solo testo.",
+    "Enter any internal or external URL.": "Inserisci qualsiasi URL interno o esterno.",
     "Enter URL": "Inserisci URL",
     "Entries": "Voci",
     "Entries successfully reordered": "Voci riordinate correttamente",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -288,7 +288,7 @@
     "Enable Pro Mode": "Pro Mode activeren",
     "Enable Publish Dates": "Publiceerdata inschakelen",
     "Encryption": "Encryptie",
-    "Enter any internal or external URL. Leave blank for a text-only item.": "Interne of externe URL invoeren. Laat leeg voor een text-only item.",
+    "Enter any internal or external URL.": "Interne of externe URL invoeren.",
     "Enter URL": "URL invoerern",
     "Entries": "Entries",
     "Entries successfully reordered": "Entries succesvol herschikt.",

--- a/resources/lang/pt.json
+++ b/resources/lang/pt.json
@@ -277,7 +277,7 @@
     "Enable Pro Mode": "Ativar Modo Pro",
     "Enable Publish Dates": "Ativar datas de publicação",
     "Encryption": "Encriptado",
-    "Enter any internal or external URL. Leave blank for a text-only item.": "Digite qualquer URL interno ou externo. Deixe em branco para um item somente de texto.",
+    "Enter any internal or external URL.": "Digite qualquer URL interno ou externo.",
     "Enter URL": "Digite o URL",
     "Entries": "Entradas",
     "Entries successfully reordered": "Entradas reordenadas correctamente",

--- a/resources/lang/sl.json
+++ b/resources/lang/sl.json
@@ -277,7 +277,7 @@
     "Enable Pro Mode": "Omogoči način Pro",
     "Enable Publish Dates": "Omogoči datume objave",
     "Encryption": "Šifriranje",
-    "Enter any internal or external URL. Leave blank for a text-only item.": "Vnesite kateri koli notranji ali zunanji URL. Pustite prazno za element samo z besedilom.",
+    "Enter any internal or external URL.": "Vnesite kateri koli notranji ali zunanji URL.",
     "Enter URL": "Vnesite URL",
     "Entries": "Vnosi",
     "Entries successfully reordered": "Vnosi uspešno preurejeni",

--- a/resources/lang/zh_TW.json
+++ b/resources/lang/zh_TW.json
@@ -289,7 +289,7 @@
     "Enable Pro Mode": "啟用 Pro 版",
     "Enable Publish Dates": "啟用發佈日期",
     "Encryption": "加密",
-    "Enter any internal or external URL. Leave blank for a text-only item.": "輸入任意內部或外部 URL。留空以用於純文字項目。",
+    "Enter any internal or external URL.": "輸入任意內部或外部 URL。",
     "Enter URL": "輸入 URL",
     "Entries": "條目",
     "Entries successfully reordered": "已成功重新排序條目",


### PR DESCRIPTION
Removing the `title` instructions:
- For regular nav items, the fallback behavior doesn't even happen as it was saying.
- For entry nav items, the entry's title will be displayed in the field due to the syncing feature, so it will be implied to the user.

Changing the `url` instructions to remove the "leave blank for a text-only item" part. It's clear enough. If you leave out a url, you don't get a url.

Fixes #4140 