### PR TITLE
Fix blueprint handles and validation

### DIFF
--- a/resources/views/collections/blueprints/create.blade.php
+++ b/resources/views/collections/blueprints/create.blade.php
@@ -16,6 +16,9 @@
                 <div class="text-2xs text-grey-60 mt-1 flex items-center">
                     {{ __('statamic::messages.blueprints_title_instructions') }}
                 </div>
+                @if ($errors->has('title'))
+                    <div class="text-red text-xs mt-1">{{ $errors->first('title') }}</div>
+                @endif
             </div>
         </div>
 

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -101,8 +101,8 @@ trait ManagesBlueprints
     {
         $handle = Str::slug($request->title, '_');
 
-        if (Facades\Blueprint::find($handle)) {
-            throw ValidationException::withMessages([__('A blueprint with that name already exists.')]);
+        if (Facades\Blueprint::in($namespace)->has($handle)) {
+            throw ValidationException::withMessages(['title' => __('A blueprint with that name already exists.')]);
         }
 
         $blueprint = (new Blueprint)

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -99,7 +99,7 @@ trait ManagesBlueprints
 
     private function storeBlueprint(Request $request, string $namespace)
     {
-        $handle = Str::snake($request->title);
+        $handle = Str::slug($request->title, '_');
 
         if (Facades\Blueprint::find($handle)) {
             throw ValidationException::withMessages([__('A blueprint with that name already exists.')]);


### PR DESCRIPTION
Slugify blueprint handles with underscores instead of snake casing.
This removes things like colons and question marks.
Fixes #4114 

While I was in here I noticed the validation wasn't working.
This also fixes that.