### PR TITLE
Add isEmpty and isNotEmpty methods to Field, Fields, Fieldset and Value.

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -24,6 +24,16 @@ class Field implements Arrayable
         $this->config = $config;
     }
 
+    public function isEmpty()
+    {
+        return empty($this->value);
+    }
+
+    public function isNotEmpty()
+    {
+        return ! $this->isEmpty();
+    }
+
     public function newInstance()
     {
         return (new static($this->handle, $this->config))

--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -23,6 +23,16 @@ class Fields
             ->setItems($items);
     }
 
+    public function isEmpty()
+    {
+        return $this->fields->isEmpty();
+    }
+
+    public function isNotEmpty()
+    {
+        return ! $this->isEmpty();
+    }
+
     public function setItems($items)
     {
         if ($items instanceof Collection) {

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -13,6 +13,16 @@ class Fieldset
     protected $handle;
     protected $contents = [];
 
+    public function isEmpty()
+    {
+        return empty($this->contents);
+    }
+
+    public function isNotEmpty()
+    {
+        return ! $this->isEmpty();
+    }
+
     public function setHandle(string $handle)
     {
         $this->handle = $handle;

--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -31,6 +31,16 @@ class Value implements IteratorAggregate, JsonSerializable
         }
     }
 
+    public function isEmpty()
+    {
+        return empty($this->raw);
+    }
+
+    public function isNotEmpty()
+    {
+        return ! $this->isEmpty();
+    }
+
     public function raw()
     {
         return $this->raw;

--- a/tests/Fields/FieldTest.php
+++ b/tests/Fields/FieldTest.php
@@ -11,6 +11,20 @@ use Tests\TestCase;
 class FieldTest extends TestCase
 {
     /** @test */
+    public function it_can_check_empty()
+    {
+        $field = new Field('test', ['type' => 'fieldtype']);
+
+        $this->assertTrue($field->isEmpty());
+        $this->assertFalse($field->isNotEmpty());
+
+        $field->setValue('foo');
+
+        $this->assertFalse($field->isEmpty());
+        $this->assertTrue($field->isNotEmpty());
+    }
+
+    /** @test */
     public function it_gets_the_display_value()
     {
         $this->assertEquals(
@@ -51,8 +65,7 @@ class FieldTest extends TestCase
     /** @test */
     public function it_gets_the_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
         };
 
         FieldtypeRepository::shouldReceive('find')
@@ -67,8 +80,7 @@ class FieldTest extends TestCase
     /** @test */
     public function it_gets_validation_rules_from_field()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $rules = null;
         };
 
@@ -89,8 +101,7 @@ class FieldTest extends TestCase
     /** @test */
     public function it_gets_validation_rules_from_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $rules = 'min:2|max:5';
         };
 
@@ -108,8 +119,7 @@ class FieldTest extends TestCase
     /** @test */
     public function it_merges_validation_rules_from_field_with_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $rules = 'min:2|max:5';
         };
 
@@ -130,8 +140,7 @@ class FieldTest extends TestCase
     /** @test */
     public function it_merges_extra_fieldtype_rules()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $extraRules = [
                 'test.*.one' => 'required|min:2',
                 'test.*.two' => 'max:2',
@@ -157,8 +166,7 @@ class FieldTest extends TestCase
     /** @test */
     public function it_checks_if_a_field_is_required_when_defined_in_field()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $rules = null;
         };
 
@@ -183,8 +191,7 @@ class FieldTest extends TestCase
     /** @test */
     public function it_checks_if_a_field_is_required_when_defined_in_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $rules = 'required|min:2';
         };
 
@@ -203,8 +210,7 @@ class FieldTest extends TestCase
     /** @test */
     public function it_checks_if_a_field_is_required_when_defined_as_its_own_field_property()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $rules = null;
         };
 
@@ -237,8 +243,7 @@ class FieldTest extends TestCase
     /** @test */
     public function it_adds_nullable_rule_when_not_required()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             protected $rules = null;
         };
 
@@ -278,8 +283,7 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('example')
-            ->andReturn(new class extends Fieldtype
-            {
+            ->andReturn(new class extends Fieldtype {
                 protected $component = 'example';
                 protected $configFields = [
                     'a_config_field_with_pre_processing' => ['type' => 'with_processing'],
@@ -289,8 +293,7 @@ class FieldTest extends TestCase
 
         FieldtypeRepository::shouldReceive('find')
                 ->with('with_processing')
-                ->andReturn(new class extends Fieldtype
-                {
+                ->andReturn(new class extends Fieldtype {
                     public function preProcess($data)
                     {
                         return $data.' preprocessed';
@@ -299,8 +302,7 @@ class FieldTest extends TestCase
 
         FieldtypeRepository::shouldReceive('find')
                 ->with('without_processing')
-                ->andReturn(new class extends Fieldtype
-                {
+                ->andReturn(new class extends Fieldtype {
                     public function preProcess($data)
                     {
                         return $data;
@@ -347,8 +349,7 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype
-            {
+            ->andReturn(new class extends Fieldtype {
                 public function process($data)
                 {
                     return $data.' processed';
@@ -368,8 +369,7 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype
-            {
+            ->andReturn(new class extends Fieldtype {
                 public function preProcess($data)
                 {
                     return $data.' preprocessed';
@@ -389,8 +389,7 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype
-            {
+            ->andReturn(new class extends Fieldtype {
                 public function preProcessIndex($data)
                 {
                     return $data.' preprocessed for index';
@@ -410,8 +409,7 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype
-            {
+            ->andReturn(new class extends Fieldtype {
                 public function preProcess($data)
                 {
                     return $data.' preprocessed';
@@ -431,8 +429,7 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype
-            {
+            ->andReturn(new class extends Fieldtype {
                 public function preProcess($data)
                 {
                     return $data.' preprocessed';
@@ -490,8 +487,7 @@ class FieldTest extends TestCase
     /** @test */
     public function it_augments_the_value_through_its_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             public function augment($data)
             {
                 return $data.' augmented';
@@ -536,8 +532,7 @@ class FieldTest extends TestCase
      **/
     public function it_gets_the_graphql_type()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             public function toGqlType()
             {
                 return new \GraphQL\Type\Definition\FloatType;
@@ -563,8 +558,7 @@ class FieldTest extends TestCase
      **/
     public function it_makes_the_graphql_type_non_nullable_if_its_required()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             public function toGqlType()
             {
                 return new \GraphQL\Type\Definition\FloatType;

--- a/tests/Fields/FieldTest.php
+++ b/tests/Fields/FieldTest.php
@@ -292,8 +292,7 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('example')
-            ->andReturn(new class extends Fieldtype
-        {
+            ->andReturn(new class extends Fieldtype {
                 protected $component = 'example';
                 protected $configFields = [
                     'a_config_field_with_pre_processing' => ['type' => 'with_processing'],
@@ -303,8 +302,7 @@ class FieldTest extends TestCase
 
         FieldtypeRepository::shouldReceive('find')
                 ->with('with_processing')
-                ->andReturn(new class extends Fieldtype
-        {
+                ->andReturn(new class extends Fieldtype {
                     public function preProcess($data)
                     {
                         return $data.' preprocessed';
@@ -313,8 +311,7 @@ class FieldTest extends TestCase
 
         FieldtypeRepository::shouldReceive('find')
                 ->with('without_processing')
-                ->andReturn(new class extends Fieldtype
-        {
+                ->andReturn(new class extends Fieldtype {
                     public function preProcess($data)
                     {
                         return $data;
@@ -361,8 +358,7 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype
-        {
+            ->andReturn(new class extends Fieldtype {
                 public function process($data)
                 {
                     return $data.' processed';
@@ -382,8 +378,7 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype
-        {
+            ->andReturn(new class extends Fieldtype {
                 public function preProcess($data)
                 {
                     return $data.' preprocessed';
@@ -403,8 +398,7 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype
-        {
+            ->andReturn(new class extends Fieldtype {
                 public function preProcessIndex($data)
                 {
                     return $data.' preprocessed for index';
@@ -424,8 +418,7 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype
-        {
+            ->andReturn(new class extends Fieldtype {
                 public function preProcess($data)
                 {
                     return $data.' preprocessed';
@@ -445,8 +438,7 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype
-        {
+            ->andReturn(new class extends Fieldtype {
                 public function preProcess($data)
                 {
                     return $data.' preprocessed';

--- a/tests/Fields/FieldTest.php
+++ b/tests/Fields/FieldTest.php
@@ -292,7 +292,8 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('example')
-            ->andReturn(new class extends Fieldtype {
+            ->andReturn(new class extends Fieldtype
+            {
                 protected $component = 'example';
                 protected $configFields = [
                     'a_config_field_with_pre_processing' => ['type' => 'with_processing'],
@@ -302,7 +303,8 @@ class FieldTest extends TestCase
 
         FieldtypeRepository::shouldReceive('find')
                 ->with('with_processing')
-                ->andReturn(new class extends Fieldtype {
+                ->andReturn(new class extends Fieldtype
+                {
                     public function preProcess($data)
                     {
                         return $data.' preprocessed';
@@ -311,7 +313,8 @@ class FieldTest extends TestCase
 
         FieldtypeRepository::shouldReceive('find')
                 ->with('without_processing')
-                ->andReturn(new class extends Fieldtype {
+                ->andReturn(new class extends Fieldtype
+                {
                     public function preProcess($data)
                     {
                         return $data;
@@ -358,7 +361,8 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype {
+            ->andReturn(new class extends Fieldtype
+            {
                 public function process($data)
                 {
                     return $data.' processed';
@@ -378,7 +382,8 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype {
+            ->andReturn(new class extends Fieldtype
+            {
                 public function preProcess($data)
                 {
                     return $data.' preprocessed';
@@ -398,7 +403,8 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype {
+            ->andReturn(new class extends Fieldtype
+            {
                 public function preProcessIndex($data)
                 {
                     return $data.' preprocessed for index';
@@ -418,7 +424,8 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype {
+            ->andReturn(new class extends Fieldtype
+            {
                 public function preProcess($data)
                 {
                     return $data.' preprocessed';
@@ -438,7 +445,8 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype {
+            ->andReturn(new class extends Fieldtype
+            {
                 public function preProcess($data)
                 {
                     return $data.' preprocessed';

--- a/tests/Fields/FieldTest.php
+++ b/tests/Fields/FieldTest.php
@@ -65,7 +65,7 @@ class FieldTest extends TestCase
     /** @test */
     public function it_gets_the_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype 
+        $fieldtype = new class extends Fieldtype
         {
         };
 
@@ -103,7 +103,8 @@ class FieldTest extends TestCase
     /** @test */
     public function it_gets_validation_rules_from_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             protected $rules = 'min:2|max:5';
         };
 
@@ -121,7 +122,8 @@ class FieldTest extends TestCase
     /** @test */
     public function it_merges_validation_rules_from_field_with_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             protected $rules = 'min:2|max:5';
         };
 
@@ -142,7 +144,8 @@ class FieldTest extends TestCase
     /** @test */
     public function it_merges_extra_fieldtype_rules()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             protected $extraRules = [
                 'test.*.one' => 'required|min:2',
                 'test.*.two' => 'max:2',
@@ -168,7 +171,8 @@ class FieldTest extends TestCase
     /** @test */
     public function it_checks_if_a_field_is_required_when_defined_in_field()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             protected $rules = null;
         };
 
@@ -193,7 +197,8 @@ class FieldTest extends TestCase
     /** @test */
     public function it_checks_if_a_field_is_required_when_defined_in_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             protected $rules = 'required|min:2';
         };
 
@@ -212,7 +217,8 @@ class FieldTest extends TestCase
     /** @test */
     public function it_checks_if_a_field_is_required_when_defined_as_its_own_field_property()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             protected $rules = null;
         };
 
@@ -245,7 +251,8 @@ class FieldTest extends TestCase
     /** @test */
     public function it_adds_nullable_rule_when_not_required()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             protected $rules = null;
         };
 
@@ -285,7 +292,8 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('example')
-            ->andReturn(new class extends Fieldtype {
+            ->andReturn(new class extends Fieldtype
+        {
                 protected $component = 'example';
                 protected $configFields = [
                     'a_config_field_with_pre_processing' => ['type' => 'with_processing'],
@@ -295,7 +303,8 @@ class FieldTest extends TestCase
 
         FieldtypeRepository::shouldReceive('find')
                 ->with('with_processing')
-                ->andReturn(new class extends Fieldtype {
+                ->andReturn(new class extends Fieldtype
+        {
                     public function preProcess($data)
                     {
                         return $data.' preprocessed';
@@ -304,7 +313,8 @@ class FieldTest extends TestCase
 
         FieldtypeRepository::shouldReceive('find')
                 ->with('without_processing')
-                ->andReturn(new class extends Fieldtype {
+                ->andReturn(new class extends Fieldtype
+        {
                     public function preProcess($data)
                     {
                         return $data;
@@ -351,7 +361,8 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype {
+            ->andReturn(new class extends Fieldtype
+        {
                 public function process($data)
                 {
                     return $data.' processed';
@@ -371,7 +382,8 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype {
+            ->andReturn(new class extends Fieldtype
+        {
                 public function preProcess($data)
                 {
                     return $data.' preprocessed';
@@ -391,7 +403,8 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype {
+            ->andReturn(new class extends Fieldtype
+        {
                 public function preProcessIndex($data)
                 {
                     return $data.' preprocessed for index';
@@ -411,7 +424,8 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype {
+            ->andReturn(new class extends Fieldtype
+        {
                 public function preProcess($data)
                 {
                     return $data.' preprocessed';
@@ -431,7 +445,8 @@ class FieldTest extends TestCase
     {
         FieldtypeRepository::shouldReceive('find')
             ->with('fieldtype')
-            ->andReturn(new class extends Fieldtype {
+            ->andReturn(new class extends Fieldtype
+        {
                 public function preProcess($data)
                 {
                     return $data.' preprocessed';
@@ -489,7 +504,8 @@ class FieldTest extends TestCase
     /** @test */
     public function it_augments_the_value_through_its_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             public function augment($data)
             {
                 return $data.' augmented';
@@ -534,7 +550,8 @@ class FieldTest extends TestCase
      **/
     public function it_gets_the_graphql_type()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             public function toGqlType()
             {
                 return new \GraphQL\Type\Definition\FloatType;
@@ -560,7 +577,8 @@ class FieldTest extends TestCase
      **/
     public function it_makes_the_graphql_type_non_nullable_if_its_required()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             public function toGqlType()
             {
                 return new \GraphQL\Type\Definition\FloatType;

--- a/tests/Fields/FieldTest.php
+++ b/tests/Fields/FieldTest.php
@@ -65,7 +65,8 @@ class FieldTest extends TestCase
     /** @test */
     public function it_gets_the_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype 
+        {
         };
 
         FieldtypeRepository::shouldReceive('find')
@@ -80,7 +81,8 @@ class FieldTest extends TestCase
     /** @test */
     public function it_gets_validation_rules_from_field()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             protected $rules = null;
         };
 

--- a/tests/Fields/FieldsTest.php
+++ b/tests/Fields/FieldsTest.php
@@ -16,6 +16,25 @@ use Tests\TestCase;
 class FieldsTest extends TestCase
 {
     /** @test */
+    public function it_can_check_empty()
+    {
+        $field = [
+            'handle' => 'test',
+            'field' => [],
+        ];
+
+        $fields = new Fields;
+
+        $this->assertTrue($fields->isEmpty());
+        $this->assertFalse($fields->isNotEmpty());
+
+        $fields->setItems([$field]);
+
+        $this->assertFalse($fields->isEmpty());
+        $this->assertTrue($fields->isNotEmpty());
+    }
+
+    /** @test */
     public function it_converts_to_a_collection()
     {
         $fields = new Fields;
@@ -537,8 +556,7 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_processes_each_fields_values_by_its_fieldtype()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
-        {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
             public function process($data)
             {
                 return $data.' processed';
@@ -577,8 +595,7 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_preprocesses_each_fields_values_by_its_fieldtype()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
-        {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
             public function preProcess($data)
             {
                 return $data.' preprocessed';
@@ -617,8 +634,7 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_augments_each_fields_values_by_its_fieldtype()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
-        {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
             public function augment($data)
             {
                 return $data.' augmented';
@@ -674,8 +690,7 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_gets_meta_data_from_all_fields()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
-        {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
             public function preload()
             {
                 return 'meta data from field '.$this->field->handle().' is '.($this->field->value() * 2);

--- a/tests/Fields/FieldsTest.php
+++ b/tests/Fields/FieldsTest.php
@@ -556,7 +556,8 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_processes_each_fields_values_by_its_fieldtype()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
+        {
             public function process($data)
             {
                 return $data.' processed';
@@ -595,7 +596,8 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_preprocesses_each_fields_values_by_its_fieldtype()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
+        {
             public function preProcess($data)
             {
                 return $data.' preprocessed';
@@ -634,7 +636,8 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_augments_each_fields_values_by_its_fieldtype()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
+        {
             public function augment($data)
             {
                 return $data.' augmented';
@@ -690,7 +693,8 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_gets_meta_data_from_all_fields()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
+        {
             public function preload()
             {
                 return 'meta data from field '.$this->field->handle().' is '.($this->field->value() * 2);

--- a/tests/Fields/FieldsetTest.php
+++ b/tests/Fields/FieldsetTest.php
@@ -11,6 +11,22 @@ use Tests\TestCase;
 class FieldsetTest extends TestCase
 {
     /** @test */
+    public function it_can_check_empty()
+    {
+        $fieldset = new Fieldset;
+
+        $this->assertTrue($fieldset->isEmpty());
+        $this->assertFalse($fieldset->isNotEmpty());
+
+        $fieldset->setContents([
+            'title' => 'Test',
+        ]);
+
+        $this->assertFalse($fieldset->isEmpty());
+        $this->assertTrue($fieldset->isNotEmpty());
+    }
+
+    /** @test */
     public function it_gets_the_handle()
     {
         $fieldset = new Fieldset;

--- a/tests/Fields/ValueTest.php
+++ b/tests/Fields/ValueTest.php
@@ -26,7 +26,8 @@ class ValueTest extends TestCase
     /** @test */
     public function it_augments_through_the_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             public function augment($data)
             {
                 return strtoupper($data).'!';
@@ -46,7 +47,8 @@ class ValueTest extends TestCase
     /** @test */
     public function it_shallow_augments_through_the_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             public function augment($data)
             {
                 return strtoupper($data).'!';
@@ -68,7 +70,8 @@ class ValueTest extends TestCase
     /** @test */
     public function it_converts_to_string_using_the_augmented_value()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             public function augment($data)
             {
                 return strtoupper($data).'!';
@@ -83,7 +86,8 @@ class ValueTest extends TestCase
     /** @test */
     public function it_converts_to_json_using_the_augmented_value()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             public function augment($data)
             {
                 return array_map(function ($item) {
@@ -100,7 +104,8 @@ class ValueTest extends TestCase
     /** @test */
     public function it_converts_to_json_and_augments_child_values()
     {
-        $fieldtype = new class extends Fieldtype {
+        $fieldtype = new class extends Fieldtype
+        {
             public function augment($data)
             {
                 return array_map(function ($item) {
@@ -109,14 +114,16 @@ class ValueTest extends TestCase
             }
         };
 
-        $fieldtypeTwo = new class extends Fieldtype {
+        $fieldtypeTwo = new class extends Fieldtype
+        {
             public function augment($data)
             {
                 return new DummyAugmentable($data);
             }
         };
 
-        $fieldtypeThree = new class extends Fieldtype {
+        $fieldtypeThree = new class extends Fieldtype
+        {
             public function augment($data)
             {
                 return collect($data)->map(function ($id) {

--- a/tests/Fields/ValueTest.php
+++ b/tests/Fields/ValueTest.php
@@ -10,10 +10,23 @@ use Tests\TestCase;
 class ValueTest extends TestCase
 {
     /** @test */
+    public function it_can_check_empty()
+    {
+        $value = new Value(null);
+
+        $this->assertTrue($value->isEmpty());
+        $this->assertFalse($value->isNotEmpty());
+
+        $value = new Value('test');
+
+        $this->assertFalse($value->isEmpty());
+        $this->assertTrue($value->isNotEmpty());
+    }
+
+    /** @test */
     public function it_augments_through_the_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             public function augment($data)
             {
                 return strtoupper($data).'!';
@@ -33,8 +46,7 @@ class ValueTest extends TestCase
     /** @test */
     public function it_shallow_augments_through_the_fieldtype()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             public function augment($data)
             {
                 return strtoupper($data).'!';
@@ -56,8 +68,7 @@ class ValueTest extends TestCase
     /** @test */
     public function it_converts_to_string_using_the_augmented_value()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             public function augment($data)
             {
                 return strtoupper($data).'!';
@@ -72,8 +83,7 @@ class ValueTest extends TestCase
     /** @test */
     public function it_converts_to_json_using_the_augmented_value()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             public function augment($data)
             {
                 return array_map(function ($item) {
@@ -90,8 +100,7 @@ class ValueTest extends TestCase
     /** @test */
     public function it_converts_to_json_and_augments_child_values()
     {
-        $fieldtype = new class extends Fieldtype
-        {
+        $fieldtype = new class extends Fieldtype {
             public function augment($data)
             {
                 return array_map(function ($item) {
@@ -100,16 +109,14 @@ class ValueTest extends TestCase
             }
         };
 
-        $fieldtypeTwo = new class extends Fieldtype
-        {
+        $fieldtypeTwo = new class extends Fieldtype {
             public function augment($data)
             {
                 return new DummyAugmentable($data);
             }
         };
 
-        $fieldtypeThree = new class extends Fieldtype
-        {
+        $fieldtypeThree = new class extends Fieldtype {
             public function augment($data)
             {
                 return collect($data)->map(function ($id) {


### PR DESCRIPTION
Adds isEmpty() and isNotEmpty() methods to Field, Fields, Fieldset and Value classes.

This would allow developers to check if those classes are empty or not.

Example:
If we had Author on our blueprint and $author was the Value class of that field.

```php
if($author->isNotEmpty()){

}
```

Should be functionally the same as: 
```php
if(! empty($author->value())){

}
// Or
if(! empty($author->raw())){

}
```