### PR TITLE
Fix the LinkFieldtype's perpetual dirty state

### DIFF
--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -44,10 +44,10 @@ export default {
     data() {
 
         return {
-            option: null,
-            options: [],
-            urlValue: null,
-            selectedEntries: [],
+            option: this.initialOption(),
+            options: this.initialOptions(),
+            urlValue: this.initialUrlValue(),
+            selectedEntries: this.initialSelectedEntries()
         }
 
     },
@@ -86,26 +86,21 @@ export default {
 
     },
 
-    created() {
-        this.options = this.initialOptions();
-
-        if (! this.value) {
-            this.option = this.config.required ? 'url' : null;
-            return;
-        }
-
-        if (this.value === '@child') {
-            this.option = 'first-child';
-        } else if (this.value.startsWith('entry::')) {
-            this.option = 'entry';
-            this.selectedEntries = [this.value.substr(7)];
-        } else {
-            this.option = 'url';
-            this.urlValue = this.value;
-        }
-    },
-
     methods: {
+
+        initialOption() {
+            if (! this.value) {
+                return this.config.required ? 'url' : null;
+            }
+
+            if (this.value === '@child') {
+                return 'first-child';
+            } else if (this.value.startsWith('entry::')) {
+                return 'entry';
+            } else {
+                return 'url';
+            }
+        },
 
         initialOptions() {
             return [
@@ -124,6 +119,15 @@ export default {
 
             ].filter(option => option);
         },
+
+        initialUrlValue() {
+            return (this.value && this.value  !== '@child' && !this.value.startsWith('entry::')) ? this.value : null;
+        },
+
+        initialSelectedEntries() {
+            return (this.value && this.value.startsWith('entry::')) ? [this.value.substr(7)] : [];
+        },
+
 
         entriesSelected(entries) {
             this.selectedEntries = entries;

--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -46,8 +46,8 @@ export default {
         return {
             option: this.initialOption(),
             options: this.initialOptions(),
-            urlValue: this.initialUrlValue(),
-            selectedEntries: this.initialSelectedEntries()
+            urlValue: this.meta.initialUrl,
+            selectedEntries: this.meta.initialSelectedEntries,
         }
 
     },
@@ -118,14 +118,6 @@ export default {
                 { label: __('Entry'), value: 'entry' }
 
             ].filter(option => option);
-        },
-
-        initialUrlValue() {
-            return (this.value && this.value !== '@child' && !this.value.startsWith('entry::')) ? this.value : null;
-        },
-
-        initialSelectedEntries() {
-            return (this.value && this.value.startsWith('entry::')) ? [this.value.substr(7)] : [];
         },
 
         entriesSelected(entries) {

--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -121,13 +121,12 @@ export default {
         },
 
         initialUrlValue() {
-            return (this.value && this.value  !== '@child' && !this.value.startsWith('entry::')) ? this.value : null;
+            return (this.value && this.value !== '@child' && !this.value.startsWith('entry::')) ? this.value : null;
         },
 
         initialSelectedEntries() {
             return (this.value && this.value.startsWith('entry::')) ? [this.value.substr(7)] : [];
         },
-
 
         entriesSelected(entries) {
             this.selectedEntries = entries;

--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -44,7 +44,7 @@ export default {
     data() {
 
         return {
-            option: this.initialOption(),
+            option: this.meta.initialOption,
             options: this.initialOptions(),
             urlValue: this.meta.initialUrl,
             selectedEntries: this.meta.initialSelectedEntries,
@@ -87,20 +87,6 @@ export default {
     },
 
     methods: {
-
-        initialOption() {
-            if (! this.value) {
-                return this.config.required ? 'url' : null;
-            }
-
-            if (this.value === '@child') {
-                return 'first-child';
-            } else if (this.value.startsWith('entry::')) {
-                return 'entry';
-            } else {
-                return 'url';
-            }
-        },
 
         initialOptions() {
             return [

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -46,12 +46,28 @@ class Link extends Fieldtype
         return [
             'initialUrl' => $url,
             'initialSelectedEntries' => $selectedEntry ? [$selectedEntry] : [],
+            'initialOption' => $this->initialOption($value, $selectedEntry),
             'showFirstChildOption' => $this->showFirstChildOption(),
             'entry' => [
                 'config' => $entryFieldtype->config(),
                 'meta' => $entryFieldtype->preload(),
             ],
         ];
+    }
+
+    private function initialOption($value, $entry)
+    {
+        if (! $value) {
+            return $this->field->isRequired() ? 'url' : null;
+        }
+
+        if ($value === '@child') {
+            return 'first-child';
+        } elseif ($entry) {
+            return 'entry';
+        }
+
+        return 'url';
     }
 
     private function nestedEntriesFieldtype($value): Fieldtype

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -37,18 +37,43 @@ class Link extends Fieldtype
     {
         $value = $this->field->value();
 
+        $selectedEntry = Str::startsWith($value, 'entry::') ? Str::after($value, 'entry::') : null;
+
+        $url = ($value !== '@child' && ! $selectedEntry) ? $value : null;
+
+        $entryFieldtype = $this->nestedEntriesFieldtype($selectedEntry);
+
+        return [
+            'initialUrl' => $url,
+            'initialSelectedEntries' => $selectedEntry ? [$selectedEntry] : [],
+            'showFirstChildOption' => $this->showFirstChildOption(),
+            'entry' => [
+                'config' => $entryFieldtype->config(),
+                'meta' => $entryFieldtype->preload(),
+            ],
+        ];
+    }
+
+    private function nestedEntriesFieldtype($value): Fieldtype
+    {
         $entryField = (new Field('entry', [
             'type' => 'entries',
             'max_items' => 1,
             'create' => false,
         ]));
 
-        if (Str::startsWith($value, 'entry::')) {
-            $entryField->setValue(Str::after($value, 'entry::'));
-        }
+        $entryField->setValue($value);
 
-        $entryFieldtype = $entryField->fieldtype();
+        $entryField->setConfig(array_merge(
+            $entryField->config(),
+            ['collections' => $this->collections()]
+        ));
 
+        return $entryField->fieldtype();
+    }
+
+    private function collections()
+    {
         $collections = $this->config('collections');
 
         if (empty($collections)) {
@@ -57,20 +82,14 @@ class Link extends Fieldtype
             $collections = Blink::once('routable-collection-handles-'.$site, function () use ($site) {
                 return Facades\Collection::all()->reject(function ($collection) use ($site) {
                     return is_null($collection->route($site));
-                })->map->handle()->values();
+                })->map->handle()->values()->all();
             });
         }
 
-        return [
-            'showFirstChildOption' => $this->showFirstChildOption(),
-            'entry' => [
-                'config' => array_merge($entryFieldtype->config(), ['collections' => $collections]),
-                'meta' => $entryFieldtype->preload(),
-            ],
-        ];
+        return $collections;
     }
 
-    protected function showFirstChildOption()
+    private function showFirstChildOption()
     {
         $parent = $this->field()->parent();
 


### PR DESCRIPTION
Replaces #4146. Moves a bunch of the logic to the server side, so the initial values are passed directly into the component.

Also targets 3.1 instead of master.

Fixes #4133
Ref #3500