### PR TITLE
Ignore query string when determining active status in CP nav

### DIFF
--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -80,7 +80,7 @@ class NavItem
                 $cpUrl = url(config('statamic.cp.route')).'/';
 
                 if (! $this->active && Str::startsWith($url, $cpUrl)) {
-                    $this->active = str_replace($cpUrl, '', $url).'(/(.*)?|$)';
+                    $this->active = str_replace($cpUrl, '', Str::before($url, '?')).'(/(.*)?|$)';
                 }
             })
             ->value($url);


### PR DESCRIPTION
Fixes #3794.