### PR TITLE
Augmented term titles uses supplemental data

### DIFF
--- a/src/Taxonomies/AugmentedTerm.php
+++ b/src/Taxonomies/AugmentedTerm.php
@@ -59,4 +59,11 @@ class AugmentedTerm extends AbstractAugmented
     {
         return $this->data->absoluteUrl();
     }
+
+    public function title()
+    {
+        $title = $this->data->getSupplement('title') ?? $this->data->title();
+
+        return $this->wrapValue($title, 'title');
+    }
 }

--- a/tests/Data/Taxonomies/AugmentedTermTest.php
+++ b/tests/Data/Taxonomies/AugmentedTermTest.php
@@ -69,4 +69,24 @@ class AugmentedTermTest extends AugmentedTestCase
 
         $this->assertAugmentedCorrectly($expectations, $augmented);
     }
+
+    /** @test */
+    public function supplemented_title_is_used()
+    {
+        tap(Taxonomy::make('test'))->save();
+
+        $term = Term::make()
+            ->taxonomy('test')
+            ->blueprint('test')
+            ->in('en')
+            ->slug('term-slug')
+            ->data(['title' => 'Actual Title'])
+            ->setSupplement('title', 'Supplemented Title');
+
+        $augmented = new AugmentedTerm($term);
+
+        $title = $augmented->get('title');
+        $this->assertInstanceOf(Value::class, $title);
+        $this->assertEquals('Supplemented Title', $title->value());
+    }
 }


### PR DESCRIPTION
In #4090 I noticed that editing a title in live preview would not be reflected on the front end.

Turns out it's because the `title` method doesn't use supplemental data.
Live preview supplements the item with values you've entered in live preview.

I put it in the augmented term class rather than change the term's title() method because the title() seems more of an "official" value - you probably don't want the temporary supplemental values to have an effect there.