### PR TITLE
Always hit `/installed` endpoint instead of conditionally hitting `/e…

### DIFF
--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -494,7 +494,7 @@ final class Installer
     }
 
     /**
-     * Complete starter kit install on successful installation.
+     * Complete starter kit install, expiring license key and/or increment install count.
      *
      * @return $this
      */

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -142,7 +142,7 @@ final class Installer
             ->removeStarterKit()
             ->removeRepository()
             ->removeComposerJsonBackup()
-            ->expireLicense();
+            ->completeInstall();
     }
 
     /**
@@ -494,15 +494,13 @@ final class Installer
     }
 
     /**
-     * Expire starter kit license on successful installation.
+     * Complete starter kit install on successful installation.
      *
      * @return $this
      */
-    protected function expireLicense()
+    protected function completeInstall()
     {
-        if ($this->licenseManager->hasValidLicenseKey()) {
-            $this->licenseManager->expireLicense();
-        }
+        $this->licenseManager->completeInstall();
 
         return $this;
     }

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -494,7 +494,7 @@ final class Installer
     }
 
     /**
-     * Complete starter kit install, expiring license key and/or increment install count.
+     * Complete starter kit install, expiring license key and/or incrementing install count.
      *
      * @return $this
      */

--- a/src/StarterKits/LicenseManager.php
+++ b/src/StarterKits/LicenseManager.php
@@ -53,25 +53,11 @@ final class LicenseManager
     }
 
     /**
-     * Check if user has valid starter kit or site license key, for the purpose of expiring after a successful install.
-     *
-     * @return bool
+     * Expire license key and increment install count.
      */
-    public function hasValidLicenseKey()
+    public function completeInstall()
     {
-        return $this->valid && $this->licenseKey;
-    }
-
-    /**
-     * Expire license key.
-     */
-    public function expireLicense()
-    {
-        if (! $this->hasValidLicenseKey()) {
-            return;
-        }
-
-        Http::post(self::OUTPOST_ENDPOINT.'expire', [
+        Http::post(self::OUTPOST_ENDPOINT.'installed', [
             'license' => $this->licenseKey,
             'configured_site_license' => config('statamic.system.license_key'),
             'package' => $this->package,


### PR DESCRIPTION
- [x] Always hit `/installed` endpoint instead of conditionally hitting `/expire`.