### PR TITLE
The `BlueprintRepository` does not have an `all` method anymore

### DIFF
--- a/src/Facades/Blueprint.php
+++ b/src/Facades/Blueprint.php
@@ -9,7 +9,6 @@ use Statamic\Fields\BlueprintRepository;
  * @method static self setDirectory(string $directory)
  * @method static self setFallbackDirectory(string $directory)
  * @method static null|\Statamic\Fields\Blueprint find($handle)
- * @method static \Illuminate\Support\Collection all()
  * @method static void save(Blueprint $blueprint)
  * @method static void delete(Blueprint $blueprint)
  * @method static \Statamic\Fields\Blueprint make($handle = null)


### PR DESCRIPTION
Updated the docblocks as the source of truth, the [BlueprintRepository](https://github.com/statamic/cms/blob/3.2/src/Fields/BlueprintRepository.php) doesn't have an `all` method anymore.

