### PR TITLE
Add new folders to container contents cache

### DIFF
--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -136,7 +136,7 @@ class AssetContainerContents
                 $this->add($dir);
             }
 
-            $this->files->put($path, $metadata + Util::pathinfo($path));
+            $this->all()->put($path, $metadata + Util::pathinfo($path));
 
             $this->filteredFiles = null;
             $this->filteredDirectories = null;

--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -100,6 +100,8 @@ class AssetFolder implements Contract, Arrayable
     {
         $this->disk()->makeDirectory($this->path());
 
+        $this->container()->contents()->add($this->path())->save();
+
         AssetFolderSaved::dispatch($this);
 
         return $this;

--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Statamic\Assets\Asset;
+use Statamic\Assets\AssetContainerContents;
 use Statamic\Assets\AssetFolder as Folder;
 use Statamic\Contracts\Assets\AssetContainer;
 use Statamic\Facades;
@@ -185,8 +186,10 @@ class AssetFolderTest extends TestCase
         Storage::fake('local');
 
         $container = $this->mock(AssetContainer::class);
-        $container->shouldReceive('disk')->andReturn($disk = Storage::disk('local'));
+        $container->shouldReceive('contents')->andReturn(new AssetContainerContents($container));
+        $container->shouldReceive('disk')->andReturn(new FlysystemAdapter($disk = Storage::disk('local')));
         $container->shouldReceive('foldersCacheKey')->andReturn('irrelevant for test');
+        $container->shouldReceive('handle')->andReturn('local');
 
         $folder = (new Folder)
             ->container($container)

--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -199,6 +199,7 @@ class AssetFolderTest extends TestCase
 
         $return = $folder->save();
 
+        $this->assertEquals($container->contents()->cached(), $container->contents()->all());
         $this->assertEquals($folder, $return);
         $disk->assertExists($path);
     }


### PR DESCRIPTION
Adds new folders to the asset container contents path, so they still show after a refresh when the stache watcher is disabled. Let me know if you want anything changing.

Fixes #3722