### PR TITLE
Page can have supplemental values

### DIFF
--- a/src/Structures/AugmentedPage.php
+++ b/src/Structures/AugmentedPage.php
@@ -30,6 +30,7 @@ class AugmentedPage extends AugmentedEntry
 
         $keys = $keys
             ->merge($this->page->data()->keys())
+            ->merge($this->page->supplements()->keys())
             ->merge(['entry_id']);
 
         $keys = Statamic::isApiRoute() ? $this->apiKeys($keys) : $keys;
@@ -51,7 +52,7 @@ class AugmentedPage extends AugmentedEntry
             return $this->page->title();
         }
 
-        return $this->page->value($key);
+        return $this->page->getSupplement($key) ?? $this->page->value($key);
     }
 
     protected function blueprintFields()

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -12,6 +12,7 @@ use Statamic\Contracts\Entries\Entry;
 use Statamic\Contracts\GraphQL\ResolvesValues as ResolvesValuesContract;
 use Statamic\Contracts\Routing\UrlBuilder;
 use Statamic\Contracts\Structures\Nav;
+use Statamic\Data\ContainsSupplementalData;
 use Statamic\Data\HasAugmentedInstance;
 use Statamic\Data\TracksQueriedColumns;
 use Statamic\Facades\Blink;
@@ -22,7 +23,7 @@ use Statamic\GraphQL\ResolvesValues;
 
 class Page implements Entry, Augmentable, Responsable, Protectable, JsonSerializable, ResolvesValuesContract
 {
-    use HasAugmentedInstance, ForwardsCalls, TracksQueriedColumns, ResolvesValues;
+    use HasAugmentedInstance, ForwardsCalls, TracksQueriedColumns, ResolvesValues, ContainsSupplementalData;
 
     protected $tree;
     protected $reference;
@@ -35,6 +36,11 @@ class Page implements Entry, Augmentable, Responsable, Protectable, JsonSerializ
     protected $title;
     protected $depth;
     protected $data = [];
+
+    public function __construct()
+    {
+        $this->supplements = collect();
+    }
 
     public function setUrl($url)
     {

--- a/tests/Data/Structures/AugmentedPageTest.php
+++ b/tests/Data/Structures/AugmentedPageTest.php
@@ -18,6 +18,7 @@ class AugmentedPageTest extends AugmentedTestCase
         $page = Mockery::mock(Page::class);
         $page->shouldReceive('reference')->andReturnFalse();
         $page->shouldReceive('data')->andReturn(collect(['one' => 'two', 'three' => 'four']));
+        $page->shouldReceive('supplements')->andReturn(collect(['five' => 'six']));
 
         $augmented = new AugmentedPage($page);
 
@@ -30,6 +31,7 @@ class AugmentedPageTest extends AugmentedTestCase
             'permalink',
             'one',
             'three',
+            'five',
         ];
 
         $actual = $augmented->keys();
@@ -74,6 +76,10 @@ class AugmentedPageTest extends AugmentedTestCase
             'jane' => 'doe',
             'three' => 'four',
         ]));
+        $page->shouldReceive('supplements')->andReturn(collect([
+            'echo' => 'foxtrot',
+            'golf' => 'hotel',
+        ]));
 
         $augmented = new AugmentedPage($page);
 
@@ -92,6 +98,8 @@ class AugmentedPageTest extends AugmentedTestCase
             'jane',
             // page data
             'john',
+            // page augmente
+            'echo', 'golf',
             // page keys
             'entry_id',
         ];
@@ -121,9 +129,14 @@ class AugmentedPageTest extends AugmentedTestCase
         $page->shouldReceive('uri')->andReturn('/the-uri');
         $page->shouldReceive('absoluteUrl')->andReturn('https://site.com/the-permalink');
         $page->shouldReceive('data')->andReturn(collect(['one' => 'two', 'three' => 'four', 'five' => 'six']));
+        $page->shouldReceive('supplements')->andReturn(collect(['seven' => 'eight']));
         $page->shouldReceive('value')->with('one')->andReturn('two');
         $page->shouldReceive('value')->with('three')->andReturn('four');
         $page->shouldReceive('value')->with('five')->andReturn('six');
+        $page->shouldReceive('getSupplement')->with('one')->andReturnNull();
+        $page->shouldReceive('getSupplement')->with('three')->andReturnNull();
+        $page->shouldReceive('getSupplement')->with('five')->andReturnNull();
+        $page->shouldReceive('getSupplement')->with('seven')->andReturn('eight');
 
         $augmented = new AugmentedPage($page);
 
@@ -135,6 +148,7 @@ class AugmentedPageTest extends AugmentedTestCase
             'one' => ['type' => Value::class, 'value' => 'two'],
             'three' => ['type' => Value::class, 'value' => 'four'],
             'five' => ['type' => 'string', 'value' => 'six'],
+            'seven' => ['type' => 'string', 'value' => 'eight'],
             'id' => ['type' => 'string', 'value' => 'page-id'],
             'entry_id' => ['type' => 'string', 'value' => null],
         ];
@@ -184,10 +198,15 @@ class AugmentedPageTest extends AugmentedTestCase
         $page->shouldReceive('entry')->andReturn($entry);
         $page->shouldReceive('blueprint')->andReturn($pageBlueprint);
         $page->shouldReceive('data')->andReturn(collect(['one' => 'dos', 'three' => 'quatro', 'five' => 'seis']));
+        $page->shouldReceive('supplements')->andReturn(collect(['seven' => 'ocho']));
         $page->shouldReceive('title')->andReturn('The Page Title');
         $page->shouldReceive('value')->with('one')->andReturn('dos');
         $page->shouldReceive('value')->with('three')->andReturn('quatro');
         $page->shouldReceive('value')->with('five')->andReturn('seis');
+        $page->shouldReceive('getSupplement')->with('one')->andReturnNull();
+        $page->shouldReceive('getSupplement')->with('three')->andReturnNull();
+        $page->shouldReceive('getSupplement')->with('five')->andReturnNull();
+        $page->shouldReceive('getSupplement')->with('seven')->andReturn('ocho');
 
         $augmented = new AugmentedPage($page);
 
@@ -199,6 +218,7 @@ class AugmentedPageTest extends AugmentedTestCase
             'one' => ['type' => Value::class, 'value' => 'dos', 'fieldtype' => 'textarea'], // assert fieldtype to ensure the field from the page blueprint wins
             'three' => ['type' => Value::class, 'value' => 'quatro'],
             'five' => ['type' => 'string', 'value' => 'seis'],
+            'seven' => ['type' => 'string', 'value' => 'ocho'],
             'id' => ['type' => 'string', 'value' => 'page-id'],
             'entry_id' => ['type' => 'string', 'value' => '123'],
         ];


### PR DESCRIPTION
Fixes #4173 

In the `nav:breadcrumbs` tag, when it supplements `is_current` onto each page, it was technically supplementing it onto the entry, which pretty much worked by fluke.

The way that page data is retrieved was changed a bit in 3.2, and because supplemental data wasn't being tested, it ended up being missed, and broke.

This PR lets `Page` objects have supplemental data. The nav:breacrumbs code doesn't change, but now when it supplements `is_current`, it goes directly on the page instead of onto the entry.