### PR TITLE
Send JSON back for form submissions via a standard fetch request

### DIFF
--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -92,7 +92,7 @@ class FormController extends Controller
      */
     private function formSuccess($params, $submission, $silentFailure = false)
     {
-        if (request()->ajax()) {
+        if (request()->ajax() || request()->wantsJson()) {
             return response([
                 'success' => true,
                 'submission_created' => ! $silentFailure,


### PR DESCRIPTION
Currently, the form controller is looking for a `X-Requested-With` header to equal `XMLHttpRequest` in order to respond with JSON. This isn't standard though, and is mostly used with libraries such as Axios.

This means a regular `fetch` request won't get a JSON response. The user can add this header manually, but I think this PR adds a sensible check to see if the request is wanting a JSON response as well.