### PR TITLE
Don't stack add-on seller avatars above infobars

### DIFF
--- a/resources/js/components/AddonList.vue
+++ b/resources/js/components/AddonList.vue
@@ -55,7 +55,7 @@
                         <div class="h-64 rounded-t bg-cover bg-center" :style="'background-image: url(\''+getCover(addon)+'\')'"></div>
                         <div class="px-3 mb-2 relative text-center">
                             <a :href="addon.seller.website" class="relative">
-                                <img :src="addon.seller.avatar" :alt="addon.seller.name" class="rounded-full h-14 w-14 z-30 bg-white relative -mt-4 border-2 border-white inline">
+                                <img :src="addon.seller.avatar" :alt="addon.seller.name" class="rounded-full h-14 w-14 bg-white relative -mt-4 border-2 border-white inline">
                             </a>
                             <div class="addon-card-title mb-1 text-lg font-bold text-center">{{ addon.name }}</div>
                             <p class="text-grey mb-2" v-text="getPriceRange(addon)" />


### PR DESCRIPTION
When working on a trial site in the Control Panel, the add-on seller avatars show in front of the info bar. Removing the `z-index` resolves this.

<img width="1678" alt="wrong-stack-order" src="https://user-images.githubusercontent.com/6348321/131350321-eaa5ae30-771c-49ec-bf89-6f9d9f85ff45.png">
