### PR TITLE
Validate replicator as an array

### DIFF
--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -14,6 +14,7 @@ use Statamic\Support\Str;
 class Replicator extends Fieldtype
 {
     protected $defaultValue = [];
+    protected $rules = ['array'];
 
     protected function configFieldItems(): array
     {


### PR DESCRIPTION
Fixes #4208

When using a validation rule such as `min`, it'll act like a string unless you also have an `array` rule, then it'll treat it like an array. 
