### PR TITLE
Make collection widget title into a link

### DIFF
--- a/resources/views/widgets/collection.blade.php
+++ b/resources/views/widgets/collection.blade.php
@@ -1,10 +1,12 @@
 <div class="card p-0 overflow-hidden h-full">
     <div class="flex justify-between items-center p-2">
-        <h2 class="flex items-center">
-            <div class="h-6 w-6 mr-1 text-grey-80">
-                @cp_svg('content-writing')
-            </div>
-            <span>{{ $title  }}</span>
+        <h2>
+            <a class="flex items-center" href="{{ $collection->showUrl() }}">
+                <div class="h-6 w-6 mr-1 text-grey-80">
+                    @cp_svg('content-writing')
+                </div>
+                <span>{{ $title }}</span>
+            </a>
         </h2>
         <a href="{{ $collection->createEntryUrl() }}" class="text-blue hover:text-blue-dark text-sm">{{ $button }}</a>
     </div>


### PR DESCRIPTION
This pull request makes the title of the collection widget into a link.

Closes statamic/ideas#636