### PR TITLE
Read inline svgs from composer vendor directory

### DIFF
--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -228,7 +228,7 @@ class Statamic
         }
 
         $svg = StaticStringy::collapseWhitespace(
-            File::get(base_path("vendor/statamic/cms/resources/dist/svg/{$name}.svg"))
+            File::get(statamic_path("resources/svg/{$name}.svg"))
         );
 
         return str_replace('<svg', sprintf('<svg%s', $attrs), $svg);

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -228,7 +228,7 @@ class Statamic
         }
 
         $svg = StaticStringy::collapseWhitespace(
-            File::get(public_path("vendor/statamic/cp/svg/{$name}.svg"))
+            File::get(base_path("vendor/statamic/cms/resources/dist/svg/{$name}.svg"))
         );
 
         return str_replace('<svg', sprintf('<svg%s', $attrs), $svg);

--- a/tests/Facades/CP/NavTest.php
+++ b/tests/Facades/CP/NavTest.php
@@ -107,7 +107,7 @@ class NavTest extends TestCase
     /** @test */
     public function it_can_create_a_nav_item_with_a_bundled_svg_icon()
     {
-        File::put(public_path('vendor/statamic/cp/svg/test.svg'), 'the totally real svg');
+        File::put(base_path('vendor/statamic/cms/resources/dist/svg/test.svg'), 'the totally real svg');
 
         $this->actingAs(tap(User::make()->makeSuper())->save());
 

--- a/tests/Facades/CP/NavTest.php
+++ b/tests/Facades/CP/NavTest.php
@@ -107,7 +107,7 @@ class NavTest extends TestCase
     /** @test */
     public function it_can_create_a_nav_item_with_a_bundled_svg_icon()
     {
-        File::put(base_path('vendor/statamic/cms/resources/dist/svg/test.svg'), 'the totally real svg');
+        File::put(statamic_path('resources/svg/test.svg'), 'the totally real svg');
 
         $this->actingAs(tap(User::make()->makeSuper())->save());
 


### PR DESCRIPTION
References #4022 

When using Vapor, the assets in the `public` directory won't exist. They get sent over to S3 and served via a CDN.

The `Statamic::svg()` method reads the svg files from the `public` directory. But again, on Vapor, they're not there.

This PR just changes the method to look for svgs in the Composer vendor directory, which _would_ be there.