### PR TITLE
Remove dashboard nav when widgets are empty

### DIFF
--- a/src/CP/Navigation/CoreNav.php
+++ b/src/CP/Navigation/CoreNav.php
@@ -50,9 +50,11 @@ class CoreNav
      */
     protected function makeTopLevel()
     {
-        Nav::topLevel('Dashboard')
-            ->route('dashboard')
-            ->icon('charts');
+        if (count(config('statamic.cp.widgets')) > 0 || config('statamic.cp.start_page') === 'dashboard') {
+            Nav::topLevel('Dashboard')
+                ->route('dashboard')
+                ->icon('charts');
+        }
 
         // Nav::topLevel('Playground')
         //     ->route('playground')


### PR DESCRIPTION
Just an idea, it is mostly personal preference.
I would like to be able te remove the dashboard link.
This way when there are no widgets, so no content for the dashboard and its not the default route it can be omitted.

It can also be an extra config option but that feels like config bloat.