### PR TITLE
Custom taxonomy routes

### DIFF
--- a/resources/js/bootstrap/fieldtypes.js
+++ b/resources/js/bootstrap/fieldtypes.js
@@ -54,6 +54,7 @@ Vue.component('status-fieldtype', StatusFieldtype);
 Vue.component('table-fieldtype', require('../components/fieldtypes/TableFieldtype.vue').default);
 Vue.component('tags-fieldtype', require('../components/fieldtypes/TagsFieldtype.vue').default);
 Vue.component('tags-fieldtype-index', require('../components/fieldtypes/TagsIndexFieldtype.vue').default);
+Vue.component('taxonomy_routes-fieldtype', require('../components/taxonomies/Routes.vue').default);
 Vue.component('template-fieldtype', TemplateFieldtype);
 Vue.component('time-fieldtype', require('../components/fieldtypes/TimeFieldtype.vue').default);
 Vue.component('toggle-fieldtype', require('../components/fieldtypes/ToggleFieldtype.vue').default);

--- a/resources/js/components/taxonomies/Routes.vue
+++ b/resources/js/components/taxonomies/Routes.vue
@@ -1,0 +1,122 @@
+<template>
+
+    <div>
+        <div v-if="hasMultipleSites">
+            <div class="radio-fieldtype mb-1">
+                <radio-fieldtype handle="route_mode" :value="routeMode" @input="setRouteMode" :config="{
+                    inline: true,
+                    options: {
+                        single: 'Single route',
+                        multiple: 'Separate route for each site',
+                    }
+                }" />
+            </div>
+            <table class="grid-table" v-if="hasPerSiteRouting">
+                <thead>
+                    <tr>
+                        <th>Site</th>
+                        <th class="w-2/3">Route</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr v-for="site in sites" :key="site.handle">
+                        <td class="align-middle" v-text="site.name" />
+                        <td>
+                            <text-input
+                                class="font-mono text-xs"
+                                :value="value[site.handle]"
+                                @input="updateSiteRoute(site.handle, $event)" />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div v-if="!hasMultipleSites || !hasPerSiteRouting">
+            <text-input :value="value" @input="update" class="font-mono text-xs" />
+        </div>
+    </div>
+
+</template>
+
+<script>
+export default {
+
+    mixins: [Fieldtype],
+
+    inject: ['storeName'],
+
+    data() {
+        return {
+            singleValue: null,
+            multipleValue: null,
+        }
+    },
+
+
+    computed: {
+
+        routeMode() {
+            return (typeof this.value === 'string') ? 'single' : 'multiple';
+        },
+
+        sites() {
+            let state = this.$store.state.publish[this.storeName];
+
+            if (!state.values.sites) return [];
+
+            return state.values.sites.map((handle, i) => {
+                return {
+                    handle,
+                    name: state.meta.sites.data[i].title
+                }
+            });
+        },
+
+        hasMultipleSites() {
+            return this.sites.length > 1;
+        },
+
+        hasPerSiteRouting() {
+            return this.routeMode === 'multiple';
+        },
+
+    },
+
+    methods: {
+
+        setRouteMode(mode) {
+            if (mode === this.routeMode) return;
+
+            let value;
+
+            if (mode === 'single') {
+                this.multipleValue = this.value;
+
+                value = this.singleValue || Object.values(this.value)[0];
+            } 
+            
+            if (mode === 'multiple') {
+                this.singleValue = this.value;
+                
+                if (this.multipleValue) {
+                    value = this.multipleValue;
+                } else {
+                    value = {};
+                    this.sites.forEach(site => value[site.handle] = '');
+                }
+            }
+
+            if (value) this.update(value);
+        },
+
+        updateSiteRoute(site, route) {
+            let value = this.value;
+            value[site] = route;
+            this.update(value);
+        }
+
+    }
+
+}
+</script>

--- a/resources/lang/da/messages.php
+++ b/resources/lang/da/messages.php
@@ -149,6 +149,7 @@ return [
     'tab_sections_instructions' => 'Felterne i hvert afsnit grupperes i faner. Opret nye felter, genbrug eksisterende felter, eller importer hele grupper af felter fra eksisterende feltsæt.',
     'taxonomies_blueprints_instructions' => 'Vilkår i denne taksonomi kan bruge en hvilken som helst af disse blueprints.',
     'taxonomies_collections_instructions' => 'De samlinger, der bruger denne taksonomi.',
+    'taxonomies_route_instructions' => 'Ruten styrer begrepene URL -mønster.',
     'taxonomy_configure_handle_instructions' => 'Bruges til at henvise til denne taksonomi på frontend. Det er besværligt at ændre senere.',
     'taxonomy_configure_intro' => 'En taksonomi er et system til klassificering af data omkring et sæt unikke egenskaber, såsom kategori eller farve.',
     'taxonomy_configure_title_instructions' => 'Vi anbefaler at bruge et flertal navneord, som "Kategorier" eller "Mærker".',

--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -152,6 +152,7 @@ return [
     'tab_sections_instructions' => 'Die Felder in jedem Abschnitt werden in Tabs gruppiert. Du kannst neue Felder erstellen, vorhandene Felder wieder verwenden oder ganze Feldgruppen aus vorhandenen Fieldsets importieren.',
     'taxonomies_blueprints_instructions' => 'Begriffe in dieser Taxonomie können jedes dieser Blueprints verwenden.',
     'taxonomies_collections_instructions' => 'Die Sammlungen, in denen diese Taxonomie verwendet wird.',
+    'taxonomies_route_instructions' => 'Die Route steuert das URL-Schema der Begriffe.',
     'taxonomy_configure_handle_instructions' => 'Verweist im Frontend auf diese Taxonomie. Es ist nicht unproblematisch, dies nachträglich zu ändern.',
     'taxonomy_configure_intro' => 'Eine Taxonomie ist ein System zum Klassifizieren von Daten anhand einer Reihe eindeutiger Merkmale, wie z.B. Kategorie oder Farbe.',
     'taxonomy_configure_title_instructions' => 'Wir empfehlen ein Substantiv im Plural, wie z.B. Kategorien oder Tags.',

--- a/resources/lang/de_CH/messages.php
+++ b/resources/lang/de_CH/messages.php
@@ -152,6 +152,7 @@ return [
     'tab_sections_instructions' => 'Die Felder in jedem Abschnitt werden in Tabs gruppiert. Du kannst neue Felder erstellen, vorhandene Felder wieder verwenden oder ganze Feldgruppen aus vorhandenen Fieldsets importieren.',
     'taxonomies_blueprints_instructions' => 'Begriffe in dieser Taxonomie können jedes dieser Blueprints verwenden.',
     'taxonomies_collections_instructions' => 'Die Sammlungen, in denen diese Taxonomie verwendet wird.',
+    'taxonomies_route_instructions' => 'Die Route steuert das URL-Schema der Begriffe.',
     'taxonomy_configure_handle_instructions' => 'Verweist im Frontend auf diese Taxonomie. Es ist nicht unproblematisch, dies nachträglich zu ändern.',
     'taxonomy_configure_intro' => 'Eine Taxonomie ist ein System zum Klassifizieren von Daten anhand einer Reihe eindeutiger Merkmale, wie z.B. Kategorie oder Farbe.',
     'taxonomy_configure_title_instructions' => 'Wir empfehlen ein Substantiv im Plural, wie z.B. Kategorien oder Tags.',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -153,6 +153,7 @@ return [
     'tab_sections_instructions' => 'The fields in each section will be grouped together into tabs. Create new fields, reuse existing fields, or import entire groups of fields from existing fieldsets.',
     'taxonomies_blueprints_instructions' => 'Terms in this taxonomy may use any of these blueprints.',
     'taxonomies_collections_instructions' => 'The collections that use this taxonomy.',
+    'taxonomies_route_instructions' => 'The route controls terms URL pattern.',
     'taxonomy_configure_handle_instructions' => 'Used to reference this taxonomy on the frontend. It\'s non-trivial to change later.',
     'taxonomy_configure_intro' => 'A taxonomy is a system of classifying data around a set of unique characteristics, such as category or color.',
     'taxonomy_configure_title_instructions' => 'We recommend using a plural noun, like "Categories" or "Tags".',

--- a/resources/lang/es/messages.php
+++ b/resources/lang/es/messages.php
@@ -150,6 +150,7 @@ return [
     'tab_sections_instructions' => 'Los campos en cada sección se agruparán en pestañas. Crea nuevos campos, reutiliza campos existentes o importa grupos enteros de campos en conjuntos de campos existentes.',
     'taxonomies_blueprints_instructions' => 'Los términos en esta taxonomía pueden ser usados en cualquiera de estos planos.',
     'taxonomies_collections_instructions' => 'Las colecciones que usan esta taxonomía.',
+    'taxonomies_route_instructions' => 'La ruta controla el patrón de URL de los términos.',
     'taxonomy_configure_handle_instructions' => 'Se usa para hacer referencia a esta taxonomía en la interfaz. Es complicado cambiarlo más tarde.',
     'taxonomy_configure_intro' => 'Una taxonomía es un sistema de clasificación de datos en torno a un conjunto de características únicas, como "categoría" o "color".',
     'taxonomy_configure_title_instructions' => 'Recomendamos utilizar un sustantivo plural, como "Categorías" o "Etiquetas".',

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -152,6 +152,7 @@ return [
     'tab_sections_instructions' => 'Les champs de chaque section seront regroupés dans des onglets. Créez de nouveaux champs, réutilisez des champs existants ou importez des groupes entiers de champs à partir de jeux de champs existants.',
     'taxonomies_blueprints_instructions' => 'Les termes de cette taxonomie peuvent utiliser n’importe lequel de ces Blueprints.',
     'taxonomies_collections_instructions' => 'Les collections qui utilisent cette taxonomie.',
+    'taxonomies_route_instructions' => 'La route contrôle le modèle d’URL des termes.',
     'taxonomy_configure_handle_instructions' => 'Comment vous allez faire référence à cette taxonomie sur le frontal. Ne peut pas être facilement changé.',
     'taxonomy_configure_intro' => 'Une taxonomie est un système de classification des données autour d’un ensemble de caractéristiques uniques, telles que la catégorie ou la couleur.',
     'taxonomy_configure_title_instructions' => 'Nous recommandons un nom au pluriel, comme "Catégories" ou "Etiquettes".',

--- a/resources/lang/id/messages.php
+++ b/resources/lang/id/messages.php
@@ -148,6 +148,7 @@ return [
     'tab_sections_instructions' => 'Bidang di setiap bagian akan dikelompokkan menjadi beberapa tab. Buat bidang baru, gunakan kembali bidang yang ada, atau impor seluruh grup bidang dari fieldsets yang ada.',
     'taxonomies_blueprints_instructions' => 'Istilah dalam taksonomi ini dapat menggunakan salah satu dari cetak biru ini.',
     'taxonomies_collections_instructions' => 'Koleksi yang menggunakan taksonomi ini.',
+    'taxonomies_route_instructions' => 'Rute mengontrol istilah pola URL.',
     'taxonomy_configure_handle_instructions' => 'Digunakan untuk mereferensikan taksonomi ini di frontend. Tidak sepele untuk berubah nanti.',
     'taxonomy_configure_intro' => 'Taksonomi adalah sistem pengklasifikasian data di sekitar sekumpulan karakteristik unik, seperti kategori atau warna.',
     'taxonomy_configure_title_instructions' => 'Kami merekomendasikan penggunaan kata benda jamak, seperti "Kategori" atau "Tag".',

--- a/resources/lang/it/messages.php
+++ b/resources/lang/it/messages.php
@@ -148,6 +148,7 @@ return [
     'tab_sections_instructions' => 'I campi in ciascuna sezione saranno raggruppati in schede. Crea nuovi campi, riutilizza campi esistenti o importa interi gruppi di campi da fieldset esistenti.',
     'taxonomies_blueprints_instructions' => 'I termini di questa tassonomia possono utilizzare uno qualsiasi di questi progetti.',
     'taxonomies_collections_instructions' => 'Le raccolte che utilizzano questa tassonomia.',
+    'taxonomies_route_instructions' => 'La route definisce il pattern URL dei termini.',
     'taxonomy_configure_handle_instructions' => 'Utilizzato come riferimento a questa tassonomia sul frontend. Non è semplice modificarlo successivamente.',
     'taxonomy_configure_intro' => 'Una tassonomia è un sistema di classificazione dei dati in base ad un insieme di caratteristiche uniche, come categoria o colore.',
     'taxonomy_configure_title_instructions' => 'Ti consigliamo di utilizzare un sostantivo plurale, come "Categorie" o "Tags".',

--- a/resources/lang/nl/messages.php
+++ b/resources/lang/nl/messages.php
@@ -153,6 +153,7 @@ return [
     'tab_sections_instructions' => 'De velden in iedere sectie worden gegroepeerd in tabs. Voeg nieuwe velden toe, herbruik bestaande velden of importeer groepen van velden uit reeds bestaande fieldsets.',
     'taxonomies_blueprints_instructions' => 'Termen in deze taxonomie mogen in al deze blueprints gebruikt worden.',
     'taxonomies_collections_instructions' => 'De collectie die deze taxonomie gebruikt.',
+    'taxonomies_route_instructions' => 'De route definieert de termen URL-patroon.',
     'taxonomy_configure_handle_instructions' => 'Wordt gebruikt om in de frontend aan deze taxonomie te refereren. Het is niet persé eenvoudig om dit nadien te wijzigen.',
     'taxonomy_configure_intro' => 'Een taxonomie is een systeem waarmee je data kunt classificeren op basis van unieke eigenschappen, zoals categorie of kleur.',
     'taxonomy_configure_title_instructions' => 'We adviseren een meervoudig zeflstandig naamwoord, zoals "Categorieën" of "Tags".',

--- a/resources/lang/pt/messages.php
+++ b/resources/lang/pt/messages.php
@@ -148,6 +148,7 @@ return [
     'tab_sections_instructions' => 'Os campos em cada secção serão agrupados em guias. Crie novos campos, reutilize campos existentes ou importe grupos inteiros de campos de conjuntos de campos existentes.',
     'taxonomies_blueprints_instructions' => 'Os termos nesta taxonomia podem usar qualquer um desses diagramas.',
     'taxonomies_collections_instructions' => 'As coleções que usam essa taxonomia.',
+    'taxonomies_route_instructions' => 'A rota controla o padrão de URL dos termos.',
     'taxonomy_configure_handle_instructions' => 'Usado para referenciar essa taxonomia no frontend. Não é trivial mudar mais tarde.',
     'taxonomy_configure_intro' => 'Uma taxonomia é um sistema de classificação de dados em torno de um conjunto de características únicas, como categoria ou cor.',
     'taxonomy_configure_title_instructions' => 'Recomendamos o uso de um substantivo no plural, como "Categorias" ou "Etiquetas".',

--- a/resources/lang/sl/messages.php
+++ b/resources/lang/sl/messages.php
@@ -148,6 +148,7 @@ return [
     'tab_sections_instructions' => 'Polja v vsakem odseku bodo združena v zavihke. Ustvarite nova polja, znova uporabite obstoječa polja ali uvozite celotne skupine polj iz obstoječih naborov polj.',
     'taxonomies_blueprints_instructions' => 'Izrazi v tej taksonomiji lahko uporabljajo katerega koli od teh načrtov.',
     'taxonomies_collections_instructions' => 'Zbirke, ki uporabljajo to taksonomijo.',
+    'taxonomies_route_instructions' => 'Pot nadzira vzorec URL-ja izraza.',
     'taxonomy_configure_handle_instructions' => 'Uporablja se za sklicevanje na to taksonomijo na sprednji strani. Pozneje se spreminjati ni trivialno.',
     'taxonomy_configure_intro' => 'Taksonomija je sistem razvrščanja podatkov po nizu edinstvenih značilnosti, kot sta kategorija ali barva.',
     'taxonomy_configure_title_instructions' => 'Priporočamo uporabo samostalnika v množini, na primer &quot;Kategorije&quot; ali &quot;Oznake&quot;.',

--- a/resources/lang/zh_TW/messages.php
+++ b/resources/lang/zh_TW/messages.php
@@ -150,6 +150,7 @@ return [
     'tab_sections_instructions' => '在各個段落中的欄位都將被分組在一起，放置於同一個頁籤內。建立新欄位、重複使用現有欄位、或是從現有欄位組匯入整組欄位。',
     'taxonomies_blueprints_instructions' => '此分類中的字詞組可用於下列任意藍圖。',
     'taxonomies_collections_instructions' => '使用此分類的條目集。',
+    'taxonomies_route_instructions' => '路由控制術語的 URL 格式。',
     'taxonomy_configure_handle_instructions' => '用於在前端參照到此分類。設定後將難以修改。',
     'taxonomy_configure_intro' => '分類是一個依據一組獨立特色來將資料分門別類的系統，就像類別或色彩。',
     'taxonomy_configure_title_instructions' => '我們建議使用英語複數名詞，如「Categories」或「Tags」。',

--- a/src/Fieldtypes/TaxonomyRoutes.php
+++ b/src/Fieldtypes/TaxonomyRoutes.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Statamic\Fieldtypes;
+
+use Statamic\Fields\Fieldtype;
+
+class TaxonomyRoutes extends Fieldtype
+{
+    protected $selectable = false;
+}

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -242,7 +242,7 @@ class TaxonomiesController extends CpController
                     'route' => [
                         'display' => __('Route'),
                         'instructions' => __('statamic::messages.collections_route_instructions'),
-                        'type' => 'collection_routes',
+                        'type' => 'taxonomy_routes',
                     ],
                 ],
             ],

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -234,6 +234,11 @@ class TaxonomiesController extends CpController
                         'type' => 'collections',
                         'mode' => 'select',
                     ],
+                ],
+            ],
+            'routing' => [
+                'display' => __('Routing & URLs'),
+                'fields' => [
                     'route' => [
                         'display' => __('Route'),
                         'instructions' => __('statamic::messages.collections_route_instructions'),

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -128,6 +128,7 @@ class TaxonomiesController extends CpController
             'title' => $taxonomy->title(),
             'blueprints' => $taxonomy->termBlueprints()->map->handle()->all(),
             'collections' => $taxonomy->collections()->map->handle()->all(),
+            'route' => $taxonomy->route(),
             'sites' => $taxonomy->sites()->all(),
         ];
 
@@ -155,6 +156,8 @@ class TaxonomiesController extends CpController
         $values = $fields->process()->values()->all();
 
         $taxonomy->title($values['title']);
+
+        $taxonomy->route($values['route']);
 
         if ($sites = array_get($values, 'sites')) {
             $taxonomy->sites($sites);
@@ -230,6 +233,11 @@ class TaxonomiesController extends CpController
                         'instructions' => __('statamic::messages.taxonomies_collections_instructions'),
                         'type' => 'collections',
                         'mode' => 'select',
+                    ],
+                    'route' => [
+                        'display' => __('Route'),
+                        'instructions' => __('statamic::messages.collections_route_instructions'),
+                        'type' => 'collection_routes',
                     ],
                 ],
             ],

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -241,7 +241,7 @@ class TaxonomiesController extends CpController
                 'fields' => [
                     'route' => [
                         'display' => __('Route'),
-                        'instructions' => __('statamic::messages.collections_route_instructions'),
+                        'instructions' => __('statamic::messages.taxonomies_route_instructions'),
                         'type' => 'taxonomy_routes',
                     ],
                 ],

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -71,6 +71,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Fieldtypes\Taggable::class,
         Fieldtypes\Terms::class,
         Fieldtypes\Taxonomies::class,
+        Fieldtypes\TaxonomyRoutes::class,
         Fieldtypes\Template::class,
         Fieldtypes\Text::class,
         Fieldtypes\Textarea::class,

--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -56,24 +56,9 @@ class TermRepository implements RepositoryContract
         if ($collection) {
             $uri = Str::after($uri, $collection->uri($site) ?? $collection->handle());
         }
-
         
-        $uri = Str::after($uri, '/');
-
-        $taxonomy = Str::beforeLast($uri, '/');
-        $slug = Str::afterLast($uri, '/');
-        
-        if (! $slug) {
-            return null;
-        }
-
-        if (! $taxonomy = $this->findTaxonomyHandleByUri($taxonomy)) {
-            return null;
-        }
-
         $term = $this->query()
-            ->where('slug', $slug)
-            ->where('taxonomy', $taxonomy)
+            ->where('uri', $uri)
             ->where('site', $site)
             ->first();
 

--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -56,7 +56,7 @@ class TermRepository implements RepositoryContract
         if ($collection) {
             $uri = Str::after($uri, $collection->uri($site) ?? $collection->handle());
         }
-        
+
         $term = $this->query()
             ->where('uri', $uri)
             ->where('site', $site)

--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -57,10 +57,12 @@ class TermRepository implements RepositoryContract
             $uri = Str::after($uri, $collection->uri($site) ?? $collection->handle());
         }
 
-        $uri = Str::removeLeft($uri, '/');
+        
+        $uri = Str::after($uri, '/');
 
-        [$taxonomy, $slug] = array_pad(explode('/', $uri), 2, null);
-
+        $taxonomy = Str::beforeLast($uri, '/');
+        $slug = Str::afterLast($uri, '/');
+        
         if (! $slug) {
             return null;
         }

--- a/src/Stache/Stores/TaxonomiesStore.php
+++ b/src/Stache/Stores/TaxonomiesStore.php
@@ -40,6 +40,7 @@ class TaxonomiesStore extends BasicStore
 
         return Taxonomy::make($handle)
             ->title(array_get($data, 'title'))
+            ->route(array_get($data, 'route'))
             ->cascade(array_get($data, 'inject', []))
             ->revisionsEnabled(array_get($data, 'revisions', false))
             ->searchIndex(array_get($data, 'search_index'))

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -317,7 +317,7 @@ class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, Reso
 
     public function route()
     {
-        $route = '/'.str_replace('_', '-', $this->taxonomyHandle()).'/{slug}';
+        $route = '/'.$this->taxonomy()->route().'/{slug}';
 
         if ($this->collection()) {
             $collectionUrl = $this->collection()->url() ?? $this->collection()->handle();

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -317,7 +317,7 @@ class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, Reso
 
     public function route()
     {
-        $route = '/'.$this->taxonomy()->route().'/{slug}';
+        $route = '/'.$this->taxonomy()->route();
 
         if ($this->collection()) {
             $collectionUrl = $this->collection()->url() ?? $this->collection()->handle();

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -28,6 +28,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
     use FluentlyGetsAndSets, ExistsAsFile, HasAugmentedData, ContainsCascadingData, ContainsSupplementalData;
 
     protected $handle;
+    protected $route;
     protected $title;
     protected $blueprints = [];
     protected $sites = [];
@@ -50,6 +51,10 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
     public function handle($handle = null)
     {
         return $this->fluentlyGetOrSet('handle')->args(func_get_args());
+    }
+
+    public function route($route = null) {
+        return $this->fluentlyGetOrSet('route')->args(func_get_args());
     }
 
     public function title($title = null)
@@ -180,6 +185,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
     {
         $data = [
             'title' => $this->title,
+            'route' => $this->route(),
             'blueprints' => $this->blueprints,
         ];
 
@@ -201,6 +207,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
     {
         return [
             'title' => $this->title,
+            'route' => $this->route(),
             'handle' => $this->handle,
             'blueprints' => $this->blueprints,
         ];
@@ -257,7 +264,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
 
         $prefix = $this->collection() ? $this->collection()->uri($site->handle()) : '/';
 
-        return URL::tidy($prefix.str_replace('_', '-', '/'.$this->handle));
+        return URL::tidy($prefix.str_replace('_', '-', '/'.($this->route() ?? $this->handle())));
     }
 
     public function collection($collection = null)

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -264,7 +264,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
 
         $prefix = $this->collection() ? $this->collection()->uri($site->handle()) : '/';
 
-        return URL::tidy($prefix.str_replace('_', '-', '/'.($this->route() ?? $this->handle())));
+        return URL::tidy($prefix.'/'.($this->route() ?? $this->route(str_replace('_', '-', $this->handle()))));
     }
 
     public function collection($collection = null)

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -3,6 +3,7 @@
 namespace Statamic\Taxonomies;
 
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Str;
 use Statamic\Contracts\Data\Augmentable as AugmentableContract;
 use Statamic\Contracts\Taxonomies\Taxonomy as Contract;
 use Statamic\Data\ContainsCascadingData;
@@ -54,7 +55,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
     }
 
     public function route($route = null) {
-        return $this->fluentlyGetOrSet('route')->args(func_get_args()) ?? str_replace('_', '-', $this->handle());
+        return $this->fluentlyGetOrSet('route')->args(func_get_args()) ?? str_replace('_', '-', $this->handle()) . '/{slug}';
     }
 
     public function title($title = null)
@@ -264,7 +265,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
 
         $prefix = $this->collection() ? $this->collection()->uri($site->handle()) : '/';
 
-        return URL::tidy($prefix.'/'.$this->route());
+        return URL::tidy($prefix.'/'.Str::before($this->route(), '/{slug}'));
     }
 
     public function collection($collection = null)

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -54,11 +54,12 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
         return $this->fluentlyGetOrSet('handle')->args(func_get_args());
     }
 
-    public function route($route = null) {
+    public function route($route = null)
+    {
         return $this
             ->fluentlyGetOrSet('route')
             ->getter(function ($route) {
-                return $route ?? (str_replace('_', '-', $this->handle) . '/{slug}');
+                return $route ?? (str_replace('_', '-', $this->handle).'/{slug}');
             })
             ->args(func_get_args());
     }

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -191,7 +191,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
     {
         $data = [
             'title' => $this->title,
-            'route' => $this->route(),
+            'route' => $this->route,
             'blueprints' => $this->blueprints,
         ];
 
@@ -213,7 +213,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
     {
         return [
             'title' => $this->title,
-            'route' => $this->route(),
+            'route' => $this->route,
             'handle' => $this->handle,
             'blueprints' => $this->blueprints,
         ];

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -55,7 +55,12 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
     }
 
     public function route($route = null) {
-        return $this->fluentlyGetOrSet('route')->args(func_get_args()) ?? str_replace('_', '-', $this->handle()) . '/{slug}';
+        return $this
+            ->fluentlyGetOrSet('route')
+            ->getter(function ($route) {
+                return $route ?? (str_replace('_', '-', $this->handle) . '/{slug}');
+            })
+            ->args(func_get_args());
     }
 
     public function title($title = null)

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -54,7 +54,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
     }
 
     public function route($route = null) {
-        return $this->fluentlyGetOrSet('route')->args(func_get_args());
+        return $this->fluentlyGetOrSet('route')->args(func_get_args()) ?? str_replace('_', '-', $this->handle());
     }
 
     public function title($title = null)
@@ -264,7 +264,7 @@ class Taxonomy implements Contract, Responsable, AugmentableContract
 
         $prefix = $this->collection() ? $this->collection()->uri($site->handle()) : '/';
 
-        return URL::tidy($prefix.'/'.($this->route() ?? $this->route(str_replace('_', '-', $this->handle()))));
+        return URL::tidy($prefix.'/'.$this->route());
     }
 
     public function collection($collection = null)

--- a/tests/Stache/FeatureTest.php
+++ b/tests/Stache/FeatureTest.php
@@ -250,7 +250,7 @@ class FeatureTest extends TestCase
 
         $this->assertStringEqualsFile(
             $path = __DIR__.'/__fixtures__/content/taxonomies/new.yaml',
-            "title: 'New Taxonomy'\nroute: 'new/{slug}'\n"
+            "title: 'New Taxonomy'\n"
         );
         @unlink($path);
     }

--- a/tests/Stache/FeatureTest.php
+++ b/tests/Stache/FeatureTest.php
@@ -250,7 +250,7 @@ class FeatureTest extends TestCase
 
         $this->assertStringEqualsFile(
             $path = __DIR__.'/__fixtures__/content/taxonomies/new.yaml',
-            "title: 'New Taxonomy'\n"
+            "title: 'New Taxonomy'\nroute: new\n"
         );
         @unlink($path);
     }

--- a/tests/Stache/FeatureTest.php
+++ b/tests/Stache/FeatureTest.php
@@ -250,7 +250,7 @@ class FeatureTest extends TestCase
 
         $this->assertStringEqualsFile(
             $path = __DIR__.'/__fixtures__/content/taxonomies/new.yaml',
-            "title: 'New Taxonomy'\nroute: new\n"
+            "title: 'New Taxonomy'\nroute: 'new/{slug}'\n"
         );
         @unlink($path);
     }


### PR DESCRIPTION
Implements #2403 - allows setting route on taxonomies similarly to how it would be set using a collection.

- By default, the route will be the same as the previous default. `{taxonomy_handle}/{slug}`.
- If the route is not set, the default will be used. The default will not be returned by fileData().
- The taxonomy view will be set to what comes before `/{slug}`. So if the route is `category/{slug}/view`, the taxonomy route would be `category`.
- CP implementation is a direct copy from the collection route, excluding strings.
- Translations are all from google translate, not sure how accurate they are. I've tried to keep them as similar to the collection route translations as possible.