### PR TITLE
Don't use array validation for bard

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -24,6 +24,7 @@ class Bard extends Replicator
 
     public $category = ['text', 'structured'];
     protected $defaultValue = '[]';
+    protected $rules = [];
 
     protected function configFieldItems(): array
     {


### PR DESCRIPTION
Fixes #4240 

There's more to the issue, it only happens when it's inside a replicator. But this'll at least let it pass validation.