### PR TITLE
Fix user binding and shallow augmenting

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -20,6 +20,7 @@ class User extends BaseUser
     protected $roles;
     protected $groups;
 
+    /** @deprecated */
     public static function fromModel(Model $model)
     {
         return tap(new static, function ($user) use ($model) {

--- a/src/Auth/Eloquent/UserQueryBuilder.php
+++ b/src/Auth/Eloquent/UserQueryBuilder.php
@@ -3,6 +3,7 @@
 namespace Statamic\Auth\Eloquent;
 
 use Statamic\Auth\UserCollection;
+use Statamic\Facades\User;
 use Statamic\Query\EloquentQueryBuilder;
 
 class UserQueryBuilder extends EloquentQueryBuilder
@@ -10,7 +11,7 @@ class UserQueryBuilder extends EloquentQueryBuilder
     protected function transform($items, $columns = ['*'])
     {
         return UserCollection::make($items)->map(function ($model) {
-            return User::fromModel($model);
+            return User::make()->model($model);
         })->each->selectedQueryColumns($columns);
     }
 }

--- a/src/Auth/Eloquent/UserRepository.php
+++ b/src/Auth/Eloquent/UserRepository.php
@@ -22,7 +22,7 @@ class UserRepository extends BaseRepository
     public function all(): UserCollection
     {
         $users = $this->model('all')->keyBy('id')->map(function ($model) {
-            return $this->makeUser($model);
+            return $this->make()->model($model);
         });
 
         return UserCollection::make($users);
@@ -32,7 +32,7 @@ class UserRepository extends BaseRepository
     {
         return Blink::once("eloquent-user-find-{$id}", function () use ($id) {
             if ($model = $this->model('find', $id)) {
-                return $this->makeUser($model);
+                return $this->make()->model($model);
             }
 
             return null;
@@ -45,7 +45,7 @@ class UserRepository extends BaseRepository
             return null;
         }
 
-        return $this->makeUser($model);
+        return $this->make()->model($model);
     }
 
     public function model($method, ...$args)
@@ -53,17 +53,6 @@ class UserRepository extends BaseRepository
         $model = $this->config['model'];
 
         return call_user_func_array([$model, $method], $args);
-    }
-
-    /**
-     * Convert an Eloquent User model to a Statamic User instance.
-     *
-     * @param  Model  $model
-     * @return User
-     */
-    private function makeUser(Model $model)
-    {
-        return User::fromModel($model);
     }
 
     public function query()

--- a/src/Auth/Eloquent/UserRepository.php
+++ b/src/Auth/Eloquent/UserRepository.php
@@ -19,11 +19,6 @@ class UserRepository extends BaseRepository
         $this->config = $config;
     }
 
-    public function make(): UserContract
-    {
-        return (new User)->model(new $this->config['model']);
-    }
-
     public function all(): UserCollection
     {
         $users = $this->model('all')->keyBy('id')->map(function ($model) {
@@ -105,5 +100,17 @@ class UserRepository extends BaseRepository
         }
 
         return null;
+    }
+
+    public static function bindings(): array
+    {
+        return [
+            UserContract::class => User::class,
+        ];
+    }
+
+    public function make(): UserContract
+    {
+        return parent::make()->model(new $this->config['model']);
     }
 }

--- a/src/Auth/UserRepository.php
+++ b/src/Auth/UserRepository.php
@@ -18,6 +18,11 @@ abstract class UserRepository implements RepositoryContract
         return app(UserFactory::class);
     }
 
+    public function make(): User
+    {
+        return app(User::class);
+    }
+
     public function current(): ?User
     {
         if (! $user = auth()->user()) {

--- a/src/Console/Composer/Lock.php
+++ b/src/Console/Composer/Lock.php
@@ -99,7 +99,10 @@ class Lock
     {
         $this->ensureExists();
 
-        $installed = collect(json_decode($this->files->get($this->path))->packages)
+        $lock = json_decode($this->files->get($this->path));
+
+        $installed = collect($lock->packages)
+            ->merge($lock->{'packages-dev'})
             ->keyBy('name')
             ->get($package);
 

--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -117,6 +117,11 @@ class Users extends Relationship
         return User::find($value);
     }
 
+    protected function shallowAugmentValue($value)
+    {
+        return $value->toShallowAugmentedCollection();
+    }
+
     protected function getCreateItemUrl()
     {
         return cp_route('users.create');

--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -43,7 +43,15 @@ class AuthServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton(UserRepository::class, function ($app) {
-            return $app[UserRepositoryManager::class]->repository();
+            $repository = $app[UserRepositoryManager::class]->repository();
+
+            foreach ($repository::bindings() as $abstract => $concrete) {
+                if (! $this->app->bound($abstract)) {
+                    $this->app->bind($abstract, $concrete);
+                }
+            }
+
+            return $repository;
         });
 
         $this->app->singleton(RoleRepository::class, function ($app) {

--- a/src/Stache/Repositories/UserRepository.php
+++ b/src/Stache/Repositories/UserRepository.php
@@ -26,11 +26,6 @@ class UserRepository extends BaseRepository
         $this->config = $config;
     }
 
-    public function make(): User
-    {
-        return new FileUser;
-    }
-
     public function all(): UserCollection
     {
         return $this->query()->get();
@@ -72,5 +67,12 @@ class UserRepository extends BaseRepository
         }
 
         return null;
+    }
+
+    public static function bindings(): array
+    {
+        return [
+            User::class => FileUser::class,
+        ];
     }
 }

--- a/tests/Auth/EloquentUserRepositoryTest.php
+++ b/tests/Auth/EloquentUserRepositoryTest.php
@@ -9,6 +9,16 @@ class EloquentUserRepositoryTest extends TestCase
 {
     use UserRepositoryTests;
 
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (version_compare($this->app->version(), '7.0', '<')) {
+            // honestly just a pain to support this in earlier versions of laravel/testbench
+            $this->markTestSkipped('Needs newer testbench');
+        }
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);

--- a/tests/Auth/EloquentUserRepositoryTest.php
+++ b/tests/Auth/EloquentUserRepositoryTest.php
@@ -9,16 +9,6 @@ class EloquentUserRepositoryTest extends TestCase
 {
     use UserRepositoryTests;
 
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        if (version_compare($this->app->version(), '7.0', '<')) {
-            // honestly just a pain to support this in earlier versions of laravel/testbench
-            $this->markTestSkipped('Needs newer testbench');
-        }
-    }
-
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);

--- a/tests/Auth/EloquentUserRepositoryTest.php
+++ b/tests/Auth/EloquentUserRepositoryTest.php
@@ -2,12 +2,24 @@
 
 namespace Tests\Auth;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 /** @group user-repo */
 class EloquentUserRepositoryTest extends TestCase
 {
     use UserRepositoryTests;
+
+    public function setUp(): void
+    {
+        parent::setup();
+
+        $testbench = (new \Statamic\Console\Processes\Composer(__DIR__.'/../../'))->installedVersion('orchestra/testbench-core');
+
+        if (version_compare($testbench, '6.7.0', '<')) {
+            $this->markTestSkipped('Need defineDatabaseMigrations method only introduced in 6.7.0');
+        }
+    }
 
     protected function getEnvironmentSetUp($app)
     {

--- a/tests/Auth/EloquentUserRepositoryTest.php
+++ b/tests/Auth/EloquentUserRepositoryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Auth;
+
+use Tests\TestCase;
+
+/** @group user-repo */
+class EloquentUserRepositoryTest extends TestCase
+{
+    use UserRepositoryTests;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('statamic.users.repository', 'eloquent');
+        $app['config']->set('auth.providers', [
+            'users' => [
+                'driver' => 'eloquent',
+                'model' => ActualUserModel::class,
+            ],
+        ]);
+
+        // Just so we can override saveToDatabase()
+        app()->bind(\Statamic\Auth\Eloquent\User::class, ActualEloquentUser::class);
+    }
+
+    protected function defineDatabaseMigrations()
+    {
+        $this->loadLaravelMigrations();
+    }
+
+    public function userClass()
+    {
+        return ActualEloquentUser::class;
+    }
+
+    public function fakeUserClass()
+    {
+        return FakeEloquentUser::class;
+    }
+}
+
+class ActualEloquentUser extends \Statamic\Auth\Eloquent\User
+{
+    public function saveToDatabase()
+    {
+        $this->model()->save();
+
+        // dont save roles/groups
+    }
+}
+
+class FakeEloquentUser extends ActualEloquentUser
+{
+    public function initials()
+    {
+        return 'FAKEINITIALS';
+    }
+}
+
+class ActualUserModel extends \Illuminate\Database\Eloquent\Model
+{
+    protected $table = 'users';
+}

--- a/tests/Auth/EloquentUserRepositoryTest.php
+++ b/tests/Auth/EloquentUserRepositoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Auth;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 /** @group user-repo */

--- a/tests/Auth/StacheUserRepositoryTest.php
+++ b/tests/Auth/StacheUserRepositoryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Auth;
+
+use Statamic\Auth\File\User;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+/** @group user-repo */
+class StacheUserRepositoryTest extends TestCase
+{
+    use UserRepositoryTests;
+    use PreventSavingStacheItemsToDisk;
+
+    public function userClass()
+    {
+        return User::class;
+    }
+
+    public function fakeUserClass()
+    {
+        return FakeStacheUser::class;
+    }
+}
+
+class FakeStacheUser extends \Statamic\Auth\File\User
+{
+    public function initials()
+    {
+        return 'FAKEINITIALS';
+    }
+}

--- a/tests/Auth/UserRepositoryTests.php
+++ b/tests/Auth/UserRepositoryTests.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Auth;
+
+use Statamic\Facades\User;
+
+trait UserRepositoryTests
+{
+    abstract public function userClass();
+
+    abstract public function fakeUserClass();
+
+    /** @test */
+    public function it_gets_the_class()
+    {
+        $this->assertInstanceOf($this->userClass(), User::make());
+    }
+
+    /** @test **/
+    public function it_overrides_the_class()
+    {
+        app()->bind(\Statamic\Contracts\Auth\User::class, $this->fakeUserClass());
+
+        $this->assertInstanceOf($this->fakeUserClass(), $user = User::make());
+        $this->assertEquals('FAKEINITIALS', $user->initials());
+    }
+
+    /** @test */
+    public function it_gets_all_users()
+    {
+        User::make()->email('foo@bar.com')->data(['name' => 'foo', 'password' => 'foo'])->save();
+        $this->assertEveryItemIsInstanceOf($this->userClass(), User::all());
+    }
+
+    /** @test */
+    public function it_gets_all_users_with_overridden_classes()
+    {
+        app()->bind(\Statamic\Contracts\Auth\User::class, $this->fakeUserClass());
+
+        User::make()->email('foo@bar.com')->data(['name' => 'foo', 'password' => 'foo'])->save();
+        $this->assertEveryItemIsInstanceOf($this->fakeUserClass(), User::all());
+    }
+
+    /** @test */
+    public function it_gets_user_by_id()
+    {
+        User::make()->id(1)->email('foo@bar.com')->data(['name' => 'foo', 'password' => 'foo'])->save();
+        $this->assertInstanceOf($this->userClass(), User::find(1));
+    }
+
+    /** @test */
+    public function it_gets_user_by_id_with_overridden_classes()
+    {
+        app()->bind(\Statamic\Contracts\Auth\User::class, $this->fakeUserClass());
+
+        User::make()->id(1)->email('foo@bar.com')->data(['name' => 'foo', 'password' => 'foo'])->save();
+        $this->assertInstanceOf($this->fakeUserClass(), User::find(1));
+    }
+
+    /** @test */
+    public function it_gets_user_by_email()
+    {
+        User::make()->email('foo@bar.com')->data(['name' => 'foo', 'password' => 'foo'])->save();
+        $this->assertInstanceOf($this->userClass(), User::findByEmail('foo@bar.com'));
+    }
+
+    /** @test */
+    public function it_gets_user_by_email_with_overridden_classes()
+    {
+        app()->bind(\Statamic\Contracts\Auth\User::class, $this->fakeUserClass());
+
+        User::make()->email('foo@bar.com')->data(['name' => 'foo', 'password' => 'foo'])->save();
+        $this->assertInstanceOf($this->fakeUserClass(), User::findByEmail('foo@bar.com'));
+    }
+}

--- a/tests/Fakes/Composer/Package/PackToTheFuture.php
+++ b/tests/Fakes/Composer/Package/PackToTheFuture.php
@@ -78,9 +78,8 @@ class PackToTheFuture
      */
     public static function generateComposerLock(string $package, string $version, $path = null, $dev = false)
     {
-        $packagesKey = $dev
-            ? 'packages-dev'
-            : 'packages';
+        $packagesKey = $dev ? 'packages-dev' : 'packages';
+        $nonFavouritePackagesKey = $dev ? 'packages' : 'packages-dev';
 
         $content = [
             $packagesKey => [
@@ -89,6 +88,7 @@ class PackToTheFuture
                     'version' => $version,
                 ],
             ],
+            $nonFavouritePackagesKey => [],
         ];
 
         file_put_contents(
@@ -117,6 +117,7 @@ class PackToTheFuture
 
         $content = [
             'packages' => $packages,
+            'packages-dev' => [],
         ];
 
         file_put_contents(


### PR DESCRIPTION
This fixes an issue where you couldn't override the user class.

You can now do:

```php
public function register()
{
    $this->app->bind(\Statamic\Contracts\Auth\User::class, CustomUser::class);
}
```

- [x] Add custom bindable user class.
- [x] Add shallow augmentation to users fieldtype.
- [x] Add tests

Bonus: Fixes `Composer::getInstalledVersion()` not checking dev packages.