### PR TITLE
Adjustments to Search::indexExists

### DIFF
--- a/src/Search/Search.php
+++ b/src/Search/Search.php
@@ -33,7 +33,7 @@ class Search
 
     public function indexExists($index = null)
     {
-        return $this->index($index)->exists();
+        return $this->indexes()->has($index) && $this->index($index)->exists();
     }
 
     public function extend($driver, $callback)


### PR DESCRIPTION
Hi There,

Unsure if it was the desired outcome, but I would have expected for \Statamic\Facades\Search::indexExists('Index does not exist') to return false, however this isn't the case and instead the exception below is thrown.

```
InvalidArgumentException
Search index [Index does not exist] is not defined.
```

This PR changes the following check, which will throw the exception if the index doesn't exist in the config and will return true or false, if it does but then the index data file does or does not exist.
```php
    public function indexExists($index = null)
    {
        return $this->index($index)->exists();
    }
```

To this, which will return false instead of throwning the exception, if the index has not been entered in the config, and then will respond with the same true or false condition that would have normally happened.
```php
    public function indexExists($index = null)
    {
        return $this->indexes()->has($index) && $this->index($index)->exists();
    }
```