### PR TITLE
Save index as unescaped unicode

### DIFF
--- a/src/Search/Comb/Index.php
+++ b/src/Search/Comb/Index.php
@@ -115,6 +115,6 @@ class Index extends BaseIndex
 
     protected function save($documents)
     {
-        File::put($this->path(), $documents->toJson());
+        File::put($this->path(), $documents->toJson(JSON_UNESCAPED_UNICODE));
     }
 }


### PR DESCRIPTION
This allows the Comb index to properly work with characters other than latin.