### PR TITLE
Add enable single-page application

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -40,4 +40,18 @@ return [
 
     'middleware' => 'web',
 
+    /**
+    |--------------------------------------------------------------------------
+    | Single-page application
+    |--------------------------------------------------------------------------
+    |
+    | Define the application will be running as a single-page application "SPA"
+    | and will use the view default to render your SPA.
+    |
+    */
+    'spa' => [
+        'enabled' => false,
+        'view' => 'layout'
+    ]
+
 ];

--- a/config/routes.php
+++ b/config/routes.php
@@ -52,6 +52,6 @@ return [
     'spa' => [
         'enabled' => false,
         'view' => 'layout'
-    ]
+    ],
 
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,7 +9,7 @@ use Statamic\Statamic;
 Route::name('statamic.')->group(function () {
     /**
      * Front-end
-     * All front-end website requests go through a single-page application view
+     * All front-end website requests go through a single-page application view layout.
      */
     if (config('statamic.routes.spa.enabled')) {
         Route::get('/{any}', function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,16 @@ use Statamic\Statamic;
 
 Route::name('statamic.')->group(function () {
     /**
+     * Front-end
+     * All front-end website requests go through a single-page application view
+     */
+    if (config('statamic.routes.spa.enabled')) {
+        Route::get('/{any}', function () {
+            return view(config('statamic.routes.spa.view'));
+        })->where('any', '.*');
+    }
+
+    /**
      * Glide
      * On-the-fly URL-based image transforms.
      */


### PR DESCRIPTION
This allows to have a single-page application direct on the main source, all front-end website requests go through a single-page application using `view` **layout** by default.
* By default the enabled is `false`
* Can define which view want's to render the SPA
* By default uses view layout