### PR TITLE
Adjust Globals listing

### DIFF
--- a/resources/views/globals/configure.blade.php
+++ b/resources/views/globals/configure.blade.php
@@ -4,10 +4,7 @@
 @section('content')
 
     <header class="mb-3">
-        @include('statamic::partials.breadcrumb', [
-            'url' => $set->inSelectedSite()->editUrl(),
-            'title' => $set->title()
-        ])
+        @include('statamic::partials.breadcrumb', $breadcrumb)
         <h1>@yield('title')</h1>
     </header>
 

--- a/src/Policies/GlobalSetPolicy.php
+++ b/src/Policies/GlobalSetPolicy.php
@@ -38,14 +38,12 @@ class GlobalSetPolicy
     {
         $user = User::fromUser($user);
 
-        return $this->edit($user, $set);
+        return $user->hasPermission("edit {$set->handle()} globals");
     }
 
     public function edit($user, $set)
     {
-        $user = User::fromUser($user);
-
-        return $user->hasPermission("edit {$set->handle()} globals");
+        // handled by before()
     }
 
     public function configure($user, $set)

--- a/src/Policies/GlobalSetVariablesPolicy.php
+++ b/src/Policies/GlobalSetVariablesPolicy.php
@@ -4,5 +4,8 @@ namespace Statamic\Policies;
 
 class GlobalSetVariablesPolicy extends GlobalSetPolicy
 {
-    //
+    public function edit($user, $set)
+    {
+        return $this->view($user, $set);
+    }
 }

--- a/tests/Feature/Globals/ConfigureGlobalsTest.php
+++ b/tests/Feature/Globals/ConfigureGlobalsTest.php
@@ -3,13 +3,12 @@
 namespace Tests\Feature\Globals;
 
 use Facades\Tests\Factories\GlobalFactory;
-use Statamic\Facades\Blueprint;
 use Statamic\Facades\User;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
-class EditGlobalVariablesTest extends TestCase
+class ConfigureGlobalsTest extends TestCase
 {
     use FakesRoles;
     use PreventSavingStacheItemsToDisk;
@@ -24,7 +23,7 @@ class EditGlobalVariablesTest extends TestCase
         $this
             ->from('/original')
             ->actingAs($user)
-            ->get($global->in('en')->editUrl())
+            ->get($global->editUrl())
             ->assertRedirect('/original')
             ->assertSessionHas('error');
     }
@@ -32,22 +31,14 @@ class EditGlobalVariablesTest extends TestCase
     /** @test */
     public function it_shows_the_form()
     {
-        $blueprint = Blueprint::make()->setContents(['fields' => [
-            ['handle' => 'foo', 'field' => ['type' => 'text']],
-            ['handle' => 'unused', 'field' => ['type' => 'text']],
-        ]]);
-        $userBlueprint = Blueprint::make();
-        Blueprint::shouldReceive('find')->with('globals.test')->andReturn($blueprint);
-        Blueprint::shouldReceive('find')->with('user')->andReturn($userBlueprint);
-        $this->setTestRoles(['test' => ['access cp', 'edit test globals']]);
+        $this->setTestRoles(['test' => ['access cp', 'configure globals']]);
         $user = User::make()->assignRole('test')->save();
 
         $global = GlobalFactory::handle('test')->data(['foo' => 'bar'])->create();
 
         $this
             ->actingAs($user)
-            ->get($global->in('en')->editUrl())
-            ->assertSuccessful()
-            ->assertViewHas('values', ['foo' => 'bar', 'unused' => null]);
+            ->get($global->editUrl())
+            ->assertSuccessful();
     }
 }

--- a/tests/Feature/Globals/ViewGlobalsListingTest.php
+++ b/tests/Feature/Globals/ViewGlobalsListingTest.php
@@ -21,7 +21,7 @@ class ViewGlobalsListingTest extends TestCase
         $this->setTestRoles(['test' => [
             'access cp',
             'edit test_one globals',
-            'edit test_three globals'
+            'edit test_three globals',
         ]]);
         $user = User::make()->assignRole('test')->save();
         GlobalFactory::handle('test_one')->create();
@@ -76,7 +76,7 @@ class ViewGlobalsListingTest extends TestCase
         $this->setTestRoles(['test' => [
             'access cp',
             'edit test_one globals',
-            'edit test_three globals'
+            'edit test_three globals',
         ]]);
         $user = User::make()->assignRole('test')->save();
         $one = GlobalFactory::handle('test_one')->create();

--- a/tests/Feature/Globals/ViewGlobalsListingTest.php
+++ b/tests/Feature/Globals/ViewGlobalsListingTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Globals;
 use Facades\Tests\Factories\GlobalFactory;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
+use Statamic\Support\Arr;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -31,10 +32,12 @@ class ViewGlobalsListingTest extends TestCase
         $this->actingAs($user)
             ->get(cp_route('globals.index'))
             ->assertOk()
-            ->assertViewHas('globals.0.handle', 'test_one')
-            ->assertViewHas('globals.0.edit_url', url('/cp/globals/test_one'))
-            ->assertViewHas('globals.1.handle', 'test_three')
-            ->assertViewHas('globals.1.edit_url', url('/cp/globals/test_three'));
+            ->assertViewHas('globals', function ($globals) {
+                return Arr::get($globals, '0.handle', 'test_one')
+                    && Arr::get($globals, '0.edit_url', url('/cp/globals/test_one'))
+                    && Arr::get($globals, '1.handle', 'test_three')
+                    && Arr::get($globals, '1.edit_url', url('/cp/globals/test_three'));
+            });
     }
 
     /** @test */
@@ -59,10 +62,12 @@ class ViewGlobalsListingTest extends TestCase
         $this->actingAs($user)
             ->get(cp_route('globals.index'))
             ->assertOk()
-            ->assertViewHas('globals.0.handle', 'test_one')
-            ->assertViewHas('globals.0.edit_url', url('/cp/globals/test_one?site=fr'))
-            ->assertViewHas('globals.1.handle', 'test_two')
-            ->assertViewHas('globals.1.edit_url', url('/cp/globals/test_two/edit'));
+            ->assertViewHas('globals', function ($globals) {
+                return Arr::get($globals, '0.handle', 'test_one')
+                    && Arr::get($globals, '0.edit_url', url('/cp/globals/test_one?site=fr'))
+                    && Arr::get($globals, '1.handle', 'test_two')
+                    && Arr::get($globals, '1.edit_url', url('/cp/globals/test_two/edit'));
+            });
     }
 
     /** @test */
@@ -92,7 +97,9 @@ class ViewGlobalsListingTest extends TestCase
             ->assertViewHas('globals', function ($globals) {
                 return $globals->count() === 1;
             })
-            ->assertViewHas('globals.0.handle', 'test_one')
-            ->assertViewHas('globals.0.edit_url', url('/cp/globals/test_one?site=fr'));
+            ->assertViewHas('globals', function ($globals) {
+                return Arr::get($globals, '0.handle', 'test_one')
+                    && Arr::get($globals, '0.edit_url', url('/cp/globals/test_one?site=fr'));
+            });
     }
 }

--- a/tests/Feature/Globals/ViewGlobalsListingTest.php
+++ b/tests/Feature/Globals/ViewGlobalsListingTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\Globals;
+
+use Facades\Tests\Factories\GlobalFactory;
+use Statamic\Facades\Site;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ViewGlobalsListingTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    /** @test */
+    public function it_lists_globals()
+    {
+        $this->withoutExceptionHandling();
+        $this->setTestRoles(['test' => [
+            'access cp',
+            'edit test_one globals',
+            'edit test_three globals'
+        ]]);
+        $user = User::make()->assignRole('test')->save();
+        GlobalFactory::handle('test_one')->create();
+        GlobalFactory::handle('test_two')->create();
+        GlobalFactory::handle('test_three')->create();
+
+        $this->actingAs($user)
+            ->get(cp_route('globals.index'))
+            ->assertOk()
+            ->assertViewHas('globals.0.handle', 'test_one')
+            ->assertViewHas('globals.0.edit_url', url('/cp/globals/test_one'))
+            ->assertViewHas('globals.1.handle', 'test_three')
+            ->assertViewHas('globals.1.edit_url', url('/cp/globals/test_three'));
+    }
+
+    /** @test */
+    public function it_uses_the_configure_url_if_it_doesnt_exist_in_the_selected_site_but_you_have_permission()
+    {
+        Site::setConfig(['sites' => [
+            'en' => ['url' => 'http://localhost/', 'locale' => 'en', 'name' => 'English'],
+            'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr', 'name' => 'French'],
+        ]]);
+
+        $this->setTestRoles(['test' => [
+            'access cp',
+            'configure globals',
+        ]]);
+        $user = User::make()->assignRole('test')->save();
+        $one = GlobalFactory::handle('test_one')->create();
+        $one->addLocalization($one->makeLocalization('fr'))->save();
+        $two = GlobalFactory::handle('test_two')->create();
+
+        session()->put('statamic.cp.selected-site', 'fr');
+
+        $this->actingAs($user)
+            ->get(cp_route('globals.index'))
+            ->assertOk()
+            ->assertViewHas('globals.0.handle', 'test_one')
+            ->assertViewHas('globals.0.edit_url', url('/cp/globals/test_one?site=fr'))
+            ->assertViewHas('globals.1.handle', 'test_two')
+            ->assertViewHas('globals.1.edit_url', url('/cp/globals/test_two/edit'));
+    }
+
+    /** @test */
+    public function it_filters_out_globals_if_it_doesnt_exist_in_the_selected_site_and_you_dont_have_permission_to_configure()
+    {
+        Site::setConfig(['sites' => [
+            'en' => ['url' => 'http://localhost/', 'locale' => 'en', 'name' => 'English'],
+            'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr', 'name' => 'French'],
+        ]]);
+
+        $this->setTestRoles(['test' => [
+            'access cp',
+            'edit test_one globals',
+            'edit test_three globals'
+        ]]);
+        $user = User::make()->assignRole('test')->save();
+        $one = GlobalFactory::handle('test_one')->create();
+        $one->addLocalization($one->makeLocalization('fr'))->save();
+        $two = GlobalFactory::handle('test_two')->create();
+        $three = GlobalFactory::handle('test_three')->create();
+
+        session()->put('statamic.cp.selected-site', 'fr');
+
+        $this->actingAs($user)
+            ->get(cp_route('globals.index'))
+            ->assertOk()
+            ->assertViewHas('globals', function ($globals) {
+                return $globals->count() === 1;
+            })
+            ->assertViewHas('globals.0.handle', 'test_one')
+            ->assertViewHas('globals.0.edit_url', url('/cp/globals/test_one?site=fr'));
+    }
+}


### PR DESCRIPTION
Fixes #1636

- Globals that don't exist for the selected site will use the "configure" url instead of the "edit variables" url.
- If you don't have permission to configure it, it'll just get filtered out.
- Applies to the side nav and the globals index listing.
- Also fixes an issue where a user without permission to configure a set could visit the edit page. (They couldn't submit, though)