### PR TITLE
Re-enable slugification when creating a localization

### DIFF
--- a/resources/js/components/Slugify.vue
+++ b/resources/js/components/Slugify.vue
@@ -55,6 +55,14 @@ export default {
 
     render() {
         return this.$scopedSlots.default({});
+    },
+
+    methods: {
+
+        reset() {
+            if (this.enabled) this.shouldSlugify = true;
+        }
+
     }
 
 }

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -601,7 +601,7 @@ export default {
             const url = this.activeLocalization.url + '/localize';
             this.$axios.post(url, { site: localization.handle }).then(response => {
                 this.editLocalization(response.data)
-                    .then(() => this.$events.$emit('localization.created'));
+                    .then(() => this.$events.$emit('localization.created', {store: this.publishContainer}));
             });
         },
 

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -570,7 +570,7 @@ export default {
         },
 
         editLocalization(localization) {
-            this.$axios.get(localization.url).then(response => {
+            return this.$axios.get(localization.url).then(response => {
                 const data = response.data;
                 this.values = data.values;
                 this.originValues = data.originValues;
@@ -600,7 +600,8 @@ export default {
 
             const url = this.activeLocalization.url + '/localize';
             this.$axios.post(url, { site: localization.handle }).then(response => {
-                this.editLocalization(response.data);
+                this.editLocalization(response.data)
+                    .then(() => this.$events.$emit('localization.created'));
             });
         },
 

--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -1,6 +1,7 @@
 <template>
 
     <slugify
+        ref="slugify"
         :enabled="generate"
         :from="source"
         :separator="separator"
@@ -71,6 +72,22 @@ export default {
 
         slug(slug) {
             this.update(slug);
+        }
+
+    },
+
+    created() {
+        this.$events.$on('localization.created', this.reset);
+    },
+
+    destroyed() {
+        this.$events.$off('localization.created', this.reset);
+    },
+
+    methods: {
+
+        reset() {
+            this.$refs.slugify.reset();
         }
 
     }

--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -77,17 +77,21 @@ export default {
     },
 
     created() {
-        this.$events.$on('localization.created', this.reset);
+        this.$events.$on('localization.created', this.handleLocalizationCreated);
     },
 
     destroyed() {
-        this.$events.$off('localization.created', this.reset);
+        this.$events.$off('localization.created', this.handleLocalizationCreated);
     },
 
     methods: {
 
-        reset() {
-            this.$refs.slugify.reset();
+        handleLocalizationCreated({ store }) {
+            // Only reset for the "slug" field in the matching store.
+            // Other slug fields that aren't named "slug" should be left alone.
+            if (this.handle === 'slug' && store === this.store) {
+                this.$refs.slugify.reset();
+            }
         }
 
     }


### PR DESCRIPTION
When you create a localization of an entry, the `slug` will become reactive to the `title` change again.
Only happens when creating the initial localization, not when switching to an existing one.

Closes #3933
Closes statamic/ideas#334

~WIP. Not sold on this particular event approach, it feels too global. But it's working so far.~
It only does it for "the slug field". Other `slug` fieldtypes that aren't called slug won't be affected. It'll do.
