### PR TITLE
Localize the parent tag

### DIFF
--- a/src/Facades/Entry.php
+++ b/src/Facades/Entry.php
@@ -10,7 +10,7 @@ use Statamic\Contracts\Entries\EntryRepository;
  * @method static \Statamic\Entries\EntryCollection whereCollection(string $handle)
  * @method static \Statamic\Entries\EntryCollection whereInCollection(array $handles)
  * @method static null|\Statamic\Contracts\Entries\Entry find($id)
- * @method static null|\Statamic\Contracts\Entries\Entry findByUri(string $uri)
+ * @method static null|\Statamic\Contracts\Entries\Entry findByUri(string $uri, string $site)
  * @method static \Statamic\Contracts\Entries\Entry make()
  * @method static \Statamic\Contracts\Entries\QueryBuilder query()
  * @method static void save($entry)

--- a/src/Tags/ParentTags.php
+++ b/src/Tags/ParentTags.php
@@ -3,6 +3,7 @@
 namespace Statamic\Tags;
 
 use Statamic\Facades\Entry;
+use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Support\Arr;
 use Stringy\StaticStringy as Stringy;
@@ -71,9 +72,7 @@ class ParentTags extends Tags
      */
     private function getParent()
     {
-        $crumbs = [];
-
-        $segments = explode('/', URL::getCurrent());
+        $segments = explode('/', URL::tidy(URL::removeSiteUrl(URL::getCurrent())));
         $segment_count = count($segments);
         $segments[0] = '/';
 
@@ -92,7 +91,7 @@ class ParentTags extends Tags
 
         // Find the parent by stripping away URL segments
         foreach ($segment_urls as $segment_url) {
-            if ($content = Entry::findByUri($segment_url)) {
+            if ($content = Entry::findByUri($segment_url, Site::current())) {
                 return $content->toAugmentedArray();
             }
         }

--- a/src/Tags/ParentTags.php
+++ b/src/Tags/ParentTags.php
@@ -6,6 +6,7 @@ use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 use Stringy\StaticStringy as Stringy;
 
 class ParentTags extends Tags
@@ -72,7 +73,7 @@ class ParentTags extends Tags
      */
     private function getParent()
     {
-        $segments = explode('/', URL::tidy(URL::removeSiteUrl(URL::getCurrent())));
+        $segments = explode('/', Str::after(URL::getCurrent(), Site::current()->url()));
         $segment_count = count($segments);
         $segments[0] = '/';
 


### PR DESCRIPTION
Fetch the parent data from the current site/locale.

Updated the Entry::findByUri `@method` signature to include the `$site` parameter

Also, `URL::removeSiteUrl()` adds a superfluous slash and should probably call `URL::tidy()` before returning. I did not change `removeSiteUrl` in this PR  yet, because I wanted to confirm whether the current behavior is intentional (as far as I see, that method is not covered by a test).