### PR TITLE
Add "exists" method to Partial tag

### DIFF
--- a/src/Tags/Partial.php
+++ b/src/Tags/Partial.php
@@ -55,11 +55,12 @@ class Partial extends Tags
      * Requires the partial be provided as the 'src' parameter.
      *
      * @return bool
+     *
      * @throws \Exception
      */
     public function exists()
     {
-        if (!$partial = $this->params->get('src', false)) {
+        if (! $partial = $this->params->get('src', false)) {
             throw new \Exception('partial:exists requires a src parameter');
         }
 

--- a/src/Tags/Partial.php
+++ b/src/Tags/Partial.php
@@ -52,16 +52,12 @@ class Partial extends Tags
      * The {{ partial:exists }} tag.
      *
      * Returns true if the partial exists, false otherwise.
-     * Requires the partial be provided as the 'src' parameter.
-     *
-     * @return bool
-     *
-     * @throws \Exception
+     * If the src parameter is omitted, it acts like the user is trying to use a partial named "exists".
      */
     public function exists()
     {
-        if (! $partial = $this->params->get('src', false)) {
-            throw new \Exception('partial:exists requires a src parameter');
+        if (! $partial = $this->params->get('src')) {
+            return $this->wildcard('exists');
         }
 
         return view()->exists($this->viewName($partial));

--- a/src/Tags/Partial.php
+++ b/src/Tags/Partial.php
@@ -47,6 +47,7 @@ class Partial extends Tags
 
         return $bits->implode('.').'._'.$last;
     }
+
     
     /**
      * The {{ partial:exists }} tag.

--- a/src/Tags/Partial.php
+++ b/src/Tags/Partial.php
@@ -48,7 +48,6 @@ class Partial extends Tags
         return $bits->implode('.').'._'.$last;
     }
 
-    
     /**
      * The {{ partial:exists }} tag.
      *

--- a/src/Tags/Partial.php
+++ b/src/Tags/Partial.php
@@ -10,6 +10,11 @@ class Partial extends Tags
         // an argument, but fall back to the studly version just in case.
         $partial = $this->params->get('src', $tag);
 
+        return $this->render($partial);
+    }
+
+    protected function render($partial)
+    {
         $variables = array_merge($this->context->all(), $this->params->all(), [
             '__frontmatter' => $this->params->all(),
             'slot' => $this->isPair ? trim($this->parse()) : null,
@@ -61,5 +66,22 @@ class Partial extends Tags
         }
 
         return view()->exists($this->viewName($partial));
+    }
+
+    /**
+     * The {{ partial:if_exists }} tag.
+     *
+     * Returns true if the partial exists, false otherwise.
+     * If the src parameter is omitted, it acts like the user is trying to use a partial named "if_exists".
+     */
+    public function ifExists()
+    {
+        if (! $partial = $this->params->get('src')) {
+            return $this->wildcard('if_exists');
+        }
+
+        if (view()->exists($this->viewName($partial))) {
+            return $this->render($partial);
+        }
     }
 }

--- a/src/Tags/Partial.php
+++ b/src/Tags/Partial.php
@@ -47,4 +47,22 @@ class Partial extends Tags
 
         return $bits->implode('.').'._'.$last;
     }
+    
+    /**
+     * The {{ partial:exists }} tag.
+     *
+     * Returns true if the partial exists, false otherwise.
+     * Requires the partial be provided as the 'src' parameter.
+     *
+     * @return bool
+     * @throws \Exception
+     */
+    public function exists()
+    {
+        if (!$partial = $this->params->get('src', false)) {
+            throw new \Exception('partial:exists requires a src parameter');
+        }
+
+        return view()->exists($this->viewName($partial));
+    }
 }


### PR DESCRIPTION
There are instances where it can be useful to check if a partial exists before including it, and conditionally change the output based on this check's result.

For example, you could have a partial (such as an SVG icon) that gets included based on the slug of a Taxonomy Term. During dev, you can create Terms and their associated partials. But if a content author creates a new Term in production, and a partial doesn't exist, the partial inclusion will throw an exception (and bring that page down).

The aim of this is to provide a simple mechanism to check if the partial exists using Laravel's `exists` method on the view. This uses the same `src` attribute as the `partial` tag, and works for a string, dynamic string, or variable

Use as a string:
```
{{ if {partial:exists src="path/to/partial"} }}
    // The partial exists, so we can safely include it as we normally would
{{ else }}
    // The partial doesn't exist
{{ /if }}
```

Use dynamically:
```
{{ if {partial:exists src="path/to/partial/{variable_name}"} }}
    // The partial exists, so we can safely include it as we normally would
{{ else }}
    // The partial doesn't exist
{{ /if }}
```

As a variable:
```
{{ if {partial:exists :src="variable_name"} }}
    // The partial exists, so we can safely include it as we normally would
{{ else }}
    // The partial doesn't exist
{{ /if }}
```

This PR is simply adding a new method to the Partial tag - no other behavioural changes have been introduced.