### PR TITLE
Prevent explicit nulls from falling back to origin

### DIFF
--- a/src/Data/HasOrigin.php
+++ b/src/Data/HasOrigin.php
@@ -15,8 +15,7 @@ trait HasOrigin
 
     public function value($key)
     {
-        return $this->get($key)
-            ?? ($this->hasOrigin() ? $this->origin()->value($key) : null);
+        return $this->values()->get($key);
     }
 
     public function origin($origin = null)

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -703,11 +703,6 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
         return Facades\Entry::find($origin);
     }
 
-    public function value($key)
-    {
-        return $this->originValue($key) ?? $this->collection()->cascade($key);
-    }
-
     public function values()
     {
         return $this->collection()->cascade()->merge($this->originValues());

--- a/tests/Search/SearchablesTest.php
+++ b/tests/Search/SearchablesTest.php
@@ -13,6 +13,7 @@ use Statamic\Facades\Term;
 use Statamic\Facades\User;
 use Statamic\Search\Searchables;
 use Statamic\Taxonomies\TermCollection;
+use Facades\Tests\Factories\EntryFactory;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -289,7 +290,7 @@ class SearchablesTest extends TestCase
             'config' => config('statamic.search.indexes.default'),
         ]);
 
-        $searchable = Entry::make()->data(['title' => 'Hello']);
+        $searchable = EntryFactory::collection('test')->data(['title' => 'Hello'])->make();
         $searchables = new Searchables($index);
 
         $this->assertEquals([
@@ -319,7 +320,7 @@ class SearchablesTest extends TestCase
             'config' => config('statamic.search.indexes.default'),
         ]);
 
-        $searchable = Entry::make()->data(['title' => 'Hello']);
+        $searchable = EntryFactory::collection('test')->data(['title' => 'Hello'])->make();
         $searchables = new Searchables($index);
 
         $this->assertEquals([

--- a/tests/Search/SearchablesTest.php
+++ b/tests/Search/SearchablesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Search;
 
+use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Collection;
 use Statamic\Assets\AssetCollection;
 use Statamic\Auth\UserCollection;
@@ -13,7 +14,6 @@ use Statamic\Facades\Term;
 use Statamic\Facades\User;
 use Statamic\Search\Searchables;
 use Statamic\Taxonomies\TermCollection;
-use Facades\Tests\Factories\EntryFactory;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 


### PR DESCRIPTION
By setting `field: null` in your front-matter on a localized entry, it should actually be null, instead of falling back to the value in the origin entry. If you omit the field, it'll fall back. 

Fixes #3987
Fixes #3738
Actually fixes #3406 even though it was closed. The previous "fix" only added the nulls to the files.
