### PR TITLE
Fix slow entries fieldtype

### DIFF
--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -67,6 +67,7 @@
                     :filters-url="filtersUrl"
                     :selections-url="selectionsUrl"
                     :site="site"
+                    :initial-columns="columns"
                     initial-sort-column="title"
                     initial-sort-direction="asc"
                     :initial-selections="value"
@@ -122,6 +123,10 @@ export default {
             default: 'default',
         },
         taggable: Boolean,
+        columns: {
+            type: Array,
+            default: () => []
+        }
     },
 
     components: {

--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -116,6 +116,10 @@ export default {
         exclusions: {
             type: Array,
             default: () => []
+        },
+        initialColumns: {
+            type: Array,
+            default: () => []
         }
     },
 
@@ -131,7 +135,8 @@ export default {
             sortDirection: this.initialSortDirection,
             page: 1,
             selections: _.clone(this.initialSelections),
-            columns: [],
+            columns: this.initialColumns,
+            visibleColumns: this.initialColumns.filter(column => column.visible),
         }
     },
 
@@ -145,6 +150,7 @@ export default {
                 site: this.site,
                 exclusions: this.exclusions,
                 filters: utf8btoa(JSON.stringify(this.activeFilters)),
+                columns: this.visibleColumns.map(column => column.field).join(','),
             }
         },
 

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -84,9 +84,7 @@ class Entries extends Relationship
             $query->orderBy($sort, $this->getSortDirection($request));
         }
 
-        $items = $request->boolean('paginate', true) ? $query->paginate() : $query->get();
-
-        return $items->preProcessForIndex();
+        return $request->boolean('paginate', true) ? $query->paginate() : $query->get();
     }
 
     public function getResourceCollection($request, $items)
@@ -99,7 +97,7 @@ class Entries extends Relationship
             ]]);
     }
 
-    protected function getBlueprint($request)
+    protected function getBlueprint($request = null)
     {
         return $this->getFirstCollectionFromRequest($request)->entryBlueprint();
     }
@@ -260,5 +258,10 @@ class Entries extends Relationship
         }
 
         return $type;
+    }
+
+    public function getColumns()
+    {
+        return $this->getBlueprint()->columns()->values()->all();
     }
 }

--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -109,6 +109,7 @@ abstract class Relationship extends Fieldtype
     {
         return [
             'data' => $this->getItemData($this->field->value())->all(),
+            'columns' => $this->getColumns(),
             'itemDataUrl' => $this->getItemDataUrl(),
             'filtersUrl' => $this->getFiltersUrl(),
             'baseSelectionsUrl' => $this->getBaseSelectionsUrl(),


### PR DESCRIPTION
Regular entry listings are fast, they only get the values for the columns that are visible.

This wasn't happening for the `entries` fieldtype. It was getting all the values for each entry.

This PR applies the treatment to the `entries` fieldtype.

Related: #2857
