### PR TITLE
Split Modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2063,8 +2063,8 @@ class CoreModifiers extends Modifier
             ->map(function ($collection) use ($groups_name, $items_name) {
                 return [
                     $groups_name => [
-                        $items_name => $collection->all()
-                    ]
+                        $items_name => $collection->all(),
+                    ],
                 ];
             })->all();
     }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2055,15 +2055,13 @@ class CoreModifiers extends Modifier
     public function split($value, $params)
     {
         $size = Arr::get($params, 0, 1);
-        $groups_name = Arr::get($params, 1, 'groups');
-        $items_name = Arr::get($params, 2, 'items');
 
         return collect($value)
             ->split($size)
-            ->map(function ($collection) use ($groups_name, $items_name) {
+            ->map(function ($collection) {
                 return [
-                    $groups_name => [
-                        $items_name => $collection->all(),
+                    'groups' => [
+                        'items' => $collection->all(),
                     ],
                 ];
             })->all();

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2060,9 +2060,7 @@ class CoreModifiers extends Modifier
             ->split($size)
             ->map(function ($collection) {
                 return [
-                    'groups' => [
-                        'items' => $collection->all(),
-                    ],
+                    'items' => $collection->all(),
                 ];
             })->all();
     }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2046,7 +2046,7 @@ class CoreModifiers extends Modifier
     }
 
     /**
-     * Break an array into a given number of groups
+     * Break an array into a given number of groups.
      *
      * @param $value
      * @param $params
@@ -2063,8 +2063,8 @@ class CoreModifiers extends Modifier
             ->map(function ($collection) use ($group_name, $items_name) {
                 return [
                     $group_name => [
-                        $items_name => $collection->all()
-                    ]
+                        $items_name => $collection->all(),
+                    ],
                 ];
             })->all();
     }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2046,6 +2046,30 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Break an array into a given number of groups
+     *
+     * @param $value
+     * @param $params
+     * @return array
+     */
+    public function split($value, $params)
+    {
+        $size = Arr::get($params, 0, 1);
+        $group_name = Arr::get($params, 1, 'group');
+        $items_name = Arr::get($params, 2, 'items');
+
+        return collect($value)
+            ->split($size)
+            ->map(function ($collection) use ($group_name, $items_name) {
+                return [
+                    $group_name => [
+                        $items_name => $collection->all()
+                    ]
+                ];
+            })->all();
+    }
+
+    /**
      * Returns true if the string starts with a given substring ($params[0]), false otherwise.
      * The comparison is case-insensitive.
      *

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2055,16 +2055,16 @@ class CoreModifiers extends Modifier
     public function split($value, $params)
     {
         $size = Arr::get($params, 0, 1);
-        $group_name = Arr::get($params, 1, 'group');
+        $groups_name = Arr::get($params, 1, 'groups');
         $items_name = Arr::get($params, 2, 'items');
 
         return collect($value)
             ->split($size)
-            ->map(function ($collection) use ($group_name, $items_name) {
+            ->map(function ($collection) use ($groups_name, $items_name) {
                 return [
-                    $group_name => [
-                        $items_name => $collection->all(),
-                    ],
+                    $groups_name => [
+                        $items_name => $collection->all()
+                    ]
                 ];
             })->all();
     }


### PR DESCRIPTION
## Overview
This modifier lets you split an array into `$n` number of equal groups. You can loop through the groups with `{{ groups }}` and the items inside each group with `{{ items }}`. This is really useful for breaking a list up into multiple columns or boxes and other things like such as.

```
<div class="flex">
{{ collection:blog as="entries" }}
    {{ entries split="2" }}
        {{ items }}
        <div class="w-1/2">
            {{ items }}
            <a href="{{ url }}">{{ title }}</a><br>
            {{ /items }}
        </div>
        {{ /items }}
    {{ /entries }}
{{ /collection:blog }}
</div>
```

### Example:

```
{{ entries split="2" }}
```