### PR TITLE
Fixed issue where `parent` wasn't being passed in correctly for assets

### DIFF
--- a/src/Http/Resources/CP/Assets/Asset.php
+++ b/src/Http/Resources/CP/Assets/Asset.php
@@ -57,7 +57,8 @@ class Asset extends JsonResource
 
     protected function publishFormData()
     {
-        $fields = $this->blueprint()->fields()
+        $fields = $this->blueprint()->setParent($this->resource)
+            ->fields()
             ->addValues($this->data()->all())
             ->preProcess();
 


### PR DESCRIPTION
This PR fixes an issue where trying to do `$this->field->parent()` inside a fieldtype, on an Asset would just return `null`. Now it will return an `Asset` instance.

Fixes #4291