### PR TITLE
Don't show 'toggle all' checkbox if `max_items` is 1

### DIFF
--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -3,7 +3,7 @@
         <thead v-if="allowBulkActions || allowColumnPicker || visibleColumns.length > 1">
             <tr>
                 <th class="checkbox-column" v-if="allowBulkActions || reorderable">
-                    <data-list-toggle-all ref="toggleAll" v-if="allowBulkActions" />
+                    <data-list-toggle-all ref="toggleAll" v-if="allowBulkActions && !singleSelect" />
                 </th>
                 <th
                     v-for="column in visibleColumns"


### PR DESCRIPTION
This pull request partly addresses #4246 by hiding the 'toggle all' checkbox in the Asset Browser if `max_items` on the field is 1.