### PR TITLE
Fix #4213 - Only treat 'cp/' slugs as CP

### DIFF
--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -150,7 +150,12 @@ class Statamic
             return false;
         }
 
-        return starts_with(request()->path(), config('statamic.cp.route'));
+        // The route needs to start with the configured CP route,
+        // e.g. 'cp/' including trailing slash. See #4213.
+        return starts_with(
+            request()->path(),
+            str_finish(config('statamic.cp.route'), '/')
+        );
     }
 
     public static function cpRoute($route, $params = [])

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -152,10 +152,15 @@ class Statamic
 
         // The route needs to start with the configured CP route,
         // e.g. 'cp/' including trailing slash. See #4213.
-        return starts_with(
-            request()->path(),
-            str_finish(config('statamic.cp.route'), '/')
-        );
+        $cpRoute = config('statamic.cp.route');
+        $currentRoute = request()->path();
+
+        return
+            $currentRoute === $cpRoute
+            || starts_with(
+                $currentRoute,
+                str_finish($cpRoute, '/')
+            );
     }
 
     public static function cpRoute($route, $params = [])


### PR DESCRIPTION
This prevents pages like 'cpaaa' from being treated as belonging to the omnipotent Control Panel, which causes the wrong 404s to appear.

See #4213.