### PR TITLE
Return queries from `QueriesConditions` trait

### DIFF
--- a/src/Tags/Concerns/QueriesConditions.php
+++ b/src/Tags/Concerns/QueriesConditions.php
@@ -125,22 +125,22 @@ trait QueriesConditions
 
     protected function queryIsCondition($query, $field, $value)
     {
-        $query->where($field, $value);
+        return $query->where($field, $value);
     }
 
     protected function queryNotCondition($query, $field, $value)
     {
-        $query->where($field, '!=', $value);
+        return $query->where($field, '!=', $value);
     }
 
     protected function queryContainsCondition($query, $field, $value)
     {
-        $query->where($field, 'like', "%{$value}%");
+        return $query->where($field, 'like', "%{$value}%");
     }
 
     protected function queryDoesntContainCondition($query, $field, $value)
     {
-        $query->where($field, 'not like', "%{$value}%");
+        return $query->where($field, 'not like', "%{$value}%");
     }
 
     protected function queryInCondition($query, $field, $value)
@@ -149,7 +149,7 @@ trait QueriesConditions
             $value = $this->getPipedValues($value);
         }
 
-        $query->whereIn($field, $value);
+        return $query->whereIn($field, $value);
     }
 
     protected function queryNotInCondition($query, $field, $value)
@@ -158,47 +158,47 @@ trait QueriesConditions
             $value = $this->getPipedValues($value);
         }
 
-        $query->whereNotIn($field, $value);
+        return $query->whereNotIn($field, $value);
     }
 
     protected function queryStartsWithCondition($query, $field, $value)
     {
-        $query->where($field, 'like', "{$value}%");
+        return $query->where($field, 'like', "{$value}%");
     }
 
     protected function queryDoesntStartWithCondition($query, $field, $value)
     {
-        $query->where($field, 'not like', "{$value}%");
+        return $query->where($field, 'not like', "{$value}%");
     }
 
     protected function queryEndsWithCondition($query, $field, $value)
     {
-        $query->where($field, 'like', "%{$value}");
+        return $query->where($field, 'like', "%{$value}");
     }
 
     protected function queryDoesntEndWithCondition($query, $field, $value)
     {
-        $query->where($field, 'not like', "%{$value}");
+        return $query->where($field, 'not like', "%{$value}");
     }
 
     protected function queryGreaterThanCondition($query, $field, $value)
     {
-        $query->where($field, '>', $value);
+        return $query->where($field, '>', $value);
     }
 
     protected function queryLessThanCondition($query, $field, $value)
     {
-        $query->where($field, '<', $value);
+        return $query->where($field, '<', $value);
     }
 
     protected function queryGreaterThanOrEqualToCondition($query, $field, $value)
     {
-        $query->where($field, '>=', $value);
+        return $query->where($field, '>=', $value);
     }
 
     protected function queryLessThanOrEqualToCondition($query, $field, $value)
     {
-        $query->where($field, '<=', $value);
+        return $query->where($field, '<=', $value);
     }
 
     protected function queryMatchesRegexCondition($query, $field, $pattern)
@@ -207,7 +207,7 @@ trait QueriesConditions
             $pattern = $this->removeRegexDelimitersAndModifiers($pattern);
         }
 
-        $query->where($field, 'regexp', $pattern);
+        return $query->where($field, 'regexp', $pattern);
     }
 
     protected function queryDoesntMatchRegexCondition($query, $field, $pattern)
@@ -216,27 +216,27 @@ trait QueriesConditions
             $pattern = $this->removeRegexDelimitersAndModifiers($pattern);
         }
 
-        $query->where($field, 'not regexp', $pattern);
+        return $query->where($field, 'not regexp', $pattern);
     }
 
     protected function queryIsAlphaCondition($query, $field, $regexOperator)
     {
-        $query->where($field, $regexOperator, '^[a-z]+$');
+        return $query->where($field, $regexOperator, '^[a-z]+$');
     }
 
     protected function queryIsAlphaNumericCondition($query, $field, $regexOperator)
     {
-        $query->where($field, $regexOperator, '^[a-z0-9]+$');
+        return $query->where($field, $regexOperator, '^[a-z0-9]+$');
     }
 
     protected function queryIsNumericCondition($query, $field, $regexOperator)
     {
-        $query->where($field, $regexOperator, '^[0-9]*(\.[0-9]+)?$');
+        return $query->where($field, $regexOperator, '^[0-9]*(\.[0-9]+)?$');
     }
 
     protected function queryIsUrlCondition($query, $field, $regexOperator)
     {
-        $query->where($field, $regexOperator, '^(https|http):\/\/[^\ ]+$');
+        return $query->where($field, $regexOperator, '^(https|http):\/\/[^\ ]+$');
     }
 
     protected function queryIsEmbeddableCondition($query, $field, $regexOperator)
@@ -247,18 +247,18 @@ trait QueriesConditions
             'youtu.be',
         ])->implode('|');
 
-        $query->where($field, $regexOperator, "^(https|http):\/\/[^\ ]*({$domainPatterns})[^\/]*\/[^\ ]+$");
+        return $query->where($field, $regexOperator, "^(https|http):\/\/[^\ ]*({$domainPatterns})[^\/]*\/[^\ ]+$");
     }
 
     protected function queryIsEmailCondition($query, $field, $regexOperator)
     {
-        $query->where($field, $regexOperator, '^[^\ ]+@[^\ ]+\.[^\ ]+$');
+        return $query->where($field, $regexOperator, '^[^\ ]+@[^\ ]+\.[^\ ]+$');
     }
 
     protected function queryIsEmptyCondition($query, $field, $boolean)
     {
         // TODO: Add `whereNull()` and `whereNotNull()` to our query builder so that this can be Eloquent compatible.
-        $query->where($field, $boolean ? '=' : '!=', null);
+        return $query->where($field, $boolean ? '=' : '!=', null);
     }
 
     protected function queryIsAfterCondition($query, $field, $value)
@@ -283,7 +283,7 @@ trait QueriesConditions
 
     protected function queryIsNumberwangCondition($query, $field, $regexOperator)
     {
-        $query->where($field, $regexOperator, "^(1|22|7|9|1002|2\.3|15|109876567|31)$");
+        return $query->where($field, $regexOperator, "^(1|22|7|9|1002|2\.3|15|109876567|31)$");
     }
 
     /**

--- a/src/Tags/Concerns/QueriesConditions.php
+++ b/src/Tags/Concerns/QueriesConditions.php
@@ -291,7 +291,7 @@ trait QueriesConditions
      * Passing delimiters doesn't work with Eloquent and `regexp`, so we remove them from
      * the user's pattern if passed, so that regex conditions will work as expected.
      *
-     * @param string $pattern
+     * @param  string $pattern
      * @return string
      */
     protected function removeRegexDelimitersAndModifiers($pattern)

--- a/src/Tags/Concerns/QueriesConditions.php
+++ b/src/Tags/Concerns/QueriesConditions.php
@@ -291,7 +291,7 @@ trait QueriesConditions
      * Passing delimiters doesn't work with Eloquent and `regexp`, so we remove them from
      * the user's pattern if passed, so that regex conditions will work as expected.
      *
-     * @param  string $pattern
+     * @param  string  $pattern
      * @return string
      */
     protected function removeRegexDelimitersAndModifiers($pattern)


### PR DESCRIPTION
This pull request returns the queries from the `QueriesConditions` trait.

## My Use Case

Essentially, I've copied over the GraphQL filtering logic from the Entries Query. At the end of the method I copied (`filterQuery`), it calls the `queryCondition` on the [`QueriesConditions` trait](https://github.com/statamic/cms/blob/3.2/src/Tags/Concerns/QueriesConditions.php#L44) to do something with the query conditions the user passed in.

My issue is that without returning the queries, nothing actually happens to my query - the results are the same as if they were never filtered. However, with the `return`s, everything works.

I'm not sure if changing this breaks other things (I guess I'll find out when the test suite runs) but it would certainly fix my issue 😅 

Here's my `filterQuery` method if you want to see it - a tad different from the one I copied...

```php
protected function filterQuery($query, $filters)
{
    foreach ($filters as $field => $definitions) {
        if (! is_array($definitions)) {
            $definitions = [['equals' => $definitions]];
        }

        if (Arr::assoc($definitions)) {
            $definitions = collect($definitions)->map(function ($value, $key) {
                return [$key => $value];
            })->values()->all();
        }


        foreach ($definitions as $definition) {
            $condition = array_keys($definition)[0];
            $value = array_values($definition)[0];

            $query = $this->queryCondition($query, $field, $condition, $value);
        }
    }

    return $query;
}
```