### PR TITLE
Enhance the `group_by` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -760,10 +760,19 @@ class CoreModifiers extends Modifier
 
     private function getGroupByValue($item, $groupBy)
     {
-        if (is_array($item)) {
-            return $item[$groupBy];
+        $value = is_object($item)
+            ? $this->getGroupByValueFromObject($item, $groupBy)
+            : $item[$groupBy];
+
+        if ($value instanceof Value) {
+            $value = $value->value();
         }
 
+        return $value;
+    }
+
+    private function getGroupByValueFromObject($item, $groupBy)
+    {
         // Make the array just from the params, so it only augments the values that might be needed.
         $keys = explode(':', $groupBy);
         $context = $item->toAugmentedArray($keys);

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -733,15 +733,20 @@ class CoreModifiers extends Modifier
      */
     public function groupBy($value, $params)
     {
-        $groupBy = implode(':', $params);
+        // Workaround for https://github.com/statamic/cms/issues/3614
+        // At the moment this modifier only works properly when using the param syntax.
+        $params = implode(':', $params);
+        $params = explode('|', $params);
+        $groupBy = $params[0];
 
-        $grouped = collect($value)->groupBy(function ($item) use ($groupBy, $params) {
+        $grouped = collect($value)->groupBy(function ($item) use ($groupBy) {
             if (is_array($item)) {
                 return $item[$groupBy];
             }
 
             // Make the array just from the params, so it only augments the values that might be needed.
-            $context = $item->toAugmentedArray($params);
+            $keys = explode(':', $groupBy);
+            $context = $item->toAugmentedArray($keys);
 
             return Antlers::parser()->getVariable($groupBy, $context);
         });

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -732,7 +732,15 @@ class CoreModifiers extends Modifier
      */
     public function groupBy($value, $params)
     {
-        return collect($value)->groupBy($params[0])->toArray();
+        $groupBy = $params[0];
+
+        $grouped = collect($value)->groupBy($groupBy);
+
+        $iterable = $grouped->map(function ($items, $key) {
+            return collect(['group' => $key, 'items' => $items]);
+        })->values();
+
+        return collect($grouped)->merge(['groups' => $iterable])->toArray();
     }
 
     /**

--- a/tests/Modifiers/GroupByTest.php
+++ b/tests/Modifiers/GroupByTest.php
@@ -2,11 +2,16 @@
 
 namespace Tests\Modifiers;
 
+use Facades\Tests\Factories\EntryFactory;
+use Statamic\Facades\Collection;
 use Statamic\Modifiers\Modify;
+use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class GroupByTest extends TestCase
 {
+    use PreventSavingStacheItemsToDisk;
+
     /** @test */
     public function it_groups_an_array()
     {
@@ -16,29 +21,81 @@ class GroupByTest extends TestCase
             ['sport' => 'basketball', 'team' => 'bulls'],
         ];
 
-        $expected = [
-            'basketball' => [
+        $expected = collect([
+            'basketball' => collect([
                 ['sport' => 'basketball', 'team' => 'jazz'],
                 ['sport' => 'basketball', 'team' => 'bulls'],
-            ],
-            'baseball' => [
+            ]),
+            'baseball' => collect([
                 ['sport' => 'baseball', 'team' => 'yankees'],
-            ],
-            'groups' => [
-                ['group' => 'basketball', 'items' => [
-                    ['sport' => 'basketball', 'team' => 'jazz'],
-                    ['sport' => 'basketball', 'team' => 'bulls'],
-                ]],
-                ['group' => 'baseball', 'items' => [
-                    ['sport' => 'baseball', 'team' => 'yankees'],
-                ]],
-            ],
-        ];
+            ]),
+            'groups' => collect([
+                [
+                    'group' => 'basketball',
+                    'items' => collect([
+                        ['sport' => 'basketball', 'team' => 'jazz'],
+                        ['sport' => 'basketball', 'team' => 'bulls'],
+                    ]),
+                ],
+                [
+                    'group' => 'baseball',
+                    'items' => collect([
+                        ['sport' => 'baseball', 'team' => 'yankees'],
+                    ]),
+                ],
+            ]),
+        ]);
 
-        $this->assertEquals($expected, $this->modify($items, 'sport'));
+        $this->assertEquals($expected, $this->modify($items, ['sport']));
     }
 
-    public function modify($items, $value)
+    /** @test */
+    public function it_can_get_keys_from_objects()
+    {
+        $items = collect([
+            $jazz = EntryFactory::collection('sports')->data(['sport' => 'basketball', 'team' => 'jazz'])->create(),
+            $yankees = EntryFactory::collection('sports')->data(['sport' => 'baseball', 'team' => 'yankees'])->create(),
+            $bulls = EntryFactory::collection('sports')->data(['sport' => 'basketball', 'team' => 'bulls'])->create(),
+        ]);
+
+        $expected = collect([
+            'basketball' => collect([$jazz, $bulls]),
+            'baseball' => collect([$yankees]),
+            'groups' => collect([
+                ['group' => 'basketball', 'items' => collect([$jazz, $bulls])],
+                ['group' => 'baseball', 'items' => collect([$yankees])],
+            ]),
+        ]);
+
+        $this->assertEquals($expected, $this->modify($items, ['sport']));
+    }
+
+    /** @test */
+    public function it_can_get_nested_keys_from_objects()
+    {
+        Collection::make('basketball')->title('Basketball')->save();
+        Collection::make('baseball')->title('Baseball')->save();
+
+        $items = collect([
+            $jazz = EntryFactory::collection('basketball')->data(['team' => 'jazz'])->create(),
+            $yankees = EntryFactory::collection('baseball')->data(['team' => 'yankees'])->create(),
+            $bulls = EntryFactory::collection('basketball')->data(['team' => 'bulls'])->create(),
+        ]);
+
+        $expected = collect([
+            'Basketball' => collect([$jazz, $bulls]),
+            'Baseball' => collect([$yankees]),
+            'groups' => collect([
+                ['group' => 'Basketball', 'items' => collect([$jazz, $bulls])],
+                ['group' => 'Baseball', 'items' => collect([$yankees])],
+            ]),
+        ]);
+
+        // passing an array like ['collection', 'title'] translates to group_by="collection:title"
+        $this->assertEquals($expected, $this->modify($items, ['collection', 'title']));
+    }
+
+    public function modify($items, array $value)
     {
         return Modify::value($items)->groupBy($value)->fetch();
     }

--- a/tests/Modifiers/GroupByTest.php
+++ b/tests/Modifiers/GroupByTest.php
@@ -24,6 +24,15 @@ class GroupByTest extends TestCase
             'baseball' => [
                 ['sport' => 'baseball', 'team' => 'yankees'],
             ],
+            'groups' => [
+                ['group' => 'basketball', 'items' => [
+                    ['sport' => 'basketball', 'team' => 'jazz'],
+                    ['sport' => 'basketball', 'team' => 'bulls'],
+                ]],
+                ['group' => 'baseball', 'items' => [
+                    ['sport' => 'baseball', 'team' => 'yankees'],
+                ]],
+            ],
         ];
 
         $this->assertEquals($expected, $this->modify($items, 'sport'));

--- a/tests/Modifiers/GroupByTest.php
+++ b/tests/Modifiers/GroupByTest.php
@@ -46,7 +46,7 @@ class GroupByTest extends TestCase
             ]),
         ]);
 
-        $this->assertEquals($expected, $this->modify($items, ['sport']));
+        $this->assertEquals($expected, $this->modify($items, 'sport'));
     }
 
     /** @test */
@@ -67,7 +67,7 @@ class GroupByTest extends TestCase
             ]),
         ]);
 
-        $this->assertEquals($expected, $this->modify($items, ['sport']));
+        $this->assertEquals($expected, $this->modify($items, 'sport'));
     }
 
     /** @test */
@@ -91,11 +91,10 @@ class GroupByTest extends TestCase
             ]),
         ]);
 
-        // passing an array like ['collection', 'title'] translates to group_by="collection:title"
-        $this->assertEquals($expected, $this->modify($items, ['collection', 'title']));
+        $this->assertEquals($expected, $this->modify($items, 'collection:title'));
     }
 
-    public function modify($items, array $value)
+    public function modify($items, $value)
     {
         return Modify::value($items)->groupBy($value)->fetch();
     }

--- a/tests/Modifiers/GroupByTest.php
+++ b/tests/Modifiers/GroupByTest.php
@@ -5,6 +5,7 @@ namespace Tests\Modifiers;
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Carbon;
 use Statamic\Facades\Collection;
+use Statamic\Fields\Value;
 use Statamic\Modifiers\Modify;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -20,6 +21,47 @@ class GroupByTest extends TestCase
             ['sport' => 'basketball', 'team' => 'jazz'],
             ['sport' => 'baseball', 'team' => 'yankees'],
             ['sport' => 'basketball', 'team' => 'bulls'],
+        ];
+
+        $expected = collect([
+            'basketball' => collect([
+                ['sport' => 'basketball', 'team' => 'jazz'],
+                ['sport' => 'basketball', 'team' => 'bulls'],
+            ]),
+            'baseball' => collect([
+                ['sport' => 'baseball', 'team' => 'yankees'],
+            ]),
+            'groups' => collect([
+                [
+                    'key' => 'basketball',
+                    'group' => 'basketball',
+                    'items' => collect([
+                        ['sport' => 'basketball', 'team' => 'jazz'],
+                        ['sport' => 'basketball', 'team' => 'bulls'],
+                    ]),
+                ],
+                [
+                    'key' => 'baseball',
+                    'group' => 'baseball',
+                    'items' => collect([
+                        ['sport' => 'baseball', 'team' => 'yankees'],
+                    ]),
+                ],
+            ]),
+        ]);
+
+        $this->assertEquals($expected, $this->modify($items, 'sport'));
+    }
+
+    /** @test */
+    public function it_groups_an_array_with_value_objects()
+    {
+        // eg. replicator sets
+
+        $items = [
+            ['sport' => new Value('basketball', 'sport'), 'team' => new Value('jazz', 'team')],
+            ['sport' => new Value('baseball', 'sport'), 'team' => new Value('yankees', 'team')],
+            ['sport' => new Value('basketball', 'sport'), 'team' => new Value('bulls', 'team')],
         ];
 
         $expected = collect([

--- a/tests/Modifiers/GroupByTest.php
+++ b/tests/Modifiers/GroupByTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class GroupByTest extends TestCase
+{
+    /** @test */
+    public function it_groups_an_array()
+    {
+        $items = [
+            ['sport' => 'basketball', 'team' => 'jazz'],
+            ['sport' => 'baseball', 'team' => 'yankees'],
+            ['sport' => 'basketball', 'team' => 'bulls'],
+        ];
+
+        $expected = [
+            'basketball' => [
+                ['sport' => 'basketball', 'team' => 'jazz'],
+                ['sport' => 'basketball', 'team' => 'bulls'],
+            ],
+            'baseball' => [
+                ['sport' => 'baseball', 'team' => 'yankees'],
+            ],
+        ];
+
+        $this->assertEquals($expected, $this->modify($items, 'sport'));
+    }
+
+    public function modify($items, $value)
+    {
+        return Modify::value($items)->groupBy($value)->fetch();
+    }
+}


### PR DESCRIPTION
The existing `group_by` modifier does the grouping, but then it's keyed so in order to template anything, you need to know the key. This is from the existing docs:

```yaml
sponsors:
  -
    sport: basketball
    team: Jazz
  -
    sport: baseball
    team: Yankees
  -
    sport: basketball
    team: Bulls
```
```html
{{ sponsors group_by="sport" }}
  {{ basketball }}
    <h2>{{ team }}</h2>
  {{ /basketball }}
{{ /sponsors }}
```
```html
<h2>Jazz</h2>
<h2>Bulls</h2>
```

This PR adds a `groups` array that lets you loop over all the groups, with the the `items` inside each one.

```html
{{ sponsors group_by="sport" }}
  {{ groups }}
    <h2>{{ group }}</h2>
    <ul>
    {{ items }}
      <li>{{ title }}</li>
    {{ /items }}
    </ul>
  {{ /groups }}
{{ /sponsors }}
```
```html
<h2>basketball</h2>
<ul>
  <li>Jazz</li>
  <li>Bulls</li>
</ul>
<h2>baseball</h2>
<ul>
  <li>Yankees</li>
</ul>
```

You can also use the colon notation you're familiar with to get nested values. For example, an `entries` fieldtype where you've selected from multiple collections.

```yaml
related_entries:
  - abc
  - def
  - ghi
  - jkl
```
```html
{{ related_entries group_by="collection:title" }}
  {{ groups }}
    <h2>{{ group }}</h2>
    <ul>
    {{ items }}
      <li>{{ id }}</li>
    {{ /items }}
    </ul>
  {{ /groups }}
{{ /related_entries }}
```
```html
<h2>Collection One</h2>
<ul>
  <li>abc</li>
  <li>def</li>
</ul>
<h2>Collection Two</h2>
<ul>
  <li>ghi</li>
  <li>jkl</li>
</ul>
```

You may also use this modifier to group by dates.

```html
{{ collection:articles as="entries" sort="datefield" }}
    {{ entries group_by="datefield|Y-m" }}
      {{ groups }}
        <h3>{{ group }}</h3>
        {{ items }}
          {{ title }} <br>
        {{ /items }}
      {{ /groups }}
    {{ /entries }}
{{ /collection:articles }}
```

If you need to _group_ by a date format but _display_ the date with a different format, you can pass two formats in:

```
{{ entries group_by="datefield|Y-m|F Y" }}
```

Closes #2064 
Closes #4163
Closes #1406 
Closes statamic/ideas#10