### PR TITLE
Allow to ensure multiple Blueprint fields at once

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -383,6 +383,17 @@ class Blueprint implements Augmentable
         return $this;
     }
 
+    public function ensureFieldsInSection($fields, $section, $prepend = false)
+    {
+        foreach ($fields as $handle => $config) {
+            $this->ensuredFields[] = compact('handle', 'section', 'prepend', 'config');
+        }
+
+        $this->resetFieldsCache();
+
+        return $this;
+    }
+
     public function ensureFieldPrepended($handle, $field, $section = null)
     {
         return $this->ensureField($handle, $field, $section, true);


### PR DESCRIPTION
This simple PR makes it possible to ensure multiple Blueprint fields at once by providing an array of fields like so:

```php
$event->blueprint->ensureFieldsInSection([
    'seo_title' => [
        'type' => 'seo_meta_title',
        'display' => 'Meta Title',
        'instructions' => 'Set the Meta Title of this entry. Defaults to the entry\'s `Title`.',
        'localizable' => true,
        'listable' => 'hidden',
        'character_limit' => 60,
        'input_type' => 'text',
        'antlers' => false,
        'validate' => [
            'max:60',
        ],
    ],
    'seo_description' => [
        'type' => 'textarea',
        'display' => 'Meta Description',
        'instructions' => 'Set the Meta Description of this entry.',
        'localizable' => true,
        'listable' => 'hidden',
        'character_limit' => 160,
        'validate' => [
            'max:160',
        ],
    ],
], 'SEO');
```