### PR TITLE
Fix term entries and entry counts

### DIFF
--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -9,6 +9,7 @@ use Statamic\Facades\Taxonomy;
 use Statamic\Stache\Query\TermQueryBuilder;
 use Statamic\Stache\Stache;
 use Statamic\Support\Str;
+use Statamic\Taxonomies\LocalizedTerm;
 use Statamic\Taxonomies\TermCollection;
 
 class TermRepository implements RepositoryContract
@@ -119,11 +120,20 @@ class TermRepository implements RepositoryContract
 
     public function entriesCount(Term $term): int
     {
-        return $this->store->store($term->taxonomyHandle())
+        $items = $this->store->store($term->taxonomyHandle())
             ->index('associations')
             ->items()
-            ->where('value', $term->slug())
-            ->count();
+            ->where('value', $term->slug());
+
+        if ($term instanceof LocalizedTerm) {
+            $items = $items->where('site', $term->locale());
+        }
+
+        if ($collection = $term->collection()) {
+            $items = $items->where('collection', $collection->handle());
+        }
+
+        return $items->count();
     }
 
     protected function ensureAssociations()

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -146,7 +146,12 @@ class Term implements TermContract
 
     public function entriesCount()
     {
-        return Blink::once('term-entries-count-'.$this->id(), function () {
+        $key = vsprintf('term-entries-count-%s-%s', [
+            $this->id(),
+            optional($this->collection())->handle(),
+        ]);
+
+        return Blink::once($key, function () {
             return Facades\Term::entriesCount($this);
         });
     }

--- a/tests/Data/Taxonomies/LocalizedTermTest.php
+++ b/tests/Data/Taxonomies/LocalizedTermTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Data\Taxonomies;
+
+use Statamic\Facades;
+use Statamic\Taxonomies\LocalizedTerm;
+use Statamic\Taxonomies\Term;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class LocalizedTermTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    /** @test */
+    public function it_gets_the_entry_count_through_the_repository()
+    {
+        $term = (new Term)->taxonomy('tags')->slug('foo');
+        $localized = new LocalizedTerm($term, 'en');
+
+        $mock = \Mockery::mock(Facades\Term::getFacadeRoot())->makePartial();
+        Facades\Term::swap($mock);
+        $mock->shouldReceive('entriesCount')->with($localized)->andReturn(7)->once();
+
+        $this->assertEquals(7, $localized->entriesCount());
+        $this->assertEquals(7, $localized->entriesCount());
+    }
+}

--- a/tests/Feature/Taxonomies/TermEntriesTest.php
+++ b/tests/Feature/Taxonomies/TermEntriesTest.php
@@ -37,6 +37,16 @@ class TermEntriesTest extends TestCase
         $this->assertEquals(['red-shirt'], Term::find('colors::red')->entries()->map->slug()->all());
         $this->assertEquals(['panther', 'black-shirt'], Term::find('colors::black')->entries()->map->slug()->all());
         $this->assertEquals(['cheetah'], Term::find('colors::yellow')->entries()->map->slug()->all());
+
+        // and for the base Term class, it should work the same way
+
+        $this->assertEquals(1, Term::find('colors::red')->term()->entriesCount());
+        $this->assertEquals(2, Term::find('colors::black')->term()->entriesCount());
+        $this->assertEquals(1, Term::find('colors::yellow')->term()->entriesCount());
+
+        $this->assertEquals(['red-shirt'], Term::find('colors::red')->term()->entries()->map->slug()->all());
+        $this->assertEquals(['panther', 'black-shirt'], Term::find('colors::black')->term()->entries()->map->slug()->all());
+        $this->assertEquals(['cheetah'], Term::find('colors::yellow')->term()->entries()->map->slug()->all());
     }
 
     /** @test */
@@ -68,6 +78,22 @@ class TermEntriesTest extends TestCase
         $this->assertEquals(['red-shirt'], Term::find('colors::red')->collection($clothes)->entries()->map->slug()->all());
         $this->assertEquals(['black-shirt'], Term::find('colors::black')->collection($clothes)->entries()->map->slug()->all());
         $this->assertEquals([], Term::find('colors::yellow')->collection($clothes)->entries()->map->slug()->all());
+
+        // and for the base Term class, it should work the same way
+
+        $this->assertEquals(0, Term::find('colors::red')->term()->collection($animals)->entriesCount());
+        $this->assertEquals(1, Term::find('colors::black')->term()->collection($animals)->entriesCount());
+        $this->assertEquals(1, Term::find('colors::yellow')->term()->collection($animals)->entriesCount());
+        $this->assertEquals(1, Term::find('colors::red')->term()->collection($clothes)->entriesCount());
+        $this->assertEquals(1, Term::find('colors::black')->term()->collection($clothes)->entriesCount());
+        $this->assertEquals(0, Term::find('colors::yellow')->term()->collection($clothes)->entriesCount());
+
+        $this->assertEquals([], Term::find('colors::red')->term()->collection($animals)->entries()->map->slug()->all());
+        $this->assertEquals(['panther'], Term::find('colors::black')->term()->collection($animals)->entries()->map->slug()->all());
+        $this->assertEquals(['cheetah'], Term::find('colors::yellow')->term()->collection($animals)->entries()->map->slug()->all());
+        $this->assertEquals(['red-shirt'], Term::find('colors::red')->term()->collection($clothes)->entries()->map->slug()->all());
+        $this->assertEquals(['black-shirt'], Term::find('colors::black')->term()->collection($clothes)->entries()->map->slug()->all());
+        $this->assertEquals([], Term::find('colors::yellow')->term()->collection($clothes)->entries()->map->slug()->all());
     }
 
     /** @test */
@@ -121,6 +147,17 @@ class TermEntriesTest extends TestCase
         $this->assertEquals(['cheetah'], Term::find('colors::yellow')->in('en')->entries()->map->slug()->all());
         $this->assertEquals(1, Term::find('colors::yellow')->in('fr')->entriesCount());
         $this->assertEquals(['guepard'], Term::find('colors::yellow')->in('fr')->entries()->map->slug()->all());
+
+        // and for the base Term class, it should not filter by locale
+
+        $this->assertEquals(2, Term::find('colors::red')->term()->entriesCount());
+        $this->assertEquals(['red-shirt', 'rouge-shirt'], Term::find('colors::red')->term()->entries()->map->slug()->all());
+
+        $this->assertEquals(4, Term::find('colors::black')->term()->entriesCount());
+        $this->assertEquals(['panther', 'panthere', 'black-shirt', 'noir-shirt'], Term::find('colors::black')->term()->entries()->map->slug()->all());
+
+        $this->assertEquals(2, Term::find('colors::yellow')->term()->entriesCount());
+        $this->assertEquals(['cheetah', 'guepard'], Term::find('colors::yellow')->term()->entries()->map->slug()->all());
     }
 
     /** @test */
@@ -175,8 +212,6 @@ class TermEntriesTest extends TestCase
         $this->assertEquals(1, Term::find('colors::yellow')->collection($animals)->in('fr')->entriesCount());
         $this->assertEquals(['guepard'], Term::find('colors::yellow')->collection($animals)->in('fr')->entries()->map->slug()->all());
 
-        // ---
-
         $this->assertEquals(1, Term::find('colors::red')->collection($clothes)->in('en')->entriesCount());
         $this->assertEquals(['red-shirt'], Term::find('colors::red')->collection($clothes)->in('en')->entries()->map->slug()->all());
         $this->assertEquals(1, Term::find('colors::red')->collection($clothes)->in('fr')->entriesCount());
@@ -191,5 +226,25 @@ class TermEntriesTest extends TestCase
         $this->assertEquals([], Term::find('colors::yellow')->collection($clothes)->in('en')->entries()->map->slug()->all());
         $this->assertEquals(0, Term::find('colors::yellow')->collection($clothes)->in('fr')->entriesCount());
         $this->assertEquals([], Term::find('colors::yellow')->collection($clothes)->in('fr')->entries()->map->slug()->all());
+
+        // and for the base Term class, it should not filter by locale
+
+        $this->assertEquals(0, Term::find('colors::red')->collection($animals)->term()->entriesCount());
+        $this->assertEquals([], Term::find('colors::red')->collection($animals)->term()->entries()->map->slug()->all());
+
+        $this->assertEquals(2, Term::find('colors::black')->collection($animals)->term()->entriesCount());
+        $this->assertEquals(['panther', 'panthere'], Term::find('colors::black')->collection($animals)->term()->entries()->map->slug()->all());
+
+        $this->assertEquals(2, Term::find('colors::yellow')->collection($animals)->term()->entriesCount());
+        $this->assertEquals(['cheetah', 'guepard'], Term::find('colors::yellow')->collection($animals)->term()->entries()->map->slug()->all());
+
+        $this->assertEquals(2, Term::find('colors::red')->collection($clothes)->term()->entriesCount());
+        $this->assertEquals(['red-shirt', 'rouge-shirt'], Term::find('colors::red')->collection($clothes)->term()->entries()->map->slug()->all());
+
+        $this->assertEquals(2, Term::find('colors::black')->collection($clothes)->term()->entriesCount());
+        $this->assertEquals(['black-shirt', 'noir-shirt'], Term::find('colors::black')->collection($clothes)->term()->entries()->map->slug()->all());
+
+        $this->assertEquals(0, Term::find('colors::yellow')->collection($clothes)->term()->entriesCount());
+        $this->assertEquals([], Term::find('colors::yellow')->collection($clothes)->term()->entries()->map->slug()->all());
     }
 }

--- a/tests/Feature/Taxonomies/TermEntriesTest.php
+++ b/tests/Feature/Taxonomies/TermEntriesTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Tests\Feature\Taxonomies;
+
+use Facades\Tests\Factories\EntryFactory;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Site;
+use Statamic\Facades\Taxonomy;
+use Statamic\Facades\Term;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class TermEntriesTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    /** @test */
+    public function it_gets_and_counts_entries_for_a_term_across_collections()
+    {
+        Taxonomy::make('colors')->save();
+        Term::make()->taxonomy('colors')->inDefaultLocale()->slug('red')->data([])->save();
+        Term::make()->taxonomy('colors')->inDefaultLocale()->slug('black')->data([])->save();
+        Term::make()->taxonomy('colors')->inDefaultLocale()->slug('yellow')->data([])->save();
+
+        Collection::make('animals')->taxonomies(['colors'])->save();
+        Collection::make('clothes')->taxonomies(['colors'])->save();
+
+        EntryFactory::collection('animals')->slug('panther')->data(['colors' => ['black']])->create();
+        EntryFactory::collection('animals')->slug('cheetah')->data(['colors' => ['yellow']])->create();
+        EntryFactory::collection('clothes')->slug('red-shirt')->data(['colors' => ['red']])->create();
+        EntryFactory::collection('clothes')->slug('black-shirt')->data(['colors' => ['black']])->create();
+
+        $this->assertEquals(1, Term::find('colors::red')->entriesCount());
+        $this->assertEquals(2, Term::find('colors::black')->entriesCount());
+        $this->assertEquals(1, Term::find('colors::yellow')->entriesCount());
+
+        $this->assertEquals(['red-shirt'], Term::find('colors::red')->entries()->map->slug()->all());
+        $this->assertEquals(['panther', 'black-shirt'], Term::find('colors::black')->entries()->map->slug()->all());
+        $this->assertEquals(['cheetah'], Term::find('colors::yellow')->entries()->map->slug()->all());
+    }
+
+    /** @test */
+    public function it_gets_and_counts_entries_for_a_term_for_a_single_collection()
+    {
+        Taxonomy::make('colors')->save();
+        Term::make()->taxonomy('colors')->inDefaultLocale()->slug('red')->data([])->save();
+        Term::make()->taxonomy('colors')->inDefaultLocale()->slug('black')->data([])->save();
+        Term::make()->taxonomy('colors')->inDefaultLocale()->slug('yellow')->data([])->save();
+
+        $animals = tap(Collection::make('animals')->taxonomies(['colors']))->save();
+        $clothes = tap(Collection::make('clothes')->taxonomies(['colors']))->save();
+
+        EntryFactory::collection('animals')->slug('panther')->data(['colors' => ['black']])->create();
+        EntryFactory::collection('animals')->slug('cheetah')->data(['colors' => ['yellow']])->create();
+        EntryFactory::collection('clothes')->slug('red-shirt')->data(['colors' => ['red']])->create();
+        EntryFactory::collection('clothes')->slug('black-shirt')->data(['colors' => ['black']])->create();
+
+        $this->assertEquals(0, Term::find('colors::red')->collection($animals)->entriesCount());
+        $this->assertEquals(1, Term::find('colors::black')->collection($animals)->entriesCount());
+        $this->assertEquals(1, Term::find('colors::yellow')->collection($animals)->entriesCount());
+        $this->assertEquals(1, Term::find('colors::red')->collection($clothes)->entriesCount());
+        $this->assertEquals(1, Term::find('colors::black')->collection($clothes)->entriesCount());
+        $this->assertEquals(0, Term::find('colors::yellow')->collection($clothes)->entriesCount());
+
+        $this->assertEquals([], Term::find('colors::red')->collection($animals)->entries()->map->slug()->all());
+        $this->assertEquals(['panther'], Term::find('colors::black')->collection($animals)->entries()->map->slug()->all());
+        $this->assertEquals(['cheetah'], Term::find('colors::yellow')->collection($animals)->entries()->map->slug()->all());
+        $this->assertEquals(['red-shirt'], Term::find('colors::red')->collection($clothes)->entries()->map->slug()->all());
+        $this->assertEquals(['black-shirt'], Term::find('colors::black')->collection($clothes)->entries()->map->slug()->all());
+        $this->assertEquals([], Term::find('colors::yellow')->collection($clothes)->entries()->map->slug()->all());
+    }
+
+    /** @test */
+    public function it_gets_and_counts_entries_for_a_localized_term_across_collections()
+    {
+        Site::setConfig(['sites' => [
+            'en' => ['locale' => 'en_US', 'name' => 'English', 'url' => '/'],
+            'fr' => ['locale' => 'fr_FR', 'name' => 'French', 'url' => '/fr/'],
+        ]]);
+
+        Taxonomy::make('colors')->save();
+        tap(Term::make()->taxonomy('colors'), function ($term) {
+            $term->in('en')->slug('red')->data(['hex' => 'f00'])->save();
+            $term->in('fr')->slug('rouge')->data([])->save();
+        });
+        tap(Term::make()->taxonomy('colors'), function ($term) {
+            $term->in('en')->slug('black')->data(['hex' => '000'])->save();
+            $term->in('fr')->slug('noir')->data([])->save();
+        });
+        tap(Term::make()->taxonomy('colors'), function ($term) {
+            $term->in('en')->slug('yellow')->data(['hex' => 'ff0'])->save();
+            $term->in('fr')->slug('jaune')->data([])->save();
+        });
+
+        Collection::make('animals')->taxonomies(['colors'])->save();
+        Collection::make('clothes')->taxonomies(['colors'])->save();
+
+        $panther = EntryFactory::collection('animals')->slug('panther')->data(['colors' => ['black']])->create();
+        $frPanther = EntryFactory::collection('animals')->locale('fr')->origin($panther->id())->slug('panthere')->data([])->create();
+
+        $cheetah = EntryFactory::collection('animals')->slug('cheetah')->data(['colors' => ['yellow']])->create();
+        $frCheetah = EntryFactory::collection('animals')->locale('fr')->origin($cheetah->id())->slug('guepard')->data([])->create();
+
+        $redShirt = EntryFactory::collection('clothes')->slug('red-shirt')->data(['colors' => ['red']])->create();
+        $frRedShirt = EntryFactory::collection('clothes')->locale('fr')->origin($redShirt->id())->slug('rouge-shirt')->data([])->create();
+
+        $blackShirt = EntryFactory::collection('clothes')->slug('black-shirt')->data(['colors' => ['black']])->create();
+        $frBlackShirt = EntryFactory::collection('clothes')->locale('fr')->origin($blackShirt->id())->slug('noir-shirt')->data([])->create();
+
+        $this->assertEquals(1, Term::find('colors::red')->in('en')->entriesCount());
+        $this->assertEquals(['red-shirt'], Term::find('colors::red')->in('en')->entries()->map->slug()->all());
+        $this->assertEquals(1, Term::find('colors::red')->in('fr')->entriesCount());
+        $this->assertEquals(['rouge-shirt'], Term::find('colors::red')->in('fr')->entries()->map->slug()->all());
+
+        $this->assertEquals(2, Term::find('colors::black')->in('en')->entriesCount());
+        $this->assertEquals(['panther', 'black-shirt'], Term::find('colors::black')->in('en')->entries()->map->slug()->all());
+        $this->assertEquals(2, Term::find('colors::black')->in('fr')->entriesCount());
+        $this->assertEquals(['panthere', 'noir-shirt'], Term::find('colors::black')->in('fr')->entries()->map->slug()->all());
+
+        $this->assertEquals(1, Term::find('colors::yellow')->in('en')->entriesCount());
+        $this->assertEquals(['cheetah'], Term::find('colors::yellow')->in('en')->entries()->map->slug()->all());
+        $this->assertEquals(1, Term::find('colors::yellow')->in('fr')->entriesCount());
+        $this->assertEquals(['guepard'], Term::find('colors::yellow')->in('fr')->entries()->map->slug()->all());
+    }
+
+    /** @test */
+    public function it_gets_and_counts_entries_for_a_localized_term_for_a_single_collection()
+    {
+        Site::setConfig(['sites' => [
+            'en' => ['locale' => 'en_US', 'name' => 'English', 'url' => '/'],
+            'fr' => ['locale' => 'fr_FR', 'name' => 'French', 'url' => '/fr/'],
+        ]]);
+
+        Taxonomy::make('colors')->save();
+        tap(Term::make()->taxonomy('colors'), function ($term) {
+            $term->in('en')->slug('red')->data(['hex' => 'f00'])->save();
+            $term->in('fr')->slug('rouge')->data([])->save();
+        });
+        tap(Term::make()->taxonomy('colors'), function ($term) {
+            $term->in('en')->slug('black')->data(['hex' => '000'])->save();
+            $term->in('fr')->slug('noir')->data([])->save();
+        });
+        tap(Term::make()->taxonomy('colors'), function ($term) {
+            $term->in('en')->slug('yellow')->data(['hex' => 'ff0'])->save();
+            $term->in('fr')->slug('jaune')->data([])->save();
+        });
+
+        $animals = tap(Collection::make('animals')->taxonomies(['colors']))->save();
+        $clothes = tap(Collection::make('clothes')->taxonomies(['colors']))->save();
+
+        $panther = EntryFactory::collection('animals')->slug('panther')->data(['colors' => ['black']])->create();
+        $frPanther = EntryFactory::collection('animals')->locale('fr')->origin($panther->id())->slug('panthere')->data([])->create();
+
+        $cheetah = EntryFactory::collection('animals')->slug('cheetah')->data(['colors' => ['yellow']])->create();
+        $frCheetah = EntryFactory::collection('animals')->locale('fr')->origin($cheetah->id())->slug('guepard')->data([])->create();
+
+        $redShirt = EntryFactory::collection('clothes')->slug('red-shirt')->data(['colors' => ['red']])->create();
+        $frRedShirt = EntryFactory::collection('clothes')->locale('fr')->origin($redShirt->id())->slug('rouge-shirt')->data([])->create();
+
+        $blackShirt = EntryFactory::collection('clothes')->slug('black-shirt')->data(['colors' => ['black']])->create();
+        $frBlackShirt = EntryFactory::collection('clothes')->locale('fr')->origin($blackShirt->id())->slug('noir-shirt')->data([])->create();
+
+        $this->assertEquals(0, Term::find('colors::red')->collection($animals)->in('en')->entriesCount());
+        $this->assertEquals([], Term::find('colors::red')->collection($animals)->in('en')->entries()->map->slug()->all());
+        $this->assertEquals(0, Term::find('colors::red')->collection($animals)->in('fr')->entriesCount());
+        $this->assertEquals([], Term::find('colors::red')->collection($animals)->in('fr')->entries()->map->slug()->all());
+
+        $this->assertEquals(1, Term::find('colors::black')->collection($animals)->in('en')->entriesCount());
+        $this->assertEquals(['panther'], Term::find('colors::black')->collection($animals)->in('en')->entries()->map->slug()->all());
+        $this->assertEquals(1, Term::find('colors::black')->collection($animals)->in('fr')->entriesCount());
+        $this->assertEquals(['panthere'], Term::find('colors::black')->collection($animals)->in('fr')->entries()->map->slug()->all());
+
+        $this->assertEquals(1, Term::find('colors::yellow')->collection($animals)->in('en')->entriesCount());
+        $this->assertEquals(['cheetah'], Term::find('colors::yellow')->collection($animals)->in('en')->entries()->map->slug()->all());
+        $this->assertEquals(1, Term::find('colors::yellow')->collection($animals)->in('fr')->entriesCount());
+        $this->assertEquals(['guepard'], Term::find('colors::yellow')->collection($animals)->in('fr')->entries()->map->slug()->all());
+
+        // ---
+
+        $this->assertEquals(1, Term::find('colors::red')->collection($clothes)->in('en')->entriesCount());
+        $this->assertEquals(['red-shirt'], Term::find('colors::red')->collection($clothes)->in('en')->entries()->map->slug()->all());
+        $this->assertEquals(1, Term::find('colors::red')->collection($clothes)->in('fr')->entriesCount());
+        $this->assertEquals(['rouge-shirt'], Term::find('colors::red')->collection($clothes)->in('fr')->entries()->map->slug()->all());
+
+        $this->assertEquals(1, Term::find('colors::black')->collection($clothes)->in('en')->entriesCount());
+        $this->assertEquals(['black-shirt'], Term::find('colors::black')->collection($clothes)->in('en')->entries()->map->slug()->all());
+        $this->assertEquals(1, Term::find('colors::black')->collection($clothes)->in('fr')->entriesCount());
+        $this->assertEquals(['noir-shirt'], Term::find('colors::black')->collection($clothes)->in('fr')->entries()->map->slug()->all());
+
+        $this->assertEquals(0, Term::find('colors::yellow')->collection($clothes)->in('en')->entriesCount());
+        $this->assertEquals([], Term::find('colors::yellow')->collection($clothes)->in('en')->entries()->map->slug()->all());
+        $this->assertEquals(0, Term::find('colors::yellow')->collection($clothes)->in('fr')->entriesCount());
+        $this->assertEquals([], Term::find('colors::yellow')->collection($clothes)->in('fr')->entries()->map->slug()->all());
+    }
+}


### PR DESCRIPTION
Fixes #4320 

`entriesCount()` was not filtering by site or collection. Now it does both.

`entries()` was filtering by collection, but not site. Now it does both.

When calling `entries()` or `entriesCount()` from the base Term class, it won't do any site filtering. It will do the collection filtering.