### PR TITLE
Add support for orWhere() on query build for entries and terms

### DIFF
--- a/src/Assets/QueryBuilder.php
+++ b/src/Assets/QueryBuilder.php
@@ -93,7 +93,7 @@ class QueryBuilder extends BaseQueryBuilder implements Contract
             : Facades\AssetContainer::find($this->container);
     }
 
-    public function where($column, $operator = null, $value = null)
+    public function where($column, $operator = null, $value = null, $boolean = null)
     {
         if ($column === 'container') {
             throw_if($this->container, new Exception('Only one asset container may be queried.'));
@@ -102,7 +102,7 @@ class QueryBuilder extends BaseQueryBuilder implements Contract
             return $this;
         }
 
-        return parent::where($column, $operator, $value);
+        return parent::where($column, $operator, $value, $boolean);
     }
 
     protected function collect($items = [])

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -62,7 +62,7 @@ abstract class Builder implements Contract
 
     abstract public function inRandomOrder();
 
-    public function where($column, $operator = null, $value = null)
+    public function where($column, $operator = null, $value = null, $boolean = null)
     {
         // Here we will make some assumptions about the operator. If only 2 values are
         // passed to the method, we will assume that the operator is an equals sign
@@ -79,10 +79,17 @@ abstract class Builder implements Contract
         }
 
         $type = 'Basic';
+        if (is_null($boolean))
+            $boolean = 'and';
 
-        $this->wheres[] = compact('type', 'column', 'value', 'operator');
+        $this->wheres[] = compact('type', 'column', 'value', 'operator', 'boolean');
 
         return $this;
+    }
+
+    public function orWhere($column, $operator = null, $value = null)
+    {
+        return $this->where($column, $operator, $value, 'or');
     }
 
     public function prepareValueAndOperator($value, $operator, $useDefault = false)
@@ -107,23 +114,49 @@ abstract class Builder implements Contract
         return ! in_array(strtolower($operator), array_keys($this->operators), true);
     }
 
-    public function whereIn($column, $values)
+    public function whereIn($column, $values, $boolean = null)
     {
         $this->wheres[] = [
             'type' => 'In',
             'column' => $column,
             'values' => $values,
+            'boolean' => $boolean,
         ];
 
         return $this;
     }
 
-    public function whereNotIn($column, $values)
+    public function orWhereIn($column, $values)
+    {
+        $this->wheres[] = [
+            'type' => 'In',
+            'column' => $column,
+            'values' => $values,
+            'boolean' => 'or',
+        ];
+
+        return $this;
+    }
+
+    public function whereNotIn($column, $values, $boolean = null)
     {
         $this->wheres[] = [
             'type' => 'NotIn',
             'column' => $column,
             'values' => $values,
+            'boolean' => $boolean,
+        ];
+
+        return $this;
+    }
+
+    public function orWhereNotIn($column, $values)
+    {
+        $this->wheres[] = [
+            'type' => 'NotIn',
+            'column' => $column,
+            'values' => $values,
+            'boolean' => 'or',
         ];
 
         return $this;

--- a/src/Stache/Query/TermQueryBuilder.php
+++ b/src/Stache/Query/TermQueryBuilder.php
@@ -33,7 +33,7 @@ class TermQueryBuilder extends Builder
         return $this->where($column, $operator, $value, 'or');
     }
 
-    public function whereIn($column, $values)
+    public function whereIn($column, $values, $boolean = null)
     {
         if (in_array($column, ['taxonomy', 'taxonomies'])) {
             $this->taxonomies = array_merge($this->taxonomies ?? [], $values);
@@ -105,6 +105,9 @@ class TermQueryBuilder extends Builder
             // Perform the filtering, and get the keys (the references, we don't care about the values).
             $method = 'filterWhere'.$where['type'];
             $keys = $this->{$method}($items, $where)->keys();
+
+            if ($where['boolean'] == 'or')
+                return $ids ? $ids->concat($keys)->values() : $keys;
 
             // Continue intersecting the keys across the where clauses.
             // If a key exists in the reduced array but not in the current iteration, it should be removed.

--- a/src/Stache/Query/TermQueryBuilder.php
+++ b/src/Stache/Query/TermQueryBuilder.php
@@ -11,7 +11,7 @@ class TermQueryBuilder extends Builder
     protected $taxonomies;
     protected $collections;
 
-    public function where($column, $operator = null, $value = null)
+    public function where($column, $operator = null, $value = null, $boolean = null)
     {
         if ($column === 'taxonomy') {
             $this->taxonomies[] = $operator;
@@ -25,7 +25,12 @@ class TermQueryBuilder extends Builder
             return $this;
         }
 
-        return parent::where($column, $operator, $value);
+        return parent::where($column, $operator, $value, $boolean);
+    }
+
+    public function orWhere($column, $operator = null, $value = null)
+    {
+        return $this->where($column, $operator, $value, 'or');
     }
 
     public function whereIn($column, $values)
@@ -43,6 +48,11 @@ class TermQueryBuilder extends Builder
         }
 
         return parent::whereIn($column, $values);
+    }
+
+    public function orWhereIn($column, $values)
+    {
+        return $this->whereIn($column, $values, 'or');
     }
 
     protected function collect($items = [])

--- a/tests/Data/Taxonomies/TermQueryBuilderTest.php
+++ b/tests/Data/Taxonomies/TermQueryBuilderTest.php
@@ -41,6 +41,18 @@ class TermQueryBuilderTest extends TestCase
     }
 
     /** @test */
+    public function it_filters_using_or_wheres()
+    {
+        Taxonomy::make('tags')->save();
+        Term::make('a')->taxonomy('tags')->data(['test' => 'foo'])->save();
+        Term::make('b')->taxonomy('tags')->data(['test' => 'bar'])->save();
+        Term::make('c')->taxonomy('tags')->data(['test' => 'foo'])->save();
+
+        $terms = Term::query()->where('test', 'foo')->orWhere('test', 'bar')->get();
+        $this->assertEquals(['a', 'b', 'c'], $terms->map->slug()->sort()->values()->all());
+    }
+
+    /** @test */
     public function it_filters_by_taxonomy()
     {
         Taxonomy::make('tags')->save();

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -48,6 +48,6 @@ class BuilderTest extends TestCase
     {
         $this->createDummyCollectionAndEntries();
         $entries = Entry::query()->where('title', 'Post 1')->orWhere('title', 'Post 3')->get();
-        $this->assertCount(2, $entries->count());
+        $this->assertCount(2, $entries);
     }
 }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -42,4 +42,12 @@ class BuilderTest extends TestCase
         $this->assertSame($searchedEntry, $retrievedEntry);
         $this->assertSame($retrievedEntry->selectedQueryColumns(), $columns);
     }
+
+    /** @test **/
+    public function entries_are_found_using_or_where()
+    {
+        $this->createDummyCollectionAndEntries();
+        $entries = Entry::query()->where('title', 'Post 1')->orWhere('title', 'Post 3')->get();
+        $this->assertCount(2, $entries->count());
+    }
 }


### PR DESCRIPTION
I'm cautiously offering this as I'm not sure if I've covered off everything required and there are likely cases I've not thought of. But at an initial level this offers support for orWhere(), orWhereIn() and orWhereNotIn() support on Entries, and orWhere() and orWhereIn() on Terms. 

It doesnt consider nesting in any way, but as you'll see works on the basis of concat-ing the ids passed by reduce() in the filter function instead of intersect-ing. This might not be sufficient for merging, but I felt it was better than no orWhere() support at all.