### PR TITLE
Fix cascade hydration

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -395,7 +395,9 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
 
     public function toLivePreviewResponse($request, $extras)
     {
-        Cascade::set('live_preview', $extras);
+        Cascade::hydrated(function ($cascade) use ($extras) {
+            $cascade->set('live_preview', $extras);
+        });
 
         return $this->toResponse($request);
     }

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Http\Responses;
 
-use Facades\Statamic\View\Cascade;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Str;
 use Statamic\Auth\Protect\Protection;
@@ -159,11 +158,6 @@ class DataResponse implements Responsable
         }
 
         return $contents;
-    }
-
-    protected function cascade()
-    {
-        return Cascade::instance()->withContent($this->data)->hydrate();
     }
 
     protected function adjustResponseType()

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -360,7 +360,9 @@ class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, Reso
 
     public function toLivePreviewResponse($request, $extras)
     {
-        Cascade::set('live_preview', $extras);
+        Cascade::hydrated(function ($cascade) use ($extras) {
+            $cascade->set('live_preview', $extras);
+        });
 
         return $this->toResponse($request);
     }

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -17,6 +17,7 @@ class Cascade
     protected $data;
     protected $content;
     protected $sections;
+    protected $hydratedCallbacks = [];
 
     public function __construct(Request $request, Site $site, array $data = [])
     {
@@ -77,6 +78,13 @@ class Cascade
         $this->data = $data;
     }
 
+    public function hydrated($callback)
+    {
+        $this->hydratedCallbacks[] = $callback;
+
+        return $this;
+    }
+
     public function hydrate()
     {
         $this->data([]);
@@ -87,7 +95,19 @@ class Cascade
             ->hydrateSegments()
             ->hydrateGlobals()
             ->hydrateContent()
-            ->hydrateViewModel();
+            ->hydrateViewModel()
+            ->runHydratedCallbacks();
+    }
+
+    private function runHydratedCallbacks()
+    {
+        foreach ($this->hydratedCallbacks as $callback) {
+            $callback($this);
+        }
+
+        $this->hydratedCallbacks = [];
+
+        return $this;
     }
 
     private function hydrateVariables()

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -105,8 +105,6 @@ class Cascade
             $callback($this);
         }
 
-        $this->hydratedCallbacks = [];
-
         return $this;
     }
 

--- a/tests/View/CascadeTest.php
+++ b/tests/View/CascadeTest.php
@@ -385,6 +385,24 @@ class CascadeTest extends TestCase
     }
 
     /** @test */
+    public function the_cascade_can_be_manipulated_after_hydration()
+    {
+        $cascade = $this->cascade();
+
+        $cascade->hydrated(function ($cascade) {
+            $cascade->set('foo', 'bar');
+            $cascade->set('xml_header', 'not the xml header');
+        });
+
+        tap($cascade->hydrate()->toArray(), function ($cascade) {
+            $this->assertEquals('bar', $cascade['foo']);
+
+            // a var that would normally be there to show the callbacks are run at the end
+            $this->assertEquals('not the xml header', $cascade['xml_header']);
+        });
+    }
+
+    /** @test */
     public function page_data_overrides_globals()
     {
         $this->withoutEvents(); // prevents taxonomy term tracker from kicking in.


### PR DESCRIPTION
Adds a `Cascade::hydrated()` method so you can do whatever to the cascade after it's been populated with data.

```php
Cascade::hydrated(function ($cascade) {
  $cascade->set('foo', 'bar');
});
```

Fixes #4013
Closes #4156 