### PR TITLE
Add buttons open and download for readonly assets

### DIFF
--- a/resources/js/components/fieldtypes/assets/Asset.js
+++ b/resources/js/components/fieldtypes/assets/Asset.js
@@ -61,6 +61,14 @@ export default {
             this.$emit('removed', this.asset);
         },
 
+        open() {
+            window.open(this.asset.url, '_blank');
+        },
+
+        download() {
+            window.open(this.asset.downloadUrl);
+        },
+
         makeZoomable() {
             const el = $(this.$el).find('a.zoom')[0];
 

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -49,6 +49,7 @@
 
                 <div class="asset-controls" v-if="readOnly">
                     <button
+                        v-if="asset.url"
                         @click="open"
                         class="btn btn-icon icon icon-link"
                         :alt="__('Open in a new window')"></button>

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -46,6 +46,19 @@
                         class="btn btn-icon icon icon-trash"
                         :alt="__('Remove')"></button>
                 </div>
+
+                <div class="asset-controls" v-if="readOnly">
+                    <button
+                        @click="open"
+                        class="btn btn-icon icon icon-link"
+                        :alt="__('Open in a new window')"></button>
+
+                    <button
+                        v-if="asset.allowDownloading"
+                        @click="download"
+                        class="btn btn-icon icon icon-download"
+                        :alt="__('Download file')"></button>
+                </div>
             </div>
         </div>
 

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -52,7 +52,8 @@
                         v-if="asset.url"
                         @click="open"
                         class="btn btn-icon"
-                        :alt="__('Open in a new window')">
+                        :alt="__('Open in a new window')"
+                    >
                         <svg-icon name="external-link" class="h-4 my-1"/>
                     </button>
 
@@ -60,7 +61,8 @@
                         v-if="asset.allowDownloading"
                         @click="download"
                         class="btn btn-icon"
-                        :alt="__('Download file')">
+                        :alt="__('Download file')"
+                    >
                         <svg-icon name="download" class="h-4 my-1"/>
                     </button>
                 </div>

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -51,14 +51,18 @@
                     <button
                         v-if="asset.url"
                         @click="open"
-                        class="btn btn-icon icon icon-link"
-                        :alt="__('Open in a new window')"></button>
+                        class="btn btn-icon"
+                        :alt="__('Open in a new window')">
+                        <svg-icon name="external-link" class="h-4 my-1"/>
+                    </button>
 
                     <button
                         v-if="asset.allowDownloading"
                         @click="download"
-                        class="btn btn-icon icon icon-download"
-                        :alt="__('Download file')"></button>
+                        class="btn btn-icon"
+                        :alt="__('Download file')">
+                        <svg-icon name="download" class="h-4 my-1"/>
+                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR adds buttons to view and download assets uploaded via a form when hovering over an AssetTile.

**OUTDATED IMAGE, see comment below for recent version:**
![image](https://user-images.githubusercontent.com/14234815/135843520-f4e94a02-5e4a-4579-a68a-ab975ece1037.png)

~I tried to use `icon-external-link` to have the same icon as in the asset editor but that doesn't seem to be available in the icon font.~

I'm not sure which other parts of the CP are affected by this change as I'm always showing the buttons on read-only AssetTiles.

Edit: Please also see this for more context: https://github.com/statamic/ideas/issues/669

Closes #4514