### PR TITLE
Bard: fix popover button styles when using floating mode

### DIFF
--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -134,7 +134,7 @@
         margin-left: -3px
     }
 
-    button {
+    .bard-toolbar-button {
         @apply text-grey-20 h-10 w-10 text-center bg-black rounded-lg flex items-center justify-center;
         font-size: 16px;
         transition: all .1s ease-in-out;
@@ -143,19 +143,19 @@
         }
     }
 
-    button:hover {
+    .bard-toolbar-button:hover {
         @apply .text-white;
     }
 
-    button.active {
+    .bard-toolbar-button.active {
         @apply .text-blue;
     }
 
-    button:focus {
+    .bard-toolbar-button:focus {
         outline: none;
     }
 
-    button:disabled {
+    .bard-toolbar-button:disabled {
         @apply .opacity-50;
         &:hover {
             @apply .text-grey-20;


### PR DESCRIPTION
The floating toolbar button styles are applied broadly to all toolbar buttons, including the link popover buttons. This PR scopes it to the `bard-toolbar-button` class, same as in fixed mode.

<img src="https://user-images.githubusercontent.com/2236267/135928274-effde9b3-adfa-49c2-8149-1cc2854896c8.jpg" width="512">

<img src="https://user-images.githubusercontent.com/2236267/135928307-01c7aeb3-aa94-4a37-aeb0-d9d9c33d9a85.jpg" width="512">