### PR TITLE
Fieldtype debounce update

### DIFF
--- a/resources/js/components/fieldtypes/ArrayFieldtype.vue
+++ b/resources/js/components/fieldtypes/ArrayFieldtype.vue
@@ -90,7 +90,7 @@ export default {
         data: {
             deep: true,
             handler (data) {
-                this.update(this.sortableToObject(data));
+                this.updateDebounced(this.sortableToObject(data));
             }
         },
 

--- a/resources/js/components/fieldtypes/CodeFieldtype.vue
+++ b/resources/js/components/fieldtypes/CodeFieldtype.vue
@@ -83,7 +83,7 @@ export default {
         });
 
         this.codemirror.on('change', (cm) => {
-            this.update(cm.doc.getValue());
+            this.updateDebounced(cm.doc.getValue());
         });
 
         this.codemirror.on('focus', () => this.$emit('focus'));

--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -30,6 +30,10 @@ export default {
             this.$emit('input', value);
         },
 
+        updateDebounced: _.debounce(function (value) {
+            this.update(value);
+        }, 300),
+
         updateMeta(value) {
             this.$emit('meta-updated', value);
         }

--- a/resources/js/components/fieldtypes/FloatFieldtype.vue
+++ b/resources/js/components/fieldtypes/FloatFieldtype.vue
@@ -7,7 +7,7 @@
         :value="value"
         :is-read-only="isReadOnly"
         :id="fieldId"
-        @input="update"
+        @input="updateDebounced"
         @focus="$emit('focus')"
         @blur="$emit('blur')"
     />

--- a/resources/js/components/fieldtypes/IntegerFieldtype.vue
+++ b/resources/js/components/fieldtypes/IntegerFieldtype.vue
@@ -7,7 +7,7 @@
         :value="value"
         :is-read-only="isReadOnly"
         :id="fieldId"
-        @input="update"
+        @input="updateDebounced"
         @focus="$emit('focus')"
         @blur="$emit('blur')"
     />

--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -68,7 +68,7 @@ export default {
             if (option === null) {
                 this.update(null);
             } else if (option === 'url') {
-                this.update(this.urlValue);
+                this.updateDebounced(this.urlValue);
             } else if (option === 'first-child') {
                 this.update('@child');
             } else if (option === 'entry') {

--- a/resources/js/components/fieldtypes/ListFieldtype.vue
+++ b/resources/js/components/fieldtypes/ListFieldtype.vue
@@ -86,7 +86,7 @@ export default {
             deep: true,
             handler(data) {
                 if (!this.mounted) return;
-                this.update(this.sortableToArray(data));
+                this.updateDebounced(this.sortableToArray(data));
             }
         },
 

--- a/resources/js/components/fieldtypes/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/MarkdownFieldtype.vue
@@ -180,7 +180,7 @@ export default {
     watch: {
 
         data(data) {
-            this.update(data);
+            this.updateDebounced(data);
         },
 
         fullScreenMode: {

--- a/resources/js/components/fieldtypes/RangeFieldtype.vue
+++ b/resources/js/components/fieldtypes/RangeFieldtype.vue
@@ -52,7 +52,7 @@ export default {
 
     watch: {
         val(value) {
-            this.update(value);
+            this.updateDebounced(value);
         }
     }
 

--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -71,7 +71,7 @@ export default {
         },
 
         slug(slug) {
-            this.update(slug);
+            this.updateDebounced(slug);
         }
 
     },

--- a/resources/js/components/fieldtypes/TableFieldtype.vue
+++ b/resources/js/components/fieldtypes/TableFieldtype.vue
@@ -101,7 +101,7 @@ export default {
         data: {
             deep: true,
             handler (data) {
-                this.update(this.sortableToArray(data));
+                this.updateDebounced(this.sortableToArray(data));
             }
         },
 

--- a/resources/js/components/fieldtypes/TextFieldtype.vue
+++ b/resources/js/components/fieldtypes/TextFieldtype.vue
@@ -13,7 +13,7 @@
         :placeholder="config.placeholder"
         :name="name"
         :id="fieldId"
-        @input="update"
+        @input="updateDebounced"
         @focus="$emit('focus')"
         @blur="$emit('blur')"
     />

--- a/resources/js/components/fieldtypes/TextareaFieldtype.vue
+++ b/resources/js/components/fieldtypes/TextareaFieldtype.vue
@@ -8,7 +8,7 @@
         :id="fieldId"
         @blur="$emit('blur')"
         @focus="$emit('focus')"
-        @input="update" />
+        @input="updateDebounced" />
 </template>
 
 <script>

--- a/resources/js/components/fieldtypes/YamlFieldtype.vue
+++ b/resources/js/components/fieldtypes/YamlFieldtype.vue
@@ -40,7 +40,7 @@ export default {
         });
 
         this.codemirror.on('change', (cm) => {
-            this.update(cm.doc.getValue());
+            this.updateDebounced(cm.doc.getValue());
         });
     },
 

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -282,7 +282,7 @@ export default {
             if (!this.mounted) return;
 
             // Use a json string otherwise Laravel's TrimStrings middleware will remove spaces where we need them.
-            this.update(JSON.stringify(json));
+            this.updateDebounced(JSON.stringify(json));
         },
 
         value(value, oldValue) {


### PR DESCRIPTION
## Problem
UI performance / responsiveness decreases when user is typing in fields which are part of replicator (or even nested replicators) fieldset.

The reason for the decrease of performance is side effects caused by `fieldtypes/Fieldtype.vue` component emitted `input` event, which starts to bubble events to parent components (keep in mind that in some cases, depending on field sets size, payloads of events can be quite big) as a result of which data in parent components is replaced and then passed down back to child components, where events related to data changes might also be triggered.

This issue affects all field types where a lot of user input is expected - Bard, Code, Text, etc.

## Considerations
The first thought that came to my mind is debouncing of `update` method in `fieldtypes/Fieldtype.vue` component. Debouncing of method seems to improve the situation - number of events decreases and performance / typing responsiveness is much better.

## Solution
Add `updateDebounced` method to `fieldtypes/Fieldtype.vue` which debounces `update` method, because:
- we don't want to debounce update of every field which uses `Fieldtype` mixin
- it can be used in custom field types
- it's simple and remains flexible

Use `updateDebounced` method in all field types where a lot of user input is expected.

## Sidenote
Futher investigation showed that `fieldtypes/replicator/Replicator.vue` method `updated`, which replaces whole values array, triggers large number of redundant events and leads to unwanted side effects, but this is out of this PR context and possible solution will be provided as separate PR.