### PR TITLE
Allow for separate first/last name fields when creating user, if they are separate in the blueprint

### DIFF
--- a/resources/js/components/users/Wizard.vue
+++ b/resources/js/components/users/Wizard.vue
@@ -32,12 +32,28 @@
             </div>
 
             <!-- Name -->
-            <div class="max-w-md mx-auto px-2 pb-7">
+            <div v-if="! separateNameFields" class="max-w-md mx-auto px-2 pb-7">
                 <label class="font-bold text-base mb-sm" for="name">{{ __('Name') }}</label>
                 <input type="text" v-model="user.name" id="name" class="input-text" autofocus tabindex="2">
                 <div class="text-2xs text-grey-60 mt-1 flex items-center">
                     <svg-icon name="info-circle" class="mr-sm flex items-center mb-px"></svg-icon>
                     {{ __('messages.user_wizard_name_instructions') }}
+                </div>
+            </div>
+
+            <div v-else class="max-w-md mx-auto px-2 pb-7 flex space-x-4">
+                <div class="flex-1">
+                    <label class="font-bold text-base mb-sm" for="first_name">{{ __('First Name') }}</label>
+                    <input type="text" v-model="user.first_name" id="first_name" class="input-text" autofocus tabindex="2">
+                    <div class="text-2xs text-grey-60 mt-1 flex items-center">
+                        <svg-icon name="info-circle" class="mr-sm flex items-center mb-px"></svg-icon>
+                        {{ __('messages.user_wizard_name_instructions') }}
+                    </div>
+                </div>
+
+                <div class="flex-1">
+                    <label class="font-bold text-base mb-sm" for="last_name">{{ __('Last Name') }}</label>
+                    <input type="text" v-model="user.last_name" id="last_name" class="input-text" autofocus tabindex="2">
                 </div>
             </div>
         </div>
@@ -191,6 +207,7 @@ export default {
         usersIndexUrl: { type: String },
         canCreateSupers: { type: Boolean },
         activationExpiry: { type: Number },
+        separateNameFields: { type: Boolean },
     },
 
     data() {

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -9,6 +9,7 @@
         users-create-url="{{ cp_route('users.create') }}"
         :can-create-supers="{{ $str::bool($user->can('super')) }}"
         :activation-expiry="{{ $expiry }}"
+        :separate-name-fields="{{ $str::bool($separate_name_fields) }}"
     >
     </user-wizard>
 @stop

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -9,7 +9,7 @@
         users-create-url="{{ cp_route('users.create') }}"
         :can-create-supers="{{ $str::bool($user->can('super')) }}"
         :activation-expiry="{{ $expiry }}"
-        :separate-name-fields="{{ $str::bool($separate_name_fields) }}"
+        :separate-name-fields="{{ $str::bool($separateNameFields) }}"
     >
     </user-wizard>
 @stop

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -92,7 +92,7 @@ class UsersController extends CpController
                 'save' => cp_route('users.store'),
             ],
             'expiry' => $expiry,
-            'separate_name_fields' => $blueprint->hasField('first_name'),
+            'separateNameFields' => $blueprint->hasField('first_name'),
         ];
 
         if ($request->wantsJson()) {

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -92,6 +92,7 @@ class UsersController extends CpController
                 'save' => cp_route('users.store'),
             ],
             'expiry' => $expiry,
+            'separate_name_fields' => $blueprint->hasField('first_name'),
         ];
 
         if ($request->wantsJson()) {
@@ -108,7 +109,7 @@ class UsersController extends CpController
 
         $blueprint = User::blueprint();
 
-        $fields = $blueprint->fields()->only(['email', 'name'])->addValues($request->all());
+        $fields = $blueprint->fields()->only(['email', 'name', 'first_name', 'last_name'])->addValues($request->all());
 
         $fields->validate(['email' => 'required|email|unique_user_value']);
 


### PR DESCRIPTION
Essentially, whenever a user is being created using the wizard, they will either be presented with a single name field or two name fields (first/last) - depending on if a `first_name` field exists on the user blueprint.

Feel free to close if you're planning on implementing in a different way.

## Screenshot

![image](https://user-images.githubusercontent.com/19637309/136100436-96ee0211-7872-455f-8ab8-41a9342d7fe6.png)

## Issues

Closes #4395