### PR TITLE
Smarter `published` toggle when localizing an entry for the first time

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -600,8 +600,13 @@ export default {
 
             const url = this.activeLocalization.url + '/localize';
             this.$axios.post(url, { site: localization.handle }).then(response => {
-                this.editLocalization(response.data)
-                    .then(() => this.$events.$emit('localization.created', {store: this.publishContainer}));
+                this.editLocalization(response.data).then(() => {
+                    this.$events.$emit('localization.created', {store: this.publishContainer});
+
+                    if (this.originValues.published) {
+                        this.setFieldValue('published', true);
+                    }
+                });
             });
         },
 


### PR DESCRIPTION
- [x] When creating new localized entry, automatically set published toggle to match the origin entry's status.
    - If the origin entry is saved as a draft, then the new localized entry will also remain a draft.
    - If the origin entry is saved as a published entry, then the new localized entry will be created as a draft, but will automatically set the published toggle to true, so that it automatically gets published after reviewing, editing, and saving.

![CleanShot 2021-10-08 at 17 48 51](https://user-images.githubusercontent.com/5187394/136628357-8372a664-910f-4ef3-b99d-4d30d3a79b8b.gif)

Closes https://github.com/statamic/cms/issues/2486