### PR TITLE
Remove array type hint on Statamic\Tags\ArrayAccessor hasAny

### DIFF
--- a/src/Tags/ArrayAccessor.php
+++ b/src/Tags/ArrayAccessor.php
@@ -12,7 +12,7 @@ class ArrayAccessor extends Collection
         return Arr::getFirst($this->items, Arr::wrap($key), $default);
     }
 
-    public function hasAny(array $keys)
+    public function hasAny($keys)
     {
         foreach ($keys as $key) {
             if ($this->has($key)) {


### PR DESCRIPTION
Removes the `array` type hint that breaks compatibility with the latest version of Laravel due to https://github.com/laravel/framework/pull/39155.

Prevents error: 

```
Declaration of Statamic\Tags\ArrayAccessor::hasAny(array $keys) must be compatible with Illuminate\Support\Collection::hasAny($key)
```