### PR TITLE
Remove hasAny array typehint

### DIFF
--- a/src/Tags/ArrayAccessor.php
+++ b/src/Tags/ArrayAccessor.php
@@ -12,7 +12,7 @@ class ArrayAccessor extends Collection
         return Arr::getFirst($this->items, Arr::wrap($key), $default);
     }
 
-    public function hasAny(array $keys)
+    public function hasAny($keys)
     {
         foreach ($keys as $key) {
             if ($this->has($key)) {

--- a/tests/Tags/ParametersTest.php
+++ b/tests/Tags/ParametersTest.php
@@ -116,6 +116,9 @@ class ParametersTest extends TestCase
     {
         $this->assertTrue($this->params->has('string'));
         $this->assertFalse($this->params->has('unknown'));
+
+        $this->assertTrue($this->params->hasAny(['string', 'unknown']));
+        $this->assertFalse($this->params->hasAny(['unknown', 'another_unknown']));
     }
 
     /** @test */


### PR DESCRIPTION
Due to laravel/framework#39155, our `hasAny` method causes an error due to a mismatched typehint.

Luckily it does the exact same thing as the method they added, so removing the typehint is enough.
Added a test as well just in case.

Fixes #4455