### PR TITLE
Fix issue with Glide signature and Laravel Octane

### DIFF
--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -149,7 +149,7 @@ class GlideController extends Controller
         $path = Str::after($this->request->url(), Site::current()->absoluteUrl());
 
         try {
-            SignatureFactory::create(Config::getAppKey())->validateRequest($path, $_GET);
+            SignatureFactory::create(Config::getAppKey())->validateRequest($path, $this->request->query->all());
         } catch (SignatureException $e) {
             abort(400, $e->getMessage());
         }


### PR DESCRIPTION
Laravel Octane doesn't pass get parameters as `$_GET` which makes Glide think there's no signature, however getting them through the request object works.