### PR TITLE
Fix styles of lists in Markdown Preview

### DIFF
--- a/resources/sass/components/fieldtypes/markdown.scss
+++ b/resources/sass/components/fieldtypes/markdown.scss
@@ -194,8 +194,17 @@
 
 .markdown-preview {
     @apply mx-auto;
+
     padding: 16px 20px;
     min-height: 167px; // @TODO Refactor to avoid a magic number.
+
+    ol {
+        @apply list-decimal;
+    }
+
+    ul {
+        @apply list-disc;
+    }
 }
 
 .markdown-fieldtype-wrapper.markdown-fullscreen {
@@ -229,10 +238,6 @@
 
     .markdown-preview {
         @apply max-w-xl bg-transparent mx-auto relative p-4 text-lg;
-        
-        ul, li {
-            @apply list-auto;   
-        }
     }
 
     .helpers {


### PR DESCRIPTION
This pull request fixes the styles of ordered & unordered lists when previewing markdown with the Markdown fieldtype.

## Screenshots

**Currently:**

![image](https://user-images.githubusercontent.com/19637309/137172689-a8abf18f-5d5d-4068-83c7-e963e70fe5ee.png)

**With this change:**

![image](https://user-images.githubusercontent.com/19637309/137364788-ab8d22a9-5521-4de3-8117-87a51c8822a2.png)

## Test Markdown

```
Markdown here we are...

First with an ordered list

1. One
2. Two
3. Three

And secondly, with an unordered list:

* No order
* In this
* List
```