### PR TITLE
Add margin to Bard codeblocks

### DIFF
--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -424,6 +424,10 @@
         top: -1px;
     }
 
+    pre {
+        margin-bottom: .85em;
+    }
+
     pre code {
         @apply font-mono bg-grey-40 text-xs p-2 block w-full rounded;
         line-height: 1.8;


### PR DESCRIPTION
Codeblocks don't have margins so they butt up against content that follows them. This PR adds a bottom margin to match other bard styles.

<img src="https://user-images.githubusercontent.com/2236267/137208259-420cbd48-1152-4e4e-8b2a-bf6d97739ff7.jpg" width="512">

<img src="https://user-images.githubusercontent.com/2236267/137208302-2768c448-10b1-480b-9410-f61f1c7f791a.jpg" width="512">