### PR TITLE
Localize content in GetContent tag

### DIFF
--- a/src/Tags/GetContent.php
+++ b/src/Tags/GetContent.php
@@ -55,9 +55,13 @@ class GetContent extends Tags
         $usingUris = Str::startsWith($first, '/');
 
         $query = Entry::query()
-            ->where('site', $this->params->get(['site', 'locale'], Site::current()->handle()))
             ->whereIn($usingUris ? 'uri' : 'id', $items);
 
-        return $this->output($query->get());
+        $items = $query->get();
+        $localized = $items->map(function ($item) {
+            return $item->in(Site::current()->handle()) ?? $item;
+        });
+
+        return $this->output($localized);
     }
 }


### PR DESCRIPTION
When fetching content using the tag `get_content`, you have to specify the entry ID for the current site. If the ID is for another site, the tag returns the root page instead, which probably is not what users want.

This PR changes the behavior to the way that `{{ link id=` works: The entry is fetched by its ID and *then* gets localized to the current site. If the current site has no localization, the original entry is used.