### PR TITLE
Fix SVG compatibility & consistency in Thumbnail.vue

### DIFF
--- a/resources/js/components/assets/Browser/Thumbnail.vue
+++ b/resources/js/components/assets/Browser/Thumbnail.vue
@@ -1,7 +1,7 @@
 <template>
 
     <div class="">
-        <div v-if="showSvg" class="rounded mb-1 flex items-center justify-center asset-thumbnail h-full w-full">
+        <div v-if="showSvg" class="rounded flex items-center justify-center asset-thumbnail h-full w-full">
             <img
                 class="w-full h-full max-w-full max-h-full mx-auto"
                 :src="asset.url"
@@ -37,8 +37,7 @@ export default {
     computed: {
 
         showSvg() {
-            let url = this.asset.url;
-            return url.substring(url.length - 3) === 'svg';
+            return this.asset.extension === 'svg';
         }
 
     }

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -198,6 +198,7 @@ class Assets extends Fieldtype
             $arr = [
                 'id' => $asset->id(),
                 'is_image' => $isImage = $asset->isImage(),
+                'extension' => $asset->extension(),
                 'url' => $asset->url(),
             ];
 


### PR DESCRIPTION
This PR makes two changes to the Thumbnail component used within a collection index.

### 1. Fixes SVG detection
Currently (and at least with assets hosted on S3) an SVG isn't displayed correctly within the Thumbnail component. This is because the `showSvg()` computed prop is attempting to determine SVG-ness via `this.asset.extension`, and the `extension` property doesn't exist on `this.asset`. Maybe that prop is just missing and it's an easy fix elsewhere, but if not, checking URL for substring of 'svg' does the trick.

### 2. Displays SVGs at the same size as other, non-SVG formats
Once the SVG is being displayed correctly, it feels much smaller than other, non-SVG images. That's because of the `p-1` class on the wrapping `<div>`, which adds 8px of padding on all sides—shouldn't be needed. Comparison below.

**Before:**
![image](https://user-images.githubusercontent.com/13950848/138331191-55a1e8d0-6073-4087-bcb8-54306c857494.png)

**After:**
![image](https://user-images.githubusercontent.com/13950848/138331257-6a227ef5-7a4f-4f5c-8e17-b96e712dcf77.png)
