### PR TITLE
Add data to ResponseCreated event

### DIFF
--- a/src/Events/ResponseCreated.php
+++ b/src/Events/ResponseCreated.php
@@ -11,11 +11,14 @@ class ResponseCreated extends Event
      */
     public $response;
 
+    public $data;
+
     /**
      * @param  Response  $response
      */
-    public function __construct(Response $response)
+    public function __construct(Response $response, $data)
     {
         $this->response = $response;
+        $this->data = $data;
     }
 }

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -45,7 +45,7 @@ class DataResponse implements Responsable
             ->make($this->contents())
             ->withHeaders($this->headers);
 
-        ResponseCreated::dispatch($response);
+        ResponseCreated::dispatch($response, $this->data);
 
         return $response;
     }


### PR DESCRIPTION
The ResponseCreated is great for adding headers. We use it to add a header that makes Varnish cache pages. Only for our usecase we need to exempt some pages based on a switch. Having access to the Page that the response was created for allows for conditionally adding headers like this. 