### PR TITLE
Add multisite support to Globals API

### DIFF
--- a/src/Http/Controllers/API/GlobalsController.php
+++ b/src/Http/Controllers/API/GlobalsController.php
@@ -19,10 +19,10 @@ class GlobalsController extends ApiController
         );
     }
 
-    public function show($globalSet)
+    public function show($global)
     {
         $this->abortIfDisabled();
 
-        return app(GlobalSetResource::class)::make($globalSet);
+        return app(GlobalSetResource::class)::make($global->globalSet()->in($this->queryParam('site')));
     }
 }

--- a/src/Http/Controllers/API/GlobalsController.php
+++ b/src/Http/Controllers/API/GlobalsController.php
@@ -19,10 +19,12 @@ class GlobalsController extends ApiController
         );
     }
 
-    public function show($global)
+    public function show($variables)
     {
         $this->abortIfDisabled();
 
-        return app(GlobalSetResource::class)::make($global->globalSet()->in($this->queryParam('site')));
+        $localized = $variables->globalSet()->in($this->queryParam('site'));
+
+        return app(GlobalSetResource::class)::make($localized);
     }
 }


### PR DESCRIPTION
Fixes #4184. Allows for fetching localized content via the Globals API endpoint for a single global like you can for all globals.

```
/api/globals/some_global # returns default site content
/api/globals/some_global?site=sitetwo # returns sitetwo's localized content
```