### PR TITLE
Prevent filtering out @ from search queries in Comb

### DIFF
--- a/tests/Search/CombIndexTest.php
+++ b/tests/Search/CombIndexTest.php
@@ -4,15 +4,12 @@ namespace Tests\Search;
 
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Mockery;
-use Statamic\Facades\Search;
-use Statamic\Facades\User;
 use Statamic\Search\Comb\Index;
-use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class CombIndexTest extends TestCase
 {
-    use IndexTests, PreventSavingStacheItemsToDisk;
+    use IndexTests;
 
     private $fs;
 
@@ -41,37 +38,5 @@ class CombIndexTest extends TestCase
     public function getIndex()
     {
         return app(Index::class);
-    }
-
-    /** @test */
-    public function it_can_find_users_by_their_email_address()
-    {
-        config([
-            'statamic.search.indexes.users' => [
-                'driver' => 'local',
-                'searchables' => 'users',
-                'fields' => ['name', 'email'],
-            ],
-        ]);
-
-        $john = User::make()
-            ->set('name', 'John Doe')
-            ->email('john@doe.com')
-            ->save();
-
-        $jane = User::make()
-            ->set('name', 'Jane Doe')
-            ->email('jane@doe.com')
-            ->save();
-
-        $index = Search::index('users');
-
-        $index->update();
-
-        $users = $index->search('john@doe.com')->get();
-
-        $this->assertCount(1, $users, 'User could not be found by his email address');
-        $this->assertEquals($john->id(), $users->first()->id());
-        $this->assertNotEquals($jane->id(), $users->first()->id());
     }
 }

--- a/tests/Search/CombTest.php
+++ b/tests/Search/CombTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Search;
+
+use Statamic\Search\Comb\Comb;
+use Statamic\Search\Comb\Exceptions\NoResultsFound;
+use Tests\TestCase;
+
+class CombTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider searchesProvider
+     **/
+    public function it_searches($term, $expected)
+    {
+        $comb = new Comb([
+            ['title' => 'John Doe', 'email' => 'john@doe.com'],
+            ['title' => 'Jane Doe', 'email' => 'jane@doe.com'],
+        ]);
+
+        try {
+            $results = $comb->lookUp($term);
+        } catch (NoResultsFound $e) {
+            $results = [];
+        }
+
+        $this->assertEquals($expected, collect($results['data'] ?? [])->pluck('data.title')->all());
+    }
+
+    public function searchesProvider()
+    {
+        return [
+            'string with single result' => ['jane', ['Jane Doe']],
+            'string with multiple results' => ['doe', ['John Doe', 'Jane Doe']],
+            'email' => ['john@doe.com', ['John Doe']],
+        ];
+    }
+}


### PR DESCRIPTION
Since this causes searches for email addresses to fail; searching for `john@doe.com` would actually search for `johndoe.com`.

Fixes #4519