### PR TITLE
Don't show view link in entry actions if the entry can't be viewed.

### DIFF
--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -75,7 +75,7 @@
                         </template>
                         <template slot="actions" slot-scope="{ row: entry, index }">
                             <dropdown-list>
-                                <dropdown-item :text="__('View')" :external-link="entry.permalink" v-if="entry.viewable" />
+                                <dropdown-item :text="__('View')" :external-link="entry.permalink" v-if="entry.viewable && entry.permalink" />
                                 <dropdown-item :text="__('Edit')" :redirect="entry.edit_url" v-if="entry.editable" />
                                 <div class="divider" v-if="entry.actions.length" />
                                 <data-list-inline-actions


### PR DESCRIPTION
Fixes #4349 by checking whether the entry has a permalink before showing the link.