### PR TITLE
Support floating point numbers in the sum modifier.

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2220,15 +2220,22 @@ class CoreModifiers extends Modifier
     {
         $key = Arr::get($params, 0, null);
 
-        return collect($value)->reduce(function ($carry, $value) use ($key) {
+        $sum = collect($value)->reduce(function ($carry, $value) use ($key) {
             if ($key) {
                 $value = data_get($value, $key);
             }
 
             $value = $value instanceof Value ? $value->value() : $value;
 
-            return $carry + (int) $value;
+            return $carry + (float) $value;
         }, 0);
+
+        // For backwards compatibility integers get cast to integers.
+        if ($sum === round($sum)) {
+            return (int) $sum;
+        }
+
+        return $sum;
     }
 
     /**

--- a/tests/Modifiers/SumTest.php
+++ b/tests/Modifiers/SumTest.php
@@ -14,7 +14,7 @@ class SumTest extends TestCase
      **/
     public function it_sums($sum, $key, $array)
     {
-        $this->assertEquals($sum, $this->modify($array, $key));
+        $this->assertSame($sum, $this->modify($array, $key));
     }
 
     public function sums()
@@ -22,6 +22,9 @@ class SumTest extends TestCase
         return [
             'list of ints' => [7, null, [1, 2, 3, 1]],
             'list of strings' => [7, null, ['1', '2', '3', '1']],
+            'list of floats, should return an integer' => [7, null, [1.5, 2.5, 3]],
+            'list of floats, should return a float' => [7.5, null, [1.5, 2, 3, 1]],
+            'list of strings with points' => [7.5, null, ['1.5', '2', '3', '1.0']],
             'associative array of ints' => [7, 'foo', [
                 ['foo' => 1],
                 ['foo' => 2],


### PR DESCRIPTION
Fixes #4512

For backwards compatibility I've used `assertSame` instead of `assertEquals` which also checks the data type. For this reason float numbers will also get casted to integers if they're also integers.