### PR TITLE
Hide the twirldown on the collection view page when it's empty.

### DIFF
--- a/resources/js/components/collections/View.vue
+++ b/resources/js/components/collections/View.vue
@@ -9,7 +9,7 @@
             <div class="flex items-center">
                 <h1 class="flex-1" v-text="title" />
 
-                <dropdown-list class="mr-1">
+                <dropdown-list class="mr-1" v-if="!!this.$scopedSlots.twirldown">
                     <slot name="twirldown" />
                 </dropdown-list>
 

--- a/resources/views/collections/show.blade.php
+++ b/resources/views/collections/show.blade.php
@@ -30,6 +30,11 @@
         :structure-show-slugs="{{ Statamic\Support\Str::bool($structure->showSlugs()) }}"
         @endif
     >
+        @if(
+            auth()->user()->can('edit', $collection)
+            || auth()->user()->can('delete', $collection)
+            || auth()->user()->can('configure fields')
+        )
         <template #twirldown>
             @can('edit', $collection)
                 <dropdown-item :text="__('Edit Collection')" redirect="{{ $collection->editUrl() }}"></dropdown-item>
@@ -51,6 +56,7 @@
                 </dropdown-item>
             @endcan
         </template>
+        @endif
     </collection-view>
 
 @endsection


### PR DESCRIPTION
Honestly this is not as beautiful as I'd hoped it could be, but it works. I can't find a clean way to check in Vue to check whether the slot is 'empty'. That's why now it's just doing a check to see if the slot is missing instead.

Closes #4348