### PR TITLE
Fix user:reset_password_form tag.

### DIFF
--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -261,7 +261,7 @@ class UserTags extends Tags
 
         $data['url_invalid'] = request()->isNotFilled('token');
 
-        if (!$this->params->has('redirect')) {
+        if (! $this->params->has('redirect')) {
             $this->params->put('redirect', request()->getPathInfo());
         }
 

--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Auth;
 
+use Illuminate\Support\Facades\Password;
+use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Fields\Field;
@@ -258,6 +260,8 @@ class UserTags extends Tags
         if (session('errors')) {
             $data['errors'] = session('errors')->all();
         }
+
+        $data['url_invalid'] = request()->isNotFilled('token');
 
         $knownParams = ['redirect'];
 

--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\Auth;
 
-use Illuminate\Support\Facades\Password;
-use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Fields\Field;
@@ -253,7 +251,7 @@ class UserTags extends Tags
             'errors' => [],
         ];
 
-        if (session('success')) {
+        if (session()->has('status')) {
             return $this->parse(['success' => true]);
         }
 

--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -263,6 +263,10 @@ class UserTags extends Tags
 
         $data['url_invalid'] = request()->isNotFilled('token');
 
+        if (!$this->params->has('redirect')) {
+            $this->params->put('redirect', request()->getPathInfo());
+        }
+
         $knownParams = ['redirect'];
 
         $html = $this->formOpen(route('statamic.password.reset.action'), 'POST', $knownParams);


### PR DESCRIPTION
This one will also be accompanied by [a PR to the docs](https://github.com/statamic/docs/pull/573), since the docs are outdated; nowadays we only add a `token` variable to the password reset URL. This token is then sent with the email address + password (& confirmation) to check whether the reset is valid.

Closes #4340 => adds the `url_invalid` variable for in the template.
Closes #4370 => redirects to the current page when you don't pass a `redirect` parameter to the `user:reset_password_form` tag.

Fixes another bug that hasn't been opened: it now actually sets the `success` variable for you when the reset was successful. Before it was checking for the `success` session, [but it's actually named `status`](https://github.com/statamic/cms/blob/3.2/src/Auth/ResetsPasswords.php#L152)

**Note:** it's easy to use this repo for testing the update to the tag: https://github.com/marcorieser/statamic-login
Thanks @marcorieser 😄 