### PR TITLE
Fix a couple of code fieldtype issues

### DIFF
--- a/src/Fieldtypes/Code.php
+++ b/src/Fieldtypes/Code.php
@@ -61,7 +61,6 @@ class Code extends Fieldtype
                 'display' => __('Selectable Mode'),
                 'instructions' => __('statamic::fieldtypes.code.config.mode_selectable'),
                 'type' => 'toggle',
-                'default' => true,
                 'width' => 50,
             ],
             'indent_type' => [

--- a/src/Fieldtypes/Code.php
+++ b/src/Fieldtypes/Code.php
@@ -125,7 +125,7 @@ class Code extends Fieldtype
 
     public function process($value)
     {
-        if ($this->isModeSelectable()) {
+        if (! $this->isModeSelectable()) {
             return $value['code'];
         }
 

--- a/src/Fieldtypes/Code.php
+++ b/src/Fieldtypes/Code.php
@@ -118,6 +118,11 @@ class Code extends Fieldtype
         return $value;
     }
 
+    public function preProcessConfig($value)
+    {
+        return $value;
+    }
+
     public function process($value)
     {
         if ($this->isModeSelectable()) {

--- a/tests/Fieldtypes/CodeTest.php
+++ b/tests/Fieldtypes/CodeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Code;
+use Tests\TestCase;
+
+class CodeTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider processValues
+     **/
+    public function it_processes_values($isSelectable, $value, $expected)
+    {
+        $field = (new Code)->setField(new Field('test', [
+            'type' => 'code',
+            'mode_selectable' => $isSelectable,
+        ]));
+
+        $this->assertEquals($expected, $field->process($value));
+    }
+
+    public function processValues()
+    {
+        return [
+            'selectable' => [true, ['code' => 'bar', 'mode' => 'htmlmixed'], ['code' => 'bar', 'mode' => 'htmlmixed']],
+            'non selectable' => [false, ['code' => 'bar', 'mode' => 'htmlmixed'], 'bar'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider preProcessValues
+     **/
+    public function it_preprocesses_values($value, $expected)
+    {
+        $field = (new Code)->setField(new Field('test', ['type' => 'code']));
+
+        $this->assertEquals($expected, $field->preProcess($value));
+    }
+
+    public function preProcessValues()
+    {
+        return [
+            'string' => ['bar', ['code' => 'bar', 'mode' => 'htmlmixed']],
+            'array' => [['code' => 'bar', 'mode' => 'htmlmixed'], ['code' => 'bar', 'mode' => 'htmlmixed']],
+            'null' => [null, ['code' => null, 'mode' => 'htmlmixed']],
+        ];
+    }
+
+    /** @test */
+    public function it_doesnt_do_any_preprocessing_for_config()
+    {
+        $field = (new Code)->setField(new Field('test', ['type' => 'code']));
+
+        $this->assertEquals('whatever', $field->preProcessConfig('whatever'));
+    }
+}


### PR DESCRIPTION
- Add processing tests
- The tests showed I had the condition backwards for how it's processed. Fields with a selectable mode should save the mode. Non-selectable modes should just save the string. It was the other way.
- Prevent preprocessing config. `html` fields were showing the code/mode array because it was running preProcess on the code field.
