### PR TITLE
Throw exception when navigation could not be found.

### DIFF
--- a/src/Exceptions/NavigationNotFoundException.php
+++ b/src/Exceptions/NavigationNotFoundException.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Statamic\Exceptions;
+
+use Exception;
+use Facade\Ignition\Support\StringComparator;
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\IgnitionContracts\ProvidesSolution;
+use Facade\IgnitionContracts\Solution;
+use Statamic\Facades\Nav;
+use Statamic\Statamic;
+
+class NavigationNotFoundException extends Exception implements ProvidesSolution
+{
+    protected $navigation;
+
+    public function __construct($navigation)
+    {
+        parent::__construct("Navigation [{$navigation}] not found");
+
+        $this->navigation = $navigation;
+    }
+
+    public function getSolution(): Solution
+    {
+        $description = ($suggestedNavigation = $this->getSuggestedNavigation())
+            ? "Did you mean `$suggestedNavigation`?"
+            : 'Are you sure the navigation exists?';
+
+        return BaseSolution::create("The {$this->navigation} navigation was not found.")
+            ->setSolutionDescription($description)
+            ->setDocumentationLinks([
+                'Read the navigation guide' => Statamic::docsUrl('navigation'),
+            ]);
+    }
+
+    protected function getSuggestedNavigation()
+    {
+        return StringComparator::findClosestMatch(
+            Nav::all()->map->handle()->all(),
+            $this->navigation
+        );
+    }
+}

--- a/src/Tags/Nav.php
+++ b/src/Tags/Nav.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Tags;
 
+use Statamic\Exceptions\NavigationNotFoundException;
 use Statamic\Facades\Data;
+use Statamic\Facades\Nav as NavFacade;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Support\Str;
@@ -11,7 +13,20 @@ class Nav extends Structure
 {
     public function index()
     {
-        return $this->structure($this->params->get('handle', 'collection::pages'));
+        $handle = $this->params->get('handle', 'collection::pages');
+
+        if ($handle !== 'collection::pages' && ! NavFacade::findByHandle($handle)) {
+            throw new NavigationNotFoundException($handle);
+        }
+
+        return $this->structure($handle);
+    }
+
+    public function wildcard($handle)
+    {
+        $this->params->put('handle', $handle);
+
+        return $this->index();
     }
 
     public function breadcrumbs()

--- a/src/Tags/Nav.php
+++ b/src/Tags/Nav.php
@@ -2,9 +2,7 @@
 
 namespace Statamic\Tags;
 
-use Statamic\Exceptions\NavigationNotFoundException;
 use Statamic\Facades\Data;
-use Statamic\Facades\Nav as NavFacade;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Support\Str;
@@ -13,20 +11,7 @@ class Nav extends Structure
 {
     public function index()
     {
-        $handle = $this->params->get('handle', 'collection::pages');
-
-        if ($handle !== 'collection::pages' && ! NavFacade::findByHandle($handle)) {
-            throw new NavigationNotFoundException($handle);
-        }
-
-        return $this->structure($handle);
-    }
-
-    public function wildcard($handle)
-    {
-        $this->params->put('handle', $handle);
-
-        return $this->index();
+        return $this->structure($this->params->get('handle', 'collection::pages'));
     }
 
     public function breadcrumbs()

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -3,7 +3,9 @@
 namespace Statamic\Tags;
 
 use Statamic\Contracts\Structures\Structure as StructureContract;
+use Statamic\Exceptions\CollectionNotFoundException;
 use Statamic\Exceptions\NavigationNotFoundException;
+use Statamic\Facades\Collection;
 use Statamic\Facades\Nav;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
@@ -52,14 +54,13 @@ class Structure extends Tags
     protected function ensureStructureExists(string $handle): void
     {
         if (Str::startsWith($handle, 'collection::')) {
+            $collection = Str::after($handle, 'collection::');
+            throw_unless(Collection::findByHandle($collection), new CollectionNotFoundException($collection));
+
             return;
         }
 
-        if (Nav::findByHandle($handle)) {
-            return;
-        }
-
-        throw new NavigationNotFoundException($handle);
+        throw_unless(Nav::findByHandle($handle), new NavigationNotFoundException($handle));
     }
 
     public function toArray($tree, $parent = null, $depth = 1)

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -3,9 +3,12 @@
 namespace Statamic\Tags;
 
 use Statamic\Contracts\Structures\Structure as StructureContract;
+use Statamic\Exceptions\NavigationNotFoundException;
+use Statamic\Facades\Nav;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Structures\TreeBuilder;
+use Statamic\Support\Str;
 
 class Structure extends Tags
 {
@@ -32,6 +35,8 @@ class Structure extends Tags
             $handle = $handle->handle();
         }
 
+        $this->ensureStructureExists($handle);
+
         $tree = (new TreeBuilder)->build([
             'structure' => $handle,
             'include_home' => $this->params->get('include_home'),
@@ -42,6 +47,19 @@ class Structure extends Tags
         ]);
 
         return $this->toArray($tree);
+    }
+
+    protected function ensureStructureExists(string $handle): void
+    {
+        if (Str::startsWith($handle, 'collection::')) {
+            return;
+        }
+
+        if (Nav::findByHandle($handle)) {
+            return;
+        }
+
+        throw new NavigationNotFoundException($handle);
     }
 
     public function toArray($tree, $parent = null, $depth = 1)


### PR DESCRIPTION
It now does boom 💥 .

![Schermafbeelding 2021-10-29 om 22 26 03](https://user-images.githubusercontent.com/9193686/139498107-d4dd7fdf-86cf-42d2-b28d-11413daef6fc.png)

The question is whether it should only do it for the `handle` parameter, or for everything. Right now it does so for:
- `{{ nav:doesnt_exist }}`
- `{{ nav handle="doesnt_exist" }}`

But **not** for: `{{ nav }}`, this falls back to `{{ nav:collection:pages }}` like before.

Since it now says boom instead of 'silent fail' it's not a backwards compatible change, but maybe that's fine?

Closes #4223