### PR TITLE
Add config option to hide email login button when using OAuth

### DIFF
--- a/config/oauth.php
+++ b/config/oauth.php
@@ -4,6 +4,8 @@ return [
 
     'enabled' => env('STATAMIC_OAUTH_ENABLED', false),
 
+    'email_login_enabled' => true,
+
     'providers' => [
         // 'github',
     ],

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -20,13 +20,15 @@
                 @endforeach
             </div>
 
-            <div class="text-center italic my-3">or</div>
+            @if($emailLoginEnabled)
+                <div class="text-center italic my-3">or</div>
 
-            <div class="login-with-email" v-if="! showEmailLogin">
-                <a class="btn block" @click.prevent="showEmailLogin = true">
-                    {{ __('Log in with email') }}
-                </a>
-            </div>
+                <div class="login-with-email" v-if="! showEmailLogin">
+                    <a class="btn block" @click.prevent="showEmailLogin = true">
+                        {{ __('Log in with email') }}
+                    </a>
+                </div>
+            @endif
         @endif
 
         <form method="POST" v-show="showEmailLogin" class="email-login select-none" @if ($oauth) v-cloak @endif>

--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -35,6 +35,7 @@ class LoginController extends CpController
         $data = [
             'title' => __('Log in'),
             'oauth' => $enabled = OAuth::enabled(),
+            'emailLoginEnabled' => $enabled ? config('statamic.oauth.email_login_enabled') : false,
             'providers' => $enabled ? OAuth::providers() : [],
             'referer' => $this->getReferrer($request),
             'hasError' => $this->hasError(),


### PR DESCRIPTION
This pull request adds a config option in case developers want to hide the 'Login with email' button when their using OAuth.

For reference: #4599 