### PR TITLE
Bring back the old apostrophe for older versions

### DIFF
--- a/resources/lang/da.json
+++ b/resources/lang/da.json
@@ -375,6 +375,7 @@
     "HTML view": "HTML-visning",
     "I remember my password": "Jeg husker min adgangskode",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Hvis du har problemer med at klikke på knappen \" :actionText \", skal du kopiere og indsætte nedenstående URL i din webbrowser:",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Hvis du har problemer med at klikke på knappen \" :actionText \", skal du kopiere og indsætte nedenstående URL i din webbrowser:",
     "Image": "Billede",
     "Image Cache": "Billedcache",
     "Image cache cleared.": "Billedcache ryddet.",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -399,6 +399,7 @@
     "I remember my password": "Ich erinnere mich an mein Passwort",
     "ID regenerated and Stache cleared": "ID regeneriert und Stache gelöscht",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Wenn du beim Klicken auf den Button „:actionText“ Probleme hast, kopiere die folgende URL und füge sie in deinem Browser ein:",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Wenn du beim Klicken auf den Button „:actionText“ Probleme hast, kopiere die folgende URL und füge sie in deinem Browser ein:",
     "Image": "Bild",
     "Image Cache": "Bildercache",
     "Image cache cleared.": "Der Bildercache wurde gelöscht.",

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -399,6 +399,7 @@
     "I remember my password": "Ich erinnere mich an mein Passwort",
     "ID regenerated and Stache cleared": "ID regeneriert und Stache gelöscht",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Wenn du beim Klicken auf den Button «:actionText» Probleme hast, kopiere die folgende URL und füge sie in deinem Browser ein:",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Wenn du beim Klicken auf den Button «:actionText» Probleme hast, kopiere die folgende URL und füge sie in deinem Browser ein:",
     "Image": "Bild",
     "Image Cache": "Bildercache",
     "Image cache cleared.": "Der Bildercache wurde gelöscht.",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -375,6 +375,7 @@
     "HTML view": "Vista HTML",
     "I remember my password": "Recuerdo mi contraseña",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Si tienes problemas para hacer clic en el botón de \":actionText\", copia y pega el siguiente URL en tu navegador:",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Si tienes problemas para hacer clic en el botón de \":actionText\", copia y pega el siguiente URL en tu navegador:",
     "Image": "Imagen",
     "Image Cache": "Caché de imágenes",
     "Image cache cleared.": "Caché de imágenes borrado.",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -397,6 +397,7 @@
     "I remember my password": "Je me souviens de mon mot de passe",
     "ID regenerated and Stache cleared": "ID regénéré et Stache effacé",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Si vous ne parvenez pas à cliquer sur le bouton \":actionText\", copiez et collez l'URL ci-dessous dans votre navigateur Web :",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Si vous ne parvenez pas à cliquer sur le bouton \":actionText\", copiez et collez l'URL ci-dessous dans votre navigateur Web :",
     "Image": "Image",
     "Image Cache": "Cache des images",
     "Image cache cleared.": "Cache des images effacé.",

--- a/resources/lang/id.json
+++ b/resources/lang/id.json
@@ -375,6 +375,7 @@
     "HTML view": "Tampilan HTML",
     "I remember my password": "Saya ingat kata sandi saya",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Jika anda mengalami masalah saat mengklik tombol \":actionText\", salin dan tempel URL di bawah ini ke browser: Anda",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Jika anda mengalami masalah saat mengklik tombol \":actionText\", salin dan tempel URL di bawah ini ke browser: Anda",
     "Image": "Gambar",
     "Image Cache": "Cache Gambar",
     "Image cache cleared.": "ache Gambar dibersihkan",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -375,6 +375,7 @@
     "HTML view": "Formato HTML",
     "I remember my password": "Ricordo la mia password",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Se riscontri problemi a cliccare il pulsante \":actionText\", copia e incolla l'URL seguente nel browser:",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Se riscontri problemi a cliccare il pulsante \":actionText\", copia e incolla l'URL seguente nel browser:",
     "Image": "Immagine",
     "Image Cache": "Cache immagini",
     "Image cache cleared.": "Cache immagini cancellata.",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -399,6 +399,7 @@
     "I remember my password": "Ik herinner me mijn wachtwoord",
     "ID regenerated and Stache cleared": "ID's gegenereerd en stache geleegd",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Als je problemen ondervindt bij het klikken op de knop \":actionText\", kopieer en plak de onderstaande URL dan in je webbrowser:",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Als je problemen ondervindt bij het klikken op de knop \":actionText\", kopieer en plak de onderstaande URL dan in je webbrowser:",
     "Image": "Afbeelding",
     "Image Cache": "Afbeeldingcache",
     "Image cache cleared.": "Afbeeldingcache geleegd",

--- a/resources/lang/pt.json
+++ b/resources/lang/pt.json
@@ -375,6 +375,7 @@
     "HTML view": "Visualização HTML",
     "I remember my password": "Lembro a minha senha",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Se estiver com problemas para clicar no botão &quot; :actionText &quot;, copie e cole o URL abaixo no seu navegador da web:",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Se estiver com problemas para clicar no botão &quot; :actionText &quot;, copie e cole o URL abaixo no seu navegador da web:",
     "Image": "Imagem",
     "Image Cache": "Cache de imagem",
     "Image cache cleared.": "Cache de imagem apagado",

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -397,6 +397,7 @@
     "HTML view": "Представление HTML",
     "I remember my password": "Я помню свой пароль",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Если у вас возникли проблемы с нажатием кнопки \":actionText\" скопируйте и вставьте URL ниже\nв свой веб-браузер:",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Если у вас возникли проблемы с нажатием кнопки \":actionText\" скопируйте и вставьте URL ниже\nв свой веб-браузер:",
     "Image": "Изображения",
     "Image Cache": "Кэш изображений",
     "Image cache cleared.": "Кэш изображений очищен.",

--- a/resources/lang/sl.json
+++ b/resources/lang/sl.json
@@ -375,6 +375,7 @@
     "HTML view": "Pogled HTML",
     "I remember my password": "Spomnim se svojega gesla",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Če imate težave s klikom na gumb » :actionText «, kopirajte in prilepite spodnji URL v svoj spletni brskalnik:",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Če imate težave s klikom na gumb » :actionText «, kopirajte in prilepite spodnji URL v svoj spletni brskalnik:",
     "Image": "Slika",
     "Image Cache": "Predpomnilnik slike",
     "Image cache cleared.": "Predpomnilnik slik je očiščen.",

--- a/resources/lang/zh_TW.json
+++ b/resources/lang/zh_TW.json
@@ -392,6 +392,7 @@
     "HTML view": "HTML 檢視",
     "I remember my password": "我記得密碼",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "若無法點擊「:actionText」按鈕，請將下方網址複製並貼至瀏覽器上：",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "若無法點擊「:actionText」按鈕，請將下方網址複製並貼至瀏覽器上：",
     "Image": "圖片",
     "Image Cache": "圖片快取",
     "Image cache cleared.": "已清除圖片快取。",

--- a/translator
+++ b/translator
@@ -43,6 +43,7 @@ $additionalStrings = [
     'Whoops!',
     'Regards',
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:", // laravel <8.48.0
     'All rights reserved.',
     'The given data was invalid.',
 ];


### PR DESCRIPTION
In #4630, the line should have been added, not replaced.
In versions of Laravel before 8.48.0, users will still have the translation with the older apostrophe, so the line would be untranslated. This PR adds both. Same translation though.
