### PR TITLE
Add supplemental page data to the parent of trees.

### DIFF
--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -89,6 +89,7 @@ abstract class Tree implements Contract, Localization
             ->setTitle($branch['title'] ?? null)
             ->setRoute($this->route())
             ->setDepth(1)
+            ->setPageData($branch['data'] ?? [])
             ->setRoot(true);
     }
 

--- a/tests/Data/Structures/TreeTest.php
+++ b/tests/Data/Structures/TreeTest.php
@@ -139,6 +139,9 @@ class TreeTest extends TestCase
 
         $this->assertInstanceOf(Pages::class, $pages);
         $this->assertCount(3, $pages->all());
+
+        $this->assertEquals(['test' => 'home'], $pages->all()[0]->pageData()->all());
+        $this->assertEquals(['test' => 'about'], $pages->all()[1]->pageData()->all());
     }
 
     /** @test */
@@ -160,9 +163,11 @@ class TreeTest extends TestCase
             [
                 'id' => 'root-id',
                 'entry' => 'pages-home',
+                'data' => ['test' => 'home'],
             ],
             [
                 'id' => 'pages-about',
+                'data' => ['test' => 'about'],
                 'children' => [
                     [
                         'id' => 'pages-board',
@@ -195,9 +200,11 @@ class TreeTest extends TestCase
             [
                 'id' => 'root-id',
                 'entry' => 'pages-home',
+                'data' => ['test' => 'home'],
             ],
             [
                 'id' => 'pages-about',
+                'data' => ['test' => 'about'],
                 'children' => [
                     [
                         'id' => 'pages-board',
@@ -235,9 +242,11 @@ class TreeTest extends TestCase
             [
                 'id' => 'root-id',
                 'entry' => 'pages-home',
+                'data' => ['test' => 'home'],
             ],
             [
                 'id' => 'pages-about',
+                'data' => ['test' => 'about'],
                 'children' => [
                     [
                         'id' => 'pages-board',
@@ -261,9 +270,11 @@ class TreeTest extends TestCase
         $tree = $this->tree($arr = [
             [
                 'id' => 'pages-home',
+                'data' => ['test' => 'home'],
             ],
             [
                 'id' => 'pages-about',
+                'data' => ['test' => 'about'],
                 'children' => [
                     [
                         'id' => 'pages-board',
@@ -529,9 +540,11 @@ class TreeTest extends TestCase
                 [
                     'id' => 'root-id',
                     'entry' => 'pages-home',
+                    'data' => ['test' => 'home'],
                 ],
                 [
                     'id' => 'pages-about',
+                    'data' => ['test' => 'about'],
                     'children' => [
                         [
                             'id' => 'pages-board',


### PR DESCRIPTION
Quite the rabbit hole, but it turns out that the `parent` method of a tree was not yet supplying the page data to the new page instance it was creating.

This means that when displaying navs with `include_home="true"` there wouldn't be any supplemental data available that was set on the nav.

Fixes #4258