### PR TITLE
Fix null and empty string field condition handling

### DIFF
--- a/resources/js/components/field-conditions/Converter.js
+++ b/resources/js/components/field-conditions/Converter.js
@@ -36,7 +36,7 @@ export default class {
         let operator = '==';
 
         _.chain(this.getOperatorsAndAliases())
-            .filter(value => new RegExp(`^${value} [^=]`).test(condition.toString()))
+            .filter(value => new RegExp(`^${value} [^=]`).test(this.normalizeConditionString(condition)))
             .each(value => operator = value);
 
         return this.normalizeOperator(operator);
@@ -49,7 +49,7 @@ export default class {
     }
 
     getValueFromRhs(condition) {
-        let rhs = condition.toString();
+        let rhs = this.normalizeConditionString(condition);
 
         _.chain(this.getOperatorsAndAliases())
             .filter(value => new RegExp(`^${value} [^=]`).test(rhs))
@@ -67,5 +67,12 @@ export default class {
 
     getOperatorsAndAliases() {
         return OPERATORS.concat(Object.keys(ALIASES));
+    }
+
+    normalizeConditionString(value) {
+        // You cannot `null.toString()`, so we'll manually cast it here to prevent error.
+        if (value === null) return 'null';
+
+        return value.toString();
     }
 }

--- a/resources/js/components/field-conditions/Converter.js
+++ b/resources/js/components/field-conditions/Converter.js
@@ -73,6 +73,11 @@ export default class {
         // You cannot `null.toString()`, so we'll manually cast it here to prevent error.
         if (value === null) return 'null';
 
+        // Note: We don't document the use of an '' empty string in the yaml,
+        // but for the people that manually add this to their yaml, we'll
+        // treat it as an `empty` check so that it doesn't feel broken.
+        if (value === '') return 'empty';
+
         return value.toString();
     }
 }


### PR DESCRIPTION
- [x] Prevent JS errors when field condition is literal `null` in yaml.
- [x] Handle `''` (even though not documented) as `empty` so it doesn't feel broken when used in yaml.

cc/ @edalzell