### PR TITLE
Enhance Locales Tag

### DIFF
--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -101,6 +101,7 @@ class Site implements Augmentable
             'locale' => $this->locale(),
             'short_locale' => $this->shortLocale(),
             'url' => $this->url(),
+            'permalink' => $this->absoluteUrl(),
             'direction' => $this->direction(),
             'attributes' => $this->attributes(),
         ];

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -2,11 +2,11 @@
 
 namespace Statamic\Tags;
 
-use Statamic\Support\Str;
-use Statamic\Facades\Data;
-use Statamic\Facades\Site;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Statamic\Facades\Data;
+use Statamic\Facades\Site;
+use Statamic\Support\Str;
 
 class Locales extends Tags
 {
@@ -85,7 +85,8 @@ class Locales extends Tags
             'name' => $site->name(),
             'full' => $site->locale(),
             'short' => $site->shortLocale(),
-            'url' => $site->absoluteUrl(),
+            'url' => $site->url(),
+            'permalink' => $site->absoluteUrl(),
         ];
     }
 
@@ -104,7 +105,8 @@ class Locales extends Tags
                 $localized['current'] = Site::current()->handle();
                 $localized['is_current'] = $key === Site::current()->handle();
                 $localized['exists'] = Arr::exists($localized, 'status');
-                $localized['permalink'] = Arr::get($localized, 'permalink', $locale['url']);
+                $localized['url'] = Arr::get($localized, 'url', $locale['url']);
+                $localized['permalink'] = Arr::get($localized, 'permalink', $locale['permalink']);
             }
 
             return $localized;

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -66,7 +66,9 @@ class Locales extends Tags
             return $this->sort($locales);
         })->pipe(function ($locales) {
             return $this->addData($locales);
-        })->filter()->values();
+        })->filter(function ($item) {
+            return $this->shouldInclude($item);
+        })->values();
     }
 
     /**
@@ -218,5 +220,18 @@ class Locales extends Tags
             })
             ->put('id', null)
             ->all();
+    }
+
+    private function shouldInclude($item)
+    {
+        if (! $item) {
+            return false;
+        }
+
+        if (! $this->params->bool('self', true) && $item['locale']['handle'] === $this->data->locale()) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -24,7 +24,13 @@ class Locales extends Tags
             return '';
         }
 
-        return $this->getLocales();
+        $locales = $this->getLocales();
+
+        if ($locales->isEmpty()) {
+            return '';
+        }
+
+        return $locales;
     }
 
     /**

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -99,7 +99,7 @@ class Locales extends Tags
         return $locales->map(function ($locale, $key) {
             $localized = $this->getLocalizedData($key);
 
-            if ($localized || $this->params->bool('include_all')) {
+            if ($localized || $this->params->bool('all')) {
                 $localized['locale'] = $locale;
                 $localized['current'] = Site::current()->handle();
                 $localized['is_current'] = $key === Site::current()->handle();

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -79,15 +79,11 @@ class Locales extends Tags
     {
         $site = $key instanceof \Statamic\Sites\Site ? $key : Site::get($key);
 
-        return [
-            'key' => $site->handle(),
-            'handle' => $site->handle(),
-            'name' => $site->name(),
-            'full' => $site->locale(),
+        return array_merge($site->toAugmentedArray(), [
             'short' => $site->shortLocale(),
-            'url' => $site->url(),
-            'permalink' => $site->absoluteUrl(),
-        ];
+            'full' => $site->locale(),
+            'key' => $site->handle(),
+        ]);
     }
 
     /**

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -103,7 +103,7 @@ class Locales extends Tags
                 $localized['locale'] = $locale;
                 $localized['current'] = Site::current()->handle();
                 $localized['is_current'] = $key === Site::current()->handle();
-                $localized['available'] = Arr::exists($localized, 'status');
+                $localized['exists'] = Arr::exists($localized, 'status');
                 $localized['permalink'] = Arr::get($localized, 'permalink', $locale['url']);
             }
 

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -2,10 +2,11 @@
 
 namespace Statamic\Tags;
 
-use Illuminate\Support\Collection;
+use Statamic\Support\Str;
 use Statamic\Facades\Data;
 use Statamic\Facades\Site;
-use Statamic\Support\Str;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 
 class Locales extends Tags
 {
@@ -84,6 +85,7 @@ class Locales extends Tags
             'name' => $site->name(),
             'full' => $site->locale(),
             'short' => $site->shortLocale(),
+            'url' => $site->absoluteUrl(),
         ];
     }
 
@@ -95,13 +97,15 @@ class Locales extends Tags
     private function addData($locales)
     {
         return $locales->map(function ($locale, $key) {
-            if (! $localized = $this->getLocalizedData($key)) {
-                return null;
-            }
+            $localized = $this->getLocalizedData($key);
 
-            $localized['locale'] = $locale;
-            $localized['current'] = Site::current()->handle();
-            $localized['is_current'] = $key === Site::current()->handle();
+            if ($localized || $this->params->bool('include_all')) {
+                $localized['locale'] = $locale;
+                $localized['current'] = Site::current()->handle();
+                $localized['is_current'] = $key === Site::current()->handle();
+                $localized['available'] = Arr::exists($localized, 'status');
+                $localized['permalink'] = Arr::get($localized, 'permalink', $locale['url']);
+            }
 
             return $localized;
         });

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -97,6 +97,7 @@ class Locales extends Tags
             $localized = $this->getLocalizedData($key);
 
             if ($localized || $this->params->bool('all')) {
+                $localized = $this->fillWithNullsFromBlueprint($localized);
                 $localized['locale'] = $locale;
                 $localized['current'] = Site::current()->handle();
                 $localized['is_current'] = $key === Site::current()->handle();
@@ -198,5 +199,24 @@ class Locales extends Tags
         $current = $locales->pull($key);
 
         return collect([$key => $current])->merge($locales);
+    }
+
+    private function fillWithNullsFromBlueprint($item)
+    {
+        // If $item is already an array, it's an entry. We're done.
+        if ($item) {
+            return $item;
+        }
+
+        // Otherwise, the localization doesn't exist, but we don't want
+        // the previous iteration of the loop to be carried over into
+        // this iteration, so we'll add null values for all the fields.
+        return $this->data->blueprint()
+            ->fields()->all()
+            ->map(function () {
+                return null;
+            })
+            ->put('id', null)
+            ->all();
     }
 }

--- a/tests/Sites/SiteTest.php
+++ b/tests/Sites/SiteTest.php
@@ -234,7 +234,7 @@ class SiteTest extends TestCase
     {
         $site = new Site('test', [
             'name' => 'Test',
-            'url' => 'http://test.com',
+            'url' => '/sub',
             'locale' => 'en_US',
         ]);
 
@@ -246,18 +246,19 @@ class SiteTest extends TestCase
             'lang' => 'en',
             'locale' => 'en_US',
             'short_locale' => 'en',
-            'url' => 'http://test.com',
+            'url' => '/sub',
+            'permalink' => 'http://absolute-url-resolved-from-request.com/sub',
             'direction' => 'ltr',
             'attributes' => [],
         ], $values->all());
 
         $this->assertEquals(
-            'test Test en_US en http://test.com',
-            Antlers::parse('{{ site }}{{ handle }} {{ name }} {{ locale }} {{ short_locale }} {{ url }}{{ /site }}', ['site' => $site])
+            'test Test en_US en /sub http://absolute-url-resolved-from-request.com/sub',
+            (string) Antlers::parse('{{ site }}{{ handle }} {{ name }} {{ locale }} {{ short_locale }} {{ url }} {{ permalink }}{{ /site }}', ['site' => $site])
         );
         $this->assertEquals(
-            'test Test en_US en http://test.com',
-            Antlers::parse('{{ site:handle }} {{ site:name }} {{ site:locale }} {{ site:short_locale }} {{ site:url }}', ['site' => $site])
+            'test Test en_US en /sub http://absolute-url-resolved-from-request.com/sub',
+            (string) Antlers::parse('{{ site:handle }} {{ site:name }} {{ site:locale }} {{ site:short_locale }} {{ site:url }} {{ site:permalink }}', ['site' => $site])
         );
     }
 

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -25,6 +25,7 @@ $tag
 - {{ locale:handle }}
 - {{ locale:key }}
 - {{ locale:short }}
+- {{ locale:full }}
 - {{ locale:url }}
 - {{ locale:permalink }}
 - {{ current }}
@@ -92,6 +93,7 @@ EOT;
 - english
 - english
 - en
+- en_US
 - /en
 - http://localhost/en
 - english
@@ -105,6 +107,7 @@ EOT;
 - french
 - french
 - fr
+- fr_FR
 - /fr
 - http://localhost/fr
 - english
@@ -118,6 +121,7 @@ EOT;
 - espanol
 - espanol
 - es
+- es_ES
 - /es
 - http://localhost/es
 - english
@@ -178,6 +182,7 @@ HTML;
 - english
 - english
 - en
+- en_US
 - /en
 - http://localhost/en
 - english
@@ -191,6 +196,7 @@ HTML;
 - french
 - french
 - fr
+- fr_FR
 - /fr
 - http://localhost/fr
 - english
@@ -204,6 +210,7 @@ HTML;
 - espanol
 - espanol
 - es
+- es_ES
 - /es
 - http://localhost/es
 - english
@@ -280,6 +287,7 @@ HTML;
 - english
 - english
 - en
+- en_US
 - /en
 - http://localhost/en
 - english
@@ -293,6 +301,7 @@ HTML;
 - french
 - french
 - fr
+- fr_FR
 - /fr
 - http://localhost/fr
 - english
@@ -306,6 +315,7 @@ HTML;
 - espanol
 - espanol
 - es
+- es_ES
 - /es
 - http://localhost/es
 - english

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -17,19 +17,19 @@ class LocalesTagTest extends TestCase
     {
         $contents = <<<EOT
 $tag
-- {{ id }}
-- {{ title }}
-- {{ url }}
-- {{ permalink }}
-- {{ locale:name }}
-- {{ locale:handle }}
-- {{ locale:key }}
-- {{ locale:short }}
-- {{ locale:full }}
-- {{ locale:url }}
-- {{ locale:permalink }}
-- {{ current }}
-- {{ is_current ? 'current' : 'not current' }}
+-{{ id }}
+-{{ title }}
+-{{ url }}
+-{{ permalink }}
+-{{ locale:name }}
+-{{ locale:handle }}
+-{{ locale:key }}
+-{{ locale:short }}
+-{{ locale:full }}
+-{{ locale:url }}
+-{{ locale:permalink }}
+-{{ current }}
+-{{ is_current ? 'current' : 'not current' }}
 
 {{ /locales }}
 EOT;
@@ -85,47 +85,47 @@ EOT;
             ->create();
 
         $expected = <<<'HTML'
-- 1
-- hello
-- /en/1
-- http://localhost/en/1
-- English
-- english
-- english
-- en
-- en_US
-- /en
-- http://localhost/en
-- english
-- current
+-1
+-hello
+-/en/1
+-http://localhost/en/1
+-English
+-english
+-english
+-en
+-en_US
+-/en
+-http://localhost/en
+-english
+-current
 
-- 2
-- bonjour
-- /fr/2
-- http://localhost/fr/2
-- French
-- french
-- french
-- fr
-- fr_FR
-- /fr
-- http://localhost/fr
-- english
-- not current
+-2
+-bonjour
+-/fr/2
+-http://localhost/fr/2
+-French
+-french
+-french
+-fr
+-fr_FR
+-/fr
+-http://localhost/fr
+-english
+-not current
 
-- 3
-- hola
-- /es/3
-- http://localhost/es/3
-- Spanish
-- espanol
-- espanol
-- es
-- es_ES
-- /es
-- http://localhost/es
-- english
-- not current
+-3
+-hola
+-/es/3
+-http://localhost/es/3
+-Spanish
+-espanol
+-espanol
+-es
+-es_ES
+-/es
+-http://localhost/es
+-english
+-not current
 
 
 HTML;
@@ -174,47 +174,47 @@ HTML;
             ->create();
 
         $expected = <<<'HTML'
-- 1
-- hello
-- /en/1
-- http://localhost/en/1
-- English
-- english
-- english
-- en
-- en_US
-- /en
-- http://localhost/en
-- english
-- current
+-1
+-hello
+-/en/1
+-http://localhost/en/1
+-English
+-english
+-english
+-en
+-en_US
+-/en
+-http://localhost/en
+-english
+-current
 
 -
 -
-- /fr
-- http://localhost/fr
-- French
-- french
-- french
-- fr
-- fr_FR
-- /fr
-- http://localhost/fr
-- english
-- not current
+-/fr
+-http://localhost/fr
+-French
+-french
+-french
+-fr
+-fr_FR
+-/fr
+-http://localhost/fr
+-english
+-not current
 
-- 3
-- hola
-- /es/3
-- http://localhost/es/3
-- Spanish
-- espanol
-- espanol
-- es
-- es_ES
-- /es
-- http://localhost/es
-- english
-- not current
+-3
+-hola
+-/es/3
+-http://localhost/es/3
+-Spanish
+-espanol
+-espanol
+-es
+-es_ES
+-/es
+-http://localhost/es
+-english
+-not current
 
 
 HTML;
@@ -279,47 +279,47 @@ HTML;
             ->create();
 
         $expected = <<<'HTML'
-- 1
-- hello
-- /en/1
-- http://localhost/en/1
-- English
-- english
-- english
-- en
-- en_US
-- /en
-- http://localhost/en
-- english
-- current
+-1
+-hello
+-/en/1
+-http://localhost/en/1
+-English
+-english
+-english
+-en
+-en_US
+-/en
+-http://localhost/en
+-english
+-current
 
 -
 -
-- /fr
-- http://localhost/fr
-- French
-- french
-- french
-- fr
-- fr_FR
-- /fr
-- http://localhost/fr
-- english
-- not current
+-/fr
+-http://localhost/fr
+-French
+-french
+-french
+-fr
+-fr_FR
+-/fr
+-http://localhost/fr
+-english
+-not current
 
-- 3
-- hola
-- /es/3
-- http://localhost/es/3
-- Spanish
-- espanol
-- espanol
-- es
-- es_ES
-- /es
-- http://localhost/es
-- english
-- not current
+-3
+-hola
+-/es/3
+-http://localhost/es/3
+-Spanish
+-espanol
+-espanol
+-es
+-es_ES
+-/es
+-http://localhost/es
+-english
+-not current
 
 
 HTML;

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -19,9 +19,9 @@ class LocalesTagTest extends TestCase
         $this->withoutEvents();
 
         Site::setConfig(['sites' => [
-            'en' => ['url' => '/en', 'name' => 'English', 'locale' => 'en_US'],
-            'fr' => ['url' => '/fr', 'name' => 'French', 'locale' => 'fr_FR'],
-            'es' => ['url' => '/es', 'name' => 'Spanish', 'locale' => 'es_ES'],
+            'english' => ['url' => '/en', 'name' => 'English', 'locale' => 'en_US'],
+            'french' => ['url' => '/fr', 'name' => 'French', 'locale' => 'fr_FR'],
+            'espanol' => ['url' => '/es', 'name' => 'Spanish', 'locale' => 'es_ES'],
         ]]);
     }
 
@@ -35,29 +35,67 @@ class LocalesTagTest extends TestCase
     {
         (new EntryFactory)
             ->collection('test')
-            ->locale('en')
+            ->locale('english')
             ->id('1')
             ->data(['title' => 'hello'])
             ->create();
         (new EntryFactory)
             ->collection('test')
-            ->locale('fr')
+            ->locale('french')
             ->id('2')
             ->origin('1')
             ->data(['title' => 'bonjour'])
             ->create();
         (new EntryFactory)
             ->collection('test')
-            ->locale('es')
+            ->locale('espanol')
             ->id('3')
             ->origin('1')
             ->data(['title' => 'hola'])
             ->create();
 
-        $this->assertEquals(
-            '<hello><bonjour><hola>',
-            $this->tag('{{ locales }}<{{ title }}>{{ /locales }}', ['id' => '1'])
-        );
+        $template = <<<'HTML'
+{{ locales }}
+- {{ id }}
+- {{ title }}
+- {{ locale:name }}
+- {{ locale:handle }}
+- {{ locale:short }}
+- {{ current }}
+- {{ is_current ? 'current' : 'not current' }}
+
+{{ /locales }}
+HTML;
+
+        $expected = <<<'HTML'
+- 1
+- hello
+- English
+- english
+- en
+- english
+- current
+
+- 2
+- bonjour
+- French
+- french
+- fr
+- english
+- not current
+
+- 3
+- hola
+- Spanish
+- espanol
+- es
+- english
+- not current
+
+
+HTML;
+
+        $this->assertEquals($expected, $this->tag($template, ['id' => '1']));
     }
 
     /** @test */
@@ -65,13 +103,13 @@ class LocalesTagTest extends TestCase
     {
         (new EntryFactory)
             ->collection('test')
-            ->locale('en')
+            ->locale('english')
             ->id('1')
             ->data(['title' => 'hello'])
             ->create();
         (new EntryFactory)
             ->collection('test')
-            ->locale('es')
+            ->locale('espanol')
             ->id('3')
             ->origin('1')
             ->data(['title' => 'hola'])
@@ -88,13 +126,13 @@ class LocalesTagTest extends TestCase
     {
         (new EntryFactory)
             ->collection('test')
-            ->locale('en')
+            ->locale('english')
             ->id('1')
             ->data(['title' => 'hello'])
             ->create();
         (new EntryFactory)
             ->collection('test')
-            ->locale('fr')
+            ->locale('french')
             ->id('2')
             ->origin('1')
             ->data(['title' => 'bonjour'])
@@ -102,7 +140,7 @@ class LocalesTagTest extends TestCase
             ->create();
         (new EntryFactory)
             ->collection('test')
-            ->locale('es')
+            ->locale('espanol')
             ->id('3')
             ->origin('1')
             ->data(['title' => 'hola'])
@@ -119,13 +157,13 @@ class LocalesTagTest extends TestCase
     {
         (new EntryFactory)
             ->collection('test')
-            ->locale('en')
+            ->locale('english')
             ->id('1')
             ->data(['title' => 'hello'])
             ->create();
         (new EntryFactory)
             ->collection('test')
-            ->locale('es')
+            ->locale('espanol')
             ->id('3')
             ->origin('1')
             ->data(['title' => 'hola'])
@@ -133,7 +171,7 @@ class LocalesTagTest extends TestCase
 
         $this->assertEquals(
             '<hola>',
-            $this->tag('{{ locales:es }}<{{ title }}>{{ /locales:es }}', ['id' => '1'])
+            $this->tag('{{ locales:espanol }}<{{ title }}>{{ /locales:espanol }}', ['id' => '1'])
         );
     }
 
@@ -142,14 +180,14 @@ class LocalesTagTest extends TestCase
     {
         (new EntryFactory)
             ->collection('test')
-            ->locale('en')
+            ->locale('english')
             ->id('1')
             ->data(['title' => 'hello'])
             ->create();
 
         $this->assertEquals(
             '',
-            $this->tag('{{ locales:es }}<{{ title }}>{{ /locales:es }}', ['id' => '1'])
+            $this->tag('{{ locales:espanol }}<{{ title }}>{{ /locales:espanol }}', ['id' => '1'])
         );
     }
 }

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -328,6 +328,36 @@ HTML;
     }
 
     /** @test */
+    public function it_skips_its_own_locale_when_self_param_is_false()
+    {
+        (new EntryFactory)
+            ->collection('test')
+            ->locale('english')
+            ->id('1')
+            ->data(['title' => 'hello'])
+            ->create();
+        (new EntryFactory)
+            ->collection('test')
+            ->locale('french')
+            ->id('2')
+            ->origin('1')
+            ->data(['title' => 'bonjour'])
+            ->create();
+        (new EntryFactory)
+            ->collection('test')
+            ->locale('espanol')
+            ->id('3')
+            ->origin('1')
+            ->data(['title' => 'hola'])
+            ->create();
+
+        $this->assertEquals(
+            '<bonjour><hola>',
+            $this->tag('{{ locales self="false" }}<{{ title }}>{{ /locales }}', ['id' => '1'])
+        );
+    }
+
+    /** @test */
     public function it_shows_the_entry_in_a_given_site()
     {
         (new EntryFactory)

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Tags;
 
+use Statamic\Facades\Collection;
 use Statamic\Facades\Parse;
 use Statamic\Facades\Site;
 use Tests\Factories\EntryFactory;
@@ -18,9 +19,13 @@ class LocalesTagTest extends TestCase
 $tag
 - {{ id }}
 - {{ title }}
+- {{ url }}
+- {{ permalink }}
 - {{ locale:name }}
 - {{ locale:handle }}
 - {{ locale:short }}
+- {{ locale:url }}
+- {{ locale:permalink }}
 - {{ current }}
 - {{ is_current ? 'current' : 'not current' }}
 
@@ -41,6 +46,11 @@ EOT;
             'french' => ['url' => '/fr', 'name' => 'French', 'locale' => 'fr_FR'],
             'espanol' => ['url' => '/es', 'name' => 'Spanish', 'locale' => 'es_ES'],
         ]]);
+
+        Collection::make('test')
+            ->routes('{id}')
+            ->sites(['english', 'french', 'espanol'])
+            ->save();
     }
 
     private function tag($tag, $context = [])
@@ -75,25 +85,37 @@ EOT;
         $expected = <<<'HTML'
 - 1
 - hello
+- /en/1
+- http://localhost/en/1
 - English
 - english
 - en
+- /en
+- http://localhost/en
 - english
 - current
 
 - 2
 - bonjour
+- /fr/2
+- http://localhost/fr/2
 - French
 - french
 - fr
+- /fr
+- http://localhost/fr
 - english
 - not current
 
 - 3
 - hola
+- /es/3
+- http://localhost/es/3
 - Spanish
 - espanol
 - es
+- /es
+- http://localhost/es
 - english
 - not current
 
@@ -146,25 +168,37 @@ HTML;
         $expected = <<<'HTML'
 - 1
 - hello
+- /en/1
+- http://localhost/en/1
 - English
 - english
 - en
+- /en
+- http://localhost/en
 - english
 - current
 
 -
 -
+- /fr
+- http://localhost/fr
 - French
 - french
 - fr
+- /fr
+- http://localhost/fr
 - english
 - not current
 
 - 3
 - hola
+- /es/3
+- http://localhost/es/3
 - Spanish
 - espanol
 - es
+- /es
+- http://localhost/es
 - english
 - not current
 
@@ -233,25 +267,37 @@ HTML;
         $expected = <<<'HTML'
 - 1
 - hello
+- /en/1
+- http://localhost/en/1
 - English
 - english
 - en
+- /en
+- http://localhost/en
 - english
 - current
 
 -
 -
+- /fr
+- http://localhost/fr
 - French
 - french
 - fr
+- /fr
+- http://localhost/fr
 - english
 - not current
 
 - 3
 - hola
+- /es/3
+- http://localhost/es/3
 - Spanish
 - espanol
 - es
+- /es
+- http://localhost/es
 - english
 - not current
 

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -23,6 +23,7 @@ $tag
 - {{ permalink }}
 - {{ locale:name }}
 - {{ locale:handle }}
+- {{ locale:key }}
 - {{ locale:short }}
 - {{ locale:url }}
 - {{ locale:permalink }}
@@ -89,6 +90,7 @@ EOT;
 - http://localhost/en/1
 - English
 - english
+- english
 - en
 - /en
 - http://localhost/en
@@ -101,6 +103,7 @@ EOT;
 - http://localhost/fr/2
 - French
 - french
+- french
 - fr
 - /fr
 - http://localhost/fr
@@ -112,6 +115,7 @@ EOT;
 - /es/3
 - http://localhost/es/3
 - Spanish
+- espanol
 - espanol
 - es
 - /es
@@ -172,6 +176,7 @@ HTML;
 - http://localhost/en/1
 - English
 - english
+- english
 - en
 - /en
 - http://localhost/en
@@ -184,6 +189,7 @@ HTML;
 - http://localhost/fr
 - French
 - french
+- french
 - fr
 - /fr
 - http://localhost/fr
@@ -195,6 +201,7 @@ HTML;
 - /es/3
 - http://localhost/es/3
 - Spanish
+- espanol
 - espanol
 - es
 - /es
@@ -271,6 +278,7 @@ HTML;
 - http://localhost/en/1
 - English
 - english
+- english
 - en
 - /en
 - http://localhost/en
@@ -283,6 +291,7 @@ HTML;
 - http://localhost/fr
 - French
 - french
+- french
 - fr
 - /fr
 - http://localhost/fr
@@ -294,6 +303,7 @@ HTML;
 - /es/3
 - http://localhost/es/3
 - Spanish
+- espanol
 - espanol
 - es
 - /es

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -21,6 +21,7 @@ $tag
 -{{ title }}
 -{{ url }}
 -{{ permalink }}
+-{{ exists ? 'exists' : 'does not exist' }}
 -{{ locale:name }}
 -{{ locale:handle }}
 -{{ locale:key }}
@@ -89,6 +90,7 @@ EOT;
 -hello
 -/en/1
 -http://localhost/en/1
+-exists
 -English
 -english
 -english
@@ -103,6 +105,7 @@ EOT;
 -bonjour
 -/fr/2
 -http://localhost/fr/2
+-exists
 -French
 -french
 -french
@@ -117,6 +120,7 @@ EOT;
 -hola
 -/es/3
 -http://localhost/es/3
+-exists
 -Spanish
 -espanol
 -espanol
@@ -178,6 +182,7 @@ HTML;
 -hello
 -/en/1
 -http://localhost/en/1
+-exists
 -English
 -english
 -english
@@ -192,6 +197,7 @@ HTML;
 -
 -/fr
 -http://localhost/fr
+-does not exist
 -French
 -french
 -french
@@ -206,6 +212,7 @@ HTML;
 -hola
 -/es/3
 -http://localhost/es/3
+-exists
 -Spanish
 -espanol
 -espanol
@@ -283,6 +290,7 @@ HTML;
 -hello
 -/en/1
 -http://localhost/en/1
+-exists
 -English
 -english
 -english
@@ -297,6 +305,7 @@ HTML;
 -
 -/fr
 -http://localhost/fr
+-does not exist
 -French
 -french
 -french
@@ -311,6 +320,7 @@ HTML;
 -hola
 -/es/3
 -http://localhost/es/3
+-exists
 -Spanish
 -espanol
 -espanol

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -395,4 +395,20 @@ HTML;
             $this->tag('{{ locales:espanol }}<{{ title }}>{{ /locales:espanol }}', ['id' => '1'])
         );
     }
+
+    /** @test */
+    public function it_displays_nothing_when_there_are_no_results()
+    {
+        (new EntryFactory)
+            ->collection('test')
+            ->locale('english')
+            ->id('1')
+            ->data(['title' => 'hello'])
+            ->create();
+
+        $this->assertEquals(
+            '',
+            $this->tag('{{ locales self="false" }}you should not see this{{ /locales }}', ['id' => '1'])
+        );
+    }
 }


### PR DESCRIPTION
This PR enhances the `locales` tag with an `all` parameter. When set to `true` the tag will include basic data for all entries that are not localized or published. This makes it possible to use the tag for a global language switcher that falls back to the homepage if an entry doesn't exist for a particular site. I've also added an `exists` variable, which lets you visusally indicate if a site is localized or not.

This PR solves an issue that is talked about on Discord on a regular basis. It's one of the most asked for features when working with multi-sites. It also closes this idea: https://github.com/statamic/ideas/issues/695.

Closes statamic/ideas#695
Closes statamic/ideas#588