### PR TITLE
Ability to infer template from blueprint

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -402,9 +402,9 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
 
         $slugifiedTemplate = str_replace('_', '-', $template);
 
-        return view()->exists($template) && ! view()->exists($slugifiedTemplate)
-            ? $template
-            : $slugifiedTemplate;
+        return view()->exists($slugifiedTemplate)
+            ? $slugifiedTemplate
+            : $template;
     }
 
     public function layout($layout = null)

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -387,9 +387,24 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
         return $this
             ->fluentlyGetOrSet('template')
             ->getter(function ($template) {
-                return $template ?? optional($this->origin())->template() ?? $this->collection()->template();
+                $template = $template ?? optional($this->origin())->template() ?? $this->collection()->template();
+
+                return $template === '@blueprint'
+                    ? $this->inferTemplateFromBlueprint()
+                    : $template;
             })
             ->args(func_get_args());
+    }
+
+    protected function inferTemplateFromBlueprint()
+    {
+        $template = $this->collection()->handle().'.'.$this->blueprint();
+
+        $slugifiedTemplate = str_replace('_', '-', $template);
+
+        return view()->exists($template) && ! view()->exists($slugifiedTemplate)
+            ? $template
+            : $slugifiedTemplate;
     }
 
     public function layout($layout = null)

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -7,6 +7,7 @@ use Facades\Statamic\Stache\Repositories\CollectionTreeRepository;
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\View;
 use Mockery;
 use Statamic\Entries\Collection;
 use Statamic\Entries\Entry;
@@ -1200,6 +1201,27 @@ class EntryTest extends TestCase
         $return = $entry->template('baz');
         $this->assertEquals($entry, $return);
         $this->assertEquals('baz', $entry->template());
+    }
+
+    /** @test */
+    public function it_gets_and_sets_an_inferred_template_from_blueprint()
+    {
+        $collection = tap(Collection::make('articles')->template('@blueprint'))->save();
+        $blueprint = tap(Blueprint::make('standard_article')->setNamespace('collections.articles'))->save();
+        $entry = Entry::make('test')->collection($collection)->blueprint($blueprint->handle());
+
+        // entry uses `articles.standard-article` template
+        $this->assertEquals('articles.standard-article', $entry->template());
+
+        // entry uses `articles.standard_article` template (snake case)
+        // when user has snake cased article instead of slug case in views folder
+        View::shouldReceive('exists')->with('articles.standard_article')->andReturn(true);
+        View::shouldReceive('exists')->with('articles.standard-article')->andReturn(false);
+        $this->assertEquals('articles.standard_article', $entry->template());
+
+        // entry level template overrides `@blueprint` on the collection
+        $entry->template('articles.custom');
+        $this->assertEquals('articles.custom', $entry->template());
     }
 
     /** @test */

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -1210,14 +1210,13 @@ class EntryTest extends TestCase
         $blueprint = tap(Blueprint::make('standard_article')->setNamespace('collections.articles'))->save();
         $entry = Entry::make('test')->collection($collection)->blueprint($blueprint->handle());
 
-        // entry uses `articles.standard-article` template
-        $this->assertEquals('articles.standard-article', $entry->template());
-
-        // entry uses `articles.standard_article` template (snake case)
-        // when user has snake cased article instead of slug case in views folder
-        View::shouldReceive('exists')->with('articles.standard_article')->andReturn(true);
-        View::shouldReceive('exists')->with('articles.standard-article')->andReturn(false);
+        // entry looks for `articles.standard_article` template (snake case) by default
         $this->assertEquals('articles.standard_article', $entry->template());
+
+        // entry uses `articles.standard-article` template (slug case)
+        // when user has slug cased template in views folder
+        View::shouldReceive('exists')->with('articles.standard-article')->andReturn(true);
+        $this->assertEquals('articles.standard-article', $entry->template());
 
         // entry level template overrides `@blueprint` on the collection
         $entry->template('articles.custom');


### PR DESCRIPTION
- [x] If `template: '@blueprint'` is set on the collection, look for a template that corresponds with the blueprint.
    - ie. If the collection is `articles` and the blueprint is `standard_article`, it will load the following template: `resources/views/articles/standard_article.antlers.html`.
- [x] If the user chooses to use slug case convention typically used in template filenames, check for matching view using slug case convention.
- [x] Ensure user can still explicitly override template on the entry level.

Closes https://github.com/statamic/ideas/issues/192.