### PR TITLE
Configurable queue (connection)

### DIFF
--- a/config/system.php
+++ b/config/system.php
@@ -98,7 +98,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Enable Cache Tags
+    | Queue
     |--------------------------------------------------------------------------
     |
     | Some actions like sending emails and invalidating caches are queued.

--- a/config/system.php
+++ b/config/system.php
@@ -98,6 +98,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Enable Cache Tags
+    |--------------------------------------------------------------------------
+    |
+    | Some actions like sending emails and invalidating caches are queued.
+    | By default we will use the laravel queue and connection
+    | unless specified here.
+    |
+    */
+
+    'queue' => env('STATAMIC_QUEUE'),
+    'queue_connection' => env('STATAMIC_QUEUE_CONNECTION'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Intensive Operations
     |--------------------------------------------------------------------------
     |

--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -27,6 +27,12 @@ class Email extends Mailable
         $this->config = $this->parseConfig($config);
         $this->site = $site;
         $this->locale($site->shortLocale());
+        if ($queue = config('statamic.system.queue')) {
+            $this->onQueue($queue);
+        }
+        if ($connection = config('statamic.system.queue_connection')) {
+            $this->onConnection($connection);
+        }
     }
 
     public function build()

--- a/src/Forms/SendEmails.php
+++ b/src/Forms/SendEmails.php
@@ -23,6 +23,12 @@ class SendEmails implements ShouldQueue
     {
         $this->submission = $submission;
         $this->site = $site;
+        if ($queue = config('statamic.system.queue')) {
+            $this->onQueue($queue);
+        }
+        if ($connection = config('statamic.system.queue_connection')) {
+            $this->onConnection($connection);
+        }
     }
 
     /**

--- a/src/Git/CommitJob.php
+++ b/src/Git/CommitJob.php
@@ -27,6 +27,12 @@ class CommitJob implements ShouldQueue
     public function __construct($message = null)
     {
         $this->message = $message;
+        if ($queue = config('statamic.system.queue')) {
+            $this->onQueue($queue);
+        }
+        if ($connection = config('statamic.system.queue_connection')) {
+            $this->onConnection($connection);
+        }
     }
 
     /**

--- a/src/Jobs/GeneratePresetImageManipulation.php
+++ b/src/Jobs/GeneratePresetImageManipulation.php
@@ -20,6 +20,12 @@ class GeneratePresetImageManipulation implements ShouldQueue
     {
         $this->asset = $asset;
         $this->preset = $preset;
+        if ($queue = config('statamic.system.queue')) {
+            $this->onQueue($queue);
+        }
+        if ($connection = config('statamic.system.queue_connection')) {
+            $this->onConnection($connection);
+        }
     }
 
     public function handle(PresetGenerator $generator)

--- a/src/Jobs/RunComposer.php
+++ b/src/Jobs/RunComposer.php
@@ -37,6 +37,12 @@ class RunComposer implements ShouldQueue
     {
         $this->params = $params;
         $this->cacheKey = $cacheKey;
+        if ($queue = config('statamic.system.queue')) {
+            $this->onQueue($queue);
+        }
+        if ($connection = config('statamic.system.queue_connection')) {
+            $this->onConnection($connection);
+        }
     }
 
     /**

--- a/src/Listeners/GeneratePresetImageManipulations.php
+++ b/src/Listeners/GeneratePresetImageManipulations.php
@@ -33,6 +33,7 @@ class GeneratePresetImageManipulations implements ShouldQueue
         if ($connection = config('statamic.system.queue_connection')) {
             return $connection;
         }
+
         return config('queue.default');
     }
 
@@ -46,6 +47,7 @@ class GeneratePresetImageManipulations implements ShouldQueue
         if ($queue = config('statamic.system.queue')) {
             return $queue;
         }
+
         return config('queue.connections.'.$this->viaConnection().'.queue');
     }
 

--- a/src/Listeners/GeneratePresetImageManipulations.php
+++ b/src/Listeners/GeneratePresetImageManipulations.php
@@ -46,7 +46,7 @@ class GeneratePresetImageManipulations implements ShouldQueue
         if ($queue = config('statamic.system.queue')) {
             return $queue;
         }
-        return config('queue.connections.'. $this->viaConnection().'.queue');
+        return config('queue.connections.'.$this->viaConnection().'.queue');
     }
 
     /**

--- a/src/Listeners/GeneratePresetImageManipulations.php
+++ b/src/Listeners/GeneratePresetImageManipulations.php
@@ -24,6 +24,32 @@ class GeneratePresetImageManipulations implements ShouldQueue
     }
 
     /**
+     * Get the name of the listener's queue connection.
+     *
+     * @return string
+     */
+    public function viaConnection()
+    {
+        if ($connection = config('statamic.system.queue_connection')) {
+            return $connection;
+        }
+        return config('queue.default');
+    }
+
+    /**
+     * Get the name of the listener's queue.
+     *
+     * @return string
+     */
+    public function viaQueue()
+    {
+        if ($queue = config('statamic.system.queue')) {
+            return $queue;
+        }
+        return config('queue.connections.'. $this->viaConnection().'.queue');
+    }
+
+    /**
      * Register the listeners for the subscriber.
      *
      * @param  \Illuminate\Events\Dispatcher  $events

--- a/src/Listeners/UpdateAssetReferences.php
+++ b/src/Listeners/UpdateAssetReferences.php
@@ -33,7 +33,7 @@ class UpdateAssetReferences implements ShouldQueue
         if ($queue = config('statamic.system.queue')) {
             return $queue;
         }
-        return config('queue.connections.'. $this->viaConnection().'.queue');
+        return config('queue.connections.'.$this->viaConnection().'.queue');
     }
 
     /**

--- a/src/Listeners/UpdateAssetReferences.php
+++ b/src/Listeners/UpdateAssetReferences.php
@@ -11,6 +11,32 @@ class UpdateAssetReferences implements ShouldQueue
     use Concerns\GetsItemsContainingData;
 
     /**
+     * Get the name of the listener's queue connection.
+     *
+     * @return string
+     */
+    public function viaConnection()
+    {
+        if ($connection = config('statamic.system.queue_connection')) {
+            return $connection;
+        }
+        return config('queue.default');
+    }
+
+    /**
+     * Get the name of the listener's queue.
+     *
+     * @return string
+     */
+    public function viaQueue()
+    {
+        if ($queue = config('statamic.system.queue')) {
+            return $queue;
+        }
+        return config('queue.connections.'. $this->viaConnection().'.queue');
+    }
+
+    /**
      * Register the listeners for the subscriber.
      *
      * @param  \Illuminate\Events\Dispatcher  $events

--- a/src/Listeners/UpdateAssetReferences.php
+++ b/src/Listeners/UpdateAssetReferences.php
@@ -20,6 +20,7 @@ class UpdateAssetReferences implements ShouldQueue
         if ($connection = config('statamic.system.queue_connection')) {
             return $connection;
         }
+
         return config('queue.default');
     }
 
@@ -33,6 +34,7 @@ class UpdateAssetReferences implements ShouldQueue
         if ($queue = config('statamic.system.queue')) {
             return $queue;
         }
+
         return config('queue.connections.'.$this->viaConnection().'.queue');
     }
 

--- a/src/Listeners/UpdateTermReferences.php
+++ b/src/Listeners/UpdateTermReferences.php
@@ -20,6 +20,7 @@ class UpdateTermReferences implements ShouldQueue
         if ($connection = config('statamic.system.queue_connection')) {
             return $connection;
         }
+
         return config('queue.default');
     }
 
@@ -33,6 +34,7 @@ class UpdateTermReferences implements ShouldQueue
         if ($queue = config('statamic.system.queue')) {
             return $queue;
         }
+
         return config('queue.connections.'.$this->viaConnection().'.queue');
     }
 

--- a/src/Listeners/UpdateTermReferences.php
+++ b/src/Listeners/UpdateTermReferences.php
@@ -33,7 +33,7 @@ class UpdateTermReferences implements ShouldQueue
         if ($queue = config('statamic.system.queue')) {
             return $queue;
         }
-        return config('queue.connections.'. $this->viaConnection().'.queue');
+        return config('queue.connections.'.$this->viaConnection().'.queue');
     }
 
     /**

--- a/src/Listeners/UpdateTermReferences.php
+++ b/src/Listeners/UpdateTermReferences.php
@@ -11,6 +11,32 @@ class UpdateTermReferences implements ShouldQueue
     use Concerns\GetsItemsContainingData;
 
     /**
+     * Get the name of the listener's queue connection.
+     *
+     * @return string
+     */
+    public function viaConnection()
+    {
+        if ($connection = config('statamic.system.queue_connection')) {
+            return $connection;
+        }
+        return config('queue.default');
+    }
+
+    /**
+     * Get the name of the listener's queue.
+     *
+     * @return string
+     */
+    public function viaQueue()
+    {
+        if ($queue = config('statamic.system.queue')) {
+            return $queue;
+        }
+        return config('queue.connections.'. $this->viaConnection().'.queue');
+    }
+
+    /**
      * Register the listeners for the subscriber.
      *
      * @param  \Illuminate\Events\Dispatcher  $events

--- a/src/Mail/Test.php
+++ b/src/Mail/Test.php
@@ -18,7 +18,12 @@ class Test extends Mailable implements ShouldQueue
      */
     public function __construct()
     {
-        //
+        if ($queue = config('statamic.system.queue')) {
+            $this->onQueue($queue);
+        }
+        if ($connection = config('statamic.system.queue_connection')) {
+            $this->onConnection($connection);
+        }
     }
 
     /**

--- a/src/Notifications/PasswordReset.php
+++ b/src/Notifications/PasswordReset.php
@@ -16,6 +16,12 @@ class PasswordReset extends Notification
     public function __construct($token)
     {
         $this->token = $token;
+        if ($queue = config('statamic.system.queue')) {
+            $this->onQueue($queue);
+        }
+        if ($connection = config('statamic.system.queue_connection')) {
+            $this->onConnection($connection);
+        }
     }
 
     /**

--- a/src/StaticCaching/Invalidate.php
+++ b/src/StaticCaching/Invalidate.php
@@ -39,6 +39,32 @@ class Invalidate implements ShouldQueue
         $this->invalidator = $invalidator;
     }
 
+    /**
+     * Get the name of the listener's queue connection.
+     *
+     * @return string
+     */
+    public function viaConnection()
+    {
+        if ($connection = config('statamic.system.queue_connection')) {
+            return $connection;
+        }
+        return config('queue.default');
+    }
+
+    /**
+     * Get the name of the listener's queue.
+     *
+     * @return string
+     */
+    public function viaQueue()
+    {
+        if ($queue = config('statamic.system.queue')) {
+            return $queue;
+        }
+        return config('queue.connections.'. $this->viaConnection().'.queue');
+    }
+
     public function subscribe($dispatcher)
     {
         foreach ($this->events as $event => $method) {

--- a/src/StaticCaching/Invalidate.php
+++ b/src/StaticCaching/Invalidate.php
@@ -62,7 +62,7 @@ class Invalidate implements ShouldQueue
         if ($queue = config('statamic.system.queue')) {
             return $queue;
         }
-        return config('queue.connections.'. $this->viaConnection().'.queue');
+        return config('queue.connections.'.$this->viaConnection().'.queue');
     }
 
     public function subscribe($dispatcher)

--- a/src/StaticCaching/Invalidate.php
+++ b/src/StaticCaching/Invalidate.php
@@ -49,6 +49,7 @@ class Invalidate implements ShouldQueue
         if ($connection = config('statamic.system.queue_connection')) {
             return $connection;
         }
+
         return config('queue.default');
     }
 
@@ -62,6 +63,7 @@ class Invalidate implements ShouldQueue
         if ($queue = config('statamic.system.queue')) {
             return $queue;
         }
+
         return config('queue.connections.'.$this->viaConnection().'.queue');
     }
 


### PR DESCRIPTION
It might be nice to set a different queue/connection for statamic queued jobs, notifications and events.

I was able to test these files in our company install
```
src/Forms/SendEmails.php
src/Listeners/UpdateAssetReferences.php
src/Listeners/UpdateTermReferences.php
src/Mail/Test.php 
```

I should probably test/write tests for the other files but i have limited time for these things at work.
Let me know what needs to be done/changed/tested for this to be merged (if you are interested)
