### PR TITLE
Allow custom option templates in Select fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -29,6 +29,9 @@
                         v-bind="attributes"
                     >
                 </template>
+                <template #option="option">
+                    <slot name="option" v-bind="option" />
+                </template>
                 <template #no-options>
                     <div class="text-sm text-grey-70 text-left py-1 px-2" v-text="__('No options to choose from.')" />
                 </template>
@@ -71,7 +74,7 @@ export default {
         },
 
         options() {
-            return this.normalizeInputOptions(this.config.options);
+            return this.config.options_are_normalized ? this.config.options : this.normalizeInputOptions(this.config.options);
         },
 
         replicatorPreview() {


### PR DESCRIPTION
I've been working on something where I wanted a select field with a custom options list format. `vue-select` supports a custom option template but the Select fieldtype doesn't support passing a slot through.

This PR adds that functionality. 

It also adds an `options_are_normalized` option to the config. If you're creating a custom template you probably want to use some extra data in it as well, but `normalizeInputOptions` forces everything into the `value` and `label` keys. Setting this to `true` prevents `normalizeInputOptions` from running, so you can pass in any data you like so long as it has the standard keys.

Here's an example of how this can be used:

```vue
<select-fieldtype
    //...
    :config="{ options_are_normalized: true }">
    <template #option="option">
        <div class="flex items-center">
            <strong class="w-8">{{ option.emoji }}</strong>
            <strong class="flex-1">{{ option.label }}</strong>
            <span>{{ option.value }}</span>
        </div>
    </template>
</select-fieldtype>
```
![Screenshot 2021-11-09 at 16 31 33](https://user-images.githubusercontent.com/126740/140968307-1b3ba8c4-b58e-4d8e-b000-c32121cbaf11.png)

