### PR TITLE
Handle selects (etc) with numeric keys

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -65,7 +65,7 @@ trait HasSelectOptions
         if ($this->multiple()) {
             return collect($value)->map(function ($value) {
                 return [
-                    'key' => $value,
+                    'key' => $value = $this->normalizeAugmentableValue($value),
                     'value' => $value,
                     'label' => $this->getLabel($value),
                 ];
@@ -74,7 +74,26 @@ trait HasSelectOptions
 
         throw_if(is_array($value), new MultipleValuesEncounteredException($this));
 
+        $value = $this->normalizeAugmentableValue($value);
+
         return new LabeledValue($value, $this->getLabel($value));
+    }
+
+    private function normalizeAugmentableValue($value)
+    {
+        if (! is_numeric($value)) {
+            return $value;
+        }
+
+        if ($value == (int) $value) {
+            return (int) $value;
+        }
+
+        if ($value == (float) $value) {
+            return (string) $value;
+        }
+
+        return $value;
     }
 
     private function getLabel($actualValue)

--- a/tests/Fieldtypes/LabeledValueTests.php
+++ b/tests/Fieldtypes/LabeledValueTests.php
@@ -45,6 +45,65 @@ trait LabeledValueTests
     }
 
     /** @test */
+    public function it_augments_to_a_LabeledValue_object_with_options_with_numeric_keys()
+    {
+        $field = $this->field([
+            'type' => 'select',
+            'options' => [
+                1 => 'Australia',
+                2 => 'Canada',
+                '2.5' => 'Canada and a half',
+                3 => 'USA',
+            ],
+        ]);
+
+        $augmented = $field->augment(2);
+        $this->assertInstanceOf(LabeledValue::class, $augmented);
+        $this->assertEquals(2, $augmented->value());
+        $this->assertEquals('Canada', $augmented->label());
+
+        // Javascript converts numeric keys to strings. Thanks.
+        // People will end up with string in their data. We should treat it like a number though.
+        $augmented = $field->augment('2');
+        $this->assertInstanceOf(LabeledValue::class, $augmented);
+        $this->assertEquals(2, $augmented->value());
+        $this->assertEquals('Canada', $augmented->label());
+
+        // Just a sanity check that floats aren't converted to ints.
+        // You can't have a float as a key in an array.
+        $augmented = $field->augment(2.5);
+        $this->assertInstanceOf(LabeledValue::class, $augmented);
+        $this->assertEquals('2.5', $augmented->value());
+        $this->assertEquals('Canada and a half', $augmented->label());
+
+        // and again for the string version
+        $augmented = $field->augment('2.5');
+        $this->assertInstanceOf(LabeledValue::class, $augmented);
+        $this->assertEquals('2.5', $augmented->value());
+        $this->assertEquals('Canada and a half', $augmented->label());
+
+        $augmented = $field->augment(null);
+        $this->assertInstanceOf(LabeledValue::class, $augmented);
+        $this->assertNull($augmented->value());
+        $this->assertNull($augmented->label());
+
+        $augmented = $field->augment(false);
+        $this->assertInstanceOf(LabeledValue::class, $augmented);
+        $this->assertFalse($augmented->value());
+        $this->assertFalse($augmented->label());
+
+        $augmented = $field->augment(true);
+        $this->assertInstanceOf(LabeledValue::class, $augmented);
+        $this->assertTrue($augmented->value());
+        $this->assertTrue($augmented->label());
+
+        $augmented = $field->augment('missing');
+        $this->assertInstanceOf(LabeledValue::class, $augmented);
+        $this->assertEquals('missing', $augmented->value());
+        $this->assertEquals('missing', $augmented->label());
+    }
+
+    /** @test */
     public function it_augments_to_a_LabeledValue_object_with_options_without_keys()
     {
         $field = $this->field([

--- a/tests/Fieldtypes/MultipleLabeledValueTests.php
+++ b/tests/Fieldtypes/MultipleLabeledValueTests.php
@@ -34,6 +34,57 @@ trait MultipleLabeledValueTests
     }
 
     /** @test */
+    public function it_augments_multiple_enabled_to_an_array_of_LabeledValue_equivalents_with_numeric_keys()
+    {
+        $field = $this->field([
+            'type' => 'select',
+            'multiple' => true,
+            'options' => [
+                1 => 'Australia',
+                2 => 'Canada',
+                3 => 'USA',
+            ],
+        ]);
+
+        $this->assertEquals([
+            ['key' => 2, 'value' => 2, 'label' => 'Canada'],
+            ['key' => null, 'value' => null, 'label' => null],
+            ['key' => false, 'value' => false, 'label' => false],
+            ['key' => true, 'value' => true, 'label' => true],
+            ['key' => 'missing', 'value' => 'missing', 'label' => 'missing'],
+        ], $field->augment([2, null, false, true, 'missing']));
+
+        $this->assertEquals([
+            ['key' => 2, 'value' => 2, 'label' => 'Canada'],
+        ], $field->augment(['2']));
+
+        $this->assertEquals([
+            ['key' => '2.5', 'value' => '2.5', 'label' => '2.5'],
+        ], $field->augment(['2.5']));
+    }
+
+    /** @test */
+    public function it_augments_multiple_enabled_to_an_array_of_LabeledValue_equivalents_with_floats_for_keys()
+    {
+        $field = $this->field([
+            'type' => 'select',
+            'multiple' => true,
+            'options' => [
+                '1.5' => 'One point five',
+                '2.5' => 'Two point five',
+            ],
+        ]);
+
+        $this->assertEquals([
+            ['key' => '2.5', 'value' => '2.5', 'label' => 'Two point five'],
+        ], $field->augment(['2.5']));
+
+        $this->assertEquals([
+            ['key' => '2.5', 'value' => '2.5', 'label' => 'Two point five'],
+        ], $field->augment([2.5]));
+    }
+
+    /** @test */
     public function it_augments_multiple_enabled_to_an_array_of_LabeledValue_equivalents_with_boolean_casting()
     {
         $field = $this->field([


### PR DESCRIPTION
When select fields (or radio/checkboxes/button_group fields) use numeric options, like this...

```yaml
myfield:
  field:
    type: select
    options:
      1: One
      2: Two
```

...the fieldtype ends up saving the value as a string (javascript objects can't have numeric keys), so you end up with this:

```
myfield: '1'
```

Then in #4483, it was made so that if the value didn't match an option exactly, it would use itself as the value and label.
The string version of the number does not exactly equal the option in this case.

This PR makes it so that integer strings get treated as integers.

ie. both these work

```
myfield: '1'
```
```
myfield: 1
```

Floats get treated as strings though, since you can't have a float as a key in PHP. They'll be strings, even if there's a real float in the data.

```yaml
myfield:
  field:
    type: select
    options:
      1.5: One point five  # technically '1.5'
      2.5: Two point five  # and '2.5'
```

ie. both these work:

```
myfield: '2.5'
```
```
myfield: 2.5
```

Fixes #4574
