### PR TITLE
Set the app locale to the sites lang

### DIFF
--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -17,9 +17,10 @@ class Localize
         // installed on your actual server. You can check by running `locale -a`).
         setlocale(LC_TIME, $site->locale());
 
-        // The short locale is used for your translations. (eg. if you set your site's locale
-        // to "fr_FR", the translator will look for "fr" files rather than "fr_FR" files.)
-        app()->setLocale($site->shortLocale());
+        // The sites lang is used for your translations. (eg. if you set your site's lang
+        // to "fr_FR", the translator will look for "fr_FR" files rather than "fr" files
+        // but if not set the translator will look for "fr" files rather than "fr_FR" files.)
+        app()->setLocale($site->lang());
 
         Carbon::setToStringFormat(Statamic::dateFormat());
 


### PR DESCRIPTION
Configures the app to take advantage of the new `lang` config introduced in https://github.com/statamic/cms/pull/4612. This allows the `trans` modifier to search for translations like `fr_FR` when `lang` is configured for a site.