### PR TITLE
PHP 8.1 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Set PHP 8.1 Testbench
         run: composer require orchestra/testbench:^6.26.0 --no-interaction --no-update
-        if: matrix.laravel == '8.*'' && matrix.php >= 8.1
+        if: matrix.laravel == '8.*' && matrix.php >= 8.1
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         php: [7.4, 7.3, 7.2, 8.0, 8.1]
         laravel: [8.*, 7.*, 6.*]
-        dependency-version: [prefer-lowest, prefer-stable]
+        stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-20.04]
         include:
           - laravel: 8.*
@@ -32,7 +32,7 @@ jobs:
           - laravel: 6.*
             php: 8.1
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ubuntu-latest
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.framework }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,8 @@ jobs:
         exclude:
           - laravel: 8.*
             php: 7.2
-        exclude:
           - laravel: 7.*
             php: 8.1
-        exclude:
           - laravel: 6.*
             php: 8.1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 7.3, 7.2, 8.0]
+        php: [7.4, 7.3, 7.2, 8.0, 8.1]
         laravel: [8.*, 7.*, 6.*]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-20.04]
@@ -30,6 +30,9 @@ jobs:
             dependency-version: prefer-lowest
             additional-deps: '"mockery/mockery:>=1.2.3"'
           - php: 8.0
+            dependency-version: prefer-lowest
+            additional-deps: '"mockery/mockery:>=1.3.3"'
+          - php: 8.1
             dependency-version: prefer-lowest
             additional-deps: '"mockery/mockery:>=1.3.3"'
         exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,16 @@ jobs:
             laravel-constraint: ^6.20.14
           - php: 7.4
             additional-deps: '"mockery/mockery:>=1.2.3"'
-          - php: [8.0, 8.1]
+          - php: 8.0
+            additional-deps: '"mockery/mockery:>=1.3.3"'
+          - php: 8.1
             additional-deps: '"mockery/mockery:>=1.3.3"'
         exclude:
           - laravel: 8.*
             php: 7.2
-          - laravel: [7.*, 6.*]
+          - laravel: 7.*
+            php: 8.1
+          - laravel: 6.*
             php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,17 +19,11 @@ jobs:
         os: [ubuntu-20.04]
         include:
           - laravel: 8.*
-            laravel-constraint: ^8.24.0
+            framework: ^8.24.0
           - laravel: 7.*
-            laravel-constraint: ^7.30.4
+            framework: ^7.30.4
           - laravel: 6.*
-            laravel-constraint: ^6.20.14
-          - php: 7.4
-            additional-deps: '"mockery/mockery:>=1.2.3"'
-          - php: 8.0
-            additional-deps: '"mockery/mockery:>=1.3.3"'
-          - php: 8.1
-            additional-deps: '"mockery/mockery:>=1.3.3"'
+            framework: ^6.20.14
         exclude:
           - laravel: 8.*
             php: 7.2
@@ -51,9 +45,21 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 
+      - name: Set PHP 7.4 Mockery
+        run: composer require mockery/mockery:>=1.2.3 --no-interaction --no-update
+        if: matrix.php >= 7.4 && matrix.php <8.0
+
+      - name: Set PHP 8 Mockery
+        run: composer require mockery/mockery:>=1.3.3 --no-interaction --no-update
+        if: matrix.php >= 8.0
+
+      - name: Set PHP 8.1 Testbench
+        run: composer require orchestra/testbench:^6.26.0 --no-interaction --no-update
+        if: matrix.laravel == 8.* && matrix.php >= 8.1
+
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel-constraint }}" ${{ matrix.additional-deps }} --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.framework }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,15 +46,15 @@ jobs:
           coverage: none
 
       - name: Set PHP 7.4 Mockery
-        run: composer require mockery/mockery:>=1.2.3 --no-interaction --no-update
+        run: composer require "mockery/mockery:>=1.2.3" --no-interaction --no-update
         if: matrix.php >= 7.4 && matrix.php <8.0
 
       - name: Set PHP 8 Mockery
-        run: composer require mockery/mockery:>=1.3.3 --no-interaction --no-update
+        run: composer require "mockery/mockery:>=1.3.3" --no-interaction --no-update
         if: matrix.php >= 8.0
 
       - name: Set PHP 8.1 Testbench
-        run: composer require orchestra/testbench:^6.26.0 --no-interaction --no-update
+        run: composer require "orchestra/testbench:^6.26.0" --no-interaction --no-update
         if: matrix.laravel == '8.*' && matrix.php >= 8.1
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Set PHP 8.1 Testbench
         run: composer require orchestra/testbench:^6.26.0 --no-interaction --no-update
-        if: matrix.laravel == 8.* && matrix.php >= 8.1
+        if: matrix.laravel == '8.*'' && matrix.php >= 8.1
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,12 @@ jobs:
         exclude:
           - laravel: 8.*
             php: 7.2
+        exclude:
+          - laravel: 7.*
+            php: 8.1
+        exclude:
+          - laravel: 6.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ubuntu-latest
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,14 +51,6 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 
-      - name: Set minimum PHP 7.4 versions
-        run: composer require mockery/mockery:>=1.2.3 --no-interaction --no-update
-        if: matrix.php >= 7.4
-
-      - name: Set minimum PHP 8.0 versions
-        run: composer require mockery/mockery:>=1.2.3 --no-interaction --no-update
-        if: matrix.php >= 8.0
-
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel-constraint }}" ${{ matrix.additional-deps }} --no-interaction --no-update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         if: matrix.php >= 8.0
 
       - name: Set PHP 8.1 Testbench
-        run: composer require "orchestra/testbench:^6.26.0" --no-interaction --no-update
+        run: composer require "orchestra/testbench:^6.22.0" --no-interaction --no-update
         if: matrix.laravel == '8.*' && matrix.php >= 8.1
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.framework }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,28 +19,19 @@ jobs:
         os: [ubuntu-20.04]
         include:
           - laravel: 8.*
-            testbench: 6.*
-            laravel-constraint: ^8.18.1
+            laravel-constraint: ^8.24.0
           - laravel: 7.*
-            testbench: 5.*
+            laravel-constraint: ^7.30.4
           - laravel: 6.*
-            testbench: 4.*
-            laravel-constraint: ^6.6.2
+            laravel-constraint: ^6.20.14
           - php: 7.4
-            dependency-version: prefer-lowest
             additional-deps: '"mockery/mockery:>=1.2.3"'
-          - php: 8.0
-            dependency-version: prefer-lowest
-            additional-deps: '"mockery/mockery:>=1.3.3"'
-          - php: 8.1
-            dependency-version: prefer-lowest
+          - php: [8.0, 8.1]
             additional-deps: '"mockery/mockery:>=1.3.3"'
         exclude:
           - laravel: 8.*
             php: 7.2
-          - laravel: 7.*
-            php: 8.1
-          - laravel: 6.*
+          - laravel: [7.*, 6.*]
             php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ubuntu-latest
@@ -56,9 +47,17 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 
+      - name: Set minimum PHP 7.4 versions
+        run: composer require mockery/mockery:>=1.2.3 --no-interaction --no-update
+        if: matrix.php >= 7.4
+
+      - name: Set minimum PHP 8.0 versions
+        run: composer require mockery/mockery:>=1.2.3 --no-interaction --no-update
+        if: matrix.php >= 8.0
+
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel-constraint || matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" ${{ matrix.additional-deps }} --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel-constraint }}" ${{ matrix.additional-deps }} --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests

--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -54,6 +54,7 @@ class Value implements IteratorAggregate, JsonSerializable
         return (string) $this->value();
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize($options = 0)
     {
         $value = $this->value();
@@ -65,6 +66,7 @@ class Value implements IteratorAggregate, JsonSerializable
         return $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->value());

--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -9,6 +9,7 @@ use JsonSerializable;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Support\Str;
 use Statamic\View\Antlers\Parser;
+use Traversable;
 
 class Value implements IteratorAggregate, JsonSerializable
 {
@@ -54,7 +55,7 @@ class Value implements IteratorAggregate, JsonSerializable
         return (string) $this->value();
     }
 
-    public function jsonSerialize($options = 0)
+    public function jsonSerialize($options = 0): mixed
     {
         $value = $this->value();
 
@@ -65,7 +66,7 @@ class Value implements IteratorAggregate, JsonSerializable
         return $value;
     }
 
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->value());
     }

--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -9,7 +9,6 @@ use JsonSerializable;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Support\Str;
 use Statamic\View\Antlers\Parser;
-use Traversable;
 
 class Value implements IteratorAggregate, JsonSerializable
 {
@@ -55,7 +54,7 @@ class Value implements IteratorAggregate, JsonSerializable
         return (string) $this->value();
     }
 
-    public function jsonSerialize($options = 0): mixed
+    public function jsonSerialize($options = 0)
     {
         $value = $this->value();
 
@@ -66,7 +65,7 @@ class Value implements IteratorAggregate, JsonSerializable
         return $value;
     }
 
-    public function getIterator(): Traversable
+    public function getIterator()
     {
         return new ArrayIterator($this->value());
     }

--- a/tests/Data/AugmentedCollectionTest.php
+++ b/tests/Data/AugmentedCollectionTest.php
@@ -137,6 +137,7 @@ class TestJsonableObject implements Jsonable
 
 class TestJsonSerializeObject implements JsonSerializable
 {
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ['foo' => 'bar'];

--- a/tests/Data/AugmentedCollectionTest.php
+++ b/tests/Data/AugmentedCollectionTest.php
@@ -137,7 +137,7 @@ class TestJsonableObject implements Jsonable
 
 class TestJsonSerializeObject implements JsonSerializable
 {
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return ['foo' => 'bar'];
     }

--- a/tests/Data/AugmentedCollectionTest.php
+++ b/tests/Data/AugmentedCollectionTest.php
@@ -137,7 +137,7 @@ class TestJsonableObject implements Jsonable
 
 class TestJsonSerializeObject implements JsonSerializable
 {
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return ['foo' => 'bar'];
     }


### PR DESCRIPTION
Closes #4720

I've updated the GitHub test suite workflow to include 8.1, as well as a little general cleanup.
- Mockery min versions are required in a separate step rather than cramming into 'additional-deps'.
- Testbench can rely on the regular composer constraint, except for L8/P8.1 which needs a specific min version installed in a separate step.
- Adjusted laravel/framework constraint to match what's in composer.json. We've updated composer.json a couple of times but never matched it in the test suite. It would be nice if we could just read from composer.json, but I don't think that's possible without a custom action.
- Removed composer's deprecated no-suggest option.
- Renamed laravel-constraint to framework, and dependency-version to stability.

Everything passed without needing to make any changes to the code. There were a few deprecation messages, which have been fixed by adding beautiful `#[\ReturnTypeWillChange]` annotations.