### PR TITLE
Store parent ID in the Stache

### DIFF
--- a/src/Stache/Indexes/Value.php
+++ b/src/Stache/Indexes/Value.php
@@ -17,6 +17,10 @@ class Value extends Index
     {
         $method = Str::camel($this->name);
 
+        if ($method == 'parent') {
+            return optional($item)->parent()->id();
+        }
+
         if ($method === 'blueprint') {
             return $item->blueprint()->handle();
         }


### PR DESCRIPTION
Instead of storing the entire Page object in the Stache, we'll just store the ID.

That'll let you query for it easier.

For example, to get children of a particular page:

```
{{ collection:pages :parent:id="id" }}
```
