### PR TITLE
Use the output method so filter + sort gets applied on assets.

### DIFF
--- a/src/Tags/Assets.php
+++ b/src/Tags/Assets.php
@@ -33,7 +33,10 @@ class Assets extends Tags
         $value = Arr::get($this->context, $this->method);
 
         if ($this->isAssetsFieldValue($value)) {
-            return $value->value();
+            // Normalize to an asset collection, this way it works for a single asset but also a collection.
+            $this->assets = (new AssetCollection([$value->value()]))->flatten();
+
+            return $this->output();
         }
 
         if ($value instanceof Value) {

--- a/src/Tags/Assets.php
+++ b/src/Tags/Assets.php
@@ -33,7 +33,6 @@ class Assets extends Tags
         $value = Arr::get($this->context, $this->method);
 
         if ($this->isAssetsFieldValue($value)) {
-            // Normalize to an asset collection, this way it works for a single asset but also a collection.
             $this->assets = (new AssetCollection([$value->value()]))->flatten();
 
             return $this->output();


### PR DESCRIPTION
For the asset field values the sort + limit was not being applied since the value was directly returned. Now it outputs the assets through the `output` method, which will make sure they get applied.

Fixes #4680