### PR TITLE
Querybuilder: add whereNull / whereNotNull

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -159,6 +159,38 @@ abstract class Builder implements Contract
         return $this;
     }
 
+    public function whereNull($column, $boolean = 'and')
+    {
+        $this->wheres[] = [
+            'type' => 'Null',
+            'column' => $column,
+            'boolean' => $boolean,
+        ];
+
+        return $this;
+    }
+
+    public function orWhereNull($column)
+    {
+        return $this->whereNull($column, 'or');
+    }
+
+    public function whereNotNull($column, $boolean = 'and')
+    {
+        $this->wheres[] = [
+            'type' => 'NotNull',
+            'column' => $column,
+            'boolean' => $boolean,
+        ];
+
+        return $this;
+    }
+
+    public function orWhereNotNull($column)
+    {
+        return $this->whereNotNull($column, 'or');
+    }
+
     public function find($id, $columns = ['*'])
     {
         return $this->where('id', $id)->get($columns)->first();

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -159,10 +159,10 @@ abstract class Builder implements Contract
         return $this;
     }
 
-    public function whereNull($column, $boolean = 'and')
+    public function whereNull($column, $boolean = 'and', $not = false)
     {
         $this->wheres[] = [
-            'type' => 'Null',
+            'type' => ($not ? 'Not' : '').'Null',
             'column' => $column,
             'boolean' => $boolean,
         ];
@@ -177,13 +177,7 @@ abstract class Builder implements Contract
 
     public function whereNotNull($column, $boolean = 'and')
     {
-        $this->wheres[] = [
-            'type' => 'NotNull',
-            'column' => $column,
-            'boolean' => $boolean,
-        ];
-
-        return $this;
+        return $this->whereNull($column, $boolean, true);
     }
 
     public function orWhereNotNull($column)

--- a/src/Query/IteratorBuilder.php
+++ b/src/Query/IteratorBuilder.php
@@ -87,6 +87,20 @@ abstract class IteratorBuilder extends Builder
         });
     }
 
+    protected function filterWhereNull($entries, $where)
+    {
+        return $entries->filter(function ($entry) use ($where) {
+            return $this->getFilterItemValue($entry, $where['column']) === null;
+        });
+    }
+
+    protected function filterWhereNotNull($entries, $where)
+    {
+        return $entries->filter(function ($entry) use ($where) {
+            return $this->getFilterItemValue($entry, $where['column']) !== null;
+        });
+    }
+
     protected function getFilterItemValue($item, $column)
     {
         if (is_array($item)) {

--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -141,4 +141,18 @@ abstract class Builder extends BaseBuilder
             return ! in_array($value, $where['values']);
         });
     }
+
+    protected function filterWhereNull($values, $where)
+    {
+        return $values->filter(function ($value) {
+            return $value === null;
+        });
+    }
+
+    protected function filterWhereNotNull($values, $where)
+    {
+        return $values->filter(function ($value) {
+            return $value !== null;
+        });
+    }
 }

--- a/src/Tags/Concerns/QueriesConditions.php
+++ b/src/Tags/Concerns/QueriesConditions.php
@@ -257,8 +257,7 @@ trait QueriesConditions
 
     protected function queryIsEmptyCondition($query, $field, $boolean)
     {
-        // TODO: Add `whereNull()` and `whereNotNull()` to our query builder so that this can be Eloquent compatible.
-        return $query->where($field, $boolean ? '=' : '!=', null);
+        return $boolean ? $query->whereNull($field) : $query->whereNotNull($field);
     }
 
     protected function queryIsAfterCondition($query, $field, $value)

--- a/src/Tags/Concerns/QueriesConditions.php
+++ b/src/Tags/Concerns/QueriesConditions.php
@@ -257,7 +257,7 @@ trait QueriesConditions
 
     protected function queryIsEmptyCondition($query, $field, $boolean)
     {
-        return $boolean ? $query->whereNull($field) : $query->whereNotNull($field);
+        return $query->where($field, $boolean ? '=' : '!=', null);
     }
 
     protected function queryIsAfterCondition($query, $field, $value)

--- a/tests/Data/Assets/AssetQueryBuilderTest.php
+++ b/tests/Data/Assets/AssetQueryBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Data\Assets;
 
 use Illuminate\Support\Facades\Storage;
+use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -69,5 +70,69 @@ class AssetQueryBuilderTest extends TestCase
 
         $this->assertCount(2, $assets);
         $this->assertEquals(['d', 'e'], $assets->map->filename()->all());
+    }
+
+    /** @test **/
+    public function assets_are_found_using_where_null()
+    {
+        Asset::find('test::a.jpg')->data(['text' => 'Text 1'])->save();
+        Asset::find('test::b.txt')->data(['text' => 'Text 2'])->save();
+        Asset::find('test::c.txt')->data([])->save();
+        Asset::find('test::d.jpg')->data(['text' => 'Text 4'])->save();
+        Asset::find('test::e.jpg')->data([])->save();
+        Asset::find('test::f.jpg')->data([])->save();
+
+        $assets = $this->container->queryAssets()->whereNull('text')->get();
+
+        $this->assertCount(3, $assets);
+        $this->assertEquals(['c', 'e', 'f'], $assets->map->filename()->all());
+    }
+
+    /** @test **/
+    public function assets_are_found_using_where_not_null()
+    {
+        Asset::find('test::a.jpg')->data(['text' => 'Text 1'])->save();
+        Asset::find('test::b.txt')->data(['text' => 'Text 2'])->save();
+        Asset::find('test::c.txt')->data([])->save();
+        Asset::find('test::d.jpg')->data(['text' => 'Text 4'])->save();
+        Asset::find('test::e.jpg')->data([])->save();
+        Asset::find('test::f.jpg')->data([])->save();
+
+        $assets = $this->container->queryAssets()->whereNotNull('text')->get();
+
+        $this->assertCount(3, $assets);
+        $this->assertEquals(['a', 'b', 'd'], $assets->map->filename()->all());
+    }
+
+    /** @test **/
+    public function assets_are_found_using_or_where_null()
+    {
+        Asset::find('test::a.jpg')->data(['text' => 'Text 1', 'content' => 'Content 1'])->save();
+        Asset::find('test::b.txt')->data(['text' => 'Text 2'])->save();
+        Asset::find('test::c.txt')->data(['content' => 'Content 1'])->save();
+        Asset::find('test::d.jpg')->data(['text' => 'Text 4'])->save();
+        Asset::find('test::e.jpg')->data([])->save();
+        Asset::find('test::f.jpg')->data([])->save();
+
+        $assets = $this->container->queryAssets()->whereNull('text')->orWhereNull('content')->get();
+
+        $this->assertCount(5, $assets);
+        $this->assertEquals(['c', 'e', 'f', 'b', 'd'], $assets->map->filename()->all());
+    }
+
+    /** @test **/
+    public function assets_are_found_using_or_where_not_null()
+    {
+        Asset::find('test::a.jpg')->data(['text' => 'Text 1', 'content' => 'Content 1'])->save();
+        Asset::find('test::b.txt')->data(['text' => 'Text 2'])->save();
+        Asset::find('test::c.txt')->data(['content' => 'Content 1'])->save();
+        Asset::find('test::d.jpg')->data(['text' => 'Text 4'])->save();
+        Asset::find('test::e.jpg')->data([])->save();
+        Asset::find('test::f.jpg')->data([])->save();
+
+        $assets = $this->container->queryAssets()->whereNotNull('content')->orWhereNotNull('text')->get();
+
+        $this->assertCount(4, $assets);
+        $this->assertEquals(['a', 'c', 'b', 'd'], $assets->map->filename()->all());
     }
 }

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -83,4 +83,64 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertCount(2, $entries);
         $this->assertEquals(['Post 3', 'Post 4'], $entries->map->title->all());
     }
+
+    /** @test **/
+    public function entries_are_found_using_where_null()
+    {
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'text' => 'Text 1'])->create();
+        EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'text' => 'Text 2'])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3'])->create();
+        EntryFactory::id('4')->slug('post-4')->collection('posts')->data(['title' => 'Post 4', 'text' => 'Text 4'])->create();
+        EntryFactory::id('5')->slug('post-5')->collection('posts')->data(['title' => 'Post 5'])->create();
+
+        $entries = Entry::query()->whereNull('text')->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 3', 'Post 5'], $entries->map->title->all());
+    }
+
+    /** @test **/
+    public function entries_are_found_using_where_not_null()
+    {
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'text' => 'Text 1'])->create();
+        EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'text' => 'Text 2'])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3'])->create();
+        EntryFactory::id('4')->slug('post-4')->collection('posts')->data(['title' => 'Post 4', 'text' => 'Text 4'])->create();
+        EntryFactory::id('5')->slug('post-5')->collection('posts')->data(['title' => 'Post 5'])->create();
+
+        $entries = Entry::query()->whereNotNull('text')->get();
+
+        $this->assertCount(3, $entries);
+        $this->assertEquals(['Post 1', 'Post 2', 'Post 4'], $entries->map->title->all());
+    }
+
+    /** @test **/
+    public function entries_are_found_using_or_where_null()
+    {
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'text' => 'Text 1', 'content' => 'Content 1'])->create();
+        EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'text' => 'Text 2'])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'content' => 'Content 1'])->create();
+        EntryFactory::id('4')->slug('post-4')->collection('posts')->data(['title' => 'Post 4', 'text' => 'Text 4'])->create();
+        EntryFactory::id('5')->slug('post-5')->collection('posts')->data(['title' => 'Post 5'])->create();
+
+        $entries = Entry::query()->whereNull('text')->orWhereNull('content')->get();
+
+        $this->assertCount(4, $entries);
+        $this->assertEquals(['Post 3', 'Post 5', 'Post 2', 'Post 4'], $entries->map->title->all());
+    }
+
+    /** @test **/
+    public function entries_are_found_using_or_where_not_null()
+    {
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'text' => 'Text 1', 'content' => 'Content 1'])->create();
+        EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'text' => 'Text 2'])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'content' => 'Content 1'])->create();
+        EntryFactory::id('4')->slug('post-4')->collection('posts')->data(['title' => 'Post 4', 'text' => 'Text 4'])->create();
+        EntryFactory::id('5')->slug('post-5')->collection('posts')->data(['title' => 'Post 5'])->create();
+
+        $entries = Entry::query()->whereNotNull('content')->orWhereNotNull('text')->get();
+
+        $this->assertCount(4, $entries);
+        $this->assertEquals(['Post 1', 'Post 3', 'Post 2', 'Post 4'], $entries->map->title->all());
+    }
 }

--- a/tests/Search/QueryBuilderTest.php
+++ b/tests/Search/QueryBuilderTest.php
@@ -52,6 +52,52 @@ class QueryBuilderTest extends TestCase
     {
         $this->markTestSkipped();
     }
+
+    /** @test */
+    public function results_are_found_using_where_null()
+    {
+        $items = collect([
+            ['reference' => 'a', 'text' => 'Text 1'],
+            ['reference' => 'b', 'text' => 'Text 2'],
+            ['reference' => 'c'],
+            ['reference' => 'd', 'text' => 'Text 4'],
+            ['reference' => 'e'],
+        ]);
+
+        $results = (new FakeQueryBuilder($items))->withoutData()->whereNull('text')->get();
+
+        $this->assertCount(2, $results);
+        $this->assertEquals(['c', 'e'], $results->map->reference->all());
+    }
+
+    /** @test */
+    public function results_are_found_using_where_not_null()
+    {
+        $items = collect([
+            ['reference' => 'a', 'text' => 'Text 1'],
+            ['reference' => 'b', 'text' => 'Text 2'],
+            ['reference' => 'c'],
+            ['reference' => 'd', 'text' => 'Text 4'],
+            ['reference' => 'e'],
+        ]);
+
+        $results = (new FakeQueryBuilder($items))->withoutData()->whereNotNull('text')->get();
+
+        $this->assertCount(3, $results);
+        $this->assertEquals(['a', 'b', 'd'], $results->map->reference->all());
+    }
+
+    /** @test **/
+    public function results_are_found_using_or_where_null()
+    {
+        $this->markTestSkipped();
+    }
+
+    /** @test **/
+    public function results_are_found_using_or_where_not_null()
+    {
+        $this->markTestSkipped();
+    }
 }
 
 class FakeQueryBuilder extends QueryBuilder


### PR DESCRIPTION
Sorry for all the PRs but for the sake of completeness this adds `whereNull` / `whereNotNull` methods to the QueryBuilder.

Allows you to write queries such as:

```
Entry::query()
    ->whereNull('field')
    ->get();
    
 Entry::query()
    ->whereNull('field')
    ->orWhereNotNull('another_field')
    ->get();
```

This test is failing, however should the assert count not be 2 rather than 3? Or does is_empty cover both blank and null?
https://github.com/statamic/cms/blob/d49cbf9cf9fc67d4cc6bea77a333e6a682bddafc/tests/Tags/Concerns/QueriesConditionsTest.php#L472