### PR TITLE
Make the existence of a collection optional

### DIFF
--- a/src/Http/Resources/CP/Entries/ListedEntry.php
+++ b/src/Http/Resources/CP/Entries/ListedEntry.php
@@ -34,7 +34,7 @@ class ListedEntry extends JsonResource
             'id' => $entry->id(),
             'published' => $entry->published(),
             'private' => $entry->private(),
-            'date' => $this->when($collection->dated(), function () {
+            'date' => $this->when(optional($collection)->dated(), function () {
                 return $this->resource->date()->inPreferredFormat();
             }),
 
@@ -44,7 +44,7 @@ class ListedEntry extends JsonResource
             'edit_url' => $entry->editUrl(),
             'viewable' => User::current()->can('view', $entry),
             'editable' => User::current()->can('edit', $entry),
-            'actions' => Action::for($entry, ['collection' => $collection->handle()]),
+            'actions' => Action::for($entry, ['collection' => optional($collection)->handle()]),
         ];
     }
 


### PR DESCRIPTION
By using Algolia for our backend, I am constantly running into 500er errors, that the `dated()` function on null could not be found.

This PR does add more stability in case of not existing collections.