### PR TITLE
Provide errors indexed by field names for {{ user:forgot_password_form }}

### DIFF
--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -247,17 +247,11 @@ class UserTags extends Tags
      */
     public function resetPasswordForm()
     {
-        $data = [
-            'errors' => [],
-        ];
-
         if (session()->has('status')) {
             return $this->parse(['success' => true]);
         }
 
-        if (session('errors')) {
-            $data['errors'] = session('errors')->all();
-        }
+        $data = $this->getErrorsFromSession('default');
 
         $data['url_invalid'] = request()->isNotFilled('token');
 

--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -251,7 +251,7 @@ class UserTags extends Tags
             return $this->parse(['success' => true]);
         }
 
-        $data = $this->getErrorsFromSession('default');
+        $data = $this->getErrorsFromSession();
 
         $data['url_invalid'] = request()->isNotFilled('token');
 

--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -251,7 +251,7 @@ class UserTags extends Tags
             return $this->parse(['success' => true]);
         }
 
-        $data = $this->getErrorsFromSession();
+        $data = $this->getErrorsFromFormSession();
 
         $data['url_invalid'] = request()->isNotFilled('token');
 

--- a/src/Tags/Concerns/GetsFormSession.php
+++ b/src/Tags/Concerns/GetsFormSession.php
@@ -12,12 +12,7 @@ trait GetsFormSession
      */
     protected function getFormSession($formName = 'default')
     {
-        $data = [];
-
-        $errors = optional(session()->get('errors'))->getBag($formName);
-
-        $data['errors'] = $errors ? $errors->all() : [];
-        $data['error'] = $errors ? $this->getFirstErrorForEachField($errors) : [];
+        $data = $this->getErrorsFromSession($formName);
         $data['success'] = $this->getFromFormSession($formName, 'success');
 
         // Only include this boolean if it's actually passed in session;
@@ -64,5 +59,23 @@ trait GetsFormSession
                 return $errors[0];
             })
             ->all();
+    }
+
+    /**
+     * Get errors from session
+     *
+     * @param string $formName
+     * @return array
+     */
+    protected function getErrorsFromSession(string $formName): array
+    {
+        $data = [];
+
+        $errors = optional(session()->get('errors'))->getBag($formName);
+
+        $data['errors'] = $errors ? $errors->all() : [];
+        $data['error'] = $errors ? $this->getFirstErrorForEachField($errors) : [];
+
+        return $data;
     }
 }

--- a/src/Tags/Concerns/GetsFormSession.php
+++ b/src/Tags/Concerns/GetsFormSession.php
@@ -62,9 +62,9 @@ trait GetsFormSession
     }
 
     /**
-     * Get errors from session
+     * Get errors from session.
      *
-     * @param string $formName
+     * @param  string  $formName
      * @return array
      */
     protected function getErrorsFromFormSession($formName = 'default')

--- a/src/Tags/Concerns/GetsFormSession.php
+++ b/src/Tags/Concerns/GetsFormSession.php
@@ -67,7 +67,7 @@ trait GetsFormSession
      * @param string $formName
      * @return array
      */
-    protected function getErrorsFromSession(string $formName): array
+    protected function getErrorsFromSession($formName = 'default')
     {
         $data = [];
 

--- a/src/Tags/Concerns/GetsFormSession.php
+++ b/src/Tags/Concerns/GetsFormSession.php
@@ -12,7 +12,7 @@ trait GetsFormSession
      */
     protected function getFormSession($formName = 'default')
     {
-        $data = $this->getErrorsFromSession($formName);
+        $data = $this->getErrorsFromFormSession($formName);
         $data['success'] = $this->getFromFormSession($formName, 'success');
 
         // Only include this boolean if it's actually passed in session;
@@ -67,7 +67,7 @@ trait GetsFormSession
      * @param string $formName
      * @return array
      */
-    protected function getErrorsFromSession($formName = 'default')
+    protected function getErrorsFromFormSession($formName = 'default')
     {
         $data = [];
 


### PR DESCRIPTION
Add an array of validation errors indexed by field names. Suitable for targeting fields. eg. {{ error:email }}
Similar to https://statamic.dev/tags/user-register_form#variables.