### PR TITLE
Added taxanomy to Graphql EntriesQuery

### DIFF
--- a/src/GraphQL/Queries/EntriesQuery.php
+++ b/src/GraphQL/Queries/EntriesQuery.php
@@ -3,6 +3,7 @@
 namespace Statamic\GraphQL\Queries;
 
 use GraphQL\Type\Definition\Type;
+use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Facades\Entry;
 use Statamic\Facades\GraphQL;
 use Statamic\GraphQL\Middleware\ResolvePage;
@@ -11,8 +12,6 @@ use Statamic\GraphQL\Types\JsonArgument;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Tags\Concerns\QueriesConditions;
-
-use Statamic\Contracts\Taxonomies\Term;
 
 class EntriesQuery extends Query
 {


### PR DESCRIPTION
This allows you to filter in GraphQL on the taxanomy. The basic filter function is pretty simple and doesn't allow to filter on multiple values. 

How the query looks when using taxanomy.
```
query Entry {
  entries(collection: "products", filter: {
    taxonomy: ["target::moederfiets","target::fiets"],
  }) {
    data {
      ... on Entry_Products_Products {
        id
        title
        slug
        product_type {
          slug
          id
        }
        target {
          slug
          id
        }
      }
    }
  }
}
```

I tried using queries like this, but no luck. Added a quick fix at https://github.com/statamic/cms/issues/4739 but that doesn't work correctly either.
```
query Entry {
  entries(collection: "products", filter: {
    target: {in: {slug : [ "fiets"]}},
  }) {
    data {
      ... on Entry_Products_Products {
        id
        title
        slug
        product_type {
          slug
          id
        }
        target {
          slug
          id
        }
      }
    }
  }
}
```

I copied this function from https://github.com/statamic/cms/blob/3.2/src/Tags/Collection/Entries.php:300

