### PR TITLE
Allow watermarks with glide

### DIFF
--- a/src/Imaging/GlideImageManipulator.php
+++ b/src/Imaging/GlideImageManipulator.php
@@ -45,7 +45,8 @@ class GlideImageManipulator implements ImageManipulator
      */
     private $api = [
         'or', 'crop', 'w', 'h', 'fit', 'dpr', 'bri', 'con', 'gam', 'sharp', 'blur', 'pixel', 'filt',
-        'mark', 'markw', 'markx', 'marky', 'markpad', 'markpos', 'bg', 'border', 'q', 'fm', 'p',
+        'mark', 'markw', 'markh', 'markx', 'marky', 'markpad', 'markpos', 'markalpha', 'markfit', 'bg',
+        'border', 'q', 'fm', 'p',
     ];
 
     /**

--- a/src/Imaging/GlideServer.php
+++ b/src/Imaging/GlideServer.php
@@ -18,6 +18,7 @@ class GlideServer
     {
         return ServerFactory::create([
             'source'   => base_path(), // this gets overriden on the fly by the image generator
+            'watermarks' => public_path(),
             'cache'    => $this->cachePath(),
             'response' => new LaravelResponseFactory(app('request')),
             'driver'   => Config::get('statamic.assets.image_manipulation.driver'),


### PR DESCRIPTION
This PR allows to use Glide's [watermark parameters](https://glide.thephpleague.com/2.0/api/watermarks/). 