### PR TITLE
Allow replicator sets to be grouped in 'add set' popover

### DIFF
--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -14,7 +14,11 @@
             <div :class="{'grid grid-flow-col w-80' : groupToShow != ''}" v-if="groupedSets.keys.length >= 1">
                 <div>
                     <div v-for="group in groupedSets.keys">
-                        <a @click="showGroup(group)">{{ group }}</a>
+                        <a @click="showGroup(group)" :class="{'' : groupToShow == group }">
+                            <span :class="{ 'float-left' : groupToShow == '', 'float-left' : groupToShow != '' && groupToShow == group, 'float-left text-grey-60' : groupToShow != '' && groupToShow != group }">{{ group }}</span>
+                            <span class="icon icon-arrow-right float-right"></span>
+                            <span class="clear-both block"></span>
+                        </a>
                     </div>
                 </div>
                 <div v-if="groupToShow != ''">

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -11,9 +11,25 @@
                 </button>
             </template>
 
-            <div v-for="set in sets" :key="set.handle">
-                <dropdown-item :text="set.display || set.handle" @click="addSet(set.handle)" />
+            <div :class="{'grid grid-flow-col w-80' : groupToShow != ''}" v-if="groupedSets.keys.length >= 1">
+                <div>
+                    <div v-for="group in groupedSets.keys">
+                        <a @click="showGroup(group)">{{ group }}</a>
+                    </div>
+                </div>
+                <div v-if="groupToShow != ''">
+                    <div v-for="set in groupedSets.sets[groupToShow]" :key="set.handle">
+                        <dropdown-item :text="set.display || set.handle" @click="addSet(set.handle)" />
+                    </div>
+                </div>
             </div>
+
+            <div v-else>
+                <div v-for="set in sets" :key="set.handle">
+                    <dropdown-item :text="set.display || set.handle" @click="addSet(set.handle)" />
+                </div>
+            </div>
+
         </dropdown-list>
         <button v-else :class="{'btn-round': last, 'dropdown-icon': !last }" v-tooltip.right="__('Add Set')" :aria-label="__('Add Set')" @click="addSet(sets[0].handle)">
             <span class="icon icon-plus text-grey-80 antialiased"></span>
@@ -31,11 +47,50 @@ export default {
         last: Boolean,
     },
 
+    data() {
+        return {
+            groupToShow: '',
+        }
+    },
+
+    computed: {
+
+        groupedSets() {
+            let groupedSets = this.groupBy(this.sets, 'group');
+            return {
+                keys: Object.keys(groupedSets),
+                sets: groupedSets,
+            };
+        }
+
+    },
+
     methods: {
 
         addSet(handle) {
             this.$emit('added', handle, this.index + 1);
-        }
+            this.groupToShow = '';
+        },
+
+        groupBy(array, key) {
+            const result = {};
+            array.forEach(item => {
+                if (!item[key]) {
+                    item[key] = '';
+                }
+
+                if (!result[item[key]]){
+                    result[item[key]] = [];
+                }
+
+                result[item[key]].push(item);
+            })
+            return result;
+        },
+
+        showGroup(group) {
+            return this.groupToShow = group;
+        },
 
     }
 

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -76,7 +76,7 @@ export default {
             const result = {};
             array.forEach(item => {
                 if (!item[key]) {
-                    item[key] = '';
+                    item[key] = 'Default';
                 }
 
                 if (!result[item[key]]){

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -13,12 +13,13 @@
 
             <div :class="{'grid grid-flow-col w-80' : groupToShow != ''}" v-if="groupedSets.keys.length >= 1">
                 <div>
-                    <div v-for="group in groupedSets.keys">
-                        <a @click="showGroup(group)" :class="{'' : groupToShow == group }">
-                            <span :class="{ 'float-left' : groupToShow == '', 'float-left' : groupToShow != '' && groupToShow == group, 'float-left text-grey-60' : groupToShow != '' && groupToShow != group }">{{ group }}</span>
+                    <div v-for="group in groupedSets.selectionList">
+                        <a @click="showGroup(group.text)" :class="{'' : groupToShow == group.text }" v-if="group.type == 'group'">
+                            <span :class="{ 'float-left' : groupToShow == '', 'float-left' : groupToShow != '' && groupToShow == group.text, 'float-left text-grey-60' : groupToShow != '' && groupToShow != group.text }">{{ group.text }}</span>
                             <span class="icon icon-arrow-right float-right"></span>
                             <span class="clear-both block"></span>
                         </a>
+                        <dropdown-item :text="group.set.display || group.set.handle" @click="addSet(group.set.handle)" v-else />
                     </div>
                 </div>
                 <div v-if="groupToShow != ''">
@@ -61,8 +62,38 @@ export default {
 
         groupedSets() {
             let groupedSets = this.groupBy(this.sets, 'group');
+            let keys = Object.keys(groupedSets);
+            let selectionList = [];
+            keys.forEach((key) => {
+                if (key == '') {
+
+                    groupedSets[''].forEach((set) => {
+
+                        selectionList.push({
+                           type: 'set',
+                           text: set.display || set.handle,
+                           set: set
+                        });
+
+                    });
+
+                } else {
+
+                    selectionList.push({
+                       type: 'group',
+                       text: key
+                    });
+
+                }
+            });
+
+            selectionList = selectionList.sort((a, b) => {
+                return a.text > b.text ? 1 : -1;
+            });
+
             return {
-                keys: Object.keys(groupedSets),
+                keys: keys,
+                selectionList: selectionList,
                 sets: groupedSets,
             };
         }
@@ -80,7 +111,7 @@ export default {
             const result = {};
             array.forEach(item => {
                 if (!item[key]) {
-                    item[key] = 'Default';
+                    item[key] = '';
                 }
 
                 if (!result[item[key]]){
@@ -94,7 +125,7 @@ export default {
 
         showGroup(group) {
             return this.groupToShow = group;
-        },
+        }
 
     }
 


### PR DESCRIPTION
We are very heavy replicator users, often having 30+ sets on a site which can become unwieldy when adding a set through the popover. Inspired by https://github.com/statamic/ideas/issues/361 this PR lets you group replicator sets by adding a 'group' key to the blueprint yaml.

Blueprint:
<img width="359" alt="Screenshot 2021-11-24 at 11 39 32" src="https://user-images.githubusercontent.com/51899/143231990-2412a753-d395-4190-a6a2-ada6eb1fd407.png">

When group are present, the set popover will initially show the group list:
<img width="346" alt="Screenshot 2021-11-24 at 11 40 59" src="https://user-images.githubusercontent.com/51899/143232242-bb53789e-e672-4b32-8d31-7288e0f26d81.png">

Which when clicked on, would let you select from the sets in that group:
<img width="430" alt="Screenshot 2021-11-24 at 11 41 02" src="https://user-images.githubusercontent.com/51899/143232275-cddf47b5-e8aa-4f56-b9ca-f4dcbb9bce12.png">

I haven't considered a UI on the replicator field setup for this, but if this PR is something you would consider I'd be happy to work on the best way to do that. It may also make sense to add an arrow or different styling to the group list, to indicate they are a filter rather than a set selector.

Currently if an item is not in a group it goes to a 'Default' group, but it may be better for them to be selectable alongside the groups, depending on the styling approach taken.
