### PR TITLE
Fix eloquent user last login

### DIFF
--- a/src/Auth/SetLastLoginTimestamp.php
+++ b/src/Auth/SetLastLoginTimestamp.php
@@ -3,15 +3,12 @@
 namespace Statamic\Auth;
 
 use Illuminate\Auth\Events\Login;
-use Statamic\Contracts\Auth\User as StatamicUser;
 use Statamic\Facades\User;
 
 class SetLastLoginTimestamp
 {
     public function handle(Login $event)
     {
-        if ($event->user instanceof StatamicUser) {
-            User::fromUser($event->user)->setLastLogin(now());
-        }
+        User::fromUser($event->user)->setLastLogin(now());
     }
 }


### PR DESCRIPTION
Possibly fixes https://github.com/statamic/cms/issues/4030

I feel like I could have missed something crucial here, but as `User::fromUser($event->user)` returns a `Statamic\Auth\Eloquent\User` object, which also implements `setLastLogin` just like `Statamic\Auth\File\User` does, it didn't look like you need to check that the user is a Statamic user...

Maybe this could be a problem with other user configurations?