### PR TITLE
Resolve asset custom field values in GraphQL queries

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -29,6 +29,7 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 use Stringy\Stringy;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Mime\MimeTypes;
+use Statamic\GraphQL\ResolvesValues;
 
 class Asset implements AssetContract, Augmentable
 {
@@ -37,6 +38,10 @@ class Asset implements AssetContract, Augmentable
         get as traitGet;
         remove as traitRemove;
         data as traitData;
+    }
+
+    use ResolvesValues {
+        resolveGqlValue as traitResolveGqlValue;
     }
 
     protected $container;
@@ -773,5 +778,14 @@ class Asset implements AssetContract, Augmentable
     protected function shallowAugmentedArrayKeys()
     {
         return ['id', 'url', 'permalink', 'api_url'];
+    }
+
+    public function resolveGqlValue($field)
+    {
+        if ($field === 'blueprint') {
+            return $this->blueprint();
+        }
+
+        return $this->traitResolveGqlValue($field);
     }
 }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -22,6 +22,7 @@ use Statamic\Facades\Image;
 use Statamic\Facades\Path;
 use Statamic\Facades\URL;
 use Statamic\Facades\YAML;
+use Statamic\GraphQL\ResolvesValues;
 use Statamic\Statamic;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
@@ -29,7 +30,6 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 use Stringy\Stringy;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Mime\MimeTypes;
-use Statamic\GraphQL\ResolvesValues;
 
 class Asset implements AssetContract, Augmentable
 {


### PR DESCRIPTION
## Bug

GraphQL queries on Assets with custom fields 

```graphql
query {
  assets(container: "assets") {
    data {
      ... on Asset_Assets {
        __typename
        custom_button_group {
          label
          value
        }
      }
    }
  }
}

```

would throw an Error `Call to undefined method Statamic\\Assets\\Asset::resolveGqlValue()`.