### PR TITLE
Use full locale for emails

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -26,7 +26,7 @@ class Email extends Mailable
         $this->submission = $submission;
         $this->config = $this->parseConfig($config);
         $this->site = $site;
-        $this->locale($site->shortLocale());
+        $this->locale($site->lang());
     }
 
     public function build()

--- a/tests/Forms/EmailTest.php
+++ b/tests/Forms/EmailTest.php
@@ -28,10 +28,12 @@ class EmailTest extends TestCase
         Site::setConfig(['sites' => [
             'one' => ['locale' => 'en_US', 'url' => '/one'],
             'two' => ['locale' => 'fr_Fr', 'url' => '/two'],
+            'three' => ['locale' => 'de_CH', 'lang' => 'de_CH', 'url' => '/three'],
         ]]);
 
         $this->assertEquals('en', $this->makeEmail(Site::get('one'))->locale);
         $this->assertEquals('fr', $this->makeEmail(Site::get('two'))->locale);
+        $this->assertEquals('de_CH', $this->makeEmail(Site::get('three'))->locale);
     }
 
     private function makeEmail($site = null)


### PR DESCRIPTION
Hi

We are using forms for sending emails. For emails the site's short locale will be used for translations. As we live in Switzerland we need to use de_CH (mainly because Germany has this ß character when needing ss, but only sometimes. I do not now the exact grammer here. I only know we don't have this on our "German"-Language variant).

So I think for emails the full locale should be used.

This can be a breaking change, since other swiss devs could used this and after this PR is merged, the locale will no longer be found (as de_CH will be used instead of de).

What do you think @jasonvarga?
