### PR TITLE
Fix `{{ user:variable_name }}`  tag

### DIFF
--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -26,13 +26,11 @@ class UserTags extends Tags
      */
     public function __call($method, $args)
     {
-        $user = $this->getUser();
-
-        if (! $user) {
+        if (! $user = $this->getUser()) {
             return $this->parseNoResults();
         }
 
-        return $user->get($method);
+        return $user->augmentedValue($method);
     }
 
     /**
@@ -44,9 +42,7 @@ class UserTags extends Tags
      */
     public function index()
     {
-        $user = $this->getUser();
-
-        if (! $user) {
+        if (! $user = $this->getUser()) {
             return $this->parseNoResults();
         }
 
@@ -56,7 +52,7 @@ class UserTags extends Tags
     /**
      * Fetch a user.
      *
-     * @return User
+     * @return User|null
      */
     protected function getUser()
     {
@@ -65,28 +61,28 @@ class UserTags extends Tags
         // Get a user by ID, if the `id` parameter was used.
         if ($id = $this->params->get('id')) {
             if (! $user = User::find($id)) {
-                return false;
+                return null;
             }
         }
 
         // Get a user by email, if the `email` parameter was used.
         if ($email = $this->params->get('email')) {
             if (! $user = User::findByEmail($email)) {
-                return false;
+                return null;
             }
         }
 
         // Get a user by field, if the `field` parameter was used.
         if ($field = $this->params->get('field')) {
             if (! $user = User::query()->where($field, $this->params->get('value'))->first()) {
-                return false;
+                return null;
             }
         }
 
         // No user found? Get the current one.
         if (! $user) {
             if (! $user = User::current()) {
-                return false;
+                return null;
             }
         }
 

--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -24,13 +24,13 @@ class UserTags extends Tags
      *
      * @return string
      */
-    public function __call($method, $args)
+    public function wildcard(string $name)
     {
         if (! $user = $this->getUser()) {
             return $this->parseNoResults();
         }
 
-        return $user->augmentedValue($method);
+        return $user->augmentedValue($name);
     }
 
     /**

--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -26,13 +26,13 @@ class UserTags extends Tags
      */
     public function __call($method, $args)
     {
-        $id = Arr::get($this->context, $method);
+        $user = $this->getUser();
 
-        if (! $user = User::find($id)) {
-            return;
+        if (! $user) {
+            return $this->parseNoResults();
         }
 
-        return $user;
+        return $user->get($method);
     }
 
     /**
@@ -44,33 +44,49 @@ class UserTags extends Tags
      */
     public function index()
     {
+        $user = $this->getUser();
+
+        if (! $user) {
+            return $this->parseNoResults();
+        }
+
+        return $user;
+    }
+
+    /**
+     * Fetch a user.
+     *
+     * @return User
+     */
+    protected function getUser()
+    {
         $user = null;
 
         // Get a user by ID, if the `id` parameter was used.
         if ($id = $this->params->get('id')) {
             if (! $user = User::find($id)) {
-                return $this->parseNoResults();
+                return false;
             }
         }
 
         // Get a user by email, if the `email` parameter was used.
         if ($email = $this->params->get('email')) {
             if (! $user = User::findByEmail($email)) {
-                return $this->parseNoResults();
+                return false;
             }
         }
 
         // Get a user by field, if the `field` parameter was used.
         if ($field = $this->params->get('field')) {
             if (! $user = User::query()->where($field, $this->params->get('value'))->first()) {
-                return $this->parseNoResults();
+                return false;
             }
         }
 
         // No user found? Get the current one.
         if (! $user) {
             if (! $user = User::current()) {
-                return $this->parseNoResults();
+                return false;
             }
         }
 

--- a/tests/Tags/User/UserTagsTest.php
+++ b/tests/Tags/User/UserTagsTest.php
@@ -22,6 +22,14 @@ class UserTagsTest extends TestCase
     }
 
     /** @test */
+    public function it_renders_user_variable()
+    {
+        $this->actingAs(User::make()->email('foo@bar.com')->save());
+
+        $this->assertEquals('foo@bar.com', $this->tag('{{ user:email }}'));
+    }
+
+    /** @test */
     public function it_renders_user_can_tag_content()
     {
         $this->setTestRoles([


### PR DESCRIPTION
The existing `{{ user:variable_name }}` tag doesn't seem to work, this fixes that.

One odd thing I ran into was that if I call `$user->get($name)` it works perfectly when used in a view, but fails when run in the test (`get()` returns `null`). Calling `$user->augmentedValue($name)` seems to work in both contexts. Not sure why.