### PR TITLE
Schedule doesn't need to be in `booted`

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -166,9 +166,7 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected function bootSchedule()
     {
         if ($this->app->runningInConsole()) {
-            $this->app->booted(function () {
-                $this->schedule($this->app->make(Schedule::class));
-            });
+            $this->schedule($this->app->make(Schedule::class));
         }
 
         return $this;


### PR DESCRIPTION
When it's in a `booted` closure it's actually called twice. Since this method is already in a `Statamic::booted` closure we don't need it here.