### PR TITLE
add `trackable_embed_url`

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2693,9 +2693,7 @@ class CoreModifiers extends Modifier
     public function trackableEmbedUrl($url)
     {
         if (Str::contains($url, 'vimeo')) {
-            $url = str_replace('/vimeo.com', '/player.vimeo.com/video', $url);
-
-            return $url;
+            return str_replace('/vimeo.com', '/player.vimeo.com/video', $url);
         }
 
         if (Str::contains($url, 'youtu.be')) {

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2684,6 +2684,37 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Get the embed URL when given a youtube or vimeo link that's
+     * direct to the page.
+     *
+     * @param  string  $url
+     * @return string
+     */
+    public function trackableEmbedUrl($url)
+    {
+        if (Str::contains($url, 'vimeo')) {
+            $url = str_replace('/vimeo.com', '/player.vimeo.com/video', $url);
+
+            return $url;
+        }
+
+        if (Str::contains($url, 'youtu.be')) {
+            $url = str_replace('youtu.be', 'www.youtube.com/embed', $url);
+
+            // Check for start at point and replace it with correct parameter.
+            if (Str::contains($url, '?t=')) {
+                $url = str_replace('?t=', '?start=', $url);
+            }
+        }
+
+        if (Str::contains($url, 'youtube.com/watch?v=')) {
+            $url = str_replace('watch?v=', 'embed/', $url);
+        }
+
+        return $url;
+    }
+
+    /**
      * Whether a given video URL is embeddable.
      *
      * @param  string  $url

--- a/tests/Modifiers/TrackableEmbedUrlTest.php
+++ b/tests/Modifiers/TrackableEmbedUrlTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class TrackableEmbedUrlTest extends TestCase
+{
+    /** @test */
+    public function it_leaves_urls_from_unknown_providers_untouched()
+    {
+        $this->assertEquals('https://statamic.com/video/hello', $this->embed('https://statamic.com/video/hello'));
+    }
+
+    /** @test */
+    public function it_transforms_vimeo_urls()
+    {
+        $embedUrl = 'https://player.vimeo.com/video/71360261';
+
+        $this->assertEquals($embedUrl, $this->embed('https://vimeo.com/71360261'));
+
+        $this->assertEquals(
+            $embedUrl.'?foo=bar',
+            $this->embed('https://vimeo.com/71360261?foo=bar'),
+            'It appends the do not track query param if a query string already exists.'
+        );
+    }
+
+    /** @test */
+    public function it_transforms_youtube_urls()
+    {
+        $embedUrl = 'https://www.youtube.com/embed/s72r_wu_NVY';
+
+        $this->assertEquals(
+            $embedUrl,
+            $this->embed('https://www.youtube.com/watch?v=s72r_wu_NVY')
+        );
+        $this->assertEquals(
+            $embedUrl,
+            $this->embed('https://youtu.be/s72r_wu_NVY'),
+            'It transforms shortened youtube video sharing links'
+        );
+
+        $this->assertEquals(
+            $embedUrl.'?start=559',
+            $this->embed('https://youtu.be/s72r_wu_NVY?t=559'),
+            'It transforms the start time parameter of shortened sharing links'
+        );
+    }
+
+    public function embed($url)
+    {
+        return Modify::value($url)->trackableEmbedUrl()->fetch();
+    }
+}


### PR DESCRIPTION
We have a client who would like to gather analytics on their video links (I know I know), but the `embed_url` always adds do not tracking.