### PR TITLE
Adjust licensing messaging

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -120,6 +120,7 @@ return [
     'licensing_production_alert' => 'This site is using Statamic Pro and commercial addons. Please purchase appropriate licenses.',
     'licensing_production_alert_addons' => 'This site is using commercial addons. Please purchase appropriate licenses.',
     'licensing_production_alert_statamic' => 'This site is using Statamic Pro. Please purchase a license.',
+    'licensing_production_alert_renew_statamic' => 'Using this version of Statamic Pro requires a license renewal.',
     'licensing_sync_instructions' => 'Data from statamic.com is synced once per hour. Force a sync to see any changes you\'ve made.',
     'licensing_trial_mode_alert' => 'This site is using Statamic Pro and commercial addons. Make sure to buy licenses before launching. Thanks!',
     'licensing_trial_mode_alert_addons' => 'This site is using commercial addons. Make sure to buy licenses before launching. Thanks!',

--- a/resources/views/partials/licensing-alerts.blade.php
+++ b/resources/views/partials/licensing-alerts.blade.php
@@ -48,7 +48,11 @@
                         @if ($licenses->onlyAddonsAreInvalid())
                             {{ __('statamic::messages.licensing_production_alert_addons') }}
                         @elseif ($licenses->onlyStatamicIsInvalid())
-                            {{ __('statamic::messages.licensing_production_alert_statamic') }}
+                            @if ($licenses->statamicNeedsRenewal())
+                                {{ __('statamic::messages.licensing_production_alert_renew_statamic') }}
+                            @else
+                                {{ __('statamic::messages.licensing_production_alert_statamic') }}
+                            @endif
                         @else
                             {{ __('statamic::messages.licensing_production_alert') }}
                         @endif

--- a/src/Licensing/LicenseManager.php
+++ b/src/Licensing/LicenseManager.php
@@ -83,6 +83,11 @@ class LicenseManager
         return $this->statamicValid() && ! $this->addonsValid();
     }
 
+    public function statamicNeedsRenewal()
+    {
+        return $this->statamic()->needsRenewal();
+    }
+
     public function response($key = null, $default = null)
     {
         $response = $this->outpost->response();

--- a/src/Licensing/StatamicLicense.php
+++ b/src/Licensing/StatamicLicense.php
@@ -3,6 +3,7 @@
 namespace Statamic\Licensing;
 
 use Statamic\Statamic;
+use Statamic\Support\Arr;
 
 class StatamicLicense extends License
 {
@@ -14,5 +15,21 @@ class StatamicLicense extends License
     public function version()
     {
         return Statamic::version();
+    }
+
+    public function needsRenewal()
+    {
+        return Arr::get($this->response, 'reason') === 'outside_license_range';
+    }
+
+    public function invalidReason()
+    {
+        if (Arr::get($this->response, 'reason') === 'outside_license_range') {
+            [$start, $end] = $this->response['range'];
+
+            return trans('statamic::messages.licensing_error_outside_license_range', compact('start', 'end'));
+        }
+
+        return parent::invalidReason();
     }
 }

--- a/tests/Licensing/LicenseManagerTest.php
+++ b/tests/Licensing/LicenseManagerTest.php
@@ -132,6 +132,22 @@ class LicenseManagerTest extends TestCase
     }
 
     /** @test */
+    public function it_checks_if_statamic_license_needs_renewal()
+    {
+        $this->assertFalse($this->managerWithResponse([
+            'statamic' => ['valid' => true],
+        ])->statamicNeedsRenewal());
+
+        $this->assertFalse($this->managerWithResponse([
+            'statamic' => ['valid' => false, 'reason' => 'unlicensed'],
+        ])->statamicNeedsRenewal());
+
+        $this->assertTrue($this->managerWithResponse([
+            'statamic' => ['valid' => false, 'reason' => 'outside_license_range'],
+        ])->statamicNeedsRenewal());
+    }
+
+    /** @test */
     public function it_checks_for_request_failures()
     {
         Carbon::setTestNow(now()->startOfMinute());

--- a/tests/Licensing/StatamicLicenseTest.php
+++ b/tests/Licensing/StatamicLicenseTest.php
@@ -39,4 +39,31 @@ class StatamicLicenseTest extends TestCase
         $this->assertEquals('3.4.5', $license->version());
         $this->assertEquals('6.7.8', $license->version());
     }
+
+    /** @test */
+    public function it_gets_the_invalid_reason_for_a_range_issue()
+    {
+        $license = $this->license([
+            'reason' => 'outside_license_range',
+            'range' => ['2', '4'],
+        ]);
+
+        $key = 'statamic::messages.licensing_error_outside_license_range';
+        $message = trans($key, ['start' => '2', 'end' => '4']);
+        $this->assertNotEquals($key, $message);
+        $this->assertEquals($message, $license->invalidReason());
+    }
+
+    /** @test */
+    public function it_needs_renewal_if_outside_license_range()
+    {
+        $license = $this->license(['valid' => true]);
+        $this->assertFalse($license->needsRenewal());
+
+        $license = $this->license(['valid' => false, 'reason' => 'unlicensed']);
+        $this->assertFalse($license->needsRenewal());
+
+        $license = $this->license(['valid' => false, 'reason' => 'outside_license_range']);
+        $this->assertTrue($license->needsRenewal());
+    }
 }


### PR DESCRIPTION
Right now if your license's support window has ended, it'll just tell you it's invalid. This makes the messaging a little more user friendly.