### PR TITLE
Performance enhancements to Structure/Nav and Locales tags

### DIFF
--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -91,7 +91,7 @@ abstract class AbstractAugmented implements Augmented
 
     protected function blueprintFields()
     {
-        if (!isset($this->blueprintFields)) {
+        if (! isset($this->blueprintFields)) {
             $this->blueprintFields = (method_exists($this->data, 'blueprint') && $blueprint = $this->data->blueprint())
                 ? $blueprint->fields()->all()
                 : collect();

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -15,7 +15,6 @@ abstract class AbstractAugmented implements Augmented
     public function __construct($data)
     {
         $this->data = $data;
-        $this->blueprintFields = $this->blueprintFields();
     }
 
     public function all()
@@ -76,7 +75,7 @@ abstract class AbstractAugmented implements Augmented
 
     protected function wrapValue($value, $handle)
     {
-        $fields = $this->blueprintFields;
+        $fields = $this->blueprintFields();
 
         if (! $fields->has($handle)) {
             return $value;
@@ -92,8 +91,12 @@ abstract class AbstractAugmented implements Augmented
 
     protected function blueprintFields()
     {
-        return (method_exists($this->data, 'blueprint') && $blueprint = $this->data->blueprint())
-            ? $blueprint->fields()->all()
-            : collect();
+        if (!isset($this->blueprintFields)) {
+            $this->blueprintFields = (method_exists($this->data, 'blueprint') && $blueprint = $this->data->blueprint())
+                ? $blueprint->fields()->all()
+                : collect();
+        }
+
+        return $this->blueprintFields;
     }
 }

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -10,10 +10,12 @@ use Statamic\Support\Str;
 abstract class AbstractAugmented implements Augmented
 {
     protected $data;
+    protected $blueprintFields;
 
     public function __construct($data)
     {
         $this->data = $data;
+        $this->blueprintFields = $this->blueprintFields();
     }
 
     public function all()
@@ -74,7 +76,7 @@ abstract class AbstractAugmented implements Augmented
 
     protected function wrapValue($value, $handle)
     {
-        $fields = $this->blueprintFields();
+        $fields = $this->blueprintFields;
 
         if (! $fields->has($handle)) {
             return $value;

--- a/src/Data/AugmentedData.php
+++ b/src/Data/AugmentedData.php
@@ -6,12 +6,12 @@ use Illuminate\Support\Collection;
 
 class AugmentedData extends AbstractAugmented
 {
-    protected $data;
     protected $array;
 
     public function __construct($data, $array)
     {
-        $this->data = $data;
+        parent::__construct($data);
+
         $this->array = $array instanceof Collection ? $array->all() : $array;
     }
 

--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -168,7 +168,7 @@ class Glide extends Tags
         static $urls = [];
 
         $token = is_string($item)
-            ? $item . '?' . http_build_query($this->params->except(['src', 'id', 'path'])->sortKeys()->all())
+            ? $item.'?'.http_build_query($this->params->except(['src', 'id', 'path'])->sortKeys()->all())
             : null;
         if ($token && isset($urls[$token])) {
             return $urls[$token];

--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -165,6 +165,15 @@ class Glide extends Tags
      */
     private function generateGlideUrl($item)
     {
+        static $urls = [];
+
+        $token = is_string($item)
+            ? $item . '?' . http_build_query($this->params->except(['src', 'id', 'path'])->sortKeys()->all())
+            : null;
+        if ($token && isset($urls[$token])) {
+            return $urls[$token];
+        }
+
         try {
             $url = $this->isResizable($item) ? $this->getManipulator($item)->build() : $this->normalizeItem($item);
         } catch (\Exception $e) {
@@ -174,6 +183,10 @@ class Glide extends Tags
         }
 
         $url = ($this->params->bool('absolute')) ? URL::makeAbsolute($url) : URL::makeRelative($url);
+
+        if ($token !== null) {
+            $urls[$token] = $url;
+        }
 
         return $url;
     }

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -138,7 +138,12 @@ class Locales extends Tags
             return null;
         }
 
-        return $localized->toAugmentedArray();
+        $defaultKeys = ['id', 'permalink', 'status', 'title', 'uri', 'url'];
+        $augmentKeys = $this->params->get('shallow', false)
+            ? array_merge($defaultKeys, explode('|', $this->params->get('augment_keys', '')))
+            : null;
+
+        return $localized->toAugmentedArray($augmentKeys);
     }
 
     /**

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -14,6 +14,15 @@ use Statamic\Support\Str;
 
 class Structure extends Tags
 {
+    protected $siteCurrentUrl;
+    protected $siteAbsoluteUrl;
+
+    public function __construct()
+    {
+        $this->siteCurrentUrl = URL::getCurrent();
+        $this->siteAbsoluteUrl = Site::current()->absoluteUrl();
+    }
+
     public function wildcard($tag)
     {
         $handle = $this->context->value($tag, $tag);
@@ -70,6 +79,9 @@ class Structure extends Tags
             $data = $page->toAugmentedArray();
             $children = empty($item['children']) ? [] : $this->toArray($item['children'], $data, $depth + 1);
 
+            $currentUrl = $page->urlWithoutRedirect();
+            $absoluteUrl = $page->absoluteUrl();
+
             return array_merge($data, [
                 'children'    => $children,
                 'parent'      => $parent,
@@ -78,9 +90,9 @@ class Structure extends Tags
                 'count'       => $index + 1,
                 'first'       => $index === 0,
                 'last'        => $index === count($tree) - 1,
-                'is_current'  => rtrim(URL::getCurrent(), '/') == rtrim($page->urlWithoutRedirect(), '/'),
-                'is_parent'   => Site::current()->absoluteUrl() === $page->absoluteUrl() ? false : URL::isAncestorOf(URL::getCurrent(), $page->urlWithoutRedirect()),
-                'is_external' => URL::isExternal($page->absoluteUrl()),
+                'is_current'  => rtrim($this->siteCurrentUrl, '/') === rtrim($currentUrl, '/'),
+                'is_parent'   => $this->siteAbsoluteUrl === $absoluteUrl ? false : URL::isAncestorOf($this->siteCurrentUrl, $currentUrl),
+                'is_external' => URL::isExternal($absoluteUrl),
             ]);
         })->filter()->values()->all();
     }

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -16,6 +16,7 @@ class Structure extends Tags
 {
     protected $siteCurrentUrl;
     protected $siteAbsoluteUrl;
+    protected $augmentKeys;
 
     public function __construct()
     {
@@ -57,6 +58,11 @@ class Structure extends Tags
             'max_depth' => $this->params->get('max_depth'),
         ]);
 
+        $defaultKeys = ['id', 'permalink', 'title', 'uri', 'url'];
+        $this->augmentKeys = $this->params->get('shallow', true)
+            ? array_merge($defaultKeys, explode('|', $this->params->get('augment_keys', '')))
+            : null;
+
         return $this->toArray($tree);
     }
 
@@ -76,7 +82,7 @@ class Structure extends Tags
     {
         return collect($tree)->map(function ($item, $index) use ($parent, $depth, $tree) {
             $page = $item['page'];
-            $data = $page->toAugmentedArray();
+            $data = $page->toAugmentedArray($this->augmentKeys);
             $children = empty($item['children']) ? [] : $this->toArray($item['children'], $data, $depth + 1);
 
             $currentUrl = $page->urlWithoutRedirect();

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -59,7 +59,7 @@ class Structure extends Tags
         ]);
 
         $defaultKeys = ['id', 'permalink', 'title', 'uri', 'url'];
-        $this->augmentKeys = $this->params->get('shallow', true)
+        $this->augmentKeys = $this->params->get('shallow', false)
             ? array_merge($defaultKeys, explode('|', $this->params->get('augment_keys', '')))
             : null;
 


### PR DESCRIPTION
- Optimized state variables of Stucture/Nav tag loop
- Added `shallow` option to Structure/Nav and Locales tags (`boolean` default: `false`)
  Will reduce outputted variables for entries to default `id`, `permalink`, `title`, `uri`, `url` (plus `status` for Locales`)
- Added `augment_keys` option to Structure/Nav and Locales tags (`string` separated by pipe `|`)
  Additional keys added during augmentation
- Added static caching for subsequent Glide image url generation for identical images and params - boosts image heavy sites using srcset with background images