### PR TITLE
Collections: Sort nested structure by order

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -373,7 +373,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
     public function order()
     {
         if (! $this->hasStructure()) {
-            return null;
+            return $this->value('order');
         }
 
         return $this->structure()->in($this->locale())

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -372,7 +372,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
 
     public function order()
     {
-        if (! $this->collection()->orderable()) {
+        if (! $this->hasStructure()) {
             return null;
         }
 

--- a/src/Entries/UpdateStructuredEntryOrder.php
+++ b/src/Entries/UpdateStructuredEntryOrder.php
@@ -10,13 +10,6 @@ class UpdateStructuredEntryOrder
     {
         $tree = $event->tree;
         $collection = $tree->collection();
-
-        // Only orderable (single depth structure) entries will
-        // have order attributes, so don't bother otherwise.
-        if (! $collection->orderable()) {
-            return;
-        }
-
         $diff = $tree->diff();
 
         $ids = array_merge($diff->moved(), $diff->added());

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -18,12 +18,10 @@ use Statamic\Tags\Concerns;
 class Entries
 {
     use Concerns\QueriesScopes,
+        Concerns\QueriesOrderBys,
         Concerns\GetsQueryResults;
     use Concerns\QueriesConditions {
         queryableConditionParams as traitQueryableConditionParams;
-    }
-    use Concerns\QueriesOrderBys {
-        queryOrderBys as traitQueryOrderBys;
     }
 
     protected $ignoredParams = ['as'];
@@ -333,22 +331,6 @@ class Entries
                 );
             }
         });
-    }
-
-    protected function queryOrderBys($query)
-    {
-        $isSortingByOrder = null !== $this->orderBys->first(function ($orderBy) {
-            return $orderBy->sort === 'order';
-        });
-
-        if ($isSortingByOrder) {
-            $nonOrderableCollections = $this->collections->reject->hasStructure();
-            if ($nonOrderableCollections->isNotEmpty()) {
-                throw new \LogicException('Cannot sort a structureless collection by order.');
-            }
-        }
-
-        return $this->traitQueryOrderBys($query);
     }
 
     protected function queryRedirects($query)

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -342,9 +342,9 @@ class Entries
         });
 
         if ($isSortingByOrder) {
-            $nonOrderableCollections = $this->collections->reject->orderable();
+            $nonOrderableCollections = $this->collections->reject->hasStructure();
             if ($nonOrderableCollections->isNotEmpty()) {
-                throw new \LogicException('Cannot sort a nested collection by order.');
+                throw new \LogicException('Cannot sort a structureless collection by order.');
             }
         }
 

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -537,25 +537,48 @@ class EntryTest extends TestCase
         $one = tap((new Entry)->locale('en')->id('one')->collection($collection))->save();
         $two = tap((new Entry)->locale('en')->id('two')->collection($collection))->save();
         $three = tap((new Entry)->locale('en')->id('three')->collection($collection))->save();
+        $four = tap((new Entry)->locale('en')->id('four')->collection($collection))->save();
 
         $this->assertNull($one->order());
-        $this->assertNull($one->order());
-        $this->assertNull($one->order());
+        $this->assertNull($two->order());
+        $this->assertNull($three->order());
+        $this->assertNull($four->order());
 
         $collection->structureContents([
-            'max_depth' => 1,
+            'max_depth' => 3,
         ])->save();
         $collection->structure()->in('en')->tree(
             [
                 ['entry' => 'three'],
-                ['entry' => 'one'],
+                ['entry' => 'one', 'children' => [
+                    ['entry' => 'four'],
+                ]],
                 ['entry' => 'two'],
             ]
         )->save();
 
         $this->assertEquals(2, $one->order());
-        $this->assertEquals(3, $two->order());
+        $this->assertEquals(4, $two->order());
         $this->assertEquals(1, $three->order());
+        $this->assertEquals(3, $four->order());
+    }
+
+    /** @test */
+    public function it_gets_the_order_from_the_data_if_not_structured()
+    {
+        $collection = tap(Collection::make('test'))->save();
+
+        $one = tap((new Entry)->locale('en')->id('one')->collection($collection))->save();
+        $two = tap((new Entry)->locale('en')->id('two')->collection($collection)->data(['order' => 17]))->save();
+        $three = tap((new Entry)->locale('en')->id('three')->collection($collection)->data(['order' => 'potato']))->save();
+        $four = tap((new Entry)->locale('en')->id('four')->collection($collection)->data(['order' => 24]))->save();
+        $five = tap((new Entry)->locale('fr')->id('five')->collection($collection)->origin('four'))->save();
+
+        $this->assertNull($one->order());
+        $this->assertEquals(17, $two->order());
+        $this->assertEquals('potato', $three->order());
+        $this->assertEquals(24, $four->order());
+        $this->assertEquals(24, $five->order());
     }
 
     /** @test */

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -386,15 +386,6 @@ class EntriesTest extends TestCase
     }
 
     /** @test */
-    public function it_cannot_sort_a_structureless_collection()
-    {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Cannot sort a structureless collection by order.');
-
-        $this->getEntries(['sort' => 'order|title']);
-    }
-
-    /** @test */
     public function it_can_sort_a_nested_structured_collection()
     {
         $this->makeEntry('a')->save();


### PR DESCRIPTION
I didn't want to mess around with `Collection::orderable()` as it looks like being used a lot of places.

Since the order behind the scenes uses a flatmap of the structure IDs, I can't see why this shouldn't be included, as long as users understand that the order is done depth-first instead of breadth-first.

Thoughts?