### PR TITLE
Only cache fields of blueprint when parent entry is the same

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -278,7 +278,7 @@ class Blueprint implements Augmentable
 
     public function fields(): Fields
     {
-        if ($this->fieldsCache) {
+        if ($this->fieldsCache and $this->fieldsCache->parent() === $this->parent) {
             return $this->fieldsCache;
         }
 

--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -62,6 +62,11 @@ class Fields
         return $this->items;
     }
 
+    public function parent()
+    {
+        return $this->parent;
+    }
+
     public function all(): Collection
     {
         return $this->fields;


### PR DESCRIPTION
This pull request fixes https://github.com/statamic/cms/issues/4889