### PR TITLE
Dynamic chunks within statically cached pages

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -145,6 +145,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Tags\Member::class,
         Tags\Mix::class,
         Tags\Nav::class,
+        Tags\Nocache::class,
         Tags\NotFound::class,
         Tags\Obfuscate::class,
         Tags\ParentTags::class,

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -42,7 +42,7 @@ class Cache
         $response = $next($request);
 
         if ($this->shouldBeCached($request, $response)) {
-            $this->cacher->cachePage($request, $response);
+            $this->cacher->cachePage($request, $this->replaceNoCache($response));
         }
 
         return $response;

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -84,7 +84,7 @@ class Cache
 
     private function replaceNoCache(Response $response)
     {
-        $content = preg_replace_callback('/__STATIC_NOCACHE_(.*)__/', function ($matches) use ($response) {
+        $content = preg_replace_callback('/__STATIC_NOCACHE_(.*)__/', function ($matches) {
             $key = $matches[1];
             $cached = FacadesCache::get('nocache-tag-'.$key);
             $context = unserialize($cached);

--- a/src/Tags/Nocache.php
+++ b/src/Tags/Nocache.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Statamic\Tags;
+
+use Illuminate\Support\Facades\Cache;
+
+class Nocache extends Tags
+{
+    public function index()
+    {
+        // if (! config('statamic.static_caching.strategy')) {
+        //     return [];
+        // }
+
+        $context = $this->context->except('__env', 'app')->all();
+
+        $context['__content'] = $this->content;
+
+        $serialized = serialize($context);
+
+        $key = md5($serialized);
+
+        Cache::forever('nocache-tag-'.$key, $serialized);
+
+        return sprintf('__STATIC_NOCACHE_%s__', $key);
+    }
+}


### PR DESCRIPTION
The idea here is to be able to let you enable (half measure) static caching, but keep parts of your pages dynamic by using `{{ nocache }}` tags.

It's the opposite approach to leaving static caching off, and littering your templates with `{{ cache }}` tags.

This is a quick and dirty concept. Not near finished.

This is essentially the "replacements" feature of [Spatie's Response Cache package](https://github.com/spatie/laravel-responsecache) which we should... borrow (❤️ )

- [ ] Implement "replacers"
- [ ] Move the nocache tag replacement into a replacer
- [ ] Add a csrf_token replacer so people can use forms normally
- [ ] Look into adding a cache="false" param to tags rather than adding nocache tags