### PR TITLE
Fix replicator updated logic

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -115,14 +115,7 @@ export default {
         },
 
         updated(index, set) {
-            let oldValues = clone(this.values);
-            let newValues = clone(this.values);
-
-            newValues.splice(index, 1, set);
-
-            if (JSON.stringify(oldValues) !== JSON.stringify(newValues)) {
-                this.values = newValues;
-            }
+            this.values.splice(index, 1, set);
         },
 
         removed(set, index) {


### PR DESCRIPTION
Closes #4774.

I'm basically undoing what we did in https://github.com/statamic/cms/commit/323234748145e1ad4330499fdb66ca182d8cea64 to fix https://github.com/statamic/cms/issues/564 way back in the v3-beta days. That said, I can't reproduce either issue with this fix, so I think it's fine?

Also noteworthy is that we're splicing `this.values` directly in `removed()`, so I think we should be fine splicing `this.values` directly in `updated()`.