### PR TITLE
Links shouldn't be red. That was dumb.

### DIFF
--- a/resources/sass/elements/forms.scss
+++ b/resources/sass/elements/forms.scss
@@ -308,9 +308,9 @@ input.slug {
 .help-block {
     @apply .block .mb-1 .text-grey-70 .text-xs;
     a {
-        @apply .text-red;
+        @apply .text-grey-80 underline;
         &:hover {
-            @apply .text-grey-80;
+            @apply .text-blue-darker;
         }
     }
 }


### PR DESCRIPTION
Closes statamic/a11y#13.

<img width="328" alt="CleanShot 2021-12-14 at 11 50 45@2x" src="https://user-images.githubusercontent.com/44739/146042658-e5779fd3-c965-42a9-8750-0b56b86e5247.png">
