### PR TITLE
Fix `site` query param on tree API endpoints

### DIFF
--- a/src/Http/Controllers/API/CollectionTreeController.php
+++ b/src/Http/Controllers/API/CollectionTreeController.php
@@ -14,18 +14,20 @@ class CollectionTreeController extends ApiController
     {
         $this->abortIfDisabled();
 
-        return app(TreeResource::class)::make($this->getCollectionTree($collection))
+        $site = $this->queryParam('site');
+
+        return app(TreeResource::class)::make($this->getCollectionTree($collection, $site))
             ->fields($this->queryParam('fields'))
-            ->maxDepth($this->queryParam('max_depth'));
+            ->maxDepth($this->queryParam('max_depth'))
+            ->site($site);
     }
 
-    private function getCollectionTree($collection)
+    private function getCollectionTree($collection, $site)
     {
         $structure = $collection->structure();
 
         throw_unless($structure, new NotFoundHttpException("Collection [{$collection->handle()}] is not a structured collection"));
 
-        $site = $this->queryParam('site');
         $tree = $structure->in($site);
 
         throw_unless($tree, new NotFoundHttpException("Collection [{$collection->handle()}] not found in [{$site}] site"));

--- a/src/Http/Controllers/API/NavigationTreeController.php
+++ b/src/Http/Controllers/API/NavigationTreeController.php
@@ -15,18 +15,20 @@ class NavigationTreeController extends ApiController
     {
         $this->abortIfDisabled();
 
-        return app(TreeResource::class)::make($this->getNavTree($handle))
+        $site = $this->queryParam('site');
+
+        return app(TreeResource::class)::make($this->getNavTree($handle, $site))
             ->fields($this->queryParam('fields'))
-            ->maxDepth($this->queryParam('max_depth'));
+            ->maxDepth($this->queryParam('max_depth'))
+            ->site($site);
     }
 
-    private function getNavTree($handle)
+    private function getNavTree($handle, $site)
     {
         $nav = Nav::find($handle);
 
         throw_unless($nav, new NotFoundHttpException("Navigation [{$handle}] not found"));
 
-        $site = $this->queryParam('site');
         $tree = $nav->in($site);
 
         throw_unless($tree, new NotFoundHttpException("Navigation [{$handle}] not found in [{$site}] site"));

--- a/src/Http/Resources/API/TreeResource.php
+++ b/src/Http/Resources/API/TreeResource.php
@@ -10,6 +10,7 @@ class TreeResource extends JsonResource
 {
     protected $fields;
     protected $depth;
+    protected $site;
 
     /**
      * Set selected fields.
@@ -38,6 +39,19 @@ class TreeResource extends JsonResource
     }
 
     /**
+     * Set site.
+     *
+     * @param  string|null  $site
+     * @return $this
+     */
+    public function site($site = null)
+    {
+        $this->site = $site;
+
+        return $this;
+    }
+
+    /**
      * Transform the resource into an array.
      *
      * @param \Illuminate\Http\Request
@@ -49,7 +63,7 @@ class TreeResource extends JsonResource
             'structure' => $this->resource->structure(),
             'include_home' => true,
             'show_unpublished' => false,
-            'site' => Site::default()->handle(),
+            'site' => $this->site ?? Site::default()->handle(),
             'fields' => $this->fields,
             'max_depth' => $this->maxDepth,
         ]);


### PR DESCRIPTION
Closes #4581.

I suppose this is not accurate across all endpoints though...

![image](https://user-images.githubusercontent.com/5187394/146071466-bb4b2748-eaa7-4193-8710-88d484b336d1.png)

For example...

- Hitting an `/entries` endpoint will serve entries from all sites at once, as the doc says
- But hitting `/globals` will serve global set(s) will serve from default site, unless the `site` query param is used

I don't think it makes sense for the tree endpoints to serve from all sites at once, as it'd be a confusing payload. Maybe we should just tweak the docs to better explain this?