### PR TITLE
Added shallow option to locales tag to speed up augmentation

### DIFF
--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -138,7 +138,12 @@ class Locales extends Tags
             return null;
         }
 
-        return $localized->toAugmentedArray();
+        $defaultKeys = ['id', 'permalink', 'status', 'title', 'uri', 'url'];
+        $augmentKeys = $this->params->get('shallow', false)
+            ? array_merge($defaultKeys, explode('|', $this->params->get('augment_keys', '')))
+            : null;
+
+        return $localized->toAugmentedArray($augmentKeys);
     }
 
     /**


### PR DESCRIPTION
- Added `shallow` option to Locales tag (`boolean` default: `false`)
  Will reduce outputted variables for entries to default `id`, `permalink`, `title`, `uri`, `url`, `status`
- Added `augment_keys` option to Locales tag (`string` separated by pipe `|`)
  Additional keys added during augmentation