### PR TITLE
Added shallow option to Structure/Nav tag to speed up augmentation

### DIFF
--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -14,6 +14,8 @@ use Statamic\Support\Str;
 
 class Structure extends Tags
 {
+    protected $augmentKeys;
+
     public function wildcard($tag)
     {
         $handle = $this->context->value($tag, $tag);
@@ -48,6 +50,11 @@ class Structure extends Tags
             'max_depth' => $this->params->get('max_depth'),
         ]);
 
+        $defaultKeys = ['id', 'permalink', 'title', 'uri', 'url'];
+        $this->augmentKeys = $this->params->get('shallow', false)
+            ? array_merge($defaultKeys, explode('|', $this->params->get('augment_keys', '')))
+            : null;
+
         return $this->toArray($tree);
     }
 
@@ -67,7 +74,7 @@ class Structure extends Tags
     {
         return collect($tree)->map(function ($item, $index) use ($parent, $depth, $tree) {
             $page = $item['page'];
-            $data = $page->toAugmentedArray();
+            $data = $page->toAugmentedArray($this->augmentKeys);
             $children = empty($item['children']) ? [] : $this->toArray($item['children'], $data, $depth + 1);
 
             return array_merge($data, [


### PR DESCRIPTION
Related to statamic/ideas#543
- Added `shallow` option to Structure/Nav tag (`boolean` default: `false`)
  Will reduce outputted variables for entries to default `id`, `permalink`, `title`, `uri`, `url`
- Added `augment_keys` option to Structure/Nav tag (`string` separated by pipe `|`)
  Additional keys added during augmentation