### PR TITLE
Allow configuring of the pool concurrency when warming the static cache

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -71,7 +71,7 @@ class StaticWarm extends Command
         $promise->wait();
     }
 
-    public function concurrency(): int
+    private function concurrency(): int
     {
         $strategy = config('statamic.static_caching.strategy');
 

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -58,6 +58,7 @@ class StaticWarm extends Command
         $this->line('Compiling URLs...');
 
         $pool = new Pool($client, $this->requests(), [
+            'concurrency' => $this->concurrency(),
             'fulfilled' => [$this, 'outputSuccessLine'],
             'rejected' => [$this, 'outputFailureLine'],
         ]);
@@ -68,6 +69,13 @@ class StaticWarm extends Command
         $this->line('Visiting URLs...');
 
         $promise->wait();
+    }
+
+    public function concurrency(): int
+    {
+        $strategy = config('statamic.static_caching.strategy');
+
+        return config("statamic.static_caching.strategies.$strategy.warm_concurrency", 25);
     }
 
     public function outputSuccessLine(Response $response, $index): void


### PR DESCRIPTION
Tiny change, it allows you to configure the amount of concurrent requests when warming the static cache in your strategy. By default the guzzle pool will use `25`, so that's what I've set as the default as well to remain backwards compatible.

i.e.

```php
    'strategies' => [

        'full' => [
            'driver' => 'file',
            'path' => public_path('static'),
            'lock_hold_length' => 0,
            'warm_concurrency' => 10,
        ],

    ],
```

**Edit**: tpyo