### PR TITLE
Add increment:reset tag

### DIFF
--- a/src/Tags/Increment.php
+++ b/src/Tags/Increment.php
@@ -6,6 +6,29 @@ class Increment extends Tags
 {
     protected static $arr = [];
 
+    public function reset()
+    {
+        $counter = $this->params->get('counter', null);
+
+        if ($counter == null) {
+            return '';
+        }
+
+        $toValue = $this->params->get('to', null);
+
+        if ($toValue == null) {
+            unset(self::$arr[$counter]);
+        } else {
+            self::$arr[$counter] = $toValue;
+        }
+
+        if ($this->isPair) {
+            return $this->parse();
+        }
+
+        return '';
+    }
+
     public function wildcard($tag)
     {
         if (! isset(self::$arr[$tag])) {

--- a/tests/Tags/IncrementTest.php
+++ b/tests/Tags/IncrementTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Tags;
+
+use Statamic\Facades\Parse;
+use Tests\TestCase;
+
+class IncrementTest extends TestCase
+{
+    protected $data = [
+        'data' => [
+            [
+                'articles' => [
+                    ['title' => 'One'],
+                    ['title' => 'Two'],
+                ],
+            ],
+            [
+                'articles' => [
+                    ['title' => 'Three'],
+                    ['title' => 'Four'],
+                ],
+            ],
+        ],
+    ];
+
+    private function tag($tag, $context = [])
+    {
+        return (string) Parse::template($tag, $context);
+    }
+
+    /** @test */
+    public function basic_increment_works()
+    {
+        $template = <<<'EOT'
+{{ data }}{{ articles }}{{ increment:test by="10" }}-{{ /articles }}{{ /data }}
+EOT;
+
+        $this->assertSame(
+            '0-10-20-30-',
+            $this->tag($template, $this->data)
+        );
+    }
+
+    /** @test */
+    public function increment_with_starting_value_works()
+    {
+        $template = <<<'EOT'
+{{ data }}{{ articles }}{{ increment:test_two from="30" by="10" }}-{{ /articles }}{{ /data }}
+EOT;
+
+        $this->assertSame(
+            '30-40-50-60-',
+            $this->tag($template, $this->data)
+        );
+    }
+
+    /** @test */
+    public function resetting_an_increment_counter_with_a_value_resets_to_zero()
+    {
+        $template = <<<'EOT'
+{{ data }}{{ increment:reset counter="test_three" }}{{ articles }}{{ title }}-{{ increment:test_three by="10" }}-{{ /articles }}{{ /data }}
+EOT;
+
+        $this->assertSame(
+            'One-0-Two-10-Three-0-Four-10-',
+            $this->tag($template, $this->data)
+        );
+    }
+
+    /** @test */
+    public function resetting_an_increment_counter_with_a_value_uses_the_new_starting_point()
+    {
+        $template = <<<'EOT'
+{{ data }}{{ increment:reset counter="test_four" to="50" }}{{ articles }}{{ title }}-{{ increment:test_four by="10" }}-{{ /articles }}{{ /data }}
+EOT;
+
+        $this->assertSame(
+            'One-0-Two-10-Three-60-Four-70-',
+            $this->tag($template, $this->data)
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a new `increment:reset` tag that enables developers to reset an incrementing value. This is useful when using the `increment` tag within partials, or when iterating any list where the `increment` value is being used to generate CSS class-names (such as z-index).

## Backwards Compatibility

Anyone who is currently using `reset` as an incrementing counter name would need to rename `{{ increment:reset }}` to something else. Due to issues with tag pairing while testing, the decision was made not to use a "reset" parameter.

## Usage

The `increment:reset` tag accepts the following parameters:

* `counter`: The name of the increment variable to reset. Required.
* `to`: A value to reset the counter to. Not required.

```html
{{ data }}
    Reset the counter, so everything starts over at 0 for each iteration of data.
    {{ increment:reset counter="zindex" }}
    {{ data }}

        {{ articles }}
            <span class="z-{{ increment:zindex by="10" }}">Some Text</span>
        {{ /articles }}
    {{ /data }}
{{ /data }}
```