### PR TITLE
Adds a compact modifier to convert a list of variables to an array

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -246,6 +246,23 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Converts a comma-separated list of variable names into an array.
+     *
+     * @param  string  $value
+     * @param $params
+     * @param $context
+     * @return array
+     */
+    public function compact($value, $params, $context)
+    {
+        return collect(explode(',', $value))
+            ->map(function ($variable) use ($context) {
+                return Antlers::parser()
+                    ->getVariable(trim($variable), $context);
+            })->all();
+    }
+
+    /**
      * Debug a value with a call to JavaScript's console.log.
      *
      * @param  $value

--- a/tests/Modifiers/CompactTest.php
+++ b/tests/Modifiers/CompactTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Facades\Parse;
+use Tests\TestCase;
+
+class CompactTest extends TestCase
+{
+    protected $data = [
+        'view' => [
+            'var_one' => 'value one',
+            'var_two' => 'value two',
+        ],
+        'title' => 'Hello, there!',
+        'nested' => [
+            'variable' => [
+                'path' => 'nested-value',
+            ],
+        ],
+    ];
+
+    private function tag($tag, $data = [])
+    {
+        return (string) Parse::template($tag, $data);
+    }
+
+    /** @test */
+    public function compact_coverts_variables_to_array()
+    {
+        $template = <<<'EOT'
+{{ foreach :array="'view:var_one, view:var_two, title, nested:variable:path'|compact" }}{{ value }}-{{ /foreach }}
+EOT;
+
+        $this->assertSame(
+            'value one-value two-Hello, there!-nested-value-',
+            $this->tag($template, $this->data)
+        );
+    }
+}

--- a/tests/Modifiers/CompactTest.php
+++ b/tests/Modifiers/CompactTest.php
@@ -29,11 +29,11 @@ class CompactTest extends TestCase
     public function compact_coverts_variables_to_array()
     {
         $template = <<<'EOT'
-{{ foreach :array="'view:var_one, view:var_two, title, nested:variable:path'|compact" }}{{ value }}-{{ /foreach }}
+{{ foreach :array="'view:var_one, view:var_two, title, nested:variable:path'|compact" }}<{{ value }}>{{ /foreach }}
 EOT;
 
         $this->assertSame(
-            'value one-value two-Hello, there!-nested-value-',
+            '<value one><value two><Hello, there!><nested-value>',
             $this->tag($template, $this->data)
         );
     }


### PR DESCRIPTION
This PR introduces a new `compact` modifier that accepts a list of comma-delimited variable names as input, resolves their values, and then returns a new array containing the requested values.

## Usage

The `compact` modifier would accept a `string` as its input, which should be a comma-delimited list of variable names. The return value of this modifier can be used anywhere arrays are accepted:

```
---
var_one: 'Value One'
var_two: 'Value Two'
var_three: 'Value Three'
---

{{ foreach :array="'view:var_one, view:var_two, view:var_three'|compact" }}
    {{ value }}
{{ /foreach }}
```

would produce the following output:

```
Value One
Value Two
Value Three
```

## Documentation

Attached is an entry that can be used as a starting point for the Docs site

[compact.md](https://github.com/statamic/cms/files/7741353/compact.md)