### PR TITLE
Fix noparse extractions with non-Antlers layouts

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -87,13 +87,11 @@ class View
 
         if ($this->shouldUseLayout()) {
             if (Str::endsWith($this->layoutViewPath(), Engine::EXTENSIONS)) {
-                $renderedContent = $contents->withoutExtractions()->render();
-            } else {
-                $renderedContent = $contents->render();
+                $contents = $contents->withoutExtractions();
             }
 
             $contents = view($this->layoutViewName(), array_merge($cascade, [
-                'template_content' => $renderedContent,
+                'template_content' => $contents->render(),
             ]));
         }
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -85,8 +85,14 @@ class View
         $contents = view($this->templateViewName(), $cascade);
 
         if ($this->shouldUseLayout()) {
+            if (Str::endsWith($this->layoutViewPath(), '.blade.php')) {
+                $renderedContent = $contents->render();
+            } else {
+                $renderedContent = $contents->withoutExtractions()->render();
+            }
+
             $contents = view($this->layoutViewName(), array_merge($cascade, [
-                'template_content' => $contents->withoutExtractions()->render(),
+                'template_content' => $renderedContent,
             ]));
         }
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -6,6 +6,7 @@ use Facades\Statamic\View\Cascade;
 use InvalidArgumentException;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
+use Statamic\View\Antlers\Engine;
 use Statamic\View\Antlers\Engine as AntlersEngine;
 use Statamic\View\Events\ViewRendered;
 
@@ -85,10 +86,10 @@ class View
         $contents = view($this->templateViewName(), $cascade);
 
         if ($this->shouldUseLayout()) {
-            if (Str::endsWith($this->layoutViewPath(), '.blade.php')) {
-                $renderedContent = $contents->render();
-            } else {
+            if (Str::endsWith($this->layoutViewPath(), Engine::EXTENSIONS)) {
                 $renderedContent = $contents->withoutExtractions()->render();
+            } else {
+                $renderedContent = $contents->render();
             }
 
             $contents = view($this->layoutViewName(), array_merge($cascade, [

--- a/tests/View/Antlers/BladeLayoutTest.php
+++ b/tests/View/Antlers/BladeLayoutTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\View\Antlers;
+
+use Statamic\View\View;
+use Tests\TestCase;
+
+class BladeLayoutTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $currentViews = $app['config']->get('view.paths');
+
+        $currentViews[] = __DIR__.'/fixtures/';
+
+        $app['config']->set('view.paths', $currentViews);
+    }
+
+    /** @test */
+    public function no_parse_extractions_are_replaced_when_extending_a_blade_layout()
+    {
+        $view = (new View)
+            ->template('blade_injection')
+            ->layout('blade_layout')
+            ->with(['title' => 'The Title'])->render();
+
+        $this->assertStringNotContainsString('noparse_', $view);
+        $this->assertStringContainsString('The Title', $view);
+        $this->assertStringContainsString('{{ title }}', $view);
+    }
+}

--- a/tests/View/Antlers/fixtures/blade_injection.antlers.html
+++ b/tests/View/Antlers/fixtures/blade_injection.antlers.html
@@ -1,0 +1,5 @@
+{{ title }}
+
+{{ noparse }}
+{{ title }}
+{{ /noparse }}

--- a/tests/View/Antlers/fixtures/blade_layout.blade.php
+++ b/tests/View/Antlers/fixtures/blade_layout.blade.php
@@ -1,0 +1,1 @@
+{!! $template_content !!}


### PR DESCRIPTION
This PR corrects an issue where `{{ noparse }}` extractions were not being replaced in the rendered output when extending a Blade layout.

**Setup**

Data:
```yaml
title: 'The Title'
```

`layout.blade.php`
```blade
{!! $template_content !!}
```

Any Antlers template that extends `layout.blade.php`:
```
{{ title }}

{{ noparse }}
{{ title }}
{{ /noparse }}
```

Before, an Antlers template that included `{{ noparse }}` tags would produce output similar to this when extending a Blade layout:

```
The Title

noparse_167a28b913b93a01d90aa945a4cd7770
```

With this PR, the output would now be:

```
The Title

{{ title }}
```