### PR TITLE
Add ends_with validation rule

### DIFF
--- a/resources/js/components/field-validation/Rules.js
+++ b/resources/js/components/field-validation/Rules.js
@@ -109,6 +109,12 @@ export default [
         label: 'E-Mail',
         value: 'email'
     },
+    {
+        label: 'Ends With',
+        value: 'ends_with:',
+        example: 'ends_with:foo,bar,...',
+        minVersion: '5.8.17'
+    },
     // {
     //     label: 'Exists (Database)',
     //     value: 'exists:',


### PR DESCRIPTION
This PR adds an `ends_with` validation rule, that is an accompanying rule for already existing `starts_with`. `ends_with` was introduced in Laravel v5.8.17 (https://github.com/laravel/framework/releases/tag/v5.8.17).