### PR TITLE
Fix pasting into Bard image alt field

### DIFF
--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -7,7 +7,7 @@
                 <img :src="src" class="block mx-auto" data-drag-handle />
             </div>
 
-            <div class="flex items-center p-1 pt-0 rounded-b">
+            <div class="flex items-center p-1 pt-0 rounded-b" @paste.stop>
                 <text-input name="alt" v-model="alt" prepend="Alt Text" class="mr-1" />
                 <button class="btn-flat mr-1" @click="openSelector">
                     {{ __('Replace') }}


### PR DESCRIPTION
Due to the way event propagation for child node inputs is handled in TipTap v1, pasting into Image alt field in Bard is broken (results in text pasted in main content flow). This has beed [changed in TipTap v2](https://github.com/ueberdosis/tiptap-next/commit/1a74bbb0fbb8949a3aa26b9ccebe4bd3808666af). This PR stops event propagation for Alt field, as [recommended](https://github.com/ueberdosis/tiptap/issues/1100#issuecomment-800432299) by TipTap author.

Fixes #4768.