### PR TITLE
Don't show asset container handle when editing

### DIFF
--- a/src/Http/Controllers/CP/Assets/AssetContainersController.php
+++ b/src/Http/Controllers/CP/Assets/AssetContainersController.php
@@ -71,7 +71,7 @@ class AssetContainersController extends CpController
     {
         $this->authorize('update', $container, 'You are not authorized to edit asset containers.');
 
-        $fields = $this->formBlueprint()->fields()->addValues($request->all());
+        $fields = $this->formBlueprint($container)->fields()->addValues($request->all());
 
         $fields->validate();
 
@@ -170,15 +170,21 @@ class AssetContainersController extends CpController
                         'instructions' => __('statamic::messages.asset_container_title_instructions'),
                         'validate' => 'required',
                     ],
-                    'handle' => [
-                        'type' => 'slug',
-                        'display' => __('Handle'),
-                        'validate' => 'required|alpha_dash',
-                        'separator' => '_',
-                        'instructions' => __('statamic::messages.asset_container_handle_instructions'),
-                    ],
                 ],
             ],
+        ];
+
+        if (! $container) {
+            $fields['name']['fields']['handle'] = [
+                'type' => 'slug',
+                'display' => __('Handle'),
+                'validate' => 'required|alpha_dash',
+                'separator' => '_',
+                'instructions' => __('statamic::messages.asset_container_handle_instructions'),
+            ];
+        }
+
+        $fields = array_merge($fields, [
             'filesystem' => [
                 'display' => __('File Driver'),
                 'fields' => [
@@ -191,7 +197,7 @@ class AssetContainersController extends CpController
                     ],
                 ],
             ],
-        ];
+        ]);
 
         if ($container) {
             $fields['fields'] = [

--- a/tests/Feature/AssetContainers/UpdateAssetContainerTest.php
+++ b/tests/Feature/AssetContainers/UpdateAssetContainerTest.php
@@ -52,10 +52,9 @@ class UpdateAssetContainerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->update($container, ['title' => '', 'handle' => '', 'disk' => ''])
+            ->update($container, ['title' => '', 'disk' => ''])
             ->assertJsonValidationErrors([
                 'title' => trans('statamic::validation.required'),
-                'handle' => trans('statamic::validation.required'),
                 'disk' => trans('statamic::validation.required'),
             ]);
 
@@ -69,7 +68,6 @@ class UpdateAssetContainerTest extends TestCase
             cp_route('asset-containers.update', $container->handle()),
             array_merge([
                 'title' => 'Title',
-                'handle' => 'test',
                 'disk' => 'local',
             ], $payload)
         );


### PR DESCRIPTION
Closes #4952

The field was there, but even if you edit it, it didn't update.
We don't really want you to change it, so to be consistent with editing a collection, I've just removed the field.

It's there when you're creating the container, though.