### PR TITLE
Allow `group_by` modifier to support stringable objects

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -761,7 +761,7 @@ class CoreModifiers extends Modifier
         $grouped = collect($value)->groupBy(function ($item) use ($groupBy, $params, &$groupLabels) {
             $value = $this->getGroupByValue($item, $groupBy);
 
-            return $this->handleGroupByDateValue($value, $params, $groupLabels);
+            return (string) $this->handleGroupByDateValue($value, $params, $groupLabels);
         });
 
         $iterable = $grouped->map(function ($items, $key) use ($groupLabels) {

--- a/tests/Modifiers/GroupByTest.php
+++ b/tests/Modifiers/GroupByTest.php
@@ -140,6 +140,27 @@ class GroupByTest extends TestCase
     }
 
     /** @test */
+    public function if_the_grouped_keys_are_objects_itll_convert_them_to_strings()
+    {
+        $items = collect([
+            $jazz = EntryFactory::collection('sports')->data(['sport' => new TestGroupByClass('basketball'), 'team' => 'jazz'])->create(),
+            $yankees = EntryFactory::collection('sports')->data(['sport' => new TestGroupByClass('baseball'), 'team' => 'yankees'])->create(),
+            $bulls = EntryFactory::collection('sports')->data(['sport' => new TestGroupByClass('basketball'), 'team' => 'bulls'])->create(),
+        ]);
+
+        $expected = collect([
+            'basketball' => collect([$jazz, $bulls]),
+            'baseball' => collect([$yankees]),
+            'groups' => collect([
+                ['key' => 'basketball', 'group' => 'basketball', 'items' => collect([$jazz, $bulls])],
+                ['key' => 'baseball', 'group' => 'baseball', 'items' => collect([$yankees])],
+            ]),
+        ]);
+
+        $this->assertEquals($expected, $this->modify($items, 'sport'));
+    }
+
+    /** @test */
     public function it_groups_by_date()
     {
         Carbon::setTestNow(now()->startOfDay());
@@ -230,5 +251,20 @@ class GroupByTest extends TestCase
     public function modify($items, $value)
     {
         return Modify::value($items)->groupBy($value)->fetch();
+    }
+}
+
+class TestGroupByClass
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->value;
     }
 }


### PR DESCRIPTION
Fixes #4898

If you target an object in the `group_by` modifier, it didn't know how to handle it.

Now if it enounters an object, it'll convert it to a string. (i.e. in the case of a `Blueprint`, it'll convert it to its handle.)
