### PR TITLE
Fix checkbox position

### DIFF
--- a/resources/sass/elements/forms.scss
+++ b/resources/sass/elements/forms.scss
@@ -17,7 +17,7 @@ label {
 input[type="checkbox"] {
     font-size: 18px;
     position: relative;
-    top: -1px;
+    top: 1px;
 }
 
 input[type="radio"] {


### PR DESCRIPTION
Browsers keep changing how they render checkboxes vertical position. This fixes em again.