### PR TITLE
Fix readonly fields in localizable grids

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -147,6 +147,7 @@ export default {
     provide() {
         return {
             setConfigs: this.config.sets,
+            isReadOnly: this.readOnly,
         }
     },
 

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -44,6 +44,7 @@
                 :parent-name="parentName"
                 :set-index="index"
                 :error-key="errorKey(field)"
+                :read-only="isReadOnly"
                 @updated="updated(field.handle, $event)"
                 @meta-updated="metaUpdated(field.handle, $event)"
                 @focus="focused"
@@ -76,7 +77,7 @@ export default {
 
     mixins: [ValidatesFieldConditions, ManagesPreviewText],
 
-    inject: ['setConfigs'],
+    inject: ['setConfigs', 'isReadOnly'],
 
     computed: {
 

--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -12,19 +12,20 @@
             <button v-if="canDelete" class="icon icon-cross cursor-pointer" @click="$emit('removed', index)" :aria-label="__('Delete Row')" />
         </div>
         <publish-fields-container>
-            <publish-field
+            <set-field
                 v-for="field in fields"
                 v-show="showField(field)"
                 :key="field.handle"
-                :config="{...field, localizable: grid.config.localizable}"
-                :value="values[field.handle]"
+                :field="field"
                 :meta="meta[field.handle]"
-                :read-only="grid.isReadOnly"
-                :name-prefix="namePrefix"
+                :value="values[field.handle]"
+                :parent-name="name"
+                :set-index="index"
                 :errors="errors(field.handle)"
                 :error-key-prefix="errorKey(field.handle)"
                 class="p-2"
-                @input="updated(field.handle, $event)"
+                :read-only="grid.isReadOnly"
+                @updated="updated(field.handle, $event)"
                 @meta-updated="metaUpdated(field.handle, $event)"
                 @focus="$emit('focus')"
                 @blur="$emit('blur')"
@@ -46,7 +47,7 @@
 
 <script>
 import Row from './Row.vue';
-import PublishField from '../../publish/Field.vue';
+import SetField from '../replicator/Field.vue';
 import { ValidatesFieldConditions } from '../../field-conditions/FieldConditions.js';
 
 export default {
@@ -56,13 +57,7 @@ export default {
         ValidatesFieldConditions,
     ],
 
-    components: { PublishField },
-
-    computed: {
-        namePrefix() {
-            return `${this.name}[${this.index}]`;
-        }
-    }
+    components: { SetField },
 
 }
 </script>


### PR DESCRIPTION
This fixes #3498 fully. It replaces the quick fix in #3518 with a proper fix. Grid uses the same Field component now as Replicator and Bard do.

Working on this I saw that when a Bard field is readonly, its sets were still editable. This PR fixes that too (separate commit).