### PR TITLE
If you only have one asset container, use that as a default in form submissions

### DIFF
--- a/src/Forms/Uploaders/AssetsUploader.php
+++ b/src/Forms/Uploaders/AssetsUploader.php
@@ -2,8 +2,11 @@
 
 namespace Statamic\Forms\Uploaders;
 
+use Statamic\Exceptions\AssetContainerNotFoundException;
 use Statamic\Facades\Asset;
+use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Path;
+use Statamic\Fieldtypes\Assets\UndefinedContainerException;
 use Statamic\Support\Arr;
 
 class AssetsUploader
@@ -76,12 +79,34 @@ class AssetsUploader
         $path = Path::assemble($this->config->get('folder'), $file->getClientOriginalName());
 
         $asset = Asset::make()
-            ->container($this->config->get('container'))
+            ->container($this->assetContainer())
             ->path(ltrim($path, '/'));
 
         $asset->upload($file)->save();
 
         return $asset;
+    }
+
+    /**
+     * Find the asset container.
+     *
+     * @return null|\Statamic\Contracts\Assets\AssetContainer
+     */
+    protected function assetContainer()
+    {
+        if ($configured = $this->config->get('container')) {
+            if ($container = AssetContainer::find($configured)) {
+                return $container;
+            }
+
+            throw new AssetContainerNotFoundException($configured);
+        }
+
+        if (($containers = AssetContainer::all())->count() === 1) {
+            return $containers->first();
+        }
+
+        throw new UndefinedContainerException;
     }
 
     /**

--- a/src/Forms/Uploaders/AssetsUploader.php
+++ b/src/Forms/Uploaders/AssetsUploader.php
@@ -90,7 +90,7 @@ class AssetsUploader
     /**
      * Find the asset container.
      *
-     * @return null|\Statamic\Contracts\Assets\AssetContainer
+     * @return \Statamic\Contracts\Assets\AssetContainer
      */
     protected function assetContainer()
     {


### PR DESCRIPTION
Fixes #4777. Uses the same logic now as the Assets fieldtype.