### PR TITLE
Add min and max file size validation rules for assets

### DIFF
--- a/resources/js/components/field-validation/Rules.js
+++ b/resources/js/components/field-validation/Rules.js
@@ -188,6 +188,11 @@ export default [
         example: 'max:value',
     },
     {
+        label: 'Max Filesize (KB)',
+        value: 'max_filesize:',
+        example: 'max_filesize:value',
+    },
+    {
         label: 'MIME Types',
         value: 'mimetypes:',
         example: 'mimetypes:text/plain,...'
@@ -201,6 +206,11 @@ export default [
         label: 'Min',
         value: 'min:',
         example: 'min:value'
+    },
+    {
+        label: 'Min Filesize (KB)',
+        value: 'min_filesize:',
+        example: 'min_filesize:value',
     },
     {
         label: 'Not In',

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -183,10 +183,10 @@ class Assets extends Fieldtype
         $classes = [
             'dimensions' => DimensionsRule::class,
             'image' => ImageRule::class,
-            'max' => MaxRule::class,
+            'max_filesize' => MaxRule::class,
             'mimes' => MimesRule::class,
             'mimetypes' => MimetypesRule::class,
-            'min' => MinRule::class,
+            'min_filesize' => MinRule::class,
         ];
 
         return collect(parent::fieldRules())->map(function ($rule) use ($classes) {

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -9,6 +9,7 @@ use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 use Statamic\GraphQL\Types\AssetInterface;
 use Statamic\Http\Resources\CP\Assets\Asset as AssetResource;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
 class Assets extends Fieldtype
@@ -179,24 +180,22 @@ class Assets extends Fieldtype
 
     public function fieldRules()
     {
-        return collect(parent::fieldRules())->map(function ($rule) {
+        $classes = [
+            'dimensions' => DimensionsRule::class,
+            'image' => ImageRule::class,
+            'max' => MaxRule::class,
+            'mimes' => MimesRule::class,
+            'mimetypes' => MimetypesRule::class,
+            'min' => MinRule::class,
+        ];
+
+        return collect(parent::fieldRules())->map(function ($rule) use ($classes) {
             $name = Str::before($rule, ':');
-            $parameters = explode(',', Str::after($rule, ':'));
 
-            if ($name === 'dimensions') {
-                return new DimensionsRule($parameters);
-            }
+            if ($class = Arr::get($classes, $name)) {
+                $parameters = explode(',', Str::after($rule, ':'));
 
-            if ($name === 'image') {
-                return new ImageRule();
-            }
-
-            if ($name === 'mimes') {
-                return new MimesRule($parameters);
-            }
-
-            if ($name === 'mimetypes') {
-                return new MimetypesRule($parameters);
+                return new $class($parameters);
             }
 
             return $rule;

--- a/src/Fieldtypes/Assets/MaxRule.php
+++ b/src/Fieldtypes/Assets/MaxRule.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Statamic\Fieldtypes\Assets;
+
+class MaxRule extends SizeBasedRule
+{
+    /**
+     * Determine if the the rule passes for the given size.
+     *
+     * @param  int  $size
+     * @return bool
+     */
+    public function sizePasses($size)
+    {
+        return $size <= $this->parameters[0];
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return str_replace(':max', $this->parameters[0], __('statamic::validation.max.file'));
+    }
+}

--- a/src/Fieldtypes/Assets/MaxRule.php
+++ b/src/Fieldtypes/Assets/MaxRule.php
@@ -24,5 +24,4 @@ class MaxRule extends SizeBasedRule
     {
         return str_replace(':max', $this->parameters[0], __('statamic::validation.max.file'));
     }
-
 }

--- a/src/Fieldtypes/Assets/MaxRule.php
+++ b/src/Fieldtypes/Assets/MaxRule.php
@@ -24,4 +24,5 @@ class MaxRule extends SizeBasedRule
     {
         return str_replace(':max', $this->parameters[0], __('statamic::validation.max.file'));
     }
+
 }

--- a/src/Fieldtypes/Assets/MinRule.php
+++ b/src/Fieldtypes/Assets/MinRule.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Statamic\Fieldtypes\Assets;
+
+class MinRule extends SizeBasedRule
+{
+    /**
+     * Determine if the the rule passes for the given size.
+     *
+     * @param  int  $size
+     * @return bool
+     */
+    public function sizePasses($size)
+    {
+        return $size >= $this->parameters[0];
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return str_replace(':min', $this->parameters[0], __('statamic::validation.min.file'));
+    }
+}

--- a/src/Fieldtypes/Assets/SizeBasedRule.php
+++ b/src/Fieldtypes/Assets/SizeBasedRule.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Statamic\Fieldtypes\Assets;
+
+use Illuminate\Contracts\Validation\Rule;
+use Statamic\Facades\Asset;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+abstract class SizeBasedRule implements Rule
+{
+    protected $parameters;
+
+    public function __construct($parameters = null)
+    {
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return collect($value)->every(function ($id) {
+            if (($size = $this->getFileSize($id)) === false) {
+                return false;
+            }
+
+            return $this->sizePasses($size);
+        });
+    }
+
+    /**
+     * Determine if the the rule passes for the given size.
+     *
+     * @param  int  $size
+     * @return bool
+     */
+    abstract public function sizePasses($size);
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    abstract public function message();
+
+    /**
+     * Get the file size.
+     *
+     * @param  string|UploadedFile  $id
+     * 
+     * @return int|false
+     */
+    protected function getFileSize($id)
+    {
+        if ($id instanceof UploadedFile) {
+            return $id->getSize() / 1024;
+        }
+
+        if ($asset = Asset::find($id)) {
+            return $asset->size() / 1024;
+        }
+
+        return false;
+    }
+}

--- a/src/Fieldtypes/Assets/SizeBasedRule.php
+++ b/src/Fieldtypes/Assets/SizeBasedRule.php
@@ -52,7 +52,6 @@ abstract class SizeBasedRule implements Rule
      * Get the file size.
      *
      * @param  string|UploadedFile  $id
-     * 
      * @return int|false
      */
     protected function getFileSize($id)

--- a/tests/Fieldtypes/AssetsTest.php
+++ b/tests/Fieldtypes/AssetsTest.php
@@ -11,8 +11,10 @@ use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Assets\Assets;
 use Statamic\Fieldtypes\Assets\DimensionsRule;
 use Statamic\Fieldtypes\Assets\ImageRule;
+use Statamic\Fieldtypes\Assets\MaxRule;
 use Statamic\Fieldtypes\Assets\MimesRule;
 use Statamic\Fieldtypes\Assets\MimetypesRule;
+use Statamic\Fieldtypes\Assets\MinRule;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -134,13 +136,35 @@ class AssetsTest extends TestCase
     }
 
     /** @test */
-    public function it_doesnt_replace_non_image_related_rule()
+    public function it_replaces_min_rule()
     {
-        $replaced = $this->fieldtype(['validate' => ['min:3']])->fieldRules();
+        $replaced = $this->fieldtype(['validate' => ['min:100']])->fieldRules();
 
         $this->assertIsArray($replaced);
         $this->assertCount(1, $replaced);
-        $this->assertEquals('min:3', $replaced[0]);
+        $this->assertInstanceOf(MinRule::class, $replaced[0]);
+        $this->assertEquals(__('statamic::validation.min.file', ['min' => '100']), $replaced[0]->message());
+    }
+
+    /** @test */
+    public function it_replaces_max_rule()
+    {
+        $replaced = $this->fieldtype(['validate' => ['max:100']])->fieldRules();
+
+        $this->assertIsArray($replaced);
+        $this->assertCount(1, $replaced);
+        $this->assertInstanceOf(MaxRule::class, $replaced[0]);
+        $this->assertEquals(__('statamic::validation.max.file', ['max' => '100']), $replaced[0]->message());
+    }
+
+    /** @test */
+    public function it_doesnt_replace_non_image_related_rule()
+    {
+        $replaced = $this->fieldtype(['validate' => ['file']])->fieldRules();
+
+        $this->assertIsArray($replaced);
+        $this->assertCount(1, $replaced);
+        $this->assertEquals('file', $replaced[0]);
     }
 
     public function fieldtype($config = [])

--- a/tests/Fieldtypes/AssetsTest.php
+++ b/tests/Fieldtypes/AssetsTest.php
@@ -136,9 +136,9 @@ class AssetsTest extends TestCase
     }
 
     /** @test */
-    public function it_replaces_min_rule()
+    public function it_replaces_min_filesize_rule()
     {
-        $replaced = $this->fieldtype(['validate' => ['min:100']])->fieldRules();
+        $replaced = $this->fieldtype(['validate' => ['min_filesize:100']])->fieldRules();
 
         $this->assertIsArray($replaced);
         $this->assertCount(1, $replaced);
@@ -147,9 +147,9 @@ class AssetsTest extends TestCase
     }
 
     /** @test */
-    public function it_replaces_max_rule()
+    public function it_replaces_max_filesize_rule()
     {
-        $replaced = $this->fieldtype(['validate' => ['max:100']])->fieldRules();
+        $replaced = $this->fieldtype(['validate' => ['max_filesize:100']])->fieldRules();
 
         $this->assertIsArray($replaced);
         $this->assertCount(1, $replaced);


### PR DESCRIPTION
This fixes #4217 as requested. 

Careful though, this is a breaking change: before the `min` and `max` rules would validate the _number of assets_ and now they check the file size.

I'm thinking should we use custom names for these rules to differentiate between the two?