### PR TITLE
Allow pagination slider window to be adjusted

### DIFF
--- a/src/Tags/Concerns/OutputsItems.php
+++ b/src/Tags/Concerns/OutputsItems.php
@@ -36,7 +36,7 @@ trait OutputsItems
     {
         $paginator->withQueryString();
 
-        if ($window = $this->params->int('pagination_each_side')) {
+        if ($window = $this->params->int('paginate_each_side')) {
             $paginator->onEachSide($window);
         }
 

--- a/src/Tags/Concerns/OutputsItems.php
+++ b/src/Tags/Concerns/OutputsItems.php
@@ -35,6 +35,11 @@ trait OutputsItems
     protected function paginatedOutput($paginator)
     {
         $paginator->withQueryString();
+
+        if ($window = $this->params->get('pagination_window')) {
+            $paginator->onEachSide($window);
+        }
+
         $as = $this->getPaginationResultsKey();
         $items = $paginator->getCollection()->supplement('total_results', $paginator->total());
 

--- a/src/Tags/Concerns/OutputsItems.php
+++ b/src/Tags/Concerns/OutputsItems.php
@@ -36,8 +36,8 @@ trait OutputsItems
     {
         $paginator->withQueryString();
 
-        if ($window = $this->params->get('pagination_each_side')) {
-            $paginator->onEachSide((int) $window);
+        if ($window = $this->params->int('pagination_each_side')) {
+            $paginator->onEachSide($window);
         }
 
         $as = $this->getPaginationResultsKey();

--- a/src/Tags/Concerns/OutputsItems.php
+++ b/src/Tags/Concerns/OutputsItems.php
@@ -36,7 +36,7 @@ trait OutputsItems
     {
         $paginator->withQueryString();
 
-        if ($window = $this->params->int('paginate_each_side')) {
+        if ($window = $this->params->int('on_each_side')) {
             $paginator->onEachSide($window);
         }
 

--- a/src/Tags/Concerns/OutputsItems.php
+++ b/src/Tags/Concerns/OutputsItems.php
@@ -36,8 +36,8 @@ trait OutputsItems
     {
         $paginator->withQueryString();
 
-        if ($window = $this->params->get('pagination_window')) {
-            $paginator->onEachSide($window);
+        if ($window = $this->params->get('pagination_each_side')) {
+            $paginator->onEachSide((int) $window);
         }
 
         $as = $this->getPaginationResultsKey();


### PR DESCRIPTION
Allow a new optional param `on_each_side` which modifies the amount of links on each side of the slider when using `paginate="true"` and `limit="x"`

For reference, here is the link to the Laravel docs:
https://laravel.com/docs/8.x/pagination#adjusting-the-pagination-link-window

Closes statamic/ideas#710