### PR TITLE
Fix intersection on iterator query builder

### DIFF
--- a/src/Query/IteratorBuilder.php
+++ b/src/Query/IteratorBuilder.php
@@ -85,7 +85,14 @@ abstract class IteratorBuilder extends Builder
         // Otherwise, intersect to ensure each where is respected.
         return $where['boolean'] === 'or' && $where['type'] !== 'NotIn'
             ? $entries->concat($filteredEntries)->unique()->values()
-            : $entries->intersect($filteredEntries)->values();
+            : $this->intersectItems($entries, $filteredEntries)->values();
+    }
+
+    private function intersectItems($entries, $filteredEntries)
+    {
+        return $entries->filter(function ($entry) use ($filteredEntries) {
+            return $filteredEntries->contains($entry);
+        });
     }
 
     protected function filterWhereIn($entries, $where)

--- a/tests/Search/QueryBuilderTest.php
+++ b/tests/Search/QueryBuilderTest.php
@@ -149,6 +149,21 @@ class QueryBuilderTest extends TestCase
         $this->assertCount(4, $results);
         $this->assertEquals(['a', 'd', 'c', 'e'], $results->map->reference->all());
     }
+    /** @test **/
+    public function results_are_found_using_multiple_wheres()
+    {
+        $items = collect([
+            ['reference' => 'a', 'title' => 'Frodo'],
+            ['reference' => 'b', 'title' => 'Gandalf'],
+            ['reference' => 'c', 'title' => 'Frodo\'s Precious'],
+            ['reference' => 'd', 'title' => 'Smeagol\'s Precious'],
+        ]);
+
+        $results = (new FakeQueryBuilder($items))->withoutData()->where('title', 'like', '%Frodo%')->where('reference', 'a')->get();
+
+        $this->assertCount(1, $results);
+        $this->assertEquals(['a'], $results->map->reference->all());
+    }
 }
 
 class FakeQueryBuilder extends QueryBuilder


### PR DESCRIPTION
This is just the specific bug mentioned in #4899 split into its own PR.
I called the method "items" to be more generic instead of "entries" which I assume is just a copy/paste from the entry query builder.
This query builder does not necessarily deal with entries.
Also, made the method private since it's only called internally, at least for now.
