### PR TITLE
Fix View methods

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -70,7 +70,7 @@ class View
 
     public function template($template = null)
     {
-        if (! $template) {
+        if (func_num_args() === 0) {
             return $this->template;
         }
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -59,7 +59,7 @@ class View
 
     public function layout($layout = null)
     {
-        if (count(func_get_args()) === 0) {
+        if (func_num_args() === 0) {
             return $this->layout;
         }
 


### PR DESCRIPTION
The `template` method was treating a `null` argument as getter so you couldn't do `View::make()` without an argument.

Normally you'd do `View::make('foo')` but if you wanted to specify the template fluently (maybe because it's a long name and looked tidier) you couldn't. Now you can.

```php
View::make()
  ->template('foo/bar/baz/qux')
  ->with(['foo' => 'bar']);
```
