### PR TITLE
OrderBy class can support subfields

### DIFF
--- a/src/Query/OrderBy.php
+++ b/src/Query/OrderBy.php
@@ -27,8 +27,16 @@ class OrderBy
      */
     public static function parse(string $orderBy)
     {
-        $sort = explode(':', $orderBy)[0];
-        $direction = explode(':', $orderBy)[1] ?? 'asc';
+        $parts = explode(':', $orderBy);
+        $lastPart = last($parts);
+
+        if (in_array($lastPart, ['asc', 'desc'])) {
+            $direction = $lastPart;
+            $sort = implode(':', array_slice($parts, 0, -1));
+        } else {
+            $direction = 'asc';
+            $sort = $orderBy;
+        }
 
         return new static($sort, $direction);
     }

--- a/src/Query/OrderBy.php
+++ b/src/Query/OrderBy.php
@@ -32,10 +32,10 @@ class OrderBy
 
         if (in_array($lastPart, ['asc', 'desc'])) {
             $direction = $lastPart;
-            $sort = implode(':', array_slice($parts, 0, -1));
+            $sort = implode('->', array_slice($parts, 0, -1));
         } else {
             $direction = 'asc';
-            $sort = $orderBy;
+            $sort = str_replace(':', '->', $orderBy);
         }
 
         return new static($sort, $direction);

--- a/tests/Query/OrderByTest.php
+++ b/tests/Query/OrderByTest.php
@@ -26,13 +26,13 @@ class OrderByTest extends TestCase
             ['foo:asc', 'foo', 'asc'],
             ['foo:desc', 'foo', 'desc'],
 
-            ['foo:bar', 'foo:bar', 'asc'],
-            ['foo:bar:asc', 'foo:bar', 'asc'],
-            ['foo:bar:desc', 'foo:bar', 'desc'],
+            ['foo:bar', 'foo->bar', 'asc'],
+            ['foo:bar:asc', 'foo->bar', 'asc'],
+            ['foo:bar:desc', 'foo->bar', 'desc'],
 
-            ['foo:bar:baz', 'foo:bar:baz', 'asc'],
-            ['foo:bar:baz:asc', 'foo:bar:baz', 'asc'],
-            ['foo:bar:baz:desc', 'foo:bar:baz', 'desc'],
+            ['foo:bar:baz', 'foo->bar->baz', 'asc'],
+            ['foo:bar:baz:asc', 'foo->bar->baz', 'asc'],
+            ['foo:bar:baz:desc', 'foo->bar->baz', 'desc'],
         ];
     }
 }

--- a/tests/Query/OrderByTest.php
+++ b/tests/Query/OrderByTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Query;
+
+use Statamic\Query\OrderBy;
+use Tests\TestCase;
+
+class OrderByTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider parseProvider
+     **/
+    public function it_parses_string($string, $sort, $dir)
+    {
+        $orderby = OrderBy::parse($string);
+
+        $this->assertEquals($sort, $orderby->sort);
+        $this->assertEquals($dir, $orderby->direction);
+    }
+
+    public function parseProvider()
+    {
+        return [
+            ['foo', 'foo', 'asc'],
+            ['foo:asc', 'foo', 'asc'],
+            ['foo:desc', 'foo', 'desc'],
+
+            ['foo:bar', 'foo:bar', 'asc'],
+            ['foo:bar:asc', 'foo:bar', 'asc'],
+            ['foo:bar:desc', 'foo:bar', 'desc'],
+
+            ['foo:bar:baz', 'foo:bar:baz', 'asc'],
+            ['foo:bar:baz:asc', 'foo:bar:baz', 'asc'],
+            ['foo:bar:baz:desc', 'foo:bar:baz', 'desc'],
+        ];
+    }
+}


### PR DESCRIPTION
This is to complement #4758.
Closes statamic/ideas#428

It will allow you to sort collection tags using a colon syntax.

```
{{ collection:blog sort="foo:bar:baz:desc" }}
```

This will sort by `foo->bar->baz` in descending order.

If the last segment is `asc` or `desc`, it'll assume that's the direction.
For anything else, it'll just assume it's part of the subfield path, and use `asc` for the direction.

As per #4758, you could continue to use the JSON arrows if you wanted.

```
sort="foo->bar->baz:desc"
```
