### PR TITLE
Replace {this} in field validation rules

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -5,8 +5,10 @@ namespace Statamic\Fields;
 use Facades\Statamic\Fields\FieldtypeRepository;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Facades\Lang;
 use Rebing\GraphQL\Support\Field as GqlField;
 use Statamic\Facades\GraphQL;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
 class Field implements Arrayable
@@ -17,6 +19,7 @@ class Field implements Arrayable
     protected $value;
     protected $parent;
     protected $parentField;
+    protected $validationContext;
 
     public function __construct($handle, array $config)
     {
@@ -102,6 +105,10 @@ class Field implements Arrayable
 
     protected function addNullableRule($rules)
     {
+        if (in_array('nullable', $rules)) {
+            return $rules;
+        }
+
         $nullable = true;
 
         foreach ($rules as $rule) {
@@ -121,6 +128,30 @@ class Field implements Arrayable
     public function isRequired()
     {
         return collect($this->rules()[$this->handle])->contains('required');
+    }
+
+    public function setValidationContext($context)
+    {
+        $this->validationContext = $context;
+
+        return $this;
+    }
+
+    public function validationContext($key = null)
+    {
+        return func_num_args() === 0 ? $this->validationContext : Arr::get($this->validationContext, $key);
+    }
+
+    public function validationAttributes()
+    {
+        $display = Lang::has($key = 'validation.attributes.'.$this->handle())
+            ? Lang::get($key)
+            : $this->display();
+
+        return array_merge(
+            [$this->handle() => $display],
+            $this->fieldtype()->extraValidationAttributes()
+        );
     }
 
     public function isLocalizable()

--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -130,6 +130,11 @@ abstract class Fieldtype implements Arrayable
         return array_map([Validator::class, 'explodeRules'], $this->extraRules);
     }
 
+    public function extraValidationAttributes(): array
+    {
+        return [];
+    }
+
     public function preProcessValidatable($value)
     {
         return $value;

--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -95,7 +95,6 @@ class Validator
 
     public function validate()
     {
-        print_r($this->rules());
         return LaravelValidator::validate(
             $this->fields->preProcessValidatables()->values()->all(),
             $this->rules(),

--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Fields;
 
-use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Validator as LaravelValidator;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
@@ -13,6 +12,7 @@ class Validator
     protected $replacements = [];
     protected $extraRules = [];
     protected $customMessages = [];
+    protected $context = [];
 
     public function make()
     {
@@ -40,6 +40,13 @@ class Validator
         return $this;
     }
 
+    public function withContext($context)
+    {
+        $this->context = $context;
+
+        return $this;
+    }
+
     public function rules()
     {
         return $this
@@ -58,7 +65,7 @@ class Validator
         }
 
         return $this->fields->preProcessValidatables()->all()->reduce(function ($carry, $field) {
-            return $carry->merge($field->rules());
+            return $carry->merge($field->setValidationContext($this->context)->rules());
         }, collect());
     }
 
@@ -88,21 +95,20 @@ class Validator
 
     public function validate()
     {
+        print_r($this->rules());
         return LaravelValidator::validate(
             $this->fields->preProcessValidatables()->values()->all(),
             $this->rules(),
             $this->customMessages,
-            $this->fieldAttributes()
+            $this->attributes()
         );
     }
 
-    private function fieldAttributes()
+    public function attributes()
     {
-        return $this->fields->all()->map(function ($field) {
-            $handle = 'validation.attributes.'.$field->handle();
-
-            return Lang::has($handle) ? Lang::get($handle) : $field->display();
-        })->all();
+        return $this->fields->preProcessValidatables()->all()->reduce(function ($carry, $field) {
+            return $carry->merge($field->validationAttributes());
+        }, collect())->all();
     }
 
     private function parse($rule)

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -304,9 +304,26 @@ class Bard extends Replicator
         }, collect())->all();
     }
 
-    protected function setRuleFieldKey($handle, $index)
+    protected function setRuleFieldPrefix($index)
     {
-        return "{$this->field->handle()}.{$index}.attrs.values.{$handle}";
+        return "{$this->field->handle()}.{$index}.attrs.values";
+    }
+
+    public function extraValidationAttributes(): array
+    {
+        if (! $this->config('sets')) {
+            return [];
+        }
+
+        return collect($this->field->value())->filter(function ($set) {
+            return $set['type'] === 'set';
+        })->map(function ($set, $index) {
+            $set = $set['attrs']['values'];
+
+            return $this->setValidationAttributes($set['type'], $set, $index);
+        })->reduce(function ($carry, $rules) {
+            return $carry->merge($rules);
+        }, collect())->all();
     }
 
     public function isLegacyData($value)

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -135,7 +135,9 @@ class Grid extends Fieldtype
 
     protected function rowRules($data, $index)
     {
-        $rules = $this->fields()->addValues($data)->validator()->rules();
+        $rules = $this->fields()->addValues($data)->validator()->withReplacements([
+            'this' => $this->setRuleKey($index),
+        ])->rules();
 
         return collect($rules)->mapWithKeys(function ($rules, $handle) use ($index) {
             return [$this->setRuleFieldKey($handle, $index) => $rules];
@@ -144,7 +146,12 @@ class Grid extends Fieldtype
 
     protected function setRuleFieldKey($handle, $index)
     {
-        return "{$this->field->handle()}.{$index}.{$handle}";
+        return "{$this->setRuleKey($index)}.{$handle}";
+    }
+
+    protected function setRuleKey($index)
+    {
+        return "{$this->field->handle()}.{$index}";
     }
 
     public function preload()

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -105,7 +105,9 @@ class Replicator extends Fieldtype
 
     protected function setRules($handle, $data, $index)
     {
-        $rules = $this->fields($handle)->addValues($data)->validator()->rules();
+        $rules = $this->fields($handle)->addValues($data)->validator()->withReplacements([
+            'this' => $this->setRuleKey($index),
+        ])->rules();
 
         return collect($rules)->mapWithKeys(function ($rules, $handle) use ($index) {
             return [$this->setRuleFieldKey($handle, $index) => $rules];
@@ -114,7 +116,12 @@ class Replicator extends Fieldtype
 
     protected function setRuleFieldKey($handle, $index)
     {
-        return "{$this->field->handle()}.{$index}.{$handle}";
+        return "{$this->setRuleKey($index)}.{$handle}";
+    }
+
+    protected function setRuleKey($index)
+    {
+        return "{$this->field->handle()}.{$index}";
     }
 
     protected function setConfig($handle)

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -105,23 +105,44 @@ class Replicator extends Fieldtype
 
     protected function setRules($handle, $data, $index)
     {
-        $rules = $this->fields($handle)->addValues($data)->validator()->withReplacements([
-            'this' => $this->setRuleKey($index),
-        ])->rules();
+        $rules = $this
+            ->fields($handle)
+            ->addValues($data)
+            ->validator()
+            ->withContext([
+                'prefix' => $this->field->validationContext('prefix').$this->setRuleFieldPrefix($index).'.',
+            ])
+            ->withReplacements([
+                'this' => $this->field->validationContext('prefix').$this->setRuleFieldPrefix($index),
+            ])
+            ->rules();
 
         return collect($rules)->mapWithKeys(function ($rules, $handle) use ($index) {
-            return [$this->setRuleFieldKey($handle, $index) => $rules];
+            return [$this->setRuleFieldPrefix($index).'.'.$handle => $rules];
         })->all();
     }
 
-    protected function setRuleFieldKey($handle, $index)
-    {
-        return "{$this->setRuleKey($index)}.{$handle}";
-    }
-
-    protected function setRuleKey($index)
+    protected function setRuleFieldPrefix($index)
     {
         return "{$this->field->handle()}.{$index}";
+    }
+
+    public function extraValidationAttributes(): array
+    {
+        return collect($this->field->value())->map(function ($set, $index) {
+            return $this->setValidationAttributes($set['type'], $set, $index);
+        })->reduce(function ($carry, $rules) {
+            return $carry->merge($rules);
+        }, collect())->all();
+    }
+
+    protected function setValidationAttributes($handle, $data, $index)
+    {
+        $attributes = $this->fields($handle)->addValues($data)->validator()->attributes();
+
+        return collect($attributes)->mapWithKeys(function ($attribute, $handle) use ($index) {
+            return [$this->setRuleFieldPrefix($index).'.'.$handle => $attribute];
+        })->all();
     }
 
     protected function setConfig($handle)

--- a/tests/Fields/ValidatorTest.php
+++ b/tests/Fields/ValidatorTest.php
@@ -120,7 +120,7 @@ class ValidatorTest extends TestCase
         ], $validation->rules());
     }
 
-     /** @test */
+    /** @test */
     public function it_compiles_field_attributes()
     {
         $fieldWithNoExtraAttributes = Mockery::mock(Field::class);
@@ -246,7 +246,7 @@ class ValidatorTest extends TestCase
             ['handle' => 'grid', 'field' => $grid],
             ['handle' => 'grid_with_nested_replicator', 'field' => $gridWithNestedReplicator],
         ]);
-        
+
         $fields = $fields->addValues([
             'replicator' => [
                 ['type' => 'replicator_set'],
@@ -261,7 +261,7 @@ class ValidatorTest extends TestCase
                 ['text' => null],
             ],
             'grid_with_nested_replicator' => [
-                // TODO 
+                // TODO
             ],
         ]);
 

--- a/tests/Fields/ValidatorTest.php
+++ b/tests/Fields/ValidatorTest.php
@@ -253,8 +253,8 @@ class ValidatorTest extends TestCase
                 'replicator_set' => [
                     'fields' => [
                         ['handle' => 'nested_bard', 'field' => $bard],
-                    ]
-                ]
+                    ],
+                ],
             ],
         ];
 
@@ -315,7 +315,7 @@ class ValidatorTest extends TestCase
             ],
             'bard_with_nested_replicator' => [
                 ['type' => 'set', 'attrs' => ['values' => ['type' => 'bard_set', 'nested_replicator' => [['type' => 'replicator_set']]]]],
-            ]
+            ],
         ]);
 
         $rules = (new Validator)->fields($fields)->rules();
@@ -323,7 +323,7 @@ class ValidatorTest extends TestCase
         $this->assertArraySubset([
             'replicator.0.text' => [
                 'required_if:replicator.0.must_fill,true',
-            ]
+            ],
         ], $rules);
 
         $this->assertArraySubset([
@@ -335,7 +335,7 @@ class ValidatorTest extends TestCase
         $this->assertArraySubset([
             'replicator_with_double_nested_replicator.0.nested_replicator.0.nested_replicator.0.text' => [
                 'required_if:replicator_with_double_nested_replicator.0.nested_replicator.0.nested_replicator.0.must_fill,true',
-            ]
+            ],
         ], $rules);
 
         $this->assertArraySubset([


### PR DESCRIPTION
This also fixes #1702. I somehow overlooked #1703 and created this solution. It's nice and short, but doesn't display the field names nicely in the errors (yet):

<img width="941" alt="Screenshot 2022-01-10 at 17 45 00" src="https://user-images.githubusercontent.com/4067531/148826824-cc8acb5d-bb1b-4614-860e-5126ab40d4ef.png">

Edit from Jason:
The field names totally work now too.

![image](https://user-images.githubusercontent.com/105211/151245504-3dc9bc25-9d7a-4fbc-8fab-c1fd12cc8526.png)

