### PR TITLE
Support Blade section yields in Antlers layouts

### DIFF
--- a/src/Tags/Section.php
+++ b/src/Tags/Section.php
@@ -10,6 +10,27 @@ class Section extends Tags
     {
         $name = explode(':', $this->tag)[1];
 
-        Cascade::instance()->sections()->put($name, $this->parse());
+        $contents = $this->parse();
+
+        // Store the contents in both the view factory and the cascade. This way, it's retrievable in
+        // a Blade template via the @yield directive, or in an Antlers template using the yield tag.
+        // It would be nice to be able to just store it in the view factory, but when a Blade view
+        // doesn't use an @extends, the sections get flushed and lost once the view is rendered.
+        $this->storeInCascade($name, $contents);
+        $this->storeInViewFactory($name, $contents);
+    }
+
+    private function storeInCascade($name, $contents)
+    {
+        Cascade::instance()->sections()->put($name, $contents);
+    }
+
+    private function storeInViewFactory($name, $contents)
+    {
+        tap(view()->shared('__env'), function ($view) use ($name, $contents) {
+            $view->startSection($name);
+            echo $contents;
+            $view->stopSection($name);
+        });
     }
 }

--- a/src/Tags/Yields.php
+++ b/src/Tags/Yields.php
@@ -16,6 +16,10 @@ class Yields extends Tags
             return $yield;
         }
 
+        if ($fallback = $this->params->get('or')) {
+            return $fallback;
+        }
+
         return $this->isPair ? $this->parse() : null;
     }
 

--- a/src/Tags/Yields.php
+++ b/src/Tags/Yields.php
@@ -12,10 +12,25 @@ class Yields extends Tags
     {
         $name = explode(':', $this->tag)[1];
 
-        if ($yield = Cascade::instance()->sections()->get($name)) {
+        if ($yield = $this->getYieldedValue($name)) {
             return $yield;
         }
 
         return $this->isPair ? $this->parse() : null;
+    }
+
+    private function getYieldedValue($name)
+    {
+        // First try to get it from the Illuminate view factory, which may have a section
+        // in there if it was added via a Blade template using the `@section` directive.
+        if ($value = view()->shared('__env')->yieldContent($name)) {
+            return $value;
+        }
+
+        // Then try to get it from the cascade, which the `section` tag
+        // stores its contents in when used in an Antlers template.
+        if ($value = Cascade::instance()->sections()->get($name)) {
+            return $value;
+        }
     }
 }


### PR DESCRIPTION
Typically, templates are injected into layouts through a `template_content` variable.

But if you use Blade for your template, this behavior doesn't happen. We do this intentionally to allow you to use `@extends` to manage your layout, which is a totally normal thing in the Laravel world. Then you use the `@section` directive in your template to capture it and `@yield` in your layout to output it. Like this:

```blade
@extends('layout')

@section('content')
  <div>...</div>
@endsection
```
```blade
<html>
<body>
  @yield('content')
</body>
</html>
```

That's fine if you plan to use Blade all over, and you want to use a Blade layout too.

But if you want a hybrid approach - a Blade template but an Antlers layout - you couldn't. We had a `yield` tag, but it only worked with a `section` tag in another Antlers template.

This PR adds support for the Antlers `yield` tag to work with a Blade `@section` directive. Here, it'll yield the `content` section if you use it in a Blade template, and fall back to `template_content` if you were using an Antlers template:

```mustache
<html>
<body>
  {{ yield:content }}
    {{ template_content }}
  {{ /yield:content }}
</body>
</html>
```

This PR also adds an `or` param so you can write the snippet above in a simpler single tag:

```mustache
<html>
<body>
  {{ yield:content :or="template_content" }}
</body>
</html>
```

Closes statamic/ideas#231