### PR TITLE
Antlers wrapper for blade

### DIFF
--- a/src/Modifiers/Modify.php
+++ b/src/Modifiers/Modify.php
@@ -23,6 +23,11 @@ class Modify implements \IteratorAggregate
      */
     private $loader;
 
+    /**
+     * Instantiate fluent modifier helper.
+     *
+     * @param Loader $loader
+     */
     public function __construct(Loader $loader)
     {
         $this->loader = $loader;

--- a/src/Modifiers/Modify.php
+++ b/src/Modifiers/Modify.php
@@ -26,7 +26,7 @@ class Modify implements \IteratorAggregate
     /**
      * Instantiate fluent modifier helper.
      *
-     * @param Loader $loader
+     * @param  Loader  $loader
      */
     public function __construct(Loader $loader)
     {

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -349,7 +349,7 @@ class Statamic
         return $prefix.'.*';
     }
 
-    public static function tag($name, $params = [])
+    public static function tag($name, $params = [], $context = [])
     {
         if ($pos = strpos($name, ':')) {
             $original_method = substr($name, $pos + 1);
@@ -363,7 +363,7 @@ class Statamic
             'parser'     => app(Parser::class),
             'params'     => $params,
             'content'    => '',
-            'context'    => [],
+            'context'    => $context,
             'tag'        => $name.':'.$original_method,
             'tag_method' => $original_method,
         ]);

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -12,8 +12,7 @@ use Statamic\Facades\URL;
 use Statamic\Modifiers\Modify;
 use Statamic\Support\DateFormat;
 use Statamic\Support\Str;
-use Statamic\Tags\Loader as TagLoader;
-use Statamic\View\Antlers\Parser;
+use Statamic\Tags\FluentTag;
 use Stringy\StaticStringy;
 
 class Statamic
@@ -350,26 +349,9 @@ class Statamic
         return $prefix.'.*';
     }
 
-    public static function tag($name, $params = [], $context = [])
+    public static function tag($name)
     {
-        if ($pos = strpos($name, ':')) {
-            $original_method = substr($name, $pos + 1);
-            $method = Str::camel($original_method);
-            $name = substr($name, 0, $pos);
-        } else {
-            $method = $original_method = 'index';
-        }
-
-        $tag = app(TagLoader::class)->load($name, [
-            'parser'     => app(Parser::class),
-            'params'     => $params,
-            'content'    => '',
-            'context'    => $context,
-            'tag'        => $name.':'.$original_method,
-            'tag_method' => $original_method,
-        ]);
-
-        return $tag->$method();
+        return FluentTag::make($name);
     }
 
     public static function modify($value)

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -9,6 +9,7 @@ use Statamic\Facades\File;
 use Statamic\Facades\Preference;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
+use Statamic\Modifiers\Modify;
 use Statamic\Support\DateFormat;
 use Statamic\Support\Str;
 use Statamic\Tags\Loader as TagLoader;
@@ -369,5 +370,10 @@ class Statamic
         ]);
 
         return $tag->$method();
+    }
+
+    public static function modify($value)
+    {
+        return Modify::value($value);
     }
 }

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -349,7 +349,7 @@ class Statamic
         return $prefix.'.*';
     }
 
-    public static function antlersTag($name, $params = [])
+    public static function tag($name, $params = [])
     {
         if ($pos = strpos($name, ':')) {
             $original_method = substr($name, $pos + 1);

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -11,6 +11,8 @@ use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Support\DateFormat;
 use Statamic\Support\Str;
+use Statamic\Tags\Loader as TagLoader;
+use Statamic\View\Antlers\Parser;
 use Stringy\StaticStringy;
 
 class Statamic
@@ -345,5 +347,27 @@ class Statamic
         }
 
         return $prefix.'.*';
+    }
+
+    public static function antlersTag($name, $params = [])
+    {
+        if ($pos = strpos($name, ':')) {
+            $original_method = substr($name, $pos + 1);
+            $method = Str::camel($original_method);
+            $name = substr($name, 0, $pos);
+        } else {
+            $method = $original_method = 'index';
+        }
+
+        $tag = app(TagLoader::class)->load($name, [
+            'parser'     => app(Parser::class),
+            'params'     => $params,
+            'content'    => '',
+            'context'    => [],
+            'tag'        => $name.':'.$original_method,
+            'tag_method' => $original_method,
+        ]);
+
+        return call_user_func([$tag, $method]);
     }
 }

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -368,6 +368,6 @@ class Statamic
             'tag_method' => $original_method,
         ]);
 
-        return call_user_func([$tag, $method]);
+        return $tag->$method();
     }
 }

--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -115,11 +115,11 @@ class FluentTag implements \IteratorAggregate, \ArrayAccess
         }
 
         $tag = app(Loader::class)->load($name, [
-            'parser'    => app(Parser::class),
-            'params'    => $this->params,
-            'content'   => '',
-            'context'   => $this->context,
-            'tag'       => $name.':'.$originalMethod,
+            'parser'     => app(Parser::class),
+            'params'     => $this->params,
+            'content'    => '',
+            'context'    => $this->context,
+            'tag'        => $name.':'.$originalMethod,
             'tag_method' => $originalMethod,
         ]);
 

--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Statamic\Tags;
+
+use ArrayIterator;
+use Statamic\Support\Arr;
+use Statamic\Support\Str;
+use Statamic\View\Antlers\Parser;
+
+class FluentTag implements \IteratorAggregate, \ArrayAccess
+{
+    /**
+     * @var mixed
+     */
+    protected $name;
+
+    /**
+     * @var array
+     */
+    protected $context = [];
+
+    /**
+     * @var array
+     */
+    protected $params = [];
+
+    /**
+     * @var Loader
+     */
+    private $loader;
+
+    public function __construct(Loader $loader)
+    {
+        $this->loader = $loader;
+    }
+
+    /**
+     * Invoke the class as a function.
+     *
+     * @param  string  $name
+     * @return \Statamic\Tags\FluentTag
+     */
+    public function __invoke($name)
+    {
+        return static::make($name);
+    }
+
+    /**
+     * Specify a tag name to start the tag param chain.
+     *
+     * @param  string  $name
+     * @return \Statamic\Tags\FluentTag
+     */
+    public static function make($name)
+    {
+        $instance = app(self::class);
+
+        $instance->name = $name;
+
+        return $instance;
+    }
+
+    /**
+     * Set the context.
+     *
+     * @param  array  $context
+     * @return $this
+     */
+    public function context($context)
+    {
+        $this->context = $context;
+
+        return $this;
+    }
+
+    /**
+     * Fetch result of a tag.
+     *
+     * @return mixed
+     */
+    public function fetch()
+    {
+        $name = $this->name;
+
+        if ($pos = strpos($name, ':')) {
+            $originalMethod = substr($name, $pos + 1);
+            $method = Str::camel($originalMethod);
+            $name = substr($name, 0, $pos);
+        } else {
+            $method = $originalMethod = 'index';
+        }
+
+        $tag = app(Loader::class)->load($name, [
+            'parser'    => app(Parser::class),
+            'params'    => $this->params,
+            'content'   => '',
+            'context'   => $this->context,
+            'tag'       => $name.':'.$originalMethod,
+            'tag_method' => $originalMethod,
+        ]);
+
+        return $tag->$method();
+    }
+
+    /**
+     * Get the value as a string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->fetch();
+    }
+
+    /**
+     * Get the value as an array.
+     *
+     * @return \Traversable
+     */
+    public function getIterator()
+    {
+        return $this->fetch();
+    }
+
+    /**
+     * Allow calls to tag params via method names.
+     *
+     * @param  string  $method  Param name
+     * @param  array  $args  First arg will be param value
+     * @return $this
+     */
+    public function __call($method, $args)
+    {
+        $this->params[$method] = $args[0] ?? true;
+
+        return $this;
+    }
+
+    /**
+     * Determine if an item exists at an offset.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetExists($key)
+    {
+        return isset($this->fetch()[$key]);
+    }
+
+    /**
+     * Get an item at a given offset.
+     *
+     * @param  mixed  $key
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetGet($key)
+    {
+        return $this->fetch()[$key];
+    }
+
+    /**
+     * Set the item at a given offset.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetSet($key, $value)
+    {
+        //
+    }
+
+    /**
+     * Unset the item at a given offset.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($key)
+    {
+        unset($this->fetch()[$key]);
+    }
+}

--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\Tags;
 
-use ArrayIterator;
-use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\View\Antlers\Parser;
 

--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -39,7 +39,7 @@ class FluentTag implements \IteratorAggregate, \ArrayAccess
     /**
      * Instantiate fluent tag helper.
      *
-     * @param Loader $loader
+     * @param  Loader  $loader
      */
     public function __construct(Loader $loader)
     {

--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -2,6 +2,9 @@
 
 namespace Statamic\Tags;
 
+use ArrayIterator;
+use Illuminate\Support\Collection;
+use Statamic\Contracts\Data\Augmentable;
 use Statamic\Support\Str;
 use Statamic\View\Antlers\Parser;
 
@@ -97,7 +100,17 @@ class FluentTag implements \IteratorAggregate, \ArrayAccess
             'tag_method' => $originalMethod,
         ]);
 
-        return $tag->$method();
+        $output = $tag->$method();
+
+        if ($output instanceof Collection) {
+            $output = $output->toAugmentedArray();
+        }
+
+        if ($output instanceof Augmentable) {
+            $output = $output->toAugmentedArray();
+        }
+
+        return $output;
     }
 
     /**
@@ -117,7 +130,7 @@ class FluentTag implements \IteratorAggregate, \ArrayAccess
      */
     public function getIterator()
     {
-        return $this->fetch();
+        return new ArrayIterator($this->fetch());
     }
 
     /**

--- a/tests/Modifiers/FluentModifyTest.php
+++ b/tests/Modifiers/FluentModifyTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class FluentModifyTest extends TestCase
+{
+    /** @test */
+    public function it_handles_params_fluently()
+    {
+        $result = Modify::value("i love nacho libre, it's the besss")->upper()->ensureRight('!!!');
+
+        $this->assertInstanceOf(Modify::class, $result);
+        $this->assertEquals("I LOVE NACHO LIBRE, IT'S THE BESSS!!!", (string) $result);
+    }
+
+    /** @test */
+    public function it_can_explicitly_fetch_result()
+    {
+        $result = Modify::value("i love nacho libre, it's the besss")->upper()->ensureRight('!!!')->fetch();
+
+        $this->assertTrue(is_string($result));
+        $this->assertEquals("I LOVE NACHO LIBRE, IT'S THE BESSS!!!", $result);
+    }
+}

--- a/tests/StatamicTest.php
+++ b/tests/StatamicTest.php
@@ -109,6 +109,18 @@ class StatamicTest extends TestCase
         $this->assertEquals($format, Statamic::cpDateTimeFormat());
     }
 
+    /** @test */
+    public function it_wraps_fluent_tag_helper()
+    {
+        $this->assertInstanceOf(\Statamic\Tags\FluentTag::class, Statamic::tag('some_tag'));
+    }
+
+    /** @test */
+    public function it_wraps_fluent_modifier_helper()
+    {
+        $this->assertInstanceOf(\Statamic\Modifiers\Modify::class, Statamic::modify('some_value'));
+    }
+
     public function formatsWithTime()
     {
         return [

--- a/tests/Tags/FluentTagTest.php
+++ b/tests/Tags/FluentTagTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Tags;
+
+use Facades\Tests\Factories\EntryFactory;
+use Statamic\Facades;
+use Statamic\Tags\FluentTag;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class FluentTagTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Facades\Collection::make('pages')->save();
+
+        collect(['one', 'two', 'three', 'four', 'five'])->each(function ($slug) {
+            EntryFactory::id($slug)
+                ->collection('pages')
+                ->slug($slug)
+                ->make()
+                ->data(['content' => "# $slug"])
+                ->save();
+        });
+    }
+
+    /** @test */
+    public function it_handles_params_fluently()
+    {
+        $result = FluentTag::make('collection:pages')->sort('slug:desc')->limit(3);
+
+        $this->assertInstanceOf(FluentTag::class, $result);
+        $this->assertCount(3, $result);
+    }
+
+    /** @test */
+    public function it_can_explicitly_fetch_result()
+    {
+        $result = FluentTag::make('collection:pages')->sort('slug:desc')->limit(3)->fetch();
+
+        $this->assertIsArray($result);
+        $this->assertCount(3, $result);
+    }
+
+    /** @test */
+    public function it_can_iterate_over_tag_results()
+    {
+        $slugs = [];
+
+        foreach(FluentTag::make('collection:pages') as $page) {
+            $slugs[] = (string) $page['slug'];
+        }
+
+        $expected = ['one', 'two', 'three', 'four', 'five'];
+
+        $this->assertEquals($expected, $slugs);
+    }
+
+    /** @test */
+    public function it_can_pass_params_fluently_and_terate_over_results()
+    {
+        $slugs = [];
+
+        foreach(FluentTag::make('collection:pages')->sort('slug:desc')->limit(3) as $page) {
+            $slugs[] = (string) $page['slug'];
+        }
+
+        $expected = ['two', 'three', 'one'];
+
+        $this->assertEquals($expected, $slugs);
+    }
+
+    /** @test */
+    public function it_augments_by_default()
+    {
+        $slugs = [];
+
+        foreach(FluentTag::make('collection:pages')->sort('slug:desc')->limit(3) as $page) {
+            $slugs[] = (string) trim($page['content']);
+        }
+
+        $expected = ['<h1>two</h1>', '<h1>three</h1>', '<h1>one</h1>'];
+
+        $this->assertEquals($expected, $slugs);
+    }
+
+    /** @test */
+    public function it_can_disable_augmentation()
+    {
+        $slugs = [];
+
+        foreach(FluentTag::make('collection:pages')->sort('slug:desc')->limit(3)->withoutAugmentation() as $page) {
+            $slugs[] = (string) $page->content;
+        }
+
+        $expected = ['# two', '# three', '# one'];
+
+        $this->assertEquals($expected, $slugs);
+    }
+
+    /** @test */
+    public function it_allows_array_access()
+    {
+        $result = FluentTag::make('collection:pages');
+
+        $this->assertInstanceOf(FluentTag::class, $result);
+        $this->assertEquals('one', $result[0]['slug']);
+        $this->assertEquals('two', $result[1]['slug']);
+        $this->assertEquals('three', $result[2]['slug']);
+    }
+
+    /** @test */
+    public function it_casts_string_results_to_string()
+    {
+        $result = FluentTag::make('link')->to('fanny-packs');
+
+        $this->assertInstanceOf(FluentTag::class, $result);
+        $this->assertEquals('/fanny-packs', (string) $result);
+    }
+}

--- a/tests/Tags/FluentTagTest.php
+++ b/tests/Tags/FluentTagTest.php
@@ -51,7 +51,7 @@ class FluentTagTest extends TestCase
     {
         $slugs = [];
 
-        foreach(FluentTag::make('collection:pages') as $page) {
+        foreach (FluentTag::make('collection:pages') as $page) {
             $slugs[] = (string) $page['slug'];
         }
 
@@ -65,7 +65,7 @@ class FluentTagTest extends TestCase
     {
         $slugs = [];
 
-        foreach(FluentTag::make('collection:pages')->sort('slug:desc')->limit(3) as $page) {
+        foreach (FluentTag::make('collection:pages')->sort('slug:desc')->limit(3) as $page) {
             $slugs[] = (string) $page['slug'];
         }
 
@@ -79,7 +79,7 @@ class FluentTagTest extends TestCase
     {
         $slugs = [];
 
-        foreach(FluentTag::make('collection:pages')->sort('slug:desc')->limit(3) as $page) {
+        foreach (FluentTag::make('collection:pages')->sort('slug:desc')->limit(3) as $page) {
             $slugs[] = (string) trim($page['content']);
         }
 
@@ -93,7 +93,7 @@ class FluentTagTest extends TestCase
     {
         $slugs = [];
 
-        foreach(FluentTag::make('collection:pages')->sort('slug:desc')->limit(3)->withoutAugmentation() as $page) {
+        foreach (FluentTag::make('collection:pages')->sort('slug:desc')->limit(3)->withoutAugmentation() as $page) {
             $slugs[] = (string) $page->content;
         }
 


### PR DESCRIPTION
Resurrecting a version of the work done by @riasvdv in #2724 and #2717 (🎉) to bring antlers support to blade via convenient wrappers.

We don't want to pollute the global namespace, but as a `Statamic::` accessible function, we're thinking it would be nice to bring this kind of antlers support to blade.

The nice thing about Rias' approach here is that it'll allow the user to work with / loop over the output however they want in blade (ie. `@foreach`, `@forelse`, pass data into an `@include`, etc) 👍 

### TODO: 

- [x] Add `FluentTag` helper class, inspired by our fluent `Modify` helper class.
- [x] Add `Statamic::tag()` wrapper.
- [x] Add `Statamic::modify()` wrapper.
- [x] Add test coverage.

### Example `Statamic::tag()` blade usage:

```blade
{{-- // Loop over results however you want in blade --}}
@foreach(Statamic::tag('collection:pages') as $page)
	{{ $page['title'] }}<br>
@endforeach

{{-- // Fluently add tag params --}}
@foreach(Statamic::tag('collection:pages')->sort('date:desc')->limit(3) as $page)
	{{ $page['title'] }}<br>
@endforeach

{{-- // Pass in contextual data --}}
@foreach(Statamic::tag('collection:pages')->context($context) as $page)
	{{ $page['title'] }}<br>
@endforeach

{{-- // Disable augmentation --}}
@foreach(Statamic::tag('collection:pages')->withoutAugmentation() as $page)
	{{ $page['title'] }}<br>
@endforeach
```

### Example `Statamic::modify()` blade usage:

```blade
{{ Statamic::modify($title)->upper()->ensureRight('!!!') }}
```