### PR TITLE
Attributes to remove deprecation warnings

### DIFF
--- a/src/Modifiers/Modify.php
+++ b/src/Modifiers/Modify.php
@@ -102,6 +102,7 @@ class Modify implements \IteratorAggregate
      *
      * @throws \Statamic\Modifiers\ModifierException
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         if (! is_array($this->value)) {

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -422,6 +422,7 @@ class Page implements Entry, Augmentable, Responsable, Protectable, JsonSerializ
         return $this->forwardCallTo($this->entry(), $method, $args);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this


### PR DESCRIPTION
This removes a few deprecation warnings/logs on PHP 8.1