### PR TITLE
`static:warm` command updates

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -17,6 +17,7 @@ use Statamic\Console\RunsInPlease;
 use Statamic\Entries\Collection as EntriesCollection;
 use Statamic\Entries\Entry;
 use Statamic\Facades;
+use Statamic\Facades\URL;
 use Statamic\Http\Controllers\FrontendController;
 use Statamic\StaticCaching\Cacher as StaticCacher;
 use Statamic\Support\Str;
@@ -224,7 +225,7 @@ class StaticWarm extends Command
                 return $route->getActionName() === $action && ! Str::contains($route->uri(), '{');
             })
             ->map(function (Route $route) {
-                return Facades\URL::tidy(Str::start($route->uri(), config('app.url').'/'));
+                return URL::tidy(Str::start($route->uri(), config('app.url').'/'));
             });
 
         $this->line("\x1B[1A\x1B[2K<info>[✔]</info> Custom routes");

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -163,6 +163,8 @@ class StaticWarm extends Command
             })
             ->flatMap(function (Taxonomy $taxonomy) {
                 return $taxonomy->sites()->map(function ($site) use ($taxonomy) {
+                    // Needed because Taxonomy uses the current site. If the Taxonomy
+                    // class ever gets its own localization logic we can remove this.
                     Facades\Site::setCurrent($site);
 
                     return $taxonomy->absoluteUrl();


### PR DESCRIPTION
New features:

1. Visit taxonomy URLs too
2. Skip taxonomies and terms that have no template
3. Add multisite support for taxonomies and terms
4. Show the number of URLs that will be visited
5. Skip URLs in the `'exclude'` list

Fixes #4468, see feature 2.

Fixes #4732, see feature 5 and 2.
