### PR TITLE
Add ability to select fields in tags

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -781,7 +781,7 @@ class Asset implements AssetContract, Augmentable
         return $this->selectedQueryColumns;
     }
 
-    protected function shallowAugmentedArrayKeys()
+    public function shallowAugmentedArrayKeys()
     {
         return ['id', 'url', 'permalink', 'api_url'];
     }

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -225,7 +225,7 @@ abstract class User implements
         return $this->selectedQueryColumns;
     }
 
-    protected function shallowAugmentedArrayKeys()
+    public function shallowAugmentedArrayKeys()
     {
         return ['id', 'name', 'email', 'api_url'];
     }

--- a/src/Data/HasAugmentedInstance.php
+++ b/src/Data/HasAugmentedInstance.php
@@ -43,7 +43,7 @@ trait HasAugmentedInstance
         return null;
     }
 
-    protected function shallowAugmentedArrayKeys()
+    public function shallowAugmentedArrayKeys()
     {
         return ['id', 'title', 'api_url'];
     }

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -759,7 +759,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
         return $this->selectedQueryColumns;
     }
 
-    protected function shallowAugmentedArrayKeys()
+    public function shallowAugmentedArrayKeys()
     {
         return ['id', 'title', 'url', 'permalink', 'api_url'];
     }

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -342,7 +342,7 @@ class Form implements FormContract, Augmentable
         return new AugmentedForm($this);
     }
 
-    protected function shallowAugmentedArrayKeys()
+    public function shallowAugmentedArrayKeys()
     {
         return ['handle', 'title', 'api_url'];
     }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -10,6 +10,7 @@ use Statamic\Extensions\Pagination\LengthAwarePaginator;
 
 abstract class Builder implements Contract
 {
+    protected $columns;
     protected $limit;
     protected $offset = 0;
     protected $wheres = [];
@@ -27,6 +28,13 @@ abstract class Builder implements Contract
         '>=' => 'GreaterThanOrEqualTo',
         '<=' => 'LessThanOrEqualTo',
     ];
+
+    public function select($columns = ['*'])
+    {
+        $this->columns = $columns;
+
+        return $this;
+    }
 
     public function limit($value)
     {

--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -31,7 +31,7 @@ abstract class Builder extends BaseBuilder
 
         $items = $this->getItems($keys);
 
-        $items->each->selectedQueryColumns($columns);
+        $items->each->selectedQueryColumns($this->columns ?? $columns);
 
         return $this->collect($items);
     }

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -332,6 +332,11 @@ class Page implements Entry, Augmentable, Responsable, Protectable, JsonSerializ
         return new AugmentedPage($this);
     }
 
+    public function shallowAugmentedArrayKeys()
+    {
+        return optional($this->entry())->shallowAugmentedArrayKeys() ?? ['title', 'url'];
+    }
+
     public function editUrl()
     {
         return optional($this->entry())->editUrl();

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -19,7 +19,8 @@ class Entries
 {
     use Concerns\QueriesScopes,
         Concerns\QueriesOrderBys,
-        Concerns\GetsQueryResults;
+        Concerns\GetsQueryResults,
+        Concerns\GetsQuerySelectKeys;
     use Concerns\QueriesConditions {
         queryableConditionParams as traitQueryableConditionParams;
     }
@@ -142,6 +143,7 @@ class Entries
         $query = Entry::query()
             ->whereIn('collection', $this->collections->map->handle()->all());
 
+        $this->querySelect($query);
         $this->querySite($query);
         $this->queryStatus($query);
         $this->queryPastFuture($query);
@@ -215,6 +217,11 @@ class Entries
         }
 
         return 'title:asc';
+    }
+
+    protected function querySelect($query)
+    {
+        $query->select($this->getQuerySelectKeys(Entry::make()));
     }
 
     protected function querySite($query)

--- a/src/Tags/Concerns/GetsQuerySelectKeys.php
+++ b/src/Tags/Concerns/GetsQuerySelectKeys.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Statamic\Tags\Concerns;
+
+trait GetsQuerySelectKeys
+{
+    protected function getQuerySelectKeys($item)
+    {
+        $selected = $this->params->explode('select');
+
+        if (! $selected || $selected === ['*']) {
+            return null;
+        }
+
+        if (false !== ($shallow = array_search('@shallow', $selected))) {
+            unset($selected[$shallow]);
+            $selected = array_merge($selected, $item->shallowAugmentedArrayKeys());
+        }
+
+        return $selected;
+    }
+}

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -7,9 +7,12 @@ use Illuminate\Support\Collection;
 use Statamic\Facades\Data;
 use Statamic\Facades\Site;
 use Statamic\Support\Str;
+use Statamic\Tags\Concerns\GetsQuerySelectKeys;
 
 class Locales extends Tags
 {
+    use GetsQuerySelectKeys;
+
     /**
      * @var \Statamic\Contracts\Data\Content\Content
      */
@@ -138,7 +141,9 @@ class Locales extends Tags
             return null;
         }
 
-        return $localized->toAugmentedArray();
+        $keys = $this->getQuerySelectKeys($localized);
+
+        return $localized->toAugmentedArray($keys);
     }
 
     /**

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -11,9 +11,12 @@ use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Structures\TreeBuilder;
 use Statamic\Support\Str;
+use Statamic\Tags\Concerns\GetsQuerySelectKeys;
 
 class Structure extends Tags
 {
+    use GetsQuerySelectKeys;
+
     public function wildcard($tag)
     {
         $handle = $this->context->value($tag, $tag);
@@ -67,7 +70,8 @@ class Structure extends Tags
     {
         return collect($tree)->map(function ($item, $index) use ($parent, $depth, $tree) {
             $page = $item['page'];
-            $data = $page->toAugmentedArray();
+            $keys = $this->getQuerySelectKeys($page);
+            $data = $page->toAugmentedArray($keys);
             $children = empty($item['children']) ? [] : $this->toArray($item['children'], $data, $depth + 1);
 
             return array_merge($data, [

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -438,7 +438,7 @@ class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, Reso
         return $this->selectedQueryColumns;
     }
 
-    protected function shallowAugmentedArrayKeys()
+    public function shallowAugmentedArrayKeys()
     {
         return ['id', 'title', 'slug', 'url', 'permalink', 'api_url'];
     }


### PR DESCRIPTION
This PR is inspired by #4924 and #4926. Thanks @FrittenKeeZ !

Related to statamic/ideas#543

This adds a `select` parameter to some tags that use augmentation. (`nav`, `locales`, and `collection`)

It allows you to pick specific fields to be augmented if you want to improve performance. By default, all fields are augmented, even if you don't end up using them.

```
{{ nav select="title|foo" }}
```

You may also use the `@shallow` placeholder which will expand into the appropriate set of fields.

```
{{ nav select="@shallow|foo" }}
```

e.g. for entries, you'd get `id`, `title`, `url`, `permalink`, `api_url`, plus `foo`.

This also adds the `select()` method to the query builder for selecting columns.

```php
Entry::query()->select(['foo', 'bar'])->get()->toAugmentedArray();
// select foo,bar from entries
// ['foo' => '...', 'bar' => '...']
```


### Future thinking:
We plan to let the `select` parameter be smarter. We may be able to just look at what variables you're using between the tag pair and automatically select them.

```
{{ collection:blog }}
  {{ title }} {{ foo }}
{{ /collection:blog }}
```
```
->select(['title', 'foo'])
```

This may be a feature specific to the new parser, eventually.