### PR TITLE
Add allowed composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,11 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "pixelfear/composer-dist-plugin": true
+        }
     },
     "extra": {
         "download-dist": {


### PR DESCRIPTION
Composer v2.2 added a new requirement to explicitly allow plugins that can execute code during a Composer run. This addition is the result of answering "yes" to the list of given plugins during a composer install of `statamic/cms`.

See:

- https://github.com/composer/composer/pull/10314
- https://blog.packagist.com/composer-2-2/
