### PR TITLE
Use npm ci instead

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Execute tests
         run: npm run test


### PR DESCRIPTION
It's recommended to use npm ci, as the usage of `install` can lead to failures.

https://dev.to/visuellverstehen/why-to-use-npm-ci-instead-of-npm-install-mfd