### PR TITLE
Make fieldtype config extendable

### DIFF
--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -31,6 +31,7 @@ abstract class Fieldtype implements Arrayable
     protected $extraRules = [];
     protected $defaultValue;
     protected $configFields = [];
+    protected static $extraConfigFields = [];
     protected $icon;
 
     public static function title()
@@ -173,9 +174,11 @@ abstract class Fieldtype implements Arrayable
 
     public function configFields(): Fields
     {
-        $fields = collect($this->configFieldItems())->map(function ($field, $handle) {
-            return compact('handle', 'field');
-        });
+        $fields = collect($this->configFieldItems())
+            ->merge(self::$extraConfigFields)
+            ->map(function ($field, $handle) {
+                return compact('handle', 'field');
+            });
 
         return new ConfigFields($fields);
     }
@@ -183,6 +186,11 @@ abstract class Fieldtype implements Arrayable
     protected function configFieldItems(): array
     {
         return $this->configFields;
+    }
+
+    public static function extendConfigFields(array $config)
+    {
+        self::$extraConfigFields = $config;
     }
 
     public function icon()


### PR DESCRIPTION
This PR lets you extend the default config fields of a fieldtype as requested in https://github.com/statamic/ideas/issues/206. This can be useful for extra fields used by addons.

```php
use Statamic\Fieldtypes\Text;

Text::extendConfigFields([
    'group' => [
        'display' => 'Group',
        'instructions' => 'The name of the group by which to group this field by.',
        'type' => 'text',
        'width' => 50,
    ],
]);
```

One thing that might be handy is the ability to only add certain fields depending on context. For instance, a `autocomplete` config field would be useful for the Text fieldtype. But only in form blueprints. 