### PR TITLE
Suffix tricky field names in Blueprint and Fieldset builders

### DIFF
--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -205,17 +205,11 @@ export default {
         createField(handle) {
             const fieldtype = _.findWhere(this.fieldtypes, { handle });
 
-            // Some titles slugify into a field handle that can cause conflicts.
-            // We'll suffix those with '... Field'.
-            const display = ['assets', 'date', 'link'].includes(fieldtype.title.toLowerCase())
-                ? `${fieldtype.title} ${__('Field')}`
-                : fieldtype.title;
-
             // Build the initial empty field. The event listener will assign display, handle,
             // and id keys. This will be 'field_n' etc, where n would be the total root
             // level, grid, or set fields depending on the event listener location.
             let field = {
-                display,
+                display: `${fieldtype.title} ${__('Field')}`,
                 type: fieldtype.handle,
                 icon: fieldtype.icon,
                 instructions: null,

--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -205,11 +205,17 @@ export default {
         createField(handle) {
             const fieldtype = _.findWhere(this.fieldtypes, { handle });
 
+            // Some titles slugify into a field handle that can cause conflicts.
+            // We'll suffix those with '... Field'.
+            const display = ['assets', 'date', 'link'].includes(fieldtype.title.toLowerCase())
+                ? `${fieldtype.title} ${__('Field')}`
+                : fieldtype.title;
+
             // Build the initial empty field. The event listener will assign display, handle,
             // and id keys. This will be 'field_n' etc, where n would be the total root
             // level, grid, or set fields depending on the event listener location.
             let field = {
-                display: fieldtype.title,
+                display,
                 type: fieldtype.handle,
                 icon: fieldtype.icon,
                 instructions: null,


### PR DESCRIPTION
This suffixes fields names like `assets`, `date` and `link` so they become `assets_field`, `date_field` and `link_field` to avoid problems like #3687.