### PR TITLE
Add possibility to filter trees

### DIFF
--- a/src/Http/Controllers/API/CollectionTreeController.php
+++ b/src/Http/Controllers/API/CollectionTreeController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\API;
 
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Http\Resources\API\TreeResource;
+use Statamic\Structures\PageQueryBuilder;
 
 class CollectionTreeController extends ApiController
 {
@@ -16,7 +17,11 @@ class CollectionTreeController extends ApiController
 
         $site = $this->queryParam('site');
 
+        $query = new PageQueryBuilder();
+        $this->filter($query);
+
         return app(TreeResource::class)::make($this->getCollectionTree($collection, $site))
+            ->query($query)
             ->fields($this->queryParam('fields'))
             ->maxDepth($this->queryParam('max_depth'))
             ->site($site);

--- a/src/Http/Controllers/API/NavigationTreeController.php
+++ b/src/Http/Controllers/API/NavigationTreeController.php
@@ -5,6 +5,7 @@ namespace Statamic\Http\Controllers\API;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Nav;
 use Statamic\Http\Resources\API\TreeResource;
+use Statamic\Structures\PageQueryBuilder;
 
 class NavigationTreeController extends ApiController
 {
@@ -17,7 +18,11 @@ class NavigationTreeController extends ApiController
 
         $site = $this->queryParam('site');
 
+        $query = new PageQueryBuilder();
+        $this->filter($query);
+
         return app(TreeResource::class)::make($this->getNavTree($handle, $site))
+            ->query($query)
             ->fields($this->queryParam('fields'))
             ->maxDepth($this->queryParam('max_depth'))
             ->site($site);

--- a/src/Http/Resources/API/TreeResource.php
+++ b/src/Http/Resources/API/TreeResource.php
@@ -11,6 +11,7 @@ class TreeResource extends JsonResource
     protected $fields;
     protected $depth;
     protected $site;
+    protected $query;
 
     /**
      * Set selected fields.
@@ -52,6 +53,19 @@ class TreeResource extends JsonResource
     }
 
     /**
+     * Set query.
+     *
+     * @param  \Statamic\Structures\PageQueryBuilder|null  $query
+     * @return $this
+     */
+    public function query($query = null)
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+
+    /**
      * Transform the resource into an array.
      *
      * @param \Illuminate\Http\Request
@@ -61,6 +75,7 @@ class TreeResource extends JsonResource
     {
         return (new TreeBuilder)->build([
             'structure' => $this->resource->structure(),
+            'query' => $this->query,
             'include_home' => true,
             'show_unpublished' => false,
             'site' => $this->site ?? Site::default()->handle(),

--- a/src/Structures/PageQueryBuilder.php
+++ b/src/Structures/PageQueryBuilder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Structures;
+
+use Illuminate\Support\Collection;
+use Statamic\Query\IteratorBuilder;
+
+class PageQueryBuilder extends IteratorBuilder
+{
+    protected $pages;
+
+    public function withPages(Collection $pages)
+    {
+        $this->pages = $pages;
+
+        return $this;
+    }
+
+    protected function getBaseItems()
+    {
+        return $this->pages;
+    }
+}

--- a/src/Structures/TreeBuilder.php
+++ b/src/Structures/TreeBuilder.php
@@ -47,6 +47,12 @@ class TreeBuilder
 
     protected function toTree($pages, $params, $depth = 1)
     {
+        if ($query = Arr::get($params, 'query')) {
+            if (empty($pages = $query->withPages($pages)->get())) {
+                return [];
+            }
+        }
+
         $maxDepth = $params['max_depth'] ?? null;
         $fields = $params['fields'] ?? null;
         $showUnpublished = $params['show_unpublished'] ?? true;

--- a/src/Structures/TreeBuilder.php
+++ b/src/Structures/TreeBuilder.php
@@ -47,18 +47,18 @@ class TreeBuilder
 
     protected function toTree($pages, $params, $depth = 1)
     {
-        if ($query = Arr::get($params, 'query')) {
-            if (empty($pages = $query->withPages($pages)->get())) {
-                return [];
-            }
-        }
-
         $maxDepth = $params['max_depth'] ?? null;
         $fields = $params['fields'] ?? null;
         $showUnpublished = $params['show_unpublished'] ?? true;
 
         if ($maxDepth && $depth > $maxDepth) {
             return [];
+        }
+
+        if ($query = Arr::get($params, 'query')) {
+            if (empty($pages = $query->withPages($pages)->get())) {
+                return [];
+            }
         }
 
         return $pages->map(function ($page) use ($fields, $params, $depth, $showUnpublished) {

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -9,13 +9,16 @@ use Statamic\Facades\Collection;
 use Statamic\Facades\Nav;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
+use Statamic\Structures\PageQueryBuilder;
 use Statamic\Structures\TreeBuilder;
 use Statamic\Support\Str;
 use Statamic\Tags\Concerns\GetsQuerySelectKeys;
+use Statamic\Tags\Concerns\QueriesConditions;
 
 class Structure extends Tags
 {
     use GetsQuerySelectKeys;
+    use QueriesConditions;
 
     public function wildcard($tag)
     {
@@ -42,8 +45,12 @@ class Structure extends Tags
 
         $this->ensureStructureExists($handle);
 
+        $query = new PageQueryBuilder();
+        $this->queryConditions($query);
+
         $tree = (new TreeBuilder)->build([
             'structure' => $handle,
+            'query' => $query,
             'include_home' => $this->params->get('include_home'),
             'show_unpublished' => $this->params->get('show_unpublished', false),
             'site' => $this->params->get('site', Site::current()->handle()),


### PR DESCRIPTION
Adds a `PageQueryBuilder` class, which can be supplied to `TreeBuilder` to filter the `Pages`. This filtering is done per layer in the tree. The children of rejected pages won't be unnecessarily evaluated for filtering.

This will fix #2286 and fix #3451.

This is a draft to show the concept.

**TODO**

- [x] Add `PageQueryBuilder` for filtering page trees
- [x] Use it in the Nav tag
- [x] Use it in the API
- [ ] Add tests
- [ ] Make sure the `show_unpublished` logic works nicely together with `status` filters
- [ ] Update the docs (ability to use filters, maybe deprecate `show_unpublished`, add `no_results` example, ...)
- [ ] GraphQL?

