### PR TITLE
404 on Glide asset urls when there's an invalid container

### DIFF
--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -3,7 +3,6 @@
 namespace Statamic\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 use League\Flysystem\FileNotFoundException;
 use League\Glide\Server;
 use League\Glide\Signatures\SignatureException;
@@ -99,19 +98,9 @@ class GlideController extends Controller
         // The string before the first slash is the container
         [$handle, $path] = explode('/', $decoded, 2);
 
-        if (! $container = AssetContainer::find($handle)) {
-            Log::error('Invalid container: '.$handle);
-            Log::error('Request URL: '.request()->fullUrl());
+        throw_unless($container = AssetContainer::find($handle), new NotFoundHttpException);
 
-            throw new NotFoundHttpException;
-        }
-
-        if (! $asset = $container->asset($path)) {
-            Log::error('Invalid asset path: '.$path);
-            Log::error('Request URL: '.request()->fullUrl());
-
-            throw new NotFoundHttpException;
-        }
+        throw_unless($asset = $container->asset($path), new NotFoundHttpException);
 
         return $this->createResponse($this->generateBy('asset', $asset));
     }

--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -96,9 +96,9 @@ class GlideController extends Controller
         $decoded = base64_decode($encoded);
 
         // The string before the first slash is the container
-        [$handle, $path] = explode('/', $decoded, 2);
+        [$container, $path] = explode('/', $decoded, 2);
 
-        throw_unless($container = AssetContainer::find($handle), new NotFoundHttpException);
+        throw_unless($container = AssetContainer::find($container), new NotFoundHttpException);
 
         throw_unless($asset = $container->asset($path), new NotFoundHttpException);
 


### PR DESCRIPTION
In debugging an error in glide, I had to add some logging to code in production.

Would be nice to have this all the time, when there are errors.

This also prevents huge call stacks filling up the log as we only log what's relevant.

Fixes #3760