### PR TITLE
Fix replicator preview text generation

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -164,7 +164,9 @@ export default {
         },
 
         previewUpdated(handle, value) {
-            this.$emit('previews-updated', { ...this.previews, [handle]: value });
+            setTimeout(() => {
+                this.$emit('previews-updated', { ...this.previews, [handle]: value });
+            }, 0);
         },
 
         destroy() {


### PR DESCRIPTION
Fixes #5081.

All the preview texts of the fields in a set get generated simultaneously on load in `Fieldtype.vue`. Somehow that caused `meta.previews` to still contain the old data in the components when updating. Maybe because action dispatching is asynchronous, but I'm not sure here. This simple solution fixes it though.