### PR TITLE
Add ability to store custom metadata in fieldset and blueprint YAML files

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -112,7 +112,7 @@ class Blueprint implements Augmentable
 
     public function setContents(array $contents)
     {
-        if (isset($this->contents['meta'])) {
+        if (! array_key_exists('meta', $contents) && array_key_exists('meta', $this->contents)) {
             $contents['meta'] = $this->contents['meta'];
         }
 

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -112,8 +112,8 @@ class Blueprint implements Augmentable
 
     public function setContents(array $contents)
     {
-        if (! array_key_exists('meta', $contents) && isset($this->contents['meta'])) {
-            $contents['meta'] = $this->contents['meta'];
+        if (! array_key_exists('custom', $contents) && isset($this->contents['custom'])) {
+            $contents['custom'] = $this->contents['custom'];
         }
 
         $this->contents = $contents;
@@ -350,9 +350,9 @@ class Blueprint implements Augmentable
         return array_get($this->contents, 'title', Str::humanize($this->handle));
     }
 
-    public function meta()
+    public function custom()
     {
-        return array_get($this->contents, 'meta');
+        return array_get($this->contents, 'custom');
     }
 
     public function toPublishArray()

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -112,7 +112,7 @@ class Blueprint implements Augmentable
 
     public function setContents(array $contents)
     {
-        if (! array_key_exists('meta', $contents) && $this->contents && array_key_exists('meta', $this->contents)) {
+        if (! array_key_exists('meta', $contents) && isset($this->contents['meta'])) {
             $contents['meta'] = $this->contents['meta'];
         }
 

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -112,7 +112,7 @@ class Blueprint implements Augmentable
 
     public function setContents(array $contents)
     {
-        if (! array_key_exists('meta', $contents) && array_key_exists('meta', $this->contents)) {
+        if (! array_key_exists('meta', $contents) && $this->contents && array_key_exists('meta', $this->contents)) {
             $contents['meta'] = $this->contents['meta'];
         }
 

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -112,6 +112,10 @@ class Blueprint implements Augmentable
 
     public function setContents(array $contents)
     {
+        if (isset($this->contents['meta'])) {
+            $contents['meta'] = $this->contents['meta'];
+        }
+
         $this->contents = $contents;
 
         return $this
@@ -344,6 +348,11 @@ class Blueprint implements Augmentable
     public function title()
     {
         return array_get($this->contents, 'title', Str::humanize($this->handle));
+    }
+
+    public function meta()
+    {
+        return array_get($this->contents, 'meta');
     }
 
     public function toPublishArray()

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -47,7 +47,7 @@ class Fieldset
 
         $contents['fields'] = $fields;
 
-        if (! array_key_exists('meta', $contents) && $this->contents && array_key_exists('meta', $this->contents)) {
+        if (! array_key_exists('meta', $contents) && isset($this->contents['meta'])) {
             $contents['meta'] = $this->contents['meta'];
         }
 

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -47,7 +47,7 @@ class Fieldset
 
         $contents['fields'] = $fields;
 
-        if (! array_key_exists('meta', $contents) && array_key_exists('meta', $this->contents)) {
+        if (! array_key_exists('meta', $contents) && $this->contents && array_key_exists('meta', $this->contents)) {
             $contents['meta'] = $this->contents['meta'];
         }
 

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -47,7 +47,7 @@ class Fieldset
 
         $contents['fields'] = $fields;
 
-        if (isset($this->contents['meta'])) {
+        if (! array_key_exists('meta', $contents) && array_key_exists('meta', $this->contents)) {
             $contents['meta'] = $this->contents['meta'];
         }
 

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -47,8 +47,8 @@ class Fieldset
 
         $contents['fields'] = $fields;
 
-        if (! array_key_exists('meta', $contents) && isset($this->contents['meta'])) {
-            $contents['meta'] = $this->contents['meta'];
+        if (! array_key_exists('custom', $contents) && isset($this->contents['custom'])) {
+            $contents['custom'] = $this->contents['custom'];
         }
 
         $this->contents = $contents;
@@ -66,9 +66,9 @@ class Fieldset
         return array_get($this->contents, 'title', Str::humanize($this->handle));
     }
 
-    public function meta()
+    public function custom()
     {
-        return array_get($this->contents, 'meta');
+        return array_get($this->contents, 'custom');
     }
 
     public function fields(): Fields

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -47,6 +47,10 @@ class Fieldset
 
         $contents['fields'] = $fields;
 
+        if (isset($this->contents['meta'])) {
+            $contents['meta'] = $this->contents['meta'];
+        }
+
         $this->contents = $contents;
 
         return $this;
@@ -60,6 +64,11 @@ class Fieldset
     public function title()
     {
         return array_get($this->contents, 'title', Str::humanize($this->handle));
+    }
+
+    public function meta()
+    {
+        return array_get($this->contents, 'meta');
     }
 
     public function fields(): Fields

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -64,14 +64,13 @@ class BlueprintTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_meta()
+    public function it_gets_custom()
     {
         $blueprint = (new Blueprint)->setContents([
-            'title' => 'Test',
-            'meta' => 'abc',
+            'custom' => 'abc',
         ]);
 
-        $this->assertEquals('abc', $blueprint->meta());
+        $this->assertEquals('abc', $blueprint->custom());
     }
 
     /** @test */

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -64,6 +64,17 @@ class BlueprintTest extends TestCase
     }
 
     /** @test */
+    public function it_gets_meta()
+    {
+        $blueprint = (new Blueprint)->setContents([
+            'title' => 'Test',
+            'meta' => 'abc',
+        ]);
+
+        $this->assertEquals('abc', $blueprint->meta());
+    }
+
+    /** @test */
     public function it_gets_the_hidden_property_which_is_false_by_default()
     {
         $blueprint = new Blueprint;

--- a/tests/Fields/FieldsetTest.php
+++ b/tests/Fields/FieldsetTest.php
@@ -51,14 +51,13 @@ class FieldsetTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_meta()
+    public function it_gets_custom()
     {
         $fieldset = (new Fieldset)->setContents([
-            'title' => 'Test',
-            'meta' => 'abc',
+            'custom' => 'abc',
         ]);
 
-        $this->assertEquals('abc', $fieldset->meta());
+        $this->assertEquals('abc', $fieldset->custom());
     }
 
     /** @test */

--- a/tests/Fields/FieldsetTest.php
+++ b/tests/Fields/FieldsetTest.php
@@ -51,6 +51,17 @@ class FieldsetTest extends TestCase
     }
 
     /** @test */
+    public function it_gets_meta()
+    {
+        $fieldset = (new Fieldset)->setContents([
+            'title' => 'Test',
+            'meta' => 'abc',
+        ]);
+
+        $this->assertEquals('abc', $fieldset->meta());
+    }
+
+    /** @test */
     public function the_title_falls_back_to_a_humanized_handle()
     {
         $fieldset = (new Fieldset)->setHandle('the_blueprint_handle');


### PR DESCRIPTION
Implementation of this idea: https://github.com/statamic/ideas/issues/716

This does not alter the fieldsets and blueprints in any way, it simply allows the `custom` key's value to be retained when saving through the CP. If no custom data has been added nothing changes.

I tried to do this with minimal changes to the least files, as this data is purely for the user and of no use to Statamic itself. That's why everything happens in `setContents()` and the custom data doesn't get read by controllers or passed to views. If you think it would make more sense to handle this data in the same way as everything else I can make those changes.

Also includes a `custom()` method to retrieve the value from Fieldset and Blueprint objects.

Thought `custom` made sense, but another name might be better, perhaps `user_data` or similar?

There's also a simpler alternative to this: https://github.com/statamic/cms/pull/5114