### PR TITLE
Track and handle hidden fields on publish forms to fix `sometimes`, `required_if`, etc. rules

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -185,8 +185,13 @@
 import EditorActions from './EditorActions.vue';
 import FocalPointEditor from './FocalPointEditor.vue';
 import PublishFields from '../../publish/Fields.vue';
+import HasHiddenFields from '../../data-list/HasHiddenFields';
 
 export default {
+
+    mixins: [
+        HasHiddenFields,
+    ],
 
     components: {
         EditorActions,
@@ -332,7 +337,7 @@ export default {
             this.saving = true;
             const url = cp_url(`assets/${utf8btoa(this.id)}`);
 
-            this.$axios.patch(url, this.values).then(response => {
+            this.$axios.patch(url, this.visibleValues).then(response => {
                 this.$emit('saved', response.data.asset);
                 this.$toast.success(__('Saved'));
                 this.saving = false;

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -117,7 +117,7 @@
 
                 <publish-container
                     v-if="fields"
-                    name="publishContainer"
+                    :name="publishContainer"
                     :blueprint="fieldset"
                     :values="values"
                     :meta="meta"

--- a/resources/js/components/data-list/HasHiddenFields.js
+++ b/resources/js/components/data-list/HasHiddenFields.js
@@ -1,0 +1,17 @@
+export default {
+
+    computed: {
+
+        hiddenFields() {
+            return this.$store.state.publish[this.publishContainer].hiddenFields;
+        },
+
+        visibleValues() {
+            return _.omit(this.values, (_, handle) => {
+                return this.hiddenFields[handle];
+            });
+        },
+
+    }
+
+}

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -418,6 +418,12 @@ export default {
             return this.getPreference('after_save');
         },
 
+        visibleValues() {
+            return _.omit(this.values, (_, handle) => {
+                return this.$store.state.publish.base.hiddenFields[handle];
+            });
+        },
+
     },
 
     watch: {
@@ -464,7 +470,7 @@ export default {
         performSaveRequest() {
             // Once the hook has completed, we need to make the actual request.
             // We build the payload here because the before hook may have modified values.
-            const payload = { ...this.values, ...{
+            const payload = { ...this.visibleValues, ...{
                 _blueprint: this.fieldset.handle,
                 _localized: this.localizedFields,
             }};

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -420,7 +420,7 @@ export default {
 
         visibleValues() {
             return _.omit(this.values, (_, handle) => {
-                return this.$store.state.publish.base.hiddenFields[handle];
+                return this.$store.state.publish[this.publishContainer].hiddenFields[handle];
             });
         },
 

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -257,11 +257,13 @@ import PublishActions from './PublishActions';
 import SaveButtonOptions from '../publish/SaveButtonOptions';
 import RevisionHistory from '../revision-history/History';
 import HasPreferences from '../data-list/HasPreferences';
+import HasHiddenFields from '../data-list/HasHiddenFields';
 
 export default {
 
     mixins: [
         HasPreferences,
+        HasHiddenFields,
     ],
 
     components: {
@@ -416,12 +418,6 @@ export default {
 
         afterSaveOption() {
             return this.getPreference('after_save');
-        },
-
-        visibleValues() {
-            return _.omit(this.values, (_, handle) => {
-                return this.$store.state.publish[this.publishContainer].hiddenFields[handle];
-            });
         },
 
     },

--- a/resources/js/components/field-conditions/ValidatorMixin.js
+++ b/resources/js/components/field-conditions/ValidatorMixin.js
@@ -11,7 +11,7 @@ export default {
         showField(field) {
             let passes = new Validator(field, this.values, this.$store, this.storeName).passesConditions();
 
-            Statamic.$store.commit(`publish/${this.storeName}/setHiddenField`, {
+            this.$store.commit(`publish/${this.storeName}/setHiddenField`, {
                 handle: field.handle,
                 hidden: ! passes,
             });

--- a/resources/js/components/field-conditions/ValidatorMixin.js
+++ b/resources/js/components/field-conditions/ValidatorMixin.js
@@ -9,9 +9,14 @@ export default {
 
     methods: {
         showField(field) {
-            let validator = new Validator(field, this.values, this.$store, this.storeName);
+            let passes = new Validator(field, this.values, this.$store, this.storeName).passesConditions();
 
-            return validator.passesConditions();
+            Statamic.$store.commit(`publish/${this.storeName}/setHiddenField`, {
+                handle: field.handle,
+                hidden: ! passes,
+            });
+
+            return passes;
         }
     }
 }

--- a/resources/js/components/field-validation/Rules.js
+++ b/resources/js/components/field-validation/Rules.js
@@ -284,6 +284,10 @@ export default [
         example: 'size:value'
     },
     {
+        label: 'Sometimes',
+        value: 'sometimes',
+    },
+    {
         label: 'Starts With',
         value: 'starts_with:',
         example: 'starts_with:foo,bar,...',

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -85,8 +85,13 @@
 
 <script>
 import SiteSelector from '../SiteSelector.vue';
+import HasHiddenFields from '../data-list/HasHiddenFields';
 
 export default {
+
+    mixins: [
+        HasHiddenFields,
+    ],
 
     components: {
         SiteSelector
@@ -193,7 +198,7 @@ export default {
             this.saving = true;
             this.clearErrors();
 
-            const payload = { ...this.values, ...{
+            const payload = { ...this.visibleValues, ...{
                 blueprint: this.fieldset.handle,
                 _localized: this.localizedFields,
             }};

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -96,6 +96,7 @@ export default {
                 state: {
                     blueprint: initial.blueprint,
                     values: initial.values,
+                    hiddenFields: {},
                     meta: initial.meta,
                     localizedFields: initial.localizedFields,
                     site: initial.site,
@@ -111,6 +112,9 @@ export default {
                     },
                     setValues(state, values) {
                         state.values = values;
+                    },
+                    setHiddenField(state, field) {
+                        state.hiddenFields[field.handle] = field.hidden;
                     },
                     setMeta(state, meta) {
                         state.meta = meta;

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -235,11 +235,13 @@ import PublishActions from './PublishActions.vue';
 import SaveButtonOptions from '../publish/SaveButtonOptions';
 import RevisionHistory from '../revision-history/History.vue';
 import HasPreferences from '../data-list/HasPreferences';
+import HasHiddenFields from '../data-list/HasHiddenFields';
 
 export default {
 
     mixins: [
         HasPreferences,
+        HasHiddenFields,
     ],
 
     components: {
@@ -419,7 +421,7 @@ export default {
         },
 
         performSaveRequest() {
-            const payload = { ...this.values, ...{
+            const payload = { ...this.visibleValues, ...{
                 _blueprint: this.fieldset.handle,
                 published: this.published,
                 _localized: this.localizedFields,

--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -54,8 +54,13 @@
 
 <script>
 import ChangePassword from './ChangePassword.vue';
+import HasHiddenFields from '../data-list/HasHiddenFields';
 
 export default {
+
+    mixins: [
+        HasHiddenFields,
+    ],
 
     components: {
         ChangePassword,
@@ -103,7 +108,7 @@ export default {
         save() {
             this.clearErrors();
 
-            this.$axios[this.method](this.actions.save, this.values).then(response => {
+            this.$axios[this.method](this.actions.save, this.visibleValues).then(response => {
                 this.title = response.data.title;
                 if (!this.isCreating) this.$toast.success(__('Saved'));
                 this.$refs.container.saved();

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -17,6 +17,7 @@ class Field implements Arrayable
     protected $value;
     protected $parent;
     protected $parentField;
+    protected $filled = false;
 
     public function __construct($handle, array $config)
     {
@@ -29,7 +30,8 @@ class Field implements Arrayable
         return (new static($this->handle, $this->config))
             ->setParent($this->parent)
             ->setParentField($this->parentField)
-            ->setValue($this->value);
+            ->setValue($this->value)
+            ->setFilled($this->filled);
     }
 
     public function setHandle(string $handle)
@@ -168,6 +170,11 @@ class Field implements Arrayable
         return (bool) $this->get('filterable');
     }
 
+    public function isFilled()
+    {
+        return (bool) $this->filled;
+    }
+
     public function toPublishArray()
     {
         return array_merge($this->preProcessedConfig(), [
@@ -194,9 +201,24 @@ class Field implements Arrayable
         ];
     }
 
+    public function setFilled($filled)
+    {
+        $this->filled = $filled;
+
+        return $this;
+    }
+
     public function setValue($value)
     {
         $this->value = $value;
+
+        return $this;
+    }
+
+    public function fillValue($value)
+    {
+        $this->value = $value;
+        $this->filled = true;
 
         return $this;
     }

--- a/src/Fields/MissingValue.php
+++ b/src/Fields/MissingValue.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Statamic\Fields;
-
-class MissingValue
-{
-    //
-}

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -39,7 +39,7 @@ class FormController extends Controller
             return Str::startsWith($key, '_');
         })->all();
 
-        $fields = $fields->setTrackMissingValues(true)->addValues($values);
+        $fields = $fields->addValues($values);
 
         $submission = $form->makeSubmission()->data($values);
 

--- a/tests/Fields/FieldsTest.php
+++ b/tests/Fields/FieldsTest.php
@@ -536,6 +536,32 @@ class FieldsTest extends TestCase
     }
 
     /** @test */
+    public function adding_values_sets_filled_status_on_fields_for_validation()
+    {
+        FieldRepository::shouldReceive('find')->with('one')->andReturnUsing(function () {
+            return new Field('one', []);
+        });
+
+        FieldRepository::shouldReceive('find')->with('two')->andReturnUsing(function () {
+            return new Field('two', []);
+        });
+
+        $fields = new Fields([
+            ['handle' => 'one', 'field' => 'one'],
+            ['handle' => 'two', 'field' => 'two'],
+        ]);
+
+        $this->assertEquals(['one' => null, 'two' => null], $fields->values()->all());
+
+        $fields = $fields->addValues(['one' => 'foo']);
+
+        $this->assertTrue($fields->get('one')->isFilled());
+        $this->assertFalse($fields->get('two')->isFilled());
+        $this->assertEquals(['one' => 'foo', 'two' => null], $fields->values()->all());
+        $this->assertEquals(['one' => 'foo'], $fields->validatableValues()->all());
+    }
+
+    /** @test */
     public function it_processes_each_fields_values_by_its_fieldtype()
     {
         FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype


### PR DESCRIPTION
Closes https://github.com/statamic/cms/issues/5092.

### TODO:

- [x] Track hidden fields as we evaluate `showField()` logic on each publish form field.
- [x] Refactor to use dynamic publish store name, rather than hardcoding to `base`.
- [x] Remove `setTrackMissingValues()` from `Fields.php` and always track missing values when calling `addValues()`.
- [x] Ensure we filter payloads on every publish form before sending to server.
- [x] Add test coverage.
- [ ] ~Handle nested missing values within grids/replicators/bards.~
    - We can revisit this in another PR after @arthurperton finishes his grid/replicator/bard validation related fixes 👍 
