### PR TITLE
Add ability to store arbitrary data in fieldset and blueprint YAML files (alt to #5097)

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -112,7 +112,7 @@ class Blueprint implements Augmentable
 
     public function setContents(array $contents)
     {
-        $this->contents = $contents;
+        $this->contents = array_merge($this->contents ?? [], $contents);
 
         return $this
             ->normalizeSections()

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -47,7 +47,7 @@ class Fieldset
 
         $contents['fields'] = $fields;
 
-        $this->contents = $contents;
+        $this->contents = array_merge($this->contents ?? [], $contents);
 
         return $this;
     }

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -64,6 +64,16 @@ class BlueprintTest extends TestCase
     }
 
     /** @test */
+    public function it_gets_arbitrary_data()
+    {
+        $blueprint = (new Blueprint)->setContents([
+            'example' => 'abc',
+        ]);
+
+        $this->assertEquals('abc', $blueprint->contents()['example']);
+    }
+
+    /** @test */
     public function it_gets_the_hidden_property_which_is_false_by_default()
     {
         $blueprint = new Blueprint;

--- a/tests/Fields/FieldsetTest.php
+++ b/tests/Fields/FieldsetTest.php
@@ -51,6 +51,16 @@ class FieldsetTest extends TestCase
     }
 
     /** @test */
+    public function it_gets_arbitrary_data()
+    {
+        $fieldset = (new Fieldset)->setContents([
+            'example' => 'abc',
+        ]);
+
+        $this->assertEquals('abc', $fieldset->contents()['example']);
+    }
+
+    /** @test */
     public function the_title_falls_back_to_a_humanized_handle()
     {
         $fieldset = (new Fieldset)->setHandle('the_blueprint_handle');


### PR DESCRIPTION
Apologies for the dual PR's, it just occurred to me that there's an alternative approach to this that may be better...

This is a much simpler alternative to https://github.com/statamic/cms/pull/5097 and implementation of https://github.com/statamic/ideas/issues/716, allowing any arbitrary data to be stored in fieldset and blueprint YAML files.

Does a shallow merge with the existing data when setting new contents, allowing any custom user data to be retained when saving through the CP.