### PR TITLE
Nested lists now handled correctly by widont

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -178,12 +178,12 @@ class Str extends \Illuminate\Support\Str
 
             // step 2, replace all tabs and spaces based on params with &nbsp;
             $value = preg_replace_callback("/(?<!<[p|li|h1|h2|h3|h4|h5|h6|div|figcaption])([^\s]\s)([^\s]*\s?){{$words}}(<\/(?:p|li|h1|h2|h3|h4|h5|h6|div|figcaption)>)/", function ($matches) {
-                return preg_replace("/([[:blank:]])/", '&nbsp;', rtrim($matches[0]));
+                return preg_replace('/([[:blank:]])/', '&nbsp;', rtrim($matches[0]));
             }, $value);
 
             // Step 3, handle potential nested list orphans
             $value = preg_replace_callback("/(?<!<[li])([^\s]\s)([^\s]*\s?){{$words}}(<(?:ol|ul)>)/", function ($matches) {
-                return preg_replace("/[[:blank:]]/", '&nbsp;', rtrim($matches[0]));
+                return preg_replace('/[[:blank:]]/', '&nbsp;', rtrim($matches[0]));
             }, $value);
 
             // step 4, re-replace the code from step 1 with spaces

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -176,12 +176,17 @@ class Str extends \Illuminate\Support\Str
                 return str_replace(' ', '%###%##%', $matches[0]);
             }, $value);
 
-            // step 2, replace all spaces based on params with &nbsp;
+            // step 2, replace all tabs and spaces based on params with &nbsp;
             $value = preg_replace_callback("/(?<!<[p|li|h1|h2|h3|h4|h5|h6|div|figcaption])([^\s]\s)([^\s]*\s?){{$words}}(<\/(?:p|li|h1|h2|h3|h4|h5|h6|div|figcaption)>)/", function ($matches) {
-                return preg_replace("/([\s])/", '&nbsp;', rtrim($matches[0]));
+                return preg_replace("/([[:blank:]])/", '&nbsp;', rtrim($matches[0]));
             }, $value);
 
-            // step 3, re-replace the code from step 1 with spaces
+            // Step 3, handle potential nested list orphans
+            $value = preg_replace_callback("/(?<!<[li])([^\s]\s)([^\s]*\s?){{$words}}(<(?:ol|ul)>)/", function ($matches) {
+                return preg_replace("/[[:blank:]]/", '&nbsp;', rtrim($matches[0]));
+            }, $value);
+
+            // step 4, re-replace the code from step 1 with spaces
             return str_replace('%###%##%', ' ', $value);
 
         // otherwise

--- a/tests/Modifiers/WidontTest.php
+++ b/tests/Modifiers/WidontTest.php
@@ -95,4 +95,16 @@ EOD;
     {
         return Modify::value($value)->widont($params)->fetch();
     }
+
+    /** @test */
+    public function it_doesnt_add_nbsp_to_nested_list()
+    {
+        $eol = PHP_EOL;
+        $value = "<ul>$eol<li>Lorem ipsum dolor sit amet.$eol<ul>$eol<li>Consectetur adipiscing elit.</li>$eol</ul>$eol</li>$eol<li>Lorem ipsum dolor sit amet.</li>$eol</ul>$eol";
+
+        $this->assertEquals(
+            "<ul>$eol<li>Lorem ipsum dolor sit&nbsp;amet.$eol<ul>$eol<li>Consectetur adipiscing&nbsp;elit.</li>$eol</ul>$eol</li>$eol<li>Lorem ipsum dolor sit&nbsp;amet.</li>$eol</ul>$eol",
+            $this->modify($value)
+        );
+    }
 }


### PR DESCRIPTION
- Don't replace new line characters in between mismatched tags (such as Nested Lists). HTML will handle this natively, as widont is meant for orphans within text only. It does not need to be a non-breaking space.
- Add another regex to handle nested list content, before a nested list, not being "widonted". This is due to the existing widont code only matching on matching (i.e. li) tags.

I tried to add the second part to the existing step 2 but my regex skills weren't good enough to figure out how to do that. 

Fixes #5040 