### PR TITLE
Filter published entry in GraphQL

### DIFF
--- a/src/GraphQL/Queries/Concerns/FiltersQuery.php
+++ b/src/GraphQL/Queries/Concerns/FiltersQuery.php
@@ -7,8 +7,6 @@ use Statamic\Support\Arr;
 trait FiltersQuery
 {
     /**
-     * Query filters and return active filter badges.
-     *
      * @param  \Statamic\Contracts\Entries\QueryBuilder  $query
      * @param  array  $filters
      * @return void

--- a/src/GraphQL/Queries/Concerns/FiltersQuery.php
+++ b/src/GraphQL/Queries/Concerns/FiltersQuery.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Statamic\GraphQL\Queries\Concerns;
+
+use Statamic\Support\Arr;
+
+trait FiltersQuery
+{
+    /**
+     * Query filters and return active filter badges.
+     *
+     * @param  \Statamic\Contracts\Entries\QueryBuilder  $query
+     * @param  array  $filters
+     * @return void
+     */
+    private function filterQuery($query, $filters)
+    {
+        if (!isset($filters['status']) && !isset($filters['published'])) {
+            $filters['status'] = 'published';
+        }
+
+        foreach ($filters as $field => $definitions) {
+            if (!is_array($definitions)) {
+                $definitions = [['equals' => $definitions]];
+            }
+
+            if (Arr::assoc($definitions)) {
+                $definitions = collect($definitions)->map(function ($value, $key) {
+                    return [$key => $value];
+                })->values()->all();
+            }
+
+            foreach ($definitions as $definition) {
+                $condition = array_keys($definition)[0];
+                $value = array_values($definition)[0];
+                $this->queryCondition($query, $field, $condition, $value);
+            }
+        }
+    }
+}

--- a/src/GraphQL/Queries/Concerns/FiltersQuery.php
+++ b/src/GraphQL/Queries/Concerns/FiltersQuery.php
@@ -15,12 +15,12 @@ trait FiltersQuery
      */
     private function filterQuery($query, $filters)
     {
-        if (!isset($filters['status']) && !isset($filters['published'])) {
+        if (! isset($filters['status']) && ! isset($filters['published'])) {
             $filters['status'] = 'published';
         }
 
         foreach ($filters as $field => $definitions) {
-            if (!is_array($definitions)) {
+            if (! is_array($definitions)) {
                 $definitions = [['equals' => $definitions]];
             }
 

--- a/src/GraphQL/Queries/Concerns/FiltersQuery.php
+++ b/src/GraphQL/Queries/Concerns/FiltersQuery.php
@@ -3,9 +3,12 @@
 namespace Statamic\GraphQL\Queries\Concerns;
 
 use Statamic\Support\Arr;
+use Statamic\Tags\Concerns\QueriesConditions;
 
 trait FiltersQuery
 {
+    use QueriesConditions;
+
     /**
      * @param  \Statamic\Contracts\Entries\QueryBuilder  $query
      * @param  array  $filters

--- a/src/GraphQL/Queries/EntriesQuery.php
+++ b/src/GraphQL/Queries/EntriesQuery.php
@@ -10,11 +10,10 @@ use Statamic\GraphQL\Queries\Concerns\FiltersQuery;
 use Statamic\GraphQL\Types\EntryInterface;
 use Statamic\GraphQL\Types\JsonArgument;
 use Statamic\Support\Str;
-use Statamic\Tags\Concerns\QueriesConditions;
 
 class EntriesQuery extends Query
 {
-    use QueriesConditions, FiltersQuery;
+    use FiltersQuery;
 
     protected $attributes = [
         'name' => 'entries',

--- a/src/GraphQL/Queries/EntriesQuery.php
+++ b/src/GraphQL/Queries/EntriesQuery.php
@@ -6,15 +6,15 @@ use GraphQL\Type\Definition\Type;
 use Statamic\Facades\Entry;
 use Statamic\Facades\GraphQL;
 use Statamic\GraphQL\Middleware\ResolvePage;
+use Statamic\GraphQL\Queries\Concerns\FiltersQuery;
 use Statamic\GraphQL\Types\EntryInterface;
 use Statamic\GraphQL\Types\JsonArgument;
-use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Tags\Concerns\QueriesConditions;
 
 class EntriesQuery extends Query
 {
-    use QueriesConditions;
+    use QueriesConditions, FiltersQuery;
 
     protected $attributes = [
         'name' => 'entries',
@@ -53,31 +53,6 @@ class EntriesQuery extends Query
         $this->sortQuery($query, $args['sort'] ?? []);
 
         return $query->paginate($args['limit'] ?? 1000);
-    }
-
-    private function filterQuery($query, $filters)
-    {
-        if (! isset($filters['status']) && ! isset($filters['published'])) {
-            $filters['status'] = 'published';
-        }
-
-        foreach ($filters as $field => $definitions) {
-            if (! is_array($definitions)) {
-                $definitions = [['equals' => $definitions]];
-            }
-
-            if (Arr::assoc($definitions)) {
-                $definitions = collect($definitions)->map(function ($value, $key) {
-                    return [$key => $value];
-                })->values()->all();
-            }
-
-            foreach ($definitions as $definition) {
-                $condition = array_keys($definition)[0];
-                $value = array_values($definition)[0];
-                $this->queryCondition($query, $field, $condition, $value);
-            }
-        }
     }
 
     private function sortQuery($query, $sorts)

--- a/src/GraphQL/Queries/EntryQuery.php
+++ b/src/GraphQL/Queries/EntryQuery.php
@@ -5,14 +5,14 @@ namespace Statamic\GraphQL\Queries;
 use GraphQL\Type\Definition\Type;
 use Statamic\Facades;
 use Statamic\Facades\GraphQL;
+use Statamic\GraphQL\Queries\Concerns\FiltersQuery;
 use Statamic\GraphQL\Types\EntryInterface;
 use Statamic\GraphQL\Types\JsonArgument;
-use Statamic\Support\Arr;
 use Statamic\Tags\Concerns\QueriesConditions;
 
 class EntryQuery extends Query
 {
-    use QueriesConditions;
+    use QueriesConditions, FiltersQuery;
 
     protected $attributes = [
         'name' => 'entry',
@@ -62,30 +62,5 @@ class EntryQuery extends Query
         $this->filterQuery($query, $args['filter'] ?? []);
 
         return $query->limit(1)->get()->first();
-    }
-
-    private function filterQuery($query, $filters)
-    {
-        if (! isset($filters['status']) && ! isset($filters['published'])) {
-            $filters['status'] = 'published';
-        }
-
-        foreach ($filters as $field => $definitions) {
-            if (! is_array($definitions)) {
-                $definitions = [['equals' => $definitions]];
-            }
-
-            if (Arr::assoc($definitions)) {
-                $definitions = collect($definitions)->map(function ($value, $key) {
-                    return [$key => $value];
-                })->values()->all();
-            }
-
-            foreach ($definitions as $definition) {
-                $condition = array_keys($definition)[0];
-                $value = array_values($definition)[0];
-                $this->queryCondition($query, $field, $condition, $value);
-            }
-        }
     }
 }

--- a/src/GraphQL/Queries/EntryQuery.php
+++ b/src/GraphQL/Queries/EntryQuery.php
@@ -66,12 +66,12 @@ class EntryQuery extends Query
 
     private function filterQuery($query, $filters)
     {
-        if (!isset($filters['status']) && !isset($filters['published'])) {
+        if (! isset($filters['status']) && ! isset($filters['published'])) {
             $filters['status'] = 'published';
         }
 
         foreach ($filters as $field => $definitions) {
-            if (!is_array($definitions)) {
+            if (! is_array($definitions)) {
                 $definitions = [['equals' => $definitions]];
             }
 

--- a/src/GraphQL/Queries/EntryQuery.php
+++ b/src/GraphQL/Queries/EntryQuery.php
@@ -8,11 +8,10 @@ use Statamic\Facades\GraphQL;
 use Statamic\GraphQL\Queries\Concerns\FiltersQuery;
 use Statamic\GraphQL\Types\EntryInterface;
 use Statamic\GraphQL\Types\JsonArgument;
-use Statamic\Tags\Concerns\QueriesConditions;
 
 class EntryQuery extends Query
 {
-    use QueriesConditions, FiltersQuery;
+    use FiltersQuery;
 
     protected $attributes = [
         'name' => 'entry',

--- a/src/GraphQL/Queries/EntryQuery.php
+++ b/src/GraphQL/Queries/EntryQuery.php
@@ -6,9 +6,14 @@ use GraphQL\Type\Definition\Type;
 use Statamic\Facades;
 use Statamic\Facades\GraphQL;
 use Statamic\GraphQL\Types\EntryInterface;
+use Statamic\GraphQL\Types\JsonArgument;
+use Statamic\Support\Arr;
+use Statamic\Tags\Concerns\QueriesConditions;
 
 class EntryQuery extends Query
 {
+    use QueriesConditions;
+
     protected $attributes = [
         'name' => 'entry',
     ];
@@ -26,6 +31,7 @@ class EntryQuery extends Query
             'collection' => GraphQL::string(),
             'uri' => GraphQL::string(),
             'site' => GraphQL::string(),
+            'filter' => GraphQL::type(JsonArgument::NAME),
         ];
     }
 
@@ -53,6 +59,33 @@ class EntryQuery extends Query
             $query->where('site', $site);
         }
 
+        $this->filterQuery($query, $args['filter'] ?? []);
+
         return $query->limit(1)->get()->first();
+    }
+
+    private function filterQuery($query, $filters)
+    {
+        if (!isset($filters['status']) && !isset($filters['published'])) {
+            $filters['status'] = 'published';
+        }
+
+        foreach ($filters as $field => $definitions) {
+            if (!is_array($definitions)) {
+                $definitions = [['equals' => $definitions]];
+            }
+
+            if (Arr::assoc($definitions)) {
+                $definitions = collect($definitions)->map(function ($value, $key) {
+                    return [$key => $value];
+                })->values()->all();
+            }
+
+            foreach ($definitions as $definition) {
+                $condition = array_keys($definition)[0];
+                $value = array_values($definition)[0];
+                $this->queryCondition($query, $field, $condition, $value);
+            }
+        }
     }
 }

--- a/tests/Feature/GraphQL/EntryTest.php
+++ b/tests/Feature/GraphQL/EntryTest.php
@@ -263,6 +263,84 @@ GQL;
     }
 
     /** @test */
+    public function it_filters_an_entry()
+    {
+        EntryFactory::collection('blog')
+            ->id('6')
+            ->slug('that-was-so-rad')
+            ->data(['title' => 'That was so rad!'])
+            ->published(false)
+            ->create();
+
+        $query = <<<'GQL'
+{
+    entry(id: "6", filter: { status: { is: "published" } }) {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => ['entry' => null]]);
+    }
+
+    /** @test */
+    public function it_filters_entries_with_equalto_shorthand()
+    {
+        EntryFactory::collection('blog')
+            ->id('6')
+            ->slug('that-was-so-rad')
+            ->data(['title' => 'That was so rad!'])
+            ->published(true)
+            ->create();
+
+        $query = <<<'GQL'
+{
+    entry(id: "6", filter: { status: "draft" }) {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => ['entry' => null]]);
+    }
+
+    /** @test */
+    public function it_filters_entries_with_multiple_conditions_of_the_same_type()
+    {
+        EntryFactory::collection('blog')
+            ->id('6')
+            ->slug('that-was-so-rad')
+            ->data(['title' => 'That was so rad!'])
+            ->published(true)
+            ->create();
+
+        $query = <<<'GQL'
+{
+    entry(id: "6", filter: { status: "published", title: { doesnt_contain: "rad" } }) {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => ['entry' => null]]);
+    }
+
+    /** @test */
     public function it_can_add_custom_fields_to_interface()
     {
         GraphQL::addField('EntryInterface', 'one', function () {
@@ -403,5 +481,121 @@ GQL;
                 ['entry' => '4'],
             ]],
         ])->save();
+    }
+
+    /** @test */
+    public function it_only_shows_published_entries_by_default()
+    {
+        EntryFactory::collection('blog')
+            ->id('6')
+            ->slug('that-was-so-rad')
+            ->data(['title' => 'That was so rad!'])
+            ->published(false)
+            ->create();
+        EntryFactory::collection('blog')
+            ->id('7')
+            ->slug('that-will-be-so-rad')
+            ->data(['title' => 'That will be so rad!'])
+            ->date(now()->addMonths(2))
+            ->create();
+
+        $query = <<<'GQL'
+{
+    entry(id: "6") {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => ['entry' => null]]);
+
+        $query = <<<'GQL'
+{
+    entry(id: "6", filter: {published: true}) {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => ['entry' => null]]);
+
+        $query = <<<'GQL'
+{
+    entry(id: "6", filter: { status: "draft" }) {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+                ->withoutExceptionHandling()
+                ->post('/graphql', ['query' => $query])
+                ->assertGqlOk()
+                ->assertExactJson(['data' => ['entry' => [
+                    'id' => '6',
+                    'title' => 'That was so rad!',
+                ]]]);
+
+        $query = <<<'GQL'
+{
+    entry(id: "6", filter: { published: false }) {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => ['entry' => [
+                'id' => '6',
+                'title' => 'That was so rad!',
+            ]]]);
+
+        $query = <<<'GQL'
+{
+    entry(id: "6", filter: { status: "scheduled" }) {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => ['entry' => null]]);
+
+        $query = <<<'GQL'
+{
+    entry(id: "7", filter: { status: "scheduled" }) {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => ['entry' => [
+                'id' => '7',
+                'title' => 'That will be so rad!',
+            ]]]);
     }
 }


### PR DESCRIPTION
This PR implement the same filter capability and default behavior you implemented in #3349 for the `entry` query.
If you filter on status or published, the default behavior goes away and does whatever you've asked for instead.

I didn't write any tests yet. I'll be happy to add those if you're happy with the PR.