### PR TITLE
Cache user roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## 3.2.0 (2021-08-24)
+
+### What's new
+- Official 3.2 release! 🎉
+
+### What's fixed
+- References to assets in links in Bard fields will get updated. [#4152](https://github.com/statamic/cms/issues/4152)
+- Adjusted nav item editor instructions. [#4142](https://github.com/statamic/cms/issues/4142)
+- Removed the warning when renaming assets. [#4141](https://github.com/statamic/cms/issues/4141)
+- Changes from 3.1
+
+
+
 ## 3.2.0-beta.1 (2021-08-17)
 
 ### What's new


### PR DESCRIPTION
We noticed some small speed problems if a user had multiple roles. This graph shows two identical server instances with identical data sets. They only differ by using the Blink cache. 

![Bildschirmfoto 2022-01-24 um 17 57 24](https://user-images.githubusercontent.com/38906163/150829034-42d9d944-6169-47e9-be65-60744e1b89b7.png)

The test case shows a user with 6 roles in total. The request would take even longer with more roles attached.

This PR would speed up the overall cp speed, as the roles will be fetched in most requests. Our example uses the dashboard, but the article listing shows nearly identical values.

Originally authored by @jojotl 