### PR TITLE
Fix abstract query builder method

### DIFF
--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -177,5 +177,8 @@ abstract class Builder extends BaseBuilder
         });
     }
 
-    abstract protected function getWhereColumnKeyValuesByIndex($column);
+    protected function getWhereColumnKeyValuesByIndex($column)
+    {
+        return $this->store->index($column)->items();
+    }
 }

--- a/src/Stache/Query/UserQueryBuilder.php
+++ b/src/Stache/Query/UserQueryBuilder.php
@@ -50,11 +50,4 @@ class UserQueryBuilder extends Builder
             return [$orderBy->sort => $items];
         });
     }
-
-    protected function getWhereColumnKeyValuesByIndex($column)
-    {
-        return app('stache')
-                ->store('users')
-                ->index($column)->items();
-    }
 }


### PR DESCRIPTION
Fixes #5078

A new abstract method snuck into the query builder in PR #4754 which was fine for us because we implemented it everywhere, but developers who had their own classes would get an error.

The implementation in the users query builder is generic enough that I moved that to the parent class.
