### PR TITLE
Fix Eloquent query builder selects

### DIFF
--- a/src/Auth/Eloquent/UserQueryBuilder.php
+++ b/src/Auth/Eloquent/UserQueryBuilder.php
@@ -12,6 +12,6 @@ class UserQueryBuilder extends EloquentQueryBuilder
     {
         return UserCollection::make($items)->map(function ($model) {
             return User::make()->model($model);
-        })->each->selectedQueryColumns($columns);
+        });
     }
 }

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -10,6 +10,7 @@ use Statamic\Support\Arr;
 abstract class EloquentQueryBuilder implements Builder
 {
     protected $builder;
+    protected $columns;
 
     public function __construct(EloquentBuilder $builder)
     {
@@ -23,11 +24,26 @@ abstract class EloquentQueryBuilder implements Builder
         return $this;
     }
 
+    public function select($columns = ['*'])
+    {
+        $this->columns = $columns;
+
+        return $this;
+    }
+
     public function get($columns = ['*'])
     {
+        $columns = $this->columns ?? $columns;
+
         $items = $this->builder->get($this->selectableColumns($columns));
 
-        return $this->transform($items, $columns);
+        $items = $this->transform($items, $columns);
+
+        if (($first = $items->first()) && method_exists($first, 'selectedQueryColumns')) {
+            $items->each->selectedQueryColumns($columns);
+        }
+
+        return $items;
     }
 
     public function first()

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -221,7 +221,9 @@ class Entries
 
     protected function querySelect($query)
     {
-        $query->select($this->getQuerySelectKeys(Entry::make()));
+        if ($keys = $this->getQuerySelectKeys(Entry::make())) {
+            $query->select($keys);
+        }
     }
 
     protected function querySite($query)


### PR DESCRIPTION
Our Eloquent Query builder always ends up dealing with Statamic objects, which need all the columns.

When you use the new `select` param in the `collection` tag, or if you were to do `$query->select(...)`, your DB query may be faster from not selecting everything, but the objects wouldn't get hydrated correctly since they're expecting all the column values.

This PR will track the selected columns and pass them along to the eventual objects (Users, Entries, etc) so that when they're augmented, you'll only get the keys you asked for, which is a performance benefit.

I also made the `select` param on the collection tag not modify the query at all if you don't pass anything.

Fixes #5108 