### PR TITLE
Add Str::studly

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -272,7 +272,7 @@ class Str extends \Illuminate\Support\Str
             return parent::$studlyCache[$key];
         }
 
-        $words = explode(' ', \Illuminate\Support\Str::replace(['-', '_'], ' ', $value));
+        $words = explode(' ', str_replace(['-', '_'], ' ', $value));
 
         $studlyWords = array_map(function ($word) {
             return parent::ucfirst($word);

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -263,4 +263,21 @@ class Str extends \Illuminate\Support\Str
     {
         return StaticStringy::replace($string, $search, $replace);
     }
+
+    public static function studly($value)
+    {
+        $key = $value;
+
+        if (isset(parent::$studlyCache[$key])) {
+            return parent::$studlyCache[$key];
+        }
+
+        $words = explode(' ', \Illuminate\Support\Str::replace(['-', '_'], ' ', $value));
+
+        $studlyWords = array_map(function ($word) {
+            return parent::ucfirst($word);
+        }, $words);
+
+        return parent::$studlyCache[$key] = implode($studlyWords);
+    }
 }


### PR DESCRIPTION
This copies `Illuminate\Support\Str::studly` into our class verbatim except for using `str_replace()` method explicitly.

We have this weird conflict between Str and Stringy.
In v4 we'll likely make our Str class not inherit from anywhere, and not do the Stringy fallbacks.

Fixes #5126
The actual bug was that we call `Str::camel()`, which calls `Str::studly()`, which calls the problematic `Str::replace()`.