### PR TITLE
Extra blueprint/fieldset contents stay when saving in the CP

### DIFF
--- a/src/Http/Controllers/CP/Fields/FieldsetController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsetController.php
@@ -63,12 +63,12 @@ class FieldsetController extends CpController
             'fields' => 'array',
         ]);
 
-        $fieldset->setContents([
+        $fieldset->setContents(array_merge($fieldset->contents(), [
             'title' => $request->title,
             'fields' => collect($request->fields)->map(function ($field) {
                 return FieldTransformer::fromVue($field);
             })->all(),
-        ])->save();
+        ]))->save();
 
         return response('', 204);
     }

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -39,10 +39,10 @@ trait ManagesBlueprints
 
         $blueprint
             ->setHidden($request->hidden)
-            ->setContents(array_filter([
+            ->setContents(array_merge($blueprint->contents(), array_filter([
                 'title' => $request->title,
                 'sections' => $sections,
-            ]));
+            ])));
 
         return $blueprint;
     }

--- a/tests/Feature/Collections/Blueprints/UpdateBlueprintTest.php
+++ b/tests/Feature/Collections/Blueprints/UpdateBlueprintTest.php
@@ -49,7 +49,10 @@ class UpdateBlueprintTest extends TestCase
         $this->setTestRoles(['test' => ['access cp', 'configure fields']]);
         $user = tap(Facades\User::make()->assignRole('test'))->save();
         $collection = tap(Collection::make('test'))->save();
-        $blueprint = (new Blueprint)->setNamespace('collections.test')->setHandle('test')->setContents(['title' => 'Test'])->save();
+        $blueprint = (new Blueprint)->setNamespace('collections.test')->setHandle('test')->setContents([
+            'title' => 'Test',
+            'foo' => 'bar',
+        ])->save();
 
         $fieldset = (new Fieldset)->setContents([
             'fields' => [
@@ -102,6 +105,7 @@ class UpdateBlueprintTest extends TestCase
 
         $this->assertEquals([
             'title' => 'Updated title',
+            'foo' => 'bar',
             'sections' => [
                 'one' => [
                     'display' => 'Section One',

--- a/tests/Feature/Fieldsets/UpdateFieldsetTest.php
+++ b/tests/Feature/Fieldsets/UpdateFieldsetTest.php
@@ -45,7 +45,10 @@ class UpdateFieldsetTest extends TestCase
     {
         $this->withoutExceptionHandling();
         $user = tap(Facades\User::make()->makeSuper())->save();
-        $fieldset = (new Fieldset)->setHandle('test')->setContents(['title' => 'Test'])->save();
+        $fieldset = (new Fieldset)->setHandle('test')->setContents([
+            'title' => 'Test',
+            'foo' => 'bar',
+        ])->save();
 
         $this
             ->actingAs($user)
@@ -78,6 +81,7 @@ class UpdateFieldsetTest extends TestCase
 
         $this->assertEquals([
             'title' => 'Updated title',
+            'foo' => 'bar',
             'fields' => [
                 [
                     'handle' => 'one-one',

--- a/tests/Feature/Taxonomies/Blueprints/UpdateBlueprintTest.php
+++ b/tests/Feature/Taxonomies/Blueprints/UpdateBlueprintTest.php
@@ -49,7 +49,10 @@ class UpdateBlueprintTest extends TestCase
         $this->setTestRoles(['test' => ['access cp', 'configure fields']]);
         $user = tap(Facades\User::make()->assignRole('test'))->save();
         $collection = tap(Taxonomy::make('test'))->save();
-        $blueprint = (new Blueprint)->setNamespace('taxonomies.test')->setHandle('test')->setContents(['title' => 'Test'])->save();
+        $blueprint = (new Blueprint)->setNamespace('taxonomies.test')->setHandle('test')->setContents([
+            'title' => 'Test',
+            'foo' => 'bar',
+        ])->save();
 
         $fieldset = (new Fieldset)->setContents([
             'fields' => [
@@ -102,6 +105,7 @@ class UpdateBlueprintTest extends TestCase
 
         $this->assertEquals([
             'title' => 'Updated title',
+            'foo' => 'bar',
             'sections' => [
                 'one' => [
                     'display' => 'Section One',


### PR DESCRIPTION
Closes statamic/ideas#716 which in the ideas repo but I'd argue is a bug.

Replaces #5114 and #5097

cc @jacksleight 