### PR TITLE
Set the color mode default correctly

### DIFF
--- a/src/Fieldtypes/Color.php
+++ b/src/Fieldtypes/Color.php
@@ -48,13 +48,13 @@ class Color extends Fieldtype
                 'type' => 'checkboxes',
                 'inline' => 'true',
                 'options' => [
-                    'hex' => 'HEX',
+                    'hex' => 'HEXA',
                     'rgba' => 'RGBA',
                     'hsla' => 'HSLA',
                     'hsva' => 'HSVA',
                     'cmyk' => 'CMYK',
                 ],
-                'default' => ['HEXA'],
+                'default' => 'hex',
                 'width' => 50,
             ],
         ];


### PR DESCRIPTION
As seen in the screenshot, in the "Default Color Mode" the term "HEXA" is used, while the "Color Modes" uses "HEX". This PR changes "HEX" to "HEXA" to have some consistency. 

**Question:** `HEXA` is very unusual to refer to hexadecimal color code system. Was it introduced to use the same term like the user can see in the color picker?

![2022-01-27_00-14-21](https://user-images.githubusercontent.com/363363/151262919-f4ce3187-c215-403b-841f-010e14747c28.jpg)