### PR TITLE
Fix broken CP when translation filename conflicts with collection handle

### DIFF
--- a/resources/views/partials/nav-main.blade.php
+++ b/resources/views/partials/nav-main.blade.php
@@ -16,7 +16,9 @@
                                     <ul>
                                         @foreach ($item->children() as $child)
                                             <li class="{{ $child->isActive() ? 'current' : '' }}">
-                                                <a href="{{ $child->url() }}" {{ $item->attributes() }}>{{ __($child->name()) }}</a>
+                                                <a href="{{ $child->url() }}" {{ $item->attributes() }}>
+                                                    {{ is_array(__($child->name())) ? $child->name() : __($child->name()) }}
+                                                </a>
                                             </li>
                                         @endforeach
                                     </ul>

--- a/resources/views/partials/nav-mobile.blade.php
+++ b/resources/views/partials/nav-mobile.blade.php
@@ -15,7 +15,9 @@
                                 <ul>
                                     @foreach ($item->children() as $child)
                                         <li class="{{ $child->isActive() ? 'current' : '' }}">
-                                            <a href="{{ $child->url() }}">{{ __($child->name()) }}</a>
+                                            <a href="{{ $child->url() }}">
+                                                {{ is_array(__($child->name())) ? $child->name() : __($child->name()) }}
+                                            </a>
                                         </li>
                                     @endforeach
                                 </ul>


### PR DESCRIPTION
Aims to fix #4852

Background:
As described in the referenced issue, the Statamic backend throws an error when a translation file is named the same way as a collection handle (eg. `lang/en/pages.php`). The error doesn't come from Statamic getting mixed up with translation files & strings but instead, from Laravel trying to sanitize an array when compiling the blade template to actual html.

Laravel favours JSON-Translation files before php-files. This means, a translation of the collection names is still possible, even if a translation-file exists with the same name. This fix really just prevents Statamic showing an error when using a translation file like `en/pages.php` by checking, if the translated string isn't an array and returning the original handle-name instead.