### PR TITLE
Namespaced translation methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
             "Statamic\\": "src/"
         },
         "files": [
-            "src/helpers.php"
+            "src/helpers.php",
+            "src/namespaced_helpers.php"
         ]
     },
     "autoload-dev": {

--- a/resources/views/partials/nav-main.blade.php
+++ b/resources/views/partials/nav-main.blade.php
@@ -1,3 +1,5 @@
+@php use function Statamic\trans as __; @endphp
+
 @section('nav-main')
     <nav class="nav-main" v-cloak>
         <div class="nav-main-inner">

--- a/resources/views/partials/nav-mobile.blade.php
+++ b/resources/views/partials/nav-mobile.blade.php
@@ -1,3 +1,5 @@
+@php use function Statamic\trans as __; @endphp
+
 <nav class="nav-main nav-mobile" v-cloak>
     <div class="nav-main-inner">
         @foreach ($nav as $section => $items)

--- a/src/CP/Utilities/CoreUtilities.php
+++ b/src/CP/Utilities/CoreUtilities.php
@@ -10,6 +10,7 @@ use Statamic\Http\Controllers\CP\Utilities\GitController;
 use Statamic\Http\Controllers\CP\Utilities\PhpInfoController;
 use Statamic\Http\Controllers\CP\Utilities\UpdateSearchController;
 use Statamic\Statamic;
+use function Statamic\trans as __;
 
 class CoreUtilities
 {

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -346,4 +346,15 @@ class Statamic
 
         return $prefix.'.*';
     }
+
+    public static function trans($key, $replace = [], $locale = null)
+    {
+        $line = __($key, $replace, $locale);
+
+        if (is_array($line)) {
+            return $key;
+        }
+
+        return $line;
+    }
 }

--- a/src/namespaced_helpers.php
+++ b/src/namespaced_helpers.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Statamic;
+
+function trans($key, $replace = [], $locale = null)
+{
+    return Statamic::trans($key, $replace, $locale);
+}


### PR DESCRIPTION
This is a proof of concept attempt at solving the issue where if you create a translation file named the same as a string, you get an array and the site explodes.

- Fixes #2341
- Fixes #4852
- Supersedes #5139

The more ideal solution would be for Laravel to only return strings through the `__` or `trans` methods, but it looks like that's not going to happen:

- laravel/framework#30690
- laravel/framework#30666
- laravel/framework#26664

It's happening in other packages too:

- kontenta/kontour#178

So here I'm creating our own version of `trans` that will throw away the translation if it was an array.
We can import the namespaced function wherever we use `__` so we can avoid updating `__()` to `Statamic::trans()` in a million places.