### PR TITLE
Refactor JSON encoding for form attributes in JS drivers

### DIFF
--- a/src/Forms/JsDrivers/AbstractJsDriver.php
+++ b/src/Forms/JsDrivers/AbstractJsDriver.php
@@ -124,17 +124,6 @@ abstract class AbstractJsDriver implements JsDriver
     }
 
     /**
-     * Json encode for html attribute.
-     *
-     * @param  mixed  $value
-     * @return string
-     */
-    protected function jsonEncodeForHtmlAttribute($value)
-    {
-        return str_replace('"', '\'', json_encode($value));
-    }
-
-    /**
      * Get initial form data.
      *
      * @return array

--- a/src/Forms/JsDrivers/Alpine.php
+++ b/src/Forms/JsDrivers/Alpine.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Forms\JsDrivers;
 
+use Statamic\Statamic;
+
 class Alpine extends AbstractJsDriver
 {
     protected $scope;
@@ -70,7 +72,7 @@ class Alpine extends AbstractJsDriver
             ];
         }
 
-        return $this->jsonEncodeForHtmlAttribute($xData);
+        return Statamic::modify($xData)->toJson()->entities();
     }
 
     /**
@@ -96,14 +98,14 @@ class Alpine extends AbstractJsDriver
      */
     protected function renderAlpineShowFieldJs($conditions, $alpineScope)
     {
-        $attrFriendlyConditions = $this->jsonEncodeForHtmlAttribute($conditions);
+        $conditionsObject = Statamic::modify($conditions)->toJson()->entities();
 
-        $data = '$data';
+        $dataObject = '$data';
 
         if (is_string($alpineScope)) {
-            $data .= ".{$alpineScope}";
+            $dataObject .= ".{$alpineScope}";
         }
 
-        return 'Statamic.$conditions.showField('.$attrFriendlyConditions.', '.$data.')';
+        return 'Statamic.$conditions.showField('.$conditionsObject.', '.$dataObject.')';
     }
 }

--- a/tests/Tags/Form/FormCreateAlpineTest.php
+++ b/tests/Tags/Form/FormCreateAlpineTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Tags\Form;
 
+use Statamic\Statamic;
+
 class FormCreateAlpineTest extends FormTestCase
 {
     protected $defaultFields = [
@@ -88,7 +90,15 @@ class FormCreateAlpineTest extends FormTestCase
     {
         $output = $this->tag('{{ form:contact js="alpine" }}{{ /form:contact }}');
 
-        $expectedXData = "{'name':null,'email':null,'message':null,'fav_animals':[],'fav_colour':null,'fav_subject':null}";
+        $expectedXData = $this->jsonEncode([
+            'name' => null,
+            'email' => null,
+            'message' => null,
+            'fav_animals' => [],
+            'fav_colour' => null,
+            'fav_subject' => null,
+        ]);
+
         $expected = '<form method="POST" action="http://localhost/!/forms/contact" x-data="'.$expectedXData.'">';
 
         $this->assertStringContainsString($expected, $output);
@@ -105,7 +115,15 @@ class FormCreateAlpineTest extends FormTestCase
 
         $output = $this->tag('{{ form:contact js="alpine" }}{{ /form:contact }}');
 
-        $expectedXData = "{'name':'Frodo Braggins','email':null,'message':null,'fav_animals':[],'fav_colour':null,'fav_subject':null}";
+        $expectedXData = $this->jsonEncode([
+            'name' => 'Frodo Braggins',
+            'email' => null,
+            'message' => null,
+            'fav_animals' => [],
+            'fav_colour' => null,
+            'fav_subject' => null,
+        ]);
+
         $expected = '<form method="POST" action="http://localhost/!/forms/contact" x-data="'.$expectedXData.'">';
 
         $this->assertStringContainsString($expected, $output);
@@ -116,7 +134,17 @@ class FormCreateAlpineTest extends FormTestCase
     {
         $output = $this->tag('{{ form:contact js="alpine:my_form" }}{{ /form:contact }}');
 
-        $expectedXData = "{'my_form':{'name':null,'email':null,'message':null,'fav_animals':[],'fav_colour':null,'fav_subject':null}}";
+        $expectedXData = $this->jsonEncode([
+            'my_form' => [
+                'name' => null,
+                'email' => null,
+                'message' => null,
+                'fav_animals' => [],
+                'fav_colour' => null,
+                'fav_subject' => null,
+            ],
+        ]);
+
         $expected = '<form method="POST" action="http://localhost/!/forms/contact" x-data="'.$expectedXData.'">';
 
         $this->assertStringContainsString($expected, $output);
@@ -134,7 +162,17 @@ class FormCreateAlpineTest extends FormTestCase
 
         $output = $this->tag('{{ form:contact js="alpine:my_form" }}{{ /form:contact }}');
 
-        $expectedXData = "{'my_form':{'name':'Frodo Braggins','email':null,'message':null,'fav_animals':['cat'],'fav_colour':null,'fav_subject':null}}";
+        $expectedXData = $this->jsonEncode([
+            'my_form' => [
+                'name' => 'Frodo Braggins',
+                'email' => null,
+                'message' => null,
+                'fav_animals' => ['cat'],
+                'fav_colour' => null,
+                'fav_subject' => null,
+            ],
+        ]);
+
         $expected = '<form method="POST" action="http://localhost/!/forms/contact" x-data="'.$expectedXData.'">';
 
         $this->assertStringContainsString($expected, $output);
@@ -156,9 +194,9 @@ class FormCreateAlpineTest extends FormTestCase
             ],
         ];
 
-        $expectedXData = "x-data=\"{'favourite_animals':[]}\"";
+        $expected = 'x-data="'.$this->jsonEncode(['favourite_animals' => []]).'"';
 
-        $this->assertFieldRendersHtml($expectedXData, $config, [], ['js' => 'alpine']);
+        $this->assertFieldRendersHtml($expected, $config, [], ['js' => 'alpine']);
     }
 
     /** @test */
@@ -173,9 +211,9 @@ class FormCreateAlpineTest extends FormTestCase
             ],
         ];
 
-        $expectedXData = "x-data=\"{'selfies':[]}\"";
+        $expected = 'x-data="'.$this->jsonEncode(['selfies' => []]).'"';
 
-        $this->assertFieldRendersHtml($expectedXData, $config, [], ['js' => 'alpine']);
+        $this->assertFieldRendersHtml($expected, $config, [], ['js' => 'alpine']);
     }
 
     /** @test */
@@ -198,10 +236,10 @@ EOT
 
         $expected = [
             'Statamic.$conditions.showField([], $data)',
-            'Statamic.$conditions.showField({\'if\':{\'email\':\'not empty\'}}, $data)',
+            'Statamic.$conditions.showField('.$this->jsonEncode(['if' => ['email' => 'not empty']]).', $data)',
             'Statamic.$conditions.showField([], $data)',
             'Statamic.$conditions.showField([], $data)',
-            'Statamic.$conditions.showField({\'if\':{\'email\':\'not empty\'}}, $data)',
+            'Statamic.$conditions.showField('.$this->jsonEncode(['if' => ['email' => 'not empty']]).', $data)',
             'Statamic.$conditions.showField([], $data)',
             'Statamic.$conditions.showField([], $data)',
             'Statamic.$conditions.showField([], $data)',
@@ -231,10 +269,10 @@ EOT
 
         $expected = [
             'Statamic.$conditions.showField([], $data.my_form)',
-            'Statamic.$conditions.showField({\'if\':{\'email\':\'not empty\'}}, $data.my_form)',
+            'Statamic.$conditions.showField('.$this->jsonEncode(['if' => ['email' => 'not empty']]).', $data.my_form)',
             'Statamic.$conditions.showField([], $data.my_form)',
             'Statamic.$conditions.showField([], $data.my_form)',
-            'Statamic.$conditions.showField({\'if\':{\'email\':\'not empty\'}}, $data.my_form)',
+            'Statamic.$conditions.showField('.$this->jsonEncode(['if' => ['email' => 'not empty']]).', $data.my_form)',
             'Statamic.$conditions.showField([], $data.my_form)',
             'Statamic.$conditions.showField([], $data.my_form)',
             'Statamic.$conditions.showField([], $data.my_form)',
@@ -386,5 +424,10 @@ EOT
 
         $this->assertFieldRendersHtml('<input type="text" name="custom" value="" x-model="custom">', $config, [], ['js' => 'alpine']);
         $this->assertFieldRendersHtml('<input type="text" name="custom" value="" x-model="my_form.custom">', $config, [], ['js' => 'alpine:my_form']);
+    }
+
+    private function jsonEncode($data)
+    {
+        return Statamic::modify($data)->toJson()->entities();
     }
 }

--- a/tests/Tags/Form/FormCreateCustomDriverTest.php
+++ b/tests/Tags/Form/FormCreateCustomDriverTest.php
@@ -4,6 +4,7 @@ namespace Tests\Tags\Form;
 
 use Statamic\Facades\Form;
 use Statamic\Forms\JsDrivers\AbstractJsDriver;
+use Statamic\Statamic;
 
 class FormCreateCustomDriverTest extends FormTestCase
 {
@@ -43,7 +44,9 @@ EOT
     {
         $output = $this->tag('{{ form:contact js="custom_driver" }}{{ /form:contact }}');
 
-        $expected = '<form method="POST" action="http://localhost/!/forms/contact" z-data="{\'lol\':\'catz\',\'handle\':\'contact\'}" z-rad="absolutely">';
+        $expectedZData = Statamic::modify(['lol' => 'catz', 'handle' => 'contact'])->toJson()->entities();
+
+        $expected = '<form method="POST" action="http://localhost/!/forms/contact" z-data="'.$expectedZData.'" z-rad="absolutely">';
 
         $this->assertStringContainsString($expected, $output);
     }
@@ -194,7 +197,7 @@ class CustomDriver extends AbstractJsDriver
     public function addToFormAttributes()
     {
         return [
-            'z-data' => $this->jsonEncodeForHtmlAttribute(['lol' => 'catz', 'handle' => $this->form->handle()]),
+            'z-data' => Statamic::modify(['lol' => 'catz', 'handle' => $this->form->handle()])->toJson()->entities(),
             'z-rad' => 'absolutely',
         ];
     }


### PR DESCRIPTION
- [x] Delete `jsonEncodeForHtmlAttribute()` in favour of `->toJson()->entites()` modifiers.