### PR TITLE
Adjust test for 31-day months

### DIFF
--- a/tests/Modifiers/GroupByTest.php
+++ b/tests/Modifiers/GroupByTest.php
@@ -207,7 +207,7 @@ class GroupByTest extends TestCase
     /** @test */
     public function it_groups_by_date_with_custom_group_format()
     {
-        Carbon::setTestNow(now()->setMonth(9)->startOfDay());
+        Carbon::setTestNow(Carbon::parse('2022-09-01'));
 
         $items = [
             ['when' => now()->setHour(14), 'title' => '2pm'],


### PR DESCRIPTION
This test fails on the 31st day of the month. When we set `setMonth(9)` (September), it only has 30 days, so it ends up being October 1st.

This changes to a more explicit date.
