### PR TITLE
Revert type being a reserved word

### DIFF
--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -77,7 +77,6 @@ class FieldsController extends CpController
             'length',
             'reference',
             'resource',
-            'type',
             'unless',
             'value', // todo: can be removed when https://github.com/statamic/cms/issues/2495 is resolved
         ];


### PR DESCRIPTION
The word `type` is way too common to be reserved.

It should only be reseved within a Replicator or Bard set.

Reverts #5088
Reopens #5087