### PR TITLE
Remove unused variable $basename in Assets/Asset

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -641,7 +641,6 @@ class Asset implements AssetContract, Augmentable
     {
         $ext = $file->getClientOriginalExtension();
         $filename = $this->getSafeFilename(pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME));
-        $basename = $filename.'.'.$ext;
 
         $directory = $this->folder();
         $directory = ($directory === '.') ? '/' : $directory;


### PR DESCRIPTION
The variable is initialized but not used in this scope. Inside `if`-statement the variable gets initialized again with different content.