### PR TITLE
Remove PHP and Laravel versions from test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,29 +13,18 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 7.3, 7.2, 8.0, 8.1]
-        laravel: [8.*, 7.*, 6.*]
+        php: [7.4, 8.0, 8.1]
+        laravel: [8.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
           - laravel: 8.*
             framework: ^8.24.0
-          - laravel: 7.*
-            framework: ^7.30.4
-          - laravel: 6.*
-            framework: ^6.20.14
           - os: windows-latest
             php: 8.0
             laravel: 8.*
             framework: ^8.24.0
             stability: prefer-stable
-        exclude:
-          - laravel: 8.*
-            php: 7.2
-          - laravel: 7.*
-            php: 8.1
-          - laravel: 6.*
-            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 


### PR DESCRIPTION
Basically #5229 but straight to `master` so we can avoid testing extra versions until #5188 is merged.