### PR TITLE
Fix toggle fieldtype alignment issues in config panels

### DIFF
--- a/resources/sass/components/configure.scss
+++ b/resources/sass/components/configure.scss
@@ -8,8 +8,8 @@
        }
 
        // Push toggle off to the right
-       .toggle-fieldtype {
-           @apply flex justify-between;
+       > .publish-fields > .toggle-fieldtype {
+           @apply flex justify-between items-center;
            .help-block, .help-block p { @apply mb-0; }
            .field-inner { @apply pr-4; }
        }


### PR DESCRIPTION
Fixes #5091 

* This ensures that pushing the toggles to the right in `configure-sections` only applies to top level fields, and not to toggles in grids etc.
* Also fixes vertical alignment for toggles that are pushed to the right.