### PR TITLE
Append `{this}.` in validation builder

### DIFF
--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -154,6 +154,12 @@ export default {
         },
 
         instructions() {
+            if (this.appendThis) {
+                return 'Use {this} to refer to the current context';
+            }
+        },
+
+        appendThis() {
             if (! this.selectedLaravelRule) {
                 return false;
             }
@@ -163,20 +169,7 @@ export default {
                 .first()
                 .value();
 
-            return rule.instructions || false;
-        },
-
-        appendToValue() {
-            if (! this.selectedLaravelRule) {
-                return '';
-            }
-
-            let rule = _.chain(RULES)
-                .filter(rule => rule.value === this.selectedLaravelRule)
-                .first()
-                .value();
-
-            return rule.appendToValue || '';
+            return !! rule.appendThis;
         }
     },
 
@@ -247,7 +240,8 @@ export default {
             if (this.hasUnfinishedParameters(rule)) {
                 this.resetState();
                 this.selectedLaravelRule = rule;
-                this.customRule = rule + this.appendToValue;
+                this.customRule = rule;
+                if (this.appendThis) this.customRule = `${this.customRule}{this}.`;
                 this.$nextTick(() => this.$refs.customRuleInput.$refs.input.focus());
             } else {
                 this.ensure(rule);

--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -16,9 +16,9 @@
                 <p>
                     {{ __('messages.field_validation_advanced_instructions') }}
                     <a :href="laravelDocsLink" target="_blank">{{ __('Learn more') }}</a>
-                    <span v-if="helpBlock" class="italic text-grey-50 float-right">
+                    <span v-if="example" class="italic text-grey-50 float-right">
                         {{ __('Example') }}:
-                        <span class="italic text-blue-lighter">{{ helpBlock }}</span>
+                        <span class="italic text-blue-lighter">{{ example }}</span>
                     </span>
                 </p>
             </div>
@@ -61,6 +61,8 @@
                 @keydown.enter.prevent="add(customRule)"
                 @blur="add(customRule)"
             />
+
+            <span class="help-block mt-1" v-if="instructions">{{ instructions }}</span>
 
             <div class="v-select">
                 <sortable-list
@@ -138,7 +140,7 @@ export default {
                 .value();
         },
 
-        helpBlock() {
+        example() {
             if (! this.selectedLaravelRule) {
                 return false;
             }
@@ -150,6 +152,32 @@ export default {
 
             return rule.example || false;
         },
+
+        instructions() {
+            if (! this.selectedLaravelRule) {
+                return false;
+            }
+
+            let rule = _.chain(RULES)
+                .filter(rule => rule.value === this.selectedLaravelRule)
+                .first()
+                .value();
+
+            return rule.instructions || false;
+        },
+
+        appendToValue() {
+            if (! this.selectedLaravelRule) {
+                return '';
+            }
+
+            let rule = _.chain(RULES)
+                .filter(rule => rule.value === this.selectedLaravelRule)
+                .first()
+                .value();
+
+            return rule.appendToValue || '';
+        }
     },
 
     watch: {
@@ -219,7 +247,7 @@ export default {
             if (this.hasUnfinishedParameters(rule)) {
                 this.resetState();
                 this.selectedLaravelRule = rule;
-                this.customRule = rule;
+                this.customRule = rule + this.appendToValue;
                 this.$nextTick(() => this.$refs.customRuleInput.$refs.input.focus());
             } else {
                 this.ensure(rule);

--- a/resources/js/components/field-validation/Rules.js
+++ b/resources/js/components/field-validation/Rules.js
@@ -247,8 +247,7 @@ export default [
         label: 'Required If',
         value: 'required_if:',
         example: 'required_if:anotherfield,value,...',
-        instructions: 'Use {this} to refer to the current context',
-        appendToValue: '{this}.'
+        appendThis: true,
     },
     {
         label: 'Required Unless',

--- a/resources/js/components/field-validation/Rules.js
+++ b/resources/js/components/field-validation/Rules.js
@@ -84,7 +84,8 @@ export default [
     {
         label: 'Different',
         value: 'different:',
-        example: 'different:field'
+        example: 'different:field',
+        appendThis: true
     },
     {
         label: 'Digits',
@@ -131,12 +132,14 @@ export default [
     {
         label: 'Greater Than',
         value: 'gt:',
-        example: 'gt:field'
+        example: 'gt:field',
+        appendThis: true
     },
     {
         label: 'Greater Than Or Equal',
         value: 'gte:',
-        example: 'gte:field'
+        example: 'gte:field',
+        appendThis: true
     },
     {
         label: 'Image (File)',
@@ -175,12 +178,14 @@ export default [
     {
         label: 'Less Than',
         value: 'lt:',
-        example: 'lt:field'
+        example: 'lt:field',
+        appendThis: true
     },
     {
         label: 'Less Than Or Equal',
         value: 'lte:',
-        example: 'lte:field'
+        example: 'lte:field',
+        appendThis: true
     },
     {
         label: 'Max',
@@ -252,32 +257,38 @@ export default [
     {
         label: 'Required Unless',
         value: 'required_unless:',
-        example: 'required_unless:anotherfield,value,...'
+        example: 'required_unless:anotherfield,value,...',
+        appendThis: true
     },
     {
         label: 'Required With',
         value: 'required_with:',
-        example: 'required_with:foo,bar,...'
+        example: 'required_with:foo,bar,...',
+        appendThis: true
     },
     {
         label: 'Required With All',
         value: 'required_with_all:',
-        example: 'required_with_all:foo,bar,...'
+        example: 'required_with_all:foo,bar,...',
+        appendThis: true
     },
     {
         label: 'Required Without',
         value: 'required_without:',
-        example: 'required_without:foo,bar,...'
+        example: 'required_without:foo,bar,...',
+        appendThis: true
     },
     {
         label: 'Required Without All',
         value: 'required_without_all:',
-        example: 'required_without_all:foo,bar,...'
+        example: 'required_without_all:foo,bar,...',
+        appendThis: true
     },
     {
         label: 'Same',
         value: 'same:',
-        example: 'same:field'
+        example: 'same:field',
+        appendThis: true
     },
     {
         label: 'Size',

--- a/resources/js/components/field-validation/Rules.js
+++ b/resources/js/components/field-validation/Rules.js
@@ -246,7 +246,9 @@ export default [
     {
         label: 'Required If',
         value: 'required_if:',
-        example: 'required_if:anotherfield,value,...'
+        example: 'required_if:anotherfield,value,...',
+        instructions: 'Use {this} to refer to the current context',
+        appendToValue: '{this}.'
     },
     {
         label: 'Required Unless',


### PR DESCRIPTION
This goes along with #5047 

When you choose a validation rule that depends on other fields, it will now get prepopulated with `{this}.`, which we think is probably more likely what you'll need - you'll want to validate based on a field in the same replicator set, or grid row, etc.

If you want to point to a root level field, you can simply delete the appended `{this}.`.

![Screen Capture on 2022-02-10 at 13-22-45](https://user-images.githubusercontent.com/105211/153475824-de038e93-f56c-4414-9ea9-afcbbc6596f8.gif)
`