### PR TITLE
Discard `{this}.` at top level

### DIFF
--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -116,6 +116,8 @@ class Validator
             return $rule;
         }
 
+        $rule = str_replace('{this}.', $this->context['prefix'] ?? '', $rule);
+
         return preg_replace_callback('/{\s*([a-zA-Z0-9_\-]+)\s*}/', function ($match) {
             return Arr::get($this->replacements, $match[1], 'NULL');
         }, $rule);

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -142,9 +142,6 @@ class Grid extends Fieldtype
             ->withContext([
                 'prefix' => $this->field->validationContext('prefix').$this->rowRuleFieldPrefix($index).'.',
             ])
-            ->withReplacements([
-                'this' => $this->field->validationContext('prefix').$this->rowRuleFieldPrefix($index),
-            ])
             ->rules();
 
         return collect($rules)->mapWithKeys(function ($rules, $handle) use ($index) {

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -112,9 +112,6 @@ class Replicator extends Fieldtype
             ->withContext([
                 'prefix' => $this->field->validationContext('prefix').$this->setRuleFieldPrefix($index).'.',
             ])
-            ->withReplacements([
-                'this' => $this->field->validationContext('prefix').$this->setRuleFieldPrefix($index),
-            ])
             ->rules();
 
         return collect($rules)->mapWithKeys(function ($rules, $handle) use ($index) {

--- a/tests/Fields/ValidatorTest.php
+++ b/tests/Fields/ValidatorTest.php
@@ -180,7 +180,7 @@ class ValidatorTest extends TestCase
     }
 
     /** @test */
-    public function it_replaces_this()
+    public function it_replaces_this_in_sets()
     {
         $replicator = [
             'type' => 'replicator',
@@ -371,6 +371,23 @@ class ValidatorTest extends TestCase
         $this->assertArraySubset([
             'bard_with_nested_replicator.0.attrs.values.nested_replicator.0.text' => [
                 'required_if:bard_with_nested_replicator.0.attrs.values.nested_replicator.0.must_fill,true',
+            ],
+        ], $rules);
+    }
+
+    /** @test */
+    public function it_discards_this_at_top_level()
+    {
+        $fields = new Fields([
+            ['handle' => 'must_fill', 'field' => ['type' => 'toggle']],
+            ['handle' => 'text', 'field' => ['validate' => ['required_if:{this}.must_fill,true']]],
+        ]);
+
+        $rules = (new Validator)->fields($fields)->rules();
+
+        $this->assertArraySubset([
+            'text' => [
+                'required_if:must_fill,true',
             ],
         ], $rules);
     }


### PR DESCRIPTION
See title. Especially handy if you want to reuse fields or fieldsets at top level as well as nested in meta fields.