### PR TITLE
Add duration to augmented asset

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -577,6 +577,20 @@ class Asset implements AssetContract, Augmentable
     }
 
     /**
+     * Get the asset's duration.
+     *
+     * @return int|null
+     */
+    public function duration()
+    {
+        if (! $this->hasDuration()) {
+            return null;
+        }
+
+        return $this->meta('duration');
+    }
+
+    /**
      * Get the asset's orientation.
      *
      * @return string|null
@@ -789,5 +803,10 @@ class Asset implements AssetContract, Augmentable
     private function hasDimensions()
     {
         return $this->isImage() || $this->isSvg() || $this->isVideo();
+    }
+
+    private function hasDuration()
+    {
+        return $this->isAudio() || $this->isVideo();
     }
 }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -579,7 +579,7 @@ class Asset implements AssetContract, Augmentable
     /**
      * Get the asset's duration.
      *
-     * @return int|null
+     * @return float|null
      */
     public function duration()
     {

--- a/src/Assets/AugmentedAsset.php
+++ b/src/Assets/AugmentedAsset.php
@@ -166,6 +166,6 @@ class AugmentedAsset extends AbstractAugmented
 
     protected function durationMin()
     {
-        return $this->duration_minutes();
+        return $this->durationMinutes();
     }
 }

--- a/src/Assets/AugmentedAsset.php
+++ b/src/Assets/AugmentedAsset.php
@@ -54,6 +54,11 @@ class AugmentedAsset extends AbstractAugmented
                 'orientation',
                 'ratio',
                 'mime_type',
+                'duration',
+                'duration_seconds',
+                'duration_minutes',
+                'duration_sec',
+                'duration_min',
             ]);
         }
 
@@ -133,5 +138,34 @@ class AugmentedAsset extends AbstractAugmented
     protected function focusCss()
     {
         return Modify::value($this->get('focus'))->backgroundPosition()->fetch();
+    }
+
+    protected function duration()
+    {
+        return round($this->data->duration());
+    }
+
+    public function durationSeconds()
+    {
+        return $this->duration();
+    }
+
+    public function durationSec()
+    {
+        return $this->duration();
+    }
+
+    protected function durationMinutes()
+    {
+        if(!$seconds = $this->duration()) {
+            return null;
+        }
+
+        return floor($seconds / 60) . ":" . $seconds % 60;
+    }
+
+    protected function durationMin()
+    {
+        return $this->duration_minutes();
     }
 }

--- a/src/Assets/AugmentedAsset.php
+++ b/src/Assets/AugmentedAsset.php
@@ -145,12 +145,12 @@ class AugmentedAsset extends AbstractAugmented
         return round($this->data->duration());
     }
 
-    public function durationSeconds()
+    protected function durationSeconds()
     {
         return $this->duration();
     }
 
-    public function durationSec()
+    protected function durationSec()
     {
         return $this->duration();
     }

--- a/src/Assets/AugmentedAsset.php
+++ b/src/Assets/AugmentedAsset.php
@@ -157,11 +157,11 @@ class AugmentedAsset extends AbstractAugmented
 
     protected function durationMinutes()
     {
-        if(!$seconds = $this->duration()) {
+        if (! $seconds = $this->duration()) {
             return null;
         }
 
-        return floor($seconds / 60) . ":" . $seconds % 60;
+        return floor($seconds / 60).':'.$seconds % 60;
     }
 
     protected function durationMin()


### PR DESCRIPTION
The duration of audio and video files is currently added to the meta data but can't be received in antlers.
This PR adds duration (in seconds and minutes) to the `AugmentedAsset` class.

Hope this is fine. At least it's a starting point.
Sorry I need help with tests :-(
