### PR TITLE
Add a `--queue` flag to `static:warm` command

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -29,8 +29,11 @@ class StaticWarm extends Command
     use RunsInPlease;
     use EnhancesCommands;
 
-    protected $name = 'statamic:static:warm';
+    protected $signature = 'statamic:static:warm {--queue : Queue the requests}';
+
     protected $description = 'Warms the static cache by visiting all URLs';
+
+    protected $shouldQueue = false;
 
     private $uris;
 
@@ -42,12 +45,22 @@ class StaticWarm extends Command
             return 1;
         }
 
+        $this->shouldQueue = $this->option('queue');
+
+        if ($this->shouldQueue && config('queue.default') === 'sync') {
+            $this->error('The queue connection is set to "sync". Queueing will be disabled.');
+            $this->shouldQueue = false;
+        }
+
         $this->comment('Please wait. This may take a while if you have a lot of content.');
 
         $this->warm();
 
         $this->output->newLine();
-        $this->info('The static cache has been warmed.');
+        $this->info($this->shouldQueue
+            ? 'All requests to warm the static cache have been added to the queue.'
+            : 'The static cache has been warmed.'
+        );
 
         return 0;
     }
@@ -59,18 +72,29 @@ class StaticWarm extends Command
         $this->output->newLine();
         $this->line('Compiling URLs...');
 
-        $pool = new Pool($client, $this->requests(), [
-            'concurrency' => $this->concurrency(),
-            'fulfilled' => [$this, 'outputSuccessLine'],
-            'rejected' => [$this, 'outputFailureLine'],
-        ]);
-
-        $promise = $pool->promise();
+        $requests = $this->requests();
 
         $this->output->newLine();
-        $this->line('Visiting '.$this->uris()->count().' URLs...');
 
-        $promise->wait();
+        if ($this->shouldQueue) {
+            $this->line('Queueing '.count($requests).' requests...');
+
+            foreach ($requests as $request) {
+                StaticWarmJob::dispatch($request);
+            }
+        } else {
+            $this->line('Visiting '.count($requests).' URLs...');
+
+            $pool = new Pool($client, $requests, [
+                'concurrency' => $this->concurrency(),
+                'fulfilled' => [$this, 'outputSuccessLine'],
+                'rejected' => [$this, 'outputFailureLine'],
+            ]);
+
+            $promise = $pool->promise();
+
+            $promise->wait();
+        }
     }
 
     private function concurrency(): int

--- a/src/Console/Commands/StaticWarmJob.php
+++ b/src/Console/Commands/StaticWarmJob.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Statamic\Console\Commands;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+
+class StaticWarmJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public Request $request;
+
+    public $tries = 1;
+
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    public function handle(Client $client)
+    {
+        $client->send($this->request);
+    }
+}

--- a/tests/Console/Commands/StaticWarmJobTest.php
+++ b/tests/Console/Commands/StaticWarmJobTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Console\Commands;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Statamic\Console\Commands\StaticWarmJob;
+use Tests\TestCase;
+
+class StaticWarmJobTest extends TestCase
+{
+    /** @test */
+    public function it_sends_a_get_request()
+    {
+        $mock = new MockHandler([
+            new Response(200),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+
+        $client = new Client(['handler' => $handlerStack]);
+
+        $job = new StaticWarmJob(new Request('GET', '/about'));
+
+        $job->handle($client);
+
+        $this->assertEquals('/about', $mock->getLastRequest()->getUri()->getPath());
+    }
+}

--- a/tests/Console/Commands/StaticWarmTest.php
+++ b/tests/Console/Commands/StaticWarmTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Console\Commands;
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class StaticWarmTest extends TestCase
+{
+    /** @test */
+    public function it_exits_with_error_when_static_caching_is_disabled()
+    {
+        $this->artisan('statamic:static:warm')
+            ->expectsOutput('Static caching is not enabled.')
+            ->assertFailed();
+    }
+
+    /** @test */
+    public function it_warms_the_static_cache()
+    {
+        config(['statamic.static_caching.strategy' => 'half']);
+
+        $this->artisan('statamic:static:warm')
+            ->expectsOutput('Visiting 0 URLs...')
+            ->assertSuccessful();
+        // Artisan::call('statamic:static:warm');
+        // dd(Artisan::output());
+    }
+
+    /** @test */
+    public function it_doesnt_queue_the_requests_when_connection_is_set_to_sync()
+    {
+        config(['statamic.static_caching.strategy' => 'half']);
+
+        $this->artisan('statamic:static:warm', ['--queue' => true])
+            ->expectsOutput('The queue connection is set to "sync". Queueing will be disabled.')
+            ->assertSuccessful();
+    }
+
+    /** @test */
+    public function it_queues_the_requests()
+    {
+        config([
+            'statamic.static_caching.strategy' => 'half',
+            'queue.default' => 'redis',
+        ]);
+
+        $this->artisan('statamic:static:warm', ['--queue' => true])
+            ->doesntExpectOutput('The queue connection is set to "sync". Queueing will be disabled.')
+            ->assertSuccessful();
+    }
+}


### PR DESCRIPTION
An implementation of [idea #750](https://github.com/statamic/ideas/issues/750).

This also adds some tests for the static warm command. They are in no way exhaustive, but it is a (good) start.