### PR TITLE
Fix old underscore `_(var).underscoreMethod()` chain calls

### DIFF
--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -111,7 +111,7 @@ export default {
                 },
 
                 onUploadProgress: (id, percent) => {
-                    let upload = _(this.uploads).findWhere({ id });
+                    let upload = _.findWhere(this.uploads, { id });
                     upload.percent = percent;
                     this.$emit('progress', upload, this.uploads);
                 },
@@ -119,12 +119,12 @@ export default {
                 onUploadSuccess: (id, response) => {
                     this.$emit('upload-complete', response.data, this.uploads);
 
-                    let index = _(this.uploads).findIndex({ id });
+                    let index = _.findIndex(this.uploads, { id });
                     this.uploads.splice(index, 1);
                 },
 
                 onUploadError: (id, errMsg, response) => {
-                    let upload = _(this.uploads).findWhere({ id });
+                    let upload = _.findWhere(this.uploads, { id });
 
                     if (response.responseJSON) {
                         errMsg = response.responseJSON.message;

--- a/resources/js/components/fieldtypes/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/MarkdownFieldtype.vue
@@ -469,7 +469,7 @@ export default {
             this.selectedAssets = [];
 
             this.$axios.get(cp_url('assets-fieldtype'), { params: { assets } }).then(response => {
-                _(response.data).each((asset) => {
+                _.each(response.data, (asset) => {
                     var alt = asset.values.alt || '';
                     var url = encodeURI('statamic://'+asset.reference);
                     if (asset.isImage) {

--- a/resources/js/components/fieldtypes/TableFieldtype.vue
+++ b/resources/js/components/fieldtypes/TableFieldtype.vue
@@ -151,9 +151,10 @@ export default {
 
         replicatorPreview() {
             // Join all values with commas. Exclude any empties.
-            return _(this.data)
+            return _.chain(this.data)
                 .map(row => row.value.cells.filter(cell => !!cell).join(', '))
-                .filter(row => !!row).join(', ');
+                .filter(row => !!row).join(', ')
+                .value();
         }
     },
 

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -399,7 +399,7 @@ export default {
          * When an asset is updated in the editor
          */
         assetUpdated(asset) {
-            const index = _(this.assets).findIndex({ id: asset.id });
+            const index = _.findIndex(this.assets, { id: asset.id });
             this.assets.splice(index, 1, asset);
         },
 
@@ -407,7 +407,7 @@ export default {
          * When an asset remove button was clicked.
          */
         assetRemoved(asset) {
-            const index = _(this.assets).findIndex({ id: asset.id });
+            const index = _.findIndex(this.assets, { id: asset.id });
             this.assets.splice(index, 1);
         },
 

--- a/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
+++ b/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
@@ -2,7 +2,7 @@ export default {
 
     computed: {
         previewText() {
-            const previews = _(this.previews).filter((value, handle) => {
+            const previews = _.filter(this.previews, (value, handle) => {
                 const config = _.findWhere(this.config.fields, { handle }) || {};
                 return config.replicator_preview === undefined ? true : config.replicator_preview;
             });


### PR DESCRIPTION
According to underscore changelog, 

![image](https://user-images.githubusercontent.com/5187394/153920319-a6913fb7-db8c-4dfa-994f-3d87dda6e84a.png)

I believe the `_(var).underscoreMethod()` functionality was deprecated and finally removed. If we need to chain multiple methods, use `_.chain()` 👍 

Closes https://github.com/statamic/cms/issues/5181