### PR TITLE
Fix Underscore.js OOP syntax

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -3,6 +3,7 @@ import Toast from './mixins/Toast.js';
 import Statamic from './components/Statamic.js';
 import Alpine from 'alpinejs'
 import * as Globals from './bootstrap/globals'
+import { default as underscore } from 'underscore'
 
 let global_functions = Object.keys(Globals)
 global_functions.forEach(fnName => { global[fnName] = Globals[fnName] })
@@ -15,7 +16,7 @@ Vue.config.productionTip = false
 window.Alpine = Alpine
 window.Vue = Vue;
 window.Statamic = Statamic;
-window._ = require('underscore');
+window._ = underscore;
 window.$ = window.jQuery = require('jquery');
 window.rangy = require('rangy');
 

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -58,7 +58,6 @@ mix.webpackConfig({
 
         // Our files reference globals too
         new webpack.ProvidePlugin({ Vue: "vue" }),
-        new webpack.ProvidePlugin({ Alpine: "Alpine" }),
-        new webpack.ProvidePlugin({ _: "underscore" })
+        new webpack.ProvidePlugin({ Alpine: "Alpine" })
     ]
 })


### PR DESCRIPTION
Fixes #5181
Replaces #5279

Honestly I don't understand it. Seems like something changed in how underscore.js modules worked when we upgraded.
But this makes everything work again.