### PR TITLE
Query builder aliases

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace Statamic\Providers;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\ServiceProvider;
+use Statamic\Facades;
 use Statamic\Facades\Preference;
 use Statamic\Sites\Sites;
 use Statamic\Statamic;
@@ -128,6 +129,15 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(\Statamic\Fields\FieldsetRepository::class, function () {
             return (new \Statamic\Fields\FieldsetRepository)
                 ->setDirectory(resource_path('fieldsets'));
+        });
+
+        collect([
+            'entries' => fn () => Facades\Entry::query(),
+            'terms' => fn () => Facades\Term::query(),
+            'assets' => fn () => Facades\Asset::query(),
+            'users' => fn () => Facades\User::query(),
+        ])->each(function ($binding, $alias) {
+            app()->bind('statamic.queries.'.$alias, $binding);
         });
     }
 

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -358,4 +358,9 @@ class Statamic
     {
         return Modify::value($value);
     }
+
+    public static function query($name)
+    {
+        return app()->make('statamic.queries.'.$name);
+    }
 }

--- a/tests/StatamicTest.php
+++ b/tests/StatamicTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Route;
 use Statamic\Facades\User;
 use Statamic\Statamic;
@@ -132,5 +133,39 @@ class StatamicTest extends TestCase
             'ISO 8601' => ['c'],
             'RFC 2822' => ['r'],
         ];
+    }
+
+    /** @test */
+    public function it_aliases_query_builders()
+    {
+        app()->bind('statamic.queries.test', function () {
+            return 'the test query builder';
+        });
+
+        $this->assertEquals('the test query builder', Statamic::query('test'));
+    }
+
+    /** @test */
+    public function native_query_builder_aliases_are_bound()
+    {
+        $aliases = [
+            'entries' => \Statamic\Stache\Query\EntryQueryBuilder::class,
+            'terms' => \Statamic\Stache\Query\TermQueryBuilder::class,
+            'assets' => \Statamic\Assets\QueryBuilder::class,
+            'users' => \Statamic\Stache\Query\UserQueryBuilder::class,
+        ];
+
+        foreach ($aliases as $alias => $class) {
+            $this->assertInstanceOf($class, Statamic::query($alias));
+        }
+    }
+
+    /** @test */
+    public function it_throws_exception_for_invalid_query_builder_alias()
+    {
+        $this->expectException(BindingResolutionException::class);
+        $this->expectExceptionMessage('Target class [statamic.queries.test] does not exist.');
+
+        Statamic::query('test');
     }
 }


### PR DESCRIPTION
This aliases query builders into the `Statamic::query()` method, which could make your Blade templates nicer, if you wanted to perform queries in there.

```
@foreach (Statamic::query('entries')->get() as $entry)
    ...
@endforeach
```

The 4 main builders are aliased: entries, terms, assets, and users.

They are the equivalent of doing `Entry::query()`, etc.

You can bind additional queries if you want by binding a closure that returns a query into `statamic.queries.$name`. 
