### PR TITLE
Add toValuesCollection macro

### DIFF
--- a/src/Providers/CollectionsServiceProvider.php
+++ b/src/Providers/CollectionsServiceProvider.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Statamic\Contracts\Data\Augmentable;
+use Statamic\Fields\Values;
+use Statamic\Fields\ValuesCollection;
 
 class CollectionsServiceProvider extends ServiceProvider
 {
@@ -171,6 +173,12 @@ class CollectionsServiceProvider extends ServiceProvider
 
                 return $value instanceof Arrayable ? $value->toArray() : $value;
             }, $this->items);
+        });
+
+        Collection::macro('toValuesCollection', function () {
+            $items = array_map(fn ($item) => new Values($item), $this->toAugmentedCollection());
+
+            return new ValuesCollection(collect($items));
         });
     }
 }

--- a/tests/Fields/ValuesCollectionTest.php
+++ b/tests/Fields/ValuesCollectionTest.php
@@ -4,6 +4,11 @@ namespace Tests\Fields;
 
 use Illuminate\Support\Collection;
 use Mockery;
+use Statamic\Contracts\Data\Augmentable;
+use Statamic\Data\AugmentedCollection;
+use Statamic\Fields\Fieldtype;
+use Statamic\Fields\Value;
+use Statamic\Fields\Values;
 use Statamic\Fields\ValuesCollection;
 use Tests\TestCase;
 
@@ -29,5 +34,89 @@ class ValuesCollectionTest extends TestCase
         $values = new ValuesCollection($collection);
 
         $this->assertEquals('{"test":"the collection would return an array"}', json_encode($values));
+    }
+
+    /** @test */
+    public function macro_is_registered_with_arrays()
+    {
+        $one = [
+            'title' => 'plain title one',
+            'field' => 'raw field one',
+        ];
+
+        $two = [
+            'title' => 'plain title two',
+            'field' => 'raw field two',
+        ];
+
+        $collection = Collection::make([$one, $two]);
+
+        $values = $collection->toValuesCollection();
+
+        $this->assertInstanceOf(ValuesCollection::class, $values);
+        $this->assertEveryItemIsInstanceOf(Values::class, $values);
+        $this->assertEquals('plain title one', $values->first()->title);
+        $this->assertEquals('raw field one', $values->first()->field);
+        $this->assertEquals('plain title two', $values->last()->title);
+        $this->assertEquals('raw field two', $values->last()->field);
+    }
+
+    /** @test */
+    public function macro_is_registered_with_collections()
+    {
+        $one = collect([
+            'title' => 'plain title one',
+            'field' => 'raw field one',
+        ]);
+
+        $two = collect([
+            'title' => 'plain title two',
+            'field' => 'raw field two',
+        ]);
+
+        $collection = Collection::make([$one, $two]);
+
+        $values = $collection->toValuesCollection();
+
+        $this->assertInstanceOf(ValuesCollection::class, $values);
+        $this->assertEveryItemIsInstanceOf(Values::class, $values);
+        $this->assertEquals('plain title one', $values->first()->title);
+        $this->assertEquals('raw field one', $values->first()->field);
+        $this->assertEquals('plain title two', $values->last()->title);
+        $this->assertEquals('raw field two', $values->last()->field);
+    }
+
+    /** @test */
+    public function macro_is_registered_with_augmentables()
+    {
+        $fieldtype = new class extends Fieldtype {
+            public function augment($value)
+            {
+                return str_replace('raw', 'augmented', $value);
+            }
+        };
+
+        $one = Mockery::mock(Augmentable::class);
+        $one->shouldReceive('toAugmentedCollection')->once()->andReturn(new AugmentedCollection([
+            'title' => 'plain title one',
+            'field' => new Value('raw field one', null, $fieldtype),
+        ]));
+
+        $two = Mockery::mock(Augmentable::class);
+        $two->shouldReceive('toAugmentedCollection')->once()->andReturn(new AugmentedCollection([
+            'title' => 'plain title two',
+            'field' => new Value('raw field two', null, $fieldtype),
+        ]));
+
+        $collection = Collection::make([$one, $two]);
+
+        $values = $collection->toValuesCollection();
+
+        $this->assertInstanceOf(ValuesCollection::class, $values);
+        $this->assertEveryItemIsInstanceOf(Values::class, $values);
+        $this->assertEquals('plain title one', $values->first()->title);
+        $this->assertEquals('augmented field one', $values->first()->field);
+        $this->assertEquals('plain title two', $values->last()->title);
+        $this->assertEquals('augmented field two', $values->last()->field);
     }
 }


### PR DESCRIPTION
This PR adds a `toValuesCollection` macro onto the `Collection` class.

Now you can do `$collection->toValuesCollection()` and it will convert it to a `ValuesCollection` filled with `Values` instances.

This is intended to be glue between the Blade wrapper introduced in #5201 and the query builder stuff in #5285.

Now you can perform a query in your Blade template, and convert it to a ValuesCollection so it's nice to loop over.

```blade
@foreach (Statamic::query('entries')->get()->toValuesCollection() as $entry)
  {{ $entry->title }}
  {{ $entry->toggle_field }}
@endforeach
```
