### PR TITLE
adding env var for pro editions

### DIFF
--- a/config/editions.php
+++ b/config/editions.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'pro' => false,
+    'pro' => env('STATAMIC_PRO', false),
 
     'addons' => [
         //


### PR DESCRIPTION
Not sure this is needed but I hit this a couple times where I forget to make it to pro. Seems the community uses starter kits where this is already set to true. Going to venture that route as well but thought I'd suggest this move to an env var.