### PR TITLE
Changed slug transliteration to use site locale instead of CP locale

### DIFF
--- a/resources/js/plugins/slugify.js
+++ b/resources/js/plugins/slugify.js
@@ -1,14 +1,4 @@
 var getSlug = require('speakingurl');
-const langCharMap = {
-    'da': { // Danish
-        'æ': 'ae',
-        'Æ': 'Ae',
-        'ø': 'oe',
-        'Ø': 'Oe',
-        'å': 'aa',
-        'Å': 'Aa',
-    },
-};
 
 export default {
     install(Vue, options) {
@@ -17,7 +7,7 @@ export default {
             const sites = Statamic.$config.get('sites');
             const site = sites.find(site => site.handle === selectedSite);
             const lang = site?.locale ?? Statamic.$config.get('locale');
-            const custom = langCharMap[lang] ?? undefined;
+            const custom = site?.transliteration ?? undefined;
 
             return getSlug(text, { separator: glue || '-', lang, custom });
         };

--- a/resources/js/plugins/slugify.js
+++ b/resources/js/plugins/slugify.js
@@ -1,12 +1,25 @@
 var getSlug = require('speakingurl');
+const langCharMap = {
+    'da': { // Danish
+        'æ': 'ae',
+        'Æ': 'Ae',
+        'ø': 'oe',
+        'Ø': 'Oe',
+        'å': 'aa',
+        'Å': 'Aa',
+    },
+};
 
 export default {
     install(Vue, options) {
         Vue.prototype.$slugify = function(text, glue) {
-            return getSlug(text, {
-                separator: glue || '-',
-                lang: Statamic.$config.get('locale')
-            });
+            const selectedSite = Statamic.$config.get('selectedSite');
+            const sites = Statamic.$config.get('sites');
+            const site = sites.find(site => site.handle === selectedSite);
+            const lang = site?.locale ?? Statamic.$config.get('locale');
+            const custom = langCharMap[lang] ?? undefined;
+
+            return getSlug(text, { separator: glue || '-', lang, custom });
         };
     }
 };

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -10,6 +10,7 @@ use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Statamic;
 use Statamic\Support\Str;
+use voku\helper\ASCII;
 
 class JavascriptComposer
 {
@@ -56,6 +57,10 @@ class JavascriptComposer
                 'name' => $site->name(),
                 'handle' => $site->handle(),
                 'locale' => $site->shortLocale(),
+                'transliteration' => with($site, function ($site) {
+                    return ASCII::charsArrayWithOneLanguage(Str::lower($site->locale()), true, false)
+                        ?: ASCII::charsArrayWithOneLanguage($site->shortLocale(), true, false);
+                }),
             ];
         })->values();
     }

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -55,6 +55,7 @@ class JavascriptComposer
             return [
                 'name' => $site->name(),
                 'handle' => $site->handle(),
+                'locale' => $site->shortLocale(),
             ];
         })->values();
     }


### PR DESCRIPTION
@jasonvarga and @jackmcdade  this most likely need some cleanup, or modifications if you change the active locale (haven't tested that), but you get the gist of it.

It also allows us to add missing locales from the speakingurl package as well, since it sems to be abandoned.
Fixes #2631