### PR TITLE
Revert "Add toValuesCollection macro"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Antlers wrapper for Blade. [#5058](https://github.com/statamic/cms/issues/5058) by @jesseleite
 - Support Blade section yields in Antlers layouts. [#5056](https://github.com/statamic/cms/issues/5056) by @jasonvarga
 - Added wrapper classes to make working with values in Blade easier. [#5201](https://github.com/statamic/cms/issues/5201) by @jasonvarga
-- Added `toValuesCollection` Collection macro. [#5286](https://github.com/statamic/cms/issues/5286) by @jasonvarga
 - Added `Statamic::query()` aliases. [#5285](https://github.com/statamic/cms/issues/5285) by @jasonvarga
 
 ### What's fixed

--- a/src/Providers/CollectionsServiceProvider.php
+++ b/src/Providers/CollectionsServiceProvider.php
@@ -6,8 +6,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Statamic\Contracts\Data\Augmentable;
-use Statamic\Fields\Values;
-use Statamic\Fields\ValuesCollection;
 
 class CollectionsServiceProvider extends ServiceProvider
 {
@@ -173,12 +171,6 @@ class CollectionsServiceProvider extends ServiceProvider
 
                 return $value instanceof Arrayable ? $value->toArray() : $value;
             }, $this->items);
-        });
-
-        Collection::macro('toValuesCollection', function () {
-            $items = array_map(fn ($item) => new Values($item), $this->toAugmentedCollection());
-
-            return new ValuesCollection(collect($items));
         });
     }
 }

--- a/tests/Fields/ValuesCollectionTest.php
+++ b/tests/Fields/ValuesCollectionTest.php
@@ -4,11 +4,6 @@ namespace Tests\Fields;
 
 use Illuminate\Support\Collection;
 use Mockery;
-use Statamic\Contracts\Data\Augmentable;
-use Statamic\Data\AugmentedCollection;
-use Statamic\Fields\Fieldtype;
-use Statamic\Fields\Value;
-use Statamic\Fields\Values;
 use Statamic\Fields\ValuesCollection;
 use Tests\TestCase;
 
@@ -34,90 +29,5 @@ class ValuesCollectionTest extends TestCase
         $values = new ValuesCollection($collection);
 
         $this->assertEquals('{"test":"the collection would return an array"}', json_encode($values));
-    }
-
-    /** @test */
-    public function macro_is_registered_with_arrays()
-    {
-        $one = [
-            'title' => 'plain title one',
-            'field' => 'raw field one',
-        ];
-
-        $two = [
-            'title' => 'plain title two',
-            'field' => 'raw field two',
-        ];
-
-        $collection = Collection::make([$one, $two]);
-
-        $values = $collection->toValuesCollection();
-
-        $this->assertInstanceOf(ValuesCollection::class, $values);
-        $this->assertEveryItemIsInstanceOf(Values::class, $values);
-        $this->assertEquals('plain title one', $values->first()->title);
-        $this->assertEquals('raw field one', $values->first()->field);
-        $this->assertEquals('plain title two', $values->last()->title);
-        $this->assertEquals('raw field two', $values->last()->field);
-    }
-
-    /** @test */
-    public function macro_is_registered_with_collections()
-    {
-        $one = collect([
-            'title' => 'plain title one',
-            'field' => 'raw field one',
-        ]);
-
-        $two = collect([
-            'title' => 'plain title two',
-            'field' => 'raw field two',
-        ]);
-
-        $collection = Collection::make([$one, $two]);
-
-        $values = $collection->toValuesCollection();
-
-        $this->assertInstanceOf(ValuesCollection::class, $values);
-        $this->assertEveryItemIsInstanceOf(Values::class, $values);
-        $this->assertEquals('plain title one', $values->first()->title);
-        $this->assertEquals('raw field one', $values->first()->field);
-        $this->assertEquals('plain title two', $values->last()->title);
-        $this->assertEquals('raw field two', $values->last()->field);
-    }
-
-    /** @test */
-    public function macro_is_registered_with_augmentables()
-    {
-        $fieldtype = new class extends Fieldtype
-        {
-            public function augment($value)
-            {
-                return str_replace('raw', 'augmented', $value);
-            }
-        };
-
-        $one = Mockery::mock(Augmentable::class);
-        $one->shouldReceive('toAugmentedCollection')->once()->andReturn(new AugmentedCollection([
-            'title' => 'plain title one',
-            'field' => new Value('raw field one', null, $fieldtype),
-        ]));
-
-        $two = Mockery::mock(Augmentable::class);
-        $two->shouldReceive('toAugmentedCollection')->once()->andReturn(new AugmentedCollection([
-            'title' => 'plain title two',
-            'field' => new Value('raw field two', null, $fieldtype),
-        ]));
-
-        $collection = Collection::make([$one, $two]);
-
-        $values = $collection->toValuesCollection();
-
-        $this->assertInstanceOf(ValuesCollection::class, $values);
-        $this->assertEveryItemIsInstanceOf(Values::class, $values);
-        $this->assertEquals('plain title one', $values->first()->title);
-        $this->assertEquals('augmented field one', $values->first()->field);
-        $this->assertEquals('plain title two', $values->last()->title);
-        $this->assertEquals('augmented field two', $values->last()->field);
     }
 }


### PR DESCRIPTION
This reverts #5286.

It's basically rendered pointless by #5297.