### PR TITLE
Augmented classes always return Value instances

### DIFF
--- a/src/Auth/AugmentedUser.php
+++ b/src/Auth/AugmentedUser.php
@@ -6,6 +6,7 @@ use Statamic\Data\AbstractAugmented;
 use Statamic\Facades\Role;
 use Statamic\Facades\User;
 use Statamic\Facades\UserGroup;
+use Statamic\Fields\Value;
 use Statamic\Support\Str;
 
 class AugmentedUser extends AbstractAugmented
@@ -38,22 +39,22 @@ class AugmentedUser extends AbstractAugmented
         ];
     }
 
-    public function get($handle)
+    public function get($handle): Value
     {
         if ($handle === 'is_user') {
-            return true;
+            return new Value(true, 'is_user', null, $this->data);
         }
 
         if ($handle === 'is_super') {
-            return $this->data->isSuper();
+            return new Value($this->data->isSuper(), 'is_super', null, $this->data);
         }
 
         if (Str::startsWith($handle, 'is_')) {
-            return in_array(Str::after($handle, 'is_'), $this->roles());
+            return new Value(in_array(Str::after($handle, 'is_'), $this->roles()), $handle, null, $this->data);
         }
 
         if (Str::startsWith($handle, 'in_')) {
-            return in_array(Str::after($handle, 'in_'), $this->groups());
+            return new Value(in_array(Str::after($handle, 'in_'), $this->groups()), $handle, null, $this->data);
         }
 
         return parent::get($handle);

--- a/src/Contracts/Data/Augmented.php
+++ b/src/Contracts/Data/Augmented.php
@@ -2,9 +2,11 @@
 
 namespace Statamic\Contracts\Data;
 
+use Statamic\Fields\Value;
+
 interface Augmented
 {
-    public function get($key);
+    public function get($key): Value;
 
     public function all();
 

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -48,7 +48,11 @@ abstract class AbstractAugmented implements Augmented
         $method = Str::camel($handle);
 
         if ($this->methodExistsOnThisClass($method)) {
-            return new Value($this->$method(), $method, null, $this->data);
+            $value = $this->$method();
+
+            return $value instanceof Value
+                ? $value
+                : new Value($value, $method, null, $this->data);
         }
 
         if (method_exists($this->data, $method) && collect($this->keys())->contains(Str::snake($handle))) {

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -43,12 +43,12 @@ abstract class AbstractAugmented implements Augmented
 
     abstract public function keys();
 
-    public function get($handle)
+    public function get($handle): Value
     {
         $method = Str::camel($handle);
 
         if ($this->methodExistsOnThisClass($method)) {
-            return $this->$method();
+            return new Value($this->$method(), $method, null, $this->data);
         }
 
         if (method_exists($this->data, $method) && collect($this->keys())->contains(Str::snake($handle))) {
@@ -90,14 +90,10 @@ abstract class AbstractAugmented implements Augmented
     {
         $fields = $this->blueprintFields();
 
-        if (! $fields->has($handle)) {
-            return $value;
-        }
-
         return new Value(
             $value,
             $handle,
-            $fields->get($handle)->fieldtype(),
+            optional($fields->get($handle))->fieldtype(),
             $this->data
         );
     }

--- a/src/Tags/Concerns/QueriesConditions.php
+++ b/src/Tags/Concerns/QueriesConditions.php
@@ -315,7 +315,7 @@ trait QueriesConditions
         }
 
         if ($value instanceof Augmentable) {
-            $value = $value->augmentedValue($field);
+            $value = $value->augmentedValue($field)->value();
         }
 
         if ($value instanceof LabeledValue) {

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -239,7 +239,7 @@ class Locales extends Tags
             return false;
         }
 
-        if (! $this->params->bool('self', true) && $item['locale']['handle'] === $this->data->locale()) {
+        if (! $this->params->bool('self', true) && $item['locale']['handle']->value() === $this->data->locale()) {
             return false;
         }
 

--- a/src/Tags/ParentTags.php
+++ b/src/Tags/ParentTags.php
@@ -26,7 +26,7 @@ class ParentTags extends Tags
     {
         $var_name = Stringy::removeLeft($this->tag, 'parent:');
 
-        return Arr::get($this->getParent(), $var_name);
+        return Arr::get($this->getParent(), $var_name)->value();
     }
 
     /**

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -216,7 +216,7 @@ class Cascade
 
     protected function hydrateViewModel()
     {
-        if ($class = $this->get('view_model')) {
+        if ($class = optional($this->get('view_model'))->value()) {
             $viewModel = new $class($this);
             $this->data = array_merge($this->data, $viewModel->data());
         }

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -782,7 +782,7 @@ class AssetTest extends TestCase
 
         $array = $asset->toAugmentedArray();
 
-        $this->assertArraySubset([
+        $expectedValues = [
             'id' => 'test_container::path/to/asset.jpg',
             'title' => 'asset.jpg',
             'path' => 'path/to/asset.jpg',
@@ -794,7 +794,10 @@ class AssetTest extends TestCase
             'container' => $this->container,
             'blueprint' => $blueprint,
             'foo' => 'bar',
-        ], $array);
+        ];
+        foreach ($expectedValues as $k => $v) {
+            $this->assertEquals($v, $array[$k]->value());
+        }
 
         $keys = ['is_audio', 'is_previewable', 'is_image', 'is_video', 'edit_url', 'url'];
         foreach ($keys as $key) {
@@ -855,7 +858,7 @@ class AssetTest extends TestCase
             ->path('path/to/asset.jpg')
             ->set('focus', '75-25');
 
-        $this->assertSame($asset->augmentedValue('focus_css'), '75% 25%');
+        $this->assertSame($asset->augmentedValue('focus_css')->value(), '75% 25%');
     }
 
     /** @test */
@@ -869,7 +872,7 @@ class AssetTest extends TestCase
             ->container($this->container)
             ->path('path/to/asset.jpg');
 
-        $this->assertSame($asset->augmentedValue('focus_css'), '50% 50%');
+        $this->assertSame($asset->augmentedValue('focus_css')->value(), '50% 50%');
     }
 
     /** @test */

--- a/tests/Auth/AugmentedUserTest.php
+++ b/tests/Auth/AugmentedUserTest.php
@@ -6,7 +6,6 @@ use Carbon\Carbon;
 use Statamic\Auth\AugmentedUser;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\User;
-use Statamic\Fields\Value;
 use Tests\Data\AugmentedTestCase;
 use Tests\FakesRoles;
 use Tests\FakesUserGroups;
@@ -61,9 +60,9 @@ class AugmentedUserTest extends AugmentedTestCase
 
         $expectations = [
             'id'         => ['type' => 'string', 'value' => 'user-id'],
-            'name'       => ['type' => Value::class, 'value' => 'John Smith'],
+            'name'       => ['type' => 'string', 'value' => 'John Smith'],
             'title'      => ['type' => 'string', 'value' => 'john@example.com'],
-            'email'      => ['type' => Value::class, 'value' => 'john@example.com'],
+            'email'      => ['type' => 'string', 'value' => 'john@example.com'],
             'initials'   => ['type' => 'string', 'value' => 'JS'],
             'edit_url'   => ['type' => 'string', 'value' => 'http://localhost/cp/users/user-id/edit'],
             'is_user'    => ['type' => 'bool', 'value' => true],
@@ -81,10 +80,10 @@ class AugmentedUserTest extends AugmentedTestCase
             'in_group_two' => ['type' => 'bool', 'value' => false],
 
             'one'          => ['type' => 'string', 'value' => 'the "one" value on the user'],
-            'two'          => ['type' => Value::class, 'value' => 'the "two" value on the user and in the blueprint'],
+            'two'          => ['type' => 'string', 'value' => 'the "two" value on the user and in the blueprint'],
             'three'        => ['type' => 'string', 'value' => 'the "three" value supplemented on the user'],
-            'four'         => ['type' => Value::class, 'value' => 'the "four" value supplemented on the user and in the blueprint'],
-            'unused_in_bp' => ['type' => Value::class, 'value' => null],
+            'four'         => ['type' => 'string', 'value' => 'the "four" value supplemented on the user and in the blueprint'],
+            'unused_in_bp' => ['type' => 'string', 'value' => null],
         ];
 
         $this->assertAugmentedCorrectly($expectations, $augmented);

--- a/tests/Data/AugmentedTest.php
+++ b/tests/Data/AugmentedTest.php
@@ -104,6 +104,23 @@ class AugmentedTest extends TestCase
     }
 
     /** @test */
+    public function if_an_augmented_things_method_returns_a_value_instance_then_use_it()
+    {
+        // An example of this would be the AugmentedEntry::authors() method.
+
+        app()->instance('foo-return-value', $valueInstance = new Value('something completely custom'));
+
+        $augmented = new class($this->thing) extends BaseAugmentedThing {
+            public function foo()
+            {
+                return app('foo-return-value');
+            }
+        };
+
+        $this->assertSame($valueInstance, $augmented->get('foo'));
+    }
+
+    /** @test */
     public function the_value_object_returned_contains_appropriate_fieldtype_if_the_thing_has_a_blueprint_and_theres_a_matching_field()
     {
         FieldtypeRepository::shouldReceive('find')->with('test')

--- a/tests/Data/AugmentedTest.php
+++ b/tests/Data/AugmentedTest.php
@@ -40,7 +40,8 @@ class AugmentedTest extends TestCase
     /** @test */
     public function it_gets_a_single_value_by_key()
     {
-        $augmented = new class($this->thing) extends BaseAugmentedThing {
+        $augmented = new class($this->thing) extends BaseAugmentedThing
+        {
             //
         };
 
@@ -51,14 +52,16 @@ class AugmentedTest extends TestCase
     /** @test */
     public function it_gets_a_single_value_by_key_using_the_value_method_if_it_exists()
     {
-        $thingWithValueMethod = new class($this->thing->data()) extends Thing {
+        $thingWithValueMethod = new class($this->thing->data()) extends Thing
+        {
             public function value($key)
             {
                 return $this->get($key) ? $this->get($key).' (value)' : null;
             }
         };
 
-        $augmented = new class($thingWithValueMethod) extends BaseAugmentedThing {
+        $augmented = new class($thingWithValueMethod) extends BaseAugmentedThing
+        {
             //
         };
 
@@ -69,7 +72,8 @@ class AugmentedTest extends TestCase
     /** @test */
     public function it_gets_a_value_from_the_thing_if_theres_a_corresponding_method_for_a_key()
     {
-        $augmented = new class($this->thing) extends BaseAugmentedThing {
+        $augmented = new class($this->thing) extends BaseAugmentedThing
+        {
             public function keys()
             {
                 return ['slug', 'the_slug'];
@@ -86,7 +90,8 @@ class AugmentedTest extends TestCase
     /** @test */
     public function it_gets_a_value_from_the_augmented_thing_if_theres_a_method()
     {
-        $augmented = new class($this->thing) extends BaseAugmentedThing {
+        $augmented = new class($this->thing) extends BaseAugmentedThing
+        {
             public function slug()
             {
                 return 'the-augmented-thing';
@@ -110,7 +115,8 @@ class AugmentedTest extends TestCase
 
         app()->instance('foo-return-value', $valueInstance = new Value('something completely custom'));
 
-        $augmented = new class($this->thing) extends BaseAugmentedThing {
+        $augmented = new class($this->thing) extends BaseAugmentedThing
+        {
             public function foo()
             {
                 return app('foo-return-value');
@@ -124,14 +130,16 @@ class AugmentedTest extends TestCase
     public function the_value_object_returned_contains_appropriate_fieldtype_if_the_thing_has_a_blueprint_and_theres_a_matching_field()
     {
         FieldtypeRepository::shouldReceive('find')->with('test')
-            ->andReturn($fieldtype = new class extends Fieldtype {
+            ->andReturn($fieldtype = new class extends Fieldtype
+            {
                 public function augment($value)
                 {
                     return 'AUGMENTED '.strtoupper($value);
                 }
             });
 
-        $augmented = new class($this->blueprintThing) extends BaseAugmentedThing {
+        $augmented = new class($this->blueprintThing) extends BaseAugmentedThing
+        {
             public function keys()
             {
                 return array_merge(parent::keys(), ['hello', 'slug', 'the_slug']);
@@ -202,21 +210,23 @@ class AugmentedTest extends TestCase
     public function if_the_augmented_thing_has_a_method_with_a_corresponding_blueprint_field_it_will_not_use_that_fieldtype()
     {
         FieldtypeRepository::shouldReceive('find')->with('test')
-            ->andReturn($fieldtype = new class extends Fieldtype {
+            ->andReturn($fieldtype = new class extends Fieldtype
+            {
                 public function augment($value)
                 {
                     return 'AUGMENTED '.strtoupper($value);
                 }
             });
 
-        $augmented = new class($this->blueprintThing) extends BaseAugmentedThing {
+        $augmented = new class($this->blueprintThing) extends BaseAugmentedThing
+        {
             public function foo()
             {
                 return 'bar';
             }
         };
 
-        tap($augmented->get('foo'), function ($value) use ($fieldtype) {
+        tap($augmented->get('foo'), function ($value) {
             $this->assertInstanceOf(Value::class, $value);
             $this->assertEquals('bar', $value->raw());
             $this->assertEquals('bar', $value->value());
@@ -230,14 +240,16 @@ class AugmentedTest extends TestCase
     public function it_can_select_multiple_keys()
     {
         FieldtypeRepository::shouldReceive('find')->with('test')
-            ->andReturn($fieldtype = new class extends Fieldtype {
+            ->andReturn($fieldtype = new class extends Fieldtype
+            {
                 public function augment($value)
                 {
                     return 'AUGMENTED '.strtoupper($value);
                 }
             });
 
-        $augmented = new class($this->blueprintThing) extends BaseAugmentedThing {
+        $augmented = new class($this->blueprintThing) extends BaseAugmentedThing
+        {
             public function keys()
             {
                 return ['foo', 'slug', 'the_slug', 'hello', 'supplemented'];

--- a/tests/Data/AugmentedTestCase.php
+++ b/tests/Data/AugmentedTestCase.php
@@ -34,7 +34,7 @@ class AugmentedTestCase extends TestCase
     private function assertAugmentedAsExpected($expectations, $augmented)
     {
         foreach ($expectations as $key => $expectation) {
-            $actual = $augmented->get($key);
+            $actual = $augmented->get($key)->value();
 
             if (! in_array($expectation['type'], ['string', 'bool', 'array', 'int', 'null'])) {
                 $this->assertInstanceOf($expectation['type'], $actual, "Key '{$key}' is not a {$expectation['type']}");

--- a/tests/Data/AugmentedTestCase.php
+++ b/tests/Data/AugmentedTestCase.php
@@ -4,7 +4,6 @@ namespace Tests\Data;
 
 use Carbon\Carbon;
 use Statamic\Contracts\Auth\User;
-use Statamic\Fields\Value;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -34,26 +33,22 @@ class AugmentedTestCase extends TestCase
     private function assertAugmentedAsExpected($expectations, $augmented)
     {
         foreach ($expectations as $key => $expectation) {
-            $actual = $augmented->get($key)->value();
+            $valueInstance = $augmented->get($key);
+            $actual = $valueInstance->value();
 
             if (! in_array($expectation['type'], ['string', 'bool', 'array', 'int', 'null'])) {
                 $this->assertInstanceOf($expectation['type'], $actual, "Key '{$key}' is not a {$expectation['type']}");
             }
 
+            if (isset($expectation['fieldtype'])) {
+                $this->assertEquals(
+                    $expectation['fieldtype'],
+                    $valueInstance->fieldtype()->handle(),
+                    "Key '{$key}' does not have the expected fieldtype."
+                );
+            }
+
             switch ($expectation['type']) {
-                case Value::class:
-                    $this->assertSame($expectation['value'], $actual->value(), "Key '{$key}' does not match expected value.");
-
-                    if (isset($expectation['fieldtype'])) {
-                        $this->assertEquals(
-                            $expectation['fieldtype'],
-                            $actual->fieldtype()->handle(),
-                            "Key '{$key}' does not have the expected fieldtype."
-                        );
-                    }
-
-                    break;
-
                 case Carbon::class:
                     $this->assertTrue(
                         Carbon::createFromFormat('Y-m-d H:i', $expectation['value'])->eq($actual),

--- a/tests/Data/Entries/AugmentedEntryTest.php
+++ b/tests/Data/Entries/AugmentedEntryTest.php
@@ -14,7 +14,6 @@ use Statamic\Entries\Entry;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\User;
-use Statamic\Fields\Value;
 use Tests\Data\AugmentedTestCase;
 
 class AugmentedEntryTest extends AugmentedTestCase
@@ -84,7 +83,7 @@ class AugmentedEntryTest extends AugmentedTestCase
 
         $expectations = [
             'id'            => ['type' => 'string', 'value' => 'entry-id'],
-            'slug'          => ['type' => Value::class, 'value' => 'entry-slug'],
+            'slug'          => ['type' => 'string', 'value' => 'entry-slug'],
             'uri'           => ['type' => 'string', 'value' => '/test/entry-slug'],
             'url'           => ['type' => 'string', 'value' => '/test/entry-slug'],
             'edit_url'      => ['type' => 'string', 'value' => 'http://localhost/cp/collections/test/entries/entry-id'],
@@ -104,14 +103,14 @@ class AugmentedEntryTest extends AugmentedTestCase
             'updated_at'    => ['type' => Carbon::class, 'value' => '2017-02-03 14:10'],
             'updated_by'    => ['type' => UserContract::class, 'value' => 'test-user'],
             'one'           => ['type' => 'string', 'value' => 'the "one" value on the entry'],
-            'two'           => ['type' => Value::class, 'value' => 'the "two" value on the entry and in the blueprint'],
+            'two'           => ['type' => 'string', 'value' => 'the "two" value on the entry and in the blueprint'],
             'three'         => ['type' => 'string', 'value' => 'the "three" value supplemented on the entry'],
-            'four'          => ['type' => Value::class, 'value' => 'the "four" value supplemented on the entry and in the blueprint'],
+            'four'          => ['type' => 'string', 'value' => 'the "four" value supplemented on the entry and in the blueprint'],
             'five'          => ['type' => 'string', 'value' => 'the "five" value from the origin'],
-            'six'           => ['type' => Value::class, 'value' => 'the "six" value from the origin and in the blueprint'],
+            'six'           => ['type' => 'string', 'value' => 'the "six" value from the origin and in the blueprint'],
             'seven'         => ['type' => 'string', 'value' => 'the "seven" value from the collection'],
-            'title'         => ['type' => Value::class, 'value' => null],
-            'unused_in_bp'  => ['type' => Value::class, 'value' => null],
+            'title'         => ['type' => 'string', 'value' => null],
+            'unused_in_bp'  => ['type' => 'string', 'value' => null],
         ];
 
         $this->assertAugmentedCorrectly($expectations, $augmented);
@@ -129,13 +128,13 @@ class AugmentedEntryTest extends AugmentedTestCase
 
         $augmented = new AugmentedEntry($entry);
 
-        $this->assertNull($augmented->get('mount'));
+        $this->assertNull($augmented->get('mount')->value());
 
         $mount->mount($entry->id())->save();
-        $this->assertEquals($mount, $augmented->get('mount'));
+        $this->assertEquals($mount, $augmented->get('mount')->value());
 
         $entry->set('mount', 'b');
-        $this->assertEquals('b', $augmented->get('mount'));
+        $this->assertEquals('b', $augmented->get('mount')->value());
     }
 
     /** @test */
@@ -153,10 +152,10 @@ class AugmentedEntryTest extends AugmentedTestCase
 
         $augmented = new AugmentedEntry($entry);
 
-        $this->assertNull($augmented->get('authors'));
+        $this->assertNull($augmented->get('authors')->value());
 
         $entry->set('authors', 'joe and bob');
-        $this->assertEquals('joe and bob', $augmented->get('authors'));
+        $this->assertEquals('joe and bob', $augmented->get('authors')->value());
     }
 
     /** @test */
@@ -178,16 +177,12 @@ class AugmentedEntryTest extends AugmentedTestCase
         $augmented = new AugmentedEntry($entry);
 
         // Since it's in the blueprint, and is using a "users" fieldtype, it gets augmented to a collection.
-        $authors = $augmented->get('authors');
-        $this->assertInstanceOf(Value::class, $authors);
-        $authors = $authors->value();
+        $authors = $augmented->get('authors')->value();
         $this->assertInstanceOf(IlluminateCollection::class, $authors);
         $this->assertEquals([], $authors->all());
 
         $entry->set('authors', ['user-1', 'unknown-user', 'user-2']);
-        $authors = $augmented->get('authors');
-        $this->assertInstanceOf(Value::class, $authors);
-        $authors = $authors->value();
+        $authors = $augmented->get('authors')->value();
         $this->assertInstanceOf(IlluminateCollection::class, $authors);
         $this->assertEveryItemIsInstanceOf(\Statamic\Contracts\Auth\User::class, $authors);
         $this->assertEquals(['user-1', 'user-2'], $authors->map->id()->all());

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -442,7 +442,7 @@ class EntryTest extends TestCase
             ->setSupplement('baz', 'qux')
             ->setSupplement('foo', 'overridden');
 
-        $this->assertArraySubset([
+        $expectedValues = [
             'foo' => 'overridden',
             'bar' => 'baz',
             'baz' => 'qux',
@@ -451,7 +451,13 @@ class EntryTest extends TestCase
             'updated_by' => $user,
             'url' => '/blog/test',
             'permalink' => 'http://localhost/blog/test',
-        ], $entry->toAugmentedArray());
+        ];
+
+        $array = $entry->toAugmentedArray();
+
+        foreach ($expectedValues as $k => $v) {
+            $this->assertEquals($v, $array[$k]->value());
+        }
     }
 
     /** @test */

--- a/tests/Data/HasAugmentedInstanceTest.php
+++ b/tests/Data/HasAugmentedInstanceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Data;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Data\AugmentedCollection;
 use Statamic\Data\HasAugmentedInstance;
+use Statamic\Fields\Value;
 use Tests\TestCase;
 
 class HasAugmentedInstanceTest extends TestCase
@@ -17,7 +18,7 @@ class HasAugmentedInstanceTest extends TestCase
         $shallowFilteredAugmentedCollection = new AugmentedCollection(['id', 'title', 'api_url']);
 
         $mock = $this->mock(Augmented::class);
-        $mock->shouldReceive('get')->with('foo')->once()->andReturn('bar');
+        $mock->shouldReceive('get')->with('foo')->once()->andReturn(new Value('bar'));
         $mock->shouldReceive('select')->with(null)->times(2)->andReturn($augmentedCollection);
         $mock->shouldReceive('select')->with(['one'])->times(2)->andReturn($filteredAugmentedCollection);
         $mock->shouldReceive('select')->with(['id', 'title', 'api_url'])->times(1)->andReturn($shallowFilteredAugmentedCollection);

--- a/tests/Data/Structures/AugmentedPageTest.php
+++ b/tests/Data/Structures/AugmentedPageTest.php
@@ -5,7 +5,6 @@ namespace Tests\Data\Structures;
 use Mockery;
 use Statamic\Entries\Entry;
 use Statamic\Facades\Blueprint;
-use Statamic\Fields\Value;
 use Statamic\Structures\AugmentedPage;
 use Statamic\Structures\Page;
 use Tests\Data\AugmentedTestCase;
@@ -145,8 +144,8 @@ class AugmentedPageTest extends AugmentedTestCase
             'url' => ['type' => 'string', 'value' => '/the-url'],
             'uri' => ['type' => 'string', 'value' => '/the-uri'],
             'permalink' => ['type' => 'string', 'value' => 'https://site.com/the-permalink'],
-            'one' => ['type' => Value::class, 'value' => 'two'],
-            'three' => ['type' => Value::class, 'value' => 'four'],
+            'one' => ['type' => 'string', 'value' => 'two'],
+            'three' => ['type' => 'string', 'value' => 'four'],
             'five' => ['type' => 'string', 'value' => 'six'],
             'seven' => ['type' => 'string', 'value' => 'eight'],
             'id' => ['type' => 'string', 'value' => 'page-id'],
@@ -211,12 +210,12 @@ class AugmentedPageTest extends AugmentedTestCase
         $augmented = new AugmentedPage($page);
 
         $expectations = [
-            'title' => ['type' => Value::class, 'value' => 'The Page Title'],
+            'title' => ['type' => 'string', 'value' => 'The Page Title'],
             'url' => ['type' => 'string', 'value' => '/the-url'],
             'uri' => ['type' => 'string', 'value' => '/the-uri'],
             'permalink' => ['type' => 'string', 'value' => 'https://site.com/the-permalink'],
-            'one' => ['type' => Value::class, 'value' => 'dos', 'fieldtype' => 'textarea'], // assert fieldtype to ensure the field from the page blueprint wins
-            'three' => ['type' => Value::class, 'value' => 'quatro'],
+            'one' => ['type' => 'string', 'value' => 'dos', 'fieldtype' => 'textarea'], // assert fieldtype to ensure the field from the page blueprint wins
+            'three' => ['type' => 'string', 'value' => 'quatro'],
             'five' => ['type' => 'string', 'value' => 'seis'],
             'seven' => ['type' => 'string', 'value' => 'ocho'],
             'id' => ['type' => 'string', 'value' => 'page-id'],

--- a/tests/Data/Taxonomies/AugmentedTermTest.php
+++ b/tests/Data/Taxonomies/AugmentedTermTest.php
@@ -48,8 +48,8 @@ class AugmentedTermTest extends AugmentedTestCase
 
         $expectations = [
             'id'            => ['type' => 'string', 'value' => 'test::term-slug'],
-            'slug'          => ['type' => Value::class, 'value' => 'term-slug'],
-            'title'         => ['type' => Value::class, 'value' => 'term-slug'],
+            'slug'          => ['type' => 'string', 'value' => 'term-slug'],
+            'title'         => ['type' => 'string', 'value' => 'term-slug'],
             'uri'           => ['type' => 'string', 'value' => '/test/term-slug'],
             'url'           => ['type' => 'string', 'value' => '/test/term-slug'],
             'edit_url'      => ['type' => 'string', 'value' => 'http://localhost/cp/taxonomies/test/terms/term-slug/en'],
@@ -60,9 +60,9 @@ class AugmentedTermTest extends AugmentedTestCase
             'entries_count' => ['type' => 'int', 'value' => 0],
             'entries'       => ['type' => EntryQueryBuilder::class],
             'one'           => ['type' => 'string', 'value' => 'the "one" value on the term'],
-            'two'           => ['type' => Value::class, 'value' => 'the "two" value on the term and in the blueprint'],
+            'two'           => ['type' => 'string', 'value' => 'the "two" value on the term and in the blueprint'],
             'three'         => ['type' => 'string', 'value' => 'the "three" value from the taxonomy'],
-            'unused_in_bp'  => ['type' => Value::class, 'value' => null],
+            'unused_in_bp'  => ['type' => 'string', 'value' => null],
             'updated_at'    => ['type' => Carbon::class, 'value' => '2017-02-03 14:10'],
             'updated_by'    => ['type' => UserContract::class, 'value' => 'test-user'],
         ];

--- a/tests/Sites/SiteTest.php
+++ b/tests/Sites/SiteTest.php
@@ -250,7 +250,7 @@ class SiteTest extends TestCase
             'permalink' => 'http://absolute-url-resolved-from-request.com/sub',
             'direction' => 'ltr',
             'attributes' => [],
-        ], $values->all());
+        ], $values->map->value()->all());
 
         $this->assertEquals(
             'test Test en_US en /sub http://absolute-url-resolved-from-request.com/sub',


### PR DESCRIPTION
Another developer UX PR.

Currently when call augmentation methods, you'll get `Value` instances if the field exists in the blueprint. Otherwise you'd just get the raw value. That made it frustrating since you'd have to do a bunch of `instanceof Value` checks afterwards.

In this PR, you can now always expect `Value` instances.

### Before

Previously you'd have to do a bunch of instanceof checks for something like this:

```php
$entry->toAugmentedCollection();

// AugmentedCollection([
//  'id' => '123',
//  'content' => Statamic\Fields\Value('the content')
//  'collection' => Statamic\Entries\Collection,
//  'published' => true,
// ]);
```

```php
$entry->toAugmentedCollection()->map(function ($item) {
  return $item instanceof Value ? $item->value() : $item;
})->all();

// [
//   'id' => '123,
//   'content' => 'the content', 
//   'collection' => Statamic\Entries\Collection, 
//   'published' => true
// ]
```

```php
$entry->augmentedValue('id'); // 123
$entry->augmentedValue('id')->value(); // Exception: "call to function value() on string"
$entry->augmentedValue('content'); // Statamic\Field\Value
$entry->augmentedValue('content')->value(); // "the content"
```

### After

Now you can assume there will always be a `Value`.

```php
$entry->toAugmentedCollection();

// AugmentedCollection([
//  'id' => Statamic\Fields\Value('123'),
//  'title' => Statamic\Fields\Value('the content'),
//  'collection' => Statamic\Fields\Value(Statamic\Entries\Collection),
//  'published' => Statamic\Fields\Value(true),
// ]);
```

```php
$entry->toAugmentedCollection()->map->value()->all();

// [
//   'id' => '123,
//   'content' => 'the content', 
//   'collection' => Statamic\Entries\Collection, 
//   'published' => true
// ]
```

```php
$entry->augmentedValue('id'); // Statamic\Field\Value
$entry->augmentedValue('id')->value(); // 123
$entry->augmentedValue('content'); // Statamic\Field\Value
$entry->augmentedValue('content')->value(); // "the content"
```

## Breaking change

This is technically a breaking change.

If you were explicitly coding something expecting a non-`Value`, it will now be a `Value`.

For example, the entry's `published` value was just a boolean.

```yaml
published: false
```
```php
if ($entry->augmentedValue('published')) {
  // this would not run, because augmenedValue would have returned false
}
```
Now:
```php
if ($entry->augmentedValue('published')) {
  // this *will* run, because augmenedValue is now a Value instance, and in php, "if object" always return true
}
```

A suggested adjustment is to avoid using these methods completely, and use the new magic properties from #5297.

```php
if ($entry->published)
```