### PR TITLE
Add param() and params() setters to FluentTag

### DIFF
--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -192,15 +192,44 @@ class FluentTag implements \IteratorAggregate, \ArrayAccess
     }
 
     /**
-     * Allow calls to tag params via method names.
+     * Allow calls to tag params.
      *
-     * @param  string  $method  Param name
+     * @param  string  $param
+     * @param  array  $value
+     * @return $this
+     */
+    public function param($param, $value = true)
+    {
+        $this->params[$param] = $value ?? true;
+
+        return $this;
+    }
+
+    /**
+     * Allow calls to multiple tag params.
+     *
+     * @param  array  $params
+     * @return $this
+     */
+    public function params($params)
+    {
+        foreach ($params as $param => $value) {
+            $this->param($param, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Allow calls to tag params via dynamic method names.
+     *
+     * @param  string  $param  Param name
      * @param  array  $args  First arg will be param value
      * @return $this
      */
-    public function __call($method, $args)
+    public function __call($param, $args)
     {
-        $this->params[$method] = $args[0] ?? true;
+        $this->param($param, $args[0] ?? true);
 
         return $this;
     }

--- a/tests/Tags/FluentTagTest.php
+++ b/tests/Tags/FluentTagTest.php
@@ -53,7 +53,13 @@ class FluentTagTest extends TestCase
                     && is_array($arg2)
                     && $arg2['parser'] instanceof Parser
                     && Arr::except($arg2, 'parser') === [
-                        'params' => ['sort' => 'slug:desc', 'limit' => 3],
+                        'params' => [
+                            'sort' => 'slug:desc',
+                            'limit' => 3,
+                            'title:contains' => 'chewy',
+                            'slug:contains' => 'han',
+                            'description:contains' => 'luke',
+                        ],
                         'content' => '',
                         'context' => [],
                         'tag' => $expectedTag,
@@ -63,7 +69,14 @@ class FluentTagTest extends TestCase
             ->once()
             ->andReturn($tag);
 
-        $fluentTag = FluentTag::make($usedTag)->sort('slug:desc')->limit(3);
+        $fluentTag = FluentTag::make($usedTag)
+            ->sort('slug:desc')
+            ->limit(3)
+            ->param('title:contains', 'chewy')
+            ->params([
+                'slug:contains' => 'han',
+                'description:contains' => 'luke',
+            ]);
 
         $this->assertInstanceOf(FluentTag::class, $fluentTag);
 


### PR DESCRIPTION
```php
FluentTag::make($usedTag)
    ->sort('slug:desc')  // dynamically call params via methods
    ->param('title:contains', 'chewy') // explicitly set param, with colon for example
    ->params(...); // or set multiple params at once
```