### PR TITLE
Added 'field' parameter to be sent to Custom Validators

### DIFF
--- a/resources/js/components/field-conditions/Validator.js
+++ b/resources/js/components/field-conditions/Validator.js
@@ -238,6 +238,7 @@ export default class {
         let passes = customFunction({
             params: condition.params,
             target: condition.target,
+            field: this.field,
             values: this.values,
             root: this.rootValues,
             store: this.store,


### PR DESCRIPTION
Added another parameter to be sent to Custom Validators.

We have a specific case while we are using Restrict fields by role package (https://github.com/thoughtco/statamic-restrict-fields) and there is no way to define which type of validation is used when Custom Validators are added.