### PR TITLE
Fixes nested lists css to display correct list style

### DIFF
--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -386,7 +386,15 @@
     }
 
     ol ol {
-        list-style-type: lower-roman;
+        list-style-type: decimal;
+    }
+
+    ul ol {
+        list-style-type: decimal;
+    }
+
+    ol ul {
+        list-style-type: circle;
     }
 
     blockquote {


### PR DESCRIPTION
Fixes a css issue with lists in the Bard field type.

With current css
<img width="339" alt="bard-current" src="https://user-images.githubusercontent.com/3210702/154779108-4490c114-38d3-41bf-bf85-a479619897a2.png">

With updated css
<img width="345" alt="bard-fix" src="https://user-images.githubusercontent.com/3210702/154779113-2ced2526-0fe5-4e07-99c9-220edf22408e.png">

