### PR TITLE
Adjust Form Submission data logic

### DIFF
--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -104,25 +104,6 @@ class Submission implements SubmissionContract, Augmentable
     }
 
     /**
-     * Get or set the data.
-     *
-     * @param  array|null  $data
-     * @return array
-     */
-    public function data($data = null)
-    {
-        if (func_num_args() === 0) {
-            return $this->data;
-        }
-
-        $data = collect($data)->intersectByKeys($this->fields())->all();
-
-        $this->data = $data;
-
-        return $this;
-    }
-
-    /**
      * Upload files.
      */
     public function uploadFiles()
@@ -139,44 +120,11 @@ class Submission implements SubmissionContract, Augmentable
     }
 
     /**
-     * Whether the submissin has the given key.
-     *
-     * @return bool
-     */
-    public function has($field)
-    {
-        return array_has($this->data(), $field);
-    }
-
-    /**
-     * Get a value of a field.
-     *
-     * @param  string  $key
-     * @return mixed
-     */
-    public function get($field)
-    {
-        return array_get($this->data(), $field);
-    }
-
-    /**
-     * Set a value of a field.
-     *
-     * @param  string  $field
-     * @param  mixed  $value
-     * @return void
-     */
-    public function set($field, $value)
-    {
-        array_set($this->data, $field, $value);
-    }
-
-    /**
      * Save the submission.
      */
     public function save()
     {
-        File::put($this->getPath(), YAML::dump($this->data()));
+        File::put($this->getPath(), YAML::dump($this->data()->all()));
 
         SubmissionSaved::dispatch($this);
     }

--- a/tests/Forms/SubmissionTest.php
+++ b/tests/Forms/SubmissionTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Forms;
 
+use Illuminate\Support\Collection;
+use Statamic\Facades\Blueprint;
 use Statamic\Facades\Form;
 use Tests\TestCase;
 
@@ -33,5 +35,47 @@ class SubmissionTest extends TestCase
         $this->assertStringNotContainsString(',', $submission->id());
 
         setlocale(LC_ALL, 'en_US');
+    }
+
+    /** @test */
+    public function it_sets_and_gets_data()
+    {
+        $submission = Form::make('test')->makeSubmission();
+
+        $blueprint = Blueprint::makeFromFields(['foo' => ['type' => 'text']]);
+        Blueprint::shouldReceive('find')->with('forms.test')->andReturn($blueprint);
+
+        $this->assertInstanceOf(Collection::class, $data = $submission->data());
+        $this->assertEquals([], $data->all());
+        $this->assertFalse($submission->has('foo'));
+        $this->assertNull($submission->get('foo'));
+        $this->assertNull($submission->foo);
+        $this->assertFalse($submission->has('hello'));
+        $this->assertNull($submission->get('hello'));
+        $this->assertNull($submission->hello);
+
+        $return = $submission->set('hello', 'world');
+
+        $this->assertInstanceOf(Collection::class, $data = $submission->data());
+        $this->assertEquals(['hello' => 'world'], $data->all());
+        $this->assertEquals($submission, $return);
+        $this->assertFalse($submission->has('foo'));
+        $this->assertNull($submission->get('foo'));
+        $this->assertNull($submission->foo);
+        $this->assertTrue($submission->has('hello'));
+        $this->assertEquals('world', $submission->get('hello'));
+        $this->assertEquals('world', $submission->hello);
+
+        $return = $submission->data(['foo' => 'bar', 'baz' => 'qux']);
+
+        $this->assertEquals($submission, $return);
+        $this->assertInstanceOf(Collection::class, $data = $submission->data());
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'qux'], $data->all());
+        $this->assertTrue($submission->has('foo'));
+        $this->assertEquals('bar', $submission->get('foo'));
+        $this->assertEquals('bar', $submission->foo);
+        $this->assertFalse($submission->has('hello'));
+        $this->assertNull($submission->get('hello'));
+        $this->assertNull($submission->hello);
     }
 }


### PR DESCRIPTION
- Remove the has/get/set/data methods so they delegate to ContainsData which does the same thing.
- The data method will always return a collection.
- The data method used to filter out fields that weren't in the blueprint. This was a leftover thing from v2 before we moved to v3 style validation. Now it won't do any filtering.

This goes along with #5297 but moving into its own PR to avoid noise there.
