### PR TITLE
ArrayAccess

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Assets;
 
+use ArrayAccess;
 use Facades\Statamic\Assets\Attributes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
@@ -30,7 +31,7 @@ use Stringy\Stringy;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Mime\MimeTypes;
 
-class Asset implements AssetContract, Augmentable
+class Asset implements AssetContract, Augmentable, ArrayAccess
 {
     use HasAugmentedInstance, FluentlyGetsAndSets, TracksQueriedColumns, SyncsOriginalState, ContainsData {
         set as traitSet;

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Assets;
 
+use ArrayAccess;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
@@ -20,7 +21,7 @@ use Statamic\Facades\Stache;
 use Statamic\Facades\URL;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class AssetContainer implements AssetContainerContract, Augmentable
+class AssetContainer implements AssetContainerContract, Augmentable, ArrayAccess
 {
     use ExistsAsFile, FluentlyGetsAndSets, HasAugmentedInstance;
 

--- a/src/Auth/Role.php
+++ b/src/Auth/Role.php
@@ -2,12 +2,13 @@
 
 namespace Statamic\Auth;
 
+use ArrayAccess;
 use Statamic\Contracts\Auth\Role as RoleContract;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Data\HasAugmentedData;
 use Statamic\Facades;
 
-abstract class Role implements RoleContract, Augmentable
+abstract class Role implements RoleContract, Augmentable, ArrayAccess
 {
     use HasAugmentedData;
 

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Auth;
 
+use ArrayAccess;
 use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -33,7 +34,8 @@ abstract class User implements
     Augmentable,
     AuthorizableContract,
     ResolvesValuesContract,
-    HasLocalePreference
+    HasLocalePreference,
+    ArrayAccess
 {
     use Authorizable, Notifiable, CanResetPassword, HasAugmentedInstance, TracksQueriedColumns, HasAvatar, ResolvesValues;
 

--- a/src/Auth/UserGroup.php
+++ b/src/Auth/UserGroup.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Auth;
 
+use ArrayAccess;
 use Statamic\Contracts\Auth\Role;
 use Statamic\Contracts\Auth\UserGroup as UserGroupContract;
 use Statamic\Contracts\Data\Augmentable;
@@ -11,7 +12,7 @@ use Statamic\Events\UserGroupSaved;
 use Statamic\Facades;
 use Statamic\Facades\Role as RoleAPI;
 
-abstract class UserGroup implements UserGroupContract, Augmentable
+abstract class UserGroup implements UserGroupContract, Augmentable, ArrayAccess
 {
     protected $title;
     protected $handle;

--- a/src/Data/HasAugmentedInstance.php
+++ b/src/Data/HasAugmentedInstance.php
@@ -76,4 +76,24 @@ trait HasAugmentedInstance
 
         throw new BadMethodCallException(sprintf('Call to undefined method %s::%s()', static::class, $method));
     }
+
+    public function offsetGet($key)
+    {
+        return $this->__get($key);
+    }
+
+    public function offsetSet($key, $value)
+    {
+        throw new \Exception('Method offsetSet is not currently supported.');
+    }
+
+    public function offsetExists($key)
+    {
+        throw new \Exception('Method offsetExists is not currently supported.');
+    }
+
+    public function offsetUnset($key)
+    {
+        throw new \Exception('Method offsetUnset is not currently supported.');
+    }
 }

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Entries;
 
+use ArrayAccess;
 use Statamic\Contracts\Data\Augmentable as AugmentableContract;
 use Statamic\Contracts\Entries\Collection as Contract;
 use Statamic\Data\ContainsCascadingData;
@@ -25,7 +26,7 @@ use Statamic\Structures\CollectionStructure;
 use Statamic\Support\Arr;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Collection implements Contract, AugmentableContract
+class Collection implements Contract, AugmentableContract, ArrayAccess
 {
     use FluentlyGetsAndSets, ExistsAsFile, HasAugmentedData, ContainsCascadingData;
 

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Entries;
 
+use ArrayAccess;
 use Facades\Statamic\View\Cascade;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Carbon;
@@ -37,7 +38,7 @@ use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Entry implements Contract, Augmentable, Responsable, Localization, Protectable, ResolvesValuesContract
+class Entry implements Contract, Augmentable, Responsable, Localization, Protectable, ResolvesValuesContract, ArrayAccess
 {
     use Routable {
         uri as routableUri;

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fields;
 
+use ArrayAccess;
 use Facades\Statamic\Fields\BlueprintRepository;
 use Facades\Statamic\Fields\FieldRepository;
 use Illuminate\Support\Collection;
@@ -19,7 +20,7 @@ use Statamic\Facades\Path;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
-class Blueprint implements Augmentable
+class Blueprint implements Augmentable, ArrayAccess
 {
     use HasAugmentedData, ExistsAsFile;
 

--- a/src/Globals/Variables.php
+++ b/src/Globals/Variables.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Globals;
 
+use ArrayAccess;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Contracts\Data\Localization;
@@ -18,7 +19,7 @@ use Statamic\Facades\Stache;
 use Statamic\GraphQL\ResolvesValues;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Variables implements Contract, Localization, Augmentable, ResolvesValuesContract
+class Variables implements Contract, Localization, Augmentable, ResolvesValuesContract, ArrayAccess
 {
     use ExistsAsFile, ContainsData, HasAugmentedInstance, HasOrigin, FluentlyGetsAndSets, ResolvesValues;
 

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Structures;
 
+use ArrayAccess;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
@@ -21,7 +22,7 @@ use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\GraphQL\ResolvesValues;
 
-class Page implements Entry, Augmentable, Responsable, Protectable, JsonSerializable, ResolvesValuesContract
+class Page implements Entry, Augmentable, Responsable, Protectable, JsonSerializable, ResolvesValuesContract, ArrayAccess
 {
     use HasAugmentedInstance, ForwardsCalls, TracksQueriedColumns, ResolvesValues, ContainsSupplementalData;
 

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Taxonomies;
 
+use ArrayAccess;
 use Facades\Statamic\View\Cascade;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Carbon;
@@ -25,7 +26,7 @@ use Statamic\Revisions\Revisable;
 use Statamic\Routing\Routable;
 use Statamic\Statamic;
 
-class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, ResolvesValuesContract
+class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, ResolvesValuesContract, ArrayAccess
 {
     use Revisable, Routable, Publishable, HasAugmentedInstance, TracksQueriedColumns, TracksLastModified, ContainsSupplementalData, ResolvesValues;
 

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Taxonomies;
 
+use ArrayAccess;
 use Illuminate\Contracts\Support\Responsable;
 use Statamic\Contracts\Data\Augmentable as AugmentableContract;
 use Statamic\Contracts\Taxonomies\Taxonomy as Contract;
@@ -23,7 +24,7 @@ use Statamic\Facades\URL;
 use Statamic\Statamic;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Taxonomy implements Contract, Responsable, AugmentableContract
+class Taxonomy implements Contract, Responsable, AugmentableContract, ArrayAccess
 {
     use FluentlyGetsAndSets, ExistsAsFile, HasAugmentedData, ContainsCascadingData, ContainsSupplementalData;
 

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -550,7 +550,8 @@ class AssetContainerTest extends TestCase
         $container
             ->toAugmentedCollection()
             ->except(['assets'])
-            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $container->{$key}));
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $container->{$key}))
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $container[$key]));
     }
 
     private function containerWithDisk()

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -113,8 +113,11 @@ class AssetTest extends TestCase
         $asset->set('charlie', 'delta');
 
         $this->assertEquals('test.jpg', $asset->path);
+        $this->assertEquals('test.jpg', $asset['path']);
         $this->assertEquals('bravo', $asset->alfa);
+        $this->assertEquals('bravo', $asset['alfa']);
         $this->assertEquals('delta (augmented)', $asset->charlie);
+        $this->assertEquals('delta (augmented)', $asset['charlie']);
     }
 
     /**
@@ -123,7 +126,7 @@ class AssetTest extends TestCase
      **/
     public function it_has_magic_property_and_methods_for_fields_that_augment_to_query_builders($builder)
     {
-        $builder->shouldReceive('get')->once()->andReturn('query builder results');
+        $builder->shouldReceive('get')->times(2)->andReturn('query builder results');
         app()->instance('mocked-builder', $builder);
 
         (new class extends Fieldtype
@@ -143,6 +146,7 @@ class AssetTest extends TestCase
         $asset->set('foo', 'delta');
 
         $this->assertEquals('query builder results', $asset->foo);
+        $this->assertEquals('query builder results', $asset['foo']);
         $this->assertSame($builder, $asset->foo());
     }
 

--- a/tests/Auth/RoleTest.php
+++ b/tests/Auth/RoleTest.php
@@ -116,10 +116,11 @@ class RoleTest extends TestCase
     /** @test */
     public function it_gets_evaluated_augmented_value_using_magic_property()
     {
-        $role = (new Role)->handle('test');
+        $role = (new Role)->handle('test')->title('Test');
 
         $role
             ->toAugmentedCollection()
-            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $role->{$key}));
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $role->{$key}))
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $role[$key]));
     }
 }

--- a/tests/Auth/UserContractTests.php
+++ b/tests/Auth/UserContractTests.php
@@ -89,7 +89,7 @@ trait UserContractTests
      **/
     public function it_has_magic_property_and_methods_for_fields_that_augment_to_query_builders($builder)
     {
-        $builder->shouldReceive('get')->once()->andReturn('query builder results');
+        $builder->shouldReceive('get')->times(2)->andReturn('query builder results');
         app()->instance('mocked-builder', $builder);
 
         (new class extends Fieldtype
@@ -109,6 +109,7 @@ trait UserContractTests
         $user->set('foo', 'delta');
 
         $this->assertEquals('query builder results', $user->foo);
+        $this->assertEquals('query builder results', $user['foo']);
         $this->assertSame($builder, $user->foo());
     }
 

--- a/tests/Auth/UserGroupTest.php
+++ b/tests/Auth/UserGroupTest.php
@@ -312,10 +312,11 @@ class UserGroupTest extends TestCase
     /** @test */
     public function it_gets_evaluated_augmented_value_using_magic_property()
     {
-        $group = (new UserGroup)->handle('test');
+        $group = (new UserGroup)->handle('test')->title('Test');
 
         $group
             ->toAugmentedCollection()
-            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $group->{$key}));
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $group->{$key}))
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $group[$key]));
     }
 }

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -580,7 +580,8 @@ class CollectionTest extends TestCase
 
         $collection
             ->toAugmentedCollection()
-            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $collection->{$key}));
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $collection->{$key}))
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $collection[$key]));
     }
 
     /** @test */

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -155,8 +155,11 @@ class EntryTest extends TestCase
         $entry->set('charlie', 'delta');
 
         $this->assertEquals('123', $entry->id);
+        $this->assertEquals('123', $entry['id']);
         $this->assertEquals('bravo', $entry->alfa);
+        $this->assertEquals('bravo', $entry['alfa']);
         $this->assertEquals('delta (augmented)', $entry->charlie);
+        $this->assertEquals('delta (augmented)', $entry['charlie']);
     }
 
     /**
@@ -165,7 +168,7 @@ class EntryTest extends TestCase
      **/
     public function it_has_magic_property_and_methods_for_fields_that_augment_to_query_builders($builder)
     {
-        $builder->shouldReceive('get')->once()->andReturn('query builder results');
+        $builder->shouldReceive('get')->times(2)->andReturn('query builder results');
         app()->instance('mocked-builder', $builder);
 
         (new class extends Fieldtype
@@ -186,6 +189,7 @@ class EntryTest extends TestCase
         $entry->set('foo', 'delta');
 
         $this->assertEquals('query builder results', $entry->foo);
+        $this->assertEquals('query builder results', $entry['foo']);
         $this->assertSame($builder, $entry->foo());
     }
 

--- a/tests/Data/Globals/VariablesTest.php
+++ b/tests/Data/Globals/VariablesTest.php
@@ -227,7 +227,8 @@ EOT;
         $builder->shouldReceive('get')->times(2)->andReturn('query builder results');
         app()->instance('mocked-builder', $builder);
 
-        (new class extends Fieldtype {
+        (new class extends Fieldtype
+        {
             protected static $handle = 'test';
 
             public function augment($value)

--- a/tests/Data/Globals/VariablesTest.php
+++ b/tests/Data/Globals/VariablesTest.php
@@ -213,7 +213,9 @@ EOT;
         $variables->set('charlie', 'delta');
 
         $this->assertEquals('bravo', $variables->alfa);
+        $this->assertEquals('bravo', $variables['alfa']);
         $this->assertEquals('delta (augmented)', $variables->charlie);
+        $this->assertEquals('delta (augmented)', $variables['charlie']);
     }
 
     /**
@@ -222,11 +224,10 @@ EOT;
      **/
     public function it_has_magic_property_and_methods_for_fields_that_augment_to_query_builders($builder)
     {
-        $builder->shouldReceive('get')->once()->andReturn('query builder results');
+        $builder->shouldReceive('get')->times(2)->andReturn('query builder results');
         app()->instance('mocked-builder', $builder);
 
-        (new class extends Fieldtype
-        {
+        (new class extends Fieldtype {
             protected static $handle = 'test';
 
             public function augment($value)
@@ -242,6 +243,7 @@ EOT;
         $variables->set('foo', 'delta');
 
         $this->assertEquals('query builder results', $variables->foo);
+        $this->assertEquals('query builder results', $variables['foo']);
         $this->assertSame($builder, $variables->foo());
     }
 

--- a/tests/Data/Structures/PageTest.php
+++ b/tests/Data/Structures/PageTest.php
@@ -452,7 +452,8 @@ class PageTest extends TestCase
 
         $page
             ->toAugmentedCollection()
-            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $page->{$key}));
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $page->{$key}))
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $page[$key]));
     }
 
     protected function newTree()

--- a/tests/Data/Taxonomies/LocalizedTermTest.php
+++ b/tests/Data/Taxonomies/LocalizedTermTest.php
@@ -89,8 +89,11 @@ class LocalizedTermTest extends TestCase
         $localized = $term->in('en');
 
         $this->assertEquals('foo', $localized->slug);
+        $this->assertEquals('foo', $localized['slug']);
         $this->assertEquals('bravo', $localized->alfa);
+        $this->assertEquals('bravo', $localized['alfa']);
         $this->assertEquals('delta (augmented)', $localized->charlie);
+        $this->assertEquals('delta (augmented)', $localized['charlie']);
     }
 
     /**
@@ -99,7 +102,7 @@ class LocalizedTermTest extends TestCase
      **/
     public function it_has_magic_property_and_methods_for_fields_that_augment_to_query_builders($builder)
     {
-        $builder->shouldReceive('get')->once()->andReturn('query builder results');
+        $builder->shouldReceive('get')->times(2)->andReturn('query builder results');
         app()->instance('mocked-builder', $builder);
 
         (new class extends Fieldtype
@@ -124,6 +127,7 @@ class LocalizedTermTest extends TestCase
         $localized = $term->in('en');
 
         $this->assertEquals('query builder results', $localized->foo);
+        $this->assertEquals('query builder results', $localized['foo']);
         $this->assertSame($builder, $localized->foo());
     }
 

--- a/tests/Data/Taxonomies/TaxonomyTest.php
+++ b/tests/Data/Taxonomies/TaxonomyTest.php
@@ -151,6 +151,7 @@ class TaxonomyTest extends TestCase
 
         $taxonomy
             ->toAugmentedCollection()
-            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $taxonomy->{$key}));
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $taxonomy->{$key}))
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $taxonomy[$key]));
     }
 }

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -1047,6 +1047,7 @@ class BlueprintTest extends TestCase
 
         $blueprint
             ->toAugmentedCollection()
-            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $blueprint->{$key}));
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $blueprint->{$key}))
+            ->each(fn ($value, $key) => $this->assertEquals($value->value(), $blueprint[$key]));
     }
 }


### PR DESCRIPTION
Adds ArrayAccess to augmentable items, to go along with #5297.

Now you can do `$entry['field']` which will have the identical result as `$entry->field`.
