### PR TITLE
Add temporary notification of CLI tool update

### DIFF
--- a/src/Console/Commands/StarterKitInstall.php
+++ b/src/Console/Commands/StarterKitInstall.php
@@ -79,9 +79,9 @@ class StarterKitInstall extends Command
         // requests around expired licenses. The newer version of the CLI tool will also notify
         // the user of older CLI tool versions going forward, so we can rip this out later.
         if ($this->oldCliToolInstallationDetected()) {
-            $this->line(PHP_EOL.'<error>We have detected that you may be running an old version of the Statamic CLI Tool!</error>');
-            $this->line('<comment>If you have a global composer installation, you may upgrade by running the following command:</comment>');
-            $this->line('<comment>composer global update statamic/cli</comment>'.PHP_EOL);
+            $this->comment(PHP_EOL.'We have detected that you may be running an old version of the Statamic CLI Tool!');
+            $this->comment('If you have a global composer installation, you may upgrade by running the following command:');
+            $this->comment('composer global update statamic/cli'.PHP_EOL);
         }
 
         $this->info("Starter kit [$package] was successfully installed.");

--- a/src/Console/Commands/StarterKitInstall.php
+++ b/src/Console/Commands/StarterKitInstall.php
@@ -26,6 +26,7 @@ class StarterKitInstall extends Command
         { --with-config : Copy starter-kit.yaml config for local development }
         { --without-dependencies : Install without dependencies }
         { --force : Force install and allow dependency errors }
+        { --cli-install : Installing from CLI Tool }
         { --clear-site : Clear site before installing }';
 
     /**
@@ -73,6 +74,16 @@ class StarterKitInstall extends Command
             return 1;
         }
 
+        // Temporary prompt to inform user of updated CLI tool. The newest version has better messaging
+        // around paid starter kit licenses, so we want to push users to upgrade to minimize support
+        // requests around expired licenses. The newer version of the CLI tool will also notify
+        // the user of older CLI tool versions going forward, so we can rip this out later.
+        if ($this->oldCliToolInstallationDetected()) {
+            $this->line(PHP_EOL.'<error>We have detected that you may be running an old version of the Statamic CLI Tool!</error>');
+            $this->line('<comment>If you have a global composer installation, you may upgrade by running the following command:</comment>');
+            $this->line('<comment>composer global update statamic/cli</comment>'.PHP_EOL);
+        }
+
         $this->info("Starter kit [$package] was successfully installed.");
     }
 
@@ -100,5 +111,12 @@ class StarterKitInstall extends Command
         }
 
         return false;
+    }
+
+    private function oldCliToolInstallationDetected()
+    {
+        return (! $this->input->isInteractive()) // CLI tool never runs interactively.
+            && (! $this->option('cli-install'))  // Updated CLI tool passes this option.
+            && $this->option('clear-site');      // CLI tool always clears site.
     }
 }


### PR DESCRIPTION
Detect and add temporary prompt to inform user of updated CLI tool. The newest version has better messaging around paid starter kit licenses, so we want to push users to upgrade to minimize support requests around expired licenses. The newer version of the CLI tool will also notify the user of older CLI tool versions going forward, so we can revert this PR later.

![CleanShot 2022-02-23 at 16 02 07](https://user-images.githubusercontent.com/5187394/155408125-bf0f6a07-f2f2-44fb-bac4-7b3678eb6650.png)