### PR TITLE
Consolidate `preserveKeys` settings for `reverse` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1846,7 +1846,7 @@ class CoreModifiers extends Modifier
     public function reverse($value)
     {
         if ($value instanceof Collection) {
-            return $value->reverse();
+            return $value->reverse()->values()->all();
         }
 
         if (is_array($value)) {


### PR DESCRIPTION
The `reverse` modifier accepts strings, arrays and since this [PR](https://github.com/statamic/cms/pull/4003/files) also Collections. When reversing an array the modifier uses the PHP function `array_reverse()` where the flag `preserve_keys` is set to `false` by default and the modifier does not overwrite it. When adding support for Collections, it is just calling `->reverse()` on the Collection, but the method sets `preserve_keys` to `true`. This results in two different reversed arrays from the same modifier:

# Array
```php
Array
(
    [0] => party
    [1] => eat
    [2] => service
    [3] => photos
)
```

# Collection
```php
Array
(
    [3] => party
    [2] => eat
    [1] => service
    [0] => photos
)
```

This PR changes this by calling `values()` on the reversed Collection, which resets the keys of the underlying array.