### PR TITLE
Use multiple zips

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,11 @@ jobs:
       - name: Compile frontend assets
         run: npm run frontend-prod
 
-      - name: Create zip
-        run: cd resources && tar -czvf dist.tar.gz dist dist-frontend
+      - name: Create dist zip
+        run: cd resources && tar -czvf dist.tar.gz dist
+
+      - name: Create dist-frontend zip
+        run: cd resources && tar -czvf dist-frontend.tar.gz dist-frontend
 
       - name: Get Changelog
         id: changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           body: ${{ steps.changelog.outputs.text }}
           prerelease: true
 
-      - name: Upload zip to release
+      - name: Upload dist zip to release
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,4 +52,14 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./resources/dist.tar.gz
           asset_name: dist.tar.gz
+          asset_content_type: application/tar+gz
+
+      - name: Upload dist-frontend zip to release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./resources/dist-frontend.tar.gz
+          asset_name: dist-frontend.tar.gz
           asset_content_type: application/tar+gz

--- a/composer.json
+++ b/composer.json
@@ -49,10 +49,16 @@
         }
     },
     "extra": {
-        "download-dist": {
-            "url": "https://github.com/statamic/cms/releases/download/{$version}/dist.tar.gz",
-            "path": "resources"
-        },
+        "download-dist": [
+            {
+                "url": "https://github.com/statamic/cms/releases/download/{$version}/dist.tar.gz",
+                "path": "resources/dist"
+            },
+            {
+                "url": "https://github.com/statamic/cms/releases/download/{$version}/dist-frontend.tar.gz",
+                "path": "resources/dist-frontend"
+            }
+        ],
         "laravel": {
             "providers": [
                 "Statamic\\Providers\\StatamicServiceProvider"


### PR DESCRIPTION
Fixes the resources directory getting wiped out when the dist folder was copied over.
Use two separate zips instead - the composer plugin supports that.
Change introduced in #4949 