### PR TITLE
Prevents comments from being parsed as Antlers

### DIFF
--- a/src/View/Antlers/Language/Analyzers/ConditionPairAnalyzer.php
+++ b/src/View/Antlers/Language/Analyzers/ConditionPairAnalyzer.php
@@ -107,6 +107,10 @@ class ConditionPairAnalyzer
             $node = $nodes[$i];
 
             if ($node instanceof AntlersNode) {
+                if ($node->isComment) {
+                    continue;
+                }
+
                 $name = $node->name->name;
 
                 if ($node->isClosingTag && $name == 'if') {

--- a/src/View/Antlers/Language/Analyzers/TagPairAnalyzer.php
+++ b/src/View/Antlers/Language/Analyzers/TagPairAnalyzer.php
@@ -109,6 +109,9 @@ class TagPairAnalyzer
                         if ($node instanceof RecursiveNode) {
                             continue;
                         }
+                        if ($node->isComment) {
+                            continue;
+                        }
                         if ($node->index >= $lastIndexedNode->index) {
                             break;
                         }
@@ -200,7 +203,9 @@ class TagPairAnalyzer
                     if ($candidateNode->isClosingTag && $candidateNode->isOpenedBy != null) {
                         continue;
                     }
-
+                    if ($candidateNode->isComment) {
+                        continue;
+                    }
                     if ($candidateNode->isSelfClosing) {
                         continue;
                     }
@@ -274,6 +279,9 @@ class TagPairAnalyzer
             $nodes = ConditionPairAnalyzer::pairConditionals($nodes);
 
             foreach ($nodes as $node) {
+                if ($node instanceof AntlersNode && $node->isComment) {
+                    continue;
+                }
                 if ($node instanceof AntlersNode && $this->canPossiblyClose($node)) {
                     if (ConditionPairAnalyzer::isConditionalStructure($node)) {
                         continue;

--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -603,6 +603,7 @@ class DocumentParser
 
         $tagPairAnalyzer = new TagPairAnalyzer();
         $this->renderNodes = $tagPairAnalyzer->associate($this->nodes, $this);
+
         RecursiveParentAnalyzer::associateRecursiveParent($this->nodes);
 
         foreach ($this->nodes as $node) {
@@ -948,7 +949,10 @@ class DocumentParser
 
         $node->interpolationRegions = $this->interpolationRegions;
 
-        $node = $this->nodeParser->parseNode($node);
+        if (!$node->isComment) {
+            $node = $this->nodeParser->parseNode($node);
+        }
+
         $this->interpolationRegions = [];
 
         return $node;

--- a/tests/Antlers/Parser/CommentsTest.php
+++ b/tests/Antlers/Parser/CommentsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Antlers\Parser;
+
+use Tests\Antlers\ParserTestCase;
+
+class CommentsTest extends ParserTestCase
+{
+
+    public function test_antlers_in_comments_does_not_get_parsed_or_trigger_errors()
+    {
+        $template = <<<'EOT'
+{{# {{ validate | contains:required ?= "required" }} #}}
+EOT;
+
+        $this->assertSame('', $this->renderString($template));
+    }
+}


### PR DESCRIPTION
This PR prevents comments from ever making into the Antlers node parsers, which would attempt to parse the comment's contents as Antlers under certain conditions.

This also prevents comments from making it to the tag pairing algorithm on sufficiently complex templates.