### PR TITLE
Grid table UI tweaks

### DIFF
--- a/resources/sass/components/fieldtypes/datetime.scss
+++ b/resources/sass/components/fieldtypes/datetime.scss
@@ -65,6 +65,7 @@
 .time-fieldtype {
 	.time-fieldtype-container {
 		@apply flex items-center;
+		min-width: max-content;
 		max-width: 140px;
 	}
 

--- a/resources/sass/components/fieldtypes/grid.scss
+++ b/resources/sass/components/fieldtypes/grid.scss
@@ -40,7 +40,8 @@
         }
 
         &.drag-handle {
-            @apply w-3 border-r h-full p-1;
+            @apply border-r h-full p-1;
+            width: 1%;
             cursor: grab;
             background: theme('colors.grey-20') url('../img/drag-dots.svg') center center no-repeat;
             &:hover { @apply .bg-grey-30; }
@@ -59,7 +60,8 @@
 }
 
 .grid-table .row-controls {
-    @apply w-8 pl-0 text-center;
+    @apply pl-0 text-center;
+    width: 1%;
     padding-top: 21px; // pseudo-center for text/select fields
 }
 


### PR DESCRIPTION
Fixes #5073 (the time field) and also fixes the handle and row control columns that were too wide.

**before:**
<img width="630" alt="Screenshot 2022-02-28 at 14 15 53" src="https://user-images.githubusercontent.com/4067531/155990530-853705b4-5e7a-4391-bc6a-8755bd1a0e7d.png">


**after:**
<img width="635" alt="Screenshot 2022-02-28 at 14 14 52" src="https://user-images.githubusercontent.com/4067531/155990539-58bb5f83-22f0-470f-9c47-c94c3ea86cd9.png">

