### PR TITLE
Fix querying nested entries fields in GraphQL

### DIFF
--- a/src/GraphQL/Types/GridItemType.php
+++ b/src/GraphQL/Types/GridItemType.php
@@ -3,6 +3,7 @@
 namespace Statamic\GraphQL\Types;
 
 use Rebing\GraphQL\Support\Type;
+use Statamic\Contracts\Query\Builder;
 use Statamic\Fields\Value;
 
 class GridItemType extends Type
@@ -22,7 +23,13 @@ class GridItemType extends Type
                 $field['resolve'] = function ($row, $args, $context, $info) {
                     $value = $row[$info->fieldName];
 
-                    return $value instanceof Value ? $value->value() : $value;
+                    $value = $value instanceof Value ? $value->value() : $value;
+
+                    if ($value instanceof Builder) {
+                        $value = $value->get();
+                    }
+
+                    return $value;
                 };
 
                 return $field;

--- a/src/GraphQL/Types/ReplicatorSetType.php
+++ b/src/GraphQL/Types/ReplicatorSetType.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\GraphQL\Types;
 
+use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Value;
 
@@ -29,7 +30,13 @@ class ReplicatorSetType extends \Rebing\GraphQL\Support\Type
                 $field['resolve'] = function ($row, $args, $context, $info) {
                     $value = $row[$info->fieldName];
 
-                    return $value instanceof Value ? $value->value() : $value;
+                    $value = $value instanceof Value ? $value->value() : $value;
+
+                    if ($value instanceof Builder) {
+                        $value = $value->get();
+                    }
+
+                    return $value;
                 };
 
                 return $field;

--- a/tests/Feature/GraphQL/Fieldtypes/GridFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/GridFieldtypeTest.php
@@ -32,21 +32,30 @@ class GridFieldtypeTest extends TestCase
                 'fields' => [
                     ['handle' => 'food', 'field' => ['type' => 'text']],
                     ['handle' => 'drink', 'field' => ['type' => 'text']],
+                    ['handle' => 'stuff', 'field' => ['type' => 'entries']],
                 ],
             ],
         ]);
 
+        $stuff = Blueprint::makeFromFields([]);
+
         BlueprintRepository::shouldReceive('in')->with('collections/blog')->andReturn(collect([
             'article' => $article->setHandle('article'),
+        ]));
+
+        BlueprintRepository::shouldReceive('in')->with('collections/stuff')->andReturn(collect([
+            'stuff' => $stuff->setHandle('stuff'),
         ]));
 
         EntryFactory::collection('blog')->id('1')->data([
             'title' => 'Main Post',
             'meals' => [
                 ['food' => 'burger', 'drink' => 'coke'],
-                ['food' => 'salad', 'drink' => 'water'],
+                ['food' => 'salad', 'drink' => 'water', 'stuff' => ['stuff1']],
             ],
         ])->create();
+
+        EntryFactory::collection('stuff')->id('stuff1')->data(['title' => 'One'])->create();
 
         $query = <<<'GQL'
 {
@@ -56,6 +65,9 @@ class GridFieldtypeTest extends TestCase
             meals {
                 food
                 drink
+                stuff {
+                    title
+                }
             }
         }
     }
@@ -70,8 +82,8 @@ GQL;
                 'entry' => [
                     'title' => 'Main Post',
                     'meals' => [
-                        ['food' => 'burger', 'drink' => 'coke'],
-                        ['food' => 'salad', 'drink' => 'water'],
+                        ['food' => 'burger', 'drink' => 'coke', 'stuff' => []],
+                        ['food' => 'salad', 'drink' => 'water', 'stuff' => [['title' => 'One']]],
                     ],
                 ],
             ]]);

--- a/tests/Feature/GraphQL/Fieldtypes/ReplicatorFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/ReplicatorFieldtypeTest.php
@@ -40,24 +40,33 @@ class ReplicatorFieldtypeTest extends TestCase
                         'fields' => [
                             ['handle' => 'make', 'field' => ['type' => 'text']],
                             ['handle' => 'model', 'field' => ['type' => 'text']],
+                            ['handle' => 'trims', 'field' => ['type' => 'entries']],
                         ],
                     ],
                 ],
             ],
         ]);
 
+        $trim = Blueprint::makeFromFields([]);
+
         BlueprintRepository::shouldReceive('in')->with('collections/blog')->andReturn(collect([
             'article' => $article->setHandle('article'),
+        ]));
+
+        BlueprintRepository::shouldReceive('in')->with('collections/trims')->andReturn(collect([
+            'trim' => $trim->setHandle('trim'),
         ]));
 
         EntryFactory::collection('blog')->id('1')->data([
             'title' => 'Main Post',
             'things' => [
                 ['type' => 'meal', 'food' => 'burger', 'drink' => 'coke'],
-                ['type' => 'car', 'make' => 'toyota', 'model' => 'corolla'],
+                ['type' => 'car', 'make' => 'toyota', 'model' => 'corolla', 'trims' => ['trim1']],
                 ['type' => 'meal', 'food' => 'salad', 'drink' => 'water'],
             ],
         ])->create();
+
+        EntryFactory::collection('trims')->id('trim1')->data(['title' => 'Trim One'])->create();
 
         $query = <<<'GQL'
 {
@@ -74,6 +83,9 @@ class ReplicatorFieldtypeTest extends TestCase
                     type
                     make
                     model
+                    trims {
+                        title
+                    }
                 }
             }
         }
@@ -90,7 +102,7 @@ GQL;
                     'title' => 'Main Post',
                     'things' => [
                         ['type' => 'meal', 'food' => 'burger', 'drink' => 'coke'],
-                        ['type' => 'car', 'make' => 'toyota', 'model' => 'corolla'],
+                        ['type' => 'car', 'make' => 'toyota', 'model' => 'corolla', 'trims' => [['title' => 'Trim One']]],
                         ['type' => 'meal', 'food' => 'salad', 'drink' => 'water'],
                     ],
                 ],


### PR DESCRIPTION
Fixes #5366

Fixes fieldtypes that return query builders (e.g. `entries`) when nested in Grid or Replicators.
