### PR TITLE
Improve messaging around github auth errors.

### DIFF
--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -582,6 +582,15 @@ final class Installer
      */
     protected function tidyComposerErrorOutput($output)
     {
+        if (Str::contains($output, 'github.com') && Str::contains($output, ['access', 'permission', 'credential'])) {
+            return collect([
+                'Composer could not authenticate with GitHub!',
+                'Please generate a personal access token at: https://github.com/settings/tokens/new',
+                'Then save your token for future use by running the following command:',
+                'composer config --global --auth github-oauth.github.com [your-token-here]',
+            ])->implode(PHP_EOL);
+        }
+
         return preg_replace("/\\n\\nrequire \[.*$/", '', $output);
     }
 


### PR DESCRIPTION
Trying to add better github auth error handling to statamic/cli so that the starter kit installation doesn't get this far. However, it is still possible to bypass the CLI tool with `php please starter-kit:install`, so this just improves the composer error output...

![image](https://user-images.githubusercontent.com/5187394/156071565-e74fbf5d-cc37-4974-8809-da6746b2fc2b.png)

References https://github.com/statamic/cli/issues/43