### PR TITLE
Fix email fields not being loopable

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -137,7 +137,7 @@ class Email extends Mailable
             $config = $field->config();
 
             return compact('display', 'handle', 'fieldtype', 'config', 'value');
-        });
+        })->values();
     }
 
     private function getGlobalsData()


### PR DESCRIPTION
Fixes #5360

This PR will reindex the collection so it'll work across parsers.

---

Turns out the old parser allowed looping over non-numerically-indexed collections, but only if they were a collection. Arrays didn't work. We never documented it as working though.


Numerically-indexed array:

```yaml
field:
  - # technically 0
    title: Alfa
  - # technically 1
    title: Bravo
```
```
{{ field }} {{ title }} {{ /field }} // Works fine. Outputs: Alfa Bravo
```

Non-numerically indexed

```yaml
field:
  foo:
    title: Alfa
  bar:
    title: Bravo
```
```
{{ field }} {{ title }} {{ /field }} // This shouldn't work, but was, but only if it was a collection.
```


I don't consider this a parser bug since it's an undocumented case.