### PR TITLE
Remove google docs viewer references

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -103,19 +103,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | File Previews with Google Docs
-    |--------------------------------------------------------------------------
-    |
-    | Filetypes that cannot be rendered with HTML5 can opt into the Google Docs
-    | Viewer. Google will get temporary access to these files so keep that in
-    | mind for any privacy implications: https://policies.google.com/privacy
-    |
-    */
-
-    'google_docs_viewer' => false,
-
-    /*
-    |--------------------------------------------------------------------------
     | Cache Metadata
     |--------------------------------------------------------------------------
     |

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -87,10 +87,6 @@
                         <pdf-viewer :src="asset.pdfUrl"></pdf-viewer>
                     </div>
 
-                    <div class="h-full" v-else-if="asset.isPreviewable && canUseGoogleDocsViewer">
-                        <iframe class="h-full w-full" frameborder="0" :src="'https://docs.google.com/gview?url=' + asset.permalink + '&embedded=true'"></iframe>
-                    </div>
-
                     <div class="editor-file-actions" v-if="!readOnly">
                         <button v-if="isImage && isFocalPointEditorEnabled" type="button" class="btn" @click.prevent="openFocalPointEditor">
                             {{ __('Set Focal Point') }}
@@ -245,11 +241,6 @@ export default {
          */
         hasErrors: function() {
             return this.error || Object.keys(this.errors).length;
-        },
-
-        canUseGoogleDocsViewer()
-        {
-            return Statamic.$config.get('googleDocsViewer');
         },
 
         isFocalPointEditorEnabled()

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -32,7 +32,6 @@ class JavascriptComposer
             'flash' => Statamic::flash(),
             'toasts' => Toast::toArray(),
             'ajaxTimeout' => config('statamic.system.ajax_timeout'),
-            'googleDocsViewer' => config('statamic.assets.google_docs_viewer'),
             'focalPointEditorEnabled' => config('statamic.assets.focal_point_editor'),
             'user' => $this->user($user),
             'paginationSize' => config('statamic.cp.pagination_size'),


### PR DESCRIPTION
Since #5349, the Google Docs viewer is not used. This PR removes the last traces of it.
