### PR TITLE
Ordered Query Builder

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -14,6 +14,7 @@ use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Http\Resources\CP\Entries\Entries as EntriesResource;
 use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
+use Statamic\Query\OrderedQueryBuilder;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 use Statamic\Support\Arr;
 
@@ -222,8 +223,8 @@ class Entries extends Relationship
             $site = $parent->locale();
         }
 
-        $ids = Entry::query()
-            ->whereIn('id', Arr::wrap($values))
+        $ids = (new OrderedQueryBuilder(Entry::query(), $ids = Arr::wrap($values)))
+            ->whereIn('id', $ids)
             ->get()
             ->map(function ($entry) use ($site) {
                 return optional($entry->in($site))->id();
@@ -231,7 +232,7 @@ class Entries extends Relationship
             ->filter()
             ->all();
 
-        $query = Entry::query()
+        $query = (new OrderedQueryBuilder(Entry::query(), $ids))
             ->whereIn('id', $ids)
             ->where('status', 'published');
 

--- a/src/Query/OrderedQueryBuilder.php
+++ b/src/Query/OrderedQueryBuilder.php
@@ -39,7 +39,13 @@ class OrderedQueryBuilder implements Builder
 
     public function __call($method, $parameters)
     {
-        return $this->forwardDecoratedCallTo($this->builder, $method, $parameters);
+        $result = $this->forwardCallTo($this->builder, $method, $parameters);
+
+        if ($result === $this->builder) {
+            return $this;
+        }
+
+        return $result;
     }
 
     private function performFallbackOrdering($results)

--- a/src/Query/OrderedQueryBuilder.php
+++ b/src/Query/OrderedQueryBuilder.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Statamic\Query;
+
+use Illuminate\Support\Traits\ForwardsCalls;
+use Statamic\Contracts\Query\Builder;
+
+class OrderedQueryBuilder implements Builder
+{
+    use ForwardsCalls;
+
+    protected $builder;
+    protected $order;
+    protected $ordered = false;
+
+    public function __construct(Builder $builder, $order = [])
+    {
+        $this->builder = $builder;
+        $this->order = $order;
+    }
+
+    public function orderBy($column, $direction = 'asc')
+    {
+        $this->ordered = true;
+
+        return $this->forwardCallTo($this->builder, 'orderBy', func_get_args());
+    }
+
+    public function get($columns = ['*'])
+    {
+        $results = $this->builder->get($columns);
+
+        if (! $this->ordered) {
+            $results = $this->performFallbackOrdering($results);
+        }
+
+        return $results;
+    }
+
+    public function __call($method, $parameters)
+    {
+        return $this->forwardDecoratedCallTo($this->builder, $method, $parameters);
+    }
+
+    private function performFallbackOrdering($results)
+    {
+        return $results->sort(function ($a, $b) {
+            $a = array_search($a['id'], $this->order);
+            $b = array_search($b['id'], $this->order);
+
+            if ($a === false && $b === false) {
+                return 0;
+            } elseif ($a === false) {
+                return 1;
+            } elseif ($b === false) {
+                return -1;
+            }
+
+            return $a <=> $b;
+        })->values();
+    }
+}

--- a/tests/Fieldtypes/EntriesTest.php
+++ b/tests/Fieldtypes/EntriesTest.php
@@ -44,11 +44,11 @@ class EntriesTest extends TestCase
     /** @test */
     public function it_augments_to_a_query_builder()
     {
-        $augmented = $this->fieldtype()->augment(['123', 'invalid', 456, 'draft', 'scheduled', 'expired']);
+        $augmented = $this->fieldtype()->augment([456, 'invalid', '123', 'draft', 'scheduled', 'expired']);
 
         $this->assertInstanceOf(Builder::class, $augmented);
         $this->assertEveryItemIsInstanceOf(Entry::class, $augmented->get());
-        $this->assertEquals(['one', 'two'], $augmented->get()->map->slug()->all());
+        $this->assertEquals(['456', '123'], $augmented->get()->map->id()->all());
     }
 
     /** @test */

--- a/tests/Query/OrderedQueryBuilderTest.php
+++ b/tests/Query/OrderedQueryBuilderTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Query;
+
+use Statamic\Contracts\Query\Builder;
+use Statamic\Query\OrderedQueryBuilder;
+use Tests\TestCase;
+
+class OrderedQueryBuilderTest extends TestCase
+{
+    /** @test */
+    public function it_implements_query_builder()
+    {
+        $this->assertInstanceOf(Builder::class, new OrderedQueryBuilder($this->mock(Builder::class)));
+    }
+
+    /** @test */
+    public function it_proxies_methods_onto_the_builder()
+    {
+        $builder = $this->mock(Builder::class);
+        $builder->shouldReceive('where')->with('foo', 'bar')->andReturnSelf();
+        $builder->shouldReceive('where')->with('bar', 'baz')->andReturnSelf();
+        $builder->shouldReceive('limit')->with(3)->andReturnSelf();
+        $builder->shouldReceive('get')->once()->andReturn($expected = collect([
+            ['id' => 'foo'],
+            ['id' => 'bar'],
+            ['id' => 'baz'],
+        ]));
+
+        $results = (new OrderedQueryBuilder($builder))
+            ->where('foo', 'bar')
+            ->where('bar', 'baz')
+            ->limit(3)
+            ->get(['foo', 'bar']);
+
+        $this->assertEquals($expected, $results);
+    }
+
+    /** @test */
+    public function it_orders_the_items_after_getting_them()
+    {
+        $builder = $this->mock(Builder::class);
+        $builder->shouldReceive('get')->once()->andReturn(collect([
+            ['id' => '1'],
+            ['id' => '2'],
+            ['id' => '3'],
+            ['id' => '4'],
+            ['id' => '5'],
+        ]));
+
+        $results = (new OrderedQueryBuilder($builder, [4, 5, 2]))->get();
+
+        $this->assertEquals([
+            ['id' => '4'],
+            ['id' => '5'],
+            ['id' => '2'],
+            ['id' => '1'], // Not in the provided order array so it goes to the end
+            ['id' => '3'], //
+        ], $results->all());
+    }
+
+    /** @test */
+    public function it_wont_order_the_items_after_getting_them_if_the_builder_is_manually_ordered()
+    {
+        $builder = $this->mock(Builder::class);
+        $builder->shouldReceive('orderBy')->with('title')->andReturnSelf();
+        $builder->shouldReceive('get')->once()->andReturn(collect([
+            ['id' => '3'],
+            ['id' => '1'],
+            ['id' => '2'],
+        ]));
+
+        $results = (new OrderedQueryBuilder($builder, [2, 3, 1]))->orderBy('title')->get();
+
+        $this->assertEquals([
+            ['id' => '3'],
+            ['id' => '1'],
+            ['id' => '2'],
+        ], $results->all());
+    }
+
+    /** @test */
+    public function it_wont_order_the_items_when_using_pagination()
+    {
+        // This will just be a known limitation.
+        // Since order matters when using pagination, we can't change it after the page has been retrieved.
+
+        $builder = $this->mock(Builder::class);
+        $builder->shouldReceive('paginate')->once()->andReturn('paginator');
+
+        $results = (new OrderedQueryBuilder($builder, [2, 3, 1]))->paginate();
+
+        $this->assertEquals('paginator', $results);
+    }
+}


### PR DESCRIPTION
This fixes the issue where the new entries query builder augmentation (#5238) wouldn't maintain the order you picked.
i.e. In the control panel you intentionally pick entries in a specific order, and it wouldn't output them in that order. Now it will.

Adds an "ordered" query builder decorator.

It wraps up a query builder with a custom order. If you don't call `orderBy` on it, it'll apply the custom order when retrieving the items.

---

In database-land, you could do a raw orderby query, like this:

```php
->whereIn('id', [4, 2, 5])
->orderByRaw("FIELD(id, 4, 2, 5)")
```

...but we don't support that, and it would be way more effort to do it than this decorator class.