### PR TITLE
Add ArrayAccess & property access to the Value class

### DIFF
--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fields;
 
+use ArrayAccess;
 use ArrayIterator;
 use Illuminate\Support\Collection;
 use IteratorAggregate;
@@ -10,7 +11,7 @@ use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\View\Antlers\Parser;
 use Statamic\Support\Str;
 
-class Value implements IteratorAggregate, JsonSerializable
+class Value implements IteratorAggregate, JsonSerializable, ArrayAccess
 {
     protected $raw;
     protected $handle;
@@ -70,6 +71,31 @@ class Value implements IteratorAggregate, JsonSerializable
     public function getIterator()
     {
         return new ArrayIterator($this->value());
+    }
+    
+    public function __get($key)
+    {
+        return $this->value()[$key];
+    }
+
+    public function offsetExists(mixed $offset)
+    {
+        return isset($this->value()[$offset]);
+    }
+
+    public function offsetGet(mixed $offset)
+    {
+        return $this->value()[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value)
+    {
+        $this->value()[$offset] = $value;
+    }
+
+    public function offsetUnset(mixed $offset)
+    {
+        unset($this->value()[$offset]);
     }
 
     public function shouldParseAntlers()

--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -78,22 +78,22 @@ class Value implements IteratorAggregate, JsonSerializable, ArrayAccess
         return $this->value()[$key];
     }
 
-    public function offsetExists(mixed $offset)
+    public function offsetExists($offset)
     {
         return isset($this->value()[$offset]);
     }
 
-    public function offsetGet(mixed $offset)
+    public function offsetGet($offset)
     {
         return $this->value()[$offset];
     }
 
-    public function offsetSet(mixed $offset, mixed $value)
+    public function offsetSet($offset, $value)
     {
         $this->value()[$offset] = $value;
     }
 
-    public function offsetUnset(mixed $offset)
+    public function offsetUnset($offset)
     {
         unset($this->value()[$offset]);
     }


### PR DESCRIPTION
As discussed on Discord.

- Adds magic `__get()` method
- Adds `ArrayAccess`

This makes sure you'll never have to call `->value()` on a Value object anymore in Blade templates. This is because when, for example, you call `$page->sets` where `sets` is a replicator, only the top level will be augmented, any fields inside the sets will still be `Value` objects.

I've added an implementation for `offsetSet` and `offsetUnset`, but these probably won't and shouldn't work, it might be better to leave them empty and throw an exception if you try to set them? Let me know and I'll change it.