### PR TITLE
Remove unused live preview property

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -344,7 +344,6 @@ export default {
             saveKeyBinding: null,
             quickSaveKeyBinding: null,
             quickSave: false,
-            previewTarget: this.previewTargets[0],
         }
     },
 

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -314,7 +314,6 @@ export default {
             saveKeyBinding: null,
             quickSaveKeyBinding: null,
             quickSave: false,
-            previewTarget: this.previewTargets[0],
         }
     },
 


### PR DESCRIPTION
Fixes an error when trying to open an inline publish form.

This property is what's causing the error and was refactored out but never removed.
