### PR TITLE
Allow escaped braces inside tag parameters and string literals

### DIFF
--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -807,6 +807,26 @@ class DocumentParser
         return array_key_exists($offsetCheck, $this->interpolationEndOffsets);
     }
 
+    public static function getLeftBraceEscape()
+    {
+        return '__antlers:leftBrace'.GlobalRuntimeState::$environmentId;
+    }
+
+    public static function getRightBraceEscape()
+    {
+        return '__antlers:rightBrace'.GlobalRuntimeState::$environmentId;
+    }
+
+    private function getLeftBrace()
+    {
+        return str_split( self::getLeftBraceEscape());
+    }
+
+    private function getRightBrace()
+    {
+        return str_split(self::getRightBraceEscape());
+    }
+
     private function scanToEndOfAntlersRegion()
     {
         for ($this->currentIndex; $this->currentIndex < $this->inputLen; $this->currentIndex += 1) {
@@ -814,13 +834,19 @@ class DocumentParser
 
             if ($this->cur == self::LeftBrace && $this->prev == self::AtChar) {
                 array_pop($this->currentContent);
-                $this->currentContent[] = $this->cur;
+                $this->currentContent = array_merge($this->currentContent, $this->getLeftBrace());
                 continue;
             }
 
             if ($this->isInterpolatedParser && $this->cur == self::RightBrace && $this->prev == self::AtChar) {
                 array_pop($this->currentContent);
                 $this->currentContent[] = $this->cur;
+                continue;
+            }
+
+            if ($this->cur == self::RightBrace && $this->prev == self::AtChar) {
+                array_pop($this->currentContent);
+                $this->currentContent = array_merge($this->currentContent, $this->getRightBrace());
                 continue;
             }
 

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -405,6 +405,9 @@ class RuntimeParser implements Parser
         $bufferContent = LiteralReplacementManager::processReplacements($bufferContent);
         $bufferContent = StackReplacementManager::processReplacements($bufferContent);
 
+        $bufferContent = str_replace(DocumentParser::getLeftBraceEscape(), DocumentParser::LeftBrace, $bufferContent);
+        $bufferContent = str_replace(DocumentParser::getRightBraceEscape(), DocumentParser::RightBrace, $bufferContent);
+
         return new AntlersString($bufferContent, $this);
     }
 

--- a/tests/Antlers/Parser/StringsTest.php
+++ b/tests/Antlers/Parser/StringsTest.php
@@ -56,7 +56,6 @@ EOT;
 
         $this->assertSame('Yes', $this->renderString($input, ['title' => '{The Title}']));
 
-
         $input = <<<'EOT'
 {{ if title | starts_with:'@{' }}Yes{{ else }}No{{ /if }}
 EOT;

--- a/tests/Antlers/Parser/StringsTest.php
+++ b/tests/Antlers/Parser/StringsTest.php
@@ -47,4 +47,20 @@ EOT;
 
         $this->assertSame('{{}}', $this->renderString($input));
     }
+
+    public function test_escape_sequences_are_replaced_inside_the_environment()
+    {
+        $input = <<<'EOT'
+{{ if title | starts_with('@{') }}Yes{{ else }}No{{ /if }}
+EOT;
+
+        $this->assertSame('Yes', $this->renderString($input, ['title' => '{The Title}']));
+
+
+        $input = <<<'EOT'
+{{ if title | starts_with:'@{' }}Yes{{ else }}No{{ /if }}
+EOT;
+
+        $this->assertSame('Yes', $this->renderString($input, ['title' => '{The Title}']));
+    }
 }

--- a/tests/Antlers/Parser/StringsTest.php
+++ b/tests/Antlers/Parser/StringsTest.php
@@ -38,4 +38,13 @@ EOT;
 
         $this->assertSame('hello, world', $this->renderString($input));
     }
+
+    public function test_braces_can_be_escaped_inside_string_literals()
+    {
+        $input = <<<'EOT'
+{{ var = '@{@{@}@}'; }}{{ var }}
+EOT;
+
+        $this->assertSame('{{}}', $this->renderString($input));
+    }
 }

--- a/tests/Antlers/Runtime/ParametersTest.php
+++ b/tests/Antlers/Runtime/ParametersTest.php
@@ -140,6 +140,23 @@ EOT;
         $this->assertSame('2012-10-01', $this->renderString('{{ one:two format="Y-m-d" }}', $data, true));
     }
 
+    public function test_braces_can_be_escaped_inside_parameters()
+    {
+        Test::register();
+        $template = <<<'EOT'
+{{ test variable="@{@{ hello world @}@}" }}
+EOT;
+
+        $this->assertSame('{{ hello world }}', $this->renderString($template, [], true));
+
+
+        $template = <<<'EOT'
+{{ test variable="@{@{ hello @{{title}@} @}@}" }}
+EOT;
+
+        $this->assertSame('{{ hello {world} }}', $this->renderString($template, ['title' => 'world'], true));
+    }
+
     public function test_tags_are_invoked_within_interpolated_contexts()
     {
         (new class extends Tags


### PR DESCRIPTION
This PR adds support for escaping `{` and `}` inside tag parameters and string literals to the Runtime parser by prefixing each occurrence with `@` when inside parameters or strings (to prevent the interpolation parser from seeing them as interpolations)