### PR TITLE
Prevent upgrading beyond a patch number

### DIFF
--- a/resources/js/components/updater/Release.vue
+++ b/resources/js/components/updater/Release.vue
@@ -6,7 +6,10 @@
                 <h1>{{ release.version }}</h1>
                 <h5 class="date" v-text="__('Released on :date', { date: release.date })" />
             </div>
-            <div v-if="showActions">
+            <div v-if="!release.canUpdate">
+                <button class="btn opacity-50" disabled>Manual update required</button>
+            </div>
+            <div v-if="release.canUpdate && showActions">
                 <button v-if="release.type === 'current'" class="btn opacity-50" disabled v-text="__('Current Version')" />
                 <button v-else-if="release.latest" @click="confirmationPrompt = release" class="btn" v-text="__('Update to Latest')" />
                 <button v-else @click="confirmationPrompt = release" class="btn">

--- a/resources/js/components/updater/Release.vue
+++ b/resources/js/components/updater/Release.vue
@@ -7,7 +7,7 @@
                 <h5 class="date" v-text="__('Released on :date', { date: release.date })" />
             </div>
             <div v-if="!release.canUpdate">
-                <button class="btn opacity-50" disabled>Manual update required</button>
+                <button class="btn opacity-50" disabled v-text="__('Manual upgrade required')" />
             </div>
             <div v-if="release.canUpdate && showActions">
                 <button v-if="release.type === 'current'" class="btn opacity-50" disabled v-text="__('Current Version')" />

--- a/resources/js/components/updater/Updater.vue
+++ b/resources/js/components/updater/Updater.vue
@@ -12,7 +12,7 @@
                 </template>
                 <template v-else>{{ __('Last Install Log' ) }}</template>
             </button>
-            <button v-if="showActions && ! onLatestVersion" class="btn-primary ml-2" @click="updateToLatest()">{{ __('Update to Latest') }}</button>
+            <button v-if="canUpdateToLatestVersion" class="btn-primary ml-2" @click="updateToLatest()">{{ __('Update to Latest') }}</button>
             <div v-if="onLatestVersion" v-text="__('Up to date')" />
         </div>
 
@@ -97,7 +97,7 @@
                 currentVersion: null,
                 lastInstallLog: null,
                 modalOpen: false,
-                latestVersion: null,
+                latestRelease: null,
                 showingUnlicensedReleases: false,
             };
         },
@@ -129,6 +129,14 @@
 
             hasUnlicensedReleases() {
                 return this.unlicensedReleases.length > 0;
+            },
+
+            latestVersion() {
+                return this.latestRelease.version;
+            },
+
+            canUpdateToLatestVersion() {
+                return this.latestVersion.canUpdate && this.showActions && ! this.onLatestVersion;
             }
         },
 
@@ -148,7 +156,7 @@
                     this.gettingChangelog = false;
                     this.changelog = response.data.changelog;
                     this.currentVersion = response.data.currentVersion;
-                    this.latestVersion = response.data.changelog[0].version;
+                    this.latestRelease = response.data.changelog[0];
                     this.lastInstallLog = response.data.lastInstallLog;
                 });
             },

--- a/src/Updater/CoreChangelog.php
+++ b/src/Updater/CoreChangelog.php
@@ -3,6 +3,7 @@
 namespace Statamic\Updater;
 
 use Statamic\Statamic;
+use Statamic\Support\Str;
 
 class CoreChangelog extends Changelog
 {
@@ -14,5 +15,33 @@ class CoreChangelog extends Changelog
     public function currentVersion()
     {
         return Statamic::version();
+    }
+
+    public function get()
+    {
+        return parent::get()->map(function ($release) {
+            $release->canUpdate = $this->canUpdateToVersion($release->version);
+
+            return $release;
+        });
+    }
+
+    private function canUpdateToVersion($version)
+    {
+        $currentVersion = Statamic::version();
+
+        if (Str::contains($currentVersion, 'dev')) {
+            return true; // If you're on dev-master, 3.2.x-dev, etc - go nuts.
+        }
+
+        // Just get the major.minor numbers so we can compare them.
+
+        $currentVersion = preg_match('/^[0-9]+\.[0-9]+/', $currentVersion, $matches);
+        $currentVersion = $matches[0];
+
+        $version = preg_match('/^[0-9]+\.[0-9]+/', $version, $matches);
+        $version = $matches[0];
+
+        return version_compare($currentVersion, $version, '>=');
     }
 }


### PR DESCRIPTION
This PR will disable the upgrade button in the Control Panel if you're trying to upgrade to a potentially breaking version.

For example:

- Going from 3.2.x to 3.2.x is fine.
- Going from 3.2.x to 3.3.x (or 4.x) will require some manual or breaking changes, so want to prevent you from just clicking the button and maybe breaking stuff.

If there are actual Composer issues, Composer will stop the update anyway. (e.g. upgrading a Statamic 3.2 site on Laravel 7 to 3.3 won't let you because it requires Laravel 8)

This PR just prevents you from getting as far as the Composer error.

--- 

When Statamic 4 is released, we'll start using semantic versioning, so these rules will need to change.

- Going from 3.2.x to 3.2.x will be fine.
- Going from 3.x to 3.x will be fine.
- Going from 3.x to 4.x will be blocked.