### PR TITLE
Add index method to route tag

### DIFF
--- a/src/Tags/Route.php
+++ b/src/Tags/Route.php
@@ -4,6 +4,11 @@ namespace Statamic\Tags;
 
 class Route extends Tags
 {
+    public function index()
+    {
+        return $this->wildcard($this->params->get('name'));
+    }
+
     public function wildcard($tag)
     {
         return route($tag, $this->params->except('name')->all());


### PR DESCRIPTION
Fixes: #5348 

Allows route tags in the form `{{ route name="xxx" }}`