### PR TITLE
Fix rare github auth error output

### DIFF
--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -582,7 +582,7 @@ final class Installer
      */
     protected function tidyComposerErrorOutput($output)
     {
-        if (Str::contains($output, 'github.com') && Str::contains($output, ['access', 'permission', 'credential'])) {
+        if (Str::contains($output, 'github.com') && Str::contains($output, ['access', 'permission', 'credential', 'authenticate'])) {
             return collect([
                 'Composer could not authenticate with GitHub!',
                 'Please generate a personal access token at: https://github.com/settings/tokens/new',


### PR DESCRIPTION
Could only reproduce this once, normally it gives different output...

![image](https://user-images.githubusercontent.com/5187394/156842327-0fc32e7b-860b-4c26-b2d0-666dfcf8a83f.png)

By adding 'authenticate' to the composer output handling, we can show the nicer error when this happens for whatever reason.