### PR TITLE
Fix massive icon on user creation wizard when using both first & name fields

### DIFF
--- a/resources/js/components/users/Wizard.vue
+++ b/resources/js/components/users/Wizard.vue
@@ -46,7 +46,7 @@
                     <label class="font-bold text-base mb-sm" for="first_name">{{ __('First Name') }}</label>
                     <input type="text" v-model="user.first_name" id="first_name" class="input-text" autofocus tabindex="2">
                     <div class="text-2xs text-grey-60 mt-1 flex items-center">
-                        <svg-icon name="info-circle" class="mr-sm flex items-center mb-px"></svg-icon>
+                        <svg-icon name="info-circle" class="h-4 w-4 mr-sm flex items-center mb-px"></svg-icon>
                         {{ __('messages.user_wizard_name_instructions') }}
                     </div>
                 </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19637309/156894960-ea558e15-8156-4822-bd0a-5bb673303c9b.png)


Fixes #5307