### PR TITLE
Antlers Runtime Bugfixes

### DIFF
--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -622,6 +622,14 @@ class DocumentParser
 
         RecursiveParentAnalyzer::associateRecursiveParent($this->nodes);
 
+        if (count($this->nodes) >= 2) {
+            if ($this->nodes[0] instanceof AntlersNode && $this->nodes[0]->isComment) {
+                if ($this->nodes[1] instanceof LiteralNode) {
+                    $this->nodes[1]->content = ltrim($this->nodes[1]->content);
+                }
+            }
+        }
+
         foreach ($this->nodes as $node) {
             if ($node instanceof AntlersNode) {
                 $node->isInterpolationNode = $this->isInterpolatedParser;

--- a/tests/Antlers/Parser/BasicNodeTest.php
+++ b/tests/Antlers/Parser/BasicNodeTest.php
@@ -201,7 +201,6 @@ EOT;
 
         $expected = <<<'EOT'
 
-
 <div class="max-w-2xl mx-auto mb-32">
 <p>test</p> test
 </div>

--- a/tests/Antlers/Parser/CommentsTest.php
+++ b/tests/Antlers/Parser/CommentsTest.php
@@ -14,4 +14,28 @@ EOT;
 
         $this->assertSame('', $this->renderString($template));
     }
+
+    public function test_comments_at_start_of_document_remove_whitespace()
+    {
+        $template = <<<'EOT'
+{{# name #}}
+{{ xml_header }}
+<start>
+    {{# comment #}}
+    
+<end>
+EOT;
+
+        // Ensures that the whitespace surrounding the 2nd comment is left in-tact;
+        // we cannot know for certain if that whitespace was intentional or not.
+        $expected = <<<'EOT'
+<?xml version="1.0" encoding="utf-8" ?>
+<start>
+    
+    
+<end>
+EOT;
+
+        $this->assertSame($expected, $this->renderString($template, ['xml_header' => '<?xml version="1.0" encoding="utf-8" ?>']));
+    }
 }

--- a/tests/Antlers/Runtime/StacksTest.php
+++ b/tests/Antlers/Runtime/StacksTest.php
@@ -41,4 +41,40 @@ EOT;
 
         $this->assertSame('BEFOREPrepend 2Prepend 1Push 1Push 2AFTER', trim($this->renderString($template, [], true)));
     }
+
+    public function test_stacks_and_sections_work_from_partials()
+    {
+        $template = <<<'EOT'
+{{ partial:stacksections }}
+{{ stack:the_stack }}
+{{ yield:the_section }}
+
+{{ push:the_stack }}<More stack content>{{ /push:the_stack }}
+
+EOT;
+
+        $expected = <<<'EOT'
+<The stack content><More stack content>
+<Section Content>
+EOT;
+
+        $this->assertSame($expected, trim($this->renderString($template, [], true)));
+
+        // The section content should be replaced with "Different Section Content" since it is processed _after_ the partial.
+        $template = <<<'EOT'
+{{ partial:stacksections }}
+{{ stack:the_stack }}
+{{ yield:the_section }}
+
+{{ push:the_stack }}<More stack content>{{ /push:the_stack }}
+{{ section:the_section }}<Different Section Content>{{ /section:the_section }}
+EOT;
+
+        $expected = <<<'EOT'
+<The stack content><More stack content>
+<Different Section Content>
+EOT;
+
+        $this->assertSame($expected, trim($this->renderString($template, [], true)));
+    }
 }

--- a/tests/__fixtures__/views/partials/_stacksections.antlers.html
+++ b/tests/__fixtures__/views/partials/_stacksections.antlers.html
@@ -1,0 +1,2 @@
+{{ section:the_section }}<Section Content>{{ /section:the_section }}
+{{ push:the_stack }}<The stack content>{{ /push:the_stack }}


### PR DESCRIPTION
This PR closes #5425 and closes #5422 by ensuring that sections and stack content is only replaced at the very end of the current parser life-cycle.

Previously section & stack content would attempt to be evaluated too early, causing the no content issue for sections, and the array index error for stacks (since the internal list would be cleared too soon).

This PR also closes #5430 by trimming whitespace after a comment, if it is the first item in the template. Other whitespace has been left alone to not accidentally remove intentional whitespace.