### PR TITLE
Fix a few asset issues

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -285,7 +285,7 @@ class AssetContainer implements AssetContainerContract, Augmentable
 
         if ($folder && $recursive) {
             $query->where('folder', 'like', "{$folder}%");
-        } elseif ($folder) {
+        } elseif ($folder !== null) {
             $query->where('folder', $folder);
         }
 

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -283,10 +283,12 @@ class AssetContainer implements AssetContainerContract, Augmentable
             $folder = null;
         }
 
-        if ($folder && $recursive) {
-            $query->where('folder', 'like', "{$folder}%");
-        } elseif ($folder !== null) {
-            $query->where('folder', $folder);
+        if ($folder !== null) {
+            if ($recursive) {
+                $query->where('folder', 'like', "{$folder}%");
+            } else {
+                $query->where('folder', $folder);
+            }
         }
 
         return $query->get();

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -285,7 +285,7 @@ class AssetContainer implements AssetContainerContract, Augmentable
 
         if ($folder !== null) {
             if ($recursive) {
-                $query->where('folder', 'like', "{$folder}%");
+                $query->where('path', 'like', "{$folder}/%");
             } else {
                 $query->where('folder', $folder);
             }

--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -164,7 +164,7 @@ class AssetFolder implements Contract, Arrayable
             throw new \Exception('Folder cannot be moved to its own subfolder.');
         }
 
-        $name = $name ?: $this->basename();
+        $name = $name ?? $this->basename();
         $oldPath = $this->path();
         $newPath = Str::removeLeft(Path::tidy($parent.'/'.$name), '/');
 

--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -207,10 +207,10 @@ class AssetFolder implements Contract, Arrayable
     public function toArray()
     {
         return [
-            'title' => $this->title(),
-            'path' => $this->path(),
-            'parent_path' => optional($this->parent())->path(),
-            'basename' => $this->basename(),
+            'title' => (string) $this->title(),
+            'path' => (string) $this->path(),
+            'parent_path' => $this->parent() ? (string) $this->parent()->path() : null,
+            'basename' => (string) $this->basename(),
         ];
     }
 }

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -522,6 +522,7 @@ class AssetContainerTest extends TestCase
 
     /**
      * @test
+     *
      * @see https://github.com/statamic/cms/issues/5405
      * @see https://github.com/statamic/cms/pull/5433
      **/

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -562,6 +562,50 @@ class AssetContainerTest extends TestCase
         $container->disk()->delete('0');
     }
 
+    /**
+     * @test
+     *
+     * @see https://github.com/statamic/cms/issues/5405
+     * @see https://github.com/statamic/cms/pull/5433
+     **/
+    public function it_wont_get_assets_that_share_a_similar_folder_prefix()
+    {
+        $container = $this->containerWithDisk();
+
+        $container->disk()->delete('test');
+
+        $paths = [
+            'test/cat/siamese.jpg',
+            'test/cat/tabby.jpg',
+            'test/cat/cartoon/cheshire.jpg',
+            'test/categories/favorite.jpg',
+            'test/categories/non-favorite.jpg',
+        ];
+
+        foreach ($paths as $path) {
+            $container->disk()->put($path, 'test');
+        }
+
+        tap($container->assets('test/cat'), function ($assets) {
+            $this->assertInstanceOf(Collection::class, $assets);
+            $this->assertEquals([
+                'test/cat/siamese.jpg',
+                'test/cat/tabby.jpg',
+            ], $assets->map->path()->values()->all());
+        });
+
+        tap($container->assets('test/cat', true), function ($assets) {
+            $this->assertInstanceOf(Collection::class, $assets);
+            $this->assertEquals([
+                'test/cat/cartoon/cheshire.jpg',
+                'test/cat/siamese.jpg',
+                'test/cat/tabby.jpg',
+            ], $assets->map->path()->values()->all());
+        });
+
+        $container->disk()->delete('test');
+    }
+
     /** @test */
     public function it_gets_an_asset_folder()
     {

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -502,6 +502,12 @@ class AssetContainerTest extends TestCase
             $this->assertCount(2, $assets);
             $this->assertEveryItemIsInstanceOf(Asset::class, $assets);
         });
+
+        // Ensure folder named zero does not get treated as null and selects all assets.
+        tap($this->containerWithDisk()->assets('0'), function ($assets) {
+            $this->assertInstanceOf(Collection::class, $assets);
+            $this->assertCount(0, $assets);
+        });
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #5405

Part of the folder moving process is to delete the old folder.
Part of that is to delete all the assets inside it.

This is a two parter:

**One**

When the folder was attempting to find the assets inside it, since it was named just `"0"`, it was failing a strict comparison and acted as though there was no folder filter - resulting in _all_ assets being queried and then deleted.

This PR makes the folder check strict, and allows a folder named `"0"`.


**Two**

When we do a recursive asset lookup, it was doing "find assets where the asset's folder starts with this folder".
When there were assets in another folder that _started the same_ as your folder, it would pick those up too.

In #5405's case - it would be looking for assets in `2022/0` - which would include assets from `2022/01`, `2022/02`, etc.

This PR changes the condition to be "find assets where the asset's path starts with this folder and a slash".
So it'll look for `2022/0/` which wouldn't match `2022/01` anymore.