### PR TITLE
Up minimum commonmark version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "james-heinrich/getid3": "^1.9",
         "laravel/framework": "^8.24.0 || ^9.0",
         "laravel/helpers": "^1.1",
-        "league/commonmark": "^1.5 || ^2.0",
+        "league/commonmark": "^1.5 || ^2.2",
         "league/csv": "^9.0",
         "league/glide": "^1.1 || ^2.0",
         "michelf/php-smartypants": "^1.8",


### PR DESCRIPTION
We use the Commonmark parser's `convert()` method (introduced in 2.2), rather than the old `convertToHtml()` method (which is deprecated).

For context, this was causing failure in SEO Pro tests with prefer-lowest flag, but we're actually calling/using the package here in core.

References https://github.com/statamic/cms/pull/5188
References https://github.com/statamic/seo-pro/pull/204