### PR TITLE
Antlers Runtime Conditions Bugfixes

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -397,7 +397,7 @@ class NodeProcessor
     /**
      * Overrides all data in the processor instance with the provided data.
      *
-     * @param array $data The data to set.
+     * @param  array  $data  The data to set.
      * @return $this
      */
     public function swapData($data)

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -395,6 +395,19 @@ class NodeProcessor
     }
 
     /**
+     * Overrides all data in the processor instance with the provided data.
+     *
+     * @param array $data The data to set.
+     * @return $this
+     */
+    public function swapData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
      * Sets the active scope data.
      *
      * @param  array  $data  The data to set.

--- a/src/View/Antlers/Language/Runtime/PathDataManager.php
+++ b/src/View/Antlers/Language/Runtime/PathDataManager.php
@@ -675,7 +675,7 @@ class PathDataManager
                         $this->compact(false);
                     }
                 }
-                if ($path instanceof PathNode && !$path->isFinal) {
+                if ($path instanceof PathNode && ! $path->isFinal) {
                     $this->doBreak = false;
                 }
             } else {

--- a/src/View/Antlers/Language/Runtime/PathDataManager.php
+++ b/src/View/Antlers/Language/Runtime/PathDataManager.php
@@ -675,6 +675,9 @@ class PathDataManager
                         $this->compact(false);
                     }
                 }
+                if ($path instanceof PathNode && !$path->isFinal) {
+                    $this->doBreak = false;
+                }
             } else {
                 $this->reducedVar = null;
                 $this->didFind = false;

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -582,6 +582,11 @@ class RuntimeParser implements Parser
         return $this->renderText($text, $data);
     }
 
+    public function render($text, $data = [])
+    {
+        return $this->renderText($text, $data);
+    }
+
     public function valueWithNoparse($text)
     {
         // Just pass-thru.

--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -417,6 +417,27 @@ class Environment
     }
 
     /**
+     * Resolves the provided value to be used within a comparison operation.
+     *
+     * @param mixed $value The value to resolve.
+     * @return mixed|string
+     */
+    private function getComparisonValue($value)
+    {
+        if (is_object($value)) {
+            $lockData = $this->nodeProcessor->getAllData();
+            if ($value instanceof Value) {
+                $value =  $value->value();
+            } elseif ($value instanceof ArrayableString) {
+                $value = (string)$value;
+            }
+            $this->nodeProcessor->swapData($lockData);
+        }
+
+        return $value;
+    }
+
+    /**
      * Evaluates the provided nodes and returns the result.
      *
      * @param  AbstractNode[]  $nodes  The runtime nodes.
@@ -577,18 +598,19 @@ class Environment
                     $restoreRf = $this->dataRetriever->getReduceFinal();
                     $this->dataRetriever->setReduceFinal(false);
                     $this->isEvaluatingTruthValue = false;
-                    $left = $this->getValue($left);
+                    $left = $this->getComparisonValue($this->getValue($left));
                     $this->isEvaluatingTruthValue = true;
 
                     $this->dataRetriever->setReduceFinal($restoreRf);
                 } else {
-                    $right = $this->getValue($right);
-                    $left = $this->getValue($left);
+                    $right = $this->getComparisonValue($this->getValue($right));
+                    $left = $this->getComparisonValue($this->getValue($left));
+
                 }
 
                 $this->isEvaluatingTruthValue = false;
 
-                $right = $this->getValue($right);
+                $right = $this->getComparisonValue($this->getValue($right));
                 $this->isEvaluatingTruthValue = $restore;
 
                 $stack[] = $left == $right;
@@ -601,8 +623,8 @@ class Environment
 
                 $restore = $this->isEvaluatingTruthValue;
                 $this->isEvaluatingTruthValue = false;
-                $left = $this->getValue($left);
-                $right = $this->getValue($right);
+                $left = $this->getComparisonValue($this->getValue($left));
+                $right = $this->getComparisonValue($this->getValue($right));
                 $this->isEvaluatingTruthValue = $restore;
 
                 $stack[] = $left > $right;
@@ -615,8 +637,8 @@ class Environment
 
                 $restore = $this->isEvaluatingTruthValue;
                 $this->isEvaluatingTruthValue = false;
-                $left = $this->getValue($left);
-                $right = $this->getValue($right);
+                $left = $this->getComparisonValue($this->getValue($left));
+                $right = $this->getComparisonValue($this->getValue($right));
                 $this->isEvaluatingTruthValue = $restore;
 
                 $stack[] = $left >= $right;
@@ -629,8 +651,8 @@ class Environment
 
                 $restore = $this->isEvaluatingTruthValue;
                 $this->isEvaluatingTruthValue = false;
-                $left = $this->getValue($left);
-                $right = $this->getValue($right);
+                $left = $this->getComparisonValue($this->getValue($left));
+                $right = $this->getComparisonValue($this->getValue($right));
                 $this->isEvaluatingTruthValue = $restore;
 
                 $stack[] = $left < $right;
@@ -643,8 +665,8 @@ class Environment
 
                 $restore = $this->isEvaluatingTruthValue;
                 $this->isEvaluatingTruthValue = false;
-                $left = $this->getValue($left);
-                $right = $this->getValue($right);
+                $left = $this->getComparisonValue($this->getValue($left));
+                $right = $this->getComparisonValue($this->getValue($right));
                 $this->isEvaluatingTruthValue = $restore;
 
                 $stack[] = $left <= $right;
@@ -657,8 +679,8 @@ class Environment
 
                 $restore = $this->isEvaluatingTruthValue;
                 $this->isEvaluatingTruthValue = false;
-                $left = $this->getValue($left);
-                $right = $this->getValue($right);
+                $left = $this->getComparisonValue($this->getValue($left));
+                $right = $this->getComparisonValue($this->getValue($right));
                 $this->isEvaluatingTruthValue = $restore;
 
                 $stack[] = $left != $right;
@@ -671,8 +693,8 @@ class Environment
 
                 $restore = $this->isEvaluatingTruthValue;
                 $this->isEvaluatingTruthValue = false;
-                $left = $this->getValue($left);
-                $right = $this->getValue($right);
+                $left = $this->getComparisonValue($this->getValue($left));
+                $right = $this->getComparisonValue($this->getValue($right));
                 $this->isEvaluatingTruthValue = $restore;
 
                 $stack[] = $left !== $right;
@@ -685,8 +707,8 @@ class Environment
 
                 $restore = $this->isEvaluatingTruthValue;
                 $this->isEvaluatingTruthValue = false;
-                $left = $this->getValue($left);
-                $right = $this->getValue($right);
+                $left = $this->getComparisonValue($this->getValue($left));
+                $right = $this->getComparisonValue($this->getValue($right));
                 $this->isEvaluatingTruthValue = $restore;
 
                 $stack[] = $left <=> $right;
@@ -699,8 +721,8 @@ class Environment
 
                 $restore = $this->isEvaluatingTruthValue;
                 $this->isEvaluatingTruthValue = false;
-                $left = $this->getValue($left);
-                $right = $this->getValue($right);
+                $left = $this->getComparisonValue($this->getValue($left));
+                $right = $this->getComparisonValue($this->getValue($right));
                 $this->isEvaluatingTruthValue = $restore;
 
                 $stack[] = $left === $right;
@@ -711,9 +733,8 @@ class Environment
                 $left = $this->getValue(array_pop($stack));
                 $right = $this->getValue($nodes[$i + 1]);
 
-                if ($left instanceof ArrayableString) {
-                    $left = $left->value();
-                }
+                $left = $this->getComparisonValue($left);
+                $right = $this->getComparisonValue($right);
 
                 if ($this->isEvaluatingTruthValue) {
                     $stack[] = ($left || $right);
@@ -731,15 +752,14 @@ class Environment
                 $left = $this->getValue(array_pop($stack));
                 $right = $this->getValue($nodes[$i + 1]);
 
-                $stack[] = ($left && $right);
-
+                $stack[] = ($this->getComparisonValue($left) && $this->getComparisonValue($right));
                 $i += 1;
                 continue;
             } elseif ($currentNode instanceof LogicalXorOperator) {
                 $left = $this->getValue(array_pop($stack));
                 $right = $this->getValue($nodes[$i + 1]);
 
-                $stack[] = ($left xor $right);
+                $stack[] = ($this->getComparisonValue($left) xor $this->getComparisonValue($right));
 
                 $i += 1;
                 continue;
@@ -757,7 +777,7 @@ class Environment
 
                 continue;
             } elseif ($currentNode instanceof LogicalNegationOperator) {
-                $right = $this->getTruthValue($this->getValue($nodes[$i + 1]));
+                $right = $this->getTruthValue($this->getComparisonValue($this->getValue($nodes[$i + 1])));
 
                 $stack[] = $right == false;
 

--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -419,7 +419,7 @@ class Environment
     /**
      * Resolves the provided value to be used within a comparison operation.
      *
-     * @param mixed $value The value to resolve.
+     * @param  mixed  $value  The value to resolve.
      * @return mixed|string
      */
     private function getComparisonValue($value)
@@ -427,9 +427,9 @@ class Environment
         if (is_object($value)) {
             $lockData = $this->nodeProcessor->getAllData();
             if ($value instanceof Value) {
-                $value =  $value->value();
+                $value = $value->value();
             } elseif ($value instanceof ArrayableString) {
-                $value = (string)$value;
+                $value = (string) $value;
             }
             $this->nodeProcessor->swapData($lockData);
         }
@@ -605,7 +605,6 @@ class Environment
                 } else {
                     $right = $this->getComparisonValue($this->getValue($right));
                     $left = $this->getComparisonValue($this->getValue($left));
-
                 }
 
                 $this->isEvaluatingTruthValue = false;

--- a/tests/Antlers/Runtime/ConditionalLogicValueTest.php
+++ b/tests/Antlers/Runtime/ConditionalLogicValueTest.php
@@ -12,7 +12,6 @@ use Tests\Antlers\ParserTestCase;
 
 class ConditionalLogicValueTest extends ParserTestCase
 {
-
     public function test_conditionals_handle_values_transparently()
     {
         $integerFieldType = new Integer();
@@ -25,7 +24,7 @@ class ConditionalLogicValueTest extends ParserTestCase
                 'two' => 'Two',
                 'three' => 'Three',
             ],
-            'type' => 'button_group'
+            'type' => 'button_group',
         ]));
         $checkboxFieldType->setField(new Field('checkbox_value', [
             'inline' => false,

--- a/tests/Antlers/Runtime/ConditionalLogicValueTest.php
+++ b/tests/Antlers/Runtime/ConditionalLogicValueTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Antlers\Runtime;
+
+use Statamic\Fields\Field;
+use Statamic\Fields\Value;
+use Statamic\Fieldtypes\ButtonGroup;
+use Statamic\Fieldtypes\Checkboxes;
+use Statamic\Fieldtypes\Floatval;
+use Statamic\Fieldtypes\Integer;
+use Tests\Antlers\ParserTestCase;
+
+class ConditionalLogicValueTest extends ParserTestCase
+{
+
+    public function test_conditionals_handle_values_transparently()
+    {
+        $integerFieldType = new Integer();
+        $floatFieldType = new Floatval();
+        $checkboxFieldType = new Checkboxes();
+        $buttonFieldType = new ButtonGroup();
+        $buttonFieldType->setField(new Field('button_value', [
+            'options' => [
+                'one' => 'One',
+                'two' => 'Two',
+                'three' => 'Three',
+            ],
+            'type' => 'button_group'
+        ]));
+        $checkboxFieldType->setField(new Field('checkbox_value', [
+            'inline' => false,
+            'options' => [
+                'option_one' => 'Option One',
+                'option_two' => 'Option Two',
+            ],
+            'type' => 'checkboxes',
+        ]));
+
+        $integerValue = new Value(42, 'integer_value', $integerFieldType);
+        $floatValue = new Value(42.00, 'float_value', $floatFieldType);
+        $checkboxValue = new Value(['option_one'], 'checkbox_value', $checkboxFieldType);
+        $buttonGroupValue = new Value('two', 'button_value', $buttonFieldType);
+        $buttonGroupValueTwo = new Value('two', 'button_value_two', $buttonFieldType);
+        $buttonGroupValueThree = new Value('three', 'button_value_three', $buttonFieldType);
+
+        $data = [
+            'integer_value' => $integerValue,
+            'float_value' => $floatValue,
+            'checkbox_value' => $checkboxValue,
+            'button_value' => $buttonGroupValue,
+            'button_value_two' => $buttonGroupValueTwo,
+            'button_value_three' => $buttonGroupValueThree,
+        ];
+
+        $this->assertSame('Yes', $this->renderString('{{ if checkbox_value.0.value == "option_one" }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ (button_value === "two") ? "Yes" : "No" }}', $data));
+        $this->assertSame('No', $this->renderString('{{ (button_value === "three") ? "Yes" : "No" }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ (button_value === "two") ?= "Yes" }}', $data));
+        $this->assertSame('', $this->renderString('{{ (button_value === "three") ?= "Yes" }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ if button_value === "two" }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ if button_value === button_value_two }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ if button_value == button_value_two }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('No', $this->renderString('{{ if button_value === button_value_three }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('No', $this->renderString('{{ if button_value == button_value_three }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ if button_value === button_value }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ if button_value == "two" }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ if button_value == button_value }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ if (checkbox_value | raw | contains("option_one")) }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ if integer_value > 40 }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ if integer_value > "40" }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ if integer_value >= float_value }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ if integer_value >= integer_value }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('No', $this->renderString('{{ if integer_value < float_value }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('No', $this->renderString('{{ if integer_value === float_value }}Yes{{ else }}No{{ /if }}', $data));
+        $this->assertSame('Yes', $this->renderString('{{ if integer_value == float_value }}Yes{{ else }}No{{ /if }}', $data));
+    }
+}

--- a/tests/Antlers/Runtime/NullCoalescenceTest.php
+++ b/tests/Antlers/Runtime/NullCoalescenceTest.php
@@ -78,6 +78,6 @@ EOT;
             $m->shouldReceive('get')->with('settings')->once()->andReturn(null);
         });
 
-        $this->assertSame('Statamic', (string)$this->parser()->cascade($cascade)->render($template, $data));
+        $this->assertSame('Statamic', (string) $this->parser()->cascade($cascade)->render($template, $data));
     }
 }

--- a/tests/Antlers/Runtime/NullCoalescenceTest.php
+++ b/tests/Antlers/Runtime/NullCoalescenceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Antlers\Runtime;
 
+use Statamic\View\Cascade;
 use Tests\Antlers\ParserTestCase;
 
 class NullCoalescenceTest extends ParserTestCase
@@ -55,5 +56,28 @@ EOT;
             'seo_title' => 'i am the seo title',
             'title' => 'i am the the title',
         ], true));
+    }
+
+    public function test_null_coalescence_with_multi_path_parts()
+    {
+        $data = [
+            'config' => [
+                'app' => [
+                    'name' => 'Statamic',
+                ],
+            ],
+        ];
+
+        $template = <<<'EOT'
+{{ settings:copyright_name ?? config:app:name }}
+EOT;
+
+        $this->assertSame('Statamic', $this->renderString($template, $data));
+
+        $cascade = $this->mock(Cascade::class, function ($m) {
+            $m->shouldReceive('get')->with('settings')->once()->andReturn(null);
+        });
+
+        $this->assertSame('Statamic', (string)$this->parser()->cascade($cascade)->render($template, $data));
     }
 }


### PR DESCRIPTION
This PR corrects a few issues with how conditions are handled by the Antlers Runtime:

* Closes #5429 - The runtime will resolve the `->value()` of all `Value` instances it encounters when performing comparisons
* Closes #5435 - Corrects an issue where the data manager would sometimes skip the last part of a variable's path
