### PR TITLE
Allow a terms fieldtype value to be passed into the taxonomy param

### DIFF
--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Entries\EntryCollection;
 use Statamic\Facades\Collection;
+use Statamic\Facades\Compare;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Support\Arr;
@@ -305,6 +306,10 @@ class Entries
         })->each(function ($values, $param) use ($query) {
             $taxonomy = substr($param, 9);
             [$taxonomy, $modifier] = array_pad(explode(':', $taxonomy), 2, 'any');
+
+            if (Compare::isQueryBuilder($values)) {
+                $values = $values->get();
+            }
 
             if (is_string($values)) {
                 $values = array_filter(explode('|', $values));

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -7,6 +7,8 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
 use InvalidArgumentException;
+use Mockery;
+use Statamic\Contracts\Query\Builder;
 use Statamic\Facades;
 use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
@@ -512,6 +514,23 @@ class EntriesTest extends TestCase
 
         $this->assertEquals([1, 2, 3], $this->getEntries(['taxonomy:tags' => ''])->map->slug()->all());
         $this->assertEquals([1, 2, 3], $this->getEntries(['taxonomy:tags' => '|'])->map->slug()->all());
+    }
+
+    /** @test */
+    public function it_accepts_a_query_builder_to_filter_by_taxonomy()
+    {
+        $this->makeEntry('1')->data(['tags' => ['rad'], 'categories' => ['news']])->save();
+        $this->makeEntry('2')->data(['tags' => ['awesome'], 'categories' => ['events']])->save();
+        $this->makeEntry('3')->data(['tags' => ['rad', 'awesome']])->save();
+        $this->makeEntry('4')->data(['tags' => ['meh']])->save();
+
+        $builder = Mockery::mock(Builder::class);
+        $builder->shouldReceive('get')->andReturn(TermCollection::make([
+            tap(Term::make('rad')->taxonomy('tags')->dataForLocale('en', []))->save(),
+            tap(Term::make('awesome')->taxonomy('tags')->dataForLocale('en', []))->save(),
+        ]));
+
+        $this->assertEquals([3], $this->getEntries(['taxonomy:tags:all' => $builder])->map->slug()->all());
     }
 }
 


### PR DESCRIPTION
In 3.2, passing a terms field into the taxonomy parameter worked because it would be a collection of Term objects.

In 3.3, it would be a Query Builder instance instead of a collection of Terms. This PR will get the query results if it detects a Query Builder.

Fixes #5431
