### PR TITLE
Register Variables debugbar collector, only if it has not already been registered

### DIFF
--- a/src/View/Debugbar/AddVariables.php
+++ b/src/View/Debugbar/AddVariables.php
@@ -14,7 +14,7 @@ class AddVariables
      */
     public function handle(ViewRendered $event)
     {
-        if (! debugbar()->isEnabled()) {
+        if (!debugbar()->isEnabled() || debugbar()->hasCollector('Variables')) {
             return;
         }
 

--- a/src/View/Debugbar/AddVariables.php
+++ b/src/View/Debugbar/AddVariables.php
@@ -14,7 +14,7 @@ class AddVariables
      */
     public function handle(ViewRendered $event)
     {
-        if (!debugbar()->isEnabled() || debugbar()->hasCollector('Variables')) {
+        if (! debugbar()->isEnabled() || debugbar()->hasCollector('Variables')) {
             return;
         }
 


### PR DESCRIPTION
In the event that Debugbar is enabled and Statamic\View\View::make is used multiple times on a single page, an exception for DebugBar\DebugBarException 'Variables' is already a registered collector, will be thrown.

This aims to only register the Variables collector once for the page load/request.

This allows Statamic\View\View to be used multiple times, and will automatically pass the cascade data onto the views.

An example of how I had previously tried to use this can be see here: https://github.com/HandmadeWeb/buildamic/blob/e114f52411b136aec3e8620ba1359dbe29462f44/src/BuildamicRenderer.php (sections render rows, which render columns etc...) but this resulted in the exception to be thrown, I had since reverted those changes in https://github.com/HandmadeWeb/buildamic/commit/82628d18080fa9fd8bd9a3cf61af045978b14ec6#diff-b5af57f4714af12d863602b35633f1e0c2234f9212969a42296af76a10e4d806 

However I think it could still be worth only collecting the Variables for debugbar once.