### PR TITLE
Regex parser can handle when tags return query builders

### DIFF
--- a/src/View/Antlers/Engine.php
+++ b/src/View/Antlers/Engine.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\View\Antlers\Parser;
 use Statamic\Exceptions;
+use Statamic\Facades\Compare;
 use Statamic\Facades\Parse;
 use Statamic\Fields\Value;
 use Statamic\Support\Arr;
@@ -158,6 +159,10 @@ class Engine implements EngineInterface
             ]);
 
             $output = call_user_func([$tag, $method]);
+
+            if (Compare::isQueryBuilder($output)) {
+                $output = $output->get();
+            }
 
             if ($output instanceof Collection) {
                 $output = $output->toAugmentedArray();

--- a/tests/View/Antlers/ParserTests.php
+++ b/tests/View/Antlers/ParserTests.php
@@ -1430,7 +1430,8 @@ EOT;
     /** @test */
     public function callback_tags_that_return_query_builders_get_parsed()
     {
-        (new class extends Tags {
+        (new class extends Tags
+        {
             public static $handle = 'tag';
 
             public function index()

--- a/tests/View/Antlers/ParserTests.php
+++ b/tests/View/Antlers/ParserTests.php
@@ -1428,6 +1428,43 @@ EOT;
     }
 
     /** @test */
+    public function callback_tags_that_return_query_builders_get_parsed()
+    {
+        (new class extends Tags {
+            public static $handle = 'tag';
+
+            public function index()
+            {
+                $builder = Mockery::mock(Builder::class);
+                $builder->shouldReceive('get')->andReturn(collect([
+                    ['one' => 'a', 'two' => 'b'],
+                    ['one' => 'c', 'two' => 'd'],
+                ]));
+
+                return $builder;
+            }
+        })::register();
+
+        $template = <<<'EOT'
+{{ string }}
+{{ tag }}
+    {{ count }} {{ if first }}first{{ else }}not-first{{ /if }} {{ if last }}last{{ else }}not-last{{ /if }} {{ one }} {{ two }} {{ string }}
+{{ /tag }}
+EOT;
+
+        $expected = <<<'EOT'
+Hello wilderness
+
+    1 first not-last a b Hello wilderness
+
+    2 not-first last c d Hello wilderness
+
+EOT;
+
+        $this->assertEqualsWithCollapsedNewlines($expected, $this->renderString($template, $this->variables, true));
+    }
+
+    /** @test */
     public function callback_tags_that_return_value_objects_gets_parsed()
     {
         (new class extends Tags


### PR DESCRIPTION
The regex parser will now handle them.
The runtime parser already does.

Fixes #5459 