### PR TITLE
Pluck modifier supports ArrayAccess types

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Modifiers;
 
+use ArrayAccess;
 use Carbon\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
@@ -1649,7 +1650,7 @@ class CoreModifiers extends Modifier
         }
 
         $items = $value->map(function ($item) use ($key) {
-            if (is_array($item)) {
+            if (is_array($item) || $item instanceof ArrayAccess) {
                 return Arr::get($item, $key);
             }
 

--- a/tests/Modifiers/PluckTest.php
+++ b/tests/Modifiers/PluckTest.php
@@ -206,22 +206,26 @@ class ArrayAccessType implements ArrayAccess
         $this->data = $data;
     }
 
-    public function offsetGet(mixed $offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
     {
         return $this->data[$offset];
     }
 
-    public function offsetExists(mixed $offset): bool
+    #[\ReturnTypeWillChange]
+    public function offsetExists($offset)
     {
         return isset($this->data[$offset]);
     }
 
-    public function offsetSet(mixed $offset, mixed $value): void
+    #[\ReturnTypeWillChange]
+    public function offsetSet($offset, $value)
     {
         //
     }
 
-    public function offsetUnset(mixed $offset): void
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($offset)
     {
         //
     }

--- a/tests/Modifiers/PluckTest.php
+++ b/tests/Modifiers/PluckTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Modifiers;
 
+use ArrayAccess;
 use Illuminate\Support\Collection;
 use Mockery;
 use Statamic\Contracts\Query\Builder;
@@ -113,6 +114,20 @@ class PluckTest extends TestCase
         $this->assertEquals(['food', 'drink'], $modified->all());
     }
 
+    /** @test */
+    public function it_plucks_values_from_array_of_items_of_type_arrayaccess()
+    {
+        $items = $this->itemsOfTypeArrayAccess();
+
+        $modified = $this->modify($items, 'title');
+        $this->assertIsArray($modified);
+        $this->assertEquals(['Bread', 'Coffee'], $modified);
+
+        $modified = $this->modify($items, 'type');
+        $this->assertIsArray($modified);
+        $this->assertEquals(['food', 'drink'], $modified);
+    }
+
     private function items()
     {
         return [
@@ -136,6 +151,14 @@ class PluckTest extends TestCase
         return [
             ['title' => 'Bread', 'type' => 'food'],
             ['title' => 'Coffee', 'type' => 'drink'],
+        ];
+    }
+
+    private function itemsOfTypeArrayAccess()
+    {
+        return [
+            new ArrayAccessType(['title' => 'Bread', 'type' => 'food']),
+            new ArrayAccessType(['title' => 'Coffee', 'type' => 'drink']),
         ];
     }
 
@@ -169,6 +192,36 @@ class ItemWithOrigin
     }
 
     public function getOriginByString($origin)
+    {
+        //
+    }
+}
+
+class ArrayAccessType implements ArrayAccess
+{
+    private $data;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->data[$offset];
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->data[$offset]);
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        //
+    }
+
+    public function offsetUnset(mixed $offset): void
     {
         //
     }


### PR DESCRIPTION
Fixes #5460

Lets the pluck modifier support ArrayAccess items, like `Values`, which is returned from Replicators/Grids/Bards.
