### PR TITLE
Modifiers convert Values objects to arrays

### DIFF
--- a/src/Fields/Values.php
+++ b/src/Fields/Values.php
@@ -104,4 +104,9 @@ class Values implements ArrayAccess, Arrayable, IteratorAggregate
     {
         return $this->getProxiedInstance()->toArray();
     }
+
+    public function all()
+    {
+        return $this->getProxiedInstance()->all();
+    }
 }

--- a/src/Modifiers/Modify.php
+++ b/src/Modifiers/Modify.php
@@ -4,6 +4,7 @@ namespace Statamic\Modifiers;
 
 use ArrayIterator;
 use Exception;
+use Statamic\Fields\Values;
 use Statamic\Support\Arr;
 
 class Modify implements \IteratorAggregate
@@ -189,6 +190,12 @@ class Modify implements \IteratorAggregate
     {
         [$class, $method] = $this->loader->load($modifier);
 
-        return $class->$method($this->value, $params, $this->context);
+        $value = $this->value;
+
+        if ($value instanceof Values) {
+            $value = $value->all();
+        }
+
+        return $class->$method($value, $params, $this->context);
     }
 }

--- a/tests/Fields/ValuesTest.php
+++ b/tests/Fields/ValuesTest.php
@@ -57,6 +57,14 @@ class ValuesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_itself_as_an_array()
+    {
+        $values = new Values(collect(['foo' => 'bar']));
+
+        $this->assertEquals(['foo' => 'bar'], $values->all());
+    }
+
+    /** @test */
     public function its_arrayable()
     {
         $mockOne = Mockery::mock(Collection::class)->shouldReceive('toArray')->andReturn(['title' => 'first'])->getMock();

--- a/tests/Modifiers/FluentModifyTest.php
+++ b/tests/Modifiers/FluentModifyTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Modifiers;
 
+use Statamic\Fields\Values;
+use Statamic\Modifiers\Modifier;
 use Statamic\Modifiers\Modify;
 use Tests\TestCase;
 
@@ -23,5 +25,32 @@ class FluentModifyTest extends TestCase
 
         $this->assertTrue(is_string($result));
         $this->assertEquals("I LOVE NACHO LIBRE, IT'S THE BESSS!!!", $result);
+    }
+
+    /** @test */
+    public function passing_a_values_instance_into_it_will_not_convert_it_to_an_array()
+    {
+        $values = new Values(['foo' => 'bar']);
+
+        $result = Modify::value($values)->fetch();
+
+        $this->assertSame($values, $result);
+    }
+
+    /** @test */
+    public function values_instances_get_converted_to_an_array_when_passing_to_a_modifier()
+    {
+        (new class extends Modifier {
+            public static $handle = 'to_values';
+
+            public function index($value)
+            {
+                return new Values($value);
+            }
+        })::register();
+
+        $result = Modify::value(['foo' => 'bar'])->toValues()->typeOf()->fetch();
+
+        $this->assertEquals('array', $result);
     }
 }

--- a/tests/Modifiers/FluentModifyTest.php
+++ b/tests/Modifiers/FluentModifyTest.php
@@ -40,7 +40,8 @@ class FluentModifyTest extends TestCase
     /** @test */
     public function values_instances_get_converted_to_an_array_when_passing_to_a_modifier()
     {
-        (new class extends Modifier {
+        (new class extends Modifier
+        {
             public static $handle = 'to_values';
 
             public function index($value)


### PR DESCRIPTION
Since #5436, a Replicator/Bard set or Grid row would now be a Values instance and no longer an array.

We were fine with that being a breaking change, but we can avoid it from breaking _too_ much.

If you were to use certain array modifiers on them, what would previously work will no longer work because they'd have `is_array` checks in there. e.g. `contains`, `in_array`, `is_array`, etc

This PR will convert `Values` instances to their underlying arrays before running each modifier so it behaves exactly like it did before.

For cases where a _nested_ item is a `Values` instance, we'll still need to manually handle it. See #5462 for an example.