### PR TITLE
Flysystem V2 API change

### DIFF
--- a/src/Assets/ExtractInfo.php
+++ b/src/Assets/ExtractInfo.php
@@ -11,6 +11,6 @@ class ExtractInfo
         $disk = $asset->disk()->filesystem();
         $path = $asset->path();
 
-        return (new \getID3)->analyze($path, $disk->getSize($path), '', $disk->readStream($path));
+        return (new \getID3)->analyze($path, $disk->fileSize($path), '', $disk->readStream($path));
     }
 }

--- a/src/Assets/ExtractInfo.php
+++ b/src/Assets/ExtractInfo.php
@@ -11,6 +11,6 @@ class ExtractInfo
         $disk = $asset->disk()->filesystem();
         $path = $asset->path();
 
-        return (new \getID3)->analyze($path, $disk->fileSize($path), '', $disk->readStream($path));
+        return (new \getID3)->analyze($path, method_exists($disk, 'getSize') ? $disk->getSize($path) : $disk->fileSize($path), '', $disk->readStream($path));
     }
 }


### PR DESCRIPTION
When using 3.3-beta* and uploading media assets that contain an ID3 tag, they are run through the `ExtractInfo` class. This contains a call to getSize() which is removed in Flysystem V2 which is the default as of Laravel 9:

```
[2022-03-11 13:31:32] local.ERROR: Call to undefined method League\Flysystem\Filesystem::getSize() {"userId":1,"exception":"[object] (Error(code: 0): Call to undefined method League\\Flysystem\\Filesystem::getSize() at /Users/russ/Projects/cms/vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemAdapter.php:882)
[stacktrace]
#0 /Users/russ/Projects/cms/vendor/statamic/cms/src/Assets/ExtractInfo.php(14): Illuminate\\Filesystem\\FilesystemAdapter->__call('getSize', Array)
```

`fileSize` seems to be the equivalent replacement.

To replicate the issue, just try uploading a mp4 file into an asset folder when using Laravel 9.

