### PR TITLE
Fix `ExtractInfo` size call between Laravel 8 and 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "composer/composer": "^1.10.22 || ^2.0.13",
         "facade/ignition-contracts": "^1.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "james-heinrich/getid3": "^1.9.9",
+        "james-heinrich/getid3": "^1.9.21",
         "laravel/framework": "^8.24.0 || ^9.0",
         "laravel/helpers": "^1.1",
         "league/commonmark": "^1.5 || ^2.2",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "composer/composer": "^1.10.22 || ^2.0.13",
         "facade/ignition-contracts": "^1.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
-        "james-heinrich/getid3": "^1.9",
+        "james-heinrich/getid3": "^1.9.9",
         "laravel/framework": "^8.24.0 || ^9.0",
         "laravel/helpers": "^1.1",
         "league/commonmark": "^1.5 || ^2.2",

--- a/src/Assets/ExtractInfo.php
+++ b/src/Assets/ExtractInfo.php
@@ -11,6 +11,6 @@ class ExtractInfo
         $disk = $asset->disk()->filesystem();
         $path = $asset->path();
 
-        return (new \getID3)->analyze($path, $disk->getSize($path), '', $disk->readStream($path));
+        return (new \getID3)->analyze($path, method_exists($disk, 'getSize') ? $disk->getSize($path) : $disk->fileSize($path), '', $disk->readStream($path));
     }
 }

--- a/src/Assets/ExtractInfo.php
+++ b/src/Assets/ExtractInfo.php
@@ -11,6 +11,6 @@ class ExtractInfo
         $disk = $asset->disk()->filesystem();
         $path = $asset->path();
 
-        return (new \getID3)->analyze($path, method_exists($disk, 'getSize') ? $disk->getSize($path) : $disk->fileSize($path), '', $disk->readStream($path));
+        return (new \getID3)->analyze($path, $disk->size($path), '', $disk->readStream($path));
     }
 }

--- a/tests/Assets/ExtractInfoTest.php
+++ b/tests/Assets/ExtractInfoTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Assets;
+
+use Statamic\Assets\Asset;
+use Statamic\Assets\AssetContainer;
+use Statamic\Assets\ExtractInfo;
+use Tests\TestCase;
+
+class ExtractInfoTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.disks.test' => [
+            'driver' => 'local',
+            'root' => __DIR__.'/__fixtures__/container',
+        ]]);
+
+        $this->container = (new AssetContainer)
+            ->handle('test_container')
+            ->disk('test');
+    }
+
+    /** @test */
+    public function it_can_extract_basic_id3_info_from_text_asset()
+    {
+        $asset = (new Asset)->container($this->container)->path('a.txt');
+
+        $extracted = (new ExtractInfo)->fromAsset($asset);
+
+        $expected = [
+            'filesize' => 2,
+            'filename' => 'a.txt',
+            'encoding' => 'UTF-8',
+        ];
+
+        $this->assertArraySubset($expected, $extracted);
+    }
+}

--- a/tests/Assets/ExtractInfoTest.php
+++ b/tests/Assets/ExtractInfoTest.php
@@ -31,7 +31,7 @@ class ExtractInfoTest extends TestCase
         $extracted = (new ExtractInfo)->fromAsset($asset);
 
         $expected = [
-            'filesize' => 2,
+            'filesize' => $this->isRunningWindows() ? 3 : 2,
             'filename' => 'a.txt',
             'encoding' => 'UTF-8',
         ];


### PR DESCRIPTION
References #5467.