### PR TITLE
Fix terms being filtered out unintentionally

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -94,7 +94,13 @@ class Terms extends Relationship
             ->whereIn('id', $ids)
             ->where('site', $site);
 
-        if ($this->usingSingleTaxonomy() && $parent && $parent instanceof Entry && $this->field->handle() === $this->taxonomies()[0]) {
+        $shouldQueryCollection = $this->usingSingleTaxonomy()
+            && ! $this->field->parentField()
+            && $parent
+            && $parent instanceof Entry
+            && $this->field->handle() === $this->taxonomies()[0];
+
+        if ($shouldQueryCollection) {
             $query->where('collection', $parent->collectionHandle());
         }
 


### PR DESCRIPTION
Fixes #5472

When you have a `terms` field named the same as a taxonomy, there's some extra features that go along with it.
One of which is that it'll filter out any terms that aren't used in that entry's collection.

This should only happen for top level fields. If you have a field in a grid/replicator, it should leave it be.

- [x] Write a test
