### PR TITLE
Antlers Runtime Bugfixes

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -770,10 +770,13 @@ class CoreModifiers extends Modifier
      */
     public function groupBy($value, $params)
     {
-        // Workaround for https://github.com/statamic/cms/issues/3614
-        // At the moment this modifier only works properly when using the param syntax.
-        $params = implode(':', $params);
-        $params = explode('|', $params);
+        if (config('statamic.antlers.version') != 'runtime') {
+            // Workaround for https://github.com/statamic/cms/issues/3614
+            // At the moment this modifier only works properly when using the param syntax.
+            $params = implode(':', $params);
+            $params = explode('|', $params);
+        }
+
         $groupBy = $params[0];
 
         $groupLabels = [];

--- a/src/Tags/Assets.php
+++ b/src/Tags/Assets.php
@@ -3,6 +3,7 @@
 namespace Statamic\Tags;
 
 use Statamic\Assets\AssetCollection;
+use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Entry;
@@ -33,7 +34,13 @@ class Assets extends Tags
         $value = Arr::get($this->context, $this->method);
 
         if ($this->isAssetsFieldValue($value)) {
-            $this->assets = (new AssetCollection([$value->value()]))->flatten();
+            $value = $value->value();
+
+            if ($value instanceof Builder) {
+                $value = $value->get();
+            }
+
+            $this->assets = (new AssetCollection([$value]))->flatten();
 
             return $this->output();
         }

--- a/src/View/Antlers/Engine.php
+++ b/src/View/Antlers/Engine.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\View\Antlers\Parser;
 use Statamic\Exceptions;
+use Statamic\Facades\Compare;
 use Statamic\Facades\Parse;
 use Statamic\Fields\Value;
 use Statamic\Support\Arr;
@@ -158,6 +159,10 @@ class Engine implements EngineInterface
             ]);
 
             $output = call_user_func([$tag, $method]);
+
+            if (Compare::isQueryBuilder($output)) {
+                $output = $output->get();
+            }
 
             if ($output instanceof Collection) {
                 $output = $output->toAugmentedArray();

--- a/src/View/Antlers/Language/Errors/LineRetriever.php
+++ b/src/View/Antlers/Language/Errors/LineRetriever.php
@@ -66,13 +66,13 @@ class LineRetriever
         if ($node instanceof AntlersNode) {
             if ($node->originalNode != null) {
                 $line = $node->originalNode->startPosition->line;
-            } else {
+            } elseif ($node->startPosition != null) {
                 $line = $node->startPosition->line;
             }
         } else {
             if ($node->originalAbstractNode != null) {
                 $line = $node->originalAbstractNode->startPosition->line;
-            } else {
+            } elseif ($node->startPosition != null) {
                 $line = $node->startPosition->line;
             }
         }
@@ -89,7 +89,7 @@ class LineRetriever
             if ($node->originalNode != null) {
                 $line = $node->originalNode->startPosition->line;
                 $char = $node->originalNode->startPosition->char;
-            } else {
+            } elseif ($node->startPosition != null) {
                 $line = $node->startPosition->line;
                 $char = $node->startPosition->char;
             }
@@ -97,7 +97,7 @@ class LineRetriever
             if ($node->originalAbstractNode != null) {
                 $line = $node->originalAbstractNode->startPosition->line;
                 $char = $node->originalAbstractNode->startPosition->char;
-            } else {
+            } elseif ($node->startPosition != null) {
                 $line = $node->startPosition->line;
                 $char = $node->startPosition->char;
             }

--- a/src/View/Antlers/Language/Nodes/AntlersNode.php
+++ b/src/View/Antlers/Language/Nodes/AntlersNode.php
@@ -442,11 +442,11 @@ class AntlersNode extends AbstractNode
 
             $values[] = $value;
         } else {
-            if ($this->isClosedBy == null || $this->isSelfClosing) {
-                $values = explode('|', $value);
-            } else {
-                $values = explode(':', $value);
-            }
+            $pipeEscape = DocumentParser::getPipeEscape();
+
+            $values = array_map(function ($item) use ($pipeEscape) {
+                return str_replace($pipeEscape, DocumentParser::Punctuation_Pipe, $item);
+            }, explode('|', $value));
         }
 
         return array_values($values);

--- a/src/View/Antlers/Language/Nodes/AntlersNode.php
+++ b/src/View/Antlers/Language/Nodes/AntlersNode.php
@@ -443,22 +443,11 @@ class AntlersNode extends AbstractNode
 
             $values[] = $value;
         } else {
-            $splitParams = explode('|', $value);
-            $newParams = [];
-
-            foreach ($splitParams as $paramCandidate) {
-                if ($this->isClosedBy == null) {
-                    $newParams[] = $paramCandidate;
-                } else {
-                    if (Str::contains($paramCandidate, ':')) {
-                        $newParams = array_merge($newParams, explode(':', $paramCandidate));
-                    } else {
-                        $newParams[] = $paramCandidate;
-                    }
-                }
+            if ($this->isClosedBy == null || $this->isSelfClosing) {
+                $values = explode('|', $value);
+            } else {
+                $values = explode(':', $value);
             }
-
-            $values = $values + $newParams;
         }
 
         return array_values($values);
@@ -470,34 +459,7 @@ class AntlersNode extends AbstractNode
 
         /** @var ParameterNode $param */
         foreach ($this->parameters as $param) {
-            $value = $param->value;
-
-            if ($param->isVariableReference) {
-                $pathParser = new PathParser();
-                $retriever = new PathDataManager();
-                $retriever->setIsPaired($this->isClosedBy != null);
-                $value = $retriever->getData($pathParser->parse($value), $data);
-
-                $values[] = $value;
-                continue;
-            } else {
-                $splitParams = explode('|', $value);
-                $newParams = [];
-
-                foreach ($splitParams as $paramCandidate) {
-                    if ($this->isClosedBy == null) {
-                        $newParams[] = $paramCandidate;
-                    } else {
-                        if (Str::contains($paramCandidate, ':')) {
-                            $newParams = array_merge($newParams, explode(':', $paramCandidate));
-                        } else {
-                            $newParams[] = $paramCandidate;
-                        }
-                    }
-                }
-
-                $values = $values + $newParams;
-            }
+            $values += $this->getModifierParameterValuesForParameter($param, $data);
         }
 
         return array_values($values);

--- a/src/View/Antlers/Language/Nodes/AntlersNode.php
+++ b/src/View/Antlers/Language/Nodes/AntlersNode.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\View\Antlers\Language\Nodes;
 
-use Illuminate\Support\Str;
 use Statamic\Facades\Antlers;
 use Statamic\Tags\TagNotFoundException;
 use Statamic\View\Antlers\Language\Exceptions\RuntimeException;

--- a/src/View/Antlers/Language/Parser/AntlersNodeParser.php
+++ b/src/View/Antlers/Language/Parser/AntlersNodeParser.php
@@ -496,6 +496,12 @@ class AntlersNodeParser
                     $peek = $chars[$i + 1];
                 }
 
+                if ($peek == DocumentParser::Punctuation_Pipe) {
+                    $currentChars = array_merge($currentChars, DocumentParser::getPipeEscapeArray());
+                    $i += 1;
+                    continue;
+                }
+
                 if ($peek == DocumentParser::String_EscapeCharacter) {
                     $currentChars[] = DocumentParser::String_EscapeCharacter;
                     $i += 1;

--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -831,6 +831,11 @@ class DocumentParser
         return array_key_exists($offsetCheck, $this->interpolationEndOffsets);
     }
 
+    public static function getPipeEscape()
+    {
+        return '__antlers:pipe'.GlobalRuntimeState::$environmentId;
+    }
+
     public static function getLeftBraceEscape()
     {
         return '__antlers:leftBrace'.GlobalRuntimeState::$environmentId;
@@ -839,6 +844,11 @@ class DocumentParser
     public static function getRightBraceEscape()
     {
         return '__antlers:rightBrace'.GlobalRuntimeState::$environmentId;
+    }
+
+    public static function getPipeEscapeArray()
+    {
+        return str_split(self::getPipeEscape());
     }
 
     private function getLeftBrace()

--- a/src/View/Antlers/Language/Parser/LanguageKeywords.php
+++ b/src/View/Antlers/Language/Parser/LanguageKeywords.php
@@ -22,6 +22,10 @@ class LanguageKeywords
             return true;
         }
 
+        if (ctype_punct(substr($value, 0))) {
+            return true;
+        }
+
         return false;
     }
 }

--- a/src/View/Antlers/Language/Runtime/LiteralReplacementManager.php
+++ b/src/View/Antlers/Language/Runtime/LiteralReplacementManager.php
@@ -2,29 +2,93 @@
 
 namespace Statamic\View\Antlers\Language\Runtime;
 
+use Statamic\Support\Str;
+
 class LiteralReplacementManager
 {
     protected static $regions = [];
     protected static $replacements = [];
+    protected static $globalReplacement = [];
+    protected static $retargeted = [];
 
-    public static function registerRegion($name, $default)
+    public static function registerRegion($name, $section, $default)
     {
         $name = '__literalReplacement::_'.md5($name);
+        $globalName = 'section:'.$section.'__yield';
+        $globalReplacement = '__literalReplacement::_'.md5($globalName);
+
+        self::$globalReplacement[$name] = $globalReplacement;
+
+        if (array_key_exists($globalReplacement, self::$regions)) {
+            if (! array_key_exists($globalReplacement, self::$retargeted)) {
+                self::$retargeted[$globalReplacement] = [];
+            }
+
+            self::$retargeted[$globalReplacement][] = $name;
+            return $name;
+        }
+
         self::$regions[$name] = $default;
 
         return $name;
     }
 
-    public static function registerRegionReplacement($name, $string)
+    public static function registerRegionReplacement($name, $tagMethod, $string)
     {
         $name = '__literalReplacement::_'.md5($name);
-        self::$replacements[$name] = $string;
+
+        $string= (string)$string;
+
+        if (Str::contains($string, $name)) {
+            $swap = self::$globalReplacement[$name];
+            $string = str_replace($name, $swap, $string);
+            unset(self::$regions[$name]);
+            unset(self::$replacements[$name]);
+
+            if (array_key_exists($swap, self::$regions)) {
+                $swapContent = self::$regions[$swap];
+                $string = str_replace($swap, $swapContent, $string);
+                self::$regions[$swap] = $string;
+                self::$replacements[$swap] = $string;
+                return;
+            }
+
+            self::$regions[$swap] = $string;
+            self::$replacements[$swap] = $string;
+            return;
+        }
+
+        if (array_key_exists($name, self::$replacements)) {
+            $existing = (string)self::$replacements[$name];
+            $incoming = (string)$string;
+
+            if (Str::contains($existing, $name) && Str::contains($incoming, $name)) {
+                $incoming = str_replace($name, $existing, $incoming);
+
+                self::$replacements[$name] = $incoming;
+            } else {
+                self::$replacements[$name] = $string;
+            }
+        } else {
+            self::$replacements[$name] = $string;
+        }
+    }
+
+    protected static function replaceAllNames($content)
+    {
+        $names = array_keys(self::$regions);
+
+        foreach ($names as $name) {
+            $content = str_replace($name, '', $content);
+        }
+
+        return $content;
     }
 
     public static function processReplacements($content)
     {
         if (empty(self::$regions)) {
-            return $content;
+            return self::replaceAllNames($content);
         }
 
         foreach (self::$regions as $regionName => $defaultContent) {
@@ -37,6 +101,15 @@ class LiteralReplacementManager
             }
         }
 
-        return $content;
+        foreach (self::$retargeted as $globalName => $adjusted) {
+            foreach ($adjusted as $replaced) {
+                if (Str::contains($content, $replaced)) {
+                    $replaceContent = self::$regions[$globalName];
+                    $content = str_replace($replaced, $replaceContent, $content);
+                }
+            }
+        }
+
+        return self::replaceAllNames($content);
     }
 }

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -206,6 +206,8 @@ class NodeProcessor
      */
     private $validPhpOpenTags = ['<?php'];
 
+    private $lockedData = [];
+
     public function __construct(Loader $loader, EnvironmentDetails $envDetails)
     {
         $this->loader = $loader;
@@ -219,6 +221,17 @@ class NodeProcessor
         if (ini_get('short_open_tag')) {
             $this->validPhpOpenTags[] = '<?';
         }
+    }
+
+    public function createLockData()
+    {
+        $this->lockedData = $this->data;
+    }
+
+    public function restoreLockedData()
+    {
+        $this->data = $this->lockedData;
+        $this->lockedData = [];
     }
 
     /**
@@ -1758,7 +1771,7 @@ class NodeProcessor
                                                 if ($value == $regionName) {
                                                     $resolvedValue = $interpolationResult;
                                                 } else {
-                                                    $resolvedValue = str_replace($regionName, (string) $interpolationResult, $val);
+                                                    $resolvedValue = str_replace($regionName, (string)$interpolationResult, $value);
                                                 }
 
                                                 $paramValues[$paramName] = $resolvedValue;

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1771,7 +1771,7 @@ class NodeProcessor
                                                 if ($value == $regionName) {
                                                     $resolvedValue = $interpolationResult;
                                                 } else {
-                                                    $resolvedValue = str_replace($regionName, (string)$interpolationResult, $value);
+                                                    $resolvedValue = str_replace($regionName, (string) $interpolationResult, $value);
                                                 }
 
                                                 $paramValues[$paramName] = $resolvedValue;

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1789,7 +1789,9 @@ class NodeProcessor
                                     }
 
                                     if ($this->isLoopable($val) && ! empty($val) && ! Arr::isAssoc($val)) {
-                                        $val = $this->addLoopIterationVariables($val);
+                                        if (count($val) > 0 && !is_object($val[0])) {
+                                            $val = $this->addLoopIterationVariables($val);
+                                        }
                                     }
 
                                     $val = $this->runModifier($param->name, $paramValues, $val, $activeData);
@@ -2078,6 +2080,10 @@ class NodeProcessor
             }
 
             if ($value instanceof Values) {
+                $value = $value->toArray();
+            }
+
+            if ($value instanceof Arrayable) {
                 $value = $value->toArray();
             }
 

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -2108,7 +2108,7 @@ class NodeProcessor
         foreach ($loop as $index => &$data) {
             $data['prev'] = $prev;
 
-            if ($data['last'] == false) {
+            if ($data['last'] == false && array_key_exists($index + 1, $loop)) {
                 $data['next'] = $loop[$index + 1];
             } else {
                 $data['next'] = null;

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1789,7 +1789,7 @@ class NodeProcessor
                                     }
 
                                     if ($this->isLoopable($val) && ! empty($val) && ! Arr::isAssoc($val)) {
-                                        if (count($val) > 0 && !is_object($val[0])) {
+                                        if (count($val) > 0 && ! is_object($val[0])) {
                                             $val = $this->addLoopIterationVariables($val);
                                         }
                                     }

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1337,7 +1337,7 @@ class NodeProcessor
                             GlobalRuntimeState::$yieldCount += 1;
                             // Wrap it in a partial thing.
                             $wrapName = 'section:'.$tagMethod.'__yield'.GlobalRuntimeState::$yieldCount;
-                            $bufferOverride = LiteralReplacementManager::registerRegion($wrapName, $output);
+                            $bufferOverride = LiteralReplacementManager::registerRegion($wrapName, $tagMethod, $output);
 
                             if (! array_key_exists(GlobalRuntimeState::$environmentId, GlobalRuntimeState::$yieldStacks)) {
                                 GlobalRuntimeState::$yieldStacks[GlobalRuntimeState::$environmentId] = [];
@@ -1378,6 +1378,7 @@ class NodeProcessor
 
                             LiteralReplacementManager::registerRegionReplacement(
                                 $sectionName,
+                                $tagMethod,
                                 $this->cascade->sections()->get($tagMethod)
                             );
 

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -495,6 +495,10 @@ class NodeProcessor
             }
         }
 
+        if ($node->name->name == 'assets' && $node->name->methodPart == 'assets') {
+            return true;
+        }
+
         $activeData = $this->getActiveData();
 
         // The third argument "true" disables the data managers value interception mechanism.

--- a/src/View/Antlers/Language/Runtime/PathDataManager.php
+++ b/src/View/Antlers/Language/Runtime/PathDataManager.php
@@ -144,12 +144,16 @@ class PathDataManager
 
     private function lockData()
     {
-        if ($this->nodeProcessor != null) { $this->nodeProcessor->createLockData(); }
+        if ($this->nodeProcessor != null) {
+            $this->nodeProcessor->createLockData();
+        }
     }
 
     private function unlockData()
     {
-        if ($this->nodeProcessor != null) { $this->nodeProcessor->restoreLockedData(); }
+        if ($this->nodeProcessor != null) {
+            $this->nodeProcessor->restoreLockedData();
+        }
     }
 
     /**

--- a/src/View/Antlers/Language/Runtime/PathDataManager.php
+++ b/src/View/Antlers/Language/Runtime/PathDataManager.php
@@ -396,7 +396,11 @@ class PathDataManager
 
                 $this->reducedVar = $interceptResult;
             } else {
-                throw new RuntimeException('Not enough context to resolve: '.$pathItem->name);
+                $this->reducedVar = $builderCheckValue->get();
+
+                if ($this->reducedVar instanceof Collection) {
+                    $this->reducedVar = $this->reducedVar->all();
+                }
             }
         }
     }

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -504,7 +504,13 @@ class RuntimeParser implements Parser
 
         $newMessage = $typeText.$antlersException->getMessage().' '.LineRetriever::getErrorLineAndCharText($antlersException->node);
 
-        $ignitionException = new ViewException($newMessage, 0, 1, $this->view, $antlersException->node->startPosition->line, null);
+        $exceptionLine = 1;
+
+        if ($antlersException->node->startPosition != nulL) {
+            $exceptionLine = $antlersException->node->startPosition->line;
+        }
+
+        $ignitionException = new ViewException($newMessage, 0, 1, $this->view, $exceptionLine, null);
         $traceProperty = new ReflectionProperty('Exception', 'trace');
         $traceProperty->setAccessible(true);
         $traceProperty->setValue($ignitionException, $rebuiltTrace);

--- a/tests/Antlers/Parser/NodeParametersTest.php
+++ b/tests/Antlers/Parser/NodeParametersTest.php
@@ -88,7 +88,7 @@ EOT;
             'param||four',
             '',
             '',
-            'final'
+            'final',
         ], $parameters);
     }
 

--- a/tests/Antlers/Parser/NodeParametersTest.php
+++ b/tests/Antlers/Parser/NodeParametersTest.php
@@ -64,13 +64,32 @@ EOT;
     public function test_node_parameter_paired_behavior()
     {
         /** @var AntlersNode $unPairedNode */
-        $unPairedNode = $this->parseNodes('{{ date format="H:i:s" }}')[0];
+        $unPairedNode = $this->parseNodes('{{ date format="H|i|s" }}')[0];
 
         /** @var AntlersNode $pairedNode */
-        $pairedNode = $this->parseNodes('{{ date format="H:i:s" }}{{ /date }}')[0];
+        $pairedNode = $this->parseNodes('{{ date format="H|i|s" }}{{ /date }}')[0];
 
-        $this->assertCount(1, $unPairedNode->getModifierParameterValues([]));
+        $this->assertCount(3, $unPairedNode->getModifierParameterValues([]));
         $this->assertCount(3, $pairedNode->getModifierParameterValues([]));
+    }
+
+    public function test_pipe_can_be_escaped_inside_modifier_parameters()
+    {
+        /** @var AntlersNode $node */
+        $node = $this->parseNodes('{{ date format="param\|one|param_two|param_three|param\|\|four|||final" }}')[0];
+
+        $parameters = $node->getModifierParameterValues([]);
+
+        $this->assertCount(7, $parameters);
+        $this->assertSame([
+            'param|one',
+            'param_two',
+            'param_three',
+            'param||four',
+            '',
+            '',
+            'final'
+        ], $parameters);
     }
 
     public function test_parameter_details_are_parsed()

--- a/tests/Antlers/Runtime/AntlersQueryBuilderTest.php
+++ b/tests/Antlers/Runtime/AntlersQueryBuilderTest.php
@@ -5,6 +5,7 @@ namespace Tests\Antlers\Runtime;
 use Mockery;
 use Statamic\Contracts\Query\Builder;
 use Statamic\Tags\Tags;
+use Tests\Antlers\Fixtures\Addon\Tags\VarTest;
 use Tests\Antlers\ParserTestCase;
 
 class AntlersQueryBuilderTest extends ParserTestCase
@@ -83,5 +84,31 @@ EOT;
 EOT;
 
         $this->assertSame('<Foo, Baz, and Bar><source>', $this->renderString($template, $data, true));
+    }
+
+    public function test_query_builders_can_materialize_within_the_sandbox()
+    {
+        $clientData = [
+            ['title' => 'Foo'],
+            ['title' => 'Baz'],
+            ['title' => 'Bar'],
+        ];
+
+        $builder = Mockery::mock(Builder::class);
+        $builder->shouldReceive('get')->once()->andReturn(collect($clientData));
+
+        $data = [
+            'clients' => $builder
+        ];
+
+        VarTest::register();
+
+        $template = <<<'EOT'
+{{ var_test :variable="arr('clients' => clients)" }}
+EOT;
+
+        $this->renderString($template, $data, true);
+
+        $this->assertSame(['clients' => $clientData], VarTest::$var);
     }
 }

--- a/tests/Antlers/Runtime/AntlersQueryBuilderTest.php
+++ b/tests/Antlers/Runtime/AntlersQueryBuilderTest.php
@@ -98,7 +98,7 @@ EOT;
         $builder->shouldReceive('get')->once()->andReturn(collect($clientData));
 
         $data = [
-            'clients' => $builder
+            'clients' => $builder,
         ];
 
         VarTest::register();

--- a/tests/Antlers/Runtime/CoreModifiersTest.php
+++ b/tests/Antlers/Runtime/CoreModifiersTest.php
@@ -223,13 +223,13 @@ EOT;
     public function test_where()
     {
         $template = <<<'EOT'
-{{ games where="feeling:love" }}{{ title}}{{ /games }}
+{{ games where="feeling|love" }}{{ title}}{{ /games }}
 EOT;
 
         $this->assertSame('DominionNetrunner', $this->result($template));
 
         $template = <<<'EOT'
-{{ games where="{"feeling"}:{"love"}" }}{{ title}}{{ /games }}
+{{ games where="{"feeling"}|{"love"}" }}{{ title}}{{ /games }}
 EOT;
 
         $this->assertSame('DominionNetrunner', $this->result($template));
@@ -249,7 +249,7 @@ EOT;
     {
         $this->assertSame('AltruisticAlphaBlatheringBravoZealousZebra', $this->result('{{ complex sort="last_name" }}{{ first_name }}{{ last_name }}{{ /complex }}'));
 
-        $this->assertSame('ZealousZebraBlatheringBravoAltruisticAlpha', $this->result('{{ complex sort="last_name:desc" }}{{ first_name }}{{ last_name }}{{ /complex }}'));
+        $this->assertSame('ZealousZebraBlatheringBravoAltruisticAlpha', $this->result('{{ complex sort="last_name|desc" }}{{ first_name }}{{ last_name }}{{ /complex }}'));
     }
 
     public function test_repeat()

--- a/tests/Antlers/Runtime/CoreModifiersTest.php
+++ b/tests/Antlers/Runtime/CoreModifiersTest.php
@@ -504,7 +504,6 @@ EOT;
 <The Second Title><16>
 EOT;
 
-
         $this->assertSame($expected, trim($this->renderString($template, [
             'entries' => [
                 $entryOne, $entryTwo,
@@ -524,7 +523,7 @@ class SimpleEntryObject implements Arrayable
         return [
             'title' => $this->title,
             'date' => $this->date,
-            'title_length' => strlen($this->title)
+            'title_length' => strlen($this->title),
         ];
     }
 

--- a/tests/Antlers/Runtime/CoreModifiersTest.php
+++ b/tests/Antlers/Runtime/CoreModifiersTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Antlers\Runtime;
 
+use Carbon\Carbon;
+use Illuminate\Contracts\Support\Arrayable;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Value;
 use Tests\Antlers\ParserTestCase;
@@ -468,5 +470,66 @@ EOT;
                 'string' => 'testing explode modifiers',
             ], true)
         );
+    }
+
+    public function test_runtime_maintains_arrays_of_objects()
+    {
+        $entryOne = new SimpleEntryObject();
+        $entryOne->date = Carbon::parse('October 1st, 2012');
+        $entryOne->title = 'Title One';
+
+        $entryTwo = new SimpleEntryObject();
+        $entryTwo->date = Carbon::parse('November 1st, 2012');
+        $entryTwo->title = 'The Second Title';
+
+        $template = <<<'EOT'
+{{ entries group_by="date|M" }}
+{{ groups scope="month" }}
+<{{ month:group }}>
+{{ items }}
+<{{ title }}><{{ title_length }}>
+{{ /items }}
+{{ /groups }}
+{{ /entries }}
+EOT;
+
+        $expected = <<<'EOT'
+<Oct>
+
+<Title One><9>
+
+
+<Nov>
+
+<The Second Title><16>
+EOT;
+
+
+        $this->assertSame($expected, trim($this->renderString($template, [
+            'entries' => [
+                $entryOne, $entryTwo,
+            ],
+        ], true)));
+    }
+}
+
+class SimpleEntryObject implements Arrayable
+{
+    public $title = '';
+
+    public $date = null;
+
+    public function toAugmentedArray()
+    {
+        return [
+            'title' => $this->title,
+            'date' => $this->date,
+            'title_length' => strlen($this->title)
+        ];
+    }
+
+    public function toArray()
+    {
+        return $this->toAugmentedArray();
     }
 }

--- a/tests/Antlers/Runtime/InterpolationTest.php
+++ b/tests/Antlers/Runtime/InterpolationTest.php
@@ -26,7 +26,7 @@ EOT;
 
         $data = [
             'entry' => $entry,
-            'condition' => true
+            'condition' => true,
         ];
 
         $this->assertSame('<The Title>', trim(($this->renderString($template, $data, true))));

--- a/tests/Antlers/Runtime/InterpolationTest.php
+++ b/tests/Antlers/Runtime/InterpolationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Antlers\Runtime;
 
+use Facades\Tests\Factories\EntryFactory;
 use Tests\Antlers\ParserTestCase;
 
 class InterpolationTest extends ParserTestCase
@@ -13,5 +14,21 @@ class InterpolationTest extends ParserTestCase
 EOT;
 
         $this->assertSame('<input id="email"><input id="password">', $this->renderString($template, [], true));
+    }
+
+    public function test_augmented_values_do_not_get_lost_when_inside_nested_partials()
+    {
+        $template = <<<'EOT'
+{{ partial:augment_one }}
+EOT;
+
+        $entry = EntryFactory::collection('interpolation-test')->id('interpolation-one')->slug('interpolation-one')->data(['title' => 'The Title'])->create();
+
+        $data = [
+            'entry' => $entry,
+            'condition' => true
+        ];
+
+        $this->assertSame('<The Title>', trim(($this->renderString($template, $data, true))));
     }
 }

--- a/tests/Antlers/Runtime/InterpolationTest.php
+++ b/tests/Antlers/Runtime/InterpolationTest.php
@@ -20,6 +20,8 @@ EOT;
     {
         $template = <<<'EOT'
 {{ partial:augment_one }}
+{{ entry:title }}
+{{ /partial:augment_one }}
 EOT;
 
         $entry = EntryFactory::collection('interpolation-test')->id('interpolation-one')->slug('interpolation-one')->data(['title' => 'The Title'])->create();

--- a/tests/Antlers/Runtime/StackedSectionsTest.php
+++ b/tests/Antlers/Runtime/StackedSectionsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Antlers\Runtime;
+
+use Tests\Antlers\ParserTestCase;
+
+class StackedSectionsTest extends ParserTestCase
+{
+
+    public function test_sections_can_be_used_like_stacks_when_nested()
+    {
+        $template = <<<'EOT'
+<docstart>
+{{ section:section_name }}
+    <one>
+{{ yield:section_name }}
+
+{{ /section:section_name }}
+
+{{ section:section_name }}
+    <two>
+    {{ yield:section_name }}
+{{ /section:section_name }}
+
+{{ section:section_name }}
+    <three>
+    {{ yield:section_name }}
+{{ /section:section_name }}
+
+<before>
+{{ yield:section_name }}
+<after>
+<docend>
+EOT;
+
+        // The inverted order (three, two, one) was intentional to match the existing behavior.
+        $expected = <<<'EOT'
+<docstart>
+
+
+
+
+
+
+<before>
+
+    <three>
+    
+    <two>
+    
+    <one>
+
+
+
+
+
+<after>
+<docend>
+EOT;
+
+        $this->assertSame($expected, $this->renderString($template, [], true));
+    }
+}

--- a/tests/Antlers/Runtime/TemplateTest.php
+++ b/tests/Antlers/Runtime/TemplateTest.php
@@ -19,4 +19,45 @@ class TemplateTest extends ParserTestCase
         $input = 'Hey, look at that @{{ noun }}!';
         $this->assertSame('Hey, look at that {{ noun }}!', $this->renderString($input, []));
     }
+
+    /** @test */
+    public function it_applies_modifier_on_different_array_syntax()
+    {
+        $vars = [
+            'key' => 'entries',
+            'source' => [
+                'entries' => [
+                    ['id' => 0],
+                    ['id' => 1],
+                    ['id' => 2],
+                    ['id' => 3],
+                ],
+            ],
+        ];
+
+        $this->assertEquals(
+            '[0][1][2][3]',
+            $this->renderString('{{ source.entries }}[{{ id }}]{{ /source.entries }}', $vars)
+        );
+
+        $this->assertEquals(
+            '[0][1][2][3]',
+            $this->renderString('{{ source[key] }}[{{ id }}]{{ /source[key] }}', $vars)
+        );
+
+        $this->assertEquals(
+            '[0][1][2][3]',
+            $this->renderString('{{ source.entries sort="id" }}[{{ id }}]{{ /source.entries }}', $vars)
+        );
+
+        $this->assertEquals(
+            '[0][1][2][3]',
+            $this->renderString('{{ source[key] sort="id" }}[{{ id }}]{{ /source[key] }}', $vars)
+        );
+
+        $this->assertEquals(
+            '[3][2][1][0]',
+            $this->renderString('{{ source[key] sort="id|desc" }}[{{ id }}]{{ /source[key] }}', $vars)
+        );
+    }
 }

--- a/tests/Modifiers/GroupByTest.php
+++ b/tests/Modifiers/GroupByTest.php
@@ -204,7 +204,7 @@ class GroupByTest extends TestCase
             ]),
         ]);
 
-        $this->assertEquals($expected, $this->modify($items, 'when|a'));
+        $this->assertEquals($expected, $this->modify($items, ['when', 'a']));
     }
 
     /** @test */
@@ -248,7 +248,7 @@ class GroupByTest extends TestCase
             ]),
         ]);
 
-        $this->assertEquals($expected, $this->modify($items, 'when|a|F A'));
+        $this->assertEquals($expected, $this->modify($items, ['when', 'a', 'F A']));
     }
 
     public function modify($items, $value)

--- a/tests/__fixtures__/views/augment_one.antlers.html
+++ b/tests/__fixtures__/views/augment_one.antlers.html
@@ -1,0 +1,1 @@
+{{ partial:augment_two }}

--- a/tests/__fixtures__/views/augment_one.antlers.html
+++ b/tests/__fixtures__/views/augment_one.antlers.html
@@ -1,1 +1,3 @@
 {{ partial:augment_two }}
+    {{ slot }}
+{{ /partial:augment_two }}

--- a/tests/__fixtures__/views/augment_three.antlers.html
+++ b/tests/__fixtures__/views/augment_three.antlers.html
@@ -1,0 +1,3 @@
+{{ if condition == true }}
+<{{ entry:title }}>
+{{ /if }}

--- a/tests/__fixtures__/views/augment_three.antlers.html
+++ b/tests/__fixtures__/views/augment_three.antlers.html
@@ -1,3 +1,3 @@
 {{ if condition == true }}
-<{{ entry:title }}>
+{{ slot }}
 {{ /if }}

--- a/tests/__fixtures__/views/augment_two.antlers.html
+++ b/tests/__fixtures__/views/augment_two.antlers.html
@@ -1,0 +1,1 @@
+{{ partial:augment_three }}

--- a/tests/__fixtures__/views/augment_two.antlers.html
+++ b/tests/__fixtures__/views/augment_two.antlers.html
@@ -1,1 +1,3 @@
 {{ partial:augment_three }}
+    <{{ slot }}>
+{{ /partial:augment_three }}


### PR DESCRIPTION
This PR resolves/makes improvements to a few Antlers Runtime (and related) items:

* Closes #5463 - Adds support for yielding the same section within a section, and mimics the current behavior of this
* The `Assets` tag will now resolve Builder instances (affected both Regex and Runtime)
* Adds sanity checks when producing error messages to ensure that nodes lacking their start line information do not trigger their own exceptions (mainly from virtualized/constructed nodes)
* Ensures shorthand modifier syntax stops parsing when it encounters symbolic operators
* Ensures arrays of objects can be supplied to modifiers
* Makes modifier parameter delimiters consistent when using array/tag parameter style for both tag pairs and non tag pairs (the delimiter is now `|` on both cases)
* Provides a way to escape the `|` when providing multiple parameters to modifiers using array/tag parameter style
* Resolves Builder instances when treated as a variable inside existing Antlers contexts (dynamic variable binding, etc.)
* Closes #5492 by ensuring the data manager resolves augmented values if there are still parts of the variable left

## Array/Tag Parameter Style Delimiter Changes

Tag pairs and non-tag pairs will both now require the `|` character to separate parameters:

```
{{ array_var modifier="param1|param2" }}

{{ /array_var }}
```

Non tag-pairs will now require this as well:

```
{{ date_var modifier="param1|param2" }}
```

Developers may now escape the `|` character inside parameters:

```
{{ string_var ensure_right="\|" }}
```