### PR TITLE
Set header on live preview request so drafts are viewable

### DIFF
--- a/src/Tokens/Handlers/LivePreview.php
+++ b/src/Tokens/Handlers/LivePreview.php
@@ -14,6 +14,8 @@ class LivePreview
 
         $item->repository()->substitute($item);
 
+        $request->headers->set('X-Statamic-Live-Preview', true);
+
         $response = $next($request);
 
         $response->headers->set('X-Statamic-Live-Preview', true);

--- a/tests/Tokens/Handlers/LivePreviewTest.php
+++ b/tests/Tokens/Handlers/LivePreviewTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Tokens\Handlers;
+
+use Facades\Statamic\CP\LivePreview as CPLivePreview;
+use Facades\Tests\Factories\EntryFactory;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Mockery;
+use Statamic\Contracts\Tokens\Token;
+use Statamic\Tokens\Handlers\LivePreview;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class LivePreviewTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    /** @test */
+    public function it_sets_headers_on_request_and_response()
+    {
+        $token = Mockery::mock(Token::class);
+
+        CPLivePreview::shouldReceive('item')
+            ->with($token)
+            ->andReturn(EntryFactory::collection('test')->create());
+
+        $response = new Response;
+
+        $return = (new LivePreview)->handle(
+            $token,
+            $request = new Request,
+            fn () => $response
+        );
+
+        $this->assertSame($response, $return);
+        $this->assertTrue($request->headers->has('X-Statamic-Live-Preview'));
+        $this->assertTrue($response->headers->has('X-Statamic-Live-Preview'));
+    }
+}


### PR DESCRIPTION
Fixes #5484

If this header is in the request, drafts will load. The logic and tests were already there, but during #5109 the header on the request dropped off. This PR brings it back and tests that the handlers adds it.