### PR TITLE
Slug languages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "symfony/yaml": "^4.1 || ^5.1",
         "ueberdosis/html-to-prosemirror": "^1.3",
         "ueberdosis/prosemirror-to-html": "^2.6",
+        "voku/portable-ascii": "^1.2.3",
         "wilderborn/partyline": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/yaml": "^4.1 || ^5.1",
         "ueberdosis/html-to-prosemirror": "^1.3",
         "ueberdosis/prosemirror-to-html": "^2.6",
-        "voku/portable-ascii": "^1.2.3",
+        "voku/portable-ascii": "^1.6.1 || ^2.0",
         "wilderborn/partyline": "^1.0"
     },
     "require-dev": {

--- a/resources/js/components/Slugify.vue
+++ b/resources/js/components/Slugify.vue
@@ -9,6 +9,7 @@ export default {
     props: {
         from: String,
         to: String,
+        language: String,
         separator: {
             type: String,
             default: '-'
@@ -30,7 +31,7 @@ export default {
         slug() {
             if (!this.shouldSlugify) return this.to;
             if (!this.from) return '';
-            return this.$slugify(this.from, this.separator);
+            return this.$slugify(this.from, this.separator, this.language);
         }
 
     },

--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -5,6 +5,7 @@
         :enabled="generate"
         :from="source"
         :separator="separator"
+        :language="language"
         v-model="slug"
     >
         <text-fieldtype
@@ -60,6 +61,11 @@ export default {
             const field = this.config.from || 'title';
 
             return this.$store.state.publish[this.store].values[field];
+        },
+
+        language() {
+            const targetSite = this.$store.state.publish[this.store].site;
+            return Statamic.$config.get('sites').find(site => site.handle === targetSite).lang;
         }
 
     },

--- a/resources/js/plugins/slugify.js
+++ b/resources/js/plugins/slugify.js
@@ -2,11 +2,14 @@ var getSlug = require('speakingurl');
 
 export default {
     install(Vue, options) {
-        Vue.prototype.$slugify = function(text, glue) {
-            return getSlug(text, {
-                separator: glue || '-',
-                lang: Statamic.$config.get('locale')
-            });
+        Vue.prototype.$slugify = function(text, glue, lang) {
+            const selectedSite = Statamic.$config.get('selectedSite');
+            const sites = Statamic.$config.get('sites');
+            const site = sites.find(site => site.handle === selectedSite);
+            lang = lang ?? site?.lang ?? Statamic.$config.get('lang');
+            const custom = Statamic.$config.get(`charmap.${lang}`) ?? undefined;
+
+            return getSlug(text, { separator: glue || '-', lang, custom });
         };
     }
 };

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -10,6 +10,7 @@ use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Statamic;
 use Statamic\Support\Str;
+use voku\helper\ASCII;
 
 class JavascriptComposer
 {
@@ -46,6 +47,7 @@ class JavascriptComposer
             'locale' => config('app.locale'),
             'permissions' => $this->permissions($user),
             'hasLicenseBanner' => $licenses->invalid() || $licenses->requestFailed(),
+            'charmap' => ASCII::charsArray(),
         ]);
     }
 
@@ -55,6 +57,7 @@ class JavascriptComposer
             return [
                 'name' => $site->name(),
                 'handle' => $site->handle(),
+                'lang' => $site->lang(),
             ];
         })->values();
     }

--- a/src/Routing/Routable.php
+++ b/src/Routing/Routable.php
@@ -26,7 +26,9 @@ trait Routable
                 return null;
             }
 
-            return Str::slug($slug);
+            $lang = method_exists($this, 'site') ? $this->site()->lang() : null;
+
+            return Str::slug($slug, '-', $lang);
         })->args(func_get_args());
     }
 

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -76,7 +76,7 @@ class EntryTest extends TestCase
     {
         Facades\Site::setConfig(['default' => 'en', 'sites' => [
             'en' => ['locale' => 'en_US', 'url' => '/'],
-            'da' => ['locale' => 'da_DA', 'url' => '/da/'],
+            'da' => ['locale' => 'da_DK', 'url' => '/da/'],
         ]]);
 
         $entry = new Entry;

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -74,9 +74,17 @@ class EntryTest extends TestCase
     /** @test */
     public function the_slug_gets_slugified()
     {
+        Facades\Site::setConfig(['default' => 'en', 'sites' => [
+            'en' => ['locale' => 'en_US', 'url' => '/'],
+            'da' => ['locale' => 'da_DA', 'url' => '/da/'],
+        ]]);
+
         $entry = new Entry;
-        $entry->slug('foo bar');
-        $this->assertEquals('foo-bar', $entry->slug());
+        $entry->slug('foo bar æøå');
+        $this->assertEquals('foo-bar-aeoa', $entry->slug());
+
+        $entry->locale('da');
+        $this->assertEquals('foo-bar-aeoeaa', $entry->slug()); // danish replaces æøå with aeoeaa
     }
 
     /** @test */

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -259,9 +259,9 @@ class EntryTest extends TestCase
         config(['statamic.amp.enabled' => true]);
 
         Facades\Site::setConfig(['default' => 'en', 'sites' => [
-            'en' => ['url' => 'http://domain.com/'],
-            'fr' => ['url' => 'http://domain.com/fr/'],
-            'de' => ['url' => 'http://domain.de/'],
+            'en' => ['url' => 'http://domain.com/', 'locale' => 'en_US'],
+            'fr' => ['url' => 'http://domain.com/fr/', 'locale' => 'fr_FR'],
+            'de' => ['url' => 'http://domain.de/', 'locale' => 'de_DE'],
         ]]);
 
         $collection = (new Collection)->sites(['en', 'fr', 'de'])->handle('blog')->ampable(true)->routes([
@@ -506,7 +506,7 @@ class EntryTest extends TestCase
     public function it_gets_the_path_and_excludes_locale_when_theres_a_single_site()
     {
         Facades\Site::setConfig(['default' => 'en', 'sites' => [
-            'en' => ['url' => '/'],
+            'en' => ['url' => '/', 'locale' => 'en_US'],
         ]]);
 
         $collection = tap(Facades\Collection::make('blog'))->save();
@@ -520,8 +520,8 @@ class EntryTest extends TestCase
     public function it_gets_the_path_and_includes_locale_when_theres_multiple_sites()
     {
         Facades\Site::setConfig(['default' => 'en', 'sites' => [
-            'en' => ['url' => '/'],
-            'fr' => ['url' => '/'],
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/', 'locale' => 'fr_FR'],
         ]]);
 
         $collection = tap(Facades\Collection::make('blog'))->save();

--- a/tests/Routing/UrlBuilderTest.php
+++ b/tests/Routing/UrlBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Routing;
 
 use Statamic\Contracts\Routing\UrlBuilder;
+use Statamic\Facades\Site;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -23,6 +24,11 @@ class UrlBuilderTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        Site::setConfig(['sites' => [
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR'],
+        ]]);
 
         $entry = \Statamic\Facades\Entry::make()
             ->id('post')

--- a/tests/Tags/ParentTest.php
+++ b/tests/Tags/ParentTest.php
@@ -18,8 +18,8 @@ class ParentTest extends TestCase
         parent::setUp();
 
         Site::setConfig(['sites' => [
-            'en' => ['url' => '/'],
-            'fr' => ['url' => '/fr'],
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR'],
         ]]);
     }
 

--- a/tests/Validation/UniqueEntryValueTest.php
+++ b/tests/Validation/UniqueEntryValueTest.php
@@ -63,8 +63,8 @@ class UniqueEntryValueTest extends TestCase
     public function it_passes_when_theres_a_duplicate_entry_value_in_a_different_site()
     {
         \Statamic\Facades\Site::setConfig(['sites' => [
-            'site-one' => ['url' => '/'],
-            'site-two' => ['url' => '/'],
+            'site-one' => ['url' => '/', 'locale' => 'en_US'],
+            'site-two' => ['url' => '/', 'locale' => 'fr_FR'],
         ]]);
 
         EntryFactory::id(123)->slug('foo')->collection('collection-one')->locale('site-one')->create();


### PR DESCRIPTION
Replaces #5291
Fixes #2631

- The `$slugify` plugin accepts a `lang`, and will fall back to the selected site, and then the default site.
- The `<slugify>` component can accept a `language` prop.
- The `<slug>` fieldtype gets the language of the entry being edited from the store.
- The Entry's `slug()` method will use its sites locale.
- Update tests now to include locales now that the slug method looks for the site.
