### PR TITLE
Default 'Asset Container' setting on Asset fields if there's only a single asset container 

### DIFF
--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -39,6 +39,7 @@ class Assets extends Fieldtype
                 'max_items' => 1,
                 'mode' => 'select',
                 'width' => 50,
+                'default' => AssetContainer::all()->count() == 1 ? AssetContainer::all()->first()->handle() : null,
             ],
             'folder' => [
                 'display' => __('Folder'),


### PR DESCRIPTION
Not related to an issue but I noticed it can sometimes be a little bit annoying to need to select an Asset container every time you need to add another Assets field.

If you forget to do so, you'll get an error when creating/editing entries (or whatever the blueprint is for).