### PR TITLE
Support colon syntax in where modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2630,6 +2630,10 @@ class CoreModifiers extends Modifier
         $key = Arr::get($params, 0);
         $val = Arr::get($params, 1);
 
+        if (! $val && Str::contains($key, ':')) {
+            [$key, $val] = explode(':', $key);
+        }
+
         $collection = collect($value)->where($key, $val);
 
         return $collection->values()->all();

--- a/tests/Modifiers/WhereTest.php
+++ b/tests/Modifiers/WhereTest.php
@@ -23,6 +23,22 @@ class WhereTest extends TestCase
         $this->assertEquals($expected, array_pluck($modified, 'title'));
     }
 
+    /** @test */
+    public function it_has_a_workaround_for_colon_syntax()
+    {
+        // Before the runtime parser fixed the argument inconsistency, many
+        // people probably used the colon syntax. We'll just keep it working.
+
+        $games = [
+            ['feeling' => 'love', 'title' => 'Dominion'],
+            ['feeling' => 'love', 'title' => 'Netrunner'],
+            ['feeling' => 'hate', 'title' => 'Chutes and Ladders'],
+        ];
+        $expected = ['Dominion', 'Netrunner'];
+        $modified = $this->modify($games, ['feeling:love']);
+        $this->assertEquals($expected, array_pluck($modified, 'title'));
+    }
+
     private function modify($value, array $params)
     {
         return Modify::value($value)->where($params)->fetch();


### PR DESCRIPTION
Since #5477 "fixes" the inconsistency with how modifier parameters work (#3614), I'm sure plenty of people using the `where` modifier as documented will run into an issue.

This PR lets the `where` modifier continue to work if you use the colon syntax:

```
{{ myarray where="foo:bar" }}
  ...
{{ /myarray }}
```

Technically that's a single argument of `"foo:bar"` which we'll just split.
If you do it the "right" way (`where="foo|bar"`) it'll be considered two arguments (`"foo"` and `"bar"`) and work fine too.

Tip: you can use the new modifier syntax to avoid all the confusion entirely:

```
{{ myarray | where('foo', 'bar') }}
  ...
{{ /myarray }}
```