### PR TITLE
Support Flysystem 3 with Glide

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,13 +19,13 @@ jobs:
         os: [ubuntu-latest]
         include:
           - laravel: 8.*
-            framework: ^8.24.0
+            framework: ^8.48.0
           - laravel: 9.*
             framework: ^9.0
           - os: windows-latest
             php: 8.0
             laravel: 8.*
-            framework: ^8.24.0
+            framework: ^8.48.0
             stability: prefer-stable
         exclude:
           - laravel: 9.*

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "facade/ignition-contracts": "^1.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "james-heinrich/getid3": "^1.9.21",
-        "laravel/framework": "^8.24.0 || ^9.0",
+        "laravel/framework": "^8.48.0 || ^9.0",
         "laravel/helpers": "^1.1",
         "league/commonmark": "^1.5 || ^2.2",
         "league/csv": "^9.0",

--- a/src/Imaging/GuzzleAdapterV1.php
+++ b/src/Imaging/GuzzleAdapterV1.php
@@ -1,0 +1,361 @@
+<?php
+
+namespace Statamic\Imaging;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Uri;
+use League\Flysystem\AdapterInterface;
+use League\Flysystem\Config;
+use League\Flysystem\Util\MimeType;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Uses Guzzle as a backend for HTTP URLs.
+ *
+ * This is for Flysystem v1.
+ */
+class GuzzleAdapterV1 implements AdapterInterface
+{
+    /**
+     * Whether this endpoint supports head requests.
+     *
+     * @var bool
+     */
+    protected $supportsHead = true;
+
+    /**
+     * The base URL.
+     *
+     * @var string
+     */
+    protected $base;
+
+    /**
+     * The Guzzle HTTP client.
+     *
+     * @var \GuzzleHttp\ClientInterface
+     */
+    protected $client;
+
+    /**
+     * The visibility of this adapter.
+     *
+     * @var string
+     */
+    protected $visibility = AdapterInterface::VISIBILITY_PUBLIC;
+
+    /**
+     * Constructs a GuzzleAdapter object.
+     *
+     * @param  string  $base  The base URL.
+     * @param  \GuzzleHttp\ClientInterface  $client  An optional Guzzle client.
+     * @param  bool  $supportsHead  Whether the client supports HEAD requests.
+     */
+    public function __construct($base, ClientInterface $client = null, $supportsHead = true)
+    {
+        $this->base = rtrim($base, '/').'/';
+        $this->client = $client ?: new Client();
+        $this->supportsHead = $supportsHead;
+
+        if (isset(parse_url($base)['user'])) {
+            $this->visibility = AdapterInterface::VISIBILITY_PRIVATE;
+        }
+    }
+
+    /**
+     * Returns the base URL.
+     *
+     * @return string The base URL.
+     */
+    public function getBaseUrl()
+    {
+        return $this->base;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function copy($path, $newpath)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createDir($path, Config $config)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($path)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteDir($path)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadata($path)
+    {
+        if (! $response = $this->head($path)) {
+            return false;
+        }
+
+        return [
+            'type' => 'file',
+            'path' => $path,
+        ] + $this->getResponseMetadata($path, $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMimetype($path)
+    {
+        return $this->getMetadata($path);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSize($path)
+    {
+        return $this->getMetadata($path);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTimestamp($path)
+    {
+        return $this->getMetadata($path);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVisibility($path)
+    {
+        return [
+            'path' => $path,
+            'visibility' => $this->visibility,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($path)
+    {
+        return (bool) $this->head($path);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function listContents($directory = '', $recursive = false)
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($path)
+    {
+        if (! $response = $this->get($path)) {
+            return false;
+        }
+
+        return [
+            'path' => $path,
+            'contents' => (string) $response->getBody(),
+        ] + $this->getResponseMetadata($path, $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function readStream($path)
+    {
+        if (! $response = $this->get($path)) {
+            return false;
+        }
+
+        return [
+            'path' => $path,
+            'stream' => $response->getBody()->detach(),
+        ] + $this->getResponseMetadata($path, $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rename($path, $newpath)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setVisibility($path, $visibility)
+    {
+        throw new \LogicException('GuzzleAdapter does not support visibility. Path: '.$path.', visibility: '.$visibility);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update($path, $contents, Config $conf)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateStream($path, $resource, Config $config)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($path, $contents, Config $config)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writeStream($path, $resource, Config $config)
+    {
+        return false;
+    }
+
+    /**
+     * Performs a GET request.
+     *
+     * @param  string  $path  The path to GET.
+     * @return \GuzzleHttp\Psr7\Response|false The response or false if failed.
+     */
+    protected function get($path)
+    {
+        try {
+            $response = $this->client->get($this->base.$path);
+        } catch (BadResponseException $e) {
+            return false;
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            return false;
+        }
+
+        return $response;
+    }
+
+    /**
+     * Returns the mimetype of a response.
+     *
+     * @param  string  $path
+     * @param  \Psr\Http\Message\ResponseInterface  $response
+     * @return string
+     */
+    protected function getMimetypeFromResponse($path, ResponseInterface $response)
+    {
+        if ($mimetype = $response->getHeader('Content-Type')) {
+            [$mimetype] = explode(';', reset($mimetype), 2);
+
+            return trim($mimetype);
+        }
+
+        // Try to guess from file extension.
+        $uri = new Uri($path);
+
+        return MimeType::detectByFilename($uri->getPath());
+    }
+
+    /**
+     * Returns the metadata array for a response.
+     *
+     * @param  string  $path
+     * @param  \Psr\Http\Message\ResponseInterface  $response
+     * @return array
+     */
+    protected function getResponseMetadata($path, ResponseInterface $response)
+    {
+        $metadata = [
+            'visibility' => $this->visibility,
+            'mimetype' => $this->getMimetypeFromResponse($path, $response),
+        ];
+
+        if ($last_modified = $response->getHeader('Last-Modified')) {
+            $last_modified = strtotime(reset($last_modified));
+
+            if ($last_modified !== false) {
+                $metadata['timestamp'] = $last_modified;
+            }
+        }
+
+        if ($length = $response->getHeader('Content-Length')) {
+            $length = reset($length);
+
+            if (is_numeric($length)) {
+                $metadata['size'] = (int) $length;
+            }
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * Performs a HEAD request.
+     *
+     * @param  string  $path  The path to HEAD.
+     * @return \GuzzleHttp\Psr7\Response|false The response or false if failed.
+     */
+    protected function head($path)
+    {
+        if (! $this->supportsHead) {
+            return $this->get($path);
+        }
+
+        try {
+            $response = $this->client->head($this->base.$path);
+        } catch (ClientException $e) {
+            if ($e->getResponse()->getStatusCode() === 405) {
+                $this->supportsHead = false;
+
+                return $this->get($path);
+            }
+
+            return false;
+        } catch (BadResponseException $e) {
+            return false;
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            return false;
+        }
+
+        return $response;
+    }
+}

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -192,7 +192,9 @@ class ImageGenerator
             $mime = $this->asset->mimeType();
         } else {
             $path = public_path($this->path);
-            throw_unless(File::exists($path), new FlysystemFileNotFoundException($path));
+            if (! File::exists($path)) {
+                throw new FlysystemFileNotFoundException($path);
+            }
             $mime = File::mimeType($path);
         }
 

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -89,7 +89,7 @@ class ImageGenerator
         $guzzleClient = app('statamic.imaging.guzzle');
 
         $adapter = $this->isUsingFlysystemOne()
-            ? new GuzzleAdapterV1($base, $guzzleClient)
+            ? new LegacyGuzzleAdapter($base, $guzzleClient)
             : new GuzzleAdapter($base, $guzzleClient);
 
         $filesystem = new Filesystem($adapter);

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Imaging;
 
-use GuzzleHttp\Client;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\FileNotFoundException as FlysystemFileNotFoundException;
 use League\Flysystem\Filesystem;
@@ -85,7 +84,9 @@ class ImageGenerator
 
         $base = $parsed['scheme'].'://'.$parsed['host'];
 
-        $filesystem = new Filesystem(new GuzzleAdapter($base, new Client()));
+        $guzzleClient = app('statamic.imaging.guzzle');
+
+        $filesystem = new Filesystem(new GuzzleAdapter($base, $guzzleClient));
 
         $this->server->setSource($filesystem);
         $this->server->setSourcePathPrefix('/');

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -88,7 +88,11 @@ class ImageGenerator
 
         $guzzleClient = app('statamic.imaging.guzzle');
 
-        $filesystem = new Filesystem(new GuzzleAdapter($base, $guzzleClient));
+        $adapter = $this->isUsingFlysystemOne()
+            ? new GuzzleAdapterV1($base, $guzzleClient)
+            : new GuzzleAdapter($base, $guzzleClient);
+
+        $filesystem = new Filesystem($adapter);
 
         $this->server->setSource($filesystem);
         $this->server->setSourcePathPrefix('/');
@@ -201,5 +205,10 @@ class ImageGenerator
         if ($mime !== null && strncmp($mime, 'image/', 6) !== 0) {
             throw new \Exception("Image [{$path}] does not actually appear to be an image.");
         }
+    }
+
+    private function isUsingFlysystemOne()
+    {
+        return class_exists('\League\Flysystem\Util');
     }
 }

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Imaging;
 
-use League\Flysystem\Adapter\Local;
+use Illuminate\Support\Facades\Storage;
 use League\Flysystem\FileNotFoundException as FlysystemFileNotFoundException;
 use League\Flysystem\Filesystem;
 use League\Glide\Filesystem\FileNotFoundException as GlideFileNotFoundException;
@@ -61,7 +61,9 @@ class ImageGenerator
         $this->path = $path;
         $this->params = $params;
 
-        $this->server->setSource(new Filesystem(new Local(public_path())));
+        $source = Storage::build(['driver' => 'local', 'root' => public_path()])->getDriver();
+
+        $this->server->setSource($source);
         $this->server->setSourcePathPrefix('/');
         $this->server->setCachePathPrefix('paths');
 

--- a/src/Imaging/LegacyGuzzleAdapter.php
+++ b/src/Imaging/LegacyGuzzleAdapter.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ResponseInterface;
  *
  * This is for Flysystem v1.
  */
-class GuzzleAdapterV1 implements AdapterInterface
+class LegacyGuzzleAdapter implements AdapterInterface
 {
     /**
      * Whether this endpoint supports head requests.

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -147,6 +147,10 @@ class AppServiceProvider extends ServiceProvider
         ])->each(function ($binding, $alias) {
             app()->bind('statamic.queries.'.$alias, $binding);
         });
+
+        $this->app->bind('statamic.imaging.guzzle', function () {
+            return new \GuzzleHttp\Client;
+        });
     }
 
     protected function registerMiddlewareGroup()

--- a/tests/Imaging/ImageGeneratorTest.php
+++ b/tests/Imaging/ImageGeneratorTest.php
@@ -88,7 +88,10 @@ class ImageGeneratorTest extends TestCase
         $this->assertCount(0, $this->generatedImagePaths());
 
         $this->app->bind('statamic.imaging.guzzle', function () {
-            $response = new Response(200, [], UploadedFile::fake()->image('', 30, 60)->getContent());
+            $file = UploadedFile::fake()->image('', 30, 60);
+            $contents = file_get_contents($file->getPathname());
+
+            $response = new Response(200, [], $contents);
 
             // Glide, Flysystem, or the Guzzle adapter will try to perform the requests
             // at different points to check if the file exists or to get the content

--- a/tests/Imaging/ImageGeneratorTest.php
+++ b/tests/Imaging/ImageGeneratorTest.php
@@ -55,6 +55,28 @@ class ImageGeneratorTest extends TestCase
     /** @test */
     public function it_generates_an_image_by_local_path()
     {
+        $this->assertCount(0, $this->generatedImagePaths());
+
+        // Path relative to the "public" directory.
+        $imagePath = 'testimages/foo/hoff.jpg';
+
+        $image = UploadedFile::fake()->image('', 30, 60);
+        File::put(public_path($imagePath), $image->getContent());
+
+        $path = $this->makeGenerator()->generateByPath(
+            $imagePath,
+            $userParams = ['w' => 100, 'h' => 100]
+        );
+
+        // Since we can't really mock the server, we'll generate the md5 hash the same
+        // way it does. It will not include the fit parameter since it's not an asset.
+        $md5 = $this->getGlideMd5($imagePath, $userParams);
+
+        $expectedPath = "paths/testimages/foo/hoff.jpg/{$md5}.jpg";
+
+        $this->assertEquals($expectedPath, $path);
+        $this->assertCount(1, $paths = $this->generatedImagePaths());
+        $this->assertContains($expectedPath, $paths);
     }
 
     /** @test */

--- a/tests/Imaging/ImageGeneratorTest.php
+++ b/tests/Imaging/ImageGeneratorTest.php
@@ -120,6 +120,18 @@ class ImageGeneratorTest extends TestCase
         $this->assertContains($expectedPath, $paths);
     }
 
+    /** @test */
+    public function it_validates_an_asset()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /** @test */
+    public function it_validates_an_image()
+    {
+        $this->markTestIncomplete();
+    }
+
     private function makeGenerator()
     {
         return new ImageGenerator($this->app->make(Server::class));

--- a/tests/Imaging/ImageGeneratorTest.php
+++ b/tests/Imaging/ImageGeneratorTest.php
@@ -64,7 +64,8 @@ class ImageGeneratorTest extends TestCase
         $imagePath = 'testimages/foo/hoff.jpg';
 
         $image = UploadedFile::fake()->image('', 30, 60);
-        File::put(public_path($imagePath), $image->getContent());
+        $contents = file_get_contents($image->getPathname());
+        File::put(public_path($imagePath), $contents);
 
         $path = $this->makeGenerator()->generateByPath(
             $imagePath,

--- a/tests/Imaging/ImageGeneratorTest.php
+++ b/tests/Imaging/ImageGeneratorTest.php
@@ -8,6 +8,7 @@ use League\Glide\Server;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\File;
 use Statamic\Imaging\ImageGenerator;
+use Statamic\Support\Str;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -79,7 +80,7 @@ class ImageGeneratorTest extends TestCase
     private function generatedImagePaths()
     {
         return File::getFilesRecursively($this->glideCachePath())
-            ->map(fn ($path) => (string) str($path)->after($this->glideCachePath().'/'))
+            ->map(fn ($path) => (string) Str::of($path)->after($this->glideCachePath().'/'))
             ->all();
     }
 


### PR DESCRIPTION
Fixes #5358

When using Glide to point to a non-asset there would be errors because there was still Flysystem v1 specific code.

A non-asset meaning either:

1. a relative path to somewhere in your `public` directory
2. an external URL

For the public directory stuff, we use Laravel's on-demand disks pointing to the public directory. This pushes the Flysystem-specific code off to Laravel, which already handles both versions. This method wasn't available when we supported Laravel 6/7.

For the external url stuff I've added Flysystem v3 compatible version of the Guzzle adapter. It doesn't do everything an adapter should do, but has enough for our use case.