### PR TITLE
Glide tag pair can handle query builders

### DIFF
--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -6,6 +6,7 @@ use League\Glide\Server;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Facades\Asset;
+use Statamic\Facades\Compare;
 use Statamic\Facades\Config;
 use Statamic\Facades\Image;
 use Statamic\Facades\Path;
@@ -95,6 +96,10 @@ class Glide extends Tags
     public function generate($items = null)
     {
         $items = $items ?? $this->params->get(['src', 'id', 'path']);
+
+        if (Compare::isQueryBuilder($items)) {
+            $items = $items->get();
+        }
 
         $items = is_iterable($items) ? collect($items) : collect([$items]);
 


### PR DESCRIPTION
Fixes #5544

If you use the glide tag to loop over an assets field, it would be given a query builder now in 3.3. This PR just gets the results of the query before carrying on with the tag.
