### PR TITLE
The $request->path already has the base_path information.

### DIFF
--- a/src/Http/Controllers/CP/DuplicatesController.php
+++ b/src/Http/Controllers/CP/DuplicatesController.php
@@ -36,7 +36,7 @@ class DuplicatesController extends CpController
 
         $request->validate(['path' => 'required']);
 
-        $path = base_path().'/'.$request->path;
+        $path = $request->path;
 
         $store = $this->getStoreByPath($path);
 


### PR DESCRIPTION
I had the same issue like in this issue report https://github.com/statamic/cms/issues/4776
The $request->path already has the base_path information so I removed that from the $path variable.