### PR TITLE
Prevent usage of nulls as filesystem paths

### DIFF
--- a/src/Filesystem/AbstractAdapter.php
+++ b/src/Filesystem/AbstractAdapter.php
@@ -17,7 +17,7 @@ abstract class AbstractAdapter implements Filesystem
         }
     }
 
-    public function exists($path = null)
+    public function exists($path)
     {
         return $this->filesystem->exists($this->normalizePath($path));
     }

--- a/src/Filesystem/FilesystemAdapter.php
+++ b/src/Filesystem/FilesystemAdapter.php
@@ -3,6 +3,7 @@
 namespace Statamic\Filesystem;
 
 use Illuminate\Filesystem\Filesystem;
+use RuntimeException;
 use Statamic\Facades\Path;
 use Statamic\Support\Str;
 use Symfony\Component\Finder\Finder;
@@ -28,8 +29,8 @@ class FilesystemAdapter extends AbstractAdapter
 
     public function normalizePath($path)
     {
-        if (is_null($path)) {
-            $path = '/';
+        if (! is_string($path)) {
+            throw new RuntimeException('Path must be a string.');
         }
 
         // If given an absolute path, just tidy it (to adjust the slashes) and return it.

--- a/src/Filesystem/FlysystemAdapter.php
+++ b/src/Filesystem/FlysystemAdapter.php
@@ -3,6 +3,7 @@
 namespace Statamic\Filesystem;
 
 use Illuminate\Contracts\Filesystem\Filesystem as FilesystemAdapter;
+use RuntimeException;
 use Statamic\Facades\Path;
 use Statamic\Support\Str;
 
@@ -17,6 +18,10 @@ class FlysystemAdapter extends AbstractAdapter
 
     public function normalizePath($path)
     {
+        if (! is_string($path)) {
+            throw new RuntimeException('Path must be a string.');
+        }
+
         $path = Path::tidy($path);
 
         if ($path === '' || $path === '/' || $path === '.') {
@@ -45,10 +50,10 @@ class FlysystemAdapter extends AbstractAdapter
         return Path::tidy($path);
     }
 
-    public function exists($path = null)
+    public function exists($path)
     {
         // Flysystem wouldn't have let us get this far if the root directory didn't already exist.
-        if ($path === '/' || $path === null) {
+        if ($path === '/') {
             return true;
         }
 

--- a/tests/Filesystem/FilesystemAdapterTests.php
+++ b/tests/Filesystem/FilesystemAdapterTests.php
@@ -3,6 +3,7 @@
 namespace Tests\Filesystem;
 
 use Illuminate\Support\Collection;
+use RuntimeException;
 use Statamic\Support\FileCollection;
 
 trait FilesystemAdapterTests
@@ -37,9 +38,11 @@ trait FilesystemAdapterTests
     }
 
     /** @test */
-    public function assumes_existence_if_checking_on_the_root()
+    public function cannot_check_if_null_exists()
     {
-        $this->assertTrue($this->adapter->exists());
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Path must be a string.');
+        $this->adapter->exists(null);
     }
 
     /** @test */
@@ -62,6 +65,14 @@ trait FilesystemAdapterTests
         file_put_contents($this->tempDir.'/filename.txt', 'Hello World');
         $this->adapter->delete('filename.txt');
         $this->assertFileNotExists($this->tempDir.'/filename.txt');
+    }
+
+    /** @test */
+    public function cannot_delete_null()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Path must be a string.');
+        $this->adapter->delete(null);
     }
 
     /** @test */


### PR DESCRIPTION
Previously you could use `null` as a path to represent the root of a filesystem disk (the disk, not the entire server).
I believe the original intention was to be able to support `$disk->exists()` to determine if a disk had been created or not. But this also let you explicitly pass `null` in, which you might do unintentionally. This PR prevents nulls being passed in. You can still use `"/"` if you want to target the root.