### PR TITLE
Prevent filtering users by password hashes in the APIs

### DIFF
--- a/src/GraphQL/Queries/UsersQuery.php
+++ b/src/GraphQL/Queries/UsersQuery.php
@@ -56,6 +56,8 @@ class UsersQuery extends Query
 
     private function filterQuery($query, $filters)
     {
+        $filters = collect($filters)->reject(fn ($_, $filter) => Str::startsWith($filter, 'password'));
+
         foreach ($filters as $field => $definitions) {
             if (! is_array($definitions)) {
                 $definitions = [['equals' => $definitions]];

--- a/src/Http/Controllers/API/UsersController.php
+++ b/src/Http/Controllers/API/UsersController.php
@@ -5,6 +5,7 @@ namespace Statamic\Http\Controllers\API;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\User;
 use Statamic\Http\Resources\API\UserResource;
+use Statamic\Support\Str;
 
 class UsersController extends ApiController
 {
@@ -33,5 +34,11 @@ class UsersController extends ApiController
         throw_unless($user, new NotFoundHttpException("User [$id] not found."));
 
         return $user;
+    }
+
+    protected function getFilters()
+    {
+        return parent::getFilters()
+            ->reject(fn ($_, $filter) => Str::startsWith($filter, 'password'));
     }
 }


### PR DESCRIPTION
Prevents an opportunity to brute force a user's password hash. With request throttling (enabled by default) it would be a long process, but nevertheless, this prevents you from doing it.