### PR TITLE
Fix nav breadcrumbs in Blade

### DIFF
--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -4,7 +4,6 @@ namespace Statamic\Tags;
 
 use ArrayIterator;
 use Statamic\Support\Str;
-use Statamic\View\Antlers\Parser;
 use Traversable;
 
 class FluentTag implements \IteratorAggregate, \ArrayAccess
@@ -105,7 +104,7 @@ class FluentTag implements \IteratorAggregate, \ArrayAccess
         }
 
         $tag = app(Loader::class)->load($name, [
-            'parser'     => app(Parser::class),
+            'parser'     => null,
             'params'     => $this->params,
             'content'    => '',
             'context'    => $this->context,

--- a/src/Tags/Nav.php
+++ b/src/Tags/Nav.php
@@ -51,6 +51,10 @@ class Nav extends Structure
             return $crumb;
         });
 
+        if (! $this->parser) {
+            return $crumbs;
+        }
+
         $output = $this->parseLoop($crumbs->toAugmentedArray());
 
         if ($backspaces = $this->params->int('backspace', 0)) {

--- a/tests/Tags/FluentTagTest.php
+++ b/tests/Tags/FluentTagTest.php
@@ -47,7 +47,7 @@ class FluentTagTest extends TestCase
             ->withArgs(function ($arg1, $arg2) use ($expectedTag, $expectedTagName, $expectedTagMethod) {
                 return $arg1 === $expectedTagName
                     && is_array($arg2)
-                    && $arg2['parser'] instanceof Parser
+                    && is_null($arg2['parser'])
                     && Arr::except($arg2, 'parser') === [
                         'params' => [
                             'sort' => 'slug:desc',

--- a/tests/Tags/FluentTagTest.php
+++ b/tests/Tags/FluentTagTest.php
@@ -9,7 +9,6 @@ use Statamic\Support\Arr;
 use Statamic\Tags\FluentTag;
 use Statamic\Tags\Loader;
 use Statamic\Tags\Tags;
-use Statamic\View\Antlers\Parser;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 


### PR DESCRIPTION
Fixes #5598

This PR removes the Antlers parser from when a tag is loaded via Statamic::tag().
Then we can use the absence of a parser in tags for checking whether it's being used within Antlers or not.

Some tags do specific things like modifying the content of the tag pair in Antlers. When being used in Blade this isn't applicable, so we could return a useable array of stuff earlier.
