### PR TITLE
Allow query builder to accept current page parameter

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -517,9 +517,9 @@ abstract class Builder implements Contract
         return $this->get()->first();
     }
 
-    public function paginate($perPage = null, $columns = ['*'], $currentPage = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
-        $page = $currentPage ?: Paginator::resolveCurrentPage();
+        $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
         $perPage = $perPage ?: $this->defaultPerPageSize();
 
@@ -529,7 +529,7 @@ abstract class Builder implements Contract
 
         return $this->paginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),
-            'pageName' => 'page',
+            'pageName' => $pageName,
         ]);
     }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -517,9 +517,9 @@ abstract class Builder implements Contract
         return $this->get()->first();
     }
 
-    public function paginate($perPage = null, $columns = ['*'])
+    public function paginate($perPage = null, $columns = ['*'], $currentPage = null)
     {
-        $page = Paginator::resolveCurrentPage();
+        $page = $currentPage ?: Paginator::resolveCurrentPage();
 
         $perPage = $perPage ?: $this->defaultPerPageSize();
 


### PR DESCRIPTION
This morning I was working on a "load more posts" functionality for a client using Livewire and an Entry Query. Everything seemed to work, other than the same page being loaded over and over again.

Here is what I was using inside of my Livewire component to fetch new posts at the click of a button:

```
public function loadPosts()
{
    $posts = Entry::query()->where('collection', 'blog')->paginate(6, ['*'], $this->pageNumber);

    $this->pageNumber += 1;

    $this->hasMorePages = $posts->hasMorePages();

    $this->posts->push(...$posts->items());
}
```
The problem with this code, is that there was no was to explicitly set the page number. Because I was fetching posts using a load more button, it would always load the first page of entries that matched the criteria instead of the next page as I'd expected.

To address this issue, I added an additional parameter to query builder `paginate` function that accepts a current page number. This is much like the Laravel equivalent. The function works properly with or without the additional parameter. 

This is the first time I've ever create a pull request or attempted to contribute to a project, so feel free to let me know if I'm doing something wrong.
