### PR TITLE
Fix error when determining slug language on non-entry forms

### DIFF
--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -65,7 +65,7 @@ export default {
 
         language() {
             const targetSite = this.$store.state.publish[this.store].site;
-            return Statamic.$config.get('sites').find(site => site.handle === targetSite).lang;
+            return targetSite ? Statamic.$config.get('sites').find(site => site.handle === targetSite).lang : null;
         }
 
     },


### PR DESCRIPTION
This is #5523 which fixes #5522 again, but on the 3.2 branch.