### PR TITLE
Prevent filtering users by password hashes in the APIs

### DIFF
--- a/src/GraphQL/Queries/UsersQuery.php
+++ b/src/GraphQL/Queries/UsersQuery.php
@@ -56,7 +56,9 @@ class UsersQuery extends Query
 
     private function filterQuery($query, $filters)
     {
-        $filters = collect($filters)->reject(fn ($_, $filter) => Str::startsWith($filter, 'password'));
+        $filters = collect($filters)->reject(function ($_, $filter) {
+            return Str::startsWith($filter, 'password');
+        });
 
         foreach ($filters as $field => $definitions) {
             if (! is_array($definitions)) {

--- a/src/GraphQL/Queries/UsersQuery.php
+++ b/src/GraphQL/Queries/UsersQuery.php
@@ -56,6 +56,8 @@ class UsersQuery extends Query
 
     private function filterQuery($query, $filters)
     {
+        $filters = collect($filters)->reject(fn ($_, $filter) => Str::startsWith($filter, 'password'));
+
         foreach ($filters as $field => $definitions) {
             if (! is_array($definitions)) {
                 $definitions = [['equals' => $definitions]];

--- a/src/Http/Controllers/API/UsersController.php
+++ b/src/Http/Controllers/API/UsersController.php
@@ -38,7 +38,8 @@ class UsersController extends ApiController
 
     protected function getFilters()
     {
-        return parent::getFilters()
-            ->reject(fn ($_, $filter) => Str::startsWith($filter, 'password'));
+        return parent::getFilters()->reject(function ($_, $filter) {
+            return Str::startsWith($filter, 'password');
+        });
     }
 }

--- a/src/Http/Controllers/API/UsersController.php
+++ b/src/Http/Controllers/API/UsersController.php
@@ -5,6 +5,7 @@ namespace Statamic\Http\Controllers\API;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\User;
 use Statamic\Http\Resources\API\UserResource;
+use Statamic\Support\Str;
 
 class UsersController extends ApiController
 {
@@ -33,5 +34,11 @@ class UsersController extends ApiController
         throw_unless($user, new NotFoundHttpException("User [$id] not found."));
 
         return $user;
+    }
+
+    protected function getFilters()
+    {
+        return parent::getFilters()
+            ->reject(fn ($_, $filter) => Str::startsWith($filter, 'password'));
     }
 }

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -172,13 +172,13 @@ class APITest extends TestCase
     public function userPasswordFilterProvider()
     {
         return collect([
-              'password',
-              'password:is',
-              'password:regex',
-              'password_hash',
-              'password_hash:is',
-              'password_hash:regex',
-          ])->mapWithKeys(fn ($filter) => [$filter => [$filter]])->all();
+            'password',
+            'password:is',
+            'password:regex',
+            'password_hash',
+            'password_hash:is',
+            'password_hash:regex',
+        ])->mapWithKeys(fn ($filter) => [$filter => [$filter]])->all();
     }
 
     private function assertEndpointDataCount($endpoint, $count)

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -178,7 +178,9 @@ class APITest extends TestCase
             'password_hash',
             'password_hash:is',
             'password_hash:regex',
-        ])->mapWithKeys(fn ($filter) => [$filter => [$filter]])->all();
+        ])->mapWithKeys(function ($filter) {
+            return [$filter => [$filter]];
+        })->all();
     }
 
     private function assertEndpointDataCount($endpoint, $count)

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -3,6 +3,7 @@
 namespace Tests\API;
 
 use Statamic\Facades;
+use Statamic\Facades\User;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -145,6 +146,39 @@ class APITest extends TestCase
             ->get('/api/collections/pages/entries/dance')
             ->assertJsonPath('data.api_url', null)
             ->assertJsonPath('data.edit_url', null);
+    }
+
+    /**
+     * @test
+     * @dataProvider userPasswordFilterProvider
+     */
+    public function it_doesnt_allow_filtering_users_by_password($filter)
+    {
+        Facades\Config::set('statamic.api.resources.users', true);
+
+        User::make()->id('one')->email('one@domain.com')->passwordHash('abc')->save();
+        User::make()->id('two')->email('two@domain.com')->passwordHash('def')->save();
+
+        $this
+              ->get("/api/users?filter[{$filter}]=abc")
+              ->assertJson([
+                  'data' => [
+                      ['id' => 'one'],
+                      ['id' => 'two'], // this one would be filtered out if the password was allowed
+                  ],
+              ]);
+    }
+
+    public function userPasswordFilterProvider()
+    {
+        return collect([
+              'password',
+              'password:is',
+              'password:regex',
+              'password_hash',
+              'password_hash:is',
+              'password_hash:regex',
+          ])->mapWithKeys(fn ($filter) => [$filter => [$filter]])->all();
     }
 
     private function assertEndpointDataCount($endpoint, $count)

--- a/tests/Feature/GraphQL/UsersTest.php
+++ b/tests/Feature/GraphQL/UsersTest.php
@@ -268,7 +268,7 @@ GQL;
 
         $query = <<<GQL
   {
-      users(filter: $filter) {
+      users(filter: {$filter}) {
           data {
               id
           }
@@ -289,7 +289,7 @@ GQL;
     public function userPasswordFilters()
     {
         return [
-            'password' => ['{ password: "abc" }'],
+            'password' => ['password: "abc"'],
         ];
     }
 

--- a/tests/Feature/GraphQL/UsersTest.php
+++ b/tests/Feature/GraphQL/UsersTest.php
@@ -268,7 +268,7 @@ GQL;
 
         $query = <<<GQL
   {
-      users(filter: {$filter}) {
+      users(filter: {{$filter}}) {
           data {
               id
           }

--- a/tests/Feature/GraphQL/UsersTest.php
+++ b/tests/Feature/GraphQL/UsersTest.php
@@ -263,22 +263,10 @@ GQL;
      */
     public function it_doesnt_allow_filtering_users_by_password($filter)
     {
-        if (version_compare(PHP_VERSION, '7.3.0', '<')) {
-            $this->markTestSkipped('This test does not behave on 7.2.');
-        }
-
         User::make()->id('one')->email('one@domain.com')->passwordHash('abc')->save();
         User::make()->id('two')->email('two@domain.com')->passwordHash('def')->save();
 
-        $query = <<<GQL
- {
-     users(filter: $filter) {
-         data {
-             id
-         }
-     }
- }
- GQL;
+        $query = "{ users(filter: $filter) { data { id } } }";
 
         $this
              ->withoutExceptionHandling()

--- a/tests/Feature/GraphQL/UsersTest.php
+++ b/tests/Feature/GraphQL/UsersTest.php
@@ -289,12 +289,7 @@ GQL;
     public function userPasswordFilters()
     {
         return [
-            'password' => ['{ password: "abc" }'],
-            'password:is' => ['{ password: {is: "abc"} }'],
-            'password:regex' => ['{ password: {regex: "abc"} }'],
-            'password_hash' => ['{ password_hash: "abc" }'],
-            'password_hash:is' => ['{ password_hash: {is: "abc"} }'],
-            'password_hash:regex' => ['{ password_hash: {regex: "abc"} }'],
+            'password' => ['bla'],
         ];
     }
 

--- a/tests/Feature/GraphQL/UsersTest.php
+++ b/tests/Feature/GraphQL/UsersTest.php
@@ -293,13 +293,13 @@ GQL;
     public function userPasswordFilterProvider()
     {
         return [
-             'password' => ['{ password: "abc" }'],
-             'password:is' => ['{ password: {is: "abc"} }'],
-             'password:regex' => ['{ password: {regex: "abc"} }'],
-             'password_hash' => ['{ password_hash: "abc" }'],
-             'password_hash:is' => ['{ password_hash: {is: "abc"} }'],
-             'password_hash:regex' => ['{ password_hash: {regex: "abc"} }'],
-         ];
+            'password' => ['{ password: "abc" }'],
+            'password:is' => ['{ password: {is: "abc"} }'],
+            'password:regex' => ['{ password: {regex: "abc"} }'],
+            'password_hash' => ['{ password_hash: "abc" }'],
+            'password_hash:is' => ['{ password_hash: {is: "abc"} }'],
+            'password_hash:regex' => ['{ password_hash: {regex: "abc"} }'],
+        ];
     }
 
     /** @test */

--- a/tests/Feature/GraphQL/UsersTest.php
+++ b/tests/Feature/GraphQL/UsersTest.php
@@ -289,7 +289,7 @@ GQL;
     public function userPasswordFilters()
     {
         return [
-            'password' => ['bla'],
+            'password' => ['{ password: "abc" }'],
         ];
     }
 

--- a/tests/Feature/GraphQL/UsersTest.php
+++ b/tests/Feature/GraphQL/UsersTest.php
@@ -289,13 +289,13 @@ GQL;
     public function userPasswordFilterProvider()
     {
         return [
-              'password' => ['{ password: "abc" }'],
-              'password:is' => ['{ password: {is: "abc"} }'],
-              'password:regex' => ['{ password: {regex: "abc"} }'],
-              'password_hash' => ['{ password_hash: "abc" }'],
-              'password_hash:is' => ['{ password_hash: {is: "abc"} }'],
-              'password_hash:regex' => ['{ password_hash: {regex: "abc"} }'],
-          ];
+            'password' => ['{ password: "abc" }'],
+            'password:is' => ['{ password: {is: "abc"} }'],
+            'password:regex' => ['{ password: {regex: "abc"} }'],
+            'password_hash' => ['{ password_hash: "abc" }'],
+            'password_hash:is' => ['{ password_hash: {is: "abc"} }'],
+            'password_hash:regex' => ['{ password_hash: {regex: "abc"} }'],
+        ];
     }
 
     /** @test */

--- a/tests/Feature/GraphQL/UsersTest.php
+++ b/tests/Feature/GraphQL/UsersTest.php
@@ -259,7 +259,7 @@ GQL;
 
     /**
      * @test
-     * @dataProvider userPasswordFilterProvider
+     * @dataProvider userPasswordFilters
      */
     public function it_doesnt_allow_filtering_users_by_password($filter)
     {
@@ -286,7 +286,7 @@ GQL;
               ]]]]);
     }
 
-    public function userPasswordFilterProvider()
+    public function userPasswordFilters()
     {
         return [
             'password' => ['{ password: "abc" }'],

--- a/tests/Feature/GraphQL/UsersTest.php
+++ b/tests/Feature/GraphQL/UsersTest.php
@@ -257,6 +257,47 @@ GQL;
             ]]]]);
     }
 
+    /**
+     * @test
+     * @dataProvider userPasswordFilterProvider
+     */
+    public function it_doesnt_allow_filtering_users_by_password($filter)
+    {
+        User::make()->id('one')->email('one@domain.com')->passwordHash('abc')->save();
+        User::make()->id('two')->email('two@domain.com')->passwordHash('def')->save();
+
+        $query = <<<GQL
+  {
+      users(filter: $filter) {
+          data {
+              id
+          }
+      }
+  }
+  GQL;
+
+        $this
+              ->withoutExceptionHandling()
+              ->post('/graphql', ['query' => $query])
+              ->assertGqlOk()
+              ->assertExactJson(['data' => ['users' => ['data' => [
+                  ['id' => 'one'],
+                  ['id' => 'two'], // this one would be filtered out if the password was allowed
+              ]]]]);
+    }
+
+    public function userPasswordFilterProvider()
+    {
+        return [
+              'password' => ['{ password: "abc" }'],
+              'password:is' => ['{ password: {is: "abc"} }'],
+              'password:regex' => ['{ password: {regex: "abc"} }'],
+              'password_hash' => ['{ password_hash: "abc" }'],
+              'password_hash:is' => ['{ password_hash: {is: "abc"} }'],
+              'password_hash:regex' => ['{ password_hash: {regex: "abc"} }'],
+          ];
+    }
+
     /** @test */
     public function it_sorts_users()
     {


### PR DESCRIPTION
This is #5568 but on the 3.2 branch.
