### PR TITLE
Expand Windows testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,14 @@ jobs:
           - laravel: 9.*
             framework: ^9.0
           - os: windows-latest
-            php: 8.0
+            php: 7.4
             laravel: 8.*
             framework: ^8.48.0
+            stability: prefer-stable
+          - os: windows-latest
+            php: 8.1
+            laravel: 9.*
+            framework: ^9.0
             stability: prefer-stable
         exclude:
           - laravel: 9.*


### PR DESCRIPTION
Had a bit of trouble getting both of these to pass in migrator, and figured we could benefit from a bit more Windows testing in core as well...

- [x] PHP 7.4 w/ Laravel 8
- [x] PHP 8.1 w/ Laravel 9