### PR TITLE
Add CSRF parameter to form tag

### DIFF
--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -78,7 +78,7 @@ class Tags extends BaseTags
         }
 
         $knownParams = array_merge(static::HANDLE_PARAM, [
-            'redirect', 'error_redirect', 'allow_request_redirect', 'files', 'js',
+            'redirect', 'error_redirect', 'allow_request_redirect', 'csrf', 'files', 'js',
         ]);
 
         $action = $this->params->get('action', route('statamic.forms.submit', $formHandle));

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -35,7 +35,10 @@ trait RendersForms
         $paramAttrs = $this->renderAttributesFromParams(array_merge(['method', 'action'], $knownTagParams));
 
         $html = collect(['<form', $attrs, $paramAttrs])->filter()->implode(' ').'>';
-        $html .= csrf_field();
+
+        if ($this->params->bool('csrf', true)) {
+            $html .= csrf_field();
+        }
 
         $method = strtoupper($method);
 


### PR DESCRIPTION
This PR adds a `csrf` parameter to the form tag that defaults to `true`. When setting it to `false` the form tag won't add a hidden `_token` input field to the form. It looks like this:

```
{{ form:create :in="form:handle" csrf="false" }}
```

The reasoning for this is as follows. In Peak I used to do this to render forms that could be statically cached:

```js
// Get a token and set it.
this.$refs.form.querySelector('input[name="_token"]').value = await getToken()

// Post the form.
fetch(this.$refs.form.action, {
    headers: {
        'X-Requested-With' : 'XMLHttpRequest',
    }
```

In Peak 4 I changed it to this:
```js
// Post the form.
fetch(this.$refs.form.action, {
    headers: {
        'X-Requested-With' : 'XMLHttpRequest',
        'X-CSRF-Token' : await getToken()
    }
```
Which is well, cleaner and less yucky. Unfortunately on production with static caching on, it turned out that the actual hidden `_token` input field takes precedence over the header. That way you'd still get 419 errors.

I also prefer this is an example on how to you could handle CSRF requests in other parts of your application, like when you're fetching a custom route somewhere. 

Docs update: https://github.com/statamic/docs/pull/768