### PR TITLE
Fix is_external check for anchors

### DIFF
--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -221,7 +221,7 @@ class URL
      */
     public function isExternal($url)
     {
-        if (Str::startsWith($url, '/')) {
+        if (Str::startsWith($url, ['/', '#'])) {
             return false;
         }
 

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -58,6 +58,7 @@ class UrlTest extends TestCase
         $this->assertFalse(URL::isExternal('http://this-site.com/'));
         $this->assertFalse(URL::isExternal('http://this-site.com/some-slug'));
         $this->assertFalse(URL::isExternal('/foo'));
+        $this->assertFalse(URL::isExternal('#anchor'));
     }
 
     public function testDeterminesExternalUrlWhenUsingRelativeInConfig()
@@ -70,6 +71,7 @@ class UrlTest extends TestCase
         $this->assertFalse(URL::isExternal('http://absolute-url-resolved-from-request.com/'));
         $this->assertFalse(URL::isExternal('http://absolute-url-resolved-from-request.com/some-slug'));
         $this->assertFalse(URL::isExternal('/foo'));
+        $this->assertFalse(URL::isExternal('#anchor'));
     }
 
     /**


### PR DESCRIPTION
Fixes #5630

This PR fixes the `is_external` boolean incorrectly believing URLs starting with an anchor being external.