### PR TITLE
Antlers Runtime: Ignore Comments When Checking for Named Slots

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -952,7 +952,7 @@ class NodeProcessor
         $namedSlots = [];
 
         foreach ($node->children as $child) {
-            if ($child instanceof AntlersNode && $child->name->name == 'slot') {
+            if ($child instanceof AntlersNode && !$child->isComment && $child->name->name == 'slot') {
                 $namedSlots[$child->name->methodPart] = $child;
             }
         }

--- a/tests/Antlers/Runtime/NamedSlotsTest.php
+++ b/tests/Antlers/Runtime/NamedSlotsTest.php
@@ -72,4 +72,17 @@ EOT;
 
         $this->assertSame(StringUtilities::normalizeLineEndings($expected), $this->renderString($template, $data, true));
     }
+
+    public function test_comments_are_ignored_when_checking_for_named_slots()
+    {
+        $template = <<<'EOT'
+{{ partial src="prefixed" }}
+ {{# comment #}}
+ <{{ content }}>
+ {{# comment #}}
+{{ /partial }}
+EOT;
+
+        $this->assertSame('<The Content>', $this->renderString($template, ['content' => 'The Content',], true));
+    }
 }


### PR DESCRIPTION
This PR closes #5646 by ignoring comments when checking for named slots within a partial tag pair.

To reproduce/validate, create a template with the following content (or copy the included test to a the base branch and to receive the same error in the linked issue):

```
{{ partial src="partial/name/here" }}
 {{# comment #}}
 <{{ content }}>
 {{# comment #}}
{{ /partial }}
```