### PR TITLE
Prevent slug error when used on forms without containers

### DIFF
--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -64,6 +64,7 @@ export default {
         },
 
         language() {
+            if (! this.store) return;
             const targetSite = this.$store.state.publish[this.store].site;
             return targetSite ? Statamic.$config.get('sites').find(site => site.handle === targetSite).lang : null;
         }


### PR DESCRIPTION
Fixes #5653

Similar to #5523 which handled when site was missing from the publish container, but this is for when there's no publish container at all.
