### PR TITLE
Skip using the GraphQL cache if a token is passed

### DIFF
--- a/src/GraphQL/ResponseCache/DefaultCache.php
+++ b/src/GraphQL/ResponseCache/DefaultCache.php
@@ -12,11 +12,19 @@ class DefaultCache implements ResponseCache
 {
     public function get(Request $request)
     {
+        if ($request->has('token')) {
+            return null;
+        }
+
         return Cache::get($this->getCacheKey($request));
     }
 
     public function put(Request $request, $response)
     {
+        if ($request->has('token')) {
+            return null;
+        }
+        
         $key = $this->track($request);
 
         $ttl = Carbon::now()->addMinutes(config('statamic.graphql.cache.expiry', 60));


### PR DESCRIPTION
If a token is passed in the request we want to avoid using the cache so that our live preview can display the changed results, we need to perform this logic both in the get method to actually ensure we skip the cache when getting the value, but also in the put so that we don't override the standard cache with our temporary values.

Fixes https://github.com/statamic/cms/issues/5389
