### PR TITLE
Updater fixes

### DIFF
--- a/resources/views/updater/index.blade.php
+++ b/resources/views/updater/index.blade.php
@@ -3,57 +3,81 @@
 
 @section('content')
 
-    <div class="flex mb-3">
-        <h1 class="flex-1">{{ __('Updates') }}</h1>
-    </div>
+    @if ($requestError)
 
-    <h6 class="mt-4">Core</h6>
-    <div class="card p-0 mt-1">
-        <table class="data-table">
-            <tr>
-                <td class="w-64"><a href="{{ route('statamic.cp.updater.product', 'statamic') }}" class="text-blue font-bold">Statamic</a></td>
-                <td>{{ $statamic->currentVersion() }}</td>
-                @if ($count = $statamic->availableUpdatesCount())
-                    <td class="text-right"><span class="badge-sm bg-green btn-sm">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
-                @else
-                    <td class="text-right">{{ __('Up to date') }}</td>
-                @endif
-            </tr>
-        </table>
-    </div>
+        <div class="no-results md:pt-8 max-w-2xl mx-auto">
+            <div class="flex flex-wrap items-center">
+                <div class="w-full md:w-1/2">
+                    <h1 class="mb-4">{{ __('Updates') }}</h1>
+                    <p class="text-grey-70 leading-normal mb-4 text-lg antialiased">
+                        {{ __('statamic::messages.outpost_issue_try_later') }}
+                    </p>
+                    <a href="{{ cp_route('updater') }}"
+                        class="btn-primary btn-lg">{{ __('Try again') }}</a>
+                </div>
+                <div class="hidden md:block w-1/2 pl-6">
+                    @cp_svg('empty/navigation')
+                </div>
+            </div>
+        </div>
 
-    <h6 class="mt-4">{{ __('Addons') }}</h6>
-    <div class="card p-0 mt-1">
-        <table class="data-table">
-            @foreach ($addons as $addon)
+    @else
+
+        <div class="flex mb-3">
+            <h1 class="flex-1">{{ __('Updates') }}</h1>
+        </div>
+
+        <h6 class="mt-4">Core</h6>
+        <div class="card p-0 mt-1">
+            <table class="data-table">
                 <tr>
-                    <td class="w-64"><a href="{{ route('statamic.cp.updater.product', $addon->slug()) }}" class="text-blue font-bold mr-1">{{ $addon->name() }}</a>
-                    <td>{{ $addon->version() }}</td>
-                    @if ($count = $addon->changelog()->availableUpdatesCount())
+                    <td class="w-64"><a href="{{ route('statamic.cp.updater.product', 'statamic') }}" class="text-blue font-bold">Statamic</a></td>
+                    <td>{{ $statamic->currentVersion() }}</td>
+                    @if ($count = $statamic->availableUpdatesCount())
                         <td class="text-right"><span class="badge-sm bg-green btn-sm">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
                     @else
                         <td class="text-right">{{ __('Up to date') }}</td>
                     @endif
                 </tr>
-            @endforeach
-        </table>
-    </div>
+            </table>
+        </div>
 
-    <h6 class="mt-4">{{ __('Unlisted Addons') }}</h6>
-    <div class="card p-0 mt-1">
-        <table class="data-table">
-            @foreach ($unlistedAddons as $addon)
+        <h6 class="mt-4">{{ __('Addons') }}</h6>
+        <div class="card p-0 mt-1">
+            <table class="data-table">
+                @foreach ($addons as $addon)
                 <tr>
-                    <td class="w-64">{{ $addon->name() }}</td>
-                    <td>{{ $addon->version() }}</td>
+                    <td class="w-64"><a href="{{ route('statamic.cp.updater.product', $addon -> slug()) }}"
+                            class="text-blue font-bold mr-1">{{ $addon -> name() }}</a>
+                    <td>{{ $addon -> version() }}</td>
+                    @if ($count = $addon->changelog()->availableUpdatesCount())
+                    <td class="text-right"><span
+                            class="badge-sm bg-green btn-sm">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
+                    @else
+                    <td class="text-right">{{ __('Up to date') }}</td>
+                    @endif
                 </tr>
-            @endforeach
-        </table>
-    </div>
+                @endforeach
+            </table>
+        </div>
 
-    @include('statamic::partials.docs-callout', [
-        'topic' => __('Updates'),
-        'url' => 'updates'
-    ])
+        <h6 class="mt-4">{{ __('Unlisted Addons') }}</h6>
+        <div class="card p-0 mt-1">
+            <table class="data-table">
+                @foreach ($unlistedAddons as $addon)
+                    <tr>
+                        <td class="w-64">{{ $addon->name() }}</td>
+                        <td>{{ $addon->version() }}</td>
+                    </tr>
+                @endforeach
+            </table>
+        </div>
+
+        @include('statamic::partials.docs-callout', [
+            'topic' => __('Updates'),
+            'url' => 'updates'
+        ])
+
+    @endif
 
 @endsection

--- a/src/Extend/Addon.php
+++ b/src/Extend/Addon.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Extend;
 
+use Composer\Package\Version\VersionParser;
 use Facades\Statamic\Licensing\LicenseManager;
 use ReflectionClass;
 use Statamic\Facades\File;
@@ -375,7 +376,12 @@ final class Addon
             return true;
         }
 
-        return version_compare($this->version, $this->latestVersion, '=');
+        $versionParser = new VersionParser;
+
+        $version = $versionParser->normalize($this->version);
+        $latestVersion = $versionParser->normalize($this->latestVersion);
+
+        return version_compare($version, $latestVersion, '=');
     }
 
     public function license()

--- a/src/Http/Controllers/CP/Updater/UpdaterController.php
+++ b/src/Http/Controllers/CP/Updater/UpdaterController.php
@@ -7,6 +7,7 @@ use Facades\Statamic\Updater\UpdatesOverview;
 use Illuminate\Http\Request;
 use Statamic\Facades\Addon;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Licensing\LicenseManager as Licenses;
 use Statamic\Statamic;
 
 class UpdaterController extends CpController
@@ -14,7 +15,7 @@ class UpdaterController extends CpController
     /**
      * Updates overview.
      */
-    public function index()
+    public function index(Licenses $licenses)
     {
         $this->authorize('view updates');
 
@@ -25,6 +26,7 @@ class UpdaterController extends CpController
         }
 
         return view('statamic::updater.index', [
+            'requestError' => $licenses->requestFailed(),
             'statamic' => Marketplace::statamic()->changelog(),
             'addons' => Addon::all()->filter->existsOnMarketplace(),
             'unlistedAddons' => Addon::all()->reject->existsOnMarketplace(),

--- a/tests/Extend/AddonTest.php
+++ b/tests/Extend/AddonTest.php
@@ -241,6 +241,30 @@ class AddonTest extends TestCase
         $this->assertEquals('the license', Addon::make('foo/bar')->license());
     }
 
+    /**
+     * @test
+     * @dataProvider isLatestVersionProvider
+     **/
+    public function it_checks_if_its_the_latest_version($version, $latest, $isLatest)
+    {
+        $this->assertEquals($isLatest, $this->makeFromPackage([
+            'version' => $version,
+            'latestVersion' => $latest,
+        ])->isLatestVersion());
+    }
+
+    public function isLatestVersionProvider()
+    {
+        return [
+            ['1.0.0', '1.0.0', true],
+            ['1.0.1', '1.0.2', false],
+            ['1.0.1', '2.0.0', false],
+            ['2.0.0', '2.0.0', true],
+            ['1.0', '1.0.0', true],
+            ['1.0', '1.0.1', false],
+        ];
+    }
+
     private function makeFromPackage($attributes = [])
     {
         return Addon::makeFromPackage(array_merge([


### PR DESCRIPTION
- [x] Fix updater badge count in some circumstances by normalizing versions. Fixes #4681
    - Sometimes the updates badge would show an update when comparing `1.2` with `1.2.0`, which should be equal.
- [x] Show more graceful error in updater when hitting outpost rate limit.
    - Before: ![image](https://user-images.githubusercontent.com/5187394/160492859-5e661862-be31-4546-8249-427376aa1c62.png)
    - After: ![image](https://user-images.githubusercontent.com/5187394/160492984-f6b63bef-5a88-4244-8faf-49add2fb41ce.png)
