### PR TITLE
Allowing to remove ensured fields

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -402,6 +402,26 @@ class Blueprint implements Augmentable, QueryableValue, ArrayAccess, Arrayable
         return $this;
     }
 
+    public function removeEnsuredFieldFromSection($handle, $section)
+    {
+        $fieldKey = collect($this->ensuredFields)->search(function ($field) use ($handle, $section) {
+            return Arr::get($field, 'handle') === $handle && Arr::get($field, 'section') === $section;
+        });
+
+        Arr::pull($this->ensuredFields, $fieldKey);
+
+        return $this->resetFieldsCache();
+    }
+
+    public function removeEnsuredFieldsFromSection($section)
+    {
+        $this->ensuredFields = collect($this->ensuredFields)->filter(function ($field) use ($section) {
+            return Arr::get($field, 'section') !== $section;
+        })->values()->toArray();
+
+        return $this->resetFieldsCache();
+    }
+
     public function ensureFieldPrepended($handle, $field, $section = null)
     {
         return $this->ensureField($handle, $field, $section, true);

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -547,6 +547,34 @@ class BlueprintTest extends TestCase
     }
 
     /** @test */
+    public function it_can_remove_an_ensured_field_from_a_specific_section()
+    {
+        $blueprint = (new Blueprint)
+            ->ensureField('field_one', ['type' => 'textarea'], 'section_one')
+            ->ensureField('field_two', ['type' => 'textarea'], 'section_two')
+            ->ensureField('field_three', ['type' => 'textarea'], 'section_two')
+            ->removeEnsuredFieldFromSection('field_two', 'section_two');
+
+        $this->assertTrue($blueprint->hasField('field_one'));
+        $this->assertTrue(! $blueprint->hasField('field_two'));
+        $this->assertTrue($blueprint->hasField('field_three'));
+    }
+
+    /** @test */
+    public function it_can_remove_ensured_fields_from_a_specific_section()
+    {
+        $blueprint = (new Blueprint)
+            ->ensureField('field_one', ['type' => 'textarea'], 'section_one')
+            ->ensureField('field_two', ['type' => 'textarea'], 'section_two')
+            ->ensureField('field_three', ['type' => 'textarea'], 'section_two')
+            ->removeEnsuredFieldsFromSection('section_two');
+
+        $this->assertTrue($blueprint->hasField('field_one'));
+        $this->assertTrue(! $blueprint->hasField('field_two'));
+        $this->assertTrue(! $blueprint->hasField('field_three'));
+    }
+
+    /** @test */
     public function it_ensures_a_field_has_config()
     {
         $blueprint = (new Blueprint)->setContents(['sections' => [


### PR DESCRIPTION
## What it does
This PR makes it possible to remove ensured fields by section. It comes with two methods to either remove a single field in a section by its handle or remove all fields of a section.

## Issue it solves

I've got a listener that extends the blueprint on `EntryBlueprintFound`:

```php
$blueprint->ensureFieldsInSection($seoBlueprint, 'SEO');
```

If you are on a multi-site, this event gets triggered for every localization of the entry. So if you have 3 localizations and you are ensuring 10 fields, you end up with 30 ensured fields at the end. This isn't an issue per se as the duplicate fields will be removed from the blueprint. 

However, the `$seoBlueprint` fields that I'm adding to the blueprint contain localized data for things like field defaults. So I need to make sure to get the English data on the English localization, the German data on the German localization, and so on. Without this PR, you would end up with the wrong localized field data.

## Solution
The simple solution is to remove the ensured fields if they already exist:

```php
if ($blueprint->hasSection('SEO')) {
    $blueprint->removeEnsuredFieldsFromSection('SEO');
}

$blueprint->ensureFieldsInSection($seoBlueprint, 'SEO');

```