### PR TITLE
Fix to allow a date fieldtype to be cleared.

### DIFF
--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -176,6 +176,11 @@ export default {
     methods: {
 
         setDate(date) {
+            if (!date) {
+                this.update(null);
+                return;
+            }
+
             if (this.isRange) {
                 this.setDateRange(date);
             } else {


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/5681

Sets falsey date values as null rather than passing them through to setSingleDate (where it is ignored) or to setDateRange (where it creates a console error trying to access a property on a null).