### PR TITLE
Add 404 handling to entries/terms in REST API

### DIFF
--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Http\Controllers\API;
 
-use Statamic\Facades\Entry;
 use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Entry;
 use Statamic\Http\Resources\API\EntryResource;
 
 class CollectionEntriesController extends ApiController
@@ -27,14 +27,20 @@ class CollectionEntriesController extends ApiController
 
     public function show($collection, $handle)
     {
-        throw_if(
-            ! ($entry = Entry::find($handle)) || $entry->collection()->id() !== $collection->id(),
-            new NotFoundHttpException
-        );
-
         $this->abortIfDisabled();
+
+        $entry = Entry::find($handle);
+
+        $this->abortIfInvalid($entry, $collection);
         $this->abortIfUnpublished($entry);
 
         return app(EntryResource::class)::make($entry);
+    }
+
+    private function abortIfInvalid($entry, $collection)
+    {
+        if (! $entry || $entry->collection()->id() !== $collection->id()) {
+            throw new NotFoundHttpException;
+        }
     }
 }

--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\API;
 
 use Statamic\Facades\Entry;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Http\Resources\API\EntryResource;
 
 class CollectionEntriesController extends ApiController
@@ -24,9 +25,12 @@ class CollectionEntriesController extends ApiController
         );
     }
 
-    public function show($collection, $entry)
+    public function show($collection, $handle)
     {
-        $entry = Entry::find($entry);
+        throw_if(
+            ! ($entry = Entry::find($handle)) || $entry->collection()->id() !== $collection->id(),
+            new NotFoundHttpException
+        );
 
         $this->abortIfDisabled();
         $this->abortIfUnpublished($entry);

--- a/src/Http/Controllers/API/TaxonomyTermsController.php
+++ b/src/Http/Controllers/API/TaxonomyTermsController.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Http\Controllers\API;
 
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Term;
 use Statamic\Http\Resources\API\TermResource;
 
@@ -25,9 +26,11 @@ class TaxonomyTermsController extends ApiController
 
     public function show($taxonomy, $term)
     {
+        $this->abortIfDisabled();
+
         $term = Term::find($taxonomy.'::'.$term);
 
-        $this->abortIfDisabled();
+        throw_unless($term, new NotFoundHttpException);
 
         return app(TermResource::class)::make($term);
     }

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -24,6 +24,19 @@ class APITest extends TestCase
     }
 
     /** @test */
+    public function it_handles_not_found_entries()
+    {
+        Facades\Config::set('statamic.api.resources.collections', true);
+
+        Facades\Collection::make('pages')->save();
+
+        Facades\Entry::make()->collection('pages')->id('about')->slug('about')->published(true)->save();
+
+        $this->assertEndpointSuccessful('/api/collections/pages/entries/about');
+        $this->assertEndpointNotFound('/api/collections/pages/entries/dance');
+    }
+
+    /** @test */
     public function it_filters_published_entries_by_default()
     {
         Facades\Config::set('statamic.api.resources.collections', true);

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -23,17 +23,33 @@ class APITest extends TestCase
             ->assertJson(['message' => 'Not found.']);
     }
 
-    /** @test */
-    public function it_handles_not_found_entries()
+    /**
+     * @test
+     * @dataProvider entryNotFoundProvider
+     */
+    public function it_handles_not_found_entries($url, $requestShouldSucceed)
     {
         Facades\Config::set('statamic.api.resources.collections', true);
 
         Facades\Collection::make('pages')->save();
+        Facades\Collection::make('articles')->save();
 
         Facades\Entry::make()->collection('pages')->id('about')->slug('about')->published(true)->save();
 
-        $this->assertEndpointSuccessful('/api/collections/pages/entries/about');
-        $this->assertEndpointNotFound('/api/collections/pages/entries/dance');
+        if ($requestShouldSucceed) {
+            $this->assertEndpointSuccessful($url);
+        } else {
+            $this->assertEndpointNotFound($url);
+        }
+    }
+
+    public function entryNotFoundProvider()
+    {
+        return [
+            'valid entry id' => ['/api/collections/pages/entries/about', true],
+            'invalid entry id' => ['/api/collections/pages/entries/dance', false],
+            'valid entry id but wrong collection' => ['/api/collections/articles/entries/about', false],
+        ];
     }
 
     /** @test */


### PR DESCRIPTION
This adds the same missing or wrong collection check that was applied to the REST API entry lookup prior to https://github.com/statamic/cms/pull/5623. It currently throws a 500 on the unpublished check since `$entry` is `null`. With this change, we just apply the same checks as a non-REST API route and throw a 404 when the entry can't be found or the collection segment is wrong. I've also added a test to compliment the published/unpublished test and check against exists/doesn't exist entries.