### PR TITLE
Don't cache tokenized requests in GraphQL

### DIFF
--- a/src/GraphQL/Middleware/CacheResponse.php
+++ b/src/GraphQL/Middleware/CacheResponse.php
@@ -9,6 +9,10 @@ class CacheResponse
 {
     public function handle($request, Closure $next)
     {
+        if ($request->statamicToken()) {
+            return $next($request);
+        }
+
         $cache = app(ResponseCache::class);
 
         if ($response = $cache->get($request)) {


### PR DESCRIPTION
Fixes #5389
