### PR TITLE
Disable blueprint caching if needed

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -299,6 +299,10 @@ class Collection implements Contract, AugmentableContract, ArrayAccess, Arrayabl
 
     private function dispatchEntryBlueprintFoundEvent($blueprint, $entry)
     {
+        if (! optional($entry)->cacheBlueprint()) {
+            return EntryBlueprintFound::dispatch($blueprint, $entry);
+        }
+
         $id = optional($entry)->id() ?? 'null';
 
         $blink = 'collection-entry-blueprint-'.$this->handle().'-'.$blueprint->handle().'-'.$id;


### PR DESCRIPTION
As discussed on Discord and per email.

This PR makes it possible to disable the blueprint cache of an entry. This comes in handy if you need to change a blueprint after it has already been cached.

```php
$entry->cacheBlueprint(false)
```

Let me know what you think of this approach.