### PR TITLE
Runtime Parser: Uses mb_ functions when fetching DocumentParser chunks

### DIFF
--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -361,12 +361,11 @@ class DocumentParser
     public function parse($text)
     {
         $this->resetState();
+        StringUtilities::prepareSplit($text);
 
         if (! $this->processInputText($text)) {
             return [];
         }
-
-        StringUtilities::prepareSplit($text);
 
         $indexCount = count($this->antlersStartIndex);
         $lastIndex = $indexCount - 1;
@@ -664,6 +663,8 @@ class DocumentParser
             }
         }
 
+        ray($this->nodes);
+
         return $this->renderNodes;
     }
 
@@ -866,6 +867,8 @@ class DocumentParser
         for ($this->currentIndex; $this->currentIndex < $this->inputLen; $this->currentIndex += 1) {
             $this->checkCurrentOffsets();
 
+            ray($this->prev, $this->cur, $this->next);
+
             if ($this->cur == self::LeftBrace && $this->prev == self::AtChar) {
                 array_pop($this->currentContent);
                 $this->currentContent = array_merge($this->currentContent, $this->getLeftBrace());
@@ -1007,6 +1010,8 @@ class DocumentParser
             $this->lastAntlersEndIndex
         );
 
+        ray($node->endPosition);
+
         $node->interpolationRegions = $this->interpolationRegions;
 
         if (! $node->isComment) {
@@ -1105,10 +1110,12 @@ class DocumentParser
             $this->prev = $this->chars[$this->currentIndex - 1];
         }
 
+
+
         if (($this->currentIndex + 1) < $this->inputLen) {
             $doPeek = true;
             if ($this->currentIndex == $this->charLen - 1) {
-                $nextChunk = StringUtilities::split(StringUtilities::substr($this->content, $this->currentChunkOffset + $this->chunkSize, $this->chunkSize));
+                $nextChunk = mb_str_split(mb_substr($this->content, $this->currentChunkOffset + $this->chunkSize, $this->chunkSize));
                 $this->currentChunkOffset += $this->chunkSize;
 
                 if ($this->currentChunkOffset == $this->inputLen) {

--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -865,8 +865,6 @@ class DocumentParser
         for ($this->currentIndex; $this->currentIndex < $this->inputLen; $this->currentIndex += 1) {
             $this->checkCurrentOffsets();
 
-            ray($this->prev, $this->cur, $this->next);
-
             if ($this->cur == self::LeftBrace && $this->prev == self::AtChar) {
                 array_pop($this->currentContent);
                 $this->currentContent = array_merge($this->currentContent, $this->getLeftBrace());
@@ -1007,8 +1005,6 @@ class DocumentParser
             $this->lastAntlersEndIndex,
             $this->lastAntlersEndIndex
         );
-
-        ray($node->endPosition);
 
         $node->interpolationRegions = $this->interpolationRegions;
 

--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -663,8 +663,6 @@ class DocumentParser
             }
         }
 
-        ray($this->nodes);
-
         return $this->renderNodes;
     }
 

--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -1104,8 +1104,6 @@ class DocumentParser
             $this->prev = $this->chars[$this->currentIndex - 1];
         }
 
-
-
         if (($this->currentIndex + 1) < $this->inputLen) {
             $doPeek = true;
             if ($this->currentIndex == $this->charLen - 1) {

--- a/tests/Antlers/ScratchTest.php
+++ b/tests/Antlers/ScratchTest.php
@@ -58,7 +58,7 @@ next line
 EOT;
 
         $data = [
-         'title' => 'PRODUCT®',
+            'title' => 'PRODUCT®',
         ];
 
         $expected = <<<'EOT'
@@ -72,6 +72,6 @@ next line
     <before>aaa ’“”•–—˜™š›œ žŸ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿzzz<after>
 EOT;
 
-        $this->assertSame($expected, (string)Antlers::parse($template, $data));
+        $this->assertSame($expected, (string) Antlers::parse($template, $data));
     }
 }

--- a/tests/Antlers/ScratchTest.php
+++ b/tests/Antlers/ScratchTest.php
@@ -43,4 +43,35 @@ class ScratchTest extends TestCase
         $this->assertEquals('baz', (string) Antlers::parse('{{ test variable="{ bar}" }}', ['bar' => 'baz']));
         $this->assertEquals('baz', (string) Antlers::parse('{{ test variable="{ bar }" }}', ['bar' => 'baz']));
     }
+
+    public function test_runtime_can_parse_expanded_ascii_characters()
+    {
+        $template = <<<'EOT'
+<h1>{{ title }}</h1><h1>{{ title replace="®|<sup>®®</sup>" }}</h1>
+<{{ title }}>
+{{ my_var = '¥¦§¨©ª«¬®¯°±²³´µ¶¼½¾¿À' }}
+<h1>{{ title }}</h1><h1>{{ title replace="®|<sup>®®</sup>" }}</h1>
+<{{ my_var }}>
+    {{ another_var = 'aaa ’“”•–—˜™š›œ žŸ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿzzz' }}after
+next line
+    <before>{{ another_var }}<after>
+EOT;
+
+        $data = [
+         'title' => 'PRODUCT®',
+        ];
+
+        $expected = <<<'EOT'
+<h1>PRODUCT®</h1><h1>PRODUCT<sup>®®</sup></h1>
+<PRODUCT®>
+
+<h1>PRODUCT®</h1><h1>PRODUCT<sup>®®</sup></h1>
+<¥¦§¨©ª«¬®¯°±²³´µ¶¼½¾¿À>
+    after
+next line
+    <before>aaa ’“”•–—˜™š›œ žŸ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿzzz<after>
+EOT;
+
+        $this->assertSame($expected, (string)Antlers::parse($template, $data));
+    }
 }


### PR DESCRIPTION
This PR closes #5703 by swapping the dynamic split/substr functions to their mb_ counterparts when fetching the next chunk of an Antlers region.

These dynamic functions are in place to prevent them from being used on the entire document, and shouldn't have been used to handle Antlers tag internal contents.