### PR TITLE
Handle QueryBuilder instances being passed to the `scope` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -21,6 +21,7 @@ use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Facades\YAML;
 use Statamic\Fields\Value;
+use Statamic\Query\OrderedQueryBuilder;
 use Statamic\Support\Arr;
 use Statamic\Support\Html;
 use Statamic\Support\Str;
@@ -1935,7 +1936,7 @@ class CoreModifiers extends Modifier
     /**
      * Place variables in a scope.
      *
-     * @param  array|Collection  $value
+     * @param  array|Collection|OrderedQueryBuilder  $value
      * @param  array  $params
      * @return array
      */
@@ -1947,6 +1948,10 @@ class CoreModifiers extends Modifier
 
         if ($value instanceof Collection) {
             $value = $value->toAugmentedArray();
+        }
+
+        if (Compare::isQueryBuilder($value)) {
+            $value = $value->get()->all();
         }
 
         return Arr::addScope($value, $scope);

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -21,7 +21,6 @@ use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Facades\YAML;
 use Statamic\Fields\Value;
-use Statamic\Query\OrderedQueryBuilder;
 use Statamic\Support\Arr;
 use Statamic\Support\Html;
 use Statamic\Support\Str;
@@ -1936,7 +1935,7 @@ class CoreModifiers extends Modifier
     /**
      * Place variables in a scope.
      *
-     * @param  array|Collection|OrderedQueryBuilder  $value
+     * @param  $value
      * @param  array  $params
      * @return array
      */


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/5712