### PR TITLE
Add attribute to suppress deprecation notice

### DIFF
--- a/src/Fields/ArrayableString.php
+++ b/src/Fields/ArrayableString.php
@@ -36,6 +36,7 @@ class ArrayableString implements Arrayable, JsonSerializable
         return array_merge(['value' => $this->value], $this->extra);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();


### PR DESCRIPTION
fixes #5718
Choose the attribute because `:mixed` is not compatible with php 7.4.