### PR TITLE
Fix Glide cache disk permissions

### DIFF
--- a/src/Imaging/GlideServer.php
+++ b/src/Imaging/GlideServer.php
@@ -39,7 +39,7 @@ class GlideServer
             : storage_path('statamic/glide');
     }
 
-    public function cacheFilesystem()
+    private function cacheFilesystem()
     {
         return Storage::build([
             'driver' => 'local',

--- a/src/Imaging/GlideServer.php
+++ b/src/Imaging/GlideServer.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Imaging;
 
+use Illuminate\Support\Facades\Storage;
 use League\Glide\ServerFactory;
 use Statamic\Facades\Config;
 use Statamic\Facades\Image;
@@ -18,7 +19,7 @@ class GlideServer
     {
         return ServerFactory::create([
             'source'   => base_path(), // this gets overriden on the fly by the image generator
-            'cache'    => $this->cachePath(),
+            'cache'    => $this->cacheFilesystem(),
             'response' => new LaravelResponseFactory(app('request')),
             'driver'   => Config::get('statamic.assets.image_manipulation.driver'),
             'cache_with_file_extensions' => true,
@@ -36,5 +37,14 @@ class GlideServer
         return Config::get('statamic.assets.image_manipulation.cache')
             ? Config::get('statamic.assets.image_manipulation.cache_path')
             : storage_path('statamic/glide');
+    }
+
+    public function cacheFilesystem()
+    {
+        return Storage::build([
+            'driver' => 'local',
+            'root' => $this->cachePath(),
+            'visibility' => 'public',
+        ])->getDriver();
     }
 }


### PR DESCRIPTION
Fixes #5662

Passing a path into the Glide server factory will have Glide create a filesystem behind the scenes with the default visibility.
In Flysystem 1 the default visibility was public, but in Flysystem 3 the default is private, which is responsible for the bug.

Instead of passing a path, you can pass a Filesystem instance. That's what this PR is doing, and it's explicitly setting the visibility to public.
