### PR TITLE
Fix for flysystem returning pathless FileAttributes response

### DIFF
--- a/src/Stache/Stores/ContainerAssetsStore.php
+++ b/src/Stache/Stores/ContainerAssetsStore.php
@@ -81,6 +81,7 @@ class ContainerAssetsStore extends ChildStore
     {
         return $this->container()->listContents()->reject(function ($file) {
             return $file['type'] !== 'file'
+                || $file['path'] === ''
                 || $file['dirname'] === '.meta'
                 || Str::contains($file['path'], '/.meta/')
                 || in_array($file['basename'], ['.gitignore', '.gitkeep', '.DS_Store']);


### PR DESCRIPTION
I am thinking this is [a bug with flysystem](https://github.com/thephpleague/flysystem-aws-s3-v3/issues/291), but it doesn't hurt for us to filter out pathless `FileAttributes` responses here as well 👍 

Closes #5535.