### PR TITLE
Fix with CSS: CP header avatar not covering the whole circle when using weird aspect ratio images

### DIFF
--- a/resources/sass/elements/icons.scss
+++ b/resources/sass/elements/icons.scss
@@ -63,6 +63,10 @@ svg {
     width: 32px;
     line-height: 32px;
     @apply rounded-full shadow overflow-hidden;
+
+    img {
+      @apply w-full h-full object-cover;
+    }
 }
 
 .icon-user-initials {


### PR DESCRIPTION
Fixes #5729 