### PR TITLE
Square orientation user avatar generation for CP header

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -141,7 +141,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::get('assets-fieldtype', 'FieldtypeController@index');
         Route::resource('assets', 'AssetsController')->parameters(['assets' => 'encoded_asset']);
         Route::get('assets/{encoded_asset}/download', 'AssetsController@download')->name('assets.download');
-        Route::get('thumbnails/{encoded_asset}/{size?}', 'ThumbnailController@show')->name('assets.thumbnails.show');
+        Route::get('thumbnails/{encoded_asset}/{size?}/{orientation?}', 'ThumbnailController@show')->name('assets.thumbnails.show');
         Route::get('svgs/{encoded_asset}', 'SvgController@show')->name('assets.svgs.show');
         Route::get('pdfs/{encoded_asset}', 'PdfController@show')->name('assets.pdfs.show');
     });

--- a/src/Auth/HasAvatar.php
+++ b/src/Auth/HasAvatar.php
@@ -10,11 +10,11 @@ trait HasAvatar
     /**
      * Get a user's avatar URL.
      *
-     * Could be an asset's URL through a field named avatar, a Gravatar URL, or null.
+     * Could be an asset thumbnail URL through a field named avatar, a Gravatar URL, or null.
      */
     public function avatar($size = 64)
     {
-        if ($this->hasAvatarField() && ($url = $this->avatarFieldSmallSquareThumbnailUrl())) {
+        if ($this->hasAvatarField() && ($url = $this->avatarFieldSquareThumbnailUrl())) {
             return $url;
         }
 
@@ -53,7 +53,7 @@ trait HasAvatar
     /**
      * Square thumbnail URL of the avatar from the asset field.
      */
-    public function avatarFieldSmallSquareThumbnailUrl()
+    public function avatarFieldSquareThumbnailUrl()
     {
         $assetId = optional($this->avatarFieldValue()->value())->id();
 

--- a/src/Auth/HasAvatar.php
+++ b/src/Auth/HasAvatar.php
@@ -14,7 +14,7 @@ trait HasAvatar
      */
     public function avatar($size = 64)
     {
-        if ($this->hasAvatarField() && ($url = $this->avatarFieldUrl())) {
+        if ($this->hasAvatarField() && ($url = $this->avatarFieldSmallSquareThumbnailUrl())) {
             return $url;
         }
 
@@ -43,11 +43,21 @@ trait HasAvatar
     }
 
     /**
-     * The URL of the avatar from the asset field.
+     * Square thumbnail URL of the avatar from the asset field.
      */
-    public function avatarFieldUrl()
+    public function avatarFieldSmallSquareThumbnailUrl()
     {
-        return optional($this->avatarFieldValue()->value())->url();
+        $assetId = optional($this->avatarFieldValue()->value())->id();
+
+        if (!$assetId) {
+            return null;
+        }
+
+        return cp_route('assets.thumbnails.show', [
+            'encoded_asset' => base64_encode($assetId),
+            'size' => 'small',
+            'orientation' => 'square'
+        ]);
     }
 
     /**

--- a/src/Auth/HasAvatar.php
+++ b/src/Auth/HasAvatar.php
@@ -43,6 +43,14 @@ trait HasAvatar
     }
 
     /**
+     * The URL of the avatar from the asset field.
+     */
+    public function avatarFieldUrl()
+    {
+        return optional($this->avatarFieldValue()->value())->url();
+    }
+
+    /**
      * Square thumbnail URL of the avatar from the asset field.
      */
     public function avatarFieldSmallSquareThumbnailUrl()

--- a/src/Auth/HasAvatar.php
+++ b/src/Auth/HasAvatar.php
@@ -49,14 +49,14 @@ trait HasAvatar
     {
         $assetId = optional($this->avatarFieldValue()->value())->id();
 
-        if (!$assetId) {
+        if (! $assetId) {
             return null;
         }
 
         return cp_route('assets.thumbnails.show', [
             'encoded_asset' => base64_encode($assetId),
             'size' => 'small',
-            'orientation' => 'square'
+            'orientation' => 'square',
         ]);
     }
 

--- a/src/Http/Controllers/CP/Assets/ThumbnailController.php
+++ b/src/Http/Controllers/CP/Assets/ThumbnailController.php
@@ -18,7 +18,7 @@ class ThumbnailController extends Controller
     protected $server;
 
     /**
-     * @var Generator
+     * @var ImageGenerator
      */
     protected $generator;
 
@@ -31,6 +31,11 @@ class ThumbnailController extends Controller
      * @var string
      */
     protected $size;
+
+    /**
+     * @var string
+     */
+    protected $orientation;
 
     /**
      * @var string
@@ -52,11 +57,13 @@ class ThumbnailController extends Controller
      *
      * @param  string  $asset
      * @param  string  $size
+     * @param  string  $orientation
      * @return \Illuminate\Http\Response
      */
-    public function show($asset, $size = null)
+    public function show($asset, $size = null, $orientation = null)
     {
         $this->size = $size;
+        $this->orientation = $orientation;
         $this->asset = $this->asset($asset);
 
         if ($placeholder = $this->getPlaceholderResponse()) {
@@ -107,9 +114,27 @@ class ThumbnailController extends Controller
         return $path;
     }
 
-    public function getPreset()
+    /**
+     * Get control panel thumbnail image preset name
+     *
+     * Statamic has few control panel specific image presets
+     * @see \Statamic\Imaging\Manager::cpManipulationPresets
+     *
+     * @return string
+     */
+    private function getPreset()
     {
-        return "cp_thumbnail_{$this->size}_{$this->asset->orientation()}";
+        return "cp_thumbnail_{$this->size}_{$this->getOrientation()}";
+    }
+
+    /**
+     * Get orientation override from URL path or directly from asset
+     *
+     * @return string|null
+     */
+    private function getOrientation()
+    {
+        return $this->orientation ?? $this->asset->orientation();
     }
 
     /**

--- a/src/Http/Controllers/CP/Assets/ThumbnailController.php
+++ b/src/Http/Controllers/CP/Assets/ThumbnailController.php
@@ -115,7 +115,7 @@ class ThumbnailController extends Controller
     }
 
     /**
-     * Get control panel thumbnail image preset name
+     * Get control panel thumbnail image preset name.
      *
      * Statamic has few control panel specific image presets
      * @see \Statamic\Imaging\Manager::cpManipulationPresets
@@ -128,7 +128,7 @@ class ThumbnailController extends Controller
     }
 
     /**
-     * Get orientation override from URL path or directly from asset
+     * Get orientation override from URL path or directly from asset.
      *
      * @return string|null
      */

--- a/src/Http/Controllers/CP/Assets/ThumbnailController.php
+++ b/src/Http/Controllers/CP/Assets/ThumbnailController.php
@@ -118,6 +118,7 @@ class ThumbnailController extends Controller
      * Get control panel thumbnail image preset name.
      *
      * Statamic has few control panel specific image presets
+     *
      * @see \Statamic\Imaging\Manager::cpManipulationPresets
      *
      * @return string

--- a/tests/Auth/HasAvatarTest.php
+++ b/tests/Auth/HasAvatarTest.php
@@ -78,6 +78,8 @@ class HasAvatarTest extends TestCase
 
         $this->assertStringContainsString('/cp/thumbnails/YXZhdGFyczo6am9obi5qcGc=/small/square', $user->avatar());
         $this->assertStringContainsString('/cp/thumbnails/YXZhdGFyczo6am9obi5qcGc=/small/square', $user->avatar(64));
+        $this->assertEquals('/avatars/john.jpg', $user->avatarFieldUrl());
+        $this->assertEquals('/avatars/john.jpg', $user->avatarFieldUrl(64));
         $this->assertEquals('https://www.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=64', $user->gravatarUrl());
         $this->assertEquals('https://www.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=64', $user->gravatarUrl(64));
         $this->assertEquals('https://www.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=128', $user->gravatarUrl(128));

--- a/tests/Auth/HasAvatarTest.php
+++ b/tests/Auth/HasAvatarTest.php
@@ -76,10 +76,10 @@ class HasAvatarTest extends TestCase
     {
         $user = $this->withAvatarField()->withGravatar()->userWithUploadedAvatar();
 
-        $this->assertStringContainsString('/cp/thumbnails/YXZhdGFyczo6am9obi5qcGc=/small/square', $user->avatar());
-        $this->assertStringContainsString('/cp/thumbnails/YXZhdGFyczo6am9obi5qcGc=/small/square', $user->avatar(64));
         $this->assertEquals('/avatars/john.jpg', $user->avatarFieldUrl());
         $this->assertEquals('/avatars/john.jpg', $user->avatarFieldUrl(64));
+        $this->assertEquals('http://localhost/cp/thumbnails/YXZhdGFyczo6am9obi5qcGc=/small/square', $user->avatar());
+        $this->assertEquals('http://localhost/cp/thumbnails/YXZhdGFyczo6am9obi5qcGc=/small/square', $user->avatar(64));
         $this->assertEquals('https://www.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=64', $user->gravatarUrl());
         $this->assertEquals('https://www.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=64', $user->gravatarUrl(64));
         $this->assertEquals('https://www.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=128', $user->gravatarUrl(128));

--- a/tests/Auth/HasAvatarTest.php
+++ b/tests/Auth/HasAvatarTest.php
@@ -76,8 +76,8 @@ class HasAvatarTest extends TestCase
     {
         $user = $this->withAvatarField()->withGravatar()->userWithUploadedAvatar();
 
-        $this->assertEquals('/avatars/john.jpg', $user->avatar());
-        $this->assertEquals('/avatars/john.jpg', $user->avatar(64));
+        $this->assertStringContainsString('/cp/thumbnails/YXZhdGFyczo6am9obi5qcGc=/small/square', $user->avatar());
+        $this->assertStringContainsString('/cp/thumbnails/YXZhdGFyczo6am9obi5qcGc=/small/square', $user->avatar(64));
         $this->assertEquals('https://www.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=64', $user->gravatarUrl());
         $this->assertEquals('https://www.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=64', $user->gravatarUrl(64));
         $this->assertEquals('https://www.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=128', $user->gravatarUrl(128));


### PR DESCRIPTION
Fixes #5729

This one takes different approach from #5730, here I forcefully generate 1:1 aspect ratio image with existing `ThumbnailController@show` route.

However I had to change `ThumbnailController` to allow to override orientation, because before it would read the orientation from the asset, and it would be impossible to force `cp_thumbnail_small_square` image manipulation preset.

The only other place where this thumbnail route seems to be used is in `src/Assets/Asset.php`. The orientation path segment is optional and should not break existing usage.

One concern I see is that the `avatar()` method on `HasAvatar` trait could impact the avatar outputted on Antlers front-end, but from what I can see it does not (I tried outputting avatar from `{{ current_user }}`. From my understanding `Statamic/Auth/User` is used for CP user only? It would be amusing to receive an URL from CP thumbnail route.

I am okay if this PR does not get merged, while this is neater solution than #5730, it is slightly more complex and riskier (maybe it breaks something I am not aware of). But if you think this is good approach, then let me know if this needs additional adjustments, more than happy to address them. Regardless this was a journey for me to deep dive Statamic CMS source code a bit.