### PR TITLE
Create Term form: set initial value for `site` in Vue / VueX

### DIFF
--- a/resources/js/components/terms/BaseCreateForm.vue
+++ b/resources/js/components/terms/BaseCreateForm.vue
@@ -16,6 +16,7 @@
         :initial-has-origin="false"
         :initial-is-root="true"
         :initial-origin-values="{}"
+        :initial-site="site"
         :create-another-url="createAnotherUrl"
         :listing-url="listingUrl"
         :preview-targets="previewTargets"
@@ -36,6 +37,7 @@ export default {
         'meta',
         'published',
         'localizations',
+        'site',
         'createAnotherUrl',
         'listingUrl',
         'previewTargets',

--- a/resources/views/terms/create.blade.php
+++ b/resources/views/terms/create.blade.php
@@ -12,6 +12,7 @@
         :meta="{{ json_encode($meta) }}"
         :published="{{ json_encode($published) }}"
         :localizations="{{ json_encode($localizations) }}"
+        site="{{ $locale }}"
         create-another-url="{{ cp_route('taxonomies.terms.create', [$taxonomy, $locale]) }}"
         listing-url="{{ cp_route('taxonomies.show', $taxonomy) }}"
         :preview-targets="{{ json_encode($previewTargets) }}"


### PR DESCRIPTION
Fixes slugification by the proper language when creating a term.