### PR TITLE
Remove { collection } route binding

### DIFF
--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -17,10 +17,10 @@ class CollectionEntriesController extends ApiController
     {
         $this->abortIfDisabled();
 
-        $handle = $collection;
+        $collectionHandle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            throw new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$collectionHandle] not found.");
         }
 
         $with = $collection->entryBlueprints()
@@ -36,10 +36,10 @@ class CollectionEntriesController extends ApiController
     {
         $this->abortIfDisabled();
 
-        $handle = $collection;
+        $collectionHandle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            throw new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$collectionHandle] not found.");
         }
 
         $entry = Entry::find($handle);

--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\API;
 
 use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Http\Resources\API\EntryResource;
 
@@ -16,6 +17,12 @@ class CollectionEntriesController extends ApiController
     {
         $this->abortIfDisabled();
 
+        $handle = $collection;
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            throw new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $with = $collection->entryBlueprints()
             ->flatMap(fn ($blueprint) => $blueprint->fields()->all())
             ->filter->isRelationship()->keys()->all();
@@ -28,6 +35,12 @@ class CollectionEntriesController extends ApiController
     public function show($collection, $handle)
     {
         $this->abortIfDisabled();
+
+        $handle = $collection;
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            throw new NotFoundHttpException("Collection [$handle] not found.");
+        }
 
         $entry = Entry::find($handle);
 

--- a/src/Http/Controllers/API/CollectionTreeController.php
+++ b/src/Http/Controllers/API/CollectionTreeController.php
@@ -3,8 +3,8 @@
 namespace Statamic\Http\Controllers\API;
 
 use Statamic\Exceptions\NotFoundHttpException;
-use Statamic\Http\Resources\API\TreeResource;
 use Statamic\Facades\Collection;
+use Statamic\Http\Resources\API\TreeResource;
 use Statamic\Query\ItemQueryBuilder;
 
 class CollectionTreeController extends ApiController

--- a/src/Http/Controllers/API/CollectionTreeController.php
+++ b/src/Http/Controllers/API/CollectionTreeController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\API;
 
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Http\Resources\API\TreeResource;
+use Statamic\Facades\Collection;
 use Statamic\Query\ItemQueryBuilder;
 
 class CollectionTreeController extends ApiController
@@ -15,6 +16,12 @@ class CollectionTreeController extends ApiController
     public function show($collection)
     {
         $this->abortIfDisabled();
+
+        $handle = $collection;
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            throw new NotFoundHttpException("Collection [$handle] not found.");
+        }
 
         $site = $this->queryParam('site');
 

--- a/src/Http/Controllers/CP/Collections/CollectionBlueprintsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionBlueprintsController.php
@@ -4,7 +4,9 @@ namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
 use Statamic\Contracts\Entries\Collection as CollectionContract;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Blueprint;
+use Statamic\Facades\Collection;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Controllers\CP\Fields\ManagesBlueprints;
 
@@ -17,8 +19,14 @@ class CollectionBlueprintsController extends CpController
         $this->middleware(\Illuminate\Auth\Middleware\Authorize::class.':configure fields');
     }
 
-    public function index(CollectionContract $collection)
+    public function index($collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(0);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $blueprints = $this->indexItems($collection->entryBlueprints(), $collection);
 
         return view('statamic::collections.blueprints.index', compact('collection', 'blueprints'));
@@ -36,6 +44,12 @@ class CollectionBlueprintsController extends CpController
 
     public function edit($collection, $blueprint)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(0);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $blueprint = $collection->entryBlueprint($blueprint);
 
         return view('statamic::collections.blueprints.edit', [
@@ -47,6 +61,12 @@ class CollectionBlueprintsController extends CpController
 
     public function update(Request $request, $collection, $blueprint)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $request->validate([
             'title' => 'required',
             'sections' => 'array',
@@ -57,6 +77,12 @@ class CollectionBlueprintsController extends CpController
 
     public function create($collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(0);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         return view('statamic::collections.blueprints.create', [
             'action' => cp_route('collections.blueprints.store', $collection),
         ]);
@@ -64,6 +90,12 @@ class CollectionBlueprintsController extends CpController
 
     public function store(Request $request, $collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $request->validate(['title' => 'required']);
 
         // If there are no user-defined blueprints, save the default one.
@@ -82,6 +114,12 @@ class CollectionBlueprintsController extends CpController
 
     public function destroy($collection, $blueprint)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(0);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $blueprint = $collection->entryBlueprint($blueprint);
 
         $this->authorize('delete', $blueprint);

--- a/src/Http/Controllers/CP/Collections/CollectionBlueprintsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionBlueprintsController.php
@@ -24,7 +24,7 @@ class CollectionBlueprintsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(0);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $blueprints = $this->indexItems($collection->entryBlueprints(), $collection);
@@ -47,7 +47,7 @@ class CollectionBlueprintsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(0);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $blueprint = $collection->entryBlueprint($blueprint);
@@ -64,7 +64,7 @@ class CollectionBlueprintsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $request->validate([
@@ -80,7 +80,7 @@ class CollectionBlueprintsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(0);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         return view('statamic::collections.blueprints.create', [
@@ -93,7 +93,7 @@ class CollectionBlueprintsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $request->validate(['title' => 'required']);
@@ -117,7 +117,7 @@ class CollectionBlueprintsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(0);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $blueprint = $collection->entryBlueprint($blueprint);

--- a/src/Http/Controllers/CP/Collections/CollectionBlueprintsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionBlueprintsController.php
@@ -3,7 +3,6 @@
 namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
-use Statamic\Contracts\Entries\Collection as CollectionContract;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;

--- a/src/Http/Controllers/CP/Collections/CollectionBlueprintsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionBlueprintsController.php
@@ -21,9 +21,9 @@ class CollectionBlueprintsController extends CpController
 
     public function index($collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(0);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -44,9 +44,9 @@ class CollectionBlueprintsController extends CpController
 
     public function edit($collection, $blueprint)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(0);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -61,9 +61,9 @@ class CollectionBlueprintsController extends CpController
 
     public function update(Request $request, $collection, $blueprint)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -77,9 +77,9 @@ class CollectionBlueprintsController extends CpController
 
     public function create($collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(0);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -90,9 +90,9 @@ class CollectionBlueprintsController extends CpController
 
     public function store(Request $request, $collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -114,9 +114,9 @@ class CollectionBlueprintsController extends CpController
 
     public function destroy($collection, $blueprint)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(0);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 

--- a/src/Http/Controllers/CP/Collections/CollectionTreeController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionTreeController.php
@@ -20,7 +20,7 @@ class CollectionTreeController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $site = $request->site ?? Site::selected()->handle();
@@ -39,7 +39,7 @@ class CollectionTreeController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('reorder', $collection);

--- a/src/Http/Controllers/CP/Collections/CollectionTreeController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionTreeController.php
@@ -4,7 +4,8 @@ namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
-use Statamic\Contracts\Entries\Collection;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
@@ -14,8 +15,14 @@ use Statamic\Support\Arr;
 
 class CollectionTreeController extends CpController
 {
-    public function index(Request $request, Collection $collection)
+    public function index(Request $request, $collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $site = $request->site ?? Site::selected()->handle();
 
         $pages = (new TreeBuilder)->buildForController([
@@ -29,6 +36,12 @@ class CollectionTreeController extends CpController
 
     public function update(Request $request, $collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('reorder', $collection);
 
         $contents = $this->toTree($request->pages);

--- a/src/Http/Controllers/CP/Collections/CollectionTreeController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionTreeController.php
@@ -17,9 +17,9 @@ class CollectionTreeController extends CpController
 {
     public function index(Request $request, $collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -36,9 +36,9 @@ class CollectionTreeController extends CpController
 
     public function update(Request $request, $collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -327,6 +327,12 @@ class CollectionsController extends CpController
 
     public function destroy($collection)
     {
+        $handle = $collection;
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            throw new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('delete', $collection, __('You are not authorized to delete this collection.'));
 
         $collection->delete();

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use LogicException;
 use Statamic\Contracts\Entries\Collection as CollectionContract;
 use Statamic\CP\Column;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Exceptions\SiteNotFoundException;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
@@ -51,6 +52,12 @@ class CollectionsController extends CpController
 
     public function show(Request $request, $collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('view', $collection, __('You are not authorized to view this collection.'));
 
         $blueprints = $collection
@@ -125,6 +132,12 @@ class CollectionsController extends CpController
 
     public function fresh($collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(0);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('view', $collection, __('You are not authorized to view this collection.'));
 
         return view('statamic::collections.fresh');
@@ -132,6 +145,12 @@ class CollectionsController extends CpController
 
     public function edit($collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(0);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('edit', $collection, __('You are not authorized to edit this collection.'));
 
         $values = [
@@ -211,6 +230,12 @@ class CollectionsController extends CpController
 
     public function update(Request $request, $collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('update', $collection, __('You are not authorized to edit this collection.'));
 
         $fields = $this->editFormBlueprint($collection)->fields()->addValues($request->all());

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -52,9 +52,9 @@ class CollectionsController extends CpController
 
     public function show(Request $request, $collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -132,9 +132,9 @@ class CollectionsController extends CpController
 
     public function fresh($collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(0);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -145,9 +145,9 @@ class CollectionsController extends CpController
 
     public function edit($collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(0);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -230,9 +230,9 @@ class CollectionsController extends CpController
 
     public function update(Request $request, $collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -55,7 +55,7 @@ class CollectionsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('view', $collection, __('You are not authorized to view this collection.'));
@@ -135,7 +135,7 @@ class CollectionsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(0);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('view', $collection, __('You are not authorized to view this collection.'));
@@ -148,7 +148,7 @@ class CollectionsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(0);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('edit', $collection, __('You are not authorized to edit this collection.'));
@@ -233,7 +233,7 @@ class CollectionsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('update', $collection, __('You are not authorized to edit this collection.'));

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -30,7 +30,7 @@ class EntriesController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('view', $collection);
@@ -84,7 +84,7 @@ class EntriesController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('view', $entry);
@@ -176,7 +176,7 @@ class EntriesController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('update', $entry);
@@ -261,7 +261,7 @@ class EntriesController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('create', [EntryContract::class, $collection]);
@@ -339,7 +339,7 @@ class EntriesController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('store', [EntryContract::class, $collection]);

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -27,9 +27,9 @@ class EntriesController extends CpController
 
     public function index(FilteredRequest $request, $collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -81,9 +81,9 @@ class EntriesController extends CpController
 
     public function edit(Request $request, $collection, $entry)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -173,9 +173,9 @@ class EntriesController extends CpController
 
     public function update(Request $request, $collection, $entry)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -258,9 +258,9 @@ class EntriesController extends CpController
 
     public function create(Request $request, $collection, $site)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -336,9 +336,9 @@ class EntriesController extends CpController
 
     public function store(Request $request, $collection, $site)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -7,7 +7,9 @@ use Illuminate\Validation\ValidationException;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\CP\Breadcrumbs;
 use Statamic\Exceptions\BlueprintNotFoundException;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Asset;
+use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
@@ -25,6 +27,12 @@ class EntriesController extends CpController
 
     public function index(FilteredRequest $request, $collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('view', $collection);
 
         $query = $this->indexQuery($collection);
@@ -73,6 +81,12 @@ class EntriesController extends CpController
 
     public function edit(Request $request, $collection, $entry)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('view', $entry);
 
         $entry = $entry->fromWorkingCopy();
@@ -159,6 +173,12 @@ class EntriesController extends CpController
 
     public function update(Request $request, $collection, $entry)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('update', $entry);
 
         $entry = $entry->fromWorkingCopy();
@@ -238,6 +258,12 @@ class EntriesController extends CpController
 
     public function create(Request $request, $collection, $site)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('create', [EntryContract::class, $collection]);
 
         $blueprint = $collection->entryBlueprint($request->blueprint);
@@ -310,6 +336,12 @@ class EntriesController extends CpController
 
     public function store(Request $request, $collection, $site)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('store', [EntryContract::class, $collection]);
 
         $blueprint = $collection->entryBlueprint($request->_blueprint);

--- a/src/Http/Controllers/CP/Collections/EntryPreviewController.php
+++ b/src/Http/Controllers/CP/Collections/EntryPreviewController.php
@@ -4,6 +4,8 @@ namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
 use Statamic\Contracts\Entries\Entry as EntryContract;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Http\Controllers\CP\PreviewController;
 
@@ -11,6 +13,12 @@ class EntryPreviewController extends PreviewController
 {
     public function create(Request $request, $collection, $site)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('create', [EntryContract::class, $collection]);
 
         $fields = $collection->entryBlueprint($request->blueprint)

--- a/src/Http/Controllers/CP/Collections/EntryPreviewController.php
+++ b/src/Http/Controllers/CP/Collections/EntryPreviewController.php
@@ -16,7 +16,7 @@ class EntryPreviewController extends PreviewController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('create', [EntryContract::class, $collection]);

--- a/src/Http/Controllers/CP/Collections/EntryPreviewController.php
+++ b/src/Http/Controllers/CP/Collections/EntryPreviewController.php
@@ -13,9 +13,9 @@ class EntryPreviewController extends PreviewController
 {
     public function create(Request $request, $collection, $site)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 

--- a/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
+++ b/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
@@ -14,9 +14,9 @@ class EntryRevisionsController extends CpController
 {
     public function index(Request $request, $collection, $entry)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -42,9 +42,9 @@ class EntryRevisionsController extends CpController
 
     public function store(Request $request, $collection, $entry)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -58,9 +58,9 @@ class EntryRevisionsController extends CpController
 
     public function show(Request $request, $collection, $entry, $revision)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 

--- a/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
+++ b/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
@@ -3,6 +3,8 @@
 namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
@@ -12,6 +14,12 @@ class EntryRevisionsController extends CpController
 {
     public function index(Request $request, $collection, $entry)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $revisions = $entry
             ->revisions()
             ->reverse()
@@ -34,6 +42,12 @@ class EntryRevisionsController extends CpController
 
     public function store(Request $request, $collection, $entry)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $entry->createRevision([
             'message' => $request->message,
             'user' => User::fromUser($request->user()),
@@ -44,6 +58,12 @@ class EntryRevisionsController extends CpController
 
     public function show(Request $request, $collection, $entry, $revision)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $entry = $entry->makeFromRevision($revision);
 
         // TODO: Most of this is duplicated with EntriesController@edit. DRY it off.

--- a/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
+++ b/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
@@ -17,7 +17,7 @@ class EntryRevisionsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $revisions = $entry
@@ -45,7 +45,7 @@ class EntryRevisionsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $entry->createRevision([
@@ -61,7 +61,7 @@ class EntryRevisionsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $entry = $entry->makeFromRevision($revision);

--- a/src/Http/Controllers/CP/Collections/LocalizeEntryController.php
+++ b/src/Http/Controllers/CP/Collections/LocalizeEntryController.php
@@ -15,7 +15,7 @@ class LocalizeEntryController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $request->validate(['site' => 'required']);

--- a/src/Http/Controllers/CP/Collections/LocalizeEntryController.php
+++ b/src/Http/Controllers/CP/Collections/LocalizeEntryController.php
@@ -12,9 +12,9 @@ class LocalizeEntryController extends CpController
 {
     public function __invoke(Request $request, $collection, $entry)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 

--- a/src/Http/Controllers/CP/Collections/LocalizeEntryController.php
+++ b/src/Http/Controllers/CP/Collections/LocalizeEntryController.php
@@ -3,6 +3,8 @@
 namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Collection;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 
@@ -10,6 +12,12 @@ class LocalizeEntryController extends CpController
 {
     public function __invoke(Request $request, $collection, $entry)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $request->validate(['site' => 'required']);
 
         $localized = $entry->makeLocalization($site = $request->site);

--- a/src/Http/Controllers/CP/Collections/PublishedEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/PublishedEntriesController.php
@@ -16,7 +16,7 @@ class PublishedEntriesController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('publish', $entry);
@@ -34,7 +34,7 @@ class PublishedEntriesController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('publish', $entry);

--- a/src/Http/Controllers/CP/Collections/PublishedEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/PublishedEntriesController.php
@@ -13,9 +13,9 @@ class PublishedEntriesController extends CpController
 {
     public function store(Request $request, $collection, $entry)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -31,9 +31,9 @@ class PublishedEntriesController extends CpController
 
     public function destroy(Request $request, $collection, $entry)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 

--- a/src/Http/Controllers/CP/Collections/PublishedEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/PublishedEntriesController.php
@@ -3,6 +3,8 @@
 namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Collection;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
@@ -11,6 +13,12 @@ class PublishedEntriesController extends CpController
 {
     public function store(Request $request, $collection, $entry)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('publish', $entry);
 
         $entry = $entry->publish([
@@ -23,6 +31,12 @@ class PublishedEntriesController extends CpController
 
     public function destroy(Request $request, $collection, $entry)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('publish', $entry);
 
         $entry = $entry->unpublish([

--- a/src/Http/Controllers/CP/Collections/ReorderCollectionBlueprintsController.php
+++ b/src/Http/Controllers/CP/Collections/ReorderCollectionBlueprintsController.php
@@ -19,9 +19,9 @@ class ReorderCollectionBlueprintsController extends CpController
 
     public function __invoke(Request $request, $collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 

--- a/src/Http/Controllers/CP/Collections/ReorderCollectionBlueprintsController.php
+++ b/src/Http/Controllers/CP/Collections/ReorderCollectionBlueprintsController.php
@@ -3,6 +3,8 @@
 namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Collection;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Controllers\CP\Fields\ManagesBlueprints;
 
@@ -17,6 +19,12 @@ class ReorderCollectionBlueprintsController extends CpController
 
     public function __invoke(Request $request, $collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         foreach ($request->order as $index => $handle) {
             $collection->entryBlueprint($handle)->setOrder($index + 1)->save();
         }

--- a/src/Http/Controllers/CP/Collections/ReorderCollectionBlueprintsController.php
+++ b/src/Http/Controllers/CP/Collections/ReorderCollectionBlueprintsController.php
@@ -22,7 +22,7 @@ class ReorderCollectionBlueprintsController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         foreach ($request->order as $index => $handle) {

--- a/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
@@ -3,12 +3,20 @@
 namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Facades\Collection;
 
 class ReorderEntriesController extends CpController
 {
     public function __invoke(Request $request, $collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('reorder', $collection);
 
         $request->validate([

--- a/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
@@ -11,9 +11,9 @@ class ReorderEntriesController extends CpController
 {
     public function __invoke(Request $request, $collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 

--- a/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
@@ -14,7 +14,7 @@ class ReorderEntriesController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('reorder', $collection);

--- a/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
@@ -4,8 +4,8 @@ namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
 use Statamic\Exceptions\NotFoundHttpException;
-use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Facades\Collection;
+use Statamic\Http\Controllers\CP\CpController;
 
 class ReorderEntriesController extends CpController
 {

--- a/src/Http/Controllers/CP/Collections/RestoreEntryRevisionController.php
+++ b/src/Http/Controllers/CP/Collections/RestoreEntryRevisionController.php
@@ -3,6 +3,8 @@
 namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Collection;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Revisions\WorkingCopy;
 
@@ -10,6 +12,12 @@ class RestoreEntryRevisionController extends CpController
 {
     public function __invoke(Request $request, $collection, $entry)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         if (! $target = $entry->revision($request->revision)) {
             dd('no such revision', $request->revision);
             // todo: handle invalid revision reference

--- a/src/Http/Controllers/CP/Collections/RestoreEntryRevisionController.php
+++ b/src/Http/Controllers/CP/Collections/RestoreEntryRevisionController.php
@@ -12,9 +12,9 @@ class RestoreEntryRevisionController extends CpController
 {
     public function __invoke(Request $request, $collection, $entry)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 

--- a/src/Http/Controllers/CP/Collections/RestoreEntryRevisionController.php
+++ b/src/Http/Controllers/CP/Collections/RestoreEntryRevisionController.php
@@ -15,7 +15,7 @@ class RestoreEntryRevisionController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         if (! $target = $entry->revision($request->revision)) {

--- a/src/Http/Controllers/CP/Collections/ScaffoldCollectionController.php
+++ b/src/Http/Controllers/CP/Collections/ScaffoldCollectionController.php
@@ -13,9 +13,9 @@ class ScaffoldCollectionController extends CpController
 {
     public function index($collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(0);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
@@ -26,9 +26,9 @@ class ScaffoldCollectionController extends CpController
 
     public function create(Request $request, $collection)
     {
+        $handle = $collection;
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
-            $handle = func_get_arg(1);
             throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 

--- a/src/Http/Controllers/CP/Collections/ScaffoldCollectionController.php
+++ b/src/Http/Controllers/CP/Collections/ScaffoldCollectionController.php
@@ -4,6 +4,8 @@ namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
 use Statamic\Contracts\Entries\Collection as CollectionContract;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Collection;
 use Statamic\Facades\File;
 use Statamic\Http\Controllers\CP\CpController;
 
@@ -11,6 +13,12 @@ class ScaffoldCollectionController extends CpController
 {
     public function index($collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(0);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('view', $collection, __('You are not authorized to view this collection.'));
 
         return view('statamic::collections.scaffold', compact('collection'));
@@ -18,6 +26,12 @@ class ScaffoldCollectionController extends CpController
 
     public function create(Request $request, $collection)
     {
+        $collection = Collection::findByHandle($collection);
+        if (! $collection) {
+            $handle = func_get_arg(1);
+            new NotFoundHttpException("Collection [$handle] not found.");
+        }
+
         $this->authorize('store', CollectionContract::class, __('You are not authorized to scaffold resources.'));
 
         // Make the index template

--- a/src/Http/Controllers/CP/Collections/ScaffoldCollectionController.php
+++ b/src/Http/Controllers/CP/Collections/ScaffoldCollectionController.php
@@ -16,7 +16,7 @@ class ScaffoldCollectionController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(0);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('view', $collection, __('You are not authorized to view this collection.'));
@@ -29,7 +29,7 @@ class ScaffoldCollectionController extends CpController
         $collection = Collection::findByHandle($collection);
         if (! $collection) {
             $handle = func_get_arg(1);
-            new NotFoundHttpException("Collection [$handle] not found.");
+            throw new NotFoundHttpException("Collection [$handle] not found.");
         }
 
         $this->authorize('store', CollectionContract::class, __('You are not authorized to scaffold resources.'));

--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -31,7 +31,6 @@ class RouteServiceProvider extends ServiceProvider
     {
         Route::mixin(new Router);
 
-        $this->bindCollections();
         $this->bindEntries();
         $this->bindTaxonomies();
         $this->bindTerms();
@@ -43,18 +42,6 @@ class RouteServiceProvider extends ServiceProvider
         $this->bindForms();
     }
 
-    protected function bindCollections()
-    {
-        Route::bind('collection', function ($handle) {
-            throw_unless(
-                $collection = Collection::findByHandle($handle),
-                new NotFoundHttpException("Collection [$handle] not found.")
-            );
-
-            return $collection;
-        });
-    }
-
     protected function bindEntries()
     {
         Route::bind('entry', function ($handle, $route) {
@@ -63,7 +50,7 @@ class RouteServiceProvider extends ServiceProvider
             }
 
             throw_if(
-                ! ($entry = Entry::find($handle)) || $entry->collection()->id() !== $route->parameter('collection')->id(),
+                ! ($entry = Entry::find($handle)) || $entry->collection()->handle() !== $route->parameter('collection'),
                 new NotFoundHttpException("Entry [$handle] not found.")
             );
 

--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -7,7 +7,6 @@ use Illuminate\Support\ServiceProvider;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
-use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Form;
 use Statamic\Facades\GlobalSet;


### PR DESCRIPTION
I'm having issues with the `{ collection }` route binding when using Statamic alongside another package. 

So as suggested [here](https://github.com/statamic/cms/issues/4108) I've removed the collection binding from all routes that use it.

I'm happy to do the leg work on any changes you want to this - so just direct me.