### PR TITLE
Runtime: Removes ctype_space null deprecation warning

### DIFF
--- a/src/View/Antlers/Language/Lexer/AntlersLexer.php
+++ b/src/View/Antlers/Language/Lexer/AntlersLexer.php
@@ -275,7 +275,7 @@ class AntlersLexer
             if ($this->isInModifierParameterValue && ! $this->isParsingString) {
                 $breakForKeyword = false;
 
-                if (! $this->isParsingString && ctype_space($this->next)) {
+                if (! $this->isParsingString && $this->next != null && ctype_space($this->next)) {
                     $nextWord = strtolower(trim(implode($this->scanForwardTo(' ', 1))));
 
                     if (strlen($nextWord) > 0 && LanguageKeywords::isLanguageLogicalKeyword($nextWord)) {


### PR DESCRIPTION
Stops deprecation warning from appearing in logs that `ctype_space` will not accept `null`