### PR TITLE
Runtime: Prevents literal from being removed when using multiple nested double braces in a parameter

### DIFF
--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -525,8 +525,31 @@ class DocumentParser
 
                         if ($nextAntlersStart < $literalStartIndex) {
                             if ($this->lastAntlersEndIndex > $nextAntlersStart) {
-                                if ($i + 2 < $indexCount) {
-                                    $nextAntlersStart = $this->antlersStartIndex[$i + 2];
+                                $skipIndex = null;
+                                for ($j = $i; $j < $indexCount; $j++) {
+                                    if ($this->antlersStartIndex[$j] > $this->lastAntlersEndIndex) {
+                                        $skipIndex = $this->antlersStartIndex[$j];
+                                        break;
+                                    }
+                                }
+
+                                if ($skipIndex != null) {
+                                    $nextAntlersStart = $skipIndex;
+                                } else {
+                                    // In this scenario, we will create the last trailing literal node and break.
+                                    $thisOffset = $this->currentChunkOffset;
+                                    $content = StringUtilities::substr($this->content, $literalStartIndex);
+
+                                    $node = new LiteralNode();
+
+                                    $node->content = $this->prepareLiteralContent($content);
+
+                                    if (! strlen($node->content) == 0) {
+                                        $node->startPosition = $this->positionFromOffset($thisOffset, $thisOffset);
+                                        $node->endPosition = $this->positionFromOffset($nextAntlersStart, $thisOffset);
+                                        $this->nodes[] = $node;
+                                    }
+                                    break;
                                 }
                             } else {
                                 continue;

--- a/tests/Antlers/Parser/NodeParametersTest.php
+++ b/tests/Antlers/Parser/NodeParametersTest.php
@@ -225,5 +225,19 @@ EOT;
         $this->assertInstanceOf(LiteralNode::class, $nodes[2]);
         $this->assertSame('<figure>', $nodes[0]->content);
         $this->assertSame('FINAL_LITERAL</figure>', $nodes[2]->content);
+
+        $template = <<<'EOT'
+ <div class="list-of-classes">     {{ partial src="svg/" values="{{ article_icon_color:key }} {{ article_icon_size:key }}" }}FINAL_LITERAL </div> 
+EOT;
+
+        $nodes = $this->parseNodes($template);
+
+        $this->assertCount(3, $nodes);
+        $this->assertInstanceOf(LiteralNode::class, $nodes[0]);
+        $this->assertInstanceOf(AntlersNode::class, $nodes[1]);
+        $this->assertInstanceOf(LiteralNode::class, $nodes[2]);
+
+        $this->assertSame(' <div class="list-of-classes">     ', $nodes[0]->content);
+        $this->assertSame('FINAL_LITERAL </div> ', $nodes[2]->content);
     }
 }


### PR DESCRIPTION
Prevents trailing literal content from being removed if a parameter contains double braces:

```
<div>{{ tag param="{{ variable }}" }}</div>
```

will no longer remove the trailing `</div>`