### PR TITLE
Runtime: Corrects noparse behavior

### DIFF
--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -101,6 +101,7 @@ class DocumentParser
     private $antlersStartPositionIndex = [];
     private $chunkSize = 5;
     private $currentChunkOffset = 0;
+    private $isNoParse = false;
 
     /**
      * A list of node visitors.
@@ -140,6 +141,17 @@ class DocumentParser
         return $this;
     }
 
+    /**
+     * Fetches content from the source content without appending characters to the current char list.
+     *
+     * @param  int  $count  The number of characters to fetch.
+     * @return string
+     */
+    private function fetch($count)
+    {
+        return mb_substr($this->content, $this->currentChunkOffset + $this->chunkSize - count($this->chars), $count);
+    }
+
     public function getParsedContent()
     {
         return $this->content;
@@ -148,7 +160,7 @@ class DocumentParser
     private function peek($count)
     {
         if ($count == $this->charLen) {
-            $nextChunk = StringUtilities::split(StringUtilities::substr($this->content, $this->currentChunkOffset + $this->chunkSize, $this->chunkSize));
+            $nextChunk = mb_str_split(mb_substr($this->content, $this->currentChunkOffset + $this->chunkSize, $this->chunkSize));
             $this->currentChunkOffset += $this->chunkSize;
 
             foreach ($nextChunk as $nextChar) {
@@ -165,7 +177,7 @@ class DocumentParser
         $this->currentContent = [];
         $this->startIndex = 0;
 
-        $this->chars = StringUtilities::split(StringUtilities::substr($this->content, $this->currentChunkOffset, $this->chunkSize));
+        $this->chars = mb_str_split(mb_substr($this->content, $this->currentChunkOffset, $this->chunkSize));
         $this->charLen = count($this->chars);
 
         for ($this->currentIndex = 0; $this->currentIndex < $this->inputLen; $this->currentIndex += 1) {
@@ -183,7 +195,6 @@ class DocumentParser
                     $this->currentIndex + $this->seedOffset,
                     $this->currentIndex + $this->seedOffset
                 );
-
                 $escapeNode->endPosition = $this->positionFromOffset(
                     $this->currentIndex + $this->seedOffset,
                     $this->currentIndex + $this->seedOffset
@@ -206,7 +217,7 @@ class DocumentParser
                     $peek = $this->peek($this->currentIndex + 2);
                 }
 
-                if ($peek == self::Punctuation_Question) {
+                if ($peek == self::Punctuation_Question && ! $this->isNoParse) {
                     $this->isDoubleBrace = true;
                     $this->currentIndex += 3;
                     $this->scanToEndOfPhpRegion(self::Punctuation_Question);
@@ -214,7 +225,7 @@ class DocumentParser
                     break;
                 }
 
-                if ($peek == self::Punctuation_Dollar) {
+                if ($peek == self::Punctuation_Dollar && ! $this->isNoParse) {
                     $this->isDoubleBrace = true;
                     $this->currentIndex += 3;
                     $this->scanToEndOfPhpRegion(self::Punctuation_Dollar);
@@ -222,7 +233,7 @@ class DocumentParser
                     break;
                 }
 
-                if ($peek == self::Punctuation_Octothorp) {
+                if ($peek == self::Punctuation_Octothorp && ! $this->isNoParse) {
                     $this->isDoubleBrace = true;
                     $this->currentIndex += 3;
                     $this->scanToEndOfAntlersCommentRegion();
@@ -232,13 +243,32 @@ class DocumentParser
                     break;
                 }
 
-                // Advances over the {{.
-                $this->startIndex = $this->currentIndex;
+                if (! $this->isNoParse) {
+                    // Advances over the {{.
+                    $this->startIndex = $this->currentIndex;
 
-                $this->isDoubleBrace = true;
-                $this->currentIndex += 2;
-                $this->scanToEndOfAntlersRegion();
-                $this->isDoubleBrace = false;
+                    $this->isDoubleBrace = true;
+                    $this->currentIndex += 2;
+                    $this->scanToEndOfAntlersRegion();
+                    $this->isDoubleBrace = false;
+                } else {
+                    $contentPeek = strtolower(str_replace(' ', '', $this->fetch(11)));
+
+                    if (Str::startsWith($contentPeek, '{{/noparse')) {
+                        // Advances over the {{.
+                        $this->startIndex = $this->currentIndex;
+
+                        $this->isDoubleBrace = true;
+                        $this->currentIndex += 2;
+                        $this->scanToEndOfAntlersRegion();
+                        $this->isDoubleBrace = false;
+                        $this->isNoParse = false;
+                        break;
+                    } else {
+                        $this->currentContent[] = $this->cur;
+                        continue;
+                    }
+                }
 
                 break;
             }
@@ -366,11 +396,12 @@ class DocumentParser
     public function parse($text)
     {
         $this->resetState();
-        StringUtilities::prepareSplit($text);
 
         if (! $this->processInputText($text)) {
             return [];
         }
+
+        StringUtilities::prepareSplit($text);
 
         $indexCount = count($this->antlersStartIndex);
         $lastIndex = $indexCount - 1;
@@ -900,6 +931,11 @@ class DocumentParser
 
             if ($this->cur == self::RightBrace && $this->next != null && $this->next == self::RightBrace) {
                 $node = $this->makeAntlersTagNode($this->currentIndex, false);
+
+                if ($node->name != null && $node->name->name == 'noparse') {
+                    $this->isNoParse = true;
+                }
+
                 $this->currentIndex += 2;
                 $this->nodes[] = $node;
 
@@ -1029,6 +1065,10 @@ class DocumentParser
 
     private function dumpLiteralNode($index)
     {
+        if ($this->isNoParse) {
+            return;
+        }
+
         if (! empty($this->currentContent)) {
             $this->nodes[] = $this->makeLiteralNode($this->currentContent, $this->startIndex, $index);
         }
@@ -1100,6 +1140,13 @@ class DocumentParser
 
     private function checkCurrentOffsets()
     {
+        if (array_key_exists($this->currentIndex, $this->chars) == false) {
+            $this->cur = null;
+            $this->prev = null;
+            $this->next = null;
+            return;
+        }
+
         $this->cur = $this->chars[$this->currentIndex];
 
         $this->prev = null;
@@ -1125,7 +1172,7 @@ class DocumentParser
                 }
             }
 
-            if ($doPeek) {
+            if ($doPeek && array_key_exists($this->currentIndex + 1, $this->chars)) {
                 $this->next = $this->chars[$this->currentIndex + 1];
             }
         }

--- a/tests/Antlers/Runtime/NoparseTest.php
+++ b/tests/Antlers/Runtime/NoparseTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Antlers\Runtime;
+
+use Statamic\View\Antlers\Language\Utilities\StringUtilities;
+use Tests\Antlers\ParserTestCase;
+
+class NoparseTest extends ParserTestCase
+{
+
+    public function test_noparse_ignores_braces_entirely()
+    {
+        $template = <<<'EOT'
+{{ noparse }}A
+instantsearch.widgets.hits({
+    container: '#hits',
+    templates: {
+      item: `
+        <div>
+          <div class="hit-name">
+            <a href="{{url}}">{{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}</a>
+            <p>{{ description }}</p>
+            <p>Price: \${{ price }}</p>
+          </div>
+        </div>
+      `,
+      empty: 'No results for <q>{{ query }}</q>',
+    }
+}),
+Z{{ /noparse }}A
+EOT;
+
+        $expected = <<<'EOT'
+A
+instantsearch.widgets.hits({
+    container: '#hits',
+    templates: {
+      item: `
+        <div>
+          <div class="hit-name">
+            <a href="{{url}}">{{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}</a>
+            <p>{{ description }}</p>
+            <p>Price: \${{ price }}</p>
+          </div>
+        </div>
+      `,
+      empty: 'No results for <q>{{ query }}</q>',
+    }
+}),
+ZA
+EOT;
+
+        $this->assertSame($expected, StringUtilities::normalizeLineEndings(trim($this->renderString($template))));
+    }
+
+
+    public function test_multiple_noparse_regions()
+    {
+        $template = <<<'EOT'
+{{ noparse }}A
+instantsearch.widgets.hits({
+    container: '#hits',
+    templates: {
+      item: `
+        <div>
+          <div class="hit-name">
+            <a href="{{url}}">{{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}</a>
+            <p>{{ description }}</p>
+            <p>Price: \${{ price }}</p>
+          </div>
+        </div>
+      `,
+      empty: 'No results for <q>{{ query }}</q>',
+    }
+}),
+Z{{ /noparse }}A
+
+{{ title }}
+
+AB
+{{ noparse }}A
+instantsearch.widgets.hits({
+    container: '#hits',
+    templates: {
+      item: `
+        <div>
+          <div class="hit-name">
+            <a href="{{url}}">{{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}</a>
+            <p>{{ description }}</p>
+            <p>Price: \${{ price }}</p>
+          </div>
+        </div>
+      `,
+      empty: 'No results for <q>{{ query }}</q>',
+    }
+}),
+Z{{/noparse }}A
+
+{{ title }}
+EOT;
+
+        $expected = <<<'EOT'
+A
+instantsearch.widgets.hits({
+    container: '#hits',
+    templates: {
+      item: `
+        <div>
+          <div class="hit-name">
+            <a href="{{url}}">{{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}</a>
+            <p>{{ description }}</p>
+            <p>Price: \${{ price }}</p>
+          </div>
+        </div>
+      `,
+      empty: 'No results for <q>{{ query }}</q>',
+    }
+}),
+ZA
+
+the title
+
+AB
+A
+instantsearch.widgets.hits({
+    container: '#hits',
+    templates: {
+      item: `
+        <div>
+          <div class="hit-name">
+            <a href="{{url}}">{{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}</a>
+            <p>{{ description }}</p>
+            <p>Price: \${{ price }}</p>
+          </div>
+        </div>
+      `,
+      empty: 'No results for <q>{{ query }}</q>',
+    }
+}),
+ZA
+
+the title
+EOT;
+
+        $this->assertSame($expected, StringUtilities::normalizeLineEndings(trim($this->renderString($template, ['title' => 'the title',]))));
+    }
+}


### PR DESCRIPTION
This PR closes #5739 by having the DocumentParser specifically handle `{{ noparse }}`. When the DocumentParser encounters these regions, all further parsing is disabled until it finds the next `{{ /noparse }}`.