### PR TITLE
Cache result of value()

### DIFF
--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -13,6 +13,8 @@ use Statamic\View\Antlers\Language\Parser\DocumentTransformer;
 
 class Value implements IteratorAggregate, JsonSerializable
 {
+    private $cachedValue = null;
+
     protected $raw;
     protected $handle;
     protected $fieldtype;
@@ -39,6 +41,10 @@ class Value implements IteratorAggregate, JsonSerializable
 
     public function value()
     {
+        if ($this->cachedValue !== null) {
+            return $this->cachedValue;
+        }
+
         if (! $this->fieldtype) {
             return $this->raw;
         }
@@ -46,6 +52,8 @@ class Value implements IteratorAggregate, JsonSerializable
         $value = $this->shallow
             ? $this->fieldtype->shallowAugment($this->raw)
             : $this->fieldtype->augment($this->raw);
+
+        $this->cachedValue = $value;
 
         return $value;
     }


### PR DESCRIPTION
This PR caches the result of calling `value()`. No adverse effects were encountered when testing on multi-site, updated values, etc.

This PR introduces a noticeable performance increase when using the Runtime parser on taxonomy/relationship heavy sites (hundreds of entries with many taxonomies each), and a small bump in general.
