### PR TITLE
Make toggle fieldtype available in frontend forms

### DIFF
--- a/resources/js/components/fieldtypes/ToggleFieldtype.vue
+++ b/resources/js/components/fieldtypes/ToggleFieldtype.vue
@@ -1,6 +1,7 @@
 <template>
     <div class="toggle-fieldtype-wrapper">
         <toggle-input :value="value" @input="update" :read-only="isReadOnly" />
+        <label v-if="config.inline_label" class="ml-1 font-normal">{{ config.inline_label }}</label>
     </div>
 </template>
 

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -140,6 +140,7 @@ return [
     'textarea.title' => 'Textarea',
     'time.title' => 'Time',
     'toggle.title' => 'Toggle',
+    'toggle.config.inline_label' => 'Set an inline label to be shown beside the toggle input.',
     'user_groups.title' => 'User Groups',
     'user_roles.title' => 'User Roles',
     'users.title' => 'Users',

--- a/resources/views/extend/forms/fields/toggle.antlers.html
+++ b/resources/views/extend/forms/fields/toggle.antlers.html
@@ -8,4 +8,7 @@
         {{ if ! old && default }}checked{{ /if }}
         {{ if validate|contains:required }}required{{ /if }}
     >
+    {{ if inline_label }}
+        {{ inline_label }}
+    {{ /if }}
 </label>

--- a/resources/views/extend/forms/fields/toggle.antlers.html
+++ b/resources/views/extend/forms/fields/toggle.antlers.html
@@ -1,0 +1,11 @@
+<label>
+    <input type="hidden" name="{{ handle }}" value="0">
+    <input
+        type="checkbox"
+        name="{{ handle }}"
+        value="1"
+        {{ if js_driver }}{{ js_attributes }}{{ /if }}
+        {{ if ! old && default }}checked{{ /if }}
+        {{ if validate|contains:required }}required{{ /if }}
+    >
+</label>

--- a/src/Fieldtypes/Toggle.php
+++ b/src/Fieldtypes/Toggle.php
@@ -8,6 +8,7 @@ use Statamic\Fields\Fieldtype;
 class Toggle extends Fieldtype
 {
     protected $categories = ['controls'];
+    protected $selectableInForms = true;
     protected $defaultValue = false;
 
     protected function configFieldItems(): array

--- a/src/Fieldtypes/Toggle.php
+++ b/src/Fieldtypes/Toggle.php
@@ -14,6 +14,12 @@ class Toggle extends Fieldtype
     protected function configFieldItems(): array
     {
         return [
+            'inline_label' => [
+                'display' => __('Inline Label'),
+                'instructions' => __('statamic::fieldtypes.toggle.config.inline_label'),
+                'type' => 'text',
+                'default' => '',
+            ],
             'default' => [
                 'display' => __('Default Value'),
                 'instructions' => __('statamic::messages.fields_default_instructions'),

--- a/src/Forms/Uploaders/AssetsUploader.php
+++ b/src/Forms/Uploaders/AssetsUploader.php
@@ -35,20 +35,20 @@ class AssetsUploader
     }
 
     /**
-     * Upload the files and return their paths.
+     * Upload the files and return their IDs.
      *
      * @param  mixed  $files
      * @return array|string
      */
     public function upload($files)
     {
-        $paths = $this->getUploadableFiles($files)->map(function ($file) {
-            return $this->createAsset($file)->path();
+        $ids = $this->getUploadableFiles($files)->map(function ($file) {
+            return $this->createAsset($file)->id();
         });
 
         return $this->isSingleFile()
-            ? $paths->first()
-            : $paths->all();
+            ? $ids->first()
+            : $ids->all();
     }
 
     /**

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -33,15 +33,14 @@ class FormController extends Controller
         $site = Site::findByUrl(URL::previous()) ?? Site::default();
         $fields = $form->blueprint()->fields();
         $this->validateContentType($request, $form);
-        $values = array_merge($request->all(), $this->normalizeAssetsValues($fields, $request));
-
+        $values = array_merge($request->all(), $assets = $this->normalizeAssetsValues($fields, $request));
         $params = collect($request->all())->filter(function ($value, $key) {
             return Str::startsWith($key, '_');
         })->all();
 
         $fields = $fields->addValues($values);
 
-        $submission = $form->makeSubmission()->data($values);
+        $submission = $form->makeSubmission();
 
         try {
             $this->withLocale($site->lang(), function () use ($fields) {
@@ -50,7 +49,11 @@ class FormController extends Controller
 
             throw_if(Arr::get($values, $form->honeypot()), new SilentFormFailureException);
 
-            $submission->uploadFiles();
+            $values = array_merge($values, $submission->uploadFiles($assets));
+
+            $submission->data(
+                $fields->addValues($values)->process()->values()
+            );
 
             // If any event listeners return false, we'll do a silent failure.
             // If they want to add validation errors, they can throw an exception.
@@ -142,8 +145,7 @@ class FormController extends Controller
         // The assets fieldtype is expecting an array, even for `max_files: 1`, but we don't want to force that on the front end.
         return $fields->all()
             ->filter(function ($field) {
-                return $field->fieldtype()->handle() === 'assets'
-                    && $field->get('max_files') === 1;
+                return $field->fieldtype()->handle() === 'assets' && request()->hasFile($field->handle());
             })
             ->map(function ($field) use ($request) {
                 return Arr::wrap($request->file($field->handle()));


### PR DESCRIPTION
- [x] Make toggle fieldtype available in frontend forms.
- [x] Automatically render toggle fieldtype with `inline_label` in dynamic field rendering loop.
- [x] Render `inline_label` on toggles in cp as well.

![image](https://user-images.githubusercontent.com/5187394/162279589-a84c86ae-7ebf-4b59-b8e6-8648171b3072.png)
