### PR TITLE
Runtime: Resolve builders for modifiers

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -2279,6 +2279,10 @@ class NodeProcessor
         $value = $data->antlersValue($this->antlersParser, $context);
         GlobalRuntimeState::$isEvaluatingUserData = false;
 
+        if ($value instanceof Builder) {
+            $value = $value->get()->all();
+        }
+
         try {
             return Modify::value($value)->context($context)->$modifier($parameters)->fetch();
         } catch (ModifierException $e) {

--- a/tests/Antlers/Runtime/AntlersQueryBuilderTest.php
+++ b/tests/Antlers/Runtime/AntlersQueryBuilderTest.php
@@ -147,6 +147,46 @@ EOT;
         $this->assertSame(['clients' => $clientData], VarTest::$var);
     }
 
+    public function test_query_builders_and_modifiers()
+    {
+        $builder = Mockery::mock(Builder::class);
+        $builder->shouldReceive('get')->times(6)->andReturn(collect([
+            ['title' => 'Foo'],
+            ['title' => 'Baz'],
+            ['title' => 'Bar'],
+        ]));
+
+        $data = [
+            'page' => [
+                'images_entries_fieldtype' => $builder,
+            ],
+        ];
+
+        $template = <<<'EOT'
+{{ page:images_entries_fieldtype scope="image" }}<{{ image:title }}>{{ /page:images_entries_fieldtype }}
+EOT;
+
+        $this->assertSame('<Foo><Baz><Bar>', $this->renderString($template, $data));
+
+        $template = <<<'EOT'
+{{ page:images_entries_fieldtype | scope:image }}<{{ image:title }}>{{ /page:images_entries_fieldtype }}
+EOT;
+
+        $this->assertSame('<Foo><Baz><Bar>', $this->renderString($template, $data));
+
+        $template = <<<'EOT'
+{{ page:images_entries_fieldtype | scope('image') }}<{{ image:title }}>{{ /page:images_entries_fieldtype }}
+EOT;
+
+        $this->assertSame('<Foo><Baz><Bar>', $this->renderString($template, $data));
+
+        $template = <<<'EOT'
+{{ entries = ((page:images_entries_fieldtype | reverse) merge page:images_entries_fieldtype) | scope('image') }}<{{ image:title }}>{{ /entries }}
+EOT;
+
+        $this->assertSame('<Bar><Baz><Foo><Foo><Baz><Bar>', $this->renderString($template, $data));
+    }
+
     public function test_using_builders_as_a_pair_does_not_mutate_existing_variable()
     {
         $builder = Mockery::mock(Builder::class);


### PR DESCRIPTION
This PR fixes #5712  by having the Runtime resolve builder instances before it calls a modifier.

Additional fixes may include handling it directly within the modifier, but this way Runtime will just handle it internally.