### PR TITLE
Support returning front matter in custom Markdown parsers

### DIFF
--- a/src/Markdown/Parser.php
+++ b/src/Markdown/Parser.php
@@ -5,6 +5,8 @@ namespace Statamic\Markdown;
 use Closure;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Extension\Autolink\AutolinkExtension;
+use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
+use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
 use League\CommonMark\Extension\SmartPunct\SmartPunctExtension;
 use Statamic\Support\Arr;
 
@@ -22,6 +24,21 @@ class Parser
     public function parse(string $markdown): string
     {
         return $this->converter()->convert($markdown);
+    }
+
+    public function parseWithFrontMatter(string $markdown): array
+    {
+        $result = $this->converter()->convert($markdown);
+
+        $data = [
+            'content' => $result->getContent(),
+        ];
+
+        if ($result instanceof RenderedContentWithFrontMatter) {
+            $data = array_merge($result->getFrontMatter(), $data);
+        }
+
+        return $data;
     }
 
     public function converter(): CommonMarkConverter
@@ -109,6 +126,13 @@ class Parser
     {
         return $this->newInstance()->addExtension(function () {
             return new SmartPunctExtension;
+        });
+    }
+
+    public function withFrontMatter(): self
+    {
+        return $this->newInstance()->addExtension(function () {
+            return new FrontMatterExtension;
         });
     }
 

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1389,12 +1389,15 @@ class CoreModifiers extends Modifier
     public function markdown($value, $params)
     {
         $parser = $params[0] ?? 'default';
+        $withFrontMatter = $params[1] ?? false;
 
         if (in_array($parser, [true, 'true', ''], true)) {
             $parser = 'default';
         }
 
-        return Markdown::parser($parser)->parse((string) $value);
+        $method = $withFrontMatter ? 'parseWithFrontMatter' : 'parse';
+
+        return Markdown::parser($parser)->{$method}((string) $value);
     }
 
     /**

--- a/tests/Markdown/MarkdownTest.php
+++ b/tests/Markdown/MarkdownTest.php
@@ -161,4 +161,27 @@ EOT;
             rtrim(Markdown::withSmartPunctuation()->parse('"Foo" -- Bar...'))
         );
     }
+
+    /** @test */
+    public function it_uses_front_matter_on_demand()
+    {
+        $markdown = <<<'EOT'
+---
+title: Foo Bar
+---
+
+# Heading
+EOT;
+
+        $result = Markdown::withFrontMatter()->parseWithFrontMatter($markdown);
+
+        $this->assertEquals(
+            '<h1>Heading</h1>',
+            rtrim($result['content'])
+        );
+        $this->assertEquals(
+            'Foo Bar',
+            $result['title']
+        );
+    }
 }

--- a/tests/Modifiers/MarkdownTest.php
+++ b/tests/Modifiers/MarkdownTest.php
@@ -26,6 +26,33 @@ class MarkdownTest extends TestCase
     }
 
     /** @test */
+    public function it_converts_to_markdown_with_front_matter()
+    {
+        $markdown = <<<'EOT'
+---
+title: Foo Bar
+---
+
+# Heading
+EOT;
+
+        Markdown::extend('front_matter', function ($parser) {
+            return $parser->withFrontMatter();
+        });
+
+        $result = $this->modify($markdown, ['front_matter', true]);
+
+        $this->assertEquals(
+            '<h1>Heading</h1>',
+            rtrim($result['content'])
+        );
+        $this->assertEquals(
+            'Foo Bar',
+            $result['title']
+        );
+    }
+
+    /** @test */
     public function using_an_unknown_parser_throws_exception()
     {
         $this->expectExceptionMessage('Markdown parser [foo] is not defined.');


### PR DESCRIPTION
I'm working on a project where I'm loading Markdown from an external source, and the external Markdown contains front matter values I need access to. While it's possible to add the `FrontMatterExtension` to a custom parser, it's not easy to access the values, as the `Markdown\Parser::parse()` method that the modifier uses only returns a string.

This PR adds a new `parseWithFrontMatter` method, which returns an array containing the content and any front matter values. It also adds a new parameter to the modifier to tell it to use this method instead. And as a convenience it adds a `withFrontMatter` method to add the extension to a new parser.

This means you can do this to parse the markdown and access the content and front matter values:

```php
Markdown::extend('special', function ($parser) {
    return $parser
        ->withStatamicDefaults()
        ->withFrontMatter();
});
```
```html
{{ external markdown="special|true" }}
    <h1>{{ title }}</h1>
    {{ content }}
{{ /external }}
```

There were a few things I was unsure of on this, but I thought I’d give it a go anyway:

1. Should `parseWithFrontMatter` just be part of `parse`? I kept them separate as they are quite different, but there's not really any reason why it couldn't be a single method with an additional argment.
2. Is the extra parameter on the modifier a good idea or should this be a separate modifier entirely?
3. Or, is there a way the extra parameter and method could be avoided completely in a BC way? If `parse()` returned an object that could cast to a string, but also contained the front matter data, you might be able to the existing modifier as is but use the array/tag syntax when you want access to the front matter values.

If the general idea is OK I can add docs and make any suggested changes.
