### PR TITLE
Make `Markdown\Parser` macroable

### DIFF
--- a/src/Markdown/Parser.php
+++ b/src/Markdown/Parser.php
@@ -3,6 +3,7 @@
 namespace Statamic\Markdown;
 
 use Closure;
+use Illuminate\Support\Traits\Macroable;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Extension\Autolink\AutolinkExtension;
 use League\CommonMark\Extension\SmartPunct\SmartPunctExtension;
@@ -10,6 +11,8 @@ use Statamic\Support\Arr;
 
 class Parser
 {
+    use Macroable;
+
     protected $converter;
     protected $extensions = [];
     protected $config = [];


### PR DESCRIPTION
As suggested in https://github.com/statamic/cms/pull/5796#issuecomment-1092878903

Makes the  `Markdown\Parser` class macroable so that custom parsing methods can be added.