### PR TITLE
Count collections more efficiently in the `length` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -4,6 +4,7 @@ namespace Statamic\Modifiers;
 
 use ArrayAccess;
 use Carbon\Carbon;
+use Countable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Assets\Asset as AssetContract;
@@ -1279,7 +1280,7 @@ class CoreModifiers extends Modifier
      */
     public function length($value)
     {
-        if (Compare::isQueryBuilder($value)) {
+        if (Compare::isQueryBuilder($value) || $value instanceof Countable) {
             return $value->count();
         }
 

--- a/tests/Modifiers/LengthTest.php
+++ b/tests/Modifiers/LengthTest.php
@@ -44,6 +44,15 @@ class LengthTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_the_number_of_items_in_an_arrayable()
+    {
+        $arrayable = Mockery::mock(Arrayable::class)->shouldReceive('toArray')->andReturn(['one', 'two'])->getMock();
+
+        $modified = $this->modify($arrayable);
+        $this->assertSame(2, $modified);
+    }
+
+    /** @test */
     public function it_returns_the_numbers_of_chars_in_string(): void
     {
         $string = 'LEEEEROOOYYYY JEEENKINNNSS!';

--- a/tests/Modifiers/LengthTest.php
+++ b/tests/Modifiers/LengthTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Modifiers;
 
+use Illuminate\Contracts\Support\Arrayable;
+use Mockery;
+use Statamic\Contracts\Query\Builder;
 use Statamic\Modifiers\Modify;
 use Tests\TestCase;
 
@@ -20,11 +23,43 @@ class LengthTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_the_numbers_of_items_in_collection(): void
+    {
+        $arr = collect([
+            'Taylor Swift',
+            'Left Shark',
+            'Leroy Jenkins',
+        ]);
+        $modified = $this->modify($arr);
+        $this->assertSame(3, $modified);
+    }
+
+    /** @test */
+    public function it_returns_the_number_of_items_in_a_query()
+    {
+        $builder = Mockery::mock(Builder::class);
+        $builder->shouldReceive('count')->once()->andReturn(3);
+        $modified = $this->modify($builder);
+        $this->assertSame(3, $modified);
+    }
+
+    /** @test */
     public function it_returns_the_numbers_of_chars_in_string(): void
     {
         $string = 'LEEEEROOOYYYY JEEENKINNNSS!';
         $modified = $this->modify($string);
         $this->assertSame(27, $modified);
+    }
+
+    /** @test */
+    public function it_counts_a_collection_instead_of_toarraying_it(): void
+    {
+        $itemOne = Mockery::mock(Arrayable::class)->shouldNotReceive('toArray')->getMock();
+        $itemTwo = Mockery::mock(Arrayable::class)->shouldNotReceive('toArray')->getMock();
+
+        $arr = collect([$itemOne, $itemTwo]);
+        $modified = $this->modify($arr);
+        $this->assertSame(2, $modified);
     }
 
     private function modify($value)


### PR DESCRIPTION
When using the `length` modifier on a `Collection`, it would call `toArray()` on it, causing each item to also have `toArray()` called on it. If the items were augmentables (like entries or terms) it would get all the augmented values in each one.

All of that, just to count how many entries there were. Massive overhead for nothing.

This has only become a problem in 3.3 and when using the new parser, when in a situation like this:

```
{{ terms_field }}
  {{ if terms_field|length > 1 }} ... {{ /if }}
{{ /terms_field }}
```

The `terms_field` would be a query builder. The parser would store the results of it in the scope so it wouldn't have to re-query next time. Then the `length` modifier would get an instance of a `TermCollection`. It would call `toArray` on it which will do the whole augmentation dance explained above.

This didn't happen in 3.2 because Entries/Terms classes didn't implement `Arrayable`, so when `toArray` was called... it wouldn't try to do any augmentation.

Pretty edge casey, but in one site we noticed this caused a ridiculous load time.