### PR TITLE
Track and remove nested hidden fields

### DIFF
--- a/resources/js/components/data-list/HasHiddenFields.js
+++ b/resources/js/components/data-list/HasHiddenFields.js
@@ -1,3 +1,5 @@
+import HiddenValuesOmitter from '../field-conditions/Omitter.js';
+
 export default {
 
     computed: {
@@ -6,69 +8,19 @@ export default {
             return this.$store.state.publish[this.publishContainer].hiddenFields;
         },
 
-        visibleValues() {
-            let visibleValues = clone(this.values);
+        jsonSubmittingFields() {
+            return this.$store.state.publish[this.publishContainer].jsonSubmittingFields;
+        },
 
-            let hiddenKeys = _.chain(this.hiddenFields)
+        visibleValues() {
+            let hiddenFields = _.chain(this.hiddenFields)
                 .pick(hidden => hidden)
                 .keys()
-                .each(dottedKey => {
-                    let parent = this.dottedKeyToParentHandle(dottedKey);
+                .value();
 
-                    if (this.parentFieldSubmitsJson(parent)) {
-                        return visibleValues[parent] = this.forgetFromChildJson(visibleValues[parent], dottedKey);
-                    }
-
-                    eval('delete visibleValues.' + this.dottedKeyToJsProperty(dottedKey));
-                });
-
-            return visibleValues;
+            return new HiddenValuesOmitter(this.values, this.jsonSubmittingFields).omit(hiddenFields);
         },
 
-    },
-
-    methods: {
-
-        dottedKeyToJsProperty(dottedKey) {
-            return dottedKey.replace(/\.*(\d+)\./g, '[$1].');
-        },
-
-        dottedKeyToParentHandle(dottedKey) {
-            return dottedKey.replace(/\..*$/, '');
-        },
-
-        dottedKeyToChildHandle(dottedKey) {
-            return dottedKey.replace(/^[^\.]*\./, '');
-        },
-
-        getParentFieldType(handle) {
-            let fields = [];
-
-            this.$store.state.publish[this.publishContainer].blueprint.sections.forEach(section => {
-                fields = fields.concat(section.fields);
-            });
-
-            let parentFields = _.object(_.map(fields, function(field) {
-               return [field.handle, field];
-            }));
-
-            return parentFields[handle].type;
-        },
-
-        parentFieldSubmitsJson(handle) {
-            return this.getParentFieldType(handle) === 'bard';
-        },
-
-        forgetFromChildJson(json, dottedKey) {
-            let updatedJsonObject = JSON.parse(json);
-
-            let childKey = this.dottedKeyToChildHandle(dottedKey);
-
-            eval('delete updatedJsonObject' + this.dottedKeyToJsProperty(childKey));
-
-            return JSON.stringify(updatedJsonObject);
-        },
-
-    },
+    }
 
 }

--- a/resources/js/components/data-list/HasHiddenFields.js
+++ b/resources/js/components/data-list/HasHiddenFields.js
@@ -7,11 +7,26 @@ export default {
         },
 
         visibleValues() {
-            return _.omit(this.values, (_, handle) => {
-                return this.hiddenFields[handle];
-            });
+            let visibleValues = clone(this.values);
+
+            let hiddenKeys = _.chain(this.hiddenFields)
+                .pick(hidden => hidden)
+                .keys()
+                .each(dottedKey => {
+                    eval('delete visibleValues.' + this.dottedKeyToJsProperty(dottedKey));
+                });
+
+            return visibleValues;
         },
 
-    }
+    },
+
+    methods: {
+
+        dottedKeyToJsProperty(dottedKey) {
+            return dottedKey.replace(/\.*(\d+)\./g, '[$1].');
+        },
+
+    },
 
 }

--- a/resources/js/components/data-list/HasHiddenFields.js
+++ b/resources/js/components/data-list/HasHiddenFields.js
@@ -13,6 +13,12 @@ export default {
                 .pick(hidden => hidden)
                 .keys()
                 .each(dottedKey => {
+                    let parent = this.dottedKeyToParentHandle(dottedKey);
+
+                    if (this.parentFieldSubmitsJson(parent)) {
+                        return visibleValues[parent] = this.forgetFromChildJson(visibleValues[parent], dottedKey);
+                    }
+
                     eval('delete visibleValues.' + this.dottedKeyToJsProperty(dottedKey));
                 });
 
@@ -25,6 +31,42 @@ export default {
 
         dottedKeyToJsProperty(dottedKey) {
             return dottedKey.replace(/\.*(\d+)\./g, '[$1].');
+        },
+
+        dottedKeyToParentHandle(dottedKey) {
+            return dottedKey.replace(/\..*$/, '');
+        },
+
+        dottedKeyToChildHandle(dottedKey) {
+            return dottedKey.replace(/^[^\.]*\./, '');
+        },
+
+        getParentFieldType(handle) {
+            let fields = [];
+
+            this.$store.state.publish[this.publishContainer].blueprint.sections.forEach(section => {
+                fields = fields.concat(section.fields);
+            });
+
+            let parentFields = _.object(_.map(fields, function(field) {
+               return [field.handle, field];
+            }));
+
+            return parentFields[handle].type;
+        },
+
+        parentFieldSubmitsJson(handle) {
+            return this.getParentFieldType(handle) === 'bard';
+        },
+
+        forgetFromChildJson(json, dottedKey) {
+            let updatedJsonObject = JSON.parse(json);
+
+            let childKey = this.dottedKeyToChildHandle(dottedKey);
+
+            eval('delete updatedJsonObject' + this.dottedKeyToJsProperty(childKey));
+
+            return JSON.stringify(updatedJsonObject);
         },
 
     },

--- a/resources/js/components/field-conditions/Omitter.js
+++ b/resources/js/components/field-conditions/Omitter.js
@@ -1,0 +1,75 @@
+import { clone } from  '../../bootstrap/globals.js'
+
+export default class {
+    constructor(values, jsonFields) {
+        this.values = clone(values);
+        this.jsonFields = clone(jsonFields || []).sort();
+    }
+
+    omit(hiddenKeys) {
+        this.jsonDecode()
+            .omitHiddenFields(hiddenKeys)
+            .jsonEncode();
+
+        return this.values;
+    }
+
+    jsonDecode() {
+        this.jsonFields.forEach(dottedKey => {
+            this.jsonDecodeValue(dottedKey);
+        });
+
+        return this;
+    }
+
+    omitHiddenFields(hiddenKeys) {
+        hiddenKeys.forEach(dottedKey => {
+            this.forgetValue(dottedKey);
+        });
+
+        return this;
+    }
+
+    jsonEncode() {
+        clone(this.jsonFields).reverse().forEach(dottedKey => {
+            this.jsonEncodeValue(dottedKey);
+        });
+
+        return this;
+    }
+
+    dottedKeyToJsPath(dottedKey) {
+        return dottedKey.replace(/\.*(\d+)\./g, '[$1].');
+    }
+
+    jsonDecodeValue(dottedKey) {
+        let values = clone(this.values);
+        let jsPath = this.dottedKeyToJsPath(dottedKey);
+        let value = eval('values.' + jsPath);
+        let decodedFieldValue = JSON.parse(value);
+
+        eval('values.' + jsPath + ' = decodedFieldValue');
+
+        this.values = values;
+    }
+
+    jsonEncodeValue(dottedKey) {
+        let values = clone(this.values);
+        let jsPath = this.dottedKeyToJsPath(dottedKey);
+        let fieldValue = eval('values.' + jsPath);
+        let encodedFieldValue = JSON.stringify(fieldValue);
+
+        eval('values.' + jsPath + ' = encodedFieldValue');
+
+        this.values = values;
+    }
+
+    forgetValue(dottedKey) {
+        let values = clone(this.values);
+        let jsPath = this.dottedKeyToJsPath(dottedKey);
+
+        eval('delete values.' + jsPath);
+
+        this.values = values;
+    }
+}

--- a/resources/js/components/field-conditions/Omitter.js
+++ b/resources/js/components/field-conditions/Omitter.js
@@ -3,7 +3,10 @@ import { clone } from  '../../bootstrap/globals.js'
 export default class {
     constructor(values, jsonFields) {
         this.values = clone(values);
-        this.jsonFields = clone(jsonFields || []).sort();
+
+        this.jsonFields = clone(jsonFields || [])
+            .filter((field, index) => jsonFields.indexOf(field) === index)
+            .sort();
     }
 
     omit(hiddenKeys) {

--- a/resources/js/components/field-conditions/Omitter.js
+++ b/resources/js/components/field-conditions/Omitter.js
@@ -1,4 +1,5 @@
 import { clone } from  '../../bootstrap/globals.js'
+import { data_get } from  '../../bootstrap/globals.js'
 
 export default class {
     constructor(values, jsonFields) {
@@ -42,11 +43,16 @@ export default class {
         return dottedKey.replace(/\.*(\d+)\./g, '[$1].');
     }
 
+    missingValue(dottedKey) {
+        return data_get(clone(this.values), dottedKey) === null;
+    }
+
     jsonDecodeValue(dottedKey) {
+        if (this.missingValue(dottedKey)) return;
+
         let values = clone(this.values);
+        let decodedFieldValue = JSON.parse(data_get(values, dottedKey));
         let jsPath = this.dottedKeyToJsPath(dottedKey);
-        let value = eval('values.' + jsPath);
-        let decodedFieldValue = JSON.parse(value);
 
         eval('values.' + jsPath + ' = decodedFieldValue');
 
@@ -54,10 +60,11 @@ export default class {
     }
 
     jsonEncodeValue(dottedKey) {
+        if (this.missingValue(dottedKey)) return;
+
         let values = clone(this.values);
+        let encodedFieldValue = JSON.stringify(data_get(values, dottedKey));
         let jsPath = this.dottedKeyToJsPath(dottedKey);
-        let fieldValue = eval('values.' + jsPath);
-        let encodedFieldValue = JSON.stringify(fieldValue);
 
         eval('values.' + jsPath + ' = encodedFieldValue');
 
@@ -65,6 +72,8 @@ export default class {
     }
 
     forgetValue(dottedKey) {
+        if (this.missingValue(dottedKey)) return;
+
         let values = clone(this.values);
         let jsPath = this.dottedKeyToJsPath(dottedKey);
 

--- a/resources/js/components/field-conditions/Omitter.js
+++ b/resources/js/components/field-conditions/Omitter.js
@@ -1,5 +1,4 @@
 import { clone } from  '../../bootstrap/globals.js'
-import { data_get } from  '../../bootstrap/globals.js'
 
 export default class {
     constructor(values, jsonFields) {
@@ -44,15 +43,19 @@ export default class {
     }
 
     missingValue(dottedKey) {
-        return data_get(clone(this.values), dottedKey) === null;
+        var properties = Array.isArray(dottedKey) ? dottedKey : dottedKey.split('.');
+        var value = properties.reduce((prev, curr) => prev && prev[curr], clone(this.values));
+
+        return value === undefined;
     }
 
     jsonDecodeValue(dottedKey) {
         if (this.missingValue(dottedKey)) return;
 
         let values = clone(this.values);
-        let decodedFieldValue = JSON.parse(data_get(values, dottedKey));
         let jsPath = this.dottedKeyToJsPath(dottedKey);
+        let fieldValue = eval('values.' + jsPath);
+        let decodedFieldValue = JSON.parse(fieldValue);
 
         eval('values.' + jsPath + ' = decodedFieldValue');
 
@@ -63,8 +66,9 @@ export default class {
         if (this.missingValue(dottedKey)) return;
 
         let values = clone(this.values);
-        let encodedFieldValue = JSON.stringify(data_get(values, dottedKey));
         let jsPath = this.dottedKeyToJsPath(dottedKey);
+        let fieldValue = eval('values.' + jsPath);
+        let encodedFieldValue = JSON.stringify(fieldValue);
 
         eval('values.' + jsPath + ' = encodedFieldValue');
 

--- a/resources/js/components/field-conditions/ValidatorMixin.js
+++ b/resources/js/components/field-conditions/ValidatorMixin.js
@@ -8,11 +8,11 @@ export default {
     },
 
     methods: {
-        showField(field) {
+        showField(field, dottedKey) {
             let passes = new Validator(field, this.values, this.$store, this.storeName).passesConditions();
 
             this.$store.commit(`publish/${this.storeName}/setHiddenField`, {
-                handle: field.handle,
+                dottedKey: dottedKey || field.handle,
                 hidden: ! passes,
             });
 

--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -22,7 +22,7 @@ export default {
             default: false
         },
         namePrefix: String,
-        errorKeyPrefix: String,
+        fieldPathPrefix: String,
     },
 
     methods: {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -286,6 +286,8 @@ export default {
         this.$nextTick(() => this.mounted = true);
 
         this.pageHeader = document.querySelector('.global-header');
+
+        this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, this.errorKeyPrefix || this.handle);
     },
 
     beforeDestroy() {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -299,7 +299,12 @@ export default {
         json(json) {
             if (!this.mounted) return;
 
-            // Use a json string otherwise Laravel's TrimStrings middleware will remove spaces where we need them.
+            // Prosemirror's JSON will include spaces between tags.
+            // For example (this is not the actual json)...
+            // "<p>One <b>two</b> three</p>" becomes ['OneSPACE', '<b>two</b>', 'SPACEthree']
+            // But, Laravel's TrimStrings middleware would remove them.
+            // Those spaces need to be there, otherwise it would be rendered as <p>One<b>two</b>three</p>
+            // To combat this, we submit the JSON string instead of an object.
             this.updateDebounced(JSON.stringify(json));
         },
 

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -245,7 +245,7 @@ export default {
             if (! this.storeState) return [];
 
             return Object.values(this.setIndexes).filter((setIndex) => {
-                const prefix = `${this.errorKeyPrefix || this.handle}.${setIndex}.`;
+                const prefix = `${this.fieldPathPrefix || this.handle}.${setIndex}.`;
 
                 return Object.keys(this.storeState.errors).some(key => key.startsWith(prefix));
             })
@@ -287,7 +287,7 @@ export default {
 
         this.pageHeader = document.querySelector('.global-header');
 
-        this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, this.errorKeyPrefix || this.handle);
+        this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
     },
 
     beforeDestroy() {

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -36,14 +36,14 @@
         <div class="replicator-set-body" v-if="!collapsed && index !== undefined">
             <set-field
                 v-for="field in fields"
-                v-show="showField(field, dottedKey(field))"
+                v-show="showField(field, fieldPath(field))"
                 :key="field.handle"
                 :field="field"
                 :value="values[field.handle]"
                 :meta="meta[field.handle]"
                 :parent-name="parentName"
                 :set-index="index"
-                :error-key="errorKey(field)"
+                :field-path="fieldPath(field)"
                 :read-only="isReadOnly"
                 @updated="updated(field.handle, $event)"
                 @meta-updated="metaUpdated(field.handle, $event)"
@@ -191,13 +191,9 @@ export default {
             this.options.bard.expandSet(this.node.attrs.id);
         },
 
-        errorKey(field) {
-            let prefix = this.options.bard.errorKeyPrefix || this.options.bard.handle;
+        fieldPath(field) {
+            let prefix = this.options.bard.fieldPathPrefix || this.options.bard.handle;
             return `${prefix}.${this.index}.attrs.values.${field.handle}`;
-        },
-
-        dottedKey(field) {
-            return this.errorKey(field);
         },
 
     }

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -36,7 +36,7 @@
         <div class="replicator-set-body" v-if="!collapsed && index !== undefined">
             <set-field
                 v-for="field in fields"
-                v-show="showField(field)"
+                v-show="showField(field, dottedKey(field))"
                 :key="field.handle"
                 :field="field"
                 :value="values[field.handle]"
@@ -194,7 +194,11 @@ export default {
         errorKey(field) {
             let prefix = this.options.bard.errorKeyPrefix || this.options.bard.handle;
             return `${prefix}.${this.index}.attrs.values.${field.handle}`;
-        }
+        },
+
+        dottedKey(field) {
+            return this.errorKey(field);
+        },
 
     }
 }

--- a/resources/js/components/fieldtypes/grid/Cell.vue
+++ b/resources/js/components/fieldtypes/grid/Cell.vue
@@ -9,7 +9,7 @@
                 :meta="meta"
                 :handle="field.handle"
                 :name-prefix="namePrefix"
-                :error-key-prefix="errorKey"
+                :field-path-prefix="fieldPath"
                 :read-only="grid.isReadOnly"
                 @input="$emit('updated', $event)"
                 @meta-updated="$emit('meta-updated', $event)"
@@ -59,7 +59,7 @@ export default {
             type: Array,
             required: true
         },
-        errorKey: {
+        fieldPath: {
             type: String,
             required: true
         }

--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -117,7 +117,7 @@ export default {
 
     reactiveProvide: {
         name: 'grid',
-        include: ['config', 'isReorderable', 'isReadOnly', 'handle', 'errorKeyPrefix']
+        include: ['config', 'isReorderable', 'isReadOnly', 'handle', 'fieldPathPrefix']
     },
 
     watch: {
@@ -169,7 +169,7 @@ export default {
 
         removed(index) {
             if (! confirm(__('Are you sure?'))) return;
-                
+
             this.update([
                 ...this.value.slice(0, index),
                 ...this.value.slice(index + 1)

--- a/resources/js/components/fieldtypes/grid/Row.vue
+++ b/resources/js/components/fieldtypes/grid/Row.vue
@@ -4,7 +4,7 @@
         <td class="drag-handle" :class="sortableHandleClass" v-if="grid.isReorderable"></td>
         <grid-cell
             v-for="(field, i) in fields"
-            :show-inner="showField(field)"
+            :show-inner="showField(field, dottedKey(field))"
             :key="field.handle"
             :field="field"
             :value="values[field.handle]"
@@ -116,7 +116,11 @@ export default {
             const state = this.$store.state.publish[this.storeName];
             if (! state) return [];
             return state.errors[this.errorKey(handle)] || [];
-        }
+        },
+
+        dottedKey(field) {
+            return this.errorKey(field.handle);
+        },
     }
 
 }

--- a/resources/js/components/fieldtypes/grid/Row.vue
+++ b/resources/js/components/fieldtypes/grid/Row.vue
@@ -4,7 +4,7 @@
         <td class="drag-handle" :class="sortableHandleClass" v-if="grid.isReorderable"></td>
         <grid-cell
             v-for="(field, i) in fields"
-            :show-inner="showField(field, dottedKey(field))"
+            :show-inner="showField(field, fieldPath(field.handle))"
             :key="field.handle"
             :field="field"
             :value="values[field.handle]"
@@ -13,7 +13,7 @@
             :row-index="index"
             :grid-name="name"
             :errors="errors(field.handle)"
-            :error-key="errorKey(field.handle)"
+            :field-path="fieldPath(field.handle)"
             @updated="updated(field.handle, $event)"
             @meta-updated="metaUpdated(field.handle, $event)"
             @focus="$emit('focus')"
@@ -67,7 +67,7 @@ export default {
             type: String,
             required: true
         },
-        errorKeyPrefix: {
+        fieldPathPrefix: {
             type: String
         },
         canDelete: {
@@ -108,19 +108,16 @@ export default {
             this.$emit('meta-updated', meta);
         },
 
-        errorKey(handle) {
-            return `${this.errorKeyPrefix}.${this.index}.${handle}`;
+        fieldPath(handle) {
+            return `${this.fieldPathPrefix}.${this.index}.${handle}`;
         },
 
         errors(handle) {
             const state = this.$store.state.publish[this.storeName];
             if (! state) return [];
-            return state.errors[this.errorKey(handle)] || [];
+            return state.errors[this.fieldPath(handle)] || [];
         },
 
-        dottedKey(field) {
-            return this.errorKey(field.handle);
-        },
     }
 
 }

--- a/resources/js/components/fieldtypes/grid/Stacked.vue
+++ b/resources/js/components/fieldtypes/grid/Stacked.vue
@@ -18,7 +18,7 @@
                 :values="row"
                 :meta="meta[row._id]"
                 :name="name"
-                :error-key-prefix="errorKeyPrefix"
+                :field-path-prefix="fieldPathPrefix"
                 :can-delete="canDeleteRows"
                 :can-add-rows="canAddRows"
                 @updated="(row, value) => $emit('updated', row, value)"

--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -22,7 +22,7 @@
                 :parent-name="name"
                 :set-index="index"
                 :errors="errors(field.handle)"
-                :error-key-prefix="errorKey(field.handle)"
+                :field-path-prefix="fieldPath(field.handle)"
                 class="p-2"
                 :read-only="grid.isReadOnly"
                 @updated="updated(field.handle, $event)"

--- a/resources/js/components/fieldtypes/grid/Table.vue
+++ b/resources/js/components/fieldtypes/grid/Table.vue
@@ -30,7 +30,7 @@
                     :values="row"
                     :meta="meta[row._id]"
                     :name="name"
-                    :error-key-prefix="errorKeyPrefix"
+                    :field-path-prefix="fieldPathPrefix"
                     :can-delete="canDeleteRows"
                     :can-add-rows="canAddRows"
                     @updated="(row, value) => $emit('updated', row, value)"

--- a/resources/js/components/fieldtypes/grid/View.vue
+++ b/resources/js/components/fieldtypes/grid/View.vue
@@ -15,8 +15,8 @@ export default {
             return `${this.name}-drag-handle`;
         },
 
-        errorKeyPrefix() {
-            return this.grid.errorKeyPrefix || this.grid.handle;
+        fieldPathPrefix() {
+            return this.grid.fieldPathPrefix || this.grid.handle;
         }
 
     },

--- a/resources/js/components/fieldtypes/replicator/Field.vue
+++ b/resources/js/components/fieldtypes/replicator/Field.vue
@@ -20,7 +20,7 @@
             :value="value"
             :handle="field.handle"
             :name-prefix="namePrefix"
-            :error-key-prefix="errorKey"
+            :field-path-prefix="fieldPath"
             :has-error="hasError || hasNestedError"
             :read-only="isReadOnly"
             @input="$emit('updated', $event)"
@@ -65,7 +65,7 @@ export default {
             type: Number,
             required: true
         },
-        errorKey: {
+        fieldPath: {
             type: String
         },
         readOnly: Boolean,
@@ -98,7 +98,7 @@ export default {
         },
 
         errors() {
-            return this.storeState.errors[this.errorKey] || [];
+            return this.storeState.errors[this.fieldPath] || [];
         },
 
         hasError() {
@@ -106,7 +106,7 @@ export default {
         },
 
         hasNestedError() {
-            const prefix = `${this.errorKey}.`;
+            const prefix = `${this.fieldPath}.`;
 
             return Object.keys(this.storeState.errors).some(handle => handle.startsWith(prefix));
         },

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -30,7 +30,7 @@
                     :sortable-handle-class="sortableHandleClass"
                     :is-read-only="isReadOnly"
                     :collapsed="collapsed.includes(set._id)"
-                    :error-key-prefix="errorKeyPrefix || handle"
+                    :field-path-prefix="fieldPathPrefix || handle"
                     :has-error="setHasError(index)"
                     :previews="previews[set._id]"
                     @collapsed="collapseSet(set._id)"
@@ -90,7 +90,7 @@ export default {
     },
 
     computed: {
-        
+
         previews() {
             return this.meta.previews;
         },
@@ -204,7 +204,7 @@ export default {
         },
 
         setHasError(index) {
-            const prefix = `${this.errorKeyPrefix || this.handle}.${index}.`;
+            const prefix = `${this.fieldPathPrefix || this.handle}.${index}.`;
 
             return Object.keys(this.storeState.errors ?? []).some(handle => handle.startsWith(prefix));
         },

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -35,14 +35,14 @@
         <div class="replicator-set-body" v-if="!collapsed">
             <set-field
                 v-for="field in fields"
-                v-show="showField(field, dottedKey(field))"
+                v-show="showField(field, fieldPath(field))"
                 :key="field.handle"
                 :field="field"
                 :meta="meta[field.handle]"
                 :value="values[field.handle]"
                 :parent-name="parentName"
                 :set-index="index"
-                :error-key="errorKey(field)"
+                :field-path="fieldPath(field)"
                 :read-only="isReadOnly"
                 @updated="updated(field.handle, $event)"
                 @meta-updated="metaUpdated(field.handle, $event)"
@@ -104,7 +104,7 @@ export default {
             type: String,
             required: true
         },
-        errorKeyPrefix: {
+        fieldPathPrefix: {
             type: String,
             required: true
         },
@@ -199,12 +199,8 @@ export default {
             this.$emit('expanded');
         },
 
-        errorKey(field) {
-            return `${this.errorKeyPrefix}.${this.index}.${field.handle}`;
-        },
-
-        dottedKey(field) {
-            return this.errorKey(field);
+        fieldPath(field) {
+            return `${this.fieldPathPrefix}.${this.index}.${field.handle}`;
         },
 
     }

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -35,7 +35,7 @@
         <div class="replicator-set-body" v-if="!collapsed">
             <set-field
                 v-for="field in fields"
-                v-show="showField(field)"
+                v-show="showField(field, dottedKey(field))"
                 :key="field.handle"
                 :field="field"
                 :meta="meta[field.handle]"
@@ -201,7 +201,11 @@ export default {
 
         errorKey(field) {
             return `${this.errorKeyPrefix}.${this.index}.${field.handle}`;
-        }
+        },
+
+        dottedKey(field) {
+            return this.errorKey(field);
+        },
 
     }
 

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -97,6 +97,7 @@ export default {
                     blueprint: initial.blueprint,
                     values: initial.values,
                     hiddenFields: {},
+                    jsonSubmittingFields: [],
                     meta: initial.meta,
                     localizedFields: initial.localizedFields,
                     site: initial.site,
@@ -115,6 +116,9 @@ export default {
                     },
                     setHiddenField(state, field) {
                         state.hiddenFields[field.dottedKey] = field.hidden;
+                    },
+                    setFieldSubmitsJson(state, dottedKey) {
+                        state.jsonSubmittingFields.push(dottedKey);
                     },
                     setMeta(state, meta) {
                         state.meta = meta;

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -118,7 +118,9 @@ export default {
                         state.hiddenFields[field.dottedKey] = field.hidden;
                     },
                     setFieldSubmitsJson(state, dottedKey) {
-                        state.jsonSubmittingFields.push(dottedKey);
+                        if (state.jsonSubmittingFields.indexOf(dottedKey) === -1) {
+                            state.jsonSubmittingFields.push(dottedKey);
+                        }
                     },
                     setMeta(state, meta) {
                         state.meta = meta;

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -114,7 +114,7 @@ export default {
                         state.values = values;
                     },
                     setHiddenField(state, field) {
-                        state.hiddenFields[field.handle] = field.hidden;
+                        state.hiddenFields[field.dottedKey] = field.hidden;
                     },
                     setMeta(state, meta) {
                         state.meta = meta;

--- a/resources/js/components/publish/Field.vue
+++ b/resources/js/components/publish/Field.vue
@@ -61,7 +61,7 @@
                 :meta="meta"
                 :handle="config.handle"
                 :name-prefix="namePrefix"
-                :error-key-prefix="errorKeyPrefix"
+                :field-path-prefix="fieldPathPrefix"
                 :read-only="isReadOnly"
                 @input="$emit('input', $event)"
                 @meta-updated="$emit('meta-updated', $event)"
@@ -102,7 +102,7 @@ export default {
         readOnly: Boolean,
         syncable: Boolean,
         namePrefix: String,
-        errorKeyPrefix: String,
+        fieldPathPrefix: String,
         canToggleLabel: Boolean,
     },
 
@@ -191,7 +191,7 @@ export default {
         },
 
         hasNestedError() {
-            const prefix = `${this.errorKeyPrefix || this.config.handle}.`;
+            const prefix = `${this.fieldPathPrefix || this.config.handle}.`;
 
             return Object.keys(this.storeState.errors ?? []).some(handle => handle.startsWith(prefix));
         },

--- a/resources/js/tests/FieldConditionsOmitter.test.js
+++ b/resources/js/tests/FieldConditionsOmitter.test.js
@@ -143,3 +143,42 @@ test('it omits nested json field values', () => {
 
     expect(omitted).toEqual(expected);
 });
+
+test('it doesnt error when operating on non-existent keys', () => {
+    let values = {
+        first_name: 'Han',
+        last_name: 'Solo',
+        bffs: JSON.stringify([
+            {
+                name: 'Chewy',
+                type: 'Wookie',
+            },
+        ]),
+    };
+
+    let jsonFields = [
+        'bffs',
+        'middle_name',  // non-existent field
+        'bffs.0.crush', // non-existent field
+    ];
+
+    let omitted = new Omitter(values, jsonFields).omit([
+        'last_name',
+        'middle_name',  // non-existent field
+        'bffs.0.name',
+        'bffs.1.name',  // non-existent field
+        'bffs.0.crush', // non-existent field
+        'bffs.0.crush.0.name', // non-existent field
+    ]);
+
+    let expected = {
+        first_name: 'Han',
+        bffs: JSON.stringify([
+            {
+                type: 'Wookie',
+            },
+        ]),
+    };
+
+    expect(omitted).toEqual(expected);
+});

--- a/resources/js/tests/FieldConditionsOmitter.test.js
+++ b/resources/js/tests/FieldConditionsOmitter.test.js
@@ -144,6 +144,27 @@ test('it omits nested json field values', () => {
     expect(omitted).toEqual(expected);
 });
 
+test('it omits null hidden values', () => {
+    let values = {
+        first_name: 'Han',
+        last_name: 'Solo',
+        ship: 'Falcon',
+        bff: null, // this is null, but should still get removed
+    };
+
+    let omitted = new Omitter(values).omit([
+        'last_name',
+        'bff',
+    ]);
+
+    let expected = {
+        first_name: 'Han',
+        ship: 'Falcon',
+    };
+
+    expect(new Omitter(values).omit(['last_name', 'bff'])).toEqual(expected);
+});
+
 test('it doesnt error when operating on non-existent keys', () => {
     let values = {
         first_name: 'Han',

--- a/resources/js/tests/FieldConditionsOmitter.test.js
+++ b/resources/js/tests/FieldConditionsOmitter.test.js
@@ -1,0 +1,145 @@
+import Omitter from '../components/field-conditions/Omitter.js';
+
+test('it omits values at top level', () => {
+    let values = {
+        first_name: 'Han',
+        last_name: 'Solo',
+        ship: 'Falcon',
+        bff: 'Chewy',
+    };
+
+    let omitted = new Omitter(values).omit([
+        'last_name',
+        'bff',
+    ]);
+
+    let expected = {
+        first_name: 'Han',
+        ship: 'Falcon',
+    };
+
+    expect(new Omitter(values).omit(['last_name', 'bff'])).toEqual(expected);
+});
+
+test('it omits nested values', () => {
+    let values = {
+        first_name: 'Han',
+        last_name: 'Solo',
+        ship: {
+            name: 'Falcon',
+            completed_kessel_run: 'less than 12 parsecs',
+            junk: true,
+        },
+        bffs: [
+            {
+                name: 'Chewy',
+                type: 'Wookie',
+            },
+            {
+                name: 'Leia',
+                type: 'Woman',
+                crush: [
+                    {
+                        name: 'Lando',
+                        type: 'Man',
+                    }
+                ],
+            },
+        ],
+    };
+
+    let omitted = new Omitter(values).omit([
+        'last_name',
+        'ship.completed_kessel_run',
+        'bffs.0.type',
+        'bffs.1.crush.0.name',
+    ]);
+
+    let expected = {
+        first_name: 'Han',
+        ship: {
+            name: 'Falcon',
+            junk: true,
+        },
+        bffs: [
+            {
+                name: 'Chewy',
+            },
+            {
+                name: 'Leia',
+                type: 'Woman',
+                crush: [
+                    {
+                        type: 'Man',
+                    }
+                ],
+            },
+        ],
+    };
+
+    expect(omitted).toEqual(expected);
+});
+
+test('it omits nested json field values', () => {
+    let values = {
+        first_name: 'Han',
+        last_name: 'Solo',
+        ship: {
+            name: 'Falcon',
+            completed_kessel_run: 'less than 12 parsecs',
+            junk: true,
+        },
+        bffs: JSON.stringify([
+            {
+                name: 'Chewy',
+                type: 'Wookie',
+            },
+            {
+                name: 'Leia',
+                type: 'Woman',
+                crush: JSON.stringify([
+                    {
+                        name: 'Lando',
+                        type: 'Man',
+                    },
+                ]),
+            },
+        ]),
+    };
+
+    let jsonFields = [
+        'bffs.1.crush', // Intentionally passing deeper JSON value first to ensure the Omitter properly sorts these before decoding
+        'bffs',
+    ];
+
+    let omitted = new Omitter(values, jsonFields).omit([
+        'last_name',
+        'ship.completed_kessel_run',
+        'bffs.0.type',
+        'bffs.1.crush.0.name',
+    ]);
+
+    let expected = {
+        first_name: 'Han',
+        ship: {
+            name: 'Falcon',
+            junk: true,
+        },
+        bffs: JSON.stringify([
+            {
+                name: 'Chewy',
+            },
+            {
+                name: 'Leia',
+                type: 'Woman',
+                crush: JSON.stringify([
+                    {
+                        type: 'Man',
+                    },
+                ]),
+            },
+        ]),
+    };
+
+    expect(omitted).toEqual(expected);
+});

--- a/resources/js/tests/FieldConditionsOmitter.test.js
+++ b/resources/js/tests/FieldConditionsOmitter.test.js
@@ -165,7 +165,7 @@ test('it omits null hidden values', () => {
     expect(new Omitter(values).omit(['last_name', 'bff'])).toEqual(expected);
 });
 
-test('it doesnt error when operating on non-existent keys', () => {
+test('it gracefully handles errors', () => {
     let values = {
         first_name: 'Han',
         last_name: 'Solo',
@@ -179,6 +179,7 @@ test('it doesnt error when operating on non-existent keys', () => {
 
     let jsonFields = [
         'bffs',
+        'bffs',         // duplicate field
         'middle_name',  // non-existent field
         'bffs.0.crush', // non-existent field
     ];
@@ -187,6 +188,7 @@ test('it doesnt error when operating on non-existent keys', () => {
         'last_name',
         'middle_name',  // non-existent field
         'bffs.0.name',
+        'bffs.0.name',  // duplicate field
         'bffs.1.name',  // non-existent field
         'bffs.0.crush', // non-existent field
         'bffs.0.crush.0.name', // non-existent field

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -19,7 +19,6 @@ class Field implements Arrayable
     protected $value;
     protected $parent;
     protected $parentField;
-    protected $filled = false;
     protected $validationContext;
 
     public function __construct($handle, array $config)
@@ -33,8 +32,7 @@ class Field implements Arrayable
         return (new static($this->handle, $this->config))
             ->setParent($this->parent)
             ->setParentField($this->parentField)
-            ->setValue($this->value)
-            ->setFilled($this->filled);
+            ->setValue($this->value);
     }
 
     public function setHandle(string $handle)
@@ -201,11 +199,6 @@ class Field implements Arrayable
         return (bool) $this->get('filterable');
     }
 
-    public function isFilled()
-    {
-        return (bool) $this->filled;
-    }
-
     public function toPublishArray()
     {
         return array_merge($this->preProcessedConfig(), [
@@ -232,24 +225,9 @@ class Field implements Arrayable
         ];
     }
 
-    public function setFilled($filled)
-    {
-        $this->filled = $filled;
-
-        return $this;
-    }
-
     public function setValue($value)
     {
         $this->value = $value;
-
-        return $this;
-    }
-
-    public function fillValue($value)
-    {
-        $this->value = $value;
-        $this->filled = true;
 
         return $this;
     }

--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -15,6 +15,7 @@ class Fields
     protected $fields;
     protected $parent;
     protected $parentField;
+    protected $filled;
 
     public function __construct($items = [], $parent = null, $parentField = null)
     {
@@ -58,6 +59,13 @@ class Fields
         return $this;
     }
 
+    public function setFilled($dottedKeys)
+    {
+        $this->filled = $dottedKeys;
+
+        return $this;
+    }
+
     public function items()
     {
         return $this->items;
@@ -84,7 +92,8 @@ class Fields
             ->setParent($this->parent)
             ->setParentField($this->parentField)
             ->setItems($this->items)
-            ->setFields($this->fields);
+            ->setFields($this->fields)
+            ->setFilled($this->filled);
     }
 
     public function localizable()
@@ -118,13 +127,13 @@ class Fields
 
     public function addValues(array $values)
     {
+        $filled = array_keys($values);
+
         $fields = $this->fields->map(function ($field) use ($values) {
-            return Arr::has($values, $field->handle())
-                ? $field->newInstance()->fillValue(Arr::get($values, $field->handle()))
-                : $field->newInstance();
+            return $field->newInstance()->setValue(Arr::get($values, $field->handle()));
         });
 
-        return $this->newInstance()->setFields($fields);
+        return $this->newInstance()->setFilled($filled)->setFields($fields);
     }
 
     public function values()
@@ -136,8 +145,8 @@ class Fields
 
     public function validatableValues()
     {
-        return $this->values()->filter(function ($value, $handle) {
-            return $this->fields->get($handle)->isFilled();
+        return $this->values()->filter(function ($field, $handle) {
+            return in_array($handle, $this->filled);
         });
     }
 

--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -16,6 +16,7 @@ class Fields
     protected $parent;
     protected $parentField;
     protected $filled;
+    protected $withValidatableValues = false;
 
     public function __construct($items = [], $parent = null, $parentField = null)
     {
@@ -62,6 +63,13 @@ class Fields
     public function setFilled($dottedKeys)
     {
         $this->filled = $dottedKeys;
+
+        return $this;
+    }
+
+    public function withValidatableValues()
+    {
+        $this->withValidatableValues = true;
 
         return $this;
     }
@@ -138,16 +146,17 @@ class Fields
 
     public function values()
     {
-        return $this->fields->mapWithKeys(function ($field) {
+        $values = $this->fields->mapWithKeys(function ($field) {
             return [$field->handle() => $field->value()];
         });
-    }
 
-    public function validatableValues()
-    {
-        return $this->values()->filter(function ($field, $handle) {
-            return in_array($handle, $this->filled);
-        });
+        if ($this->withValidatableValues) {
+            $values = $values->filter(function ($field, $handle) {
+                return in_array($handle, $this->filled);
+            });
+        }
+
+        return $values;
     }
 
     public function process()
@@ -168,7 +177,7 @@ class Fields
     {
         return $this->newInstance()->setFields(
             $this->fields->map->preProcessValidatable()
-        );
+        )->withValidatableValues();
     }
 
     public function augment()

--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -15,7 +15,7 @@ class Fields
     protected $fields;
     protected $parent;
     protected $parentField;
-    protected $filled;
+    protected $filled = [];
     protected $withValidatableValues = false;
 
     public function __construct($items = [], $parent = null, $parentField = null)

--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -96,7 +96,7 @@ class Validator
     public function validate()
     {
         return LaravelValidator::validate(
-            $this->fields->preProcessValidatables()->validatableValues()->all(),
+            $this->fields->preProcessValidatables()->values()->all(),
             $this->rules(),
             $this->customMessages,
             $this->attributes()

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -438,7 +438,7 @@ class Bard extends Replicator
             $processed = $this->fields($values['type'])
                 ->addValues($values)
                 ->preProcessValidatables()
-                ->values()
+                ->validatableValues()
                 ->all();
 
             $item['attrs']['values'] = array_merge($values, $processed);

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -438,7 +438,7 @@ class Bard extends Replicator
             $processed = $this->fields($values['type'])
                 ->addValues($values)
                 ->preProcessValidatables()
-                ->validatableValues()
+                ->values()
                 ->all();
 
             $item['attrs']['values'] = array_merge($values, $processed);

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -235,7 +235,7 @@ class Grid extends Fieldtype
             $processed = $this->fields()
                 ->addValues($values)
                 ->preProcessValidatables()
-                ->validatableValues()
+                ->values()
                 ->all();
 
             return array_merge($values, $processed);

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -163,7 +163,7 @@ class Grid extends Fieldtype
         $attributes = $this->fields()->validator()->attributes();
 
         return collect($this->field->value())->map(function ($row, $index) use ($attributes) {
-            return collect($attributes)->except('_id')->mapWithKeys(function ($attribute, $handle) use ($attributes, $index) {
+            return collect($attributes)->except('_id')->mapWithKeys(function ($attribute, $handle) use ($index) {
                 return [$this->rowRuleFieldPrefix($index).'.'.$handle => $attribute];
             });
         })->reduce(function ($carry, $rules) {

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -163,8 +163,8 @@ class Grid extends Fieldtype
         $attributes = $this->fields()->validator()->attributes();
 
         return collect($this->field->value())->map(function ($row, $index) use ($attributes) {
-            return collect($row)->except('_id')->mapWithKeys(function ($value, $handle) use ($attributes, $index) {
-                return [$this->rowRuleFieldPrefix($index).'.'.$handle => $attributes[$handle] ?? null];
+            return collect($attributes)->except('_id')->mapWithKeys(function ($attribute, $handle) use ($attributes, $index) {
+                return [$this->rowRuleFieldPrefix($index).'.'.$handle => $attribute];
             });
         })->reduce(function ($carry, $rules) {
             return $carry->merge($rules);

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -235,7 +235,7 @@ class Grid extends Fieldtype
             $processed = $this->fields()
                 ->addValues($values)
                 ->preProcessValidatables()
-                ->values()
+                ->validatableValues()
                 ->all();
 
             return array_merge($values, $processed);

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -253,7 +253,7 @@ class Replicator extends Fieldtype
             $processed = $this->fields($values['type'])
                 ->addValues($values)
                 ->preProcessValidatables()
-                ->validatableValues()
+                ->values()
                 ->all();
 
             return array_merge($values, $processed);

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -253,7 +253,7 @@ class Replicator extends Fieldtype
             $processed = $this->fields($values['type'])
                 ->addValues($values)
                 ->preProcessValidatables()
-                ->values()
+                ->validatableValues()
                 ->all();
 
             return array_merge($values, $processed);

--- a/tests/Fields/FieldsTest.php
+++ b/tests/Fields/FieldsTest.php
@@ -555,8 +555,6 @@ class FieldsTest extends TestCase
 
         $fields = $fields->addValues(['one' => 'foo']);
 
-        $this->assertTrue($fields->get('one')->isFilled());
-        $this->assertFalse($fields->get('two')->isFilled());
         $this->assertEquals(['one' => 'foo', 'two' => null], $fields->values()->all());
         $this->assertEquals(['one' => 'foo'], $fields->validatableValues()->all());
     }
@@ -564,8 +562,7 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_processes_each_fields_values_by_its_fieldtype()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
-        {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
             public function process($data)
             {
                 return $data.' processed';
@@ -604,8 +601,7 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_preprocesses_each_fields_values_by_its_fieldtype()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
-        {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
             public function preProcess($data)
             {
                 return $data.' preprocessed';
@@ -644,8 +640,7 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_augments_each_fields_values_by_its_fieldtype()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
-        {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
             public function augment($data)
             {
                 return $data.' augmented';
@@ -701,8 +696,7 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_gets_meta_data_from_all_fields()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
-        {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
             public function preload()
             {
                 return 'meta data from field '.$this->field->handle().' is '.($this->field->value() * 2);

--- a/tests/Fields/FieldsTest.php
+++ b/tests/Fields/FieldsTest.php
@@ -556,7 +556,7 @@ class FieldsTest extends TestCase
         $fields = $fields->addValues(['one' => 'foo']);
 
         $this->assertEquals(['one' => 'foo', 'two' => null], $fields->values()->all());
-        $this->assertEquals(['one' => 'foo'], $fields->validatableValues()->all());
+        $this->assertEquals(['one' => 'foo'], $fields->preProcessValidatables()->values()->all());
     }
 
     /** @test */

--- a/tests/Fields/FieldsTest.php
+++ b/tests/Fields/FieldsTest.php
@@ -562,7 +562,8 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_processes_each_fields_values_by_its_fieldtype()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
+        {
             public function process($data)
             {
                 return $data.' processed';
@@ -601,7 +602,8 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_preprocesses_each_fields_values_by_its_fieldtype()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
+        {
             public function preProcess($data)
             {
                 return $data.' preprocessed';
@@ -640,7 +642,8 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_augments_each_fields_values_by_its_fieldtype()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
+        {
             public function augment($data)
             {
                 return $data.' augmented';
@@ -696,7 +699,8 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_gets_meta_data_from_all_fields()
     {
-        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype {
+        FieldtypeRepository::shouldReceive('find')->with('fieldtype')->andReturn(new class extends Fieldtype
+        {
             public function preload()
             {
                 return 'meta data from field '.$this->field->handle().' is '.($this->field->value() * 2);

--- a/tests/Fields/FieldsTest.php
+++ b/tests/Fields/FieldsTest.php
@@ -536,27 +536,67 @@ class FieldsTest extends TestCase
     }
 
     /** @test */
-    public function adding_values_sets_filled_status_on_fields_for_validation()
+    public function preprocessing_validatables_removes_unfilled_values()
     {
-        FieldRepository::shouldReceive('find')->with('one')->andReturnUsing(function () {
-            return new Field('one', []);
-        });
-
-        FieldRepository::shouldReceive('find')->with('two')->andReturnUsing(function () {
-            return new Field('two', []);
-        });
-
         $fields = new Fields([
-            ['handle' => 'one', 'field' => 'one'],
-            ['handle' => 'two', 'field' => 'two'],
+            ['handle' => 'title', 'field' => ['type' => 'text']],
+            ['handle' => 'one', 'field' => ['type' => 'text']],
+            ['handle' => 'two', 'field' => ['type' => 'text']],
+            ['handle' => 'reppy', 'field' => ['type' => 'replicator', 'sets' => ['replicator_set' => ['fields' => [
+                ['handle' => 'title', 'field' => ['type' => 'text']],
+                ['handle' => 'one', 'field' => ['type' => 'text']],
+                ['handle' => 'two', 'field' => ['type' => 'text']],
+                ['handle' => 'griddy_in_reppy', 'field' => ['type' => 'grid', 'fields' => [
+                    ['handle' => 'title', 'field' => ['type' => 'text']],
+                    ['handle' => 'one', 'field' => ['type' => 'text']],
+                    ['handle' => 'two', 'field' => ['type' => 'text']],
+                    ['handle' => 'bardo_in_griddy_in_reppy', 'field' => ['type' => 'bard', 'sets' => ['bard_set' => ['fields' => [
+                        ['handle' => 'title', 'field' => ['type' => 'text']],
+                        ['handle' => 'one', 'field' => ['type' => 'text']],
+                        ['handle' => 'two', 'field' => ['type' => 'text']],
+                        ['handle' => 'bardo_in_bardo_in_griddy_in_reppy', 'field' => ['type' => 'bard', 'sets' => ['bard_set_set' => ['fields' => [
+                            ['handle' => 'title', 'field' => ['type' => 'text']],
+                            ['handle' => 'one', 'field' => ['type' => 'text']],
+                            ['handle' => 'two', 'field' => ['type' => 'text']],
+                        ]]]]],
+                    ]]]]],
+                ]]],
+            ]]]]],
         ]);
 
-        $this->assertEquals(['one' => null, 'two' => null], $fields->values()->all());
+        $this->assertEquals(['title' => null, 'one' => null, 'two' => null, 'reppy' => null], $fields->values()->all());
+        $this->assertEquals([], $fields->preProcessValidatables()->values()->all());
 
-        $fields = $fields->addValues(['one' => 'foo']);
+        $values = $expected = [
+            'title' => 'recursion madness',
+            'one' => 'foo',
+            'reppy' => [
+                ['type' => 'replicator_set', 'two' => 'foo'],
+                ['type' => 'replicator_set', 'griddy_in_reppy' => [
+                    ['one' => 'foo'],
+                    ['bardo_in_griddy_in_reppy' => json_encode($bardValues = [
+                        ['type' => 'set', 'attrs' => ['values' => ['type' => 'bard_set', 'two' => 'foo']]],
+                        ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'foo']]],
+                        ['type' => 'set', 'attrs' => ['type' => 'bard_set', 'values' => ['type' => 'bard_set', 'bardo_in_bardo_in_griddy_in_reppy' => json_encode($doubleNestedBardValues = [
+                            ['type' => 'set', 'attrs' => ['values' => ['type' => 'bard_set', 'two' => 'foo']]],
+                            ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'foo']]],
+                        ])]]],
+                    ])],
+                ]],
+            ],
+        ];
 
-        $this->assertEquals(['one' => 'foo', 'two' => null], $fields->values()->all());
-        $this->assertEquals(['one' => 'foo'], $fields->preProcessValidatables()->values()->all());
+        // Calling `addValues()` should track which fields are filled at each level of nesting.
+        // When we call `preProcessValidatables()`, unfilled values should get removed, in
+        // order to ensure rules like `sometimes` and `required_if` work at all levels.
+        $validatableValues = $fields->addValues($values)->preProcessValidatables()->values()->all();
+
+        // Bard fields submit JSON values, so we'll replace them with their corresponding PHP array
+        // values here, since `preProcessValidatables()` will return JSON decoded decoded values.
+        $expected['reppy'][1]['griddy_in_reppy'][1]['bardo_in_griddy_in_reppy'] = $bardValues;
+        $expected['reppy'][1]['griddy_in_reppy'][1]['bardo_in_griddy_in_reppy'][2]['attrs']['values']['bardo_in_bardo_in_griddy_in_reppy'] = $doubleNestedBardValues;
+
+        $this->assertEquals($expected, $validatableValues);
     }
 
     /** @test */

--- a/tests/Fields/ValidatorTest.php
+++ b/tests/Fields/ValidatorTest.php
@@ -328,7 +328,9 @@ class ValidatorTest extends TestCase
                 ['type' => 'replicator_set', 'nested_replicator' => [['type' => 'replicator_set', 'nested_replicator' => [['type' => 'replicator_set']]]]],
             ],
             'replicator_with_nested_grid' => [
-                ['type' => 'replicator_set', 'nested_grid' => [[]]],
+                ['type' => 'replicator_set', 'nested_grid' => [
+                    ['text' => null, 'not_in_blueprint' => 'test'],
+                ]],
             ],
             'replicator_with_nested_bard' => [
                 ['type' => 'replicator_set', 'nested_bard' => [['type' => 'set', 'attrs' => ['values' => ['type' => 'bard_set']]]]],


### PR DESCRIPTION
In https://github.com/statamic/cms/pull/5101, we added tracking for hidden fields, so that users could use `sometimes`, `required_if`, etc. validation rules. That PR only handled fields at the top level though, and caused issues between nested fields and top level fields with the same handles. This PR adds proper handling of nested hidden fields.

- [x] Track and remove nested hidden fields on front end before submitting payload to server.
    - [x] Fields nested in replicators (Closes #5589)
    - [x] Fields nested in grids
    - [x] Fields nested in bards
        - [x] Fields nested in bards in bards, because bard fields submit values nested in JSON 🤯
- [x] Ensure hidden field values (and nested hidden field values) are properly removed on PHP side before validating.
- [x] Refactor `errorKey` and `errorKeyPrefix` props/methods to `fieldPath` and `fieldPathPrefix` respectively.
        - We are now using error key for more than error handling, since those keys match payload structure.
- [x] Add test coverage.