### PR TITLE
Antlers: Add line details for runtime parser exceptions

### DIFF
--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -651,7 +651,7 @@ INFO;
                     }
 
                     return [
-                        $currentFileStack->get($index)[0],
+                        $currentFileStack->get($index)[0] ?? 'unknown',
                         $tag,
                     ];
                 })->reverse()->all();

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -486,7 +486,7 @@ class RuntimeParser implements Parser
             [
                 'file' => $exception->getFile(),
                 'line' => $exception->getLine(),
-            ]
+            ],
         ];
 
         $rebuiltTrace = array_merge($previous, $rebuiltTrace, $exception->getTrace());

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -485,7 +485,7 @@ class RuntimeParser implements Parser
         $previous = [
             [
                 'file' => $exception->getFile(),
-                'line' => $exception->getLine()
+                'line' => $exception->getLine(),
             ]
         ];
 


### PR DESCRIPTION
This PR feebly attempts to add line details to Ignition so that you can see exactly which line is causing the error when shown the detailed exception handler by way of the line highlighter appearing in the correct place.

It also prepends the underlying (`previous`) exception's error to the top of the stack trace for clarity (as Ignition doesn't support `previous` exceptions yet), which hopefully helps join a few more dots.

I've found this really useful when debugging why my templates aren't working with the `runtime` renderer as I can pinpoint exactly where the problem lies instead of trying to guess.

It's very hacky and I haven't run any tests against it... only been using it for about 30 mins, but hopefully it's a start.

One for @JohnathonKoster 