### PR TITLE
Add a {{ search:count }} tag

### DIFF
--- a/src/Search/Tags.php
+++ b/src/Search/Tags.php
@@ -19,6 +19,26 @@ class Tags extends BaseTags
 
     protected static $handle = 'search';
 
+    public function count()
+    {
+        if (! $query = request($this->params->get('query', 'q'))) {
+            return 0;
+        }
+
+        $builder = Search::index($this->params->get('index'))
+            ->ensureExists()
+            ->search($query);
+
+        $this->querySite($builder);
+        $this->queryStatus($builder);
+        $this->queryConditions($builder);
+        $this->queryScopes($builder);
+
+        $results = $this->getQueryResults($builder);
+
+        return $results->count();
+    }
+
     public function results()
     {
         if (! $query = request($this->params->get('query', 'q'))) {


### PR DESCRIPTION
As of right now the total_results count value is only accessible within the search:results loop.

So if you want to print the total number of search results outside of said loop (e.g. in the headline as my designers love to do), you have to loop through the results only to print one number.

This tag would allow us to simple output the total results count using {{ search:count }} instead, which would be a lot cleaner.

First PR attempt ever, feel free to let me know what I'm doing wrong.