### PR TITLE
Improve whereIn query builder

### DIFF
--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -143,6 +143,10 @@ abstract class Builder extends BaseBuilder
     protected function filterWhereIn($values, $where)
     {
         return $values->filter(function ($value) use ($where) {
+            if(is_array($value)){
+                return array_filter($value, fn($value) => in_array($value, $where['values']));
+            }
+
             return in_array($value, $where['values']);
         });
     }
@@ -150,6 +154,10 @@ abstract class Builder extends BaseBuilder
     protected function filterWhereNotIn($values, $where)
     {
         return $values->filter(function ($value) use ($where) {
+            if(is_array($value)){
+                return array_filter($value, fn($value) => ! in_array($value, $where['values']));
+            }
+
             return ! in_array($value, $where['values']);
         });
     }


### PR DESCRIPTION
This PR adds filtering by whereIn for array fields. For example there is an entry:
```
id: 752ca10d-b192-4a90-a3a4-31269345a3c7
title: 'Printer XYZ'
category:
  - printers
...
```
Querying this entry will return 0 results:
```
Entry::query()->whereIn('category', ['printers', 'headphones'])->count() // 0
```
This PR fixes this and query above will return correct number of entries.
