### PR TITLE
Fix bug when adding time enabled date

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -443,6 +443,10 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
                     return Carbon::createFromFormat('Y-m-d', $date)->startOfDay();
                 }
 
+                if (strlen($date) === 17) {
+                    return Carbon::createFromFormat('Y-m-d-His', $date);
+                }
+
                 return Carbon::createFromFormat('Y-m-d-Hi', $date);
             })
             ->args(func_get_args());


### PR DESCRIPTION
When adding a date to a date-enabled collection which also has time-enabled a "Trailing data" error was being thrown by the Carbon parse method.

To fix we check the date length and if it has a length that includes seconds, it parses for seconds as well as hours and minutes.