### PR TITLE
Runtime: Prevent shorthand modifier tag pair modifiers from being evaluated twice

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1632,6 +1632,15 @@ class NodeProcessor
                             $runtimeResult = $environment->evaluate($node->parsedRuntimeNodes);
                             $this->data = $restoreData;
 
+                            // If the environment processed modifiers for the current node
+                            // and the node does _not_ have parameters, we will set the
+                            // $runtimeResolveModifiedValue flag to true to prevent
+                            // the NodeProcessor from attempting to evaluate the
+                            // modifier chain again down below before loops.
+                            if (! $node->hasParameters && $environment->getDidEvaluateModifiers()) {
+                                $runtimeResolveModifiedValue = true;
+                            }
+
                             if (is_string($runtimeResult) && $node->hasProcessedInterpolationRegions) {
                                 $interpolationScope = $this->getActiveData();
 

--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -91,6 +91,7 @@ class Environment
     protected $interpolationKeys = [];
     protected $assignments = [];
     protected $dataManagerInterpolations = [];
+    protected $evaluatedModifiers = false;
 
     /**
      * @var LanguageOperatorManager|null
@@ -309,6 +310,8 @@ class Environment
      */
     public function evaluate($nodes)
     {
+        $this->evaluatedModifiers = false;
+
         if (count($nodes) == 0) {
             return null;
         }
@@ -1241,7 +1244,14 @@ class Environment
      */
     private function applyModifiers($value, ModifierChainNode $modifierChain)
     {
+        $this->evaluatedModifiers = true;
+
         return ModifierManager::evaluate($value, $this, $modifierChain, $this->data);
+    }
+
+    public function getDidEvaluateModifiers()
+    {
+        return $this->evaluatedModifiers;
     }
 
     /**

--- a/tests/Antlers/Runtime/LoopTest.php
+++ b/tests/Antlers/Runtime/LoopTest.php
@@ -145,4 +145,35 @@ EOT;
         $this->assertSame($expected, trim($this->renderString($template, $data, true)));
         $this->assertTrue($isPaired);
     }
+
+    public function test_runtime_does_not_attempt_evaluate_modifiers_twice()
+    {
+        mt_srand(1234);
+
+        $data = [
+            'widths' => [
+                '25',
+                '50',
+                '75',
+            ],
+        ];
+
+        $template = <<<'EOT'
+{{ loop from="1" to="10" }}<{{ value }}><{{ widths | shuffle | limit:1 }}width-{{ value }}{{ /widths }}><{{ value }}>{{ unless last }}|{{ /unless}}{{ /loop }}
+EOT;
+
+        $expected = <<<'EXPECTED'
+<1><width-75><1>|<2><width-75><2>|<3><width-50><3>|<4><width-75><4>|<5><width-25><5>|<6><width-75><6>|<7><width-75><7>|<8><width-50><8>|<9><width-50><9>|<10><width-50><10>
+EXPECTED;
+
+        $this->assertSame($expected, $this->renderString($template, $data, true));
+
+        mt_srand(1234);
+
+        $template = <<<'EOT'
+{{ loop from="1" to="10" }}<{{ value }}><{{ widths | shuffle | limit:1 }}width-{{ value }}{{ /widths | shuffle | limit:1 }}><{{ value }}>{{ unless last }}|{{ /unless }}{{ /loop }}
+EOT;
+
+        $this->assertSame($expected, $this->renderString($template, $data, true));
+    }
 }


### PR DESCRIPTION
This PR resolves an issue where short-hand modifiers on tag pairs can be evaluated _twice_ when returning an array; often leading to unpredictable/incorrect results.

This bug prevent templates like the following from being evaluated correctly:

```
---
widths:
 - '25'
 - '50'
 - '75'
---

{{ loop from="1" to="10" }}
    {{ view:widths | shuffle | limit:1 }}
        {{ value }}  <-- Should pull a random width, but will get confused after the first iteration before the fix.
    {{ /view:widths }}
{{ /loop }}
```