### PR TITLE
Runtime: Prevents looping over nulls from being added to the log

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1715,6 +1715,10 @@ class NodeProcessor
                                 $val = $runtimeResult;
                             } else {
                                 if (! $runtimeResult instanceof Builder) {
+                                    if ($runtimeResult === null) {
+                                        continue;
+                                    }
+
                                     if ($this->guardRuntime($node, $runtimeResult)) {
                                         $buffer .= $this->measureBufferAppend($node, $this->modifyBufferAppend($runtimeResult));
                                     }


### PR DESCRIPTION
This PR simply checks against `null` values before attempting to loop over them/perform sanity checking. This prevents items like the following from appearing in your logs when the value is `null`:

```
local.DEBUG: Cannot loop over non-loopable variable: {{ doesnt_exist }}
```

To reproduce simply loop over a variable that contains `null` or does not exist:

```
{{ doesnt_exist  }}

{{ /doesnt_exist  }}
```