### PR TITLE
Custom domain for Control Panel

### DIFF
--- a/config/cp.php
+++ b/config/cp.php
@@ -7,13 +7,15 @@ return [
     | Control Panel
     |--------------------------------------------------------------------------
     |
-    | Whether the Control Panel should be enabled, and through what route.
+    | Whether the Control Panel should be enabled, and through what route and domain.
     |
     */
 
     'enabled' => env('CP_ENABLED', true),
 
     'route' => env('CP_ROUTE', 'cp'),
+
+    'domain' => env('CP_DOMAIN', null),
 
     /*
     |--------------------------------------------------------------------------

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -25,6 +25,7 @@ if (config('statamic.cp.enabled')) {
         Route::middleware('statamic.cp')
             ->name('statamic.cp.')
             ->prefix(config('statamic.cp.route'))
+            ->domain(config('statamic.cp.domain'))
             ->namespace('Statamic\Http\Controllers\CP')
             ->group(__DIR__.'/cp.php');
     });


### PR DESCRIPTION
In my existing Laravel installation I already have a mini admin panel for viewing subscriber counts and other items.  I hooked Statamic into the same auth guard, but because the login for the Statamic is on a separate domain than my admin panel domain I have to login twice.

What I want:

- Main site (ex. `mysite.com/blog/some-post`)
- Control Panel (ex. `admin.mysite.com`)

This PR allows for a domain to be optionally set for the CP.