### PR TITLE
Runtime: Fixes Single Letter Variables Without Spaces Skipping HTML Content

### DIFF
--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -103,6 +103,11 @@ class DocumentParser
     private $currentChunkOffset = 0;
     private $isNoParse = false;
 
+    private $interpolatedCollisions = [];
+    private $interpolatedCollisionCount = [];
+    private $threeCharCollisionCount = -1;
+    private $threeCharCollisions = [];
+
     /**
      * A list of node visitors.
      *
@@ -506,148 +511,138 @@ class DocumentParser
                     }
                 }
 
-                $shouldProduceLiteralNode = false;
+                if ($i !== $lastIndex && $this->lastAntlersNode != null) {
+                    $startCandidate = $this->positionFromOffset($offset, $offset);
 
-                if (! array_key_exists($this->currentChunkOffset, $this->antlersStartPositionIndex)) {
-                    $shouldProduceLiteralNode = true;
-                } elseif ($this->lastAntlersEndIndex < $this->currentChunkOffset) {
-                    $shouldProduceLiteralNode = true;
-                }
+                    // Skip processing potential nodes that are inside the last node.
+                    if ($startCandidate->isBefore($this->lastAntlersNode->endPosition)) {
+                        if ($i + 1 < $indexCount) {
+                            $nextAntlersStart = $this->antlersStartIndex[$i + 1];
 
-                if ($shouldProduceLiteralNode) {
-                    if ($i !== $lastIndex && $this->lastAntlersNode != null) {
-                        $startCandidate = $this->positionFromOffset($offset, $offset);
+                            if ($nextAntlersStart < $this->lastAntlersNode->endPosition->offset) {
+                                if ($i + 2 < $indexCount) {
+                                    $nextAntlersStart = $this->antlersStartIndex[$i + 2];
+                                } else {
+                                    $literalStart = $this->lastAntlersNode->endPosition->offset + 1;
+                                    $finalContent = $this->prepareLiteralContent(StringUtilities::substr($this->content, $literalStart));
 
-                        // Skip processing potential nodes that are inside the last node.
-                        if ($startCandidate->isBefore($this->lastAntlersNode->endPosition)) {
-                            if ($i + 1 < $indexCount) {
-                                $nextAntlersStart = $this->antlersStartIndex[$i + 1];
-
-                                if ($nextAntlersStart < $this->lastAntlersNode->endPosition->offset) {
-                                    if ($i + 2 < $indexCount) {
-                                        $nextAntlersStart = $this->antlersStartIndex[$i + 2];
-                                    } else {
-                                        $literalStart = $this->lastAntlersNode->endPosition->offset + 1;
-                                        $finalContent = $this->prepareLiteralContent(StringUtilities::substr($this->content, $literalStart));
-
-                                        if (! strlen($finalContent) == 0) {
-                                            $finalLiteral = new LiteralNode();
-                                            $finalLiteral->content = $finalContent;
-                                            $finalLiteral->startPosition = $this->positionFromOffset($literalStart, $literalStart);
-                                            $finalLiteral->endPosition = $this->positionFromOffset($this->inputLen - 1, $literalStart);
-                                            $this->nodes[] = $finalLiteral;
-                                            break;
-                                        }
-
-                                        continue;
+                                    if (! strlen($finalContent) == 0) {
+                                        $finalLiteral = new LiteralNode();
+                                        $finalLiteral->content = $finalContent;
+                                        $finalLiteral->startPosition = $this->positionFromOffset($literalStart, $literalStart);
+                                        $finalLiteral->endPosition = $this->positionFromOffset($this->inputLen - 1, $literalStart);
+                                        $this->nodes[] = $finalLiteral;
+                                        break;
                                     }
-                                }
-                            } else {
-                                if ($i + 1 != $lastIndex) {
+
                                     continue;
                                 }
                             }
+                        } else {
+                            if ($i + 1 != $lastIndex) {
+                                continue;
+                            }
                         }
                     }
+                }
 
-                    if ($i + 1 < $indexCount) {
-                        $nextAntlersStart = $this->antlersStartIndex[$i + 1];
-                        $literalStartIndex = $this->lastAntlersEndIndex + 1;
+                if ($i + 1 < $indexCount) {
+                    $nextAntlersStart = $this->antlersStartIndex[$i + 1];
+                    $literalStartIndex = $this->lastAntlersEndIndex + 1;
 
-                        if ($nextAntlersStart < $literalStartIndex) {
-                            if ($this->lastAntlersEndIndex > $nextAntlersStart) {
-                                $skipIndex = null;
-                                for ($j = $i; $j < $indexCount; $j++) {
-                                    if ($this->antlersStartIndex[$j] > $this->lastAntlersEndIndex) {
-                                        $skipIndex = $this->antlersStartIndex[$j];
-                                        break;
-                                    }
-                                }
-
-                                if ($skipIndex != null) {
-                                    $nextAntlersStart = $skipIndex;
-                                } else {
-                                    // In this scenario, we will create the last trailing literal node and break.
-                                    $thisOffset = $this->currentChunkOffset;
-                                    $content = StringUtilities::substr($this->content, $literalStartIndex);
-
-                                    $node = new LiteralNode();
-
-                                    $node->content = $this->prepareLiteralContent($content);
-
-                                    if (! strlen($node->content) == 0) {
-                                        $node->startPosition = $this->positionFromOffset($thisOffset, $thisOffset);
-                                        $node->endPosition = $this->positionFromOffset($nextAntlersStart, $thisOffset);
-                                        $this->nodes[] = $node;
-                                    }
+                    if ($nextAntlersStart < $literalStartIndex) {
+                        if ($this->lastAntlersEndIndex > $nextAntlersStart) {
+                            $skipIndex = null;
+                            for ($j = $i; $j < $indexCount; $j++) {
+                                if ($this->antlersStartIndex[$j] > $this->lastAntlersEndIndex) {
+                                    $skipIndex = $this->antlersStartIndex[$j];
                                     break;
                                 }
+                            }
+
+                            if ($skipIndex != null) {
+                                $nextAntlersStart = $skipIndex;
                             } else {
-                                continue;
+                                // In this scenario, we will create the last trailing literal node and break.
+                                $thisOffset = $this->currentChunkOffset;
+                                $content = StringUtilities::substr($this->content, $literalStartIndex);
+
+                                $node = new LiteralNode();
+
+                                $node->content = $this->prepareLiteralContent($content);
+
+                                if (! strlen($node->content) == 0) {
+                                    $node->startPosition = $this->positionFromOffset($thisOffset, $thisOffset);
+                                    $node->endPosition = $this->positionFromOffset($nextAntlersStart, $thisOffset);
+                                    $this->nodes[] = $node;
+                                }
+                                break;
                             }
-                        }
-
-                        if ($i + 1 == $lastIndex && ($nextAntlersStart <= $this->lastAntlersEndIndex)) {
-                            // In this scenario, we will create the last trailing literal node and break.
-                            $thisOffset = $this->currentChunkOffset;
-                            $content = StringUtilities::substr($this->content, $literalStartIndex);
-
-                            $node = new LiteralNode();
-
-                            $node->content = $this->prepareLiteralContent($content);
-
-                            if (! strlen($node->content) == 0) {
-                                $node->startPosition = $this->positionFromOffset($thisOffset, $thisOffset);
-                                $node->endPosition = $this->positionFromOffset($nextAntlersStart, $thisOffset);
-                                $this->nodes[] = $node;
-                            }
-
-                            break;
                         } else {
-                            $literalLength = $nextAntlersStart - $this->lastAntlersEndIndex - 1;
-
-                            if ($literalLength == 0) {
-                                continue;
-                            }
-
-                            $thisOffset = $this->currentChunkOffset;
-
-                            if ($this->lastAntlersNode instanceof PhpExecutionNode) {
-                                $literalStartIndex -= 1;
-                                $literalLength += 1;
-                            }
-
-                            $content = StringUtilities::substr($this->content, $literalStartIndex, $literalLength);
-
-                            $node = new LiteralNode();
-
-                            $node->content = $this->prepareLiteralContent($content);
-
-                            if (! strlen($node->content) == 0) {
-                                $node->startPosition = $this->positionFromOffset($thisOffset, $thisOffset);
-                                $node->endPosition = $this->positionFromOffset($nextAntlersStart, $thisOffset);
-                                $this->nodes[] = $node;
-                            }
+                            continue;
                         }
-
-                        continue;
                     }
 
-                    if ($i == $lastIndex) {
-                        $literalStart = $this->currentIndex + $offset;
+                    if ($i + 1 == $lastIndex && ($nextAntlersStart <= $this->lastAntlersEndIndex)) {
+                        // In this scenario, we will create the last trailing literal node and break.
+                        $thisOffset = $this->currentChunkOffset;
+                        $content = StringUtilities::substr($this->content, $literalStartIndex);
 
-                        if ($literalStart < $this->inputLen) {
-                            $node = new LiteralNode();
+                        $node = new LiteralNode();
 
-                            $node->content = $this->prepareLiteralContent(StringUtilities::substr($this->content, $literalStart));
+                        $node->content = $this->prepareLiteralContent($content);
 
-                            if (! strlen($node->content) == 0) {
-                                $node->startPosition = $this->positionFromOffset($literalStart, $literalStart);
-                                $node->endPosition = $this->positionFromOffset($this->inputLen - 1, $literalStart);
-                                $this->nodes[] = $node;
-                            }
-                            break;
+                        if (! strlen($node->content) == 0) {
+                            $node->startPosition = $this->positionFromOffset($thisOffset, $thisOffset);
+                            $node->endPosition = $this->positionFromOffset($nextAntlersStart, $thisOffset);
+                            $this->nodes[] = $node;
                         }
+
+                        break;
+                    } else {
+                        $literalLength = $nextAntlersStart - $this->lastAntlersEndIndex - 1;
+
+                        if ($literalLength == 0) {
+                            continue;
+                        }
+
+                        $thisOffset = $this->currentChunkOffset;
+
+                        if ($this->lastAntlersNode instanceof PhpExecutionNode) {
+                            $literalStartIndex -= 1;
+                            $literalLength += 1;
+                        }
+
+                        $content = StringUtilities::substr($this->content, $literalStartIndex, $literalLength);
+
+                        $node = new LiteralNode();
+
+                        $node->content = $this->prepareLiteralContent($content);
+
+                        if (! strlen($node->content) == 0) {
+                            $node->startPosition = $this->positionFromOffset($thisOffset, $thisOffset);
+                            $node->endPosition = $this->positionFromOffset($nextAntlersStart, $thisOffset);
+                            $this->nodes[] = $node;
+                        }
+                    }
+
+                    continue;
+                }
+
+                if ($i == $lastIndex) {
+                    $literalStart = $this->currentIndex + $offset;
+
+                    if ($literalStart < $this->inputLen) {
+                        $node = new LiteralNode();
+
+                        $node->content = $this->prepareLiteralContent(StringUtilities::substr($this->content, $literalStart));
+
+                        if (! strlen($node->content) == 0) {
+                            $node->startPosition = $this->positionFromOffset($literalStart, $literalStart);
+                            $node->endPosition = $this->positionFromOffset($this->inputLen - 1, $literalStart);
+                            $this->nodes[] = $node;
+                        }
+                        break;
                     }
                 }
             }
@@ -858,6 +853,31 @@ class DocumentParser
         $content = implode($subContent);
         $varSlug = 'int_'.md5($content);
         $varContent = StringUtilities::substr($varSlug, 0, mb_strlen($content));
+
+        // Rotates through more internal variable names when there are collisions.
+        // All interpolations are rewritten to normal variables behind the scenes.
+        if (array_key_exists($varContent, $this->interpolationRegions) && $content != $this->interpolationRegions[$varContent]) {
+            if (! array_key_exists($content, $this->interpolatedCollisions)) {
+                if (! array_key_exists($varContent, $this->interpolatedCollisionCount)) {
+                    $this->interpolatedCollisionCount[$varContent] = 0;
+                }
+
+                if ($varContent == 'int') {
+                    if (! array_key_exists($content, $this->threeCharCollisions)) {
+                        $this->threeCharCollisionCount += 1;
+                        $this->threeCharCollisions[$content] = $this->threeCharCollisionCount;
+                    }
+                    $varContent = 'i' . $this->threeCharCollisionCount;
+                } else {
+                    $this->interpolatedCollisionCount[$varContent] += 1;
+                    $varContent = str_replace('_', $this->interpolatedCollisionCount[$varContent], $varContent);
+                }
+
+                $this->interpolatedCollisions[$content] = $varContent;
+            }
+
+            $varContent = $this->interpolatedCollisions[$content];
+        }
 
         $newLen = mb_strlen($varContent);
         $origLen = mb_strlen($content);

--- a/tests/Antlers/Fixtures/Addon/Tags/EchoMethod.php
+++ b/tests/Antlers/Fixtures/Addon/Tags/EchoMethod.php
@@ -10,4 +10,9 @@ class EchoMethod extends Tags
     {
         return $this->method;
     }
+
+    public function parameter()
+    {
+        return $this->params->get('param');
+    }
 }


### PR DESCRIPTION
This PR closes #5842

The following will now render correctly:

```
{{ a = "A" ab = "AB" }} {{a}} invisible {{ a }} visible {{ab}} visible
```