### PR TITLE
Actions on Form Listing Table

### DIFF
--- a/resources/js/components/forms/Listing.vue
+++ b/resources/js/components/forms/Listing.vue
@@ -9,6 +9,14 @@
                     <dropdown-list>
                         <dropdown-item :text="__('Edit')" :redirect="form.edit_url" />
                         <dropdown-item :text="__('Edit Blueprint')" :redirect="form.blueprint_url" />
+                        <div class="divider" v-if="form.deleteable || form.actions.length" />
+                        <data-list-inline-actions
+                            :item="form.id"
+                            :url="actionUrl"
+                            :actions="form.actions"
+                            @started="actionStarted"
+                            @completed="actionCompleted"
+                        />
                         <dropdown-item
                             v-if="form.deleteable"
                             :text="__('Delete')"

--- a/resources/js/components/forms/Listing.vue
+++ b/resources/js/components/forms/Listing.vue
@@ -17,6 +17,18 @@
                             @started="actionStarted"
                             @completed="actionCompleted"
                         />
+                        <dropdown-item
+                            v-if="form.deleteable"
+                            :text="__('Delete')"
+                            class="warning"
+                            @click="$refs[`deleter_${form.id}`].confirm()"
+                        >
+                            <resource-deleter
+                                :ref="`deleter_${form.id}`"
+                                :resource="form"
+                                @deleted="removeRow(form)">
+                            </resource-deleter>
+                        </dropdown-item>
                     </dropdown-list>
                 </template>
             </data-list-table>

--- a/resources/js/components/forms/Listing.vue
+++ b/resources/js/components/forms/Listing.vue
@@ -17,18 +17,6 @@
                             @started="actionStarted"
                             @completed="actionCompleted"
                         />
-                        <dropdown-item
-                            v-if="form.deleteable"
-                            :text="__('Delete')"
-                            class="warning"
-                            @click="$refs[`deleter_${form.id}`].confirm()"
-                        >
-                            <resource-deleter
-                                :ref="`deleter_${form.id}`"
-                                :resource="form"
-                                @deleted="removeRow(form)">
-                            </resource-deleter>
-                        </dropdown-item>
                     </dropdown-list>
                 </template>
             </data-list-table>

--- a/resources/views/forms/index.blade.php
+++ b/resources/views/forms/index.blade.php
@@ -13,7 +13,7 @@
             @endif
         </div>
 
-        <form-listing :forms="{{ json_encode($forms) }}"></form-listing>
+        <form-listing :forms="{{ json_encode($forms) }}" action-url="{{ $actionUrl }}"></form-listing>
 
     @else
 

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -181,7 +181,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::post('forms/actions/list', 'ActionController@bulkActions')->name('forms.actions.bulk');
         Route::post('forms/{form}/submissions/actions', 'SubmissionActionController@run')->name('forms.submissions.actions.run');
         Route::post('forms/{form}/submissions/actions/list', 'SubmissionActionController@bulkActions')->name('forms.submissions.actions.bulk');
-        Route::resource('forms', 'FormsController');
+        Route::resource('forms', 'FormsController')->except('destroy');
         Route::resource('forms.submissions', 'FormSubmissionsController');
         Route::get('forms/{form}/export/{type}', 'FormExportController@export')->name('forms.export');
         Route::get('forms/{form}/blueprint', 'FormBlueprintController@edit')->name('forms.blueprint.edit');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -181,7 +181,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::post('forms/actions/list', 'ActionController@bulkActions')->name('forms.actions.bulk');
         Route::post('forms/{form}/submissions/actions', 'SubmissionActionController@run')->name('forms.submissions.actions.run');
         Route::post('forms/{form}/submissions/actions/list', 'SubmissionActionController@bulkActions')->name('forms.submissions.actions.bulk');
-        Route::resource('forms', 'FormsController')->except('destroy');
+        Route::resource('forms', 'FormsController');
         Route::resource('forms.submissions', 'FormSubmissionsController');
         Route::get('forms/{form}/export/{type}', 'FormExportController@export')->name('forms.export');
         Route::get('forms/{form}/blueprint', 'FormBlueprintController@edit')->name('forms.blueprint.edit');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -177,6 +177,8 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
     Route::post('addons/editions', 'AddonEditionsController');
 
     Route::group(['namespace' => 'Forms'], function () {
+        Route::post('forms/actions', 'ActionController@run')->name('forms.actions.run');
+        Route::post('forms/actions/list', 'ActionController@bulkActions')->name('forms.actions.bulk');
         Route::post('forms/{form}/submissions/actions', 'SubmissionActionController@run')->name('forms.submissions.actions.run');
         Route::post('forms/{form}/submissions/actions/list', 'SubmissionActionController@bulkActions')->name('forms.submissions.actions.bulk');
         Route::resource('forms', 'FormsController');

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -20,6 +20,7 @@ class Delete extends Action
             case $item instanceof Contracts\Taxonomies\Term:
             case $item instanceof Contracts\Assets\Asset:
             case $item instanceof Contracts\Assets\AssetFolder:
+            case $item instanceof Contracts\Forms\Form:
             case $item instanceof Contracts\Forms\Submission:
             case $item instanceof Contracts\Auth\User:
                 return true;

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -20,7 +20,6 @@ class Delete extends Action
             case $item instanceof Contracts\Taxonomies\Term:
             case $item instanceof Contracts\Assets\Asset:
             case $item instanceof Contracts\Assets\AssetFolder:
-            case $item instanceof Contracts\Forms\Form:
             case $item instanceof Contracts\Forms\Submission:
             case $item instanceof Contracts\Auth\User:
                 return true;

--- a/src/Http/Controllers/CP/Forms/ActionController.php
+++ b/src/Http/Controllers/CP/Forms/ActionController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Statamic\Http\Controllers\CP\Forms;
+
+use Statamic\Facades\Form;
+use Statamic\Http\Controllers\CP\ActionController as Controller;
+
+class ActionController extends Controller
+{
+    protected static $key = 'forms';
+
+    protected function getSelectedItems($items, $context)
+    {
+        return $items->map(function ($item) {
+            return Form::find($item);
+        });
+    }
+}

--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -5,6 +5,7 @@ namespace Statamic\Http\Controllers\CP\Forms;
 use Illuminate\Http\Request;
 use Statamic\Contracts\Forms\Form as FormContract;
 use Statamic\CP\Column;
+use Statamic\Facades\Action;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Form;
 use Statamic\Facades\User;
@@ -31,11 +32,15 @@ class FormsController extends CpController
                     'delete_url' => $form->deleteUrl(),
                     'blueprint_url' => cp_route('forms.blueprint.edit', $form->handle()),
                     'deleteable' => User::current()->can('delete', $form),
+                    'actions' => Action::for($form),
                 ];
             })
             ->values();
 
-        return view('statamic::forms.index', compact('forms'));
+        return view('statamic::forms.index', [
+            'forms' => $forms,
+            'actionUrl' => cp_route('forms.actions.run'),
+        ]);
     }
 
     public function show($form)

--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -29,7 +29,9 @@ class FormsController extends CpController
                     'submissions' => $form->submissions()->count(),
                     'show_url' => $form->showUrl(),
                     'edit_url' => $form->editUrl(),
+                    'delete_url' => $form->deleteUrl(),
                     'blueprint_url' => cp_route('forms.blueprint.edit', $form->handle()),
+                    'deleteable' => User::current()->can('delete', $form),
                     'actions' => Action::for($form),
                 ];
             })
@@ -191,9 +193,9 @@ class FormsController extends CpController
                     'blueprint' => [
                         'type' => 'html',
                         'instructions' => __('statamic::messages.form_configure_blueprint_instructions'),
-                        'html' => '' .
-                            '<div class="text-xs">' .
-                            '   <a href="' . cp_route('forms.blueprint.edit', $form->handle()) . '" class="text-blue">' . __('Edit') . '</a>' .
+                        'html' => ''.
+                            '<div class="text-xs">'.
+                            '   <a href="'.cp_route('forms.blueprint.edit', $form->handle()).'" class="text-blue">'.__('Edit').'</a>'.
                             '</div>',
                     ],
                     'honeypot' => [
@@ -237,7 +239,7 @@ class FormsController extends CpController
                                 'field' => [
                                     'type' => 'text',
                                     'display' => __('Sender'),
-                                    'instructions' => __('statamic::messages.form_configure_email_from_instructions') . ' (' . config('mail.from.address') . ').',
+                                    'instructions' => __('statamic::messages.form_configure_email_from_instructions').' ('.config('mail.from.address').').',
                                 ],
                             ],
                             [

--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -29,9 +29,7 @@ class FormsController extends CpController
                     'submissions' => $form->submissions()->count(),
                     'show_url' => $form->showUrl(),
                     'edit_url' => $form->editUrl(),
-                    'delete_url' => $form->deleteUrl(),
                     'blueprint_url' => cp_route('forms.blueprint.edit', $form->handle()),
-                    'deleteable' => User::current()->can('delete', $form),
                     'actions' => Action::for($form),
                 ];
             })
@@ -193,9 +191,9 @@ class FormsController extends CpController
                     'blueprint' => [
                         'type' => 'html',
                         'instructions' => __('statamic::messages.form_configure_blueprint_instructions'),
-                        'html' => ''.
-                            '<div class="text-xs">'.
-                            '   <a href="'.cp_route('forms.blueprint.edit', $form->handle()).'" class="text-blue">'.__('Edit').'</a>'.
+                        'html' => '' .
+                            '<div class="text-xs">' .
+                            '   <a href="' . cp_route('forms.blueprint.edit', $form->handle()) . '" class="text-blue">' . __('Edit') . '</a>' .
                             '</div>',
                     ],
                     'honeypot' => [
@@ -239,7 +237,7 @@ class FormsController extends CpController
                                 'field' => [
                                     'type' => 'text',
                                     'display' => __('Sender'),
-                                    'instructions' => __('statamic::messages.form_configure_email_from_instructions').' ('.config('mail.from.address').').',
+                                    'instructions' => __('statamic::messages.form_configure_email_from_instructions') . ' (' . config('mail.from.address') . ').',
                                 ],
                             ],
                             [


### PR DESCRIPTION
This pull request implements statamic/ideas#763, allowing for developers to make actions which are visible on the Forms Listing Table.

![image](https://user-images.githubusercontent.com/19637309/163575707-d59f4466-3339-43cc-be88-39c17aea6496.png)

## Use case

> I've just copied this over from the related FR for context.

I have the Duplicator addon where you can currently duplicate entries, terms & assets. Someone has requested the ability to be able to duplicate forms.

Without registering a custom action, there's nowhere for users to click to Duplicate a form. 

Related: doublethreedigital/duplicator#38

## Implementation

Initially, my plan was to refactor the 'Delete' link to be a proper action, like it is on all the other listing tables. I got this part working. 

However, after deleting, I discovered for the row to disappear I needed to refactor some bits to allow for a request to be done to re-fetch the forms with all the columns etc which I was on the edge of doing. 

However, I thought it may be a little out of scope for this PR. I'm happy to cover it in a separate PR that we can merge prior to this or integrate it as part of this one?