### PR TITLE
Fix taxonomy creation if collection exists with the same handle

### DIFF
--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -104,7 +104,7 @@ class TaxonomiesController extends CpController
 
         $handle = $request->handle ?? snake_case($request->title);
 
-        if (Collection::find($handle)) {
+        if (Taxonomy::findByHandle($handle)) {
             throw new \Exception('Taxonomy already exists');
         }
 


### PR DESCRIPTION
Fixes #5849 