### PR TITLE
Allows fieldsets and blueprints to be loaded and saved from multiple locations

### DIFF
--- a/config/system.php
+++ b/config/system.php
@@ -31,6 +31,30 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Default Blueprints Paths
+    |--------------------------------------------------------------------------
+    |
+    | The location that Statamic will use for loading and saving blueprints,
+    | can be either a single path or an array of paths.
+    |
+    */
+
+    'blueprints_path' => resource_path('blueprints'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Fieldset Paths
+    |--------------------------------------------------------------------------
+    |
+    | The location that Statamic will use for loading and saving blueprints,
+    | can be either a single path or an array of paths.
+    |
+    */
+
+    'fieldsets_path' => resource_path('fieldsets'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Send the Powered-By Header
     |--------------------------------------------------------------------------
     |

--- a/src/Facades/Blueprint.php
+++ b/src/Facades/Blueprint.php
@@ -8,6 +8,7 @@ use Statamic\Fields\BlueprintRepository;
 /**
  * @method static self setDirectory(string $directory)
  * @method static self setFallbackDirectory(string $directory)
+ * @method static null|string path(string $handle)
  * @method static null|\Statamic\Fields\Blueprint find($handle)
  * @method static void save(Blueprint $blueprint)
  * @method static void delete(Blueprint $blueprint)

--- a/src/Facades/Fieldset.php
+++ b/src/Facades/Fieldset.php
@@ -7,6 +7,7 @@ use Statamic\Fields\FieldsetRepository;
 
 /**
  * @method static self setDirectory($directory)
+ * @method static null|string path(string $handle)
  * @method static null|\Statamic\Fields\Fieldset find(string $handle)
  * @method static bool exists(string $handle)
  * @method static \Statamic\Fields\Fieldset make($handle = null)

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -18,7 +18,6 @@ use Statamic\Events\BlueprintSaved;
 use Statamic\Exceptions\DuplicateFieldException;
 use Statamic\Facades;
 use Statamic\Facades\Blink;
-use Statamic\Facades\Path;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
@@ -106,11 +105,19 @@ class Blueprint implements Augmentable, QueryableValue, ArrayAccess, Arrayable
 
     public function path()
     {
-        return Path::tidy(vsprintf('%s/%s/%s.yaml', [
-            Facades\Blueprint::directory(),
-            str_replace('.', '/', $this->namespace()),
+        $path = Facades\Blueprint::path(ltrim(vsprintf('%s/%s', [
+            $this->namespace(),
             $this->handle(),
-        ]));
+        ]), '/'));
+
+        if (! $path) {
+            return Facades\Blueprint::fallbackPath(ltrim(vsprintf('%s.%s', [
+                $this->namespace(),
+                $this->handle(),
+            ]), '.'));
+        }
+
+        return $path;
     }
 
     public function setContents(array $contents)

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -6,7 +6,6 @@ use Facades\Statamic\Fields\FieldsetRepository;
 use Statamic\Events\FieldsetDeleted;
 use Statamic\Events\FieldsetSaved;
 use Statamic\Facades;
-use Statamic\Facades\Path;
 use Statamic\Support\Str;
 
 class Fieldset
@@ -28,10 +27,7 @@ class Fieldset
 
     public function path()
     {
-        return Path::tidy(vsprintf('%s/%s.yaml', [
-            Facades\Fieldset::directory(),
-            str_replace('.', '/', $this->handle()),
-        ]));
+        return Facades\Fieldset::path($this->handle());
     }
 
     public function setContents(array $contents)

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -126,7 +126,7 @@ class AppServiceProvider extends ServiceProvider
 
         $this->app->bind(\Statamic\Fields\BlueprintRepository::class, function () {
             return (new \Statamic\Fields\BlueprintRepository)
-                ->setDirectory(resource_path('blueprints'))
+                ->setDirectory(config('statamic.system.blueprints_path', resource_path('blueprints')))
                 ->setFallback('default', function () {
                     return \Statamic\Facades\Blueprint::makeFromFields([
                         'content' => ['type' => 'markdown', 'localizable' => true],
@@ -136,7 +136,7 @@ class AppServiceProvider extends ServiceProvider
 
         $this->app->bind(\Statamic\Fields\FieldsetRepository::class, function () {
             return (new \Statamic\Fields\FieldsetRepository)
-                ->setDirectory(resource_path('fieldsets'));
+                ->setDirectory(config('statamic.system.fieldsets_path', resource_path('fieldsets')));
         });
 
         collect([

--- a/tests/Fields/FieldsetRepositoryArrayTest.php
+++ b/tests/Fields/FieldsetRepositoryArrayTest.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace Tests\Fields;
+
+use Illuminate\Support\Collection;
+use Statamic\Facades\File;
+use Statamic\Fields\Fieldset;
+use Statamic\Fields\FieldsetRepository;
+use Statamic\Support\FileCollection;
+use Tests\TestCase;
+
+class FieldsetRepositoryArrayTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repo = app(FieldsetRepository::class)
+            ->setDirectory([
+                '/path/to/resources/fieldsets',
+                '/another/path/to/resources/fieldsets',
+            ]);
+    }
+
+    /** @test */
+    public function it_still_accepts_string_for_directory()
+    {
+        $this->repo->setDirectory('test');
+
+        $this->assertEquals('test', $this->repo->directory());
+    }
+
+    /** @test */
+    public function it_returns_first_directory_as_default()
+    {
+        $this->assertEquals('/path/to/resources/fieldsets', $this->repo->directory());
+    }
+
+    /** @test */
+    public function it_returns_all_directories()
+    {
+        $this->assertEquals([
+            '/path/to/resources/fieldsets',
+            '/another/path/to/resources/fieldsets',
+        ], $this->repo->directories());
+    }
+
+    /** @test */
+    public function it_gets_a_fieldset_from_additional_directory()
+    {
+        $contents = <<<'EOT'
+title: Test External Fieldset
+fields:
+  -
+    handle: one
+    field:
+      type: text
+      display: First Field
+  -
+    handle: two
+    field:
+      type: text
+      display: Second Field
+EOT;
+        File::shouldReceive('exists')->with('/path/to/resources/fieldsets/test.yaml')->once()->andReturnFalse();
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets/test.yaml')->once()->andReturnTrue();
+        File::shouldReceive('get')->with('/another/path/to/resources/fieldsets/test.yaml')->once()->andReturn($contents);
+
+        $fieldset = $this->repo->find('test');
+
+        $this->assertInstanceOf(Fieldset::class, $fieldset);
+        $this->assertEquals('Test External Fieldset', $fieldset->title());
+        $this->assertEquals('test', $fieldset->handle());
+        $this->assertEquals(['one', 'two'], $fieldset->fields()->all()->map->handle()->values()->all());
+        $this->assertEquals(['First Field', 'Second Field'], $fieldset->fields()->all()->map->display()->values()->all());
+    }
+
+    /** @test */
+    public function it_gets_a_fieldset_path_from_additional_directory()
+    {
+        File::shouldReceive('exists')->with('/path/to/resources/fieldsets/test.yaml')->once()->andReturnFalse();
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets/test.yaml')->once()->andReturnTrue();
+
+        $path = $this->repo->path('test');
+
+        $this->assertEquals('/another/path/to/resources/fieldsets/test.yaml', $path);
+    }
+
+    /** @test */
+    public function it_fieldset_path_returns_null_if_missing()
+    {
+        File::shouldReceive('exists')->with('/path/to/resources/fieldsets/missing.yaml')->once()->andReturnFalse();
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets/missing.yaml')->once()->andReturnFalse();
+
+        $path = $this->repo->path('missing');
+
+        $this->assertNull($path);
+    }
+
+    /** @test */
+    public function it_gets_a_fieldset_in_additional_subdirectory()
+    {
+        $contents = <<<'EOT'
+title: Test Fieldset
+fields: []
+EOT;
+        File::shouldReceive('exists')->with('/path/to/resources/fieldsets/sub/test.yaml')->twice()->andReturnFalse();
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets/sub/test.yaml')->twice()->andReturnTrue();
+        File::shouldReceive('get')->with('/another/path/to/resources/fieldsets/sub/test.yaml')->twice()->andReturn($contents);
+
+        $fieldset = $this->repo->find('sub.test');
+
+        $this->assertInstanceOf(Fieldset::class, $fieldset);
+        $this->assertEquals('Test Fieldset', $fieldset->title());
+        $this->assertEquals('sub.test', $fieldset->handle());
+
+        // Test that using slash delimiter instead of dots returns the same thing.
+        $this->assertEquals($fieldset, $this->repo->find('sub/test'));
+    }
+
+    /** @test */
+    public function it_returns_null_if_path_doesnt_exist()
+    {
+        File::shouldReceive('exists')->with('/path/to/resources/fieldsets/missing.yaml')->once()->andReturnFalse();
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets/missing.yaml')->once()->andReturnFalse();
+
+        $path = $this->repo->path('missing');
+
+        $this->assertNull($path);
+    }
+
+    /** @test */
+    public function it_checks_if_a_fieldset_exists_in_additional_directory()
+    {
+        File::shouldReceive('exists')->with('/path/to/resources/fieldsets/unknown.yaml')->once()->andReturnFalse();
+        File::shouldReceive('exists')->with('/path/to/resources/fieldsets/additional.yaml')->once()->andReturnFalse();
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets/unknown.yaml')->once()->andReturnFalse();
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets/additional.yaml')->once()->andReturnTrue();
+
+        $this->assertTrue($this->repo->exists('additional'));
+        $this->assertFalse($this->repo->exists('unknown'));
+    }
+
+    /** @test */
+    public function it_gets_all_fieldsets()
+    {
+        $firstContents = <<<'EOT'
+title: First Fieldset
+fields:
+  one:
+    type: text
+    display: First Field
+EOT;
+        $secondContents = <<<'EOT'
+title: Second Fieldset
+fields:
+  two:
+    type: text
+    display: Second Field
+EOT;
+        $thirdContents = <<<'EOT'
+title: Third Fieldset
+fields:
+  three:
+    type: text
+    display: Third Field
+EOT;
+        $fourthContents = <<<'EOT'
+title: Fourth Fieldset
+fields:
+  three:
+    type: text
+    display: Fourth Field
+EOT;
+
+        File::shouldReceive('withAbsolutePaths')->twice()->andReturnSelf();
+        File::shouldReceive('exists')->with('/path/to/resources/fieldsets')->once()->andReturnTrue();
+        File::shouldReceive('getFilesByTypeRecursively')->with('/path/to/resources/fieldsets', 'yaml')->once()->andReturn(new FileCollection([
+            '/path/to/resources/fieldsets/first.yaml',
+            '/path/to/resources/fieldsets/second.yaml',
+        ]));
+        File::shouldReceive('get')->with('/path/to/resources/fieldsets/first.yaml')->once()->andReturn($firstContents);
+        File::shouldReceive('get')->with('/path/to/resources/fieldsets/second.yaml')->once()->andReturn($secondContents);
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets')->once()->andReturnTrue();
+        File::shouldReceive('getFilesByTypeRecursively')->with('/another/path/to/resources/fieldsets', 'yaml')->once()->andReturn(new FileCollection([
+            '/another/path/to/resources/fieldsets/sub/third.yaml',
+            '/another/path/to/resources/fieldsets/fourth.yaml',
+        ]));
+        File::shouldReceive('get')->with('/another/path/to/resources/fieldsets/sub/third.yaml')->once()->andReturn($thirdContents);
+        File::shouldReceive('get')->with('/another/path/to/resources/fieldsets/fourth.yaml')->once()->andReturn($fourthContents);
+
+        $all = $this->repo->all();
+
+        $this->assertInstanceOf(Collection::class, $all);
+        $this->assertCount(4, $all);
+        $this->assertEveryItemIsInstanceOf(Fieldset::class, $all);
+        $this->assertEquals(['first', 'second', 'sub.third', 'fourth'], $all->keys()->all());
+        $this->assertEquals(['first', 'second', 'sub.third', 'fourth'], $all->map->handle()->values()->all());
+        $this->assertEquals(['First Fieldset', 'Second Fieldset', 'Third Fieldset', 'Fourth Fieldset'], $all->map->title()->values()->all());
+    }
+
+    /** @test */
+    public function it_returns_first_fieldset_when_duplicates_exists()
+    {
+        $duplicateContents = <<<'EOT'
+title: Duplicate Fieldset
+fields:
+  one:
+    type: text
+    display: Duplicate Field
+EOT;
+        $originalContents = <<<'EOT'
+title: Original Fieldset
+fields:
+  two:
+    type: text
+    display: Original Field
+EOT;
+
+        File::shouldReceive('withAbsolutePaths')->twice()->andReturnSelf();
+        File::shouldReceive('exists')->with('/path/to/resources/fieldsets')->once()->andReturnTrue();
+        File::shouldReceive('getFilesByTypeRecursively')->with('/path/to/resources/fieldsets', 'yaml')->once()->andReturn(new FileCollection([
+            '/path/to/resources/fieldsets/test.yaml',
+        ]));
+        File::shouldReceive('get')->with('/path/to/resources/fieldsets/test.yaml')->once()->andReturn($duplicateContents);
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets')->once()->andReturnTrue();
+        File::shouldReceive('getFilesByTypeRecursively')->with('/another/path/to/resources/fieldsets', 'yaml')->once()->andReturn(new FileCollection([
+            '/another/path/to/resources/fieldsets/test.yaml',
+        ]));
+        File::shouldReceive('get')->with('/another/path/to/resources/fieldsets/test.yaml')->once()->andReturn($originalContents);
+
+        $all = $this->repo->all();
+
+        $this->assertInstanceOf(Collection::class, $all);
+        $this->assertCount(1, $all);
+        $this->assertEveryItemIsInstanceOf(Fieldset::class, $all);
+        $this->assertEquals(['test'], $all->keys()->all());
+        $this->assertEquals(['test'], $all->map->handle()->values()->all());
+        $this->assertEquals(['Duplicate Fieldset'], $all->map->title()->values()->all());
+    }
+
+    /** @test */
+    public function it_returns_empty_collection_if_fieldset_directory_doesnt_exist()
+    {
+        File::shouldReceive('exists')->with('/path/to/resources/fieldsets')->once()->andReturnFalse();
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets')->once()->andReturnFalse();
+
+        $all = $this->repo->all();
+
+        $this->assertInstanceOf(Collection::class, $all);
+        $this->assertCount(0, $all);
+    }
+
+    /** @test */
+    public function it_saves_to_disk_in_additional_folder()
+    {
+        $expectedYaml = <<<'EOT'
+title: 'Test Fieldset'
+fields:
+  -
+    handle: foo
+    field:
+      type: textarea
+      bar: baz
+
+EOT;
+        File::shouldReceive('exists')->with('/path/to/resources/fieldsets/the_test_fieldset.yaml')->once()->andReturnFalse();
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets/the_test_fieldset.yaml')->once()->andReturnTrue();
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets')->once()->andReturnTrue();
+        File::shouldReceive('put')->with('/another/path/to/resources/fieldsets/the_test_fieldset.yaml', $expectedYaml)->once();
+
+        $fieldset = (new Fieldset)->setHandle('the_test_fieldset')->setContents([
+            'title' => 'Test Fieldset',
+            'fields' => [
+                [
+                    'handle' => 'foo',
+                    'field' => ['type' => 'textarea', 'bar' => 'baz'],
+                ],
+            ],
+        ]);
+
+        $this->repo->save($fieldset);
+    }
+
+    /** @test */
+    public function it_deletes_from_disk_in_additional_folder()
+    {
+        File::shouldReceive('exists')->with('/path/to/resources/fieldsets/the_test_fieldset.yaml')->once()->andReturnFalse();
+        File::shouldReceive('exists')->with('/another/path/to/resources/fieldsets/the_test_fieldset.yaml')->once()->andReturnTrue();
+        File::shouldReceive('delete')->with('/another/path/to/resources/fieldsets/the_test_fieldset.yaml')->once();
+
+        $fieldset = (new Fieldset)->setHandle('the_test_fieldset')->setContents([
+            'title' => 'Test Fieldset',
+            'fields' => [
+                [
+                    'handle' => 'foo',
+                    'field' => ['type' => 'textarea', 'bar' => 'baz'],
+                ],
+            ],
+        ]);
+
+        $this->repo->delete($fieldset);
+    }
+}


### PR DESCRIPTION
Continuining on from previous pull request https://github.com/statamic/cms/pull/5803 to resolve a silly silly force push of mine. 

---

**Allows fieldsets and blueprints to be loaded and saved from multiple locations**

This is a larger edit to the FieldsetRepository and BlueprintRepository to allow saving and loading from multiple fieldset / blueprint locations. This allows for a modular approach for loading and saving fieldsets and blueprints, for example:

```
ARTICLES:

Articles/resources/blueprints/collections/articles.yaml
Articles/resources/blueprints/collections/articles/default.yaml
Articles/resources/fieldsets/articles-details.yaml

PAGES:

Pages/resources/blueprints/collections/pages.yaml
Pages/resources/blueprints/collections/pages/default.yaml
Pages/resources/blueprints/collections/pages/sidebar-left.yaml
Pages/resources/blueprints/collections/pages/sidebar-right.yaml
Pages/resources/fieldsets/pages-details.yaml
```

It works by allowing either a single string path or an array of paths to be passed in to a new `statamic.system.fieldsets_path` config setting. This has been added to the default config but falls back to the original setting of `resource_path('fieldsets')` to preserve backwards compatibility. I have also left the original `FieldsetRepository->directory()` method in place, it returns the first entry from the array as the _default_ fieldset directory.

Fieldsets are loaded / saved on a first come, first serve basis based on the supplied `fieldsets_path` array order, so original versions of fieldsets that might be loaded in by modules can be overridden and customised where required.

I have also created separate `FieldsetRepositoryArrayTest` and `BlueprintRepositoryArrayTest` to handle the array specific test cases.

---

**Allows saving a fieldset in a subdirectory** 

This is a small edit to allow fieldsets that are stored in subdirectories to be saved in their original location. The ability to read from a subdirectory was already implemented but upon saving they would revert to a flattened format.

```php
// before
fields/sub-test.yaml -> fields.sub-test.yaml        

// after
fields/sub-test.yaml -> fields/sub-test.yaml
```

_Note:_ I have not modified the control panel to accommodate this. When attempting to save a path with `/` or `.` the user is still presented with an error message: `May only contain letters, numbers, dashes and underscores.`. I am assuming this was an intentional decision and just wanted to keep the pull request fairly low impact.

---

Please let me know if there are any issues with the approach i've taken, thanks for all your hard work!
