### PR TITLE
Add ability to require multiple composer / starter kit dependencies at once

### DIFF
--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -413,7 +413,11 @@ final class Installer
      */
     protected function requireDependencies($packages, $dev = false)
     {
-        $this->console->info('Installing dependencies...');
+        if ($dev) {
+            $this->console->info('Installing development dependencies...');
+        } else {
+            $this->console->info('Installing dependencies...');
+        }
 
         $args = array_merge(['require'], $this->normalizePackagesArrayToRequireArgs($packages));
 

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -292,13 +292,13 @@ final class Installer
             return $this;
         }
 
-        $this->installableDependencies('dependencies')->each(function ($version, $package) {
-            $this->ensureCompatibleDependency($package, $version);
-        });
+        if ($packages = $this->installableDependencies('dependencies')) {
+            $this->ensureCanRequireDependencies($packages);
+        }
 
-        $this->installableDependencies('dependencies_dev')->each(function ($version, $package) {
-            $this->ensureCompatibleDependency($package, $version, true);
-        });
+        if ($packages = $this->installableDependencies('dependencies_dev')) {
+            $this->ensureCanRequireDependencies($packages, true);
+        }
 
         return $this;
     }
@@ -377,61 +377,56 @@ final class Installer
             return $this;
         }
 
-        $this->installableDependencies('dependencies')->each(function ($version, $package) {
-            $this->installDependency($package, $version);
-        });
+        if ($packages = $this->installableDependencies('dependencies')) {
+            $this->requireDependencies($packages);
+        }
 
-        $this->installableDependencies('dependencies_dev')->each(function ($version, $package) {
-            $this->installDependency($package, $version, true);
-        });
+        if ($packages = $this->installableDependencies('dependencies_dev')) {
+            $this->requireDependencies($packages, true);
+        }
 
         return $this;
     }
 
     /**
-     * Ensure compatible dependency by performing a dry-run.
+     * Ensure dependencies are installable by performing a dry-run.
      *
-     * @param  string  $package
-     * @param  string  $version
+     * @param  array  $packages
      * @param  bool  $dev
      */
-    protected function ensureCompatibleDependency($package, $version, $dev = false)
+    protected function ensureCanRequireDependencies($packages, $dev = false)
     {
-        $requireMethod = $dev ? 'requireDev' : 'require';
+        $requireMethod = $dev ? 'requireMultipleDev' : 'requireMultiple';
 
         try {
-            Composer::withoutQueue()->throwOnFailure()->{$requireMethod}($package, $version, '--dry-run');
+            Composer::withoutQueue()->throwOnFailure()->{$requireMethod}($packages, '--dry-run');
         } catch (ProcessException $exception) {
-            $this->rollbackWithError("Cannot install due to error with [{$package}] dependency.", $exception->getMessage());
+            $this->rollbackWithError('Cannot install due to dependency conflict.', $exception->getMessage());
         }
     }
 
     /**
      * Install starter kit dependency permanently into app.
      *
-     * @param  string  $package
-     * @param  string  $version
+     * @param  array  $packages
      * @param  bool  $dev
      */
-    protected function installDependency($package, $version, $dev = false)
+    protected function requireDependencies($packages, $dev = false)
     {
-        $this->console->info("Installing dependency [{$package}]...");
+        $this->console->info('Installing dependencies...');
 
-        $args = ['require'];
+        $args = array_merge(['require'], $this->normalizePackagesArrayToRequireArgs($packages));
 
         if ($dev) {
             $args[] = '--dev';
         }
-
-        $args[] = $package;
-        $args[] = $version;
 
         try {
             Composer::withoutQueue()->throwOnFailure()->runAndOperateOnOutput($args, function ($output) {
                 return $this->outputFromSymfonyProcess($output);
             });
         } catch (ProcessException $exception) {
-            $this->console->error("Error installing [{$package}].");
+            $this->console->error('Error installing dependencies.');
         }
     }
 
@@ -743,12 +738,30 @@ final class Installer
      * Get installable dependencies from appropriate require key in composer.json.
      *
      * @param  string  $configKey
-     * @return \Illuminate\Support\Collection
+     * @return array
      */
     protected function installableDependencies($configKey)
     {
         return collect($this->config($configKey))->filter(function ($version, $package) {
             return Str::contains($package, '/');
-        });
+        })->all();
+    }
+
+    /**
+     * Normalize packages array to require args, with version handling if `package => version` array structure is passed.
+     *
+     * @param  array  $packages
+     * @return array
+     */
+    private function normalizePackagesArrayToRequireArgs(array $packages)
+    {
+        return collect($packages)
+            ->map(function ($value, $key) {
+                return Str::contains($key, '/')
+                    ? "{$key}:{$value}"
+                    : "{$value}";
+            })
+            ->values()
+            ->all();
     }
 }

--- a/tests/Composer/ComposerTest.php
+++ b/tests/Composer/ComposerTest.php
@@ -22,16 +22,22 @@ class ComposerTest extends TestCase
         Cache::forget('composer.test/package');
 
         Composer::swap(new \Statamic\Console\Processes\Composer($this->basePath()));
+
+        $this->files = app('files');
+
+        if (! $this->files->exists($tmpDir = $this->basePath('tmp'))) {
+            $this->files->makeDirectory($tmpDir, 0755, true);
+        }
     }
 
     public function tearDown(): void
     {
-        $fs = app('files');
-        $fs->deleteDirectory($this->basePath('vendor'));
-        $fs->delete($this->basePath('composer.json'));
-        $fs->delete($this->basePath('composer.lock'));
-        $fs->move($this->basePath('composer.lock.bak'), $this->basePath('composer.lock'));
-        $fs->move($this->basePath('composer.json.bak'), $this->basePath('composer.json'));
+        $this->files->deleteDirectory($this->basePath('tmp'));
+        $this->files->deleteDirectory($this->basePath('vendor'));
+        $this->files->delete($this->basePath('composer.json'));
+        $this->files->delete($this->basePath('composer.lock'));
+        $this->files->move($this->basePath('composer.lock.bak'), $this->basePath('composer.lock'));
+        $this->files->move($this->basePath('composer.json.bak'), $this->basePath('composer.json'));
 
         parent::tearDown();
     }
@@ -204,6 +210,126 @@ class ComposerTest extends TestCase
         $this->assertStringNotContainsString('test/package', Composer::installed()->keys());
         $this->assertFileNotExists($this->basePath('vendor/test/package'));
         $this->assertStringContainsString('Removing test/package', Cache::get('composer.test/package')['output']);
+    }
+
+    /**
+     * This method is intentionally doing way too much, for the sake of test suite performance.
+     *
+     * @group integration
+     * @group slow
+     * @test
+     */
+    public function it_can_require_and_remove_multiple_packages_in_one_shot()
+    {
+        PackToTheFuture::generateComposerJson('test/one', '1.0.0', [], $this->basePath('tmp/one/composer.json'));
+        PackToTheFuture::generateComposerJson('test/two', '2.0.0', [], $this->basePath('tmp/two/composer.json'));
+
+        $repositories = [
+            'require' => [
+                'composer/composer' => '^2.0.0',
+            ],
+            'repositories' => [
+                ['type' => 'path', 'url' => $this->basePath('tmp/one'), 'options' => ['symlink' => false]],
+                ['type' => 'path', 'url' => $this->basePath('tmp/two'), 'options' => ['symlink' => false]],
+            ],
+        ];
+
+        PackToTheFuture::generateComposerJson('statamic/composer-test-app', '1.0.0', $repositories, $this->basePath('composer.json'));
+
+        // Test that the packages aren't installed yet...
+
+        $this->assertNotContains('test/one', Composer::installed()->keys());
+        $this->assertNotContains('test/two', Composer::installed()->keys());
+        $this->assertFileNotExists($this->basePath('vendor/test/one'));
+        $this->assertFileNotExists($this->basePath('vendor/test/two'));
+
+        // Test that we can require multiple packages...
+
+        Composer::requireMultiple([
+            'test/one',
+            'test/two' => '2.0.0', // Test it can require explicit version.
+        ]);
+
+        $installed = Composer::installed();
+        $output = Cache::get('composer.test/one')['output'];
+        $this->assertTrue($installed->keys()->contains('test/one'));
+        $this->assertTrue($installed->keys()->contains('test/two'));
+        $this->assertFileExists($this->basePath('vendor/test/one'));
+        $this->assertFileExists($this->basePath('vendor/test/two'));
+        $this->assertEquals('1.0.0', $installed->get('test/one')->version);
+        $this->assertEquals('2.0.0', $installed->get('test/two')->version);
+        $this->assertFalse($installed->get('test/one')->dev);
+        $this->assertFalse($installed->get('test/two')->dev);
+        $this->assertStringContainsString('Installing test/one', $output);
+        $this->assertStringContainsString('Installing test/two', $output);
+
+        // Test that we can remove multiple packages...
+
+        Composer::removeMultiple(['test/one', 'test/two']);
+
+        $output = Cache::get('composer.test/one')['output'];
+        $this->assertStringNotContainsString('test/one', Composer::installed()->keys());
+        $this->assertStringNotContainsString('test/two', Composer::installed()->keys());
+        $this->assertFileNotExists($this->basePath('vendor/test/one'));
+        $this->assertFileNotExists($this->basePath('vendor/test/two'));
+        $this->assertStringContainsString('Removing test/one', $output);
+        $this->assertStringContainsString('Removing test/two', $output);
+
+        // Test that we can add extra params when requiring...
+
+        Composer::requireMultiple(['test/one', 'test/two'], '--dry-run');
+
+        $output = Cache::get('composer.test/one')['output'];
+        $this->assertStringNotContainsString('test/one', Composer::installed()->keys());
+        $this->assertStringNotContainsString('test/two', Composer::installed()->keys());
+        $this->assertFileNotExists($this->basePath('vendor/test/one'));
+        $this->assertFileNotExists($this->basePath('vendor/test/two'));
+        $this->assertStringContainsString('Installing test/one', $output);
+        $this->assertStringContainsString('Installing test/two', $output);
+
+        // Test that we can add extra params when requiring dev dependencies...
+
+        Composer::requireMultipleDev(['test/one', 'test/two'], '--dry-run');
+
+        $output = Cache::get('composer.test/one')['output'];
+        $this->assertStringNotContainsString('test/one', Composer::installed()->keys());
+        $this->assertStringNotContainsString('test/two', Composer::installed()->keys());
+        $this->assertFileNotExists($this->basePath('vendor/test/one'));
+        $this->assertFileNotExists($this->basePath('vendor/test/two'));
+        $this->assertStringContainsString('Installing test/one', $output);
+        $this->assertStringContainsString('Installing test/two', $output);
+
+        // Test that we can require multiple packages as dev dependencies...
+
+        Composer::requireMultipleDev([
+            'test/one',
+            'test/two' => '2.0.0', // Test it can require explicit version.
+        ]);
+
+        $installed = Composer::installed();
+        $output = Cache::get('composer.test/one')['output'];
+        $this->assertTrue($installed->keys()->contains('test/one'));
+        $this->assertTrue($installed->keys()->contains('test/two'));
+        $this->assertFileExists($this->basePath('vendor/test/one'));
+        $this->assertFileExists($this->basePath('vendor/test/two'));
+        $this->assertEquals('1.0.0', $installed->get('test/one')->version);
+        $this->assertEquals('2.0.0', $installed->get('test/two')->version);
+        $this->assertTrue($installed->get('test/one')->dev);
+        $this->assertTrue($installed->get('test/two')->dev);
+        $this->assertStringContainsString('Installing test/one', $output);
+        $this->assertStringContainsString('Installing test/two', $output);
+
+        // Test that we can remove multiple dev dependencies...
+
+        Composer::removeMultipleDev(['test/one', 'test/two']);
+
+        $output = Cache::get('composer.test/one')['output'];
+        $this->assertStringNotContainsString('test/one', Composer::installed()->keys());
+        $this->assertStringNotContainsString('test/two', Composer::installed()->keys());
+        $this->assertFileNotExists($this->basePath('vendor/test/one'));
+        $this->assertFileNotExists($this->basePath('vendor/test/two'));
+        $this->assertStringContainsString('Removing test/one', $output);
+        $this->assertStringContainsString('Removing test/two', $output);
     }
 
     private function basePath($path = null)

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -652,6 +652,20 @@ class FakeComposer
         $this->fakeInstallVendorFiles($package);
     }
 
+    public function requireMultiple($packages)
+    {
+        foreach ($packages as $package => $version) {
+            $this->require($package, $version);
+        }
+    }
+
+    public function requireMultipleDev($packages)
+    {
+        foreach ($packages as $package => $version) {
+            $this->requireDev($package, $version);
+        }
+    }
+
     public function remove($package)
     {
         $this->removeFromComposerJson($package);


### PR DESCRIPTION
We used to run a separate `composer require` call for each dependency. This PR groups dependencies into one `require`, and dev dependencies into another `require`, for a more efficient install...

![CleanShot 2022-04-18 at 18 14 34](https://user-images.githubusercontent.com/5187394/163886172-19cecae7-8f65-4b31-840f-e19affe4d933.png)