### PR TITLE
Ignore null image in Bard

### DIFF
--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -112,7 +112,8 @@ export default {
             this.assetId = src.substr(7);
         }
 
-        this.loadAsset(this.assetId || src);
+        let id = this.assetId || src;
+        if (id) this.loadAsset(id);
     },
 
     watch: {
@@ -155,9 +156,6 @@ export default {
         },
 
         loadAsset(id) {
-            if(id === null)
-                return;
-
             let preloaded = _.find(this.$store.state.publish[this.storeName].preloadedAssets, asset => asset.id === id);
 
             if (preloaded) {

--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -155,6 +155,9 @@ export default {
         },
 
         loadAsset(id) {
+            if(id === null)
+                return;
+
             let preloaded = _.find(this.$store.state.publish[this.storeName].preloadedAssets, asset => asset.id === id);
 
             if (preloaded) {


### PR DESCRIPTION
It seems that the Bard inline image component tries to load null images before they are set.  This is related to the following issues: https://github.com/statamic/cms/issues/5860 https://github.com/statamic/cms/issues/5861

This PR makes the image not attempt to be loaded if the `id` is null.

Closes #5860 
