### PR TITLE
Add another condition for when the terms fieldtype filters with collection

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -98,7 +98,8 @@ class Terms extends Relationship
             && ! $this->field->parentField()
             && $parent
             && $parent instanceof Entry
-            && $this->field->handle() === $this->taxonomies()[0];
+            && $this->field->handle() === $this->taxonomies()[0]
+            && $parent->collection()->taxonomies()->map->handle()->contains($this->field->handle());
 
         if ($shouldQueryCollection) {
             $query->where('collection', $parent->collectionHandle());

--- a/tests/Fieldtypes/TermsTest.php
+++ b/tests/Fieldtypes/TermsTest.php
@@ -338,7 +338,7 @@ class TermsTest extends TestCase
      * @test
      * @dataProvider collectionAttachmentProvider
      **/
-    public function it_attaches_collection_during_augmentation($parentIsEntry, $handle, $isRootLevel, $collectionUsesTaxonomy)
+    public function it_attaches_collection_during_augmentation($expectCollection, $parentIsEntry, $handle, $isRootLevel, $collectionUsesTaxonomy)
     {
         if ($collectionUsesTaxonomy) {
             Facades\Collection::find('blog')->taxonomies(['tags'])->save();
@@ -368,7 +368,7 @@ class TermsTest extends TestCase
 
         $collection = $augmented->first()->collection();
 
-        if ($parentIsEntry && $handle === 'tags' && $isRootLevel && $collectionUsesTaxonomy) {
+        if ($expectCollection) {
             $this->assertInstanceOf(CollectionContract::class, $collection);
         } else {
             $this->assertNull($collection);
@@ -377,26 +377,60 @@ class TermsTest extends TestCase
 
     public function collectionAttachmentProvider()
     {
+        $expectCollection = $parentIsEntry = $isRootLevel = $collectionUsesTaxonomy = true;
+        $dontExpectCollection = $parentIsNotEntry = $isNested = $collectionDoesNotUseTaxonomy = false;
+        $fieldHandleMatchesTaxonomy = 'tags';
+        $fieldHandleDoesNotMatchTaxonomy = 'related_tags';
+
         return [
-            'parent is entry and handle matches taxonomy' => [true, 'tags', true, true],
-            'parent is entry and handle does not match taxonomy' => [true, 'related_tags', true, true],
-            'parent is not entry and handle matches taxonomy' => [false, 'tags', true, true],
-            'parent is not entry and handle does not match taxonomy' => [false, 'related_tags', true, true],
-
-            'parent is entry, handle matches taxonomy, nested field' => [true, 'tags', false, true],
-            'parent is entry, handle does not match taxonomy, nested field' => [true, 'related_tags', false, true],
-            'parent is not entry, handle matches taxonomy, nested field' => [false, 'tags', false, true],
-            'parent is not entry, handle does not match taxonomy, nested field' => [false, 'related_tags', false, true],
-
-            'parent is entry and handle matches taxonomy, collection doesnt use taxonomy' => [true, 'tags', true, false],
-            'parent is entry and handle does not match taxonomy, collection doesnt use taxonomy' => [true, 'related_tags', true, false],
-            'parent is not entry and handle matches taxonomy, collection doesnt use taxonomy' => [false, 'tags', true, false],
-            'parent is not entry and handle does not match taxonomy, collection doesnt use taxonomy' => [false, 'related_tags', true, false],
-
-            'parent is entry, handle matches taxonomy, nested field, collection doesnt use taxonomy' => [true, 'tags', false, false],
-            'parent is entry, handle does not match taxonomy, nested field, collection doesnt use taxonomy' => [true, 'related_tags', false, false],
-            'parent is not entry, handle matches taxonomy, nested field, collection doesnt use taxonomy' => [false, 'tags', false, false],
-            'parent is not entry, handle does not match taxonomy, nested field, collection doesnt use taxonomy' => [false, 'related_tags', false, false],
+            'parent is entry and handle matches taxonomy' => [
+                $expectCollection, $parentIsEntry, $fieldHandleMatchesTaxonomy, $isRootLevel, $collectionUsesTaxonomy,
+            ],
+            'parent is entry and handle does not match taxonomy' => [
+                $dontExpectCollection, $parentIsEntry, $fieldHandleDoesNotMatchTaxonomy, $isRootLevel, $collectionUsesTaxonomy,
+            ],
+            'parent is not entry and handle matches taxonomy' => [
+                $dontExpectCollection, $parentIsNotEntry, $fieldHandleMatchesTaxonomy, $isRootLevel, $collectionUsesTaxonomy,
+            ],
+            'parent is not entry and handle does not match taxonomy' => [
+                $dontExpectCollection, $parentIsNotEntry, $fieldHandleDoesNotMatchTaxonomy, $isRootLevel, $collectionUsesTaxonomy,
+            ],
+            'parent is entry, handle matches taxonomy, nested field' => [
+                $dontExpectCollection, $parentIsEntry, $fieldHandleMatchesTaxonomy, $isNested, $collectionUsesTaxonomy,
+            ],
+            'parent is entry, handle does not match taxonomy, nested field' => [
+                $dontExpectCollection, $parentIsEntry, $fieldHandleDoesNotMatchTaxonomy, $isNested, $collectionUsesTaxonomy,
+            ],
+            'parent is not entry, handle matches taxonomy, nested field' => [
+                $dontExpectCollection, $parentIsNotEntry, $fieldHandleMatchesTaxonomy, $isNested, $collectionUsesTaxonomy,
+            ],
+            'parent is not entry, handle does not match taxonomy, nested field' => [
+                $dontExpectCollection, $parentIsNotEntry, $fieldHandleDoesNotMatchTaxonomy, $isNested, $collectionUsesTaxonomy,
+            ],
+            'parent is entry and handle matches taxonomy, collection doesnt use taxonomy' => [
+                $dontExpectCollection, $parentIsEntry, $fieldHandleMatchesTaxonomy, $isRootLevel, $collectionDoesNotUseTaxonomy,
+            ],
+            'parent is entry and handle does not match taxonomy, collection doesnt use taxonomy' => [
+                $dontExpectCollection, $parentIsEntry, $fieldHandleDoesNotMatchTaxonomy, $isRootLevel, $collectionDoesNotUseTaxonomy,
+            ],
+            'parent is not entry and handle matches taxonomy, collection doesnt use taxonomy' => [
+                $dontExpectCollection, $parentIsNotEntry, $fieldHandleMatchesTaxonomy, $isRootLevel, $collectionDoesNotUseTaxonomy,
+            ],
+            'parent is not entry and handle does not match taxonomy, collection doesnt use taxonomy' => [
+                $dontExpectCollection, $parentIsNotEntry, $fieldHandleDoesNotMatchTaxonomy, $isRootLevel, $collectionDoesNotUseTaxonomy,
+            ],
+            'parent is entry, handle matches taxonomy, nested field, collection doesnt use taxonomy' => [
+                $dontExpectCollection, $parentIsEntry, $fieldHandleMatchesTaxonomy, $isNested, $collectionDoesNotUseTaxonomy,
+            ],
+            'parent is entry, handle does not match taxonomy, nested field, collection doesnt use taxonomy' => [
+                $dontExpectCollection, $parentIsEntry, $fieldHandleDoesNotMatchTaxonomy, $isNested, $collectionDoesNotUseTaxonomy,
+            ],
+            'parent is not entry, handle matches taxonomy, nested field, collection doesnt use taxonomy' => [
+                $dontExpectCollection, $parentIsNotEntry, $fieldHandleMatchesTaxonomy, $isNested, $collectionDoesNotUseTaxonomy,
+            ],
+            'parent is not entry, handle does not match taxonomy, nested field, collection doesnt use taxonomy' => [
+                $dontExpectCollection, $parentIsNotEntry, $fieldHandleDoesNotMatchTaxonomy, $isNested, $collectionDoesNotUseTaxonomy,
+            ],
         ];
     }
 

--- a/tests/Fieldtypes/TermsTest.php
+++ b/tests/Fieldtypes/TermsTest.php
@@ -338,8 +338,14 @@ class TermsTest extends TestCase
      * @test
      * @dataProvider collectionAttachmentProvider
      **/
-    public function it_attaches_collection_during_augmentation($parentIsEntry, $handle, $isRootLevel)
+    public function it_attaches_collection_during_augmentation($parentIsEntry, $handle, $isRootLevel, $collectionUsesTaxonomy)
     {
+        if ($collectionUsesTaxonomy) {
+            Facades\Collection::find('blog')->taxonomies(['tags'])->save();
+        } else {
+            Facades\Collection::find('blog')->taxonomies([])->save();
+        }
+
         // Make sure there is an entry that uses the term.
         EntryFactory::collection('blog')->data(['tags' => ['one']])->create();
 
@@ -362,7 +368,7 @@ class TermsTest extends TestCase
 
         $collection = $augmented->first()->collection();
 
-        if ($parentIsEntry && $handle === 'tags' && $isRootLevel) {
+        if ($parentIsEntry && $handle === 'tags' && $isRootLevel && $collectionUsesTaxonomy) {
             $this->assertInstanceOf(CollectionContract::class, $collection);
         } else {
             $this->assertNull($collection);
@@ -372,15 +378,25 @@ class TermsTest extends TestCase
     public function collectionAttachmentProvider()
     {
         return [
-            'parent is entry and handle matches taxonomy' => [true, 'tags', true],
-            'parent is entry and handle does not match taxonomy' => [true, 'related_tags', true],
-            'parent is not entry and handle matches taxonomy' => [false, 'tags', true],
-            'parent is not entry and handle does not match taxonomy' => [false, 'related_tags', true],
+            'parent is entry and handle matches taxonomy' => [true, 'tags', true, true],
+            'parent is entry and handle does not match taxonomy' => [true, 'related_tags', true, true],
+            'parent is not entry and handle matches taxonomy' => [false, 'tags', true, true],
+            'parent is not entry and handle does not match taxonomy' => [false, 'related_tags', true, true],
 
-            'parent is entry, handle matches taxonomy, nested field' => [true, 'tags', false],
-            'parent is entry, handle does not match taxonomy, nested field' => [true, 'related_tags', false],
-            'parent is not entry, handle matches taxonomy, nested field' => [false, 'tags', false],
-            'parent is not entry, handle does not match taxonomy, nested field' => [false, 'related_tags', false],
+            'parent is entry, handle matches taxonomy, nested field' => [true, 'tags', false, true],
+            'parent is entry, handle does not match taxonomy, nested field' => [true, 'related_tags', false, true],
+            'parent is not entry, handle matches taxonomy, nested field' => [false, 'tags', false, true],
+            'parent is not entry, handle does not match taxonomy, nested field' => [false, 'related_tags', false, true],
+
+            'parent is entry and handle matches taxonomy, collection doesnt use taxonomy' => [true, 'tags', true, false],
+            'parent is entry and handle does not match taxonomy, collection doesnt use taxonomy' => [true, 'related_tags', true, false],
+            'parent is not entry and handle matches taxonomy, collection doesnt use taxonomy' => [false, 'tags', true, false],
+            'parent is not entry and handle does not match taxonomy, collection doesnt use taxonomy' => [false, 'related_tags', true, false],
+
+            'parent is entry, handle matches taxonomy, nested field, collection doesnt use taxonomy' => [true, 'tags', false, false],
+            'parent is entry, handle does not match taxonomy, nested field, collection doesnt use taxonomy' => [true, 'related_tags', false, false],
+            'parent is not entry, handle matches taxonomy, nested field, collection doesnt use taxonomy' => [false, 'tags', false, false],
+            'parent is not entry, handle does not match taxonomy, nested field, collection doesnt use taxonomy' => [false, 'related_tags', false, false],
         ];
     }
 


### PR DESCRIPTION
Fixes #5768 

In addition to all the existing conditions, also only do the extra collection filtering/attachment magic when the parent entry is configured to use that taxonomy.

The bug in #5768 in a nutshell:
- You're on a `page` collection's entry.
- That entry has a terms field named `tags` (which matches a taxonomy named `tags`)
- When trying to use the `tags` field, it would filter down the terms to ones that are used within the `pages` collection, since that's the parent entry.

That last point was the issue. It was filtering the terms down, which since the collection wasn't configured to use it, was zero. You ended up with an empty array of terms. It should only do that if the `pages` collection also had `taxonomies: [tags]` in it.

This also adjusts the test to use named variables instead of a bunch of booleans, to make it a little clearer.