### PR TITLE
Make query builders macroable

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -10,9 +10,12 @@ use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 use Statamic\Contracts\Query\Builder as Contract;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
+use Statamic\Query\Macroable;
 
 abstract class Builder implements Contract
 {
+    use Macroable;
+
     protected $columns;
     protected $limit;
     protected $offset = 0;

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -3,10 +3,10 @@
 namespace Statamic\Query;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Support\Traits\Macroable;
 use Statamic\Contracts\Query\Builder;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
 use Statamic\Support\Arr;
+use Statamic\Query\Macroable;
 
 abstract class EloquentQueryBuilder implements Builder
 {

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -3,12 +3,15 @@
 namespace Statamic\Query;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Support\Traits\Macroable;
 use Statamic\Contracts\Query\Builder;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
 use Statamic\Support\Arr;
 
 abstract class EloquentQueryBuilder implements Builder
 {
+    use Macroable;
+
     protected $builder;
     protected $columns;
 

--- a/src/Query/Macroable.php
+++ b/src/Query/Macroable.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Statamic\Query;
+
+use BadMethodCallException;
+use Closure;
+use Illuminate\Support\Arr;
+use ReflectionClass;
+use ReflectionMethod;
+
+trait Macroable
+{
+    /**
+     * The registered string macros.
+     *
+     * @var array
+     */
+    protected static $macros = [];
+
+    /**
+     * Register a custom macro.
+     *
+     * @param  string  $name
+     * @param  object|callable  $macro
+     * @return void
+     */
+    public static function macro($name, $macro)
+    {
+        static::$macros[static::class][$name] = $macro;
+    }
+
+    /**
+     * Mix another object into the class.
+     *
+     * @param  object  $mixin
+     * @param  bool  $replace
+     * @return void
+     *
+     * @throws \ReflectionException
+     */
+    public static function mixin($mixin, $replace = true)
+    {
+        $methods = (new ReflectionClass($mixin))->getMethods(
+            ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED
+        );
+
+        foreach ($methods as $method) {
+            if ($replace || ! static::hasMacro($method->name)) {
+                $method->setAccessible(true);
+                static::macro($method->name, $method->invoke($mixin));
+            }
+        }
+    }
+
+    /**
+     * Checks if macro is registered.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public static function hasMacro($name)
+    {
+        return isset(static::$macros[static::class])
+            ? isset(static::$macros[static::class][$name])
+            : false;
+    }
+
+    /**
+     * Flush the existing macros.
+     *
+     * @return void
+     */
+    public static function flushMacros()
+    {
+        static::$macros = [];
+    }
+
+    /**
+     * Dynamically handle calls to the class.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public static function __callStatic($method, $parameters)
+    {
+        if (! static::hasMacro($method)) {
+            throw new BadMethodCallException(sprintf(
+                'Method %s::%s does not exist.',
+                static::class,
+                $method
+            ));
+        }
+
+        $macro = static::$macros[static::class][$method];
+
+        if ($macro instanceof Closure) {
+            $macro = $macro->bindTo(null, static::class);
+        }
+
+        return $macro(...$parameters);
+    }
+
+    /**
+     * Dynamically handle calls to the class.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        if (! static::hasMacro($method)) {
+            throw new BadMethodCallException(sprintf(
+                'Method %s::%s does not exist.',
+                static::class,
+                $method
+            ));
+        }
+
+        $macro = static::$macros[static::class][$method];
+
+        if ($macro instanceof Closure) {
+            $macro = $macro->bindTo($this, static::class);
+        }
+
+        return $macro(...$parameters);
+    }
+}

--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -2,12 +2,15 @@
 
 namespace Statamic\Stache\Query;
 
+use Illuminate\Support\Traits\Macroable;
 use Statamic\Data\DataCollection;
 use Statamic\Query\Builder as BaseBuilder;
 use Statamic\Stache\Stores\Store;
 
 abstract class Builder extends BaseBuilder
 {
+    use Macroable;
+
     protected $store;
     protected $randomize = false;
 

--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -2,15 +2,12 @@
 
 namespace Statamic\Stache\Query;
 
-use Illuminate\Support\Traits\Macroable;
 use Statamic\Data\DataCollection;
 use Statamic\Query\Builder as BaseBuilder;
 use Statamic\Stache\Stores\Store;
 
 abstract class Builder extends BaseBuilder
 {
-    use Macroable;
-
     protected $store;
     protected $randomize = false;
 

--- a/tests/Query/MacroableTest.php
+++ b/tests/Query/MacroableTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Query;
+
+use Tests\TestCase;
+use Statamic\Facades\Term;
+use Statamic\Facades\User;
+use BadMethodCallException;
+use Statamic\Facades\Entry;
+use Tests\PreventSavingStacheItemsToDisk;
+
+class MacroableTest extends TestCase
+{
+    /** @test **/
+    public function it_can_add_custom_query_macro()
+    {
+        Entry::query()->macro('customEntryQuery', function () {
+            return $this->where('foor', 'bar');
+        });
+
+        Term::query()->macro('customTermQuery', function () {
+            return $this->where('foo', 'bar');
+        });
+
+        User::query()->macro('customUserQuery', function () {
+            return $this->where('foo', 'bar');
+        });
+
+        try {
+            Entry::query()->customEntryQuery();
+            Term::query()->customTermQuery();
+            User::query()->customUserQuery();
+            $this->assertTrue(true);
+        } catch (BadMethodCallException) {
+            $this->assertTrue(false);
+        }
+    }
+
+    /** @test **/
+    public function it_ensures_that_the_custom_query_macros_are_scoped_to_the_individual_query_builder()
+    {
+        Entry::query()->macro('customEntryQuery', function () {
+            return $this->where('foor', 'bar');
+        });
+
+        try {
+            Term::query()->customEntryQuery();
+            $this->assertTrue(false);
+        } catch (BadMethodCallException) {
+            $this->assertTrue(true);
+        }
+    }
+}

--- a/tests/Query/MacroableTest.php
+++ b/tests/Query/MacroableTest.php
@@ -5,7 +5,6 @@ namespace Tests\Query;
 use Tests\TestCase;
 use Statamic\Facades\Term;
 use Statamic\Facades\User;
-use BadMethodCallException;
 use Statamic\Facades\Entry;
 use Tests\PreventSavingStacheItemsToDisk;
 
@@ -31,7 +30,7 @@ class MacroableTest extends TestCase
             Term::query()->customTermQuery();
             User::query()->customUserQuery();
             $this->assertTrue(true);
-        } catch (BadMethodCallException) {
+        } catch (\BadMethodCallException $e) {
             $this->assertTrue(false);
         }
     }
@@ -46,7 +45,7 @@ class MacroableTest extends TestCase
         try {
             Term::query()->customEntryQuery();
             $this->assertTrue(false);
-        } catch (BadMethodCallException) {
+        } catch (\BadMethodCallException $e) {
             $this->assertTrue(true);
         }
     }


### PR DESCRIPTION
This PR allows adding additional methods to the query builders by using Laravel's Macroable trait. As discussed a few months back in a partners' chat. This is super useful for custom query methods.

```php
// Instead of this …
Entry::query()
    ->where('payment_status', 'succeeded')
    ->orWhere('payment_status', 'pending');

// … we can now do something like this
Entry::query()->wherePaymentSuccessful();
```