### PR TITLE
Fix hidden field tracking in stacked grid rows

### DIFF
--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -14,7 +14,7 @@
         <publish-fields-container>
             <set-field
                 v-for="field in fields"
-                v-show="showField(field)"
+                v-show="showField(field, fieldPath(field.handle))"
                 :key="field.handle"
                 :field="field"
                 :meta="meta[field.handle]"


### PR DESCRIPTION
I started tracking hidden nested fields in https://github.com/statamic/cms/pull/5805, but forgot to account for "stacked" grid row mode.