### PR TITLE
Runtime: Prevent variables from leaking out of tags

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -372,9 +372,8 @@ class NodeProcessor
      * Updates the current scope with any new variable assignments.
      *
      * @param  array  $assignments  The assignments.
-     * @param  array  $lockData
      */
-    private function processAssignments($assignments, &$lockData = null)
+    private function processAssignments($assignments)
     {
         $this->clearInterpolationCache();
 
@@ -382,11 +381,6 @@ class NodeProcessor
             if (array_key_exists($path, $this->previousAssignments) == false) {
                 $this->previousAssignments[$path] = count($this->data) - 1;
                 Arr::set($this->data[count($this->data) - 1], $path, $value);
-
-                if ($lockData != null) {
-                    $this->previousAssignments[$path] = count($lockData) - 1;
-                    Arr::set($lockData[count($lockData) - 1], $path, $value);
-                }
             } else {
                 $start = $this->previousAssignments[$path];
 
@@ -398,12 +392,6 @@ class NodeProcessor
                     $targetIndex = count($this->data) - 1;
                     Arr::set($this->data[$targetIndex], $path, $value);
                     $this->previousAssignments[$path] = $targetIndex;
-                }
-
-                if ($lockData != null) {
-                    for ($i = $start; $i < count($lockData); $i++) {
-                        Arr::set($lockData[$i], $path, $value);
-                    }
                 }
             }
         }
@@ -793,6 +781,8 @@ class NodeProcessor
     {
         $processor = new NodeProcessor($this->loader, $this->envDetails);
         $processor->allowPhp($this->allowPhp);
+        $processor->setRuntimeAssignments($this->runtimeAssignments);
+
         if ($this->antlersParser != null) {
             $processor->setAntlersParserInstance($this->antlersParser);
         }
@@ -1386,7 +1376,15 @@ class NodeProcessor
                             $methodToCall = 'index';
                         }
 
+                        $beforeAssignments = $this->runtimeAssignments;
                         $output = call_user_func([$tag, $methodToCall]);
+                        $afterAssignments = $this->runtimeAssignments;
+
+                        foreach ($afterAssignments as $assignedVar => $val) {
+                            if (! array_key_exists($assignedVar, $beforeAssignments)) {
+                                unset($this->runtimeAssignments[$assignedVar]);
+                            }
+                        }
 
                         // While the PathDataManager can resolve builder instances,
                         // we will handle this case here so that the values can
@@ -2023,7 +2021,7 @@ class NodeProcessor
                                     $processor->allowPhp($this->allowPhp);
                                     $processor->cascade($this->cascade);
                                     $processor->setAntlersParserInstance($this->antlersParser);
-                                    $processor->setRuntimeAssignments($this->runtimeAssignments, $this->previousAssignments);
+                                    $processor->setRuntimeAssignments($this->runtimeAssignments);
 
                                     if ($this->runtimeConfiguration != null) {
                                         $processor->setRuntimeConfiguration($this->runtimeConfiguration);
@@ -2075,7 +2073,7 @@ class NodeProcessor
                                         }
                                     }
 
-                                    $this->processAssignments($runtimeAssignmentsToProcess, $lockData);
+                                    $this->processAssignments($runtimeAssignmentsToProcess);
                                     $lockData = $this->data;
 
                                     $buffer .= $this->measureBufferAppend($node, $loopBuffer);


### PR DESCRIPTION
This PR fixes #5880 by checking what assignments were present before and after a tag call. Only assignments present in both will be respected.