### PR TITLE
Runtime: corrects parameter style modifier scope overwriting issue

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1243,12 +1243,13 @@ class NodeProcessor
                                 $childDataToUse = $depths + $childData;
 
                                 if (! empty($recursiveParent->parameters)) {
+                                    $lockData = $this->data;
                                     foreach ($recursiveParent->parameters as $param) {
                                         if (ModifierManager::isModifier($param)) {
                                             $childDataToUse = $this->runModifier($param->name, $parentParameterValues, $childDataToUse, $rootData);
                                         }
                                     }
-
+                                    $this->data = $lockData;
                                     $childDataToUse = $childDataToUse + $rootData;
                                 } else {
                                     $childDataToUse = $childDataToUse + $rootData;
@@ -1844,6 +1845,7 @@ class NodeProcessor
                         if (! $shouldProcessAsTag && $val !== null) {
                             foreach ($node->parameters as $param) {
                                 if (ModifierManager::isModifier($param)) {
+                                    $lockData = $this->data;
                                     $activeData = $this->getActiveData();
                                     $paramValues = [];
 
@@ -1851,6 +1853,7 @@ class NodeProcessor
                                         $varValue = $node->getSingleParameterValue($param, $this, $activeData);
 
                                         if ($varValue == 'void::'.GlobalRuntimeState::$environmentId) {
+                                            $this->data = $lockData;
                                             continue;
                                         }
 
@@ -1919,6 +1922,7 @@ class NodeProcessor
                                     $val = $this->runModifier($param->name, $paramValues, $val, $activeData);
 
                                     if ($val === null) {
+                                        $this->data = $lockData;
                                         break;
                                     }
                                 } else {
@@ -1939,6 +1943,8 @@ class NodeProcessor
                                         throw new ModifierNotFoundException($param->name);
                                     }
                                 }
+
+                                $this->data = $lockData;
                             }
 
                             if ($val instanceof Collection) {
@@ -1947,6 +1953,8 @@ class NodeProcessor
                                     $val = $this->addLoopIterationVariables($val);
                                 }
                             }
+
+
                         }
                         $executedParamModifiers = true;
 
@@ -2100,7 +2108,9 @@ class NodeProcessor
 
                         foreach ($node->parameters as $param) {
                             if (ModifierManager::isModifier($param)) {
+                                $lockData = $this->data;
                                 $val = $this->runModifier($param->name, array_values($node->getParameterValues($this, $curActiveData)), $val, $this->getActiveData());
+                                $this->data = $lockData;
                             }
                         }
                     }

--- a/tests/Antlers/Runtime/ParameterStyleModifierTest.php
+++ b/tests/Antlers/Runtime/ParameterStyleModifierTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Antlers\Runtime;
 
 use Statamic\Entries\Collection;
+use Statamic\View\Antlers\Language\Utilities\StringUtilities;
 use Tests\Antlers\ParserTestCase;
 use Facades\Tests\Factories\EntryFactory;
 use Tests\FakesViews;
@@ -56,6 +57,6 @@ EOT;
 <3-Three><3>
 EOT;
 
-        $this->assertSame($expected, trim($response->content()));
+        $this->assertSame($expected, StringUtilities::normalizeLineEndings(trim($response->content())));
     }
 }

--- a/tests/Antlers/Runtime/ParameterStyleModifierTest.php
+++ b/tests/Antlers/Runtime/ParameterStyleModifierTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Antlers\Runtime;
+
+use Statamic\Entries\Collection;
+use Tests\Antlers\ParserTestCase;
+use Facades\Tests\Factories\EntryFactory;
+use Tests\FakesViews;
+use Tests\PreventSavingStacheItemsToDisk;
+
+class ParameterStyleModifierTest extends ParserTestCase
+{
+    use FakesViews;
+    use PreventSavingStacheItemsToDisk;
+
+    public function test_scope_is_not_impacted_by_parameter_style_modifiers()
+    {
+        Collection::make('blog')->routes('{slug}')->save();
+
+        EntryFactory::collection('blog')->id('1')->data(['title' => '1-One'])->slug('one')->create();
+        EntryFactory::collection('blog')->id('2')->data(['title' => '2-Two'])->slug('two')->create();
+        EntryFactory::collection('blog')->id('3')->data(['title' => '3-Three'])->slug('three')->create();
+
+        $data = [
+            'hello' => 'Wilderness',
+            'data' => [
+                [ 'title' => 'One', ],
+                [ 'title' => 'Two', ],
+                [ 'title' => 'Three', ]
+            ]
+        ];
+
+        $template = <<<'EOT'
+{{ collection:blog as="entries" }}
+
+{{ collection from="blog" as="some_alias" }}
+{{ entries scope="entry" }}
+<{{ entry.title }}><{{ some_alias | length }}>
+{{ /entries }}
+{{ /collection }}
+
+{{ /collection:blog }}
+EOT;
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('default', $template);
+
+        $response = $this->get('one')->assertOk();
+
+        $expected = <<<'EOT'
+<1-One><3>
+
+<2-Two><3>
+
+<3-Three><3>
+EOT;
+
+        $this->assertSame($expected, trim($response->content()));
+    }
+}


### PR DESCRIPTION
This PR corrects an issue where using parameter style modifiers under certain conditions can overwrite the scope accidentally. The setup to encounter this bug is to have something like this:

```
{{ collection:articles as="entries" }}
    {{ taxonomy from="topics" sort="title:asc" as="some_alias" }}
        {{ entries scope="entry" }}
        Title: {{ entry.title }}<br />
        Taxonomy Length: {{ some_alias | length }}<br />
        {{ /entries  }}
    {{ /taxonomy }}
{{ /collection:articles }}
```

I've created this repo to compare the before/after behavior in: https://github.com/Stillat/antlers-runtime-parameter-style-scope-reproduce

Before output:

```
Title: 'Dance Like No One is Watching' Is Bad Advice
Taxonomy Length:
Title: Nectar of the Gods
Taxonomy Length:
Title: The Magic Happens at 7 1/2 Pumps
Taxonomy Length:
```

After output:

```
Title: 'Dance Like No One is Watching' Is Bad Advice
Taxonomy Length: 3
Title: Nectar of the Gods
Taxonomy Length: 3
Title: The Magic Happens at 7 1/2 Pumps
Taxonomy Length: 3
```

