### PR TITLE
Update data when replicator set is toggled

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -181,6 +181,7 @@ export default {
 
         toggleEnabledState() {
             Vue.set(this.values, 'enabled', ! this.values.enabled);
+            this.updated('enabled', this.values.enabled);
         },
 
         toggleCollapsedState() {

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -180,8 +180,7 @@ export default {
         },
 
         toggleEnabledState() {
-            Vue.set(this.values, 'enabled', ! this.values.enabled);
-            this.updated('enabled', this.values.enabled);
+            this.updated('enabled', ! this.values.enabled);
         },
 
         toggleCollapsedState() {


### PR DESCRIPTION
It looks like that when a replicator set is toggled "off", the `updated` method isn't called and therefore it's not stored w/ the data nor available in Live Preview.

Not sure if this is the right approach, but it worked for me in extremely limited testing.

Closes https://github.com/statamic/cms/issues/5785