### PR TITLE
Runtime: Adds support for uppercase logical keywords

### DIFF
--- a/src/View/Antlers/Language/Lexer/AntlersLexer.php
+++ b/src/View/Antlers/Language/Lexer/AntlersLexer.php
@@ -460,6 +460,7 @@ class AntlersLexer
                     }
 
                     $parsedValue = trim(implode('', $this->currentContent));
+                    $lowerParsedValue = strtolower($parsedValue);
                     $valueLen = mb_strlen($parsedValue);
                     $valueStartIndex = $this->currentIndex - $valueLen;
                     $startPosition = $node->relativeOffset($valueStartIndex);
@@ -467,7 +468,7 @@ class AntlersLexer
                     $this->currentContent = [];
 
                     // Check against internal keywords.
-                    if ($parsedValue == LanguageKeywords::LogicalAnd) {
+                    if ($lowerParsedValue == LanguageKeywords::LogicalAnd) {
                         $logicalAnd = new LogicalAndOperator();
                         $logicalAnd->content = LanguageKeywords::LogicalAnd;
                         $logicalAnd->startPosition = $startPosition;
@@ -476,7 +477,7 @@ class AntlersLexer
                         $this->runtimeNodes[] = $logicalAnd;
                         $this->lastNode = $logicalAnd;
                         continue;
-                    } elseif ($parsedValue == LanguageKeywords::LogicalOr) {
+                    } elseif ($lowerParsedValue == LanguageKeywords::LogicalOr) {
                         $logicalOr = new LogicalOrOperator();
                         $logicalOr->content = LanguageKeywords::LogicalOr;
                         $logicalOr->startPosition = $startPosition;
@@ -485,7 +486,7 @@ class AntlersLexer
                         $this->runtimeNodes[] = $logicalOr;
                         $this->lastNode = $logicalOr;
                         continue;
-                    } elseif ($parsedValue == LanguageKeywords::LogicalXor) {
+                    } elseif ($lowerParsedValue == LanguageKeywords::LogicalXor) {
                         $logicalXor = new LogicalXorOperator();
                         $logicalXor->content = LanguageKeywords::LogicalXor;
                         $logicalXor->startPosition = $startPosition;
@@ -494,7 +495,7 @@ class AntlersLexer
                         $this->runtimeNodes[] = $logicalXor;
                         $this->lastNode = $logicalXor;
                         continue;
-                    } elseif ($parsedValue == LanguageKeywords::ConstNull) {
+                    } elseif ($lowerParsedValue == LanguageKeywords::ConstNull) {
                         $constNull = new NullConstant();
                         $constNull->content = LanguageKeywords::ConstNull;
                         $constNull->startPosition = $startPosition;
@@ -503,7 +504,7 @@ class AntlersLexer
                         $this->runtimeNodes[] = $constNull;
                         $this->lastNode = $constNull;
                         continue;
-                    } elseif ($parsedValue == LanguageKeywords::ConstTrue) {
+                    } elseif ($lowerParsedValue == LanguageKeywords::ConstTrue) {
                         $constTrue = new TrueConstant();
                         $constTrue->content = LanguageKeywords::ConstNull;
                         $constTrue->startPosition = $startPosition;
@@ -512,7 +513,7 @@ class AntlersLexer
                         $this->runtimeNodes[] = $constTrue;
                         $this->lastNode = $constTrue;
                         continue;
-                    } elseif ($parsedValue == LanguageKeywords::ConstFalse) {
+                    } elseif ($lowerParsedValue == LanguageKeywords::ConstFalse) {
                         $constFalse = new FalseConstant();
                         $constFalse->content = LanguageKeywords::ConstFalse;
                         $constFalse->startPosition = $startPosition;
@@ -521,7 +522,7 @@ class AntlersLexer
                         $this->runtimeNodes[] = $constFalse;
                         $this->lastNode = $constFalse;
                         continue;
-                    } elseif ($parsedValue == LanguageKeywords::LogicalNot) {
+                    } elseif ($lowerParsedValue == LanguageKeywords::LogicalNot) {
                         $logicNegation = new LogicalNegationOperator();
                         $logicNegation->content = LanguageKeywords::LogicalNot;
                         $logicNegation->startPosition = $startPosition;

--- a/tests/Antlers/Parser/BasicNodeTest.php
+++ b/tests/Antlers/Parser/BasicNodeTest.php
@@ -3,11 +3,16 @@
 namespace Tests\Antlers\Parser;
 
 use Statamic\View\Antlers\Language\Nodes\AntlersNode;
+use Statamic\View\Antlers\Language\Nodes\Constants\FalseConstant;
+use Statamic\View\Antlers\Language\Nodes\Constants\TrueConstant;
 use Statamic\View\Antlers\Language\Nodes\LiteralNode;
 use Statamic\View\Antlers\Language\Nodes\Operators\Comparison\EqualCompOperator;
+use Statamic\View\Antlers\Language\Nodes\Operators\LogicalAndOperator;
+use Statamic\View\Antlers\Language\Nodes\Operators\LogicalOrOperator;
 use Statamic\View\Antlers\Language\Nodes\Paths\PathNode;
 use Statamic\View\Antlers\Language\Nodes\Paths\VariableReference;
 use Statamic\View\Antlers\Language\Nodes\Structures\LogicGroup;
+use Statamic\View\Antlers\Language\Nodes\Structures\SemanticGroup;
 use Statamic\View\Antlers\Language\Nodes\VariableNode;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
 use Tests\Antlers\Fixtures\Addon\Tags\EchoMethod;
@@ -465,5 +470,36 @@ ABCDEFGHIJKLMNOPQRSTUVWXYZ
 EOT;
 
         $this->assertSame($expected, $this->renderString($template, $data, true));
+    }
+
+    public function test_uppercase_logical_keywords_are_parsed_into_keywords_and_not_variables()
+    {
+        $nodes = $this->getParsedRuntimeNodes('{{ TrUe AND FALSE oR something }}');
+        $this->assertCount(1, $nodes);
+        $this->assertInstanceOf(SemanticGroup::class, $nodes[0]);
+
+        /** @var SemanticGroup $semanticGroupWrapper */
+        $semanticGroupWrapper = $nodes[0];
+        $this->assertCount(1, $semanticGroupWrapper->nodes);
+        $this->assertInstanceOf(LogicGroup::class, $semanticGroupWrapper->nodes[0]);
+
+        /** @var LogicGroup $logicWrapper */
+        $logicWrapper = $semanticGroupWrapper->nodes[0];
+        $this->assertCount(3, $logicWrapper->nodes);
+
+        $this->assertInstanceOf(LogicGroup::class, $logicWrapper->nodes[0]);
+        $this->assertInstanceOf(LogicalOrOperator::class, $logicWrapper->nodes[1]);
+        $this->assertInstanceOf(VariableNode::class, $logicWrapper->nodes[2]);
+
+        /** @var LogicGroup $innerGroup */
+        $innerGroup = $logicWrapper->nodes[0];
+        $this->assertCount(3, $innerGroup->nodes);
+        $this->assertInstanceOf(TrueConstant::class, $innerGroup->nodes[0]);
+        $this->assertInstanceOf(LogicalAndOperator::class, $innerGroup->nodes[1]);
+        $this->assertInstanceOf(FalseConstant::class, $innerGroup->nodes[2]);
+
+        /** @var VariableNode $var */
+        $var = $logicWrapper->nodes[2];
+        $this->assertSame('something', $var->name);
     }
 }

--- a/tests/Antlers/Runtime/ConditionLogicTest.php
+++ b/tests/Antlers/Runtime/ConditionLogicTest.php
@@ -746,4 +746,13 @@ EOT;
 
         $this->assertSame('Yes', (string) $this->parser()->cascade($cascade)->parse($template));
     }
+
+    public function test_uppercase_logical_keywords_in_conditions()
+    {
+        $template = <<<'EOT'
+{{ if true AND false }}Yes{{ else }}No{{ /if }}
+EOT;
+
+        $this->assertSame('No', $this->renderString($template));
+    }
 }


### PR DESCRIPTION
This PR closes #5910 by adding support for uppercase/mixed-case language keywords.

The following will now work as expected:

```
{{ if something AND something_else == 'some value' }}

{{ /if }}
```