### PR TITLE
Asset browser uses HasActions mixin

### DIFF
--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -21,6 +21,7 @@ export default {
             default: () => [],
         },
         filters: Array,
+        actionUrl: String,
     },
 
     data() {

--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -93,7 +93,7 @@
                             <data-list-table
                                 v-if="mode === 'table' && ! containerIsEmpty"
                                 :allow-bulk-actions="true"
-                                :loading="loadingAssets"
+                                :loading="loading"
                                 :rows="rows"
                                 :toggle-selection-on-row-click="true"
                                 @sorted="sorted"
@@ -295,7 +295,7 @@ export default {
             containers: [],
             container: {},
             initializing: true,
-            loadingAssets: true,
+            loading: true,
             assets: [],
             path: this.selectedPath,
             folders: [],
@@ -332,10 +332,6 @@ export default {
 
         showContainerTabs() {
             return !this.restrictContainerNavigation && Object.keys(this.containers).length > 1
-        },
-
-        loading() {
-            return this.loadingAssets;
         },
 
         showAssetEditor() {
@@ -463,7 +459,7 @@ export default {
         },
 
         loadAssets() {
-            this.loadingAssets = true;
+            this.loading = true;
 
             const url = this.searchQuery
                 ? cp_url(`assets/browse/search/${this.container.id}`)
@@ -484,13 +480,13 @@ export default {
                     this.folderActionUrl = data.links.folder_action;
                 }
 
-                this.loadingAssets = false;
+                this.loading = false;
                 this.initializing = false;
             }).catch(e => {
                 this.$toast.error(e.response.data.message, { action: null, duration: null });
                 this.assets = [];
                 this.folders = [];
-                this.loadingAssets = false;
+                this.loading = false;
                 this.initializing = false;
             });
         },

--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -254,10 +254,12 @@ import HasPagination from '../../data-list/HasPagination';
 import HasPreferences from '../../data-list/HasPreferences';
 import Uploader from '../Uploader.vue';
 import Uploads from '../Uploads.vue';
+import HasActions from '../../data-list/HasActions';
 
 export default {
 
     mixins: [
+        HasActions,
         HasPagination,
         HasPreferences,
     ],
@@ -437,17 +439,7 @@ export default {
 
     methods: {
 
-        actionStarted() {
-            this.loadingAssets = true;
-        },
-
-        actionCompleted(success) {
-            if (success) {
-                this.$toast.success(__('Action completed'));
-            }
-
-            this.$events.$emit('clear-selections');
-
+        afterActionSuccessfullyCompleted() {
             this.loadAssets();
         },
 

--- a/resources/js/components/data-list/HasActions.js
+++ b/resources/js/components/data-list/HasActions.js
@@ -1,9 +1,5 @@
 export default {
 
-    props: {
-        actionUrl: String,
-    },
-
     methods: {
 
         actionStarted() {
@@ -26,6 +22,10 @@ export default {
                 this.$toast.success(response.message || __("Action completed"));
             }
 
+            this.afterActionSuccessfullyCompleted();
+        },
+
+        afterActionSuccessfullyCompleted() {
             this.request();
         }
 


### PR DESCRIPTION
- `Browser.vue` uses the mixin, which has the extra stuff like javascript callbacks ready to go, so #5901 will be able to work.
- Removed the `actionUrl` prop from the mixin. `Listing.vue` (the only thing using this mixin) needs a prop, but the asset browser uses a data property.
- Renamed `loadingAssets` to just `loading` in `Browser.vue`. It was called that back when we also had `loadingContainers`. Now using `loading` will allow the HasAction mixin to "just work" a little better.
- Added an `afterActionSuccessfullyCompleted` method to make it easier to override.