### PR TITLE
Fix "filtering a collection throws an exception"

### DIFF
--- a/src/Http/Resources/CP/Concerns/HasRequestedColumns.php
+++ b/src/Http/Resources/CP/Concerns/HasRequestedColumns.php
@@ -23,7 +23,11 @@ trait HasRequestedColumns
 
         return collect($requested)
             ->map(function ($field) use ($columns) {
-                return $columns->get($field)->visible(true);
+                if ($columns->get($field) !== null) {
+                    return $columns->get($field)->visible(true);
+                }
+
+                return false;
             })
             ->merge($columns->except($requested))
             ->values();

--- a/src/Http/Resources/CP/Concerns/HasRequestedColumns.php
+++ b/src/Http/Resources/CP/Concerns/HasRequestedColumns.php
@@ -22,13 +22,8 @@ trait HasRequestedColumns
         $columns = $this->columns->keyBy('field')->map->visible(false);
 
         return collect($requested)
-            ->map(function ($field) use ($columns) {
-                if ($columns->get($field) !== null) {
-                    return $columns->get($field)->visible(true);
-                }
-
-                return false;
-            })
+            ->filter(fn ($field) => $columns->has($field))
+            ->map(fn ($field) => $columns->get($field)->visible(true))
             ->merge($columns->except($requested))
             ->values();
     }


### PR DESCRIPTION
In an Entries fieldtype, when I filter by a collection, an exception is thrown. It happens when the first collection in the list has fields that are listable (listable: true) and when those fields do not exist in the collection selected for filtering.

This PR fixes that problem.

Also fixes #4317