### PR TITLE
Added str_pad() modifiers

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2233,6 +2233,66 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Make str_pad() with padding available as a modifier.
+     *
+     * Example: {{ my_index | str_pad_both:2:0:left }}
+     *
+     * @param string $value   The value to be modified.
+     * @param array  $params  Any parameters used in the modifier.
+     * @return string
+     */
+    public function strPad(string $value, array $params): string
+    {
+        $pad_length = Arr::get($params, 0);
+        $pad_string = Arr::get($params, 1, ' ');
+        $pad_type = constant('STR_PAD_' . Str::upper(Arr::get($params, 2, 'RIGHT')));
+
+        return str_pad($value, $pad_length, $pad_string, $pad_type);
+    }
+
+    /**
+     * Make str_pad() with both padding available as a modifier.
+     *
+     * Example: {{ my_index | str_pad_both:2:0 }}
+     *
+     * @param string $value   The value to be modified.
+     * @param array  $params  Any parameters used in the modifier.
+     * @return string
+     */
+    public function strPadBoth(string $value, array $params): string
+    {
+        return $this->strPad($value, array_merge($params, [2 => 'BOTH']));
+    }
+
+    /**
+     * Make str_pad() with left padding available as a modifier.
+     *
+     * Example: {{ my_index | str_pad_left:2:0 }}
+     *
+     * @param string $value   The value to be modified.
+     * @param array  $params  Any parameters used in the modifier.
+     * @return string
+     */
+    public function strPadLeft(string $value, array $params): string
+    {
+        return $this->strPad($value, array_merge($params, [2 => 'LEFT']));
+    }
+
+    /**
+     * Make str_pad() with right padding available as a modifier.
+     *
+     * Example: {{ my_index | str_pad_right:2:0 }}
+     *
+     * @param string $value   The value to be modified.
+     * @param array  $params  Any parameters used in the modifier.
+     * @return string
+     */
+    public function strPadRight(string $value, array $params): string
+    {
+        return $this->strPad($value, array_merge($params, [2 => 'RIGHT']));
+    }
+
+    /**
      * Converts a string to StudlyCase.
      *
      * @param $value

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2235,7 +2235,7 @@ class CoreModifiers extends Modifier
     /**
      * Make str_pad() with padding available as a modifier.
      *
-     * Example: {{ my_index | str_pad_both:2:0:left }}
+     * Example: {{ my_index | str_pad:2:0:left }}
      *
      * @param  string  $value  The value to be modified.
      * @param  array  $params  Any parameters used in the modifier.

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2237,15 +2237,15 @@ class CoreModifiers extends Modifier
      *
      * Example: {{ my_index | str_pad_both:2:0:left }}
      *
-     * @param string $value   The value to be modified.
-     * @param array  $params  Any parameters used in the modifier.
+     * @param  string  $value  The value to be modified.
+     * @param  array  $params  Any parameters used in the modifier.
      * @return string
      */
     public function strPad(string $value, array $params): string
     {
         $pad_length = Arr::get($params, 0);
         $pad_string = Arr::get($params, 1, ' ');
-        $pad_type = constant('STR_PAD_' . Str::upper(Arr::get($params, 2, 'RIGHT')));
+        $pad_type = constant('STR_PAD_'.Str::upper(Arr::get($params, 2, 'RIGHT')));
 
         return str_pad($value, $pad_length, $pad_string, $pad_type);
     }
@@ -2255,8 +2255,8 @@ class CoreModifiers extends Modifier
      *
      * Example: {{ my_index | str_pad_both:2:0 }}
      *
-     * @param string $value   The value to be modified.
-     * @param array  $params  Any parameters used in the modifier.
+     * @param  string  $value  The value to be modified.
+     * @param  array  $params  Any parameters used in the modifier.
      * @return string
      */
     public function strPadBoth(string $value, array $params): string
@@ -2269,8 +2269,8 @@ class CoreModifiers extends Modifier
      *
      * Example: {{ my_index | str_pad_left:2:0 }}
      *
-     * @param string $value   The value to be modified.
-     * @param array  $params  Any parameters used in the modifier.
+     * @param  string  $value  The value to be modified.
+     * @param  array  $params  Any parameters used in the modifier.
      * @return string
      */
     public function strPadLeft(string $value, array $params): string
@@ -2283,8 +2283,8 @@ class CoreModifiers extends Modifier
      *
      * Example: {{ my_index | str_pad_right:2:0 }}
      *
-     * @param string $value   The value to be modified.
-     * @param array  $params  Any parameters used in the modifier.
+     * @param  string  $value  The value to be modified.
+     * @param  array  $params  Any parameters used in the modifier.
      * @return string
      */
     public function strPadRight(string $value, array $params): string

--- a/tests/Modifiers/StrPadBothTest.php
+++ b/tests/Modifiers/StrPadBothTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class StrPadBothTest extends TestCase
+{
+    public function paddington(): array
+    {
+        return [
+            'pads_5_tilde' => ['test~', 'test', [5, '~']],
+            'pads_8_plus' => ['++test++', 'test', [8, '+']],
+            'pads_4_two' => ['2022', '02', [4, '2']],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider paddington
+     */
+    public function it_pads_a_string(string $expected, string $input, array $params): void
+    {
+        $modified = $this->modify($input, $params);
+        $this->assertEquals($expected, $modified);
+    }
+
+    private function modify(string $value, array $params): string
+    {
+        return Modify::value($value)->strPadBoth($params)->fetch();
+    }
+}

--- a/tests/Modifiers/StrPadLeftTest.php
+++ b/tests/Modifiers/StrPadLeftTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class StrPadLeftTest extends TestCase
+{
+    public function paddington(): array
+    {
+        return [
+            'pads_5_tilde' => ['~test', 'test', [5, '~']],
+            'pads_8_plus' => ['++++test', 'test', [8, '+']],
+            'pads_4_two' => ['2202', '02', [4, '2']],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider paddington
+     */
+    public function it_pads_a_string(string $expected, string $input, array $params): void
+    {
+        $modified = $this->modify($input, $params);
+        $this->assertEquals($expected, $modified);
+    }
+
+    private function modify(string $value, array $params): string
+    {
+        return Modify::value($value)->strPadLeft($params)->fetch();
+    }
+}

--- a/tests/Modifiers/StrPadRightTest.php
+++ b/tests/Modifiers/StrPadRightTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class StrPadRightTest extends TestCase
+{
+    public function paddington(): array
+    {
+        return [
+            'pads_5_tilde' => ['test~', 'test', [5, '~']],
+            'pads_8_plus' => ['test++++', 'test', [8, '+']],
+            'pads_4_two' => ['2022', '20', [4, '2']],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider paddington
+     */
+    public function it_pads_a_string(string $expected, string $input, array $params): void
+    {
+        $modified = $this->modify($input, $params);
+        $this->assertEquals($expected, $modified);
+    }
+
+    private function modify(string $value, array $params): string
+    {
+        return Modify::value($value)->strPadRight($params)->fetch();
+    }
+}

--- a/tests/Modifiers/StrPadTest.php
+++ b/tests/Modifiers/StrPadTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class StrPadTest extends TestCase
+{
+    public function paddington(): array
+    {
+        return [
+            'pads_4_default' => ['test', 'test', [4]],
+            'pads_8_default' => ['test    ', 'test', [8]],
+            'pads_8_tilde_both' => ['~~test~~', 'test', [8, '~', 'both']],
+            'pads_8_tilde_left' => ['~~~~test', 'test', [8, '~', 'left']],
+            'pads_8_tilde_right' => ['test~~~~', 'test', [8, '~', 'right']],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider paddington
+     */
+    public function it_pads_a_string(string $expected, string $input, array $params): void
+    {
+        $modified = $this->modify($input, $params);
+        $this->assertEquals($expected, $modified);
+    }
+
+    private function modify(string $value, array $params): string
+    {
+        return Modify::value($value)->strPad($params)->fetch();
+    }
+}


### PR DESCRIPTION
As the title says, here's core modifiers for `str_pad()` with additional `str_pad_both`, `str_pad_left` and `str_pad_right` modifier helpers.