### PR TITLE
Fix hidden code field

### DIFF
--- a/src/Fieldtypes/Code.php
+++ b/src/Fieldtypes/Code.php
@@ -125,6 +125,10 @@ class Code extends Fieldtype
 
     public function process($value)
     {
+        if (! $value) {
+            return null;
+        }
+
         if (! $this->isModeSelectable()) {
             return $value['code'];
         }


### PR DESCRIPTION
Fixes #5555
Replaces #5896

The code fieldtype was written expecting the Vue component to submit an array.
However if it's hidden using field conditions, nothing will be submitted. This PR handles the null.
