### PR TITLE
Add backwards compatibility to entry edit url

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -75,6 +75,11 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
                 Route::get('preview', 'EntryPreviewController@show')->name('collections.entries.preview.popout');
                 Route::patch('/', 'EntriesController@update')->name('collections.entries.update');
             });
+            
+            // Provides backwards compatibility, in case an old URL will with a slug will be called
+            Route::get('{entry}/{slug}', function ($collection, $entry, $slug) {
+                return redirect($entry->editUrl(), 301);
+            });
         });
     });
 

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -75,7 +75,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
                 Route::get('preview', 'EntryPreviewController@show')->name('collections.entries.preview.popout');
                 Route::patch('/', 'EntriesController@update')->name('collections.entries.update');
             });
-            
+
             // Provides backwards compatibility, in case an old URL will with a slug will be called
             Route::get('{entry}/{slug}', function ($collection, $entry, $slug) {
                 return redirect($entry->editUrl(), 301);

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -61,6 +61,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
 
             Route::group(['prefix' => '{entry}'], function () {
                 Route::get('/', 'EntriesController@edit')->name('collections.entries.edit');
+                Route::get('{slug}', fn ($collection, $entry, $slug) => redirect($entry->editUrl()));
                 Route::post('publish', 'PublishedEntriesController@store')->name('collections.entries.published.store');
                 Route::post('unpublish', 'PublishedEntriesController@destroy')->name('collections.entries.published.destroy');
                 Route::post('localize', 'LocalizeEntryController')->name('collections.entries.localize');
@@ -74,11 +75,6 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
                 Route::post('preview', 'EntryPreviewController@edit')->name('collections.entries.preview.edit');
                 Route::get('preview', 'EntryPreviewController@show')->name('collections.entries.preview.popout');
                 Route::patch('/', 'EntriesController@update')->name('collections.entries.update');
-            });
-
-            // Provides backwards compatibility, in case an old URL will with a slug will be called
-            Route::get('{entry}/{slug}', function ($collection, $entry, $slug) {
-                return redirect($entry->editUrl(), 301);
             });
         });
     });


### PR DESCRIPTION
Statamic 3.3 did introduce the change, that the edit url of an entry did change. The slug has been removed from the url:
https://github.com/statamic/cms/commit/da97be6389b34113a13f3d41ef10b6e95419c2a8#diff-1d817f0299e963881205eac675e8f8b1e4cc38c5cf5a35659d46f1d19a42bbcf

In our case, this is introduction a breaking change for external systems, which did save the "old" edit url. Having such a change from 3.2 to 3.3 is fine and should generally not be a problem to many others I guess.

**I am suggestion this PR anyways, as this does add backwards compatibility and is not doing any harm to the core itself.** 

I am interested to hear if this is a good addition or if there are any concerns about this PR.