### PR TITLE
Fix limit and offset on ordered query builders

### DIFF
--- a/src/Query/OrderedQueryBuilder.php
+++ b/src/Query/OrderedQueryBuilder.php
@@ -12,6 +12,8 @@ class OrderedQueryBuilder implements Builder
     protected $builder;
     protected $order;
     protected $ordered = false;
+    protected $limit;
+    protected $offset;
 
     public function __construct(Builder $builder, $order = [])
     {
@@ -34,7 +36,7 @@ class OrderedQueryBuilder implements Builder
             $results = $this->performFallbackOrdering($results);
         }
 
-        return $results;
+        return $results->limit($this->limit)->skip($this->offset);
     }
 
     public function __call($method, $parameters)
@@ -64,5 +66,19 @@ class OrderedQueryBuilder implements Builder
 
             return $a <=> $b;
         })->values();
+    }
+
+    public function limit($value)
+    {
+        $this->limit = $value;
+
+        return $this;
+    }
+
+    public function offset($value)
+    {
+        $this->offset = max(0, $value);
+
+        return $this;
     }
 }

--- a/src/Query/OrderedQueryBuilder.php
+++ b/src/Query/OrderedQueryBuilder.php
@@ -36,7 +36,7 @@ class OrderedQueryBuilder implements Builder
             $results = $this->performFallbackOrdering($results);
         }
 
-        return $results->take($this->limit)->skip($this->offset);
+        return $results->take($this->limit)->skip($this->offset)->values();
     }
 
     public function __call($method, $parameters)

--- a/src/Query/OrderedQueryBuilder.php
+++ b/src/Query/OrderedQueryBuilder.php
@@ -36,7 +36,7 @@ class OrderedQueryBuilder implements Builder
             $results = $this->performFallbackOrdering($results);
         }
 
-        return $results->limit($this->limit)->skip($this->offset);
+        return $results->take($this->limit)->skip($this->offset);
     }
 
     public function __call($method, $parameters)

--- a/tests/Query/OrderedQueryBuilderTest.php
+++ b/tests/Query/OrderedQueryBuilderTest.php
@@ -92,4 +92,49 @@ class OrderedQueryBuilderTest extends TestCase
 
         $this->assertEquals('paginator', $results);
     }
+
+    /** @test */
+    public function it_limits_after_the_results_have_been_retrieved()
+    {
+        $builder = $this->mock(Builder::class);
+        $builder->shouldReceive('limit')->never();
+        $builder->shouldReceive('get')->once()->andReturn(collect([
+            ['id' => '1'],
+            ['id' => '2'],
+            ['id' => '3'],
+            ['id' => '4'],
+            ['id' => '5'],
+        ]));
+
+        $results = (new OrderedQueryBuilder($builder, [4, 5, 2, 1, 3]))->limit(3)->get();
+
+        $this->assertEquals([
+            ['id' => '4'],
+            ['id' => '5'],
+            ['id' => '2'],
+        ], $results->all());
+    }
+
+    /** @test */
+    public function it_offsets_after_the_results_have_been_retrieved()
+    {
+        $builder = $this->mock(Builder::class);
+        $builder->shouldReceive('offset')->never();
+        $builder->shouldReceive('get')->once()->andReturn(collect([
+            ['id' => '1'],
+            ['id' => '2'],
+            ['id' => '3'],
+            ['id' => '4'],
+            ['id' => '5'],
+        ]));
+
+        $results = (new OrderedQueryBuilder($builder, [4, 5, 2, 1, 3]))->offset(1)->get();
+
+        $this->assertEquals([
+            ['id' => '5'],
+            ['id' => '2'],
+            ['id' => '1'],
+            ['id' => '3'],
+        ], $results->all());
+    }
 }


### PR DESCRIPTION
This PR moves the limiting and offsetting from the query to the collection after the results have been retrieved.

For assets/entries/etc fields, the query gets wrapped in a decorator that'll apply the order after the results are retrieved. If you limit/offset, it would have already limited it on the query level before the decorator has a chance to change the order. This made using limit/offset on those types of fields sometimes output things in an unexpected/incorrect order.
