### PR TITLE
Allow overwriting the `getAddon` method

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -424,7 +424,7 @@ abstract class AddonServiceProvider extends ServiceProvider
         return $this->getAddon()->namespace();
     }
 
-    private function getAddon()
+    protected function getAddon()
     {
         throw_unless($this->app->isBooted(), new NotBootedException);
 


### PR DESCRIPTION
This change does allow to overwrite the `getAddon()` method if extending it.

**Our usecase**

We are working on an addon, which can be customized a lot. To allow for that behaviour, that addon has two ServiceProviders, as done by knows addons like Laravel Horizon or Laravel Telescope.

This does allow for multiple things, but to name one concrete example, it's useful to register Fieldtypes. After publishing the ServiceProvider into the app Namespace, our Fieldtypes can be used or replaced by own implementations.

As known from addon context, you can simply register everything like this, just to give one example:
```php
protected $fieldtypes = [
        \Spiegel\SomeFiedltype::class,
        \Spiegel\AnotherFieldtype::class,
    ];
```
BUT

If the ServiceProvider is not in the addon Namespace, nothing will get booted, as `this->getAddon()` and `getAddonByServiceProvider()` can't find any addon in the actual namespace. 
https://github.com/statamic/cms/blob/3.3/src/Providers/AddonServiceProvider.php#L45-L47

Making `getAddon` protected does allow for such hocus pocus use cases 🧞‍♀️