### PR TITLE
Reindex query builder results

### DIFF
--- a/src/Query/IteratorBuilder.php
+++ b/src/Query/IteratorBuilder.php
@@ -27,7 +27,7 @@ abstract class IteratorBuilder extends Builder
             $items = $items->multisort($sort)->values();
         }
 
-        return $this->limitItems($items);
+        return $this->limitItems($items)->values();
     }
 
     protected function getFilteredItems()

--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -35,7 +35,7 @@ abstract class Builder extends BaseBuilder
             ->selectedQueryColumns($this->columns ?? $columns)
             ->selectedQueryRelations($this->with));
 
-        return $this->collect($items);
+        return $this->collect($items)->values();
     }
 
     abstract protected function getFilteredKeys();

--- a/tests/Data/Assets/AssetQueryBuilderTest.php
+++ b/tests/Data/Assets/AssetQueryBuilderTest.php
@@ -521,4 +521,14 @@ class AssetQueryBuilderTest extends TestCase
         $this->assertCount(1, $assets);
         $this->assertEquals(['a'], $assets->map->filename()->all());
     }
+
+    /** @test */
+    public function assets_are_found_using_offset()
+    {
+        $query = $this->container->queryAssets()->limit(3);
+
+        $this->assertEquals(['a.jpg', 'b.txt', 'c.txt'], $query->get()->map->path()->all());
+
+        $this->assertEquals(['b.txt', 'c.txt', 'd.jpg'], $query->offset(1)->get()->map->path()->all());
+    }
 }

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -649,4 +649,19 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertNotNull($found);
         $this->assertSame($found, $substituteFr);
     }
+
+    /** @test */
+    public function entries_are_found_using_offset()
+    {
+        $this->createDummyCollectionAndEntries();
+
+        $entries = Entry::query()->get();
+        $this->assertCount(3, $entries);
+        $this->assertEquals(['Post 1', 'Post 2', 'Post 3'], $entries->map->title->all());
+
+        $entries = Entry::query()->offset(1)->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 2', 'Post 3'], $entries->map->title->all());
+    }
 }

--- a/tests/Data/Taxonomies/TermQueryBuilderTest.php
+++ b/tests/Data/Taxonomies/TermQueryBuilderTest.php
@@ -566,4 +566,19 @@ class TermQueryBuilderTest extends TestCase
         $this->assertCount(2, $entries);
         $this->assertEquals(['2', '5'], $entries->map->slug()->all());
     }
+
+    /** @test */
+    public function terms_are_found_using_offset()
+    {
+        Taxonomy::make('tags')->save();
+        Term::make('a')->taxonomy('tags')->data([])->save();
+        Term::make('b')->taxonomy('tags')->data([])->save();
+        Term::make('c')->taxonomy('tags')->data([])->save();
+
+        $terms = Term::query()->get();
+        $this->assertEquals(['a', 'b', 'c'], $terms->map->slug()->all());
+
+        $terms = Term::query()->offset(1)->get();
+        $this->assertEquals(['b', 'c'], $terms->map->slug()->all());
+    }
 }

--- a/tests/Search/QueryBuilderTest.php
+++ b/tests/Search/QueryBuilderTest.php
@@ -548,6 +548,23 @@ class QueryBuilderTest extends TestCase
         $this->assertCount(2, $results);
         $this->assertEquals(['a', 'c'], $results->map->reference->all());
     }
+
+    /** @test */
+    public function results_are_found_using_offset()
+    {
+        $items = collect([
+            ['reference' => 'a'],
+            ['reference' => 'b'],
+            ['reference' => 'c'],
+            ['reference' => 'd'],
+        ]);
+
+        $query = (new FakeQueryBuilder($items))->withoutData();
+
+        $this->assertEquals(['a', 'b', 'c', 'd'], $query->get()->map->reference->all());
+
+        $this->assertEquals(['b', 'c', 'd'], $query->offset(1)->get()->map->reference->all());
+    }
 }
 
 class FakeQueryBuilder extends QueryBuilder


### PR DESCRIPTION
When performing some queries, you might get results that are no longer zero indexed. This causes issues in Antlers because you can only loop over zero indexed things.

e.g.

```php
[
  'foo',
  'bar',
  'baz'
]
```

If you do something to filter out foo, like `offset(1)`, you'd get

```php
[
  1 => 'bar',
  2 => 'foo',
]
```

This PR will call `values()` on the results which resets the indexes.

```php
[
  'bar',
  'baz'
]
```

This is consistent with Laravel's Query Builder.

Fixes #5758