### PR TITLE
Preserve strings like `0.0` and `1.0`

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -85,12 +85,12 @@ trait HasSelectOptions
             return $value;
         }
 
-        if ($value == (int) $value) {
-            return (int) $value;
-        }
-
         if ($value == (float) $value) {
             return (string) $value;
+        }
+
+        if ($value == (int) $value) {
+            return (int) $value;
         }
 
         return $value;


### PR DESCRIPTION
This very simple PR fixes an issue with select options. Before this PR, option `'0.0'` would be cast to `0` and option `'1.0'` to `0`. Now they will be output correctly. 

I came across this problem when getting the augmented value of the following field.

```yaml
'field' => [
    'handle' => 'seo_sitemap_priority',
    'type' => 'select',
    'options' => [
        '0.0' => '0.0',
        '1.0' => '1.0',
    ],
],
```