### PR TITLE
Runtime: evaluate Antlers within `code` fieldtype when `antlers: true` is set

### DIFF
--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -82,9 +82,8 @@ class Value implements IteratorAggregate, JsonSerializable
     {
         $value = $this->value();
         $shouldParseAntlers = $this->shouldParseAntlers();
-        $isRuntime = config('statamic.antlers.version') === 'runtime';
 
-        if ($value instanceof  ArrayableString && $shouldParseAntlers && $isRuntime) {
+        if ($value instanceof  ArrayableString && $shouldParseAntlers) {
             $value = (string) $value;
         }
 
@@ -93,7 +92,7 @@ class Value implements IteratorAggregate, JsonSerializable
         }
 
         if ($shouldParseAntlers) {
-            if ($isRuntime) {
+            if (config('statamic.antlers.version') === 'runtime') {
                 $value = (new DocumentTransformer())->correct($value);
             }
 

--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -81,13 +81,19 @@ class Value implements IteratorAggregate, JsonSerializable
     public function antlersValue(Parser $parser, $variables)
     {
         $value = $this->value();
+        $shouldParseAntlers = $this->shouldParseAntlers();
+        $isRuntime = config('statamic.antlers.version') === 'runtime';
+
+        if ($value instanceof  ArrayableString && $shouldParseAntlers && $isRuntime) {
+            $value = (string) $value;
+        }
 
         if (! is_string($value)) {
             return $value;
         }
 
-        if ($this->shouldParseAntlers()) {
-            if (config('statamic.antlers.version') === 'runtime') {
+        if ($shouldParseAntlers) {
+            if ($isRuntime) {
                 $value = (new DocumentTransformer())->correct($value);
             }
 

--- a/tests/Antlers/Runtime/Fieldtypes/CodeFieldtypeTest.php
+++ b/tests/Antlers/Runtime/Fieldtypes/CodeFieldtypeTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Antlers\Runtime\Fieldtypes;
 
+use Statamic\Fields\Field;
+use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Code;
 use Tests\Antlers\ParserTestCase;
 
 class CodeFieldtypeTest extends ParserTestCase
@@ -9,5 +12,23 @@ class CodeFieldtypeTest extends ParserTestCase
     public function test_render_code_fieldtype()
     {
         $this->runFieldTypeTest('code');
+    }
+
+    public function test_code_fieldtype_with_antlers_true()
+    {
+        $code = new Code();
+        $field = new Field('code_field', [
+            'type' => 'code',
+            'antlers' => true,
+        ]);
+
+        $code->setField($field);
+        $value = new Value('Hello, {{ name }}.', 'code_field', $code);
+
+        $template = <<<'EOT'
+<{{ code_field }}>
+EOT;
+
+        $this->assertSame('<Hello, wilderness.>', $this->renderString($template, ['code_field' => $value, 'name' => 'wilderness',]));
     }
 }


### PR DESCRIPTION
This PR closes #5963  by casting instances of `ArrayableString` to strings when resolving a value for Antlers when the field is configured with `antlers: true`. This is only done when the site is set to `runtime` to prevent accidentally breaking something else.

To reproduce the original issue create a code field and set `antlers: true` on the field and include some Antlers code in the value. The code will not be evaluated before this PR, but will afterwards (the included test will also fail when moved to the main branch as another way to validate).