### PR TITLE
Move route to fix live preview pop out

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -61,7 +61,6 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
 
             Route::group(['prefix' => '{entry}'], function () {
                 Route::get('/', 'EntriesController@edit')->name('collections.entries.edit');
-                Route::get('{slug}', fn ($collection, $entry, $slug) => redirect($entry->editUrl()));
                 Route::post('publish', 'PublishedEntriesController@store')->name('collections.entries.published.store');
                 Route::post('unpublish', 'PublishedEntriesController@destroy')->name('collections.entries.published.destroy');
                 Route::post('localize', 'LocalizeEntryController')->name('collections.entries.localize');
@@ -75,6 +74,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
                 Route::post('preview', 'EntryPreviewController@edit')->name('collections.entries.preview.edit');
                 Route::get('preview', 'EntryPreviewController@show')->name('collections.entries.preview.popout');
                 Route::patch('/', 'EntriesController@update')->name('collections.entries.update');
+                Route::get('{slug}', fn ($collection, $entry, $slug) => redirect($entry->editUrl()));
             });
         });
     });


### PR DESCRIPTION
In #5924 I moved a route too early in order to tidy up. Since it's a wildcard it needs to come after the other routes.

Fixes #5960
