### PR TITLE
Update default Markdown editor URL prompt value to `https://`

### DIFF
--- a/resources/js/components/fieldtypes/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/MarkdownFieldtype.vue
@@ -289,7 +289,7 @@ export default {
             }
 
             if (! url) {
-                url = prompt(__('Enter URL'), 'http://');
+                url = prompt(__('Enter URL'), 'https://');
                 if (! url) {
                     url = '';
                 }


### PR DESCRIPTION
The browser prompt asking for a URL in the Markdown field editor is currently defaulting to `http://`.
This PR just updates that value to `https://` by default.

![image](https://user-images.githubusercontent.com/1066486/166238950-423a3a3a-4914-4236-ab23-e5698f174fb2.png)
![image](https://user-images.githubusercontent.com/1066486/166239099-651b42ff-ea93-41c1-adc9-c003140c163f.png)
