### PR TITLE
Cleans up null string deprecation warnings

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -584,11 +584,12 @@ abstract class Builder implements Contract
 
     protected function filterTestEquals($item, $value)
     {
-        if ($item === null && $value === null) {
-            return true;
+        if ($item === null) {
+            $item = '';
         }
-        if ($item === null || $value === null) {
-            return false;
+
+        if ($value === null) {
+            $value = '';
         }
 
         return strtolower($item) === strtolower($value);
@@ -598,7 +599,7 @@ abstract class Builder implements Contract
     {
         if (is_string($item)) {
             if ($value === null) {
-                return true;
+                $value = '';
             }
 
             return strtolower($item) !== strtolower($value);

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -584,12 +584,17 @@ abstract class Builder implements Contract
 
     protected function filterTestEquals($item, $value)
     {
+        if ($item === null && $value === null) { return true; }
+        if ($item === null || $value === null) { return false; }
+
         return strtolower($item) === strtolower($value);
     }
 
     protected function filterTestNotEquals($item, $value)
     {
         if (is_string($item)) {
+            if ($value === null) { return true; }
+
             return strtolower($item) !== strtolower($value);
         }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -584,8 +584,12 @@ abstract class Builder implements Contract
 
     protected function filterTestEquals($item, $value)
     {
-        if ($item === null && $value === null) { return true; }
-        if ($item === null || $value === null) { return false; }
+        if ($item === null && $value === null) {
+            return true;
+        }
+        if ($item === null || $value === null) {
+            return false;
+        }
 
         return strtolower($item) === strtolower($value);
     }
@@ -593,7 +597,9 @@ abstract class Builder implements Contract
     protected function filterTestNotEquals($item, $value)
     {
         if (is_string($item)) {
-            if ($value === null) { return true; }
+            if ($value === null) {
+                return true;
+            }
 
             return strtolower($item) !== strtolower($value);
         }

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -85,6 +85,8 @@ class Str extends \Illuminate\Support\Str
 
     public static function slug($string, $separator = '-', $language = 'en')
     {
+        if ($string === null) { return ''; }
+
         // Statamic is a-OK with underscores in slugs.
         $string = str_replace('_', $placeholder = strtolower(str_random(16)), $string);
 

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -85,7 +85,9 @@ class Str extends \Illuminate\Support\Str
 
     public static function slug($string, $separator = '-', $language = 'en')
     {
-        if ($string === null) { return ''; }
+        if ($string === null) {
+            return '';
+        }
 
         // Statamic is a-OK with underscores in slugs.
         $string = str_replace('_', $placeholder = strtolower(str_random(16)), $string);

--- a/src/Tags/Concerns/QueriesOrderBys.php
+++ b/src/Tags/Concerns/QueriesOrderBys.php
@@ -30,10 +30,6 @@ trait QueriesOrderBys
 
         $piped = Arr::getFirst($this->params, ['order_by', 'sort'], $this->defaultOrderBy());
 
-        if ($piped === null) {
-            return collect();
-        }
-
         return collect(explode('|', $piped))->filter()->map(function ($orderBy) {
             return OrderBy::parse($orderBy);
         });
@@ -46,6 +42,6 @@ trait QueriesOrderBys
 
     protected function defaultOrderBy()
     {
-        return null;
+        return '';
     }
 }

--- a/src/Tags/Concerns/QueriesOrderBys.php
+++ b/src/Tags/Concerns/QueriesOrderBys.php
@@ -30,6 +30,8 @@ trait QueriesOrderBys
 
         $piped = Arr::getFirst($this->params, ['order_by', 'sort'], $this->defaultOrderBy());
 
+        if ($piped === null) { return collect(); }
+
         return collect(explode('|', $piped))->filter()->map(function ($orderBy) {
             return OrderBy::parse($orderBy);
         });

--- a/src/Tags/Concerns/QueriesOrderBys.php
+++ b/src/Tags/Concerns/QueriesOrderBys.php
@@ -30,7 +30,9 @@ trait QueriesOrderBys
 
         $piped = Arr::getFirst($this->params, ['order_by', 'sort'], $this->defaultOrderBy());
 
-        if ($piped === null) { return collect(); }
+        if ($piped === null) {
+            return collect();
+        }
 
         return collect(explode('|', $piped))->filter()->map(function ($orderBy) {
             return OrderBy::parse($orderBy);

--- a/src/Tags/Concerns/QueriesScopes.php
+++ b/src/Tags/Concerns/QueriesScopes.php
@@ -23,6 +23,8 @@ trait QueriesScopes
     {
         $scopes = Arr::getFirst($this->params, ['query_scope', 'filter']);
 
+        if ($scopes === null) { return collect(); }
+
         return collect(explode('|', $scopes));
     }
 }

--- a/src/Tags/Concerns/QueriesScopes.php
+++ b/src/Tags/Concerns/QueriesScopes.php
@@ -23,7 +23,9 @@ trait QueriesScopes
     {
         $scopes = Arr::getFirst($this->params, ['query_scope', 'filter']);
 
-        if ($scopes === null) { return collect(); }
+        if ($scopes === null) {
+            return collect();
+        }
 
         return collect(explode('|', $scopes));
     }

--- a/src/Tags/Concerns/QueriesScopes.php
+++ b/src/Tags/Concerns/QueriesScopes.php
@@ -21,11 +21,7 @@ trait QueriesScopes
 
     protected function parseQueryScopes()
     {
-        $scopes = Arr::getFirst($this->params, ['query_scope', 'filter']);
-
-        if ($scopes === null) {
-            return collect();
-        }
+        $scopes = Arr::getFirst($this->params, ['query_scope', 'filter'], '');
 
         return collect(explode('|', $scopes));
     }

--- a/src/Tags/Taxonomy/Terms.php
+++ b/src/Tags/Taxonomy/Terms.php
@@ -86,7 +86,7 @@ class Terms
     protected function parseTaxonomies()
     {
         $from = Arr::getFirst($this->params, ['from', 'in', 'folder', 'use', 'taxonomy']);
-        $not = Arr::getFirst($this->params, ['not_from', 'not_in', 'not_folder', 'dont_use', 'not_taxonomy']);
+        $not = Arr::getFirst($this->params, ['not_from', 'not_in', 'not_folder', 'dont_use', 'not_taxonomy'], '');
 
         $taxonomies = $from === '*'
             ? collect(Taxonomy::handles())


### PR DESCRIPTION
This PR checks for `null` strings in a variety of "hot" code paths to reduce the number of `null` string deprecation warnings appearing in the log files.

The reduction of these warnings has had positive performance improvements on some sites that were generating many log entries (especially on slower file systems, or emulated file systems such as WSL2).