### PR TITLE
Fix issues with Bard `save_html`, support custom `HtmlToProseMirror` extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/var-exporter": "^4.3 || ^5.1",
         "symfony/yaml": "^4.1 || ^5.1 || ^6.0",
         "ueberdosis/html-to-prosemirror": "^1.3",
-        "ueberdosis/prosemirror-to-html": "^2.6",
+        "ueberdosis/prosemirror-to-html": "^2.7",
         "voku/portable-ascii": "^1.6.1 || ^2.0",
         "wilderborn/partyline": "^1.0"
     },

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -11,6 +11,7 @@ use Statamic\Facades\GraphQL;
 use Statamic\Facades\Site;
 use Statamic\Fields\Fields;
 use Statamic\Fieldtypes\Bard\Augmentor;
+use Statamic\Fieldtypes\Bard\Deaugmentor;
 use Statamic\GraphQL\Types\BardSetsType;
 use Statamic\GraphQL\Types\BardTextType;
 use Statamic\GraphQL\Types\ReplicatorSetType;
@@ -233,9 +234,7 @@ class Bard extends Replicator
         }
 
         if (is_string($value)) {
-            $value = str_replace('statamic://', '', $value);
-            $doc = (new \HtmlToProseMirror\Renderer)->render($value);
-            $value = $doc['content'];
+            $value = (new Deaugmentor($this))->deaugment($value);
         } elseif ($this->isLegacyData($value)) {
             $value = $this->convertLegacyData($value);
         }
@@ -350,9 +349,8 @@ class Bard extends Replicator
                 if (empty($set['text'])) {
                     return;
                 }
-                $doc = (new \HtmlToProseMirror\Renderer)->render($set['text']);
 
-                return $doc['content'];
+                return (new Deaugmentor($this))->deaugment($set['text']);
             }
 
             return [

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -127,12 +127,12 @@ class Augmentor
 
     public static function addNode($node)
     {
-        static::$customNodes[] = $node;
+        static::$customNodes[$node] = $node;
     }
 
     public static function addMark($mark)
     {
-        static::$customMarks[] = $mark;
+        static::$customMarks[$mark] = $mark;
     }
 
     public static function replaceNode($searchNode, $replaceNode)

--- a/src/Fieldtypes/Bard/Deaugmentor.php
+++ b/src/Fieldtypes/Bard/Deaugmentor.php
@@ -53,12 +53,12 @@ class Deaugmentor
 
     public static function addNode($node)
     {
-        static::$customNodes[] = $node;
+        static::$customNodes[$node] = $node;
     }
 
     public static function addMark($mark)
     {
-        static::$customMarks[] = $mark;
+        static::$customMarks[$mark] = $mark;
     }
 
     public static function replaceNode($searchNode, $replaceNode)

--- a/src/Fieldtypes/Bard/Deaugmentor.php
+++ b/src/Fieldtypes/Bard/Deaugmentor.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Statamic\Fieldtypes\Bard;
+
+use HtmlToProseMirror\Marks\Link as DefaultLinkMarkHtml;
+use HtmlToProseMirror\Renderer;
+use Statamic\Fieldtypes\Bard\LinkMarkHtml as CustomLinkMarkHtml;
+
+class Deaugmentor
+{
+    protected $fieldtype;
+
+    protected static $customMarks = [];
+    protected static $customNodes = [];
+    protected static $replaceMarks = [];
+    protected static $replaceNodes = [];
+
+    public function __construct($fieldtype)
+    {
+        $this->fieldtype = $fieldtype;
+    }
+
+    public function deaugment($value)
+    {
+        $value = $this->removeStatamicUrlPrefix($value);
+        $value = $this->convertToProseMirror($value);
+
+        return $value;
+    }
+
+    protected function removeStatamicUrlPrefix($value)
+    {
+        return str_replace('statamic://', '', $value);
+    }
+
+    public function convertToProseMirror($value)
+    {
+        $renderer = (new Renderer)
+            ->replaceMark(DefaultLinkMarkHtml::class, CustomLinkMarkHtml::class)
+            ->addNodes(static::$customNodes)
+            ->addMarks(static::$customMarks);
+
+        foreach (static::$replaceNodes as $searchNode => $replaceNode) {
+            $renderer->replaceNode($searchNode, $replaceNode);
+        }
+
+        foreach (static::$replaceMarks as $searchMark => $replaceMark) {
+            $renderer->replaceMark($searchMark, $replaceMark);
+        }
+
+        return $renderer->render($value)['content'];
+    }
+
+    public static function addNode($node)
+    {
+        static::$customNodes[] = $node;
+    }
+
+    public static function addMark($mark)
+    {
+        static::$customMarks[] = $mark;
+    }
+
+    public static function replaceNode($searchNode, $replaceNode)
+    {
+        static::$replaceNodes[$searchNode] = $replaceNode;
+    }
+
+    public static function replaceMark($searchMark, $replaceMark)
+    {
+        static::$replaceMarks[$searchMark] = $replaceMark;
+    }
+}

--- a/src/Fieldtypes/Bard/LinkMark.php
+++ b/src/Fieldtypes/Bard/LinkMark.php
@@ -14,6 +14,10 @@ class LinkMark extends Link
 
         $tag[0]['attrs']['href'] = $this->convertHref($tag[0]['attrs']['href']);
 
+        if (isset($this->mark->attrs->title)) {
+            $tag[0]['attrs']['title'] = $this->mark->attrs->title;
+        }
+
         return $tag;
     }
 

--- a/src/Fieldtypes/Bard/LinkMark.php
+++ b/src/Fieldtypes/Bard/LinkMark.php
@@ -14,10 +14,6 @@ class LinkMark extends Link
 
         $tag[0]['attrs']['href'] = $this->convertHref($tag[0]['attrs']['href']);
 
-        if (isset($this->mark->attrs->title)) {
-            $tag[0]['attrs']['title'] = $this->mark->attrs->title;
-        }
-
         return $tag;
     }
 

--- a/src/Fieldtypes/Bard/LinkMarkHtml.php
+++ b/src/Fieldtypes/Bard/LinkMarkHtml.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Statamic\Fieldtypes\Bard;
+
+use HtmlToProseMirror\Marks\Link;
+
+class LinkMarkHtml extends Link
+{
+    public function data()
+    {
+        $data = parent::data();
+
+        if ($title = $this->DOMNode->getAttribute('title')) {
+            $data['attrs']['title'] = $title;
+        }
+
+        return $data;
+    }
+}

--- a/src/Fieldtypes/Bard/Marks/SmallHtml.php
+++ b/src/Fieldtypes/Bard/Marks/SmallHtml.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Statamic\Fieldtypes\Bard\Marks;
+
+use HtmlToProseMirror\Marks\Mark;
+
+class SmallHtml extends Mark
+{
+    public function matching()
+    {
+        return $this->DOMNode->nodeName === 'small';
+    }
+
+    public function data()
+    {
+        return [
+            'type' => 'small',
+        ];
+    }
+}

--- a/src/Providers/BardServiceProvider.php
+++ b/src/Providers/BardServiceProvider.php
@@ -4,12 +4,15 @@ namespace Statamic\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Statamic\Fieldtypes\Bard\Augmentor;
+use Statamic\Fieldtypes\Bard\Deaugmentor;
 use Statamic\Fieldtypes\Bard\Marks\Small;
+use Statamic\Fieldtypes\Bard\Marks\SmallHtml;
 
 class BardServiceProvider extends ServiceProvider
 {
     public function boot()
     {
         Augmentor::addMark(Small::class);
+        Deaugmentor::addMark(SmallHtml::class);
     }
 }

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -543,7 +543,7 @@ EOT;
 
         $html = '<p><small>Small text</small></p>';
 
-        $this->assertEquals($html, $bard->process($bard->preProcess($html)));
+        $this->assertStringContainsString('<small>', $bard->process($bard->preProcess($html)));
     }
 
     /** @test */
@@ -553,7 +553,7 @@ EOT;
 
         $html = '<p><a title="Title text" href="#">Link text</a></p>';
 
-        $this->assertEquals($html, $bard->process($bard->preProcess($html)));
+        $this->assertStringContainsString('title="Title text"', $bard->process($bard->preProcess($html)));
     }
 
     private function bard($config = [])

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -542,7 +542,7 @@ EOT;
         $bard = $this->bard(['save_html' => true, 'sets' => null]);
 
         $html = '<p><small>Small text</small></p>';
-        
+
         $this->assertEquals($html, $bard->process($bard->preProcess($html)));
     }
 
@@ -552,7 +552,7 @@ EOT;
         $bard = $this->bard(['save_html' => true, 'sets' => null]);
 
         $html = '<p><a title="Title text" href="#">Link text</a></p>';
-        
+
         $this->assertEquals($html, $bard->process($bard->preProcess($html)));
     }
 

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -536,6 +536,26 @@ EOT;
         $this->assertEquals($expected, $bard->augment($html));
     }
 
+    /** @test */
+    public function it_deaugments_small_mark_when_stored_as_html()
+    {
+        $bard = $this->bard(['save_html' => true, 'sets' => null]);
+
+        $html = '<p><small>Small text</small></p>';
+        
+        $this->assertEquals($html, $bard->process($bard->preProcess($html)));
+    }
+
+    /** @test */
+    public function it_deaugments_link_mark_title_when_stored_as_html()
+    {
+        $bard = $this->bard(['save_html' => true, 'sets' => null]);
+
+        $html = '<p><a title="Title text" href="#">Link text</a></p>';
+        
+        $this->assertEquals($html, $bard->process($bard->preProcess($html)));
+    }
+
     private function bard($config = [])
     {
         return (new Bard)->setField(new Field('test', array_merge(['type' => 'bard', 'sets' => ['one' => []]], $config)));


### PR DESCRIPTION
The Bard augmentor class uses the `ProseMirrorToHtml` renderer to convert ProseMirror documents to HTML, and supports adding custom node and mark extensions to the renderer, a feature used by both Statamic and various addons.

When a Bard field is set to `save_html` the Bard fieldtype class uses the `HtmlToProseMirror` renderer to convert the stored HTML back to a ProseMirror document. However, Statamic does not implement any custom extensions in this renderer, and does not offer the ability for addons to do that either.

This creates the following issues:

1. When a Link is saved and then rendered back to a ProseMirror document for editing the `title` attribute is lost. `HtmlToProseMirror` isn’t aware of that so it's discarded.
2. When the Small mark is saved and then rendered back to a ProseMirror document for editing it is lost. For the same reason as above.
3. Addons are unable to add custom extensions to the `HtmlToProseMirror` renderer, which means they cannot work correctly with the `save_html` option either.

This PR aims to resolve those issues.

It implements a companion to the Bard augmentor, which (for lack of a better idea) I’ve called the deaugmentor. This class works in exactly the same way as the augmentor but in reverse, and allows Statamic and addons to register custom node and mark extensions in the `HtmlToProseMirror` renderer.

I’ve added new Link and Small mark extensions for this renderer which resolves the two issues above. 