### PR TITLE
Runtime: fix numeric variables inside parameters and shares cascade data

### DIFF
--- a/src/View/Antlers/Language/Nodes/AntlersNode.php
+++ b/src/View/Antlers/Language/Nodes/AntlersNode.php
@@ -388,6 +388,7 @@ class AntlersNode extends AbstractNode
                 $pathParser = new PathParser();
                 $retriever = new PathDataManager();
                 $retriever->setIsPaired(false)->setReduceFinal(false)
+                    ->cascade($processor->getCascade())
                     ->setShouldDoValueIntercept(false);
                 $value = $retriever->getData($pathParser->parse($pathToParse), $data);
             }
@@ -419,9 +420,10 @@ class AntlersNode extends AbstractNode
                 if (array_key_exists($interpolationVar, $param->parent->processedInterpolationRegions)) {
                     $interpolationResult = $processor->cloneProcessor()
                         ->setData($data)
+                        ->cascade($processor->getCascade())
                         ->setIsInterpolationProcessor(true)
                         ->setIsProvidingParameterContent(true)
-                        ->render($param->parent->processedInterpolationRegions[$interpolationVar]);
+                        ->reduce($param->parent->processedInterpolationRegions[$interpolationVar]);
 
                     if ((is_object($interpolationResult) || is_array($interpolationResult)) && count($param->interpolations) == 1) {
                         return $interpolationResult;

--- a/src/View/Antlers/Language/Parser/LanguageParser.php
+++ b/src/View/Antlers/Language/Parser/LanguageParser.php
@@ -1794,6 +1794,10 @@ class LanguageParser
                     $right = $this->wrapNumberInVariable($right);
                 }
 
+                if ($left instanceof NumberNode && $right instanceof VariableNode) {
+                    $left = $this->wrapNumberInVariable($left);
+                }
+
                 if ($left instanceof VariableNode && $right instanceof VariableNode && NodeHelpers::distance($left, $right) === 1) {
                     // Note: It is important when we do this merge
                     // that we start from the right, and merge

--- a/tests/Antlers/Runtime/ParametersTest.php
+++ b/tests/Antlers/Runtime/ParametersTest.php
@@ -8,9 +8,12 @@ use Tests\Antlers\Fixtures\Addon\Tags\EchoMethod;
 use Tests\Antlers\Fixtures\Addon\Tags\Test;
 use Tests\Antlers\Fixtures\MethodClasses\ClassTwo;
 use Tests\Antlers\ParserTestCase;
+use Tests\FakesViews;
 
 class ParametersTest extends ParserTestCase
 {
+    use FakesViews;
+
     public function test_using_interpolations_with_variable_reference_resolves_correctly()
     {
         Test::register();
@@ -269,5 +272,21 @@ EOT;
 EOT;
 
         $this->assertSame($expected, $this->renderString($template, $data, true));
+    }
+
+    public function test_parameters_with_numeric_variables()
+    {
+        $template = <<<'EOT'
+{{ partial:button :the_button_text="404:button_text" }}
+EOT;
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('button', '<{{ the_button_text }}>');
+
+        $this->assertSame('<The Button Text>', $this->renderString($template, [
+            404 => [
+                'button_text' => 'The Button Text'
+            ]
+        ]));
     }
 }


### PR DESCRIPTION
This PR corrects an issue where parameters would not receive Cascade data, and also improves variable parsing when a numeric value makes up the beginning of a variable (like `{{ 404:button_text }}`).

Discovered while reading here: https://github.com/statamic/cms/discussions/5994