### PR TITLE
Fix adding new s3 folder to asset listing cache with stache watcher disabled

### DIFF
--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -79,10 +79,16 @@ class AssetContainerContents
         $lastModifiedMethod = $isFlysystemV1 ? 'getTimestamp' : 'lastModified';
         $fileSizeMethod = $isFlysystemV1 ? 'getSize' : 'fileSize';
 
-        // Use exception handling to avoid another `has()` API method call.
+        // Use exception handling to avoid another `has()` API method call if possible.
         try {
             $timestamp = $this->filesystem()->{$lastModifiedMethod}($path);
         } catch (\Exception $exception) {
+            $timestamp = null;
+        }
+
+        // Only perform explicit `has()` API file existence check as a fallback if timestamp ends
+        // up being null. This is needed when `add()`ing new directories to the files cache.
+        if ($timestamp === null && $this->filesystem()->has($path) === false) {
             return false;
         }
 

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -86,8 +86,9 @@ class AssetContainerContents
             $timestamp = null;
         }
 
-        // Only perform explicit `has()` API file existence check as a fallback if timestamp ends
-        // up being null. This is needed when `add()`ing new directories to the files cache.
+        // Only perform explicit `has()` API file existence check as a fallback
+        // if timestamp ends up as null. This is needed when `add()`ing new
+        // directories to the files cache with the flysystem S3 driver.
         if ($timestamp === null && $this->filesystem()->has($path) === false) {
             return false;
         }


### PR DESCRIPTION
When adding a new folder to an s3 asset container with the stache watcher disabled, when refreshing the asset browser, the new folder would disappear because it wasn't being added to asset listing cache properly. It _looked_ like a data loss bug, but was just a caching thing.

I was able to reproduce this all the way back in 3.2.0 even with Flysystem 1.x even, so I'm not sure what could have changed. Maybe we just didn't catch it until now?

References #5723.
Closes #5888.