### PR TITLE
Fix overzealous deleting from asset listing cache with stache watcher disabled

### DIFF
--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -124,8 +124,9 @@ class AssetFolder implements Contract, Arrayable
         $this->disk()->delete($this->path());
 
         $cache = $this->container->contents();
+
         $cache->all()->keys()->filter(function ($path) {
-            return Str::startsWith($path, $this->path());
+            return Str::startsWith($path.'/', $this->path().'/');
         })->each(function ($path) use ($cache) {
             $cache->forget($path);
         });


### PR DESCRIPTION
This fixes little bug I found while messing with #5996.

Say you had the following folders...

```
kit/
kitten/
kittens/
```

And you delete `kit`, all three would be deleted from the asset listing cache with stache watcher disabled, due to an overzealous `Str::startsWith()` check.