### PR TITLE
Update Blueprint Parent

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -264,6 +264,8 @@ class Blueprint implements Augmentable, QueryableValue, ArrayAccess, Arrayable
     {
         $this->parent = $parent;
 
+        $this->resetFieldsCache();
+
         return $this;
     }
 

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -83,6 +83,8 @@ class EntriesController extends CpController
             throw new BlueprintNotFoundException($entry->value('blueprint'), 'collections/'.$collection->handle());
         }
 
+        $blueprint->setParent($entry);
+
         if (User::current()->cant('edit-other-authors-entries', [EntryContract::class, $collection, $blueprint])) {
             $blueprint->ensureFieldHasConfig('author', ['read_only' => true]);
         }


### PR DESCRIPTION
This simple PR closes https://github.com/statamic/cms/issues/5991. We set a blueprint's parent when we edit an entry. And we also reset the fields cache whenever a parent gets set.