### PR TITLE
Clean up deprecations

### DIFF
--- a/src/Assets/AugmentedAsset.php
+++ b/src/Assets/AugmentedAsset.php
@@ -149,7 +149,7 @@ class AugmentedAsset extends AbstractAugmented
 
     protected function duration()
     {
-        return round($this->data->duration());
+        return round($this->data->duration() ?? 0);
     }
 
     protected function durationSeconds()

--- a/src/Auth/Protect/Protectors/Authenticated.php
+++ b/src/Auth/Protect/Protectors/Authenticated.php
@@ -42,7 +42,7 @@ class Authenticated extends Protector
 
     protected function isLoginUrl()
     {
-        return parse_url($this->url, PHP_URL_PATH) === parse_url($this->getLoginUrl(), PHP_URL_PATH);
+        return parse_url($this->url, PHP_URL_PATH) === parse_url((string) $this->getLoginUrl(), PHP_URL_PATH);
     }
 
     protected function shouldAppendRedirect()

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -70,7 +70,7 @@ abstract class User implements
                 [$name, $surname] = explode(' ', $name);
             }
         } else {
-            $name = $this->email();
+            $name = (string) $this->email();
         }
 
         return strtoupper(mb_substr($name, 0, 1).mb_substr($surname, 0, 1));

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -108,7 +108,7 @@ class Blueprint implements Augmentable, QueryableValue, ArrayAccess, Arrayable
     {
         return Path::tidy(vsprintf('%s/%s/%s.yaml', [
             Facades\Blueprint::directory(),
-            str_replace('.', '/', $this->namespace()),
+            str_replace('.', '/', (string) $this->namespace()),
             $this->handle(),
         ]));
     }

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -426,7 +426,7 @@ class Bard extends Replicator
             return $value;
         }
 
-        $value = json_decode($value, true);
+        $value = json_decode($value ?? '[]', true);
 
         return collect($value)->map(function ($item) {
             if ($item['type'] !== 'set') {

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2141,7 +2141,7 @@ class CoreModifiers extends Modifier
     public function sort($value, $params)
     {
         $key = Arr::get($params, 0, 'true');
-        $desc = strtolower(Arr::get($params, 1)) == 'desc';
+        $desc = strtolower(Arr::get($params, 1, 'asc')) == 'desc';
 
         $value = $value instanceof Collection ? $value : collect($value);
 
@@ -2445,7 +2445,7 @@ class CoreModifiers extends Modifier
      */
     public function toJson($value, $params)
     {
-        $options = Arr::get($params, 0) === 'pretty' ? JSON_PRETTY_PRINT : null;
+        $options = Arr::get($params, 0) === 'pretty' ? JSON_PRETTY_PRINT : 0;
 
         if (Compare::isQueryBuilder($value)) {
             $value = $value->get();

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -167,6 +167,10 @@ abstract class Builder implements Contract
 
     protected function invalidOperator($operator)
     {
+        if (is_null($operator)) {
+            return true;
+        }
+
         return ! in_array(strtolower($operator), array_keys($this->operators), true);
     }
 
@@ -584,13 +588,13 @@ abstract class Builder implements Contract
 
     protected function filterTestEquals($item, $value)
     {
-        return strtolower($item) === strtolower($value);
+        return strtolower($item ?? '') === strtolower($value ?? '');
     }
 
     protected function filterTestNotEquals($item, $value)
     {
         if (is_string($item)) {
-            return strtolower($item) !== strtolower($value);
+            return strtolower($item) !== strtolower($value ?? '');
         }
 
         return $item !== $value;
@@ -624,7 +628,7 @@ abstract class Builder implements Contract
             $item = json_encode($item);
         }
 
-        return preg_match($pattern, $item);
+        return preg_match($pattern, (string) $item);
     }
 
     protected function filterTestNotLike($item, $like)

--- a/src/Query/OrderedQueryBuilder.php
+++ b/src/Query/OrderedQueryBuilder.php
@@ -36,7 +36,10 @@ class OrderedQueryBuilder implements Builder
             $results = $this->performFallbackOrdering($results);
         }
 
-        return $results->take($this->limit)->skip($this->offset)->values();
+        return $results
+            ->when($this->limit, fn ($results) => $results->take($this->limit))
+            ->when($this->offset, fn ($results) => $results->skip($this->offset))
+            ->values();
     }
 
     public function __call($method, $parameters)

--- a/src/Routing/ResolveRedirect.php
+++ b/src/Routing/ResolveRedirect.php
@@ -16,6 +16,10 @@ class ResolveRedirect
 
     public function resolve($redirect, $parent = null)
     {
+        if (is_null($redirect)) {
+            return null;
+        }
+
         if ($redirect === '@child') {
             $redirect = $this->firstChildUrl($parent);
         }

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -85,6 +85,8 @@ class Str extends \Illuminate\Support\Str
 
     public static function slug($string, $separator = '-', $language = 'en')
     {
+        $string = (string) $string;
+
         // Statamic is a-OK with underscores in slugs.
         $string = str_replace('_', $placeholder = strtolower(str_random(16)), $string);
 

--- a/src/Tags/Concerns/QueriesOrderBys.php
+++ b/src/Tags/Concerns/QueriesOrderBys.php
@@ -30,7 +30,7 @@ trait QueriesOrderBys
 
         $piped = Arr::getFirst($this->params, ['order_by', 'sort'], $this->defaultOrderBy());
 
-        return collect(explode('|', $piped))->filter()->map(function ($orderBy) {
+        return collect(explode('|', $piped ?? ''))->filter()->map(function ($orderBy) {
             return OrderBy::parse($orderBy);
         });
     }

--- a/src/Tags/Concerns/QueriesScopes.php
+++ b/src/Tags/Concerns/QueriesScopes.php
@@ -23,6 +23,6 @@ trait QueriesScopes
     {
         $scopes = Arr::getFirst($this->params, ['query_scope', 'filter']);
 
-        return collect(explode('|', $scopes));
+        return collect(explode('|', $scopes ?? ''));
     }
 }

--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -130,6 +130,7 @@ class FluentTag implements \IteratorAggregate, \ArrayAccess
      *
      * @return Traversable
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $output = $this->fetch();

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -139,7 +139,7 @@ class Structure extends Tags
                 'last'        => $index === count($tree) - 1,
                 'is_current'  => ! is_null($url) && rtrim($url, '/') === rtrim($this->currentUrl, '/'),
                 'is_parent'   => ! is_null($url) && $this->siteAbsoluteUrl !== $absoluteUrl && URL::isAncestorOf($this->currentUrl, $url),
-                'is_external' => URL::isExternal($absoluteUrl),
+                'is_external' => URL::isExternal((string) $absoluteUrl),
             ]);
         })->filter()->values();
 

--- a/src/Tags/Taxonomy/Terms.php
+++ b/src/Tags/Taxonomy/Terms.php
@@ -92,7 +92,7 @@ class Terms
             ? collect(Taxonomy::handles())
             : collect(explode('|', $from));
 
-        $excludedTaxonomies = collect(explode('|', $not))->filter();
+        $excludedTaxonomies = collect(explode('|', $not ?? ''))->filter();
 
         return $taxonomies
             ->diff($excludedTaxonomies)

--- a/src/Tags/Theme.php
+++ b/src/Tags/Theme.php
@@ -162,7 +162,14 @@ class Theme extends Tags
 
     private function versioned($type, $file)
     {
+        $file = "{$type}/{$file}.{$type}";
+
         [$manifest, $method] = $this->getManifestAndMethod();
+
+        if (! $manifest) {
+            return '/'.$file;
+        }
+
         $manifest = json_decode($manifest, true);
 
         // Mix prepends filenames with slashes.
@@ -171,7 +178,7 @@ class Theme extends Tags
             return [ltrim($key, '/') => ltrim($path, '/')];
         });
 
-        if (! $manifest->has($file = "{$type}/{$file}.{$type}")) {
+        if (! $manifest->has($file)) {
             return '/'.$file;
         }
 

--- a/src/View/Antlers/Language/Lexer/AntlersLexer.php
+++ b/src/View/Antlers/Language/Lexer/AntlersLexer.php
@@ -668,7 +668,7 @@ class AntlersLexer
                 // -
                 if ($this->isParsingModifierName == false && $this->cur == DocumentParser::Punctuation_Minus) {
                     if (ctype_digit($this->next) && (
-                            ctype_digit($this->prev) == false &&
+                            ctype_digit((string) $this->prev) == false &&
                             $this->prev != DocumentParser::RightParent) && $this->isRightOfInterpolationRegion() == false) {
                         $this->currentContent[] = $this->cur;
                         continue;

--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -405,7 +405,7 @@ class Parser implements ParserContract
         // Null coalescence through "or", "??" or "?:"
         if (Str::contains($var, [' or ', ' ?? ', ' ?: '])) {
             $isCoalesce = true;
-            $vars = preg_split('/(\s+or\s+|\s+\?\?\s+|\s+\?\:\s+)/ms', $var, null, PREG_SPLIT_NO_EMPTY);
+            $vars = preg_split('/(\s+or\s+|\s+\?\?\s+|\s+\?\:\s+)/ms', $var, -1, PREG_SPLIT_NO_EMPTY);
         } else {
             $isCoalesce = false;
             $vars = [$var];
@@ -651,7 +651,7 @@ class Parser implements ParserContract
                 $replacement = $this->valueToLiteral($replacement);
             }
 
-            $text = $this->preg_replace('/'.preg_quote($tag, '/').'/m', addcslashes($replacement, '\\$'), $text, 1);
+            $text = $this->preg_replace('/'.preg_quote($tag, '/').'/m', addcslashes((string) $replacement, '\\$'), $text, 1);
             $text = $this->injectExtractions($text, 'nested_tag_pair');
         }
 

--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -771,7 +771,7 @@ class Parser implements ParserContract
                     [$if_true, $if_false] = explode(': ', $bits[1]);
 
                     // Build a PHP string to evaluate
-                    $conditional = '<?php echo('.$condition.') ? "'.addslashes($this->getVariable(trim($if_true), $data)).'" : "'.addslashes($this->getVariable(trim($if_false), $data)).'"; ?>';
+                    $conditional = '<?php echo('.$condition.') ? "'.addslashes($this->getVariable(trim($if_true), $data, '')).'" : "'.addslashes($this->getVariable(trim($if_false), $data, '')).'"; ?>';
 
                     // Do the evaluation
                     $output = stripslashes($this->parsePhp($conditional));

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -56,7 +56,7 @@ class AssetTest extends TestCase
     /** @test */
     public function it_sets_and_gets_data_values()
     {
-        $asset = (new Asset)->container($this->container);
+        $asset = (new Asset)->path('test.txt')->container($this->container);
         $this->assertNull($asset->get('foo'));
 
         $return = $asset->set('foo', 'bar');
@@ -70,7 +70,7 @@ class AssetTest extends TestCase
     /** @test */
     public function it_removes_data_values()
     {
-        $asset = (new Asset)->container($this->container);
+        $asset = (new Asset)->path('test.txt')->container($this->container);
 
         $this->assertNull($asset->get('foo'));
 
@@ -87,7 +87,7 @@ class AssetTest extends TestCase
     /** @test */
     public function it_sets_data_values_using_magic_properties()
     {
-        $asset = (new Asset)->container($this->container);
+        $asset = (new Asset)->path('test.txt')->container($this->container);
         $this->assertNull($asset->get('foo'));
 
         $asset->foo = 'bar';
@@ -146,7 +146,7 @@ class AssetTest extends TestCase
         $blueprint = Facades\Blueprint::makeFromFields(['foo' => ['type' => 'test']]);
         BlueprintRepository::shouldReceive('find')->with('assets/test_container')->andReturn($blueprint);
 
-        $asset = (new Asset)->container($this->container);
+        $asset = (new Asset)->path('test.txt')->container($this->container);
         $asset->set('foo', 'delta');
 
         $this->assertEquals('query builder results', $asset->foo);
@@ -169,13 +169,13 @@ class AssetTest extends TestCase
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Call to undefined method Statamic\Assets\Asset::thisFieldDoesntExist()');
 
-        (new Asset)->container($this->container)->thisFieldDoesntExist();
+        (new Asset)->path('test.txt')->container($this->container)->thisFieldDoesntExist();
     }
 
     /** @test */
     public function it_gets_and_sets_all_data()
     {
-        $asset = (new Asset)->container($this->container);
+        $asset = (new Asset)->path('test.txt')->container($this->container);
         $this->assertEquals([], $asset->data()->all());
 
         $return = $asset->data(['foo' => 'bar']);
@@ -806,6 +806,7 @@ class AssetTest extends TestCase
     public function it_doesnt_regenerate_the_meta_file_when_getting_non_image_dimensions()
     {
         $asset = $this->partialMock(Asset::class);
+        $asset->shouldReceive('extension')->andReturn('txt');
 
         $asset->shouldReceive('meta')->times(0);
 
@@ -834,10 +835,10 @@ class AssetTest extends TestCase
             ->andReturn($blueprint = (new Blueprint)->setHandle('test_container')->setNamespace('assets'));
 
         $asset = (new Asset)
+            ->path('path/to/asset.jpg')
             ->container($this->container)
             ->set('title', 'test')
-            ->setSupplement('foo', 'bar')
-            ->path('path/to/asset.jpg');
+            ->setSupplement('foo', 'bar');
 
         $array = $asset->toAugmentedArray();
 
@@ -876,9 +877,9 @@ class AssetTest extends TestCase
             ->andReturn($blueprint = (new Blueprint)->setHandle('test_container')->setNamespace('assets'));
 
         $array = (new Asset)
+            ->path('path/to/asset.jpg')
             ->container($this->container)
             ->set('title', 'test')
-            ->path('path/to/asset.jpg')
             ->set('foo', 'bar')
             ->set('bar', 'baz')
             ->toAugmentedArray();

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -93,8 +93,8 @@ class EloquentUserTest extends TestCase
     {
         return (new EloquentUser)
             ->model(User::create([
-                'name' => $this->faker->name,
-                'email' => $this->faker->unique()->safeEmail,
+                'name' => $this->faker->name(),
+                'email' => $this->faker->unique()->safeEmail(),
                 // 'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
                 'remember_token' => str_random(10),
             ])

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -408,7 +408,7 @@ class BardTest extends TestCase
                     ],
                 ],
             ],
-        ]));
+        ]))->setValue('[]'); // what an empty value would get preprocessed into.
 
         $expected = [
             'things' => [],
@@ -443,7 +443,7 @@ class BardTest extends TestCase
                     ],
                 ],
             ],
-        ]));
+        ]))->setValue('[]'); // what an empty value would get preprocessed into.
 
         $expected = [
             '_' => '_',

--- a/tests/FluentlyGetsAndSetsTest.php
+++ b/tests/FluentlyGetsAndSetsTest.php
@@ -107,7 +107,7 @@ class Entry
     {
         return $this->fluentlyGetOrSet('title')
             ->getter(function ($title) {
-                return Str::title($title) ?: null;
+                return $title ? Str::title($title) : null;
             })
             ->setter(function ($title) {
                 return Str::plural($title);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,13 +2,11 @@
 
 namespace Tests;
 
-use Illuminate\Foundation\Testing\Concerns\InteractsWithDeprecationHandling;
 use PHPUnit\Framework\Assert;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
     use WindowsHelpers;
-    use InteractsWithDeprecationHandling;
 
     protected $shouldFakeVersion = true;
     protected $shouldPreventNavBeingBuilt = true;
@@ -36,8 +34,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         }
 
         $this->addGqlMacros();
-
-        $this->withoutDeprecationHandling();
     }
 
     public function tearDown(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,11 +2,13 @@
 
 namespace Tests;
 
+use Illuminate\Foundation\Testing\Concerns\InteractsWithDeprecationHandling;
 use PHPUnit\Framework\Assert;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
     use WindowsHelpers;
+    use InteractsWithDeprecationHandling;
 
     protected $shouldFakeVersion = true;
     protected $shouldPreventNavBeingBuilt = true;
@@ -34,6 +36,8 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         }
 
         $this->addGqlMacros();
+
+        $this->withoutDeprecationHandling();
     }
 
     public function tearDown(): void


### PR DESCRIPTION
This PR expands on #5981 by fixing up more deprecated things.

I disabled deprecation handling in the test suite so it throws errors, and this PR is the result of fixing everything until there were no failures.

I don't have a good way to automate it on GitHub actions, but it's not difficult to do this manually every now and then.

```php
use Illuminate\Foundation\Testing\Concerns\InteractsWithDeprecationHandling;

abstract class TestCase extends \Orchestra\Testbench\TestCase
{
    use InteractsWithDeprecationHandling;

    // ...

    protected function setUp(): void
    {
        // ....

        $this->withoutDeprecationHandling();
    }
}
```