### PR TITLE
Enable spellcheck in markdown fields, improve CodeMirror accessibility

### DIFF
--- a/resources/js/components/fieldtypes/CodeFieldtype.vue
+++ b/resources/js/components/fieldtypes/CodeFieldtype.vue
@@ -110,6 +110,7 @@ export default {
             matchBrackets: true,
             readOnly: this.readOnlyOption,
             theme: this.exactTheme,
+            inputStyle: 'contenteditable',
         });
 
         this.codemirror.on('change', (cm) => {

--- a/resources/js/components/fieldtypes/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/MarkdownFieldtype.vue
@@ -572,6 +572,8 @@ export default {
             tabindex: 0,
             autoRefresh: true,
             readOnly: self.isReadOnly ? 'nocursor' : false,
+            inputStyle: 'contenteditable',
+            spellcheck: true,
             extraKeys: {
                 "Enter": "newlineAndIndentContinueMarkdownList",
                 "Cmd-Left": "goLineLeftSmart"

--- a/resources/js/components/fieldtypes/YamlFieldtype.vue
+++ b/resources/js/components/fieldtypes/YamlFieldtype.vue
@@ -38,6 +38,7 @@ export default {
             lineWrapping: true,
             readOnly: this.readOnlyOption,
             theme: this.config.theme || 'material',
+            inputStyle: 'contenteditable',
         });
 
         this.codemirror.on('change', (cm) => {


### PR DESCRIPTION
CodeMirror supports the browser spellcheck but it is not enabled by default. This would be really useful in markdown fields. It's only supported with the `inputStyle: 'contenteditable'` option, but the documentation states:

> **inputStyle: string**
>  Selects the way CodeMirror handles input and focus. The core library defines the "textarea" and "contenteditable" input models. On mobile browsers, the default is "contenteditable". On desktop browsers, the default is "textarea". Support for IME and screen readers is better in the "contenteditable" model. The intention is to make it the default on modern desktop browsers in the future.

https://codemirror.net/doc/manual.html

Given that `contenteditable` mode is already the default on mobile, will become the default on desktop, improves accessibility, and allows spellchecking, it seems like a good thing to use.

This PR switches all CodeMirror based fields (markdown, code and yaml)  to `contenteditable` mode and enables spellcheck in markdown fields.
