### PR TITLE
Add `mount` tag

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -150,6 +150,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Tags\Markdown::class,
         Tags\Member::class,
         Tags\Mix::class,
+        Tags\Mount::class,
         Tags\Nav::class,
         Tags\NotFound::class,
         Tags\Obfuscate::class,

--- a/src/Tags/Mount.php
+++ b/src/Tags/Mount.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Statamic\Tags;
+
+use Statamic\Facades\Collection;
+
+class Mount extends Tags
+{
+    /**
+     * {{ mount:* }}.
+     */
+    public function wildcard($tag)
+    {
+        return $this->mount($tag);
+    }
+
+    /**
+     * {{ mount handle="" }}.
+     */
+    public function index()
+    {
+        return $this->mount($this->params->get('handle'));
+    }
+
+    private function mount($handle)
+    {
+        if (! $collection = Collection::find($handle)) {
+            return;
+        }
+
+        return $collection->url();
+    }
+}

--- a/src/Tags/Mount.php
+++ b/src/Tags/Mount.php
@@ -3,6 +3,7 @@
 namespace Statamic\Tags;
 
 use Statamic\Facades\Collection;
+use Statamic\Facades\Site;
 
 class Mount extends Tags
 {
@@ -28,6 +29,6 @@ class Mount extends Tags
             return;
         }
 
-        return $collection->url();
+        return $collection->url(Site::current()->handle());
     }
 }

--- a/tests/Tags/MountTagTest.php
+++ b/tests/Tags/MountTagTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Tags;
+
+use Facades\Tests\Factories\EntryFactory;
+use Statamic\Facades\Antlers;
+use Statamic\Facades\Collection;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class MountTagTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    /** @test */
+    public function it_gets_collection_mount()
+    {
+        Collection::make('pages')->routes('pages/{slug}')->save();
+        $mount = EntryFactory::collection('pages')->slug('blog')->create();
+        Collection::make('blog')->routes('{mount}/{slug}')->mount($mount->id())->save();
+
+        $this->assertParseEquals(
+            '/pages/blog',
+            '{{ mount:blog }}',
+        );
+
+        $this->assertParseEquals(
+            '/pages/blog',
+            '{{ mount handle="blog" }}',
+        );
+    }
+
+    private function assertParseEquals($expected, $template, $context = [])
+    {
+        $this->assertEquals($expected, (string) Antlers::parse($template, $context));
+    }
+}

--- a/tests/Tags/MountTagTest.php
+++ b/tests/Tags/MountTagTest.php
@@ -5,6 +5,7 @@ namespace Tests\Tags;
 use Facades\Tests\Factories\EntryFactory;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Collection;
+use Statamic\Facades\Site;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -15,19 +16,25 @@ class MountTagTest extends TestCase
     /** @test */
     public function it_gets_collection_mount()
     {
-        Collection::make('pages')->routes('pages/{slug}')->save();
-        $mount = EntryFactory::collection('pages')->slug('blog')->create();
-        Collection::make('blog')->routes('{mount}/{slug}')->mount($mount->id())->save();
+        Site::setConfig(['sites' => [
+            'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'french' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+        ]]);
 
-        $this->assertParseEquals(
-            '/pages/blog',
-            '{{ mount:blog }}',
-        );
+        Collection::make('pages')->sites(['english', 'french'])->routes([
+            'english' => 'pages/{slug}',
+            'french' => 'le-pages/{slug}',
+        ])->save();
+        $mountEn = EntryFactory::collection('pages')->slug('blog')->locale('english')->id('blog-en')->create();
+        $mountFr = EntryFactory::collection('pages')->slug('le-blog')->locale('french')->origin('blog-en')->id('blog-fr')->create();
+        Collection::make('blog')->routes('{mount}/{slug}')->mount($mountEn->id())->save();
 
-        $this->assertParseEquals(
-            '/pages/blog',
-            '{{ mount handle="blog" }}',
-        );
+        $this->assertParseEquals('/pages/blog', '{{ mount:blog }}');
+        $this->assertParseEquals('/pages/blog', '{{ mount handle="blog" }}');
+
+        Site::setCurrent('french');
+        $this->assertParseEquals('/fr/le-pages/le-blog', '{{ mount:blog }}');
+        $this->assertParseEquals('/fr/le-pages/le-blog', '{{ mount handle="blog" }}');
     }
 
     private function assertParseEquals($expected, $template, $context = [])


### PR DESCRIPTION
This PR adds a `mount` tag which returns the mount URL of a collection, useful if you want to dynamically link to a collection's main page:

```html
<a href="{{ mount:blog }}">Read Our Blog</a>
```

If this might be accepted I can do a docs PR as well.