### PR TITLE
Update search indexes for assets, terms, and users

### DIFF
--- a/src/Search/UpdateItemIndexes.php
+++ b/src/Search/UpdateItemIndexes.php
@@ -2,8 +2,14 @@
 
 namespace Statamic\Search;
 
+use Statamic\Events\AssetDeleted;
+use Statamic\Events\AssetSaved;
 use Statamic\Events\EntryDeleted;
 use Statamic\Events\EntrySaved;
+use Statamic\Events\TermDeleted;
+use Statamic\Events\TermSaved;
+use Statamic\Events\UserDeleted;
+use Statamic\Events\UserSaved;
 use Statamic\Facades\Search;
 
 class UpdateItemIndexes
@@ -12,11 +18,17 @@ class UpdateItemIndexes
     {
         $event->listen(EntrySaved::class, self::class.'@update');
         $event->listen(EntryDeleted::class, self::class.'@delete');
+        $event->listen(AssetSaved::class, self::class.'@update');
+        $event->listen(AssetDeleted::class, self::class.'@delete');
+        $event->listen(UserSaved::class, self::class.'@update');
+        $event->listen(UserDeleted::class, self::class.'@delete');
+        $event->listen(TermSaved::class, self::class.'@update');
+        $event->listen(TermDeleted::class, self::class.'@delete');
     }
 
     public function update($event)
     {
-        $item = $event->entry;
+        $item = $event->entry ?? $event->asset ?? $event->user ?? $event->term;
 
         $this->indexes($item)->each(function ($index) use ($item) {
             $index->exists() ? $index->insert($item) : $index->update();
@@ -25,7 +37,7 @@ class UpdateItemIndexes
 
     public function delete($event)
     {
-        $item = $event->entry;
+        $item = $event->entry ?? $event->asset ?? $event->user ?? $event->term;
 
         $this->indexes($item)->each->delete($item);
     }

--- a/tests/Feature/GlobalSearch/GlobalSearchTest.php
+++ b/tests/Feature/GlobalSearch/GlobalSearchTest.php
@@ -40,11 +40,12 @@ class GlobalSearchTest extends TestCase
         $index = $this->mock(Index::class);
         $index->shouldReceive('ensureExists')->once()->andReturnSelf();
         $index->shouldReceive('search')->with('test')->once()->andReturn($builder);
+        $testUser = User::make()->assignRole('test')->save();
         Search::shouldReceive('index')->once()->andReturn($index);
 
         $this->setTestRoles(['test' => ['access cp', 'view test-collection-1 entries']]);
         $this
-            ->actingAs(tap(User::make()->assignRole('test'))->save())
+            ->actingAs($testUser)
             ->get('/cp/search?q=test')
             ->assertOk()
             ->assertJsonCount(1)


### PR DESCRIPTION
Hi,

When using Statamic's search feature we can index Users, Assets, Entries and Taxonomies. But when it comes to updating existing indexed entities, only entries will be updated in `src/Search/UpdateItemIndexes.php`.

This PR adds events for all four entities and triggers an update of the corresponding indexed document.