### PR TITLE
Fix revealers and inline field errors within stacked grid rows

### DIFF
--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -22,7 +22,7 @@
                 :parent-name="name"
                 :set-index="index"
                 :errors="errors(field.handle)"
-                :field-path-prefix="fieldPath(field.handle)"
+                :field-path="fieldPath(field.handle)"
                 class="p-2"
                 :read-only="grid.isReadOnly"
                 @updated="updated(field.handle, $event)"


### PR DESCRIPTION
- [x] Fix revealers nested within grids with `mode: stacked` enabled.
- [x] Fix inline field errors when nested within grids with `mode: stacked` enabled.

References: #5878