### PR TITLE
Replace reference to FlysystemFileNotFoundException

### DIFF
--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -119,7 +119,7 @@ class GlideController extends Controller
 
         try {
             return $this->generator->$method($item, $this->request->all());
-        } catch (FileNotFoundException | UnableToReadFile $e) {
+        } catch (FileNotFoundException|UnableToReadFile $e) {
             throw new NotFoundHttpException;
         }
     }

--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers;
 
 use Illuminate\Http\Request;
 use League\Flysystem\FileNotFoundException;
+use League\Flysystem\UnableToReadFile;
 use League\Glide\Server;
 use League\Glide\Signatures\SignatureException;
 use League\Glide\Signatures\SignatureFactory;
@@ -118,7 +119,7 @@ class GlideController extends Controller
 
         try {
             return $this->generator->$method($item, $this->request->all());
-        } catch (FileNotFoundException $e) {
+        } catch (FileNotFoundException | UnableToReadFile $e) {
             throw new NotFoundHttpException;
         }
     }

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -3,7 +3,9 @@
 namespace Statamic\Imaging;
 
 use Illuminate\Support\Facades\Storage;
+use League\Flysystem\FileNotFoundException as FlysystemFileNotFoundException;
 use League\Flysystem\Filesystem;
+use League\Flysystem\UnableToReadFile;
 use League\Glide\Filesystem\FileNotFoundException as GlideFileNotFoundException;
 use League\Glide\Manipulators\Watermark;
 use League\Glide\Server;
@@ -282,7 +284,7 @@ class ImageGenerator
         } else {
             $path = public_path($this->path);
             if (! File::exists($path)) {
-                throw new \Exception("File not found at path: {$path}");
+                throw $this->isUsingFlysystemOne() ? new FlysystemFileNotFoundException($path) : UnableToReadFile::fromLocation($path);
             }
             $mime = File::mimeType($path);
         }

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -3,7 +3,6 @@
 namespace Statamic\Imaging;
 
 use Illuminate\Support\Facades\Storage;
-use League\Flysystem\FileNotFoundException as FlysystemFileNotFoundException;
 use League\Flysystem\Filesystem;
 use League\Glide\Filesystem\FileNotFoundException as GlideFileNotFoundException;
 use League\Glide\Manipulators\Watermark;
@@ -283,7 +282,7 @@ class ImageGenerator
         } else {
             $path = public_path($this->path);
             if (! File::exists($path)) {
-                throw new FlysystemFileNotFoundException($path);
+                throw new \Exception("File not found at path: {$path}");
             }
             $mime = File::mimeType($path);
         }


### PR DESCRIPTION
Resolve https://github.com/statamic/cms/issues/5709 by changing reference to FlysystemFileNotFoundException from Flysystem 1.x to \Exception, so that Flysystem 2.x and 3.x can be used.