### PR TITLE
Runtime: Removes literal/stack replacements on 404/error

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -9,6 +9,8 @@ use Statamic\Support\Str;
 use Statamic\View\Antlers\Engine;
 use Statamic\View\Antlers\Engine as AntlersEngine;
 use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
+use Statamic\View\Antlers\Language\Runtime\LiteralReplacementManager;
+use Statamic\View\Antlers\Language\Runtime\StackReplacementManager;
 use Statamic\View\Events\ViewRendered;
 
 class View
@@ -105,7 +107,14 @@ class View
 
         ViewRendered::dispatch($this);
 
-        return $contents->render();
+        $renderedContents = $contents->render();
+
+        if (config('statamic.antlers.version') == 'runtime') {
+            $renderedContents = LiteralReplacementManager::processReplacements($renderedContents);
+            $renderedContents = StackReplacementManager::processReplacements($renderedContents);
+        }
+
+        return $renderedContents;
     }
 
     private function shouldUseLayout()

--- a/tests/Antlers/Runtime/StacksTest.php
+++ b/tests/Antlers/Runtime/StacksTest.php
@@ -166,4 +166,33 @@ TEMPLATE;
 
         $this->assertSame('Home Page', trim($response->getContent()));
     }
+
+    public function test_stack_replacements_are_removed_if_nothing_is_pushed_to_them_on_not_found()
+    {
+        $layoutTemplate = <<<'LAYOUT'
+{{ stack:head }}
+{{ template_content }}
+{{ stack:footer }}
+LAYOUT;
+
+        $templateTemplate = <<<'TEMPLATE'
+{{ not_found }}
+TEMPLATE;
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', $layoutTemplate);
+        $this->viewShouldReturnRaw('errors.404', '404');
+        $this->viewShouldReturnRaw('home', $templateTemplate);
+
+        $this->createPage('home', [
+            'with' => [
+                'title' => 'Home Page',
+                'template' => 'home',
+            ],
+        ]);
+
+        $response = $this->get('/home');
+
+        $this->assertSame('404', trim($response->getContent()));
+    }
 }


### PR DESCRIPTION
This PR improves stack/literal replacements when combined with tags like `{{ 404 }}`. If there is something (like the 404 tag) that stops the current parser process, it won't reach its final stack count where it removes the stack/literal replacements. This simply adds a "catch all" step that will remove anything left over at the very end.

Steps to reproduce:

1. Create a `stack` within a layout
2. On a template, do not push anything to the stack and trigger a 404 error with the `{{ 404 }}` tag.
3. Observe items like `__stackReplacement::_96e89a298e0a9f469b9ae458d6afae9f` or `__literalReplacement::_96e89a298e0a9f469b9ae458d6afae9f` in final output