### PR TITLE
Grey out active read-only toggle field

### DIFF
--- a/resources/js/components/inputs/Toggle.vue
+++ b/resources/js/components/inputs/Toggle.vue
@@ -2,7 +2,7 @@
     <button
         type="button"
         class="toggle-container"
-        :class="{ 'on': value, 'cursor-not-allowed': readOnly }"
+        :class="{ 'on': value, 'cursor-not-allowed read-only': readOnly }"
         @click="toggle"
         :aria-pressed="stateLiteral"
         :aria-label="__('Toggle Button')"

--- a/resources/sass/components/toggle.scss
+++ b/resources/sass/components/toggle.scss
@@ -69,6 +69,12 @@ $toggle_radius: 20px;
     }
 }
 
+.toggle-container.on.read-only {
+    .toggle-slider {
+        @apply bg-grey-50;
+    }
+}
+
 /* Size Variants
   ========================================================================== */
 .toggle-sm.toggle-fieldtype-wrapper {


### PR DESCRIPTION
Active read-only toggle fields still kinda look like they can be interacted with due to the green colour, this PR greys them out so it's more obvious they're read-only.

Before:

![Screenshot 2022-05-24 at 14 12 07](https://user-images.githubusercontent.com/126740/170043600-dc408389-aa9f-48a5-a6de-068c2eb1d65b.png)

After:

![Screenshot 2022-05-24 at 14 11 47](https://user-images.githubusercontent.com/126740/170043631-955ec91f-6b37-48f1-aff5-8ea32c454d73.png)

