### PR TITLE
Refactor saveQuietly logic

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -284,20 +284,19 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
     {
         $this->withEvents = false;
 
-        $result = $this->save();
-
-        $this->withEvents = true;
-
-        return $result;
+        return $this->save();
     }
 
     public function save()
     {
         $isNew = is_null(Facades\Entry::find($this->id()));
 
+        $withEvents = $this->withEvents;
+        $this->withEvents = true;
+
         $afterSaveCallbacks = $this->afterSaveCallbacks;
         $this->afterSaveCallbacks = [];
-        if ($this->withEvents) {
+        if ($withEvents) {
             if (EntrySaving::dispatch($this) === false) {
                 return false;
             }
@@ -324,7 +323,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
             $callback($this);
         }
 
-        if ($this->withEvents) {
+        if ($withEvents) {
             if ($isNew) {
                 EntryCreated::dispatch($this);
             }

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -1043,6 +1043,32 @@ class EntryTest extends TestCase
     }
 
     /** @test */
+    public function it_saves_quietly_and_then_not_quietly()
+    {
+        Event::fake();
+
+        $collection = (new Collection)->handle('pages')->save();
+        $entry = (new Entry)->id('a')->collection($collection);
+        Facades\Entry::shouldReceive('save')->with($entry);
+        Facades\Entry::shouldReceive('taxonomize')->with($entry);
+        Facades\Entry::shouldReceive('find')->with('a')->andReturnNull();
+
+        $return = $entry->saveQuietly();
+
+        $this->assertTrue($return);
+        Event::assertNotDispatched(EntrySaving::class);
+        Event::assertNotDispatched(EntrySaved::class);
+        Event::assertNotDispatched(EntryCreated::class);
+
+        $return = $entry->save();
+
+        $this->assertTrue($return);
+        Event::assertDispatched(EntrySaving::class);
+        Event::assertDispatched(EntrySaved::class);
+        Event::assertDispatched(EntryCreated::class);
+    }
+
+    /** @test */
     public function it_clears_blink_caches_when_saving()
     {
         $collection = tap(Collection::make('test')->structure(new CollectionStructure))->save();


### PR DESCRIPTION
This PR refactors the Entry saveQuietly logic to avoid the value being cached/saved across multiple calls. I've also increased test coverage to ensure that events are fired after an initial saveQuietly call.

Fixes: #5628

