### PR TITLE
Clear tree cache on entry save

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -316,6 +316,10 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
             Blink::store('structure-entries')->forget($this->id());
         }
 
+        if ($this->hasStructure()) {
+            $this->structure()->in($this->locale())->clearTreeCache();
+        }
+
         $this->taxonomize();
 
         optional(Collection::findByMount($this))->updateEntryUris();

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -55,6 +55,7 @@ abstract class Tree implements Contract, Localization
     public function clearTreeCache()
     {
         Blink::forget($this->treeCacheKey());
+
         return $this;
     }
 

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -45,13 +45,22 @@ abstract class Tree implements Contract, Localization
     {
         return $this->fluentlyGetOrSet('tree')
             ->getter(function ($tree) {
-                $key = "structure-{$this->handle()}-{$this->locale()}-".md5(json_encode($tree));
-
-                return Blink::once($key, function () use ($tree) {
+                return Blink::once($this->treeCacheKey(), function () use ($tree) {
                     return $this->structure()->validateTree($tree, $this->locale());
                 });
             })
             ->args(func_get_args());
+    }
+
+    public function clearTreeCache()
+    {
+        Blink::forget($this->treeCacheKey());
+        return $this;
+    }
+
+    public function treeCacheKey()
+    {
+        return "structure-{$this->handle()}-{$this->locale()}-".md5(json_encode($this->tree));
     }
 
     public function root()

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -1810,5 +1810,20 @@ class EntryTest extends TestCase
         ], $entryDe->previewTargets()->all());
     }
 
+    /** @test */
+    public function it_clears_the_tree_cache_when_saving_an_entry()
+    {
+        $collection = (new Collection)->handle('pages')->routes('{parent_uri}/{slug}');
+        $collection->save();
+
+        $a = tap(Entry::make()->collection('pages')->slug('one')->merge(['title' => 1]))->save();
+        $b = tap(Entry::make()->collection('pages')->slug('two')->merge(['title' => 2]))->save();
+        $c = tap(Entry::make()->collection('pages')->slug('three')->merge(['title' => 3]))->save();
+
+        $this->assertEquals($a->url(), '/one');
+        $this->assertEquals($b->url(), '/two');
+        $this->assertEquals($c->url(), '/three');
+    }
+
     // todo: add tests for localization things. in(), descendants(), addLocalization(), etc
 }


### PR DESCRIPTION
Fixes #5046 by calling a method to clear the blink cache for the tree when an entry is saved