### PR TITLE
Add config for pretty DebugBar variables

### DIFF
--- a/config/antlers.php
+++ b/config/antlers.php
@@ -57,4 +57,19 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | DebugBar Integration
+    |--------------------------------------------------------------------------
+    |
+    | Antlers integrates with Laravel DebugBar to bring more detail to your
+    | debugging experience. On complex pages however, this can be slow.
+    | Feel free to disable this setting for a snappier DebugBar.
+    |
+    */
+
+    'debugbar' => [
+        'prettyPrintVariables' => true,
+    ],
+
 ];

--- a/src/View/Debugbar/VariableCollector.php
+++ b/src/View/Debugbar/VariableCollector.php
@@ -18,9 +18,7 @@ class VariableCollector extends ConfigCollector
     public function useHtmlVarDumper($value = true)
     {
         if (! config('statamic.antlers.debugbar.prettyPrintVariables', true)) {
-            $this->useHtmlVarDumper = false;
-
-            return $this;
+            $value = false;
         }
 
         return parent::useHtmlVarDumper($value);

--- a/src/View/Debugbar/VariableCollector.php
+++ b/src/View/Debugbar/VariableCollector.php
@@ -14,4 +14,13 @@ class VariableCollector extends ConfigCollector
 
         return $widgets;
     }
+
+    public function useHtmlVarDumper($value = true)
+    {
+        if (config('statamic.antlers.debugbar.prettyPrintVariables', true)) {
+            $this->useHtmlVarDumper = $value;
+        }
+
+        return $this;
+    }
 }

--- a/src/View/Debugbar/VariableCollector.php
+++ b/src/View/Debugbar/VariableCollector.php
@@ -17,10 +17,12 @@ class VariableCollector extends ConfigCollector
 
     public function useHtmlVarDumper($value = true)
     {
-        if (config('statamic.antlers.debugbar.prettyPrintVariables', true)) {
-            $this->useHtmlVarDumper = $value;
+        if (! config('statamic.antlers.debugbar.prettyPrintVariables', true)) {
+            $this->useHtmlVarDumper = false;
+
+            return $this;
         }
 
-        return $this;
+        return parent::useHtmlVarDumper($value);
     }
 }


### PR DESCRIPTION
For complex pages with lots of variables, the rendered HTML in DebugBar makes pages unusable when DebugBar is enabled.

I want DebugBar, but not at the expense of a horrific on-page performance.

Turning this option off speeds things back up again.