### PR TITLE
Move debugbar config

### DIFF
--- a/config/antlers.php
+++ b/config/antlers.php
@@ -57,19 +57,4 @@ return [
 
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | DebugBar Integration
-    |--------------------------------------------------------------------------
-    |
-    | Antlers integrates with Laravel DebugBar to bring more detail to your
-    | debugging experience. On complex pages however, this can be slow.
-    | Feel free to disable this setting for a snappier DebugBar.
-    |
-    */
-
-    'debugbar' => [
-        'prettyPrintVariables' => true,
-    ],
-
 ];

--- a/config/system.php
+++ b/config/system.php
@@ -112,4 +112,18 @@ return [
     'ajax_timeout' => '600000',
     'pcre_backtrack_limit' => '-1',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Debugbar Integration
+    |--------------------------------------------------------------------------
+    |
+    | Statamic integrates with Laravel Debugbar to bring more detail to your
+    | debugging experience. Here you may adjust various default options.
+    |
+    */
+
+    'debugbar' => [
+        'pretty_print_variables' => true,
+    ],
+
 ];

--- a/src/View/Debugbar/VariableCollector.php
+++ b/src/View/Debugbar/VariableCollector.php
@@ -17,7 +17,7 @@ class VariableCollector extends ConfigCollector
 
     public function useHtmlVarDumper($value = true)
     {
-        if (! config('statamic.antlers.debugbar.prettyPrintVariables', true)) {
+        if (! config('statamic.system.debugbar.pretty_print_variables', true)) {
             $value = false;
         }
 


### PR DESCRIPTION
Continues from #6094

This moves the config from antlers.php into system.php since that's where more generic stuff goes.
