### PR TITLE
Shallow augment the user

### DIFF
--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -75,7 +75,7 @@ class JavascriptComposer
             return [];
         }
 
-        return array_merge($user->toAugmentedArray(), [
+        return array_merge($user->toShallowAugmentedArray(), [
             'preferences' => Preference::all(),
             'permissions' => $user->permissions()->all(),
         ]);


### PR DESCRIPTION
Prevents recursion into user blueprint fieldtypes which causes json encoding to fail.

Fixes: #6074, #4123