### PR TITLE
Improve Bard replicator preview

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -250,7 +250,24 @@ export default {
 
                 return Object.keys(this.storeState.errors).some(key => key.startsWith(prefix));
             })
-        }
+        },
+
+        replicatorPreview() {
+            const stack = JSON.parse(this.value);
+            let text = '';
+            while (stack.length) {
+                const next = stack.shift();
+                if (next.type === 'text') {
+                    text += ` ${next.text || ''}`;
+                    if (text.length > 120) {
+                        break;
+                    }
+                } else if (next.content) {
+                    stack.unshift(...next.content);
+                }
+            }
+            return text;
+        },
 
     },
 

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -259,7 +259,7 @@ export default {
                 const next = stack.shift();
                 if (next.type === 'text') {
                     text += ` ${next.text || ''}`;
-                    if (text.length > 120) {
+                    if (text.length > 150) {
                         break;
                     }
                 } else if (next.content) {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -256,14 +256,19 @@ export default {
             const stack = JSON.parse(this.value);
             let text = '';
             while (stack.length) {
-                const next = stack.shift();
-                if (next.type === 'text') {
-                    text += ` ${next.text || ''}`;
-                    if (text.length > 150) {
-                        break;
-                    }
-                } else if (next.content) {
-                    stack.unshift(...next.content);
+                const node = stack.shift();
+                if (node.type === 'text') {
+                    text += ` ${node.text || ''}`;
+                } else if (node.type === 'set') {
+                    const handle = node.attrs.values.type;
+                    const set = this.config.sets.find(set => set.handle === handle);
+                    text += ` [${set ? set.display : handle}]`;
+                }
+                if (text.length > 150) {
+                    break;
+                }
+                if (node.content) {
+                    stack.unshift(...node.content);
                 }
             }
             return text;


### PR DESCRIPTION
This PR adds a simple `replicatorPreview()` method to the Bard fieldtype, so you get the actual text content instead of a JSON string. Turns this:

![Screenshot 2022-05-26 at 15 53 49](https://user-images.githubusercontent.com/126740/170515542-598c893c-c8a4-4077-99d2-26a5aa536ab5.png)

Into this:

![Screenshot 2022-05-26 at 15 54 04](https://user-images.githubusercontent.com/126740/170515565-48a4807d-9b5d-4941-a524-f3e1f62fc4ac.png)
![Screenshot 2022-05-27 at 09 46 31](https://user-images.githubusercontent.com/126740/170665720-30619f52-7a33-4d68-a588-6571bbb8c6ee.png)

Parses the value and walks the data, concatenating any text node content. Breaks out of the loop once it hits >150 chars as that's all that's needed.
