### PR TITLE
Add taxonomy column to return data in taxonomy terms field

### DIFF
--- a/src/Http/Resources/CP/Taxonomies/ListedTerm.php
+++ b/src/Http/Resources/CP/Taxonomies/ListedTerm.php
@@ -53,6 +53,10 @@ class ListedTerm extends JsonResource
         return $this->columns->mapWithKeys(function ($column) use ($extra) {
             $key = $column->field;
 
+            if ($key == 'taxonomy') {
+                return [$key => $this->resource->taxonomy()->title()];
+            }
+
             $value = $this->blueprint
                 ->field($key)
                 ->setValue($extra[$key] ?? $this->resource->value($key))

--- a/src/Http/Resources/CP/Taxonomies/Terms.php
+++ b/src/Http/Resources/CP/Taxonomies/Terms.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Resources\CP\Taxonomies;
 
 use Illuminate\Http\Resources\Json\ResourceCollection;
+use Statamic\CP\Column;
 use Statamic\Http\Resources\CP\Concerns\HasRequestedColumns;
 
 class Terms extends ResourceCollection
@@ -30,6 +31,18 @@ class Terms extends ResourceCollection
     private function setColumns()
     {
         $columns = $this->blueprint->columns();
+
+        $columns->push(
+            Column::make()
+                ->field('taxonomy')
+                ->fieldtype('term')
+                ->label(__('Taxonomy'))
+                ->listable(true)
+                ->defaultVisibility(true)
+                ->visible(true)
+                ->sortable(true)
+                ->defaultOrder($columns->count() + 1)
+        );
 
         if ($key = $this->columnPreferenceKey) {
             $columns->setPreferred($key);


### PR DESCRIPTION
Fixes: #5983 by ensuring the taxonomy title is returned in the JSON payload. It was erroring previously as it was only returning blueprint fields, which didn't include the taxonomy.