### PR TITLE
Fix parser error when using Blade, provide raw data to Blade

### DIFF
--- a/src/Tags/Tags.php
+++ b/src/Tags/Tags.php
@@ -150,6 +150,10 @@ abstract class Tags
             $data = Arr::addScope($data, $scope);
         }
 
+        if (! $this->parser) {
+            return $data;
+        }
+
         return Antlers::usingParser($this->parser, function ($antlers) use ($data) {
             return $antlers
                 ->parse($this->content, array_merge($this->context->all(), $data))
@@ -172,6 +176,10 @@ abstract class Tags
 
         if ($scope = $this->params->get('scope')) {
             $data = Arr::addScope($data, $scope);
+        }
+
+        if (! $this->parser) {
+            return $data;
         }
 
         return Antlers::usingParser($this->parser, function ($antlers) use ($data, $supplement) {


### PR DESCRIPTION
At the moment any tag that calls `Tags::parse()`, `Tags::parseLoop()`, or `Tags::parseNoResults()` fails when used from Blade with the following error:

```
Statamic\View\Antlers\Antlers::usingParser(): Argument #1 ($parser) must be of type Statamic\Contracts\View\Antlers\Parser, null given
```

Eg. `search:results` and `assets` when there are no results, or `get_files`.

This is because the `FluentTag` class doesn't set a parser, but `Antlers::usingParser()` expects one.

While that method could just be changed to accept nulls to fix the error, that still leaves Blade receiving `AntlersString` and `AntlersLoop` objects, which aren't particularly useful to Blade. Instead, this implements the same change from https://github.com/statamic/cms/pull/5599 to just return the raw data if no parser is set.

It's kind of a catch-all Blade fix for any tags that use those methods but dont implement the `!$this->parser` check themselves.
