### PR TITLE
Blink blueprint fields

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -134,6 +134,11 @@ class Blueprint implements Augmentable, QueryableValue, ArrayAccess, Arrayable
         return "blueprint-contents-{$this->namespace()}-{$this->handle()}";
     }
 
+    private function fieldsBlinkKey()
+    {
+        return "blueprint-fields-{$this->namespace()}-{$this->handle()}";
+    }
+
     private function getContents()
     {
         $contents = $this->contents;
@@ -285,9 +290,15 @@ class Blueprint implements Augmentable, QueryableValue, ArrayAccess, Arrayable
             return $this->fieldsCache;
         }
 
-        $this->validateUniqueHandles();
+        $fn = function () {
+            $this->validateUniqueHandles();
 
-        $fields = new Fields($this->sections()->map->fields()->flatMap->items(), $this->parent);
+            return new Fields($this->sections()->map->fields()->flatMap->items());
+        };
+
+        $fields = $this->handle() ? Blink::once($this->fieldsBlinkKey(), $fn) : $fn();
+
+        $fields->setParent($this->parent);
 
         $this->fieldsCache = $fields;
 
@@ -384,7 +395,11 @@ class Blueprint implements Augmentable, QueryableValue, ArrayAccess, Arrayable
 
     public function ensureFieldInSection($handle, $config, $section, $prepend = false)
     {
-        $this->ensuredFields[] = compact('handle', 'section', 'prepend', 'config');
+        if (isset($this->ensuredFields[$handle])) {
+            return $this;
+        }
+
+        $this->ensuredFields[$handle] = compact('handle', 'section', 'prepend', 'config');
 
         $this->resetFieldsCache();
 
@@ -394,10 +409,8 @@ class Blueprint implements Augmentable, QueryableValue, ArrayAccess, Arrayable
     public function ensureFieldsInSection($fields, $section, $prepend = false)
     {
         foreach ($fields as $handle => $config) {
-            $this->ensuredFields[] = compact('handle', 'section', 'prepend', 'config');
+            $this->ensureFieldInSection($handle, $config, $section, $prepend);
         }
-
-        $this->resetFieldsCache();
 
         return $this;
     }
@@ -507,6 +520,7 @@ class Blueprint implements Augmentable, QueryableValue, ArrayAccess, Arrayable
         $this->fieldsCache = null;
 
         Blink::forget($this->contentsBlinkKey());
+        Blink::forget($this->fieldsBlinkKey());
 
         return $this;
     }

--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -50,12 +50,20 @@ class Fields
     {
         $this->parent = $parent;
 
+        if ($this->fields) {
+            $this->fields->each(fn ($field) => $field->setParent($parent));
+        }
+
         return $this;
     }
 
     public function setParentField($field)
     {
         $this->parentField = $field;
+
+        if ($this->fields) {
+            $this->fields->each(fn ($field) => $field->setParentField($field));
+        }
 
         return $this;
     }


### PR DESCRIPTION
This helps fix a performance issue introduced in 3.3.

On one test site which included a large number of fieldset imports into the blueprint, and has SEO Pro installed which adds fields to the blueprint, the `stache:warm` command went from ~4 minutes down to ~20 seconds.
