### PR TITLE
Runtime: improves interpolated dynamic access

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -513,8 +513,13 @@ class NodeProcessor
 
         $this->pathDataManager->setIsPaired(false);
         $this->pathDataManager->setReduceFinal(false);
+
+        $currentData = $this->getActiveData();
+
         $managerResults = $this->pathDataManager->cascade($this->cascade)
-            ->getDataWithExistence($node->pathReference, $this->getActiveData(), true);
+            ->setInterpolations($node->processedInterpolationRegions)
+            ->setNodeProcessor($this->cloneProcessor()->setData($currentData))
+            ->getDataWithExistence($node->pathReference, $currentData, true);
         $this->pathDataManager->setIsPaired($cur);
         $this->pathDataManager->setReduceFinal($curReduce);
 

--- a/tests/Antlers/Runtime/InterpolationTest.php
+++ b/tests/Antlers/Runtime/InterpolationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Antlers\Runtime;
 
 use Facades\Tests\Factories\EntryFactory;
+use Statamic\Fields\LabeledValue;
 use Tests\Antlers\ParserTestCase;
 
 class InterpolationTest extends ParserTestCase
@@ -32,5 +33,138 @@ EOT;
         ];
 
         $this->assertSame('<The Title>', trim(($this->renderString($template, $data, true))));
+    }
+
+    public function test_interpolation_inside_dynamic_access()
+    {
+        $valueZero = new LabeledValue('0', 'zero');
+        $valueOne = new LabeledValue('1', 'one');
+        $valueTwo = new LabeledValue('2', 'two');
+
+        $data = [
+            'items' => [
+                [ 'title' => 'One', ],
+                [ 'title' => 'Two', ],
+                [ 'title' => 'Three', ],
+            ],
+            'chars' => [
+                't', 'i', 't', 'l', 'e',
+            ],
+            'var_zero' => 0,
+            'var_one' => 1,
+            'var_two' => 2,
+            'var_title' => 'title',
+            'value_zero' => $valueZero,
+            'value_one' => $valueOne,
+            'value_two' => $valueTwo,
+        ];
+
+        $this->assertSame('One', $this->renderString('{{ items.{value_zero}.title }}', $data));
+        $this->assertSame('Two', $this->renderString('{{ items.{value_one}.title }}', $data));
+        $this->assertSame('Three', $this->renderString('{{ items.{value_two}.title }}', $data));
+        $this->assertSame('One', $this->renderString('{{ items[var_zero][var_title] }}', $data));
+        $this->assertSame('Two', $this->renderString('{{ items[var_one][var_title] }}', $data));
+        $this->assertSame('Three', $this->renderString('{{ items[var_two][var_title] }}', $data));
+        $this->assertSame('One', $this->renderString('{{ items[var_zero]["title"] }}', $data));
+        $this->assertSame('Two', $this->renderString('{{ items[var_one]["title"] }}', $data));
+        $this->assertSame('Three', $this->renderString('{{ items[var_two]["title"] }}', $data));
+        $this->assertSame('One', $this->renderString('{{ items[var_zero][{"title"}] }}', $data));
+        $this->assertSame('Two', $this->renderString('{{ items[var_one][{"title"}] }}', $data));
+        $this->assertSame('Three', $this->renderString('{{ items[var_two][{"title"}] }}', $data));
+        $this->assertSame('One', $this->renderString('{{ items.{var_zero}[{"title"}] }}', $data));
+        $this->assertSame('Two', $this->renderString('{{ items.{var_one}[{"title"}] }}', $data));
+        $this->assertSame('Three', $this->renderString('{{ items.{var_two}[{"title"}] }}', $data));
+        $this->assertSame('One', $this->renderString('{{ items.{var_zero}.{"title"} }}', $data));
+        $this->assertSame('Two', $this->renderString('{{ items.{var_one}.{"title"} }}', $data));
+        $this->assertSame('Three', $this->renderString('{{ items.{var_two}.{"title"} }}', $data));
+        $this->assertSame('One', $this->renderString('{{ items.{var_zero}.title }}', $data));
+        $this->assertSame('Two', $this->renderString('{{ items.{var_one}.title }}', $data));
+        $this->assertSame('Three', $this->renderString('{{ items.{var_two}.title }}', $data));
+        $this->assertSame('One', $this->renderString('{{ items.0.title }}', $data));
+        $this->assertSame('Two', $this->renderString('{{ items.1.title }}', $data));
+        $this->assertSame('Three', $this->renderString('{{ items.2.title }}', $data));
+
+        $this->assertSame('One', $this->renderString('{{ items.0.{chars|join("")} }}', $data));
+        $this->assertSame('Two', $this->renderString('{{ items.1.{chars|join("")} }}', $data));
+        $this->assertSame('Three', $this->renderString('{{ items.2.{chars|join("")} }}', $data));
+
+        $this->assertSame('<><One>|<One><Two>|<Two><Three>', $this->renderString(
+            '{{ items }}<{{ items.{index - 1}.title }}><{{ title }}>{{ unless last }}|{{ /unless }}{{ /items }}',
+            $data
+        ));
+
+        $this->assertSame('<One><One><Two><Two><Three><Three>', $this->renderString(
+            '{{ items }}<{{ items[{index}]title }}><{{ title }}>{{ /items }}',
+            $data
+        ));
+
+        $this->assertSame('<><One>|<One><Two>|<Two><Three>', $this->renderString(
+            '{{ items }}<{{ items[{index - 1}]title }}><{{ title }}>{{ unless last }}|{{ /unless }}{{ /items }}',
+            $data
+        ));
+
+        $template = <<<'EOT'
+{{ items }}
+<prev:{{ items[{index - 1}]title }}>
+<cur:{{ title }}>
+<next:{{ items[{index + 1}]title }}>
+{{ /items }}
+EOT;
+
+        $expected = <<<'EOT'
+<prev:>
+<cur:One>
+<next:Two>
+
+<prev:One>
+<cur:Two>
+<next:Three>
+
+<prev:Two>
+<cur:Three>
+<next:>
+EOT;
+
+        $this->assertSame($expected, trim($this->renderString($template, $data)));
+
+        $template = <<<'EOT'
+{{ the_current_item = 0; }}
+{{ items }}
+<prev:{{ items[{the_current_item - 1}]title }}>
+<cur:{{ title }}>
+<next:{{ items[{the_current_item + 1}]title }}>
+{{ the_current_item += 1; }}
+{{ /items }}
+EOT;
+
+        $expected = <<<'EOT'
+<prev:>
+<cur:One>
+<next:Two>
+
+
+<prev:One>
+<cur:Two>
+<next:Three>
+
+
+<prev:Two>
+<cur:Three>
+<next:>
+EOT;
+
+        $this->assertSame($expected, trim($this->renderString($template, $data)));
+
+        $template = <<<'EOT'
+{{ the_current_item = 0; }}
+{{ items }}
+<prev:{{ items[{the_current_item - 1}]['title'] }}>
+<cur:{{ title }}>
+<next:{{ items[{the_current_item + 1}]['title'] }}>
+{{ the_current_item += 1; }}
+{{ /items }}
+EOT;
+
+        $this->assertSame($expected, trim($this->renderString($template, $data)));
     }
 }


### PR DESCRIPTION
This PR improves how interpolated variables interact with dynamic access (inspired by this discussions post: https://github.com/statamic/cms/discussions/6100)

While the Runtime version provides `next` and `prev` variables in arrays automatically, the following was very temperamental to get working and felt like a papercut:

```antlers
{{ items }}
    {{ items[{index - 1}]url }}
{{ /items }}
```

The changes in this PR now make the previous example behave intuitively. Additionally, if someone wants to use interpolated values for dynamic access, they can now omit the `[]` as the Runtime will implicitly treat interpolated regions as dynamic access:

```antlers
{{ items }}
    {{ items.{index - 1}.url }}
{{ /items }}
```