### PR TITLE
Add duplicate set option to Replicator and Bard

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -363,6 +363,22 @@ export default {
             });
         },
 
+        duplicateSet(old_id, attrs, pos) {
+            const id = `set-${uniqid()}`;
+            const enabled = attrs.enabled;
+            const values = Object.assign({}, attrs.values);
+
+            let previews = Object.assign({}, this.previews[old_id]);
+            this.previews = Object.assign({}, this.previews, { [id]: previews });
+
+            this.updateSetMeta(id, this.meta.existing[old_id]);
+
+            // Perform this in nextTick because the meta data won't be ready until then.
+            this.$nextTick(() => {
+                this.editor.commands.setAt({ attrs: { id, enabled, values }, pos });
+            });
+        },
+
         collapseSet(id) {
             if (!this.collapsed.includes(id)) {
                 this.collapsed.push(id)

--- a/resources/js/components/fieldtypes/bard/Set.js
+++ b/resources/js/components/fieldtypes/bard/Set.js
@@ -28,11 +28,18 @@ export default class SetNode extends Node {
     }
 
     commands({ type, schema }) {
-        return attrs => (state, dispatch) => {
-            const { selection } = state;
-            const node = type.create(attrs);
-            const transaction = state.tr.insert(selection.$cursor.pos - 1, node);
-            dispatch(transaction);
+        return {
+            set: attrs => (state, dispatch) => {
+                const { selection } = state;
+                const node = type.create(attrs);
+                const transaction = state.tr.insert(selection.$cursor.pos - 1, node);
+                dispatch(transaction);
+            },
+            setAt: ({ attrs, pos }) => (state, dispatch) => {
+                const node = type.create(attrs);
+                const transaction = state.tr.insert(pos, node);
+                dispatch(transaction);
+            },
         };
     }
 

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -29,6 +29,7 @@
                     v-tooltip.top="(enabled) ? __('Included in output') : __('Hidden from output')" />
                 <dropdown-list class="-mt-sm">
                     <dropdown-item :text="__(collapsed ? __('Expand Set') : __('Collapse Set'))" @click="toggleCollapsedState" />
+                    <dropdown-item :text="__('Duplicate Set')" @click="duplicate" />
                     <dropdown-item :text="__('Delete Set')" class="warning" @click="destroy" />
                 </dropdown-list>
             </div>
@@ -189,6 +190,11 @@ export default {
         expand() {
             // this.$events.$emit('expanded', this.node.attrs.id);
             this.options.bard.expandSet(this.node.attrs.id);
+        },
+
+        duplicate() {
+            // this.$events.$emit('duplicated', this.node.attrs.id);
+            this.options.bard.duplicateSet(this.node.attrs.id, this.node.attrs, this.getPos() + this.node.nodeSize);
         },
 
         fieldPath(field) {

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -33,8 +33,10 @@
                     :field-path-prefix="fieldPathPrefix || handle"
                     :has-error="setHasError(index)"
                     :previews="previews[set._id]"
+                    :can-add-set="canAddSet"
                     @collapsed="collapseSet(set._id)"
                     @expanded="expandSet(set._id)"
+                    @duplicate="duplicateSet(set._id)"
                     @updated="updated"
                     @meta-updated="updateSetMeta(set._id, $event)"
                     @removed="removed(set, index)"
@@ -156,6 +158,27 @@ export default {
                 ...this.value.slice(index)
             ]);
 
+            this.expandSet(set._id);
+        },
+
+        duplicateSet(old_id) {
+            const index = this.value.findIndex(v => v._id === old_id);
+            const old = this.value[index];
+            const set = {
+                ...old,
+                _id: `set-${uniqid()}`,
+            };
+
+            this.updateSetPreviews(set._id, {});
+
+            this.updateSetMeta(set._id, this.meta.existing[old_id]);
+
+            this.update([
+                ...this.value.slice(0, index + 1),
+                set,
+                ...this.value.slice(index + 1)
+            ]);
+            
             this.expandSet(set._id);
         },
 

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -36,7 +36,7 @@
                     :can-add-set="canAddSet"
                     @collapsed="collapseSet(set._id)"
                     @expanded="expandSet(set._id)"
-                    @duplicate="duplicateSet(set._id)"
+                    @duplicated="duplicateSet(set._id)"
                     @updated="updated"
                     @meta-updated="updateSetMeta(set._id, $event)"
                     @removed="removed(set, index)"

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -27,6 +27,7 @@
                     v-tooltip.top="(values.enabled) ? __('Included in output') : __('Hidden from output')" />
                 <dropdown-list class="-mt-sm">
                     <dropdown-item :text="__(collapsed ? __('Expand Set') : __('Collapse Set'))" @click="toggleCollapsedState" />
+                    <dropdown-item :text="__('Duplicate Set')" @click="duplicate" v-if="canAddSet" />
                     <dropdown-item :text="__('Delete Set')" class="warning" @click="destroy" />
                 </dropdown-list>
             </div>
@@ -118,6 +119,10 @@ export default {
         sortableHandleClass: {
             type: String
         },
+        canAddSet: {
+            type: Boolean,
+            default: true
+        },
         isReadOnly: Boolean,
         previews: Object,
     },
@@ -197,6 +202,10 @@ export default {
 
         expand() {
             this.$emit('expanded');
+        },
+
+        duplicate() {
+            this.$emit('duplicate');
         },
 
         fieldPath(field) {

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -205,7 +205,7 @@ export default {
         },
 
         duplicate() {
-            this.$emit('duplicate');
+            this.$emit('duplicated');
         },
 
         fieldPath(field) {


### PR DESCRIPTION
This PR adds a duplicate set option to the Replicator and Bard fieldtypes. Closes https://github.com/statamic/ideas/issues/756 and closes https://github.com/statamic/ideas/issues/81.

https://user-images.githubusercontent.com/126740/170833249-ae490b51-b3a7-4520-b8de-f579096d4774.mp4

I wasn't sure if there's a simple way for `BardFieldtype` to access the node attributes and position just using the set ID, which is why I'm parsing those values to `duplicateSet()` along with the ID.
