### PR TITLE
Add actionUrl method to Form class

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -336,4 +336,14 @@ class Form implements FormContract, Augmentable, Arrayable
     {
         return Statamic::apiRoute('forms.show', $this->handle());
     }
+
+    /**
+     * Get the form action url.
+     *
+     * @return string
+     */
+    public function actionUrl()
+    {
+        return route('statamic.forms.submit', $this->handle());
+    }
 }

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -81,7 +81,7 @@ class Tags extends BaseTags
             'redirect', 'error_redirect', 'allow_request_redirect', 'csrf', 'files', 'js',
         ]);
 
-        $action = $this->params->get('action', route('statamic.forms.submit', $formHandle));
+        $action = $this->params->get('action', $form->actionUrl());
         $method = $this->params->get('method', 'POST');
 
         $attrs = [];

--- a/tests/Forms/FormTest.php
+++ b/tests/Forms/FormTest.php
@@ -82,4 +82,13 @@ class FormTest extends TestCase
                 $this->assertEquals($expected, $value);
             });
     }
+
+    /** @test */
+    public function it_can_get_action_url()
+    {
+        $form = Form::make('contact_us');
+        $route = route('statamic.forms.submit', $form->handle());
+
+        $this->assertEquals($route, $form->actionUrl());
+    }
 }


### PR DESCRIPTION
This adds an actionUrl method to the form class, so that it is easier to get the correct action url for the form.

Usage:

```php
$form = \Statamic\Facades\Form::find('contact');
$form->actionUrl();
```

`actionUrl` will return the action route from `route('statamic.forms.submit', $handle)`, which in the above context and with a default configuration should be ` /!/forms/contact`