### PR TITLE
Runtime: Corrects assignments across nested query builder scopes

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -2063,6 +2063,9 @@ class NodeProcessor
 
                                             $runtimeData = array_merge($runtimeData, $runtimeAssignmentsToProcess);
                                         }
+
+                                        $processor->setRuntimeAssignments($runtimeAssignments);
+
                                         if (count($this->data) > $dataCount) {
                                             $this->popLoopScope();
                                         }


### PR DESCRIPTION
This PR resolves #6127 by updating the internal assignments when iterating loops. Currently, the Runtime will start over with the variable's initial values when re-entering the nested query builder loop. This change ensures that those custom values are always up-to-date.

The steps in the linked issue can be followed to validate. In addition to the steps there, the provided test will fail and incorrectly print "Total: 20" when moved to the base branch. To set up your own test, the important part is to have at least two nested query builder loops.