### PR TITLE
Runtime: fixes variable scope across parser boundaries

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -751,6 +751,11 @@ class NodeProcessor
         $this->runtimeAssignments = $assignments;
     }
 
+    public function mergeRuntimeAssignments($assignments)
+    {
+        $this->runtimeAssignments = array_merge($this->runtimeAssignments, $assignments);
+    }
+
     /**
      * Tests if the node sequence represents an iterable assignment.
      *
@@ -1362,7 +1367,10 @@ class NodeProcessor
 
                         if (! empty($this->runtimeAssignments)) {
                             GlobalRuntimeState::$traceTagAssignments = true;
-                            GlobalRuntimeState::$tracedRuntimeAssignments = $this->runtimeAssignments;
+                            GlobalRuntimeState::$tracedRuntimeAssignments = array_merge(
+                                $this->runtimeAssignments,
+                                GlobalRuntimeState::$tracedRuntimeAssignments
+                            );
                         }
                         /** @var Tags $tag */
                         $tag = $this->loader->load($tagToLoad, [

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -378,6 +378,7 @@ class RuntimeParser implements Parser
             $this->nodeProcessor->setAntlersParserInstance($this);
             $this->nodeProcessor->cascade($this->cascade);
 
+            $this->nodeProcessor->mergeRuntimeAssignments(GlobalRuntimeState::$tracedRuntimeAssignments);
             $bufferContent = $this->nodeProcessor->render($renderNodes);
 
             $this->nodeProcessor->triggerRenderComplete();

--- a/tests/Antlers/ParserTestCase.php
+++ b/tests/Antlers/ParserTestCase.php
@@ -110,7 +110,7 @@ class ParserTestCase extends TestCase
         return $documentParser->getNodes();
     }
 
-    protected function runFieldTypeTest($handle, $testTemplate = null)
+    protected function runFieldTypeTest($handle, $testTemplate = null, $additionalValues = [])
     {
         if ($testTemplate == null) {
             $testTemplate = $handle;
@@ -120,8 +120,16 @@ class ParserTestCase extends TestCase
         $template = file_get_contents(__DIR__.'/../__fixtures__/fieldtype_tests/'.$testTemplate.'/template.antlers.html');
         $expectedResults = file_get_contents(__DIR__.'/../__fixtures__/fieldtype_tests/'.$testTemplate.'/expected.txt');
 
+        $testData = [
+            $handle => $value
+        ];
+
+        foreach ($additionalValues as $valueName) {
+            $testData[$valueName] = $this->getTestValue($valueName);
+        }
+
         $this->assertSame($this->normalize($expectedResults), $this->normalize(
-            $this->renderString($template, [$handle => $value], true)
+            $this->renderString($template, $testData, true)
         ), 'Field Type Test: '.$handle);
     }
 

--- a/tests/Antlers/Sandbox/VariableAssignmentTest.php
+++ b/tests/Antlers/Sandbox/VariableAssignmentTest.php
@@ -1011,4 +1011,29 @@ EOT;
 
         $this->assertSame('<foo><default>', trim($this->renderString($template)));
     }
+
+    public function test_variable_assignments_are_not_reset_when_crossing_parser_boundaries()
+    {
+        $textTemplate = <<<'EOT'
+<count:{{ counter }}>
+
+{{ increment:something_else }}
+{{ increment:something_else }}
+{{ increment:something_else }}
+{{ increment:something_else }}
+{{ increment:something_else }}
+
+{{ bard }}
+{{ partial:echo }}{{ partial:echo }}{{ partial:echo }}{{ partial:echo }}{{ partial:echo }}{{ foreach:array_dynamic }}{{ /foreach:array_dynamic }}{{ /partial:echo }}{{ /partial:echo }}{{ /partial:echo }}{{ /partial:echo }}{{ /partial:echo }}
+{{ /bard }}
+
+{{ increment:something_else }}
+EOT;
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('components.text', $textTemplate);
+        $this->viewShouldReturnRaw('echo', '{{ slot }}');
+
+        $this->runFieldTypeTest('replicator_blocks', null, ['bard']);
+    }
 }

--- a/tests/__fixtures__/blueprints/article.yaml
+++ b/tests/__fixtures__/blueprints/article.yaml
@@ -39,6 +39,30 @@ sections:
           icon: array
           listable: hidden
       -
+        handle: replicator_blocks
+        field:
+          collapse: false
+          sets:
+            text:
+              display: Text
+              fields:
+                -
+                  handle: text
+                  field:
+                    antlers: false
+                    display: Text
+                    type: textarea
+                    icon: textarea
+                    listable: hidden
+                    instructions_position: above
+                    read_only: false
+          display: Blocks
+          type: replicator
+          icon: replicator
+          listable: hidden
+          instructions_position: above
+          read_only: false
+      -
         handle: array_keyed
         field:
           mode: keyed

--- a/tests/__fixtures__/content/1996-11-18-dance.md
+++ b/tests/__fixtures__/content/1996-11-18-dance.md
@@ -17,6 +17,19 @@ button_group: button2
 checkboxes:
   - checkbox1
   - checkbox3
+replicator_blocks:
+  -
+    text: 'First text'
+    type: text
+    enabled: true
+  -
+    text: 'Second text'
+    type: text
+    enabled: true
+  -
+    text: 'Third text'
+    type: text
+    enabled: true
 code: |-
   /**
        * Because sometimes you just gotta /shrug.

--- a/tests/__fixtures__/fieldtype_tests/replicator_blocks/expected.txt
+++ b/tests/__fixtures__/fieldtype_tests/replicator_blocks/expected.txt
@@ -1,0 +1,65 @@
+
+
+
+    <count:1>
+
+0
+1
+2
+3
+4
+
+
+
+
+
+
+
+
+
+5
+        <counter:1>
+        <text:First text>
+
+    <count:2>
+
+6
+7
+8
+9
+10
+
+
+
+
+
+
+
+
+
+11
+        <counter:2>
+        <text:Second text>
+
+    <count:3>
+
+12
+13
+14
+15
+16
+
+
+
+
+
+
+
+
+
+17
+        <counter:3>
+        <text:Third text>
+
+
+<final:3>

--- a/tests/__fixtures__/fieldtype_tests/replicator_blocks/template.antlers.html
+++ b/tests/__fixtures__/fieldtype_tests/replicator_blocks/template.antlers.html
@@ -1,0 +1,12 @@
+{{ counter = 0 }}
+
+{{ replicator_blocks }}
+    {{ partial:echo }}
+        {{ counter += 1 }}
+        {{ partial:components/{type} /}}
+        <counter:{{ counter }}>
+        <text:{{ text }}>
+    {{ /partial:echo }}
+{{ /replicator_blocks }}
+
+<final:{{ counter }}>


### PR DESCRIPTION
This PR fixes #6137 by improving how variables are managed when moving between parser boundaries. The linked repository in the original issue is a great way to test this fix. Additionally, the provided test case will fail when moved to the base branch.