### PR TITLE
Runtime: resets stack state

### DIFF
--- a/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
+++ b/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
@@ -207,8 +207,9 @@ class GlobalRuntimeState
         self::$environmentId = StringUtilities::uuidv4();
         self::$yieldCount = 0;
         self::$yieldStacks = [];
-        StackReplacementManager::clearStackState();
 
+        StackReplacementManager::clearStackState();
+        LiteralReplacementManager::resetLiteralState();
         RecursiveNodeManager::resetRecursiveNodeState();
     }
 

--- a/src/View/Antlers/Language/Runtime/LiteralReplacementManager.php
+++ b/src/View/Antlers/Language/Runtime/LiteralReplacementManager.php
@@ -11,6 +11,14 @@ class LiteralReplacementManager
     protected static $globalReplacement = [];
     protected static $retargeted = [];
 
+    public static function resetLiteralState()
+    {
+        self::$regions = [];
+        self::$replacements = [];
+        self::$globalReplacement = [];
+        self::$retargeted = [];
+    }
+
     public static function registerRegion($name, $section, $default)
     {
         $name = '__literalReplacement::_'.md5($name);

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -84,6 +84,8 @@ class View
 
     public function render(): string
     {
+        GlobalRuntimeState::resetGlobalState();
+
         $cascade = $this->gatherData();
 
         if ($this->shouldUseLayout()) {


### PR DESCRIPTION
This PR fixes https://github.com/statamic/ssg/issues/98 by clearing the stack contents when the main Antlers render method is invoked.

To validate the fix, use stacks in the site's layout, and push to it from a template that is rendered multiple times. Once you run the `ssg:generate` command, you will find that the pushed contents are rendered multiple times on subsequent pages. In addition to validating against an SSG site, the provided test case will also fail when moving it to the base branch 👍

There exists a test case already to ensure this change does not break using stacks from partials: https://github.com/statamic/ssg/issues/98