### PR TITLE
New Single Mode for Array Fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/ArrayFieldtype.vue
+++ b/resources/js/components/fieldtypes/ArrayFieldtype.vue
@@ -1,7 +1,30 @@
 <template>
     <div class="array-fieldtype-container">
 
-        <table v-if="isKeyed" class="array-table">
+        <div v-if="isSingle" class="flex items-center">
+            <div class="input-group">
+                <div class="input-group-prepend">
+                     <select class="bg-transparent shadow-none outline-none border-0 text-sm" @input="setKey($event.target.value)">
+                        <option
+                            v-for="(element, index) in keyedData"
+                            v-text="config.keys[element.key] || element.key"
+                            :key="element._id"
+                            :value="element.key"
+                            :selected="element.key === selectedKey" />
+                    </select>
+                </div>
+                    <input
+                        type="text"
+                        class="input-text"
+                        v-for="(element, index) in keyedData"
+                        :key="element._id"
+                        v-if="element.key === selectedKey"
+                        :id="fieldId+'__'+element.key" v-model="data[index].value" :readonly="isReadOnly"
+                    />
+            </div>
+        </div>
+
+        <table v-else-if="isKeyed" class="array-table">
             <tbody>
                 <tr v-if="data" v-for="(element, index) in keyedData" :key="element._id">
                     <th class="w-1/4"><label :for="fieldId+'__'+element.key">{{ config.keys[element.key] || element.key }}</label></th>
@@ -82,6 +105,7 @@ export default {
     data() {
         return {
             data: this.objectToSortable(this.value || []),
+            selectedKey:  Object.keys(this.value)[0],
             deleting: false
         }
     },
@@ -107,6 +131,10 @@ export default {
 
         isDynamic() {
             return ! this.isKeyed;
+        },
+
+        isSingle() {
+            return this.config.mode === 'single';
         },
 
         keyedData() {
@@ -171,6 +199,10 @@ export default {
 
         deleteCancelled() {
             this.deleting = false;
+        },
+
+        setKey(key) {
+            this.selectedKey = key
         }
     }
 

--- a/resources/js/components/fieldtypes/ArrayFieldtype.vue
+++ b/resources/js/components/fieldtypes/ArrayFieldtype.vue
@@ -3,8 +3,8 @@
 
         <div v-if="isSingle" class="flex items-center">
             <div class="input-group">
-                <div class="input-group-prepend">
-                     <select class="bg-transparent shadow-none outline-none border-0 text-sm" @input="setKey($event.target.value)">
+                <div class="input-group-prepend flex items-center">
+                     <select class="bg-transparent appearance-none shadow-none outline-none border-0 text-sm" @input="setKey($event.target.value)">
                         <option
                             v-for="(element, index) in keyedData"
                             v-text="config.keys[element.key] || element.key"
@@ -12,6 +12,7 @@
                             :value="element.key"
                             :selected="element.key === selectedKey" />
                     </select>
+                    <svg-icon name="chevron-down-xs" class="w-2 ml-1" />
                 </div>
                     <input
                         type="text"

--- a/src/Fieldtypes/Arr.php
+++ b/src/Fieldtypes/Arr.php
@@ -22,6 +22,7 @@ class Arr extends Fieldtype
                 'options' => [
                     'dynamic' => __('Dynamic'),
                     'keyed' => __('Keyed'),
+                    'single' => __('Single'),
                 ],
             ],
             'keys' => [
@@ -30,8 +31,8 @@ class Arr extends Fieldtype
                 'type' => 'array',
                 'key_header' => __('Key'),
                 'value_header' => __('Label').' ('.__('Optional').')',
-                'if' => [
-                    'mode' => 'keyed',
+                'unless' => [
+                    'mode' => 'dynamic',
                 ],
             ],
         ];


### PR DESCRIPTION
This is useful if you want to manage an array one item at a time, using a select box to switch between keys. Could be super useful for translatable Blueprint fields. 😊 

![CleanShot 2022-06-02 at 09 29 47](https://user-images.githubusercontent.com/44739/171641487-bf6cfee1-c771-4f25-8796-f741deb41792.gif)