### PR TITLE
Fix CP language direction

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ config('app.locale') }}" dir="{{ Statamic\Facades\Site::current()->direction ?? 'rtl' }}">
+<html lang="{{ config('app.locale') }}" dir="{{ Statamic\Facades\Site::selected()->direction() }}">
 <head>
     @include('statamic::partials.head')
 </head>


### PR DESCRIPTION
Reference statamic/ideas#248

The `dir` attribute in the Control Panel's `<html>` tag uses the direction from the "current" site, which will always just be the first/default site.

By changing it to "selected", it will use the direction for whichever site is selected in the global site picker, as expected.

This also removes the fallback. It would never be reached because the `direction` method already handled it, plus the fallback should have been ltr anyway.

