### PR TITLE
Runtime: Fixes variables created in PHP not staying in scope

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -409,6 +409,8 @@ class NodeProcessor
                     $this->previousAssignments[$path] = $targetIndex;
                 }
             }
+
+            $this->runtimeAssignments[$path] = $value;
         }
 
         if (GlobalRuntimeState::$traceTagAssignments) {
@@ -2227,7 +2229,7 @@ class NodeProcessor
                 $___antlersVarAfter = get_defined_vars();
 
                 foreach ($___antlersVarAfter as $varKey => $varValue) {
-                    if (! array_key_exists($varKey, $___antlersVarBefore) || array_key_exists($varKey, $this->previousAssignments)) {
+                    if (! array_key_exists($varKey, $___antlersVarBefore) || array_key_exists($varKey, $this->previousAssignments) || array_key_exists($varKey, $this->runtimeAssignments)) {
                         $phpRuntimeAssignments[$varKey] = $varValue;
                     }
                 }
@@ -2237,6 +2239,9 @@ class NodeProcessor
         }
 
         if (! $node->isEchoNode && ! empty($phpRuntimeAssignments)) {
+            unset($phpRuntimeAssignments['___antlersVarBefore']);
+            unset($phpRuntimeAssignments['___antlersPhpExecutionResult']);
+
             $this->processAssignments($phpRuntimeAssignments);
         }
 

--- a/tests/Antlers/Runtime/PhpEnabledTest.php
+++ b/tests/Antlers/Runtime/PhpEnabledTest.php
@@ -508,4 +508,28 @@ EOT;
 
         $this->assertSame($expected, trim($this->renderString($template, $data)));
     }
+
+    public function test_assignments_from_php_nodes()
+    {
+        $template = <<<'EOT'
+{{? 
+    $value_one = 100; 
+    $value_two = 0;
+?}}
+
+{{ loop from="1" to="5" }}
+{{? $value_one += 5; ?}}
+{{? $value_two += 5; ?}}
+{{ /loop }}
+
+{{ value_one += 1000; value_two += 1000; }}
+
+<value_one: {{ value_one }}>
+<value_two: {{ value_two }}>
+EOT;
+
+        $result = $this->renderString($template, [], true);
+        $this->assertStringContainsString('<value_one: 1125>', $result);
+        $this->assertStringContainsString('<value_two: 1025>', $result);
+    }
 }


### PR DESCRIPTION
This PR corrects an issue where variables defined in a PHP node would not stay in scope. This PR addresses this by ensuring that all variables created in a PHP context are set within the Antlers internal variable assignments state.

To reproduce the issue this PR addresses, attempt to evaluate a template similar to the following:

```antlers
{{? 
    $value_one = 100; 
    $value_two = 0;
?}}

{{ loop from="1" to="5" }}
    {{? $value_one += 5; ?}}
    {{? $value_two += 5; ?}}
{{ /loop }}

{{ value_one }}

{{ value_two }}
```

The provided test case will also fail if moved to the base branch 👍