### PR TITLE
Runtime: Applies Antlers escape sequences to parameter string values

### DIFF
--- a/src/View/Antlers/Language/Nodes/AntlersNode.php
+++ b/src/View/Antlers/Language/Nodes/AntlersNode.php
@@ -368,6 +368,10 @@ class AntlersNode extends AbstractNode
                 continue;
             }
 
+            if (is_string($value)) {
+                $value = DocumentParser::applyEscapeSequences($value);
+            }
+
             $values[$param->name] = $value;
         }
 
@@ -435,6 +439,10 @@ class AntlersNode extends AbstractNode
             $value = $this->reduceParameterInterpolations($param, $processor, $value, $data);
         }
 
+        if (is_string($value)) {
+            $value = DocumentParser::applyEscapeSequences($value);
+        }
+
         return $value;
     }
 
@@ -488,12 +496,16 @@ class AntlersNode extends AbstractNode
             $retriever->setIsPaired($this->isClosedBy != null);
             $value = $retriever->getData($pathParser->parse($value), $data);
 
+            if (is_string($value)) {
+                $value = DocumentParser::applyEscapeSequences($value);
+            }
+
             $values[] = $value;
         } else {
             $pipeEscape = DocumentParser::getPipeEscape();
 
             $values = array_map(function ($item) use ($pipeEscape) {
-                return str_replace($pipeEscape, DocumentParser::Punctuation_Pipe, $item);
+                return DocumentParser::applyEscapeSequences(str_replace($pipeEscape, DocumentParser::Punctuation_Pipe, $item));
             }, explode('|', $value));
         }
 

--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -945,6 +945,14 @@ class DocumentParser
         return str_split(self::getPipeEscape());
     }
 
+    public static function applyEscapeSequences($string)
+    {
+        $string = str_replace(DocumentParser::getRightBraceEscape(), DocumentParser::RightBrace, $string);
+        $string = str_replace(DocumentParser::getLeftBraceEscape(), DocumentParser::LeftBrace, $string);
+
+        return $string;
+    }
+
     private function getLeftBrace()
     {
         return str_split(self::getLeftBraceEscape());

--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -1536,7 +1536,7 @@ class Environment
 
                 $returnVal = $stringValue;
             } else {
-                $returnVal = $this->applyEscapeSequences($val->value);
+                $returnVal = DocumentParser::applyEscapeSequences($val->value);
             }
         } elseif ($val instanceof NullCoalescenceGroup) {
             $returnVal = $this->evaluateNullCoalescence($val);
@@ -1544,10 +1544,10 @@ class Environment
             $returnVal = $this->evaluateTernaryGroup($val);
         } elseif ($val instanceof ModifierValueNode) {
             if (is_string($val->value) && in_array(trim($val->value), GlobalRuntimeState::$interpolatedVariables)) {
-                return $this->applyEscapeSequences($this->nodeProcessor->evaluateDeferredInterpolation(trim($val->value)));
+                return DocumentParser::applyEscapeSequences($this->nodeProcessor->evaluateDeferredInterpolation(trim($val->value)));
             }
 
-            $returnVal = $this->applyEscapeSequences($val->value);
+            $returnVal = DocumentParser::applyEscapeSequences($val->value);
         } elseif ($val instanceof ArrayNode) {
             $returnVal = $this->resolveArrayValue($val);
         }
@@ -1581,13 +1581,5 @@ class Environment
         }
 
         return $this->adjustValue($returnVal, $val);
-    }
-
-    private function applyEscapeSequences($string)
-    {
-        $string = str_replace(DocumentParser::getRightBraceEscape(), DocumentParser::RightBrace, $string);
-        $string = str_replace(DocumentParser::getLeftBraceEscape(), DocumentParser::LeftBrace, $string);
-
-        return $string;
     }
 }

--- a/tests/Antlers/Fixtures/Addon/Modifiers/VarTestModifier.php
+++ b/tests/Antlers/Fixtures/Addon/Modifiers/VarTestModifier.php
@@ -9,9 +9,11 @@ class VarTestModifier extends Modifier
     protected static $handle = 'var_test_modifier';
 
     public static $value = null;
+    public static $params = null;
 
-    public function index($value)
+    public function index($value, $params)
     {
         self::$value = $value;
+        self::$params = $params;
     }
 }

--- a/tests/Antlers/Runtime/ParameterStyleModifierTest.php
+++ b/tests/Antlers/Runtime/ParameterStyleModifierTest.php
@@ -5,6 +5,7 @@ namespace Tests\Antlers\Runtime;
 use Facades\Tests\Factories\EntryFactory;
 use Statamic\Entries\Collection;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
+use Tests\Antlers\Fixtures\Addon\Modifiers\VarTestModifier;
 use Tests\Antlers\ParserTestCase;
 use Tests\FakesViews;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -58,5 +59,14 @@ EOT;
 EOT;
 
         $this->assertSame($expected, StringUtilities::normalizeLineEndings(trim($response->content())));
+    }
+
+    public function test_modifier_style_parameters_applies_brace_escape_sequences()
+    {
+        VarTestModifier::register();
+        $template = '{{ value var_test_modifier="test@{}|param_two@{@}" }} ';
+        $this->renderString($template, ['value' => 'value'], true);
+
+        $this->assertSame(['test{}', 'param_two{}'], VarTestModifier::$params);
     }
 }


### PR DESCRIPTION
This PR corrects an issue where Antlers escape sequences were not correctly applied to string parameter values:

```antlers
{{ value modifier="@{parameter_one}|@{parameter_two}" }}
```

Before the change, modifiers would receive two strings, each containing the internal escape string. After the change, the modifier would receive the following parameters:

```
{parameter_one}
{parameter_two}
```

To replicate, attempt to use curly braces escaped with `@` when using parameter style modifiers. The provided test case will also fail when moved to the base branch.