### PR TITLE
Fix user recursion

### DIFF
--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -75,9 +75,9 @@ class JavascriptComposer
             return [];
         }
 
-        return array_merge($user->toAugmentedArray(), [
+        return $user->toAugmentedCollection()->merge([
             'preferences' => Preference::all(),
             'permissions' => $user->permissions()->all(),
-        ]);
+        ])->toArray();
     }
 }


### PR DESCRIPTION
This fixes an recursion issue when the authenticated user has a relationship field on them, which references an item that has a reference to themselves, (eg. on an updated_by).

ie.
- User has an entries field
- The entries field has an entry selected
- That entry has updated_by the original user

This PR uses the augmented collection and toarray methods, which has handling built in for preventing recursion when using relationship fields.

Fixes #6074