### PR TITLE
Runtime: Resolves Values objects

### DIFF
--- a/tests/Antlers/ParserTestCase.php
+++ b/tests/Antlers/ParserTestCase.php
@@ -71,6 +71,11 @@ class ParserTestCase extends TestCase
     protected function getTestValue($handle)
     {
         $field = $this->getTestField($handle);
+
+        if ($field == null) {
+            return null;
+        }
+
         $value = self::$testFieldValues[$handle];
 
         return new Value($value, $handle, $field->fieldtype());

--- a/tests/Antlers/Runtime/Fieldtypes/GridFieldtypeTest.php
+++ b/tests/Antlers/Runtime/Fieldtypes/GridFieldtypeTest.php
@@ -15,4 +15,9 @@ class GridFieldtypeTest extends ParserTestCase
     {
         $this->runFieldTypeTest('stacked_grid');
     }
+
+    public function test_grid_array_plucking()
+    {
+        $this->runFieldTypeTest('grid_array_plucking', null, ['grid']);
+    }
 }

--- a/tests/__fixtures__/fieldtype_tests/grid_array_plucking/expected.txt
+++ b/tests/__fixtures__/fieldtype_tests/grid_array_plucking/expected.txt
@@ -1,0 +1,23 @@
+<Grid 1>
+<Grid 2>
+<Grid 5>
+<Grid 6>
+<Empty>
+<Empty>
+<Grid 7>
+<Grid 8>
+<Grid 3>
+<Grid 4>
+<Empty>
+<Empty>
+
+
+<Grid 1>
+
+<Grid 3>
+
+<Grid 5>
+
+<Grid 7>
+
+<Empty>

--- a/tests/__fixtures__/fieldtype_tests/grid_array_plucking/template.antlers.html
+++ b/tests/__fixtures__/fieldtype_tests/grid_array_plucking/template.antlers.html
@@ -1,0 +1,16 @@
+<{{ grid.0.grid_text_1 }}>
+<{{ grid.0.grid_text_2 }}>
+<{{ grid.2.grid_text_1 }}>
+<{{ grid.2.grid_text_2 }}>
+<{{ grid.4.grid_text_1 ?? 'Empty' }}>
+<{{ grid.4.grid_text_2 ?? 'Empty' }}>
+<{{ grid.3.grid_text_1 }}>
+<{{ grid.3.grid_text_2 }}>
+<{{ grid.1.grid_text_1 }}>
+<{{ grid.1.grid_text_2 }}>
+<{{ grid.10.grid_text_1 ?? 'Empty' }}>
+<{{ grid.10.grid_text_2 ?? 'Empty' }}>
+
+{{ loop from="0" to="4" }}
+<{{ grid.{value}.grid_text_1 ?? 'Empty' }}>
+{{ /loop }}


### PR DESCRIPTION
This PR resolves `Statamic\Fields\Values` objects within the data manager. This change makes array plucking, dynamic access, etc. work with fieldtypes that argument to `Values`, such as the grid.

Before the fix, using array plucking on a grid field would not work as expected:

```antlers
{{ grid_field.0.field_name }}
```

The provided test case will also fail when moved to the base branch.

Source: https://discord.com/channels/489818810157891584/489819906540568593/983275015992659980