### PR TITLE
Rename mount tag so it doesn't clash with variable

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -150,7 +150,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Tags\Markdown::class,
         Tags\Member::class,
         Tags\Mix::class,
-        Tags\Mount::class,
+        Tags\MountUrl::class,
         Tags\Nav::class,
         Tags\NotFound::class,
         Tags\Obfuscate::class,

--- a/src/Tags/MountUrl.php
+++ b/src/Tags/MountUrl.php
@@ -5,10 +5,12 @@ namespace Statamic\Tags;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
 
-class Mount extends Tags
+class MountUrl extends Tags
 {
+    protected static $aliases = ['mount'];
+
     /**
-     * {{ mount:* }}.
+     * {{ mount_url:* }}.
      */
     public function wildcard($tag)
     {
@@ -16,7 +18,7 @@ class Mount extends Tags
     }
 
     /**
-     * {{ mount handle="" }}.
+     * {{ mount_url handle="" }}.
      */
     public function index()
     {

--- a/src/Tags/MountUrl.php
+++ b/src/Tags/MountUrl.php
@@ -7,8 +7,6 @@ use Statamic\Facades\Site;
 
 class MountUrl extends Tags
 {
-    protected static $aliases = ['mount'];
-
     /**
      * {{ mount_url:* }}.
      */

--- a/tests/Tags/MountUrlTagTest.php
+++ b/tests/Tags/MountUrlTagTest.php
@@ -29,10 +29,14 @@ class MountTagTest extends TestCase
         $mountFr = EntryFactory::collection('pages')->slug('le-blog')->locale('french')->origin('blog-en')->id('blog-fr')->create();
         Collection::make('blog')->routes('{mount}/{slug}')->mount($mountEn->id())->save();
 
+        $this->assertParseEquals('/pages/blog', '{{ mount_url:blog }}');
+        $this->assertParseEquals('/pages/blog', '{{ mount_url handle="blog" }}');
         $this->assertParseEquals('/pages/blog', '{{ mount:blog }}');
         $this->assertParseEquals('/pages/blog', '{{ mount handle="blog" }}');
 
         Site::setCurrent('french');
+        $this->assertParseEquals('/fr/le-pages/le-blog', '{{ mount_url:blog }}');
+        $this->assertParseEquals('/fr/le-pages/le-blog', '{{ mount_url handle="blog" }}');
         $this->assertParseEquals('/fr/le-pages/le-blog', '{{ mount:blog }}');
         $this->assertParseEquals('/fr/le-pages/le-blog', '{{ mount handle="blog" }}');
     }

--- a/tests/Tags/MountUrlTagTest.php
+++ b/tests/Tags/MountUrlTagTest.php
@@ -9,7 +9,7 @@ use Statamic\Facades\Site;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
-class MountTagTest extends TestCase
+class MountUrlTagTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
@@ -31,14 +31,10 @@ class MountTagTest extends TestCase
 
         $this->assertParseEquals('/pages/blog', '{{ mount_url:blog }}');
         $this->assertParseEquals('/pages/blog', '{{ mount_url handle="blog" }}');
-        $this->assertParseEquals('/pages/blog', '{{ mount:blog }}');
-        $this->assertParseEquals('/pages/blog', '{{ mount handle="blog" }}');
 
         Site::setCurrent('french');
         $this->assertParseEquals('/fr/le-pages/le-blog', '{{ mount_url:blog }}');
         $this->assertParseEquals('/fr/le-pages/le-blog', '{{ mount_url handle="blog" }}');
-        $this->assertParseEquals('/fr/le-pages/le-blog', '{{ mount:blog }}');
-        $this->assertParseEquals('/fr/le-pages/le-blog', '{{ mount handle="blog" }}');
     }
 
     private function assertParseEquals($expected, $template, $context = [])


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/6180

Includes `mount` as an alias so it's non-breaking and you can still use that in Blade or with disambiguation.