### PR TITLE
Add column selector to users listing

### DIFF
--- a/resources/js/components/users/Listing.vue
+++ b/resources/js/components/users/Listing.vue
@@ -31,6 +31,7 @@
                         v-show="items.length"
                         :allow-bulk-actions="true"
                         :allow-column-picker="true"
+                        :column-preferences-key="preferencesKey('columns')"
                         @sorted="sorted"
                     >
                         <template slot="cell-email" slot-scope="{ row: user, value }">
@@ -87,6 +88,7 @@ export default {
 
     data() {
         return {
+            preferencesPrefix: 'users',
             requestUrl: cp_url('users'),
         }
     },

--- a/resources/js/components/users/Listing.vue
+++ b/resources/js/components/users/Listing.vue
@@ -45,6 +45,9 @@
                             <span v-if="!roles || roles.length === 0" />
                             <span v-for="role in (roles || [])" class="badge-pill-sm mr-sm">{{ role.title }}</span>
                         </template>
+                        <template slot="cell-groups" slot-scope="{ row: user, value: groups }">
+                            <span v-for="group in (groups || [])" class="badge-pill-sm mr-sm">{{ group.title }}</span>
+                        </template>
                         <template slot="actions" slot-scope="{ row: user, index }">
                             <dropdown-list>
                                 <dropdown-item :text="__('Edit')" :redirect="user.edit_url" v-if="user.editable" />

--- a/resources/js/components/users/Listing.vue
+++ b/resources/js/components/users/Listing.vue
@@ -27,9 +27,10 @@
                         @started="actionStarted"
                         @completed="actionCompleted"
                     />
-                    <data-list-table 
+                    <data-list-table
                         v-show="items.length"
                         :allow-bulk-actions="true"
+                        :allow-column-picker="true"
                         @sorted="sorted"
                     >
                         <template slot="cell-email" slot-scope="{ row: user, value }">

--- a/src/Auth/UserRepository.php
+++ b/src/Auth/UserRepository.php
@@ -54,10 +54,10 @@ abstract class UserRepository implements RepositoryContract
     public function blueprint()
     {
         $blueprint = Blueprint::find('user') ?? Blueprint::makeFromFields([
-            'name' => ['type' => 'text', 'display' => 'Name'],
-            'email' => ['type' => 'text', 'input_type' => 'email', 'display' => 'Email Address'],
-            'roles' => ['type' => 'user_roles', 'mode' => 'select', 'width' => 50],
-            'groups' => ['type' => 'user_groups', 'mode' => 'select', 'width' => 50],
+            'email' => ['type' => 'text', 'input_type' => 'email', 'display' => 'Email Address', 'listable' => true],
+            'name' => ['type' => 'text', 'display' => 'Name', 'listable' => true],
+            'roles' => ['type' => 'user_roles', 'mode' => 'select', 'width' => 50, 'listable' => true],
+            'groups' => ['type' => 'user_groups', 'mode' => 'select', 'width' => 50, 'listable' => 'hidden'],
         ])->setHandle('user');
 
         UserBlueprintFound::dispatch($blueprint);

--- a/src/Auth/UserRepository.php
+++ b/src/Auth/UserRepository.php
@@ -53,14 +53,11 @@ abstract class UserRepository implements RepositoryContract
 
     public function blueprint()
     {
-        // TODO: Cache this?
-        $groupsExist = UserGroup::all()->count() > 0;
-
         $blueprint = Blueprint::find('user') ?? Blueprint::makeFromFields([
             'email' => ['type' => 'text', 'input_type' => 'email', 'display' => 'Email Address', 'listable' => true],
             'name' => ['type' => 'text', 'display' => 'Name', 'listable' => true],
             'roles' => ['type' => 'user_roles', 'mode' => 'select', 'width' => 50, 'listable' => true],
-            'groups' => ['type' => 'user_groups', 'mode' => 'select', 'width' => 50, 'listable' => $groupsExist ?: 'hidden'],
+            'groups' => ['type' => 'user_groups', 'mode' => 'select', 'width' => 50, 'listable' => true],
         ])->setHandle('user');
 
         UserBlueprintFound::dispatch($blueprint);

--- a/src/Auth/UserRepository.php
+++ b/src/Auth/UserRepository.php
@@ -53,11 +53,14 @@ abstract class UserRepository implements RepositoryContract
 
     public function blueprint()
     {
+        // TODO: Cache this?
+        $groupsExist = UserGroup::all()->count() > 0;
+
         $blueprint = Blueprint::find('user') ?? Blueprint::makeFromFields([
             'email' => ['type' => 'text', 'input_type' => 'email', 'display' => 'Email Address', 'listable' => true],
             'name' => ['type' => 'text', 'display' => 'Name', 'listable' => true],
             'roles' => ['type' => 'user_roles', 'mode' => 'select', 'width' => 50, 'listable' => true],
-            'groups' => ['type' => 'user_groups', 'mode' => 'select', 'width' => 50, 'listable' => 'hidden'],
+            'groups' => ['type' => 'user_groups', 'mode' => 'select', 'width' => 50, 'listable' => $groupsExist ?: 'hidden'],
         ])->setHandle('user');
 
         UserBlueprintFound::dispatch($blueprint);

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -5,7 +5,6 @@ namespace Statamic\Http\Controllers\CP\Users;
 use Illuminate\Http\Request;
 use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Contracts\Auth\User as UserContract;
-use Statamic\CP\Column;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Scope;
 use Statamic\Facades\User;
@@ -15,7 +14,6 @@ use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Http\Resources\CP\Users\Users;
 use Statamic\Notifications\ActivateAccount;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
-use Statamic\Statamic;
 
 class UsersController extends CpController
 {
@@ -65,15 +63,8 @@ class UsersController extends CpController
             ->paginate(request('perPage'));
 
         return (new Users($users))
-            ->blueprint($blueprint = User::blueprint())
-            ->columns(collect([
-                Column::make('email')->label(__('Email')),
-                $blueprint->hasField('name') ? Column::make('name')->label(__('Name')) : null,
-                $blueprint->hasField('first_name') ? Column::make('first_name')->label(__('First Name')) : null,
-                $blueprint->hasField('last_name') ? Column::make('last_name')->label(__('Last Name')) : null,
-                Statamic::pro() ? Column::make('roles')->label(__('Roles'))->fieldtype('relationship')->sortable(false) : null,
-                Column::make('last_login')->label(__('Last Login'))->sortable(false),
-            ])->filter()->values()->all())
+            ->blueprint(User::blueprint())
+            ->columnPreferenceKey('users.columns')
             ->additional(['meta' => [
                 'activeFilterBadges' => $activeFilterBadges,
             ]]);

--- a/src/Http/Resources/CP/Users/ListedUser.php
+++ b/src/Http/Resources/CP/Users/ListedUser.php
@@ -30,7 +30,11 @@ class ListedUser extends JsonResource
         return [
             'id' => $this->id(),
             'last_login' => optional($this->lastLogin())->diffForHumans() ?? __('Never'),
-            $this->merge($this->values(['email' => $this->email()])),
+            $this->merge($this->values([
+                'email' => $this->email(),
+                'roles' => $this->roles()->map->handle()->all(),
+                'groups' => $this->groups()->map->handle()->all(),
+            ])),
             'super' => $this->isSuper(),
             'edit_url' => $this->editUrl(),
             'avatar' => $this->avatar(),

--- a/src/Http/Resources/CP/Users/Users.php
+++ b/src/Http/Resources/CP/Users/Users.php
@@ -44,7 +44,12 @@ class Users extends ResourceCollection
 
         $columns->forget('avatar');
 
-        $columns->put('last_login', Column::make('last_login')->label(__('Last Login'))->sortable(false));
+        $lastLogin = Column::make('last_login')
+            ->label(__('Last Login'))
+            ->sortable(false)
+            ->defaultOrder($columns->max('defaultOrder') + 1);
+
+        $columns->put('last_login', $lastLogin);
 
         if ($key = $this->columnPreferenceKey) {
             $columns->setPreferred($key);

--- a/src/Http/Resources/CP/Users/Users.php
+++ b/src/Http/Resources/CP/Users/Users.php
@@ -3,12 +3,18 @@
 namespace Statamic\Http\Resources\CP\Users;
 
 use Illuminate\Http\Resources\Json\ResourceCollection;
+use Statamic\CP\Column;
+use Statamic\Http\Resources\CP\Concerns\HasRequestedColumns;
+use Statamic\Statamic;
 
 class Users extends ResourceCollection
 {
+    use HasRequestedColumns;
+
     public $collects = ListedUser::class;
     protected $blueprint;
     protected $columns;
+    protected $columnPreferenceKey;
 
     public function blueprint($blueprint)
     {
@@ -17,24 +23,51 @@ class Users extends ResourceCollection
         return $this;
     }
 
-    public function columns($columns)
+    public function columnPreferenceKey($key)
     {
-        $this->columns = collect($columns);
+        $this->columnPreferenceKey = $key;
+
+        return $this;
+    }
+
+    private function setColumns()
+    {
+        $columns = $this->blueprint->columns();
+
+        if (Statamic::pro()) {
+            $columns->put('roles', $columns->get('roles')->fieldtype('relationship')->sortable(false));
+            $columns->put('groups', $columns->get('groups')->fieldtype('relationship')->sortable(false));
+        } else {
+            $columns->forget('roles');
+            $columns->forget('groups');
+        }
+
+        $columns->forget('avatar');
+
+        $columns->put('last_login', Column::make('last_login')->label(__('Last Login'))->sortable(false));
+
+        if ($key = $this->columnPreferenceKey) {
+            $columns->setPreferred($key);
+        }
+
+        $this->columns = $columns->rejectUnlisted()->values();
 
         return $this;
     }
 
     public function toArray($request)
     {
+        $this->setColumns();
+
         return [
             'data' => $this->collection->each(function ($user) {
                 $user
                     ->blueprint($this->blueprint)
-                    ->columns($this->columns);
+                    ->columns($this->requestedColumns());
             }),
 
             'meta' => [
-                'columns' => $this->columns,
+                'columns' => $this->visibleColumns(),
             ],
         ];
     }


### PR DESCRIPTION
- [x] Add column selector to users listing.
    - [x] Wire up column preferences.
    - [x] Ensure email column displays first by default (unless user preferences dictate otherwise).
    - [x] Add user groups column (shown by default, but only if groups exist).
    - [x] Fix roles and user groups on users listing when using Eloquent users.
    - [x] Ensure all of this feels the same with and without default `user.yaml` blueprint file in app.

![CleanShot 2022-06-21 at 18 20 06](https://user-images.githubusercontent.com/5187394/174906517-a357ebc2-609d-4fff-bf07-efe34b456b48.gif)