### PR TITLE
Fix JS error when a field has a number

### DIFF
--- a/resources/js/components/field-conditions/Omitter.js
+++ b/resources/js/components/field-conditions/Omitter.js
@@ -42,7 +42,7 @@ export default class {
     }
 
     dottedKeyToJsPath(dottedKey) {
-        return dottedKey.replace(/\.*(\d+)\./g, '[$1].');
+        return dottedKey.replace(/\.*\.(\d+)\./g, '[$1].');
     }
 
     missingValue(dottedKey) {

--- a/resources/js/tests/FieldConditionsOmitter.test.js
+++ b/resources/js/tests/FieldConditionsOmitter.test.js
@@ -46,7 +46,7 @@ test('it omits nested values', () => {
                 ],
             },
         ],
-        foo_123: [
+        foo123: [
             {
                 hello: 'alfa',
                 world: 'bravo'
@@ -55,7 +55,17 @@ test('it omits nested values', () => {
                 hello: 'charlie',
                 world: 'delta'
             }
-        ]
+        ],
+        foo123bar: [
+            {
+                hello: 'alfa',
+                world: 'bravo'
+            },
+            {
+                hello: 'charlie',
+                world: 'delta'
+            }
+        ],
     };
 
     let omitted = new Omitter(values).omit([
@@ -63,7 +73,8 @@ test('it omits nested values', () => {
         'ship.completed_kessel_run',
         'bffs.0.type',
         'bffs.1.crush.0.name',
-        'foo_123.0.hello',
+        'foo123.0.hello',
+        'foo123bar.0.hello',
     ]);
 
     let expected = {
@@ -86,7 +97,7 @@ test('it omits nested values', () => {
                 ],
             },
         ],
-        foo_123: [
+        foo123: [
             {
                 world: 'bravo'
             },
@@ -94,7 +105,16 @@ test('it omits nested values', () => {
                 hello: 'charlie',
                 world: 'delta'
             }
-        ]
+        ],
+        foo123bar: [
+            {
+                world: 'bravo'
+            },
+            {
+                hello: 'charlie',
+                world: 'delta'
+            }
+        ],
     };
 
     expect(omitted).toEqual(expected);

--- a/resources/js/tests/FieldConditionsOmitter.test.js
+++ b/resources/js/tests/FieldConditionsOmitter.test.js
@@ -46,6 +46,16 @@ test('it omits nested values', () => {
                 ],
             },
         ],
+        foo_123: [
+            {
+                hello: 'alfa',
+                world: 'bravo'
+            },
+            {
+                hello: 'charlie',
+                world: 'delta'
+            }
+        ]
     };
 
     let omitted = new Omitter(values).omit([
@@ -53,6 +63,7 @@ test('it omits nested values', () => {
         'ship.completed_kessel_run',
         'bffs.0.type',
         'bffs.1.crush.0.name',
+        'foo_123.0.hello',
     ]);
 
     let expected = {
@@ -75,6 +86,15 @@ test('it omits nested values', () => {
                 ],
             },
         ],
+        foo_123: [
+            {
+                world: 'bravo'
+            },
+            {
+                hello: 'charlie',
+                world: 'delta'
+            }
+        ]
     };
 
     expect(omitted).toEqual(expected);


### PR DESCRIPTION
Fixes #5907
Fixes #6175 

There's some logic in a JS class that converts a "dotted path" to a "js path" that uses braces around numeric keys.
e.g. `foo.0.bar.baz` to `foo[0].bar.baz`

But the regex was too aggressive, causing braces to be added around parts of field names with numbers.
e.g. `field_1.0.bar.baz` to `field_[1].[0].bar.baz`, which is invalid, and results in the errors from the issues.

**Numbers at the *start* of a field name will still be broken.** I think this is a less common situation though. It requires a more drastic change to fix, so leaving it for another time.