### PR TITLE
Use old generic validation exception summary

### DIFF
--- a/src/Exceptions/ControlPanelExceptionHandler.php
+++ b/src/Exceptions/ControlPanelExceptionHandler.php
@@ -5,6 +5,7 @@ namespace Statamic\Exceptions;
 use Illuminate\Foundation\Exceptions\Handler;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Validation\ValidationException;
+use Statamic\Exceptions\ValidationException as StatamicValidationException;
 use Throwable;
 
 class ControlPanelExceptionHandler extends Handler
@@ -18,6 +19,8 @@ class ControlPanelExceptionHandler extends Handler
 
     protected function convertValidationExceptionToResponse(ValidationException $e, $request)
     {
+        $e = $this->newStatamicValidationException($e);
+
         $response = parent::convertValidationExceptionToResponse($e, $request);
 
         if ($response instanceof JsonResponse) {
@@ -27,5 +30,15 @@ class ControlPanelExceptionHandler extends Handler
         }
 
         return $response;
+    }
+
+    private function newStatamicValidationException(ValidationException $old): StatamicValidationException
+    {
+        $e = new StatamicValidationException($old->validator, $old->response, $old->errorBag);
+
+        $e->redirectTo($old->redirectTo);
+        $e->status($old->status);
+
+        return $e;
     }
 }

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Exceptions;
+
+use Illuminate\Validation\ValidationException as Exception;
+
+class ValidationException extends Exception
+{
+    public static function summarize($validation)
+    {
+        return 'The given data was invalid.';
+    }
+}


### PR DESCRIPTION
Laravel 9 introduced a "validation summary". https://github.com/laravel/framework/pull/35524

![CleanShot 2022-06-10 at 17 35 16](https://user-images.githubusercontent.com/105211/173154302-cc9a846f-5aa6-49ad-bb31-a1259c644d0a.png)

Normally when you have a validation exception, you'd loop over the validation errors and it wouldn't be an issue.

However in Statamic we're using inline validation messages. e.g. `This field is required` instead of `The title field is required`. Then we displayed the generic exception message in the toast: `The given data is invalid.`

In Laravel 9 the messaged changed to `[first validation message] (and 3 more)` which is super awkward when our inline translations are used.

"This" field? Which field?

This PR adds a custom Validation exception class that overrides the summary to the old text, but only within the Control Panel.
