### PR TITLE
Fix get_error tag outputting something when there are other errors

### DIFF
--- a/src/Tags/GetError.php
+++ b/src/Tags/GetError.php
@@ -15,6 +15,10 @@ class GetError extends GetErrors
             return false;
         }
 
-        return ['message' => $errors->first($name)];
+        if (! $error = $errors->first($name)) {
+            return false;
+        }
+
+        return ['message' => $error];
     }
 }

--- a/tests/Tags/GetErrorTest.php
+++ b/tests/Tags/GetErrorTest.php
@@ -37,6 +37,19 @@ class GetErrorTest extends TestCase
     }
 
     /** @test */
+    public function it_outputs_nothing_when_there_are_errors_but_not_for_the_given_field_in_a_specific_bag()
+    {
+        view()->share('errors', (new ViewErrorBag())->put('custom', new MessageBag([
+            'name' => ['name is required'],
+        ])));
+
+        $this->assertEquals(
+            '',
+            $this->tag('{{ get_error:email bag="custom" }}before {{ message }} after{{ /get_error:email }}')
+        );
+    }
+
+    /** @test */
     public function it_outputs_nothing_when_the_field_doesnt_have_an_error_for_specific_bag()
     {
         view()->share('errors', (new ViewErrorBag())->put('custom', new MessageBag([])));
@@ -44,6 +57,19 @@ class GetErrorTest extends TestCase
         $this->assertEquals(
             '',
             $this->tag('{{ get_error:email bag="custom" }}before {{ message }} after{{ /get_error:email }}')
+        );
+    }
+
+    /** @test */
+    public function it_outputs_nothing_when_there_are_errors_but_not_for_the_given_field()
+    {
+        view()->share('errors', (new ViewErrorBag())->put('default', new MessageBag([
+            'name' => ['name is required'],
+        ])));
+
+        $this->assertEquals(
+            '',
+            $this->tag('{{ get_error:email }}before {{ message }} after{{ /get_error:email }}')
         );
     }
 


### PR DESCRIPTION
Fixes #6196

The `get_error:somefield` tag pair should output nothing if there are no `somefield` errors.

Currently, the tag pair only outputs nothing if there are no validation errors *at all*. This fixes that.
