### PR TITLE
Maintain iframe scroll position in live preview

### DIFF
--- a/resources/js/components/live-preview/UpdatesIframe.js
+++ b/resources/js/components/live-preview/UpdatesIframe.js
@@ -21,7 +21,9 @@ export default {
 
             container.replaceChild(iframe, container.firstChild);
 
-            iframe.contentWindow.scrollTo(...scroll);
+            setTimeout(() => {
+                iframe.contentWindow.scrollTo(...scroll);
+            }, 200);
         },
 
         setIframeAttributes(iframe) {

--- a/resources/js/components/live-preview/UpdatesIframe.js
+++ b/resources/js/components/live-preview/UpdatesIframe.js
@@ -8,11 +8,20 @@ export default {
             this.setIframeAttributes(iframe);
 
             const container = this.$refs.contents;
-            container.firstChild
-                ? container.replaceChild(iframe, container.firstChild)
-                : container.appendChild(iframe);
 
-            // todo: maintain scroll position
+            if (! container.firstChild) {
+                container.appendChild(iframe);
+                return;
+            }
+
+            const scroll = [
+                container.firstChild.contentWindow.scrollX ?? 0,
+                container.firstChild.contentWindow.scrollY ?? 0
+            ];
+
+            container.replaceChild(iframe, container.firstChild);
+
+            iframe.contentWindow.scrollTo(...scroll);
         },
 
         setIframeAttributes(iframe) {


### PR DESCRIPTION
There may be other use cases I've not considered, but on a vanilla Statamic install its very frustrating to have live preview keep jumping back to the top every time you make a change... so this PR attempts to maintain the scroll position by getting and resetting the scroll position.

Fixes: #5564 