### PR TITLE
[Fix] class Field : Using config type fallback

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -165,7 +165,7 @@ class Field implements Arrayable
             return true;
         }
 
-        if ($this->config()['type'] === 'section') {
+        if ($this->type() === 'section') {
             return false;
         }
 


### PR DESCRIPTION
The 'isListable' method is tying to access an undefined array key "type" while accessing page listing.
The issue is fixed using the method 'type' which provide a fallback.