### PR TITLE
Augment date fields to Illuminate\Support\Carbon

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Fieldtypes;
 
-use Carbon\Carbon;
 use Carbon\Exceptions\InvalidFormatException;
+use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Fieldtypes;
 
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Date;
 use Tests\TestCase;


### PR DESCRIPTION
This allows you to use any available macros on the date field values.

Closes: [662](https://github.com/statamic/ideas/issues/662)