### PR TITLE
Add truncate method to collections and taxonomies

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -680,6 +680,13 @@ class Collection implements Contract, AugmentableContract, ArrayAccess, Arrayabl
         return true;
     }
 
+    public function truncate()
+    {
+        $this->queryEntries()->get()->each->delete();
+
+        return true;
+    }
+
     public function mount($page = null)
     {
         return $this

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -179,6 +179,13 @@ class Taxonomy implements Contract, Responsable, AugmentableContract, ArrayAcces
         return true;
     }
 
+    public function truncate()
+    {
+        $this->queryTerms()->get()->each->delete();
+
+        return true;
+    }
+
     public function fileData()
     {
         $data = [

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -742,6 +742,21 @@ class CollectionTest extends TestCase
         ], $collection->additionalPreviewTargets()->all());
     }
 
+    /** @test */
+    public function it_trucates_entries()
+    {
+        $collection = Facades\Collection::make('test')->save();
+        Facades\Entry::make()->collection('test')->id('1')->slug('one')->save();
+        Facades\Entry::make()->collection('test')->id('2')->slug('two')->save();
+        Facades\Entry::make()->collection('test')->id('3')->slug('three')->save();
+
+        $this->assertCount(3, $collection->queryEntries()->get());
+
+        $collection->truncate();
+
+        $this->assertCount(0, $collection->queryEntries()->get());
+    }
+
     public function additionalPreviewTargetProvider()
     {
         return [

--- a/tests/Data/Taxonomies/TaxonomyTest.php
+++ b/tests/Data/Taxonomies/TaxonomyTest.php
@@ -5,6 +5,7 @@ namespace Tests\Data\Taxonomies;
 use Facades\Statamic\Fields\BlueprintRepository;
 use Illuminate\Contracts\Support\Arrayable;
 use Statamic\Contracts\Entries\Entry as EntryContract;
+use Statamic\Facades;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
@@ -230,6 +231,21 @@ class TaxonomyTest extends TestCase
             ['label' => 'Baz', 'format' => '{baz}'],
             ['label' => 'Qux', 'format' => '{qux}'],
         ], $taxonomy->additionalPreviewTargets()->all());
+    }
+
+    /** @test */
+    public function it_trucates_terms()
+    {
+        $taxonomy = tap(Facades\Taxonomy::make('tags'))->save();
+        Facades\Term::make()->taxonomy('tags')->slug('one')->data([])->save();
+        Facades\Term::make()->taxonomy('tags')->slug('two')->data([])->save();
+        Facades\Term::make()->taxonomy('tags')->slug('three')->data([])->save();
+
+        $this->assertCount(3, $taxonomy->queryTerms()->get());
+
+        $taxonomy->truncate();
+
+        $this->assertCount(0, $taxonomy->queryTerms()->get());
     }
 
     public function additionalPreviewTargetProvider()


### PR DESCRIPTION
I've been working on a script to import data into a fresh Statamic install. When testing the script I want to clear out the previous data first. While this is simple enough, this PR adds a shorter convenience method called `truncate` that you can use to empty out a collection or taxonomy.