### PR TITLE
Handle query builder when using json_encode or to_json.

### DIFF
--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -61,12 +61,12 @@ class Value implements IteratorAggregate, JsonSerializable
     {
         $value = $this->value();
 
-        if ($value instanceof Augmentable || $value instanceof Collection) {
-            $value = $value->toAugmentedArray();
+        if ($value instanceof OrderedQueryBuilder) {
+            $value = $value->get();
         }
 
-        if ($value instanceof OrderedQueryBuilder) {
-            $value = $this->value()->get()->toAugmentedArray();
+        if ($value instanceof Augmentable || $value instanceof Collection) {
+            $value = $value->toAugmentedArray();
         }
 
         return $value;

--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -8,8 +8,8 @@ use IteratorAggregate;
 use JsonSerializable;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\View\Antlers\Parser;
-use Statamic\Support\Str;
 use Statamic\Query\OrderedQueryBuilder;
+use Statamic\Support\Str;
 use Statamic\View\Antlers\Language\Parser\DocumentTransformer;
 
 class Value implements IteratorAggregate, JsonSerializable

--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -66,7 +66,7 @@ class Value implements IteratorAggregate, JsonSerializable
         }
 
         if ($value instanceof OrderedQueryBuilder) {
-            $value = $this->value()->get();
+            $value = $this->value()->get()->toAugmentedArray();
         }
 
         return $value;

--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -9,6 +9,7 @@ use JsonSerializable;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\View\Antlers\Parser;
 use Statamic\Support\Str;
+use Statamic\Query\OrderedQueryBuilder;
 use Statamic\View\Antlers\Language\Parser\DocumentTransformer;
 
 class Value implements IteratorAggregate, JsonSerializable
@@ -62,6 +63,10 @@ class Value implements IteratorAggregate, JsonSerializable
 
         if ($value instanceof Augmentable || $value instanceof Collection) {
             $value = $value->toAugmentedArray();
+        }
+
+        if ($value instanceof OrderedQueryBuilder) {
+            $value = $this->value()->get();
         }
 
         return $value;


### PR DESCRIPTION
This fixes #5866, #6130 and other related to `to_json` bugs. (also tested in Duncan's demo of this bug)

Since 3.3 we have a lot of trouble with the `to_json`modifer or with custom PHP code that uses `json_encode` when trying to pass data to Vue. Generally, when using the fields that now return QueryBuilder instances like `Assets` or `Taxonomy Terms` nested inside `Bard` or `Replicator` fields, when converting them to JSON they turn out empty.

I am not sure if this is a complete (or even correct) fix, I am just hoping to speed things up as we have to keep many sites at 3.2 because fixing this issue otherwise requires changing a lot of frontend code.

Thanks!