### PR TITLE
Move data finding controller logic into repository

### DIFF
--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -5,11 +5,8 @@ namespace Statamic\Http\Controllers;
 use Illuminate\Http\Request;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Data;
-use Statamic\Facades\Site;
 use Statamic\Http\Responses\DataResponse;
-use Statamic\Statamic;
 use Statamic\Support\Arr;
-use Statamic\Support\Str;
 use Statamic\View\View;
 
 /**
@@ -29,21 +26,7 @@ class FrontendController extends Controller
      */
     public function index(Request $request)
     {
-        $url = Site::current()->relativePath($request->getUri());
-
-        if (Statamic::isAmpRequest()) {
-            $url = Str::ensureLeft(Str::after($url, '/'.config('statamic.amp.route')), '/');
-        }
-
-        if (Str::contains($url, '?')) {
-            $url = substr($url, 0, strpos($url, '?'));
-        }
-
-        if (Str::endsWith($url, '/') && Str::length($url) > 1) {
-            $url = rtrim($url, '/');
-        }
-
-        if ($data = Data::findByUri($url, Site::current()->handle())) {
+        if ($data = Data::findByRequestUrl($request->url())) {
             return $data;
         }
 


### PR DESCRIPTION
When you visit a Statamic route, the `FrontendController` has a bunch of logic to work out which entry/term/etc should be loaded.

This PR moves that controller logic into the `DataRepository` class so it can be used it in other places. (e.g in the upcoming static caching exclusion PR #6231)

```php
Statamic\Facades\Data::findByRequestUrl('http://mysite.com/foo');
```