### PR TITLE
Support passing additional view data into parsers

### DIFF
--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -754,7 +754,7 @@ INFO;
         }
 
         $data = array_merge($data, [
-            'view' => $this->cascade->getViewData($view),
+            'view' => array_merge($this->cascade->getViewData($view), $data['view'] ?? []),
         ]);
 
         $parsed = $this->renderText($text, $data);

--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -128,7 +128,9 @@ class Parser implements ParserContract
 
         $this->view = $view;
 
-        $data = array_merge($data, ['view' => $this->cascade->getViewData($view)]);
+        $data = array_merge($data, [
+            'view' => array_merge($this->cascade->getViewData($view), $data['view'] ?? []),
+        ]);
 
         try {
             $parsed = $this->parse($text, $data);

--- a/tests/Antlers/ParserTestCase.php
+++ b/tests/Antlers/ParserTestCase.php
@@ -211,6 +211,20 @@ class ParserTestCase extends TestCase
 
     protected function renderString($text, $data = [], $withCoreTagsAndModifiers = false)
     {
+        $runtimeParser = $this->newParser($data, $withCoreTagsAndModifiers);
+
+        return StringUtilities::normalizeLineEndings((string) $runtimeParser->parse($text, $data));
+    }
+
+    protected function renderView($view, $template, $data = [], $withCoreTagsAndModifiers = false)
+    {
+        $runtimeParser = $this->newParser($data, $withCoreTagsAndModifiers);
+
+        return StringUtilities::normalizeLineEndings((string) $runtimeParser->parseView($view, $template, $data));
+    }
+
+    protected function newParser($data, $withCoreTagsAndModifiers)
+    {
         ModifierManager::$statamicModifiers = null;
         GlobalRuntimeState::resetGlobalState();
 
@@ -234,7 +248,7 @@ class ParserTestCase extends TestCase
             $runtimeParser->cascade(app(Cascade::class));
         }
 
-        return StringUtilities::normalizeLineEndings((string) $runtimeParser->parse($text, $data));
+        return $runtimeParser;
     }
 
     protected function getParsedRuntimeNodes($text)

--- a/tests/View/Antlers/ParserTest.php
+++ b/tests/View/Antlers/ParserTest.php
@@ -20,6 +20,11 @@ class ParserTest extends TestCase
         return (string) $this->parser()->parse($template, $data);
     }
 
+    private function renderView($view, $template, $data = [])
+    {
+        return (string) $this->parser()->parseView($view, $template, $data);
+    }
+
     private function parser()
     {
         return Antlers::parser();

--- a/tests/View/Antlers/ParserTests.php
+++ b/tests/View/Antlers/ParserTests.php
@@ -2460,6 +2460,32 @@ EOT;
         ];
     }
 
+    /** @test */
+    public function it_parses_a_view()
+    {
+        \Facades\Statamic\View\Cascade::set('views', ['testview' => ['author' => 'bob']]);
+
+        $rendered = $this->renderView('testview', 'its me, {{ view:author }}', [], true);
+
+        $this->assertEquals('its me, bob', $rendered);
+    }
+
+    /** @test */
+    public function it_parses_a_view_with_extra_view_array()
+    {
+        \Facades\Statamic\View\Cascade::set('views', ['testview' => ['author' => 'bob']]);
+
+        $data = [
+            'view' => [
+                'name' => 'joe',
+            ],
+        ];
+
+        $rendered = $this->renderView('testview', 'hello {{ view:name }}, its {{ view:author }}', $data, true);
+
+        $this->assertEquals('hello joe, its bob', $rendered);
+    }
+
     private function assertEqualsWithCollapsedNewlines($expected, $actual)
     {
         $expected = trim($expected);


### PR DESCRIPTION
At the moment if you do `{{ view:something }}`, it will only look at front-matter for the view.

```antlers
---
greeting: hello
person: jerry
---
{{ view:greeting }} {{ view:person }}    outputs "hello jerry"
```

However if a tag or something explicitly provides an array called `view`, it will ignore that and still just look at the front-matter.

```php
return [
  'view' => [
    'person' => 'newman'
  ]
];
```
```antlers
---
greeting: hello
person: jerry
---
{{ mytag }}
  {{ view:greeting }}
  {{ view:person }}
{{ /mytag }} 

outputs "hello jerry"
```

With this PR, if there's an explicit `view` array somewhere, it'll merge that in.

```antlers
---
greeting: hello
person: jerry
---
{{ mytag }}
  {{ view:greeting }}
  {{ view:person }}
{{ /mytag }} 

outputs "hello newman"
```

Will be used by #6231.