### PR TITLE
Add item totals to CP listings/pagination

### DIFF
--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -151,11 +151,11 @@ export default {
         },
 
         fromItem() {
-            return this.resourceMeta.from;
+            return this.resourceMeta.from ?? 0;
         },
 
         toItem() {
-            return this.resourceMeta.to;
+            return this.resourceMeta.to ?? 0;
         },
 
         totalItems() {

--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -2,7 +2,11 @@
 
     <div class="w-full flex">
 
-        <div class="flex-1" v-if="! inline"></div>
+        <div class="flex flex-1" v-if="! inline">
+            <div class="text-xs text-grey-70">
+                {{ __(':fromItem–:toItem of :totalItems items', { fromItem, toItem, totalItems }) }}
+            </div>
+        </div>
 
         <ul v-if="hasMultiplePages" class="pagination" :class="{'pagination-inline': inline}">
 
@@ -144,6 +148,18 @@ export default {
 
         isPerPageEvenUseful() {
             return this.resourceMeta.total > this.perPageOptions[0].value;
+        },
+
+        fromItem() {
+            return this.resourceMeta.from;
+        },
+
+        toItem() {
+            return this.resourceMeta.to;
+        },
+
+        totalItems() {
+            return this.resourceMeta.total;
         },
 
     },

--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -4,7 +4,7 @@
 
         <div class="flex flex-1" v-if="! inline && totalItems > 0">
             <div class="text-xs text-grey-70">
-                {{ __(':fromItem–:toItem of :totalItems items', { fromItem, toItem, totalItems }) }}
+                {{ __(':start-:end of :total', { start: fromItem, end: toItem, total: totalItems }) }}
             </div>
         </div>
 

--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -2,7 +2,7 @@
 
     <div class="w-full flex">
 
-        <div class="flex flex-1" v-if="! inline">
+        <div class="flex flex-1" v-if="! inline && totalItems > 0">
             <div class="text-xs text-grey-70">
                 {{ __(':fromItem–:toItem of :totalItems items', { fromItem, toItem, totalItems }) }}
             </div>

--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -151,11 +151,11 @@ export default {
         },
 
         fromItem() {
-            return this.resourceMeta.from ?? 0;
+            return this.resourceMeta.from || 0;
         },
 
         toItem() {
-            return this.resourceMeta.to ?? 0;
+            return this.resourceMeta.to || 0;
         },
 
         totalItems() {

--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -2,7 +2,7 @@
 
     <div class="w-full flex">
 
-        <div class="flex flex-1" v-if="! inline && totalItems > 0">
+        <div class="flex flex-1 items-center" v-if="! inline && totalItems > 0">
             <div class="text-xs text-grey-70">
                 {{ __(':start-:end of :total', { start: fromItem, end: toItem, total: totalItems }) }}
             </div>


### PR DESCRIPTION
This PR adds item totals to the CP listings/pagination. This is otherwise unused space so I though it might be a nice touch:

![Screenshot 2022-06-23 at 17 01 05](https://user-images.githubusercontent.com/126740/175344258-d2b5f645-18cc-4d66-99ee-86069d384b88.png)

Useful when you're searching and want to see how many entries match the filter.