### PR TITLE
Fix missing context when fetching bulk actions list

### DIFF
--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -48,6 +48,7 @@
 
                     <data-list-bulk-actions
                         :url="actionUrl"
+                        :context="actionContext"
                         @started="actionStarted"
                         @completed="actionCompleted"
                     />
@@ -124,6 +125,12 @@ export default {
             currentSite: this.site,
             initialSite: this.site,
         }
+    },
+
+    computed: {
+        actionContext() {
+            return {collection: this.collection};
+        },
     },
 
     watch: {

--- a/resources/js/components/forms/SubmissionListing.vue
+++ b/resources/js/components/forms/SubmissionListing.vue
@@ -30,6 +30,7 @@
 
                     <data-list-bulk-actions
                         :url="actionUrl"
+                        :context="actionContext"
                         @started="actionStarted"
                         @completed="actionCompleted"
                     />
@@ -89,6 +90,12 @@ export default {
             preferencesPrefix: `forms.${this.form}`,
             requestUrl: cp_url(`forms/${this.form}/submissions`),
         }
+    },
+
+    computed: {
+        actionContext() {
+            return {form: this.form};
+        },
     },
 
 }

--- a/resources/js/components/terms/Listing.vue
+++ b/resources/js/components/terms/Listing.vue
@@ -47,6 +47,7 @@
 
                     <data-list-bulk-actions
                         :url="actionUrl"
+                        :context="actionContext"
                         @started="actionStarted"
                         @completed="actionCompleted"
                     />
@@ -112,6 +113,12 @@ export default {
             preferencesPrefix: `taxonomies.${this.taxonomy}`,
             requestUrl: cp_url(`taxonomies/${this.taxonomy}/terms`),
         }
+    },
+
+    computed: {
+        actionContext() {
+            return {taxonomy: this.taxonomy};
+        },
     },
 
     methods: {


### PR DESCRIPTION
Currently only the asset browser provides context to the bulk actions component, which means the context values are missing when fetching the bulk actions for entries, terms and form submissions.

This PR adds context values to the bulk actions in the other listing components.