### PR TITLE
Runtime: fix scope reset bug with conditions under very specific circumstances

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1208,7 +1208,9 @@ class NodeProcessor
                 }
 
                 if ($node instanceof ConditionNode && ! empty($node->logicBranches)) {
+                    $lockData = $this->data;
                     $result = $this->conditionProcessor->process($node, $this->getActiveData());
+                    $this->data = $lockData;
 
                     if ($result == null) {
                         if ($this->isTracingEnabled()) {

--- a/tests/Antlers/Runtime/TagCheckScopeTest.php
+++ b/tests/Antlers/Runtime/TagCheckScopeTest.php
@@ -6,6 +6,7 @@ use Facades\Statamic\Fields\BlueprintRepository;
 use Facades\Tests\Factories\EntryFactory;
 use Statamic\Facades\Collection;
 use Statamic\Fields\Blueprint;
+use Statamic\Tags\Tags;
 use Tests\FakesViews;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -127,5 +128,45 @@ EOT;
 
         $this->assertStringContainsString('<Home Page>', $content);
         $this->assertStringContainsString('<p>I am some text<a href="/about">I am the link</a></p>', $content);
+    }
+
+    public function test_condition_augmentation_doesnt_reset_up_the_scope()
+    {
+        $this->createData();
+        $this->withFakeViews();
+
+        (new class extends Tags
+        {
+            public static $handle = 'just_a_tag';
+
+            public function index()
+            {
+                return [];
+            }
+        })::register();
+        $template = <<<'EOT'
+
+{{ just_a_tag }}
+    {{ replicator_field }}
+        {{ partial:inner }}
+    {{ /replicator_field }}
+{{ /just_a_tag }}
+EOT;
+        $partial = <<<PARTIAL
+{{ stuff }}
+
+{{ if bard_field }} {{ bard_field }} {{ /if }}
+PARTIAL;
+
+
+        $this->viewShouldReturnRaw('inner', $partial);
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('default', $template);
+
+
+        $responseOne = $this->get('/home')->assertOk();
+        $content = trim($responseOne->content());
+
+        $this->assertSame('<p>I am some text<a href="/about">I am the link</a></p>', $content);
     }
 }


### PR DESCRIPTION
This PR fixes #6256 by restoring the scope after processing conditions.

To reproduce, you may visit this repo: https://github.com/jasonvarga/statamic-issue-6256. The provided test case will also fail when moved to the base branch :)