### PR TITLE
Fix `locales` tag when using Live Preview

### DIFF
--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -157,7 +157,7 @@ class Locales extends Tags
             return $this->data;
         }
 
-        $id = $this->params->get('id', $this->context->get('id'));
+        $id = $this->params->get('id', $this->context->value('id'));
 
         return $this->data = Data::find($id);
     }

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Event;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Parse;
 use Statamic\Facades\Site;
+use Statamic\Fields\Value;
 use Tests\Factories\EntryFactory;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -429,6 +430,23 @@ HTML;
         $this->assertEquals(
             '',
             $this->tag('{{ locales self="false" }}you should not see this{{ /locales }}', ['id' => '1'])
+        );
+    }
+
+    /** @test */
+    public function it_displays_nothing_when_context_id_is_null()
+    {
+        $entry = (new EntryFactory)
+            ->collection('test')
+            ->locale('english')
+            ->data(['title' => 'hello'])
+            ->make();
+
+        $value = new Value(null, 'id', null, $entry);
+
+        $this->assertEquals(
+            '',
+            $this->tag('{{ locales }}you should not see this{{ /locales }}', ['id' => $value])
         );
     }
 }


### PR DESCRIPTION
On a multi-site, if you have a `locales` tag in your template/layout AND you create a new entry but do not save it AND you use Live Preview, there's an error because the `id` in the context is a `Value` object, which the `Data:find` method can't handle.

Using the `value` method on the context instead of `get` resolve this.

Fixes #6262 