### PR TITLE
Added Vite tag

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -174,6 +174,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Tags\Trans::class,
         Tags\TransChoice::class,
         Tags\Users::class,
+        Tags\Vite::class,
         Tags\Widont::class,
         Tags\Yields::class,
         \Statamic\Forms\Tags::class,

--- a/src/Tags/Vite.php
+++ b/src/Tags/Vite.php
@@ -13,10 +13,10 @@ class Vite extends Tags
      */
     public function index()
     {
-        if (! $src = $this->params->get('src')) {
+        if (! $src = $this->params->explode('src')) {
             throw new \Exception('Please provide a source file.');
         }
 
-        return app(LaravelVite::class)->__invoke($src);
+        return app(LaravelVite::class)($src);
     }
 }

--- a/src/Tags/Vite.php
+++ b/src/Tags/Vite.php
@@ -14,7 +14,7 @@ class Vite extends Tags
     public function index()
     {
         if (! $src = $this->params->get('src')) {
-            throw new \Exception('Please provide a source file."');
+            throw new \Exception('Please provide a source file.');
         }
 
         return app(LaravelVite::class)->__invoke($src);

--- a/src/Tags/Vite.php
+++ b/src/Tags/Vite.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Statamic\Tags;
+
+use Illuminate\Foundation\Vite as LaravelVite;
+
+class Vite extends Tags
+{
+    /**
+     * The {{ vite }} tag.
+     *
+     * @return string|array
+     */
+    public function index()
+    {
+        if (! $src = $this->params->get('src')) {
+            throw new \Exception('Please provide a source file."');
+        }
+
+        return app(LaravelVite::class)->__invoke($src);
+    }
+}


### PR DESCRIPTION
Since version [v9.19.0](https://github.com/laravel/framework/releases/tag/v9.19.0) of Laravel, Vite is now the default tool for bundling frontend assets.

In order for Statamic to fully migrate to this we will also have to change the `statamic/statamic` repo and remove the default Laravel Mix. Vite also plays nicely with Vue@2 which is required to build Fieldtypes or extending any frontend stuff.

If required I can also submit a PR to the docs for the new Vite tag.

More info on Vite at the Laravel [docs](https://laravel.com/docs/9.x/vite).

P.s thanks to @duncanmcclean for the tag.