### PR TITLE
Changes for view overrides

### DIFF
--- a/src/Exceptions/NotFoundHttpException.php
+++ b/src/Exceptions/NotFoundHttpException.php
@@ -21,7 +21,7 @@ class NotFoundHttpException extends SymfonyException
 
     protected function contents()
     {
-        return (new View)
+        return app(View::class)
             ->template('errors.404')
             ->layout($this->layout())
             ->with(['response_code' => 404])

--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -40,7 +40,7 @@ class FrontendController extends Controller
         $data = Arr::pull($params, 'data');
         $data = array_merge($params, $data);
 
-        $view = (new View)
+        $view = app(View::class)
             ->template($view)
             ->layout(Arr::get($data, 'layout', 'layout'))
             ->with($data)

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -142,7 +142,7 @@ class DataResponse implements Responsable
 
     protected function view()
     {
-        return (new View)
+        return app(View::class)
             ->template($this->data->template())
             ->layout($this->data->layout())
             ->with($this->with)

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -23,7 +23,7 @@ class View
 
     public static function make($template = null, $data = [])
     {
-        return (new static)
+        return app(static::class)
             ->template($template)
             ->with($data);
     }


### PR DESCRIPTION
Hi guys

I'd like to override the View class render method to implement some special custom caching stuff. But since the View class is called via "new View" in DataResponse and some important methods in the View class are private, this is not possible with a clean Laravel binding override approach. This would make that possible.