### PR TITLE
Remove item totals in widgets and selectors

### DIFF
--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -2,8 +2,8 @@
 
     <div class="w-full flex">
 
-        <div class="flex flex-1 items-center" v-if="! inline && totalItems > 0">
-            <div class="text-xs text-grey-70">
+        <div class="flex flex-1 items-center" v-if="! inline">
+            <div class="text-xs text-grey-70" v-if="! widget && totalItems > 0">
                 {{ __(':start-:end of :total', { start: fromItem, end: toItem, total: totalItems }) }}
             </div>
         </div>
@@ -56,6 +56,10 @@ export default {
 
     props: {
         inline: {
+            type: Boolean,
+            default: false
+        },
+        widget: {
             type: Boolean,
             default: false
         },

--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -3,7 +3,7 @@
     <div class="w-full flex">
 
         <div class="flex flex-1 items-center" v-if="! inline">
-            <div class="text-xs text-grey-70" v-if="! widget && totalItems > 0">
+            <div class="text-xs text-grey-70" v-if="totals && totalItems > 0">
                 {{ __(':start-:end of :total', { start: fromItem, end: toItem, total: totalItems }) }}
             </div>
         </div>
@@ -59,9 +59,9 @@ export default {
             type: Boolean,
             default: false
         },
-        widget: {
+        totals: {
             type: Boolean,
-            default: false
+            default: true
         },
         perPage: {
             type: Number

--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -3,7 +3,7 @@
     <div class="w-full flex">
 
         <div class="flex flex-1 items-center" v-if="! inline">
-            <div class="text-xs text-grey-70" v-if="totals && totalItems > 0">
+            <div class="text-xs text-grey-70" v-if="showTotals && totalItems > 0">
                 {{ __(':start-:end of :total', { start: fromItem, end: toItem, total: totalItems }) }}
             </div>
         </div>
@@ -59,7 +59,7 @@ export default {
             type: Boolean,
             default: false
         },
-        totals: {
+        showTotals: {
             type: Boolean,
             default: false
         },

--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -61,7 +61,7 @@ export default {
         },
         totals: {
             type: Boolean,
-            default: true
+            default: false
         },
         perPage: {
             type: Number

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -94,7 +94,7 @@
                     class="mt-3"
                     :resource-meta="meta"
                     :per-page="perPage"
-                    :totals="true"
+                    :show-totals="true"
                     @page-selected="selectPage"
                     @per-page-changed="changePerPage"
                 />

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -94,6 +94,7 @@
                     class="mt-3"
                     :resource-meta="meta"
                     :per-page="perPage"
+                    :totals="true"
                     @page-selected="selectPage"
                     @per-page-changed="changePerPage"
                 />

--- a/resources/js/components/entries/Widget.vue
+++ b/resources/js/components/entries/Widget.vue
@@ -25,7 +25,7 @@
                     v-if="meta.last_page != 1"
                     class="py-1 border-t bg-grey-20 rounded-b-lg text-sm"
                     :resource-meta="meta"
-                    :widget="true"
+                    :totals="false"
                     @page-selected="selectPage"
                     :scroll-to-top="false"
                 />

--- a/resources/js/components/entries/Widget.vue
+++ b/resources/js/components/entries/Widget.vue
@@ -25,6 +25,7 @@
                     v-if="meta.last_page != 1"
                     class="py-1 border-t bg-grey-20 rounded-b-lg text-sm"
                     :resource-meta="meta"
+                    :widget="true"
                     @page-selected="selectPage"
                     :scroll-to-top="false"
                 />

--- a/resources/js/components/entries/Widget.vue
+++ b/resources/js/components/entries/Widget.vue
@@ -25,7 +25,6 @@
                     v-if="meta.last_page != 1"
                     class="py-1 border-t bg-grey-20 rounded-b-lg text-sm"
                     :resource-meta="meta"
-                    :totals="false"
                     @page-selected="selectPage"
                     :scroll-to-top="false"
                 />

--- a/resources/js/components/forms/SubmissionListing.vue
+++ b/resources/js/components/forms/SubmissionListing.vue
@@ -64,6 +64,7 @@
                     class="mt-3"
                     :resource-meta="meta"
                     :per-page="perPage"
+                    :totals="true"
                     @page-selected="selectPage"
                     @per-page-changed="changePerPage"
                 />

--- a/resources/js/components/forms/SubmissionListing.vue
+++ b/resources/js/components/forms/SubmissionListing.vue
@@ -64,7 +64,7 @@
                     class="mt-3"
                     :resource-meta="meta"
                     :per-page="perPage"
-                    :totals="true"
+                    :show-totals="true"
                     @page-selected="selectPage"
                     @per-page-changed="changePerPage"
                 />

--- a/resources/js/components/terms/Listing.vue
+++ b/resources/js/components/terms/Listing.vue
@@ -87,7 +87,7 @@
                 <data-list-pagination
                     class="mt-3"
                     :resource-meta="meta"
-                    :totals="true"
+                    :show-totals="true"
                     @page-selected="selectPage"
                     @per-page-changed="changePerPage"
                 />

--- a/resources/js/components/terms/Listing.vue
+++ b/resources/js/components/terms/Listing.vue
@@ -87,6 +87,7 @@
                 <data-list-pagination
                     class="mt-3"
                     :resource-meta="meta"
+                    :totals="true"
                     @page-selected="selectPage"
                     @per-page-changed="changePerPage"
                 />

--- a/resources/js/components/users/Listing.vue
+++ b/resources/js/components/users/Listing.vue
@@ -63,6 +63,7 @@
                     class="mt-3"
                     :resource-meta="meta"
                     :per-page="perPage"
+                    :totals="true"
                     @page-selected="selectPage"
                     @per-page-changed="changePerPage"
                 />

--- a/resources/js/components/users/Listing.vue
+++ b/resources/js/components/users/Listing.vue
@@ -63,7 +63,7 @@
                     class="mt-3"
                     :resource-meta="meta"
                     :per-page="perPage"
-                    :totals="true"
+                    :show-totals="true"
                     @page-selected="selectPage"
                     @per-page-changed="changePerPage"
                 />


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/6276

Apologies, I overlooked this in the original PR. Have gone with the suggestion in the issue to hide them within widgets. I've also changed they way they work to be opt-in generally, as they only really work in the main listings and don't look great in the selectors either.