### PR TITLE
Include mount in a collection's augmented data

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -796,6 +796,7 @@ class Collection implements Contract, AugmentableContract, ArrayAccess, Arrayabl
         return [
             'title' => $this->title(),
             'handle' => $this->handle(),
+            'mount' => $this->mount(),
         ];
     }
 }

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Data\Entries;
 
 use Facades\Statamic\Fields\BlueprintRepository;
+use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Event;
 use Statamic\Contracts\Data\Augmentable;
@@ -571,6 +572,22 @@ class CollectionTest extends TestCase
         $this->assertEquals([
             'title' => 'Test',
             'handle' => 'test',
+            'mount' => '',
+        ], $collection->toAugmentedArray());
+    }
+
+    /** @test */
+    public function it_augments_with_mount()
+    {
+        (new Collection)->handle('pages')->save();
+        $mount = EntryFactory::id('mount')->collection('pages')->make();
+        $collection = (new Collection)->handle('test')->mount($mount->id());
+
+        $this->assertInstanceof(Augmentable::class, $collection);
+        $this->assertEquals([
+            'title' => 'Test',
+            'handle' => 'test',
+            'mount' => $mount,
         ], $collection->toAugmentedArray());
     }
 

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -572,23 +572,20 @@ class CollectionTest extends TestCase
         $this->assertEquals([
             'title' => 'Test',
             'handle' => 'test',
-            'mount' => '',
-        ], $collection->toAugmentedArray());
+        ], collect($collection->toAugmentedArray())->except(['mount'])->all());
     }
 
     /** @test */
     public function it_augments_with_mount()
     {
         (new Collection)->handle('pages')->save();
-        $mount = EntryFactory::id('mount')->collection('pages')->make();
+        $mount = tap(EntryFactory::id('mount')->collection('pages')->make())->save();
         $collection = (new Collection)->handle('test')->mount($mount->id());
 
-        $this->assertInstanceof(Augmentable::class, $collection);
-        $this->assertEquals([
-            'title' => 'Test',
-            'handle' => 'test',
-            'mount' => $mount,
-        ], $collection->toAugmentedArray());
+        $augmented = $collection->toAugmentedArray();
+
+        $this->assertArrayHasKey('mount', $augmented);
+        $this->assertEquals($augmented['mount']->value(), $mount);
     }
 
     /** @test */


### PR DESCRIPTION
If you're in a show template you might want to output a value from the collection's mount entry. For example within a blog post you might want to output the "Our Blog" title from the mount entry.

I could be wrong but I dont _think_ there's currently a straightforward way to do that dynamically?

This PR adds `mount` to a collection's augmented data, so you can do:

```antlers
{{ $collection:mount:title }}
```