### PR TITLE
Don't show hidden blueprints from Entries fieldtype

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -180,12 +180,14 @@ class Entries extends Relationship
 
             $blueprints = $collection->entryBlueprints();
 
-            return $blueprints->map(function ($blueprint) use ($collection, $collections, $blueprints) {
-                return [
-                    'title' => $this->getCreatableTitle($collection, $blueprint, count($collections), $blueprints->count()),
-                    'url' => $collection->createEntryUrl(Site::selected()->handle()).'?blueprint='.$blueprint->handle(),
-                ];
-            });
+            return $blueprints
+                ->reject->hidden()
+                ->map(function ($blueprint) use ($collection, $collections, $blueprints) {
+                    return [
+                        'title' => $this->getCreatableTitle($collection, $blueprint, count($collections), $blueprints->count()),
+                        'url' => $collection->createEntryUrl(Site::selected()->handle()).'?blueprint='.$blueprint->handle(),
+                    ];
+                });
         })->all();
     }
 


### PR DESCRIPTION
This pull request fixes #6281 by returning only blueprints that haven't been marked as hidden when using the 'Create' function on the Entries fieldtype.