### PR TITLE
Add file size to asset row tooltip

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -7,10 +7,18 @@
                  :style="'background-image:url('+thumbnail+')'">
             </div>
             <button class="w-7 h-7 cursor-pointer whitespace-no-wrap flex items-center justify-center" @click="edit" v-else>
-                <img class="asset-thumbnail max-h-full max-w-full rounded w-7 h-7 fit-cover" loading="lazy" :src="thumbnail" v-if="isImage" />
+                <img
+                    class="asset-thumbnail max-h-full max-w-full rounded w-7 h-7 fit-cover"
+                    loading="lazy"
+                    :src="thumbnail"
+                    :alt="asset.basename"
+                    v-if="isImage"
+                />
                 <file-icon :extension="asset.extension" v-else />
             </button>
-            <button v-if="showFilename" @click="edit" class="flex-1 ml-1 text-sm text-left truncate" :aria-label="__('Edit Asset')" v-tooltip="asset.basename">{{ asset.basename }}</button>
+            <button v-if="showFilename" @click="edit" class="flex items-center flex-1 ml-1 text-sm text-left truncate" :aria-label="__('Edit Asset')" v-tooltip="asset.basename + ' (' + asset.size + ')'">
+                {{ asset.basename }}
+            </button>
         </td>
         <td class="p-0 w-8 text-right align-middle">
 


### PR DESCRIPTION
This PR adds the size of the asset to the tooltip.

**Reason behind PR:**
Content editors usually want an easy way to check the sizes of the assets that are uploaded for performance reasons. Now, you have to popup a modal that takes the whole screen and then close it again just to check the file size. Annoying. Now you can just hover over the asset.

**How it looks:**
![bilde](https://user-images.githubusercontent.com/10024730/177050693-60d307a7-ac6f-45b8-ae85-303476be0ffe.png)

