### PR TITLE
Live preview scroll handling - update approach to use events

### DIFF
--- a/resources/js/components/live-preview/UpdatesIframe.js
+++ b/resources/js/components/live-preview/UpdatesIframe.js
@@ -24,9 +24,13 @@ export default {
             container.replaceChild(iframe, container.firstChild);
 
             if (isSameOrigin) {
-                setTimeout(() => {
-                    iframe.contentWindow.scrollTo(...scroll);
-                }, 200);
+                let iframeContentWindow = iframe.contentWindow;
+                const iframeScrollUpdate = (event) => {
+                    iframeContentWindow.scrollTo(...scroll);
+                };
+
+                iframeContentWindow.addEventListener('DOMContentLoaded', iframeScrollUpdate, true);
+                iframeContentWindow.addEventListener('load', iframeScrollUpdate, true);
             }
         },
 


### PR DESCRIPTION
First of all sorry for the bugs introduced by #6206 and thanks for applying the same origin work around.

This is a refactoring to listen for both `DOMContentLoaded` and `load` to reset the scroll position. I'm not sure how you feel about using both, but the logic was that a large image load may affect the scroll so the position would need reset after that loads. It may be that `DOMContentLoaded` is sufficient.

