### PR TITLE
Use `implode()` instead of `join()` alias to appease style fixers

### DIFF
--- a/src/Fieldtypes/Assets/MimesRule.php
+++ b/src/Fieldtypes/Assets/MimesRule.php
@@ -48,6 +48,6 @@ class MimesRule implements Rule
      */
     public function message()
     {
-        return str_replace(':values', join(', ', $this->parameters), __('statamic::validation.mimes'));
+        return str_replace(':values', implode(', ', $this->parameters), __('statamic::validation.mimes'));
     }
 }

--- a/src/Fieldtypes/Assets/MimetypesRule.php
+++ b/src/Fieldtypes/Assets/MimetypesRule.php
@@ -43,6 +43,6 @@ class MimetypesRule implements Rule
      */
     public function message()
     {
-        return str_replace(':values', join(', ', $this->parameters), __('statamic::validation.mimetypes'));
+        return str_replace(':values', implode(', ', $this->parameters), __('statamic::validation.mimetypes'));
     }
 }

--- a/src/Forms/Exporters/CsvExporter.php
+++ b/src/Forms/Exporters/CsvExporter.php
@@ -59,7 +59,7 @@ class CsvExporter extends AbstractExporter
             unset($submission['id']);
 
             return collect($submission)->map(function ($value) {
-                return (is_array($value)) ? join(', ', $value) : $value;
+                return (is_array($value)) ? implode(', ', $value) : $value;
             })->all();
         })->all();
 

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -30,16 +30,16 @@ class Str extends \Illuminate\Support\Str
         switch ($length) {
             case 0:
             case 1:
-                return join('', $list);
+                return implode('', $list);
                 break;
 
             case 2:
-                return join(' '.$glue.' ', $list);
+                return implode(' '.$glue.' ', $list);
                 break;
 
             default:
                 $last = array_pop($list);
-                $sentence = join(', ', $list);
+                $sentence = implode(', ', $list);
                 $sentence .= ($oxford_comma) ? ',' : '';
 
                 return $sentence.' '.$glue.' '.$last;
@@ -75,7 +75,7 @@ class Str extends \Illuminate\Support\Str
             ];
 
             $allowed_tags = array_diff($all_tags, $tags_list);
-            $allowed_tag_string = '<'.join('><', $allowed_tags).'>';
+            $allowed_tag_string = '<'.implode('><', $allowed_tags).'>';
 
             return strip_tags($html, $allowed_tag_string);
         }

--- a/src/Tags/Nav.php
+++ b/src/Tags/Nav.php
@@ -27,7 +27,7 @@ class Nav extends Structure
         }
 
         $crumbs = collect($segments)->map(function () use (&$segments) {
-            $uri = URL::tidy(join('/', $segments));
+            $uri = URL::tidy(implode('/', $segments));
             array_pop($segments);
 
             return $uri;

--- a/src/Tags/ParentTags.php
+++ b/src/Tags/ParentTags.php
@@ -76,7 +76,7 @@ class ParentTags extends Tags
         // Create crumbs from segments
         $segment_urls = [];
         for ($i = 1; $i <= $segment_count; $i++) {
-            $segment_urls[] = URL::tidy(join('/', $segments));
+            $segment_urls[] = URL::tidy(implode('/', $segments));
             array_pop($segments);
         }
 


### PR DESCRIPTION
We keep discarding these php-cs-fixer changes. Might as well just use the actual functions instead of the aliases. Also cleans up output for https://github.com/statamic/cms/pull/6298