### PR TITLE
Fix bard nested table styling

### DIFF
--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -300,8 +300,10 @@
         }
     }
 
-    blockquote, ol, ul {
-        p {
+    blockquote,
+    ol li,
+    ul li {
+        > p {
             margin-top: 0;
             margin-bottom: .85em;
         }
@@ -410,7 +412,10 @@
         margin-bottom: 0;
     }
 
-    .tableWrapper table {
+    .tableWrapper table,
+    blockquote > .tableWrapper table,
+    ol li > .tableWrapper table,
+    ul li > .tableWrapper table {
         @apply w-full overflow-hidden m-0 mb-2 bg-white text-sm ;
         border-collapse: collapse;
         table-layout: fixed;


### PR DESCRIPTION
Tables are valid inside list items and blockquotes, and Bard allows you to add them. Everything works fine except they have no styling due to the CSS only targeting tables that are a direct descendant of the editor.

This PR fixes that. It adds selectors for tables inside `blockquote` and `li` elements. It also tweaks the selector for paragraphs inside lists/blockquotes, so those styles do not apply to paragraphs in tables that also happen to be inside lists/blockquotes.

Before:
![Screenshot 2022-07-08 at 10 17 39](https://user-images.githubusercontent.com/126740/177961036-a28d0b23-20ee-4b71-b299-3b2fc7f0bb99.png)

After:
![Screenshot 2022-07-08 at 10 16 16](https://user-images.githubusercontent.com/126740/177961021-f6f187a7-4014-4e9e-b9dd-e9e80456b27c.png)
