### PR TITLE
Fix long lines/words in code mirror breaking the layout width

### DIFF
--- a/resources/js/components/publish/Sections.vue
+++ b/resources/js/components/publish/Sections.vue
@@ -37,7 +37,7 @@
         </div>
 
         <div class="flex justify-between">
-            <div ref="publishSectionWrapper" class="publish-section-wrapper w-full">
+            <div ref="publishSectionWrapper" class="publish-section-wrapper w-full min-w-0">
                 <div
                     role="tabpanel"
                     class="publish-section w-full"


### PR DESCRIPTION
Very long lines/words in code mirror based fields can kick out the layout, forcing the main section wrapper too wide and the sidebar offscreen. This problem can also occur when using `line_wrapping: true` if the content has very long "words".

This PR fixes that by setting the wrapper's `min-width` to `0`.

https://user-images.githubusercontent.com/126740/177972186-254c775a-a1d1-43a0-9e5d-8239415fadfc.mp4


