### PR TITLE
Runtime: Fixes using many `{{ *recursive children* }}` within a nav tag (and many recursive navs within a single template)

### DIFF
--- a/src/View/Antlers/Language/Analyzers/RecursiveParentAnalyzer.php
+++ b/src/View/Antlers/Language/Analyzers/RecursiveParentAnalyzer.php
@@ -51,7 +51,7 @@ class RecursiveParentAnalyzer
                                 break;
                             }
                         } else {
-                            if (Str::contains($subNode->runtimeContent, $recursiveContent) && mb_substr_count($subNode->runtimeContent, '*recursive') == 1) {
+                            if (Str::contains($subNode->runtimeContent, $recursiveContent) && mb_substr_count($subNode->runtimeContent, '*recursive') == 1 && $node->getRootRef() == $subNode->getRootRef()) {
                                 $lastNode = $subNode;
                                 continue;
                             } else {

--- a/src/View/Antlers/Language/Nodes/AbstractNode.php
+++ b/src/View/Antlers/Language/Nodes/AbstractNode.php
@@ -81,4 +81,13 @@ abstract class AbstractNode
     {
         return $this->content;
     }
+
+    public function getRootRef()
+    {
+        if ($this->parent != null) {
+            return $this->parent->getRootRef();
+        }
+
+        return $this->refId;
+    }
 }

--- a/tests/Antlers/Runtime/RecursiveNodesTest.php
+++ b/tests/Antlers/Runtime/RecursiveNodesTest.php
@@ -150,6 +150,128 @@ EOT;
         $this->assertSame($expected, trim($this->renderString($template, [], true)));
 
         $template = <<<'EOT'
+<ul>
+{{ nav:main }}
+{{ if depth === 1 }}
+<li class="if-depth-one">
+{{ title }} - {{ depth }}<br />
+{{ if children }}
+<ul class="if-depth-one-children">
+{{ *recursive children* }}
+</ul>
+{{ /if }}
+
+</li>
+{{ elseif depth == 2 }}
+<li class="else-depth-two">
+{{ title }} - {{ depth }}<br />
+{{ if children }}
+<ul class="if-else-depth-two-children">
+{{ *recursive children* }}
+</ul>
+{{ /if }}
+</li>
+
+{{ else }}
+<li class="else-other-depths">
+{{ title }} -- {{ depth }}
+</li>
+{{ /if }}
+{{ /nav:main }}
+</ul>
+EOT;
+
+        $expected = <<<'EOT'
+<ul>
+
+
+<li class="if-depth-one">
+Home - 1<br />
+
+
+</li>
+
+
+
+<li class="if-depth-one">
+About - 1<br />
+
+<ul class="if-depth-one-children">
+
+
+<li class="else-depth-two">
+Team - 2<br />
+
+</li>
+
+
+
+
+<li class="else-depth-two">
+Leadership - 2<br />
+
+</li>
+
+
+
+</ul>
+
+
+</li>
+
+
+
+<li class="if-depth-one">
+Projects - 1<br />
+
+<ul class="if-depth-one-children">
+
+
+<li class="else-depth-two">
+Project-1 - 2<br />
+
+</li>
+
+
+
+
+<li class="else-depth-two">
+Project-2 - 2<br />
+
+<ul class="if-else-depth-two-children">
+
+
+<li class="else-other-depths">
+Project 2 Nested -- 3
+</li>
+
+
+</ul>
+
+</li>
+
+
+
+</ul>
+
+
+</li>
+
+
+
+<li class="if-depth-one">
+Contact - 1<br />
+
+
+</li>
+
+
+</ul>
+EOT;
+
+        $this->assertSame($expected, trim($this->renderString($template, [], true)));
+
+        $template = <<<'EOT'
 <ul class="parent-menu">
 {{ nav:main }}
 {{ if depth == 1 }}

--- a/tests/Antlers/Runtime/RecursiveNodesTest.php
+++ b/tests/Antlers/Runtime/RecursiveNodesTest.php
@@ -79,6 +79,77 @@ EOT;
         $this->assertSame($expected, trim($this->renderString($template, [], true)));
 
         $template = <<<'EOT'
+{{ nav:main include_home="true" }}
+<div>ONE: {{ depth }} {{ title }}</div>
+{{ if children }}{{ *recursive children* }}{{ /if }}
+{{ /nav:main }}
+
+{{ nav:main include_home="true" }}
+<div>TWO: {{ depth }} {{ title }}</div>
+{{ if children }}{{ *recursive children* }}{{ /if }}
+{{ /nav:main }}
+EOT;
+
+        $expected = <<<'EOT'
+<div>ONE: 1 Home</div>
+
+
+<div>ONE: 1 About</div>
+
+<div>ONE: 2 Team</div>
+
+
+<div>ONE: 2 Leadership</div>
+
+
+
+<div>ONE: 1 Projects</div>
+
+<div>ONE: 2 Project-1</div>
+
+
+<div>ONE: 2 Project-2</div>
+
+<div>ONE: 3 Project 2 Nested</div>
+
+
+
+
+<div>ONE: 1 Contact</div>
+
+
+
+
+<div>TWO: 1 Home</div>
+
+
+<div>TWO: 1 About</div>
+
+<div>TWO: 2 Team</div>
+
+
+<div>TWO: 2 Leadership</div>
+
+
+
+<div>TWO: 1 Projects</div>
+
+<div>TWO: 2 Project-1</div>
+
+
+<div>TWO: 2 Project-2</div>
+
+<div>TWO: 3 Project 2 Nested</div>
+
+
+
+
+<div>TWO: 1 Contact</div>
+EOT;
+
+        $this->assertSame($expected, trim($this->renderString($template, [], true)));
+
+        $template = <<<'EOT'
 <ul class="parent-menu">
 {{ nav:main }}
 {{ if depth == 1 }}


### PR DESCRIPTION
This PR fixes #6319 by correcting two subtle issues that are working together to produced the undesired behavior.

The first is an issue where the runtime would resolve the incorrect recursive parent when rendering recursive children. This issue is most apparent when using multiple nav tags in the same template, but having many recursive children nodes was enough to confuse it when nested inside if statements. To reproduce, create any nav with children and attempt a template like the following:

```antlers
<ul>
    {{ nav:test }}
        <li class="one">
            {{ title }} - {{ depth }}<br />
            {{ if children }}
                <ul>
                    ONE
                    {{ *recursive children* }}
                </ul>
            {{ /if }}
        </li>

    {{ /nav:test }}
</ul>

<ul>
    {{ nav:test }}
        <li class="two">
            {{ title }} - {{ depth }}<br />
            {{ if children }}
                <ul>
                    TWO
                    {{ *recursive children* }}
                </ul>
            {{ /if }}
        </li>

    {{ /nav:test }}
</ul>

```

With the bugged behavior, the second nav will incorrectly bind to the first nav tag, leading to strange/unexpected results. This behavior was resolved by constraining the recursive parent check to the same root node pair.

The second issue was a result of an internal "named depth mapping" that provides the active depth for the recursive variable currently being iterated. This logic was adjusted such that these named depth mappings no longer override the outer depth.

The following template now behaves the same as it would in Regex:

```antlers
<ul>
    {{ nav:test }}
        {{ if depth === 1 }}
            <li class="if-depth-one">
                {{ title }} - {{ depth }}<br />
                {{ if children }}
                    <ul class="if-depth-one-children">
                        {{ *recursive children* }}
                    </ul>
                {{ /if }}

            </li>
        {{ elseif depth == 2 }}
            <li class="else-depth-two">
                {{ title }} - {{ depth }}<br />
                {{ if children }}
                    <ul class="if-else-depth-two-children">
                        {{ *recursive children* }}
                    </ul>
                {{ /if }}
            </li>
        
        {{ else }}
            <li class="else-other-depths">
                {{ title }} -- {{ depth }}
            </li>
        {{ /if }}
    {{ /nav:test }}
</ul>
```

Both provided test cases will also fail when moved the base branch.