### PR TITLE
Runtime: improves dynamic binding and query builders

### DIFF
--- a/src/View/Antlers/Language/Nodes/AntlersNode.php
+++ b/src/View/Antlers/Language/Nodes/AntlersNode.php
@@ -429,11 +429,14 @@ class AntlersNode extends AbstractNode
                 $value = Antlers::parser()->getVariable($pathToParse, $data, null);
             } else {
                 $pathParser = new PathParser();
+                $path = $pathParser->parse($pathToParse);
+                $doIntercept = count($path->pathParts) > 1;
+
                 $retriever = new PathDataManager();
                 $retriever->setIsPaired(false)->setReduceFinal(false)
                     ->cascade($processor->getCascade())
-                    ->setShouldDoValueIntercept(false);
-                $value = $retriever->getData($pathParser->parse($pathToParse), $data);
+                    ->setShouldDoValueIntercept($doIntercept);
+                $value = $retriever->getData($path, $data);
             }
         } else {
             $value = $this->reduceParameterInterpolations($param, $processor, $value, $data);

--- a/src/View/Antlers/Language/Runtime/PathDataManager.php
+++ b/src/View/Antlers/Language/Runtime/PathDataManager.php
@@ -450,23 +450,33 @@ class PathDataManager
 
         if ($builderCheckValue instanceof Builder) {
             $nodeProcessor = $this->getNodeProcessor();
-            $activeNode = $nodeProcessor->getActiveNode();
 
-            if ($activeNode instanceof AntlersNode || $activeNode instanceof ConditionNode) {
-                $interceptResult = $nodeProcessor->evaluateDeferredNodeAsTag(
-                    $activeNode,
-                    'query',
-                    'index', ['builder' => $builderCheckValue]
-                );
+            if ($nodeProcessor != null) {
+                $activeNode = $nodeProcessor->getActiveNode();
 
-                $this->reducedVar = $interceptResult;
-            } else {
-                $this->reducedVar = $builderCheckValue->get();
+                if ($activeNode instanceof AntlersNode || $activeNode instanceof ConditionNode) {
+                    $interceptResult = $nodeProcessor->evaluateDeferredNodeAsTag(
+                        $activeNode,
+                        'query',
+                        'index', ['builder' => $builderCheckValue]
+                    );
 
-                if ($this->reducedVar instanceof Collection) {
-                    $this->reducedVar = $this->reducedVar->all();
+                    $this->reducedVar = $interceptResult;
+                } else {
+                    $this->collapseQueryBuilder($builderCheckValue);
                 }
+            } else {
+                $this->collapseQueryBuilder($builderCheckValue);
             }
+        }
+    }
+
+    private function collapseQueryBuilder($builder)
+    {
+        $this->reducedVar = $builder->get();
+
+        if ($this->reducedVar instanceof Collection) {
+            $this->reducedVar = $this->reducedVar->all();
         }
     }
 

--- a/src/View/Antlers/Language/Utilities/StringUtilities.php
+++ b/src/View/Antlers/Language/Utilities/StringUtilities.php
@@ -61,7 +61,8 @@ class StringUtilities
             if (ctype_punct($char) && $char != DocumentParser::LeftBracket &&
                 $char != DocumentParser::RightBracket &&
                 $char != DocumentParser::Punctuation_Colon &&
-                $char != DocumentParser::Punctuation_Underscore) {
+                $char != DocumentParser::Punctuation_Underscore &&
+                $char != DocumentParser::Punctuation_FullStop) {
                 return true;
             }
         }

--- a/tests/Antlers/Runtime/AntlersQueryBuilderTest.php
+++ b/tests/Antlers/Runtime/AntlersQueryBuilderTest.php
@@ -220,10 +220,13 @@ EOT;
         ];
 
         $builder = Mockery::mock(Builder::class);
-        $builder->shouldReceive('get')->once()->andReturn(collect($clientData));
+        $builder->shouldReceive('get')->times(4)->andReturn(collect($clientData));
 
         $data = [
             'clients' => $builder,
+            'nested' => [
+                'clients' => $builder
+            ]
         ];
 
         VarTest::register();
@@ -241,6 +244,18 @@ EOT;
 EOT;
 
         $this->renderString($template, $data, true);
+        $this->assertSame(VarTest::$var, $builder);
+
+        $this->renderString('{{ var_test :variable="clients.0.title" }}', $data, true);
+        $this->assertSame('Foo', VarTest::$var);
+
+        $this->renderString('{{ var_test :variable="clients.1.title" }}', $data, true);
+        $this->assertSame('Baz', VarTest::$var);
+
+        $this->renderString('{{ var_test :variable="clients.2.title" }}', $data, true);
+        $this->assertSame('Bar', VarTest::$var);
+
+        $this->renderString('{{ var_test :variable="nested.clients" }}', $data, true);
         $this->assertSame(VarTest::$var, $builder);
     }
 


### PR DESCRIPTION
This PR fixes #6323 by improving the checks that happen when deciding what to do with a given dynamic binding expression.

The following will now work as expected:

```antlers
{{ glide :src="assetsfield:0:id" }}
```

Doing something like the following (where `assetsfield` is a query builder) will still return the query builder:

```antlers
{{ tag :param="assetsfield" }}

{{ tag :param="some:nested:path:assetsfield" }}
```

The provided test cases will also fail when moved to the base branch.

