### PR TITLE
Translate breadcrumbs using statamic trans method

### DIFF
--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -293,7 +293,7 @@ class Statamic
 
     public static function crumb(...$values)
     {
-        return implode(' ‹ ', array_map('__', $values));
+        return implode(' ‹ ', array_map(fn ($str) => Statamic::trans($str), $values));
     }
 
     public static function docsUrl($url)

--- a/tests/StatamicTest.php
+++ b/tests/StatamicTest.php
@@ -168,4 +168,21 @@ class StatamicTest extends TestCase
 
         Statamic::query('test');
     }
+
+    /**
+     * @test
+     * @define-env useFixtureTranslations
+     **/
+    public function it_makes_breadcrumbs()
+    {
+        // confirm the fake translations are being loaded
+        $this->assertIsArray(__('messages'));
+
+        $this->assertEquals('one ‹ messages ‹ two', Statamic::crumb('one', 'messages', 'two'));
+    }
+
+    public function useFixtureTranslations($app)
+    {
+        $app->useLangPath(__DIR__.'/__fixtures__/lang');
+    }
 }


### PR DESCRIPTION
Fixes #6326 

When you have a custom translation file and you try to use the name of it as a translation string, it loads that file.

e.g. `__('file')`

To combat this, we introduced `Statamic::trans()` that will just return the string if an array is encountered.

This PR uses that method within breadcrumbs.