### PR TITLE
Respect ascii replace option in JavaScript slugify function

### DIFF
--- a/resources/js/plugins/slugify.js
+++ b/resources/js/plugins/slugify.js
@@ -13,7 +13,7 @@ export default {
                 separator: glue || '-',
                 lang,
                 custom,
-                symbols: true // Use this in 3.4: Statamic.$config.get('asciiReplaceExtraSymbols')
+                symbols: Statamic.$config.get('asciiReplaceExtraSymbols')
             });
         };
     }


### PR DESCRIPTION
Related to #5496

This PR makes the JS `slugify()` function respect the `statamic.system.ascii_replace_extra_symbols` option.

This is technically a breaking change.

If you were to type `Huge sale & 10% off`, in 3.3 you'd get `huge-sale-and-10-off`. The `&` was incorrectly getting replaced in JS.

In 3.3, you will now get `huge-sale-10-off`.

The fix is simple. Enable the setting, and you will then get `huge-sale-and-10-percent-off`.
