### PR TITLE
A versioned asset path can contain a extension

### DIFF
--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -400,7 +400,12 @@ class Statamic
             // a random version number will be created.
             if (! Str::contains($path, '?v=')) {
                 $version = str_random();
-                $path = str_finish($path, ".{$extension}?v={$version}");
+                
+                // Add the file extension if not provided.
+                $path = str_finish($path, ".{$extension}");
+
+                // Add the version to the path.
+                $path = str_finish($path, "?v={$version}");
             }
 
             return $path;

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -400,7 +400,7 @@ class Statamic
             // a random version number will be created.
             if (! Str::contains($path, '?v=')) {
                 $version = str_random();
-                
+
                 // Add the file extension if not provided.
                 $path = str_finish($path, ".{$extension}");
 


### PR DESCRIPTION
Better safe than sorry ☺️
(I just run into this myself)

There might be cases, where a full path to an asset does contain a extension already. That would lead to a file path like `app.css.css?v=xxx` which is not wanted. 

The PR does fix that. Before extending the path with the extension, it will check if the path already ends with the given extension. 