### PR TITLE
Fix toggle field casting to boolean when field is hidden

### DIFF
--- a/src/Fieldtypes/Toggle.php
+++ b/src/Fieldtypes/Toggle.php
@@ -36,6 +36,10 @@ class Toggle extends Fieldtype
 
     public function process($data)
     {
+        if (is_null($data)) {
+            return null;
+        }
+
         return (bool) $data;
     }
 

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -182,8 +182,8 @@ class Form implements FormContract, Augmentable, Arrayable
             'title' => $this->title,
             'honeypot' => $this->honeypot,
             'email' => collect($this->email)->map(function ($email) {
-                $email['markdown'] = $email['markdown'] ?: null;
-                $email['attachments'] = $email['attachments'] ?: null;
+                $email['markdown'] = isset($email['markdown']) ? $email['markdown'] : null;
+                $email['attachments'] = isset($email['attachments']) ? $email['attachments'] : null;
 
                 return Arr::removeNullValues($email);
             })->all(),

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -182,8 +182,8 @@ class Form implements FormContract, Augmentable, Arrayable
             'title' => $this->title,
             'honeypot' => $this->honeypot,
             'email' => collect($this->email)->map(function ($email) {
-                $email['markdown'] = isset($email['markdown']) ? $email['markdown'] : null;
-                $email['attachments'] = isset($email['attachments']) ? $email['attachments'] : null;
+                $email['markdown'] = $email['markdown'] ?: null;
+                $email['attachments'] = $email['attachments'] ?: null;
 
                 return Arr::removeNullValues($email);
             })->all(),

--- a/tests/Feature/Forms/UpdateFormTest.php
+++ b/tests/Feature/Forms/UpdateFormTest.php
@@ -64,7 +64,34 @@ class UpdateFormTest extends TestCase
         $form = tap(Form::make('test'))->save();
         $this->assertNull($form->email());
 
-        $emailConfig = [
+        $this
+            ->actingAs($this->userWithPermission())
+            ->update($form, ['email' => [
+                [
+                    'to' => 'john@example.com',
+                    'from' => 'jane@example.com',
+                    'reply_to' => null,
+                    'subject' => null,
+                    'text' => null,
+                    'html' => null,
+                    'markdown' => false,
+                    'attachments' => false,
+                ],
+                [
+                    'to' => 'foo@example.com',
+                    'from' => 'bar@example.com',
+                    'reply_to' => null,
+                    'subject' => null,
+                    'text' => 'emails.contact.text',
+                    'html' => 'emails.contact.html',
+                    'markdown' => false,
+                    'attachments' => false,
+                ],
+            ]])
+            ->assertOk();
+
+        $updated = Form::all()->first();
+        $this->assertEquals([
             [
                 'to' => 'john@example.com',
                 'from' => 'jane@example.com',
@@ -75,15 +102,7 @@ class UpdateFormTest extends TestCase
                 'text' => 'emails.contact.text',
                 'html' => 'emails.contact.html',
             ],
-        ];
-
-        $this
-            ->actingAs($this->userWithPermission())
-            ->update($form, ['email' => $emailConfig])
-            ->assertOk();
-
-        $updated = Form::all()->first();
-        $this->assertEquals($emailConfig, $updated->email());
+        ], $updated->email());
     }
 
     private function userWithoutPermission()

--- a/tests/Fieldtypes/ToggleTest.php
+++ b/tests/Fieldtypes/ToggleTest.php
@@ -17,4 +17,14 @@ class ToggleTest extends TestCase
         $this->assertFalse($field->augment(null));
         $this->assertTrue($field->augment(true));
     }
+
+    /** @test */
+    public function it_processes_to_a_boolean_only_when_value_is_actually_set_or_submitted()
+    {
+        $field = (new Toggle)->setField(new Field('test', ['type' => 'toggle']));
+
+        $this->assertTrue($field->process(true));
+        $this->assertFalse($field->process(false));
+        $this->assertNull($field->process(null));
+    }
 }


### PR DESCRIPTION
Ensure the toggle fieldtype only casts to a saveable boolean when the value is submitted. When conditionally hidden, it should save neither `true` nor `false`, [according to our docs on conditional field data flow](https://statamic.dev/conditional-fields#data-flow).

Fixes #6347.