### PR TITLE
Deprecate format localized

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -671,6 +671,8 @@ class CoreModifiers extends Modifier
     /**
      * Converts a string to a Carbon instance and formats it according to the whim of the Overlord.
      *
+     * @deprecated formatLocalized is deprecated since Carbon 2.55.0. You may want to use formatTranslated instead.
+     *
      * @param $value
      * @param $params
      * @return string


### PR DESCRIPTION
In an older Statamic project we worked on, we had problems formatting dates with Antlers modifier `format_localized`.

While deep diving into the source I found out that the modifier `format_localized` uses Carbon's `formatLocalized` which is deprecated since version 2.55.0.

This PR deprecates the modifier corresponding to Carbon's comment (https://github.com/briannesbitt/Carbon/blob/master/src/Carbon/Traits/Date.php#L1836).

You may want to also add a point in the changelog that contains this chance to let people know about this fact.

Hope this helps ✌️ 