### PR TITLE
About command

### DIFF
--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -53,16 +53,20 @@ class SupportDetails extends Command
 </div>
 EOT;
 
-        $dir = base_path('vendor/laravel/framework/src/Illuminate/Console/resources/views/components');
-
+        $dir = $this->viewDir();
         app('files')->move($dir.'/two-column-detail.php', $dir.'/two-column-detail.php.bak');
         app('files')->put($dir.'/two-column-detail.php', $view);
     }
 
     private function restoreView()
     {
-        $dir = base_path('vendor/laravel/framework/src/Illuminate/Console/resources/views/components');
+        $dir = $this->viewDir();
         app('files')->delete($dir.'/two-column-detail.php');
         app('files')->move($dir.'/two-column-detail.php.bak', $dir.'/two-column-detail.php');
+    }
+
+    private function viewDir()
+    {
+        return base_path('vendor/laravel/framework/src/Illuminate/Console/resources/views/components');
     }
 }

--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -49,8 +49,12 @@ class SupportDetails extends Command
     private function handleUsingAboutCommand()
     {
         $this->replaceView();
-        $this->call('about');
-        $this->restoreView();
+
+        try {
+            $this->call('about');
+        } finally {
+            $this->restoreView();
+        }
 
         return static::SUCCESS;
     }

--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -48,7 +48,7 @@ class SupportDetails extends Command
     private function replaceView()
     {
         $view = <<<'EOT'
-<div class="flex mx-2 max-w-150">
+<div class="flex">
     <?php echo htmlspecialchars($first) ?><?php if ($second !== '') { ?>: <?php echo htmlspecialchars($second) ?> <?php } ?>
 </div>
 EOT;

--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -18,18 +18,19 @@ class SupportDetails extends Command
 
     public function handle()
     {
-        if (class_exists(AboutCommand::class)) {
-            $this->replaceView();
-            $this->call('about');
-            $this->restoreView();
+        return class_exists(AboutCommand::class)
+            ? $this->handleUsingAboutCommand()
+            : $this->handleUsingStatamic();
+    }
 
-            return static::SUCCESS;
-        }
-
+    private function handleUsingStatamic()
+    {
         $this->line(sprintf('<info>Statamic</info> %s %s', Statamic::version(), Statamic::pro() ? 'Pro' : 'Solo'));
         $this->line('<info>Laravel</info> '.Application::VERSION);
         $this->line('<info>PHP</info> '.phpversion());
         $this->addons();
+
+        return static::SUCCESS;
     }
 
     private function addons()
@@ -43,6 +44,15 @@ class SupportDetails extends Command
         foreach ($addons as $addon) {
             $this->line(sprintf('<info>%s</info> %s', $addon->package(), $addon->version()));
         }
+    }
+
+    private function handleUsingAboutCommand()
+    {
+        $this->replaceView();
+        $this->call('about');
+        $this->restoreView();
+
+        return static::SUCCESS;
     }
 
     private function replaceView()

--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -19,7 +19,11 @@ class SupportDetails extends Command
     public function handle()
     {
         if (class_exists(AboutCommand::class)) {
-            return $this->call('about');
+            $this->replaceView();
+            $this->call('about');
+            $this->restoreView();
+
+            return static::SUCCESS;
         }
 
         $this->line(sprintf('<info>Statamic</info> %s %s', Statamic::version(), Statamic::pro() ? 'Pro' : 'Solo'));
@@ -39,5 +43,27 @@ class SupportDetails extends Command
         foreach ($addons as $addon) {
             $this->line(sprintf('<info>%s</info> %s', $addon->package(), $addon->version()));
         }
+    }
+
+    private function replaceView()
+    {
+        $view = <<<'EOT'
+<div class="flex mx-2 max-w-150">
+    <?php echo htmlspecialchars($first) ?>
+    <?php if ($second !== '') { ?> : <?php echo htmlspecialchars($second) ?> <?php } ?>
+</div>
+EOT;
+
+        $dir = base_path('vendor/laravel/framework/src/Illuminate/Console/resources/views/components');
+
+        app('files')->move($dir.'/two-column-detail.php', $dir.'/two-column-detail.php.bak');
+        app('files')->put($dir.'/two-column-detail.php', $view);
+    }
+
+    private function restoreView()
+    {
+        $dir = base_path('vendor/laravel/framework/src/Illuminate/Console/resources/views/components');
+        app('files')->delete($dir.'/two-column-detail.php');
+        app('files')->move($dir.'/two-column-detail.php.bak', $dir.'/two-column-detail.php');
     }
 }

--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -49,8 +49,7 @@ class SupportDetails extends Command
     {
         $view = <<<'EOT'
 <div class="flex mx-2 max-w-150">
-    <?php echo htmlspecialchars($first) ?>
-    <?php if ($second !== '') { ?> : <?php echo htmlspecialchars($second) ?> <?php } ?>
+    <?php echo htmlspecialchars($first) ?><?php if ($second !== '') { ?>: <?php echo htmlspecialchars($second) ?> <?php } ?>
 </div>
 EOT;
 

--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -4,6 +4,7 @@ namespace Statamic\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Console\AboutCommand;
 use Statamic\Console\RunsInPlease;
 use Statamic\Facades\Addon;
 use Statamic\Statamic;
@@ -17,6 +18,10 @@ class SupportDetails extends Command
 
     public function handle()
     {
+        if (class_exists(AboutCommand::class)) {
+            return $this->call('about');
+        }
+
         $this->line(sprintf('<info>Statamic</info> %s %s', Statamic::version(), Statamic::pro() ? 'Pro' : 'Solo'));
         $this->line('<info>Laravel</info> '.Application::VERSION);
         $this->line('<info>PHP</info> '.phpversion());

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -178,7 +178,7 @@ class AppServiceProvider extends ServiceProvider
         $addons = Addon::all();
 
         AboutCommand::add('Statamic', [
-            'Version' => Statamic::version().' '.(Statamic::pro() ? '<fg=yellow;options=bold>PRO</>' : 'Solo'),
+            'Version' => fn () => Statamic::version().' '.(Statamic::pro() ? '<fg=yellow;options=bold>PRO</>' : 'Solo'),
             'Antlers' => config('statamic.antlers.version'),
             'Addons' => $addons->count(),
         ]);

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -2,11 +2,13 @@
 
 namespace Statamic\Providers;
 
+use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\ServiceProvider;
 use Statamic\Facades;
+use Statamic\Facades\Addon;
 use Statamic\Facades\Preference;
 use Statamic\Facades\Token;
 use Statamic\Sites\Sites;
@@ -82,6 +84,8 @@ class AppServiceProvider extends ServiceProvider
                 return Token::find($token);
             }
         });
+
+        $this->addAboutCommandInfo();
     }
 
     public function register()
@@ -163,5 +167,24 @@ class AppServiceProvider extends ServiceProvider
             \Statamic\Http\Middleware\AuthGuard::class,
             \Statamic\StaticCaching\Middleware\Cache::class,
         ]);
+    }
+
+    protected function addAboutCommandInfo()
+    {
+        if (! class_exists(AboutCommand::class)) {
+            return;
+        }
+
+        $addons = Addon::all();
+
+        AboutCommand::add('Statamic', [
+            'Version' => Statamic::version().' '.(Statamic::pro() ? '<fg=yellow;options=bold>PRO</>' : 'Solo'),
+            'Antlers' => config('statamic.antlers.version'),
+            'Addons' => $addons->count(),
+        ]);
+
+        foreach ($addons as $addon) {
+            AboutCommand::add('Statamic Addons', $addon->package(), $addon->version());
+        }
     }
 }


### PR DESCRIPTION
This PR adds items to the new `artisan about` command.

![CleanShot 2022-07-19 at 11 41 14](https://user-images.githubusercontent.com/105211/179792120-4555f488-fb05-45e1-9499-675171dd0d75.png)


It also now treats `please support:details` as an alias for `artisan about` with more copy-pasteable formatting for GitHub issues.

![CleanShot 2022-07-19 at 12 36 50](https://user-images.githubusercontent.com/105211/179803321-5ce3917e-9450-4f21-ad2a-3f13231b8a4b.png)

On older versions of Laravel that don't yet have the `about` command, `support:details` will continue to work as it always did.