### PR TITLE
Fix infinite loop when user file doesn't have id

### DIFF
--- a/src/Stache/Stores/UsersStore.php
+++ b/src/Stache/Stores/UsersStore.php
@@ -42,7 +42,7 @@ class UsersStore extends BasicStore
             ->data($data);
 
         if (array_get($data, 'password') || isset($idGenerated)) {
-            $user->save();
+            $user->writeFile();
         }
 
         // $this->queueGroups($user);


### PR DESCRIPTION
When a user file doesn't have an `id`, Statamic would generate one and put it back in the file.

This was working fine until #3379 which introduced an infinite loop.

https://github.com/statamic/cms/blob/e71a79b94bacde2746455e2b87caf539d510afa1/src/Auth/User.php#L158

Instead of "saving" the entry again (which would trigger a bunch of other logic causing the loop) we can simply write the file.