### PR TITLE
Allow custom graphql fields to be added to collections

### DIFF
--- a/src/GraphQL/Types/CollectionType.php
+++ b/src/GraphQL/Types/CollectionType.php
@@ -25,8 +25,12 @@ class CollectionType extends \Rebing\GraphQL\Support\Type
             'structure' => [
                 'type' => GraphQL::type(CollectionStructureType::NAME),
             ],
-        ])->map(function (array $arr) {
-            $arr['resolve'] = $this->resolver();
+        ])
+        ->merge(collect(GraphQL::getExtraTypeFields($this->name))->map(function ($closure) {
+            return $closure();
+        }))
+        ->map(function (array $arr) {
+            $arr['resolve'] = $arr['resolve'] ?? $this->resolver();
 
             return $arr;
         })


### PR DESCRIPTION
This allows you to add custom fields to collections, like this:

```php
GraphQL::addField('Collection', 'mount', function () {
     return [
         'type' => GraphQL::type('EntryInterface'),
         'resolve' => fn ($collection) => $collection->mount(),
     ];
 });
```