### PR TITLE
Runtime: Modulo throwing DivisionByZeroError

### DIFF
--- a/src/View/Antlers/Language/Parser/LanguageParser.php
+++ b/src/View/Antlers/Language/Parser/LanguageParser.php
@@ -1538,6 +1538,7 @@ class LanguageParser
         $nodes = $this->groupNodesByType($nodes, DivisionOperator::class);
         $nodes = $this->groupNodesByType($nodes, AdditionOperator::class);
         $nodes = $this->groupNodesByType($nodes, SubtractionOperator::class);
+        $nodes = $this->groupNodesByType($nodes, ModulusOperator::class);
 
         return $nodes;
     }

--- a/tests/Antlers/Runtime/ArithmeticTest.php
+++ b/tests/Antlers/Runtime/ArithmeticTest.php
@@ -70,4 +70,10 @@ class ArithmeticTest extends ParserTestCase
         // Note: This is not the same as "double factorial". This syntax is just iterative:
         $this->assertSame(720, intval($this->renderString('{{ 3!! }}')));
     }
+
+    public function test_modulus_operator()
+    {
+        $this->assertSame('Yes', $this->renderString('{{ if 6 % 2 == 0 }}Yes{{ else }}No{{ endif }}'));
+        $this->assertSame('No', $this->renderString('{{ if 6 % 2 == 1 }}Yes{{ else }}No{{ endif }}'));
+    }
 }


### PR DESCRIPTION
This PR fixes #6360 by correctly grouping the `%` operator with its operands.

The following will now work as expected without explicitly adding `()`:

```antlers
{{ if 6 % 2 == 0 }} ... {{ /if }}
```

The provided test case will also fail when moved to the base branch.