### PR TITLE
Fix word count in CoreModifiers treating punctuation as a word

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2824,7 +2824,7 @@ class CoreModifiers extends Modifier
         // adapted mb_str_word_count from https://stackoverflow.com/a/17725577
         $words = empty($string = trim($value)) ? [] : preg_split('~[^\p{L}\p{N}\']+~u', $value);
 
-        return count($words);
+        return count(array_filter($words));
     }
 
     /**

--- a/tests/Antlers/Runtime/CoreModifiersTest.php
+++ b/tests/Antlers/Runtime/CoreModifiersTest.php
@@ -217,7 +217,7 @@ EOT;
 
     public function test_word_count()
     {
-        $this->assertSame('2', $this->result('{{  "one two"|word_count }}'));
+        $this->assertSame('8', $this->result('{{  "There are probably seven words in this sentence."|word_count }}'));
     }
 
     public function test_where()


### PR DESCRIPTION
Now the test matches [the documentation](https://statamic.dev/modifiers/word_count). Could also pass the `PREG_SPLIT_NO_EMPTY` flag through to `preg_split()` for the same effect.