### PR TITLE
Always include no_results in tags that output items

### DIFF
--- a/src/Tags/Concerns/OutputsItems.php
+++ b/src/Tags/Concerns/OutputsItems.php
@@ -24,10 +24,7 @@ trait OutputsItems
         $extra = [];
 
         $extra['total_results'] = $items->count();
-
-        if ($items->isEmpty()) {
-            $extra['no_results'] = true;
-        }
+        $extra['no_results'] = $items->isEmpty();
 
         return $extra;
     }


### PR DESCRIPTION
If there are no results when using the search tag `no_results` is set to `true`, but if there are results `no_results` doesn't exist at all. This is fine in antlers because antlers doesn't mind the missing variable, but in blade you cant simply check for `@if ($search['no_results'])` without getting an undefined array key error when there are results.

This PR fixes that by always including `no_results` in the data, even when it's `false`.