### PR TITLE
Fix reordering entries in a collection named literally collection

### DIFF
--- a/src/Stache/Stores/CollectionTreeStore.php
+++ b/src/Stache/Stores/CollectionTreeStore.php
@@ -5,7 +5,6 @@ namespace Statamic\Stache\Stores;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Path;
 use Statamic\Structures\CollectionTree;
-use Statamic\Support\Str;
 use Symfony\Component\Finder\SplFileInfo;
 
 class CollectionTreeStore extends NavTreeStore
@@ -38,16 +37,5 @@ class CollectionTreeStore extends NavTreeStore
             ->initialPath($path)
             ->locale($site)
             ->handle($handle);
-    }
-
-    public function getItemKey($item)
-    {
-        $key = parent::getItemKey($item);
-
-        if (Str::startsWith($key, 'collection::')) {
-            $key = Str::after($key, 'collection::');
-        }
-
-        return $key;
     }
 }

--- a/tests/Feature/Collections/UpdateCollectionTreeTest.php
+++ b/tests/Feature/Collections/UpdateCollectionTreeTest.php
@@ -15,12 +15,15 @@ class UpdateCollectionTreeTest extends TestCase
     use PreventSavingStacheItemsToDisk;
     use FakesRoles;
 
-    /** @test */
-    public function it_updates_the_tree()
+    /**
+     * @test
+     * @dataProvider collectionTreeDataProvider
+     */
+    public function it_updates_the_tree($collectionHandle)
     {
         $this->withoutExceptionHandling();
         $user = tap(User::make()->makeSuper())->save();
-        $collection = tap(Collection::make('test')->routes('{parent_uri}/{slug}'))->save();
+        $collection = tap(Collection::make($collectionHandle)->routes('{parent_uri}/{slug}'))->save();
         EntryFactory::id('e1')->collection($collection)->slug('a')->create();
         EntryFactory::id('e2')->collection($collection)->slug('b')->create();
         EntryFactory::id('e3')->collection($collection)->slug('c')->create();
@@ -57,6 +60,17 @@ class UpdateCollectionTreeTest extends TestCase
             ['entry' => 'e1'],
             ['entry' => 'e2'],
         ], $collection->structure()->in('en')->tree());
+    }
+
+    public function collectionTreeDataProvider()
+    {
+        return [
+            'arbitrary handle' => ['pages'],
+            'handle of collection' => ['collection'],
+            'handle ending with collection' => ['foo_collection'],
+            'handle starting with collection' => ['collection_foo'],
+            'handle with collection inside' => ['foo_collection_foo'],
+        ];
     }
 
     /** @test */


### PR DESCRIPTION
This basically reverts #4978 and fixes #4495.

#4978 only seemed to fix the problem when the collection had the word `collection` _within_ it. e.g. `my_collection`. However it was still broken when the handle was literally just `collection`.

Removing the "fix" makes it works for all scenarios:
- Handle named literally `collection`
- Handle with `collection` in it, like `my_collection`
- Completely different handle like `pages`

Something else in the codebase must have resolved #4495 since the issue was originally opened.

Added test coverage to prevent another regression.