### PR TITLE
Fieldtype meta changes

### DIFF
--- a/resources/js/bootstrap/globals.js
+++ b/resources/js/bootstrap/globals.js
@@ -1,5 +1,6 @@
 import { marked } from 'marked';
 import { translate, translateChoice } from '../translations/translator';
+import { default as set } from './set';
 
 export function cp_url(url) {
     url = Statamic.$config.get('cpUrl') + '/' + url;
@@ -33,6 +34,10 @@ export function data_get(obj, path, fallback=null) {
     var value = properties.reduce((prev, curr) => prev && prev[curr], obj);
     return value !== undefined ? value : fallback;
 };
+
+export function data_set(obj, path, value) {
+    set(obj, path.split('.'), value);
+}
 
 export function clone(value) {
     if (value === undefined) return undefined;

--- a/resources/js/bootstrap/set.js
+++ b/resources/js/bootstrap/set.js
@@ -1,0 +1,37 @@
+import isObject from 'underscore/modules/isObject.js';
+import toPath from 'underscore/modules/_toPath.js';
+import contains from 'underscore/modules/contains.js';
+
+
+var arrayIndex = /^\d+$/;
+
+// Internal function of `set`.
+function deepSet(obj, path, value) {
+    var key = path[0];
+
+    if (path.length === 1) {
+        obj[key] = value;
+        return;
+    }
+
+    if (!isObject(obj[key])) {
+        var nextKey = path[1];
+        obj[key] = arrayIndex.test(nextKey) ? [] : {};
+    }
+
+    return deepSet(obj[key], path.slice(1), value);
+}
+
+// Set the value on `path` of `object`.
+// If any property in `path` does not exist it will be created.
+// Returns mutated object (`obj`).
+export default function set(obj, path, value) {
+    path = toPath(path);
+
+    if (!isObject(obj) || !path.length) return obj;
+    if (contains(path, '__proto__')) throw new Error('Prototype assignment attempted');
+
+    deepSet(obj, path, value);
+
+    return obj;
+}

--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -23,11 +23,20 @@ export default {
         },
         namePrefix: String,
         fieldPathPrefix: String,
+        fieldPathPlaceholder: String,
+    },
+
+    inject: {
+        publishContainer: {
+            default: () => null
+        },
     },
 
     methods: {
         update(value) {
-            this.$emit('input', value);
+            let handle = this.fieldPathPlaceholder || this.handle;
+
+            this.publishContainer.setFieldValue(handle, value);
         },
 
         updateDebounced: _.debounce(function (value) {

--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -22,7 +22,7 @@
 
             <!-- Entry select -->
             <relationship-fieldtype
-                v-if="option === 'entry'"
+                v-show="option === 'entry'"
                 ref="entries"
                 handle="entry"
                 :value="selectedEntries"
@@ -34,7 +34,7 @@
 
             <!-- Asset select -->
             <assets-fieldtype
-                v-if="option === 'asset'"
+                v-show="option === 'asset'"
                 ref="assets"
                 handle="asset"
                 :value="selectedAssets"
@@ -121,6 +121,28 @@ export default {
             this.selectedEntries = meta.initialSelectedEntries;
             this.selectedAssets = meta.initialSelectedAssets;
             this.$nextTick(() => this.metaChanging = false);
+        },
+
+        value(value) {
+            let option = this.option;
+
+            if (!value || !value.startsWith('entry::')) this.selectedEntries = [];
+            if (!value || !value.startsWith('asset::')) this.selectedAssets = [];
+
+            if (value === null) {
+                if (option === 'url') this.option = null;
+            } else if (value === '@child') {
+                this.option = 'first-child';
+            } else if (value.startsWith('entry::')) {
+                this.option = 'entry';
+                this.selectedEntries = [value.replace('entry::', '')];
+            } else if (value.startsWith('asset::')) {
+                this.option = 'asset'
+                this.selectedAssets = [value.replace('asset::', '')];
+            } else {
+                this.option = 'url';
+                this.urlValue = value;
+            }
         }
 
     },

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -322,6 +322,19 @@ export default {
                 this.editor.commands.clearContent()
                 this.editor.commands.setContent(content, true);
             }
+
+            let sets = content.content.filter(node => node.type === 'set');
+
+            // Add or update meta for each set in the value.
+            sets.forEach(set => {
+                let id = set.attrs.id;
+                if (!this.meta.existing[id]) this.updateSetMeta(id, this.meta.new[set.attrs.values.type]);
+            });
+
+            // Remove any meta for sets that are no longer in the value.
+            Object.keys(this.meta.existing).forEach(id => {
+                if (!sets.find(set => set.attrs.id === id)) this.removeSetMeta(id);
+            });
         },
 
         readOnly(readOnly) {
@@ -362,8 +375,6 @@ export default {
             Object.keys(this.meta.defaults[handle]).forEach(key => previews[key] = null);
             this.previews = Object.assign({}, this.previews, { [id]: previews });
 
-            this.updateSetMeta(id, this.meta.new[handle]);
-
             // Perform this in nextTick because the meta data won't be ready until then.
             this.$nextTick(() => {
                 this.editor.commands.set({ id, values });
@@ -377,8 +388,6 @@ export default {
 
             let previews = Object.assign({}, this.previews[old_id]);
             this.previews = Object.assign({}, this.previews, { [id]: previews });
-
-            this.updateSetMeta(id, this.meta.existing[old_id]);
 
             // Perform this in nextTick because the meta data won't be ready until then.
             this.$nextTick(() => {

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -48,6 +48,7 @@
                     :parent-name="parentName"
                     :set-index="index"
                     :field-path="fieldPath(field)"
+                    :field-path-placeholder="fieldPathPlaceholder(field)"
                     :read-only="isReadOnly"
                     @updated="updated(field.handle, $event)"
                     @meta-updated="metaUpdated(field.handle, $event)"
@@ -203,6 +204,11 @@ export default {
         fieldPath(field) {
             let prefix = this.extension.options.bard.fieldPathPrefix || this.extension.options.bard.handle;
             return `${prefix}.${this.index}.attrs.values.${field.handle}`;
+        },
+
+        fieldPathPlaceholder(field) {
+            let prefix = this.extension.options.bard.fieldPathPrefix || this.extension.options.bard.handle;
+            return `${prefix}.{bard:${this.node.attrs.id}}.${field.handle}`;
         },
 
     }

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -136,7 +136,7 @@ export default {
         },
 
         showFieldPreviews() {
-            return this.options.bard.config.previews;
+            return this.extension.options.bard.config.previews;
         },
 
     },

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -1,7 +1,9 @@
 <template>
 
     <node-view-wrapper>
-        <div class="bard-set whitespace-normal my-3 rounded bg-white border shadow"
+        <div
+            v-if="meta"
+            class="bard-set whitespace-normal my-3 rounded bg-white border shadow"
             :class="{ 'border-blue-lighter': selected, 'has-error': hasError }"
             contenteditable="false" @copy.stop @paste.stop @cut.stop
         >
@@ -99,7 +101,7 @@ export default {
         },
 
         previews() {
-            return this.extension.options.bard.meta.previews[this.node.attrs.id];
+            return this.extension.options.bard.meta.previews[this.node.attrs.id] || {};
         },
 
         collapsed() {

--- a/resources/js/components/fieldtypes/grid/Cell.vue
+++ b/resources/js/components/fieldtypes/grid/Cell.vue
@@ -10,6 +10,7 @@
                 :handle="field.handle"
                 :name-prefix="namePrefix"
                 :field-path-prefix="fieldPath"
+                :field-path-placeholder="fieldPathPlaceholder"
                 :read-only="grid.isReadOnly"
                 @input="$emit('updated', $event)"
                 @meta-updated="$emit('meta-updated', $event)"
@@ -62,7 +63,10 @@ export default {
         fieldPath: {
             type: String,
             required: true
-        }
+        },
+        fieldPathPlaceholder: {
+            type: String
+        },
     },
 
     inject: ['grid'],

--- a/resources/js/components/fieldtypes/grid/Row.vue
+++ b/resources/js/components/fieldtypes/grid/Row.vue
@@ -14,6 +14,7 @@
             :grid-name="name"
             :errors="errors(field.handle)"
             :field-path="fieldPath(field.handle)"
+            :field-path-placeholder="fieldPathPlaceholder(field.handle)"
             @updated="updated(field.handle, $event)"
             @meta-updated="metaUpdated(field.handle, $event)"
             @focus="$emit('focus')"
@@ -110,6 +111,10 @@ export default {
 
         fieldPath(handle) {
             return `${this.fieldPathPrefix}.${this.index}.${handle}`;
+        },
+
+        fieldPathPlaceholder(handle) {
+            return `${this.fieldPathPrefix}.{grid:${this.values._id}}.${handle}`;
         },
 
         errors(handle) {

--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -23,6 +23,7 @@
                 :set-index="index"
                 :errors="errors(field.handle)"
                 :field-path="fieldPath(field.handle)"
+                :field-path-placeholder="fieldPathPlaceholder(field.handle)"
                 class="p-2"
                 :read-only="grid.isReadOnly"
                 @updated="updated(field.handle, $event)"

--- a/resources/js/components/fieldtypes/replicator/Field.vue
+++ b/resources/js/components/fieldtypes/replicator/Field.vue
@@ -21,6 +21,7 @@
             :handle="field.handle"
             :name-prefix="namePrefix"
             :field-path-prefix="fieldPath"
+            :field-path-placeholder="fieldPathPlaceholder"
             :has-error="hasError || hasNestedError"
             :read-only="isReadOnly"
             @input="$emit('updated', $event)"
@@ -66,6 +67,9 @@ export default {
             required: true
         },
         fieldPath: {
+            type: String
+        },
+        fieldPathPlaceholder: {
             type: String
         },
         readOnly: Boolean,

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -44,6 +44,7 @@
                 :parent-name="parentName"
                 :set-index="index"
                 :field-path="fieldPath(field)"
+                :field-path-placeholder="fieldPathPlaceholder(field)"
                 :read-only="isReadOnly"
                 @updated="updated(field.handle, $event)"
                 @meta-updated="metaUpdated(field.handle, $event)"
@@ -213,6 +214,10 @@ export default {
 
         fieldPath(field) {
             return `${this.fieldPathPrefix}.${this.index}.${field.handle}`;
+        },
+
+        fieldPathPlaceholder(field) {
+            return `${this.fieldPathPrefix}.{replicator:${this.values._id}}.${field.handle}`;
         },
 
     }

--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -201,6 +201,13 @@ export default {
         itemData(data, olddata) {
             if (this.initializing) return;
             this.$emit('item-data-updated', data);
+        },
+
+        value(value) {
+            // If all the values already have their data stored, then don't bother fetching it again.
+            if (value.every(id => this.data.map(item => item.id).includes(id))) return;
+
+            this.getDataForSelections(value);
         }
 
     },

--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -203,7 +203,9 @@ export default {
             this.$emit('item-data-updated', data);
         },
 
-        value(value) {
+        value(value, oldValue) {
+            if (JSON.stringify(value) === JSON.stringify(oldValue)) return;
+
             // If all the values already have their data stored, then don't bother fetching it again.
             if (value.every(id => this.data.map(item => item.id).includes(id))) return;
 

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -111,7 +111,7 @@ export default {
                 mutations: {
                     setFieldValue(state, payload) {
                         const { handle, value } = payload;
-                        state.values[handle] = value;
+                        data_set(state.values, handle, value);
                     },
                     setValues(state, values) {
                         state.values = values;

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -1,6 +1,7 @@
 <script>
 import uniqid from 'uniqid';
 import Component from '../Component';
+import resolvePath from './FieldPathResolver';
 
 export default {
 
@@ -66,7 +67,8 @@ export default {
 
     provide() {
         return {
-            storeName: this.name
+            storeName: this.name,
+            publishContainer: this,
         }
     },
 
@@ -111,7 +113,15 @@ export default {
                 mutations: {
                     setFieldValue(state, payload) {
                         const { handle, value } = payload;
-                        data_set(state.values, handle, value);
+
+                        let resolvedHandle = resolvePath(handle, state.values);
+
+                        data_set(state.values, resolvedHandle, value);
+
+                        // Communicate to collaboration that the field has been changed, somehow.
+                        // Maybe through some sort of callback associated with this container/store.
+                        // Provide the unresolved handle, and let the other side resolve it themselves.
+                        // Statamic.collaboration.callbacks[storename](handle, value)
                     },
                     setValues(state, values) {
                         state.values = values;

--- a/resources/js/components/publish/FieldPathResolver.js
+++ b/resources/js/components/publish/FieldPathResolver.js
@@ -1,0 +1,21 @@
+import { data_get } from '../../bootstrap/globals';
+
+export default function resolvePath(path, values) {
+    let replaced = path.replace(/(.*?)\.({.*?})/, function (chunk, parent, placeholder) {
+        return chunk.replace(/{(\w+):(.*)}/, function (placeholder, fieldtype, key) {
+            let val = data_get(values, parent);
+
+            if (fieldtype === 'bard') {
+                return val.findIndex(item => item.type == 'set' && item.attrs.id === key) + '.attrs.values';
+            }
+
+            return val.findIndex(item => item._id === key);
+        });
+    });
+
+    if (replaced.includes('{')) {
+        replaced = resolvePath(replaced, values);
+    }
+
+    return replaced;
+}

--- a/resources/js/tests/FieldPathResolver.test.js
+++ b/resources/js/tests/FieldPathResolver.test.js
@@ -1,0 +1,118 @@
+import resolvePath from '../components/publish/FieldPathResolver.js';
+
+test('it resolves paths without placeholders', () => {
+    let values = {
+        text: 'dont care'
+    };
+
+    expect(resolvePath('text', values)).toEqual('text');
+    expect(resolvePath('foo.bar', values)).toEqual('foo.bar');
+});
+
+test('it resolves replicator/grid paths', () => {
+    let values = {
+        text: 'dont care',
+        replicator_field: [
+            {
+                _id: 'a',
+                text: 'alfa',
+            },
+            {
+                _id: 'b',
+                text: 'bravo',
+            }
+        ]
+    };
+
+    let resolved = resolvePath('replicator_field.{replicator:b}.text', values);
+
+    expect(resolved).toEqual('replicator_field.1.text');
+});
+
+test('it resolves bard paths', () => {
+    let values = {
+        text: 'dont care',
+        bard_field: [
+            {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'some text' }]
+            },
+            {
+                type: 'set',
+                attrs: {
+                    id: 'a',
+                    values: {
+                        text: 'alfa',
+                    }
+                }
+            },
+            {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'some more text' }]
+            },
+            {
+                type: 'set',
+                attrs: {
+                    id: 'b',
+                    values: {
+                        text: 'bravo',
+                    }
+                }
+            }
+        ]
+    };
+
+    expect(resolvePath('bard_field.{bard:a}.text', values)).toEqual('bard_field.1.attrs.values.text');
+    expect(resolvePath('bard_field.{bard:b}.text', values)).toEqual('bard_field.3.attrs.values.text');
+});
+
+test('it resolves paths recursively', () => {
+    let values = {
+        text: 'dont care',
+        replicator: [
+            {
+                _id: 'a',
+                text: 'alfa',
+                grid: [
+                    {
+                        _id: 'd',
+                        text: 'delta',
+                        bard: [
+                            { type: 'paragraph', content: [], },
+                        ]
+                    },
+                    {
+                        _id: 'g',
+                        text: 'golf',
+                        bard: [
+                            { type: 'paragraph', content: [], },
+                            { type: 'set', attrs: { id: 'y', values: {text: 'foo'} } },
+                            { type: 'paragraph', content: [], },
+                            { type: 'set', attrs: { id: 'z', values: {text: 'bar'} } }
+                        ]
+                    }
+                ]
+            },
+            {
+                _id: 'b',
+                text: 'bravo',
+                grid: [
+                    {
+                        _id: 'e',
+                        text: 'echo',
+                    },
+                    {
+                        _id: 'f',
+                        text: 'foxtrot',
+                    }
+                ]
+            }
+        ]
+    };
+
+    expect(resolvePath('replicator.{replicator:a}.grid.{grid:g}.bard.{bard:z}.text', values))
+        .toEqual('replicator.0.grid.1.bard.3.attrs.values.text');
+
+    expect(resolvePath('replicator.{replicator:b}.grid.{grid:f}.text', values))
+        .toEqual('replicator.1.grid.1.text');
+});


### PR DESCRIPTION
WIP related stuff for some upcoming collaboration features.

- You can set a deeply nested field value. For example, a text field within a replicator set, e.g. `setFieldValue('replicator.2.text', 'new text')`
- Relationship fields will get their data from the server when the value changes, if the data isn't already there.
- Link fieldtype updates the selected option appropriately.
- Replicator and Bard will update their meta data whenever the value changes.
- Todo: Bard set previews are not working quite correctly when adding a new set using setFieldValue