### PR TITLE
GraphQL: Fix terms not resolving query builders

### DIFF
--- a/src/GraphQL/Types/TermType.php
+++ b/src/GraphQL/Types/TermType.php
@@ -6,7 +6,6 @@ use Statamic\Contracts\Taxonomies\Taxonomy;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Blueprint;
-use Statamic\Fields\Value;
 use Statamic\Support\Str;
 
 class TermType extends \Rebing\GraphQL\Support\Type
@@ -51,13 +50,7 @@ class TermType extends \Rebing\GraphQL\Support\Type
     private function resolver()
     {
         return function (Term $term, $args, $context, $info) {
-            $value = $term->augmentedValue($info->fieldName);
-
-            if ($value instanceof Value) {
-                $value = $value->value();
-            }
-
-            return $value;
+            return $term->resolveGqlValue($info->fieldName);
         };
     }
 }

--- a/tests/Feature/GraphQL/TermTest.php
+++ b/tests/Feature/GraphQL/TermTest.php
@@ -19,13 +19,6 @@ class TermTest extends TestCase
 
     protected $enabledQueries = ['taxonomies'];
 
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        BlueprintRepository::partialMock();
-    }
-
     /**
      * @test
      * @environment-setup disableQueries
@@ -227,13 +220,15 @@ GQL;
     /** @test */
     public function it_resolves_query_builders()
     {
-        $blueprint = Blueprint::makeFromFields([]);
-        BlueprintRepository::shouldReceive('in')->with('collections/test')->andReturn(collect(['test' => $blueprint->setHandle('test')]));
+        BlueprintRepository::partialMock();
+
+        $blueprint = Blueprint::makeFromFields([])->setHandle('test');
+        BlueprintRepository::shouldReceive('in')->with('collections/test')->andReturn(collect(['test' => $blueprint]));
         EntryFactory::collection('test')->id('bravo')->data(['title' => 'Bravo'])->create();
         EntryFactory::collection('test')->id('charlie')->data(['title' => 'Charlie'])->create();
 
-        $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries']]);
-        BlueprintRepository::shouldReceive('in')->with('taxonomies/tags')->andReturn(collect(['tags' => $blueprint->setHandle('tags')]));
+        $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries']])->setHandle('tags');
+        BlueprintRepository::shouldReceive('in')->with('taxonomies/tags')->andReturn(collect(['tags' => $blueprint]));
 
         Taxonomy::make('tags')->save();
         Term::make()->taxonomy('tags')->inDefaultLocale()->slug('alpha')->data([

--- a/tests/Feature/GraphQL/TermTest.php
+++ b/tests/Feature/GraphQL/TermTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Feature\GraphQL;
 
+use Facades\Statamic\Fields\BlueprintRepository;
+use Facades\Tests\Factories\EntryFactory;
+use Statamic\Facades\Blueprint;
 use Statamic\Facades\GraphQL;
 use Statamic\Facades\Taxonomy;
 use Statamic\Facades\Term;
@@ -15,6 +18,13 @@ class TermTest extends TestCase
     use EnablesQueries;
 
     protected $enabledQueries = ['taxonomies'];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        BlueprintRepository::partialMock();
+    }
 
     /**
      * @test
@@ -212,5 +222,57 @@ GQL;
             ->assertJson(['errors' => [[
                 'message' => 'Cannot query field "one" on type "TermInterface". Did you mean to use an inline fragment on "Term_Tags_Tags"?',
             ]]]);
+    }
+
+    /** @test */
+    public function it_resolves_query_builders()
+    {
+        $blueprint = Blueprint::makeFromFields([])->setHandle('test');
+        BlueprintRepository::shouldReceive('in')->with('collections/test')->andReturn(collect(['test' => $blueprint]));
+        EntryFactory::collection('test')->id('bravo')->data(['title' => 'Bravo'])->create();
+        EntryFactory::collection('test')->id('charlie')->data(['title' => 'Charlie'])->create();
+
+        $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries']])->setHandle('tags');
+        BlueprintRepository::shouldReceive('in')->with('taxonomies/tags')->andReturn(collect(['tags' => $blueprint]));
+
+        Taxonomy::make('tags')->save();
+        Term::make()->taxonomy('tags')->inDefaultLocale()->slug('alpha')->data([
+            'title' => 'Alpha',
+            'entries_field' => ['bravo', 'charlie'],
+        ])->save();
+
+        $query = <<<'GQL'
+{
+    term(id: "tags::alpha") {
+        id
+        ... on Term_Tags_Tags {
+            entries_field {
+                id
+                title
+            }
+        }
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => [
+                'term' => [
+                    'id' => 'tags::alpha',
+                    'entries_field' => [
+                        [
+                            'id' => 'bravo',
+                            'title' => 'Bravo',
+                        ],
+                        [
+                            'id' => 'charlie',
+                            'title' => 'Charlie',
+                        ],
+                    ],
+                ],
+            ]]);
     }
 }

--- a/tests/Feature/GraphQL/TermTest.php
+++ b/tests/Feature/GraphQL/TermTest.php
@@ -19,6 +19,13 @@ class TermTest extends TestCase
 
     protected $enabledQueries = ['taxonomies'];
 
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        BlueprintRepository::partialMock();
+    }
+
     /**
      * @test
      * @environment-setup disableQueries
@@ -221,9 +228,6 @@ GQL;
     public function it_resolves_query_builders()
     {
         $blueprint = Blueprint::makeFromFields([])->setHandle('test');
-
-        BlueprintRepository::partialMock();
-
         BlueprintRepository::shouldReceive('in')->with('collections/test')->andReturn(collect(['test' => $blueprint]));
         EntryFactory::collection('test')->id('bravo')->data(['title' => 'Bravo'])->create();
         EntryFactory::collection('test')->id('charlie')->data(['title' => 'Charlie'])->create();
@@ -266,65 +270,6 @@ GQL;
                         [
                             'id' => 'charlie',
                             'title' => 'Charlie',
-                        ],
-                    ],
-                ],
-            ]]);
-    }
-
-    /** @test */
-    public function it_resolves_sub_terms()
-    {
-        $blueprint = Blueprint::makeFromFields([])->setHandle('test');
-
-        BlueprintRepository::partialMock();
-
-        BlueprintRepository::shouldReceive('in')->with('taxonomies/colors')->andReturn(collect(['colors' => $blueprint]));
-
-        Taxonomy::make('colors')->save();
-        Term::make()->taxonomy('colors')->inDefaultLocale()->slug('red')->data(['title' => 'Red'])->save();
-        Term::make()->taxonomy('colors')->inDefaultLocale()->slug('blue')->data(['title' => 'Blue'])->save();
-
-        $blueprint = Blueprint::makeFromFields(['colors' => ['type' => 'terms', 'taxonomies' => 'colors']])->setHandle('test');
-        BlueprintRepository::shouldReceive('in')->with('taxonomies/tags')->andReturn(collect(['tags' => $blueprint]));
-
-        Taxonomy::make('tags')->save();
-        Term::make()->taxonomy('tags')->inDefaultLocale()->slug('alpha')->data([
-            'title' => 'Alpha',
-            'colors' => ['red', 'blue'],
-        ])->save();
-
-        $query = <<<'GQL'
-{
-    term(id: "tags::alpha") {
-        id
-        ... on Term_Tags_Test {
-            colors {
-                id
-                ... on Term_Colors_Test {
-                    title
-                }
-            }
-        }
-    }
-}
-GQL;
-
-        $this
-            ->withoutExceptionHandling()
-            ->post('/graphql', ['query' => $query])
-            ->assertGqlOk()
-            ->assertExactJson(['data' => [
-                'term' => [
-                    'id' => 'tags::alpha',
-                    'colors' => [
-                        [
-                            'id' => 'colors::red',
-                            'title' => 'Red',
-                        ],
-                        [
-                            'id' => 'colors::blue',
-                            'title' => 'Blue',
                         ],
                     ],
                 ],

--- a/tests/Feature/GraphQL/TermTest.php
+++ b/tests/Feature/GraphQL/TermTest.php
@@ -227,13 +227,13 @@ GQL;
     /** @test */
     public function it_resolves_query_builders()
     {
-        $blueprint = Blueprint::makeFromFields([])->setHandle('test');
-        BlueprintRepository::shouldReceive('in')->with('collections/test')->andReturn(collect(['test' => $blueprint]));
+        $blueprint = Blueprint::makeFromFields([]);
+        BlueprintRepository::shouldReceive('in')->with('collections/test')->andReturn(collect(['test' => $blueprint->setHandle('test')]));
         EntryFactory::collection('test')->id('bravo')->data(['title' => 'Bravo'])->create();
         EntryFactory::collection('test')->id('charlie')->data(['title' => 'Charlie'])->create();
 
-        $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries']])->setHandle('tags');
-        BlueprintRepository::shouldReceive('in')->with('taxonomies/tags')->andReturn(collect(['tags' => $blueprint]));
+        $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries']]);
+        BlueprintRepository::shouldReceive('in')->with('taxonomies/tags')->andReturn(collect(['tags' => $blueprint->setHandle('tags')]));
 
         Taxonomy::make('tags')->save();
         Term::make()->taxonomy('tags')->inDefaultLocale()->slug('alpha')->data([


### PR DESCRIPTION
Fixes #6166

 Fixes `User Error: expected iterable, but did not find one for field` error.
 
 When a taxonomy has a relation to another taxonomy with multiple terms, a `Statamic\Query\OrderedQueryBuilder` is returned by the `resolver` method in `Statamic\GraphQL\Types\TermType` when it's queried as a nested taxonomy in GraphQL.

In the `completeListValue` method in `GraphQL\Executor\ReferenceExecutor` there's a check to see if the `$results` variable is an array or at least Traversable.

```
Utils::invariant(
            is_array($results) || $results instanceof Traversable,
            'User Error: expected iterable, but did not find one for field ' . $info->parentType . '.' . $info->fieldName . '.'
        );
```

By using the `resolveGqlValue` method in the resolver method of `Statamic\GraphQL\Types\TermType` an extra check is added to check if it's a builder, and in that case get the values.
