### PR TITLE
Fix `rememberWithExpiration` cache macro not found error

### DIFF
--- a/src/Providers/StatamicServiceProvider.php
+++ b/src/Providers/StatamicServiceProvider.php
@@ -14,10 +14,10 @@ class StatamicServiceProvider extends AggregateServiceProvider
     protected $providers = [
         IgnitionServiceProvider::class,
         ViewServiceProvider::class,
+        CacheServiceProvider::class,
         AppServiceProvider::class,
         ConsoleServiceProvider::class,
         CollectionsServiceProvider::class,
-        CacheServiceProvider::class,
         FilesystemServiceProvider::class,
         ExtensionServiceProvider::class,
         EventServiceProvider::class,


### PR DESCRIPTION
Credit to @JohnathonKoster for this find!

To test, throw this in your sandbox's composer.json...

```json
"require": {
    "php": "^8.0",
    "laravel/framework": "9.22.0",
    "statamic/cms": "dev-fix/cache-macro-not-found-error as 3.3.23",
    ...
},
```

Also worked when I tested deploying to Netlify...

![CleanShot 2022-07-26 at 14 56 04](https://user-images.githubusercontent.com/5187394/181089266-eb0dd4fb-8466-4339-b933-b8729142f7df.png)

Fixes https://github.com/statamic/cms/issues/6365