### PR TITLE
Add `always_save` field config to allow overriding of conditional field data flow

### DIFF
--- a/resources/js/components/field-conditions/ValidatorMixin.js
+++ b/resources/js/components/field-conditions/ValidatorMixin.js
@@ -28,6 +28,17 @@ export default {
             let validator = new Validator(field, this.values, this.$store, this.storeName);
             let passes = validator.passesConditions();
 
+            // If the field is configured to always save, never omit value.
+            if (field.always_save === true) {
+                this.$store.commit(`publish/${this.storeName}/setHiddenField`, {
+                    dottedKey: dottedFieldPath,
+                    hidden: ! passes,
+                    omitValue: false,
+                });
+
+                return passes;
+            }
+
             // Ensure DOM is updated to ensure all revealers are properly loaded and tracked before committing to store.
             this.$nextTick(() => {
                 let hasRevealerCondition = validator.hasRevealerCondition(dottedPrefix);

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -72,6 +72,7 @@ return [
     'fields_instructions_position_instructions' => 'Show instructions above or below the field.',
     'fields_listable_instructions' => 'Control the listing column visibility.',
     'fields_visibility_instructions' => 'Control field visibility on publish forms.',
+    'fields_always_save_instructions' => 'Always save field value, regardless of how field conditions are evaluated.',
     'fieldset_import_fieldset_instructions' => 'The fieldset to be imported.',
     'fieldset_import_prefix_instructions' => 'The prefix that should be applied to each field when they are imported. eg. hero_',
     'fieldset_intro' => 'Fieldsets are an optional companion to blueprints, acting as reusable partials that can be used within blueprints.',

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -101,6 +101,11 @@ class Field implements Arrayable
         return $visibility ?? 'visible';
     }
 
+    public function alwaysSave()
+    {
+        return Arr::get($this->config, 'always_save', false);
+    }
+
     public function rules()
     {
         $rules = [$this->handle => $this->addNullableRule(array_merge(
@@ -231,6 +236,7 @@ class Field implements Arrayable
             'required' => $this->isRequired(),
             'visibility' => $this->visibility(),
             'read_only' => $this->visibility() === 'read_only', // Deprecated: Addon fieldtypes should now reference new `visibility` state.
+            'always_save' => $this->alwaysSave(),
         ]);
     }
 

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -140,6 +140,13 @@ class FieldsController extends CpController
                 'type' => 'select',
                 'width' => 33,
             ],
+            'always_save' => [
+                'display' => __('Always Save'),
+                'instructions' => __('statamic::messages.fields_always_save_instructions'),
+                'type' => 'toggle',
+                'validate' => 'boolean',
+                'default' => false,
+            ],
         ]);
 
         foreach ($prepends->reverse() as $handle => $prepend) {


### PR DESCRIPTION
As [documented here](https://statamic.dev/conditional-fields#data-flow), field conditions have the following data flow behaviour:

> Only visible fields are submitted with your form data. This allows you to control data flow, and [conditionally apply validation](https://statamic.dev/conditional-fields#validation) to visible fields when needed.

We've talked about this a bunch, but never implemented it. This PR allows a user to override the default data flow behaviour on conditional fields with a setting:

![CleanShot 2022-07-27 at 16 25 22](https://user-images.githubusercontent.com/5187394/181365606-b541741a-7d84-4bfd-b31a-0c73d55f8ab3.png)

Note: You could already override this data flow behaviour by using a revealer field ([as mentioned in the revealer docs](https://statamic.dev/fieldtypes/revealer)), but this allows you to override data flow behaviour on any conditionally hidden fields, regardless of how your conditions are set up.

Closes https://github.com/statamic/cms/issues/6386