### PR TITLE
Fix aggressiveness of html minification when rendering form fields

### DIFF
--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -102,8 +102,11 @@ trait RendersForms
      */
     protected function minifyFieldHtml($html)
     {
-        // Trim whitespace between elements.
-        $html = preg_replace('/>\s*([^<>]*)\s*</', '>$1<', $html);
+        // Leave whitespace around these html elements.
+        $ignoredHtmlElements = collect(['a', 'span'])->implode('|');
+
+        // Trim whitespace between all other html elements.
+        $html = preg_replace('/\s*(<(?!\/*('.$ignoredHtmlElements.'))[^>]+>)\s*/', '$1', $html);
 
         return $html;
     }

--- a/tests/Tags/Concerns/RendersFormsTest.php
+++ b/tests/Tags/Concerns/RendersFormsTest.php
@@ -80,9 +80,12 @@ class RendersFormsTest extends TestCase
             <textarea>
                 Some <a href="/link">link</a> or <span class="tailwind">styled text
             </textarea>
+            <textarea>
+                <a href="/link">Start with</a> and end with a <a href="/link">link</a>
+            </textarea>
 EOT;
 
-        $expected = '<select><option>One</option><option>Two</option></select><label><input type="checkbox">Option <a href="/link">with link</a> text or <span class="tailwind">style</span> class</label><label><input type="radio">Intentionally<a href="/link">tight</a>link or<span class="tailwind">style</span>class</label><textarea>Some <a href="/link">link</a> or <span class="tailwind">styled text</textarea>';
+        $expected = '<select><option>One</option><option>Two</option></select><label><input type="checkbox">Option <a href="/link">with link</a> text or <span class="tailwind">style</span> class</label><label><input type="radio">Intentionally<a href="/link">tight</a>link or<span class="tailwind">style</span>class</label><textarea>Some <a href="/link">link</a> or <span class="tailwind">styled text</textarea><textarea><a href="/link">Start with</a> and end with a <a href="/link">link</a></textarea>';
 
         $this->assertEquals($expected, $this->tag->minifyFieldHtml($fields));
     }

--- a/tests/Tags/Concerns/RendersFormsTest.php
+++ b/tests/Tags/Concerns/RendersFormsTest.php
@@ -58,6 +58,34 @@ class RendersFormsTest extends TestCase
     {
         $this->assertEquals('</form>', $this->tag->formClose());
     }
+
+    /** @test */
+    public function it_minifies_space_between_field_html_elements()
+    {
+        $fields = <<<'EOT'
+            <select>
+                <option>One</option>
+                <option>
+                    Two
+                </option>
+            </select>
+            <label>
+                <input type="checkbox">
+                Option <a href="/link">with link</a> text or <span class="tailwind">style</span> class
+            </label>
+            <label>
+                <input type="radio">
+                Intentionally<a href="/link">tight</a>link or<span class="tailwind">style</span>class
+            </label>
+            <textarea>
+                Some <a href="/link">link</a> or <span class="tailwind">styled text
+            </textarea>
+EOT;
+
+        $expected = '<select><option>One</option><option>Two</option></select><label><input type="checkbox">Option <a href="/link">with link</a> text or <span class="tailwind">style</span> class</label><label><input type="radio">Intentionally<a href="/link">tight</a>link or<span class="tailwind">style</span>class</label><textarea>Some <a href="/link">link</a> or <span class="tailwind">styled text</textarea>';
+
+        $this->assertEquals($expected, $this->tag->minifyFieldHtml($fields));
+    }
 }
 
 class FakeTagWithRendersForms extends Tags


### PR DESCRIPTION
We intentionally minify dynamically rendered field html for a few reasons:

- This trims whitespace around textarea content, ensuring weird results aren't submitted
- Users should be able to use style their own margins/gaps between checkbox inputs and label text using CSS
- etc.

However, if someone wants to render an `<a>` or `<span>` tag in a checkbox option, our regex was a bit too aggressive. This PR adds a whitelist of element types to ignore, leaving whitespace around those elements where used.

Example of how minification now handles a checkbox with a link:

```html
<label><input type="checkbox">Option with <a href="/link">a link</a> to click</label>
```

See test coverage for more detailed examples.

Fixes #6390