### PR TITLE
Antlers: Makes parameters available within slots and named slots

### DIFF
--- a/src/Tags/Partial.php
+++ b/src/Tags/Partial.php
@@ -17,7 +17,7 @@ class Partial extends Tags
     {
         $variables = array_merge($this->context->all(), $this->params->all(), [
             '__frontmatter' => $this->params->all(),
-            'slot' => $this->isPair ? trim($this->parse()) : null,
+            'slot' => $this->isPair ? trim($this->parse($this->params->all())) : null,
         ]);
 
         return view($this->viewName($partial), $variables)

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1368,7 +1368,7 @@ class NodeProcessor
                                 $namedSlots = $namedSlotResults[1];
 
                                 $slotProcessor = $this->cloneProcessor();
-                                $slotProcessor->setData($tagActiveData);
+                                $slotProcessor->setData(array_merge($tagActiveData, $tagParameters));
 
                                 /** @var AntlersNode $slot */
                                 foreach ($namedSlots as $slotName => $slot) {

--- a/tests/Tags/PartialTagsTest.php
+++ b/tests/Tags/PartialTagsTest.php
@@ -101,4 +101,36 @@ class PartialTagsTest extends TestCase
             $this->partialTag('mypartial', 'foo="baz"')
         );
     }
+
+    /** @test */
+    public function parameters_can_be_accessed_within_slots()
+    {
+        $this->viewShouldReturnRaw('mypartial', '{{ slot }}');
+
+        $this->assertEquals(
+            'slot start bar slot end',
+            $this->tag('{{ partial:mypartial foo="bar" }}slot start {{ foo }} slot end{{ /partial:mypartial }}')
+        );
+    }
+
+    /** @test */
+    public function parameters_can_be_accessed_within_named_slots()
+    {
+        $this->viewShouldReturnRaw('mypartial', '<slot>{{ slot }}</slot><named:slot>{{ slot:footer | upper }}</named:slot>');
+
+        $template = <<<'EOT'
+{{ partial:mypartial foo="bar" }}
+    {{ slot:footer }}
+        Footer: {{ foo }}
+    {{ /slot:footer }}
+    
+    Slot: {{ foo }}
+{{ /partial:mypartial }}
+EOT;
+
+        $this->assertEquals(
+            '<slot>Slot: bar</slot><named:slot>FOOTER: BAR</named:slot>',
+            $this->tag($template)
+        );
+    }
 }


### PR DESCRIPTION
This PR makes partial parameters available to slots and named slots:

```antlers
{{ partial:partial_name size="lg" color="blue" }}
    {{ slot:footer }}
        Named slots can also access the parameter variables: {{ size }} - {{ color }}
    {{ /slot:footer }}

    Can now access the parameter variable: {{ size }} - {{ color }}
{{ /partial:partial_name }}
```

Currently, you cannot access the parameter values by name within slots or named slots. This PR also includes test cases for these two scenarios.