### PR TITLE
Generate appropriate token in password reset action

### DIFF
--- a/src/Actions/CopyPasswordResetLink.php
+++ b/src/Actions/CopyPasswordResetLink.php
@@ -47,7 +47,7 @@ class CopyPasswordResetLink extends Action
 
         $passwordResetLink = $user->password()
             ? PasswordReset::url($user->generatePasswordResetToken(), PasswordReset::BROKER_RESETS)
-            : PasswordReset::url($user->generatePasswordResetToken(), PasswordReset::BROKER_ACTIVATIONS);
+            : PasswordReset::url($user->generateActivateAccountToken(), PasswordReset::BROKER_ACTIVATIONS);
 
         return [
             'message' => false,


### PR DESCRIPTION
Fixes #6402

This change makes sure that the token is generated into the right spot.

i.e. If you have your `config/statamic/users.php` site configured like this

```php
'passwords' => [
    'resets' => 'resets',
    'activations' => 'activations',
],
```

then the activation token would be generated into the resets table/file, which was the issue.


Also, the "waiting for the link to expire" step mentioned in the issue was not necessary to see the bug. A first time activation link would have been just as broken.
