### PR TITLE
Add markdown support to toggle `inline_label` config

### DIFF
--- a/resources/js/components/fieldtypes/ToggleFieldtype.vue
+++ b/resources/js/components/fieldtypes/ToggleFieldtype.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="toggle-fieldtype-wrapper">
         <toggle-input :value="value" @input="update" :read-only="isReadOnly" />
-        <label v-if="config.inline_label" class="ml-1 font-normal">{{ config.inline_label }}</label>
+        <label v-if="config.inline_label" class="inline-label" v-html="$options.filters.markdown(config.inline_label)"></label>
     </div>
 </template>
 

--- a/resources/sass/components/toggle.scss
+++ b/resources/sass/components/toggle.scss
@@ -8,6 +8,16 @@ $toggle_radius: 20px;
     height: 32px;
     display: flex;
     align-items: center;
+
+    .inline-label {
+        @apply .ml-1 .font-normal .text-grey-70;
+        a {
+            @apply .text-grey-80 underline;
+            &:hover {
+                @apply .text-blue-darker;
+            }
+        }
+    }
 }
 
 .locale-status-field .toggle-fieldtype-wrapper {


### PR DESCRIPTION
```yaml
inline_label: I agree [to the terms](/terms)!
```

![CleanShot 2022-08-01 at 11 47 27](https://user-images.githubusercontent.com/5187394/182188471-a0060f38-aa81-496f-ada4-c6e0871c55db.gif)

Styles mostly copied from our `instructions` `.help-block`

Closes #6411