### PR TITLE
Handle embedding vimeo.com unlisted urls

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2853,17 +2853,7 @@ class CoreModifiers extends Modifier
         if (Str::contains($url, 'vimeo')) {
             $url = str_replace('/vimeo.com', '/player.vimeo.com/video', $url);
 
-            // private vimeo urls are in the form vimeo.com/id/hash, but embeds pass the hash as a get param
-            $hash = '';
-            if (Str::substrCount($url, '/') > 4) {
-                $hash = Str::afterLast($url, '/');
-                $url = Str::beforeLast($url, '/');
-
-                if (Str::contains($hash, '?')) {
-                    $url .= '?'.Str::after($hash, '?');
-                    $hash = Str::before($hash, '?');
-                }
-            }
+            [$url, $hash] = $this->handleUnlistedVimeoUrls($url);
 
             $paramsToAdd = '?dnt=1';
             if ($hash) {
@@ -3014,5 +3004,22 @@ class CoreModifiers extends Modifier
         return $this->usingRuntimeMethodSyntax($context) ?
                 $params[$key] :
                 Arr::get($context, $params[$key], $params[$key]);
+    }
+
+    // unlisted vimeo urls are in the form vimeo.com/id/hash, but embeds pass the hash as a get param
+    private function handleUnlistedVimeoUrls($url)
+    {
+        $hash = '';
+        if (Str::substrCount($url, '/') > 4) {
+            $hash = Str::afterLast($url, '/');
+            $url = Str::beforeLast($url, '/');
+
+            if (Str::contains($hash, '?')) {
+                $url .= '?'.Str::after($hash, '?');
+                $hash = Str::before($hash, '?');
+            }
+        }
+
+        return [$url, $hash];
     }
 }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2853,10 +2853,27 @@ class CoreModifiers extends Modifier
         if (Str::contains($url, 'vimeo')) {
             $url = str_replace('/vimeo.com', '/player.vimeo.com/video', $url);
 
+            // private vimeo urls are in the form vimeo.com/id/hash, but embeds pass the hash as a get param
+            $hash = '';
+            if (Str::substrCount($url, '/') > 4) {
+                $hash = Str::afterLast($url, '/');
+                $url = Str::beforeLast($url, '/');
+
+                if (Str::contains($hash, '?')) {
+                    $url .= '?'.Str::after($hash, '?');
+                    $hash = Str::before($hash, '?');
+                }
+            }
+
+            $paramsToAdd = '?dnt=1';
+            if ($hash) {
+                $paramsToAdd .= '&h='.$hash;
+            }
+
             if (Str::contains($url, '?')) {
-                $url = str_replace('?', '?dnt=1&', $url);
+                $url = str_replace('?', $paramsToAdd.'&', $url);
             } else {
-                $url .= '?dnt=1';
+                $url .= $paramsToAdd;
             }
 
             return $url;

--- a/tests/Modifiers/EmbedUrlTest.php
+++ b/tests/Modifiers/EmbedUrlTest.php
@@ -28,6 +28,20 @@ class EmbedUrlTest extends TestCase
     }
 
     /** @test */
+    public function it_transforms_private_vimeo_urls()
+    {
+        $embedUrl = 'https://player.vimeo.com/video/735352648?dnt=1&h=fa55a4d0fc';
+
+        $this->assertEquals($embedUrl, $this->embed('https://vimeo.com/735352648/fa55a4d0fc'));
+
+        $this->assertEquals(
+            $embedUrl.'&foo=bar',
+            $this->embed('https://vimeo.com/735352648/fa55a4d0fc?foo=bar'),
+            'It appends the do not track query param if a query string already exists.'
+        );
+    }
+
+    /** @test */
     public function it_transforms_youtube_urls()
     {
         $embedUrl = 'https://www.youtube-nocookie.com/embed/s72r_wu_NVY';


### PR DESCRIPTION
Vimeo.com unlisted videos currently can't be embedded as the embed_url modifier doesnt handle the extra 'hash' on the end of the url being converted to an URL param.

eg. currently `https://vimeo.com/735352648/fa55a4d0fc` becomes `https://vimeo.com/735352648/fa55a4d0fc?dnt=1` which gives an error.

the correct behaviour should be `https://vimeo.com/735352648/fa55a4d0fc` becomes `https://vimeo.com/735352648?dnt=1&h=fa55a4d0fc`

This PR updates the modifier and adds tests to do just that.