### PR TITLE
Default to the Runtime Antlers parser

### DIFF
--- a/config/antlers.php
+++ b/config/antlers.php
@@ -7,13 +7,12 @@ return [
     | Version
     |--------------------------------------------------------------------------
     |
-    | The desired Antlers language version to utilize. Possible values are:
-    |   - regex: Utilize pre-3.3 Antlers. Appropriate for existing sites.
-    |   - runtime: Utilizes >= 3.3 Antlers, recommended for new sites.
+    | The desired Antlers language version to utilize. Supported values are
+    | "runtime" for the modern parser, or "regex" for the legacy parser.
     |
     */
 
-    'version' => 'regex',
+    'version' => 'runtime',
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,8 +74,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         foreach ($configs as $config) {
             $app['config']->set("statamic.$config", require(__DIR__."/../config/{$config}.php"));
         }
-
-        $app['config']->set('statamic.antlers.version', 'runtime');
     }
 
     protected function getEnvironmentSetUp($app)


### PR DESCRIPTION
This makes the runtime parser the default for 3.4.

The regex parser will **not** be removed yet. It'll still be available if you need it.

**Potential breaking change**

If you had a pre-3.3 site and upgraded to 3.3 and _didn't_ opt into the new parser (by adding or editing `config/statamic/antlers.php`), you would have stayed on the old parser. When you upgrade to 3.4, you'll get switched to the new one. If you want to stay on the old one, you'll simply need to adjust the config.

```php
// config/statamic/antlers.php
'version' => 'regex',
```