### PR TITLE
Ability to use a custom Tiptap editor class

### DIFF
--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -133,7 +133,7 @@ class Augmentor
 
     protected function textValue($value)
     {
-        $fieldtype = (new Text())->setField(new Field('text', [
+        $fieldtype = (new Text)->setField(new Field('text', [
             'antlers' => $this->fieldtype->config('antlers'),
         ]));
 

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -157,12 +157,16 @@ class Augmentor
 
     public function renderHtmlToProsemirror(string $value)
     {
-        return (new Editor(['extensions' => $this->extensions()]))->setContent($value)->getDocument();
+        return app()->makeWith(Editor::class, [
+            'configuration' => ['extensions' => $this->extensions(),
+        ]])->setContent($value)->getDocument();
     }
 
     public function renderProsemirrorToHtml(array $value)
     {
-        return (new Editor(['extensions' => $this->extensions()]))->setContent($value)->getHTML();
+        return app()->makeWith(Editor::class, [
+            'configuration' => ['extensions' => $this->extensions(),
+        ]])->setContent($value)->getHTML();
     }
 
     public function extensions()

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -175,7 +175,7 @@ class Augmentor
 
     public function extensions()
     {
-        $this->addExtension('image', $this->withStatamicImageUrls ? new StatamicImageNode() : new ImageNode());
+        $this->addExtension('image', $this->withStatamicImageUrls ? new StatamicImageNode : new ImageNode);
 
         foreach (self::$replaceExtensions as $name => $replacement) {
             self::$extensions[$name] = $replacement;

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -157,20 +157,21 @@ class Augmentor
 
     public function renderHtmlToProsemirror(string $value)
     {
-        return app()->makeWith(Editor::class, [
-            'configuration' => [
-                'extensions' => $this->extensions(),
-            ],
-        ])->setContent($value)->getDocument();
+        return $this->editor()->setContent($value)->getDocument();
     }
 
     public function renderProsemirrorToHtml(array $value)
+    {
+        return $this->editor()->setContent($value)->getHTML();
+    }
+
+    private function editor()
     {
         return app()->makeWith(Editor::class, [
             'configuration' => [
                 'extensions' => $this->extensions(),
             ],
-        ])->setContent($value)->getHTML();
+        ]);
     }
 
     public function extensions()

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -133,7 +133,7 @@ class Augmentor
 
     protected function textValue($value)
     {
-        $fieldtype = (new Text)->setField(new Field('text', [
+        $fieldtype = (new Text())->setField(new Field('text', [
             'antlers' => $this->fieldtype->config('antlers'),
         ]));
 
@@ -158,20 +158,24 @@ class Augmentor
     public function renderHtmlToProsemirror(string $value)
     {
         return app()->makeWith(Editor::class, [
-            'configuration' => ['extensions' => $this->extensions(),
-        ]])->setContent($value)->getDocument();
+            'configuration' => [
+                'extensions' => $this->extensions(),
+            ],
+        ])->setContent($value)->getDocument();
     }
 
     public function renderProsemirrorToHtml(array $value)
     {
         return app()->makeWith(Editor::class, [
-            'configuration' => ['extensions' => $this->extensions(),
-        ]])->setContent($value)->getHTML();
+            'configuration' => [
+                'extensions' => $this->extensions(),
+            ],
+        ])->setContent($value)->getHTML();
     }
 
     public function extensions()
     {
-        $this->addExtension('image', $this->withStatamicImageUrls ? new StatamicImageNode : new ImageNode);
+        $this->addExtension('image', $this->withStatamicImageUrls ? new StatamicImageNode() : new ImageNode());
 
         foreach (self::$replaceExtensions as $name => $replacement) {
             self::$extensions[$name] = $replacement;


### PR DESCRIPTION
This PR adds the ability to use a custom Tiptap editor class.

This PR is for Bard 2 / TipTap 2 and targets the master branch.

## Use Case

As much as I’ve tried to work around it there are some bard customisations that are only really possible if you can get some extra logic into the start of the Tiptap rendering process. An example is the [metadata feature](https://jacksleight.github.io/statamic-bard-mutator/mutators.html#metadata) of my Mutator addon. My current implementation of this [relies on a tag](https://jacksleight.github.io/statamic-bard-mutator/rendering.html#tag), but that’s a bit of a hack and the dependency on a tag means these features aren’t available when using the REST/GraphQL APIs (without the user jumping through additional hoops).

If I could bind an extended version of the editor class I could remove the need for the tag and make those features work for everyone.