### PR TITLE
Augment submission data in email config

### DIFF
--- a/src/Forms/SendEmails.php
+++ b/src/Forms/SendEmails.php
@@ -53,8 +53,10 @@ class SendEmails implements ShouldQueue
 
         $config = isset($config['to']) ? [$config] : $config;
 
-        return collect($config)->map(function ($config) use ($submission) {
-            return $this->parseAntlersInConfig($config, $submission->toAugmentedArray());
+        $data = $submission->toAugmentedArray();
+
+        return collect($config)->map(function ($config) use ($data) {
+            return $this->parseAntlersInConfig($config, $data);
         });
     }
 

--- a/src/Forms/SendEmails.php
+++ b/src/Forms/SendEmails.php
@@ -54,7 +54,7 @@ class SendEmails implements ShouldQueue
         $config = isset($config['to']) ? [$config] : $config;
 
         return collect($config)->map(function ($config) use ($submission) {
-            return $this->parseAntlersInConfig($config, $submission->data());
+            return $this->parseAntlersInConfig($config, $submission->toAugmentedArray());
         });
     }
 


### PR DESCRIPTION
This simple PR makes the augmented submission data available to the form email config. This allows doing things like:

```
subject: 'Hi, {{ salutation:label }} {{ name }}. You signed up for course {{ course:title }}.'
```