### PR TITLE
Empty grid/replicator/bard should be indexed as null

### DIFF
--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -241,4 +241,9 @@ class Grid extends Fieldtype
             return array_merge($values, $processed);
         })->all();
     }
+
+    public function toQueryableValue($value)
+    {
+        return empty($value) ? null : $value;
+    }
 }

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -266,4 +266,9 @@ class Replicator extends Fieldtype
             return array_merge($values, $processed);
         })->all();
     }
+
+    public function toQueryableValue($value)
+    {
+        return empty($value) ? null : $value;
+    }
 }

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -536,6 +536,14 @@ EOT;
         $this->assertEquals($expected, $bard->augment($html));
     }
 
+    /** @test */
+    public function it_converts_a_queryable_value()
+    {
+        $this->assertNull((new Bard)->toQueryableValue(null));
+        $this->assertNull((new Bard)->toQueryableValue([]));
+        $this->assertEquals([['foo' => 'bar']], (new Bard)->toQueryableValue([['foo' => 'bar']]));
+    }
+
     private function bard($config = [])
     {
         return (new Bard)->setField(new Field('test', array_merge(['type' => 'bard', 'sets' => ['one' => []]], $config)));

--- a/tests/Fieldtypes/GridTest.php
+++ b/tests/Fieldtypes/GridTest.php
@@ -6,6 +6,7 @@ use Facades\Statamic\Fields\FieldRepository;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Values;
+use Statamic\Fieldtypes\Grid;
 use Tests\TestCase;
 
 class GridTest extends TestCase
@@ -347,5 +348,13 @@ class GridTest extends TestCase
             ['words' => 'one (augmented)'],
             ['words' => 'two (augmented)'],
         ], collect($augmented)->toArray());
+    }
+
+    /** @test */
+    public function it_converts_a_queryable_value()
+    {
+        $this->assertNull((new Grid)->toQueryableValue(null));
+        $this->assertNull((new Grid)->toQueryableValue([]));
+        $this->assertEquals([['foo' => 'bar']], (new Grid)->toQueryableValue([['foo' => 'bar']]));
     }
 }

--- a/tests/Fieldtypes/ReplicatorTest.php
+++ b/tests/Fieldtypes/ReplicatorTest.php
@@ -6,6 +6,7 @@ use Facades\Statamic\Fields\FieldRepository;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Values;
+use Statamic\Fieldtypes\Replicator;
 use Tests\TestCase;
 
 class ReplicatorTest extends TestCase
@@ -366,5 +367,13 @@ class ReplicatorTest extends TestCase
             ['type' => 'a', 'words' => 'one (augmented)'],
             ['type' => 'a', 'words' => 'two (augmented)'],
         ], collect($augmented)->toArray());
+    }
+
+    /** @test */
+    public function it_converts_a_queryable_value()
+    {
+        $this->assertNull((new Replicator)->toQueryableValue(null));
+        $this->assertNull((new Replicator)->toQueryableValue([]));
+        $this->assertEquals([['foo' => 'bar']], (new Replicator)->toQueryableValue([['foo' => 'bar']]));
     }
 }


### PR DESCRIPTION
If you have a template with a query like `{{ collection:products mygrid:exists="true" }}` where you are attempting to only show entries that have something in the grid field.

If you save an entry with an empty grid, the empty array was being indexed, which made the "exist" condition pass, even though it was empty.

This PR makes sure that if you have an empty Grid/Replicator/Bard, that a null will be indexed instead of an empty array.