### PR TITLE
Fix extra margin on narrow date only fields

### DIFF
--- a/resources/sass/components/fieldtypes/datetime.scss
+++ b/resources/sass/components/fieldtypes/datetime.scss
@@ -45,12 +45,8 @@
 .date-time-container.narrow {
     @apply block;
 
-    .date-container {
-        @apply mb-1;
-    }
-
     .time-container {
-        @apply ml-0;
+        @apply mt-1 ml-0;
     }
 }
 


### PR DESCRIPTION
If you have a date field with time disabled in a narrow container extra margin appears below the field. This is visible when the field appears in a grid or when the field can be toggled, where it will cause a layout shift:

https://user-images.githubusercontent.com/126740/182614214-75bcd755-8780-4196-8486-0202329e7ee0.mp4

![Screenshot 2022-08-03 at 14 07 42](https://user-images.githubusercontent.com/126740/182615457-75547802-84f4-4fd2-b3d3-2f0390fce3f1.png)

This PR fixes that by moving the margin from the date container to the time container, so it only appears when time is enabled.