### PR TITLE
Remove empty Bard paragraphs

### DIFF
--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -26,6 +26,7 @@ return [
     'bard.config.link_noreferrer' => 'Set `rel="noreferrer"` on all links.',
     'bard.config.previews' => 'Shown when sets are collapsed.',
     'bard.config.reading_time' => 'Show estimated reading time at the bottom of the field.',
+    'bard.config.remove_empty_paragraphs' => 'Choose how to deal with empty paragraphs.',
     'bard.config.save_html' => 'Save HTML instead of structured data. This simplifies but limits control of your template markup.',
     'bard.config.sets' => 'Sets are configurable blocks of fields that can be inserted anywhere in your Bard content.',
     'bard.config.target_blank' => 'Set `target="_blank"` on all links.',

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -239,11 +239,13 @@ class Bard extends Replicator
         if ($this->config('remove_empty_paragraphs') === 'trim') {
             if ($this->shouldRemoveParagraph($value->first())) {
                 $value->shift();
+
                 return $this->removeEmptyParagraphs($value);
             }
 
             if ($this->shouldRemoveParagraph($value->last())) {
                 $value->pop();
+
                 return $this->removeEmptyParagraphs($value);
             }
         }

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -169,7 +169,7 @@ class Bard extends Replicator
                 'options' => [
                     'false' => __("Don't remove empty paragraphs"),
                     'true' => __('Remove all empty paragraphs'),
-                    'trim' => __('Remove empty paragraphs at the top and the bottom'),
+                    'trim' => __('Remove empty paragraphs at the start and end'),
                 ],
                 'default' => 'false',
                 'width' => 50,

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -161,6 +161,19 @@ class Bard extends Replicator
                 'type' => 'toggle',
                 'width' => 50,
             ],
+            'remove_empty_paragraphs' => [
+                'display' => __('Remove Empty Paragraphs'),
+                'instructions' => __('statamic::fieldtypes.bard.config.remove_empty_paragraphs'),
+                'type' => 'select',
+                'cast_booleans' => true,
+                'options' => [
+                    'false' => __("Don't remove empty paragraphs"),
+                    'true' => __('Remove all empty paragraphs'),
+                    'trim' => __('Remove empty paragraphs at the top and the bottom'),
+                ],
+                'default' => 'false',
+                'width' => 50,
+            ],
         ];
     }
 
@@ -186,6 +199,8 @@ class Bard extends Replicator
     {
         $value = json_decode($value, true);
 
+        $value = $this->removeEmptyParagraphs($value);
+
         $structure = collect($value)->map(function ($row) {
             if ($row['type'] !== 'set') {
                 return $row;
@@ -207,6 +222,39 @@ class Bard extends Replicator
         }
 
         return $structure;
+    }
+
+    protected function removeEmptyParagraphs($value)
+    {
+        $value = collect($value);
+
+        if ($this->config('remove_empty_paragraphs') === true) {
+            $empty = $value->filter(function ($value) {
+                return $this->shouldRemoveParagraph($value);
+            });
+
+            return $value->diffKeys($empty)->values();
+        }
+
+        if ($this->config('remove_empty_paragraphs') === 'trim') {
+            if ($this->shouldRemoveParagraph($value->first())) {
+                $value->shift();
+                return $this->removeEmptyParagraphs($value);
+            }
+
+            if ($this->shouldRemoveParagraph($value->last())) {
+                $value->pop();
+                return $this->removeEmptyParagraphs($value);
+            }
+        }
+
+        return $value;
+    }
+
+    protected function shouldRemoveParagraph($value)
+    {
+        return Arr::get($value, 'type') === 'paragraph'
+            && ! Arr::has($value, 'content');
     }
 
     protected function shouldSaveHtml()

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -20,7 +20,8 @@ class BardTest extends TestCase
     /** @test */
     public function it_augments_prosemirror_structure_to_a_template_friendly_array()
     {
-        (new class extends Fieldtype {
+        (new class extends Fieldtype
+        {
             public static $handle = 'test';
 
             public function augment($value)

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -20,8 +20,7 @@ class BardTest extends TestCase
     /** @test */
     public function it_augments_prosemirror_structure_to_a_template_friendly_array()
     {
-        (new class extends Fieldtype
-        {
+        (new class extends Fieldtype {
             public static $handle = 'test';
 
             public function augment($value)
@@ -394,6 +393,47 @@ class BardTest extends TestCase
 
         // When it is actually null (eg. when it was not in the front matter to begin with, and was never touched), it's an empty array.
         $this->assertNull($bard->process('[]'));
+    }
+
+    /** @test */
+    public function it_removes_empty_paragraphs()
+    {
+        $content = '[
+            {"type":"paragraph"},
+            {"type":"paragraph"},
+            {"type":"paragraph", "content": "foo"},
+            {"type":"paragraph"},
+            {"type":"paragraph", "content": "foo"},
+            {"type":"paragraph"},
+            {"type":"paragraph"}
+        ]';
+
+        $containsAllEmptyParagraphs = $this->bard(['remove_empty_paragraphs' => false])->process($content);
+
+        $this->assertEquals($containsAllEmptyParagraphs, [
+            ['type' => 'paragraph'],
+            ['type' => 'paragraph'],
+            ['type' => 'paragraph', 'content' => 'foo'],
+            ['type' => 'paragraph'],
+            ['type' => 'paragraph', 'content' => 'foo'],
+            ['type' => 'paragraph'],
+            ['type' => 'paragraph'],
+        ]);
+
+        $removedAllEmptyParagraphs = $this->bard(['remove_empty_paragraphs' => true])->process($content);
+
+        $this->assertEquals($removedAllEmptyParagraphs, [
+            ['type' => 'paragraph', 'content' => 'foo'],
+            ['type' => 'paragraph', 'content' => 'foo'],
+        ]);
+
+        $trimmedEmptyParagraphs = $this->bard(['remove_empty_paragraphs' => 'trim'])->process($content);
+
+        $this->assertEquals($trimmedEmptyParagraphs, [
+            ['type' => 'paragraph', 'content' => 'foo'],
+            ['type' => 'paragraph'],
+            ['type' => 'paragraph', 'content' => 'foo'],
+        ]);
     }
 
     /** @test */


### PR DESCRIPTION
This PR allows removing empty paragraphs from Bard fields. As discussed over here: https://github.com/statamic/ideas/issues/836
 
It introduces `remove_empty_paragraphs` with three options:

- `false`: Don't remove empty paragraphs
- `true`: Remove all empty paragraphs
- `trim`: Remove empty paragraphs at the top and the bottom