### PR TITLE
Antlers Runtime: fix incorrect nav depth when using a partial multiple times

### DIFF
--- a/tests/Antlers/Runtime/RecursiveNodesTest.php
+++ b/tests/Antlers/Runtime/RecursiveNodesTest.php
@@ -5,13 +5,15 @@ namespace Tests\Antlers\Runtime;
 use Statamic\Facades\Nav;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
 use Tests\Antlers\ParserTestCase;
+use Tests\FakesViews;
 use Tests\PreventSavingStacheItemsToDisk;
 
 class RecursiveNodesTest extends ParserTestCase
 {
-    use PreventSavingStacheItemsToDisk;
+    use PreventSavingStacheItemsToDisk,
+        FakesViews;
 
-    public function test_recursive_nodes_on_structures()
+    private function makeNavTree()
     {
         $tree = [
             ['id' => 'home', 'title' => 'Home', 'url' => '/'],
@@ -40,6 +42,219 @@ class RecursiveNodesTest extends ParserTestCase
         $nav = Nav::make('main');
         $nav->makeTree('en', $tree)->save();
         $nav->save();
+    }
+
+    public function test_recursive_nodes_on_structures_inside_partials()
+    {
+        $this->makeNavTree();
+
+        $this->withFakeViews();
+
+        $navTemplate = <<<'EOT'
+{{ nav:main include_home="true" }}
+<div>{{ depth }} {{ title }}</div>
+{{ if children }}{{ *recursive children* }}{{ /if }}
+{{ /nav:main }}
+EOT;
+
+        $this->viewShouldReturnRaw('nav', $navTemplate);
+
+        $mainTemplate = <<<'EOT'
+{{ partial:nav }}
+{{ partial:nav }}
+--------------------------------------------------------------------------------
+{{ nav:main include_home="true" }}
+<div>{{ depth }} {{ title }}</div>
+{{ if children }}{{ *recursive children* }}{{ /if }}
+{{ /nav:main }}
+--------------------------------------------------------------------------------
+{{ nav:main include_home="true" }}
+<div>{{ depth }} {{ title }}</div>
+{{ if children }}{{ *recursive children* }}{{ /if }}
+{{ /nav:main }}
+--------------------------------------------------------------------------------
+{{ partial:nav }}
+{{ partial:nav }}
+EOT;
+
+        $expected = <<<'EOT'
+<div>1 Home</div>
+
+
+<div>1 About</div>
+
+<div>2 Team</div>
+
+
+<div>2 Leadership</div>
+
+
+
+<div>1 Projects</div>
+
+<div>2 Project-1</div>
+
+
+<div>2 Project-2</div>
+
+<div>3 Project 2 Nested</div>
+
+
+
+
+<div>1 Contact</div>
+
+
+
+<div>1 Home</div>
+
+
+<div>1 About</div>
+
+<div>2 Team</div>
+
+
+<div>2 Leadership</div>
+
+
+
+<div>1 Projects</div>
+
+<div>2 Project-1</div>
+
+
+<div>2 Project-2</div>
+
+<div>3 Project 2 Nested</div>
+
+
+
+
+<div>1 Contact</div>
+
+
+--------------------------------------------------------------------------------
+
+<div>1 Home</div>
+
+
+<div>1 About</div>
+
+<div>2 Team</div>
+
+
+<div>2 Leadership</div>
+
+
+
+<div>1 Projects</div>
+
+<div>2 Project-1</div>
+
+
+<div>2 Project-2</div>
+
+<div>3 Project 2 Nested</div>
+
+
+
+
+<div>1 Contact</div>
+
+
+--------------------------------------------------------------------------------
+
+<div>1 Home</div>
+
+
+<div>1 About</div>
+
+<div>2 Team</div>
+
+
+<div>2 Leadership</div>
+
+
+
+<div>1 Projects</div>
+
+<div>2 Project-1</div>
+
+
+<div>2 Project-2</div>
+
+<div>3 Project 2 Nested</div>
+
+
+
+
+<div>1 Contact</div>
+
+
+--------------------------------------------------------------------------------
+
+<div>1 Home</div>
+
+
+<div>1 About</div>
+
+<div>2 Team</div>
+
+
+<div>2 Leadership</div>
+
+
+
+<div>1 Projects</div>
+
+<div>2 Project-1</div>
+
+
+<div>2 Project-2</div>
+
+<div>3 Project 2 Nested</div>
+
+
+
+
+<div>1 Contact</div>
+
+
+
+<div>1 Home</div>
+
+
+<div>1 About</div>
+
+<div>2 Team</div>
+
+
+<div>2 Leadership</div>
+
+
+
+<div>1 Projects</div>
+
+<div>2 Project-1</div>
+
+
+<div>2 Project-2</div>
+
+<div>3 Project 2 Nested</div>
+
+
+
+
+<div>1 Contact</div>
+EOT;
+
+
+        $this->assertSame($expected, trim($this->renderString($mainTemplate, [], true)));
+    }
+
+    public function test_recursive_nodes_on_structures()
+    {
+        $this->makeNavTree();
 
         $template = <<<'EOT'
 {{ nav:main include_home="true" }}


### PR DESCRIPTION
This PR fixes #6439 by resetting the recursive state of the recursive parent node before it exits and moves onto the next internal node. This prevents depths from being carried onto the next execution if the same node is re-used (like when they are contained within partials). The linked issue contains fantastic steps to reproduce.

```antlers
<ul>
    {{# This PR now tracks how deeply nested we are on this node. #}}
    {{ nav:menu }}
    <li>
        <span>{{ title }} - {{ depth }}</span>

        {{ if children }}
                {{#
                      Each time we hit this point, we'll update the total nesting level,
                      as well as continue to update the depth mapping.
                 #}}
        <ul>{{ *recursive children* }}</ul>
        {{ /if }}
    </li>
    {{# The recursive state is now forecfully reset before we leave this point for the last time. #}}
    {{ /nav:menu }}
</ul>
```

This PR also includes new tests to cover this scenario.