### PR TITLE
Cache files with different paths differently

### DIFF
--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -394,9 +394,7 @@ class Statamic
             return (string) $path;
         }
 
-        $cachePath = substr($path, -40);
-
-        return Cache::rememberForever("statamic-{$extension}-{$name}-{$cachePath}", function () use ($path, $extension) {
+        return Cache::rememberForever("statamic-{$extension}-{$name}-{md5($path)}", function () use ($path, $extension) {
             // In case a file without any version will be passed,
             // a random version number will be created.
             if (! Str::contains($path, '?v=')) {

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -394,8 +394,9 @@ class Statamic
             return (string) $path;
         }
 
-        return Cache::rememberForever("statamic-{$extension}-{$name}", function () use ($path, $extension) {
+        $cachePath = substr($path, -40);
 
+        return Cache::rememberForever("statamic-{$extension}-{$name}-{$cachePath}", function () use ($path, $extension) {
             // In case a file without any version will be passed,
             // a random version number will be created.
             if (! Str::contains($path, '?v=')) {

--- a/tests/StatamicTest.php
+++ b/tests/StatamicTest.php
@@ -243,6 +243,17 @@ class StatamicTest extends TestCase
         $this->assertEquals($testStyle, $path);
     }
 
+    /** @test */
+    public function assets_with_equal_names_will_be_cached_differently()
+    {
+        Statamic::style('test-name', __DIR__.'/../resources/css/test-path-1.css');
+        Statamic::style('test-name', __DIR__.'/../resources/css/test-path-2.css');
+
+        $allStyles = Statamic::availableStyles(Request::create('/'));
+
+        $this->assertNotEquals($allStyles['test-name'][0], $allStyles['test-name'][1]);
+    }
+
     /**
      * @test
      * @dataProvider cpAssetUrlProvider


### PR DESCRIPTION
An Issue came up on Discord:

```php
class ServiceProvider extends AddonServiceProvider
{
    protected $stylesheets = [
        __DIR__.'/../resources/css/admin-styler-base.css'
        // Under the hood, Statamic::style() will be called. The name     
        // `admin-styler` will be used automatically as  name, as it's the addon name.
        // The cache prefix will be::
        // "statamic-{$extension}-{$name}"
        // In that case `statamic-css-admin-styler`
        // @see https://github.com/statamic/cms/pull/6312/files#diff-a932c529bea3a9e695fb0306ae4635bda104d78b85cb8eb7bc15de11bc2f44d7R397
    ];

    public function boot()
    {
        parent::boot();

        Statamic::style('admin-styler', 'admin-styler-custom');
        // The name is `admin-styler` as well, so the cache kicks in and will deliver the cached file instead.
    }
}
```

**The fix does allow for assets with the same name but different paths.** 