### PR TITLE
Add text align support to Bard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@tiptap/extension-table-header": "^2.0.0-beta.22",
         "@tiptap/extension-table-row": "^2.0.0-beta.19",
         "@tiptap/extension-text": "^2.0.0-beta.15",
+        "@tiptap/extension-text-align": "^2.0.0-beta.31",
         "@tiptap/extension-underline": "^2.0.0-beta.23",
         "@tiptap/vue-2": "^2.0.0-beta.78",
         "alpinejs": "^3.1.1",
@@ -2945,6 +2946,18 @@
       "version": "2.0.0-beta.15",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.0.0-beta.15.tgz",
       "integrity": "sha512-S3j2+HyV2gsXZP8Wg/HA+YVXQsZ3nrXgBM9HmGAxB0ESOO50l7LWfip0f3qcw1oRlh5H3iLPkA6/f7clD2/TFA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0-beta.1"
+      }
+    },
+    "node_modules/@tiptap/extension-text-align": {
+      "version": "2.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-2.0.0-beta.31.tgz",
+      "integrity": "sha512-gSJqi57piiMPc2r6WEkXv7ZgQIogigsRUhmlnZC/7s3zzOvjXrexWnV0Ctt/9A7BKcM7OHMykpZyoewvk6QRTw==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -18926,6 +18939,12 @@
       "version": "2.0.0-beta.15",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.0.0-beta.15.tgz",
       "integrity": "sha512-S3j2+HyV2gsXZP8Wg/HA+YVXQsZ3nrXgBM9HmGAxB0ESOO50l7LWfip0f3qcw1oRlh5H3iLPkA6/f7clD2/TFA==",
+      "requires": {}
+    },
+    "@tiptap/extension-text-align": {
+      "version": "2.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-2.0.0-beta.31.tgz",
+      "integrity": "sha512-gSJqi57piiMPc2r6WEkXv7ZgQIogigsRUhmlnZC/7s3zzOvjXrexWnV0Ctt/9A7BKcM7OHMykpZyoewvk6QRTw==",
       "requires": {}
     },
     "@tiptap/extension-underline": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@tiptap/extension-table-header": "^2.0.0-beta.22",
     "@tiptap/extension-table-row": "^2.0.0-beta.19",
     "@tiptap/extension-text": "^2.0.0-beta.15",
+    "@tiptap/extension-text-align": "^2.0.0-beta.31",
     "@tiptap/extension-underline": "^2.0.0-beta.23",
     "@tiptap/vue-2": "^2.0.0-beta.78",
     "alpinejs": "^3.1.1",

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -95,6 +95,7 @@ import TableRow from '@tiptap/extension-table-row';
 import TableCell from '@tiptap/extension-table-cell';
 import TableHeader from '@tiptap/extension-table-header';
 import Text from '@tiptap/extension-text';
+import TextAlign from '@tiptap/extension-text-align';
 import Underline from '@tiptap/extension-underline';
 import BardSource from './Source.vue';
 import Document from './Document';
@@ -572,6 +573,13 @@ export default {
             if (btns.includes('h5')) levels.push(5);
             if (btns.includes('h6')) levels.push(6);
             if (levels.length) exts.push(Heading.configure({ levels }));
+
+            let aligns = [];
+            if (btns.includes('alignleft')) aligns.push('left');
+            if (btns.includes('aligncenter')) aligns.push('center');
+            if (btns.includes('alignright')) aligns.push('right');
+            if (btns.includes('alignjustify')) aligns.push('justify');
+            if (aligns.length) exts.push(TextAlign.configure({ types: ['heading', 'paragraph'], aligns }));
 
             if (btns.includes('table')) {
                 exts.push(

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -574,12 +574,12 @@ export default {
             if (btns.includes('h6')) levels.push(6);
             if (levels.length) exts.push(Heading.configure({ levels }));
 
-            let aligns = [];
-            if (btns.includes('alignleft')) aligns.push('left');
-            if (btns.includes('aligncenter')) aligns.push('center');
-            if (btns.includes('alignright')) aligns.push('right');
-            if (btns.includes('alignjustify')) aligns.push('justify');
-            if (aligns.length) exts.push(TextAlign.configure({ types: ['heading', 'paragraph'], aligns }));
+            let alignments = [];
+            if (btns.includes('alignleft')) alignments.push('left');
+            if (btns.includes('aligncenter')) alignments.push('center');
+            if (btns.includes('alignright')) alignments.push('right');
+            if (btns.includes('alignjustify')) alignments.push('justify');
+            if (alignments.length) exts.push(TextAlign.configure({ types: ['heading', 'paragraph'], alignments }));
 
             if (btns.includes('table')) {
                 exts.push(

--- a/resources/js/components/fieldtypes/bard/buttons.js
+++ b/resources/js/components/fieldtypes/bard/buttons.js
@@ -22,6 +22,10 @@ const availableButtons = () => [
     { name: 'code', text: __('Inline Code'), command: (editor) => editor.commands.toggleCode(), svg: 'angle-brackets-bold' },
     { name: 'codeblock', text: __('Code Block'), command: (editor) => editor.commands.toggleCodeBlock(), svg: 'code-block' },
     { name: 'horizontalrule', text: __('Horizontal Rule'), command: (editor) => editor.commands.setHorizontalRule(), svg: 'range' },
+    { name: 'alignleft', text: __('Align Left'), command: (editor) => editor.chain().focus().setTextAlign('left').run(), icon: 'align-left' },
+    { name: 'aligncenter', text: __('Align Center'), command: (editor) => editor.chain().focus().setTextAlign('center').run(), icon: 'align-center' },
+    { name: 'alignright', text: __('Align Right'), command: (editor) => editor.chain().focus().setTextAlign('right').run(), icon: 'align-right' },
+    { name: 'alignjustify', text: __('Align Justify'), command: (editor) => editor.chain().focus().setTextAlign('justify').run(), icon: 'align-justify' },
 ];
 
 const addButtonHtml = (buttons) => {

--- a/src/Providers/BardServiceProvider.php
+++ b/src/Providers/BardServiceProvider.php
@@ -35,6 +35,7 @@ class BardServiceProvider extends ServiceProvider
             'tableHeader' => new \Tiptap\Nodes\TableHeader(),
             'tableRow' => new \Tiptap\Nodes\TableRow(),
             'text' => new \Tiptap\Nodes\Text(),
+            'textAlign' => new \Tiptap\Extensions\TextAlign(['types' => ['heading', 'paragraph']]),
         ]);
     }
 }

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -221,6 +221,7 @@ class BardTest extends TestCase
         $expected = [
             [
                 'type' => 'paragraph',
+                'attrs' => ['textAlign' => 'left'],
                 'content' => [
                     ['type' => 'text', 'text' => 'This is a paragraph with '],
                     ['type' => 'text', 'marks' => [['type' => 'bold']], 'text' => 'bold'],
@@ -229,6 +230,7 @@ class BardTest extends TestCase
             ],
             [
                 'type' => 'paragraph',
+                'attrs' => ['textAlign' => 'left'],
                 'content' => [
                     ['type' => 'text', 'text' => 'Second '],
                     ['type' => 'text', 'text' => 'paragraph', 'marks' => [
@@ -311,6 +313,7 @@ class BardTest extends TestCase
         $expected = [
             [
                 'type' => 'paragraph',
+                'attrs' => ['textAlign' => 'left'],
                 'content' => [
                     ['type' => 'text', 'text' => 'This is a paragraph with '],
                     ['type' => 'text', 'marks' => [['type' => 'bold']], 'text' => 'bold'],
@@ -319,6 +322,7 @@ class BardTest extends TestCase
             ],
             [
                 'type' => 'paragraph',
+                'attrs' => ['textAlign' => 'left'],
                 'content' => [
                     ['type' => 'text', 'text' => 'Second paragraph.'],
                 ],
@@ -337,6 +341,7 @@ class BardTest extends TestCase
             ],
             [
                 'type' => 'paragraph',
+                'attrs' => ['textAlign' => 'left'],
                 'content' => [
                     ['type' => 'text', 'text' => 'Another paragraph.'],
                 ],


### PR DESCRIPTION
This PR adds text align support to Bard by implementing the official Tiptap 2 TextAlign extension:

https://tiptap.dev/api/extensions/text-align

I think just enabling it for `heading` and `paragraph` works for everything you'd want it too, as Tiptap adds paragraphs inside list items and table cells.

When enabled this extension does add a default `textAlign` attribute to the nodes in the data, which is why I've had to tweak the tests. However when this is set to `left` the rendered HTML remains unchanged.

This PR is for Bard 2 / TipTap 2 and targets the master branch.

Closes https://github.com/statamic/ideas/issues/470
