### PR TITLE
Antlers: fix methods getting called too much

### DIFF
--- a/src/View/Antlers/Language/Parser/LanguageParser.php
+++ b/src/View/Antlers/Language/Parser/LanguageParser.php
@@ -199,18 +199,20 @@ class LanguageParser
                 $wrapperGroup->nodes[] = $lastNode;
                 $wrapperGroup->nodes[] = $thisNode;
 
+                $doBreak = false;
+
                 if ($i != $lastNodeIndex) {
                     for ($j = $i + 1; $j < $nodeLen; $j++) {
                         if ($nodes[$j] instanceof MethodInvocationNode) {
                             $wrapperGroup->nodes[] = $nodes[$j];
 
                             if ($j == $lastNodeIndex) {
-                                $i += 1; // Force the outer loop to break as well.
+                                $doBreak = true;
                                 break;
                             }
                         } else {
                             if ($j == $lastNodeIndex) {
-                                $i += 1; // Force the outer loop to break as well.
+                                $doBreak = true;
                                 break;
                             }
 
@@ -223,6 +225,10 @@ class LanguageParser
                 $wrapperGroup->endPosition = $wrapperGroup->nodes[count($wrapperGroup->nodes) - 1]->endPosition;
 
                 $newNodes[] = $wrapperGroup;
+
+                if ($doBreak) {
+                    break;
+                }
             } else {
                 $newNodes[] = $thisNode;
             }

--- a/tests/Antlers/Fixtures/MethodClasses/CallCounter.php
+++ b/tests/Antlers/Fixtures/MethodClasses/CallCounter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Antlers\Fixtures\MethodClasses;
+
+class CallCounter
+{
+    protected $count = 0;
+
+    public function increment()
+    {
+        $this->count += 1;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return 'Count: ' . $this->count;
+    }
+}

--- a/tests/Antlers/Runtime/MethodCallTest.php
+++ b/tests/Antlers/Runtime/MethodCallTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Antlers\Runtime;
 
 use Carbon\Carbon;
+use Tests\Antlers\Fixtures\MethodClasses\CallCounter;
 use Tests\Antlers\Fixtures\MethodClasses\ClassOne;
 use Tests\Antlers\Fixtures\MethodClasses\StringLengthObject;
 use Tests\Antlers\ParserTestCase;
@@ -217,5 +218,16 @@ EOT;
 EOT;
 
         $this->assertSame($expected, trim($this->renderString($template, $data, true)));
+    }
+
+    public function test_method_calls_not_get_called_more_than_declared()
+    {
+        $counter = new CallCounter();
+
+        $template = <<<'EOT'
+{{ counter:increment():increment():increment() }}
+EOT;
+
+        $this->assertSame('Count: 3', $this->renderString($template, ['counter' => $counter]));
     }
 }


### PR DESCRIPTION
This PR corrects a subtle issue with node pairing that could lead to methods being called more times than wanted.

To recreate this issue, have some class like so:

```php
<?PHP

namespace App;

class CallCounter
{
    protected $count = 0;

    public function increment()
    {
        $this->count += 1;

        return $this;
    }

    public function __toString(): string
    {
        return 'Count: ' . $this->count;
    }
}
```

Inject it into a view (`counter` in the following) and call the `increment` method three times:

```antlers
{{
    counter:increment()
           :increment()
           :increment()
}}
```

Before this fix, the result `Count: 4` would be displayed. This PR also includes new test coverage for this.