### PR TITLE
Remove unnecessary orWheres

### DIFF
--- a/src/Stache/Query/EntryQueryBuilder.php
+++ b/src/Stache/Query/EntryQueryBuilder.php
@@ -23,11 +23,6 @@ class EntryQueryBuilder extends Builder implements QueryBuilder
         return parent::where($column, $operator, $value, $boolean);
     }
 
-    public function orWhere($column, $operator = null, $value = null)
-    {
-        return $this->where($column, $operator, $value, 'or');
-    }
-
     public function whereIn($column, $values, $boolean = 'and')
     {
         if (in_array($column, ['collection', 'collections'])) {
@@ -37,11 +32,6 @@ class EntryQueryBuilder extends Builder implements QueryBuilder
         }
 
         return parent::whereIn($column, $values, $boolean);
-    }
-
-    public function orWhereIn($column, $values)
-    {
-        return $this->whereIn($column, $values, 'or');
     }
 
     protected function collect($items = [])

--- a/src/Stache/Query/TermQueryBuilder.php
+++ b/src/Stache/Query/TermQueryBuilder.php
@@ -28,11 +28,6 @@ class TermQueryBuilder extends Builder
         return parent::where($column, $operator, $value, $boolean);
     }
 
-    public function orWhere($column, $operator = null, $value = null)
-    {
-        return $this->where($column, $operator, $value, 'or');
-    }
-
     public function whereIn($column, $values, $boolean = 'and')
     {
         if (in_array($column, ['taxonomy', 'taxonomies'])) {
@@ -48,11 +43,6 @@ class TermQueryBuilder extends Builder
         }
 
         return parent::whereIn($column, $values, $boolean);
-    }
-
-    public function orWhereIn($column, $values)
-    {
-        return $this->whereIn($column, $values, 'or');
     }
 
     protected function collect($items = [])


### PR DESCRIPTION
When working on #6455 I noticed that there are some unnecessary orWhere()s in the builders (my fault) so I've removed them to keep the code tidier.