### PR TITLE
Revert "Antlers: Makes parameters available within slots and named slots (#6405)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix assets not being attached to, or listed in form submission emails. [#6408](https://github.com/statamic/cms/issues/6408) by @jacksleight
 - The `embed_url` modifier handles unlisted Vimeo URLs. [#6413](https://github.com/statamic/cms/issues/6413) by @ryanmitchell
 - The `toggle` field's `inline_label` option uses markdown. [#6412](https://github.com/statamic/cms/issues/6412) by @jesseleite
-- Fix parameters not being available within partial slots. [#6405](https://github.com/statamic/cms/issues/6405) by @JohnathonKoster
+- ~~Fix parameters not being available within partial slots.~~ Reverted in 3.3.26 [#6405](https://github.com/statamic/cms/issues/6405) by @JohnathonKoster
 - Fix aggressiveness of html minification when rendering form fields. [#6394](https://github.com/statamic/cms/issues/6394) by @jesseleite
 - Fix password reset for unactivated user accounts. [#6406](https://github.com/statamic/cms/issues/6406) by @jasonvarga
 - Bump `moment` from 2.29.2 to 2.29.4 [#6410](https://github.com/statamic/cms/issues/6410) by @dependabot

--- a/src/Tags/Partial.php
+++ b/src/Tags/Partial.php
@@ -17,7 +17,7 @@ class Partial extends Tags
     {
         $variables = array_merge($this->context->all(), $this->params->all(), [
             '__frontmatter' => $this->params->all(),
-            'slot' => $this->isPair ? trim($this->parse($this->params->all())) : null,
+            'slot' => $this->isPair ? trim($this->parse()) : null,
         ]);
 
         return view($this->viewName($partial), $variables)

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1368,7 +1368,7 @@ class NodeProcessor
                                 $namedSlots = $namedSlotResults[1];
 
                                 $slotProcessor = $this->cloneProcessor();
-                                $slotProcessor->setData(array_merge($tagActiveData, $tagParameters));
+                                $slotProcessor->setData($tagActiveData);
 
                                 /** @var AntlersNode $slot */
                                 foreach ($namedSlots as $slotName => $slot) {

--- a/tests/Tags/PartialTagsTest.php
+++ b/tests/Tags/PartialTagsTest.php
@@ -101,36 +101,4 @@ class PartialTagsTest extends TestCase
             $this->partialTag('mypartial', 'foo="baz"')
         );
     }
-
-    /** @test */
-    public function parameters_can_be_accessed_within_slots()
-    {
-        $this->viewShouldReturnRaw('mypartial', '{{ slot }}');
-
-        $this->assertEquals(
-            'slot start bar slot end',
-            $this->tag('{{ partial:mypartial foo="bar" }}slot start {{ foo }} slot end{{ /partial:mypartial }}')
-        );
-    }
-
-    /** @test */
-    public function parameters_can_be_accessed_within_named_slots()
-    {
-        $this->viewShouldReturnRaw('mypartial', '<slot>{{ slot }}</slot><named:slot>{{ slot:footer | upper }}</named:slot>');
-
-        $template = <<<'EOT'
-{{ partial:mypartial foo="bar" }}
-    {{ slot:footer }}
-        Footer: {{ foo }}
-    {{ /slot:footer }}
-    
-    Slot: {{ foo }}
-{{ /partial:mypartial }}
-EOT;
-
-        $this->assertEquals(
-            '<slot>Slot: bar</slot><named:slot>FOOTER: BAR</named:slot>',
-            $this->tag($template)
-        );
-    }
 }


### PR DESCRIPTION
This reverts #6405 as it was found to be a breaking change.
