### PR TITLE
Improve form emails

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -6,9 +6,9 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 use Statamic\Contracts\Forms\Submission;
+use Statamic\Facades\Antlers;
 use Statamic\Facades\Config;
 use Statamic\Facades\GlobalSet;
-use Statamic\Facades\Parse;
 use Statamic\Sites\Site;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
@@ -18,19 +18,38 @@ class Email extends Mailable
     use Queueable, SerializesModels;
 
     protected $submission;
+    protected $submissionData;
     protected $config;
     protected $site;
 
     public function __construct(Submission $submission, array $config, Site $site)
     {
         $this->submission = $submission;
-        $this->config = $this->parseConfig($config);
+        $this->config = $config;
         $this->site = $site;
-        $this->locale($site->lang());
+    }
+
+    public function getSubmission()
+    {
+        return $this->submission;
+    }
+
+    public function getSite()
+    {
+        return $this->site;
+    }
+
+    public function getConfig()
+    {
+        return $this->config;
     }
 
     public function build()
     {
+        $this->submissionData = $this->submission->toAugmentedArray();
+        $this->config = $this->parseConfig($this->config);
+        $this->locale($this->site->lang());
+
         $this
             ->subject(isset($this->config['subject']) ? __($this->config['subject']) : __('Form Submission'))
             ->addAddresses()
@@ -89,9 +108,7 @@ class Email extends Mailable
             return $this;
         }
 
-        $augmented = $this->submission->toAugmentedArray();
-
-        $this->getRenderableFieldData(Arr::except($augmented, ['id', 'date', 'form']))
+        $this->getRenderableFieldData(Arr::except($this->submissionData, ['id', 'date', 'form']))
             ->filter(function ($field) {
                 return $field['fieldtype'] === 'assets';
             })
@@ -182,10 +199,8 @@ class Email extends Mailable
 
     protected function parseConfig(array $config)
     {
-        $data = $this->submission->toArray();
-
-        return collect($config)->map(function ($value) use ($data) {
-            return (string) Parse::template(Parse::env($value), $data);
+        return collect($config)->map(function ($value) {
+            return (string) Antlers::parse($value, $this->submissionData);
         });
     }
 }

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -181,9 +181,9 @@ class Form implements FormContract, Augmentable, Arrayable
         $data = collect([
             'title' => $this->title,
             'honeypot' => $this->honeypot,
-            'email' => collect($this->email)->map(function ($email) {
-                $email['markdown'] = $email['markdown'] ?: null;
-                $email['attachments'] = $email['attachments'] ?: null;
+            'email' => collect(isset($this->email['to']) ? [$this->email] : $this->email)->map(function ($email) {
+                $email['markdown'] = $email['markdown'] ?? null;
+                $email['attachments'] = $email['attachments'] ?? null;
 
                 return Arr::removeNullValues($email);
             })->all(),

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -182,8 +182,8 @@ class Form implements FormContract, Augmentable, Arrayable
             'title' => $this->title,
             'honeypot' => $this->honeypot,
             'email' => collect(isset($this->email['to']) ? [$this->email] : $this->email)->map(function ($email) {
-                $email['markdown'] = $email['markdown'] ?? null;
-                $email['attachments'] = $email['attachments'] ?? null;
+                $email['markdown'] = Arr::get($email, 'markdown') === true ? true : null;
+                $email['attachments'] = Arr::get($email, 'attachments') === true ? true : null;
 
                 return Arr::removeNullValues($email);
             })->all(),

--- a/src/Forms/SendEmails.php
+++ b/src/Forms/SendEmails.php
@@ -9,7 +9,6 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Mail;
 use Statamic\Contracts\Forms\Submission;
-use Statamic\Facades\Antlers;
 use Statamic\Sites\Site;
 
 class SendEmails implements ShouldQueue
@@ -25,54 +24,19 @@ class SendEmails implements ShouldQueue
         $this->site = $site;
     }
 
-    /**
-     * Send form submission emails.
-     *
-     * @param  Submission  $submission
-     */
     public function handle()
     {
-        $this->parseEmailConfigs($this->submission)->each(function ($config) {
+        $this->emailConfigs($this->submission)->each(function ($config) {
             Mail::send(new Email($this->submission, $config, $this->site));
         });
     }
 
-    /**
-     * Parse email configs.
-     *
-     * @param  \Statamic\Forms\Submission  $submission
-     * @return \Illuminate\Support\Collection
-     */
-    protected function parseEmailConfigs($submission)
+    private function emailConfigs($submission)
     {
         $config = $submission->form()->email();
 
-        if (! $config) {
-            return collect();
-        }
-
         $config = isset($config['to']) ? [$config] : $config;
 
-        $data = $submission->toAugmentedArray();
-
-        return collect($config)->map(function ($config) use ($data) {
-            return $this->parseAntlersInConfig($config, $data);
-        });
-    }
-
-    /**
-     * Parse antlers in email configs.
-     *
-     * @param  array  $config
-     * @param  array  $data
-     * @return array
-     */
-    protected function parseAntlersInConfig($config, $data)
-    {
-        return collect($config)
-            ->map(function ($value) use ($data) {
-                return Antlers::parse($value, collect($data)->filter());
-            })
-            ->all();
+        return collect($config);
     }
 }

--- a/tests/Feature/Forms/UpdateFormTest.php
+++ b/tests/Feature/Forms/UpdateFormTest.php
@@ -84,8 +84,8 @@ class UpdateFormTest extends TestCase
                     'subject' => null,
                     'text' => 'emails.contact.text',
                     'html' => 'emails.contact.html',
-                    'markdown' => false,
-                    'attachments' => false,
+                    'markdown' => true,
+                    'attachments' => true,
                 ],
             ]])
             ->assertOk();
@@ -101,6 +101,8 @@ class UpdateFormTest extends TestCase
                 'from' => 'bar@example.com',
                 'text' => 'emails.contact.text',
                 'html' => 'emails.contact.html',
+                'markdown' => true,
+                'attachments' => true,
             ],
         ], $updated->email());
     }

--- a/tests/Forms/EmailTest.php
+++ b/tests/Forms/EmailTest.php
@@ -180,7 +180,7 @@ class EmailTest extends TestCase
 
     private function makeEmailWithSubmission(Submission $submission)
     {
-        return tap(new Email($submission, [], Site::default()))->build();
+        return tap(new Email($submission, ['to' => 'test@test.com'], Site::default()))->build();
     }
 
     private function makeEmailWithConfig(array $config)
@@ -198,7 +198,7 @@ class EmailTest extends TestCase
 
         return tap(new Email(
             $submission,
-            $config,
+            array_merge(['to' => 'test@test.com'], $config),
             Site::default()
         ))->build();
     }
@@ -216,7 +216,7 @@ class EmailTest extends TestCase
             $submission = Mockery::mock(Submission::class);
             $submission->shouldReceive('toAugmentedArray')->andReturn([]);
 
-            return tap(new Email($submission, [], $site))->build();
+            return tap(new Email($submission, ['to' => 'test@test.com'], $site))->build();
         };
 
         $this->assertEquals('en', $makeEmail(Site::get('one'))->locale);

--- a/tests/Forms/EmailTest.php
+++ b/tests/Forms/EmailTest.php
@@ -2,24 +2,205 @@
 
 namespace Tests\Forms;
 
-use Mockery as m;
-use Statamic\Facades\Antlers;
+use Facades\Statamic\Fields\BlueprintRepository;
+use Facades\Tests\Factories\GlobalFactory;
+use Mockery;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Form;
 use Statamic\Facades\Site;
 use Statamic\Forms\Email;
 use Statamic\Forms\Submission;
+use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class EmailTest extends TestCase
 {
-    /** @test */
-    public function it_sets_html_view_as_string()
+    use PreventSavingStacheItemsToDisk;
+
+    /**
+     * @test
+     * @dataProvider multipleAddressProvider
+     */
+    public function it_adds_recipient_from_the_config($address, $expected)
     {
-        $email = $this->makeEmail();
+        $email = $this->makeEmailWithConfig(['to' => $address]);
 
-        $email->build();
+        $this->assertEquals($expected, $email->to);
+    }
 
-        $this->assertTrue(is_string($email->view), 'View is not a string.');
-        $this->assertEquals('emails/test', $email->view);
+    /**
+     * @test
+     * @dataProvider singleAddressProvider
+     */
+    public function it_adds_sender_from_the_config($address, $expected)
+    {
+        $email = $this->makeEmailWithConfig(['from' => $address]);
+
+        $this->assertEquals($expected, $email->from);
+    }
+
+    /**
+     * @test
+     * @dataProvider multipleAddressProvider
+     */
+    public function it_adds_reply_to_from_the_config($address, $expected)
+    {
+        $email = $this->makeEmailWithConfig(['reply_to' => $address]);
+
+        $this->assertEquals($expected, $email->replyTo);
+    }
+
+    /**
+     * @test
+     * @dataProvider multipleAddressProvider
+     */
+    public function it_adds_cc_from_the_config($address, $expected)
+    {
+        $email = $this->makeEmailWithConfig(['cc' => $address]);
+
+        $this->assertEquals($expected, $email->cc);
+    }
+
+    /**
+     * @test
+     * @dataProvider multipleAddressProvider
+     */
+    public function it_adds_bcc_from_the_config($address, $expected)
+    {
+        $email = $this->makeEmailWithConfig(['bcc' => $address]);
+
+        $this->assertEquals($expected, $email->bcc);
+    }
+
+    public function singleAddressProvider()
+    {
+        return [
+            'single email' => ['foo@bar.com', [
+                ['address' => 'foo@bar.com', 'name' => null],
+            ]],
+            'single email with name' => ['Foo Bar <foo@bar.com>', [
+                ['address' => 'foo@bar.com', 'name' => 'Foo Bar'],
+            ]],
+            'single email using antlers' => ['{{ email }}', [
+                ['address' => 'foo@bar.com', 'name' => null],
+            ]],
+            'single email with name using antlers' => ['{{ name }} <{{ email }}>', [
+                ['address' => 'foo@bar.com', 'name' => 'Foo Bar'],
+            ]],
+        ];
+    }
+
+    public function multipleAddressProvider()
+    {
+        return array_merge($this->singleAddressProvider(), [
+            'multiple emails' => ['foo@bar.com, baz@qux.com', [
+                ['address' => 'foo@bar.com', 'name' => null],
+                ['address' => 'baz@qux.com', 'name' => null],
+            ]],
+            'multiple emails with name' => ['Foo Bar <foo@bar.com>, Baz Qux <baz@qux.com>', [
+                ['address' => 'foo@bar.com', 'name' => 'Foo Bar'],
+                ['address' => 'baz@qux.com', 'name' => 'Baz Qux'],
+            ]],
+            'multiple emails using antlers' => ['{{ email }}, baz@qux.com', [
+                ['address' => 'foo@bar.com', 'name' => null],
+                ['address' => 'baz@qux.com', 'name' => null],
+            ]],
+            'multiple emails with name using antlers' => ['{{ name }} <{{ email }}>, Baz Qux <baz@qux.com>', [
+                ['address' => 'foo@bar.com', 'name' => 'Foo Bar'],
+                ['address' => 'baz@qux.com', 'name' => 'Baz Qux'],
+            ]],
+        ]);
+    }
+
+    /** @test */
+    public function it_adds_subject_from_the_config()
+    {
+        $email = $this->makeEmailWithConfig(['subject' => 'A nice form subject']);
+
+        $this->assertEquals('A nice form subject', $email->subject);
+    }
+
+    /** @test */
+    public function it_adds_data_to_the_view()
+    {
+        $social = Blueprint::makeFromFields(['twitter' => ['type' => 'text']])->setHandle('social')->setNamespace('globals');
+        $company = Blueprint::makeFromFields(['company_name' => ['type' => 'text']])->setHandle('company')->setNamespace('globals');
+        $formBlueprint = Blueprint::makeFromFields(['foo' => ['type' => 'text']]);
+
+        BlueprintRepository::shouldReceive('find')->with('globals.social')->andReturn($social);
+        BlueprintRepository::shouldReceive('find')->with('globals.company')->andReturn($company);
+        BlueprintRepository::shouldReceive('find')->with('forms.test')->andReturn($formBlueprint);
+
+        GlobalFactory::handle('social')->data(['twitter' => '@statamic'])->create();
+        GlobalFactory::handle('company')->data(['company_name' => 'Statamic'])->create();
+
+        $form = tap(Form::make('test'))->save();
+        $submission = $form->makeSubmission()->data(['foo' => 'bar']);
+
+        $email = $this->makeEmailWithSubmission($submission);
+
+        $this->assertEquals(collect([
+            // from the submission
+            'id',
+            'foo',
+            'form',
+
+            // globals
+            'company',
+            'social',
+
+            // manual "system" vars added to email
+            'config',
+            'date',
+            'fields',
+            'locale',
+            'now',
+            'site',
+            'site_url',
+            'today',
+        ])->sort()->values()->all(), collect($email->viewData)->sortKeys()->keys()->all());
+
+        $this->assertEquals('bar', $email->viewData['foo']);
+        $this->assertEquals($submission->id(), $email->viewData['id']);
+        $this->assertEquals($form, $email->viewData['form']->value());
+        $this->assertEquals('Statamic', (string) $email->viewData['company']['company_name']);
+    }
+
+    /** @test */
+    public function attachments_are_added()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /** @test */
+    public function it_adds_renderable_fields()
+    {
+        $this->markTestIncomplete();
+    }
+
+    private function makeEmailWithSubmission(Submission $submission)
+    {
+        return tap(new Email($submission, [], Site::default()))->build();
+    }
+
+    private function makeEmailWithConfig(array $config)
+    {
+        $formBlueprint = Blueprint::makeFromFields([
+            'name' => ['type' => 'text'],
+            'email' => ['type' => 'text'],
+        ]);
+        BlueprintRepository::shouldReceive('find')->with('forms.test')->andReturn($formBlueprint);
+        $form = tap(Form::make('test'))->save();
+        $submission = $form->makeSubmission()->data([
+            'name' => 'Foo Bar',
+            'email' => 'foo@bar.com',
+        ]);
+
+        return tap(new Email(
+            $submission,
+            $config,
+            Site::default()
+        ))->build();
     }
 
     /** @test */
@@ -31,21 +212,15 @@ class EmailTest extends TestCase
             'three' => ['locale' => 'de_CH', 'lang' => 'de_CH', 'url' => '/three'],
         ]]);
 
-        $this->assertEquals('en', $this->makeEmail(Site::get('one'))->locale);
-        $this->assertEquals('fr', $this->makeEmail(Site::get('two'))->locale);
-        $this->assertEquals('de_CH', $this->makeEmail(Site::get('three'))->locale);
-    }
+        $makeEmail = function ($site) {
+            $submission = Mockery::mock(Submission::class);
+            $submission->shouldReceive('toAugmentedArray')->andReturn([]);
 
-    private function makeEmail($site = null)
-    {
-        /** @var Submission */
-        $submission = m::mock(Submission::class);
-        $submission->shouldReceive('toArray')->andReturn([]);
-        $submission->shouldReceive('toAugmentedArray')->andReturn([]);
+            return tap(new Email($submission, [], $site))->build();
+        };
 
-        return new Email($submission, [
-            'to' => Antlers::parse('test@example.com'),
-            'html' => Antlers::parse('emails/test'),
-        ], $site ?? Site::default());
+        $this->assertEquals('en', $makeEmail(Site::get('one'))->locale);
+        $this->assertEquals('fr', $makeEmail(Site::get('two'))->locale);
+        $this->assertEquals('de_CH', $makeEmail(Site::get('three'))->locale);
     }
 }

--- a/tests/Forms/SendEmailsTest.php
+++ b/tests/Forms/SendEmailsTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Forms;
+
+use Illuminate\Support\Facades\Mail;
+use Mockery;
+use Statamic\Facades\Form as FacadesForm;
+use Statamic\Forms\Email;
+use Statamic\Forms\SendEmails;
+use Statamic\Sites\Site;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class SendEmailsTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    /** @test */
+    public function it_sends_emails()
+    {
+        Mail::fake();
+
+        $form = tap(FacadesForm::make('test')->email([
+            [
+                'from' => 'first@sender.com',
+                'to' => 'first@recipient.com',
+                'foo' => 'bar',
+                'unparsed' => '{{ test }}',
+            ], [
+                'from' => 'second@sender.com',
+                'to' => 'second@recipient.com',
+                'baz' => 'qux',
+            ],
+        ]))->save();
+
+        (new SendEmails(
+            $submission = $form->makeSubmission(),
+            $site = Mockery::mock(Site::class)
+        ))->handle();
+
+        Mail::assertSent(Email::class, 2);
+
+        Mail::assertSent(function (Email $mail) use ($submission, $site) {
+            return $mail->getSubmission() === $submission
+                && $mail->getSite() === $site
+                && $mail->getConfig() === [
+                    'from' => 'first@sender.com',
+                    'to' => 'first@recipient.com',
+                    'foo' => 'bar',
+                    // test that the config is passed along unparsed.
+                    // the email class will handle that. we don't want to double parse.
+                    'unparsed' => '{{ test }}',
+                ];
+        });
+
+        Mail::assertSent(function (Email $mail) use ($submission, $site) {
+            return $mail->getSubmission() === $submission
+                && $mail->getSite() === $site
+                && $mail->getConfig() === [
+                    'from' => 'second@sender.com',
+                    'to' => 'second@recipient.com',
+                    'baz' => 'qux',
+                ];
+        });
+    }
+
+    /** @test */
+    public function it_sends_emails_when_config_contains_single_email()
+    {
+        // The email config should be an array of email configs.
+        // e.g. [ [to,from,...], [to,from,...], ... ]
+        // but it's possible that a user may have only one email config.
+        // e.g. [to,from,...]
+
+        Mail::fake();
+
+        $form = tap(FacadesForm::make('test')->email([
+            'from' => 'first@sender.com',
+            'to' => 'first@recipient.com',
+            'foo' => 'bar',
+        ]))->save();
+
+        (new SendEmails(
+            $submission = $form->makeSubmission(),
+            $site = Mockery::mock(Site::class)
+        ))->handle();
+
+        Mail::assertSent(Email::class, 1);
+
+        Mail::assertSent(function (Email $mail) use ($submission, $site) {
+            return $mail->getSubmission() === $submission
+                && $mail->getSite() === $site
+                && $mail->getConfig() === [
+                    'from' => 'first@sender.com',
+                    'to' => 'first@recipient.com',
+                    'foo' => 'bar',
+                ];
+        });
+    }
+
+    /**
+     * @test
+     * @dataProvider noEmailsProvider
+     */
+    public function no_emails_are_sent_if_none_are_configured($emailConfig)
+    {
+        Mail::fake();
+
+        $form = tap(FacadesForm::make('test')->email($emailConfig))->save();
+
+        (new SendEmails(
+            $form->makeSubmission(),
+            Mockery::mock(Site::class)
+        ))->handle();
+
+        Mail::assertNotSent(Email::class);
+    }
+
+    public function noEmailsProvider()
+    {
+        return [
+            'null' => [null],
+            'empty array' => [[]],
+        ];
+    }
+}


### PR DESCRIPTION
- Adds test coverage to email sending
- Minor refactors to ease testability
- Prevent parsing Antlers in email configs twice
- Fix issue where if you configure a single email (un-nested) and then save the form it'd fail.
  e.g.
  ```yaml
  email:
    to: foo@bar.com
  ```
  instead of the proper
  ```yaml
  email:
    -
      to: foo@bar.com
  ```