### PR TITLE
Add type information to AddonServiceProvider

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -25,7 +25,8 @@ use Statamic\Widgets\Widget;
 abstract class AddonServiceProvider extends ServiceProvider
 {
     /**
-     * Array of event class => Listener class
+     * Array of event class => Listener class.
+     *
      * @var array<class-string, class-string[]>
      */
     protected $listen = [];
@@ -108,12 +109,14 @@ abstract class AddonServiceProvider extends ServiceProvider
      * of `cp`, `web`, `actions`.
      *
      * @template TType of 'cp'|'web'|'actions'
+     *
      * @var array<TType, string>
      */
     protected $routes = [];
 
     /**
-     * Map of group name => Middlewares to apply
+     * Map of group name => Middlewares to apply.
+     *
      * @var array<string, class-string[]>
      */
     protected $middlewareGroups = [];

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -3,40 +3,145 @@
 namespace Statamic\Providers;
 
 use Closure;
+use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Statamic\Actions\Action;
 use Statamic\Exceptions\NotBootedException;
 use Statamic\Extend\Manifest;
 use Statamic\Facades\Addon;
+use Statamic\Fields\Fieldtype;
+use Statamic\Modifiers\Modifier;
+use Statamic\Query\Scopes\Scope;
 use Statamic\Statamic;
 use Statamic\Support\Str;
+use Statamic\Tags\Tags;
+use Statamic\UpdateScripts\UpdateScript;
+use Statamic\Widgets\Widget;
 
 abstract class AddonServiceProvider extends ServiceProvider
 {
+    /**
+     * Array of event class => Listener class
+     * @var array<class-string<Dispatchable>, class-string[]>
+     */
     protected $listen = [];
+
+    /**
+     * @var list<class-string>
+     */
     protected $subscribe = [];
+
+    /**
+     * @var list<class-string<Tags>>
+     */
     protected $tags = [];
+
+    /**
+     * @var list<class-string<Scope>>
+     */
     protected $scopes = [];
+
+    /**
+     * @var list<class-string<Action>>
+     */
     protected $actions = [];
+
+    /**
+     * @var list<class-string<Fieldtype>>
+     */
     protected $fieldtypes = [];
+
+    /**
+     * @var list<class-string<Modifier>>
+     */
     protected $modifiers = [];
+
+    /**
+     * @var list<class-string<Widget>>
+     */
     protected $widgets = [];
+
+    /**
+     * @var array<class-string, string>
+     */
     protected $policies = [];
+
+    /**
+     * @var list<class-string<Command>>
+     */
     protected $commands = [];
+
+    /**
+     * @var list<string> - Paths on disk
+     */
     protected $stylesheets = [];
+
+    /**
+     * @var list<string> - URLs of stylesheets
+     */
     protected $externalStylesheets = [];
+
+    /**
+     * @var list<string> - Paths on disk
+     */
     protected $scripts = [];
+
+    /**
+     * @var list<string> - URLs of scripts
+     */
     protected $externalScripts = [];
+
+    /**
+     * Map of path on disk to name in the public directory. The file will be published
+     * as `vendor/{packageName}/{value}`.
+     *
+     * @var array<string, string>
+     */
     protected $publishables = [];
+
+    /**
+     * Map of type => Path of route PHP file on disk where the key (type) can be one
+     * of `cp`, `web`, `actions`.
+     *
+     * @template TType of 'cp'|'web'|'actions'
+     * @var array<TType, string>
+     */
     protected $routes = [];
+
+    /**
+     * Map of group name => Middlewares to apply
+     * @var array<string, class-string[]>
+     */
     protected $middlewareGroups = [];
+
+    /**
+     * @var list<class-string<UpdateScript>>
+     */
     protected $updateScripts = [];
+
+    /**
+     * @var string
+     */
     protected $viewNamespace;
+
+    /**
+     * @var bool
+     */
     protected $publishAfterInstall = true;
+
+    /**
+     * @var bool
+     */
     protected $config = true;
+
+    /**
+     * @var bool
+     */
     protected $translations = true;
 
     public function boot()

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -5,7 +5,6 @@ namespace Statamic\Providers;
 use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Console\Scheduling\Schedule;
-use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
@@ -27,7 +26,7 @@ abstract class AddonServiceProvider extends ServiceProvider
 {
     /**
      * Array of event class => Listener class
-     * @var array<class-string<Dispatchable>, class-string[]>
+     * @var array<class-string, class-string[]>
      */
     protected $listen = [];
 


### PR DESCRIPTION
As a PHP Developer, I found statamics core fairly hard to discover - both, because of the indirection some Laravel features such as facades add and because of the lack of type information.

I raised this issue in Discord, where we agreed, that I would start making small PRs to add missing type information which would make the code

* Easier to discover for newer developers looking to develop addons
* Parsable by static code analyzers such as Psalm or PHPStan in order to leverage them when developing such addons

I was careful, only to add type information in docblocks. Ideally, 'real' Type information would be added (e.g. `protected array $listen`) - but that would be considered a breaking change for downstream code.