### PR TITLE
Fix locales tag not outputting collection specific term urls

### DIFF
--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -8,6 +8,7 @@ use Statamic\Facades\Data;
 use Statamic\Facades\Site;
 use Statamic\Support\Str;
 use Statamic\Tags\Concerns\GetsQuerySelectKeys;
+use Statamic\Taxonomies\LocalizedTerm;
 
 class Locales extends Tags
 {
@@ -159,7 +160,26 @@ class Locales extends Tags
 
         $id = $this->params->get('id', $this->context->value('id'));
 
-        return $this->data = Data::find($id);
+        $data = Data::find($id);
+
+        $data = $this->workaroundForCollectionTaxonomyTerm($id, $data);
+
+        return $this->data = $data;
+    }
+
+    private function workaroundForCollectionTaxonomyTerm($id, $data)
+    {
+        if (! $data instanceof LocalizedTerm) {
+            return $data;
+        }
+
+        // If the ID is the same as the root "page" item, then we'll just use that
+        // term instead, as it'll have the collection associated with it already.
+        if ($id === ($page = $this->context->get('page'))->id()) {
+            return $page;
+        }
+
+        return $data;
     }
 
     /**

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -169,6 +169,10 @@ class Locales extends Tags
 
     private function workaroundForCollectionTaxonomyTerm($id, $data)
     {
+        if (! $this->params->bool('collection_term_workaround', true)) {
+            return $data;
+        }
+
         if (! $data instanceof LocalizedTerm) {
             return $data;
         }


### PR DESCRIPTION
Fixes #6418
Fixes #3833
Replaces #4047

Since it's looking likely that there will be a [taxonomy overhaul](https://github.com/statamic/ideas/issues/839), I figured it's better to just apply a quick workaround into the locales tag, rather than a "proper" fix that'll end up affecting way too many parts of the codebase, and eventually may have not even be needed if taxonomies are changing. That's why #4047 was sitting there for so long - it was too big of a change. Plus I was tired of seeing it sit there.

This PR will make the locales tag compare the ID to the "page" ID. If it's the same term, it'll just use the term object, which will be associated with the collection already and therefore output the collection specific URL.

The downside to this is that if you're using a `taxonomy:foo` tag pair, with a `locales` tag inside it, while _on_ a collection specific taxonomy term url... if the page's term is in that loop, it'll output the collection specific url. Super edge case. In that case though, you can add `collection_term_workaround="false"` to the locales tag. Dumb, but hey.