### PR TITLE
Send Form Emails in a separate Job

### DIFF
--- a/config/forms.php
+++ b/config/forms.php
@@ -35,4 +35,15 @@ return [
 
     'email_view_folder' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Form Email send Job.
+    |--------------------------------------------------------------------------
+    |
+    | The Job to send a single Form Email.
+    |
+    */
+
+    'send_mail_job' => \Statamic\Forms\SendEmail::class,
+
 ];

--- a/src/Forms/SendEmail.php
+++ b/src/Forms/SendEmail.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Statamic\Forms;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+use Statamic\Contracts\Forms\Submission;
+use Statamic\Sites\Site;
+
+class SendEmail implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected $submission;
+    protected $site;
+    protected $config;
+
+    public function __construct(Submission $submission, Site $site, $config)
+    {
+        $this->submission = $submission;
+        $this->site = $site;
+        $this->config = $config;
+    }
+
+    public function handle()
+    {
+        Mail::send(new Email($this->submission, $this->config, $this->site));
+    }
+}

--- a/src/Forms/SendEmail.php
+++ b/src/Forms/SendEmail.php
@@ -15,9 +15,9 @@ class SendEmail implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    protected $submission;
-    protected $site;
-    protected $config;
+    public $submission;
+    public $site;
+    public $config;
 
     public function __construct(Submission $submission, Site $site, $config)
     {

--- a/tests/Forms/SendEmailTest.php
+++ b/tests/Forms/SendEmailTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Forms;
+
+use Illuminate\Support\Facades\Mail;
+use Mockery;
+use Statamic\Facades\Form as FacadesForm;
+use Statamic\Forms\Email;
+use Statamic\Forms\SendEmail;
+use Statamic\Sites\Site;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class SendEmailTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    /** @test */
+    public function it_sends_email()
+    {
+        Mail::fake();
+
+        $form = tap(FacadesForm::make('test'))->save();
+
+        (new SendEmail(
+            $submission = $form->makeSubmission(),
+            $site = Mockery::mock(Site::class),
+            [
+                'from' => 'first@sender.com',
+                'to' => 'first@recipient.com',
+                'foo' => 'bar',
+                'unparsed' => '{{ test }}',
+            ]
+        ))->handle();
+
+        Mail::assertSent(Email::class, 1);
+
+        Mail::assertSent(function (Email $mail) use ($submission, $site) {
+            return $mail->getSubmission() === $submission
+                && $mail->getSite() === $site
+                && $mail->getConfig() === [
+                    'from' => 'first@sender.com',
+                    'to' => 'first@recipient.com',
+                    'foo' => 'bar',
+                    // test that the config is passed along unparsed.
+                    // the email class will handle that. we don't want to double parse.
+                    'unparsed' => '{{ test }}',
+                ];
+        });
+    }
+}

--- a/tests/Forms/SendEmailsTest.php
+++ b/tests/Forms/SendEmailsTest.php
@@ -36,7 +36,9 @@ class SendEmailsTest extends TestCase
         (new SendEmails(
             $submission = $form->makeSubmission(),
             $site = Mockery::mock(Site::class)
-        ))->handle();
+        ))->buildJobs()->each(function ($job) {
+            $job->handle();
+        });
 
         Mail::assertSent(Email::class, 2);
 
@@ -83,7 +85,9 @@ class SendEmailsTest extends TestCase
         (new SendEmails(
             $submission = $form->makeSubmission(),
             $site = Mockery::mock(Site::class)
-        ))->handle();
+        ))->buildJobs()->each(function ($job) {
+            $job->handle();
+        });
 
         Mail::assertSent(Email::class, 1);
 

--- a/tests/Forms/SendEmailsTest.php
+++ b/tests/Forms/SendEmailsTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Forms;
 
-use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
 use Mockery;
 use Statamic\Facades\Form as FacadesForm;
-use Statamic\Forms\Email;
+use Statamic\Forms\SendEmail;
 use Statamic\Forms\SendEmails;
 use Statamic\Sites\Site;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -16,9 +16,9 @@ class SendEmailsTest extends TestCase
     use PreventSavingStacheItemsToDisk;
 
     /** @test */
-    public function it_sends_emails()
+    public function it_queues_email_jobs()
     {
-        Mail::fake();
+        Queue::fake();
 
         $form = tap(FacadesForm::make('test')->email([
             [
@@ -36,16 +36,14 @@ class SendEmailsTest extends TestCase
         (new SendEmails(
             $submission = $form->makeSubmission(),
             $site = Mockery::mock(Site::class)
-        ))->buildJobs()->each(function ($job) {
-            $job->handle();
-        });
+        ))->handle();
 
-        Mail::assertSent(Email::class, 2);
+        Queue::assertPushed(SendEmail::class, 2);
 
-        Mail::assertSent(function (Email $mail) use ($submission, $site) {
-            return $mail->getSubmission() === $submission
-                && $mail->getSite() === $site
-                && $mail->getConfig() === [
+        Queue::assertPushed(function (SendEmail $job) use ($submission, $site) {
+            return $job->submission === $submission
+                && $job->site === $site
+                && $job->config === [
                     'from' => 'first@sender.com',
                     'to' => 'first@recipient.com',
                     'foo' => 'bar',
@@ -55,10 +53,10 @@ class SendEmailsTest extends TestCase
                 ];
         });
 
-        Mail::assertSent(function (Email $mail) use ($submission, $site) {
-            return $mail->getSubmission() === $submission
-                && $mail->getSite() === $site
-                && $mail->getConfig() === [
+        Queue::assertPushed(function (SendEmail $job) use ($submission, $site) {
+            return $job->submission === $submission
+                && $job->site === $site
+                && $job->config === [
                     'from' => 'second@sender.com',
                     'to' => 'second@recipient.com',
                     'baz' => 'qux',
@@ -67,14 +65,14 @@ class SendEmailsTest extends TestCase
     }
 
     /** @test */
-    public function it_sends_emails_when_config_contains_single_email()
+    public function it_queues_email_jobs_when_config_contains_single_email()
     {
         // The email config should be an array of email configs.
         // e.g. [ [to,from,...], [to,from,...], ... ]
         // but it's possible that a user may have only one email config.
         // e.g. [to,from,...]
 
-        Mail::fake();
+        Queue::fake();
 
         $form = tap(FacadesForm::make('test')->email([
             'from' => 'first@sender.com',
@@ -85,16 +83,14 @@ class SendEmailsTest extends TestCase
         (new SendEmails(
             $submission = $form->makeSubmission(),
             $site = Mockery::mock(Site::class)
-        ))->buildJobs()->each(function ($job) {
-            $job->handle();
-        });
+        ))->handle();
 
-        Mail::assertSent(Email::class, 1);
+        Queue::assertPushed(SendEmail::class, 1);
 
-        Mail::assertSent(function (Email $mail) use ($submission, $site) {
-            return $mail->getSubmission() === $submission
-                && $mail->getSite() === $site
-                && $mail->getConfig() === [
+        Queue::assertPushed(function (SendEmail $job) use ($submission, $site) {
+            return $job->submission === $submission
+                && $job->site === $site
+                && $job->config === [
                     'from' => 'first@sender.com',
                     'to' => 'first@recipient.com',
                     'foo' => 'bar',
@@ -106,9 +102,9 @@ class SendEmailsTest extends TestCase
      * @test
      * @dataProvider noEmailsProvider
      */
-    public function no_emails_are_sent_if_none_are_configured($emailConfig)
+    public function no_email_jobs_are_queued_if_none_are_configured($emailConfig)
     {
-        Mail::fake();
+        Queue::fake();
 
         $form = tap(FacadesForm::make('test')->email($emailConfig))->save();
 
@@ -117,7 +113,7 @@ class SendEmailsTest extends TestCase
             Mockery::mock(Site::class)
         ))->handle();
 
-        Mail::assertNotSent(Email::class);
+        Queue::assertNotPushed(SendEmail::class);
     }
 
     public function noEmailsProvider()


### PR DESCRIPTION
Hi @jasonvarga 

We are using many Statamic Forms in a big project. The service we use to send mails is unfortunately very unstable.
In the latest version, Statamic sends all E-Mails in a loop by the `SendEmails` Job. 

```php
$this->emailConfigs($this->submission)->each(function ($config) {
    Mail::send(new Email($this->submission, $config, $this->site));
});        
```
https://github.com/statamic/cms/blob/3.3/src/Forms/SendEmails.php#L29

This is a problem because of the following reasons:
- When a Form has multiple Email configs to send and a single mail fails, the other may not be sent.
- We cannot add any Laravel Job configs like retries or backoff to handle this behaviour.

This PR removes the queuability from`SendEmails` and only sends Emails in a new job `SendEmail`. Further it adds a new config value in the `forms` namespace to customize the job that is used to send that single mail.

This solves the problems mentioned, as we now can create a new custom `SendEmail` job class like the following:

```php
<?php

namespace App\Notifications;

use Statamic\Contracts\Forms\Submission;
use Statamic\Forms\SendEmail;
use Statamic\Sites\Site;

class SendStatamicEmail extends SendEmail
{
    public $tries = 3;

    public function __construct(Submission $submission, Site $site, $config)
    {
        parent::__construct($submission, $site, $config);

        $this->queue = 'emails';
    }

    public function backoff()
    {
        return [5, 10, 30];
    }
}

```

And set it in the config:

```php
<?php

return [
    'send_mail_job' => \App\Notifications\SendStatamicEmail::class,
];
```

I also thought about config values to set the queue properties from the `forms` config file but as this will probably not be done much this would blow up the config file unnecessarily.

If you have a better Idea, I'm open to change this PR to match your requirements.

