### PR TITLE
Fix bard set showFieldPreviews

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -136,7 +136,7 @@ export default {
         },
 
         showFieldPreviews() {
-            return this.options.bard.config.previews;
+            return this.extension.options.bard.config.previews;
         },
 
     },


### PR DESCRIPTION
This computed was added to 3.3 after the Bard 2 upgrade. We had merged 3.3 into master but didn't tweak this, which results in an error when you add a set.
