### PR TITLE
Trim auto generated titles

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -788,7 +788,9 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
 
         // Since the slug is generated from the title, we'll avoid augmenting
         // the slug which could result in an infinite loop in some cases.
-        return (string) Antlers::parse($format, $this->augmented()->except('slug')->all());
+        $title = (string) Antlers::parse($format, $this->augmented()->except('slug')->all());
+
+        return trim($title);
     }
 
     public function previewTargets()


### PR DESCRIPTION
I've got a collection of persons with auto-generated titles:

```
title_format: '{academic_title} {first_name} {last_name}'
```

Not every person has an academic title. This would result in an untrimmed title. I hate untrimmed strings. This PR fixes that.