### PR TITLE
Runtime: fixes `raw` modifier on fields with `antlers: true`

### DIFF
--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -1277,7 +1277,7 @@ class Environment
     {
         if ($originalNode instanceof AbstractNode && $originalNode->modifierChain != null) {
             if (! empty($originalNode->modifierChain->modifierChain)) {
-                $value = $this->checkForFieldValue($value, true);
+                $value = $this->checkForFieldValue($value, true, $originalNode->modifierChain->modifierChain);
 
                 return $this->applyModifiers($value, $originalNode->modifierChain);
             }
@@ -1292,17 +1292,19 @@ class Environment
         return $this->checkForFieldValue($value);
     }
 
-    private function checkForFieldValue($value, $hasModifiers = false)
+    private function checkForFieldValue($value, $hasModifiers = false, $modifierChain = null)
     {
         if ($value instanceof Value) {
             GlobalRuntimeState::$isEvaluatingUserData = true;
             if ($value->shouldParseAntlers()) {
-                GlobalRuntimeState::$userContentEvalState = [
-                    $value,
-                    $this->nodeProcessor->getActiveNode(),
-                ];
-                $value = $value->antlersValue($this->nodeProcessor->getAntlersParser(), $this->data);
-                GlobalRuntimeState::$userContentEvalState = null;
+                if (! $hasModifiers || ($modifierChain != null && $modifierChain[0]->nameNode->name != 'raw')) {
+                    GlobalRuntimeState::$userContentEvalState = [
+                        $value,
+                        $this->nodeProcessor->getActiveNode(),
+                    ];
+                    $value = $value->antlersValue($this->nodeProcessor->getAntlersParser(), $this->data);
+                    GlobalRuntimeState::$userContentEvalState = null;
+                }
             } else {
                 if (! $hasModifiers) {
                     $value = $value->value();

--- a/tests/Antlers/ParserTestCase.php
+++ b/tests/Antlers/ParserTestCase.php
@@ -229,6 +229,7 @@ class ParserTestCase extends TestCase
         $processor->setData($data);
 
         $runtimeParser = new RuntimeParser($documentParser, $processor, new AntlersLexer(), new LanguageParser());
+        $processor->setAntlersParserInstance($runtimeParser);
 
         if ($withCoreTagsAndModifiers) {
             $runtimeParser->cascade(app(Cascade::class));

--- a/tests/Antlers/Runtime/Fieldtypes/BardFieldtypeTest.php
+++ b/tests/Antlers/Runtime/Fieldtypes/BardFieldtypeTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Statamic\Fields\Field;
 use Statamic\Fields\Value;
 use Statamic\Fieldtypes\Bard;
+use Tests\Antlers\Fixtures\Addon\Tags\VarTest;
 use Tests\Antlers\ParserTestCase;
 
 class BardFieldtypeTest extends ParserTestCase
@@ -18,6 +19,52 @@ class BardFieldtypeTest extends ParserTestCase
     public function test_raw_parameter_style_modifier_can_be_used_on_values()
     {
         $this->runFieldTypeTest('bard', 'bard_raw_parameter_modifier');
+    }
+
+    public function test_antlers_does_not_get_evaluated_when_using_raw_on_bard()
+    {
+        $bard = new Bard();
+        $field = new Field('main_content', [
+            'type' => 'bard',
+            'antlers' => true,
+        ]);
+        $bard->setField($field);
+
+        $data = [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'Hello',
+                    ],
+                    [
+                        'type' => 'text',
+                        'marks' => [
+                            [
+                                'type' => 'bold',
+                            ]
+                        ],
+                        'text' => 'World',
+                    ],
+                ],
+            ],
+        ];
+
+        $value = new Value($data, 'main_content', $bard);
+
+        VarTest::register();
+
+        $templateData = [
+            'main_content' => $value,
+        ];
+
+        $this->renderString('{{ var_test :variable="main_content|raw" }}', $templateData, true);
+
+        $this->assertSame($data, VarTest::$var);
+
+        // Ensure we didn't break other modifiers.
+        $this->assertSame('<P>HELLO<STRONG>WORLD</STRONG></P>', $this->renderString('{{ main_content | upper }}', $templateData, true));
     }
 
     public function test_antlers_true_bard_fields_correct_for_html_encoded_values()

--- a/tests/Antlers/Runtime/Fieldtypes/BardFieldtypeTest.php
+++ b/tests/Antlers/Runtime/Fieldtypes/BardFieldtypeTest.php
@@ -6,7 +6,6 @@ use Carbon\Carbon;
 use Statamic\Fields\Field;
 use Statamic\Fields\Value;
 use Statamic\Fieldtypes\Bard;
-use Tests\Antlers\Fixtures\Addon\Tags\VarTest;
 use Tests\Antlers\ParserTestCase;
 
 class BardFieldtypeTest extends ParserTestCase
@@ -19,52 +18,6 @@ class BardFieldtypeTest extends ParserTestCase
     public function test_raw_parameter_style_modifier_can_be_used_on_values()
     {
         $this->runFieldTypeTest('bard', 'bard_raw_parameter_modifier');
-    }
-
-    public function test_antlers_does_not_get_evaluated_when_using_raw_on_bard()
-    {
-        $bard = new Bard();
-        $field = new Field('main_content', [
-            'type' => 'bard',
-            'antlers' => true,
-        ]);
-        $bard->setField($field);
-
-        $data = [
-            [
-                'type' => 'paragraph',
-                'content' => [
-                    [
-                        'type' => 'text',
-                        'text' => 'Hello',
-                    ],
-                    [
-                        'type' => 'text',
-                        'marks' => [
-                            [
-                                'type' => 'bold',
-                            ],
-                        ],
-                        'text' => 'World',
-                    ],
-                ],
-            ],
-        ];
-
-        $value = new Value($data, 'main_content', $bard);
-
-        VarTest::register();
-
-        $templateData = [
-            'main_content' => $value,
-        ];
-
-        $this->renderString('{{ var_test :variable="main_content|raw" }}', $templateData, true);
-
-        $this->assertSame($data, VarTest::$var);
-
-        // Ensure we didn't break other modifiers.
-        $this->assertSame('<P>HELLO<STRONG>WORLD</STRONG></P>', $this->renderString('{{ main_content | upper }}', $templateData, true));
     }
 
     public function test_antlers_true_bard_fields_correct_for_html_encoded_values()


### PR DESCRIPTION
This PR fixes #6482  by not resolving Antlers values when the value contains the `raw` modifier as its first modifier. The linked issue contains steps to reproduce the issue. The PR contains new test coverage for this scenario.