### PR TITLE
Fix stretched SVG thumbnails

### DIFF
--- a/resources/js/components/assets/Browser/Thumbnail.vue
+++ b/resources/js/components/assets/Browser/Thumbnail.vue
@@ -3,7 +3,7 @@
     <div class="">
         <div v-if="showSvg" class="rounded flex items-center justify-center asset-thumbnail h-full w-full">
             <img
-                class="w-full h-full max-w-full max-h-full mx-auto"
+                class="w-full h-full max-w-full max-h-full mx-auto object-contain"
                 :src="asset.thumbnail"
             />
         </div>


### PR DESCRIPTION
SVG thumbanils get stretched to fill the space in the asset browser:

![Screenshot 2022-08-15 at 16 31 13](https://user-images.githubusercontent.com/126740/184668423-9130d90c-8072-4be4-9df0-09343bf603ff.png)

This PR fixes that by adding `object-contain` to the `<img>` element:

![Screenshot 2022-08-15 at 16 31 41](https://user-images.githubusercontent.com/126740/184668502-79f98eab-aa16-4c0d-a5a0-aff8052055bf.png)
