### PR TITLE
Improve updating and deleting of term and asset references

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -154,4 +154,17 @@ return [
 
     'lowercase' => true,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Update References on Change
+    |--------------------------------------------------------------------------
+    |
+    | With this enabled, Statamic will attempt to update references to your
+    | assets when moving, renaming, replacing, deleting, etc. This will
+    | be queued, but can disabled as needed for performance reasons.
+    |
+    */
+
+    'update_references' => true,
+
 ];

--- a/config/assets.php
+++ b/config/assets.php
@@ -154,17 +154,4 @@ return [
 
     'lowercase' => true,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Update References on Change
-    |--------------------------------------------------------------------------
-    |
-    | With this enabled, Statamic will attempt to update references to your
-    | assets when moving, renaming, replacing, deleting, etc. This will
-    | be queued, but can disabled as needed for performance reasons.
-    |
-    */
-
-    'update_references' => true,
-
 ];

--- a/config/system.php
+++ b/config/system.php
@@ -139,4 +139,17 @@ return [
 
     'ascii_replace_extra_symbols' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Update References on Change
+    |--------------------------------------------------------------------------
+    |
+    | With this enabled, Statamic will attempt to update references to assets
+    | and terms when moving, renaming, replacing, deleting, etc. This will
+    | be queued, but it can disabled as needed for performance reasons.
+    |
+    */
+
+    'update_references' => true,
+
 ];

--- a/resources/js/components/fieldtypes/bard/Image.js
+++ b/resources/js/components/fieldtypes/bard/Image.js
@@ -47,6 +47,7 @@ export default class ImageNode extends Node {
             const { selection } = state
             const position = selection.$cursor ? selection.$cursor.pos : selection.$to.pos
             const node = type.create(attrs)
+            node.isNew = true;
             const transaction = state.tr.insert(position, node)
             dispatch(transaction)
         }

--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -104,7 +104,7 @@ export default {
     created() {
         let src = this.node.attrs.src;
 
-        if (! src) {
+        if (this.node.isNew) {
             this.openSelector();
         }
 

--- a/src/Assets/AssetReferenceUpdater.php
+++ b/src/Assets/AssetReferenceUpdater.php
@@ -206,13 +206,19 @@ class AssetReferenceUpdater extends DataReferenceUpdater
             return;
         }
 
-        $value = "asset::{$this->container}::{$this->newValue}";
+        $newValue = $this->newValue()
+            ? "asset::{$this->container}::{$this->newValue}"
+            : null;
 
-        if ($originalValue === $value) {
+        if ($originalValue === $newValue) {
             return;
         }
 
-        Arr::set($data, $dottedKey, $value);
+        if (is_null($newValue)) {
+            Arr::forget($data, $dottedKey);
+        } else {
+            Arr::set($data, $dottedKey, $newValue);
+        }
 
         $this->item->data($data);
 

--- a/src/Assets/AssetReferenceUpdater.php
+++ b/src/Assets/AssetReferenceUpdater.php
@@ -206,15 +206,15 @@ class AssetReferenceUpdater extends DataReferenceUpdater
             return;
         }
 
-        $newValue = $this->newValue()
-            ? "asset::{$this->container}::{$this->newValue}"
-            : null;
+        $newValue = $this->isRemovingValue()
+            ? null
+            : "asset::{$this->container}::{$this->newValue}";
 
         if ($originalValue === $newValue) {
             return;
         }
 
-        if (is_null($newValue)) {
+        if ($this->isRemovingValue()) {
             Arr::forget($data, $dottedKey);
         } else {
             Arr::set($data, $dottedKey, $newValue);

--- a/src/Assets/AssetReferenceUpdater.php
+++ b/src/Assets/AssetReferenceUpdater.php
@@ -167,9 +167,11 @@ class AssetReferenceUpdater extends DataReferenceUpdater
             return;
         }
 
-        $value = preg_replace_callback('/([("]statamic:\/\/[^()"]*::)([^)"]*)([)"])/im', function ($matches) {
-            return $matches[2] === $this->originalValue
-                ? $matches[1].$this->newValue.$matches[3]
+        $value = preg_replace_callback('/([("])(statamic:\/\/[^()"]*::)([^)"]*)([)"])/im', function ($matches) {
+            $newValue = $this->isRemovingValue() ? '' : $matches[2].$this->newValue;
+
+            return $matches[3] === $this->originalValue
+                ? $matches[1].$newValue.$matches[4]
                 : $matches[0];
         }, $value);
 
@@ -267,7 +269,7 @@ class AssetReferenceUpdater extends DataReferenceUpdater
                 return "asset::{$this->container}::{$this->newValue}";
             })
             ->each(function ($value, $key) use (&$bardPayload) {
-                Arr::set($bardPayload, $key, $value);
+                Arr::set($bardPayload, $key, $this->isRemovingValue() ? '' : $value);
             });
 
         if ($changed->isEmpty()) {
@@ -311,7 +313,7 @@ class AssetReferenceUpdater extends DataReferenceUpdater
                 return "statamic://asset::{$this->container}::{$this->newValue}";
             })
             ->each(function ($value, $key) use (&$bardPayload) {
-                Arr::set($bardPayload, $key, $value);
+                Arr::set($bardPayload, $key, $this->isRemovingValue() ? '' : $value);
             });
 
         if ($changed->isEmpty()) {

--- a/src/Data/DataReferenceUpdater.php
+++ b/src/Data/DataReferenceUpdater.php
@@ -211,7 +211,13 @@ abstract class DataReferenceUpdater
             return;
         }
 
-        Arr::set($data, $dottedKey, $this->newValue());
+        $newValue = $this->newValue();
+
+        if (is_null($newValue)) {
+            Arr::forget($data, $dottedKey);
+        } else {
+            Arr::set($data, $dottedKey, $newValue);
+        }
 
         $this->item->data($data);
 
@@ -236,11 +242,18 @@ abstract class DataReferenceUpdater
             return;
         }
 
-        $fieldData->transform(function ($value) {
-            return $value === $this->originalValue() ? $this->newValue() : $value;
-        });
+        $fieldData = $fieldData
+            ->map(function ($value) {
+                return $value === $this->originalValue() ? $this->newValue() : $value;
+            })
+            ->filter()
+            ->values();
 
-        Arr::set($data, $dottedKey, $fieldData->all());
+        if ($fieldData->isEmpty()) {
+            Arr::forget($data, $dottedKey);
+        } else {
+            Arr::set($data, $dottedKey, $fieldData->all());
+        }
 
         $this->item->data($data);
 

--- a/src/Listeners/UpdateAssetReferences.php
+++ b/src/Listeners/UpdateAssetReferences.php
@@ -18,7 +18,7 @@ class UpdateAssetReferences implements ShouldQueue
      */
     public function subscribe($events)
     {
-        if (config('statamic.assets.update_references') === false) {
+        if (config('statamic.system.update_references') === false) {
             return;
         }
 

--- a/src/Listeners/UpdateAssetReferences.php
+++ b/src/Listeners/UpdateAssetReferences.php
@@ -4,6 +4,7 @@ namespace Statamic\Listeners;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Statamic\Assets\AssetReferenceUpdater;
+use Statamic\Events\AssetDeleted;
 use Statamic\Events\AssetSaved;
 
 class UpdateAssetReferences implements ShouldQueue
@@ -21,15 +22,16 @@ class UpdateAssetReferences implements ShouldQueue
             return;
         }
 
-        $events->listen(AssetSaved::class, self::class.'@handle');
+        $events->listen(AssetSaved::class, self::class.'@handleSaved');
+        $events->listen(AssetDeleted::class, self::class.'@handleDeleted');
     }
 
     /**
-     * Handle the events.
+     * Handle the asset saved event.
      *
      * @param  AssetSaved  $event
      */
-    public function handle(AssetSaved $event)
+    public function handleSaved(AssetSaved $event)
     {
         $asset = $event->asset;
 
@@ -37,6 +39,34 @@ class UpdateAssetReferences implements ShouldQueue
         $originalPath = $asset->getOriginal('path');
         $newPath = $asset->path();
 
+        $this->replaceReferences($container, $originalPath, $newPath);
+    }
+
+    /**
+     * Handle the asset deleted event.
+     *
+     * @param  AssetDeleted  $event
+     */
+    public function handleDeleted(AssetDeleted $event)
+    {
+        $asset = $event->asset;
+
+        $container = $asset->container()->handle();
+        $originalPath = $asset->getOriginal('path');
+        $newPath = null;
+
+        $this->replaceReferences($container, $originalPath, $newPath);
+    }
+
+    /**
+     * Replace asset references.
+     *
+     * @param  string  $container
+     * @param  string  $originalPath
+     * @param  string  $newPath
+     */
+    protected function replaceReferences($container, $originalPath, $newPath)
+    {
         if (! $originalPath || $originalPath === $newPath) {
             return;
         }

--- a/src/Listeners/UpdateAssetReferences.php
+++ b/src/Listeners/UpdateAssetReferences.php
@@ -17,6 +17,10 @@ class UpdateAssetReferences implements ShouldQueue
      */
     public function subscribe($events)
     {
+        if (config('statamic.assets.update_references') === false) {
+            return;
+        }
+
         $events->listen(AssetSaved::class, self::class.'@handle');
     }
 

--- a/src/Listeners/UpdateTermReferences.php
+++ b/src/Listeners/UpdateTermReferences.php
@@ -18,6 +18,10 @@ class UpdateTermReferences implements ShouldQueue
      */
     public function subscribe($events)
     {
+        if (config('statamic.system.update_references') === false) {
+            return;
+        }
+
         $events->listen(TermSaved::class, self::class.'@handleSaved');
         $events->listen(TermDeleted::class, self::class.'@handleDeleted');
     }

--- a/src/Taxonomies/TermReferenceUpdater.php
+++ b/src/Taxonomies/TermReferenceUpdater.php
@@ -99,7 +99,7 @@ class TermReferenceUpdater extends DataReferenceUpdater
      *
      * @return mixed
      */
-    public function originalValue()
+    protected function originalValue()
     {
         return $this->scope.$this->originalValue;
     }
@@ -109,7 +109,7 @@ class TermReferenceUpdater extends DataReferenceUpdater
      *
      * @return mixed
      */
-    public function newValue()
+    protected function newValue()
     {
         return $this->scope.$this->newValue;
     }

--- a/tests/Listeners/UpdateAssetReferencesTest.php
+++ b/tests/Listeners/UpdateAssetReferencesTest.php
@@ -269,7 +269,7 @@ class UpdateAssetReferencesTest extends TestCase
                 [
                     'type' => 'set_one',
                     'product' => 'hoff.jpg',
-                    'pics' => ['hoff.jpg', 'norris.jpg'],
+                    'pics' => ['hoff.jpg', 'norris.jpg', 'lee.jpg'],
                 ],
             ],
         ]))->save();
@@ -278,15 +278,16 @@ class UpdateAssetReferencesTest extends TestCase
         $this->assertEquals(['hoff.jpg', 'norris.jpg'], Arr::get($entry->data(), 'reppy.0.pics'));
         $this->assertEquals('not an asset', Arr::get($entry->data(), 'reppy.1.not_asset'));
         $this->assertEquals('hoff.jpg', Arr::get($entry->data(), 'reppy.2.product'));
-        $this->assertEquals(['hoff.jpg', 'norris.jpg'], Arr::get($entry->data(), 'reppy.2.pics'));
+        $this->assertEquals(['hoff.jpg', 'norris.jpg', 'lee.jpg'], Arr::get($entry->data(), 'reppy.2.pics'));
 
         $this->assetNorris->path('content/norris.jpg')->save();
+        $this->assetHoff->delete();
 
         $this->assertEquals('content/norris.jpg', Arr::get($entry->fresh()->data(), 'reppy.0.product'));
-        $this->assertEquals(['hoff.jpg', 'content/norris.jpg'], Arr::get($entry->fresh()->data(), 'reppy.0.pics'));
+        $this->assertEquals(['content/norris.jpg'], Arr::get($entry->fresh()->data(), 'reppy.0.pics'));
         $this->assertEquals('not an asset', Arr::get($entry->fresh()->data(), 'reppy.1.not_asset'));
-        $this->assertEquals('hoff.jpg', Arr::get($entry->fresh()->data(), 'reppy.2.product'));
-        $this->assertEquals(['hoff.jpg', 'content/norris.jpg'], Arr::get($entry->fresh()->data(), 'reppy.2.pics'));
+        $this->assertFalse(Arr::has($entry->fresh()->data(), 'reppy.2.product'));
+        $this->assertEquals(['content/norris.jpg', 'lee.jpg'], Arr::get($entry->fresh()->data(), 'reppy.2.pics'));
     }
 
     /** @test */
@@ -330,7 +331,7 @@ class UpdateAssetReferencesTest extends TestCase
                 ],
                 [
                     'product' => 'hoff.jpg',
-                    'pics' => ['hoff.jpg', 'norris.jpg'],
+                    'pics' => ['hoff.jpg', 'norris.jpg', 'lee.jpg'],
                 ],
             ],
         ]))->save();
@@ -338,14 +339,15 @@ class UpdateAssetReferencesTest extends TestCase
         $this->assertEquals('norris.jpg', Arr::get($entry->data(), 'griddy.0.product'));
         $this->assertEquals(['hoff.jpg', 'norris.jpg'], Arr::get($entry->data(), 'griddy.0.pics'));
         $this->assertEquals('hoff.jpg', Arr::get($entry->data(), 'griddy.1.product'));
-        $this->assertEquals(['hoff.jpg', 'norris.jpg'], Arr::get($entry->data(), 'griddy.1.pics'));
+        $this->assertEquals(['hoff.jpg', 'norris.jpg', 'lee.jpg'], Arr::get($entry->data(), 'griddy.1.pics'));
 
         $this->assetNorris->path('content/norris.jpg')->save();
+        $this->assetHoff->delete();
 
         $this->assertEquals('content/norris.jpg', Arr::get($entry->fresh()->data(), 'griddy.0.product'));
-        $this->assertEquals(['hoff.jpg', 'content/norris.jpg'], Arr::get($entry->fresh()->data(), 'griddy.0.pics'));
-        $this->assertEquals('hoff.jpg', Arr::get($entry->fresh()->data(), 'griddy.1.product'));
-        $this->assertEquals(['hoff.jpg', 'content/norris.jpg'], Arr::get($entry->fresh()->data(), 'griddy.1.pics'));
+        $this->assertEquals(['content/norris.jpg'], Arr::get($entry->fresh()->data(), 'griddy.0.pics'));
+        $this->assertFalse(Arr::has($entry->fresh()->data(), 'griddy.1.product'));
+        $this->assertEquals(['content/norris.jpg', 'lee.jpg'], Arr::get($entry->fresh()->data(), 'griddy.1.pics'));
     }
 
     /** @test */
@@ -417,7 +419,7 @@ class UpdateAssetReferencesTest extends TestCase
                         'values' => [
                             'type' => 'set_one',
                             'product' => 'hoff.jpg',
-                            'pics' => ['hoff.jpg', 'norris.jpg'],
+                            'pics' => ['hoff.jpg', 'norris.jpg', 'lee.jpg'],
                         ],
                     ],
                 ],
@@ -428,15 +430,16 @@ class UpdateAssetReferencesTest extends TestCase
         $this->assertEquals(['hoff.jpg', 'norris.jpg'], Arr::get($entry->data(), 'bardo.0.attrs.values.pics'));
         $this->assertEquals('not an asset', Arr::get($entry->data(), 'bardo.1.not_asset'));
         $this->assertEquals('hoff.jpg', Arr::get($entry->data(), 'bardo.2.attrs.values.product'));
-        $this->assertEquals(['hoff.jpg', 'norris.jpg'], Arr::get($entry->data(), 'bardo.2.attrs.values.pics'));
+        $this->assertEquals(['hoff.jpg', 'norris.jpg', 'lee.jpg'], Arr::get($entry->data(), 'bardo.2.attrs.values.pics'));
 
         $this->assetNorris->path('content/norris.jpg')->save();
+        $this->assetHoff->delete();
 
         $this->assertEquals('content/norris.jpg', Arr::get($entry->fresh()->data(), 'bardo.0.attrs.values.product'));
-        $this->assertEquals(['hoff.jpg', 'content/norris.jpg'], Arr::get($entry->fresh()->data(), 'bardo.0.attrs.values.pics'));
+        $this->assertEquals(['content/norris.jpg'], Arr::get($entry->fresh()->data(), 'bardo.0.attrs.values.pics'));
         $this->assertEquals('not an asset', Arr::get($entry->fresh()->data(), 'bardo.1.not_asset'));
-        $this->assertEquals('hoff.jpg', Arr::get($entry->fresh()->data(), 'bardo.2.attrs.values.product'));
-        $this->assertEquals(['hoff.jpg', 'content/norris.jpg'], Arr::get($entry->fresh()->data(), 'bardo.2.attrs.values.pics'));
+        $this->assertFalse(Arr::has($entry->fresh()->data(), 'bardo.2.attrs.values.product'));
+        $this->assertEquals(['content/norris.jpg', 'lee.jpg'], Arr::get($entry->fresh()->data(), 'bardo.2.attrs.values.pics'));
     }
 
     /** @test */

--- a/tests/Listeners/UpdateAssetReferencesTest.php
+++ b/tests/Listeners/UpdateAssetReferencesTest.php
@@ -536,6 +536,28 @@ class UpdateAssetReferencesTest extends TestCase
                         [
                             'type' => 'image',
                             'attrs' => [
+                                'src' => 'asset::test_container::surfboard.jpg',
+                                'alt' => 'surfboard',
+                            ],
+                        ],
+                        [
+                            'type' => 'link',
+                            'attrs' => [
+                                'href' => 'statamic://asset::test_container::surfboard.jpg',
+                            ],
+                        ],
+                        [
+                            'type' => 'paragraph',
+                            'content' => 'unrelated',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'image',
+                            'attrs' => [
                                 'src' => 'asset::test_container::hoff.jpg',
                                 'alt' => 'hoff',
                             ],
@@ -577,21 +599,32 @@ class UpdateAssetReferencesTest extends TestCase
             ],
         ]))->save();
 
-        $this->assertEquals('asset::test_container::hoff.jpg', Arr::get($entry->data(), 'bardo.0.content.0.attrs.src'));
-        $this->assertEquals('hoff', Arr::get($entry->data(), 'bardo.0.content.0.attrs.alt'));
-        $this->assertEquals('statamic://asset::test_container::hoff.jpg', Arr::get($entry->data(), 'bardo.0.content.1.attrs.href'));
-        $this->assertEquals('asset::test_container::norris.jpg', Arr::get($entry->data(), 'bardo.1.content.0.attrs.src'));
-        $this->assertEquals('norris', Arr::get($entry->data(), 'bardo.1.content.0.attrs.alt'));
-        $this->assertEquals('statamic://asset::test_container::norris.jpg', Arr::get($entry->data(), 'bardo.1.content.1.attrs.href'));
+        $this->assertEquals('asset::test_container::surfboard.jpg', Arr::get($entry->data(), 'bardo.0.content.0.attrs.src'));
+        $this->assertEquals('surfboard', Arr::get($entry->data(), 'bardo.0.content.0.attrs.alt'));
+        $this->assertEquals('statamic://asset::test_container::surfboard.jpg', Arr::get($entry->data(), 'bardo.0.content.1.attrs.href'));
 
-        $this->assetHoff->path('content/hoff-new.jpg')->save();
+        $this->assertEquals('asset::test_container::hoff.jpg', Arr::get($entry->data(), 'bardo.1.content.0.attrs.src'));
+        $this->assertEquals('hoff', Arr::get($entry->data(), 'bardo.1.content.0.attrs.alt'));
+        $this->assertEquals('statamic://asset::test_container::hoff.jpg', Arr::get($entry->data(), 'bardo.1.content.1.attrs.href'));
 
-        $this->assertEquals('asset::test_container::content/hoff-new.jpg', Arr::get($entry->fresh()->data(), 'bardo.0.content.0.attrs.src'));
-        $this->assertEquals('hoff', Arr::get($entry->fresh()->data(), 'bardo.0.content.0.attrs.alt'));
-        $this->assertEquals('statamic://asset::test_container::content/hoff-new.jpg', Arr::get($entry->fresh()->data(), 'bardo.0.content.1.attrs.href'));
-        $this->assertEquals('asset::test_container::norris.jpg', Arr::get($entry->fresh()->data(), 'bardo.1.content.0.attrs.src'));
-        $this->assertEquals('norris', Arr::get($entry->fresh()->data(), 'bardo.1.content.0.attrs.alt'));
-        $this->assertEquals('statamic://asset::test_container::norris.jpg', Arr::get($entry->fresh()->data(), 'bardo.1.content.1.attrs.href'));
+        $this->assertEquals('asset::test_container::norris.jpg', Arr::get($entry->data(), 'bardo.2.content.0.attrs.src'));
+        $this->assertEquals('norris', Arr::get($entry->data(), 'bardo.2.content.0.attrs.alt'));
+        $this->assertEquals('statamic://asset::test_container::norris.jpg', Arr::get($entry->data(), 'bardo.2.content.1.attrs.href'));
+
+        $this->assetHoff->delete();
+        $this->assetNorris->path('content/norris-new.jpg')->save();
+
+        $this->assertEquals('asset::test_container::surfboard.jpg', Arr::get($entry->fresh()->data(), 'bardo.0.content.0.attrs.src'));
+        $this->assertEquals('surfboard', Arr::get($entry->fresh()->data(), 'bardo.0.content.0.attrs.alt'));
+        $this->assertEquals('statamic://asset::test_container::surfboard.jpg', Arr::get($entry->fresh()->data(), 'bardo.0.content.1.attrs.href'));
+
+        $this->assertEquals('', Arr::get($entry->fresh()->data(), 'bardo.1.content.0.attrs.src'));
+        $this->assertEquals('hoff', Arr::get($entry->fresh()->data(), 'bardo.1.content.0.attrs.alt'));
+        $this->assertEquals('', Arr::get($entry->fresh()->data(), 'bardo.1.content.1.attrs.href'));
+
+        $this->assertEquals('asset::test_container::content/norris-new.jpg', Arr::get($entry->fresh()->data(), 'bardo.2.content.0.attrs.src'));
+        $this->assertEquals('norris', Arr::get($entry->fresh()->data(), 'bardo.2.content.0.attrs.alt'));
+        $this->assertEquals('statamic://asset::test_container::content/norris-new.jpg', Arr::get($entry->fresh()->data(), 'bardo.2.content.1.attrs.href'));
     }
 
     /** @test */
@@ -620,6 +653,8 @@ class UpdateAssetReferencesTest extends TestCase
 <p><a href="statamic://asset::test_container::hoff.jpg">Link</a></p>
 <img src="statamic://asset::test_container::norris.jpg">
 <p><a href="statamic://asset::test_container::norris.jpg">Link</a></p>
+<img src="statamic://asset::test_container::surfboard.jpg">
+<p><a href="statamic://asset::test_container::surfboard.jpg">Link</a></p>
 EOT;
 
         $entry = tap(Facades\Entry::make()->collection($collection)->data(['bardo' => $content]))->save();
@@ -627,6 +662,7 @@ EOT;
         $this->assertEquals($content, $entry->get('bardo'));
 
         $this->assetHoff->path('content/hoff-new.jpg')->save();
+        $this->assetNorris->delete();
 
         $expected = <<<'EOT'
 <p>Some text.</p>
@@ -634,8 +670,10 @@ EOT;
 <img src="statamic://asset::test_container::content/hoff-new.jpg" alt="test">
 </p>More text.</p>
 <p><a href="statamic://asset::test_container::content/hoff-new.jpg">Link</a></p>
-<img src="statamic://asset::test_container::norris.jpg">
-<p><a href="statamic://asset::test_container::norris.jpg">Link</a></p>
+<img src="">
+<p><a href="">Link</a></p>
+<img src="statamic://asset::test_container::surfboard.jpg">
+<p><a href="statamic://asset::test_container::surfboard.jpg">Link</a></p>
 EOT;
 
         $this->assertEquals($expected, $entry->fresh()->get('bardo'));
@@ -662,7 +700,8 @@ EOT;
 Some text.
 ![](statamic://asset::test_container::hoff.jpg)
 More text.
-![](statamic://asset::test_container::norris.jpg)
+![First link](statamic://asset::test_container::norris.jpg)
+![Second link](statamic://asset::test_container::surfboard.jpg)
 EOT;
 
         $entry = tap(Facades\Entry::make()->collection($collection)->data(['content' => $content]))->save();
@@ -670,12 +709,14 @@ EOT;
         $this->assertEquals($content, $entry->get('content'));
 
         $this->assetHoff->path('content/hoff-new.jpg')->save();
+        $this->assetNorris->delete();
 
         $expected = <<<'EOT'
 Some text.
 ![](statamic://asset::test_container::content/hoff-new.jpg)
 More text.
-![](statamic://asset::test_container::norris.jpg)
+![First link]()
+![Second link](statamic://asset::test_container::surfboard.jpg)
 EOT;
 
         $this->assertEquals($expected, $entry->fresh()->get('content'));
@@ -784,12 +825,12 @@ EOT;
                                 'values' => [
                                     'type' => 'set_two',
                                     'product' => 'norris.jpg',
-                                    'pics' => ['hoff.jpg', 'norris.jpg'],
-                                    'bio' => '# Markdown: ![](statamic://asset::test_container::norris.jpg)',
+                                    'pics' => ['hoff.jpg', 'norris.jpg', 'surfboard.jpg'],
+                                    'bio' => '# Markdown: ![Norris](statamic://asset::test_container::norris.jpg) ![Hoff](statamic://asset::test_container::hoff.jpg)',
                                     'griddy' => [
                                         [
                                             'product' => 'norris.jpg',
-                                            'pics' => ['hoff.jpg', 'norris.jpg'],
+                                            'pics' => ['hoff.jpg', 'norris.jpg', 'surfboard.jpg'],
                                         ],
                                     ],
                                 ],
@@ -803,20 +844,21 @@ EOT;
         $this->assertEquals('norris.jpg', Arr::get($entry->data(), 'avatar'));
         $this->assertEquals('not an asset', Arr::get($entry->data(), 'reppy.0.not_asset'));
         $this->assertEquals('norris.jpg', Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.product'));
-        $this->assertEquals(['hoff.jpg', 'norris.jpg'], Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.pics'));
-        $this->assertEquals('# Markdown: ![](statamic://asset::test_container::norris.jpg)', Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.bio'));
+        $this->assertEquals(['hoff.jpg', 'norris.jpg', 'surfboard.jpg'], Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.pics'));
+        $this->assertEquals('# Markdown: ![Norris](statamic://asset::test_container::norris.jpg) ![Hoff](statamic://asset::test_container::hoff.jpg)', Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.bio'));
         $this->assertEquals('norris.jpg', Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.griddy.0.product'));
-        $this->assertEquals(['hoff.jpg', 'norris.jpg'], Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.griddy.0.pics'));
+        $this->assertEquals(['hoff.jpg', 'norris.jpg', 'surfboard.jpg'], Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.griddy.0.pics'));
 
+        $this->assetHoff->delete();
         $this->assetNorris->path('content/norris.jpg')->save();
 
         $this->assertEquals('content/norris.jpg', Arr::get($entry->fresh()->data(), 'avatar'));
         $this->assertEquals('not an asset', Arr::get($entry->fresh()->data(), 'reppy.0.not_asset'));
         $this->assertEquals('content/norris.jpg', Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.product'));
-        $this->assertEquals(['hoff.jpg', 'content/norris.jpg'], Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.pics'));
-        $this->assertEquals('# Markdown: ![](statamic://asset::test_container::content/norris.jpg)', Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.bio'));
+        $this->assertEquals(['content/norris.jpg', 'surfboard.jpg'], Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.pics'));
+        $this->assertEquals('# Markdown: ![Norris](statamic://asset::test_container::content/norris.jpg) ![Hoff]()', Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.bio'));
         $this->assertEquals('content/norris.jpg', Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.griddy.0.product'));
-        $this->assertEquals(['hoff.jpg', 'content/norris.jpg'], Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.griddy.0.pics'));
+        $this->assertEquals(['content/norris.jpg', 'surfboard.jpg'], Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.griddy.0.pics'));
     }
 
     /** @test */

--- a/tests/Listeners/UpdateAssetReferencesTest.php
+++ b/tests/Listeners/UpdateAssetReferencesTest.php
@@ -117,55 +117,6 @@ class UpdateAssetReferencesTest extends TestCase
     }
 
     /** @test */
-    public function it_updates_link_fields()
-    {
-        $collection = tap(Facades\Collection::make('articles'))->save();
-
-        $this->setInBlueprints('collections/articles', [
-            'fields' => [
-                [
-                    'handle' => 'avatar',
-                    'field' => [
-                        'type' => 'link',
-                        'container' => 'test_container',
-                    ],
-                ],
-                [
-                    'handle' => 'product',
-                    'field' => [
-                        'type' => 'link',
-                        'container' => 'test_container',
-                    ],
-                ],
-                [
-                    'handle' => 'featured',
-                    'field' => [
-                        'type' => 'link',
-                        'container' => 'test_container',
-                    ],
-                ],
-            ],
-        ]);
-
-        $entry = tap(Facades\Entry::make()->collection($collection)->data([
-            'avatar' => 'asset::test_container::hoff.jpg',
-            'product' => 'asset::test_container::norris.jpg',
-            'featured' => 'asset::test_container::surfboard.jpg',
-        ]))->save();
-
-        $this->assertEquals('asset::test_container::hoff.jpg', $entry->get('avatar'));
-        $this->assertEquals('asset::test_container::norris.jpg', $entry->get('product'));
-        $this->assertEquals('asset::test_container::surfboard.jpg', $entry->get('featured'));
-
-        $this->assetHoff->path('hoff-new.jpg')->save();
-        $this->assetNorris->delete();
-
-        $this->assertEquals('asset::test_container::hoff-new.jpg', $entry->fresh()->get('avatar'));
-        $this->assertFalse($entry->fresh()->has('product'));
-        $this->assertEquals('asset::test_container::surfboard.jpg', $entry->fresh()->get('featured'));
-    }
-
-    /** @test */
     public function it_nullifies_references_when_deleting_an_asset()
     {
         $collection = tap(Facades\Collection::make('articles'))->save();
@@ -217,6 +168,55 @@ class UpdateAssetReferencesTest extends TestCase
 
         $this->assertFalse($entry->fresh()->has('products'));
         $this->assertFalse($entry->fresh()->has('featured'));
+    }
+
+    /** @test */
+    public function it_updates_link_fields()
+    {
+        $collection = tap(Facades\Collection::make('articles'))->save();
+
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                [
+                    'handle' => 'avatar',
+                    'field' => [
+                        'type' => 'link',
+                        'container' => 'test_container',
+                    ],
+                ],
+                [
+                    'handle' => 'product',
+                    'field' => [
+                        'type' => 'link',
+                        'container' => 'test_container',
+                    ],
+                ],
+                [
+                    'handle' => 'featured',
+                    'field' => [
+                        'type' => 'link',
+                        'container' => 'test_container',
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry = tap(Facades\Entry::make()->collection($collection)->data([
+            'avatar' => 'asset::test_container::hoff.jpg',
+            'product' => 'asset::test_container::norris.jpg',
+            'featured' => 'asset::test_container::surfboard.jpg',
+        ]))->save();
+
+        $this->assertEquals('asset::test_container::hoff.jpg', $entry->get('avatar'));
+        $this->assertEquals('asset::test_container::norris.jpg', $entry->get('product'));
+        $this->assertEquals('asset::test_container::surfboard.jpg', $entry->get('featured'));
+
+        $this->assetHoff->path('hoff-new.jpg')->save();
+        $this->assetNorris->delete();
+
+        $this->assertEquals('asset::test_container::hoff-new.jpg', $entry->fresh()->get('avatar'));
+        $this->assertFalse($entry->fresh()->has('product'));
+        $this->assertEquals('asset::test_container::surfboard.jpg', $entry->fresh()->get('featured'));
     }
 
     /** @test */

--- a/tests/Listeners/UpdateAssetReferencesTest.php
+++ b/tests/Listeners/UpdateAssetReferencesTest.php
@@ -137,21 +137,32 @@ class UpdateAssetReferencesTest extends TestCase
                         'container' => 'test_container',
                     ],
                 ],
+                [
+                    'handle' => 'featured',
+                    'field' => [
+                        'type' => 'link',
+                        'container' => 'test_container',
+                    ],
+                ],
             ],
         ]);
 
         $entry = tap(Facades\Entry::make()->collection($collection)->data([
             'avatar' => 'asset::test_container::hoff.jpg',
-            'product' => 'asset::test_container::surfboard.jpg',
+            'product' => 'asset::test_container::norris.jpg',
+            'featured' => 'asset::test_container::surfboard.jpg',
         ]))->save();
 
         $this->assertEquals('asset::test_container::hoff.jpg', $entry->get('avatar'));
-        $this->assertEquals('asset::test_container::surfboard.jpg', $entry->get('product'));
+        $this->assertEquals('asset::test_container::norris.jpg', $entry->get('product'));
+        $this->assertEquals('asset::test_container::surfboard.jpg', $entry->get('featured'));
 
         $this->assetHoff->path('hoff-new.jpg')->save();
+        $this->assetNorris->delete();
 
         $this->assertEquals('asset::test_container::hoff-new.jpg', $entry->fresh()->get('avatar'));
-        $this->assertEquals('asset::test_container::surfboard.jpg', $entry->fresh()->get('product'));
+        $this->assertFalse($entry->fresh()->has('product'));
+        $this->assertEquals('asset::test_container::surfboard.jpg', $entry->fresh()->get('featured'));
     }
 
     /** @test */

--- a/tests/Listeners/UpdateTermReferencesTest.php
+++ b/tests/Listeners/UpdateTermReferencesTest.php
@@ -29,6 +29,11 @@ class UpdateTermReferencesTest extends TestCase
         $this->termNorris = tap(Facades\Term::make()->taxonomy('topics')->inDefaultLocale()->slug('norris')->data([]))->save();
     }
 
+    protected function disableUpdateReferences($app)
+    {
+        $app['config']->set('statamic.system.update_references', false);
+    }
+
     /** @test */
     public function it_updates_single_term_fields()
     {
@@ -281,6 +286,63 @@ class UpdateTermReferencesTest extends TestCase
         $this->assertFalse($entry->fresh()->has('favourites'));
     }
 
+    /**
+     * @test
+     * @environment-setup disableUpdateReferences
+     **/
+    public function it_can_be_disabled()
+    {
+        $collection = tap(Facades\Collection::make('articles'))->save();
+
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                [
+                    'handle' => 'favourite',
+                    'field' => [
+                        'type' => 'terms',
+                        'taxonomies' => ['topics'],
+                        'max_items' => 1,
+                        'mode' => 'select',
+                    ],
+                ],
+                [
+                    'handle' => 'non_favourite',
+                    'field' => [
+                        'type' => 'terms',
+                        'taxonomies' => ['topics'],
+                        'max_items' => 1,
+                        'mode' => 'select',
+                    ],
+                ],
+                [
+                    'handle' => 'favourites',
+                    'field' => [
+                        'type' => 'terms',
+                        'taxonomies' => ['topics'],
+                        'mode' => 'select',
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry = tap(Facades\Entry::make()->collection($collection)->data([
+            'favourite' => 'hoff',
+            'non_favourite' => 'norris',
+            'favourites' => ['hoff', 'norris'],
+        ]))->save();
+
+        $this->assertEquals('hoff', $entry->get('favourite'));
+        $this->assertEquals('norris', $entry->get('non_favourite'));
+        $this->assertEquals(['hoff', 'norris'], $entry->get('favourites'));
+
+        $this->termNorris->delete();
+        $this->termHoff->slug('hoff-new')->save();
+
+        $this->assertEquals('hoff', $entry->fresh()->get('favourite'));
+        $this->assertEquals('norris', $entry->fresh()->get('non_favourite'));
+        $this->assertEquals(['hoff', 'norris'], $entry->fresh()->get('favourites'));
+    }
+
     /** @test */
     public function it_updates_nested_term_fields_within_replicator_fields()
     {
@@ -342,7 +404,7 @@ class UpdateTermReferencesTest extends TestCase
                 [
                     'type' => 'set_one',
                     'favourite' => 'hoff',
-                    'favourites' => ['hoff', 'norris'],
+                    'favourites' => ['hoff', 'norris', 'lee'],
                 ],
             ],
         ]))->save();
@@ -351,15 +413,16 @@ class UpdateTermReferencesTest extends TestCase
         $this->assertEquals(['hoff', 'norris'], Arr::get($entry->data(), 'reppy.0.favourites'));
         $this->assertEquals('not a term', Arr::get($entry->data(), 'reppy.1.not_term'));
         $this->assertEquals('hoff', Arr::get($entry->data(), 'reppy.2.favourite'));
-        $this->assertEquals(['hoff', 'norris'], Arr::get($entry->data(), 'reppy.2.favourites'));
+        $this->assertEquals(['hoff', 'norris', 'lee'], Arr::get($entry->data(), 'reppy.2.favourites'));
 
         $this->termNorris->slug('norris-new')->save();
+        $this->termHoff->delete();
 
         $this->assertEquals('norris-new', Arr::get($entry->fresh()->data(), 'reppy.0.favourite'));
-        $this->assertEquals(['hoff', 'norris-new'], Arr::get($entry->fresh()->data(), 'reppy.0.favourites'));
+        $this->assertEquals(['norris-new'], Arr::get($entry->fresh()->data(), 'reppy.0.favourites'));
         $this->assertEquals('not a term', Arr::get($entry->fresh()->data(), 'reppy.1.not_term'));
-        $this->assertEquals('hoff', Arr::get($entry->fresh()->data(), 'reppy.2.favourite'));
-        $this->assertEquals(['hoff', 'norris-new'], Arr::get($entry->fresh()->data(), 'reppy.2.favourites'));
+        $this->assertFalse(Arr::has($entry->fresh()->data(), 'reppy.2.favourite'));
+        $this->assertEquals(['norris-new', 'lee'], Arr::get($entry->fresh()->data(), 'reppy.2.favourites'));
     }
 
     /** @test */
@@ -403,7 +466,7 @@ class UpdateTermReferencesTest extends TestCase
                 ],
                 [
                     'favourite' => 'hoff',
-                    'favourites' => ['hoff', 'norris'],
+                    'favourites' => ['hoff', 'norris', 'lee'],
                 ],
             ],
         ]))->save();
@@ -411,14 +474,15 @@ class UpdateTermReferencesTest extends TestCase
         $this->assertEquals('norris', Arr::get($entry->data(), 'griddy.0.favourite'));
         $this->assertEquals(['hoff', 'norris'], Arr::get($entry->data(), 'griddy.0.favourites'));
         $this->assertEquals('hoff', Arr::get($entry->data(), 'griddy.1.favourite'));
-        $this->assertEquals(['hoff', 'norris'], Arr::get($entry->data(), 'griddy.1.favourites'));
+        $this->assertEquals(['hoff', 'norris', 'lee'], Arr::get($entry->data(), 'griddy.1.favourites'));
 
         $this->termNorris->slug('norris-new')->save();
+        $this->termHoff->delete();
 
         $this->assertEquals('norris-new', Arr::get($entry->fresh()->data(), 'griddy.0.favourite'));
-        $this->assertEquals(['hoff', 'norris-new'], Arr::get($entry->fresh()->data(), 'griddy.0.favourites'));
-        $this->assertEquals('hoff', Arr::get($entry->fresh()->data(), 'griddy.1.favourite'));
-        $this->assertEquals(['hoff', 'norris-new'], Arr::get($entry->fresh()->data(), 'griddy.1.favourites'));
+        $this->assertEquals(['norris-new'], Arr::get($entry->fresh()->data(), 'griddy.0.favourites'));
+        $this->assertFalse(Arr::has($entry->fresh()->data(), 'griddy.1.favourite'));
+        $this->assertEquals(['norris-new', 'lee'], Arr::get($entry->fresh()->data(), 'griddy.1.favourites'));
     }
 
     /** @test */
@@ -490,7 +554,7 @@ class UpdateTermReferencesTest extends TestCase
                         'values' => [
                             'type' => 'set_one',
                             'favourite' => 'hoff',
-                            'favourites' => ['hoff', 'norris'],
+                            'favourites' => ['hoff', 'norris', 'lee'],
                         ],
                     ],
                 ],
@@ -501,15 +565,16 @@ class UpdateTermReferencesTest extends TestCase
         $this->assertEquals(['hoff', 'norris'], Arr::get($entry->data(), 'bardo.0.attrs.values.favourites'));
         $this->assertEquals('not a term', Arr::get($entry->data(), 'bardo.1.not_term'));
         $this->assertEquals('hoff', Arr::get($entry->data(), 'bardo.2.attrs.values.favourite'));
-        $this->assertEquals(['hoff', 'norris'], Arr::get($entry->data(), 'bardo.2.attrs.values.favourites'));
+        $this->assertEquals(['hoff', 'norris', 'lee'], Arr::get($entry->data(), 'bardo.2.attrs.values.favourites'));
 
         $this->termNorris->slug('norris-new')->save();
+        $this->termHoff->delete();
 
         $this->assertEquals('norris-new', Arr::get($entry->fresh()->data(), 'bardo.0.attrs.values.favourite'));
-        $this->assertEquals(['hoff', 'norris-new'], Arr::get($entry->fresh()->data(), 'bardo.0.attrs.values.favourites'));
+        $this->assertEquals(['norris-new'], Arr::get($entry->fresh()->data(), 'bardo.0.attrs.values.favourites'));
         $this->assertEquals('not a term', Arr::get($entry->fresh()->data(), 'bardo.1.not_term'));
-        $this->assertEquals('hoff', Arr::get($entry->fresh()->data(), 'bardo.2.attrs.values.favourite'));
-        $this->assertEquals(['hoff', 'norris-new'], Arr::get($entry->fresh()->data(), 'bardo.2.attrs.values.favourites'));
+        $this->assertFalse(Arr::has($entry->fresh()->data(), 'bardo.2.attrs.values.favourite'));
+        $this->assertEquals(['norris-new', 'lee'], Arr::get($entry->fresh()->data(), 'bardo.2.attrs.values.favourites'));
     }
 
     /** @test */
@@ -612,7 +677,7 @@ class UpdateTermReferencesTest extends TestCase
                                     'griddy' => [
                                         [
                                             'favourite' => 'norris',
-                                            'favourites' => ['hoff', 'norris'],
+                                            'favourites' => ['hoff', 'norris', 'lee'],
                                         ],
                                     ],
                                 ],
@@ -628,16 +693,17 @@ class UpdateTermReferencesTest extends TestCase
         $this->assertEquals('norris', Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.favourite'));
         $this->assertEquals(['hoff', 'norris'], Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.favourites'));
         $this->assertEquals('norris', Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.griddy.0.favourite'));
-        $this->assertEquals(['hoff', 'norris'], Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.griddy.0.favourites'));
+        $this->assertEquals(['hoff', 'norris', 'lee'], Arr::get($entry->data(), 'reppy.1.bard_within_reppy.0.attrs.values.griddy.0.favourites'));
 
         $this->termNorris->slug('norris-new')->save();
+        $this->termHoff->delete();
 
         $this->assertEquals('norris-new', Arr::get($entry->fresh()->data(), 'favourite'));
         $this->assertEquals('not a term', Arr::get($entry->fresh()->data(), 'reppy.0.not_term'));
         $this->assertEquals('norris-new', Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.favourite'));
-        $this->assertEquals(['hoff', 'norris-new'], Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.favourites'));
+        $this->assertEquals(['norris-new'], Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.favourites'));
         $this->assertEquals('norris-new', Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.griddy.0.favourite'));
-        $this->assertEquals(['hoff', 'norris-new'], Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.griddy.0.favourites'));
+        $this->assertEquals(['norris-new', 'lee'], Arr::get($entry->fresh()->data(), 'reppy.1.bard_within_reppy.0.attrs.values.griddy.0.favourites'));
     }
 
     /** @test */


### PR DESCRIPTION
- [x] Handle deleted events
    - [x] Update asset references on `AssetDeleted`
    - [x] Update term references on `TermDeleted`
- [x] Add config to handle the disabling of reference updating
    - [x] For assets
    - [x] For terms
- [x] Add test coverage