### PR TITLE
Add `user_groups` tag

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -174,6 +174,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Tags\Theme::class,
         Tags\Trans::class,
         Tags\TransChoice::class,
+        Tags\UserGroups::class,
         Tags\Users::class,
         Tags\Vite::class,
         Tags\Widont::class,

--- a/src/Tags/UserGroups.php
+++ b/src/Tags/UserGroups.php
@@ -7,14 +7,6 @@ use Statamic\Facades\UserGroup;
 class UserGroups extends Tags
 {
     /**
-     * {{ user_groups:* }} ... {{ /user_groups:* }}.
-     */
-    public function wildcard($tag)
-    {
-        return UserGroup::find($tag);
-    }
-
-    /**
      * {{ user_groups }} ... {{ /user_groups }}.
      */
     public function index()

--- a/src/Tags/UserGroups.php
+++ b/src/Tags/UserGroups.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Statamic\Tags;
+
+use Statamic\Facades\UserGroup;
+
+class UserGroups extends Tags
+{
+    use Concerns\OutputsItems;
+
+    /**
+     * {{ user_groups }} ... {{ /user_groups }}.
+     */
+    public function index()
+    {
+        if ($group = $this->params->get('handle')) {
+            if (! $group = UserGroup::find($group)) {
+                return $this->parseNoResults();
+            }
+
+            return $group;
+        }
+
+        return $this->output(UserGroup::all()->values());
+    }
+}

--- a/src/Tags/UserGroups.php
+++ b/src/Tags/UserGroups.php
@@ -6,21 +6,25 @@ use Statamic\Facades\UserGroup;
 
 class UserGroups extends Tags
 {
-    use Concerns\OutputsItems;
+    /**
+     * {{ user_groups:* }} ... {{ /user_groups:* }}.
+     */
+    public function wildcard($tag)
+    {
+        return UserGroup::find($tag);
+    }
 
     /**
      * {{ user_groups }} ... {{ /user_groups }}.
      */
     public function index()
     {
-        if ($group = $this->params->get('handle')) {
-            if (! $group = UserGroup::find($group)) {
-                return $this->parseNoResults();
-            }
+        $groups = UserGroup::all();
 
-            return $group;
+        if (! $handles = $this->params->explode('handle')) {
+            return $groups->values();
         }
 
-        return $this->output(UserGroup::all()->values());
+        return $groups->filter(fn ($group) => in_array($group->handle(), $handles))->values();
     }
 }

--- a/tests/Tags/UserGroupsTagTest.php
+++ b/tests/Tags/UserGroupsTagTest.php
@@ -57,22 +57,6 @@ class UserGroupsTagTest extends TestCase
         $this->assertEquals('nothing', $this->tag('{{ user_groups handle="test2|test3" }}{{ if no_results }}nothing{{ else }}something{{ /if }}{{ /user_groups }}'));
     }
 
-    /** @test */
-    public function it_gets_a_group_using_shorthand()
-    {
-        UserGroup::make()->handle('test')->title('Test')->save();
-        UserGroup::make()->handle('test2')->title('Test 2')->save();
-        UserGroup::make()->handle('test3')->title('Test 3')->save();
-
-        $this->assertEquals('test2', $this->tag('{{ user_groups:test2 }}{{ handle }}{{ /user_groups:test2 }}'));
-    }
-
-    /** @test */
-    public function it_outputs_nothing_when_using_shorthand()
-    {
-        $this->assertEquals('', $this->tag('{{ user_groups:test2 }}{{ handle }}{{ /user_groups:test2 }}'));
-    }
-
     private function tag($tag, $data = [])
     {
         return (string) Parse::template($tag, $data);

--- a/tests/Tags/UserGroupsTagTest.php
+++ b/tests/Tags/UserGroupsTagTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Tags;
+
+use Statamic\Facades\Parse;
+use Statamic\Facades\UserGroup;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class UserGroupsTagTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    /** @test */
+    public function it_gets_all_groups()
+    {
+        UserGroup::make()->handle('test')->title('Test')->save();
+        UserGroup::make()->handle('test2')->title('Test 2')->save();
+        UserGroup::make()->handle('test3')->title('Test 3')->save();
+
+        $this->assertEquals('test|test2|test3|', $this->tag('{{ user_groups }}{{ handle }}|{{ /user_groups }}'));
+    }
+
+    /** @test */
+    public function it_gets_a_group()
+    {
+        UserGroup::make()->handle('test')->title('Test')->save();
+        UserGroup::make()->handle('test2')->title('Test 2')->save();
+        UserGroup::make()->handle('test3')->title('Test 3')->save();
+
+        $this->assertEquals('test2', $this->tag('{{ user_groups handle="test2" }}{{ handle }}{{ /user_groups }}'));
+    }
+
+    private function tag($tag, $data = [])
+    {
+        return (string) Parse::template($tag, $data);
+    }
+}

--- a/tests/Tags/UserGroupsTagTest.php
+++ b/tests/Tags/UserGroupsTagTest.php
@@ -4,12 +4,22 @@ namespace Tests\Tags;
 
 use Statamic\Facades\Parse;
 use Statamic\Facades\UserGroup;
-use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class UserGroupsTagTest extends TestCase
 {
-    use PreventSavingStacheItemsToDisk;
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        UserGroup::all()->each->delete();
+    }
+
+    /** @test */
+    public function it_outputs_no_results()
+    {
+        $this->assertEquals('nothing', $this->tag('{{ user_groups }}{{ if no_results }}nothing{{ else }}something{{ /if }}{{ /user_groups }}'));
+    }
 
     /** @test */
     public function it_gets_all_groups()
@@ -29,6 +39,38 @@ class UserGroupsTagTest extends TestCase
         UserGroup::make()->handle('test3')->title('Test 3')->save();
 
         $this->assertEquals('test2', $this->tag('{{ user_groups handle="test2" }}{{ handle }}{{ /user_groups }}'));
+    }
+
+    /** @test */
+    public function it_gets_multiple_groups()
+    {
+        UserGroup::make()->handle('test')->title('Test')->save();
+        UserGroup::make()->handle('test2')->title('Test 2')->save();
+        UserGroup::make()->handle('test3')->title('Test 3')->save();
+
+        $this->assertEquals('test2|test3|', $this->tag('{{ user_groups handle="test2|test3" }}{{ handle }}|{{ /user_groups }}'));
+    }
+
+    /** @test */
+    public function it_outputs_no_results_when_finding_multiple_groups()
+    {
+        $this->assertEquals('nothing', $this->tag('{{ user_groups handle="test2|test3" }}{{ if no_results }}nothing{{ else }}something{{ /if }}{{ /user_groups }}'));
+    }
+
+    /** @test */
+    public function it_gets_a_group_using_shorthand()
+    {
+        UserGroup::make()->handle('test')->title('Test')->save();
+        UserGroup::make()->handle('test2')->title('Test 2')->save();
+        UserGroup::make()->handle('test3')->title('Test 3')->save();
+
+        $this->assertEquals('test2', $this->tag('{{ user_groups:test2 }}{{ handle }}{{ /user_groups:test2 }}'));
+    }
+
+    /** @test */
+    public function it_outputs_nothing_when_using_shorthand()
+    {
+        $this->assertEquals('', $this->tag('{{ user_groups:test2 }}{{ handle }}{{ /user_groups:test2 }}'));
     }
 
     private function tag($tag, $data = [])


### PR DESCRIPTION
This tag allows you to return all user groups or a specific group, both of which can be useful in some situations (eg membership sites).

Usage:
`{{ user_groups }} {{ title }} {{ /user_groups }}`
`{{ user_groups handle="group_handle" }} {{ title }} {{ /user_groups }}`

I'm happy to work on this further if you feel its lacking, and I'll create a docs PR if you are happy to merge this.
