### PR TITLE
Fix evaluate query builder from entries field in jsonSerialize

### DIFF
--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -8,6 +8,7 @@ use IteratorAggregate;
 use JsonSerializable;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\View\Antlers\Parser;
+use Statamic\Query\OrderedQueryBuilder;
 use Statamic\Support\Str;
 use Statamic\View\Antlers\Language\Parser\DocumentTransformer;
 
@@ -59,6 +60,10 @@ class Value implements IteratorAggregate, JsonSerializable
     public function jsonSerialize($options = 0)
     {
         $value = $this->value();
+
+        if ($value instanceof OrderedQueryBuilder) {
+            $value = $value->get();
+        }
 
         if ($value instanceof Augmentable || $value instanceof Collection) {
             $value = $value->toAugmentedArray();


### PR DESCRIPTION
This PR fixes https://github.com/statamic/cms/issues/6467

**Bug**
Since v3.3.0 entries field serializes to empty object if used within a set or bard field.

In depth, the augmentation of entries returns a query builder instead of a collection of entries, then during serialization the query builder evaluates to an empty object.

**Fix**
This commit fixes this case by evaluating the query builder during jsonSerialize of the Field Value and makes augmentation backward compatible to v3.2.x

I think augmenting entries to an augmented colletion would be a better way to resolve the issue, but will also have other places to consider this change.
@jasonvarga you seemed to have resolved similar issues in the past. Do you see a better way?

We are currently waiting for a fix to upgrade our projects to v3.3 😍 