### PR TITLE
Add user scope on cache tag

### DIFF
--- a/src/Tags/Cache.php
+++ b/src/Tags/Cache.php
@@ -49,8 +49,14 @@ class Cache extends Tags
             'params' => $this->params->all(),
         ];
 
-        if ($this->params->get('scope', 'site') === 'page') {
+        $scope = $this->params->get('scope', 'site');
+
+        if ($scope === 'page') {
             $hash['url'] = URL::makeAbsolute(URL::getCurrent());
+        }
+
+        if ($scope === 'user') {
+            $hash['user'] = ($user = auth()->user()) ? $user->id : 'guest';
         }
 
         return 'statamic.cache-tag.'.md5(json_encode($hash));


### PR DESCRIPTION
Adds `{{ cache scope="user" }}` option to the cache tag, to scope it to the currently logged in user or guest. 

Closes: https://github.com/statamic/ideas/issues/850