### PR TITLE
Add `user_roles` tag

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -175,6 +175,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Tags\Trans::class,
         Tags\TransChoice::class,
         Tags\Users::class,
+        Tags\UserRoles::class,
         Tags\Vite::class,
         Tags\Widont::class,
         Tags\Yields::class,

--- a/src/Tags/UserRoles.php
+++ b/src/Tags/UserRoles.php
@@ -6,21 +6,17 @@ use Statamic\Facades\Role;
 
 class UserRoles extends Tags
 {
-    use Concerns\OutputsItems;
-
     /**
      * {{ user_roles }} ... {{ /user_roles }}.
      */
     public function index()
     {
-        if ($group = $this->params->get('handle')) {
-            if (! $group = Role::find($group)) {
-                return $this->parseNoResults();
-            }
+        $roles = Role::all();
 
-            return $group;
+        if (! $handles = $this->params->explode('handle')) {
+            return $roles->values();
         }
 
-        return $this->output(Role::all()->values());
+        return $roles->filter(fn ($role) => in_array($role->handle(), $handles))->values();
     }
 }

--- a/src/Tags/UserRoles.php
+++ b/src/Tags/UserRoles.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Statamic\Tags;
+
+use Statamic\Facades\Role;
+
+class UserRoles extends Tags
+{
+    use Concerns\OutputsItems;
+
+    /**
+     * {{ user_roles }} ... {{ /user_roles }}.
+     */
+    public function index()
+    {
+        if ($group = $this->params->get('handle')) {
+            if (! $group = Role::find($group)) {
+                return $this->parseNoResults();
+            }
+
+            return $group;
+        }
+
+        return $this->output(Role::all()->values());
+    }
+}

--- a/tests/Tags/UserRolesTagTest.php
+++ b/tests/Tags/UserRolesTagTest.php
@@ -9,10 +9,21 @@ use Tests\TestCase;
 
 class UserRolesTagTest extends TestCase
 {
-    use PreventSavingStacheItemsToDisk;
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Role::all()->each->delete();
+    }
 
     /** @test */
-    public function it_gets_all_groups()
+    public function it_outputs_no_results()
+    {
+         $this->assertEquals('nothing', $this->tag('{{ user_roles }}{{ if no_results }}nothing{{ else }}something{{ /if }}{{ /user_roles }}'));
+    }
+
+    /** @test */
+    public function it_gets_all_roles()
     {
         Role::make()->handle('test')->title('Test')->save();
         Role::make()->handle('test2')->title('Test 2')->save();
@@ -22,13 +33,29 @@ class UserRolesTagTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_a_group()
+    public function it_gets_a_role()
     {
         Role::make()->handle('test')->title('Test')->save();
         Role::make()->handle('test2')->title('Test 2')->save();
         Role::make()->handle('test3')->title('Test 3')->save();
 
         $this->assertEquals('test2', $this->tag('{{ user_roles handle="test2" }}{{ handle }}{{ /user_roles }}'));
+    }
+
+    /** @test */
+    public function it_gets_multiple_roles()
+    {
+        Role::make()->handle('test')->title('Test')->save();
+        Role::make()->handle('test2')->title('Test 2')->save();
+        Role::make()->handle('test3')->title('Test 3')->save();
+
+        $this->assertEquals('test2|test3|', $this->tag('{{ user_roles handle="test2|test3" }}{{ handle }}|{{ /user_roles }}'));
+    }
+
+    /** @test */
+    public function it_outputs_no_results_when_finding_multiple_roles()
+    {
+        $this->assertEquals('nothing', $this->tag('{{ user_roles handle="test2|test3" }}{{ if no_results }}nothing{{ else }}something{{ /if }}{{ /user_roles }}'));
     }
 
     private function tag($tag, $data = [])

--- a/tests/Tags/UserRolesTagTest.php
+++ b/tests/Tags/UserRolesTagTest.php
@@ -4,7 +4,6 @@ namespace Tests\Tags;
 
 use Statamic\Facades\Parse;
 use Statamic\Facades\Role;
-use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class UserRolesTagTest extends TestCase
@@ -19,7 +18,7 @@ class UserRolesTagTest extends TestCase
     /** @test */
     public function it_outputs_no_results()
     {
-         $this->assertEquals('nothing', $this->tag('{{ user_roles }}{{ if no_results }}nothing{{ else }}something{{ /if }}{{ /user_roles }}'));
+        $this->assertEquals('nothing', $this->tag('{{ user_roles }}{{ if no_results }}nothing{{ else }}something{{ /if }}{{ /user_roles }}'));
     }
 
     /** @test */

--- a/tests/Tags/UserRolesTagTest.php
+++ b/tests/Tags/UserRolesTagTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Tags;
+
+use Statamic\Facades\Parse;
+use Statamic\Facades\Role;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class UserRolesTagTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    /** @test */
+    public function it_gets_all_groups()
+    {
+        Role::make()->handle('test')->title('Test')->save();
+        Role::make()->handle('test2')->title('Test 2')->save();
+        Role::make()->handle('test3')->title('Test 3')->save();
+
+        $this->assertEquals('test|test2|test3|', $this->tag('{{ user_roles }}{{ handle }}|{{ /user_roles }}'));
+    }
+
+    /** @test */
+    public function it_gets_a_group()
+    {
+        Role::make()->handle('test')->title('Test')->save();
+        Role::make()->handle('test2')->title('Test 2')->save();
+        Role::make()->handle('test3')->title('Test 3')->save();
+
+        $this->assertEquals('test2', $this->tag('{{ user_roles handle="test2" }}{{ handle }}{{ /user_roles }}'));
+    }
+
+    private function tag($tag, $data = [])
+    {
+        return (string) Parse::template($tag, $data);
+    }
+}


### PR DESCRIPTION
Similar to the user_groups tag PR, this tag allows you to return all user roles or a specific roles, both of which can be useful in some situations (eg membership sites).

Usage:
```
{{ user_roles }} {{ title }} {{ /user_roles }}
{{ user_roles handle="role_handle" }} {{ title }} {{ /user_roles }}
```

I'll create a docs PR if you are happy to merge this.