### PR TITLE
Add collection/taxonomy names to stack selector

### DIFF
--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -66,9 +66,9 @@
                     </slot>
                 </td>
                 <td class="type-column" v-if="showType">
-                    <span v-if="row.is_entry || row.is_term" class="rounded px-sm py-px text-2xs uppercase bg-grey-20 text-grey">
-                        <template v-if="row.is_entry">{{ row.collection.title }}</template>
-                        <template v-if="row.is_term">{{ row.taxonomy.title }}</template>
+                    <span v-if="type === 'entries' || type === 'terms'" class="rounded px-sm py-px text-2xs uppercase bg-grey-20 text-grey">
+                        <template v-if="type === 'entries'">{{ row.collection.title }}</template>
+                        <template v-if="type === 'terms'">{{ row.taxonomy.title }}</template>
                     </span>
                 </td>
                 <td class="actions-column">

--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -21,7 +21,10 @@
                         <path d="M9.9,1.4L5,6.4L0,1.4L1.4,0L5,3.5L8.5,0L9.9,1.4z" fill="currentColor"/>
                     </svg>
                 </th>
-                <th class="type-column" v-if="showType"></th>
+                <th class="type-column" v-if="showType">
+                    <template v-if="type === 'entries'">{{ __('Collection') }}</template>
+                    <template v-if="type === 'terms'">{{ __('Taxonomy') }}</template>
+                </th>
                 <th class="actions-column">
                     <data-list-column-picker :preferences-key="columnPreferencesKey" v-if="allowColumnPicker" />
                 </th>
@@ -127,6 +130,9 @@ export default {
         },
         columnPreferencesKey: {
             type: String,
+        },
+        type: {
+            type: String
         },
         showType: {
             type: Boolean,

--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -21,6 +21,7 @@
                         <path d="M9.9,1.4L5,6.4L0,1.4L1.4,0L5,3.5L8.5,0L9.9,1.4z" fill="currentColor"/>
                     </svg>
                 </th>
+                <th class="type-column" v-if="showType"></th>
                 <th class="actions-column">
                     <data-list-column-picker :preferences-key="columnPreferencesKey" v-if="allowColumnPicker" />
                 </th>
@@ -60,6 +61,12 @@
                     >
                         <table-field :handle="column.field" :value="row[column.value || column.field]" :values="row" :fieldtype="column.fieldtype" :key="column.field" />
                     </slot>
+                </td>
+                <td class="type-column" v-if="showType">
+                    <span v-if="row.is_entry || row.is_term" class="rounded px-sm py-px text-2xs uppercase bg-grey-20 text-grey">
+                        <template v-if="row.is_entry">{{ row.collection.title }}</template>
+                        <template v-if="row.is_term">{{ row.taxonomy.title }}</template>
+                    </span>
                 </td>
                 <td class="actions-column">
                     <slot
@@ -120,6 +127,10 @@ export default {
         },
         columnPreferencesKey: {
             type: String,
+        },
+        showType: {
+            type: Boolean,
+            default: false
         },
     },
 

--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -21,7 +21,7 @@
                         <path d="M9.9,1.4L5,6.4L0,1.4L1.4,0L5,3.5L8.5,0L9.9,1.4z" fill="currentColor"/>
                     </svg>
                 </th>
-                <th class="type-column" v-if="showType">
+                <th class="type-column" v-if="type">
                     <template v-if="type === 'entries'">{{ __('Collection') }}</template>
                     <template v-if="type === 'terms'">{{ __('Taxonomy') }}</template>
                 </th>
@@ -65,8 +65,8 @@
                         <table-field :handle="column.field" :value="row[column.value || column.field]" :values="row" :fieldtype="column.fieldtype" :key="column.field" />
                     </slot>
                 </td>
-                <td class="type-column" v-if="showType">
-                    <span v-if="type === 'entries' || type === 'terms'" class="rounded px-sm py-px text-2xs uppercase bg-grey-20 text-grey">
+                <td class="type-column" v-if="type">
+                    <span class="rounded px-sm py-px text-2xs uppercase bg-grey-20 text-grey">
                         <template v-if="type === 'entries'">{{ row.collection.title }}</template>
                         <template v-if="type === 'terms'">{{ row.taxonomy.title }}</template>
                     </span>
@@ -133,10 +133,6 @@ export default {
         },
         type: {
             type: String
-        },
-        showType: {
-            type: Boolean,
-            default: false
         },
     },
 

--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -66,7 +66,7 @@
                     </slot>
                 </td>
                 <td class="type-column" v-if="type">
-                    <span class="rounded px-sm py-px text-2xs uppercase bg-grey-20 text-grey">
+                    <span v-if="type === 'entries' || type === 'terms'" class="rounded px-sm py-px text-2xs uppercase bg-grey-20 text-grey">
                         <template v-if="type === 'entries'">{{ row.collection.title }}</template>
                         <template v-if="type === 'terms'">{{ row.taxonomy.title }}</template>
                     </span>

--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -74,6 +74,7 @@
                     :max-selections="maxItems"
                     :search="search"
                     :exclusions="exclusions"
+                    :type="config.type"
                     @selected="selectionsUpdated"
                     @closed="close"
                 />

--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -273,14 +273,6 @@ export default {
             } else {
                 return 'bg-grey-40';
             }
-        },
-
-        getTypeTitle(entry) {
-            if (entry.collection) {
-                return entry.collection.title;
-            } else if (entry.taxonomy) {
-                return entry.taxonomy.title;
-            }
         }
 
     }

--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -41,6 +41,7 @@
                                 :loading="loading"
                                 :allow-bulk-actions="true"
                                 :toggle-selection-on-row-click="true"
+                                :type="type"
                                 :show-type="true"
                                 @sorted="sorted"
                                 class="cursor-pointer"
@@ -114,6 +115,7 @@ export default {
         maxSelections: Number,
         site: String,
         search: Boolean,
+        type: String,
         exclusions: {
             type: Array,
             default: () => []

--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -41,6 +41,7 @@
                                 :loading="loading"
                                 :allow-bulk-actions="true"
                                 :toggle-selection-on-row-click="true"
+                                :show-type="true"
                                 @sorted="sorted"
                                 class="cursor-pointer"
                             >
@@ -271,6 +272,14 @@ export default {
                 return 'bg-green';
             } else {
                 return 'bg-grey-40';
+            }
+        },
+
+        getTypeTitle(entry) {
+            if (entry.collection) {
+                return entry.collection.title;
+            } else if (entry.taxonomy) {
+                return entry.taxonomy.title;
             }
         }
 

--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -42,7 +42,6 @@
                                 :allow-bulk-actions="true"
                                 :toggle-selection-on-row-click="true"
                                 :type="type"
-                                :show-type="true"
                                 @sorted="sorted"
                                 class="cursor-pointer"
                             >

--- a/resources/sass/elements/tables.scss
+++ b/resources/sass/elements/tables.scss
@@ -48,6 +48,9 @@
 				@apply text-grey-90;
 			}
 		}
+		.type-column {
+			text-align: right;
+		}
 		.actions-column {
 			@apply p-0 pr-2 text-right;
 			width: 24px;
@@ -95,6 +98,9 @@
             td {
                 @apply py-1 px-2 break-words;
             }
+		}
+		.type-column {
+			text-align: right;
 		}
 		.actions-column {
 			@apply p-0 text-right;

--- a/src/Http/Resources/CP/Entries/ListedEntry.php
+++ b/src/Http/Resources/CP/Entries/ListedEntry.php
@@ -42,7 +42,6 @@ class ListedEntry extends JsonResource
 
             'permalink' => $entry->absoluteUrl(),
             'edit_url' => $entry->editUrl(),
-            'is_entry' => true,
             'collection' => $entry->collection()->toArray(),
             'viewable' => User::current()->can('view', $entry),
             'editable' => User::current()->can('edit', $entry),

--- a/src/Http/Resources/CP/Entries/ListedEntry.php
+++ b/src/Http/Resources/CP/Entries/ListedEntry.php
@@ -42,6 +42,8 @@ class ListedEntry extends JsonResource
 
             'permalink' => $entry->absoluteUrl(),
             'edit_url' => $entry->editUrl(),
+            'is_entry' => true,
+            'collection' => $entry->collection()->toArray(),
             'viewable' => User::current()->can('view', $entry),
             'editable' => User::current()->can('edit', $entry),
             'actions' => Action::for($entry, ['collection' => $collection->handle()]),

--- a/src/Http/Resources/CP/Taxonomies/ListedTerm.php
+++ b/src/Http/Resources/CP/Taxonomies/ListedTerm.php
@@ -42,6 +42,8 @@ class ListedTerm extends JsonResource
 
             'permalink' => $term->absoluteUrl(),
             'edit_url' => $term->editUrl(),
+            'is_term' => true,
+            'taxonomy' => $term->taxonomy()->toArray(),
             'viewable' => User::current()->can('view', $term),
             'editable' => User::current()->can('edit', $term),
             'actions' => Action::for($term, ['taxonomy' => $taxonomy->handle()]),

--- a/src/Http/Resources/CP/Taxonomies/ListedTerm.php
+++ b/src/Http/Resources/CP/Taxonomies/ListedTerm.php
@@ -42,7 +42,6 @@ class ListedTerm extends JsonResource
 
             'permalink' => $term->absoluteUrl(),
             'edit_url' => $term->editUrl(),
-            'is_term' => true,
             'taxonomy' => $term->taxonomy()->toArray(),
             'viewable' => User::current()->can('view', $term),
             'editable' => User::current()->can('edit', $term),


### PR DESCRIPTION
This PR adds the collection or taxonomy names to the stack selector, to make it easier to distinguish entries in different collections that have identical or similar names:

![Screenshot 2022-08-18 at 12 24 23](https://user-images.githubusercontent.com/126740/185384070-fda3de30-1934-41fa-b005-2282e8197211.png)

The property name "type" might be a bit generic, I'm not sure if there's a better term that would work for both collections and taxonomies?

Closes https://github.com/statamic/ideas/issues/819