### PR TITLE
Add ability to add a blueprint to user roles

### DIFF
--- a/resources/views/roles/blueprints/edit.blade.php
+++ b/resources/views/roles/blueprints/edit.blade.php
@@ -1,0 +1,21 @@
+@extends('statamic::layout')
+@section('title', __('Edit Blueprint'))
+
+@section('content')
+
+    @include('statamic::partials.breadcrumb', [
+        'url' => cp_route('roles.index'),
+        'title' => __('Roles'),
+    ])
+
+    <blueprint-builder
+        action="{{ cp_route('roles.blueprint.update') }}"
+        :initial-blueprint="{{ json_encode($blueprintVueObject) }}"
+    ></blueprint-builder>
+
+    @include('statamic::partials.docs-callout', [
+        'topic' => __('Blueprints'),
+        'url' => Statamic::docsUrl('blueprints')
+    ])
+
+@endsection

--- a/resources/views/roles/edit.blade.php
+++ b/resources/views/roles/edit.blade.php
@@ -4,12 +4,17 @@
 @section('content')
 
     <role-publish-form
-        action="{{ cp_route('roles.update', $role->handle()) }}"
+        :actions="{{ json_encode($actions) }}"
         method="patch"
         initial-title="{{ $role->title() }}"
         initial-handle="{{ $role->handle() }}"
         :initial-super="{{ Statamic\Support\Str::bool($super) }}"
         :initial-permissions="{{ json_encode($permissions) }}"
+        :initial-fieldset="{{ json_encode($blueprint) }}"
+        :initial-values="{{ json_encode($values) }}"
+        :initial-meta="{{ json_encode($meta) }}"
+        :can-edit-blueprint="{{ Statamic\Support\Str::bool($user->can('configure fields')) }}"
+        publish-container="base"
         breadcrumb-url="{{ cp_route('roles.index') }}"
         v-cloak
     >

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -198,6 +198,8 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::patch('users/{user}/password', 'PasswordController@update')->name('users.password.update');
         Route::get('account', 'AccountController')->name('account');
         Route::resource('user-groups', 'UserGroupsController');
+        Route::get('roles/blueprint', 'RoleBlueprintController@edit')->name('roles.blueprint.edit');
+        Route::patch('roles/blueprint', 'RoleBlueprintController@update')->name('roles.blueprint.update');
         Route::resource('roles', 'RolesController');
         Route::resource('preferences', 'PreferenceController')->except('destroy');
         Route::post('preferences/{key}/delete', 'PreferenceController@destroy')->name('preferences.destroy');

--- a/src/Auth/File/Role.php
+++ b/src/Auth/File/Role.php
@@ -21,6 +21,7 @@ class Role extends BaseRole
 
     public function __construct()
     {
+        parent::__construct();
         $this->permissions = collect();
     }
 

--- a/src/Auth/Role.php
+++ b/src/Auth/Role.php
@@ -6,12 +6,18 @@ use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
 use Statamic\Contracts\Auth\Role as RoleContract;
 use Statamic\Contracts\Data\Augmentable;
+use Statamic\Data\ContainsData;
 use Statamic\Data\HasAugmentedData;
 use Statamic\Facades;
 
 abstract class Role implements RoleContract, Augmentable, ArrayAccess, Arrayable
 {
-    use HasAugmentedData;
+    use ContainsData, HasAugmentedData;
+
+    public function __construct()
+    {
+        $this->data = collect();
+    }
 
     public function editUrl()
     {
@@ -23,6 +29,11 @@ abstract class Role implements RoleContract, Augmentable, ArrayAccess, Arrayable
         return cp_route('roles.destroy', $this->handle());
     }
 
+    public function updateUrl()
+    {
+        return cp_route('roles.update', $this->handle());
+    }
+
     public static function __callStatic($method, $parameters)
     {
         return Facades\Role::{$method}(...$parameters);
@@ -30,9 +41,20 @@ abstract class Role implements RoleContract, Augmentable, ArrayAccess, Arrayable
 
     public function augmentedArrayData()
     {
-        return [
+        return $this->data()->merge([
             'title' => $this->title(),
             'handle' => $this->handle(),
-        ];
+        ])->all();
+    }
+
+    /**
+      * Get or set the blueprint.
+      *
+      * @param string|null|bool
+      * @return \Statamic\Fields\Blueprint
+      */
+    public function blueprint()
+    {
+        return Facades\Role::blueprint();
     }
 }

--- a/src/Auth/RoleRepository.php
+++ b/src/Auth/RoleRepository.php
@@ -35,7 +35,8 @@ abstract class RoleRepository implements RepositoryContract
                 ->handle($handle)
                 ->title(array_get($role, 'title'))
                 ->addPermission(array_get($role, 'permissions', []))
-                ->preferences(array_get($role, 'preferences', []));
+                ->preferences(array_get($role, 'preferences', []))
+                ->data($role);
         });
     }
 
@@ -53,11 +54,11 @@ abstract class RoleRepository implements RepositoryContract
     {
         $roles = $this->raw();
 
-        $roles->put($role->handle(), Arr::removeNullValues([
+        $roles->put($role->handle(), Arr::removeNullValues(array_merge($role->data()->all(), [
             'title' => $role->title(),
             'permissions' => $role->permissions()->all(),
             'preferences' => $role->preferences(),
-        ]));
+        ])));
 
         if ($role->handle() !== $role->originalHandle()) {
             $roles->forget($role->originalHandle());

--- a/src/Auth/RoleRepository.php
+++ b/src/Auth/RoleRepository.php
@@ -5,6 +5,8 @@ namespace Statamic\Auth;
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Auth\Role;
 use Statamic\Contracts\Auth\RoleRepository as RepositoryContract;
+use Statamic\Events\RoleBlueprintFound;
+use Statamic\Facades\Blueprint;
 use Statamic\Facades;
 use Statamic\Facades\File;
 use Statamic\Facades\YAML;
@@ -90,4 +92,17 @@ abstract class RoleRepository implements RepositoryContract
     {
         File::put($this->path, YAML::dump($roles->all()));
     }
+
+    public function blueprint()
+    {
+        $blueprint = Blueprint::find('user_role') ?? Blueprint::makeFromFields([
+            'title' => ['type' => 'text', 'display' => __('Title'), 'listable' => true, 'validate' => ['required'], 'instructions' => __('Usually a singular noun, like Editor or Admin.')],
+            'handle' => ['type' => 'slug', 'display' => __('Handle'), 'listable' => true, 'validate' => ['required'], 'instructions' => __('Handles are used to reference this role on the frontend. Cannot be easily changed.')],
+            'super' => ['type' => 'toggle', 'display' => __('Super User'), 'listable' => true, 'instructions' => __('Super admins have complete control and access to everything in the control panel. Grant this role wisely.')],
+        ])->setHandle('user_role');
+
+        RoleBlueprintFound::dispatch($blueprint);
+
+        return $blueprint;
+     }
 }

--- a/src/Events/RoleBlueprintFound.php
+++ b/src/Events/RoleBlueprintFound.php
@@ -1,0 +1,13 @@
+<?php
+
+ namespace Statamic\Events;
+
+ class RoleBlueprintFound extends Event
+ {
+    public $blueprint;
+
+    public function __construct($blueprint)
+    {
+        $this->blueprint = $blueprint;
+    }
+ }

--- a/src/Http/Controllers/CP/Users/RoleBlueprintController.php
+++ b/src/Http/Controllers/CP/Users/RoleBlueprintController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Statamic\Http\Controllers\CP\Users;
+
+use Illuminate\Http\Request;
+use Statamic\Facades\Role;
+use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Http\Controllers\CP\Fields\ManagesBlueprints;
+
+class RoleBlueprintController extends CpController
+{
+    use ManagesBlueprints;
+
+    public function __construct()
+    {
+        $this->middleware(\Illuminate\Auth\Middleware\Authorize::class.':configure fields');
+    }
+
+    public function edit()
+    {
+        $blueprint = Role::make()->blueprint();
+
+        return view('statamic::roles.blueprints.edit', [
+            'blueprint' => $blueprint,
+            'blueprintVueObject' => $this->toVueObject($blueprint),
+        ]);
+    }
+
+    public function update(Request $request)
+    {
+        $request->validate(['sections' => 'array']);
+
+        $this->updateBlueprint($request, Role::make()->blueprint());
+    }
+}

--- a/tests/Auth/RoleTest.php
+++ b/tests/Auth/RoleTest.php
@@ -4,7 +4,7 @@ namespace Tests\Auth;
 
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
-use Statamic\Auth\File\Role;
+use Statamic\Facades;
 use Tests\TestCase;
 
 class RoleTest extends TestCase
@@ -12,7 +12,7 @@ class RoleTest extends TestCase
     /** @test */
     public function it_gets_and_sets_the_title()
     {
-        $role = new Role;
+        $role = Facades\Role::make();
         $this->assertNull($role->title());
 
         $return = $role->title('Test');
@@ -24,7 +24,7 @@ class RoleTest extends TestCase
     /** @test */
     public function it_gets_and_sets_the_handle()
     {
-        $role = new Role;
+        $role = Facades\Role::make();
         $this->assertNull($role->handle());
 
         $return = $role->handle('test');
@@ -36,7 +36,7 @@ class RoleTest extends TestCase
     /** @test */
     public function it_gets_and_adds_permissions()
     {
-        $role = new Role;
+        $role = Facades\Role::make();
         $this->assertInstanceOf(Collection::class, $role->permissions());
         $this->assertCount(0, $role->permissions());
 
@@ -51,7 +51,7 @@ class RoleTest extends TestCase
     /** @test */
     public function it_sets_all_permissions()
     {
-        $role = new Role;
+        $role = Facades\Role::make();
         $role->addPermission('one');
 
         $return = $role->permissions(['two', 'three']);
@@ -64,7 +64,7 @@ class RoleTest extends TestCase
     /** @test */
     public function permissions_get_deduplicated()
     {
-        $role = new Role;
+        $role = Facades\Role::make();
         $role->addPermission(['foo', 'bar']);
         $role->addPermission(['foo', 'baz']);
 
@@ -74,7 +74,7 @@ class RoleTest extends TestCase
     /** @test */
     public function it_removes_permissions()
     {
-        $role = (new Role)->addPermission(['foo', 'bar', 'baz', 'qux']);
+        $role = Facades\Role::make()->addPermission(['foo', 'bar', 'baz', 'qux']);
 
         $return = $role->removePermission('foo');
         $role->removePermission(['baz', 'qux']);
@@ -86,7 +86,7 @@ class RoleTest extends TestCase
     /** @test */
     public function it_checks_if_it_has_permission()
     {
-        $role = (new Role)->addPermission('foo');
+        $role = Facades\Role::make()->addPermission('foo');
 
         $this->assertTrue($role->hasPermission('foo'));
         $this->assertFalse($role->hasPermission('bar'));
@@ -95,8 +95,8 @@ class RoleTest extends TestCase
     /** @test */
     public function it_checks_if_it_has_super_permissions()
     {
-        $superRole = (new Role)->addPermission('super');
-        $nonSuperRole = (new Role)->addPermission('something else');
+        $superRole = Facades\Role::make()->addPermission('super');
+        $nonSuperRole = Facades\Role::make()->addPermission('something else');
 
         $this->assertTrue($superRole->isSuper());
         $this->assertFalse($nonSuperRole->isSuper());
@@ -117,7 +117,7 @@ class RoleTest extends TestCase
     /** @test */
     public function it_gets_evaluated_augmented_value_using_magic_property()
     {
-        $role = (new Role)->handle('test')->title('Test');
+        $role = Facades\Role::make()->handle('test')->title('Test');
 
         $role
             ->toAugmentedCollection()
@@ -128,12 +128,52 @@ class RoleTest extends TestCase
     /** @test */
     public function it_is_arrayable()
     {
-        $role = (new Role)->handle('test')->title('Test');
+        $role = Facades\Role::make()->handle('test')->title('Test');
 
         $this->assertInstanceOf(Arrayable::class, $role);
 
         collect($role->toArray())
             ->each(fn ($value, $key) => $this->assertEquals($value, $role->{$key}))
             ->each(fn ($value, $key) => $this->assertEquals($value, $role[$key]));
+    }
+
+    /** @test */
+    public function it_gets_data()
+    {
+        $role = Facades\Role::make()->handle('test')->data([
+            'foo' => 'bar',
+            'content' => 'Lorem Ipsum',
+        ]);
+
+        $this->assertEquals([
+            'foo' => 'bar',
+            'content' => 'Lorem Ipsum',
+        ], $role->data()->all());
+    }
+
+    /** @test */
+    public function it_gets_blueprint_values()
+    {
+        $blueprint = Facades\Role::blueprint();
+        $contents = $blueprint->contents();
+        $contents['sections']['main']['fields'] = array_merge($contents['sections']['main']['fields'], [
+            ['handle' => 'two', 'field' => ['type' => 'text']],
+            ['handle' => 'four', 'field' => ['type' => 'text']],
+            ['handle' => 'unused_in_bp', 'field' => ['type' => 'text']],
+        ]);
+        $blueprint->setContents($contents);
+        Facades\Blueprint::shouldReceive('find')->with('user_group')->andReturn($blueprint);
+
+        $data = [
+            'one' => 'the "one" value on the role',
+            'two' => 'the "two" value on the role and in the blueprint',
+        ];
+
+        $role = Facades\Role::make()
+            ->handle('group_1')
+            ->data($data);
+
+        $this->assertEquals($role->get('one'), $data['one']);
+        $this->assertEquals($role->get('two'), $data['two']);
     }
 }


### PR DESCRIPTION
This PR adds the ability to modify the blueprint associated with a user roles by adding some new routes, controllers and borrowing from the work on the similar PR for user groups. This would allow developers to add new fields to the roles, such as images, descriptions or whatever they want.

I had to approach the Vue component slightly differently due to the desire to not affect how permissions work, hopefully how I've handled it is acceptable.