### PR TITLE
Handle double `SubmissionCreated` event

### DIFF
--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -67,6 +67,9 @@ class FormController extends Controller
         if ($form->store()) {
             $submission->save();
         } else {
+            // When the submission is saved, this same created event will be dispatched.
+            // We'll also fire it here if submissions are not configured to be stored
+            // so that developers may continue to listen and modify it as needed.
             SubmissionCreated::dispatch($submission);
         }
 

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\ValidationException;
 use Statamic\Contracts\Forms\Submission;
 use Statamic\Events\FormSubmitted;
+use Statamic\Events\SubmissionCreated;
 use Statamic\Exceptions\SilentFormFailureException;
 use Statamic\Facades\Site;
 use Statamic\Forms\Exceptions\FileContentTypeRequiredException;
@@ -65,6 +66,8 @@ class FormController extends Controller
 
         if ($form->store()) {
             $submission->save();
+        } else {
+            SubmissionCreated::dispatch($submission);
         }
 
         SendEmails::dispatch($submission, $site);

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -68,7 +68,6 @@ class FormController extends Controller
             $submission->save();
         }
 
-        SubmissionCreated::dispatch($submission);
         SendEmails::dispatch($submission, $site);
 
         return $this->formSuccess($params, $submission);

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\ValidationException;
 use Statamic\Contracts\Forms\Submission;
 use Statamic\Events\FormSubmitted;
-use Statamic\Events\SubmissionCreated;
 use Statamic\Exceptions\SilentFormFailureException;
 use Statamic\Facades\Site;
 use Statamic\Forms\Exceptions\FileContentTypeRequiredException;


### PR DESCRIPTION
Event is already [fired here](https://github.com/statamic/cms/blob/b23c3e970a53fbfbcfaeaa28ed36407fd258588c/src/Forms/Submission.php#L165) so no need to fire it again