### PR TITLE
Collect eloquent roles on sync to preserve passing them as an array

### DIFF
--- a/src/Auth/Eloquent/Roles.php
+++ b/src/Auth/Eloquent/Roles.php
@@ -47,6 +47,8 @@ class Roles
      */
     public function sync($roles)
     {
+        $roles = collect($roles);
+
         $dbRoles = collect(
             $this->table()->where('user_id', $this->user->id())->get()
         )->keyBy('role_id');


### PR DESCRIPTION
Fixes: #6538 