### PR TITLE
Support passing a form instance into tags

### DIFF
--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -4,6 +4,7 @@ namespace Statamic\Forms;
 
 use DebugBar\DataCollector\ConfigCollector;
 use DebugBar\DebugBarException;
+use Statamic\Contracts\Forms\Form as FormContract;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Form;
 use Statamic\Facades\URL;
@@ -326,7 +327,15 @@ class Tags extends BaseTags
 
     protected function formHandle()
     {
-        return $this->params->get(static::HANDLE_PARAM, Arr::get($this->context, 'form'));
+        $form = $this->params->get(static::HANDLE_PARAM, Arr::get($this->context, 'form'));
+
+        if ($form instanceof FormContract) {
+            $handle = $form->handle();
+            Blink::put("form-$handle", $form);
+            $form = $handle;
+        }
+
+        return $form;
     }
 
     public function eventUrl($url, $relative = true)


### PR DESCRIPTION
When updating the docs for #6542 I noticed that you have to explicitly use the handle:

```antlers
{{ form:create :in="formfield:handle" }}
```

This PR allows you to just pass the form directly into it, which feels more intuitive:

```antlers
{{ form:create :in="formfield" }}
```
