### PR TITLE
Add toggle field true/false filter

### DIFF
--- a/src/Fieldtypes/Toggle.php
+++ b/src/Fieldtypes/Toggle.php
@@ -4,6 +4,7 @@ namespace Statamic\Fieldtypes;
 
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
+use Statamic\Query\Scopes\Filters\Fields\Toggle as ToggleFilter;
 
 class Toggle extends Fieldtype
 {
@@ -51,5 +52,10 @@ class Toggle extends Fieldtype
     public function toGqlType()
     {
         return GraphQL::boolean();
+    }
+
+    public function filter()
+    {
+        return new ToggleFilter($this);
     }
 }

--- a/src/Query/Scopes/Filters/Fields/Toggle.php
+++ b/src/Query/Scopes/Filters/Fields/Toggle.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Statamic\Query\Scopes\Filters\Fields;
+
+class Toggle extends FieldtypeFilter
+{
+    public function fieldItems()
+    {
+        return [
+            'value' => [
+                'type' => 'select',
+                'placeholder' => __('Select Value'),
+                'options' => [
+                    'true' => __('True'),
+                    'false' => __('False'),
+                ],
+            ],
+        ];
+    }
+
+    public function apply($query, $handle, $values)
+    {
+        $value = $values['value'];
+
+        $query->where($handle, '=', $value === 'true');
+    }
+
+    public function badge($values)
+    {
+        $field = $this->fieldtype->field()->display();
+        $operator = __('Is');
+        $value = $values['value'];
+
+        return $field.' '.strtolower($operator).' '.$value;
+    }
+}

--- a/src/Query/Scopes/Filters/Fields/Toggle.php
+++ b/src/Query/Scopes/Filters/Fields/Toggle.php
@@ -11,8 +11,8 @@ class Toggle extends FieldtypeFilter
                 'type' => 'select',
                 'placeholder' => __('Select Value'),
                 'options' => [
-                    'true' => __('Is true'),
-                    'false' => __('Is false'),
+                    'true' => __('True'),
+                    'false' => __('False'),
                 ],
             ],
         ];

--- a/src/Query/Scopes/Filters/Fields/Toggle.php
+++ b/src/Query/Scopes/Filters/Fields/Toggle.php
@@ -11,8 +11,8 @@ class Toggle extends FieldtypeFilter
                 'type' => 'select',
                 'placeholder' => __('Select Value'),
                 'options' => [
-                    'true' => __('True'),
-                    'false' => __('False'),
+                    'true' => __('Is true'),
+                    'false' => __('Is false'),
                 ],
             ],
         ];


### PR DESCRIPTION
This PR adds a true/false filter for the toggle fieldtype:

![Screenshot 2022-08-22 at 17 28 40](https://user-images.githubusercontent.com/126740/185982054-a9aa68aa-fe8f-4a6d-9eee-83baa72dd687.png)

You currently have to do `is: "1"` or `isnt: "1"` to filter on a toggle field, which isn't very user-friendly.

Related to https://github.com/statamic/ideas/issues/843 but doesn't close it as this doesn't cover filtering empty values.