### PR TITLE
Allow setting of entry blueprint instance using instance

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -136,7 +136,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
             ->setter(function ($blueprint) use ($key) {
                 Blink::forget($key);
 
-                return $blueprint;
+                return $blueprint instanceof \Statamic\Fields\Blueprint ? $blueprint->handle() : $blueprint;
             })
             ->args(func_get_args());
     }

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -906,6 +906,19 @@ class EntryTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_a_blueprint_using_an_instance()
+    {
+        BlueprintRepository::shouldReceive('in')->with('collections/blog')->andReturn(collect([
+            'first' => $first = (new Blueprint)->setHandle('first'),
+            'second' => $second = (new Blueprint)->setHandle('second'),
+        ]));
+        Collection::make('blog')->save();
+        $entry = (new Entry)->collection('blog')->blueprint($second);
+
+        $this->assertSame($second, $entry->blueprint());
+    }
+
+    /** @test */
     public function it_gets_the_blueprint_when_defined_in_a_value()
     {
         BlueprintRepository::shouldReceive('in')->with('collections/blog')->andReturn(collect([


### PR DESCRIPTION
- [x] Allow setting of entry blueprint instance instead of just string.
- [ ] Should this also validate correct blueprint namespace if passing an instance?