### PR TITLE
Add support for using meta fields as config fields

### DIFF
--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -55,7 +55,7 @@
                 :is-root="true"
                 @updated="values = $event"
             >
-                <div v-show="activeTab === 'settings'" slot-scope="{ setFieldValue }">
+                <div v-show="activeTab === 'settings'" slot-scope="{ setFieldValue, setFieldMeta }">
 
                     <publish-fields
                         v-if="blueprint.sections.length"
@@ -65,6 +65,7 @@
                             updateField(handle, value, setFieldValue);
                             if (handle === 'handle') isHandleModified = true
                         }"
+                        @meta-updated="setFieldMeta"
                     />
 
                 </div>


### PR DESCRIPTION
Fixes #1616. 

Tested with Grid and Replicator fields. The config gets stored in the blueprint yaml and is available in the fieldtype's Vue component.