### PR TITLE
Allow to filter searchable items by custom closure in index config

### DIFF
--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Search;
 
+use Closure;
 use Statamic\Support\Arr;
 
 abstract class Index
@@ -87,5 +88,15 @@ abstract class Index
     public function searchables()
     {
         return new Searchables($this);
+    }
+
+    public function filter($searchable)
+    {
+        if (isset($this->config()['filter'])
+            && $this->config()['filter'] instanceof Closure) {
+            return $this->config()['filter']($searchable);
+        }
+
+        return true;
     }
 }

--- a/src/Search/UpdateItemIndexes.php
+++ b/src/Search/UpdateItemIndexes.php
@@ -30,8 +30,16 @@ class UpdateItemIndexes
     {
         $item = $event->entry ?? $event->asset ?? $event->user ?? $event->term;
 
-        $this->indexes($item)->each(function ($index) use ($item) {
-            $index->exists() ? $index->insert($item) : $index->update();
+        $this->indexes($item)->each(function (Index $index) use ($item) {
+            if ($index->exists()) {
+                if ($index->filter($item)) {
+                    $index->insert($item);
+                } else {
+                    $index->delete($item);
+                }
+            } elseif ($index->filter($item)) {
+                $index->update();
+            }
         });
     }
 

--- a/tests/Search/IndexTests.php
+++ b/tests/Search/IndexTests.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Search;
 
+use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Facades\Event;
 use Statamic\Events\SearchQueryPerformed;
 
@@ -21,6 +22,51 @@ trait IndexTests
         Event::assertDispatched(SearchQueryPerformed::class, function ($event) {
             return $event->query === 'foo';
         });
+    }
+
+    /** @test */
+    public function it_filters_entries_when_filter_is_defined()
+    {
+        config()->set('statamic.search.indexes.default', [
+            'fields' => [
+                'title',
+            ],
+            'filter' => function ($entry) {
+                return $entry->data()['searchable'];
+            },
+        ]);
+
+        $index = app(\Statamic\Search\Comb\Index::class, [
+            'name' => 'default',
+            'config' => config('statamic.search.indexes.default'),
+        ]);
+
+        $hiddenEntry = EntryFactory::collection('test')->slug('i-am-hidden')->data(['title' => 'I am hidden', 'searchable' => false])->make();
+        $searchableEntry = EntryFactory::collection('test')->slug('find-me')->data(['title' => 'Find me', 'searchable' => true])->make();
+
+        $this->assertFalse($index->filter($hiddenEntry));
+        $this->assertTrue($index->filter($searchableEntry));
+    }
+
+    /** @test */
+    public function it_filters_entries_when_no_filter_is_configured()
+    {
+        config()->set('statamic.search.indexes.default', [
+            'fields' => [
+                'title',
+            ],
+        ]);
+
+        $index = app(\Statamic\Search\Comb\Index::class, [
+            'name' => 'default',
+            'config' => config('statamic.search.indexes.default'),
+        ]);
+
+        $hiddenEntry = EntryFactory::collection('test')->slug('i-am-hidden')->data(['title' => 'I am hidden', 'searchable' => false])->make();
+        $searchableEntry = EntryFactory::collection('test')->slug('find-me')->data(['title' => 'Find me', 'searchable' => true])->make();
+
+        $this->assertTrue($index->filter($hiddenEntry));
+        $this->assertTrue($index->filter($searchableEntry));
     }
 
     protected function beforeSearched()


### PR DESCRIPTION
Hi

I am using the Statamic search feature for generating an Index in Algolia. The index looks contains all types of pages of my Statamic site. 

Every entry has a field `seo_hidden` which should be used to define if it's included into the sitemap and also if the page search should contain this entry.

As of now, Statamic only removes an entry from an index if it gets deleted. 

This PR adds another config key `filter` to the index configuration, which receives every entry and decided if it should be included into the index.

This solves the problem, that an already indexed entry can become not searchable.

```php
 'website-search' => [
    'driver' => 'algolia',
    'fields' => ['title', 'uri', 'lead', 'description'],
    'searchables' => [
        'collection:pages',
        'collection:articles',
    ],
    'filter' => function ($entry) {
        return $entry->get('seo_hidden') !== true;
    },
],
```

I've also included some tests to ensure it works as expected.

Can you think of a test case or edge case I didn't though about yet?
