### PR TITLE
Destroy esc binding in Bard fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -166,6 +166,7 @@ export default {
             previews: this.meta.previews,
             mounted: false,
             pageHeader: null,
+            escBinding: null,
         }
     },
 
@@ -304,7 +305,7 @@ export default {
         this.json = this.editor.getJSON().content;
         this.html = this.editor.getHTML();
 
-        this.$keys.bind('esc', this.closeFullscreen)
+        this.escBinding = this.$keys.bind('esc', this.closeFullscreen)
 
         this.$nextTick(() => this.mounted = true);
 
@@ -315,6 +316,7 @@ export default {
 
     beforeDestroy() {
         this.editor.destroy();
+        this.escBinding.destroy();
 
         this.$store.commit(`publish/${this.storeName}/unsetFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
     },


### PR DESCRIPTION
This PR does remove the key binding if a bard fieldtype gets destroyed.

_If using the Live Preview, Statamic has memory leaks:_
- Open the Live Preview
- Close the Live Preview
- Repeat multiple times

_Depending on the size of replicator fields etc, the memory usage will grow with every switch from live preview to non-live preview._

This PR is only a small part of it, but does help to reduce the leak at least a tiny little bit.