### PR TITLE
Allow for passing custom icons to Utilities

### DIFF
--- a/resources/views/utilities/index.blade.php
+++ b/resources/views/utilities/index.blade.php
@@ -12,7 +12,7 @@
         @foreach ($utilities as $utility)
             <a href="{{ $utility->url() }}" class="w-full lg:w-1/2 p-2 md:flex items-start hover:bg-grey-20 rounded-md group">
                 <div class="h-8 w-8 mr-2 text-grey-80">
-                    @cp_svg($utility->icon())
+                    {!! $utility->icon() !!}
                 </div>
                 <div class="text-blue flex-1 mb-2 md:mb-0 md:mr-3">
                     <h3>{{ $utility->title() }}</h3>

--- a/src/CP/Utilities/Utility.php
+++ b/src/CP/Utilities/Utility.php
@@ -4,6 +4,7 @@ namespace Statamic\CP\Utilities;
 
 use Closure;
 use Statamic\Http\Controllers\CP\Utilities\UtilitiesController;
+use Statamic\Statamic;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 

--- a/src/CP/Utilities/Utility.php
+++ b/src/CP/Utilities/Utility.php
@@ -29,7 +29,12 @@ class Utility
 
     public function icon($icon = null)
     {
-        return $this->fluentlyGetOrSet('icon')->args(func_get_args());
+        return $this
+            ->fluentlyGetOrSet('icon')
+            ->setter(function ($value) {
+                return Str::startsWith($value, '<svg') ? $value : Statamic::svg($value);
+            })
+            ->value($icon);
     }
 
     public function slug()


### PR DESCRIPTION
This pull request allows for developers passing in custom SVG icons for Utilities. 

Here's a quick overview of the things I've changed:

* When creating a `Utility` and using the `->icon()` method, a developer can either provide the name of an icon in Statamic's `resources/svg` directory or they can provide a string of an SVG. 

* Instead of using the `@cp_svg` blade directive to display icons, I've changed it for a inlining it with Blade. This works for both Statamic icons and custom SVGs as they are all strings when they are returned from the `->setter` method.

This PR follows up on #2890 which did the same thing for CP Nav Items & comes after a discussion on Discord (#extending).