### PR TITLE
Destroy sortable in Relationship-Input

### DIFF
--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -144,6 +144,7 @@ export default {
             initializing: true,
             loading: true,
             inline: false,
+            sortable: null,
         }
     },
 
@@ -181,6 +182,9 @@ export default {
     },
 
     beforeDestroy() {
+        if (this.sortable) {
+            this.sortable.destroy();
+        }
         this.setLoadingProgress(false);
     },
 
@@ -245,7 +249,7 @@ export default {
         },
 
         makeSortable() {
-            new Sortable(this.$refs.items, {
+            this.sortable = new Sortable(this.$refs.items, {
                 draggable: '.item',
                 handle: '.item-move',
                 mirror: { constrainDimensions: true, xAxis: false },


### PR DESCRIPTION
This PR does remove the sortable binding if a relationship input gets destroyed.

If using the Live Preview, Statamic has memory leaks:

- Open the Live Preview
- Close the Live Preview
- Repeat multiple times

_Depending on the size of replicator fields etc, the memory usage will grow with every switch from live preview to non-live preview._

This PR is only a small part of it, but does help to reduce the leak at least a tiny little bit.