### PR TITLE
Destroy revision history key binding after closing

### DIFF
--- a/resources/js/components/revision-history/History.vue
+++ b/resources/js/components/revision-history/History.vue
@@ -63,6 +63,7 @@ export default {
         return {
             revisions: [],
             loading: true,
+            escBinding: null,
         }
     },
 
@@ -71,9 +72,13 @@ export default {
             this.loading = false;
             this.revisions = response.data.reverse();
         });
-        this.$keys.bindGlobal(['esc'], e => {
+        this.escBinding = this.$keys.bindGlobal(['esc'], e => {
             this.close();
         });
+    },
+    
+    beforeDestroy() {
+        this.escBinding.destroy();
     },
 
     methods: {


### PR DESCRIPTION
**This PR does remove key bindings if closing the revision history**

This PR is only a small part of it, but does help to reduce memory leaks by removing unused bindings.

The fastes way to reproduce:
* Open the Live Preview
* Close the Live Preview
* Repeat multiple times