### PR TITLE
Remove key bindings from popover after close

### DIFF
--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -40,7 +40,8 @@ export default {
 
     data() {
         return {
-            isOpen: false
+            isOpen: false,
+            escBinding: null,
         }
     },
 
@@ -74,10 +75,14 @@ export default {
         },
         open() {
             this.isOpen = true;
-            this.$keys.bind('esc', e => this.close())
+            this.escBinding = this.$keys.bind('esc', e => this.close())
         },
         close() {
             this.isOpen = false;
+            
+            if (this.escBinding) {
+                this.escBinding.destroy();
+            }
         }
     }
 }


### PR DESCRIPTION
This PR does remove the key binding after opening a popover.

_If using the Live Preview, Statamic has memory leaks:_

* Open the Live Preview
* Close the Live Preview
* Repeat multiple times

Depending on the size of replicator fields etc, the memory usage will grow with every switch from live preview to non-live preview.

As the Popover (small drop down menu with three dots) might exists multiple times (in our case about 180 times), this does make difference if editing an entry for a longer time. Every usage of the popover / dropdown does add another key binding, without removing it, which might pile up over time.