### PR TITLE
Add `mark` modifiers for highlighting words in text

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1885,15 +1885,13 @@ class CoreModifiers extends Modifier
 
         $attributes = $this->buildAttributesFromParameters($params);
 
-        return Html::mapText($value, function($text) use ($pattern, $attributes) {
-            // Decode any entities so we can match against real characters
-            $text = html_entity_decode($text);
-            return Str::mapRegex($text, "/({$pattern})/is", function($part, $match) use ($attributes) {
-                // Re-encode any entities so the output is still valid HTML
-                $part = htmlentities($part);
+        return Html::mapText($value, function ($text) use ($pattern, $attributes) {
+            return Str::mapRegex($text, "/({$pattern})/is", function ($part, $match) use ($attributes) {
+                $part = static::entities($part);
                 if ($match) {
                     $part = '<mark'.Html::attributes($attributes).'>'.$part.'</mark>';
                 }
+
                 return $part;
             });
         });

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1464,6 +1464,25 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Wraps matched words with <mark> tags.
+     *
+     * @param $value
+     * @param  array  $params
+     * @return string
+     */
+    public function mark($value, $params, $context)
+    {
+        $words = $params[0] ?? $context['get']['q'] ?? null;
+
+        $params[0] = collect(preg_split('/\s+/', $words))
+            ->map(fn ($word) => preg_quote($word, '/'))
+            ->filter()
+            ->join('|');
+
+        return $this->regexMark($value, $params);
+    }
+
+    /**
      * Generate a HTML link to an email address.
      *
      * @param $value
@@ -1847,6 +1866,24 @@ class CoreModifiers extends Modifier
         $words = $this->wordCount(strip_tags($value));
 
         return ceil($words / Arr::get($params, 0, 200));
+    }
+
+    /**
+     * Wraps regex matches with <mark> tags.
+     *
+     * @param $value
+     * @param  array  $params
+     * @return string
+     */
+    public function regexMark($value, $params)
+    {
+        $pattern = Arr::get($params, 0);
+        $start = Arr::get($params, 1, '<mark>');
+        $end = Arr::get($params, 2, '</mark>');
+
+        return preg_replace_callback("/{$pattern}/is", function ($match) use ($start, $end) {
+            return $start . $match[0] . $end;
+        }, $value);
     }
 
     /**

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1887,7 +1887,7 @@ class CoreModifiers extends Modifier
 
         return Html::mapText($value, function ($text) use ($pattern, $attributes) {
             return Str::mapRegex($text, "/({$pattern})/is", function ($part, $match) use ($attributes) {
-                $part = static::entities($part);
+                $part = Html::entities($part);
                 if ($match) {
                     $part = '<mark'.Html::attributes($attributes).'>'.$part.'</mark>';
                 }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1886,6 +1886,8 @@ class CoreModifiers extends Modifier
         $attributes = $this->buildAttributesFromParameters($params);
 
         return Html::mapText($value, function ($text) use ($pattern, $attributes) {
+            $text = Html::decode($text);
+
             return Str::mapRegex($text, "/({$pattern})/is", function ($part, $match) use ($attributes) {
                 $part = Html::entities($part);
                 if ($match) {

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1877,12 +1877,11 @@ class CoreModifiers extends Modifier
      */
     public function regexMark($value, $params)
     {
-        $pattern = Arr::get($params, 0);
-        $start = Arr::get($params, 1, '<mark>');
-        $end = Arr::get($params, 2, '</mark>');
+        $pattern = array_shift($params);
+        $attributes = $this->buildAttributesFromParameters($params);
 
-        return preg_replace_callback("/{$pattern}/is", function ($match) use ($start, $end) {
-            return $start . $match[0] . $end;
+        return preg_replace_callback("/{$pattern}/is", function ($match) use ($attributes) {
+            return Html::mark($match[0], $attributes);
         }, $value);
     }
 

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -193,6 +193,20 @@ class Html
     }
 
     /**
+     * Generate an HTML mark.
+     *
+     * @param  string  $value
+     * @param  array  $attributes
+     * @return \Illuminate\Support\HtmlString|string
+     */
+    public static function mark($value, $attributes = [])
+    {
+        $value = static::entities($value);
+
+        return static::toHtmlString('<mark'.static::attributes($attributes).'>'.$value.'</mark>');
+    }
+
+    /**
      * Obfuscate a string to prevent spam-bots from sniffing it.
      *
      * @param  string  $value

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -2,10 +2,12 @@
 
 namespace Statamic\Support;
 
+use Closure;
 use Illuminate\Support\HtmlString;
 use Michelf\SmartyPants;
 use Statamic\Facades\Config;
 use Statamic\Facades\Markdown;
+use Statamic\Support\Str;
 
 class Html
 {
@@ -193,20 +195,6 @@ class Html
     }
 
     /**
-     * Generate an HTML mark.
-     *
-     * @param  string  $value
-     * @param  array  $attributes
-     * @return \Illuminate\Support\HtmlString|string
-     */
-    public static function mark($value, $attributes = [])
-    {
-        $value = static::entities($value);
-
-        return static::toHtmlString('<mark'.static::attributes($attributes).'>'.$value.'</mark>');
-    }
-
-    /**
      * Obfuscate a string to prevent spam-bots from sniffing it.
      *
      * @param  string  $value
@@ -273,6 +261,23 @@ class Html
         $title = static::entities($title);
 
         return static::toHtmlString('<a href="'.static::entities($url).'"'.static::attributes($attributes).'>'.$title.'</a>');
+    }
+
+    /**
+     * Parse each text part of an HTML string (no tags) through a callback function
+     *
+     * @param  string  $value
+     * @param  Closure  $callback
+     * @return string
+     */
+    public static function mapText($value, Closure $callback)
+    {
+        return Str::mapRegex($value, '/(<[^>]+>)/', function($part, $match) use ($callback) {
+            if (! $match) {
+                $part = $callback($part);
+            }
+            return $part;
+        });
     }
 
     /**

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -263,7 +263,7 @@ class Html
     }
 
     /**
-     * Parse each text part of an HTML string (no tags) through a callback function
+     * Parse each text part of an HTML string (no tags) through a callback function.
      *
      * @param  string  $value
      * @param  Closure  $callback

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -7,7 +7,6 @@ use Illuminate\Support\HtmlString;
 use Michelf\SmartyPants;
 use Statamic\Facades\Config;
 use Statamic\Facades\Markdown;
-use Statamic\Support\Str;
 
 class Html
 {
@@ -272,11 +271,8 @@ class Html
      */
     public static function mapText($value, Closure $callback)
     {
-        return Str::mapRegex($value, '/(<[^>]+>)/', function($part, $match) use ($callback) {
-            if (! $match) {
-                $part = $callback($part);
-            }
-            return $part;
+        return Str::mapRegex($value, '/(<[^>]+>)/', function ($part, $match) use ($callback) {
+            return ! $match ? $callback($part) : $part;
         });
     }
 

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -227,10 +227,11 @@ class Str extends \Illuminate\Support\Str
      */
     public static function mapRegex($value, $regex, Closure $callback)
     {
-        $parts = preg_split($regex, $value, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split($regex, $value, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
         foreach ($parts as $i => $part) {
             $parts[$i] = $callback($part, preg_match($regex, $part));
         }
+
         return implode('', $parts);
     }
 

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Support;
 
+use Closure;
 use Statamic\Facades\Compare;
 use Stringy\StaticStringy;
 use voku\helper\ASCII;
@@ -214,6 +215,23 @@ class Str extends \Illuminate\Support\Str
     public static function compare($str1, $str2)
     {
         return Compare::strings($str1, $str2);
+    }
+
+    /**
+     * Parse each part of a string split with a regex through a callback function
+     *
+     * @param  string  $value
+     * @param  string  $regex
+     * @param  Closure  $callback
+     * @return string
+     */
+    public static function mapRegex($value, $regex, Closure $callback)
+    {
+        $parts = preg_split($regex, $value, -1, PREG_SPLIT_DELIM_CAPTURE);
+        foreach ($parts as $i => $part) {
+            $parts[$i] = $callback($part, preg_match($regex, $part));
+        }
+        return implode('', $parts);
     }
 
     /**

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -218,7 +218,7 @@ class Str extends \Illuminate\Support\Str
     }
 
     /**
-     * Parse each part of a string split with a regex through a callback function
+     * Parse each part of a string split with a regex through a callback function.
      *
      * @param  string  $value
      * @param  string  $regex

--- a/tests/Modifiers/MarkTest.php
+++ b/tests/Modifiers/MarkTest.php
@@ -34,6 +34,17 @@ class MarkTest extends TestCase
     }
 
     /** @test */
+    public function it_marks_text_with_specialchars()
+    {
+        $text = 'This number is <4 and >2: 3';
+        $words = 'and';
+
+        $expected = 'This number is &lt;4 <mark>and</mark> &gt;2: 3';
+
+        $this->assertEquals($expected, $this->modify($text, $words));
+    }
+
+    /** @test */
     public function it_marks_html()
     {
         $html = 'Lorem, ipsum <x-amet class="ipsum">dolor</x-amet> sit amet';

--- a/tests/Modifiers/MarkTest.php
+++ b/tests/Modifiers/MarkTest.php
@@ -67,6 +67,17 @@ class MarkTest extends TestCase
     }
 
     /** @test */
+    public function it_marks_html_with_entities()
+    {
+        $html = 'Lorem, ipsum el&uuml;t sit amet';
+        $words = 'elüt';
+
+        $expected = 'Lorem, ipsum <mark>el&uuml;t</mark> sit amet';
+
+        $this->assertEquals($expected, $this->modify($html, $words));
+    }
+
+    /** @test */
     public function it_marks_bard_value()
     {
         $data = new Value([

--- a/tests/Modifiers/MarkTest.php
+++ b/tests/Modifiers/MarkTest.php
@@ -10,7 +10,7 @@ class MarkTest extends TestCase
     /** @test */
     public function it_marks_text()
     {
-        $text  = 'Lorem, ipsum dolor sit amet';
+        $text = 'Lorem, ipsum dolor sit amet';
         $words = 'lorem sit';
 
         $expected = '<mark>Lorem</mark>, ipsum dolor <mark>sit</mark> amet';
@@ -21,7 +21,7 @@ class MarkTest extends TestCase
     /** @test */
     public function it_marks_text_with_class()
     {
-        $text  = 'Lorem, ipsum dolor sit amet';
+        $text = 'Lorem, ipsum dolor sit amet';
         $words = 'ipsum';
         $param = 'class:highlight';
 

--- a/tests/Modifiers/MarkTest.php
+++ b/tests/Modifiers/MarkTest.php
@@ -11,70 +11,59 @@ use Tests\TestCase;
 class MarkTest extends TestCase
 {
     /** @test */
-    public function it_marks_text()
+    public function it_marks()
     {
-        $text = 'Lorem, ipsum dolor sit amet';
+        $value = 'Lorem, ipsum dolor sit amet';
         $words = 'lorem sit';
 
         $expected = '<mark>Lorem</mark>, ipsum dolor <mark>sit</mark> amet';
 
-        $this->assertEquals($expected, $this->modify($text, $words));
+        $this->assertEquals($expected, $this->modify($value, $words));
     }
 
     /** @test */
-    public function it_marks_text_with_class()
+    public function it_marks_with_class()
     {
-        $text = 'Lorem, ipsum dolor sit amet';
+        $value = 'Lorem, ipsum dolor sit amet';
         $words = 'ipsum';
         $param = 'class:highlight';
 
         $expected = 'Lorem, <mark class="highlight">ipsum</mark> dolor sit amet';
 
-        $this->assertEquals($expected, $this->modify($text, $words, $param));
+        $this->assertEquals($expected, $this->modify($value, $words, $param));
     }
 
     /** @test */
-    public function it_marks_text_with_specialchars()
+    public function it_marks_with_tags()
     {
-        $text = 'This number is <4 and >2: 3';
-        $words = 'and';
-
-        $expected = 'This number is &lt;4 <mark>and</mark> &gt;2: 3';
-
-        $this->assertEquals($expected, $this->modify($text, $words));
-    }
-
-    /** @test */
-    public function it_marks_html()
-    {
-        $html = 'Lorem, ipsum <x-amet class="ipsum">dolor</x-amet> sit amet';
+        $value = 'Lorem, ipsum <x-amet class="ipsum">dolor</x-amet> sit amet';
         $words = 'ipsum amet';
 
         $expected = 'Lorem, <mark>ipsum</mark> <x-amet class="ipsum">dolor</x-amet> sit <mark>amet</mark>';
 
-        $this->assertEquals($expected, $this->modify($html, $words));
+        $this->assertEquals($expected, $this->modify($value, $words));
     }
 
     /** @test */
-    public function it_marks_html_with_specialchars()
+    public function it_marks_with_specialchars()
     {
-        $html = 'Lorem, ipsum &lt; 4 dolor &gt; 2 sit amet';
+        $value = 'Lorem, ipsum &lt; 4 dolor &gt; 2 sit amet';
         $words = 'dolor';
 
         $expected = 'Lorem, ipsum &lt; 4 <mark>dolor</mark> &gt; 2 sit amet';
 
-        $this->assertEquals($expected, $this->modify($html, $words));
+        $this->assertEquals($expected, $this->modify($value, $words));
     }
 
     /** @test */
-    public function it_marks_html_with_entities()
+    public function it_marks_with_entities()
     {
-        $html = 'Lorem, ipsum el&uuml;t sit amet';
+        $value = 'Lorem, ipsum el&uuml;t sit amet';
         $words = 'elüt';
 
         $expected = 'Lorem, ipsum <mark>el&uuml;t</mark> sit amet';
 
-        $this->assertEquals($expected, $this->modify($html, $words));
+        $this->assertEquals($expected, $this->modify($value, $words));
     }
 
     /** @test */

--- a/tests/Modifiers/MarkTest.php
+++ b/tests/Modifiers/MarkTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class MarkTest extends TestCase
+{
+    /** @test */
+    public function it_marks_text()
+    {
+        $text  = 'Lorem, ipsum dolor sit amet';
+        $words = 'lorem sit';
+
+        $expected = '<mark>Lorem</mark>, ipsum dolor <mark>sit</mark> amet';
+
+        $this->assertEquals($expected, $this->modify($text, $words));
+    }
+
+    /** @test */
+    public function it_marks_text_with_class()
+    {
+        $text  = 'Lorem, ipsum dolor sit amet';
+        $words = 'ipsum';
+        $param = 'class:highlight';
+
+        $expected = 'Lorem, <mark class="highlight">ipsum</mark> dolor sit amet';
+
+        $this->assertEquals($expected, $this->modify($text, $words, $param));
+    }
+
+    public function modify($arr, ...$args)
+    {
+        return Modify::value($arr)->mark($args)->fetch();
+    }
+}

--- a/tests/Modifiers/RegexMarkTest.php
+++ b/tests/Modifiers/RegexMarkTest.php
@@ -10,7 +10,7 @@ class RegexMarkTest extends TestCase
     /** @test */
     public function it_marks_text()
     {
-        $text  = 'Lorem, ipsum dolor sit amet';
+        $text = 'Lorem, ipsum dolor sit amet';
         $regex = 'ipsum dolor|amet';
 
         $expected = 'Lorem, <mark>ipsum dolor</mark> sit <mark>amet</mark>';
@@ -21,7 +21,7 @@ class RegexMarkTest extends TestCase
     /** @test */
     public function it_marks_text_with_class()
     {
-        $text  = 'Lorem, ipsum dolor sit amet';
+        $text = 'Lorem, ipsum dolor sit amet';
         $regex = 'ipsum dolor';
         $param = 'class:highlight';
 

--- a/tests/Modifiers/RegexMarkTest.php
+++ b/tests/Modifiers/RegexMarkTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase;
 class RegexMarkTest extends TestCase
 {
     /** @test */
-    public function it_marks_text()
+    public function it_marks_with_regex()
     {
         $text = 'Lorem, ipsum dolor sit amet';
         $regex = 'ipsum dolor|amet';
@@ -16,18 +16,6 @@ class RegexMarkTest extends TestCase
         $expected = 'Lorem, <mark>ipsum dolor</mark> sit <mark>amet</mark>';
 
         $this->assertEquals($expected, $this->modify($text, $regex));
-    }
-
-    /** @test */
-    public function it_marks_text_with_class()
-    {
-        $text = 'Lorem, ipsum dolor sit amet';
-        $regex = 'ipsum dolor';
-        $param = 'class:highlight';
-
-        $expected = 'Lorem, <mark class="highlight">ipsum dolor</mark> sit amet';
-
-        $this->assertEquals($expected, $this->modify($text, $regex, $param));
     }
 
     public function modify($arr, ...$args)

--- a/tests/Modifiers/RegexMarkTest.php
+++ b/tests/Modifiers/RegexMarkTest.php
@@ -10,12 +10,12 @@ class RegexMarkTest extends TestCase
     /** @test */
     public function it_marks_with_regex()
     {
-        $text = 'Lorem, ipsum dolor sit amet';
+        $value = 'Lorem, ipsum dolor sit amet';
         $regex = 'ipsum dolor|amet';
 
         $expected = 'Lorem, <mark>ipsum dolor</mark> sit <mark>amet</mark>';
 
-        $this->assertEquals($expected, $this->modify($text, $regex));
+        $this->assertEquals($expected, $this->modify($value, $regex));
     }
 
     public function modify($arr, ...$args)

--- a/tests/Modifiers/RegexMarkTest.php
+++ b/tests/Modifiers/RegexMarkTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class RegexMarkTest extends TestCase
+{
+    /** @test */
+    public function it_marks_text()
+    {
+        $text  = 'Lorem, ipsum dolor sit amet';
+        $regex = 'ipsum dolor|amet';
+
+        $expected = 'Lorem, <mark>ipsum dolor</mark> sit <mark>amet</mark>';
+
+        $this->assertEquals($expected, $this->modify($text, $regex));
+    }
+
+    /** @test */
+    public function it_marks_text_with_class()
+    {
+        $text  = 'Lorem, ipsum dolor sit amet';
+        $regex = 'ipsum dolor';
+        $param = 'class:highlight';
+
+        $expected = 'Lorem, <mark class="highlight">ipsum dolor</mark> sit amet';
+
+        $this->assertEquals($expected, $this->modify($text, $regex, $param));
+    }
+
+    public function modify($arr, ...$args)
+    {
+        return Modify::value($arr)->regex_mark($args)->fetch();
+    }
+}


### PR DESCRIPTION
This PR adds two new modifiers: `mark` and `regex_mark`.

These modifiers will wrap any matched words/phrases in `<mark>` tags, in order to highlight them on the page.

The idea behind the `mark` modifier was to highlight search queries when displaying results. For this reason it's fairly opinionated in the way it behaves:

* It will treat individual word as separate matches
* It's case-insensitive
* If no words are provided it'll use the `get:q` value from the context

The `regex_mark` modifier is more flexible, only thing it imposes is case-insensitivity.

 They expect an HTML value, if you have a plain text value you should encode any special characters first using the `entities` modifier.

## Examples

```yaml
value1: 'Lorem, ipsum dolor sit amet'
value2: 'Lorem, ipsum <x-amet class="ipsum">dolor</x-amet> sit amet'
plain: 'This number is <4 and >2: 3'

```
```antlers
{{ value1 | mark }}
{{ value1 | mark('lorem sit') }}
{{ value1 | mark('dolor', 'class:highlight') }}
{{ value1 | regex_mark('ipsum dolor|amet') }}

{{ value2 | mark('ipsum amet') }}

{{ plain | entities | mark('and') }}
```

Assuming the query is: `?q=dolor` this will output:

```html
Lorem, ipsum <mark>dolor</mark> sit amet
<mark>Lorem</mark>, ipsum dolor <mark>sit</mark> amet
Lorem, ipsum <mark class="highlight">dolor</mark> sit amet
Lorem, <mark>ipsum dolor</mark> sit <mark>amet</mark>

Lorem, <mark>ipsum</mark> <x-amet class="ipsum">dolor</x-amet> sit <mark>amet</mark>

This number is &lt;4 <mark>and</mark> &gt;2: 3
```