### PR TITLE
Add ability to temporarily disable and re-enable an event subscriber

### DIFF
--- a/src/Events/Subscriber.php
+++ b/src/Events/Subscriber.php
@@ -53,7 +53,7 @@ abstract class Subscriber
     /**
      * Normalize registered listener.
      *
-     * @param mixed $listener
+     * @param  mixed  $listener
      * @return mixed
      */
     public static function normalizeRegisteredListener($listener)

--- a/src/Events/Subscriber.php
+++ b/src/Events/Subscriber.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Statamic\Events;
+
+abstract class Subscriber
+{
+    protected $listeners = [];
+
+    /**
+     * Register the listeners for the subscriber.
+     *
+     * @param  \Illuminate\Events\Dispatcher  $events
+     */
+    public function subscribe($events)
+    {
+        foreach ($this->getListeners() as $event => $listener) {
+            $events->listen($event, $listener);
+        }
+    }
+
+    /**
+     * Get subscribable listeners.
+     *
+     * @return array
+     */
+    protected function getListeners()
+    {
+        if (! $this->listeners) {
+            throw new \Exception('No event listeners registered in [$listeners] property!');
+        }
+
+        return $this->listeners;
+    }
+
+    /**
+     * Temporarily disable the listeners handled by this subscriber.
+     */
+    public static function disable()
+    {
+        foreach ((new static)->getListeners() as $event => $listener) {
+            app('events')->forgetListener($event, $listener);
+        }
+    }
+
+    /**
+     * Re-enable the listeners handled by this subscriber.
+     */
+    public static function enable()
+    {
+        (new static)->subscribe(app('events'));
+    }
+}

--- a/src/Events/Subscriber.php
+++ b/src/Events/Subscriber.php
@@ -49,4 +49,19 @@ abstract class Subscriber
     {
         (new static)->subscribe(app('events'));
     }
+
+    /**
+     * Normalize registered listener.
+     *
+     * @param mixed $listener
+     * @return mixed
+     */
+    public static function normalizeRegisteredListener($listener)
+    {
+        // If we're using an older version of Laravel, listeners are stored as Closures.
+        // We should be able remove this when we drop support for Laravel 8.x.
+        return $listener instanceof \Closure
+            ? (new \ReflectionFunction($listener))->getStaticVariables()['listener']
+            : $listener;
+    }
 }

--- a/src/Events/Subscriber.php
+++ b/src/Events/Subscriber.php
@@ -51,6 +51,20 @@ abstract class Subscriber
     }
 
     /**
+     * Run a callback without triggering listeners handled by this subscriber.
+     *
+     * @param  \Closure  $callback
+     */
+    public static function withoutListeners($callback)
+    {
+        static::disable();
+
+        $callback();
+
+        static::enable();
+    }
+
+    /**
      * Normalize registered listener.
      *
      * @param  mixed  $listener

--- a/src/Git/Subscriber.php
+++ b/src/Git/Subscriber.php
@@ -4,9 +4,10 @@ namespace Statamic\Git;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 use Statamic\Events\Concerns\ListensForContentEvents;
+use Statamic\Events\Subscriber as StatamicSubscriber;
 use Statamic\Facades\Git;
 
-class Subscriber
+class Subscriber extends StatamicSubscriber
 {
     use ListensForContentEvents;
 

--- a/src/Git/Subscriber.php
+++ b/src/Git/Subscriber.php
@@ -12,15 +12,17 @@ class Subscriber extends StatamicSubscriber
     use ListensForContentEvents;
 
     /**
-     * Register the listeners for the subscriber.
+     * Map subscribable listeners.
      *
-     * @param  \Illuminate\Events\Dispatcher  $events
+     * @return array
      */
-    public function subscribe($events)
+    protected function getListeners()
     {
-        foreach ($this->events as $event) {
-            $events->listen($event, self::class.'@commit');
-        }
+        return collect($this->events)
+            ->mapWithKeys(function ($event) {
+                return [$event => static::class.'@commit'];
+            })
+            ->all();
     }
 
     /**

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -4,6 +4,7 @@ namespace Statamic\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
+use Statamic\Events\Subscriber;
 use Statamic\Support\Arr;
 
 class EventServiceProvider extends ServiceProvider
@@ -42,7 +43,7 @@ class EventServiceProvider extends ServiceProvider
     {
         Event::macro('forgetListener', function ($event, $handler) {
             $this->listeners[$event] = Arr::where($this->listeners[$event], function ($eventHandler) use ($handler) {
-                return $eventHandler != $handler;
+                return Subscriber::normalizeRegisteredListener($eventHandler) != $handler;
             });
         });
     }

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Statamic\Providers;
 
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Event;
+use Statamic\Support\Arr;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -35,4 +37,13 @@ class EventServiceProvider extends ServiceProvider
         \Statamic\Listeners\UpdateAssetReferences::class,
         \Statamic\Listeners\UpdateTermReferences::class,
     ];
+
+    public function boot()
+    {
+        Event::macro('forgetListener', function ($event, $handler) {
+            $this->listeners[$event] = Arr::where($this->listeners[$event], function ($eventHandler) use ($handler) {
+                return $eventHandler != $handler;
+            });
+        });
+    }
 }

--- a/tests/Events/MacroTest.php
+++ b/tests/Events/MacroTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Events;
+
+use Illuminate\Support\Facades\Event;
+use Statamic\Events\Event as StatamicEvent;
+use Tests\TestCase;
+
+class MacroTest extends TestCase
+{
+    /** @test */
+    public function it_can_forget_a_listener_using_string_notation()
+    {
+        Event::listen(PunSaved::class, 'Listener@handle');
+
+        $this->assertRegisteredListenersForEvent(PunSaved::class, [
+            'Listener@handle',
+        ]);
+
+        Event::forgetListener(PunSaved::class, 'Listener@handle');
+
+        $this->assertNoRegisteredListenersForEvent(PunSaved::class);
+    }
+
+    /** @test */
+    public function it_can_forget_a_listener_using_array_notation()
+    {
+        Event::listen(PunSaved::class, ['Listener', 'handle']);
+
+        $this->assertRegisteredListenersForEvent(PunSaved::class, [
+            ['Listener', 'handle'],
+        ]);
+
+        Event::forgetListener(PunSaved::class, ['Listener', 'handle']);
+
+        $this->assertNoRegisteredListenersForEvent(PunSaved::class);
+    }
+
+    /** @test */
+    public function forgetting_a_listener_doesnt_affect_other_events_or_listeners()
+    {
+        Event::listen(PunSaved::class, 'SubscriberOne@handle');
+        Event::listen(PunSaved::class, 'SubscriberTwo@handle');
+        Event::listen(PunDeleted::class, 'SubscriberOne@handle');
+
+        $this->assertRegisteredListenersForEvent(PunSaved::class, [
+            'SubscriberOne@handle',
+            'SubscriberTwo@handle',
+        ]);
+
+        $this->assertRegisteredListenersForEvent(PunDeleted::class, [
+            'SubscriberOne@handle',
+        ]);
+
+        Event::forgetListener(PunSaved::class, 'SubscriberOne@handle');
+
+        $this->assertRegisteredListenersForEvent(PunSaved::class, [
+            'SubscriberTwo@handle',
+        ]);
+
+        $this->assertRegisteredListenersForEvent(PunDeleted::class, [
+            'SubscriberOne@handle',
+        ]);
+    }
+
+    private function assertRegisteredListenersForEvent($event, $listeners)
+    {
+        $this->assertEquals($listeners, array_values(app('events')->getRawListeners()[$event]));
+    }
+
+    private function assertNoRegisteredListenersForEvent($event)
+    {
+        $this->assertCount(0, array_values(app('events')->getRawListeners()[$event]));
+    }
+}
+
+class PunSaved extends StatamicEvent
+{
+    //
+}
+
+class PunDeleted extends StatamicEvent
+{
+    //
+}

--- a/tests/Events/MacroTest.php
+++ b/tests/Events/MacroTest.php
@@ -11,54 +11,54 @@ class MacroTest extends TestCase
     /** @test */
     public function it_can_forget_a_listener_using_string_notation()
     {
-        Event::listen(PunSaved::class, 'Listener@handle');
+        Event::listen(JokeSaved::class, 'Listener@handle');
 
-        $this->assertRegisteredListenersForEvent(PunSaved::class, [
+        $this->assertRegisteredListenersForEvent(JokeSaved::class, [
             'Listener@handle',
         ]);
 
-        Event::forgetListener(PunSaved::class, 'Listener@handle');
+        Event::forgetListener(JokeSaved::class, 'Listener@handle');
 
-        $this->assertNoRegisteredListenersForEvent(PunSaved::class);
+        $this->assertNoRegisteredListenersForEvent(JokeSaved::class);
     }
 
     /** @test */
     public function it_can_forget_a_listener_using_array_notation()
     {
-        Event::listen(PunSaved::class, ['Listener', 'handle']);
+        Event::listen(JokeSaved::class, ['Listener', 'handle']);
 
-        $this->assertRegisteredListenersForEvent(PunSaved::class, [
+        $this->assertRegisteredListenersForEvent(JokeSaved::class, [
             ['Listener', 'handle'],
         ]);
 
-        Event::forgetListener(PunSaved::class, ['Listener', 'handle']);
+        Event::forgetListener(JokeSaved::class, ['Listener', 'handle']);
 
-        $this->assertNoRegisteredListenersForEvent(PunSaved::class);
+        $this->assertNoRegisteredListenersForEvent(JokeSaved::class);
     }
 
     /** @test */
     public function forgetting_a_listener_doesnt_affect_other_events_or_listeners()
     {
-        Event::listen(PunSaved::class, 'SubscriberOne@handle');
-        Event::listen(PunSaved::class, 'SubscriberTwo@handle');
-        Event::listen(PunDeleted::class, 'SubscriberOne@handle');
+        Event::listen(JokeSaved::class, 'SubscriberOne@handle');
+        Event::listen(JokeSaved::class, 'SubscriberTwo@handle');
+        Event::listen(JokeDeleted::class, 'SubscriberOne@handle');
 
-        $this->assertRegisteredListenersForEvent(PunSaved::class, [
+        $this->assertRegisteredListenersForEvent(JokeSaved::class, [
             'SubscriberOne@handle',
             'SubscriberTwo@handle',
         ]);
 
-        $this->assertRegisteredListenersForEvent(PunDeleted::class, [
+        $this->assertRegisteredListenersForEvent(JokeDeleted::class, [
             'SubscriberOne@handle',
         ]);
 
-        Event::forgetListener(PunSaved::class, 'SubscriberOne@handle');
+        Event::forgetListener(JokeSaved::class, 'SubscriberOne@handle');
 
-        $this->assertRegisteredListenersForEvent(PunSaved::class, [
+        $this->assertRegisteredListenersForEvent(JokeSaved::class, [
             'SubscriberTwo@handle',
         ]);
 
-        $this->assertRegisteredListenersForEvent(PunDeleted::class, [
+        $this->assertRegisteredListenersForEvent(JokeDeleted::class, [
             'SubscriberOne@handle',
         ]);
     }
@@ -74,12 +74,12 @@ class MacroTest extends TestCase
     }
 }
 
-class PunSaved extends StatamicEvent
+class JokeSaved extends StatamicEvent
 {
     //
 }
 
-class PunDeleted extends StatamicEvent
+class JokeDeleted extends StatamicEvent
 {
     //
 }

--- a/tests/Events/SubscriberTest.php
+++ b/tests/Events/SubscriberTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Events;
+
+use Illuminate\Support\Facades\Event;
+use Statamic\Events\Event as StatamicEvent;
+use Statamic\Events\Subscriber as StatamicSubscriber;
+use Statamic\Facades\Blink;
+use Tests\TestCase;
+
+class SubscriberTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Blink::put(PunSaved::class, 0);
+        Blink::put(PunDeleted::class, 0);
+        Blink::put(StaticCachePunSubscriber::class, 0);
+        Blink::put(EmailPunSubscriber::class, 0);
+    }
+
+    /** @test */
+    public function it_handles_dispatched_events()
+    {
+        Event::subscribe(StaticCachePunSubscriber::class);
+
+        $this->assertSubscriberNotHandled(StaticCachePunSubscriber::class);
+        $this->assertEventHandledCount(0, PunSaved::class);
+        $this->assertEventHandledCount(0, PunDeleted::class);
+
+        PunSaved::dispatch();
+        PunDeleted::dispatch();
+        PunDeleted::dispatch();
+
+        $this->assertSubscriberHandled(StaticCachePunSubscriber::class);
+        $this->assertEventHandledCount(1, PunSaved::class);
+        $this->assertEventHandledCount(2, PunDeleted::class);
+    }
+
+    /** @test */
+    public function it_can_temporarily_disable_and_re_enable_subscriber_handled_listeners()
+    {
+        Event::subscribe(StaticCachePunSubscriber::class);
+
+        $this->assertEventHandledCount(0, PunSaved::class);
+        $this->assertEventHandledCount(0, PunDeleted::class);
+
+        PunSaved::dispatch();
+        PunDeleted::dispatch();
+
+        $this->assertEventHandledCount(1, PunSaved::class);
+        $this->assertEventHandledCount(1, PunDeleted::class);
+
+        StaticCachePunSubscriber::disable();
+        PunSaved::dispatch();
+        PunDeleted::dispatch();
+
+        $this->assertEventHandledCount(1, PunSaved::class);
+        $this->assertEventHandledCount(1, PunDeleted::class);
+
+        StaticCachePunSubscriber::enable();
+        PunSaved::dispatch();
+        PunDeleted::dispatch();
+
+        $this->assertEventHandledCount(2, PunSaved::class);
+        $this->assertEventHandledCount(2, PunDeleted::class);
+    }
+
+    /** @test */
+    public function disabling_one_subscriber_does_not_affect_other_subscribers()
+    {
+        Event::subscribe(StaticCachePunSubscriber::class);
+        Event::subscribe(EmailPunSubscriber::class);
+
+        $this->assertEventHandledCount(0, PunSaved::class);
+        $this->assertEventHandledCount(0, PunDeleted::class);
+
+        PunSaved::dispatch();
+        PunDeleted::dispatch();
+
+        $this->assertEventHandledCount(2, PunSaved::class);
+        $this->assertEventHandledCount(1, PunDeleted::class);
+
+        StaticCachePunSubscriber::disable();
+        PunSaved::dispatch();
+        PunDeleted::dispatch();
+
+        $this->assertEventHandledCount(3, PunSaved::class);
+        $this->assertEventHandledCount(1, PunDeleted::class);
+    }
+
+    private function assertSubscriberNotHandled($subscriber)
+    {
+        $this->assertEquals(0, Blink::get($subscriber));
+    }
+
+    private function assertSubscriberHandled($subscriber)
+    {
+        $this->assertNotEquals(0, Blink::get($subscriber));
+    }
+
+    private function assertEventHandledCount($count, $event)
+    {
+        $this->assertEquals($count, Blink::get($event));
+    }
+}
+
+class PunSaved extends StatamicEvent
+{
+    //
+}
+
+class PunDeleted extends StatamicEvent
+{
+    //
+}
+
+class StaticCachePunSubscriber extends StatamicSubscriber
+{
+    public $listeners = [
+        PunSaved::class => self::class.'@handleSaved', // string notation
+        PunDeleted::class => [self::class, 'handleDeleted'], // array notation
+    ];
+
+    public function handleSaved(PunSaved $event)
+    {
+        Blink::increment(PunSaved::class);
+        Blink::increment(self::class);
+    }
+
+    public function handleDeleted(PunDeleted $event)
+    {
+        Blink::increment(PunDeleted::class);
+        Blink::increment(self::class);
+    }
+}
+
+class EmailPunSubscriber extends StatamicSubscriber
+{
+    public $listeners = [
+        PunSaved::class => self::class.'@handleSaved',
+    ];
+
+    public function handleSaved(PunSaved $event)
+    {
+        Blink::increment(PunSaved::class);
+        Blink::increment(self::class);
+    }
+}

--- a/tests/Events/SubscriberTest.php
+++ b/tests/Events/SubscriberTest.php
@@ -68,6 +68,35 @@ class SubscriberTest extends TestCase
     }
 
     /** @test */
+    public function it_can_temporarily_disable_listeners_on_code_run_within_a_callback()
+    {
+        Event::subscribe(StaticCachePunSubscriber::class);
+
+        $this->assertEventHandledCount(0, PunSaved::class);
+        $this->assertEventHandledCount(0, PunDeleted::class);
+
+        PunSaved::dispatch();
+        PunDeleted::dispatch();
+
+        $this->assertEventHandledCount(1, PunSaved::class);
+        $this->assertEventHandledCount(1, PunDeleted::class);
+
+        StaticCachePunSubscriber::withoutListeners(function () {
+            PunSaved::dispatch();
+            PunDeleted::dispatch();
+        });
+
+        $this->assertEventHandledCount(1, PunSaved::class);
+        $this->assertEventHandledCount(1, PunDeleted::class);
+
+        PunSaved::dispatch();
+        PunDeleted::dispatch();
+
+        $this->assertEventHandledCount(2, PunSaved::class);
+        $this->assertEventHandledCount(2, PunDeleted::class);
+    }
+
+    /** @test */
     public function disabling_one_subscriber_does_not_affect_other_subscribers()
     {
         Event::subscribe(StaticCachePunSubscriber::class);

--- a/tests/Git/GitEventTest.php
+++ b/tests/Git/GitEventTest.php
@@ -97,9 +97,10 @@ class GitEventTest extends TestCase
 
         $collection = Facades\Collection::make('pages');
 
-        GitSubscriber::disable();
-        $collection->save();
-        GitSubscriber::enable();
+        GitSubscriber::withoutListeners(function () use ($collection) {
+            $collection->save();
+        });
+
         $collection->delete();
     }
 

--- a/tests/Git/GitEventTest.php
+++ b/tests/Git/GitEventTest.php
@@ -11,6 +11,7 @@ use Statamic\Facades;
 use Statamic\Facades\Config;
 use Statamic\Facades\Git;
 use Statamic\Facades\User;
+use Statamic\Git\Subscriber as GitSubscriber;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -85,6 +86,20 @@ class GitEventTest extends TestCase
         $collection = Facades\Collection::make('pages');
 
         $collection->save();
+        $collection->delete();
+    }
+
+    /** @test */
+    public function it_doesnt_commit_when_event_subscriber_is_disabled()
+    {
+        Git::shouldReceive('dispatchCommit')->with('Collection saved')->never();
+        Git::shouldReceive('dispatchCommit')->with('Collection deleted')->once();
+
+        $collection = Facades\Collection::make('pages');
+
+        GitSubscriber::disable();
+        $collection->save();
+        GitSubscriber::enable();
         $collection->delete();
     }
 


### PR DESCRIPTION
- [x] Add `Event::forgetListener()` helper macro.
- [x] Add abstract `Subscriber` class with `disable()` and `enable()` methods.
- [x] Implement on `Git\Subscriber` for #6535.
- [x] Add test coverage.

This is also needed for #4832, but I'll wait for this PR to be merged first.