### PR TITLE
Fix asset data handling

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -132,7 +132,10 @@ class Asset implements AssetContract, Augmentable, ArrayAccess, Arrayable, Conta
         }
 
         if ($this->meta) {
-            return array_merge($this->meta, ['data' => $this->data->all()]);
+            $meta = $this->meta;
+            $meta['data'] = array_merge($meta['data'], $this->data->all());
+
+            return $meta;
         }
 
         return $this->meta = Cache::rememberForever($this->metaCacheKey(), function () {

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -102,6 +102,14 @@ class Asset implements AssetContract, Augmentable, ArrayAccess, Arrayable, Conta
     {
         $this->hydrate();
 
+        if (func_get_args()) {
+            $this->removedData = collect($this->meta['data'])
+                ->diffKeys($data)
+                ->keys()
+                ->merge($this->removedKeys)
+                ->all();
+        }
+
         return call_user_func_array([$this, 'traitData'], func_get_args());
     }
 

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -126,8 +126,11 @@ class AssetTest extends TestCase
         // Assert data is correct without hydrating, to ensure the hydrate call happened when calling `set()` above
         $asset->withoutHydrating(function ($asset) {
             $this->assertEquals('new-foo', $asset->get('one'));
+            $this->assertEquals('new-foo', Arr::get($asset->meta(), 'data.one'));
             $this->assertEquals('bar', $asset->get('two'));
+            $this->assertEquals('bar', Arr::get($asset->meta(), 'data.two'));
             $this->assertEquals('qux', $asset->get('three'));
+            $this->assertEquals('qux', Arr::get($asset->meta(), 'data.three'));
             $this->assertEquals('fallback', $asset->get('unknown', 'fallback'));
         });
 
@@ -162,8 +165,11 @@ class AssetTest extends TestCase
         // Assert data is correct without hydrating, to ensure the hydrate call happened when calling `merge()` above
         $asset->withoutHydrating(function ($asset) {
             $this->assertEquals('new-foo', $asset->get('one'));
+            $this->assertEquals('new-foo', Arr::get($asset->meta(), 'data.one'));
             $this->assertEquals('bar', $asset->get('two'));
+            $this->assertEquals('bar', Arr::get($asset->meta(), 'data.two'));
             $this->assertEquals('qux', $asset->get('three'));
+            $this->assertEquals('qux', Arr::get($asset->meta(), 'data.three'));
             $this->assertEquals('fallback', $asset->get('unknown', 'fallback'));
         });
 
@@ -198,9 +204,13 @@ class AssetTest extends TestCase
         // Assert data is correct without hydrating, to ensure the hydrate call happened when setting with `data()` above
         $asset->withoutHydrating(function ($asset) {
             $this->assertNull($asset->get('one'));
+            $this->assertFalse(Arr::has($asset->meta(), 'data.one'));
             $this->assertNull($asset->get('two'));
+            $this->assertFalse(Arr::has($asset->meta(), 'data.two'));
             $this->assertEquals('baz', $asset->get('three'));
+            $this->assertEquals('baz', Arr::get($asset->meta(), 'data.three'));
             $this->assertEquals('qux', $asset->get('four'));
+            $this->assertEquals('qux', Arr::get($asset->meta(), 'data.four'));
         });
 
         $this->assertEquals(123, $asset->getRawMeta()['size']);
@@ -230,8 +240,11 @@ class AssetTest extends TestCase
         // Assert data is correct without hydrating, to ensure the hydrate call happened when setting magical property via `__set()`
         $asset->withoutHydrating(function ($asset) {
             $this->assertEquals('new-foo', $asset->get('one'));
+            $this->assertEquals('new-foo', Arr::get($asset->meta(), 'data.one'));
             $this->assertEquals('bar', $asset->get('two'));
+            $this->assertEquals('bar', Arr::get($asset->meta(), 'data.two'));
             $this->assertEquals('qux', $asset->get('three'));
+            $this->assertEquals('qux', Arr::get($asset->meta(), 'data.three'));
             $this->assertEquals('fallback', $asset->get('unknown', 'fallback'));
         });
 
@@ -265,7 +278,9 @@ class AssetTest extends TestCase
         // Assert data is correct without hydrating, to ensure the hydrate call happened when calling `remove()` above
         $asset->withoutHydrating(function ($asset) {
             $this->assertNull($asset->get('one'));
+            $this->assertFalse(Arr::has($asset->meta(), 'data.one'));
             $this->assertEquals('bar', $asset->get('two'));
+            $this->assertEquals('bar', Arr::get($asset->meta(), 'data.two'));
         });
 
         $this->assertEquals(123, $asset->getRawMeta()['size']);

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -58,7 +58,7 @@ class AssetTest extends TestCase
     public function it_gets_data_values()
     {
         Storage::disk('test')->put('foo/test.txt', '');
-        Storage::disk('test')->put('foo/.meta/test.txt.yaml', YAML::dump($expectedBeforeMerge = [
+        Storage::disk('test')->put('foo/.meta/test.txt.yaml', YAML::dump([
             'data' => [
                 'one' => 'foo',
             ],
@@ -80,7 +80,7 @@ class AssetTest extends TestCase
     public function it_sets_data_values()
     {
         Storage::disk('test')->put('foo/test.txt', '');
-        Storage::disk('test')->put('foo/.meta/test.txt.yaml', YAML::dump($expectedBeforeMerge = [
+        Storage::disk('test')->put('foo/.meta/test.txt.yaml', YAML::dump([
             'data' => [
                 'one' => 'foo',
                 'two' => 'bar',
@@ -114,7 +114,7 @@ class AssetTest extends TestCase
     public function it_merges_data_values()
     {
         Storage::disk('test')->put('foo/test.txt', '');
-        Storage::disk('test')->put('foo/.meta/test.txt.yaml', YAML::dump($expectedBeforeMerge = [
+        Storage::disk('test')->put('foo/.meta/test.txt.yaml', YAML::dump([
             'data' => [
                 'one' => 'foo',
                 'two' => 'bar',
@@ -150,7 +150,7 @@ class AssetTest extends TestCase
     public function it_sets_all_data_at_once()
     {
         Storage::disk('test')->put('foo/test.txt', '');
-        Storage::disk('test')->put('foo/.meta/test.txt.yaml', YAML::dump($expectedBeforeMerge = [
+        Storage::disk('test')->put('foo/.meta/test.txt.yaml', YAML::dump([
             'data' => [
                 'one' => 'foo',
                 'two' => 'bar',
@@ -186,7 +186,7 @@ class AssetTest extends TestCase
     public function it_removes_data_values()
     {
         Storage::disk('test')->put('foo/test.txt', '');
-        Storage::disk('test')->put('foo/.meta/test.txt.yaml', YAML::dump($expectedBeforeMerge = [
+        Storage::disk('test')->put('foo/.meta/test.txt.yaml', YAML::dump([
             'data' => [
                 'one' => 'foo',
                 'two' => 'bar',


### PR DESCRIPTION
While working on #6585, we found a bug when trying to dump `$asset->meta()` more than once, which seemed to clear out asset meta completely (in-memory, not on the filesystem). This PR fixes meta hydration, and fleshes out test coverage around our `meta()` and `hydrate()` methods.

- [x] Fix merging of meta from unsaved asset data
- [x] Add test coverage for the `ContainsData` trait method aliases to ensure they all properly `hydrate()` the asset