### PR TITLE
Support the `page_name` pagination parameter in the collection tag

### DIFF
--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -38,7 +38,8 @@ trait GetsQueryResults
             $this->queryPaginationFriendlyOffset($query, $offset);
         }
 
-        $paginator = $query->paginate($perPage);
+        $pageName = $this->params->get('page_name', 'page');
+        $paginator = $query->paginate($perPage, ['*'], $pageName);
 
         Blink::put('tag-paginator', $paginator);
 

--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -3,6 +3,7 @@
 namespace Statamic\Tags\Concerns;
 
 use Statamic\Facades\Blink;
+use Statamic\Query\EloquentQueryBuilder;
 
 trait GetsQueryResults
 {
@@ -38,8 +39,9 @@ trait GetsQueryResults
             $this->queryPaginationFriendlyOffset($query, $offset);
         }
 
+        $columns = $query instanceof EloquentQueryBuilder ? [] : ['*'];
         $pageName = $this->params->get('page_name', 'page');
-        $paginator = $query->paginate($perPage, ['*'], $pageName);
+        $paginator = $query->paginate($perPage, $columns, $pageName);
 
         Blink::put('tag-paginator', $paginator);
 

--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -3,7 +3,6 @@
 namespace Statamic\Tags\Concerns;
 
 use Statamic\Facades\Blink;
-use Statamic\Query\EloquentQueryBuilder;
 
 trait GetsQueryResults
 {
@@ -39,9 +38,8 @@ trait GetsQueryResults
             $this->queryPaginationFriendlyOffset($query, $offset);
         }
 
-        $columns = $query instanceof EloquentQueryBuilder ? [] : ['*'];
         $pageName = $this->params->get('page_name', 'page');
-        $paginator = $query->paginate($perPage, $columns, $pageName);
+        $paginator = $query->paginate($perPage, ['*'], $pageName);
 
         Blink::put('tag-paginator', $paginator);
 


### PR DESCRIPTION
This PR adds support for the `page_name` pagination parameter in the collection tag. This parameter allows you to customise the name of the URL query parameter used for a particular paginator, from the default of `page`.

## Use Case

When working with Livewire components multiple components on the same page can have their own pagination, however if they all use `page` they conflict with one another. Livewire supports different parameter names for each component, this change allows you to use those with the collection tag:

```antlers
{{ collection:pages paginate="10" }} ... {{ /collection:pages }}
```
```antlers
{{ collection:posts paginate="10" page_name="postsPage" }} ... {{ /collection:posts }}
```

```
http://localhost/?page=3&postsPage=6
```