### PR TITLE
Add "Download" Action to Assets

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -215,6 +215,20 @@ Statamic.app({
                 await alert(url);
             }
         });
+
+        Statamic.$callbacks.add("downloadUrl", async function(url) {
+            try {
+                const response = await fetch(url);
+                const blob = await response.blob();
+                const link = document.createElement("a");
+
+                link.href = window.URL.createObjectURL(blob);
+                link.download = url.substring(url.lastIndexOf("/") + 1);
+                link.click();
+            } catch (err) {
+                await alert(url);
+            }
+        });
     },
 
     methods: {

--- a/src/Actions/DownloadAsset.php
+++ b/src/Actions/DownloadAsset.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Statamic\Actions;
+
+use Statamic\Contracts\Assets\Asset;
+
+class DownloadAsset extends Action
+{
+    protected $confirm = false;
+
+    public static function title()
+    {
+        return __('Download');
+    }
+
+    public function visibleTo($item)
+    {
+        return $item instanceof Asset;
+    }
+
+    public function visibleToBulk($items)
+    {
+        return false;
+    }
+
+    public function authorize($authed, $asset)
+    {
+        return $authed->can('view', $asset);
+    }
+
+    public function run($items, $values)
+    {
+        $asset = $items->first();
+
+        return [
+            'message' => false,
+            'callback' => ['downloadUrl', $asset->absoluteUrl()],
+        ];
+    }
+}

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -28,6 +28,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Actions\CopyPasswordResetLink::class,
         Actions\Delete::class,
         Actions\DeleteMultisiteEntry::class,
+        Actions\DownloadAsset::class,
         Actions\Publish::class,
         Actions\Unpublish::class,
         Actions\SendPasswordReset::class,


### PR DESCRIPTION
This PR adds a "download" option to Assets. Currently, we have the feature to download Assets when you open an asset. This addition will add an option in the dropdown to download an Asset from the Assets folder navigation saving a click.

![Xnapper-2022-08-30-12 55 27](https://user-images.githubusercontent.com/17038330/187509020-84843eac-b5ef-42ae-96a8-0c5dcb47f69d.png)


https://user-images.githubusercontent.com/17038330/187508902-3de4754d-4497-4c26-86ba-d6182f39b0e9.mov


