### PR TITLE
Make eloquent paginate columns argument default to asterisk

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -69,7 +69,7 @@ abstract class EloquentQueryBuilder implements Builder
         return $this->get()->first();
     }
 
-    public function paginate($perPage = null, $columns = [], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
         $paginator = $this->builder->paginate($perPage, $this->selectableColumns($columns), $pageName, $page);
 


### PR DESCRIPTION
Everything still works the same way. The empty array was a mistake. If you were to pass an empty array or an asterisk before, you'd still end up with the behavior of passing `['*']`.
