### PR TITLE
Use `download()` instead of custom JS callback in `DownloadAsset` action

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -215,20 +215,6 @@ Statamic.app({
                 await alert(url);
             }
         });
-
-        Statamic.$callbacks.add("downloadUrl", async function(url) {
-            try {
-                const response = await fetch(url);
-                const blob = await response.blob();
-                const link = document.createElement("a");
-
-                link.href = window.URL.createObjectURL(blob);
-                link.download = url.substring(url.lastIndexOf("/") + 1);
-                link.click();
-            } catch (err) {
-                await alert(url);
-            }
-        });
     },
 
     methods: {

--- a/src/Actions/DownloadAsset.php
+++ b/src/Actions/DownloadAsset.php
@@ -3,7 +3,6 @@
 namespace Statamic\Actions;
 
 use Statamic\Contracts\Assets\Asset;
-use Statamic\Facades\URL;
 
 class DownloadAsset extends Action
 {
@@ -31,12 +30,6 @@ class DownloadAsset extends Action
 
     public function download($items, $values)
     {
-        $asset = $items->first();
-
-        if (URL::isExternal($asset->absoluteUrl())) {
-            return $asset->download();
-        }
-
-        return $asset->resolvedPath();
+        return $items->first()->download();
     }
 }

--- a/src/Actions/DownloadAsset.php
+++ b/src/Actions/DownloadAsset.php
@@ -28,13 +28,10 @@ class DownloadAsset extends Action
         return $authed->can('view', $asset);
     }
 
-    public function run($items, $values)
+    public function download($items, $values)
     {
         $asset = $items->first();
 
-        return [
-            'message' => false,
-            'callback' => ['downloadUrl', $asset->absoluteUrl()],
-        ];
+        return $asset->resolvedPath();
     }
 }

--- a/src/Actions/DownloadAsset.php
+++ b/src/Actions/DownloadAsset.php
@@ -3,6 +3,7 @@
 namespace Statamic\Actions;
 
 use Statamic\Contracts\Assets\Asset;
+use Statamic\Facades\URL;
 
 class DownloadAsset extends Action
 {
@@ -31,6 +32,10 @@ class DownloadAsset extends Action
     public function download($items, $values)
     {
         $asset = $items->first();
+
+        if (URL::isExternal($asset->absoluteUrl())) {
+            return $asset->download();
+        }
 
         return $asset->resolvedPath();
     }


### PR DESCRIPTION
References #6594

Our abstract action already provides a handy `download()` method, so the JS callback isn't necessary.