### PR TITLE
Fix form email language

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -28,6 +28,7 @@ class Email extends Mailable
         $this->submission = $submission;
         $this->config = $config;
         $this->site = $site;
+        $this->locale($site->lang());
     }
 
     public function getSubmission()
@@ -49,7 +50,6 @@ class Email extends Mailable
     {
         $this->submissionData = $this->submission->toAugmentedArray();
         $this->config = $this->parseConfig($this->config);
-        $this->locale($this->site->lang());
 
         $this
             ->subject(isset($this->config['subject']) ? __($this->config['subject']) : __('Form Submission'))

--- a/tests/Forms/EmailTest.php
+++ b/tests/Forms/EmailTest.php
@@ -214,9 +214,8 @@ class EmailTest extends TestCase
 
         $makeEmail = function ($site) {
             $submission = Mockery::mock(Submission::class);
-            $submission->shouldReceive('toAugmentedArray')->andReturn([]);
 
-            return tap(new Email($submission, ['to' => 'test@test.com'], $site))->build();
+            return new Email($submission, ['to' => 'test@test.com'], $site);
         };
 
         $this->assertEquals('en', $makeEmail(Site::get('one'))->locale);

--- a/tests/Forms/SendEmailTest.php
+++ b/tests/Forms/SendEmailTest.php
@@ -24,7 +24,7 @@ class SendEmailTest extends TestCase
 
         (new SendEmail(
             $submission = $form->makeSubmission(),
-            $site = Mockery::mock(Site::class),
+            $site = Mockery::mock(Site::class)->shouldReceive('lang')->andReturn('en')->getMock(),
             [
                 'from' => 'first@sender.com',
                 'to' => 'first@recipient.com',


### PR DESCRIPTION
In order for the language to be applied to the mailable, the `locale` method needs to be called _before_ `build`.

Peek under the hood: https://github.com/laravel/framework/blob/e07e00507e67c710798eb98cdb09845f65026429/src/Illuminate/Mail/Mailable.php#L194-L197

The refactor in #6464 mistakenly moved that.

Fixes #6602
