### PR TITLE
API: Add support for filtering entries by taxonomy terms

### DIFF
--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -56,10 +56,9 @@ class CollectionEntriesController extends ApiController
 
     protected function applyTaxonomyFilter($query, $filter, $terms)
     {
-        [$keyword, $taxonomy, $condition] = array_pad(explode(':', $filter), 3, null);
+        [$_, $taxonomy, $condition] = array_pad(explode(':', $filter), 3, null);
 
-        $terms = collect($this->getPipedValues($terms))
-            ->map(fn ($term) => "$taxonomy::$term");
+        $terms = collect(explode(',', $terms))->map(fn ($term) => "$taxonomy::$term");
 
         if ($condition === 'in') {
             $query->whereTaxonomyIn($terms->all());

--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -5,12 +5,14 @@ namespace Statamic\Http\Controllers\API;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Entry;
 use Statamic\Http\Resources\API\EntryResource;
+use Statamic\Support\Str;
 
 class CollectionEntriesController extends ApiController
 {
     protected $resourceConfigKey = 'collections';
     protected $routeResourceKey = 'collection';
     protected $filterPublished = true;
+    protected $query;
 
     public function index($collection)
     {
@@ -20,8 +22,10 @@ class CollectionEntriesController extends ApiController
             ->flatMap(fn ($blueprint) => $blueprint->fields()->all())
             ->filter->isRelationship()->keys()->all();
 
+        $this->query = $collection->queryEntries()->with($with);
+
         return app(EntryResource::class)::collection(
-            $this->filterSortAndPaginate($collection->queryEntries()->with($with))
+            $this->filterSortAndPaginate($this->query)
         );
     }
 
@@ -35,6 +39,35 @@ class CollectionEntriesController extends ApiController
         $this->abortIfUnpublished($entry);
 
         return app(EntryResource::class)::make($entry);
+    }
+
+    protected function getFilters()
+    {
+        return parent::getFilters()->filter(function ($value, $filter) {
+            if (! Str::startsWith($filter, 'taxonomy:')) {
+                return true;
+            }
+
+            $this->applyTaxonomyFilter($filter, $value);
+
+            return false;
+        });
+    }
+
+    protected function applyTaxonomyFilter($filter, $terms)
+    {
+        [$keyword, $taxonomy, $condition] = array_pad(explode(':', $filter), 3, null);
+
+        $terms = collect($this->getPipedValues($terms))
+            ->map(fn ($term) => "$taxonomy::$term");
+
+        if ($condition === 'in') {
+            $this->query->whereTaxonomyIn($terms->all());
+        } elseif ($condition === 'not_in') {
+            $this->query->whereTaxonomyNotIn($terms->all());
+        } else {
+            $terms->each(fn ($term) => $this->query->whereTaxonomy($term));
+        }
     }
 
     private function abortIfInvalid($entry, $collection)

--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -12,7 +12,6 @@ class CollectionEntriesController extends ApiController
     protected $resourceConfigKey = 'collections';
     protected $routeResourceKey = 'collection';
     protected $filterPublished = true;
-    protected $query;
 
     public function index($collection)
     {

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -148,7 +148,6 @@ class APITest extends TestCase
     public function it_filters_by_taxonomy_terms()
     {
         Facades\Config::set('statamic.api.resources.collections', true);
-        Facades\Config::set('statamic.api.cache', false);
 
         $this->makeTaxonomy('tags')->save();
         $this->makeTerm('tags', 'rad')->save();

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -145,6 +145,35 @@ class APITest extends TestCase
     }
 
     /** @test */
+    public function it_filters_by_taxonomy_terms()
+    {
+        Facades\Config::set('statamic.api.resources.collections', true);
+        Facades\Config::set('statamic.api.cache', false);
+
+        $this->makeTaxonomy('tags')->save();
+        $this->makeTerm('tags', 'rad')->save();
+        $this->makeTerm('tags', 'meh')->save();
+        $this->makeTerm('tags', 'wow')->save();
+
+        $this->makeCollection('test')->taxonomies(['tags'])->save();
+
+        $this->makeEntry('test', '1')->data(['tags' => ['rad', 'wow']])->save();
+        $this->makeEntry('test', '2')->data(['tags' => ['rad']])->save();
+        $this->makeEntry('test', '3')->data(['tags' => ['meh']])->save();
+
+        $this->assertEndpointDataCount('/api/collections/test/entries?filter[taxonomy:tags]=rad', 2);
+        $this->assertEndpointDataCount('/api/collections/test/entries?filter[taxonomy:tags]=boring', 0);
+        $this->assertEndpointDataCount('/api/collections/test/entries?filter[taxonomy:tags:in]=boring', 0);
+        $this->assertEndpointDataCount('/api/collections/test/entries?filter[taxonomy:tags:in]=boring,rad', 2);
+        $this->assertEndpointDataCount('/api/collections/test/entries?filter[taxonomy:tags:in]=wow,rad', 2);
+        $this->assertEndpointDataCount('/api/collections/test/entries?filter[taxonomy:tags:in]=rad,meh', 3);
+        $this->assertEndpointDataCount('/api/collections/test/entries?filter[taxonomy:tags:not_in]=boring', 3);
+        $this->assertEndpointDataCount('/api/collections/test/entries?filter[taxonomy:tags:not_in]=rad', 1);
+        $this->assertEndpointDataCount('/api/collections/test/entries?filter[taxonomy:tags:not_in]=boring,rad', 1);
+        $this->assertEndpointDataCount('/api/collections/test/entries?filter[taxonomy:tags:not_in]=rad,meh,wow', 0);
+    }
+
+    /** @test */
     public function it_excludes_keys()
     {
         Facades\Config::set('statamic.api.resources.collections', true);
@@ -340,6 +369,26 @@ class APITest extends TestCase
             'invalid term id' => ['/api/taxonomies/tags/terms/missing', false],
             'valid term id but wrong collection' => ['/api/taxonomies/categories/terms/test', false],
         ];
+    }
+
+    private function makeCollection($handle)
+    {
+        return Facades\Collection::make($handle);
+    }
+
+    private function makeEntry($collection, $slug)
+    {
+        return Facades\Entry::make()->collection($collection)->id($slug)->slug($slug);
+    }
+
+    private function makeTaxonomy($handle)
+    {
+        return Facades\Taxonomy::make($handle);
+    }
+
+    private function makeTerm($taxonomy, $slug, $data = [])
+    {
+        return Facades\Term::make()->taxonomy($taxonomy)->inDefaultLocale()->slug($slug)->data($data);
     }
 
     private function assertEndpointDataCount($endpoint, $count)


### PR DESCRIPTION
Fixes #6119.

Supported syntax:
`?filter[taxonomy:categories]=events`
`?filter[taxonomy:categories:in]=events|bananas`
`?filter[taxonomy:categories:not_in]=apples|pears`

I am removing the taxonomy filters from the list by overriding `->getFilters()`, so they don't also get applied as regular filters in `ApiController->filter()`.