### PR TITLE
Only show permission descriptions if the translation exists.

### DIFF
--- a/src/Auth/CorePermissions.php
+++ b/src/Auth/CorePermissions.php
@@ -214,11 +214,11 @@ class CorePermissions
             $permission = Permission::make($permission);
         }
 
-        return $permission->label(
-            __('statamic::permissions.'.str_replace(' ', '_', $permission->value()))
-        )->description(
-            __('statamic::permissions.'.str_replace(' ', '_', $permission->value().'_desc'))
-        );
+        $label = __('statamic::permissions.'.str_replace(' ', '_', $permission->value()));
+        $description = __($descKey = 'statamic::permissions.'.str_replace(' ', '_', $permission->value().'_desc'));
+        $description = $description === $descKey ? null : $description;
+
+        return $permission->label($label)->description($description);
     }
 
     protected function group($name, $callback)


### PR DESCRIPTION
Replaces #6613
Fixes #2483
