### PR TITLE
Fix numeric separators JS error

### DIFF
--- a/resources/js/components/field-conditions/Omitter.js
+++ b/resources/js/components/field-conditions/Omitter.js
@@ -42,7 +42,10 @@ export default class {
     }
 
     dottedKeyToJsPath(dottedKey) {
-        return dottedKey.replace(/\.*\.(\d+)\./g, '[$1].');
+        return dottedKey.split('.')
+            .map(key => new RegExp(/^\d+.*/).test(key) ? '["' + key + '"]' : key)
+            .join('.')
+            .replace(/\.\[/g, '[');
     }
 
     missingValue(dottedKey) {
@@ -56,11 +59,11 @@ export default class {
         if (this.missingValue(dottedKey)) return;
 
         let values = clone(this.values);
-        let jsPath = this.dottedKeyToJsPath(dottedKey);
-        let fieldValue = eval('values.' + jsPath);
+        let jsPath = this.dottedKeyToJsPath('values.' + dottedKey);
+        let fieldValue = eval(jsPath);
         let decodedFieldValue = JSON.parse(fieldValue);
 
-        eval('values.' + jsPath + ' = decodedFieldValue');
+        eval(jsPath + ' = decodedFieldValue');
 
         this.values = values;
     }
@@ -69,11 +72,11 @@ export default class {
         if (this.missingValue(dottedKey)) return;
 
         let values = clone(this.values);
-        let jsPath = this.dottedKeyToJsPath(dottedKey);
-        let fieldValue = eval('values.' + jsPath);
+        let jsPath = this.dottedKeyToJsPath('values.' + dottedKey);
+        let fieldValue = eval(jsPath);
         let encodedFieldValue = JSON.stringify(fieldValue);
 
-        eval('values.' + jsPath + ' = encodedFieldValue');
+        eval(jsPath + ' = encodedFieldValue');
 
         this.values = values;
     }
@@ -82,9 +85,9 @@ export default class {
         if (this.missingValue(dottedKey)) return;
 
         let values = clone(this.values);
-        let jsPath = this.dottedKeyToJsPath(dottedKey);
+        let jsPath = this.dottedKeyToJsPath('values.' + dottedKey);
 
-        eval('delete values.' + jsPath);
+        eval('delete ' + jsPath);
 
         this.values = values;
     }

--- a/resources/js/tests/FieldConditionsOmitter.test.js
+++ b/resources/js/tests/FieldConditionsOmitter.test.js
@@ -245,3 +245,46 @@ test('it gracefully handles errors', () => {
 
     expect(omitted).toEqual(expected);
 });
+
+test('it properly handles keys that javascript considers having numeric separators', () => {
+    let values = {
+        title: 'Millenium Falcon',
+        '404_text': JSON.stringify('This ship is the fastest hunk of junk in the galaxy!'),
+        page: {
+            title: 'X-Wing',
+            '404_text': JSON.stringify('Permission to jump in an X-Wing and blow something up?'),
+        },
+        '123_key': {
+            '456_key': {
+                'title': 'Y-Wing',
+                '404_text': JSON.stringify('Y-Wings are the BOMB!'),
+            },
+        },
+    };
+
+    let jsonFields = [
+        '404_text', // Field handles like this were causing numeric separator error.
+        'page.404_text',
+        '123_key.456_key.404_text',
+    ];
+
+    let omitted = new Omitter(values, jsonFields).omit([
+        '404_text',
+        '123_key.456_key.404_text',
+    ]);
+
+    let expected = {
+        title: 'Millenium Falcon',
+        page: {
+            title: 'X-Wing',
+            '404_text': JSON.stringify('Permission to jump in an X-Wing and blow something up?'),
+        },
+        '123_key': {
+            '456_key': {
+                'title': 'Y-Wing',
+            },
+        },
+    };
+
+    expect(omitted).toEqual(expected);
+});


### PR DESCRIPTION
Fixes #6611
References #6187

There's some logic in a JS class that converts a "dotted path" to a "js path" that uses braces around numeric keys...

e.g. `foo.0.bar.baz` to `foo[0].bar.baz`

However, JS considers an underscore `_` after an integer as a numeric separator, so keys like `404_text` need to be wrapped in square braces as strings in the converted js path as well...

e.g. `field.404_text.bar.baz` needs to be converted to `field["404_text"].bar.baz`