### PR TITLE
Fix popper causing overflow

### DIFF
--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -46,6 +46,10 @@ export default {
         }
     },
 
+    mounted() {
+        if (! this.disabled) this.bindPopper();
+    },
+
     beforeDestroy() {
         this.destroyPopper();
     },
@@ -75,27 +79,16 @@ export default {
             this.isOpen ? this.close() : this.open();
         },
         open() {
-            if (this.popper) return;
-
-            this.bindPopper();
             this.isOpen = true;
             this.escBinding = this.$keys.bind('esc', e => this.close())
         },
         close() {
-            if (!this.popper) return;
-
             this.isOpen = false;
             if (this.escBinding) {
                 this.escBinding.destroy();
             }
-            // timeout so that the fade out animation is still called correctly
-            setTimeout(() => { 
-                this.destroyPopper(); 
-            }, 100);
         },
         destroyPopper() {
-            if (!this.popper) return;
-
             this.popper.destroy();
             this.popper = null; 
         },


### PR DESCRIPTION
The change in #6601 caused the popper elements to remain on the screen (but invisible) which was causing the overflow pointed out in #6627.

Turns out it's necessary for the poppers to be initialized when mounted. We can't just initialize when clicking them.

This PR reverts the initialize-on-click behavior, but will make sure they are still destroyed when the component is destroyed, which should help with the memory leak that #6601 was trying to fix.

Fixes #6627
