### PR TITLE
Ability to edit alt text in an asset field inline

### DIFF
--- a/resources/js/components/fieldtypes/assets/Asset.js
+++ b/resources/js/components/fieldtypes/assets/Asset.js
@@ -1,10 +1,12 @@
 import Luminous from 'luminous-lightbox';
 import AssetEditor from '../../assets/Editor/Editor.vue';
+import InlineAssetEditor from './InlineAssetEditor.vue';
 
 export default {
 
     components: {
-        AssetEditor
+        AssetEditor,
+        InlineAssetEditor
     },
 
     props: {

--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -20,6 +20,19 @@
                 {{ asset.basename }}
             </button>
         </td>
+        <td>
+            <inline-asset-editor :asset="asset">
+                <div slot-scope="{ values, setFieldValue, submit, error, saving, recentlySaved }">
+                    <div class="flex">
+                        <input type="text" class="input-text" :value="values.alt" @input="setFieldValue('alt', $event.target.value)" />
+                        <button type="button" class="btn" @click="submit" :disabled="saving">Save</button>
+                    </div>
+                    <div v-if="error" class="text-red text-xs">{{ error }}</div>
+                    <div v-if="saving" class="text-xs">Saving...</div>
+                    <div v-if="recentlySaved" class="text-xs text-green">Saved!</div>
+                </div>
+            </inline-asset-editor>
+        </td>
         <td class="p-0 w-8 text-right align-middle">
 
             <button v-if="!readOnly" class="flex items-center p-1 w-full h-full text-grey-60 hover:text-grey-90" @click="remove" :aria-label="__('Remove Asset')">

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -72,6 +72,18 @@
         <div class="asset-meta" v-if="showFilename">
             <div class="asset-filename" :title="label">{{ label }}</div>
         </div>
+
+        <inline-asset-editor :asset="asset">
+            <div slot-scope="{ values, setFieldValue, submit, error, saving, recentlySaved }">
+                <div class="flex">
+                    <input type="text" class="input-text" :value="values.alt" @input="setFieldValue('alt', $event.target.value)" />
+                    <button type="button" class="btn" @click="submit" :disabled="saving">Save</button>
+                </div>
+                <div v-if="error" class="text-red text-xs">{{ error }}</div>
+                <div v-if="saving" class="text-xs">Saving...</div>
+                <div v-if="recentlySaved" class="text-xs text-green">Saved!</div>
+            </div>
+        </inline-asset-editor>
     </div>
 
 </template>

--- a/resources/js/components/fieldtypes/assets/InlineAssetEditor.vue
+++ b/resources/js/components/fieldtypes/assets/InlineAssetEditor.vue
@@ -1,0 +1,61 @@
+<script>
+export default {
+
+    props: {
+        asset: { required: true, type: Object }
+    },
+
+    data() {
+        return {
+            saving: false,
+            recentlySaved: false,
+            error: null,
+            values: this.asset.values,
+        }
+    },
+
+    render() {
+        return this.$scopedSlots.default({
+            values: this.values,
+            setFieldValue: this.setFieldValue,
+            submit: this.submit,
+            error: this.error,
+            saving: this.saving,
+            recentlySaved: this.recentlySaved,
+        });
+    },
+
+    methods: {
+
+        setFieldValue(handle, value) {
+            this.values = {...this.values, [handle]: value};
+        },
+
+        submit() {
+            this.saving = true;
+            this.recentlySaved = false;
+            const url = cp_url(`assets/${utf8btoa(this.asset.id)}`);
+
+            this.$axios.patch(url, this.values).then(response => {
+                this.$emit('saved', response.data.asset);
+                this.saving = false;
+                this.recentlySaved = true;
+                setTimeout(() => this.recentlySaved = false, 1000);
+                this.error = null;
+            }).catch(e => {
+                this.saving = false;
+
+                if (e.response && e.response.status === 422) {
+                    this.error = Object.values(e.response.data.errors)[0][0];
+                } else if (e.response) {
+                    this.error = e.response.data.message;
+                } else {
+                    this.error = __('Something went wrong');
+                }
+            });
+        }
+
+    }
+
+}
+</script>


### PR DESCRIPTION
This PR adds the ability to show a text field in the `assets` fieldtype for a user to edit the alt text without needing to open up the editor.

At the moment the intention is to only show the alt field. If you want to edit more fields, you can click the edit button to open up the full asset editor like you've always done. We may add the ability to show more fields inline in the future.

- [x] Wire up inline form
- [ ] Make the inline field optional
- [ ] Make pretty
