### PR TITLE
 Remove Glide cache when asset `focus` changes

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -49,11 +49,17 @@ class Asset implements AssetContract, Augmentable, ArrayAccess, Arrayable, Conta
     }
 
     protected $container;
+
     protected $path;
+
     protected $meta;
-    protected $syncOriginalProperties = ['path'];
+
+    protected $syncOriginalProperties = ['focus', 'path'];
+
     protected $withEvents = true;
+
     protected $shouldHydrate = true;
+
     protected $removedData = [];
 
     public function __construct()

--- a/src/Listeners/ClearAssetGlideCache.php
+++ b/src/Listeners/ClearAssetGlideCache.php
@@ -4,6 +4,7 @@ namespace Statamic\Listeners;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Statamic\Events\AssetDeleted;
+use Statamic\Events\AssetSaved;
 use Statamic\Facades\Glide;
 
 class ClearAssetGlideCache implements ShouldQueue
@@ -15,16 +16,29 @@ class ClearAssetGlideCache implements ShouldQueue
      */
     public function subscribe($events)
     {
-        $events->listen(AssetDeleted::class, self::class.'@handle');
+        $events->listen(AssetDeleted::class, self::class.'@handleDeleted');
+        $events->listen(AssetSaved::class, self::class.'@handleSaved');
     }
 
     /**
-     * Handle the events.
+     * Handle the AssetDeleted event.
      *
      * @param  AssetDeleted  $event
      */
-    public function handle($event)
+    public function handleDeleted($event)
     {
         Glide::clearAsset($event->asset);
+    }
+
+    /**
+     * Handle the AssetSaved event.
+     *
+     * @param  AssetSaved  $event
+     */
+    public function handleSaved($event)
+    {
+        if ($event->asset->getOriginal('focus') != $event->asset->get('focus')) {
+            Glide::clearAsset($event->asset);
+        }
     }
 }

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -940,30 +940,30 @@ class AssetTest extends TestCase
         $asset->delete();
     }
 
-        /** @test */
-        public function it_clears_asset_glide_cache_when_focus_is_added()
-        {
-            config()->set('statamic.search.indexes.default.searchables', null);
-            Storage::fake('local');
-            $disk = Storage::disk('local');
-            $disk->put('path/to/asset.txt', '');
-            $container = Facades\AssetContainer::make('test')->disk('local');
-            Facades\AssetContainer::shouldReceive('save')->with($container);
-            Facades\AssetContainer::shouldReceive('findByHandle')->with('test')->andReturn($container);
-            $asset = (new Asset)
+    /** @test */
+    public function it_clears_asset_glide_cache_when_focus_is_added()
+    {
+        config()->set('statamic.search.indexes.default.searchables', null);
+        Storage::fake('local');
+        $disk = Storage::disk('local');
+        $disk->put('path/to/asset.txt', '');
+        $container = Facades\AssetContainer::make('test')->disk('local');
+        Facades\AssetContainer::shouldReceive('save')->with($container);
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test')->andReturn($container);
+        $asset = (new Asset)
                 ->container($container)
                 ->path('path/to/asset.txt');
 
-            $asset->save();
+        $asset->save();
 
-            $asset->set('focus', '50-50');
+        $asset->set('focus', '50-50');
 
-            Facades\Glide::shouldReceive('clearAsset')->withArgs(function ($arg) use ($asset) {
-                return $arg->id() === $asset->id();
-            })->once();
+        Facades\Glide::shouldReceive('clearAsset')->withArgs(function ($arg) use ($asset) {
+            return $arg->id() === $asset->id();
+        })->once();
 
-            $asset->save();
-        }
+        $asset->save();
+    }
 
     /** @test */
     public function it_clears_asset_glide_cache_when_focus_changes()


### PR DESCRIPTION
Closes https://github.com/statamic/cms/issues/6308

Requires https://github.com/statamic/cms/pull/4832 to be merged first