### PR TITLE
Avoid fieldtypes getting mounted twice

### DIFF
--- a/resources/js/components/publish/Sections.vue
+++ b/resources/js/components/publish/Sections.vue
@@ -2,7 +2,7 @@
 
     <element-container @resized="containerWasResized">
     <div>
-        <div class="tabs-container flex items-center" :class="{ 'offset-for-sidebar': shouldShowSidebar }">
+        <div v-if="containerWidth !== null" class="tabs-container flex items-center" :class="{ 'offset-for-sidebar': shouldShowSidebar }">
             <div
                 class="publish-tabs tabs flex-shrink" v-show="mainSections.length > 1"
                 ref="tabs"
@@ -36,7 +36,7 @@
             </dropdown-list>
         </div>
 
-        <div class="flex justify-between">
+        <div v-if="containerWidth !== null" class="flex justify-between">
             <div ref="publishSectionWrapper" class="publish-section-wrapper w-full min-w-0">
                 <div
                     role="tabpanel"

--- a/resources/js/components/publish/Sections.vue
+++ b/resources/js/components/publish/Sections.vue
@@ -2,9 +2,9 @@
 
     <element-container @resized="containerWasResized">
     <div>
-        <div v-if="containerWidth !== null" class="tabs-container flex items-center" :class="{ 'offset-for-sidebar': shouldShowSidebar }">
+        <div v-if="containerWidth !== null && mainSections.length > 1" class="tabs-container flex items-center" :class="{ 'offset-for-sidebar': shouldShowSidebar }">
             <div
-                class="publish-tabs tabs flex-shrink" v-show="mainSections.length > 1"
+                class="publish-tabs tabs flex-shrink"
                 ref="tabs"
                 role="tablist"
                 :aria-label="__('Edit Content')"


### PR DESCRIPTION
This is an easy way to fix #6584.

Bonus: Fixes the layout shift. Before when you had no tabs, three little dots where briefly rendered above the edit form and then disappeared, making the main and side bar panels shift upward. 