### PR TITLE
Multisite: Propagate date change to descendants

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -207,7 +207,7 @@ class EntriesController extends CpController
 
         if ($entry->collection()->dated()) {
             $date = $this->formatDateForSaving($request->date);
-
+            
             $entry->date($date);
 
             $entry->descendants()->each(fn ($entry) => $this->saveUpdatedEntry($entry->date($date)));
@@ -461,7 +461,7 @@ class EntriesController extends CpController
                 ->user(User::current())
                 ->save();
         } else {
-            if (! is_null($published) && ! $entry->revisionsEnabled() && User::current()->can('publish', $entry)) {
+            if (!is_null($published) && ! $entry->revisionsEnabled() && User::current()->can('publish', $entry)) {
                 $entry->published($published);
             }
 

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -207,7 +207,7 @@ class EntriesController extends CpController
 
         if ($entry->collection()->dated()) {
             $date = $this->formatDateForSaving($request->date);
-            
+
             $entry->date($date);
 
             $entry->descendants()->each(fn ($entry) => $this->saveUpdatedEntry($entry->date($date)));
@@ -461,7 +461,7 @@ class EntriesController extends CpController
                 ->user(User::current())
                 ->save();
         } else {
-            if (!is_null($published) && ! $entry->revisionsEnabled() && User::current()->can('publish', $entry)) {
+            if (! is_null($published) && ! $entry->revisionsEnabled() && User::current()->can('publish', $entry)) {
                 $entry->published($published);
             }
 

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -848,6 +848,23 @@ class EntryTest extends TestCase
     }
 
     /** @test */
+    public function it_copies_a_changed_date_to_its_descendants()
+    {
+        $collection = tap(Collection::make('dated')->dated(true))->save();
+
+        $origin = (new Entry)->collection('dated')->id('origin')->date('2022-09-06');
+        $origin->save();
+        $descendant = (new Entry)->collection('dated')->id('descendant')->date('2022-09-06')->origin($origin);
+        $descendant->save();
+
+        $this->assertTrue(Carbon::createFromFormat('Y-m-d H:i', '2022-09-06 00:00')->eq($descendant->date()));
+
+        $origin->date('2022-09-08')->save();
+
+        $this->assertTrue(Carbon::createFromFormat('Y-m-d H:i', '2022-09-08 00:00')->eq($descendant->date()));
+    }
+
+    /** @test */
     public function future_dated_entries_are_private_when_configured_in_the_collection()
     {
         Carbon::setTestNow('2019-01-01');


### PR DESCRIPTION
This fixes #3440.

I made these choices:
- The date set on an 'origin' entry will automatically also be set on any of its descendant entries*
- If any of the descendants have revisions enabled, a working copy will be made when needed
- The published state for the origin entry won't be propagated to its descendants

\* Note that this won't take into account if the (custom) date field has been desynced. The date will be copied regardless.