### PR TITLE
Show placeholder in form select fields

### DIFF
--- a/resources/views/extend/forms/fields/select.antlers.html
+++ b/resources/views/extend/forms/fields/select.antlers.html
@@ -5,7 +5,13 @@
     {{ if validate|contains:required }}required{{ /if }}
 >
     {{ unless multiple }}
-        <option value>{{ trans key="Please select..." }}</option>
+        <option value>
+            {{ if placeholder }}
+                {{ placeholder }}
+            {{ else }}
+                {{ trans key="Please select..." }}
+            {{ /if }}
+        </option>
     {{ /unless }}
     {{ foreach:options as="value|label" }}
         <option value="{{ value }}"{{ if old|in_array:value or old === value }} selected{{ /if }}{{ if ! old && default === value }} selected{{ /if }}>


### PR DESCRIPTION
The [documentation for select fields](https://statamic.dev/fieldtypes/select#options) says that the `placeholder` is used for the 'non-selectable placeholder text'. Currently, the value does not do anything for fieldtypes in forms. The placeholder text for those currently is hardcoded with `{{ trans key="Please select..." }}`.

I believe that the value from `placeholder` should be used instead (if available).