### PR TITLE
Asset field improvements

### DIFF
--- a/resources/js/components/fieldtypes/TextFieldtype.vue
+++ b/resources/js/components/fieldtypes/TextFieldtype.vue
@@ -3,7 +3,7 @@
         ref="input"
         :value="value"
         :classes="config.classes"
-        :focus="config.focus || name === 'title'"
+        :focus="config.focus || name === 'title' || name === 'alt'"
         :autoselect="config.autoselect"
         :type="config.input_type"
         :isReadOnly="isReadOnly"

--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -1,12 +1,16 @@
 <template>
-
     <tr class="cursor-grab bg-white hover:bg-grey-10">
         <td class="flex items-center">
-            <div v-if="canShowSvg"
-                 class="img svg-img mr-1 h-7 w-7 bg-no-repeat bg-center bg-cover text-center flex items-center justify-center"
-                 :style="'background-image:url('+thumbnail+')'">
-            </div>
-            <button class="w-7 h-7 cursor-pointer whitespace-no-wrap flex items-center justify-center" @click="edit" v-else>
+            <div
+                v-if="canShowSvg"
+                class="img svg-img mr-1 h-7 w-7 bg-no-repeat bg-center bg-cover text-center flex items-center justify-center"
+                :style="'background-image:url(' + thumbnail + ')'"
+            ></div>
+            <button
+                class="w-7 h-7 cursor-pointer whitespace-no-wrap flex items-center justify-center"
+                @click="edit"
+                v-else
+            >
                 <img
                     class="asset-thumbnail max-h-full max-w-full rounded w-7 h-7 fit-cover"
                     loading="lazy"
@@ -16,13 +20,30 @@
                 />
                 <file-icon :extension="asset.extension" v-else />
             </button>
-            <button v-if="showFilename" @click="edit" class="flex items-center flex-1 ml-1 text-sm text-left truncate" :aria-label="__('Edit Asset')" v-tooltip="asset.basename + ' (' + asset.size + ')'">
+            <button
+                v-if="showFilename"
+                @click="edit"
+                class="flex items-center flex-1 ml-1 text-xs text-left truncate"
+                :aria-label="__('Edit Asset')"
+            >
                 {{ asset.basename }}
             </button>
+            <button
+                class="text-blue px-2 text-sm hover:text-black"
+                @click="edit"
+                v-if="needsAlt"
+            >
+                {{ asset.values.alt ? "✅" : __("Set Alt") }}
+            </button>
+            <div v-text="asset.size" class="text-xs text-grey-50 px-1" />
         </td>
         <td class="p-0 w-8 text-right align-middle">
-
-            <button v-if="!readOnly" class="flex items-center p-1 w-full h-full text-grey-60 hover:text-grey-90" @click="remove" :aria-label="__('Remove Asset')">
+            <button
+                v-if="!readOnly"
+                class="flex items-center p-1 w-full h-full text-grey-60 hover:text-grey-90"
+                @click="remove"
+                :aria-label="__('Remove Asset')"
+            >
                 <svg-icon name="trash" class="w-6 h-6" />
             </button>
 
@@ -31,18 +52,22 @@
                 :id="asset.id"
                 :allow-deleting="false"
                 @closed="closeEditor"
-                @saved="assetSaved">
+                @saved="assetSaved"
+            >
             </asset-editor>
         </td>
     </tr>
-
 </template>
 
 <script>
-import Asset from './Asset';
+import Asset from "./Asset";
 export default {
+    mixins: [Asset],
 
-    mixins: [Asset]
-
-}
+    computed: {
+        needsAlt() {
+            return this.asset.isImage && !this.asset.values.alt;
+        }
+    }
+};
 </script>

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -1,60 +1,79 @@
 <template>
-
-    <div class="asset-tile"
-         :class="{ 'is-image': isImage && !canShowSvg, 'is-svg': canShowSvg, 'is-file': !isImage && !canShowSvg }"
-         :title="asset.filename"
+    <div
+        class="asset-tile"
+        :class="{
+            'is-image': isImage && !canShowSvg,
+            'is-svg': canShowSvg,
+            'is-file': !isImage && !canShowSvg
+        }"
+        :title="asset.filename"
     >
-
         <asset-editor
             v-if="editing"
             :id="asset.id"
             :allow-deleting="false"
             @closed="closeEditor"
-            @saved="assetSaved">
+            @saved="assetSaved"
+        >
         </asset-editor>
 
         <div class="asset-thumb-container">
-
-            <div class="asset-thumb" :class="{ 'bg-checkerboard': canBeTransparent }">
-
+            <div
+                class="asset-thumb"
+                :class="{ 'bg-checkerboard': canBeTransparent }"
+            >
                 <!-- Solo Bard -->
                 <template v-if="isImage && isInBardField && !isInAssetBrowser">
-                    <img :src="asset.url" >
+                    <img :src="asset.url" />
                 </template>
 
                 <template v-else>
                     <img :src="thumbnail" v-if="isImage" :title="label" />
 
                     <template v-else>
-                        <div v-if="canShowSvg"
-                             class="svg-img"
-                             :style="'background-image:url('+thumbnail+')'">
-                        </div>
-                        <file-icon v-else :extension="asset.extension" class="p-2 h-40 w-40" />
+                        <img
+                            v-if="canShowSvg"
+                            :src="asset.url"
+                            class="p-2"
+                        />
+                        <file-icon
+                            v-else
+                            :extension="asset.extension"
+                            class="p-2 h-full w-full"
+                        />
                     </template>
-
                 </template>
 
                 <div class="asset-controls" v-if="!readOnly">
-                    <button
-                        @click="edit"
-                        class="btn btn-icon icon icon-pencil"
-                        :alt="__('Edit')"></button>
+                    <div class="h-full w-full flex items-center justify-center space-x-1">
+                        <button
+                            @click="edit"
+                            class="btn btn-icon icon icon-pencil"
+                            :alt="__('Edit')"
+                        ></button>
 
-                    <button
-                        @click="remove"
-                        class="btn btn-icon icon icon-trash"
-                        :alt="__('Remove')"></button>
+                        <button
+                            @click="remove"
+                            class="btn btn-icon icon icon-trash"
+                            :alt="__('Remove')"
+                        ></button>
+                    </div>
                 </div>
 
                 <div class="asset-controls" v-if="readOnly">
                     <button
-                        v-if="asset.url && (asset.isImage || asset.isAudio || asset.isVideo) && this.canDownload"
+                        v-if="
+                            asset.url &&
+                                (asset.isImage ||
+                                    asset.isAudio ||
+                                    asset.isVideo) &&
+                                this.canDownload
+                        "
                         @click="open"
                         class="btn btn-icon"
                         :alt="__('Open in a new window')"
                     >
-                        <svg-icon name="external-link" class="h-4 my-1"/>
+                        <svg-icon name="external-link" class="h-4 my-1" />
                     </button>
 
                     <button
@@ -63,25 +82,35 @@
                         class="btn btn-icon"
                         :alt="__('Download file')"
                     >
-                        <svg-icon name="download" class="h-4 my-1"/>
+                        <svg-icon name="download" class="h-4 my-1" />
                     </button>
                 </div>
             </div>
         </div>
 
-        <div class="asset-meta" v-if="showFilename">
-            <div class="asset-filename" :title="label">{{ label }}</div>
+        <div class="asset-meta flex items-center" v-if="showFilename">
+            <div
+                class="asset-filename flex-1 px-1 py-sm"
+                :title="label"
+                :class="{ 'text-center': !needsAlt }"
+            >
+                {{ label }}
+            </div>
+            <button
+                class="text-blue border-l px-1 py-sm hover:bg-grey-20"
+                @click="edit"
+                v-if="needsAlt"
+            >
+                {{ asset.values.alt ? "✅" : __("Set Alt") }}
+            </button>
         </div>
     </div>
-
 </template>
 
-
 <script>
-import Asset from './Asset';
+import Asset from "./Asset";
 
 export default {
-
     mixins: [Asset],
 
     computed: {
@@ -92,9 +121,9 @@ export default {
             while (true) {
                 let parent = vm.$parent;
 
-                if (! parent) return false;
+                if (!parent) return false;
 
-                if (parent.constructor.name === 'AssetBrowser') {
+                if (parent.constructor.name === "AssetBrowser") {
                     return true;
                 }
 
@@ -104,7 +133,11 @@ export default {
 
         isInBardField() {
             return this.$parent.isInBardField;
+        },
+
+        needsAlt() {
+            return this.asset.isImage && !this.asset.values.alt;
         }
     }
-}
+};
 </script>

--- a/resources/sass/components/assets.scss
+++ b/resources/sass/components/assets.scss
@@ -82,31 +82,29 @@
   ========================================================================== */
 
 .asset-grid-listing {
-    background: #fff;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-    grid-row-gap: 16px;
-    grid-column-gap: 8px;
+    @apply bg-white grid relative grid-cols-2;
+    grid-gap: 16px;
     padding: 16px;
-    position: relative;
 
     .asset-tile {
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        flex-direction: column;
-        justify-content: space-between;
-        padding: 8px;
+        @apply flex items-center w-full flex-col justify-between cursor-pointer border rounded;
+        aspect-ratio: 1 / 1;
 
         .asset-thumb-container {
-            align-items: center;
-            display: flex;
-            flex: 1;
+            @apply flex items-center flex-1 w-full justify-center relative;
         }
     }
+}
 
-    img {
-        width: 100%;
+@screen md {
+    .asset-grid-listing {
+        @apply grid-cols-3;
+    }
+}
+
+@screen lg {
+    .asset-grid-listing {
+        @apply grid-cols-4;
     }
 }
 
@@ -142,73 +140,40 @@
    ========================================================================== */
 
 .asset-tile {
+    @apply bg-white;
     min-width: 0;
     position: relative;
-    padding: 8px;
 
     .asset-thumb {
         @apply flex justify-center items-center;
-        overflow: hidden;
-
-        img,
-        .svg-img {
-            border: 5px solid #fff;
-            max-height: 150px;
-            max-width: 150px;
-            margin: 0 auto;
-        }
-
-        img {
-            @apply block w-auto h-auto;
+        img, svg, .svg-img {
+            @apply max-h-full max-w-full absolute;
         }
     }
 
     .asset-meta {
-        padding-top: 8px;
+        @apply border-t w-full;
         font-size: 12px;
         color: $color_gray_light;
+    }
+
+    .asset-filename {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        max-width: 150px;
-        text-align: center;
     }
 
     .asset-controls {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        margin-left: -40px;
-        display: none;
-        width: 80px;
-        height: 32px;
-        margin-top: -16px;
-        text-align: center;
+        @apply absolute hidden;
     }
 
-    &:hover .asset-controls {
+    .asset-thumb-container:hover .asset-controls {
         display: block;
     }
 
     &.is-selected {
         background: rgba($color_dark_blue, .07);
         border-radius: 4px;
-    }
-
-    .svg-img {
-        background-size: contain;
-        background-position: 50% 50%;
-        background-repeat: no-repeat;
-        padding-bottom: 100%;
-        padding-bottom: calc(100% - 10px); // take the border of 5px each into account
-        height: 150px;
-        width: 150px;
-    }
-
-    .svg-icon {
-        height: 150px;
-        width: 150px;
-        margin: 0 auto;
     }
 }
 

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -173,8 +173,8 @@ class AssetContainer implements AssetContainerContract, Augmentable, ArrayAccess
         $blueprint = Blueprint::find('assets/'.$this->handle()) ?? Blueprint::makeFromFields([
             'alt' => [
                 'type' => 'text',
-                'display' => 'Alt Text',
-                'instructions' => 'Description of the image',
+                'display' => __('Alt Text'),
+                'instructions' => __('Description of the image')
             ],
         ])->setHandle($this->handle())->setNamespace('assets');
 

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -174,7 +174,7 @@ class AssetContainer implements AssetContainerContract, Augmentable, ArrayAccess
             'alt' => [
                 'type' => 'text',
                 'display' => __('Alt Text'),
-                'instructions' => __('Description of the image')
+                'instructions' => __('Description of the image'),
             ],
         ])->setHandle($this->handle())->setNamespace('assets');
 

--- a/src/Imaging/Manager.php
+++ b/src/Imaging/Manager.php
@@ -79,9 +79,9 @@ class Manager
     public function cpManipulationPresets()
     {
         return [
-            'cp_thumbnail_small_landscape' => ['w' => '400', 'h' => '300', 'fit' => 'crop'],
-            'cp_thumbnail_small_portrait' => ['h' => '300', 'fit' => 'crop'],
-            'cp_thumbnail_small_square' => ['w' => '300', 'h' => '300'],
+            'cp_thumbnail_small_landscape' => ['w' => '400', 'h' => '400', 'fit' => 'contain'],
+            'cp_thumbnail_small_portrait' => ['h' => '400', 'fit' => 'contain'],
+            'cp_thumbnail_small_square' => ['w' => '400', 'h' => '400'],
         ];
     }
 


### PR DESCRIPTION
First, image ratios are now properly shown in landscape and portrait orientations in Grid mode. I've added a border to each grid asset tile to help make things feel a bit tighter.

Next, added a "Set Alt" button if an image doesn't have an alt tag. Clicking it will open the Asset Editor and make sure the Alt field is autofocused. This is present in both grid and list modes.

![image](https://user-images.githubusercontent.com/44739/188475578-79913e09-a6e9-468d-af57-3656a7a0771d.png)
![image](https://user-images.githubusercontent.com/44739/188475597-7c6eee4b-79e1-4205-8d23-abec5032d373.png)
