### PR TITLE
Exclude published from data when saving entries

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -197,7 +197,7 @@ class EntriesController extends CpController
             $entry->blueprint($explicitBlueprint);
         }
 
-        $values = $values->except(['slug', 'date']);
+        $values = $values->except(['slug', 'date', 'published']);
 
         if ($entry->hasOrigin()) {
             $entry->data($values->only($request->input('_localized')));
@@ -340,7 +340,7 @@ class EntriesController extends CpController
                 'site' => $site->handle(),
             ])->validate();
 
-        $values = $fields->process()->values()->except(['slug', 'date', 'blueprint']);
+        $values = $fields->process()->values()->except(['slug', 'date', 'blueprint', 'published']);
 
         $entry = Entry::make()
             ->collection($collection)


### PR DESCRIPTION
In #6353 we included the published value in order to be able to validate against it.
This was unintentionally forcibly adding it to the data. We only needed it there for validation.

This caused the problem reported in #6557.
When a revision was created, it would have that published boolean in the data, but shouldn't have.
Then when the entry is published, the `published` boolean remains in the data.
When you clear the cache, it would need to read the entry from the file, which would see that `published: false` in the data, and set it as a draft.

Fixes #6557
