### PR TITLE
Fix deleting an entry with children from the tree view

### DIFF
--- a/resources/js/components/structures/Branch.vue
+++ b/resources/js/components/structures/Branch.vue
@@ -134,13 +134,10 @@ export default {
 
         orphanChildren() {
             const store = this.page._vm.store;
-            let children = this.vm.data.children;
-            let length = children.length;
-            for (let index = 0; index < length; index++) {
-                // As the item is moved out, the rest of the items are moved up an index.
-                // We always just want to move the first item.
-                th.appendTo(children[0], this.vm.data.parent);
-            }
+
+            this.vm.data.children.slice().forEach((child) =>
+                th.insertBefore(child, this.vm.data)
+            );
 
             this.$emit('children-orphaned', store);
         }

--- a/src/Http/Controllers/CP/Collections/CollectionTreeController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionTreeController.php
@@ -40,11 +40,11 @@ class CollectionTreeController extends CpController
         // validate URI uniqueness without affecting the real object in memory.
         $this->validateUniqueUris((clone $tree)->disableUriCache()->tree($contents));
 
+        $this->deleteEntries($request);
+
         // Validate the tree, which will add any missing entries or throw an exception
         // if somehow the root would end up having child pages, which isn't allowed.
         $contents = $structure->validateTree($contents, $request->site);
-
-        $this->deleteEntries($request);
 
         $tree->tree($contents)->save();
     }

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -293,7 +293,7 @@ abstract class Tree implements Contract, Localization
             return $this;
         }
 
-        if ($this->structure()->expectsRoot() && Arr::get($this->tree, '0.id') === $target) {
+        if ($this->structure()->expectsRoot() && Arr::get($this->tree, '0.'.$this->idKey()) === $target) {
             throw new \Exception('Root page cannot have children');
         }
 


### PR DESCRIPTION
This fixes #4453.

It may fix #3791 too, although I had trouble reproducing that one in the first place.

- The changes in `Tree->move()` fix 4453 
- The changes in `CollectionTreeController->update()` prevent any deleted pages from staying in the tree file afterwards (this issue was not reported)
- The changes in `Branch.vue` make sure that any orphaned children are moved up one level "in place", instead of moving them to the bottom of the list.