### PR TITLE
Fix date field default format not including time when mode isnt explicitly set

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -219,7 +219,7 @@ class Date extends Fieldtype
 
     private function defaultFormat()
     {
-        if ($this->config('time_enabled') && $this->config('mode') === 'single') {
+        if ($this->config('time_enabled') && $this->config('mode', 'single') === 'single') {
             return $this->config('time_seconds_enabled')
                 ? self::DEFAULT_DATETIME_WITH_SECONDS_FORMAT
                 : self::DEFAULT_DATETIME_FORMAT;


### PR DESCRIPTION
If `time_enabled: true` without `mode` explicitly being set to `single`, then date will be stripped of its time component.