### PR TITLE
Add missing view nav authorization

### DIFF
--- a/src/Http/Controllers/CP/Navigation/NavigationController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationController.php
@@ -65,6 +65,8 @@ class NavigationController extends CpController
     {
         abort_if(! $nav = Nav::find($nav), 404);
 
+        $this->authorize('view', $nav, __('You are not authorized to view navs.'));
+
         $site = $request->site ?? Site::selected()->handle();
 
         if (! $nav->existsIn($site)) {


### PR DESCRIPTION
This PR adds the missing "view" authorisation check on the CP navigation show method

Fixes: #6653 