### PR TITLE
Distinguish between a missing and a `null` supplemental value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Release Notes
 
+## 3.3.34 (2022-09-05)
+
+### What's new
+- Add support for downloading multiple assets as a zip. [#6606](https://github.com/statamic/cms/issues/6606) [#6626](https://github.com/statamic/cms/issues/6626) by @jacksleight
+- Add support for filtering entries by taxonomy terms in the REST API. [#6615](https://github.com/statamic/cms/issues/6615) by @arthurperton
+
+### What's improved
+- Asset fieldtype UI/UX improvements such as ability to set missing alt attributes, and better thumbnails. [#6638](https://github.com/statamic/cms/issues/6638) by @jackmcdade
+- Static caching: When saving a collection (or its tree), the configured collection urls will be invalidated. [#6636](https://github.com/statamic/cms/issues/6636) by @arthurperton
+- Static caching excluded URLs treat trailing slashes as optional. [#6633](https://github.com/statamic/cms/issues/6633) by @arthurperton
+
+### What's fixed
+- Exclude `published` from data when saving entries. [#6641](https://github.com/statamic/cms/issues/6641) by @jasonvarga
+- Show placeholder in form select fields. [#6637](https://github.com/statamic/cms/issues/6637) by @fjahn
+- Avoid fieldtypes getting mounted twice. [#6632](https://github.com/statamic/cms/issues/6632) by @arthurperton
+- Fix popper causing overflow. [#6628](https://github.com/statamic/cms/issues/6628) by @jasonvarga
+- Fix missing permission translation keys being shown. [#6624](https://github.com/statamic/cms/issues/6624) by @jasonvarga
+- Fix numeric separators JS error. [#6625](https://github.com/statamic/cms/issues/6625) by @jesseleite
+- Fix asset data handling. [#6591](https://github.com/statamic/cms/issues/6591) by @jesseleite
+
+
+
 ## 3.3.33 (2022-08-31)
 
 ### What's new

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -85,9 +85,13 @@ abstract class AbstractAugmented implements Augmented
         $value = method_exists($this->data, 'value') ? $this->data->value($handle) : $this->data->get($handle);
 
         if (method_exists($this->data, 'getSupplement')) {
-            $value = $this->data->hasSupplement($handle)
-                ? $this->data->getSupplement($handle)
-                : $value;
+            if (method_exists($this->data, 'hasSupplement')) {
+                $value = $this->data->hasSupplement($handle)
+                    ? $this->data->getSupplement($handle)
+                    : $value;
+            } else {
+                $value = $this->data->getSupplement($handle) ?? $value;
+            }
         }
 
         return $value;

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -85,7 +85,7 @@ abstract class AbstractAugmented implements Augmented
         $value = method_exists($this->data, 'value') ? $this->data->value($handle) : $this->data->get($handle);
 
         if (method_exists($this->data, 'getSupplement')) {
-            $value = $this->data->getSupplement($handle) ?? $value;
+            $value = $this->data->getSupplement($handle, $value);
         }
 
         return $value;

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -85,13 +85,9 @@ abstract class AbstractAugmented implements Augmented
         $value = method_exists($this->data, 'value') ? $this->data->value($handle) : $this->data->get($handle);
 
         if (method_exists($this->data, 'getSupplement')) {
-            if (method_exists($this->data, 'hasSupplement')) {
-                $value = $this->data->hasSupplement($handle)
-                    ? $this->data->getSupplement($handle)
-                    : $value;
-            } else {
-                $value = $this->data->getSupplement($handle) ?? $value;
-            }
+            $value = $this->data->hasSupplement($handle)
+                ? $this->data->getSupplement($handle)
+                : $value;
         }
 
         return $value;

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -85,7 +85,9 @@ abstract class AbstractAugmented implements Augmented
         $value = method_exists($this->data, 'value') ? $this->data->value($handle) : $this->data->get($handle);
 
         if (method_exists($this->data, 'getSupplement')) {
-            $value = $this->data->getSupplement($handle, $value);
+            $value = $this->data->hasSupplement($handle)
+                ? $this->data->getSupplement($handle)
+                : $value;
         }
 
         return $value;

--- a/src/Data/ContainsSupplementalData.php
+++ b/src/Data/ContainsSupplementalData.php
@@ -18,8 +18,13 @@ trait ContainsSupplementalData
         return $this;
     }
 
-    public function getSupplement($key)
+    public function getSupplement($key, $fallback = null)
     {
-        return $this->supplements[$key] ?? null;
+        return $this->hasSupplement($key) ? $this->supplements[$key] : $fallback;
+    }
+
+    public function hasSupplement($key)
+    {
+        return $this->supplements->has($key);
     }
 }

--- a/src/Data/ContainsSupplementalData.php
+++ b/src/Data/ContainsSupplementalData.php
@@ -18,9 +18,9 @@ trait ContainsSupplementalData
         return $this;
     }
 
-    public function getSupplement($key, $fallback = null)
+    public function getSupplement($key)
     {
-        return $this->hasSupplement($key) ? $this->supplements[$key] : $fallback;
+        return $this->supplements[$key] ?? null;
     }
 
     public function hasSupplement($key)

--- a/src/Data/ContainsSupplementalData.php
+++ b/src/Data/ContainsSupplementalData.php
@@ -25,6 +25,6 @@ trait ContainsSupplementalData
 
     public function hasSupplement($key)
     {
-        return $this->supplements->has($key);
+        return collect($this->supplements)->has($key);
     }
 }

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -197,7 +197,7 @@ class EntriesController extends CpController
             $entry->blueprint($explicitBlueprint);
         }
 
-        $values = $values->except(['slug', 'date']);
+        $values = $values->except(['slug', 'date', 'published']);
 
         if ($entry->hasOrigin()) {
             $entry->data($values->only($request->input('_localized')));
@@ -340,7 +340,7 @@ class EntriesController extends CpController
                 'site' => $site->handle(),
             ])->validate();
 
-        $values = $fields->process()->values()->except(['slug', 'date', 'blueprint']);
+        $values = $fields->process()->values()->except(['slug', 'date', 'blueprint', 'published']);
 
         $entry = Entry::make()
             ->collection($collection)

--- a/tests/Data/AugmentedTest.php
+++ b/tests/Data/AugmentedTest.php
@@ -50,6 +50,21 @@ class AugmentedTest extends TestCase
     }
 
     /** @test */
+    public function it_can_use_null_as_a_supplement_value()
+    {
+        $augmented = new class($this->thing) extends BaseAugmentedThing
+        {
+            //
+        };
+
+        $this->assertEqualsValue('bar', $augmented->get('foo'));
+
+        $this->thing->setSupplement('foo', null);
+
+        $this->assertNullValue($augmented->get('foo'));
+    }
+
+    /** @test */
     public function it_gets_a_single_value_by_key_using_the_value_method_if_it_exists()
     {
         $thingWithValueMethod = new class($this->thing->data()) extends Thing

--- a/tests/Data/AugmentedTest.php
+++ b/tests/Data/AugmentedTest.php
@@ -50,6 +50,21 @@ class AugmentedTest extends TestCase
     }
 
     /** @test */
+    public function it_can_use_null_as_a_supplement_value()
+    {
+        $augmented = new class($this->thing) extends BaseAugmentedThing
+        {
+            //
+        };
+
+        $this->assertEqualsValue('bar', $augmented->get('foo'));
+
+        $this->thing->setSupplement('foo', null);
+
+        $this->assertNullValue($augmented->get('foo'));
+    }
+
+    /** @test */
     public function it_gets_a_single_value_by_key_using_the_value_method_if_it_exists()
     {
         $thingWithValueMethod = new class($this->thing->data()) extends Thing
@@ -318,12 +333,10 @@ class Thing
 {
     use ContainsData;
 
-    public function __construct($data)
+    public function __construct($data, $supplements = ['supplemented' => 'supplemented value'])
     {
         $this->data = $data;
-        $this->supplements = [
-            'supplemented' => 'supplemented value',
-        ];
+        $this->supplements = $supplements;
     }
 
     public function slug()

--- a/tests/Data/AugmentedTest.php
+++ b/tests/Data/AugmentedTest.php
@@ -50,21 +50,6 @@ class AugmentedTest extends TestCase
     }
 
     /** @test */
-    public function it_can_use_null_as_a_supplement_value()
-    {
-        $augmented = new class($this->thing) extends BaseAugmentedThing
-        {
-            //
-        };
-
-        $this->assertEqualsValue('bar', $augmented->get('foo'));
-
-        $this->thing->setSupplement('foo', null);
-
-        $this->assertNullValue($augmented->get('foo'));
-    }
-
-    /** @test */
     public function it_gets_a_single_value_by_key_using_the_value_method_if_it_exists()
     {
         $thingWithValueMethod = new class($this->thing->data()) extends Thing
@@ -333,10 +318,12 @@ class Thing
 {
     use ContainsData;
 
-    public function __construct($data, $supplements = ['supplemented' => 'supplemented value'])
+    public function __construct($data)
     {
         $this->data = $data;
-        $this->supplements = $supplements;
+        $this->supplements = [
+            'supplemented' => 'supplemented value',
+        ];
     }
 
     public function slug()

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -519,7 +519,6 @@ class EntryTest extends TestCase
         $this->assertEquals('bar', $entry->getSupplement('foo'));
         $this->assertNull($entry->getSupplement('bar'));
         $this->assertNull($entry->getSupplement('baz'));
-        $this->assertNull($entry->getSupplement('baz', 'quux'));
         $this->assertTrue($entry->hasSupplement('foo'));
         $this->assertFalse($entry->hasSupplement('bar'));
         $this->assertTrue($entry->hasSupplement('baz'));

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -513,11 +513,17 @@ class EntryTest extends TestCase
         $entry = new Entry;
         $this->assertEquals([], $entry->supplements()->all());
 
-        $return = $entry->setSupplement('foo', 'bar');
+        $return = $entry->setSupplement('foo', 'bar')->setSupplement('baz', null);
 
         $this->assertEquals($entry, $return);
         $this->assertEquals('bar', $entry->getSupplement('foo'));
-        $this->assertEquals(['foo' => 'bar'], $entry->supplements()->all());
+        $this->assertNull($entry->getSupplement('bar'));
+        $this->assertNull($entry->getSupplement('baz'));
+        $this->assertNull($entry->getSupplement('baz', 'quux'));
+        $this->assertTrue($entry->hasSupplement('foo'));
+        $this->assertFalse($entry->hasSupplement('bar'));
+        $this->assertTrue($entry->hasSupplement('baz'));
+        $this->assertEquals(['foo' => 'bar', 'baz' => null], $entry->supplements()->all());
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #6002.

Live Preview supplements the saved entry data with the current values in the edit form. Right now supplementing with `null` (the value for an empty field) will be interpreted as "there is no supplement, let's use the original value".

To check if there is a supplemental value (possibly null) for a key, I added the `->hasSupplement($key)` method to the`ContainsSupplementalData` trait.

For convenience I also added a `$fallback` parameter to `->getSupplement()`. If that is not cool, we can just do the `->hasSupplement()` check in `AbstractAugmented->getFromData()` instead.