### PR TITLE
Fix blank URLs being flagged as external

### DIFF
--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -221,7 +221,7 @@ class URL
      */
     public function isExternal($url)
     {
-        if (Str::startsWith($url, ['/', '#']) || ! Str::length($url)) {
+        if (! $url || Str::startsWith($url, ['/', '#'])) {
             return false;
         }
 

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -221,7 +221,7 @@ class URL
      */
     public function isExternal($url)
     {
-        if (Str::startsWith($url, ['/', '#'])) {
+        if (Str::startsWith($url, ['/', '#']) || ! Str::length($url)) {
             return false;
         }
 

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -59,6 +59,8 @@ class UrlTest extends TestCase
         $this->assertFalse(URL::isExternal('http://this-site.com/some-slug'));
         $this->assertFalse(URL::isExternal('/foo'));
         $this->assertFalse(URL::isExternal('#anchor'));
+        $this->assertFalse(URL::isExternal(''));
+        $this->assertFalse(URL::isExternal(null));
     }
 
     public function testDeterminesExternalUrlWhenUsingRelativeInConfig()
@@ -72,6 +74,8 @@ class UrlTest extends TestCase
         $this->assertFalse(URL::isExternal('http://absolute-url-resolved-from-request.com/some-slug'));
         $this->assertFalse(URL::isExternal('/foo'));
         $this->assertFalse(URL::isExternal('#anchor'));
+        $this->assertFalse(URL::isExternal(''));
+        $this->assertFalse(URL::isExternal(null));
     }
 
     /**


### PR DESCRIPTION
An a tag with a blank href will link back to the same page (likewise for form actions), so I don't think blank URLs should be considered external. This PR fixes that.