### PR TITLE
Fix JS error when downloading assets

### DIFF
--- a/resources/js/components/data-list/HasActions.js
+++ b/resources/js/components/data-list/HasActions.js
@@ -6,7 +6,7 @@ export default {
             this.loading = true;
         },
 
-        actionCompleted(successful=null, response) {
+        actionCompleted(successful=null, response={}) {
             this.loading = false;
 
             if (successful === false) return;


### PR DESCRIPTION
There's a JS error in the console when you download assets because `response` is undefined.

![Screenshot 2022-09-08 at 12 18 18](https://user-images.githubusercontent.com/126740/189109757-84f0551c-8ab8-4cb2-8791-3aa8674a4227.png)

This PR fixes that.