### PR TITLE
Fix large drag mirror in assets fieldtype

### DIFF
--- a/resources/sass/components/assets.scss
+++ b/resources/sass/components/assets.scss
@@ -87,7 +87,7 @@
     padding: 16px;
 
     .asset-tile {
-        @apply flex items-center w-full flex-col justify-between cursor-pointer border rounded overflow-hidden;
+        @apply flex items-center flex-col justify-between cursor-pointer border rounded overflow-hidden;
 
         .asset-thumb-container {
             @apply flex items-center flex-1 w-full justify-center relative;


### PR DESCRIPTION
Fixes #6649.

It removes the width: 100% on the .asset-tile, since it doesn't seem to do anything and messes with the drag mirror.