### PR TITLE
Fix 'Add child link to entry' appearing when no collection is set

### DIFF
--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -112,7 +112,7 @@
                     :text="__('Add child nav item')"
                     @click="linkPage(vm)" />
                 <dropdown-item
-                    v-if="depth < maxDepth"
+                    v-if="depth < maxDepth && hasCollections"
                     :text="__('Add child link to entry')"
                     @click="linkEntries(vm)" />
                 <dropdown-item


### PR DESCRIPTION
When adding a child to a nav item the "Add child link to entry" option appears even if no collections are configured. Clicking on this results in a JS error:

![Screenshot 2022-09-08 at 12 58 41](https://user-images.githubusercontent.com/126740/189123653-600ca97d-43f5-404b-b287-632527080965.png)
![Screenshot 2022-09-08 at 12 59 09](https://user-images.githubusercontent.com/126740/189123651-e620165b-5fe9-4073-a2de-970103d30677.png)

This PR fixes that by removing the option if no collections are set.

Closes https://github.com/statamic/cms/issues/4201