### PR TITLE
Asset Browser: Optionally restrict the search to a single folder

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -454,7 +454,7 @@ export default {
             this.loading = true;
 
             const url = this.searchQuery
-                ? cp_url(`assets/browse/search/${this.container.id}`)
+                ? cp_url(`assets/browse/search/${this.container.id}/${this.restrictFolderNavigation ? this.path : ''}`).replace(/\/$/, '')
                 : cp_url(`assets/browse/folders/${this.container.id}/${this.path || ''}`).replace(/\/$/, '');
 
             this.$axios.get(url, { params: this.parameters }).then(response => {

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -134,7 +134,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::post('assets/actions', 'ActionController@run')->name('assets.actions.run');
         Route::post('assets/actions/list', 'ActionController@bulkActions')->name('assets.actions.bulk');
         Route::get('assets/browse', 'BrowserController@index')->name('assets.browse.index');
-        Route::get('assets/browse/search/{asset_container}', 'BrowserController@search');
+        Route::get('assets/browse/search/{asset_container}/{path?}', 'BrowserController@search');
         Route::post('assets/browse/folders/{asset_container}/actions', 'FolderActionController@run')->name('assets.folders.actions.run');
         Route::get('assets/browse/folders/{asset_container}/{path?}', 'BrowserController@folder')->where('path', '.*');
         Route::get('assets/browse/{asset_container}/{path?}/edit', 'BrowserController@edit')->where('path', '.*')->name('assets.browse.edit');

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -86,13 +86,17 @@ class BrowserController extends CpController
         return (new FolderAssetsCollection($assets))->folder($folder);
     }
 
-    public function search(Request $request, $container)
+    public function search(Request $request, $container, $path = null)
     {
         $this->authorize('view', $container);
 
         $query = $container->hasSearchIndex()
             ? $container->searchIndex()->ensureExists()->search($request->search)
             : $container->queryAssets()->where('path', 'like', '%'.$request->search.'%');
+
+        if ($path) {
+            $query->where('folder', $path);
+        }
 
         $assets = $query->paginate(request('perPage'));
 

--- a/tests/Feature/Assets/BrowserTest.php
+++ b/tests/Feature/Assets/BrowserTest.php
@@ -219,7 +219,7 @@ class BrowserTest extends TestCase
             ->makeAsset('nested/subdirectory/asset-three.txt')
             ->upload(UploadedFile::fake()->create('asset-three.txt'));
         $containerTwo
-            ->makeAsset('asset-three.txt')
+            ->makeAsset('asset-four.txt')
             ->upload(UploadedFile::fake()->create('asset-four.txt'));
 
         $this

--- a/tests/Feature/Assets/BrowserTest.php
+++ b/tests/Feature/Assets/BrowserTest.php
@@ -227,7 +227,7 @@ class BrowserTest extends TestCase
 
         $this
             ->actingAs($this->userWithPermission())
-            ->getJson('/cp/assets/browse/search/one/nested?asset')
+            ->getJson('/cp/assets/browse/search/one/nested?search=asset')
             ->assertSuccessful()
             ->assertJsonCount(1, 'data.assets')
             ->assertJsonPath('data.assets.0.id', 'one::nested/asset-two.txt');

--- a/tests/Feature/Assets/BrowserTest.php
+++ b/tests/Feature/Assets/BrowserTest.php
@@ -207,8 +207,14 @@ class BrowserTest extends TestCase
             ->makeAsset('asset-one.txt')
             ->upload(UploadedFile::fake()->create('asset-one.txt'));
         $containerOne
+            ->makeAsset('no-match.txt')
+            ->upload(UploadedFile::fake()->create('no-match.txt'));
+        $containerOne
             ->makeAsset('nested/asset-two.txt')
             ->upload(UploadedFile::fake()->create('asset-two.txt'));
+        $containerOne
+            ->makeAsset('nested/nope.txt')
+            ->upload(UploadedFile::fake()->create('nope.txt'));
         $containerOne
             ->makeAsset('nested/subdirectory/asset-three.txt')
             ->upload(UploadedFile::fake()->create('asset-three.txt'));
@@ -218,7 +224,7 @@ class BrowserTest extends TestCase
 
         $this
             ->actingAs($this->userWithPermission())
-            ->getJson('/cp/assets/browse/search/one?asset')
+            ->getJson('/cp/assets/browse/search/one?search=asset')
             ->assertSuccessful()
             ->assertJsonCount(3, 'data.assets')
             ->assertJsonPath('data.assets.0.id', 'one::asset-one.txt')

--- a/tests/Feature/Assets/BrowserTest.php
+++ b/tests/Feature/Assets/BrowserTest.php
@@ -198,6 +198,42 @@ class BrowserTest extends TestCase
     }
 
     /** @test */
+    public function it_searches_for_assets()
+    {
+        $containerOne = AssetContainer::make('one')->disk('test')->save();
+        $containerTwo = AssetContainer::make('two')->disk('test')->save();
+
+        $containerOne
+            ->makeAsset('asset-one.txt')
+            ->upload(UploadedFile::fake()->create('asset-one.txt'));
+        $containerOne
+            ->makeAsset('nested/asset-two.txt')
+            ->upload(UploadedFile::fake()->create('asset-two.txt'));
+        $containerOne
+            ->makeAsset('nested/subdirectory/asset-three.txt')
+            ->upload(UploadedFile::fake()->create('asset-three.txt'));
+        $containerTwo
+            ->makeAsset('asset-three.txt')
+            ->upload(UploadedFile::fake()->create('asset-four.txt'));
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->getJson('/cp/assets/browse/search/one?asset')
+            ->assertSuccessful()
+            ->assertJsonCount(3, 'data.assets')
+            ->assertJsonPath('data.assets.0.id', 'one::asset-one.txt')
+            ->assertJsonPath('data.assets.1.id', 'one::nested/asset-two.txt')
+            ->assertJsonPath('data.assets.2.id', 'one::nested/subdirectory/asset-three.txt');
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->getJson('/cp/assets/browse/search/one/nested?asset')
+            ->assertSuccessful()
+            ->assertJsonCount(1, 'data.assets')
+            ->assertJsonPath('data.assets.0.id', 'one::nested/asset-two.txt');
+    }
+
+    /** @test */
     public function it_shows_an_assets_edit_page()
     {
         $container = AssetContainer::make('test')->disk('test')->save();
@@ -248,7 +284,7 @@ class BrowserTest extends TestCase
 
     private function userWithPermission()
     {
-        $this->setTestRoles(['test' => ['access cp', 'view test assets']]);
+        $this->setTestRoles(['test' => ['access cp', 'view test assets', 'view one assets', 'view two assets']]);
 
         return User::make()->assignRole('test')->save();
     }


### PR DESCRIPTION
Fixes #6275.

Pretty straightforward. I have one thing I am not sure about though. In `BrowserController@search`, will it be okay to add the where clause `$query->where('folder', $path)` when a search index is used?