### PR TITLE
Fix augmentation test

### DIFF
--- a/tests/Data/AugmentedTestCase.php
+++ b/tests/Data/AugmentedTestCase.php
@@ -61,7 +61,7 @@ class AugmentedTestCase extends TestCase
                     break;
 
                 default:
-                    if (isset($expectation['value'])) {
+                    if (array_key_exists('value', $expectation)) {
                         $this->assertSame(
                             $expectation['value'],
                             $actual,

--- a/tests/Data/Structures/AugmentedPageTest.php
+++ b/tests/Data/Structures/AugmentedPageTest.php
@@ -121,7 +121,7 @@ class AugmentedPageTest extends AugmentedTestCase
 
         $page = Mockery::mock(Page::class);
         $page->shouldReceive('id')->andReturn('page-id');
-        $page->shouldReceive('reference')->andReturnFalse();
+        $page->shouldReceive('reference')->andReturnNull();
         $page->shouldReceive('title')->andReturn('The Page Title');
         $page->shouldReceive('blueprint')->andReturn($blueprint);
         $page->shouldReceive('url')->andReturn('/the-url');


### PR DESCRIPTION
We have an assertion helper to help test augmentation values. I noticed it was behaving incorrectly when reviewing #6666.

When you tried to assert that a value is `null`, it was essentially being skipped. This is because we were using isset instead of array_key_exists. If the value was null, it didn't pass the condition, so basically nothing happens.

There's one place where this was being used, and has been updated.

```php
'entry_id' => ['type' => 'string', 'value' => null],
```

The mock was returning false, which should have caused the test to fail. When adjusting the assertion, it started to fail, showing that the mock was returning the wrong value - it should have been null.

