### PR TITLE
Fix JavaScript error in Popover when resizing

### DIFF
--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -89,8 +89,10 @@ export default {
             }
         },
         destroyPopper() {
-            this.popper.destroy();
-            this.popper = null; 
+            if (this.popper) {
+                this.popper.destroy();
+                this.popper = null;
+            }
         },
     }
 }


### PR DESCRIPTION
There's a bug in Popover.vue which can occur in an entry edit page while resizing the window: "TypeError: Cannot read properties of null (reading 'destroy')". This fixes that.
