### PR TITLE
Ability to override search:results tag query value

### DIFF
--- a/src/Search/Tags.php
+++ b/src/Search/Tags.php
@@ -21,7 +21,7 @@ class Tags extends BaseTags
 
     public function results()
     {
-        if (! $query = request($this->params->get('query', 'q'))) {
+        if (! $query = $this->params->get('value') ?? request($this->params->get('query', 'q'))) {
             return $this->parseNoResults();
         }
 

--- a/src/Search/Tags.php
+++ b/src/Search/Tags.php
@@ -21,7 +21,7 @@ class Tags extends BaseTags
 
     public function results()
     {
-        if (! $query = $this->params->get('value') ?? request($this->params->get('query', 'q'))) {
+        if (! $query = $this->params->get('for') ?? request($this->params->get('query', 'q'))) {
             return $this->parseNoResults();
         }
 


### PR DESCRIPTION
This PR allows you to override the search query _value_ used in the `{{ search:results }}` tag (not the query parameter name).

Not sure if `value` is the right name, `query` would probably be better but that's already taken. Maybe `q` could work?

## Use Case

I've written a spellcheck modifier that I want to use to correct spelling mistakes in search queries before they're run, but at the moment it's not possible to get the corrected query string into the search tag as it will only read a value from the request. 

This PR would allow you to do:

```antlers
{{ search:results :for="get:q | spellcheck" }}
```