### PR TITLE
Fix styling of lists inside tables and blockquotes in bard fields

### DIFF
--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -301,6 +301,8 @@
     }
 
     blockquote,
+    blockquote ol li,
+    blockquote ul li,
     ol li,
     ul li {
         > p {
@@ -359,17 +361,21 @@
     }
 
     ul, 
+    blockquote ul,
     .tableWrapper table ul {
         list-style-type: disc;
     }
 
     ol, 
+    blockquote ol,
     .tableWrapper table ol {
         list-style-type: decimal;
     }
 
     ol,
-    ul {
+    ul,
+    blockquote ol,
+    blockquote ul {
         padding: 0;
         margin: 0;
         margin-bottom: .85em;
@@ -378,6 +384,8 @@
 
     .tableWrapper table ol,
     .tableWrapper table ul {
+        padding: 0;
+        margin: 0;
         padding-left: 2em;
     }
 

--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -358,11 +358,13 @@
         margin-top: 0;
     }
 
-    ul {
+    ul, 
+    .tableWrapper table ul {
         list-style-type: disc;
     }
 
-    ol {
+    ol, 
+    .tableWrapper table ol {
         list-style-type: decimal;
     }
 
@@ -371,6 +373,11 @@
         padding: 0;
         margin: 0;
         margin-bottom: .85em;
+        padding-left: 2em;
+    }
+
+    .tableWrapper table ol,
+    .tableWrapper table ul {
         padding-left: 2em;
     }
 


### PR DESCRIPTION
Lists are valid inside tables and blockquotes, and Bard allows you to add them. Everything works fine except they have no styling due to the CSS only targeting lists that are a direct descendant of the editor.

This PR fixes that.

![Screenshot 2022-09-09 at 15 06 04](https://user-images.githubusercontent.com/126740/189369437-2824fcc7-8d61-4082-86ca-d7e2b0b7f907.png)

I didn't add any bottom margin to the lists inside tables as paragraphs dont have any either.

Related to https://github.com/statamic/cms/pull/6315, that fixed tables inside lists.