### PR TITLE
Adjust date picker value format

### DIFF
--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -29,7 +29,7 @@
                     :popover="{ visibility: 'focus' }"
                     :rows="$screens({ default: 1, lg: config.rows })"
                     :update-on-input="true"
-                    :value="dateString"
+                    :value="datePickerValue"
                     @input="setDate"
                 >
                     <template v-if="!config.inline" v-slot="{ inputValue, inputEvents }">
@@ -154,8 +154,8 @@ export default {
             }
         },
 
-        dateString() {
-            return this.value.split(' ')[0];
+        datePickerValue() {
+            return new Date(this.value.replace(' ', 'T'));
         },
 
         timeString() {

--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -155,7 +155,7 @@ export default {
         },
 
         datePickerValue() {
-            return new Date(this.value.replace(' ', 'T'));
+            return this.value.replace(' ', 'T');
         },
 
         timeString() {


### PR DESCRIPTION
In #6651 I noticed that the day was showing up incorrectly.

e.g. My entry's date was 1996-11-18 but the fieldtype rendered it as 1996-11-17

This is because when you pass a date-only string into `new Date` (which the date component does) then it'll assume you mean UTC. That's why the day turned a little wonky.

If you pass a time into `new Date`, then it'll assume local time, and is why it worked before.

![CleanShot 2022-09-09 at 15 43 05](https://user-images.githubusercontent.com/105211/189431111-e846d00a-8e3f-45be-b735-9706e841ec64.png)

But, it didn't work in Safari, probably because the format was wrong. Looking at the [MDN Date docs page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date), it explains that the time string should have a T in it. `"1970-01-01T12:00"`. Swapping the space for a T fixes it.