### PR TITLE
Fix negative assertion counts

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,12 +24,12 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         }
 
         if ($this->shouldFakeVersion) {
-            \Facades\Statamic\Version::shouldReceive('get')->andReturn('3.0.0-testing');
+            \Facades\Statamic\Version::shouldReceive('get')->zeroOrMoreTimes()->andReturn('3.0.0-testing');
             $this->addToAssertionCount(-1); // Dont want to assert this
         }
 
         if ($this->shouldPreventNavBeingBuilt) {
-            \Statamic\Facades\CP\Nav::shouldReceive('build')->andReturn([]);
+            \Statamic\Facades\CP\Nav::shouldReceive('build')->zeroOrMoreTimes()->andReturn([]);
             $this->addToAssertionCount(-1); // Dont want to assert this
         }
 


### PR DESCRIPTION
In our base test class, we have a couple of mocks that fake the version and nav being built.

In versions of Mockery prior to 1.5.1, this would add an assertion count, but we didn't care about it actually counting it, so we negated it.

For example:

```php
\Facades\Statamic\Version::shouldReceive('get')->andReturn('3.0.0-testing');
$this->addToAssertionCount(-1); // Dont want to assert this
```

In Mockery 1.5.1, they fixed it so that if you aren't actually counting the number of times the method is called, it doesn't consider it an assertion. https://github.com/mockery/mockery/pull/1180

So now our tests can go into the negative.

```
OK (1 test, -1 assertions)
```

We could bump the mockery requirement to 1.5.1 and remove the `$this->addToAssertionCount(-1)`, but it's a bit hairy with all the different versions of Laravel/PHP/etc we test with. The simpler solution was this PR, where we add a `zeroOrMoreTimes` expectation. That'll make sure it gets counted, then we can continue to un-count it.