### PR TITLE
Fix risky test warnings

### DIFF
--- a/tests/Extend/AddonTest.php
+++ b/tests/Extend/AddonTest.php
@@ -144,11 +144,9 @@ class AddonTest extends TestCase
     /** @test */
     public function it_writes_file_contents()
     {
-        $this->expectNotToPerformAssertions();
-
         $addon = $this->makeFromPackage();
 
-        File::shouldReceive('put')->with($this->addonFixtureDir.'test.txt', 'the file contents');
+        File::shouldReceive('put')->with($this->addonFixtureDir.'test.txt', 'the file contents')->once();
 
         $addon->putFile('test.txt', 'the file contents');
     }

--- a/tests/Extend/AddonTest.php
+++ b/tests/Extend/AddonTest.php
@@ -144,6 +144,8 @@ class AddonTest extends TestCase
     /** @test */
     public function it_writes_file_contents()
     {
+        $this->expectNotToPerformAssertions();
+
         $addon = $this->makeFromPackage();
 
         File::shouldReceive('put')->with($this->addonFixtureDir.'test.txt', 'the file contents');

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -29,8 +29,8 @@ class FrontendTest extends TestCase
 
     private function withStandardBlueprints()
     {
-        Blueprint::shouldReceive('in')->withAnyArgs()->andReturn(collect([new \Statamic\Fields\Blueprint]));
         $this->addToAssertionCount(-1);
+        Blueprint::shouldReceive('in')->withAnyArgs()->zeroOrMoreTimes()->andReturn(collect([new \Statamic\Fields\Blueprint]));
     }
 
     /** @test */

--- a/tests/Licensing/AddonLicenseTest.php
+++ b/tests/Licensing/AddonLicenseTest.php
@@ -13,6 +13,7 @@ class AddonLicenseTest extends TestCase
     protected function license($response = [])
     {
         Addon::shouldReceive('get')->with('test/addon')
+            ->zeroOrMoreTimes()
             ->andReturn(new FakeAddonLicenseAddon('Test Addon', '1.2.3', 'rad'));
         $this->addToAssertionCount(-1); // dont need to assert this.
 

--- a/tests/Licensing/LicenseManagerTest.php
+++ b/tests/Licensing/LicenseManagerTest.php
@@ -190,8 +190,8 @@ class LicenseManagerTest extends TestCase
     {
         $outpost = $this->mock(Outpost::class);
 
-        $outpost->shouldReceive('response')->andReturn($response);
         $this->addToAssertionCount(-1); // Dont want to assert this
+        $outpost->shouldReceive('response')->zeroOrMoreTimes()->andReturn($response);
 
         return new LicenseManager($outpost);
     }

--- a/tests/Stache/FeatureTest.php
+++ b/tests/Stache/FeatureTest.php
@@ -2,14 +2,13 @@
 
 namespace Tests\Stache;
 
-use Mockery;
-use Statamic\Contracts\Structures\StructureRepository;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Data;
 use Statamic\Facades\Entry;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Nav;
+use Statamic\Facades\Nav as NavRepository;
 use Statamic\Facades\Structure;
 use Statamic\Facades\Taxonomy;
 use Statamic\Facades\User;
@@ -209,13 +208,9 @@ class FeatureTest extends TestCase
     /** @test */
     public function it_saves_structures()
     {
-        $this->expectNotToPerformAssertions();
-
         $structure = Structure::find('footer');
 
-        $repo = Mockery::mock(StructureRepository::class);
-        $repo->shouldReceive('save')->with($structure);
-        $this->app->instance(StructureRepository::class, $repo);
+        NavRepository::shouldReceive('save')->with($structure)->once();
 
         $structure->save();
     }

--- a/tests/Stache/FeatureTest.php
+++ b/tests/Stache/FeatureTest.php
@@ -209,6 +209,8 @@ class FeatureTest extends TestCase
     /** @test */
     public function it_saves_structures()
     {
+        $this->expectNotToPerformAssertions();
+
         $structure = Structure::find('footer');
 
         $repo = Mockery::mock(StructureRepository::class);


### PR DESCRIPTION
Because of an update to Mockery, we had to fix negative assertion counts in #6689. I noticed when running the suite, we are now getting all these risky test warnings for the same reason (see below). This PR fixes these warnings.

```
There were 15 risky tests:

1) Statamic\Testing\Extend\AddonTest::it_writes_file_contents
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Extend/AddonTest.php:145

2) Tests\Licensing\AddonLicenseTest::it_gets_the_addons_name
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/AddonLicenseTest.php:23

3) Tests\Licensing\AddonLicenseTest::it_gets_the_addons_version
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/AddonLicenseTest.php:29

4) Tests\Licensing\AddonLicenseTest::it_gets_the_addons_edition
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/AddonLicenseTest.php:35

5) Tests\Licensing\AddonLicenseTest::it_checks_if_it_exists_on_the_marketplace
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/AddonLicenseTest.php:41

6) Tests\Licensing\AddonLicenseTest::it_gets_the_version_limit
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/AddonLicenseTest.php:76

7) Tests\Licensing\AddonLicenseTest::it_gets_the_response
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/LicenseTests.php:8

8) Tests\Licensing\AddonLicenseTest::it_checks_if_its_valid
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/LicenseTests.php:16

9) Tests\Licensing\AddonLicenseTest::it_gets_the_invalid_reason
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/LicenseTests.php:23

10) Tests\Licensing\AddonLicenseTest::invalid_reason_is_null_if_there_isnt_one
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/LicenseTests.php:34

11) Tests\Licensing\LicenseManagerTest::it_gets_the_outpost_response
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/LicenseManagerTest.php:18

12) Tests\Licensing\LicenseManagerTest::it_checks_for_public_domains
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/LicenseManagerTest.php:35

13) Tests\Licensing\LicenseManagerTest::it_checks_for_test_domains
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/LicenseManagerTest.php:42

14) Tests\Licensing\LicenseManagerTest::it_checks_if_statamic_license_needs_renewal
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Licensing/LicenseManagerTest.php:135

15) Tests\Stache\FeatureTest::it_saves_structures
This test did not perform any assertions

/Users/jesseleite/Code/Wilderborn/cms/tests/Stache/FeatureTest.php:210
```

I also found that the `StructureRepository::save()` method was never actually getting called in my last commit, but the test was still passing. This must’ve changed when we refactored from Structures to Navigations. I fixed this as well.