### PR TITLE
Merge user data on new OAuth login for an existing user

### DIFF
--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -39,7 +39,7 @@ class Provider
         }
 
         if ($user = User::findByEmail($socialite->getEmail())) {
-            return $this->mergeUser($socialite, $user);
+            return $this->mergeUser($user, $socialite);
         }
 
         return $this->createUser($socialite);
@@ -73,7 +73,7 @@ class Provider
             ->data($this->userData($socialite));
     }
 
-    public function mergeUser($socialite, $user): StatamicUser
+    public function mergeUser($user, $socialite): StatamicUser
     {
         collect($this->userData($socialite))->each(fn ($value, $key) => $user->set($key, $value));
 

--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -38,6 +38,10 @@ class Provider
             return $user;
         }
 
+        if ($user = User::findByEmail($socialite->getEmail())) {
+            return $this->mergeUser($socialite, $user);
+        }
+
         return $this->createUser($socialite);
     }
 
@@ -67,6 +71,17 @@ class Provider
         return User::make()
             ->email($socialite->getEmail())
             ->data($this->userData($socialite));
+    }
+
+    public function mergeUser($socialite, $user): StatamicUser
+    {
+        collect($this->userData($socialite))->each(fn ($value, $key) => $user->set($key, $value));
+
+        $user->save();
+
+        $this->setUserProviderId($user, $socialite->getId());
+
+        return $user;
     }
 
     public function userData($socialite)

--- a/tests/OAuth/ProviderTest.php
+++ b/tests/OAuth/ProviderTest.php
@@ -64,9 +64,9 @@ class ProviderTest extends TestCase
     public function it_makes_a_user()
     {
         $this->assertCount(0, UserFacade::all());
-        
+
         $user = $this->provider()->makeUser($this->socialite());
-        
+
         $this->assertNotNull($user);
         $this->assertEquals('foo@bar.com', $user->email());
         $this->assertEquals('Foo Bar', $user->name());
@@ -78,11 +78,9 @@ class ProviderTest extends TestCase
         $this->assertCount(0, UserFacade::all());
 
         $provider = $this->provider();
-        $provider->withUser(fn ($socialite) =>
-            UserFacade::make()->email($socialite->getEmail())->data(['very' => 'custom'])
-        );
+        $provider->withUser(fn ($socialite) => UserFacade::make()->email($socialite->getEmail())->data(['very' => 'custom']));
         $user = $provider->makeUser($this->socialite());
-        
+
         $this->assertNotNull($user);
         $this->assertEquals('foo@bar.com', $user->email());
         $this->assertEquals(['very' => 'custom'], $user->data()->all());
@@ -92,10 +90,10 @@ class ProviderTest extends TestCase
     public function it_creates_a_user()
     {
         $this->assertCount(0, UserFacade::all());
-        
+
         $provider = $this->provider();
         $provider->createUser($this->socialite());
-        
+
         $this->assertCount(1, UserFacade::all());
         $user = UserFacade::all()->get(0);
         $this->assertNotNull($user);
@@ -124,7 +122,7 @@ class ProviderTest extends TestCase
     /** @test */
     public function it_gets_the_user_by_id_after_merging_data()
     {
-        $provider = $this->provider();
+        $provider = $this->provider() ;
 
         $user = UserFacade::make()->id('foo')->email('foo@bar.com')->data(['name' => 'foo', 'extra' => 'bar'])->save();
 

--- a/tests/OAuth/ProviderTest.php
+++ b/tests/OAuth/ProviderTest.php
@@ -122,7 +122,7 @@ class ProviderTest extends TestCase
     /** @test */
     public function it_gets_the_user_by_id_after_merging_data()
     {
-        $provider = $this->provider() ;
+        $provider = $this->provider();
 
         $user = UserFacade::make()->id('foo')->email('foo@bar.com')->data(['name' => 'foo', 'extra' => 'bar'])->save();
 

--- a/tests/OAuth/ProviderTest.php
+++ b/tests/OAuth/ProviderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\OAuth;
+
+use Statamic\Facades\User as UserFacade;
+use Statamic\OAuth\Provider;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ProviderTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.disks.test' => [
+            'driver' => 'local',
+            'root' => $this->tempDir = __DIR__.'/tmp',
+        ]]);
+    }
+
+    public function tearDown(): void
+    {
+        app('files')->deleteDirectory($this->tempDir);
+        app('files')->deleteDirectory(storage_path('statamic/oauth'));
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_merges_data()
+    {
+        $provider = $this->provider();
+
+        $user = $this->user()->save();
+
+        $provider->mergeUser(new Socialite(), $user);
+
+        $this->assertEquals(['name' => 'Foo Bar', 'extra' => 'bar'], $user->data()->all());
+    }
+
+    /** @test */
+    public function it_finds_an_existing_user_by_email()
+    {
+        $provider = $this->provider();
+
+        $savedUser = $this->user()->save();
+
+        $this->assertCount(1, UserFacade::all());
+        $this->assertEquals([$savedUser], UserFacade::all()->all());
+
+        $foundUser = $provider->findOrCreateUser(new Socialite());
+
+        $this->assertCount(1, UserFacade::all());
+        $this->assertEquals([$savedUser], UserFacade::all()->all());
+        $this->assertEquals($savedUser, $foundUser);
+    }
+
+    /** @test */
+    public function it_finds_the_user_by_id_after_merging_the_data()
+    {
+        $provider = $this->provider();
+
+        $user = UserFacade::make()->id('foo')->email('foo@bar.com')->data(['name' => 'foo', 'extra' => 'bar'])->save();
+
+        $this->assertNull($provider->getUserId('foo-bar'));
+
+        $provider->mergeUser(new Socialite(), $user);
+
+        $this->assertEquals('foo', $provider->getUserId('foo-bar'));
+    }
+
+    private function provider()
+    {
+        return new Provider('test');
+    }
+
+    private function user()
+    {
+        return UserFacade::make()->id('foo')->email('foo@bar.com')->data(['name' => 'foo', 'extra' => 'bar']);
+    }
+}
+
+class Socialite
+{
+    public function getId()
+    {
+        return 'foo-bar';
+    }
+
+    public function getName()
+    {
+        return 'Foo Bar';
+    }
+
+    public function getEmail()
+    {
+        return 'foo@bar.com';
+    }
+}


### PR DESCRIPTION
Fixes #3269.

For any conflicts in the data I've set the merge strategy to "Socialite wins".

