### PR TITLE
Fix asset folder permissions

### DIFF
--- a/src/Policies/AssetFolderPolicy.php
+++ b/src/Policies/AssetFolderPolicy.php
@@ -26,7 +26,8 @@ class AssetFolderPolicy
         }
 
         return $assetFolder
-            ->assets(true)->reject(fn ($asset) => $user->can('move', $asset))
+            ->assets(true)
+            ->reject(fn ($asset) => $user->can('move', $asset))
             ->isEmpty();
     }
 

--- a/src/Policies/AssetFolderPolicy.php
+++ b/src/Policies/AssetFolderPolicy.php
@@ -25,7 +25,7 @@ class AssetFolderPolicy
             return false;
         }
 
-        return $assetFolder->assets()->reject(function ($asset) use ($user) {
+        return $assetFolder->assets(true)->reject(function ($asset) use ($user) {
             return $user->can('move', $asset);
         })->isEmpty();
     }
@@ -38,7 +38,7 @@ class AssetFolderPolicy
             return false;
         }
 
-        return $assetFolder->assets()->reject(function ($asset) use ($user) {
+        return $assetFolder->assets(true)->reject(function ($asset) use ($user) {
             return $user->can('rename', $asset);
         })->isEmpty();
     }
@@ -51,7 +51,7 @@ class AssetFolderPolicy
             return false;
         }
 
-        return $assetFolder->assets()->reject(function ($asset) use ($user) {
+        return $assetFolder->assets(true)->reject(function ($asset) use ($user) {
             return $user->can('delete', $asset);
         })->isEmpty();
     }

--- a/src/Policies/AssetFolderPolicy.php
+++ b/src/Policies/AssetFolderPolicy.php
@@ -17,6 +17,32 @@ class AssetFolderPolicy
         return $assetContainer->createFolders();
     }
 
+    public function move($user, $assetFolder)
+    {
+        $user = User::fromUser($user);
+
+        if (! $user->hasPermission("move {$assetFolder->container()->handle()} assets")) {
+            return false;
+        }
+
+        return $assetFolder->assets()->reject(function ($asset) use ($user) {
+            return $user->can('move', $asset);
+        })->isEmpty();
+    }
+
+    public function rename($user, $assetFolder)
+    {
+        $user = User::fromUser($user);
+
+        if (! $user->hasPermission("rename {$assetFolder->container()->handle()} assets")) {
+            return false;
+        }
+
+        return $assetFolder->assets()->reject(function ($asset) use ($user) {
+            return $user->can('rename', $asset);
+        })->isEmpty();
+    }
+
     public function delete($user, $assetFolder)
     {
         $user = User::fromUser($user);

--- a/src/Policies/AssetFolderPolicy.php
+++ b/src/Policies/AssetFolderPolicy.php
@@ -25,9 +25,9 @@ class AssetFolderPolicy
             return false;
         }
 
-        return $assetFolder->assets(true)->reject(function ($asset) use ($user) {
-            return $user->can('move', $asset);
-        })->isEmpty();
+        return $assetFolder
+            ->assets(true)->reject(fn ($asset) => $user->can('move', $asset))
+            ->isEmpty();
     }
 
     public function rename($user, $assetFolder)
@@ -38,9 +38,10 @@ class AssetFolderPolicy
             return false;
         }
 
-        return $assetFolder->assets(true)->reject(function ($asset) use ($user) {
-            return $user->can('rename', $asset);
-        })->isEmpty();
+        return $assetFolder
+            ->assets(true)
+            ->reject(fn ($asset) => $user->can('rename', $asset))
+            ->isEmpty();
     }
 
     public function delete($user, $assetFolder)
@@ -51,8 +52,9 @@ class AssetFolderPolicy
             return false;
         }
 
-        return $assetFolder->assets(true)->reject(function ($asset) use ($user) {
-            return $user->can('delete', $asset);
-        })->isEmpty();
+        return $assetFolder
+            ->assets(true)
+            ->reject(fn ($asset) => $user->can('delete', $asset))
+            ->isEmpty();
     }
 }


### PR DESCRIPTION
Fixes #6696

The "move" and "rename" asset folder permissions weren't hooked up properly.

Also, the "delete" folder permission was only checking assets in that folder, not nested folders.
