### PR TITLE
Fix cache tag with scope="site" on multisite

### DIFF
--- a/src/Tags/Cache.php
+++ b/src/Tags/Cache.php
@@ -3,6 +3,7 @@
 namespace Statamic\Tags;
 
 use Illuminate\Support\Facades\Cache as LaraCache;
+use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 
 class Cache extends Tags
@@ -34,7 +35,7 @@ class Cache extends Tags
             return false;
         }
 
-        // Only get requests. This disables the cache during live preview.
+        // Only GET requests. This disables the cache during live preview.
         return request()->method() === 'GET';
     }
 
@@ -50,6 +51,10 @@ class Cache extends Tags
         ];
 
         $scope = $this->params->get('scope', 'site');
+
+        if ($scope === 'site') {
+            $hash['site'] = Site::current()->handle();
+        }
 
         if ($scope === 'page') {
             $hash['url'] = URL::makeAbsolute(URL::getCurrent());

--- a/tests/Tags/CacheTagTest.php
+++ b/tests/Tags/CacheTagTest.php
@@ -5,22 +5,28 @@ namespace Tests\Tags;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
 use Statamic\Facades\Config;
+use Statamic\Facades\Endpoint\URL;
 use Statamic\Facades\Parse;
-use Statamic\Facades\Site;
+use Statamic\Facades\User;
+use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class CacheTagTest extends TestCase
 {
+    use PreventSavingStacheItemsToDisk;
+
     /** @test */
-    public function it_caches_its_contents()
+    public function it_caches_its_contents_the_first_time()
     {
+        $template = '{{ cache }}expensive{{ /cache }}';
+
         Cache::shouldReceive('store')->andReturn(
             $this->mock(\Illuminate\Contracts\Cache\Store::class)
                 ->shouldReceive('get')->once()->andReturn(null)
                 ->shouldReceive('put')->once()->with(Mockery::any(), 'expensive', Mockery::any())
                 ->getMock()
         );
-        $this->assertEquals('expensive', $this->tag('{{ cache }}expensive{{ /cache }}'));
+        $this->assertEquals('expensive', $this->tag($template));
     }
 
     /** @test */
@@ -31,6 +37,143 @@ class CacheTagTest extends TestCase
         Cache::shouldReceive('store')->never();
 
         $this->assertEquals('expensive', $this->tag('{{ cache }}expensive{{ /cache }}'));
+    }
+
+    /** @test */
+    public function it_uses_the_cached_content_for_the_same_user_when_using_scope_user()
+    {
+        $template = '{{ cache scope="user" }}expensive{{ /cache }}';
+
+        $this->actingAs(tap(User::make()->id('user1'))->save());
+
+        $this->tag($template);
+
+        Cache::shouldReceive('store')->andReturn(
+            $this->mock(\Illuminate\Contracts\Cache\Store::class)
+                ->shouldReceive('get')->once()->andReturn('expensive')
+                ->getMock()
+        );
+
+        $this->tag($template);
+    }
+
+    /** @test */
+    public function it_does_not_use_the_cached_content_for_a_different_user_when_using_scope_user()
+    {
+        $template = '{{ cache scope="user" }}expensive{{ /cache }}';
+
+        $this->actingAs(tap(User::make()->id('user1'))->save());
+
+        $this->tag($template);
+
+        $this->actingAs(tap(User::make()->id('user2'))->save());
+
+        Cache::shouldReceive('store')->andReturn(
+            $this->mock(\Illuminate\Contracts\Cache\Store::class)
+                ->shouldReceive('get')->once()->andReturn(null)
+                ->shouldReceive('put')->once()->with(Mockery::any(), 'expensive', Mockery::any())
+                ->getMock()
+        );
+
+        $this->tag($template);
+    }
+
+    /** @test */
+    public function it_uses_the_cached_content_for_the_same_page_when_using_scope_page()
+    {
+        $template = '{{ cache scope="page" }}expensive{{ /cache }}';
+
+        $this->mock(URL::class)->shouldReceive('getCurrent')->andReturn('/test/url');
+
+        $this->tag($template);
+
+        Cache::shouldReceive('store')->andReturn(
+            $this->mock(\Illuminate\Contracts\Cache\Store::class)
+                ->shouldReceive('get')->once()->andReturn('expensive')
+                ->getMock()
+        );
+
+        $this->tag($template);
+    }
+
+    /** @test */
+    public function it_does_not_use_the_cached_content_for_a_different_page_when_using_scope_page()
+    {
+        $template = '{{ cache scope="page" }}expensive{{ /cache }}';
+
+        $this->mock(URL::class)->shouldReceive('getCurrent')->andReturn('/test/url');
+
+        $this->tag($template);
+
+        $this->mock(URL::class)->shouldReceive('getCurrent')->andReturn('/some/other/url');
+
+        Cache::shouldReceive('store')->andReturn(
+            $this->mock(\Illuminate\Contracts\Cache\Store::class)
+                ->shouldReceive('get')->once()->andReturn(null)
+                ->shouldReceive('put')->once()->with(Mockery::any(), 'expensive', Mockery::any())
+                ->getMock()
+        );
+
+        $this->tag($template);
+    }
+
+    /** @test */
+    public function it_uses_the_cached_content_for_the_same_site_when_using_scope_site()
+    {
+        $template = '{{ cache scope="site" }}expensive{{ /cache }}';
+
+        $this->mock(Sites::class)->shouldReceive('getCurrent')->andReturn('default');
+
+        $this->tag($template);
+
+        Cache::shouldReceive('store')->andReturn(
+            $this->mock(\Illuminate\Contracts\Cache\Store::class)
+                ->shouldReceive('get')->once()->andReturn('expensive')
+                ->getMock()
+        );
+
+        $this->tag($template);
+    }
+
+    /** @test */
+    public function it_does_not_use_the_cached_content_for_a_different_site_when_using_scope_site()
+    {
+        $template = '{{ cache scope="site" }}expensive{{ /cache }}';
+
+        $this->mock(Sites::class)->shouldReceive('getCurrent')->andReturn('default');
+
+        $this->tag($template);
+
+        $this->mock(Sites::class)->shouldReceive('getCurrent')->andReturn('other');
+
+        Cache::shouldReceive('store')->andReturn(
+            $this->mock(\Illuminate\Contracts\Cache\Store::class)
+                ->shouldReceive('get')->once()->andReturn(null)
+                ->shouldReceive('put')->once()->with(Mockery::any(), 'expensive', Mockery::any())
+                ->getMock()
+        );
+
+        $this->tag($template);
+    }
+
+    /** @test */
+    public function it_uses_the_cached_content_for_a_different_site_when_using_scope_global()
+    {
+        $template = '{{ cache scope="global" }}expensive{{ /cache }}';
+
+        $this->mock(Sites::class)->shouldReceive('getCurrent')->andReturn('default');
+
+        $this->tag($template);
+
+        $this->mock(Sites::class)->shouldReceive('getCurrent')->andReturn('other');
+
+        Cache::shouldReceive('store')->andReturn(
+            $this->mock(\Illuminate\Contracts\Cache\Store::class)
+                ->shouldReceive('get')->once()->andReturn('expensive')
+                ->getMock()
+        );
+
+        $this->tag($template);
     }
 
     // Site::setConfig(['sites' => [

--- a/tests/Tags/CacheTagTest.php
+++ b/tests/Tags/CacheTagTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Tags;
+
+use Illuminate\Support\Facades\Cache;
+use Mockery;
+use Statamic\Facades\Config;
+use Statamic\Facades\Parse;
+use Statamic\Facades\Site;
+use Tests\TestCase;
+
+class CacheTagTest extends TestCase
+{
+    /** @test */
+    public function it_caches_its_contents()
+    {
+        Cache::shouldReceive('store')->andReturn(
+            $this->mock(\Illuminate\Contracts\Cache\Store::class)
+                ->shouldReceive('get')->once()->andReturn(null)
+                ->shouldReceive('put')->once()->with(Mockery::any(), 'expensive', Mockery::any())
+                ->getMock()
+        );
+        $this->assertEquals('expensive', $this->tag('{{ cache }}expensive{{ /cache }}'));
+    }
+
+    /** @test */
+    public function it_skips_the_cache_if_cache_tags_are_not_enabled()
+    {
+        Config::set('statamic.system.cache_tags_enabled', false);
+
+        Cache::shouldReceive('store')->never();
+
+        $this->assertEquals('expensive', $this->tag('{{ cache }}expensive{{ /cache }}'));
+    }
+
+    // Site::setConfig(['sites' => [
+    //     'en' => ['url' => '/'],
+    //     'fr' => ['url' => '/fr'],
+    // ]]);
+
+    private function tag($tag, $data = [])
+    {
+        return (string) Parse::template($tag, $data);
+    }
+}


### PR DESCRIPTION
Fixes #4127. It also adds tests for the `Cache` tag class.

This will make sure that on multisite, a cache tag with scope="site" will cache its contents **per site**. When you do want to cache across all sites, you can use scope="global".