### PR TITLE
Improve handling of invalid Replicator and Bard field data

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -5,10 +5,10 @@
         contenteditable="false" @copy.stop @paste.stop @cut.stop
     >
         <div ref="content" hidden />
-        <div class="replicator-set-header" :class="{'collapsed': collapsed}">
+        <div class="replicator-set-header" :class="{'collapsed': collapsed, 'invalid': isInvalid }">
             <div class="item-move sortable-handle" data-drag-handle />
-            <div class="flex-1 p-1" :class="{'flex items-center': collapsed}" @dblclick="toggleCollapsedState">
-                <label v-text="config.display || config.handle" class="text-xs whitespace-no-wrap mr-1"/>
+            <div class="flex-1 p-1 replicator-set-header-inner" :class="{'flex items-center': collapsed}" @dblclick="toggleCollapsedState">
+                <label v-text="display || config.handle" class="text-xs whitespace-no-wrap mr-1"/>
                 <div
                     v-if="config.instructions"
                     v-show="!collapsed"
@@ -86,6 +86,10 @@ export default {
             return this.config.fields;
         },
 
+        display() {
+            return this.config.display || this.values.type;
+        },
+
         values() {
             return this.node.attrs.values;
         },
@@ -103,7 +107,7 @@ export default {
         },
 
         config() {
-            return _.findWhere(this.setConfigs, { handle: this.values.type });
+            return _.findWhere(this.setConfigs, { handle: this.values.type }) || {};
         },
 
         enabled: {
@@ -133,6 +137,10 @@ export default {
 
         showFieldPreviews() {
             return this.options.bard.config.previews;
+        },
+
+        isInvalid() {
+            return Object.keys(this.config).length === 0;
         }
 
     },

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -4,10 +4,10 @@
 
         <slot name="picker" />
 
-        <div class="replicator-set-header" :class="{ 'p-1': isReadOnly, 'collapsed': collapsed }">
+        <div class="replicator-set-header" :class="{ 'p-1': isReadOnly, 'collapsed': collapsed, 'invalid': isInvalid }">
             <div class="item-move sortable-handle" :class="sortableHandleClass" v-if="!isReadOnly"></div>
-            <div class="flex-1 p-1" :class="{'flex items-center': collapsed}" @dblclick="toggleCollapsedState">
-                <label v-text="config.display || config.handle" class="text-xs whitespace-no-wrap mr-1"/>
+            <div class="flex-1 p-1 replicator-set-header-inner" :class="{'flex items-center': collapsed}" @dblclick="toggleCollapsedState">
+                <label v-text="display || config.handle" class="text-xs whitespace-no-wrap mr-1"/>
                 <div
                     v-if="config.instructions"
                     v-show="!collapsed"
@@ -150,6 +150,10 @@ export default {
 
         isHidden() {
             return this.values['#hidden'] === true;
+        },
+
+        isInvalid() {
+            return Object.keys(this.config).length === 0;
         },
 
         classes() {

--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -16,6 +16,10 @@
     @apply p-1 min-h-48;
 }
 
+.bard-editor .bard-invalid {
+    @apply p-1 bg-red-lighter text-red text-xs whitespace-no-wrap;
+}
+
 // Modes
 .bard-editor.mode\:read-only .ProseMirror {
     @apply bg-grey-30 text-grey-70;
@@ -28,6 +32,7 @@
 // Responive Wangjangling
 @screen md {
     .bard-editor .ProseMirror { @apply p-2; }
+    .bard-editor .bard-invalid { @apply px-2; }
 }
 
 .bard-fixed-toolbar {

--- a/resources/sass/components/fieldtypes/replicator.scss
+++ b/resources/sass/components/fieldtypes/replicator.scss
@@ -40,6 +40,15 @@
             bottom: 1px;
         }
     }
+
+    &.invalid {
+        .replicator-set-header-inner {
+            @apply bg-red-lighter;
+            label {
+                @apply text-red;
+            }
+        }
+    }
 }
 
 .replicator-set-body {


### PR DESCRIPTION
When a Replicator or Bard field contains invalid data, for example a set that has no configuration or a node for an extension that isn’t enabled, the feedback in the CP can be a little mysterious:

- Replicator fields with an invalid set will render an empty item:
  ![Screenshot 2022-09-13 at 12 27 00](https://user-images.githubusercontent.com/126740/189889789-cd2cb44f-e50b-4840-9609-ce15eaea1258.png)
- Bard fields with an invalid set will render the raw json (because the `BardSet` component errors):
  ![Screenshot 2022-09-13 at 12 27 07](https://user-images.githubusercontent.com/126740/189889812-e1be6606-f75a-430e-9110-74b160c4937f.png)
- Bard fields with invalid nodes/marks end up with a completely blank value.

This PR aims to improve this by fixing the `BardSet` error, checking for invalid data, and adding invalid states (a bit like the Entries and Assets fieldtypes have):

![Screenshot 2022-09-13 at 10 07 31](https://user-images.githubusercontent.com/126740/189889838-84a7c3d0-3c65-4640-9702-379648581ccd.png)

The idea was just to give a bit of a hint about what the problem is, but more details could be added or logged to the console. Tiptap already logs errors when it runs into invalid nodes/marks.

Here is a blueprint and entry for testing invalid values: https://gist.github.com/jacksleight/8d936be1f4966ca9833cbcf52dd697ec

Fixes https://github.com/statamic/cms/issues/6143