### PR TITLE
Fix Live Preview with `nocache` tag when entry is draft

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -46,22 +46,17 @@ class Cache
 
         $response = $next($request);
 
-        if ($this->shouldBeCached($request, $response)) {
-            $this->makeReplacementsAndCacheResponse($request, $response);
-
-            $this->nocache->write();
-        }
-
-        return $response;
-    }
-
-    private function makeReplacementsAndCacheResponse($request, $response)
-    {
         $cachedResponse = clone $response;
 
         $this->getReplacers()->each(fn (Replacer $replacer) => $replacer->prepareResponseToCache($cachedResponse, $response));
 
-        $this->cacher->cachePage($request, $cachedResponse);
+        $this->nocache->write();
+
+        if ($this->shouldBeCached($request, $response)) {
+            $this->cacher->cachePage($request, $cachedResponse);
+        }
+
+        return $response;
     }
 
     private function getReplacers(): Collection


### PR DESCRIPTION
If an entry is a draft and the entry's template uses the `nocache` tag, then you see the nocache placeholder when in Live Preview.

This fixes it.

**NOTE**: @jasonvarga gave me this code, hoping he can explain it.