### PR TITLE
Fix asset replicator preview

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -326,6 +326,8 @@ export default {
                 this.initializing = false;
                 this.loading = false;
             });
+
+            this.$emit('replicator-preview-updated', this.replicatorPreview);
         },
 
         /**


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/6730

The issue seems to be that `replicatorPreview` is being read before `initializeAssets` is run, so `this.assets` is empty.

I'm no vue expert, but I thought `replicatorPreview`should react when `this.assets` changes, but that doesn't seem to be happening. There may be a better way to fix this, but emitting `replicator-preview-updated` at the end of `initializeAssets` seems to work.