### PR TITLE
Improve display of Grid and Replicator replicator preview

### DIFF
--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -113,6 +113,10 @@ export default {
             return !this.isReadOnly && this.config.reorderable && this.maxRows > 1
         },
 
+        replicatorPreview() {
+            return `${this.value.length} ${this.config.display}`;
+        }
+
     },
 
     reactiveProvide: {

--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -194,10 +194,6 @@ export default {
             this.update(rows);
         },
 
-        getReplicatorPreviewText() {
-            // TODO
-        },
-
         focus() {
             // TODO
         },

--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -114,7 +114,7 @@ export default {
         },
 
         replicatorPreview() {
-            return `${this.value.length} ${this.config.display}`;
+            return this.value.length + ' ' + this.config.display;
         }
 
     },

--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -114,7 +114,7 @@ export default {
         },
 
         replicatorPreview() {
-            return this.value.length + ' ' + this.config.display;
+            return `${this.config.display}: ${__n(':count row|:count rows', this.value.length)}`;
         }
 
     },

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -121,7 +121,7 @@ export default {
         },
 
         replicatorPreview() {
-            return this.value.length + ' ' + this.config.display;
+            return `${this.config.display}: ${__n(':count set|:count sets', this.value.length)}`;
         }
     },
 

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -118,6 +118,10 @@ export default {
 
         storeState() {
             return this.$store.state.publish[this.storeName] || {};
+        },
+
+        replicatorPreview() {
+            return `${this.value.length} ${this.config.display}`;
         }
     },
 

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -121,7 +121,7 @@ export default {
         },
 
         replicatorPreview() {
-            return `${this.value.length} ${this.config.display}`;
+            return this.value.length + ' ' + this.config.display;
         }
     },
 


### PR DESCRIPTION
The replicator preview for grid and replicator fields isn't very useful/user friendly:

![Screenshot 2022-09-16 at 14 16 33](https://user-images.githubusercontent.com/126740/190647881-1ca68f91-d01a-4bde-9b8a-56bbe0fc5a79.png)

This PR implements a very simple alternative, just showing the count and field display name:

![Screenshot 2022-09-16 at 14 16 44](https://user-images.githubusercontent.com/126740/190648026-925bead3-e496-40ef-9dd6-d0284466c0ce.png)
![Screenshot 2022-09-16 at 14 28 08](https://user-images.githubusercontent.com/126740/190650027-24a5db36-6bda-4ab5-a668-a9f4d7fdda64.png)

Not as fancy as maybe displaying values from a field in each row/set, which would be really nice, but I'm not sure if there's a simple way to do that.

## SIdenote

When working on this I noticed that there are `getReplicatorPreviewText()` methods in the List, Assets and Grid fieldtypes. The one in grid was empty. I implemented this with a `replicatorPreview` computed property as per the docs. I'm not really sure what `getReplicatorPreviewText()` is for or even where it's called from?