### PR TITLE
Fix live preview scroll position handling when url contains a port number

### DIFF
--- a/resources/js/components/live-preview/UpdatesIframe.js
+++ b/resources/js/components/live-preview/UpdatesIframe.js
@@ -14,7 +14,7 @@ export default {
                 return;
             }
 
-            let isSameOrigin = url.startsWith('/') || new URL(url).hostname === window.location.host;
+            let isSameOrigin = url.startsWith('/') || new URL(url).host === window.location.host;
 
             let scroll = isSameOrigin ? [
                 container.firstChild.contentWindow.scrollX ?? 0,


### PR DESCRIPTION
This PR fixes an issue with live preview not restoring the scroll position when site url contains a port number, e.g. `localhost:8080`.

PR #6282 introduced a same origin check which compares the iframe url `hostname` with `window.host`, which may return a port number. Same Origin fails when port number is not the same. 

https://github.com/statamic/cms/blob/68ba9d4686fae18293b4dff566cfdd83b4b0dec7/resources/js/components/live-preview/UpdatesIframe.js#L17
