### PR TITLE
Add custom build directory and hot file to Vite tag

### DIFF
--- a/src/Tags/Vite.php
+++ b/src/Tags/Vite.php
@@ -16,7 +16,14 @@ class Vite extends Tags
         if (! $src = $this->params->explode('src')) {
             throw new \Exception('Please provide a source file.');
         }
+        
+        $directory = $this->params->get('directory');
+        $hot = $this->params->get('hot');
 
-        return app(LaravelVite::class)($src);
+        return app(LaravelVite::class)
+            ->withEntryPoints($src)
+            ->useBuildDirectory($directory)
+            ->useHotFile($hot)
+            ->toHtml();
     }
 }

--- a/src/Tags/Vite.php
+++ b/src/Tags/Vite.php
@@ -17,13 +17,13 @@ class Vite extends Tags
             throw new \Exception('Please provide a source file.');
         }
 
-        $directory = $this->params->get('directory');
+        $directory = $this->params->get('directory', 'build');
         $hot = $this->params->get('hot');
 
         return app(LaravelVite::class)
             ->withEntryPoints($src)
             ->useBuildDirectory($directory)
-            ->useHotFile($hot)
+            ->useHotFile($hot ? base_path($hot) : null)
             ->toHtml();
     }
 }

--- a/src/Tags/Vite.php
+++ b/src/Tags/Vite.php
@@ -16,7 +16,7 @@ class Vite extends Tags
         if (! $src = $this->params->explode('src')) {
             throw new \Exception('Please provide a source file.');
         }
-        
+
         $directory = $this->params->get('directory');
         $hot = $this->params->get('hot');
 


### PR DESCRIPTION
Closes https://github.com/statamic/ideas/issues/866

Adds the ability to set a custom build directory and hot file location via Laravel's Vite implementation. Requires [laravel/vite-plugin](https://github.com/laravel/vite-plugin/releases/tag/v0.6.0) >=0.6.

Example usage:
```antlers
{{ vite src="resources/css/tailwind.css|resources/js/site.js" directory="bundle" hot="storage/vite.hot" }}
```