### PR TITLE
Add `{{ glide:data }}` tag to generate data URIs

### DIFF
--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -88,6 +88,20 @@ class Glide extends Tags
     }
 
     /**
+     * Maps to {{ glide:data }}.
+     *
+     * Converts a Glide image to a data URI.
+     *
+     * @return string
+     */
+    public function data()
+    {
+        $item = $this->params->get(['src', 'id', 'path']);
+
+        return $this->generateGlideDataUri($item);
+    }
+
+    /**
      * Maps to {{ glide:generate }} ... {{ /glide:generate }}.
      *
      * Generates the image and makes variables available within the pair.
@@ -173,6 +187,29 @@ class Glide extends Tags
         }
 
         $url = ($this->params->bool('absolute', $this->useAbsoluteUrls())) ? URL::makeAbsolute($url) : URL::makeRelative($url);
+
+        return $url;
+    }
+
+    /**
+     * The data URI generation.
+     *
+     * @param  string  $item  Either the ID or path of the image.
+     * @return string
+     */
+    private function generateGlideDataUri($item)
+    {
+        $path = $this->generateImage($item);
+        $cache = GlideManager::cacheDisk();
+
+        try {
+            $source = $cache->read($path);
+            $url = 'data:'.$cache->mimeType($path).';base64,'.base64_encode($source);
+        } catch (\Exception $e) {
+            \Log::error($e->getMessage());
+
+            return;
+        }
 
         return $url;
     }

--- a/tests/Tags/GlideTest.php
+++ b/tests/Tags/GlideTest.php
@@ -48,6 +48,20 @@ class GlideTest extends TestCase
         $this->assertEquals('https://localhost/glide/paths/bar.jpg/689e9cd88cc1d852c9a4d3a1e27d68c2.jpg', $this->absoluteTestTag(true));
     }
 
+    /**
+     * @test
+     */
+    public function it_outputs_a_data_uri()
+    {
+        $this->createImageInPublicDirectory();
+
+        $tag = <<<'EOT'
+{{ glide:data :src="foo" }}
+EOT;
+
+        $this->assertStringStartsWith('data:image/jpeg;base64', (string) Parse::template($tag, ['foo' => 'bar.jpg']));
+    }
+
     public function relativeRouteUrl($app)
     {
         $this->configureGlideCacheDiskWithUrl($app, '/glide');


### PR DESCRIPTION
This PR adds a `{{ glide:data }}` tag, which returns the manipulated image as a data URI:

```antlers
{{ glide:data src="assets/donut.jpg" width="2" height="2" format="gif" }}
```
```
data:image/gif;base64,R0lGODlhAgACAJEAALwWrOQqhOwqhP///yH5BAEAAAMALAAAAAACAAIAAAIDBBIFADs=
```

Closes https://github.com/statamic/ideas/issues/869