### PR TITLE
Fix action value processing

### DIFF
--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -102,7 +102,7 @@ abstract class Action implements Arrayable
             'warningText' => $this->warningText(),
             'dangerous' => $this->dangerous,
             'fields' => $this->fields()->toPublishArray(),
-            'values' => $this->fields()->values(),
+            'values' => $this->fields()->preProcess()->values(),
             'meta' => $this->fields()->meta(),
             'context' => $this->context,
         ];

--- a/src/Http/Controllers/CP/ActionController.php
+++ b/src/Http/Controllers/CP/ActionController.php
@@ -33,7 +33,9 @@ abstract class ActionController extends CpController
 
         abort_unless($unauthorized->isEmpty(), 403, __('You are not authorized to run this action.'));
 
-        $response = $action->run($items, $values = $request->all());
+        $values = $action->fields()->addValues($request->all())->process()->values()->all();
+
+        $response = $action->run($items, $values);
 
         if ($redirect = $action->redirect($items, $values)) {
             return ['redirect' => $redirect];


### PR DESCRIPTION
This PR will pre- and post-process action values.

If you were to add, for example, an `assets` field to an action, it wouldn't be preprocessed. ie. It wouldn't default to an empty array, and there'd be an error when you try to use the field.

Post-processing is also added. Again, if you were to submit an assets field with a max_files option of 1, you _should_ receive just the string. But you didn't, you got an array with a single item in it. Adding processing fixes it.

This would be a "breaking" change if you were relying on the incorrect behavior. However I'm just considering this a bug fix.

For simple fields, like text fields, which are mainly what's used within action modals, the lack of processing wouldn't make a difference, which is why this went unnoticed.

(Needed for #4832)