### PR TITLE
Allow starter kits to run console commands

### DIFF
--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -486,10 +486,10 @@ final class Installer
             return $this;
         }
 
-        $klass = $hook[0];
+        $class = $hook[0];
         $method = $hook[1];
 
-        (new $klass)->$method($this->console);
+        (new $class)->$method($this->console);
 
         return $this;
     }

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -470,7 +470,7 @@ final class Installer
     }
 
     /**
-     * Run any post install hooks defined in the starter kit
+     * Run any post install hooks defined in the starter kit.
      *
      * @return $this
      */

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -482,7 +482,7 @@ final class Installer
 
         (new $hook)->handle($this->console);
 
-        $reflector = new ReflectionClass($hook);
+        $reflector = new \ReflectionClass($hook);
         unlink($reflector->getFileName());
 
         return $this;

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -480,16 +480,7 @@ final class Installer
             return $this;
         }
 
-        $hook = explode('::', $hook);
-
-        if (count($hook) != 2) {
-            return $this;
-        }
-
-        $class = $hook[0];
-        $method = $hook[1];
-
-        (new $class)->$method($this->console);
+        (new $hook)->handle($this->console);
 
         return $this;
     }

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -140,6 +140,7 @@ final class Installer
             ->installDependencies()
             ->makeSuperUser()
             ->reticulateSplines()
+            ->runAfterInstallHook()
             ->removeStarterKit()
             ->removeRepository()
             ->removeComposerJsonBackup()
@@ -464,6 +465,31 @@ final class Installer
         if (config('app.env') !== 'testing') {
             sleep(2);
         }
+
+        return $this;
+    }
+
+    /**
+     * Run any post install hooks defined in the starter kit
+     *
+     * @return $this
+     */
+    protected function runAfterInstallHook()
+    {
+        if (! $hook = $this->config('after_install_hook')) {
+            return $this;
+        }
+
+        $hook = explode('::', $hook);
+
+        if (count($hook) != 2) {
+            return $this;
+        }
+
+        $klass = $hook[0];
+        $method = $hook[1];
+
+        (new $klass)->$method($this->console);
 
         return $this;
     }

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -482,6 +482,9 @@ final class Installer
 
         (new $hook)->handle($this->console);
 
+        $reflector = new ReflectionClass($hook);
+        unlink($reflector->getFileName());
+
         return $this;
     }
 


### PR DESCRIPTION
Opening this as a draft as you may want an entirely different approach.

This PR allows starter kits to specify an `after_install_hook` key which is a class name and method (`\App\Hooks\MyHook::handle`) which receives the console as an argument so further input can be requested.

As requested here: https://github.com/statamic/ideas/issues/863