### PR TITLE
Antlers: Fixes using prefixed variables in conditions

### DIFF
--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -1171,12 +1171,12 @@ class Environment
      */
     private function scopeValue($name, $originalNode = null)
     {
+        if (! empty(GlobalRuntimeState::$prefixState)) {
+            $this->dataRetriever->setHandlePrefixes(array_reverse(GlobalRuntimeState::$prefixState));
+        }
+
         if ($name instanceof VariableReference) {
             if (! $this->isEvaluatingTruthValue) {
-                if (! empty(GlobalRuntimeState::$prefixState)) {
-                    $this->dataRetriever->setHandlePrefixes(array_reverse(GlobalRuntimeState::$prefixState));
-                }
-
                 $this->dataRetriever->setReduceFinal(false);
             }
 

--- a/tests/Antlers/Runtime/PrefixedFieldsTest.php
+++ b/tests/Antlers/Runtime/PrefixedFieldsTest.php
@@ -28,6 +28,19 @@ class PrefixedFieldsTest extends ParserTestCase
         ];
     }
 
+    public function test_scope_prefixes_work_inside_conditions()
+    {
+        $template = <<<'EOT'
+{{ scope handle_prefix="prefix_" }}
+<Title: {{ title }}><Condition: {{ if title }}{{title}}{{ /if }}{{ /scope }}>
+EOT;
+
+        $this->assertSame(
+            '<Title: Prefix: Title><Condition: Prefix: Title>',
+            trim($this->renderString($template, $this->data, true))
+        );
+    }
+
     public function test_scope_prefixes_can_apply_to_array_vars()
     {
         $template = <<<'EOT'


### PR DESCRIPTION
This PR fixes #6759 by modifying where handle prefixes are injected into the ConditionProcessor.

The following will now work as expected if a variable named `prefixed_title` exists:

```antlers
{{ scope handle_prefx="prefixed_" }}

   {{# This will now properly check if the variable "prefixed_title" exists. #}}
   {{ if title }}
       {{ title }}
   {{ /if }}

{{ /scope }}
```
