### PR TITLE
Add key_by modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1341,6 +1341,20 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Rekeys an array or collection.
+     *
+     * @param $value
+     * @param $params
+     * @return string
+     */
+    public function keyBy($value, $params)
+    {
+        $rekeyed = collect($value)->keyBy(fn ($item) => $item[$params[0]]);
+
+        return is_array($value) ? $rekeyed->all() : $rekeyed;
+    }
+
+    /**
      * Returns the last $params[0] characters of a string, or the last element of an array.
      *
      * @param $value

--- a/tests/Modifiers/KeyByTest.php
+++ b/tests/Modifiers/KeyByTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Illuminate\Support\Collection;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class KeyByTest extends TestCase
+{
+    /** @test */
+    public function it_rekeys_an_array(): void
+    {
+        $modified = $this->modify([
+            ['handle' => 'one', 'title' => 'One'],
+            ['handle' => 'two', 'title' => 'Two'],
+        ], 'handle');
+
+        $this->assertEquals([
+            'one' => ['handle' => 'one', 'title' => 'One'],
+            'two' => ['handle' => 'two', 'title' => 'Two'],
+        ], $modified);
+    }
+
+    /** @test */
+    public function it_rekeys_a_collection(): void
+    {
+        $modified = $this->modify(collect([
+            ['handle' => 'one', 'title' => 'One'],
+            ['handle' => 'two', 'title' => 'Two'],
+        ]), 'handle');
+
+        $this->assertInstanceOf(Collection::class, $modified);
+        $this->assertEquals([
+            'one' => ['handle' => 'one', 'title' => 'One'],
+            'two' => ['handle' => 'two', 'title' => 'Two'],
+        ], $modified->all());
+    }
+
+    private function modify($value, $key)
+    {
+        return Modify::value($value)->keyBy($key)->fetch();
+    }
+}


### PR DESCRIPTION
This adds a `key_by` modifier that basically calls keyBy on a collection.

A use case might be to target specific values of a numerically indexed array, like the `fields` loop in a form tag.

```antlers
{{ rekeyed = fields | key_by('handle') }}

<div class="foo-field">
  {{ rekeyed:foo:display }}
</div>

<div class="bar-field">
  {{ rekeyed:bar:display }}
</div>
```
