### PR TITLE
Fix svg asset replicator preview and add Set Alt option

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -66,7 +66,7 @@ export default {
 
     computed: {
         needsAlt() {
-            return this.asset.isImage && !this.asset.values.alt;
+            return (this.asset.isImage || this.asset.isSvg) && !this.asset.values.alt;
         }
     }
 };

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -130,7 +130,7 @@ export default {
         },
 
         needsAlt() {
-            return this.asset.isImage && !this.asset.values.alt;
+            return (this.asset.isImage || this.asset.isSvg) && !this.asset.values.alt;
         }
     }
 };

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -316,7 +316,7 @@ export default {
 
         replicatorPreview() {
             return _.map(this.assets, (asset) => {
-                return asset.isImage ?
+                return (asset.isImage || asset.isSvg) ?
                     `<img src="${asset.thumbnail}" width="20" height="20" title="${asset.basename}" />`
                     : asset.basename;
             }).join(', ');


### PR DESCRIPTION
SVG assets just display their names in the replicator preview:
 
![Screenshot 2022-09-22 at 13 53 43](https://user-images.githubusercontent.com/126740/191752378-702ece52-ff20-4a79-99d8-57716ed078b1.png)

This PR fixes that:

![Screenshot 2022-09-22 at 13 53 21](https://user-images.githubusercontent.com/126740/191752419-ad3d9c7d-98ea-4b0d-bbb3-b1efe7b06efe.png)

I've also enabled the Set Alt option for SVGs. I thought it made sense as they can be used as regular images in an `img` tag, so alt text could be applicable. 