### PR TITLE
Fix shallow Bard set drag and drop ghost in Chrome

### DIFF
--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -178,9 +178,8 @@
     }
 }
 
-.bard-set {
-    position: relative;
-    z-index: 0;
+.bard-set:active .popover {
+    display: none;
 }
 
 .bard-set.has-error > .replicator-set-header label {

--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -178,6 +178,11 @@
     }
 }
 
+.bard-set {
+    position: relative;
+    z-index: 0;
+}
+
 .bard-set.has-error > .replicator-set-header label {
     color: $color_red;
 }


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/6775

As mentioned in the issue this appears to be due to a Chrome bug. Based on the suggestion in a [comment I found](https://bugs.chromium.org/p/chromium/issues/detail?id=605119#c13) in a related bug report I've added ` position: relative; z-index: 0;` to the set element, which seems to fix it.