### PR TITLE
Fix Bard set menu options not working

### DIFF
--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -183,7 +183,7 @@
     }
 }
 
-.bard-set:active .popover {
+.bard-set:active .sortable-handle:hover ~ * .popover {
     display: none;
 }
 


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/6778

This is an tweak to the fix in https://github.com/statamic/cms/pull/6776, works exactly the same way but it only applies the `display: none` when the sort handle is being hovered, that way it has no impact on other things that could cause the set element to be active (like the popover options).