### PR TITLE
Fix asset browse button inside link feldtype

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -322,7 +322,7 @@ export default {
             while (true) {
                 let parent = vm.$parent;
 
-                if (! parent) return false;           
+                if (! parent) return false;
 
                 if (parent.config.type === 'link') {
                     return true;
@@ -343,9 +343,7 @@ export default {
         showPicker() {
             if (this.maxFilesReached && ! this.isFullWidth) return false
 
-            if (this.maxFilesReached && this.isInGridField) return false
-
-            if (this.maxFilesReached && this.isInLinkField) return false
+            if (this.maxFilesReached && (this.isInGridField || this.isInLinkField)) return false
 
             return true
         },

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -316,6 +316,22 @@ export default {
             }
         },
 
+        isInLinkField() {
+            let vm = this;
+
+            while (true) {
+                let parent = vm.$parent;
+
+                if (! parent) return false;           
+
+                if (parent.config.type === 'link') {
+                    return true;
+                }
+
+                vm = parent;
+            }
+        },
+
         replicatorPreview() {
             return _.map(this.assets, (asset) => {
                 return (asset.isImage || asset.isSvg) ?
@@ -328,6 +344,8 @@ export default {
             if (this.maxFilesReached && ! this.isFullWidth) return false
 
             if (this.maxFilesReached && this.isInGridField) return false
+
+            if (this.maxFilesReached && this.isInLinkField) return false
 
             return true
         },


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/6786

For some reason checking `parent.constructor.name` like in the Bard check doesn't work, always comes back as `VueComponent` not `LinkFieldtype`. Which is why this is checking `config.type` instead.