### PR TITLE
Fix asset selector grid columns

### DIFF
--- a/resources/sass/components/assets.scss
+++ b/resources/sass/components/assets.scss
@@ -124,6 +124,10 @@
 }
 
 @screen 2xl {
+    .asset-grid-listing {
+        @apply grid-cols-6;
+    }
+
     .asset-manager .asset-grid-listing {
         @apply grid-cols-8;
     }


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/6789

This reinstates the 6 column asset grid in the selector at the 2xl breakpoint.

Looks like the selector uses slightly fewer columns per breakpoint than the assets section does, so this follows that convention.

TBH I feel like the breakpoints/columns could be exactly the same as the asset section, there's just as much width available, but I'll leave that to your judgment.