### PR TITLE
Starter kit post-install hooks

### DIFF
--- a/src/StarterKits/Exporter.php
+++ b/src/StarterKits/Exporter.php
@@ -201,12 +201,8 @@ class Exporter
         $hooks = ['StarterKitPostInstall.php'];
 
         collect($hooks)
-            ->filter(function ($hook) {
-                return $this->files->exists(base_path($hook));
-            })
-            ->each(function ($hook) {
-                $this->copyPath($hook);
-            });
+            ->filter(fn ($hook) => $this->files->exists(base_path($hook)))
+            ->each(fn ($hook) => $this->copyPath($hook));
 
         return $this;
     }

--- a/src/StarterKits/Exporter.php
+++ b/src/StarterKits/Exporter.php
@@ -43,6 +43,7 @@ class Exporter
         $this
             ->exportFiles()
             ->exportConfig()
+            ->exportHooks()
             ->exportComposerJson();
     }
 
@@ -186,6 +187,26 @@ class Exporter
         $config = $this->exportDependenciesFromComposerJson($config);
 
         $this->files->put("{$this->exportPath}/starter-kit.yaml", YAML::dump($config->all()));
+
+        return $this;
+    }
+
+    /**
+     * Export starter kit hooks.
+     *
+     * @return $this
+     */
+    protected function exportHooks()
+    {
+        $hooks = ['StarterKitPostInstall.php'];
+
+        collect($hooks)
+            ->filter(function ($hook) {
+                return $this->files->exists(base_path($hook));
+            })
+            ->each(function ($hook) {
+                $this->copyPath($hook);
+            });
 
         return $this;
     }

--- a/src/StarterKits/Hook.php
+++ b/src/StarterKits/Hook.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Statamic\StarterKits;
+
+class Hook
+{
+    public function find($path)
+    {
+        if (app('files')->exists($path)) {
+            require_once $path;
+        }
+
+        $class = pathinfo($path, PATHINFO_FILENAME);
+
+        if (! class_exists($class)) {
+            return null;
+        }
+
+        return new $class;
+    }
+}

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -320,6 +320,7 @@ final class Installer
 
         if ($this->withConfig) {
             $this->copyStarterKitConfig();
+            $this->copyStarterKitHooks();
         }
 
         return $this;
@@ -345,6 +346,10 @@ final class Installer
      */
     protected function copyStarterKitConfig()
     {
+        if (! $this->withConfig) {
+            return;
+        }
+
         if ($this->withoutDependencies) {
             return $this->copyFile($this->starterKitPath('starter-kit.yaml'), base_path('starter-kit.yaml'));
         }
@@ -366,6 +371,26 @@ final class Installer
         }
 
         $this->files->put(base_path('starter-kit.yaml'), YAML::dump($config->all()));
+    }
+
+    /**
+     * Copy starter kit hook scripts.
+     */
+    protected function copyStarterKitHooks()
+    {
+        if (! $this->withConfig) {
+            return;
+        }
+
+        $hooks = ['StarterKitPostInstall.php'];
+
+        collect($hooks)
+            ->filter(function ($hook) {
+                return $this->files->exists($this->starterKitPath($hook));
+            })
+            ->each(function ($hook) {
+                $this->copyFile($this->starterKitPath($hook), base_path($hook));
+            });
     }
 
     /**

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -3,6 +3,7 @@
 namespace Statamic\StarterKits;
 
 use Facades\Statamic\Console\Processes\Composer;
+use Facades\Statamic\StarterKits\Hook;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Http;
 use Statamic\Console\NullConsole;
@@ -460,17 +461,7 @@ final class Installer
      */
     protected function runPostInstallHook()
     {
-        if ($this->files->exists($path = $this->starterKitPath('StarterKitPostInstall.php'))) {
-            require $path;
-        }
-
-        if (! class_exists(\StarterKitPostInstall::class)) {
-            return $this;
-        }
-
-        $postInstallHook = new \StarterKitPostInstall;
-
-        if (! method_exists($postInstallHook, 'handle')) {
+        if (! $postInstallHook = Hook::find($this->starterKitPath('StarterKitPostInstall.php'))) {
             return $this;
         }
 

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -490,8 +490,6 @@ final class Installer
             return $this;
         }
 
-        $this->console->info('Running post-install hook...');
-
         $postInstallHook->handle($this->console);
 
         return $this;

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -385,12 +385,8 @@ final class Installer
         $hooks = ['StarterKitPostInstall.php'];
 
         collect($hooks)
-            ->filter(function ($hook) {
-                return $this->files->exists($this->starterKitPath($hook));
-            })
-            ->each(function ($hook) {
-                $this->copyFile($this->starterKitPath($hook), base_path($hook));
-            });
+            ->filter(fn ($hook) => $this->files->exists($this->starterKitPath($hook)))
+            ->each(fn ($hook) => $this->copyFile($this->starterKitPath($hook), base_path($hook)));
     }
 
     /**

--- a/tests/StarterKits/ExportTest.php
+++ b/tests/StarterKits/ExportTest.php
@@ -169,12 +169,12 @@ class ExportTest extends TestCase
 
         $this->assertFileNotExists($postInstallHook = $this->exportPath('StarterKitPostInstall.php'));
 
-        $this->files->put(base_path('StarterKitPostInstall.php'), 'php file contents');
+        $this->files->put(base_path('StarterKitPostInstall.php'), '<?php');
 
         $this->exportCoolRunnings();
 
         $this->assertFileExists($postInstallHook);
-        $this->assertFileHasContent('php file contents', $postInstallHook);
+        $this->assertFileHasContent('<?php', $postInstallHook);
     }
 
     /** @test */

--- a/tests/StarterKits/ExportTest.php
+++ b/tests/StarterKits/ExportTest.php
@@ -169,24 +169,12 @@ class ExportTest extends TestCase
 
         $this->assertFileNotExists($postInstallHook = $this->exportPath('StarterKitPostInstall.php'));
 
-        $this->files->put(base_path('StarterKitPostInstall.php'), <<<'EOT'
-<?php
-
-class StarterKitPostInstall
-{
-    public function handle($console)
-    {
-        //
-    }
-}
-EOT
-        );
+        $this->files->put(base_path('StarterKitPostInstall.php'), 'php file contents');
 
         $this->exportCoolRunnings();
 
         $this->assertFileExists($postInstallHook);
-        $this->assertFileHasContent('class StarterKitPostInstall', $postInstallHook);
-        $this->assertFileHasContent('public function handle($console)', $postInstallHook);
+        $this->assertFileHasContent('php file contents', $postInstallHook);
     }
 
     /** @test */

--- a/tests/StarterKits/ExportTest.php
+++ b/tests/StarterKits/ExportTest.php
@@ -20,6 +20,7 @@ class ExportTest extends TestCase
 
         $this->files = app(Filesystem::class);
         $this->configPath = base_path('starter-kit.yaml');
+        $this->postInstallHookPath = base_path('StarterKitPostInstall.php');
         $this->exportPath = base_path('../cool-runnings');
 
         if ($this->files->exists($this->configPath)) {
@@ -38,6 +39,10 @@ class ExportTest extends TestCase
     {
         if ($this->files->exists($this->configPath)) {
             $this->files->delete($this->configPath);
+        }
+
+        if ($this->files->exists($this->postInstallHookPath)) {
+            $this->files->delete($this->postInstallHookPath);
         }
 
         $this->restoreComposerJson();

--- a/tests/StarterKits/ExportTest.php
+++ b/tests/StarterKits/ExportTest.php
@@ -156,6 +156,35 @@ class ExportTest extends TestCase
     }
 
     /** @test */
+    public function it_copies_post_install_script_hook_when_available()
+    {
+        $this->setExportPaths([
+            'config',
+        ]);
+
+        $this->assertFileNotExists($postInstallHook = $this->exportPath('StarterKitPostInstall.php'));
+
+        $this->files->put(base_path('StarterKitPostInstall.php'), <<<'EOT'
+<?php
+
+class StarterKitPostInstall
+{
+    public function handle($console)
+    {
+        //
+    }
+}
+EOT
+        );
+
+        $this->exportCoolRunnings();
+
+        $this->assertFileExists($postInstallHook);
+        $this->assertFileHasContent('class StarterKitPostInstall', $postInstallHook);
+        $this->assertFileHasContent('public function handle($console)', $postInstallHook);
+    }
+
+    /** @test */
     public function it_exports_all_dependencies_from_versionless_array()
     {
         $this->files->put(base_path('composer.json'), <<<'EOT'

--- a/tests/StarterKits/HookTest.php
+++ b/tests/StarterKits/HookTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\StarterKits;
+
+use Facades\Statamic\StarterKits\Hook;
+use Tests\TestCase;
+
+class HookTest extends TestCase
+{
+    /** @test */
+    public function it_can_find_and_return_hook_instance_from_class_path()
+    {
+        $this->assertFalse(class_exists('StarterKitHook'));
+
+        $hook = Hook::find(__DIR__.'/__fixtures__/StarterKitHook.php');
+
+        $this->assertTrue(class_exists('StarterKitHook'));
+        $this->assertInstanceOf('StarterKitHook', $hook);
+    }
+
+    /** @test */
+    public function it_returns_null_when_hook_class_doesnt_exist()
+    {
+        $hook = Hook::find(__DIR__.'/__fixtures__/NonExistent.php');
+
+        $this->assertNull($hook);
+    }
+}

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -298,6 +298,66 @@ EOT;
     }
 
     /** @test */
+    public function it_copies_starter_kit_post_install_script_hook_when_with_config_option_is_passed()
+    {
+        $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), <<<'EOT'
+<?php
+
+class StarterKitPostInstall
+{
+    public function handle($console)
+    {
+        //
+    }
+}
+EOT
+        );
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('handle')->once();
+
+        Hook::shouldReceive('find')
+            ->with($this->kitVendorPath('StarterKitPostInstall.php'))
+            ->once()
+            ->andReturn($mock);
+
+        $this->installCoolRunnings(['--with-config' => true]);
+
+        $this->assertFileExists($hookPath = base_path('StarterKitPostInstall.php'));
+        $this->assertFileHasContent('class StarterKitPostInstall', $hookPath);
+        $this->assertFileHasContent('public function handle($console)', $hookPath);
+    }
+
+    /** @test */
+    public function it_doesnt_copy_starter_kit_post_install_script_hook_when_with_config_option_is_not_passed()
+    {
+        $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), <<<'EOT'
+<?php
+
+class StarterKitPostInstall
+{
+    public function handle($console)
+    {
+        //
+    }
+}
+EOT
+        );
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('handle')->once();
+
+        Hook::shouldReceive('find')
+            ->with($this->kitVendorPath('StarterKitPostInstall.php'))
+            ->once()
+            ->andReturn($mock);
+
+        $this->installCoolRunnings();
+
+        $this->assertFileNotExists(base_path('StarterKitPostInstall.php'));
+    }
+
+    /** @test */
     public function it_overwrites_starter_kit_config_when_option_is_passed()
     {
         $this->files->put($configPath = base_path('starter-kit.yaml'), 'old config');

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -7,6 +7,7 @@ use Facades\Statamic\StarterKits\Hook;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Http;
 use Mockery;
+use Statamic\Console\Commands\StarterKitInstall as InstallCommand;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Config;
 use Statamic\Facades\YAML;
@@ -580,7 +581,9 @@ EOT;
     public function it_runs_post_install_script_hook_when_available()
     {
         $mock = Mockery::mock();
-        $mock->shouldReceive('handle')->once();
+        $mock->shouldReceive('handle')
+            ->withArgs(fn ($arg) => $arg instanceof InstallCommand)
+            ->once();
 
         Hook::shouldReceive('find')
             ->with($this->kitVendorPath('StarterKitPostInstall.php'))

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -300,18 +300,7 @@ EOT;
     /** @test */
     public function it_copies_starter_kit_post_install_script_hook_when_with_config_option_is_passed()
     {
-        $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), <<<'EOT'
-<?php
-
-class StarterKitPostInstall
-{
-    public function handle($console)
-    {
-        //
-    }
-}
-EOT
-        );
+        $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), 'php file contents');
 
         $mock = Mockery::mock();
         $mock->shouldReceive('handle')->once();
@@ -324,25 +313,13 @@ EOT
         $this->installCoolRunnings(['--with-config' => true]);
 
         $this->assertFileExists($hookPath = base_path('StarterKitPostInstall.php'));
-        $this->assertFileHasContent('class StarterKitPostInstall', $hookPath);
-        $this->assertFileHasContent('public function handle($console)', $hookPath);
+        $this->assertFileHasContent('php file contents', $hookPath);
     }
 
     /** @test */
     public function it_doesnt_copy_starter_kit_post_install_script_hook_when_with_config_option_is_not_passed()
     {
-        $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), <<<'EOT'
-<?php
-
-class StarterKitPostInstall
-{
-    public function handle($console)
-    {
-        //
-    }
-}
-EOT
-        );
+        $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), 'php file contents');
 
         $mock = Mockery::mock();
         $mock->shouldReceive('handle')->once();

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -558,8 +558,6 @@ EOT;
     /** @test */
     public function it_runs_post_install_script_hook_when_available()
     {
-        $this->assertNull(Blink::get('post-install-hook-successful'));
-
         $mock = Mockery::mock();
         $mock->shouldReceive('handle')->once();
 

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -302,14 +302,6 @@ EOT;
     {
         $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), 'php file contents');
 
-        $mock = Mockery::mock();
-        $mock->shouldReceive('handle')->once();
-
-        Hook::shouldReceive('find')
-            ->with($this->kitVendorPath('StarterKitPostInstall.php'))
-            ->once()
-            ->andReturn($mock);
-
         $this->installCoolRunnings(['--with-config' => true]);
 
         $this->assertFileExists($hookPath = base_path('StarterKitPostInstall.php'));
@@ -320,14 +312,6 @@ EOT;
     public function it_doesnt_copy_starter_kit_post_install_script_hook_when_with_config_option_is_not_passed()
     {
         $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), 'php file contents');
-
-        $mock = Mockery::mock();
-        $mock->shouldReceive('handle')->once();
-
-        Hook::shouldReceive('find')
-            ->with($this->kitVendorPath('StarterKitPostInstall.php'))
-            ->once()
-            ->andReturn($mock);
 
         $this->installCoolRunnings();
 

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -3,8 +3,10 @@
 namespace Tests\StarterKits;
 
 use Facades\Statamic\Console\Processes\Composer;
+use Facades\Statamic\StarterKits\Hook;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Http;
+use Mockery;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Config;
 use Statamic\Facades\YAML;
@@ -551,6 +553,22 @@ EOT;
         $this->assertFileNotExists(base_path('composer.json.bak'));
         $this->assertComposerJsonDoesntHave('repositories');
         $this->assertFileNotExists(base_path('copied.md'));
+    }
+
+    /** @test */
+    public function it_runs_post_install_script_hook_when_available()
+    {
+        $this->assertNull(Blink::get('post-install-hook-successful'));
+
+        $mock = Mockery::mock();
+        $mock->shouldReceive('handle')->once();
+
+        Hook::shouldReceive('find')
+            ->with($this->kitVendorPath('StarterKitPostInstall.php'))
+            ->once()
+            ->andReturn($mock);
+
+        $this->installCoolRunnings();
     }
 
     private function kitRepoPath($path = null)

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -301,18 +301,18 @@ EOT;
     /** @test */
     public function it_copies_starter_kit_post_install_script_hook_when_with_config_option_is_passed()
     {
-        $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), 'php file contents');
+        $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), '<?php');
 
         $this->installCoolRunnings(['--with-config' => true]);
 
         $this->assertFileExists($hookPath = base_path('StarterKitPostInstall.php'));
-        $this->assertFileHasContent('php file contents', $hookPath);
+        $this->assertFileHasContent('<?php', $hookPath);
     }
 
     /** @test */
     public function it_doesnt_copy_starter_kit_post_install_script_hook_when_with_config_option_is_not_passed()
     {
-        $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), 'php file contents');
+        $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), '<?php');
 
         $this->installCoolRunnings();
 

--- a/tests/StarterKits/__fixtures__/StarterKitHook.php
+++ b/tests/StarterKits/__fixtures__/StarterKitHook.php
@@ -1,0 +1,6 @@
+<?php
+
+class StarterKitHook
+{
+    //
+}


### PR DESCRIPTION
This is similar to @ryanmitchell's [awesome PR](https://github.com/statamic/cms/pull/6757), except that with this PR, you won't have to manually export or configure the hook in your `starter-kit.yaml` file...

```yaml
export_paths:
  - app/Hooks/SomeHook.php
after_install_hook: '\App\Hooks\SomeHook'
```

Instead of requiring the above yaml, it'll implicitly look for a `StarterKitPostInstall.php` class at the starter kit root, and run its `handle()` method...

```php
<?php

class StarterKitPostInstall
{
    public function handle($console)
    {
        //
    }
}
```

Also, since this approach isn't copying the script to user-land (it is being run directly from `vendor`), it doesn't need to be deleted/unlinked after.

### Todo

- [x] Implicitly run `StarterKitPostInstall@handle()` when running `starter-kit:install`.
- [x] Implicitly copy `StarterKitPostInstall.php` when running `starter-kit:install --with-config`.
- [x] Implicitly export `StarterKitPostInstall.php` when running `starter-kit:export`.
- [x] Add test coverage.