### PR TITLE
Fix assets fieldtype error

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -324,7 +324,7 @@ export default {
 
                 if (! parent) return false;
 
-                if (parent.config.type === 'link') {
+                if (parent.$options.name === 'link-fieldtype') {
                     return true;
                 }
 


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/6797

Sorry about this one, I somehow overlooked the fact that the parent component might not be another field 🤦‍♂️ .

Still can't get `parent.constructor.name` to give me anything other than `VueComponent`, so instead this is checking `parent.$options.name`, which gives the right value.

Don't know what's up with the tests, windows seems to be failing everything.