### PR TITLE
Fixes GitHub Action workflow to tests on multiple Laravel versions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,18 +19,14 @@ jobs:
         os: [ubuntu-latest]
         include:
           - laravel: 8.*
-            framework: ^8.48.0
           - laravel: 9.*
-            framework: ^9.0
           - os: windows-latest
             php: 7.4
             laravel: 8.*
-            framework: ^8.48.0
             stability: prefer-stable
           - os: windows-latest
             php: 8.1
             laravel: 9.*
-            framework: ^9.0
             stability: prefer-stable
         exclude:
           - laravel: 9.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: |
-            composer require "laravel/framework:${{ matrix.framework }}" --no-interaction --no-update
+            composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
             composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
-            - laravel: 8.*
+          - laravel: 8.*
           - laravel: 9.*
           - os: windows-latest
             php: 7.4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: |
-            composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+            composer require "illuminate/contracts:${{ matrix.laravel }}" --dev --no-interaction --no-update
             composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,8 +79,7 @@ jobs:
             composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
-        run: |
-          composer show -D
+        run: composer show -D
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
-          - laravel: 8.*
+            - laravel: 8.*
           - laravel: 9.*
           - os: windows-latest
             php: 7.4
@@ -77,6 +77,10 @@ jobs:
           command: |
             composer require "illuminate/contracts:${{ matrix.laravel }}" --dev --no-interaction --no-update
             composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+      - name: List Installed Dependencies
+        run: |
+          composer show -D
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "fakerphp/faker": "~1.10",
         "google/cloud-translate": "^1.6",
         "mockery/mockery": "^1.2.3",
-        "orchestra/testbench": "^6.7.0 || ^7.0"
+        "orchestra/testbench": "^6.18 || ^7.0"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
Here's some tips about testing multiple versions:

1. You should add `laravel/framework` or one of the `illuminate/*` component to `require` section (already done).
2. The workflow then should only install the opposite requirements to `require-dev`. If you require the framework you should install one of the components using `7.x`, `8.x` or `9.x` constraint, or the opposite.