### PR TITLE
Update REST API Cache middleware to not cache requests with a live preview token

### DIFF
--- a/src/API/Middleware/Cache.php
+++ b/src/API/Middleware/Cache.php
@@ -17,6 +17,10 @@ class Cache
      */
     public function handle($request, Closure $next)
     {
+        if ($request->statamicToken()) {
+            return $next($request);
+        }
+
         $cacher = app(Cacher::class);
 
         if ($response = $cacher->get($request)) {


### PR DESCRIPTION
Currently live previews don't show updated content if your preview target is using the Rest API and you have caching enabled. I've updated the REST API Cache middleware to work exactly like the GraphQL Cache middleware, which is to early exit when the statamic token is present on the request.