### PR TITLE
Register newly installed commands for use in `StarterKitPostInstall` hook

### DIFF
--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -7,6 +7,7 @@ use Facades\Statamic\StarterKits\Hook;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Http;
 use Statamic\Console\NullConsole;
+use Statamic\Console\Please\Application as PleaseApplication;
 use Statamic\Console\Processes\Exceptions\ProcessException;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Path;
@@ -486,9 +487,35 @@ final class Installer
             return $this;
         }
 
+        if (isset($postInstallHook->registerCommands)) {
+            foreach ($postInstallHook->registerCommands as $command) {
+                $this->registerInstalledCommand($command);
+            }
+        }
+
         $postInstallHook->handle($this->console);
 
         return $this;
+    }
+
+    /**
+     * Register starter kit installed command for post install hook.
+     *
+     * @param  string  $commandClass
+     */
+    protected function registerInstalledCommand($commandClass)
+    {
+        $app = $this->console->getApplication();
+
+        $command = new $commandClass($app);
+
+        if ($app instanceof PleaseApplication) {
+            $command->setRunningInPlease();
+            $command->removeStatamicGrouping();
+            $command->setHiddenInPlease();
+        }
+
+        $app->add($command);
     }
 
     /**

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -593,6 +593,18 @@ EOT;
         $this->installCoolRunnings();
     }
 
+    /** @test */
+    public function it_can_register_and_run_newly_installed_command_in_post_install_hook()
+    {
+        Hook::swap(new FakeHook);
+
+        $this->assertFalse(Blink::has('starter-kit-command-run'));
+
+        $this->installCoolRunnings();
+
+        $this->assertTrue(Blink::has('starter-kit-command-run'));
+    }
+
     private function kitRepoPath($path = null)
     {
         return collect([base_path('repo/cool-runnings'), $path])->filter()->implode('/');
@@ -791,5 +803,35 @@ class FakeComposer
     public function __call($method, $args)
     {
         return $this;
+    }
+}
+
+class FakeHook
+{
+    public function find()
+    {
+        return new StarterKitPostInstall;
+    }
+}
+
+class StarterKitPostInstall
+{
+    public $registerCommands = [
+        StarterKitTestCommand::class,
+    ];
+
+    public function handle($console)
+    {
+        $console->call('statamic:test:starter-kit-command');
+    }
+}
+
+class StarterKitTestCommand extends \Illuminate\Console\Command
+{
+    protected $name = 'statamic:test:starter-kit-command';
+
+    public function handle()
+    {
+        Blink::put('starter-kit-command-run', true);
     }
 }


### PR DESCRIPTION
## The problem

Let's say you have a starter kit like Peak that installs a new command like `statamic:peak:install-block` for the user, but you also want to run that command as a post-install hook...

```php
<?php

class StarterKitPostInstall
{
    public function handle($console)
    {
        if ($console->confirm('Do you want to install premade blocks into your page builder?', false)) {
            $console->call('statamic:peak:install-block');
        }
    }
}
```

Currently you'll get the following error...

![CleanShot 2022-09-29 at 18 44 45](https://user-images.githubusercontent.com/5187394/193155084-88221ad4-236e-4b3c-9e74-b8f384c631e3.png)

This is because of the console kernel life-cycle:

1. User runs `starter-kit:install` in their terminal
2. Laravel registers all console commands
3. Laravel finds registered `starter-kit:install` command and runs its `handle()` method
4. Starter kit copies files (including new commands like `statamic:peak:install-block` in the above example)
5. Starter kit post install hook tries to run `statamic:peak:install-block`, but it has only been copied to the app, not registered as a console command yet (see step 2, chicken/egg type situation).

## The solution

This PR adds an optional `$registerCommands` property option to post-install hooks, so that the starter kit dev can run a command that was just copied/installed from within the hook...

```php
<?php

class StarterKitPostInstall
{
    public $registerCommands = [
        \App\Console\Commands\AddPartial::class,
    ];

    public function handle($console)
    {
        if ($console->confirm('Do you want to install premade blocks into your page builder?', false)) {
            $console->call('statamic:peak:install-block');
        }
    }
}
```