### PR TITLE
Throw exception if composer.lock is missing when finding Statamic version

### DIFF
--- a/src/Updater/CoreChangelog.php
+++ b/src/Updater/CoreChangelog.php
@@ -29,7 +29,7 @@ class CoreChangelog extends Changelog
     private function canUpdateToVersion($version)
     {
         $currentVersion = Statamic::version();
-        
+
         if ($currentVersion === null) {
             throw new \Exception('Statamic version could not be found. Does the composer.lock file exist?');
         }

--- a/src/Updater/CoreChangelog.php
+++ b/src/Updater/CoreChangelog.php
@@ -29,6 +29,10 @@ class CoreChangelog extends Changelog
     private function canUpdateToVersion($version)
     {
         $currentVersion = Statamic::version();
+        
+        if ($currentVersion === null) {
+            throw new \Exception('Statamic version could not be found. Does the composer.lock file exist?');
+        }
 
         if (Str::contains($currentVersion, 'dev')) {
             return true; // If you're on dev-master, 3.2.x-dev, etc - go nuts.

--- a/src/Updater/CoreChangelog.php
+++ b/src/Updater/CoreChangelog.php
@@ -30,10 +30,6 @@ class CoreChangelog extends Changelog
     {
         $currentVersion = Statamic::version();
 
-        if ($currentVersion === null) {
-            throw new \Exception('Statamic version could not be found. Does the composer.lock file exist?');
-        }
-
         if (Str::contains($currentVersion, 'dev')) {
             return true; // If you're on dev-master, 3.2.x-dev, etc - go nuts.
         }

--- a/src/Version.php
+++ b/src/Version.php
@@ -8,6 +8,12 @@ class Version
 {
     public function get()
     {
-        return Composer::installedVersion(Statamic::PACKAGE);
+        $currentVersion = Composer::installedVersion(Statamic::PACKAGE);
+
+        if ($currentVersion === null) {
+            throw new \Exception('Statamic version could not be found. Does the composer.lock file exist?');
+        }
+
+        return $currentVersion;
     }
 }

--- a/src/Version.php
+++ b/src/Version.php
@@ -10,8 +10,8 @@ class Version
     {
         $currentVersion = Composer::installedVersion(Statamic::PACKAGE);
 
-        if ($currentVersion === null) {
-            throw new \Exception('Statamic version could not be found. Does the composer.lock file exist?');
+        if (! $currentVersion) {
+            throw new \Exception('Statamic version could not be found. The composer.lock file is missing.');
         }
 
         return $currentVersion;


### PR DESCRIPTION
I've a CI/CD GitLab Pipeline with Deployer for my own projects and all unnecessary files such as the composer.lock will get removed for deployment.

That's why I encountered the following exception in production:
`Undefined array key 0 {"userId":"<id>,"exception":"[object] (ErrorException(code: 0): Undefined array key 0 at vendor/statamic/cms/src/Updater/CoreChangelog.php:40)`

This exception gets thrown every time anyone uses the Control-Panel, and it wasn't possible to check the license with the outpost nor to view the changelog. In addition, there was a misleading error message in the Control-Panel:
`Error communicating with statamic.com`

It took me hours to find out, that the composer.lock is needed for Statamic to work properly. It would have helped me a lot if there was a better exception message in the first place. That's why I'm proposing this change.