### PR TITLE
Avoid prompt to make user when installing starter kit via statamic/cli

### DIFF
--- a/src/Console/Commands/StarterKitInstall.php
+++ b/src/Console/Commands/StarterKitInstall.php
@@ -63,7 +63,7 @@ class StarterKitInstall extends Command
             ->fromLocalRepo($this->option('local'))
             ->withConfig($this->option('with-config'))
             ->withoutDependencies($this->option('without-dependencies'))
-            ->withUser($cleared && $this->input->isInteractive())
+            ->withUser($cleared && $this->input->isInteractive() && ! $this->option('cli-install'))
             ->force($this->option('force'));
 
         try {


### PR DESCRIPTION
See explanation in https://github.com/statamic/cli/pull/56

>We're also removing the 'temporary' comment on --cli-install, because the starter kit installer should never handle the creation of a super user when using this cli installer. It needs to be here [in the cli installer] anyway, for when installing statamic/statamic without a starter kit. Also, we have some windows-specific handling for super user creation in the CLI here.