### PR TITLE
Improve Section Fieldtype and Tabs UI

### DIFF
--- a/resources/js/components/publish/Sections.vue
+++ b/resources/js/components/publish/Sections.vue
@@ -4,7 +4,7 @@
     <div>
 
         <!-- Tabs -->
-        <div v-if="showTabs" class="tabs-container flex items-center" :class="{ 'offset-for-sidebar': shouldShowSidebar }">
+        <div v-if="showTabs" class="tabs-container flex items-center" ref="tabsContainer">
             <div
                 class="publish-tabs tabs flex-shrink"
                 ref="tabs"
@@ -27,7 +27,13 @@
                     v-text="section.display || `${section.handle[0].toUpperCase()}${section.handle.slice(1)}`"
                 ></button>
             </div>
-            <dropdown-list class="ml-1" v-cloak v-if="showHiddenTabsDropdown">
+            <dropdown-list v-cloak v-if="showHiddenTabsDropdown" class="h-full">
+                <template slot="trigger">
+                    <button class="h-full flex items-center px-2 text-grey-60">
+                        <span v-text="'+'+ hiddenTabCount + __(' More')" />
+                        <svg-icon name="chevron-down-xs" class="ml-1 w-2" />
+                    </button>
+                </template>
                 <dropdown-item
                     v-for="(section, index) in mainSections"
                     v-show="isTabHidden(index)"
@@ -71,7 +77,7 @@
             <!-- Sidebar(ish) -->
             <div :class="{ 'publish-sidebar': shouldShowSidebar }">
                 <div class="publish-section">
-                    <div class="publish-section-actions" :class="{ 'as-sidebar': shouldShowSidebar }">
+                    <div class="publish-section-actions rounded-t-md" :class="{ 'as-sidebar': shouldShowSidebar }">
                         <portal :to="actionsPortal" :disabled="shouldShowSidebar">
                             <slot name="actions" :should-show-sidebar="shouldShowSidebar" />
                         </portal>
@@ -157,7 +163,11 @@ export default {
         },
 
         showHiddenTabsDropdown() {
-            return this.mainSections.length > this.visibleTabs;
+            return this.mainSections.length > this.visibleTabs && this.initialTabSet;
+        },
+
+        hiddenTabCount() {
+            return this.mainSections.length - this.visibleTabs;
         },
 
         errors() {
@@ -239,7 +249,8 @@ export default {
                 let visibleTabs = 0;
 
                 // Leave 40px for the dropdown list.
-                const maxWidth = this.$refs.publishSectionWrapper.offsetWidth - 40;
+                const maxWidth = this.$refs.tabsContainer.offsetWidth - 120;
+                console.log(maxWidth)
                 let tabWidthSum = 0;
 
                 this.$refs.tabs.childNodes.forEach((tab, index) => {
@@ -249,6 +260,8 @@ export default {
                         visibleTabs += 1;
                     }
                 })
+
+                console.log(tabWidthSum)
 
                 this.visibleTabs = visibleTabs;
 

--- a/resources/sass/components/fieldtypes/section.scss
+++ b/resources/sass/components/fieldtypes/section.scss
@@ -3,28 +3,34 @@
    ========================================================================== */
 
 .section-fieldtype {
-    @apply border-t border-b bg-grey-20;
-    top: -1px; // Avoid adjacent borders just in case they're stacked
-
     &.form-group {
         position: relative;
         &:first-child {
             @apply rounded-t border-t-0;
         }
 
-        .field-inner > label {
-            @apply uppercase text-sm font-bold mt-1;
+        label {
+            @apply mb-0;
         }
+
+        .field-inner > label {
+            @apply text-lg font-bold;
+        }
+
     }
 
     .help-block {
-        @apply .mb-0;
+        @apply m-0;
 
-        p { margin: 0; }
+        p { @apply mt-1 mb-0; }
     }
-
 
     .read-only-overlay {
         display: none;
     }
+}
+
+.replicator-fieldtype .publish-field.section-fieldtype,
+.bard-fieldtype .publish-field.section-fieldtype {
+    @apply mt-0 rounded-none bg-grey-10 #{!important};
 }

--- a/resources/sass/components/publish.scss
+++ b/resources/sass/components/publish.scss
@@ -123,9 +123,49 @@ code.parent-url {
 .publish-fields-narrow .publish-field { width: 100%; }
 
 .publish-section:not(:empty) {
-    @apply shadow bg-white rounded-md w-full;
+
+    .publish-field:first-of-type {
+        @apply rounded-t-md;
+        margin-top: 0 !important;
+    }
+
+    .publish-field, .publish-section-actions {
+        @apply bg-white w-full shadow relative;
+    }
+
+    .publish-field:has(+ .publish-field.section-fieldtype) {
+        @apply rounded-b-md;
+    }
+
+    > .publish-field::after {
+        content: '';
+        @apply absolute w-full left-0 right-0 bg-white;
+        height: 1px;
+        top: -2px;
+    }
+
+    .publish-field:first-of-type {
+        @apply rounded-tr-md;
+        &:after {
+            display: none;
+        }
+    }
+
+    .publish-field:last-of-type {
+        @apply rounded-b-md;
+    }
+
+    .publish-field.section-fieldtype {
+        @apply mt-3 rounded-t-md;
+        &:after {
+            display: none;
+        }
+    }
 }
 
+.publish-section-actions-footer {
+    @apply bg-white w-full shadow relative;
+}
 
 
 /* Inline publish form

--- a/resources/sass/components/tabs.scss
+++ b/resources/sass/components/tabs.scss
@@ -2,27 +2,32 @@
    TABS
    ========================================================================== */
 
-.tabs-container.offset-for-sidebar {
-    width: calc(100% - 320px);
+.tabs-container {
+    @apply w-full mb-3 shadow rounded bg-white;
+
+    .dropdown-list button {
+        @apply outline-none;
+    }
 }
 
 .tabs {
-    @apply flex items-end overflow-hidden px-1 -ml-1;
+    @apply flex flex-1 items-end overflow-hidden px-2;
     height: 48px;
 
     .tab-button {
-        @apply whitespace-no-wrap bg-grey-10 py-sm px-2 flex-shrink-0 leading-tight text-xs w-auto relative flex items-center justify-center rounded-t-md shadow border-b border-grey-30 select-none;
-        height: 94%;
-        min-height: 94%;
+        @apply h-full text-grey-60 border-b-2 border-transparent whitespace-no-wrap flex-shrink-0 py-sm px-2 leading-tight text-xs w-auto relative flex items-center justify-center select-none;
+        &:hover {
+            @apply text-black;
+        }
     }
 
     .tab-button.active {
-        @apply bg-white text-blue border-t-2 border-blue relative h-full min-h-full border-b-0 outline-none;
+        @apply text-black border-b-2 border-blue relative h-full min-h-full outline-none;
         z-index: 1;
     }
 
     .tab-button:active, .tab-button:focus {
-        @apply bg-white text-blue border-b-0 outline-none;
+        @apply bg-white text-blue outline-none;
     }
 
     .tab-button.ghost {
@@ -44,7 +49,7 @@
 
 @screen md {
     .tabs .tab-button {
-        min-width: 120px;
+        // min-width: 120px;
     }
 }
 


### PR DESCRIPTION
The Section Fieldtype now creates a visually separate "card" for better scannability. To make the UX clear, the Tabs have been "undocked" from the fields card and have been given a fresh look. This also let me make the tabs container full-width, allowing you to see more tabs at once.

Here are a few screenshots.

![image](https://user-images.githubusercontent.com/44739/193324540-9157b36a-3412-4dcc-800d-2d927db33294.png)

![image](https://user-images.githubusercontent.com/44739/193324575-755b73c1-94a2-4660-b3a6-36ce7184b048.png)
