### PR TITLE
When a global set is deleted, delete the blueprint

### DIFF
--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -108,6 +108,8 @@ class GlobalSet implements Contract
 
     public function delete()
     {
+        $this->blueprint()->delete();
+
         Facades\GlobalSet::delete($this);
 
         GlobalSetDeleted::dispatch($this);

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -108,7 +108,7 @@ class GlobalSet implements Contract
 
     public function delete()
     {
-        $this->blueprint()->delete();
+        optional($this->blueprint())->delete();
 
         Facades\GlobalSet::delete($this);
 


### PR DESCRIPTION
This is something I've noticed recently on a couple of sites. When you delete a global set, the related blueprint file wasn't being deleted. 