### PR TITLE
Show 'Create Blueprint' link on create entry dropdown

### DIFF
--- a/resources/js/components/collections/View.vue
+++ b/resources/js/components/collections/View.vue
@@ -79,7 +79,8 @@
                     button-class="btn-primary"
                     :url="createUrl"
                     :blueprints="blueprints"
-                    :text="createLabel" />
+                    :text="createLabel"
+                    :collection="handle" />
             </div>
 
         </header>

--- a/resources/js/components/collections/View.vue
+++ b/resources/js/components/collections/View.vue
@@ -80,7 +80,8 @@
                     :url="createUrl"
                     :blueprints="blueprints"
                     :text="createLabel"
-                    :collection="handle" />
+                    :collection="handle"
+                    :can-create-blueprints="canCreateBlueprints" />
             </div>
 
         </header>
@@ -201,6 +202,7 @@ export default {
         structureMaxDepth: { type: Number, default: Infinity },
         structureExpectsRoot: { type: Boolean },
         structureShowSlugs: { type: Boolean },
+        canCreateBlueprints: { type: Boolean, default: false },
     },
 
     data() {

--- a/resources/js/components/entries/CreateEntryButton.vue
+++ b/resources/js/components/entries/CreateEntryButton.vue
@@ -15,6 +15,8 @@
         <div v-for="blueprint in blueprints" :key="blueprint.handle">
             <dropdown-item :text="blueprint.title" @click="select(blueprint.handle, $event)" />
         </div>
+
+        <dropdown-item :text="__('Create Blueprint')" :href="cp_url(`collections/${collection}/blueprints/create`)" />
     </dropdown-list>
 
 </template>
@@ -26,7 +28,8 @@ export default {
         url: String,
         blueprints: Array,
         text: { type: String, default: () => __('Create Entry') },
-        buttonClass: { type: String, default: 'btn' }
+        buttonClass: { type: String, default: 'btn' },
+        collection: String,
     },
 
     computed: {

--- a/resources/js/components/entries/CreateEntryButton.vue
+++ b/resources/js/components/entries/CreateEntryButton.vue
@@ -16,6 +16,7 @@
             <dropdown-item :text="blueprint.title" @click="select(blueprint.handle, $event)" />
         </div>
 
+        <div class="divider" />
         <dropdown-item :text="__('Create Blueprint')" :href="cp_url(`collections/${collection}/blueprints/create`)" />
     </dropdown-list>
 

--- a/resources/js/components/entries/CreateEntryButton.vue
+++ b/resources/js/components/entries/CreateEntryButton.vue
@@ -16,8 +16,8 @@
             <dropdown-item :text="blueprint.title" @click="select(blueprint.handle, $event)" />
         </div>
 
-        <div class="divider" />
-        <dropdown-item :text="__('Create Blueprint')" :href="cp_url(`collections/${collection}/blueprints/create`)" />
+        <div v-if="canCreateBlueprints" class="divider" />
+        <dropdown-item v-if="canCreateBlueprints" :text="__('Create Blueprint')" :href="cp_url(`collections/${collection}/blueprints/create`)" />
     </dropdown-list>
 
 </template>
@@ -31,6 +31,7 @@ export default {
         text: { type: String, default: () => __('Create Entry') },
         buttonClass: { type: String, default: 'btn' },
         collection: String,
+        canCreateBlueprints: Boolean,
     },
 
     computed: {

--- a/resources/views/collections/show.blade.php
+++ b/resources/views/collections/show.blade.php
@@ -11,6 +11,7 @@
         :can-create="@can('create', ['Statamic\Contracts\Entries\Entry', $collection]) true @else false @endcan"
         create-url="{{ cp_route('collections.entries.create', [$collection->handle(), $site]) }}"
         create-label="{{ $collection->createLabel() }}"
+        :can-create-blueprints="@can('configure fields') true @else false @endcan"
         :blueprints='@json($blueprints)'
         sort-column="{{ $collection->sortField() }}"
         sort-direction="{{ $collection->sortDirection() }}"


### PR DESCRIPTION
<img width="273" alt="image" src="https://user-images.githubusercontent.com/19637309/193401483-e611764c-8b8a-4202-9d67-5a3a179a9d17.png">

This pull request implements statamic/ideas#614. It adds a 'Create Blueprint' link onto the 'Create Entry' dropdown which lets you choose between available blueprints.

From what I've done so far, I wonder if there needs to be something to differentiate the 'Create Blueprint' button from the list of blueprints.. not quite sure how to do that (up for ideas) 🤔 

Closes statamic/ideas#614