### PR TITLE
Fix focal point not saving when asset blueprint has no fields

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -295,10 +295,9 @@ export default {
                 const data = response.data.data;
                 this.asset = data;
 
-                // If empty, `data.values` will be an array, but we need object for `selectFocalPoint` later on
-                if (!_.isEmpty(data.values)) {
-                    this.values = data.values;
-                }
+                // If there are no fields, it will be an empty array when PHP encodes
+                // it into JSON on the server. We'll ensure it's always an object.
+                this.values = _.isArray(data.values) ? {} : data.values;
 
                 this.meta = data.meta;
                 this.actionUrl = data.actionUrl;

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -294,7 +294,12 @@ export default {
             this.$axios.get(url).then(response => {
                 const data = response.data.data;
                 this.asset = data;
-                this.values = data.values;
+
+                // If empty, `data.values` will be an array, but we need object for `selectFocalPoint` later on
+                if (!_.isEmpty(data.values)) {
+                    this.values = data.values;
+                }
+
                 this.meta = data.meta;
                 this.actionUrl = data.actionUrl;
                 this.actions = data.actions;


### PR DESCRIPTION
Fixes #2954.

The issue was that focal point setter assumes that `values` will be an object.

https://github.com/ncla/cms/blob/b28df0896d614383cd0a561359d9d885cb7c00e8/resources/js/components/assets/Editor/Editor.vue#L330-L334

As far as I understood, Vue's special $set is used to trigger reactivity in a component. When the blueprint has no fields, an array is set from the HTTP response. When blueprint has fields, the response value gives us an object.

https://github.com/ncla/cms/blob/b28df0896d614383cd0a561359d9d885cb7c00e8/resources/js/components/assets/Editor/Editor.vue#L295-L298

However because `values` is an array now, `this.$set(this.values, 'focus', point);` will not work because it assumes the property in an object. If you set 2nd argument to a number then it will be used as an array index and a value will be set.

See Vue 2 docs here: https://v2.vuejs.org/v2/guide/reactivity.html#For-Objects

As a fix, I simply check if `values` in the HTTP response is empty to prevent changing the `values` type from object to array.

Side note: I initially thought that this was bug introduced with hidden fields changes but that came much later than the bug report.