### PR TITLE
Return width from field when returned by GraphQL

### DIFF
--- a/src/GraphQL/Types/FieldType.php
+++ b/src/GraphQL/Types/FieldType.php
@@ -40,15 +40,17 @@ class FieldType extends \Rebing\GraphQL\Support\Type
                     return $field->instructions();
                 },
             ],
+            'width' => [
+                'type' => GraphQL::int(),
+                'resolve' => function ($field) {
+                    return $field->config()['width'] ?? 100;
+                },
+            ],
             'config' => [
                 'type' => GraphQL::type(ArrayType::NAME),
                 'resolve' => function ($field) {
                     // Only show values that the fieldtype exposes.
                     $fields = $field->fieldtype()->configFields()->all()->keys()->all();
-
-                    if (isset($field->config()['width'])) {
-                        $fields[] = 'width';
-                    }
 
                     return Arr::only($field->config(), $fields);
                 },

--- a/src/GraphQL/Types/FieldType.php
+++ b/src/GraphQL/Types/FieldType.php
@@ -46,6 +46,10 @@ class FieldType extends \Rebing\GraphQL\Support\Type
                     // Only show values that the fieldtype exposes.
                     $fields = $field->fieldtype()->configFields()->all()->keys()->all();
 
+                    if (isset($field->config()['width'])) {
+                        $fields[] = 'width';
+                    }
+
                     return Arr::only($field->config(), $fields);
                 },
             ],

--- a/tests/Feature/GraphQL/FormTest.php
+++ b/tests/Feature/GraphQL/FormTest.php
@@ -78,9 +78,10 @@ GQL;
                 'instructions' => 'Enter your name',
                 'placeholder' => 'Type here...',
                 'invalid' => 'This isnt in the fieldtypes config fields so it shouldnt be output',
+                'width' => 50,
             ],
             'subject' => ['type' => 'select', 'options' => ['disco' => 'Disco', 'house' => 'House']],
-            'message' => ['type' => 'textarea'],
+            'message' => ['type' => 'textarea', 'width' => 33],
         ]);
 
         BlueprintRepository::shouldReceive('find')->with('forms.contact')->andReturn($blueprint);
@@ -93,6 +94,7 @@ GQL;
             type
             display
             instructions
+            width
             config
         }
     }
@@ -111,6 +113,7 @@ GQL;
                             'type' => 'text',
                             'display' => 'Your Name',
                             'instructions' => 'Enter your name',
+                            'width' => 50,
                             'config' => [
                                 'placeholder' => 'Type here...',
                             ],
@@ -120,6 +123,7 @@ GQL;
                             'type' => 'select',
                             'display' => 'Subject',
                             'instructions' => null,
+                            'width' => 100,
                             'config' => [
                                 'options' => ['disco' => 'Disco', 'house' => 'House'],
                             ],
@@ -129,6 +133,7 @@ GQL;
                             'type' => 'textarea',
                             'display' => 'Message',
                             'instructions' => null,
+                            'width' => 33,
                             'config' => [],
                         ],
                     ],


### PR DESCRIPTION
This pull request closes statamic/ideas#873. It makes it so the defined width is returned in the GraphQL response when grabbing a form fields's config.

<img width="940" alt="image" src="https://user-images.githubusercontent.com/19637309/193414962-bbec0bee-5757-4f88-82e4-e733cb907f0d.png">

<img width="1510" alt="image" src="https://user-images.githubusercontent.com/19637309/193414985-f5c906ff-04a8-4358-b0a5-bf7179daf40d.png">
