### PR TITLE
Data list's toggle all button now selects maximum possible entries

### DIFF
--- a/resources/js/components/data-list/HasFilters.js
+++ b/resources/js/components/data-list/HasFilters.js
@@ -70,8 +70,8 @@ export default {
         },
 
         unselectAllItems() {
-            if (this.$refs.toggleAll) {
-                this.$refs.toggleAll.uncheckAllItems();
+            if (this.$refs.dataList) {
+                this.$refs.dataList.clearSelections();
             }
         },
 

--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -3,7 +3,7 @@
         <thead v-if="allowBulkActions || allowColumnPicker || visibleColumns.length > 1">
             <tr>
                 <th class="checkbox-column" v-if="allowBulkActions || reorderable">
-                    <data-list-toggle-all ref="toggleAll" v-if="allowBulkActions && !singleSelect" />
+                    <data-list-toggle-all v-if="allowBulkActions && !singleSelect" />
                 </th>
                 <th
                     v-for="column in visibleColumns"

--- a/resources/js/components/data-list/ToggleAll.vue
+++ b/resources/js/components/data-list/ToggleAll.vue
@@ -18,10 +18,10 @@ export default {
         },
 
         checkMaximumAmountOfItems() {
-          this.sharedState.selections = _.chain(this.sharedState.rows)
-              .map(item => item.id)
-              .first(this.sharedState.maxSelections ?? Infinity)
-              .value()
+            this.sharedState.selections = _.chain(this.sharedState.rows)
+                .map(item => item.id)
+                .first(this.sharedState.maxSelections ?? Infinity)
+                .value()
         },
 
         uncheckAllItems() {

--- a/resources/js/components/data-list/ToggleAll.vue
+++ b/resources/js/components/data-list/ToggleAll.vue
@@ -8,22 +8,20 @@
 export default {
     inject: ['sharedState'],
     computed: {
-        allItemsChecked() {
-            if (this.sharedState.rows.length === 0) return false;
-
-            return this.sharedState.selections.length === this.sharedState.rows.length;
-        },
         anyItemsChecked() {
             return this.sharedState.selections.length > 0;
         },
     },
     methods: {
         toggle() {
-            this.anyItemsChecked ? this.uncheckAllItems() : this.checkAllItems()
+            this.anyItemsChecked ? this.uncheckAllItems() : this.checkMaximumAmountOfItems()
         },
 
-        checkAllItems() {
-            this.sharedState.selections = _.values(_.map(this.sharedState.rows, item => item.id))
+        checkMaximumAmountOfItems() {
+          this.sharedState.selections = _.chain(this.sharedState.rows)
+              .map(item => item.id)
+              .first(this.sharedState.maxSelections ?? Infinity)
+              .value()
         },
 
         uncheckAllItems() {

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -128,6 +128,7 @@ export default {
             initialSite: this.site,
         }
     },
+
     computed: {
         actionContext() {
             return {collection: this.collection};

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -7,6 +7,7 @@
 
         <data-list
             v-if="!initializing"
+            ref="dataList"
             :rows="items"
             :columns="columns"
             :sort="false"
@@ -127,7 +128,6 @@ export default {
             initialSite: this.site,
         }
     },
-
     computed: {
         actionContext() {
             return {collection: this.collection};


### PR DESCRIPTION
Closes #4246.

In the first [PR](https://github.com/statamic/cms/pull/4309), Duncan hid the toggle all button completely if max. selections was only 1. This PR addresses the issue further to handle values larger than 1.

This change will select maximum amount of possible entries, while respecting max. items value. If none is provided, it will toggle all items in the data list page.

As a side mission I was checking out where else this button is utilized, to cover my bases. I found out that `uncheckAllItems` was being used in `HasFilters` mixin, which depended on component reference to `ToggleAll`. When the filters change, the selections are suppose to be cleared. However this reference did not work anymore as the reference was now one level deeper from where `HasFilters` mixin was being used. I updated this mixin to point to a newly added `DataList` component reference, which conveniently already had a `clearSelections` method for clearing selections.

I am not sure if selection clearing when changing filters is relevant anymore, as the changes that broke this are before my times, before I discovered Statamic. Feel free to disregard by removing `ref="dataList"`. I noticed that relationship item selector `resources/js/components/inputs/relationship/Selector.vue` does not have selection clearing , despite using the same `HasFilters` mixin. I would update it, but this is outside of the scope of this issue and I don't know if it's even an issue yet.