### PR TITLE
Fix users tag role and group parameters

### DIFF
--- a/src/Auth/Role.php
+++ b/src/Auth/Role.php
@@ -35,4 +35,9 @@ abstract class Role implements RoleContract, Augmentable, ArrayAccess, Arrayable
             'handle' => $this->handle(),
         ];
     }
+
+    public function __toString()
+    {
+        return $this->handle();
+    }
 }

--- a/src/Auth/UserGroup.php
+++ b/src/Auth/UserGroup.php
@@ -178,4 +178,9 @@ abstract class UserGroup implements UserGroupContract, Augmentable, ArrayAccess,
             'handle' => $this->handle(),
         ];
     }
+
+    public function __toString()
+    {
+        return $this->handle();
+    }
 }

--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -244,23 +244,23 @@ abstract class Builder extends BaseBuilder
             case '<>':
             case '!=':
                 $method = 'neq';
-                break;
+            break;
 
             case '>':
                 $method = 'gt';
-                break;
+            break;
 
             case '>=':
                 $method = 'gte';
-                break;
+            break;
 
             case '<':
                 $method = 'lt';
-                break;
+            break;
 
             case '<=':
                 $method = 'lte';
-                break;
+            break;
         }
 
         return $method;

--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Stache\Query;
 
+use Illuminate\Support\Collection;
 use Statamic\Data\DataCollection;
 use Statamic\Query\Builder as BaseBuilder;
 use Statamic\Stache\Stores\Store;
@@ -243,23 +244,23 @@ abstract class Builder extends BaseBuilder
             case '<>':
             case '!=':
                 $method = 'neq';
-            break;
+                break;
 
             case '>':
                 $method = 'gt';
-            break;
+                break;
 
             case '>=':
                 $method = 'gte';
-            break;
+                break;
 
             case '<':
                 $method = 'lt';
-            break;
+                break;
 
             case '<=':
                 $method = 'lte';
-            break;
+                break;
         }
 
         return $method;
@@ -282,6 +283,10 @@ abstract class Builder extends BaseBuilder
     protected function filterWhereJsonContains($values, $where)
     {
         return $values->filter(function ($value) use ($where) {
+            if ($value instanceof Collection) {
+                $value = $value->all();
+            }
+
             if (! is_array($value)) {
                 return false;
             }
@@ -293,6 +298,10 @@ abstract class Builder extends BaseBuilder
     protected function filterWhereJsonDoesntContain($values, $where)
     {
         return $values->filter(function ($value) use ($where) {
+            if ($value instanceof Collection) {
+                $value = $value->all();
+            }
+
             if (! is_array($value)) {
                 return true;
             }
@@ -306,6 +315,10 @@ abstract class Builder extends BaseBuilder
         $method = 'filterTest'.$this->operators[$where['operator']];
 
         return $values->filter(function ($value) use ($method, $where) {
+            if ($value instanceof Collection) {
+                $value = $value->all();
+            }
+
             if (! is_array($value)) {
                 return false;
             }

--- a/src/Tags/Users.php
+++ b/src/Tags/Users.php
@@ -20,11 +20,21 @@ class Users extends Tags
         $query = $this->query();
 
         if ($group = $this->params->get('group')) {
-            $query->whereJsonContains('groups', explode('|', $group), 'or');
+            $groups = explode('|', $group);
+            $query->where(function ($query) use ($groups) {
+                foreach ($groups as $group) {
+                    $query->whereJsonContains('groups', $group, 'or');
+                }
+            });
         }
 
         if ($role = $this->params->get('role')) {
-            $query->whereJsonContains('roles', explode('|', $role), 'or');
+            $roles = explode('|', $role);
+            $query->where(function ($query) use ($roles) {
+                foreach ($roles as $role) {
+                    $query->whereJsonContains('roles', $role, 'or');
+                }
+            });
         }
 
         return $this->output($this->results($query));

--- a/src/Tags/Users.php
+++ b/src/Tags/Users.php
@@ -20,11 +20,21 @@ class Users extends Tags
         $query = $this->query();
 
         if ($group = $this->params->get('group')) {
-            $query->where('group', $group);
+            $groups = explode('|', $group);
+            $query->where(function ($query) use ($groups) {
+                foreach ($groups as $group) {
+                    $query->orWhere('groups', 'like', "%{$group}%");
+                }
+            });
         }
 
         if ($role = $this->params->get('role')) {
-            $query->where('role', $role);
+            $roles = explode('|', $role);
+            $query->where(function ($query) use ($roles) {
+                foreach ($roles as $role) {
+                    $query->orWhere('roles', 'like', "%{$role}%");
+                }
+            });
         }
 
         return $this->output($this->results($query));

--- a/src/Tags/Users.php
+++ b/src/Tags/Users.php
@@ -20,21 +20,11 @@ class Users extends Tags
         $query = $this->query();
 
         if ($group = $this->params->get('group')) {
-            $groups = explode('|', $group);
-            $query->where(function ($query) use ($groups) {
-                foreach ($groups as $group) {
-                    $query->orWhere('groups', 'like', "%{$group}%");
-                }
-            });
+            $query->whereJsonContains('groups', explode('|', $group), 'or');
         }
 
         if ($role = $this->params->get('role')) {
-            $roles = explode('|', $role);
-            $query->where(function ($query) use ($roles) {
-                foreach ($roles as $role) {
-                    $query->orWhere('roles', 'like', "%{$role}%");
-                }
-            });
+            $query->whereJsonContains('roles', explode('|', $role), 'or');
         }
 
         return $this->output($this->results($query));

--- a/tests/Tags/UsersTagTest.php
+++ b/tests/Tags/UsersTagTest.php
@@ -57,6 +57,24 @@ class UsersTagTest extends TestCase
         $this->assertEquals('baz@bar.com|qux@bar.com|', $this->tag('{{ users group="group1|group2" }}{{ email }}|{{ /users }}'));
     }
 
+    /** @test */
+    public function it_gets_users_by_role_and_group()
+    {
+        $this->setTestRoles([
+            'role1',
+            'role2',
+        ]);
+        $this->setTestUserGroups([
+            'group1',
+        ]);
+
+        User::make()->email('foo@bar.com')->save();
+        User::make()->email('baz@bar.com')->assignRole('role1')->addToGroup('group1')->save();
+        User::make()->email('qux@bar.com')->assignRole('role2')->save();
+
+        $this->assertEquals('baz@bar.com|', $this->tag('{{ users role="role1|role2" group="group1" }}{{ email }}|{{ /users }}'));
+    }
+
     private function tag($tag, $data = [])
     {
         return (string) Parse::template($tag, $data);

--- a/tests/Tags/UsersTagTest.php
+++ b/tests/Tags/UsersTagTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Tags;
+
+use Statamic\Facades\Parse;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\FakesUserGroups;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class UsersTagTest extends TestCase
+{
+    use FakesRoles,
+        FakesUserGroups,
+        PreventSavingStacheItemsToDisk;
+
+    /** @test */
+    public function it_gets_all_users()
+    {
+        User::make()->email('foo@bar.com')->save();
+        User::make()->email('baz@bar.com')->save();
+        User::make()->email('qux@bar.com')->save();
+
+        $this->assertEquals('foo@bar.com|baz@bar.com|qux@bar.com|', $this->tag('{{ users }}{{ email }}|{{ /users }}'));
+    }
+
+    /** @test */
+    public function it_gets_users_by_role()
+    {
+        $this->setTestRoles([
+            'role1',
+            'role2',
+        ]);
+
+        User::make()->email('foo@bar.com')->save();
+        User::make()->email('baz@bar.com')->assignRole('role1')->save();
+        User::make()->email('qux@bar.com')->assignRole('role2')->save();
+
+        $this->assertEquals('baz@bar.com|', $this->tag('{{ users role="role1" }}{{ email }}|{{ /users }}'));
+        $this->assertEquals('baz@bar.com|qux@bar.com|', $this->tag('{{ users role="role1|role2" }}{{ email }}|{{ /users }}'));
+    }
+
+    /** @test */
+    public function it_gets_users_by_group()
+    {
+        $this->setTestUserGroups([
+            'group1',
+            'group2',
+        ]);
+
+        User::make()->email('foo@bar.com')->save();
+        User::make()->email('baz@bar.com')->addToGroup('group1')->save();
+        User::make()->email('qux@bar.com')->addToGroup('group2')->save();
+
+        $this->assertEquals('baz@bar.com|', $this->tag('{{ users group="group1" }}{{ email }}|{{ /users }}'));
+        $this->assertEquals('baz@bar.com|qux@bar.com|', $this->tag('{{ users group="group1|group2" }}{{ email }}|{{ /users }}'));
+    }
+
+    private function tag($tag, $data = [])
+    {
+        return (string) Parse::template($tag, $data);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/5584

The `{{ users }}` tag accepts `role` and `group` parameters that are supposed to filter the users, however if you use them you get an empty result. This PR fixes that and adds some tests.

To make this work I had to make a couple of tweaks to the role/group and builder classes:

1. `Role` and `UserGroup` now have a `__toString()` method that returns the handle
2. The `Builder::whereJson...` methods will now accept a `Collection` object