### PR TITLE
Fix asset meta bottleneck

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -255,7 +255,7 @@ class Asset implements AssetContract, Augmentable, ArrayAccess, Arrayable, Conta
 
     protected function metaExists()
     {
-        return $this->disk()->exists($this->metaPath());
+        return $this->container()->metaFiles()->contains($this->metaPath());
     }
 
     public function writeMeta($meta)

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -293,6 +293,16 @@ class AssetContainer implements AssetContainerContract, Augmentable, ArrayAccess
         return $this->contents()->filteredFilesIn($folder, $recursive)->keys();
     }
 
+    public function metaFiles($folder = '/', $recursive = false)
+    {
+        // When requesting files() as-is, we want all of them.
+        if (func_num_args() === 0) {
+            $recursive = true;
+        }
+
+        return $this->contents()->metaFilesIn($folder, $recursive)->keys();
+    }
+
     public function foldersCacheKey($folder = '/', $recursive = false)
     {
         $rec = $recursive ? '-recursive' : '';

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -9,6 +9,7 @@ class AssetContainerContents
 {
     protected $container;
     protected $files;
+    protected $metaFiles;
     protected $filteredFiles;
     protected $filteredDirectories;
 
@@ -132,6 +133,36 @@ class AssetContainerContents
     public function directories()
     {
         return $this->all()->where('type', 'dir');
+    }
+
+    public function metaFilesIn($folder, $recursive)
+    {
+        if (isset($this->metaFiles[$key = $folder.($recursive ? '-recursive' : '')])) {
+            return $this->metaFiles[$key];
+        }
+
+        $files = $this->files();
+
+        $files = $files->filter(function ($file, $path) {
+            return Str::startsWith($path, '.meta/')
+                || Str::contains($path, '/.meta/');
+        });
+
+        // Filter by folder and recursiveness. But don't bother if we're
+        // requesting the root recursively as it's already that way.
+        if ($folder === '/' && $recursive) {
+            //
+        } else {
+            $files = $files->filter(function ($file) use ($folder, $recursive) {
+                $dir = $file['dirname'];
+                $dir = substr($dir, 0, -6); // remove .meta/ from the end
+                $dir = $dir === '' ? '/' : $dir;
+
+                return $recursive ? Str::startsWith($dir, $folder) : $dir == $folder;
+            });
+        }
+
+        return $this->metaFiles[$key] = $files;
     }
 
     public function filteredFilesIn($folder, $recursive)

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -156,7 +156,7 @@ class AssetContainerContents
             $files = $files->filter(function ($file) use ($folder, $recursive) {
                 $dir = $file['dirname'];
                 $dir = substr($dir, 0, -6); // remove .meta/ from the end
-                $dir = $dir === '' ? '/' : $dir;
+                $dir = $dir ?: '/';
 
                 return $recursive ? Str::startsWith($dir, $folder) : $dir == $folder;
             });

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -294,6 +294,19 @@ class AssetContainerTest extends TestCase
     }
 
     /** @test */
+    public function it_gets_all_meta_files_by_default()
+    {
+        $this->assertEquals([
+            '.meta/a.txt.yaml',
+            '.meta/b.txt.yaml',
+            'nested/.meta/nested-a.txt.yaml',
+            'nested/.meta/nested-b.txt.yaml',
+            'nested/double-nested/.meta/double-nested-a.txt.yaml',
+            'nested/double-nested/.meta/double-nested-b.txt.yaml',
+        ], $this->containerWithDisk()->metaFiles()->all());
+    }
+
+    /** @test */
     public function it_gets_files_in_a_folder()
     {
         $this->assertEquals([
@@ -305,6 +318,20 @@ class AssetContainerTest extends TestCase
             'nested/nested-a.txt',
             'nested/nested-b.txt',
         ], $this->containerWithDisk()->files('nested')->all());
+    }
+
+    /** @test */
+    public function it_gets_meta_files_in_a_folder()
+    {
+        $this->assertEquals([
+            '.meta/a.txt.yaml',
+            '.meta/b.txt.yaml',
+        ], $this->containerWithDisk()->metaFiles('/')->all());
+
+        $this->assertEquals([
+            'nested/.meta/nested-a.txt.yaml',
+            'nested/.meta/nested-b.txt.yaml',
+        ], $this->containerWithDisk()->metaFiles('nested')->all());
     }
 
     /** @test */
@@ -325,6 +352,26 @@ class AssetContainerTest extends TestCase
             'nested/nested-a.txt',
             'nested/nested-b.txt',
         ], $this->containerWithDisk()->files('nested', true)->all());
+    }
+
+    /** @test */
+    public function it_gets_meta_files_in_a_folder_recursively()
+    {
+        $this->assertEquals([
+            '.meta/a.txt.yaml',
+            '.meta/b.txt.yaml',
+            'nested/.meta/nested-a.txt.yaml',
+            'nested/.meta/nested-b.txt.yaml',
+            'nested/double-nested/.meta/double-nested-a.txt.yaml',
+            'nested/double-nested/.meta/double-nested-b.txt.yaml',
+        ], $this->containerWithDisk()->metaFiles('/', true)->all());
+
+        $this->assertEquals([
+            'nested/.meta/nested-a.txt.yaml',
+            'nested/.meta/nested-b.txt.yaml',
+            'nested/double-nested/.meta/double-nested-a.txt.yaml',
+            'nested/double-nested/.meta/double-nested-b.txt.yaml',
+        ], $this->containerWithDisk()->metaFiles('nested', true)->all());
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #6821, a performance issue introduced by #6769. 

In order to sync the original state to get the focal point, it would read the meta file. We would only try to read it if the file existed though, but on remote filesystems like S3 this would still result in an API request. The bottleneck is cause by all these new API requests.

This PR fixes the issue by checking whether the meta file is in the already locally cached file listing. It avoids those API requests.

Here are some benchmarks of the average times over 5 requests for a few simple pages I threw together.

**Asset browser:**
Before:  1.23s
After: 202ms

**Frontend page:**
Before: 1.09s
After: 222ms

**Publish form:**
Before: 2.6s
After: 257ms