### PR TITLE
Remove utf8_encode() function

### DIFF
--- a/src/Http/Controllers/CP/Fieldtypes/RelationshipFieldtypeController.php
+++ b/src/Http/Controllers/CP/Fieldtypes/RelationshipFieldtypeController.php
@@ -42,8 +42,7 @@ class RelationshipFieldtypeController extends CpController
 
     protected function fieldtype($request)
     {
-        $config = json_decode(utf8_encode(base64_decode($request->config)), true);
-
+        $config = json_decode(mb_convert_encoding(base64_decode($request->config), 'UTF-8', mb_list_encodings()), true);
         return Fieldtype::find($config['type'])->setField(
             new Field('relationship', $config)
         );

--- a/src/Http/Controllers/CP/Fieldtypes/RelationshipFieldtypeController.php
+++ b/src/Http/Controllers/CP/Fieldtypes/RelationshipFieldtypeController.php
@@ -43,6 +43,7 @@ class RelationshipFieldtypeController extends CpController
     protected function fieldtype($request)
     {
         $config = json_decode(mb_convert_encoding(base64_decode($request->config), 'UTF-8', mb_list_encodings()), true);
+
         return Fieldtype::find($config['type'])->setField(
             new Field('relationship', $config)
         );


### PR DESCRIPTION
With PHP8.2 `utf8_encode` function will be deprecated ([source](https://www.php.net/manual/en/function.utf8-encode.php)). I refactored:
```php
utf8_encode($text)
```

to:
```php
mb_convert_encoding($text, 'UTF-8', mb_list_encodings())
```

to avoid problems with newer PHP versions.