### PR TITLE
Fix issue where AssetReferenceUpdater would fail if $bardPayload was `NULL`

### DIFF
--- a/src/Assets/AssetReferenceUpdater.php
+++ b/src/Assets/AssetReferenceUpdater.php
@@ -253,7 +253,7 @@ class AssetReferenceUpdater extends DataReferenceUpdater
 
         $bardPayload = Arr::get($data, $dottedKey, []);
 
-        if (!$bardPayload) {
+        if (! $bardPayload) {
             return;
         }
 
@@ -301,7 +301,7 @@ class AssetReferenceUpdater extends DataReferenceUpdater
 
         $bardPayload = Arr::get($data, $dottedKey, []);
 
-        if (!$bardPayload) {
+        if (! $bardPayload) {
             return;
         }
 

--- a/src/Assets/AssetReferenceUpdater.php
+++ b/src/Assets/AssetReferenceUpdater.php
@@ -253,6 +253,10 @@ class AssetReferenceUpdater extends DataReferenceUpdater
 
         $bardPayload = Arr::get($data, $dottedKey, []);
 
+        if (!$bardPayload) {
+            return;
+        }
+
         $changed = collect(Arr::dot($bardPayload))
             ->filter(function ($value, $key) {
                 return preg_match('/(.*)\.(type)/', $key) && $value === 'image';
@@ -296,6 +300,10 @@ class AssetReferenceUpdater extends DataReferenceUpdater
         $dottedKey = $dottedPrefix.$field->handle();
 
         $bardPayload = Arr::get($data, $dottedKey, []);
+
+        if (!$bardPayload) {
+            return;
+        }
 
         $changed = collect(Arr::dot($bardPayload))
             ->filter(function ($value, $key) {

--- a/tests/Listeners/UpdateAssetReferencesTest.php
+++ b/tests/Listeners/UpdateAssetReferencesTest.php
@@ -775,12 +775,6 @@ class UpdateAssetReferencesTest extends TestCase
                         'container' => 'test_container',
                     ],
                 ],
-                [
-                    'handle' => 'name',
-                    'field' => [
-                        'type' => 'text',
-                    ],
-                ],
             ],
         ]);
 

--- a/tests/Listeners/UpdateAssetReferencesTest.php
+++ b/tests/Listeners/UpdateAssetReferencesTest.php
@@ -762,6 +762,42 @@ class UpdateAssetReferencesTest extends TestCase
     }
 
     /** @test */
+    public function it_fails_gracefully_when_bard_value_is_null()
+    {
+        $collection = tap(Facades\Collection::make('articles'))->save();
+
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                [
+                    'handle' => 'bardo',
+                    'field' => [
+                        'type' => 'bard',
+                        'container' => 'test_container',
+                    ],
+                ],
+                [
+                    'handle' => 'name',
+                    'field' => [
+                        'type' => 'text',
+                    ],
+                ],
+            ],
+        ]);
+
+        // Though nulls are normally filtered out, they may not be in multisite and/or eloquent situations...
+        $entry = tap(Facades\Entry::make()->collection($collection)->data([
+            'bardo' => null,
+        ]))->save();
+
+        $this->assertNull($entry->fresh()->get('bardo'));
+
+        $this->assetHoff->delete();
+        $this->assetNorris->path('content/norris-new.jpg')->save();
+
+        $this->assertNull($entry->fresh()->get('bardo'));
+    }
+
+    /** @test */
     public function it_updates_asset_references_in_bard_field_when_saved_as_html()
     {
         $collection = tap(Facades\Collection::make('articles'))->save();


### PR DESCRIPTION
Fixes #6824 