### PR TITLE
Add custom javascript on nocache replacement.

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -225,6 +225,8 @@ fetch('/!/nocache', {
     for (const meta of document.querySelectorAll('meta[content=$csrfPlaceholder]')) {
         meta.content = data.csrf;
     }
+    
+    document.dispatchEvent(new CustomEvent('statamic::nocache-replaced'));
 });
 EOT;
 


### PR DESCRIPTION
This pull request adds a simple javascript event which gets triggered once the 'nocache' sections of a template have been replaced.

The event name signature could easily be adjusted in this PR, but I went with something simple that is extremely unlikely to collide.

The PR should not introduce any breaking changes.

The custom event may be listened for using something along the lines of the following:
```js
document.addEventListener('statamic::nocache-replaced', (event) => {
    alert('nocache elements have been replaced!');
});
```

This could be used for any number of things such as triggering animations, to loading code from external libraries.

Please let me know if there is anything else you would like me to add for this PR.