### PR TITLE
Handle starter-kit post-install for statamic/cli users in Windows

### DIFF
--- a/src/Console/Commands/StarterKitInstall.php
+++ b/src/Console/Commands/StarterKitInstall.php
@@ -59,7 +59,7 @@ class StarterKitInstall extends Command
             $this->call('statamic:site:clear', ['--no-interaction' => true]);
         }
 
-        $installer = StarterKitInstaller::package($package, $licenseManager, $this)
+        $installer = StarterKitInstaller::package($package, $this, $licenseManager)
             ->fromLocalRepo($this->option('local'))
             ->withConfig($this->option('with-config'))
             ->withoutDependencies($this->option('without-dependencies'))

--- a/src/Console/Commands/StarterKitInstall.php
+++ b/src/Console/Commands/StarterKitInstall.php
@@ -64,6 +64,7 @@ class StarterKitInstall extends Command
             ->withConfig($this->option('with-config'))
             ->withoutDependencies($this->option('without-dependencies'))
             ->withUser($cleared && $this->input->isInteractive() && ! $this->option('cli-install'))
+            ->usingSubProcess($this->option('cli-install'))
             ->force($this->option('force'));
 
         try {

--- a/src/Console/Commands/StarterKitRunPostInstall.php
+++ b/src/Console/Commands/StarterKitRunPostInstall.php
@@ -39,7 +39,7 @@ class StarterKitRunPostInstall extends Command
         $installer = StarterKitInstaller::package($package, $this);
 
         try {
-            $installer->runPostInstall();
+            $installer->runPostInstallHook(true);
         } catch (StarterKitException $exception) {
             $this->error($exception->getMessage());
 

--- a/src/Console/Commands/StarterKitRunPostInstall.php
+++ b/src/Console/Commands/StarterKitRunPostInstall.php
@@ -36,6 +36,12 @@ class StarterKitRunPostInstall extends Command
             return;
         }
 
+        if (! app('files')->exists(base_path("vendor/{$package}"))) {
+            $this->error("Cannot find starter kit [{$package}] in vendor.");
+
+            return 1;
+        }
+
         $installer = StarterKitInstaller::package($package, $this);
 
         try {

--- a/src/Console/Commands/StarterKitRunPostInstall.php
+++ b/src/Console/Commands/StarterKitRunPostInstall.php
@@ -39,7 +39,7 @@ class StarterKitRunPostInstall extends Command
         $installer = StarterKitInstaller::package($package, $this);
 
         try {
-            $installer->runPostInstallHook(true);
+            $installer->runPostInstallHook(true)->removeStarterKit();
         } catch (StarterKitException $exception) {
             $this->error($exception->getMessage());
 

--- a/src/Console/Commands/StarterKitRunPostInstall.php
+++ b/src/Console/Commands/StarterKitRunPostInstall.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Statamic\Console\Commands;
+
+use Illuminate\Console\Command;
+use Statamic\Console\RunsInPlease;
+use Statamic\Console\ValidatesInput;
+use Statamic\Rules\ComposerPackage;
+use Statamic\StarterKits\Exceptions\StarterKitException;
+use Statamic\StarterKits\Installer as StarterKitInstaller;
+
+class StarterKitRunPostInstall extends Command
+{
+    use RunsInPlease, ValidatesInput;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'statamic:starter-kit:run-post-install { package : Specify the starter kit package }';
+
+    /**
+     * Indicates whether the command should be shown in the Artisan command list.
+     *
+     * @var bool
+     */
+    protected $hidden = true;
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if ($this->validationFails($package = $this->argument('package'), new ComposerPackage)) {
+            return;
+        }
+
+        $installer = StarterKitInstaller::package($package, $this);
+
+        try {
+            $installer->runPostInstall();
+        } catch (StarterKitException $exception) {
+            $this->error($exception->getMessage());
+
+            return 1;
+        }
+
+        $this->info("Starter kit [$package] was successfully installed.");
+    }
+}

--- a/src/Console/Processes/TtyDetector.php
+++ b/src/Console/Processes/TtyDetector.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Statamic\Console\Processes;
+
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+class TtyDetector
+{
+    /**
+     * Try to `setTty()` using symfony/process, since that method ultimately determines whether or not we can TTY.
+     *
+     * @return bool
+     */
+    public function isTtySupported()
+    {
+        try {
+            (new Process)->setTty(true);
+        } catch (RuntimeException $exception) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Console/Processes/TtyDetector.php
+++ b/src/Console/Processes/TtyDetector.php
@@ -15,7 +15,7 @@ class TtyDetector
     public function isTtySupported()
     {
         try {
-            (new Process)->setTty(true);
+            (new Process([]))->setTty(true);
         } catch (RuntimeException $exception) {
             return false;
         }

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -32,6 +32,7 @@ class ConsoleServiceProvider extends ServiceProvider
         Commands\StacheDoctor::class,
         Commands\StarterKitExport::class,
         Commands\StarterKitInstall::class,
+        Commands\StarterKitRunPostInstall::class,
         Commands\StaticClear::class,
         Commands\StaticWarm::class,
         // Commands\MakeUserMigration::class,

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -587,7 +587,7 @@ EOT;
      *
      * @return $this
      */
-    protected function removeStarterKit()
+    public function removeStarterKit()
     {
         if ($this->disableCleanup) {
             return $this;

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -493,13 +493,19 @@ final class Installer
     }
 
     /**
-     * Run post install hook, if one exists in the starter kit.
+     * Run post-install hook, if one exists in the starter kit.
      *
      * @return $this
+     *
+     * @throws StarterKitException
      */
-    protected function runPostInstallHook()
+    public function runPostInstallHook($throwExceptions = false)
     {
-        if (! $postInstallHook = Hook::find($this->starterKitPath('StarterKitPostInstall.php'))) {
+        $postInstallHook = Hook::find($this->starterKitPath('StarterKitPostInstall.php'));
+
+        if ($throwExceptions && ! $postInstallHook) {
+            throw new StarterKitException("Cannot find post-install hook for [$this->package].");
+        } elseif (! $postInstallHook) {
             return $this;
         }
 

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -35,10 +35,10 @@ final class Installer
      * Instantiate starter kit installer.
      *
      * @param  string  $package
-     * @param  LicenseManager  $licenseManager
      * @param  mixed  $console
+     * @param  LicenseManager|null  $licenseManager
      */
-    public function __construct(string $package, LicenseManager $licenseManager, $console = null)
+    public function __construct(string $package, $console = null, LicenseManager $licenseManager = null)
     {
         $this->package = $package;
         $this->licenseManager = $licenseManager;
@@ -51,13 +51,13 @@ final class Installer
      * Instantiate starter kit installer.
      *
      * @param  string  $package
-     * @param  LicenseManager  $licenseManager
      * @param  mixed  $console
+     * @param  LicenseManager|null  $licenseManager
      * @return static
      */
-    public static function package(string $package, LicenseManager $licenseManager, $console = null)
+    public static function package(string $package, $console = null, LicenseManager $licenseManager = null)
     {
-        return new static($package, $licenseManager, $console);
+        return new static($package, $console, $licenseManager);
     }
 
     /**

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -24,6 +24,7 @@ final class Installer
     protected $withConfig;
     protected $withoutDependencies;
     protected $withUser;
+    protected $usingSubProcess;
     protected $force;
     protected $console;
     protected $url;
@@ -105,6 +106,19 @@ final class Installer
     public function withUser($withUser = false)
     {
         $this->withUser = $withUser;
+
+        return $this;
+    }
+
+    /**
+     * Install using sub-process.
+     *
+     * @param  bool  $usingSubProcess
+     * @return $this
+     */
+    public function usingSubProcess($usingSubProcess = false)
+    {
+        $this->usingSubProcess = $usingSubProcess;
 
         return $this;
     }

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -29,6 +29,7 @@ final class Installer
     protected $force;
     protected $console;
     protected $url;
+    protected $disableCleanup;
 
     /**
      * Instantiate starter kit installer.
@@ -534,6 +535,8 @@ EOT;
 
         $this->files->put($path, $instructions);
 
+        $this->disableCleanup = true;
+
         return $this;
     }
 
@@ -580,6 +583,10 @@ EOT;
      */
     protected function removeStarterKit()
     {
+        if ($this->disableCleanup) {
+            return $this;
+        }
+
         $this->console->info('Cleaning up temporary files...');
 
         if (Composer::isInstalled($this->package)) {

--- a/tests/Fakes/Composer/FakeComposer.php
+++ b/tests/Fakes/Composer/FakeComposer.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Fakes\Composer;
+
+use Illuminate\Filesystem\Filesystem;
+use Statamic\Support\Arr;
+use Statamic\Support\Str;
+
+class FakeComposer
+{
+    public function __construct()
+    {
+        $this->files = app(Filesystem::class);
+    }
+
+    public function require($package, $version = null, ...$extraParams)
+    {
+        if (collect($extraParams)->contains('--dry-run')) {
+            return;
+        }
+
+        $this->fakeInstallComposerJson('require', $package, $version);
+        $this->fakeInstallVendorFiles($package);
+    }
+
+    public function requireDev($package, $version = null, ...$extraParams)
+    {
+        if (collect($extraParams)->contains('--dry-run')) {
+            return;
+        }
+
+        $this->fakeInstallComposerJson('require-dev', $package, $version);
+        $this->fakeInstallVendorFiles($package);
+    }
+
+    public function requireMultiple($packages, ...$extraParams)
+    {
+        foreach ($packages as $package => $version) {
+            $this->require($package, $version, ...$extraParams);
+        }
+    }
+
+    public function requireMultipleDev($packages, ...$extraParams)
+    {
+        foreach ($packages as $package => $version) {
+            $this->requireDev($package, $version, ...$extraParams);
+        }
+    }
+
+    public function remove($package)
+    {
+        $this->removeFromComposerJson($package);
+        $this->removeFromVendorFiles($package);
+    }
+
+    public function removeDev($package)
+    {
+        $this->remove($package);
+    }
+
+    public function runAndOperateOnOutput($args, $callback)
+    {
+        $args = collect($args);
+
+        if (! $args->contains('require')) {
+            return;
+        }
+
+        $requireMethod = $args->contains('--dev')
+            ? 'requireMultipleDev'
+            : 'requireMultiple';
+
+        $packages = $args
+            ->filter(function ($arg) {
+                return Str::contains($arg, '/');
+            })
+            ->mapWithKeys(function ($arg) {
+                $parts = explode(':', $arg);
+
+                return [$parts[0] => $parts[1]];
+            })
+            ->all();
+
+        $this->{$requireMethod}($packages);
+    }
+
+    private function fakeInstallComposerJson($requireKey, $package, $version)
+    {
+        $composerJson = json_decode($this->files->get(base_path('composer.json')), true);
+
+        $composerJson[$requireKey][$package] = $version ?? '*';
+
+        $this->files->put(
+            base_path('composer.json'),
+            json_encode($composerJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+        );
+    }
+
+    private function removeFromComposerJson($package)
+    {
+        $composerJson = json_decode($this->files->get(base_path('composer.json')), true);
+
+        Arr::forget($composerJson, "require.{$package}");
+        Arr::forget($composerJson, "require-dev.{$package}");
+
+        $this->files->put(
+            base_path('composer.json'),
+            json_encode($composerJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+        );
+    }
+
+    private function fakeInstallVendorFiles($package)
+    {
+        if ($this->files->exists($path = base_path("vendor/{$package}"))) {
+            $this->files->deleteDirectory($path);
+        }
+
+        if ($package === 'statamic/cool-runnings') {
+            $this->files->copyDirectory(base_path('repo/cool-runnings'), $path);
+        } else {
+            $this->files->makeDirectory($path, 0755, true);
+        }
+    }
+
+    private function removeFromVendorFiles($package)
+    {
+        if ($this->files->exists($path = base_path("vendor/{$package}"))) {
+            $this->files->deleteDirectory($path);
+        }
+    }
+
+    public function __call($method, $args)
+    {
+        return $this;
+    }
+}

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -304,6 +304,11 @@ EOT;
     {
         $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), '<?php');
 
+        Hook::shouldReceive('find')
+            ->with($this->kitVendorPath('StarterKitPostInstall.php'))
+            ->once()
+            ->andReturn(null);
+
         $this->installCoolRunnings(['--with-config' => true]);
 
         $this->assertFileExists($hookPath = base_path('StarterKitPostInstall.php'));
@@ -314,6 +319,11 @@ EOT;
     public function it_doesnt_copy_starter_kit_post_install_script_hook_when_with_config_option_is_not_passed()
     {
         $this->files->put($this->kitRepoPath('StarterKitPostInstall.php'), '<?php');
+
+        Hook::shouldReceive('find')
+            ->with($this->kitVendorPath('StarterKitPostInstall.php'))
+            ->once()
+            ->andReturn(null);
 
         $this->installCoolRunnings();
 

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -597,7 +597,7 @@ EOT;
     /** @test */
     public function it_can_register_and_run_newly_installed_command_in_post_install_hook()
     {
-        Hook::swap(new FakeHook);
+        Hook::shouldReceive('find')->andReturn(new StarterKitPostInstall);
 
         $this->assertFalse(Blink::has('starter-kit-command-run'));
 
@@ -846,14 +846,6 @@ class FakeComposer
     public function __call($method, $args)
     {
         return $this;
-    }
-}
-
-class FakeHook
-{
-    public function find()
-    {
-        return new StarterKitPostInstall;
     }
 }
 

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -12,8 +12,8 @@ use Statamic\Console\Commands\StarterKitInstall as InstallCommand;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Config;
 use Statamic\Facades\YAML;
-use Statamic\Support\Arr;
 use Statamic\Support\Str;
+use Tests\Fakes\Composer\FakeComposer;
 use Tests\TestCase;
 
 class InstallTest extends TestCase
@@ -722,135 +722,6 @@ EOT;
     private function assertComposerJsonDoesntHave($package)
     {
         $this->assertFileDoesntHaveContent($package, base_path('composer.json'));
-    }
-}
-
-class FakeComposer
-{
-    public function __construct()
-    {
-        $this->files = app(Filesystem::class);
-    }
-
-    public function require($package, $version = null, ...$extraParams)
-    {
-        if (collect($extraParams)->contains('--dry-run')) {
-            return;
-        }
-
-        $this->fakeInstallComposerJson('require', $package, $version);
-        $this->fakeInstallVendorFiles($package);
-    }
-
-    public function requireDev($package, $version = null, ...$extraParams)
-    {
-        if (collect($extraParams)->contains('--dry-run')) {
-            return;
-        }
-
-        $this->fakeInstallComposerJson('require-dev', $package, $version);
-        $this->fakeInstallVendorFiles($package);
-    }
-
-    public function requireMultiple($packages, ...$extraParams)
-    {
-        foreach ($packages as $package => $version) {
-            $this->require($package, $version, ...$extraParams);
-        }
-    }
-
-    public function requireMultipleDev($packages, ...$extraParams)
-    {
-        foreach ($packages as $package => $version) {
-            $this->requireDev($package, $version, ...$extraParams);
-        }
-    }
-
-    public function remove($package)
-    {
-        $this->removeFromComposerJson($package);
-        $this->removeFromVendorFiles($package);
-    }
-
-    public function removeDev($package)
-    {
-        $this->remove($package);
-    }
-
-    public function runAndOperateOnOutput($args, $callback)
-    {
-        $args = collect($args);
-
-        if (! $args->contains('require')) {
-            return;
-        }
-
-        $requireMethod = $args->contains('--dev')
-            ? 'requireMultipleDev'
-            : 'requireMultiple';
-
-        $packages = $args
-            ->filter(function ($arg) {
-                return Str::contains($arg, '/');
-            })
-            ->mapWithKeys(function ($arg) {
-                $parts = explode(':', $arg);
-
-                return [$parts[0] => $parts[1]];
-            })
-            ->all();
-
-        $this->{$requireMethod}($packages);
-    }
-
-    private function fakeInstallComposerJson($requireKey, $package, $version)
-    {
-        $composerJson = json_decode($this->files->get(base_path('composer.json')), true);
-
-        $composerJson[$requireKey][$package] = $version ?? '*';
-
-        $this->files->put(
-            base_path('composer.json'),
-            json_encode($composerJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
-        );
-    }
-
-    private function removeFromComposerJson($package)
-    {
-        $composerJson = json_decode($this->files->get(base_path('composer.json')), true);
-
-        Arr::forget($composerJson, "require.{$package}");
-        Arr::forget($composerJson, "require-dev.{$package}");
-
-        $this->files->put(
-            base_path('composer.json'),
-            json_encode($composerJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
-        );
-    }
-
-    private function fakeInstallVendorFiles($package)
-    {
-        if ($this->files->exists($path = base_path("vendor/{$package}"))) {
-            $this->files->deleteDirectory($path);
-        }
-
-        if ($package === 'statamic/cool-runnings') {
-            $this->files->copyDirectory(base_path('repo/cool-runnings'), $path);
-        } else {
-            $this->files->makeDirectory($path, 0755, true);
-        }
-    }
-
-    private function removeFromVendorFiles($package)
-    {
-        if ($this->files->exists($path = base_path("vendor/{$package}"))) {
-            $this->files->deleteDirectory($path);
-        }
-    }
-
-    public function __call($method, $args)
-    {
-        return $this;
     }
 }
 

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -626,6 +626,10 @@ EOT;
         $this->assertFileExists($cachedInstructionsPath);
         $this->assertFileHasContent('Warning', $cachedInstructionsPath);
         $this->assertFileHasContent('php please starter-kit:run-post-install statamic/cool-runnings', $cachedInstructionsPath);
+
+        // Ensure the starter kit repo is not cleaned up so that `starter-kit:run-post-install` can be run by the
+        // user afterwards. It will be cleaned up after the post-install hook is successfully run instead.
+        $this->assertFileExists(base_path('vendor/statamic/cool-runnings'));
     }
 
     /** @test */
@@ -646,6 +650,7 @@ EOT;
         $this->installCoolRunnings(['--cli-install' => false]);
 
         $this->assertFileNotExists(storage_path('statamic/tmp/cli/post-install-instructions.txt'));
+        $this->assertFileNotExists(base_path('vendor/statamic/cool-runnings'));
     }
 
     private function kitRepoPath($path = null)

--- a/tests/StarterKits/RunPostInstallTest.php
+++ b/tests/StarterKits/RunPostInstallTest.php
@@ -58,7 +58,7 @@ class RunPostInstallTest extends TestCase
             ->artisan('statamic:starter-kit:run-post-install', [
                 'package' => 'statamic/cool-runnings',
             ])
-            ->assertOk();
+            ->assertSuccessful();
 
         // Now we should see that the hook has been run, and the starter kit has been cleaned up from vendor
         $this->assertTrue(Blink::has('post-install-hook-run'));

--- a/tests/StarterKits/RunPostInstallTest.php
+++ b/tests/StarterKits/RunPostInstallTest.php
@@ -58,7 +58,7 @@ class RunPostInstallTest extends TestCase
             ->artisan('statamic:starter-kit:run-post-install', [
                 'package' => 'statamic/cool-runnings',
             ])
-            ->assertSuccessful();
+            ->assertExitCode(0);
 
         // Now we should see that the hook has been run, and the starter kit has been cleaned up from vendor
         $this->assertTrue(Blink::has('post-install-hook-run'));
@@ -80,7 +80,7 @@ class RunPostInstallTest extends TestCase
                 'package' => 'statamic/cool-runnings',
             ])
             ->expectsOutput('Cannot find post-install hook for [statamic/cool-runnings].')
-            ->assertFailed();
+            ->assertExitCode(1);
 
         $this->assertFalse(Blink::has('post-install-hook-run'));
         $this->assertFileExists($this->kitVendorPath());
@@ -98,7 +98,7 @@ class RunPostInstallTest extends TestCase
                 'package' => 'statamic/non-existent',
             ])
             ->expectsOutput('Cannot find starter kit [statamic/non-existent] in vendor.')
-            ->assertFailed();
+            ->assertExitCode(1);
 
         $this->assertFalse(Blink::has('post-install-hook-run'));
         $this->assertFileExists($this->kitVendorPath());

--- a/tests/StarterKits/RunPostInstallTest.php
+++ b/tests/StarterKits/RunPostInstallTest.php
@@ -126,7 +126,7 @@ class RunPostInstallTest extends TestCase
 
     private function simulateCliInstallWithoutTtySupport()
     {
-        Http::fake($customFake ?? [
+        Http::fake([
             'outpost.*' => Http::response(['data' => ['price' => null]], 200),
             'repo.packagist.org/*' => Http::response('', 200),
             '*' => Http::response('', 404),

--- a/tests/StarterKits/RunPostInstallTest.php
+++ b/tests/StarterKits/RunPostInstallTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\StarterKits;
+
+use Facades\Statamic\Console\Processes\Composer;
+use Facades\Statamic\Console\Processes\TtyDetector;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Http;
+use Statamic\Facades\Blink;
+use Tests\Fakes\Composer\FakeComposer;
+use Tests\TestCase;
+
+class RunPostInstallTest extends TestCase
+{
+    use Concerns\BacksUpSite;
+
+    protected $files;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = app(Filesystem::class);
+
+        $this->restoreSite();
+        $this->backupSite();
+        $this->prepareRepo();
+
+        Composer::swap(new FakeComposer($this));
+    }
+
+    public function tearDown(): void
+    {
+        $this->restoreSite();
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_runs_post_install_hook_script()
+    {
+        $this->assertFileNotExists($this->kitVendorPath());
+        $this->assertFileNotExists(base_path('copied.md'));
+
+        $this->simulateCliInstallWithoutTtySupport();
+
+        // Ensure starter kit itself was installed, but not yet cleaned up because a manual post-install is required
+        $this->assertFileExists(base_path('copied.md'));
+        $this->assertFileNotExists(base_path('composer.json.bak'));
+        $this->assertFileExists(base_path('composer.json'));
+        $this->assertComposerJsonDoesntHave('repositories');
+        $this->assertFileExists($this->kitVendorPath());
+        $this->assertFalse(Blink::has('post-install-hook-run'));
+
+        $this->artisan('statamic:starter-kit:run-post-install', [
+            'package' => 'statamic/cool-runnings',
+        ]);
+
+        // Now we should see that the hook has been run, and the starter kit has been cleaned up from vendor
+        $this->assertTrue(Blink::has('post-install-hook-run'));
+        $this->assertFileNotExists($this->kitVendorPath());
+    }
+
+    private function kitRepoPath($path = null)
+    {
+        return collect([base_path('repo/cool-runnings'), $path])->filter()->implode('/');
+    }
+
+    protected function kitVendorPath($path = null)
+    {
+        return collect([base_path('vendor/statamic/cool-runnings'), $path])->filter()->implode('/');
+    }
+
+    private function prepareRepo()
+    {
+        $this->files->copyDirectory(__DIR__.'/__fixtures__/cool-runnings', $this->kitRepoPath());
+
+        $this->files->copy(
+            __DIR__.'/__fixtures__/cool-runnings-post-install-hook/StarterKitPostInstall.php',
+            $this->kitRepoPath('StarterKitPostInstall.php')
+        );
+    }
+
+    private function simulateCliInstallWithoutTtySupport()
+    {
+        Http::fake($customFake ?? [
+            'outpost.*' => Http::response(['data' => ['price' => null]], 200),
+            'repo.packagist.org/*' => Http::response('', 200),
+            '*' => Http::response('', 404),
+        ]);
+
+        // This is required to simulate no TTY in Windows,
+        // so that starter kit doesn't get cleaned up on install
+        TtyDetector::shouldReceive('isTtySupported')->andReturn(false);
+
+        $this->artisan('statamic:starter-kit:install', array_merge([
+            'package' => 'statamic/cool-runnings',
+            '--no-interaction' => true,
+            '--cli-install' => true, // This is also required to simulate cli installer, for same reason as above
+        ]));
+    }
+
+    private function assertFileDoesntHaveContent($expected, $path)
+    {
+        $this->assertFileExists($path);
+
+        $this->assertStringNotContainsString($expected, $this->files->get($path));
+    }
+
+    private function assertComposerJsonDoesntHave($package)
+    {
+        $this->assertFileDoesntHaveContent($package, base_path('composer.json'));
+    }
+}

--- a/tests/StarterKits/__fixtures__/cool-runnings-post-install-hook/StarterKitPostInstall.php
+++ b/tests/StarterKits/__fixtures__/cool-runnings-post-install-hook/StarterKitPostInstall.php
@@ -1,0 +1,25 @@
+<?php
+
+use Statamic\Facades\Blink;
+
+class StarterKitPostInstall
+{
+    public $registerCommands = [
+        StarterKitTestCommand::class,
+    ];
+
+    public function handle($console)
+    {
+        $console->call('statamic:test:starter-kit-command');
+    }
+}
+
+class StarterKitTestCommand extends \Illuminate\Console\Command
+{
+    protected $name = 'statamic:test:starter-kit-command';
+
+    public function handle()
+    {
+        Blink::put('post-install-hook-run', true);
+    }
+}


### PR DESCRIPTION
## The problem

When working on https://github.com/statamic/cli/pull/56 for https://github.com/statamic/cms/pull/6792, we realized that asking the user for input doesn't work within a sub-process in Windows environments. This is due to the lack of TTY support in Windows, and thus is not supported by symfony/process in Windows environments.

To be clear, this only affects:

- Starter kits which contain post-install hooks
- Where those post-install hooks ask the end user for input
- Where the end user is running Windows

## The solution

The solution we came up with is to cache friendly post-install instructions for statamic/cli to show at the end of the install process...

![CleanShot 2022-10-04 at 17 48 46](https://user-images.githubusercontent.com/5187394/193936716-de85e7da-b19c-4195-924d-2f569b4b7daf.png)

By having the user manually run the post-install hook, it can be run as a regular process, rather than as a sub-process (via symfony/process), which allows the post-install hook to ask the user for input without issues in Windows.