### PR TITLE
Fix `stache:warm` and `stache:refresh` performance regression when using S3 assets

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -65,6 +65,12 @@ class Asset implements AssetContract, Augmentable, ArrayAccess, Arrayable, Conta
             $this->original[$property] = $this->{$property};
         }
 
+        // Temporary performance hotfix for when running `stache:refresh` or `stache:warm` with
+        // assets in S3, as we don't need to sync `$this->meta('data')` in those situations.
+        if (Str::startsWith(Arr::get(request()->server(), 'argv.1'), 'stache:')) {
+            return $this;
+        }
+
         $this->original['data'] = $this->metaExists() ? $this->meta('data') : $this->data->all();
 
         return $this;


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/6831

## The problem

This line was added in 3.3.41...

![CleanShot 2022-10-05 at 10 58 15](https://user-images.githubusercontent.com/5187394/194101470-aed4183b-7953-4d05-857f-e6e1b88dbe19.png)

We improved the performance of `metaExists()` in 3.3.42, but the `$this->meta('data')` call still hits the API for every asset, which really slows down `stache:warm` and `stache:refresh`.

Here you can see me profiling the time it takes to run `stache:refresh` on a site with 100 assets in an S3 container, with 5 entries referencing those assets...

![CleanShot 2022-10-05 at 10 43 27](https://user-images.githubusercontent.com/5187394/194101955-613aeadd-f2e2-4ade-bff0-3d526e1b5f9b.png)

## The solution

We should work on a better solution, but for now this hotfix just prevents this line from being run by the stache warm/refresh commands, so that users' deployments aren't affected in the meantime. (This line isn't needed for stache warm/refresh anyway, as it never existed prior to 3.3.41.)