### PR TITLE
Fix nocache placeholder appearing in responses

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -39,7 +39,7 @@ class Cache
         if ($this->canBeCached($request) && $this->cacher->hasCachedPage($request)) {
             $response = response($this->cacher->getCachedPage($request));
 
-            $this->getReplacers()->each(fn (Replacer $replacer) => $replacer->replaceInCachedResponse($response));
+            $this->makeReplacements($response);
 
             return $response;
         }
@@ -50,6 +50,8 @@ class Cache
             $this->makeReplacementsAndCacheResponse($request, $response);
 
             $this->nocache->write();
+        } else {
+            $this->makeReplacements($response);
         }
 
         return $response;
@@ -62,6 +64,11 @@ class Cache
         $this->getReplacers()->each(fn (Replacer $replacer) => $replacer->prepareResponseToCache($cachedResponse, $response));
 
         $this->cacher->cachePage($request, $cachedResponse);
+    }
+
+    private function makeReplacements($response)
+    {
+        $this->getReplacers()->each(fn (Replacer $replacer) => $replacer->replaceInCachedResponse($response));
     }
 
     private function getReplacers(): Collection

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -50,7 +50,7 @@ class Cache
             $this->makeReplacementsAndCacheResponse($request, $response);
 
             $this->nocache->write();
-        } else {
+        } elseif ($this->shouldMakeReplacements($response)) {
             $this->makeReplacements($response);
         }
 
@@ -99,7 +99,7 @@ class Cache
         }
 
         // Draft and private pages should not be cached.
-        if ($response->headers->has('X-Statamic-Draft') || $response->headers->has('X-Statamic-Private')) {
+        if ($this->isDraftOrPrivate($response)) {
             return false;
         }
 
@@ -108,5 +108,15 @@ class Cache
         }
 
         return true;
+    }
+
+    private function shouldMakeReplacements($response)
+    {
+        return $this->isDraftOrPrivate($response) || $response->getStatusCode() === 404;
+    }
+
+    private function isDraftOrPrivate($response)
+    {
+        return $response->headers->has('X-Statamic-Draft') || $response->headers->has('X-Statamic-Private');
     }
 }

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -50,7 +50,7 @@ class Cache
             $this->makeReplacementsAndCacheResponse($request, $response);
 
             $this->nocache->write();
-        } else {
+        } elseif (! $response->isRedirect()) {
             $this->makeReplacements($response);
         }
 

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -50,7 +50,7 @@ class Cache
             $this->makeReplacementsAndCacheResponse($request, $response);
 
             $this->nocache->write();
-        } elseif ($this->shouldMakeReplacements($response)) {
+        } else {
             $this->makeReplacements($response);
         }
 
@@ -99,7 +99,7 @@ class Cache
         }
 
         // Draft and private pages should not be cached.
-        if ($this->isDraftOrPrivate($response)) {
+        if ($response->headers->has('X-Statamic-Draft') || $response->headers->has('X-Statamic-Private')) {
             return false;
         }
 
@@ -108,15 +108,5 @@ class Cache
         }
 
         return true;
-    }
-
-    private function shouldMakeReplacements($response)
-    {
-        return $this->isDraftOrPrivate($response) || $response->getStatusCode() === 404;
-    }
-
-    private function isDraftOrPrivate($response)
-    {
-        return $response->headers->has('X-Statamic-Draft') || $response->headers->has('X-Statamic-Private');
     }
 }


### PR DESCRIPTION
Fixes #6725 and fixes #6543. 

If the response is not cached (because it is a 404 or a draft viewed in Live Preview) the placeholders are now still replaced with the actual content, to get valid output.
