### PR TITLE
Update Date.php preProcessIndex to use format from config

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -197,11 +197,11 @@ class Date extends Fieldtype
             return $start.' - '.$end;
         }
         
-        if(!is_null($this->config('format'))){
-            return Carbon::createFromFormat($this->config('format'), $data)->format($this->indexDisplayFormat());
+        if(is_null($this->config('format'))){
+            return Carbon::parse($data)->format($this->indexDisplayFormat());
         }
 
-        return Carbon::parse($data)->format($this->indexDisplayFormat());
+        return Carbon::createFromFormat($this->config('format'), $data)->format($this->indexDisplayFormat());
     }
 
     private function saveFormat()

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -197,11 +197,7 @@ class Date extends Fieldtype
             return $start.' - '.$end;
         }
 
-        if (is_null($this->config('format'))) {
-            return Carbon::parse($data)->format($this->indexDisplayFormat());
-        }
-
-        return Carbon::createFromFormat($this->config('format'), $data)->format($this->indexDisplayFormat());
+        return $this->parseSaved($data)->format($this->indexDisplayFormat());
     }
 
     private function saveFormat()

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -196,7 +196,7 @@ class Date extends Fieldtype
 
             return $start.' - '.$end;
         }
-        
+
         if (is_null($this->config('format'))) {
             return Carbon::parse($data)->format($this->indexDisplayFormat());
         }

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -196,6 +196,10 @@ class Date extends Fieldtype
 
             return $start.' - '.$end;
         }
+        
+        if(!is_null($this->config('format'))){
+            return Carbon::createFromFormat($this->config('format'), $data)->format($this->indexDisplayFormat());
+        }
 
         return Carbon::parse($data)->format($this->indexDisplayFormat());
     }

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -197,7 +197,7 @@ class Date extends Fieldtype
             return $start.' - '.$end;
         }
         
-        if(is_null($this->config('format'))){
+        if (is_null($this->config('format'))) {
             return Carbon::parse($data)->format($this->indexDisplayFormat());
         }
 


### PR DESCRIPTION
When a format is specified for a Date field and the field is present on the list, it always throw a DateTime::__construct(): Failed to parse time string exception. Example I have created a date field with the format: "y-m" and when I add that field to the list then this is the thrown exception:

```
Could not parse '20-10': DateTime::__construct(): Failed to parse time string (20-10) at position 0 (2): Unexpected character {"userId":2,"exception":"[object] (Carbon\\Exceptions\\InvalidFormatException(code: 0): Could not parse '20-10': DateTime::__construct(): Failed to parse time string (20-10) at position 0 (2): Unexpected character at /var/www/html/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php:190) [stacktrace]
#0 /var/www/html/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php(216): Carbon\\Carbon::rawParse('20-10', NULL)
#1 /var/www/html/vendor/statamic/cms/src/Fieldtypes/Date.php(300): Carbon\\Carbon::parse('20-10')
#2 /var/www/html/vendor/statamic/cms/src/Fieldtypes/Date.php(126): Statamic\\Fieldtypes\\Date->parseSaved('20-10')
#3 /var/www/html/vendor/statamic/cms/src/Fieldtypes/Date.php(110): Statamic\\Fieldtypes\\Date->preProcessSingle('20-10')
#4 /var/www/html/vendor/statamic/cms/src/Fields/Field.php(314): Statamic\\Fieldtypes\\Date->preProcess('20-10')
#5 /var/www/html/vendor/laravel/framework/src/Illuminate/Collections/HigherOrderCollectionProxy.php(60): Statamic\\Fields\\Field->preProcess()
#6 [internal function]: Illuminate\\Support\\HigherOrderCollectionProxy->Illuminate\\Support\\{closure}(Object(Statamic\\Fields\\Field), 'date
```