### PR TITLE
Update "save_html" display label from  "Display HTML" to "Save as HTML"

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -91,7 +91,7 @@ class Bard extends Replicator
                 ],
             ],
             'save_html' => [
-                'display' => __('Display HTML'),
+                'display' => __('Save as HTML'),
                 'instructions' => __('statamic::fieldtypes.bard.config.save_html'),
                 'type' => 'toggle',
             ],


### PR DESCRIPTION
This renames the "save_html" display label from "Display HTML" to "Save as HTML" for the Bard field type. Fixes #6847.