### PR TITLE
Add `input_label` field to revealer config

### DIFF
--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -115,6 +115,7 @@ return [
     'replicator.title' => 'Replicator',
     'revealer.title' => 'Revealer',
     'revealer.config.mode' => 'Choose your preferred layout style.',
+    'revealer.config.input_label' => 'Set a label to be shown in the button or beside the toggle.',
     'section.title' => 'Section',
     'select.config.clearable' => 'Enable to allow deselecting your option.',
     'select.config.multiple' => 'Allow multiple selections.',

--- a/src/Fieldtypes/Revealer.php
+++ b/src/Fieldtypes/Revealer.php
@@ -23,6 +23,14 @@ class Revealer extends Fieldtype
                     'toggle' => __('Toggle'),
                 ],
                 'default' => 'button',
+                'width' => 50,
+            ],
+            'input_label' => [
+                'display' => __('Input Label'),
+                'instructions' => __('statamic::fieldtypes.revealer.config.input_label'),
+                'type' => 'text',
+                'default' => '',
+                'width' => 50,
             ],
         ];
     }


### PR DESCRIPTION
The revealer fieldtype supports an `input_label` option that allows you to customise the text in the button or beside the toggle, but there is no config field for it in the blueprint editor.

This PR adds that.