### PR TITLE
Add Edit Blueprint option to term publish form

### DIFF
--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -13,6 +13,10 @@
                 </div>
             </h1>
 
+            <dropdown-list class="mr-2" v-if="canEditBlueprint">
+                <dropdown-item :text="__('Edit Blueprint')" :redirect="actions.editBlueprint" />
+            </dropdown-list>
+
             <div class="pt-px text-2xs text-grey-60 flex mr-2" v-if="readOnly">
                 <svg-icon name="lock" class="w-4 mr-sm -mt-sm" /> {{ __('Read Only') }}
             </div>
@@ -277,6 +281,7 @@ export default {
         initialPermalink: String,
         revisionsEnabled: Boolean,
         preloadedAssets: Array,
+        canEditBlueprint: Boolean,
         createAnotherUrl: String,
         listingUrl: String,
         previewTargets: Array,

--- a/resources/views/terms/edit.blade.php
+++ b/resources/views/terms/edit.blade.php
@@ -30,6 +30,7 @@
         :initial-read-only="{{ $str::bool($readOnly) }}"
         :preloaded-assets="{{ json_encode($preloadedAssets) }}"
         :breadcrumbs="{{ $breadcrumbs->toJson() }}"
+        :can-edit-blueprint="{{ $str::bool($user->can('configure fields')) }}"
         create-another-url="{{ cp_route('taxonomies.terms.create', [$taxonomy, $locale]) }}"
         listing-url="{{ cp_route('taxonomies.show', $taxonomy) }}"
         :preview-targets="{{ json_encode($previewTargets) }}"

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -97,6 +97,7 @@ class TermsController extends CpController
                 'revisions' => $term->revisionsUrl(),
                 'restore' => $term->restoreRevisionUrl(),
                 'createRevision' => $term->createRevisionUrl(),
+                'editBlueprint' => cp_route('taxonomies.blueprints.edit', [$taxonomy, $blueprint]),
             ],
             'values' => array_merge($values, ['id' => $term->id()]),
             'meta' => $meta,


### PR DESCRIPTION
Entry publish forms have an Edit Blueprint option, but term publish forms don't.

This PR adds that.