### PR TITLE
Add glide tag `flip` parameter

### DIFF
--- a/src/Imaging/GlideImageManipulator.php
+++ b/src/Imaging/GlideImageManipulator.php
@@ -264,6 +264,17 @@ class GlideImageManipulator implements ImageManipulator
      * @param  string  $value
      * @return $this
      */
+    public function flip($value)
+    {
+        $this->params['flip'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  string  $value
+     * @return $this
+     */
     public function brightness($value)
     {
         $this->params['bri'] = $value;

--- a/tests/Imaging/GlideImageManipulatorTest.php
+++ b/tests/Imaging/GlideImageManipulatorTest.php
@@ -115,6 +115,7 @@ class GlideImageManipulatorTest extends TestCase
             'height' => ['height', 10, ['h' => 10]],
             'square' => ['square', 50, ['w' => 50, 'h' => 50]],
             'orient' => ['orient', 90, ['or' => 90]],
+            'flip' => ['flip', 'h', ['flip' => 'h']],
             'brightness' => ['brightness', 50, ['bri' => 50]],
             'contrast' => ['contrast', 50, ['con' => 50]],
             'gamma' => ['gamma', 50, ['gam' => 50]],


### PR DESCRIPTION
Glide supports a `flip` parameter that allows you to flip an image horizontally, vertically or both (https://glide.thephpleague.com/2.0/api/flip/#flip-flip), but the glide tag does not support it.

This PR adds that.

Accepted values are `v`, `h` or `both`.

```antlers
{{ glide src="donut.jpg" flip="v" }}
{{ glide src="donut.jpg" flip="h" }}
{{ glide src="donut.jpg" flip="both" }}
```