### PR TITLE
Preserve asset data from fields when running statamic:assets:meta generation command

### DIFF
--- a/src/Console/Commands/AssetsMeta.php
+++ b/src/Console/Commands/AssetsMeta.php
@@ -22,6 +22,7 @@ class AssetsMeta extends Command
         $bar = $this->output->createProgressBar($assets->count());
 
         $assets->each(function ($asset) use ($bar) {
+            $asset->hydrate();
             $asset->save();
             $bar->advance();
         });
@@ -32,6 +33,9 @@ class AssetsMeta extends Command
         $this->info('Asset metadata generated');
     }
 
+    /**
+     * @return \Statamic\Assets\AssetCollection
+     */
     protected function getAssets()
     {
         if (! $container = $this->argument('container')) {

--- a/tests/Console/Commands/AssetsMetaTest.php
+++ b/tests/Console/Commands/AssetsMetaTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Console\Commands;
+
+use Illuminate\Support\Facades\Storage;
+use Statamic\Assets\AssetContainer;
+use Statamic\Facades\AssetContainer as AssetContainerFacade;
+use Statamic\Facades\YAML;
+use Statamic\Support\Arr;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class AssetsMetaTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    /**
+     * @var AssetContainer
+     */
+    private $container;
+
+    /**
+     * @var array
+     */
+    private $sampleTextFileContentArray = [
+        'data' => [
+            'foo' => 'bar'
+        ],
+        'size' => 6,
+        'last_modified' => 1665086377,
+        'width' => null,
+        'height' => null,
+        'mime_type' => 'text/plain',
+        'duration' => null,
+    ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('test');
+    }
+
+    private function containerWithDisk()
+    {
+        config(['filesystems.disks.test' => [
+            'driver' => 'local',
+            'root' => __DIR__ . '/__fixtures__/container',
+        ]]);
+
+        $container = (new AssetContainer)->handle('test')->disk('test');
+
+        AssetContainerFacade::partialMock()
+            ->shouldReceive('findByHandle')
+            ->andReturn($container);
+
+        return $container;
+    }
+
+    /** @test */
+    public function it_generates_one_asset_meta_file_for_asset_with_no_meta_file()
+    {
+        $this->containerWithDisk();
+
+        Storage::disk('test')->assertMissing('foo/bar.txt');
+        Storage::disk('test')->assertMissing('foo/.meta/bar.txt.yaml');
+
+        Storage::disk('test')->put('foo/bar.txt', 'foobar');
+
+        Storage::disk('test')->assertExists('foo/bar.txt');
+
+        Storage::disk('test')->assertMissing('foo/.meta/bar.txt.yaml');
+
+        $this->artisan('statamic:assets:meta test_container')
+             ->expectsOutput('Asset metadata generated');
+
+        Storage::disk('test')->assertExists('foo/bar.txt');
+        Storage::disk('test')->assertExists('foo/.meta/bar.txt.yaml');
+    }
+
+    /** @test */
+    public function it_preserves_data_property_in_meta_data_file()
+    {
+        $this->containerWithDisk();
+
+        Storage::disk('test')->put('foo/bar.txt', 'foobar');
+        Storage::disk('test')->put(
+            'foo/.meta/bar.txt.yaml',
+            YAML::dump($this->sampleTextFileContentArray)
+        );
+
+        $this->artisan('statamic:assets:meta test_container')
+            ->expectsOutput('Asset metadata generated');
+
+        $this->assertEquals(
+            Arr::get(YAML::parse(Storage::disk('test')->get('foo/.meta/bar.txt.yaml')), 'data.foo'),
+            'bar'
+        );
+    }
+}

--- a/tests/Console/Commands/AssetsMetaTest.php
+++ b/tests/Console/Commands/AssetsMetaTest.php
@@ -24,7 +24,7 @@ class AssetsMetaTest extends TestCase
      */
     private $sampleTextFileContentArray = [
         'data' => [
-            'foo' => 'bar'
+            'foo' => 'bar',
         ],
         'size' => 6,
         'last_modified' => 1665086377,
@@ -45,7 +45,7 @@ class AssetsMetaTest extends TestCase
     {
         config(['filesystems.disks.test' => [
             'driver' => 'local',
-            'root' => __DIR__ . '/__fixtures__/container',
+            'root' => __DIR__.'/__fixtures__/container',
         ]]);
 
         $container = (new AssetContainer)->handle('test')->disk('test');


### PR DESCRIPTION
Fixes #4595

The fix in the issue description works fine. It also affects `focus` being saved as it goes under `data` property too.

I thought that `generateMeta` method in `Asset` class already accounts for existing asset data and merges it together here:

https://github.com/ncla/cms/blob/3ed1e592b309f34379db07fb95af406b97fe87f8/src/Assets/Asset.php#L235-L253

But with line `$meta = ['data' => $this->data->all()];`, as far as I understood it is for use cases where you are creating `Asset` object manually? So as that is not the case here, we have to simply hydrate the asset, as `AssetRepository::save()` does not account for such situation.

It is an additional call to file system for generating meta. No matter how I look at it, the command will have to look up the meta file, unless we can pull this `data` from stache/cache or something?

I think most people are fine with this behavior (?) so there's no need to include a separate command flag like `--without-hydration` for disregarding existing data, or to make the command create less file system calls. I am just wondering as there's lately been some issues with the asset hydration, so just want to be considerate.

As bonus I have added tests to sleep better at night. Borrowed, inspired logic from other asset tests.