### PR TITLE
Wrap nocache query selector values with quotes

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -218,11 +218,11 @@ fetch('/!/nocache', {
         if (map[key]) map[key].outerHTML = regions[key];
     }
 
-    for (const input of document.querySelectorAll('input[value=$csrfPlaceholder]')) {
+    for (const input of document.querySelectorAll('input[value="$csrfPlaceholder"]')) {
         input.value = data.csrf;
     }
 
-    for (const meta of document.querySelectorAll('meta[content=$csrfPlaceholder]')) {
+    for (const meta of document.querySelectorAll('meta[content="$csrfPlaceholder"]')) {
         meta.content = data.csrf;
     }
 });


### PR DESCRIPTION
While reviewing #6828 I noticed that there was a JS error complaining about an invalid query selector.

Doing `[attr=value]` is fine if `value` starts with a letter. But if it starts with a number, it'll fail.
e.g. `input[value=1bd3]` will throw an error.

The error only happens sometimes, which would be the luck of the draw depending on whether your CSRF token starts with a number.
