### PR TITLE
Disable password protection when in live preview

### DIFF
--- a/src/Auth/Protect/Protectors/Password/PasswordProtector.php
+++ b/src/Auth/Protect/Protectors/Password/PasswordProtector.php
@@ -4,8 +4,6 @@ namespace Statamic\Auth\Protect\Protectors\Password;
 
 use Facades\Statamic\Auth\Protect\Protectors\Password\Token;
 use Statamic\Auth\Protect\Protectors\Protector;
-use Statamic\CP\LivePreview;
-use Statamic\Statamic;
 
 class PasswordProtector extends Protector
 {

--- a/src/Auth/Protect/Protectors/Password/PasswordProtector.php
+++ b/src/Auth/Protect/Protectors/Password/PasswordProtector.php
@@ -4,6 +4,8 @@ namespace Statamic\Auth\Protect\Protectors\Password;
 
 use Facades\Statamic\Auth\Protect\Protectors\Password\Token;
 use Statamic\Auth\Protect\Protectors\Protector;
+use Statamic\CP\LivePreview;
+use Statamic\Statamic;
 
 class PasswordProtector extends Protector
 {
@@ -16,6 +18,10 @@ class PasswordProtector extends Protector
     {
         if (empty(array_get($this->config, 'allowed', []))) {
             abort(403);
+        }
+
+        if (request()->statamicToken()) {
+            return;
         }
 
         if ($this->isPasswordFormUrl()) {

--- a/src/Auth/Protect/Protectors/Password/PasswordProtector.php
+++ b/src/Auth/Protect/Protectors/Password/PasswordProtector.php
@@ -18,7 +18,7 @@ class PasswordProtector extends Protector
             abort(403);
         }
 
-        if (request()->statamicToken()) {
+        if (request()->statamicToken() && request()->statamicToken()->handler() === 'Statamic\Tokens\Handlers\LivePreview') {
             return;
         }
 

--- a/src/Auth/Protect/Protectors/Password/PasswordProtector.php
+++ b/src/Auth/Protect/Protectors/Password/PasswordProtector.php
@@ -4,6 +4,7 @@ namespace Statamic\Auth\Protect\Protectors\Password;
 
 use Facades\Statamic\Auth\Protect\Protectors\Password\Token;
 use Statamic\Auth\Protect\Protectors\Protector;
+use Statamic\Tokens\Handlers\LivePreview;
 
 class PasswordProtector extends Protector
 {
@@ -18,7 +19,7 @@ class PasswordProtector extends Protector
             abort(403);
         }
 
-        if (request()->statamicToken() && request()->statamicToken()->handler() === 'Statamic\Tokens\Handlers\LivePreview') {
+        if (optional(request()->statamicToken())->handler() === LivePreview::class) {
             return;
         }
 


### PR DESCRIPTION
This pull request fixes #4968 by disabling password protection when in Live Preview. 

I opted for checking if the request has a `statamicToken` rather than checking if `live_preview` exists in the entry's supplement data.