### PR TITLE
Invalidate statically cached urls with query strings

### DIFF
--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -290,8 +290,12 @@ abstract class AbstractCacher implements Cacher
 
         $parsed = parse_url($url);
 
+        $query = isset($parsed['query']) ? '?'.$parsed['query'] : '';
+
+        $path = $parsed['path'] ?? '/';
+
         return [
-            $parsed['path'] ?? '/',
+            $path.$query,
             $parsed['scheme'].'://'.$parsed['host'],
         ];
     }

--- a/src/StaticCaching/Cachers/ApplicationCacher.php
+++ b/src/StaticCaching/Cachers/ApplicationCacher.php
@@ -103,13 +103,12 @@ class ApplicationCacher extends AbstractCacher
      */
     public function invalidateUrl($url, $domain = null)
     {
-        if (! $key = $this->getUrls($domain)->flip()->get($url)) {
-            // URL doesn't exist, nothing to invalidate.
-            return;
-        }
-
-        $this->cache->forget($this->normalizeKey('responses:'.$key));
-
-        $this->forgetUrl($key);
+        $this
+            ->getUrls($domain)
+            ->filter(fn ($value) => str_starts_with($value, $url))
+            ->each(function ($value, $key) {
+                $this->cache->forget($this->normalizeKey('responses:'.$key));
+                $this->forgetUrl($key);
+            });
     }
 }

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -116,16 +116,15 @@ class FileCacher extends AbstractCacher
      */
     public function invalidateUrl($url, $domain = null)
     {
-        if (! $key = $this->getUrls($domain)->flip()->get($url)) {
-            // URL doesn't exist, nothing to invalidate.
-            return;
-        }
-
         $site = optional(Site::findByUrl($domain.$url))->handle();
 
-        $this->writer->delete($this->getFilePath($url, $site));
-
-        $this->forgetUrl($key, $domain);
+        $this
+            ->getUrls($domain)
+            ->filter(fn ($value) => str_starts_with($value, $url))
+            ->each(function ($value, $key) use ($site, $domain) {
+                $this->writer->delete($this->getFilePath($value, $site));
+                $this->forgetUrl($key, $domain);
+            });
     }
 
     public function getCachePaths()

--- a/tests/StaticCaching/ApplicationCacherTest.php
+++ b/tests/StaticCaching/ApplicationCacherTest.php
@@ -69,6 +69,26 @@ class ApplicationCacherTest extends TestCase
     }
 
     /** @test */
+    public function invalidating_a_url_will_invalidate_all_query_string_versions_too()
+    {
+        $cache = app(Repository::class);
+        $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
+        $cache->forever('static-cache:'.md5('http://example.com').'.urls', [
+            'one' => '/one',
+            'oneqs' => '/one?foo=bar',
+            'two' => '/two',
+        ]);
+        $cache->forever('static-cache:responses:one', 'html content');
+        $cache->forever('static-cache:responses:oneqs', 'querystring html content');
+
+        $cacher->invalidateUrl('/one');
+
+        $this->assertEquals(['two' => '/two'], $cacher->getUrls()->all());
+        $this->assertNull($cache->get('static-cache:responses:one'));
+        $this->assertNull($cache->get('static-cache:responses:oneqs'));
+    }
+
+    /** @test */
     public function it_flushes()
     {
         $cache = app(Repository::class);


### PR DESCRIPTION
Fixes #6859

- [x] Check how it works with the ignore_query_strings setting