### PR TITLE
Avoid loading asset meta data until necessary

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -624,7 +624,7 @@ class Asset implements AssetContract, Augmentable, ArrayAccess, Arrayable, Conta
      * Get or set the container where this asset is located.
      *
      * @param  string|AssetContainerContract  $container  ID of the container
-     * @return AssetContainerContract|self
+     * @return AssetContainerContract
      */
     public function container($container = null)
     {

--- a/src/Assets/PendingMeta.php
+++ b/src/Assets/PendingMeta.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Assets;
+
+class PendingMeta
+{
+    protected $key;
+
+    public function __construct($key)
+    {
+        $this->key = $key;
+    }
+}


### PR DESCRIPTION
Fixes #6846 
Reverts the hotfix added in #6835 