### PR TITLE
Return an empty string if no parser is defined

### DIFF
--- a/src/Tags/Tags.php
+++ b/src/Tags/Tags.php
@@ -179,7 +179,7 @@ abstract class Tags
         }
 
         if (! $this->parser) {
-            return $data;
+            return '';
         }
 
         return Antlers::usingParser($this->parser, function ($antlers) use ($data, $supplement) {


### PR DESCRIPTION
Since a string is expected as a return type returning array causes issues.
If no parser is available we don't know how to change the array, thus the best option is to return an empty string