### PR TITLE
Fix array to string conversion

### DIFF
--- a/src/Tags/Tags.php
+++ b/src/Tags/Tags.php
@@ -151,7 +151,7 @@ abstract class Tags
         }
 
         if (! $this->parser) {
-            return $data;
+            return '';
         }
 
         return Antlers::usingParser($this->parser, function ($antlers) use ($data) {


### PR DESCRIPTION
Found this out after updating and using a tag. When the parser is null it returns an array but it expects a string.