### PR TITLE
Asset title could use a field named title if exists

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -833,7 +833,7 @@ class Asset implements AssetContract, Augmentable, ArrayAccess, Arrayable, Conta
      */
     public function title()
     {
-        return $this->basename();
+        return $this->get('title') ?? $this->basename();
     }
 
     /**

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1433,6 +1433,21 @@ class AssetTest extends TestCase
     }
 
     /** @test */
+    public function it_gets_the_title()
+    {
+        $asset = (new Asset)
+            ->path('path/to/asset.jpg')
+            ->container($this->container);
+
+        $this->assertEquals('asset.jpg', $asset->title());
+        $this->assertEquals('asset.jpg', $asset->title);
+
+        $asset->set('title', 'custom title');
+        $this->assertEquals('custom title', $asset->title());
+        $this->assertEquals('custom title', $asset->title);
+    }
+
+    /** @test */
     public function it_compiles_augmented_array_data()
     {
         Facades\Blueprint::shouldReceive('find')
@@ -1442,7 +1457,6 @@ class AssetTest extends TestCase
         $asset = (new Asset)
             ->path('path/to/asset.jpg')
             ->container($this->container)
-            ->set('title', 'test')
             ->setSupplement('foo', 'bar');
 
         $array = $asset->toAugmentedArray();


### PR DESCRIPTION
Fixes #6882

Note that if you're using `title` in a search index containing assets, it was previously indexing the filename. But now it'll use the custom `title` field's value. If you want to also be able to search the filename, you can add `basename` to your search index. I'd consider this a bug fix, but something to be aware of.
