### PR TITLE
Use a users search index if it exists

### DIFF
--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -7,6 +7,7 @@ use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Scope;
+use Statamic\Facades\Search;
 use Statamic\Facades\User;
 use Statamic\Facades\UserGroup;
 use Statamic\Http\Controllers\CP\CpController;
@@ -44,6 +45,10 @@ class UsersController extends CpController
         $query = User::query();
 
         if ($search = request('search')) {
+            if (Search::indexes()->has('users')) {
+                return Search::index('users')->ensureExists()->search($search);
+            }
+
             $query->where('email', 'like', '%'.$search.'%')->orWhere('name', 'like', '%'.$search.'%');
         }
 


### PR DESCRIPTION
Fixes #5913

If you have a search index named `users`, the control panel user listing will use that for searching. Otherwise, it'll fall back to doing a simple `where` on email and name like it currently does.
