### PR TITLE
Fix asset grid listing in narrow containers

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -5,7 +5,7 @@
             'is-image': isImage && !canShowSvg,
             'is-svg': canShowSvg,
             'is-file': !isImage && !canShowSvg,
-            'col-span-2 row-span-2': isSolo
+            'col-span-full': isSolo
         }"
         :title="asset.filename"
     >

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -5,7 +5,7 @@
             'is-image': isImage && !canShowSvg,
             'is-svg': canShowSvg,
             'is-file': !isImage && !canShowSvg,
-            'col-span-full': isSolo
+            'col-span-2': isSolo
         }"
         :title="asset.filename"
     >

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -1,6 +1,6 @@
 <template>
     <element-container @resized="containerWidth = $event.width">
-    <div :class="{ 'narrow': containerWidth < 500, 'really-narrow': containerWidth < 280 }">
+    <div :class="{ 'narrow': containerWidth < 500, 'really-narrow': containerWidth < 280, 'extremely-narrow': containerWidth < 160 }">
 
         <uploader
             ref="uploader"

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -1,6 +1,6 @@
 <template>
     <element-container @resized="containerWidth = $event.width">
-    <div :class="{ 'narrow': containerWidth < 500, 'really-narrow': containerWidth < 280, 'extremely-narrow': containerWidth < 160 }">
+    <div :class="{ 'narrow': containerWidth < 500, 'really-narrow': containerWidth < 280, 'extremely-narrow': containerWidth < 180 }">
 
         <uploader
             ref="uploader"

--- a/resources/sass/components/assets.scss
+++ b/resources/sass/components/assets.scss
@@ -85,11 +85,16 @@
 
 .assets-fieldtype .draggable-mirror { display: none; }
 
+.assets-fieldtype .extremely-narrow .asset-grid-listing {
+    grid-template-columns: 1fr;
+}
+
   /* Grid Listing
   ========================================================================== */
 
 .asset-grid-listing {
-    @apply bg-white grid relative grid-cols-2;
+    @apply bg-white grid relative;
+    grid-template-columns: repeat(auto-fill, minmax(125px, 1fr));
     grid-gap: 16px;
     padding: 16px;
 
@@ -100,36 +105,6 @@
             @apply flex items-center flex-1 w-full justify-center relative;
             aspect-ratio: 1 / 1;
         }
-    }
-}
-
-@screen md {
-    .asset-grid-listing {
-        @apply grid-cols-3;
-    }
-
-    .asset-manager .asset-grid-listing {
-        @apply grid-cols-4;
-    }
-}
-
-@screen lg {
-    .asset-grid-listing {
-        @apply grid-cols-4;
-    }
-
-    .asset-manager .asset-grid-listing {
-        @apply grid-cols-6;
-    }
-}
-
-@screen 2xl {
-    .asset-grid-listing {
-        @apply grid-cols-6;
-    }
-
-    .asset-manager .asset-grid-listing {
-        @apply grid-cols-8;
     }
 }
 


### PR DESCRIPTION
Partial fix for https://github.com/statamic/cms/issues/6832, this does not address the list mode narrow layout.

This replaces all of the breakpoint based asset grid columns with a single auto-fill column rule, so that they'll adjust automatically to any container size.

* The `125px` value was roughly based on the size that the tiles used to appear, but could be adjusted.
* The `extremely-narrow` class and column width override were added to prevent overflowing if theres not even enough space for one tile (eg. in 25% wide fields at smaller screen sizes).

Before:

![Screenshot 2022-10-15 at 14 53 33](https://user-images.githubusercontent.com/126740/195992773-fc07873d-15df-446e-a130-e460a04b3574.png)

After:

![Screenshot 2022-10-15 at 15 38 27](https://user-images.githubusercontent.com/126740/195992777-823a6088-0137-4bd4-8bf8-2f3b71c02821.png)