### PR TITLE
Add namespace around JS cache replacement variables

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -196,10 +196,10 @@ class FileCacher extends AbstractCacher
 
         $default = <<<EOT
 var els = document.getElementsByClassName('nocache');
-var map = {};
+var Statamic = {map: {}};
 for (var i = 0; i < els.length; i++) {
     var section = els[i].getAttribute('data-nocache');
-    map[section] = els[i];
+    Statamic.map[section] = els[i];
 }
 
 fetch('/!/nocache', {
@@ -207,14 +207,14 @@ fetch('/!/nocache', {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
         url: window.location.href,
-        sections: Object.keys(map)
+        sections: Object.keys(Statamic.map)
     })
 })
 .then((response) => response.json())
 .then((data) => {
     const regions = data.regions;
     for (var key in regions) {
-        if (map[key]) map[key].outerHTML = regions[key];
+        if (Statamic.map[key]) Statamic.map[key].outerHTML = regions[key];
     }
 
     for (const input of document.querySelectorAll('input[value="$csrfPlaceholder"]')) {
@@ -224,7 +224,7 @@ fetch('/!/nocache', {
     for (const meta of document.querySelectorAll('meta[content="$csrfPlaceholder"]')) {
         meta.content = data.csrf;
     }
-    
+
     document.dispatchEvent(new CustomEvent('statamic:nocache.replaced'));
 });
 EOT;


### PR DESCRIPTION
As reported in #6891 `map` is a very common variable name, so this PR adds it to a `Statamic` namespace to avoid collisions.

An alternative approach would be to wrap the code in an anonymous function - I'm happy to update to that if you would prefer.