### PR TITLE
Prevent recursion when generating slug from autogenerated title

### DIFF
--- a/src/Routing/Routable.php
+++ b/src/Routing/Routable.php
@@ -19,7 +19,9 @@ trait Routable
     {
         return $this->fluentlyGetOrSet('slug')->getter(function ($slug) {
             if ($slug instanceof Closure) {
+                $this->slug = null;
                 $slug = $slug($this);
+                $this->slug = $slug;
             }
 
             if (! $slug) {

--- a/src/Routing/Routable.php
+++ b/src/Routing/Routable.php
@@ -21,7 +21,6 @@ trait Routable
             if ($slug instanceof Closure) {
                 $this->slug = null;
                 $slug = $slug($this);
-                $this->slug = $slug;
             }
 
             if (! $slug) {

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -117,6 +117,27 @@ class EntryTest extends TestCase
     }
 
     /** @test */
+    public function if_the_slug_is_a_function_it_will_only_resolve_it_once()
+    {
+        $count = 0;
+        $slugWithinClosure = 'not yet set';
+        $entry = new Entry;
+        $entry->slug(function ($entry) use (&$count, &$slugWithinClosure) {
+            $count++;
+
+            // Call slug in here again to attempt infinite recursion. This could
+            // happen if something in the closure logic indirectly calls slug again.
+            $slugWithinClosure = $entry->slug();
+
+            return 'the-slug';
+        });
+
+        $this->assertEquals('the-slug', $entry->slug());
+        $this->assertNull($slugWithinClosure);
+        $this->assertEquals(1, $count);
+    }
+
+    /** @test */
     public function it_sets_gets_and_removes_data_values()
     {
         $collection = tap(Collection::make('test'))->save();


### PR DESCRIPTION
Fixes #5757

The issue is that when the slug is generated, it calls a function, which generates the title, which needs the augmented data, which includes the slug, which calls that function, ... and there's the infinite loop.

By nulling out the closure, when the slug is retrieved anywhere _within_ that loop, it'll be null and won't get the recursion.
Then set the slug to the end result, so it can actually be used.

I threw this in here and it worked.

I'd like to add some tests and try some other things because this seemed suspiciously simple. There's probably more to it.
