### PR TITLE
Destroy autosize for textarea elements on close

### DIFF
--- a/resources/js/components/inputs/Textarea.vue
+++ b/resources/js/components/inputs/Textarea.vue
@@ -44,6 +44,10 @@ export default {
         }, 1);
         this.$events.$on('tab-switched', this.updateSize);
     },
+    
+    beforeDestroy() {
+        autosize.destroy(this.$refs.textarea);
+    },
 
     methods: {
         updateSize() {


### PR DESCRIPTION
This PR does remove autosize for textarea elements for example when opening and closing the live preview

When opening and closing the live preview, there are always problems with memory growth (depending on the size of the replicator fields etc).

This PR is only a small part of it, but does help to reduce the growth at least a little bit.