### PR TITLE
Relationship-Input: Check if inputs are sortable and destroy on close

### DIFF
--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -178,13 +178,16 @@ export default {
     mounted() {
         this.initializeData().then(() => {
             this.initializing = false;
-            this.$nextTick(() => this.makeSortable());
+            if (this.canReorder) {
+                this.$nextTick(() => this.makeSortable());
+            }
         });
     },
 
     beforeDestroy() {
         if (this.sortable) {
             this.sortable.destroy();
+            this.sortable = null;
         }
         this.setLoadingProgress(false);
     },


### PR DESCRIPTION
This PR does add a check if the inputs are sortable at all and remove the sortable element for example when opening and closing the live preview. I think we don't need to make the element sortable if the condition 'canReorder' doesn't apply, right?

When opening and closing the live preview, there are always problems with memory growth (depending on the size of the replicator fields etc). 
This PR is only a small part of it, but does help to reduce the growth at least a little bit.