### PR TITLE
Support binding a custom `LocalizedTerm` class

### DIFF
--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -118,7 +118,10 @@ class Term implements TermContract
 
     public function in($site)
     {
-        return new LocalizedTerm($this, $site);
+        return app()->makeWith(LocalizedTerm::class, [
+            'term' => $this,
+            'locale' => $site,
+        ]);
     }
 
     public function inDefaultLocale()


### PR DESCRIPTION
It's currently possible to [bind a custom](https://statamic.dev/extending/repositories#custom-data-classes) `Term` class, but a lot of the action is in the `LocalizedTerm` class. While you can bind a custom `Term` and then override the `in()` method, it would be simpler to just bind a custom `LocalizedTerm` class.

This PR adds that.