### PR TITLE
Fix id being used for slug when creating entries

### DIFF
--- a/src/Routing/Routable.php
+++ b/src/Routing/Routable.php
@@ -21,6 +21,7 @@ trait Routable
             if ($slug instanceof Closure) {
                 $this->slug = null;
                 $slug = $slug($this);
+                $this->slug = $slug;
             }
 
             if (! $slug) {

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -135,6 +135,9 @@ class EntryTest extends TestCase
         $this->assertEquals('the-slug', $entry->slug());
         $this->assertNull($slugWithinClosure);
         $this->assertEquals(1, $count);
+
+        // Ensure that the temporary null slug is reset back the actual one for subsequent calls.
+        $this->assertEquals('the-slug', $entry->slug());
     }
 
     /** @test */


### PR DESCRIPTION
Introduced by #6903.

[This "this isnt necessary" commit](https://github.com/statamic/cms/pull/6903/commits/e0476435c242f4055e1cec9340e70615ce70206e) was absolutely necessary.
