### PR TITLE
Introduce auto-registration for addons

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -269,18 +269,30 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootModifiers()
     {
-        foreach ($this->modifiers as $class) {
-            $class::register();
-        }
+        $srcPath = $this->getAddon()->directory() . $this->getAddon()->autoload();
+        $modifiersPath = $srcPath . '/Modifiers';
+
+        collect(File::exists($modifiersPath) ? File::allFiles($modifiersPath) : [])
+            ->map(fn ($modifierFile) => $this->namespace() . '\\' . $this->classFromFile($modifierFile, $srcPath))
+            ->filter(fn ($modifierClass) => is_subclass_of($modifierClass, \Statamic\Modifiers\Modifier::class))
+            ->merge($this->actions)
+            ->unique()
+            ->each(fn ($modifierClass) => $modifierClass::register());
 
         return $this;
     }
 
     protected function bootWidgets()
     {
-        foreach ($this->widgets as $class) {
-            $class::register();
-        }
+        $srcPath = $this->getAddon()->directory() . $this->getAddon()->autoload();
+        $widgetsPath = $srcPath . '/Widgets';
+
+        collect(File::exists($widgetsPath) ? File::allFiles($widgetsPath) : [])
+            ->map(fn ($widgetFile) => $this->namespace() . '\\' . $this->classFromFile($widgetFile, $srcPath))
+            ->filter(fn ($widgetClass) => is_subclass_of($widgetClass, \Statamic\Widgets\Widget::class))
+            ->merge($this->actions)
+            ->unique()
+            ->each(fn ($widgetClass) => $widgetClass::register());
 
         return $this;
     }

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -299,10 +299,6 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootFormJsDrivers()
     {
-        foreach ($this->formJsDrivers as $class) {
-            $class::register();
-        }
-
         $srcPath = $this->getAddon()->directory() . $this->getAddon()->autoload();
         $formJsDriversPath = $srcPath . '/Forms/JsDrivers';
 
@@ -430,6 +426,8 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootRoutes()
     {
+
+
         if ($web = array_get($this->routes, 'web')) {
             $this->registerWebRoutes($web);
         }

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -318,6 +318,16 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected function bootCommands()
     {
         if ($this->app->runningInConsole()) {
+            $srcPath = $this->getAddon()->directory() . $this->getAddon()->autoload();
+            $commandsPath = $srcPath . '/Commands';
+
+            collect(File::exists($commandsPath) ? File::allFiles($commandsPath) : [])
+                ->map(fn ($commandFile) => $this->namespace() . '\\' . $this->classFromFile($commandFile, $srcPath))
+                ->filter(fn ($commandClass) => is_subclass_of($commandClass, \Illuminate\Console\Command::class))
+                ->merge($this->commands)
+                ->unique()
+                ->each(fn ($commandClass) => $commandClass::register());
+
             $this->commands($this->commands);
         }
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -212,7 +212,7 @@ abstract class AddonServiceProvider extends ServiceProvider
         $srcPath = $this->getAddon()->directory() . $this->getAddon()->autoload();
         $tagsPath = $srcPath . '/Tags';
 
-        collect(File::allFiles($tagsPath))
+        collect(File::exists($tagsPath) ? File::allFiles($tagsPath) : [])
             ->map(fn ($tagFile) => $this->namespace() . '\\' . $this->classFromFile($tagFile, $srcPath))
             ->filter(fn ($tagClass) => is_subclass_of($tagClass, \Statamic\Tags\Tags::class))
             ->merge($this->tags)
@@ -224,9 +224,15 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootScopes()
     {
-        foreach ($this->scopes as $class) {
-            $class::register();
-        }
+        $srcPath = $this->getAddon()->directory() . $this->getAddon()->autoload();
+        $scopesPath = $srcPath . '/Scopes';
+
+        collect(File::exists($scopesPath) ? File::allFiles($scopesPath) : [])
+            ->map(fn ($scopeFile) => $this->namespace() . '\\' . $this->classFromFile($scopeFile, $srcPath))
+            ->filter(fn ($scopeClass) => is_subclass_of($scopeClass, \Statamic\Query\Scopes\Scope::class))
+            ->merge($this->scopes)
+            ->unique()
+            ->each(fn ($scopeClass) => $scopeClass::register());
 
         return $this;
     }
@@ -236,9 +242,9 @@ abstract class AddonServiceProvider extends ServiceProvider
         $srcPath = $this->getAddon()->directory() . $this->getAddon()->autoload();
         $actionsPath = $srcPath . '/Actions';
 
-        collect(File::allFiles($actionsPath))
+        collect(File::exists($actionsPath) ? File::allFiles($actionsPath) : [])
             ->map(fn ($actionFile) => $this->namespace() . '\\' . $this->classFromFile($actionFile, $srcPath))
-            ->filter(fn ($tagClass) => is_subclass_of($tagClass, \Statamic\Actions\Action::class))
+            ->filter(fn ($actionClass) => is_subclass_of($actionClass, \Statamic\Actions\Action::class))
             ->merge($this->actions)
             ->unique()
             ->each(fn ($actionClass) => $actionClass::register());

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -260,7 +260,7 @@ abstract class AddonServiceProvider extends ServiceProvider
         collect(File::exists($fieldtypesPath) ? File::allFiles($fieldtypesPath) : [])
             ->map(fn ($fieldtypeFile) => $this->namespace() . '\\' . $this->classFromFile($fieldtypeFile, $srcPath))
             ->filter(fn ($fieldtypeClass) => is_subclass_of($fieldtypeClass, \Statamic\Fields\Fieldtype::class))
-            ->merge($this->actions)
+            ->merge($this->fieldtypes)
             ->unique()
             ->each(fn ($fieldtypeClass) => $fieldtypeClass::register());
 
@@ -275,7 +275,7 @@ abstract class AddonServiceProvider extends ServiceProvider
         collect(File::exists($modifiersPath) ? File::allFiles($modifiersPath) : [])
             ->map(fn ($modifierFile) => $this->namespace() . '\\' . $this->classFromFile($modifierFile, $srcPath))
             ->filter(fn ($modifierClass) => is_subclass_of($modifierClass, \Statamic\Modifiers\Modifier::class))
-            ->merge($this->actions)
+            ->merge($this->modifiers)
             ->unique()
             ->each(fn ($modifierClass) => $modifierClass::register());
 
@@ -290,7 +290,7 @@ abstract class AddonServiceProvider extends ServiceProvider
         collect(File::exists($widgetsPath) ? File::allFiles($widgetsPath) : [])
             ->map(fn ($widgetFile) => $this->namespace() . '\\' . $this->classFromFile($widgetFile, $srcPath))
             ->filter(fn ($widgetClass) => is_subclass_of($widgetClass, \Statamic\Widgets\Widget::class))
-            ->merge($this->actions)
+            ->merge($this->widgets)
             ->unique()
             ->each(fn ($widgetClass) => $widgetClass::register());
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -303,6 +303,16 @@ abstract class AddonServiceProvider extends ServiceProvider
             $class::register();
         }
 
+        $srcPath = $this->getAddon()->directory() . $this->getAddon()->autoload();
+        $formJsDriversPath = $srcPath . '/Forms/JsDrivers';
+
+        collect(File::exists($formJsDriversPath) ? File::allFiles($formJsDriversPath) : [])
+            ->map(fn ($formJsDriverFile) => $this->namespace() . '\\' . $this->classFromFile($formJsDriverFile, $srcPath))
+            ->filter(fn ($formJsDriverClass) => is_subclass_of($formJsDriverClass, \Statamic\Forms\JsDrivers\AbstractJsDriver::class))
+            ->merge($this->formJsDrivers)
+            ->unique()
+            ->each(fn ($formJsDriverClass) => $formJsDriverClass::register());
+
         return $this;
     }
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -426,17 +426,21 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootRoutes()
     {
-
-
         if ($web = array_get($this->routes, 'web')) {
+            $this->registerWebRoutes($web);
+        } elseif (File::exists($web = $this->getAddon()->directory() . '/routes/web.php')) {
             $this->registerWebRoutes($web);
         }
 
         if ($cp = array_get($this->routes, 'cp')) {
             $this->registerCpRoutes($cp);
+        } elseif (File::exists($cp = $this->getAddon()->directory() . '/routes/cp.php')) {
+            $this->registerCpRoutes($cp);
         }
 
         if ($actions = array_get($this->routes, 'actions')) {
+            $this->registerActionRoutes($actions);
+        } elseif (File::exists($actions = $this->getAddon()->directory() . '/routes/actions.php')) {
             $this->registerActionRoutes($actions);
         }
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -318,16 +318,6 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected function bootCommands()
     {
         if ($this->app->runningInConsole()) {
-            $srcPath = $this->getAddon()->directory() . $this->getAddon()->autoload();
-            $commandsPath = $srcPath . '/Commands';
-
-            collect(File::exists($commandsPath) ? File::allFiles($commandsPath) : [])
-                ->map(fn ($commandFile) => $this->namespace() . '\\' . $this->classFromFile($commandFile, $srcPath))
-                ->filter(fn ($commandClass) => is_subclass_of($commandClass, \Illuminate\Console\Command::class))
-                ->merge($this->commands)
-                ->unique()
-                ->each(fn ($commandClass) => $commandClass::register());
-
             $this->commands($this->commands);
         }
 


### PR DESCRIPTION
This pull request implements statamic/ideas#88. It introduces auto-registration for _things_ in addon service providers.

## Supported _things_

As long as the folder structure convention is followed, any _things_ will be automatically registered.

* Actions (`src/Actions`)
* Tags (`src/Tags`)
* Scopes (`src/Scopes`)
* Fieldtypes (`src/Fieldtypes`)
* Modifiers (`src/Modifiers`)
* Widgets (`src/Widgets`)
* Form JS Drivers (`src/Forms/JsDrivers`)
* Routes (`routes/web.php`, `routes/cp.php`, `routes/actions.php`)
* Update Scripts (`src/UpdateScripts`)

## Unsupported _things_

There are still a few bits & pieces which will need to be registered manually after this PR.

* Event listeners
* Event subscriptions
* Policies
* Commands
* Scheduled commands
* Stylesheets
* Scripts
* Middleware

----

_things_ is a rather ambiguous word but wasn't sure what to refer to them by 😅 