### PR TITLE
Fix overly aggressive static cache invalidation

### DIFF
--- a/src/StaticCaching/Cachers/ApplicationCacher.php
+++ b/src/StaticCaching/Cachers/ApplicationCacher.php
@@ -105,7 +105,7 @@ class ApplicationCacher extends AbstractCacher
     {
         $this
             ->getUrls($domain)
-            ->filter(fn ($value) => str_starts_with($value, $url))
+            ->filter(fn ($value) => $value === $url || str_starts_with($value, $url.'?'))
             ->each(function ($value, $key) {
                 $this->cache->forget($this->normalizeKey('responses:'.$key));
                 $this->forgetUrl($key);

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -120,7 +120,7 @@ class FileCacher extends AbstractCacher
 
         $this
             ->getUrls($domain)
-            ->filter(fn ($value) => str_starts_with($value, $url))
+            ->filter(fn ($value) => $value === $url || str_starts_with($value, $url.'?'))
             ->each(function ($value, $key) use ($site, $domain) {
                 $this->writer->delete($this->getFilePath($value, $site));
                 $this->forgetUrl($key, $domain);

--- a/tests/StaticCaching/ApplicationCacherTest.php
+++ b/tests/StaticCaching/ApplicationCacherTest.php
@@ -58,14 +58,23 @@ class ApplicationCacherTest extends TestCase
         $cache = app(Repository::class);
         $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
         $cache->forever('static-cache:'.md5('http://example.com').'.urls', [
-            'one' => '/one', 'two' => '/two',
+            'one' => '/one',
+            'onemore' => '/onemore',
+            'two' => '/two',
         ]);
         $cache->forever('static-cache:responses:one', 'html content');
+        $cache->forever('static-cache:responses:onemore', 'onemore html content');
+        $cache->forever('static-cache:responses:two', 'two html content');
 
         $cacher->invalidateUrl('/one');
 
-        $this->assertEquals(['two' => '/two'], $cacher->getUrls()->all());
+        $this->assertEquals([
+            'onemore' => '/onemore',
+            'two' => '/two',
+        ], $cacher->getUrls()->all());
         $this->assertNull($cache->get('static-cache:responses:one'));
+        $this->assertNotNull($cache->get('static-cache:responses:onemore'));
+        $this->assertNotNull($cache->get('static-cache:responses:two'));
     }
 
     /** @test */
@@ -76,16 +85,24 @@ class ApplicationCacherTest extends TestCase
         $cache->forever('static-cache:'.md5('http://example.com').'.urls', [
             'one' => '/one',
             'oneqs' => '/one?foo=bar',
+            'onemore' => '/onemore',
             'two' => '/two',
         ]);
         $cache->forever('static-cache:responses:one', 'html content');
         $cache->forever('static-cache:responses:oneqs', 'querystring html content');
+        $cache->forever('static-cache:responses:onemore', 'onemore html content');
+        $cache->forever('static-cache:responses:two', 'two html content');
 
         $cacher->invalidateUrl('/one');
 
-        $this->assertEquals(['two' => '/two'], $cacher->getUrls()->all());
+        $this->assertEquals([
+            'two' => '/two',
+            'onemore' => '/onemore',
+        ], $cacher->getUrls()->all());
         $this->assertNull($cache->get('static-cache:responses:one'));
         $this->assertNull($cache->get('static-cache:responses:oneqs'));
+        $this->assertNotNull($cache->get('static-cache:responses:onemore'));
+        $this->assertNotNull($cache->get('static-cache:responses:two'));
     }
 
     /** @test */

--- a/tests/StaticCaching/FileCacherTest.php
+++ b/tests/StaticCaching/FileCacherTest.php
@@ -179,13 +179,19 @@ class FileCacherTest extends TestCase
         $cacher = $this->fileCacher([], $writer, $cache, []);
 
         $cache->forever($this->cacheKey('http://example.com'), [
-            'one' => '/one', 'two' => '/two',
+            'one' => '/one',
+            'onemore' => '/onemore',
+            'two' => '/two',
         ]);
 
         $cacher->invalidateUrl('/one', 'http://example.com');
 
-        $writer->shouldHaveReceived('delete')->with($cacher->getFilePath('/one'));
-        $this->assertEquals(['two' => '/two'], $cacher->getUrls('http://example.com')->all());
+        $writer->shouldHaveReceived('delete')->once();
+        $writer->shouldHaveReceived('delete')->with($cacher->getFilePath('/one'))->once();
+        $this->assertEquals([
+            'onemore' => '/onemore',
+            'two' => '/two',
+        ], $cacher->getUrls('http://example.com')->all());
 
         // TODO Check fallback to app url.
         // Config::set('app.url', 'http://example.com');
@@ -201,14 +207,19 @@ class FileCacherTest extends TestCase
         $cache->forever($this->cacheKey('http://example.com'), [
             'one' => '/one',
             'oneqs' => '/one?foo=bar',
+            'onemore' => '/onemore',
             'two' => '/two',
         ]);
 
         $cacher->invalidateUrl('/one', 'http://example.com');
 
-        $writer->shouldHaveReceived('delete')->with($cacher->getFilePath('/one'));
-        $writer->shouldHaveReceived('delete')->with($cacher->getFilePath('/one?foo=bar'));
-        $this->assertEquals(['two' => '/two'], $cacher->getUrls('http://example.com')->all());
+        $writer->shouldHaveReceived('delete')->times(2);
+        $writer->shouldHaveReceived('delete')->with($cacher->getFilePath('/one'))->once();
+        $writer->shouldHaveReceived('delete')->with($cacher->getFilePath('/one?foo=bar'))->once();
+        $this->assertEquals([
+            'two' => '/two',
+            'onemore' => '/onemore',
+        ], $cacher->getUrls('http://example.com')->all());
     }
 
     /** @test */


### PR DESCRIPTION
The fix introduced by #6866 would do a simple "starts with" check.

If you invalidate `/foo` it was invalidating any urls that start with `/foo`.

Invalidating `/foo` would invalidate `/foo`, `/foobar`, `/foo/bar`, `/foo?bar=baz`
It should have only invalidated the url itself (`/foo`) and any query string versions (`/foo?bar=baz`).

Also, if you invalidated the home page, it would essentially invalidate your whole site.
Invalidating `/` would invalidate everything, since all URLs start with `/`.

This PR makes the check stricter to only invalidate itself and any query string versions.
