### PR TITLE
Blade @nocache directive improvements

### DIFF
--- a/src/StaticCaching/NoCache/BladeDirective.php
+++ b/src/StaticCaching/NoCache/BladeDirective.php
@@ -16,7 +16,7 @@ class BladeDirective
 
     public function handle($expression, array $params, array $data = null)
     {
-        if (! isset($data)) {
+        if (func_num_args() == 2) {
             $data = $params;
             $params = [];
         }

--- a/src/StaticCaching/NoCache/BladeDirective.php
+++ b/src/StaticCaching/NoCache/BladeDirective.php
@@ -14,9 +14,16 @@ class BladeDirective
         $this->nocache = $nocache;
     }
 
-    public function handle($expression, $context)
+    public function handle($expression, array $params, array $data = null)
     {
+        if (! isset($data)) {
+            $data = $params;
+            $params = [];
+        }
+
         $view = $expression;
+
+        $context = array_merge($data, $params);
 
         return $this->nocache->pushView($view, $context)->placeholder();
     }

--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -70,7 +70,7 @@ class ServiceProvider extends LaravelServiceProvider
         });
 
         Blade::directive('nocache', function ($exp) {
-            return '<?php echo app("Statamic\StaticCaching\NoCache\BladeDirective")->handle('.$exp.', $__data); ?>';
+            return '<?php echo app("Statamic\StaticCaching\NoCache\BladeDirective")->handle('.$exp.', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>';
         });
     }
 }


### PR DESCRIPTION
Closes https://github.com/statamic/ideas/issues/862

The docs say "use the nocache directive just like you would use the include directive", but it doesn't quite work in the same way as `@include` currently. This PR makes two small changes to bring it in line:

## Additional parameters

Laravel's `@include` directive allows you to pass in an array of additional parameters as a second argument. This kind of half works at the moment (see the linked issue) but this adds proper support.

```blade
@nocache('mypartial', ['type' => 'list'])
```

## Pass all variables from current context

At the moment variables defined in the view that calls `@nocache` are not included in the context, only ones that already exist in `$__data`. This has been changed to grab all variables using `get_defined_vars()`,  which is [exactly what Laravel does](https://github.com/laravel/framework/blob/a709c26b8e37b20826e8ebe7fa14d29751fedcc5/src/Illuminate/View/Compilers/BladeCompiler.php#L781).

```blade
@php
$page = 'home';
@endphp
@nocache('mypartial') {{-- $page will now be available in mypartial --}}
```