### PR TITLE
Fix @nocache serialization errors

### DIFF
--- a/src/StaticCaching/NoCache/Region.php
+++ b/src/StaticCaching/NoCache/Region.php
@@ -27,7 +27,7 @@ abstract class Region
 
     protected function filterContext(array $context)
     {
-        foreach (['__env', 'app', 'errors'] as $var) {
+        foreach (['__env', 'app', 'errors', 'resolve', 'resolveComponentsUsing', 'forgetComponentsResolver', 'forgetFactory', 'flushCache', 'constructor'] as $var) {
             unset($context[$var]);
         }
 


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/6923

The changes in Laravel 9.36 introduced a bunch of extra variables in the view context, some of which are Closures or objects that contain Closures (resolve, resolveComponentsUsing, forgetComponentsResolver, forgetFactory, flushCache). 

Additionally, if you render a component before calling `@nocache` a constructor variable is left behind that is a ReflectionMethod that also cant be serialized. This mostly becomes a problem with the change in https://github.com/statamic/cms/pull/6934, but I don't think that's really the fault of that change (it could also occur without that).

This PR adds those keys to the exclusion list.