### PR TITLE
Add GlobalSet Contract

### DIFF
--- a/src/Contracts/Globals/GlobalSet.php
+++ b/src/Contracts/Globals/GlobalSet.php
@@ -6,4 +6,11 @@ use Statamic\Contracts\Data\Localizable;
 
 interface GlobalSet extends Localizable
 {
+    public function in($locale): ?Variables;
+
+    public function inSelectedSite(): ?Variables;
+
+    public function inCurrentSite(): ?Variables;
+
+    public function inDefaultSite(): ?Variables;
 }

--- a/src/Contracts/Globals/GlobalSet.php
+++ b/src/Contracts/Globals/GlobalSet.php
@@ -6,11 +6,11 @@ use Statamic\Contracts\Data\Localizable;
 
 interface GlobalSet extends Localizable
 {
-    public function in($locale): ?Variables;
+    public function in($locale);
 
-    public function inSelectedSite(): ?Variables;
+    public function inSelectedSite();
 
-    public function inCurrentSite(): ?Variables;
+    public function inCurrentSite();
 
-    public function inDefaultSite(): ?Variables;
+    public function inDefaultSite();
 }

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -153,22 +153,22 @@ class GlobalSet implements Contract
         return $this;
     }
 
-    public function in($locale)
+    public function in($locale): ?Variables
     {
         return $this->localizations[$locale] ?? null;
     }
 
-    public function inSelectedSite()
+    public function inSelectedSite(): ?Variables
     {
         return $this->in(Site::selected()->handle());
     }
 
-    public function inCurrentSite()
+    public function inCurrentSite(): ?Variables
     {
         return $this->in(Site::current()->handle());
     }
 
-    public function inDefaultSite()
+    public function inDefaultSite(): ?Variables
     {
         return $this->in(Site::default()->handle());
     }

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -153,22 +153,22 @@ class GlobalSet implements Contract
         return $this;
     }
 
-    public function in($locale): ?Variables
+    public function in($locale)
     {
         return $this->localizations[$locale] ?? null;
     }
 
-    public function inSelectedSite(): ?Variables
+    public function inSelectedSite()
     {
         return $this->in(Site::selected()->handle());
     }
 
-    public function inCurrentSite(): ?Variables
+    public function inCurrentSite()
     {
         return $this->in(Site::current()->handle());
     }
 
-    public function inDefaultSite(): ?Variables
+    public function inDefaultSite()
     {
         return $this->in(Site::default()->handle());
     }


### PR DESCRIPTION
Given following:
```php
Statamic\Facades\GlobalSet::findByHandle('global_set')?->inCurrentSite()?->get('field') ?? '';
```

PHPStan static analysis fails
![globalset-phpstan](https://user-images.githubusercontent.com/75579178/197266777-c6f1065f-a675-4e72-9837-2ddbb51de0d7.png)

This is because `Statamic\Facades\GlobalSet::findByHandle()` method has a return type of `Statamic\Contracts\Globals\GlobalSet | null`. The problem is `Statamic\Contracts\Globals\GlobalSet` is empty, hence PHPStan failure.

This PR adds the following to `Statamic\Contracts\Globals\GlobalSet` to mitigate this
```php
public function in($locale);

public function inSelectedSite();

public function inCurrentSite();

public function inDefaultSite();
```


