### PR TITLE
Runtime: Improves array shorthand syntax

### DIFF
--- a/src/View/Antlers/Language/Parser/LanguageParser.php
+++ b/src/View/Antlers/Language/Parser/LanguageParser.php
@@ -1895,7 +1895,7 @@ class LanguageParser
             } elseif ($node instanceof ImplicitArrayEnd && $newNodeCount > 0) {
                 $left = $newNodes[$newNodeCount - 1];
 
-                if ($left instanceof VariableNode && NodeHelpers::distance($left, $node) <= 1) {
+                if ($left instanceof VariableNode && NodeHelpers::distance($left, $node) <= 1 && Str::contains($left->name, '[')) {
                     array_pop($newNodes);
                     NodeHelpers::mergeVarContentLeft($node->content, $node, $left);
                     $newNodes[] = $left;

--- a/tests/Antlers/Runtime/ArraysTest.php
+++ b/tests/Antlers/Runtime/ArraysTest.php
@@ -364,4 +364,16 @@ EOT;
 
         $this->assertSame('<True Value><False Value><Null Value>', $this->renderString($template, $data));
     }
+
+    public function test_array_shorthand_syntax_can_be_used_without_trailing_spaces()
+    {
+        $template = <<<'EOT'
+{{ keyword1 = 'dance' }}
+{{ keyword2 = 'party' }}
+{{ keywords = [$keyword1, $keyword2] }}
+{{ keywords }}<{{ value }}>{{ /keywords }}
+EOT;
+
+        $this->assertSame('<dance><party>', trim($this->renderString($template)));
+    }
 }


### PR DESCRIPTION
This PR improves the array shorthand syntax and resolves an "Unexpected end of logic group" error that could appear if there was no whitespace before the final "]. "

The following templates will now "just work" without obnoxious space requirements 🙂🎉

```antlers
{{ keyword1 = 'dance' }}
{{ keyword2 = 'party' }}

{{ keywords = [$keyword1, $keyword2] }}

{{
    things = ['one', 'two']
    more_things = ['hello']
}}
```