### PR TITLE
Show modal with origin selector before creating localization

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -155,24 +155,24 @@
                                 <div class="p-2 border-t" v-if="localizations.length > 1">
                                     <label class="publish-field-label font-medium mb-1" v-text="__('Sites')" />
                                     <div
-                                        v-for="localization in localizations"
-                                        :key="localization.handle"
+                                        v-for="option in localizations"
+                                        :key="option.handle"
                                         class="text-sm flex items-center -mx-2 px-2 py-1 cursor-pointer"
-                                        :class="localization.active ? 'bg-blue-100' : 'hover:bg-grey-20'"
-                                        @click="localizationSelected(localization)"
+                                        :class="option.active ? 'bg-blue-100' : 'hover:bg-grey-20'"
+                                        @click="localizationSelected(option)"
                                     >
-                                        <div class="flex-1 flex items-center" :class="{ 'line-through': !localization.exists }">
+                                        <div class="flex-1 flex items-center" :class="{ 'line-through': !option.exists }">
                                             <span class="little-dot mr-1" :class="{
-                                                'bg-green': localization.published,
-                                                'bg-grey-50': !localization.published,
-                                                'bg-red': !localization.exists
+                                                'bg-green': option.published,
+                                                'bg-grey-50': !option.published,
+                                                'bg-red': !option.exists
                                             }" />
-                                            {{ localization.name }}
-                                            <loading-graphic :size="14" text="" class="ml-1" v-if="localization.handle === localizing.handle" />
+                                            {{ option.name }}
+                                            <loading-graphic :size="14" text="" class="ml-1" v-if="option.handle === localizing.handle" />
                                         </div>
-                                        <div class="badge-sm bg-orange" v-if="localization.origin" v-text="__('Origin')" />
-                                        <div class="badge-sm bg-blue" v-if="localization.active" v-text="__('Active')" />
-                                        <div class="badge-sm bg-purple" v-if="localization.root && !localization.origin && !localization.active" v-text="__('Root')" />
+                                        <div class="badge-sm bg-orange" v-if="option.origin" v-text="__('Origin')" />
+                                        <div class="badge-sm bg-blue" v-if="option.active" v-text="__('Active')" />
+                                        <div class="badge-sm bg-purple" v-if="option.root && !option.origin && !option.active" v-text="__('Root')" />
                                     </div>
                                 </div>
 

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -599,8 +599,10 @@ export default {
 
             if (localization.exists) {
                 this.editLocalization(localization);
-            } else {
+            } else if (this.localizations.length > 2) {
                 this.selectingOrigin = true;
+            } else {
+                this.createLocalization(localization);
             }
 
             if (this.isBase) {

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -258,16 +258,18 @@
             :title="__('Create Localization')"
             :buttonText="__('Create')"
             @cancel="cancelLocalization()"
-            @confirm="createLocalization(localizing)"            
+            @confirm="createLocalization(localizing)"
         >
-
-            <div class="form-group">
-                <label v-text="__('Origin')" />
-                <select-input
-                    v-model="selectedOrigin"
-                    :options="originOptions"
-                    :placeholder="false"
-                />
+            <div class="publish-fields">
+                <div class="form-group publish-field field-w-full">
+                    <label v-text="__('Origin')" />
+                    <div class="help-block -mt-1" v-text="__('messages.entry_origin_instructions')"></div>
+                    <select-input
+                        v-model="selectedOrigin"
+                        :options="originOptions"
+                        :placeholder="false"
+                    />
+                </div>
             </div>
 
         </confirmation-modal>

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -610,7 +610,7 @@ export default {
             const url = this.activeLocalization.url + '/localize';
             this.$axios.post(url, { site: localization.handle }).then(response => {
                 this.editLocalization(response.data).then(() => {
-                    this.$events.$emit('localization.created', {store: this.publishContainer});
+                    this.$events.$emit('localization.created', { store: this.publishContainer });
 
                     if (this.originValues.published) {
                         this.setFieldValue('published', true);

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -250,21 +250,21 @@
         />
 
         <confirmation-modal
-            v-if="true"
+            v-if="selectingOrigin"
             :title="__('Create Localization')"
             :buttonText="__('Create')"
             
         >
-        <!-- @confirm="confirm"
-            @cancel="reset" -->
+        <!-- 
+                @confirm="confirm"
+                -->
             <select-input
-                v-model="type"
-                :options="originOptions"
-                :placeholder="false"
                 class="ml-2" 
+                v-model="selectedOrigin"
+                :options="originOptions"
+                @cancel="selectingOrigin = false"
+                @confirm="selectingOrigin = false; createLocalization()"
             />
-            <!-- TODO set :value to first site -->
-            <!-- TODO @input="..." -->
 
         </confirmation-modal>
     </div>
@@ -342,6 +342,8 @@ export default {
             originValues: this.initialOriginValues || {},
             originMeta: this.initialOriginMeta || {},
             site: this.initialSite,
+            selectingOrigin: false,
+            selectedOrigin: this.initialLocalizations[0].handle,
             isWorkingCopy: this.initialIsWorkingCopy,
             error: null,
             errors: {},
@@ -440,6 +442,13 @@ export default {
 
         afterSaveOption() {
             return this.getPreference('after_save');
+        },
+
+        originOptions() {
+            return this.localizations.map(localization => ({
+                value: localization.handle,
+                label: localization.name,
+            }));
         },
 
     },

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -168,7 +168,11 @@
                                                 'bg-red': !option.exists
                                             }" />
                                             {{ option.name }}
-                                            <loading-graphic :size="14" text="" class="ml-1" v-if="option.handle === localizing.handle" />
+                                            <loading-graphic
+                                                :size="14"
+                                                text=""
+                                                class="ml-1"
+                                                v-if="localizing && localizing.handle === option.handle" />
                                         </div>
                                         <div class="badge-sm bg-orange" v-if="option.origin" v-text="__('Origin')" />
                                         <div class="badge-sm bg-blue" v-if="option.active" v-text="__('Active')" />

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -248,6 +248,25 @@
             @saving="saving = true"
             @saved="publishActionCompleted"
         />
+
+        <confirmation-modal
+            v-if="true"
+            :title="__('Create Localization')"
+            :buttonText="__('Create')"
+            
+        >
+        <!-- @confirm="confirm"
+            @cancel="reset" -->
+            <select-input
+                v-model="type"
+                :options="originOptions"
+                :placeholder="false"
+                class="ml-2" 
+            />
+            <!-- TODO set :value to first site -->
+            <!-- TODO @input="..." -->
+
+        </confirmation-modal>
     </div>
 
 </template>

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -155,24 +155,24 @@
                                 <div class="p-2 border-t" v-if="localizations.length > 1">
                                     <label class="publish-field-label font-medium mb-1" v-text="__('Sites')" />
                                     <div
-                                        v-for="option in localizations"
-                                        :key="option.handle"
+                                        v-for="localization in localizations"
+                                        :key="localization.handle"
                                         class="text-sm flex items-center -mx-2 px-2 py-1 cursor-pointer"
-                                        :class="option.active ? 'bg-blue-100' : 'hover:bg-grey-20'"
-                                        @click="localizationSelected(option)"
+                                        :class="localization.active ? 'bg-blue-100' : 'hover:bg-grey-20'"
+                                        @click="localizationSelected(localization)"
                                     >
-                                        <div class="flex-1 flex items-center" :class="{ 'line-through': !option.exists }">
+                                        <div class="flex-1 flex items-center" :class="{ 'line-through': !localization.exists }">
                                             <span class="little-dot mr-1" :class="{
-                                                'bg-green': option.published,
-                                                'bg-grey-50': !option.published,
-                                                'bg-red': !option.exists
+                                                'bg-green': localization.published,
+                                                'bg-grey-50': !localization.published,
+                                                'bg-red': !localization.exists
                                             }" />
-                                            {{ option.name }}
-                                            <loading-graphic :size="14" text="" class="ml-1" v-if="localizing === option.handle" />
+                                            {{ localization.name }}
+                                            <loading-graphic :size="14" text="" class="ml-1" v-if="localizing === localization.handle" />
                                         </div>
-                                        <div class="badge-sm bg-orange" v-if="option.origin" v-text="__('Origin')" />
-                                        <div class="badge-sm bg-blue" v-if="option.active" v-text="__('Active')" />
-                                        <div class="badge-sm bg-purple" v-if="option.root && !option.origin && !option.active" v-text="__('Root')" />
+                                        <div class="badge-sm bg-orange" v-if="localization.origin" v-text="__('Origin')" />
+                                        <div class="badge-sm bg-blue" v-if="localization.active" v-text="__('Active')" />
+                                        <div class="badge-sm bg-purple" v-if="localization.root && !localization.origin && !localization.active" v-text="__('Root')" />
                                     </div>
                                 </div>
 

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -162,24 +162,24 @@
                                 <div class="p-2 border-t" v-if="localizations.length > 1">
                                     <label class="publish-field-label font-medium mb-1" v-text="__('Sites')" />
                                     <div
-                                        v-for="option in localizations"
-                                        :key="option.handle"
+                                        v-for="localization in localizations"
+                                        :key="localization.handle"
                                         class="text-sm flex items-center -mx-2 px-2 py-1 cursor-pointer"
-                                        :class="option.active ? 'bg-blue-100' : 'hover:bg-grey-20'"
-                                        @click="localizationSelected(option)"
+                                        :class="localization.active ? 'bg-blue-100' : 'hover:bg-grey-20'"
+                                        @click="localizationSelected(localization)"
                                     >
-                                        <div class="flex-1 flex items-center" :class="{ 'line-through': !option.exists }">
+                                        <div class="flex-1 flex items-center" :class="{ 'line-through': !localization.exists }">
                                             <span class="little-dot mr-1" :class="{
-                                                'bg-green': option.published,
-                                                'bg-grey-50': !option.published,
-                                                'bg-red': !option.exists
+                                                'bg-green': localization.published,
+                                                'bg-grey-50': !localization.published,
+                                                'bg-red': !localization.exists
                                             }" />
-                                            {{ option.name }}
-                                            <loading-graphic :size="14" text="" class="ml-1" v-if="localizing === option.handle" />
+                                            {{ localization.name }}
+                                            <loading-graphic :size="14" text="" class="ml-1" v-if="localizing === localization.handle" />
                                         </div>
-                                        <div class="badge-sm bg-orange" v-if="option.origin" v-text="__('Origin')" />
-                                        <div class="badge-sm bg-blue" v-if="option.active" v-text="__('Active')" />
-                                        <div class="badge-sm bg-purple" v-if="option.root && !option.origin && !option.active" v-text="__('Root')" />
+                                        <div class="badge-sm bg-orange" v-if="localization.origin" v-text="__('Origin')" />
+                                        <div class="badge-sm bg-blue" v-if="localization.active" v-text="__('Active')" />
+                                        <div class="badge-sm bg-purple" v-if="localization.root && !localization.origin && !localization.active" v-text="__('Root')" />
                                     </div>
                                 </div>
 

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -162,24 +162,24 @@
                                 <div class="p-2 border-t" v-if="localizations.length > 1">
                                     <label class="publish-field-label font-medium mb-1" v-text="__('Sites')" />
                                     <div
-                                        v-for="localization in localizations"
-                                        :key="localization.handle"
+                                        v-for="option in localizations"
+                                        :key="option.handle"
                                         class="text-sm flex items-center -mx-2 px-2 py-1 cursor-pointer"
-                                        :class="localization.active ? 'bg-blue-100' : 'hover:bg-grey-20'"
-                                        @click="localizationSelected(localization)"
+                                        :class="option.active ? 'bg-blue-100' : 'hover:bg-grey-20'"
+                                        @click="localizationSelected(option)"
                                     >
-                                        <div class="flex-1 flex items-center" :class="{ 'line-through': !localization.exists }">
+                                        <div class="flex-1 flex items-center" :class="{ 'line-through': !option.exists }">
                                             <span class="little-dot mr-1" :class="{
-                                                'bg-green': localization.published,
-                                                'bg-grey-50': !localization.published,
-                                                'bg-red': !localization.exists
+                                                'bg-green': option.published,
+                                                'bg-grey-50': !option.published,
+                                                'bg-red': !option.exists
                                             }" />
-                                            {{ localization.name }}
-                                            <loading-graphic :size="14" text="" class="ml-1" v-if="localizing === localization.handle" />
+                                            {{ option.name }}
+                                            <loading-graphic :size="14" text="" class="ml-1" v-if="localizing === option.handle" />
                                         </div>
-                                        <div class="badge-sm bg-orange" v-if="localization.origin" v-text="__('Origin')" />
-                                        <div class="badge-sm bg-blue" v-if="localization.active" v-text="__('Active')" />
-                                        <div class="badge-sm bg-purple" v-if="localization.root && !localization.origin && !localization.active" v-text="__('Root')" />
+                                        <div class="badge-sm bg-orange" v-if="option.origin" v-text="__('Origin')" />
+                                        <div class="badge-sm bg-blue" v-if="option.active" v-text="__('Active')" />
+                                        <div class="badge-sm bg-purple" v-if="option.root && !option.origin && !option.active" v-text="__('Root')" />
                                     </div>
                                 </div>
 

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -61,6 +61,7 @@ return [
     'collections_taxonomies_instructions' => 'Connect entries in this collection to taxonomies. Fields will be automatically added to publish forms.',
     'email_utility_configuration_description' => 'Mail settings are configured in <code>:path</code>',
     'email_utility_description' => 'Check email configuration settings and send test emails.',
+    'entry_origin_instructions' => 'The new localization will inherit values from the entry in the selected site.',
     'expect_root_instructions' => 'Consider the first page in the tree a "root" or "home" page.',
     'field_conditions_instructions' => 'When to show or hide this field.',
     'field_desynced_from_origin' => 'Desynced from origin. Click to sync and revert to the origin\'s value.',


### PR DESCRIPTION
As discussed, this PR shows a confirmation modal before creating a localization for an entry. The origin for the new localization will default to the first site, however in the modal you can choose a different origin if you like. 

<img width="1053" alt="Screenshot 2022-10-24 at 15 14 02" src="https://user-images.githubusercontent.com/4067531/197534990-adb31c3d-7e2b-48bb-bd83-914706d77826.png">

Feel free to update UI and text of course.