### PR TITLE
Reset locale and carbon format in localize middleware

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install French
         run: sudo apt-get install language-pack-fr
-        if: matrix.os == "ubuntu-latest"
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Check locales again
         run: locale -a

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,15 +35,9 @@ jobs:
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
-      - name: Check locales
-        run: locale -a
-
-      - name: Install French
+      - name: Install French Locale
         run: sudo apt-get install language-pack-fr
         if: matrix.os == 'ubuntu-latest'
-
-      - name: Check locales again
-        run: locale -a
 
       - name: Checkout code
         uses: actions/checkout@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,9 @@ jobs:
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
+      - name: Check locales
+        run: locale -a
+
       - name: Checkout code
         uses: actions/checkout@v1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Check locales
         run: locale -a
 
+      - name: Install French
+        run: apt-get install language-pack-fr
+
+      - name: Check locales again
+        run: locale -a
+
       - name: Checkout code
         uses: actions/checkout@v1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install French
         run: sudo apt-get install language-pack-fr
-        if: matrix.os == ubuntu-latest
+        if: matrix.os == "ubuntu-latest"
 
       - name: Check locales again
         run: locale -a

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: locale -a
 
       - name: Install French
-        run: apt-get install language-pack-fr
+        run: sudo apt-get install language-pack-fr
 
       - name: Check locales again
         run: locale -a

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Install French
         run: sudo apt-get install language-pack-fr
+        if: matrix.os == ubuntu-latest
 
       - name: Check locales again
         run: locale -a

--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -15,15 +15,33 @@ class Localize
 
         // Dates, Carbon, etc expect the full locale. (eg. "fr_FR" or whatever is
         // installed on your actual server. You can check by running `locale -a`).
+        // We'll save the original locale so we can reset it later. Of course,
+        // you can get the locale by calling the setlocale method. Logical.
+        $originalLocale = setlocale(LC_TIME, 0);
         setlocale(LC_TIME, $site->locale());
 
         // The sites lang is used for your translations. (eg. if you set your site's lang
         // to "fr_FR", the translator will look for "fr_FR" files rather than "fr" files
-        // but if not set the translator will look for "fr" files rather than "fr_FR" files.)
+        // but if not set the translator will look for "fr" files rather than "fr_FR"
+        // files.) Again, we'll save the original locale so we can reset it later.
+        $originalAppLocale = app()->getLocale();
         app()->setLocale($site->lang());
 
+        // Get original Carbon format so it can be restored later.
+        // There's no getter for it, so we'll use reflection.
+        $format = (new \ReflectionClass(Carbon::class))->getProperty('toStringFormat');
+        $format->setAccessible(true);
+        $originalToStringFormat = $format->getValue();
         Carbon::setToStringFormat(Statamic::dateFormat());
 
-        return $next($request);
+        $response = $next($request);
+
+        // Reset everything back to their originals. This allows everything
+        // not within the scope of the request to be the "defaults".
+        setlocale(LC_TIME, $originalLocale);
+        app()->setLocale($originalAppLocale);
+        Carbon::setToStringFormat($originalToStringFormat);
+
+        return $response;
     }
 }

--- a/tests/Feature/GraphQL/AssetTest.php
+++ b/tests/Feature/GraphQL/AssetTest.php
@@ -118,7 +118,7 @@ GQL;
                     'size_kb' => 0.71,
                     'size_mb' => 0,
                     'size_gb' => 0,
-                    'last_modified' => Carbon::parse('2012-01-02 4:57pm')->format('F jS, Y'),
+                    'last_modified' => '2012-01-02 16:57:00',
                     'focus_css' => '50% 50%',
                     'height' => 60,
                     'width' => 30,

--- a/tests/Feature/GraphQL/EntryTest.php
+++ b/tests/Feature/GraphQL/EntryTest.php
@@ -89,8 +89,8 @@ GQL;
                     'published' => true,
                     'private' => false,
                     'status' => 'published',
-                    'date' => 'November 3rd, 2017',
-                    'last_modified' => 'December 25th, 2017',
+                    'date' => '2017-11-03 00:00:00',
+                    'last_modified' => '2017-12-25 13:29:00',
                     'blueprint' => 'event',
                     'collection' => [
                         'title' => 'Events',

--- a/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
@@ -7,11 +7,21 @@ use Illuminate\Support\Carbon;
 /** @group graphql */
 class DateFieldtypeTest extends FieldtypeTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::macro('getToStringFormat', function () {
+            return static::$toStringFormat;
+        });
+    }
+
     /** @test */
     public function it_gets_dates()
     {
-        // The statamic.system.date_format config will set this
-        // earlier on so we'll override it here for the test.
+        // Set the to string format so can see it uses that rather than a coincidence.
+        // But reset it afterwards.
+        $originalFormat = Carbon::getToStringFormat();
         Carbon::setToStringFormat('Y-m-d g:ia');
 
         $this->createEntryWithFields([
@@ -36,13 +46,16 @@ GQL;
             'formatted' => '1514208540',
             'undefined' => null,
         ]);
+
+        Carbon::setToStringFormat($originalFormat);
     }
 
     /** @test */
     public function it_gets_date_ranges()
     {
-        // The statamic.system.date_format config will set this
-        // earlier on so we'll override it here for the test.
+        // Set the to string format so can see it uses that rather than a coincidence.
+        // But reset it afterwards.
+        $originalFormat = Carbon::getToStringFormat();
         Carbon::setToStringFormat('Y-m-d g:ia');
 
         $this->createEntryWithFields([
@@ -70,5 +83,7 @@ GQL;
             'formatted' => ['start' => '1514160000', 'end' => '1587945600'],
             'undefined' => null,
         ]);
+
+        Carbon::setToStringFormat($originalFormat);
     }
 }

--- a/tests/Forms/SubmissionTest.php
+++ b/tests/Forms/SubmissionTest.php
@@ -33,14 +33,14 @@ class SubmissionTest extends TestCase
         // this test becomes unnecessary if we ever move away from using microtime for ids.
 
         // Set the locale and reset it after.
-        $originalLocale = setlocale(LC_ALL, 0);
-        setlocale(LC_ALL, 'de_DE');
+        $originalLocale = setlocale(LC_TIME, 0);
+        setlocale(LC_TIME, 'de_DE');
 
         $submission = Form::make('test')->makeSubmission();
 
         $this->assertStringNotContainsString(',', $submission->id());
 
-        setlocale(LC_ALL, $originalLocale);
+        setlocale(LC_TIME, $originalLocale);
     }
 
     /** @test */

--- a/tests/Forms/SubmissionTest.php
+++ b/tests/Forms/SubmissionTest.php
@@ -32,13 +32,15 @@ class SubmissionTest extends TestCase
     {
         // this test becomes unnecessary if we ever move away from using microtime for ids.
 
+        // Set the locale and reset it after.
+        $originalLocale = setlocale(LC_ALL, 0);
         setlocale(LC_ALL, 'de_DE');
 
         $submission = Form::make('test')->makeSubmission();
 
         $this->assertStringNotContainsString(',', $submission->id());
 
-        setlocale(LC_ALL, 'en_US');
+        setlocale(LC_ALL, $originalLocale);
     }
 
     /** @test */

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -679,7 +679,7 @@ class FrontendTest extends TestCase
         // The names are a little different across jobs in the GitHub actions matrix.
         // We'll test against whichever was successfully applied. Finally, we will
         // reset the locale back to the original state to start the test clean.
-        $locales = ['fr_FR', 'fr_FR.utf-8', 'fr_FR.UTF-8', 'frs'];
+        $locales = ['fr_FR', 'fr_FR.utf-8', 'fr_FR.UTF-8', 'fra'];
         $originalLocale = setlocale(LC_TIME, 0);
         setlocale(LC_TIME, $locales);
         $frLocale = setlocale(LC_TIME, 0);

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -675,9 +675,15 @@ class FrontendTest extends TestCase
     /** @test */
     public function it_sets_the_locale()
     {
+        $locales = ['fr_FR', 'fr_FR.utf-8', 'fr_FR.UTF-8'];
+        $original = setlocale(LC_ALL, 0);
+        setlocale(LC_ALL, $locales);
+        $fr = setlocale(LC_ALL, 0);
+        setlocale(LC_ALL, $original);
+
         Site::setConfig(['sites' => [
             'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
-            'french' => ['url' => 'http://localhost/fr/', 'locale' => 'fr_FR'],
+            'french' => ['url' => 'http://localhost/fr/', 'locale' => $fr],
         ]]);
 
         (new class extends Tags
@@ -710,7 +716,7 @@ class FrontendTest extends TestCase
         $this->assertEquals('en', app()->getLocale());
         $this->assertEquals('C', setlocale(LC_ALL, 0));
 
-        $this->get('/fr/le-about')->assertSee('fr_FR fr');
+        $this->get('/fr/le-about')->assertSee($fr.' fr');
 
         $this->assertEquals('en', app()->getLocale());
         $this->assertEquals('C', setlocale(LC_ALL, 0));

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -685,8 +685,6 @@ class FrontendTest extends TestCase
         $frLocale = setlocale(LC_TIME, 0);
         setlocale(LC_TIME, $originalLocale);
 
-        dump($frLocale);
-
         Site::setConfig(['sites' => [
             'english' => ['url' => 'http://localhost/', 'locale' => 'en', 'lang' => 'en'],
             'french' => ['url' => 'http://localhost/fr/', 'locale' => $frLocale, 'lang' => 'fr'],

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -685,6 +685,8 @@ class FrontendTest extends TestCase
         $frLocale = setlocale(LC_TIME, 0);
         setlocale(LC_TIME, $originalLocale);
 
+        dump($frLocale);
+
         Site::setConfig(['sites' => [
             'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
             'french' => ['url' => 'http://localhost/fr/', 'locale' => $frLocale],

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -679,7 +679,7 @@ class FrontendTest extends TestCase
         // The names are a little different across jobs in the GitHub actions matrix.
         // We'll test against whichever was successfully applied. Finally, we will
         // reset the locale back to the original state to start the test clean.
-        $locales = ['fr_FR', 'fr_FR.utf-8', 'fr_FR.UTF-8', 'fra'];
+        $locales = ['fr_FR', 'fr_FR.utf-8', 'fr_FR.UTF-8', 'french'];
         $originalLocale = setlocale(LC_TIME, 0);
         setlocale(LC_TIME, $locales);
         $frLocale = setlocale(LC_TIME, 0);

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -680,10 +680,10 @@ class FrontendTest extends TestCase
         // We'll test against whichever was successfully applied. Finally, we will
         // reset the locale back to the original state to start the test clean.
         $locales = ['fr_FR', 'fr_FR.utf-8', 'fr_FR.UTF-8'];
-        $originalLocale = setlocale(LC_ALL, 0);
-        setlocale(LC_ALL, $locales);
-        $frLocale = setlocale(LC_ALL, 0);
-        setlocale(LC_ALL, $originalLocale);
+        $originalLocale = setlocale(LC_TIME, 0);
+        setlocale(LC_TIME, $locales);
+        $frLocale = setlocale(LC_TIME, 0);
+        setlocale(LC_TIME, $originalLocale);
 
         Site::setConfig(['sites' => [
             'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
@@ -718,7 +718,7 @@ class FrontendTest extends TestCase
         tap($this->makePage('le-about', ['with' => ['template' => 'some_template']])->locale('french'))->save();
 
         $this->assertEquals('en', app()->getLocale());
-        $this->assertEquals($originalLocale, setlocale(LC_ALL, 0));
+        $this->assertEquals($originalLocale, setlocale(LC_TIME, 0));
 
         $this->get('/fr/le-about')->assertSeeInOrder([
             'PHP Locale: '.$frLocale,
@@ -726,7 +726,7 @@ class FrontendTest extends TestCase
         ]);
 
         $this->assertEquals('en', app()->getLocale());
-        $this->assertEquals($originalLocale, setlocale(LC_ALL, 0));
+        $this->assertEquals($originalLocale, setlocale(LC_TIME, 0));
     }
 
     private function assertDefaultCarbonFormat()

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -714,12 +714,12 @@ class FrontendTest extends TestCase
         tap($this->makePage('le-about', ['with' => ['template' => 'some_template']])->locale('french'))->save();
 
         $this->assertEquals('en', app()->getLocale());
-        $this->assertEquals('C', setlocale(LC_ALL, 0));
+        $this->assertEquals($original, setlocale(LC_ALL, 0));
 
         $this->get('/fr/le-about')->assertSee($fr.' fr');
 
         $this->assertEquals('en', app()->getLocale());
-        $this->assertEquals('C', setlocale(LC_ALL, 0));
+        $this->assertEquals($original, setlocale(LC_ALL, 0));
     }
 
     private function assertDefaultCarbonFormat()

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -688,8 +688,8 @@ class FrontendTest extends TestCase
         dump($frLocale);
 
         Site::setConfig(['sites' => [
-            'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
-            'french' => ['url' => 'http://localhost/fr/', 'locale' => $frLocale],
+            'english' => ['url' => 'http://localhost/', 'locale' => 'en', 'lang' => 'en'],
+            'french' => ['url' => 'http://localhost/fr/', 'locale' => $frLocale, 'lang' => 'fr'],
         ]]);
 
         (new class extends Tags

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -679,7 +679,7 @@ class FrontendTest extends TestCase
         // The names are a little different across jobs in the GitHub actions matrix.
         // We'll test against whichever was successfully applied. Finally, we will
         // reset the locale back to the original state to start the test clean.
-        $locales = ['fr_FR', 'fr_FR.utf8', 'fr_FR.utf-8', 'fr_FR.UTF-8'];
+        $locales = ['fr_FR', 'fr_FR.utf-8', 'fr_FR.UTF-8', 'frs'];
         $originalLocale = setlocale(LC_TIME, 0);
         setlocale(LC_TIME, $locales);
         $frLocale = setlocale(LC_TIME, 0);

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -679,7 +679,7 @@ class FrontendTest extends TestCase
         // The names are a little different across jobs in the GitHub actions matrix.
         // We'll test against whichever was successfully applied. Finally, we will
         // reset the locale back to the original state to start the test clean.
-        $locales = ['fr_FR', 'fr_FR.utf-8', 'fr_FR.UTF-8'];
+        $locales = ['fr_FR', 'fr_FR.utf8', 'fr_FR.utf-8', 'fr_FR.UTF-8'];
         $originalLocale = setlocale(LC_TIME, 0);
         setlocale(LC_TIME, $locales);
         $frLocale = setlocale(LC_TIME, 0);


### PR DESCRIPTION
In our `Localize` middleware that's used on frontend request, we set the PHP locale, Laravel app locale, and Carbon string format based on the configured site being requested.

When setting the Carbon format, it's a static property, so it will be persisted across tests. This was manifesting itself in #6894.

This PR resets the Carbon format (as well as the locales while we're at it) once the request finishes.

This PR also adjusts some tests that were affected by Carbon string formats and locales unintentionally set in other tests.

This PR installs the French locale in the GitHub test workflow. Setting a locale requires a real locale that exists on the server, so this ensures it'll be there. There's also some ugly code in the test to set the differing name across environments. You install the same package on different environments and you get different outcomes, naturally.