### PR TITLE
Runtime: Improves recursive parent search

### DIFF
--- a/src/View/Antlers/Language/Analyzers/RecursiveParentAnalyzer.php
+++ b/src/View/Antlers/Language/Analyzers/RecursiveParentAnalyzer.php
@@ -53,6 +53,12 @@ class RecursiveParentAnalyzer
                         } else {
                             if (Str::contains($subNode->runtimeContent, $recursiveContent) && mb_substr_count($subNode->runtimeContent, '*recursive') == 1 && $node->getRootRef() == $subNode->getRootRef()) {
                                 $lastNode = $subNode;
+
+                                // Ensure we stop searching once we reach the closest nav parent.
+                                if ($subNode->name->name == 'nav') {
+                                    break;
+                                }
+
                                 continue;
                             } else {
                                 if ($lastNode != null) {


### PR DESCRIPTION
This PR fixes #6967 by exiting the parent search early when it hits the closest `nav` tag.

Doing this will now work as expected:

```antlers
{{ nav handle="main" }}
    {{ if depth == 1 }}
        <div class="{{ if is_current || is_parent }}active{{ /if }}">
            <a href="{{ url }}">First: {{ title }}</a>
            {{ if children }}
                <ul>
                    {{ *recursive children* }}
                </ul>
            {{ /if }}
        </div>
    {{ /if }}
    {{ if depth == 2 }}
        <li><a class="{{ if is_current }}active{{ /if }}" href="{{ url }}">First: {{ title }}</a></li>
    {{ /if }}
{{ /nav }}

<hr />
{{ if true }}
    {{ nav handle="main" }}
        {{ if depth == 1 }}
            <div>
                <a href="{{ url }}">Second: {{ title }}</a>
                {{ if children }}
                    <ul>
                        {{ *recursive children* }}
                    </ul>
                {{ /if }}
            </div>
        {{ /if }}
        {{ if depth == 2 }}
            <li><a class="{{ if is_current }}active{{ /if }}" href="{{ url }}">Second: {{ title }}</a></li>
        {{ /if }}
    {{ /nav }}
{{ /if }}
```

The included test case will also fail if the change is reverted.