### PR TITLE
Antlers: Corrects subtracting from parenthesis

### DIFF
--- a/src/View/Antlers/Language/Lexer/AntlersLexer.php
+++ b/src/View/Antlers/Language/Lexer/AntlersLexer.php
@@ -584,12 +584,22 @@ class AntlersLexer
                         }
                     }
 
-                    $variableRefNode = new VariableNode();
-                    $variableRefNode->name = $parsedValue;
-                    $variableRefNode->startPosition = $startPosition;
-                    $variableRefNode->endPosition = $endPosition;
-                    $this->runtimeNodes[] = $variableRefNode;
-                    $this->lastNode = $variableRefNode;
+                    if ($parsedValue == DocumentParser::Punctuation_Minus) {
+                        $subtractionOperator = new SubtractionOperator();
+                        $subtractionOperator->content = '-';
+                        $subtractionOperator->startPosition = $node->lexerRelativeOffset($this->currentIndex);
+                        $subtractionOperator->endPosition = $node->lexerRelativeOffset($this->currentIndex + 1);
+
+                        $this->runtimeNodes[] = $subtractionOperator;
+                        $this->lastNode = $subtractionOperator;
+                    } else {
+                        $variableRefNode = new VariableNode();
+                        $variableRefNode->name = $parsedValue;
+                        $variableRefNode->startPosition = $startPosition;
+                        $variableRefNode->endPosition = $endPosition;
+                        $this->runtimeNodes[] = $variableRefNode;
+                        $this->lastNode = $variableRefNode;
+                    }
 
                     continue;
                 }

--- a/tests/Antlers/Runtime/ArithmeticTest.php
+++ b/tests/Antlers/Runtime/ArithmeticTest.php
@@ -76,4 +76,13 @@ class ArithmeticTest extends ParserTestCase
         $this->assertSame('Yes', $this->renderString('{{ if 6 % 2 == 0 }}Yes{{ else }}No{{ endif }}'));
         $this->assertSame('No', $this->renderString('{{ if 6 % 2 == 1 }}Yes{{ else }}No{{ endif }}'));
     }
+
+    public function test_subtraction_after_logic_groups()
+    {
+        $data = [
+            'items' => ['a', 'b', 'c']
+        ];
+
+        $this->assertSame(2, intval($this->renderString('{{ (items|length) - 1 }}', $data, true)));
+    }
 }


### PR DESCRIPTION
This PR resolves a papercut I discovered while working on something.

Attempting to do something like this will currently lead to an unexpected stack condition:

```antlers
{{ something = (array_variable | count) - 2; }}
```

There are currently ways of doing this using interpolated syntax, but the parenthesis version definitely feels more straight-forward/natural when using modifiers.

I suspect this was caused when adding support for hyphens in variable names, but haven't dug that deep to confirm since both will work with this PR 🙂