### PR TITLE
Get the actual first item of an array with the `first` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -684,7 +684,7 @@ class CoreModifiers extends Modifier
     }
 
     /**
-     * Returns the first $params[0] characters of a string, or the last element of an array.
+     * Returns the first $params[0] characters of a string, or the first element of an array.
      *
      * @param $value
      * @param $params
@@ -693,7 +693,7 @@ class CoreModifiers extends Modifier
     public function first($value, $params)
     {
         if (is_array($value)) {
-            return Arr::get($value, 0);
+            return Arr::first($value);
         }
 
         return Stringy::first($value, Arr::get($params, 0));
@@ -1364,7 +1364,7 @@ class CoreModifiers extends Modifier
     public function last($value, $params)
     {
         if (is_array($value)) {
-            return array_pop($value);
+            return Arr::last($value);
         }
 
         return Stringy::last($value, Arr::get($params, 0));

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -5,7 +5,6 @@ namespace Statamic\Support;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr as IlluminateArr;
-use Statamic\Fields\Values;
 
 class Arr extends IlluminateArr
 {


### PR DESCRIPTION
First modifier assumes the first index is 0, which returns nothing for associative arrays or arrays where the first index is not 0. 