### PR TITLE
Fix relative modifier's `remove_modifiers` param

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1949,7 +1949,7 @@ class CoreModifiers extends Modifier
     {
         $remove_modifiers = Arr::get($params, 0, false);
 
-        return $this->carbon($value)->diffForHumans(null, in_array($remove_modifiers, [true, 'true', ''], true));
+        return $this->carbon($value)->diffForHumans(null, in_array($remove_modifiers, [true, 'true'], true));
     }
 
     /**

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1934,6 +1934,7 @@ class CoreModifiers extends Modifier
      */
     public function relative($value, $params)
     {
+        dump($params);
         return $this->diffForHumans($value, $params);
     }
 
@@ -1949,7 +1950,7 @@ class CoreModifiers extends Modifier
     {
         $remove_modifiers = Arr::get($params, 0, false);
 
-        return $this->carbon($value)->diffForHumans(null, $remove_modifiers);
+        return $this->carbon($value)->diffForHumans(null, in_array($remove_modifiers, [true, 'true', ''], true));
     }
 
     /**

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1934,7 +1934,6 @@ class CoreModifiers extends Modifier
      */
     public function relative($value, $params)
     {
-        dump($params);
         return $this->diffForHumans($value, $params);
     }
 

--- a/tests/Modifiers/RelativeTest.php
+++ b/tests/Modifiers/RelativeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Carbon\Carbon;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class RelativeTest extends TestCase
+{
+    /** @test */
+    public function it_converts_a_date_to_relative()
+    {
+        $date = new Carbon('today -1 year');
+
+        $this->assertEquals('1 year ago', $this->modify($date));
+    }
+
+    /** @test */
+    public function it_converts_a_date_to_relative_without_modifiers()
+    {
+        $date = new Carbon('today -1 year');
+
+        $this->assertEquals('1 year', $this->modify($date, true));
+        $this->assertEquals('1 year', $this->modify($date, 'true'));
+    }
+
+    protected function modify($arr, ...$args)
+    {
+        return Modify::value($arr)->relative($args)->fetch();
+    }
+}


### PR DESCRIPTION
Carbon's `diffForHumans` expects the modifier argument to be an actual bool/int, not just a truthy value like the string `"true"`. Because of this passing true using the legacy syntax doesn't work as expected.

```antlers
{{ date | relative }}
{{ date | relative:true }}
{{ date | relative(true) }}
```

```html
Before:
14 minutes ago
14 minutes ago
14 minutes

After:
14 minutes ago
14 minutes
14 minutes
```

Something else that slightly confuses this is that `remove_modifiers` should be `true` to remove the extra words, as per [the comment](https://github.com/statamic/cms/blob/5082efc80f2bf22416c79649542ee501be7a9e34/src/Modifiers/CoreModifiers.php#L1942). However the docs actually say that you should use `false`. Doing a docs PR to correct that.