### PR TITLE
Get the actual first item of an array with the first modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -684,7 +684,7 @@ class CoreModifiers extends Modifier
     }
 
     /**
-     * Returns the first $params[0] characters of a string, or the last element of an array.
+     * Returns the first $params[0] characters of a string, or the first element of an array.
      *
      * @param $value
      * @param $params
@@ -693,7 +693,7 @@ class CoreModifiers extends Modifier
     public function first($value, $params)
     {
         if (is_array($value)) {
-            return Arr::get($value, 0);
+            return Arr::first($value);
         }
 
         return Stringy::first($value, Arr::get($params, 0));
@@ -1364,7 +1364,7 @@ class CoreModifiers extends Modifier
     public function last($value, $params)
     {
         if (is_array($value)) {
-            return array_pop($value);
+            return Arr::last($value);
         }
 
         return Stringy::last($value, Arr::get($params, 0));

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -5,7 +5,6 @@ namespace Statamic\Support;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr as IlluminateArr;
-use Statamic\Fields\Values;
 
 class Arr extends IlluminateArr
 {

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -5,6 +5,7 @@ namespace Statamic\Support;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr as IlluminateArr;
+use Statamic\Fields\Values;
 
 class Arr extends IlluminateArr
 {

--- a/tests/Modifiers/FirstTest.php
+++ b/tests/Modifiers/FirstTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class FirstTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider stringProvider
+     */
+    public function it_gets_the_first_n_characters_of_a_string($arg, $expected)
+    {
+        $this->assertEquals($expected, $this->modify('Testing', $arg));
+    }
+
+    public function stringProvider()
+    {
+        return [
+            [1, 'T'],
+            [2, 'Te'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider arrayProvider
+     */
+    public function it_gets_the_first_value_of_an_array($value, $expected)
+    {
+        $this->assertEquals($expected, $this->modify($value));
+    }
+
+    public function arrayProvider()
+    {
+        return [
+            'list' => [
+                ['alfa', 'bravo', 'charlie'],
+                'alfa',
+            ],
+            'associative' => [
+                ['alfa' => 'bravo', 'charlie' => 'delta'],
+                'bravo',
+            ],
+        ];
+    }
+
+    private function modify($value, $arg = null)
+    {
+        return Modify::value($value)->first($arg)->fetch();
+    }
+}

--- a/tests/Modifiers/LastTest.php
+++ b/tests/Modifiers/LastTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class LastTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider stringProvider
+     */
+    public function it_gets_the_last_n_characters_of_a_string($arg, $expected)
+    {
+        $this->assertEquals($expected, $this->modify('Testing', $arg));
+    }
+
+    public function stringProvider()
+    {
+        return [
+            [1, 'g'],
+            [2, 'ng'],
+            [3, 'ing'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider arrayProvider
+     */
+    public function it_gets_the_last_value_of_an_array($value, $expected)
+    {
+        $this->assertEquals($expected, $this->modify($value));
+    }
+
+    public function arrayProvider()
+    {
+        return [
+            'list' => [
+                ['alfa', 'bravo', 'charlie'],
+                'charlie',
+            ],
+            'associative' => [
+                ['alfa' => 'bravo', 'charlie' => 'delta'],
+                'delta',
+            ],
+        ];
+    }
+
+    private function modify($value, $arg = null)
+    {
+        return Modify::value($value)->last($arg)->fetch();
+    }
+}


### PR DESCRIPTION
First modifier assumes the first index is 0, which returns nothing for associative arrays or arrays where the first index is not 0.