### PR TITLE
Antlers: prevent logging named slots with non-loopable debug warning

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -709,6 +709,24 @@ class NodeProcessor
     }
 
     /**
+     * Tests if the provided node is internally treated like a tag.
+     *
+     * @param AntlersNode $node The node.
+     * @return bool
+     */
+    protected function isInternalTagLike(AntlersNode $node)
+    {
+        $nodeName = $node->name->name;
+
+        if ($nodeName == 'slot' || $nodeName == 'push' || $nodeName == 'prepend' ||
+            $nodeName == 'stack' || $nodeName == 'once') {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Tests if the runtime should continue processing the node/value combination.
      *
      * This method is responsible for ensuring that developers are not
@@ -722,7 +740,7 @@ class NodeProcessor
      */
     private function guardRuntime(AntlersNode $node, $value)
     {
-        if ($node->isClosedBy != null && $this->isLoopable($value) == false) {
+        if ($node->isClosedBy != null && !$this->isInternalTagLike($node) && $this->isLoopable($value) == false) {
             $varName = $node->name->getContent();
             Log::debug("Cannot loop over non-loopable variable: {{ {$varName} }}");
 

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -740,9 +740,11 @@ class NodeProcessor
      */
     private function guardRuntime(AntlersNode $node, $value)
     {
-        if ($node->isClosedBy != null && ! $this->isInternalTagLike($node) && $this->isLoopable($value) == false) {
-            $varName = $node->name->getContent();
-            Log::debug("Cannot loop over non-loopable variable: {{ {$varName} }}");
+        if ($node->isClosedBy != null && $this->isLoopable($value) == false) {
+            if (! $this->isInternalTagLike($node)) {
+                $varName = $node->name->getContent();
+                Log::debug("Cannot loop over non-loopable variable: {{ {$varName} }}");
+            }
 
             return false;
         } elseif ($this->isInterpolationProcessor == false && $this->isLoopable($value) && $node->isClosedBy == null) {

--- a/tests/Antlers/Runtime/NamedSlotsTest.php
+++ b/tests/Antlers/Runtime/NamedSlotsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Antlers\Runtime;
 
+use Illuminate\Support\Facades\Log;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
 use Tests\Antlers\ParserTestCase;
 
@@ -84,5 +85,24 @@ EOT;
 EOT;
 
         $this->assertSame('<The Content>', $this->renderString($template, ['content' => 'The Content'], true));
+    }
+
+    public function test_named_slots_do_not_end_up_in_the_log_as_loopable_variable_warnnig()
+    {
+        $template = <<<'EOT'
+{{ partial:card }}
+{{ slot:bottom }}
+<span>I am the new content!</span>
+{{ /slot:bottom }}
+
+Test description.
+{{ /partial:card }}
+EOT;
+
+        Log::shouldReceive('debug')->never();
+
+        $this->renderString($template, [
+            'title' => 'Test Title',
+        ], true);
     }
 }


### PR DESCRIPTION
This RP fixes #6986  by preventing the `local.DEBUG: Cannot loop over non-loopable variable:` logs from being created when using named slots.

Additionally, this PR will prevent these logs from occurring on the following things that are internally treated like tags by the `NodeProcessor`:

* slot
* push
* prepend
* stack
* once

The changes only prevent the logging from happening, and there are no changes to the actual execution/render behavior.
