### PR TITLE
Fix collection form not populating the origin behavior value

### DIFF
--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -164,6 +164,7 @@ class CollectionsController extends CpController
                 ? $collection->titleFormats()->first()
                 : $collection->titleFormats()->all(),
             'preview_targets' => $collection->basePreviewTargets(),
+            'origin_behavior' => $collection->originBehavior(),
         ];
 
         $fields = ($blueprint = $this->editFormBlueprint($collection))


### PR DESCRIPTION
Continuation from #6983

The form worked fine except when you first open it, it would always default to the first option.
It wouldn't use the value from the collection. Now it does.
