### PR TITLE
Fix Replicator/Grid/Bard not displaying newly added items after saving

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -395,7 +395,7 @@ export default {
     methods: {
 
         addSet(handle) {
-            const id = `set-${uniqid()}`;
+            const id = uniqid();
             const values = Object.assign({}, { type: handle }, this.meta.defaults[handle]);
 
             let previews = {};
@@ -411,7 +411,7 @@ export default {
         },
 
         duplicateSet(old_id, attrs, pos) {
-            const id = `set-${uniqid()}`;
+            const id = uniqid();
             const enabled = attrs.enabled;
             const values = Object.assign({}, attrs.values);
 

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -148,7 +148,7 @@ export default {
         addSet(handle, index) {
             const set = {
                 ...this.meta.defaults[handle],
-                _id: `set-${uniqid()}`,
+                _id: uniqid(),
                 type: handle,
                 enabled: true,
             };
@@ -171,7 +171,7 @@ export default {
             const old = this.value[index];
             const set = {
                 ...old,
-                _id: `set-${uniqid()}`,
+                _id: uniqid(),
             };
 
             this.updateSetPreviews(set._id, {});

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fieldtypes;
 
+use Facades\Statamic\Fieldtypes\RowId;
 use ProseMirrorToHtml\Renderer;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Blink;
@@ -429,7 +430,7 @@ class Bard extends Replicator
                 [
                     'type' => 'set',
                     'attrs' => [
-                        'id' => "set-$i",
+                        'id' => RowId::generate(),
                         'values' => $set,
                     ],
                 ],

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -287,8 +287,6 @@ class Bard extends Replicator
     {
         $row['attrs']['values'] = parent::processRow($row['attrs']['values']);
 
-        unset($row['attrs']['id']);
-
         if (array_get($row, 'attrs.enabled', true) === true) {
             unset($row['attrs']['enabled']);
         }
@@ -330,7 +328,7 @@ class Bard extends Replicator
         return [
             'type' => 'set',
             'attrs' => [
-                'id' => "set-$index",
+                'id' => $row['attrs']['id'] ?? "set-$index",
                 'enabled' => $row['attrs']['enabled'] ?? true,
                 'values' => Arr::except($values, 'enabled'),
             ],

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -328,7 +328,7 @@ class Bard extends Replicator
         return [
             'type' => 'set',
             'attrs' => [
-                'id' => $row['attrs']['id'] ?? "set-$index",
+                'id' => $row['attrs']['id'] ?? str_random(8),
                 'enabled' => $row['attrs']['enabled'] ?? true,
                 'values' => Arr::except($values, 'enabled'),
             ],

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -103,7 +103,7 @@ class Grid extends Fieldtype
     {
         $fields = $this->fields()->addValues($row)->preProcess()->values()->all();
 
-        $id = Arr::pull($row, 'id') ?? "row-$index";
+        $id = Arr::pull($row, 'id') ?? str_random(8);
 
         return array_merge($row, $fields, [
             '_id' => $id,

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -77,7 +77,7 @@ class Grid extends Fieldtype
 
     private function processRow($row)
     {
-        $row = array_except($row, '_id');
+        $row['id'] = Arr::pull($row, '_id');
 
         $fields = $this->fields()->addValues($row)->process()->values()->all();
 
@@ -103,8 +103,10 @@ class Grid extends Fieldtype
     {
         $fields = $this->fields()->addValues($row)->preProcess()->values()->all();
 
+        $id = Arr::pull($row, 'id') ?? "row-$index";
+
         return array_merge($row, $fields, [
-            '_id' => "row-$index",
+            '_id' => $id,
         ]);
     }
 

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fieldtypes;
 
+use Facades\Statamic\Fieldtypes\RowId;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fields;
 use Statamic\Fields\Fieldtype;
@@ -103,7 +104,7 @@ class Grid extends Fieldtype
     {
         $fields = $this->fields()->addValues($row)->preProcess()->values()->all();
 
-        $id = Arr::pull($row, 'id') ?? str_random(8);
+        $id = Arr::pull($row, 'id') ?? RowId::generate();
 
         return array_merge($row, $fields, [
             '_id' => $id,

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -78,11 +78,9 @@ class Grid extends Fieldtype
 
     private function processRow($row)
     {
-        $row['id'] = Arr::pull($row, '_id');
-
         $fields = $this->fields()->addValues($row)->process()->values()->all();
 
-        $row = array_merge($row, $fields);
+        $row = array_merge(['id' => Arr::pull($row, '_id')], $row, $fields);
 
         return Arr::removeNullValues($row);
     }

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -68,11 +68,9 @@ class Replicator extends Fieldtype
 
     protected function processRow($row)
     {
-        $row['id'] = Arr::pull($row, '_id');
-
         $fields = $this->fields($row['type'])->addValues($row)->process()->values()->all();
 
-        $row = array_merge($row, $fields);
+        $row = array_merge(['id' => Arr::pull($row, '_id')], $row, $fields);
 
         return Arr::removeNullValues($row);
     }

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fieldtypes;
 
+use Facades\Statamic\Fieldtypes\RowId;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fields;
 use Statamic\Fields\Fieldtype;
@@ -87,7 +88,7 @@ class Replicator extends Fieldtype
     {
         $fields = $this->fields($row['type'])->addValues($row)->preProcess()->values()->all();
 
-        $id = Arr::pull($row, 'id') ?? str_random(8);
+        $id = Arr::pull($row, 'id') ?? RowId::generate();
 
         return array_merge($row, $fields, [
             '_id' => $id,

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -87,7 +87,7 @@ class Replicator extends Fieldtype
     {
         $fields = $this->fields($row['type'])->addValues($row)->preProcess()->values()->all();
 
-        $id = Arr::pull($row, 'id') ?? "set-$index";
+        $id = Arr::pull($row, 'id') ?? str_random(8);
 
         return array_merge($row, $fields, [
             '_id' => $id,

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -67,7 +67,7 @@ class Replicator extends Fieldtype
 
     protected function processRow($row)
     {
-        $row = array_except($row, '_id');
+        $row['id'] = Arr::pull($row, '_id');
 
         $fields = $this->fields($row['type'])->addValues($row)->process()->values()->all();
 
@@ -87,8 +87,10 @@ class Replicator extends Fieldtype
     {
         $fields = $this->fields($row['type'])->addValues($row)->preProcess()->values()->all();
 
+        $id = Arr::pull($row, 'id') ?? "set-$index";
+
         return array_merge($row, $fields, [
-            '_id' => "set-$index",
+            '_id' => $id,
             'enabled' => $row['enabled'] ?? true,
         ]);
     }

--- a/src/Fieldtypes/RowId.php
+++ b/src/Fieldtypes/RowId.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Statamic\Fieldtypes;
+
+class RowId
+{
+    public function generate()
+    {
+        return str_random(8);
+    }
+}

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Fieldtypes;
 
+use Facades\Statamic\Fieldtypes\RowId;
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
@@ -16,6 +17,15 @@ use Tests\TestCase;
 class BardTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
+
+    // Mocking method_exists, courtesy of https://stackoverflow.com/a/37928161
+    public static $functions;
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        static::$functions = null;
+    }
 
     /** @test */
     public function it_augments_prosemirror_structure_to_a_template_friendly_array()
@@ -303,6 +313,8 @@ class BardTest extends TestCase
     /** @test */
     public function it_transforms_v2_formatted_content_into_prosemirror_structure()
     {
+        RowId::shouldReceive('generate')->andReturn('random-string-1');
+
         $data = [
             ['type' => 'text', 'text' => '<p>This is a paragraph with <strong>bold</strong> text.</p><p>Second paragraph.</p>'],
             ['type' => 'myset', 'foo' => 'bar', 'baz' => 'qux'],
@@ -327,7 +339,7 @@ class BardTest extends TestCase
             [
                 'type' => 'set',
                 'attrs' => [
-                    'id' => 'set-2',
+                    'id' => 'random-string-1',
                     'enabled' => true,
                     'values' => [
                         'type' => 'myset',
@@ -356,6 +368,8 @@ class BardTest extends TestCase
     /** @test */
     public function it_transforms_v2_formatted_content_with_only_sets_into_prosemirror_structure()
     {
+        RowId::shouldReceive('generate')->andReturn('random-string-1');
+
         $data = [
             ['type' => 'myset', 'foo' => 'bar', 'baz' => 'qux'],
         ];
@@ -364,7 +378,7 @@ class BardTest extends TestCase
             [
                 'type' => 'set',
                 'attrs' => [
-                    'id' => 'set-0',
+                    'id' => 'random-string-1',
                     'enabled' => true,
                     'values' => [
                         'type' => 'myset',
@@ -464,6 +478,8 @@ class BardTest extends TestCase
     /** @test */
     public function it_preloads_new_meta_with_preprocessed_values()
     {
+        RowId::shouldReceive('generate')->andReturn('random1', 'random2');
+
         // For this test, use a grid field with min_rows.
         // It doesn't have to be, but it's a fieldtype that would
         // require preprocessed values to be provided down the line.
@@ -499,8 +515,8 @@ class BardTest extends TestCase
                     'one' => null, // meta for the text field
                 ],
                 'existing' => [
-                    'row-0' => ['one' => null],
-                    'row-1' => ['one' => null],
+                    'random1' => ['one' => null],
+                    'random2' => ['one' => null],
                 ],
             ],
         ];

--- a/tests/Fieldtypes/GridTest.php
+++ b/tests/Fieldtypes/GridTest.php
@@ -201,16 +201,16 @@ class GridTest extends TestCase
 
         $this->assertSame([
             [
+                'id' => 'id-1',
                 'numbers' => 2,
                 'words' => 'test',
                 'foo' => 'bar',
-                'id' => 'id-1',
             ],
             [
+                'id' => 'id-2',
                 'numbers' => 3,
                 'words' => 'more test',
                 'foo' => 'more bar',
-                'id' => 'id-2',
             ],
         ], $field->process()->value());
     }
@@ -279,44 +279,44 @@ class GridTest extends TestCase
 
         $this->assertSame([
             [
+                'id' => 'id-1',
                 'numbers' => 2,
                 'words' => 'test',
                 'foo' => 'bar',
                 'nested_grid' => [
                     [
+                        'id' => 'id-1-1',
                         'nested_numbers' => 3,
                         'nested_words' => 'nested test one',
                         'nested_foo' => 'nested bar one',
-                        'id' => 'id-1-1',
                     ],
                     [
+                        'id' => 'id-1-2',
                         'nested_numbers' => 4,
                         'nested_words' => 'nested test two',
                         'nested_foo' => 'nested bar two',
-                        'id' => 'id-1-2',
                     ],
                 ],
-                'id' => 'id-1',
             ],
             [
+                'id' => 'id-2',
                 'numbers' => 3,
                 'words' => 'more test',
                 'foo' => 'more bar',
                 'nested_grid' => [
                     [
+                        'id' => 'id-2-1',
                         'nested_numbers' => 5,
                         'nested_words' => 'more nested test one',
                         'nested_foo' => 'more nested bar one',
-                        'id' => 'id-2-1',
                     ],
                     [
+                        'id' => 'id-2-2',
                         'nested_numbers' => 6,
                         'nested_words' => 'more nested test two',
                         'nested_foo' => 'more nested bar two',
-                        'id' => 'id-2-2',
                     ],
                 ],
-                'id' => 'id-2',
             ],
         ], $field->process()->value());
     }

--- a/tests/Fieldtypes/GridTest.php
+++ b/tests/Fieldtypes/GridTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Fieldtypes;
 
 use Facades\Statamic\Fields\FieldRepository;
+use Facades\Statamic\Fieldtypes\RowId;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Values;
@@ -14,6 +15,8 @@ class GridTest extends TestCase
     /** @test */
     public function it_preprocesses_the_values()
     {
+        RowId::shouldReceive('generate')->twice()->andReturn('random-string-1', 'random-string-2');
+
         FieldRepository::shouldReceive('find')
             ->with('testfieldset.numbers')
             ->andReturnUsing(function () {
@@ -44,13 +47,13 @@ class GridTest extends TestCase
                 'numbers' => 2,
                 'words' => 'test',
                 'foo' => 'bar',
-                '_id' => 'row-0',
+                '_id' => 'random-string-1',
             ],
             [
                 'numbers' => 3,
                 'words' => 'more test',
                 'foo' => 'more bar',
-                '_id' => 'row-1',
+                '_id' => 'random-string-2',
             ],
         ], $field->preProcess()->value());
     }
@@ -58,6 +61,15 @@ class GridTest extends TestCase
     /** @test */
     public function it_preprocesses_the_values_recursively()
     {
+        RowId::shouldReceive('generate')->times(6)->andReturn(
+            'random-string-1',
+            'random-string-2',
+            'random-string-3',
+            'random-string-4',
+            'random-string-5',
+            'random-string-6',
+        );
+
         FieldRepository::shouldReceive('find')
             ->with('testfieldset.numbers')
             ->andReturnUsing(function () {
@@ -123,16 +135,16 @@ class GridTest extends TestCase
                         'nested_numbers' => 3,
                         'nested_words' => 'nested test one',
                         'nested_foo' => 'nested bar one',
-                        '_id' => 'row-0',
+                        '_id' => 'random-string-1',
                     ],
                     [
                         'nested_numbers' => 4,
                         'nested_words' => 'nested test two',
                         'nested_foo' => 'nested bar two',
-                        '_id' => 'row-1',
+                        '_id' => 'random-string-2',
                     ],
                 ],
-                '_id' => 'row-0',
+                '_id' => 'random-string-3',
             ],
             [
                 'numbers' => 3,
@@ -143,16 +155,16 @@ class GridTest extends TestCase
                         'nested_numbers' => 5,
                         'nested_words' => 'more nested test one',
                         'nested_foo' => 'more nested bar one',
-                        '_id' => 'row-0',
+                        '_id' => 'random-string-4',
                     ],
                     [
                         'nested_numbers' => 6,
                         'nested_words' => 'more nested test two',
                         'nested_foo' => 'more nested bar two',
-                        '_id' => 'row-1',
+                        '_id' => 'random-string-5',
                     ],
                 ],
-                '_id' => 'row-1',
+                '_id' => 'random-string-6',
             ],
         ], $field->preProcess()->value());
     }
@@ -192,11 +204,13 @@ class GridTest extends TestCase
                 'numbers' => 2,
                 'words' => 'test',
                 'foo' => 'bar',
+                'id' => 'id-1',
             ],
             [
                 'numbers' => 3,
                 'words' => 'more test',
                 'foo' => 'more bar',
+                'id' => 'id-2',
             ],
         ], $field->process()->value());
     }
@@ -273,13 +287,16 @@ class GridTest extends TestCase
                         'nested_numbers' => 3,
                         'nested_words' => 'nested test one',
                         'nested_foo' => 'nested bar one',
+                        'id' => 'id-1-1',
                     ],
                     [
                         'nested_numbers' => 4,
                         'nested_words' => 'nested test two',
                         'nested_foo' => 'nested bar two',
+                        'id' => 'id-1-2',
                     ],
                 ],
+                'id' => 'id-1',
             ],
             [
                 'numbers' => 3,
@@ -290,13 +307,16 @@ class GridTest extends TestCase
                         'nested_numbers' => 5,
                         'nested_words' => 'more nested test one',
                         'nested_foo' => 'more nested bar one',
+                        'id' => 'id-2-1',
                     ],
                     [
                         'nested_numbers' => 6,
                         'nested_words' => 'more nested test two',
                         'nested_foo' => 'more nested bar two',
+                        'id' => 'id-2-2',
                     ],
                 ],
+                'id' => 'id-2',
             ],
         ], $field->process()->value());
     }

--- a/tests/Fieldtypes/ReplicatorTest.php
+++ b/tests/Fieldtypes/ReplicatorTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Fieldtypes;
 
 use Facades\Statamic\Fields\FieldRepository;
+use Facades\Statamic\Fieldtypes\RowId;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Values;
@@ -14,6 +15,8 @@ class ReplicatorTest extends TestCase
     /** @test */
     public function it_preprocesses_the_values()
     {
+        RowId::shouldReceive('generate')->twice()->andReturn('random-string-1', 'random-string-2');
+
         FieldRepository::shouldReceive('find')
             ->with('testfieldset.numbers')
             ->andReturnUsing(function () {
@@ -57,7 +60,7 @@ class ReplicatorTest extends TestCase
                 'numbers' => 2,
                 'words' => 'test',
                 'foo' => 'bar',
-                '_id' => 'set-0',
+                '_id' => 'random-string-1',
                 'enabled' => true,
             ],
             [
@@ -65,7 +68,7 @@ class ReplicatorTest extends TestCase
                 'age' => 13,
                 'food' => 'pizza',
                 'foo' => 'more bar',
-                '_id' => 'set-1',
+                '_id' => 'random-string-2',
                 'enabled' => true,
             ],
         ], $field->preProcess()->value());
@@ -74,6 +77,8 @@ class ReplicatorTest extends TestCase
     /** @test */
     public function it_preprocesses_the_values_recursively()
     {
+        RowId::shouldReceive('generate')->twice()->andReturn('random-string-1', 'random-string-2');
+
         FieldRepository::shouldReceive('find')
             ->with('testfieldset.numbers')
             ->andReturnUsing(function () {
@@ -130,11 +135,11 @@ class ReplicatorTest extends TestCase
                         'nested_age' => 13,
                         'nested_food' => 'pizza',
                         'nested_foo' => 'more bar',
-                        '_id' => 'set-0',
+                        '_id' => 'random-string-1',
                         'enabled' => true,
                     ],
                 ],
-                '_id' => 'set-0',
+                '_id' => 'random-string-2',
                 'enabled' => true,
             ],
         ], $field->preProcess()->value());
@@ -188,12 +193,14 @@ class ReplicatorTest extends TestCase
                 'numbers' => 2,
                 'words' => 'test',
                 'foo' => 'bar',
+                'id' => '1',
             ],
             [
                 'type' => 'two',
                 'age' => 13,
                 'food' => 'pizza',
                 'foo' => 'more bar',
+                'id' => '2',
             ],
         ], $field->process()->value());
     }
@@ -259,8 +266,10 @@ class ReplicatorTest extends TestCase
                         'nested_age' => 13,
                         'nested_food' => 'pizza',
                         'nested_foo' => 'more bar',
+                        'id' => '2',
                     ],
                 ],
+                'id' => '1',
             ],
         ], $field->process()->value());
     }
@@ -289,6 +298,8 @@ class ReplicatorTest extends TestCase
     /** @test */
     public function it_preloads_new_meta_with_preprocessed_values()
     {
+        RowId::shouldReceive('generate')->twice()->andReturn('random-string-1', 'random-string-2');
+
         // For this test, use a grid field with min_rows.
         // It doesn't have to be, but it's a fieldtype that would
         // require preprocessed values to be provided down the line.
@@ -324,8 +335,8 @@ class ReplicatorTest extends TestCase
                     'one' => null, // meta for the text field
                 ],
                 'existing' => [
-                    'row-0' => ['one' => null],
-                    'row-1' => ['one' => null],
+                    'random-string-1' => ['one' => null],
+                    'random-string-2' => ['one' => null],
                 ],
             ],
         ];

--- a/tests/Fieldtypes/ReplicatorTest.php
+++ b/tests/Fieldtypes/ReplicatorTest.php
@@ -189,18 +189,18 @@ class ReplicatorTest extends TestCase
 
         $this->assertSame([
             [
+                'id' => '1',
                 'type' => 'one',
                 'numbers' => 2,
                 'words' => 'test',
                 'foo' => 'bar',
-                'id' => '1',
             ],
             [
+                'id' => '2',
                 'type' => 'two',
                 'age' => 13,
                 'food' => 'pizza',
                 'foo' => 'more bar',
-                'id' => '2',
             ],
         ], $field->process()->value());
     }
@@ -256,20 +256,20 @@ class ReplicatorTest extends TestCase
 
         $this->assertSame([
             [
+                'id' => '1',
                 'type' => 'one',
                 'numbers' => 2,
                 'words' => 'test',
                 'foo' => 'bar',
                 'nested_replicator' => [
                     [
+                        'id' => '2',
                         'type' => 'two',
                         'nested_age' => 13,
                         'nested_food' => 'pizza',
                         'nested_foo' => 'more bar',
-                        'id' => '2',
                     ],
                 ],
-                'id' => '1',
             ],
         ], $field->process()->value());
     }


### PR DESCRIPTION
Fixes #6993

The reported issue was about Replicator, but it also happened in Bard and Grid.

Previously, we would use ids to keep track of reordering etc just in JS, and throw the IDs away when you save just so you wouldn't get them in your data.

Now that we update the form with fresh values since #6842, the fieldtype preprocessing would assign new IDs, the JS would get confused, and the newly added items would mismatch, cause a JS error, and not display.

There would be no data loss, it would just look like it.

This PR will keep the IDs in the data/yaml. It's the simplest solution we could find, and there's no harm to having `id` keys in there.


Todo:
- [x] Put `id` at the top of the array. It's just a little nicer, it's awkward at the end especially if there are nested arrays.
- [x] See how nicely this plays with sites using https://github.com/aryehraber/statamic-uuid to store their own id fields. It will now be redundant.