### PR TITLE
Support Query Builder values in reverse modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2061,6 +2061,10 @@ class CoreModifiers extends Modifier
      */
     public function reverse($value)
     {
+        if (Compare::isQueryBuilder($value)) {
+            return $value->get()->reverse()->values()->all();
+        }
+
         if ($value instanceof Collection) {
             return $value->reverse()->values()->all();
         }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2062,7 +2062,7 @@ class CoreModifiers extends Modifier
     public function reverse($value)
     {
         if (Compare::isQueryBuilder($value)) {
-            return $value->get()->reverse()->values()->all();
+            $value = $value->get();
         }
 
         if ($value instanceof Collection) {

--- a/tests/Modifiers/ReverseTest.php
+++ b/tests/Modifiers/ReverseTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Modifiers;
 
+use Mockery;
+use Statamic\Contracts\Query\Builder;
 use Statamic\Modifiers\Modify;
 use Tests\TestCase;
 
@@ -42,6 +44,29 @@ class ReverseTest extends TestCase
             'party',
         ]);
         $modified = $this->modify($orderOfCeremony);
+        $expected = [
+            'party',
+            'eat',
+            'service',
+            'photos',
+        ];
+        $this->assertEquals($expected, $modified);
+    }
+
+    /**
+     * @test
+     */
+    public function it_reverses_items_from_query_builder(): void
+    {
+        $builder = Mockery::mock(Builder::class);
+        $builder->shouldReceive('get')->andReturn(collect([
+            'photos',
+            'service',
+            'eat',
+            'party',
+        ]));
+
+        $modified = $this->modify($builder);
         $expected = [
             'party',
             'eat',


### PR DESCRIPTION
Needed to reverse the order of an assets field but the field returns a QueryBuilder value which isn't supported by the modifier. This PR adds support.