### PR TITLE
Fix a couple of "root page cannot have children" issues

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -131,6 +131,8 @@ return [
     'unique_uri' => 'This URI has already been taken.',
     'duplicate_uri' => 'Duplicate URI :value',
     'reserved' => 'This is a reserved word.',
+    'parent_causes_root_children' => 'This would cause the root page to have children.',
+    'parent_cannot_be_itself' => 'Cannot be its own parent.',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -215,6 +215,8 @@ class EntriesController extends CpController
         if ($collection->structure() && ! $collection->orderable()) {
             $tree = $entry->structure()->in($entry->locale());
 
+            $this->validateParent($entry, $tree, $parent);
+
             $entry->afterSave(function ($entry) use ($parent, $tree) {
                 if ($parent && optional($tree->page($parent))->isRoot()) {
                     $parent = null;
@@ -476,6 +478,27 @@ class EntriesController extends CpController
     {
         // Since assume `Y-m-d ...` format, we can use `parse` here.
         return Carbon::parse($date);
+    }
+
+    private function validateParent($entry, $tree, $parent)
+    {
+        if ($entry->id() == $parent) {
+            throw ValidationException::withMessages(['parent' => __('statamic::validation.parent_cannot_be_itself')]);
+        }
+
+        // If there's no parent selected, the entry will be at end of the top level, which is fine.
+        // If the entry being edited is not the root, then we don't have anything to worry about.
+        // If the parent is the root, that's fine, and is handled during the tree update later.
+        if (! $parent || ! $entry->isRoot()) {
+            return;
+        }
+
+        // There will always be a next page since we couldn't have got this far with a single page.
+        $nextTopLevelPage = $tree->pages()->all()->skip(1)->first();
+
+        if ($nextTopLevelPage->id() === $parent || $nextTopLevelPage->pages()->all()->count() > 0) {
+            throw ValidationException::withMessages(['parent' => __('statamic::validation.parent_causes_root_children')]);
+        }
     }
 
     private function validateUniqueUri($entry, $tree, $parent)

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -366,6 +366,10 @@ class EntriesController extends CpController
             $tree = $structure->in($site->handle());
             $parent = $values['parent'] ?? null;
             $entry->afterSave(function ($entry) use ($parent, $tree) {
+                if ($parent && optional($tree->page($parent))->isRoot()) {
+                    $parent = null;
+                }
+
                 $tree->appendTo($parent, $entry)->save();
             });
         }


### PR DESCRIPTION
Closes #5426

There are two related issues.

1. When you _create_ an entry, if you select the root page as the parent, you'd get an error. This was already fixed when editing pages in #3104, but not for creating.

2. When you pick the parent and save an entry, if the movement of the page would result in the parent having children, then you'd get the error.

    A couple of examples:

	* First
		```
		|-- One
		|-- Two
		|-- Three
		```
		If you edit "One" and choose "Two" as the parent, then "Two" would become the new root, which would be invalid as it now has a child.
		```
		|-- Two
		|   |-- One
		|-- Three
		```
		
	* Second:
		
		```
		|-- One
		|-- Two
		|   |-- Three
		|-- Four
		```
		If you edit "One" and choose "Four" as the parent, then "Two" would become the new root, which is invalid because it already has child pages.
		```
		|-- Two
		|   |-- Three
		|-- Four
		    |-- One
		```

Now you will get a validation error instead of the error.

Also, not included in the linked issue, you will get a validation error if you try to pick itself as its own parent.