### PR TITLE
Allow for last_login to be casted as Carbon object.

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -323,7 +323,7 @@ class User extends BaseUser
             return null;
         }
 
-        return $date instanceof Carbon ? $date->format($this->model()->getDateFormat()) : Carbon::createFromFormat($this->model()->getDateFormat(), $date);
+        return $date instanceof Carbon ? $date : Carbon::createFromFormat($this->model()->getDateFormat(), $date);
     }
 
     public function setLastLogin($time)

--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -323,7 +323,7 @@ class User extends BaseUser
             return null;
         }
 
-        return Carbon::createFromFormat($this->model()->getDateFormat(), $date);
+        return $date instanceof Carbon ? $date->format($this->model()->getDateFormat()) : Carbon::createFromFormat($this->model()->getDateFormat(), $date);
     }
 
     public function setLastLogin($time)


### PR DESCRIPTION
When using the Eloquent User Provider if you already have a casted last_login column (which is common) it will throw an error since it passes a Carbon object to createFromFormat(). Fix is to check if it's a Carbon object first and return it otherwise send it through createFromFormat().

Couldn't think of a useful test for this but if anyone has something in mind I'd love to include it.