### PR TITLE
Fix failing test due to testbench update

### DIFF
--- a/tests/StarterKits/ExportTest.php
+++ b/tests/StarterKits/ExportTest.php
@@ -78,7 +78,7 @@ class ExportTest extends TestCase
         $this->assertFileHasContent("'disks' => [", $filesystemsConfig);
 
         $this->assertFileExists($composerJson);
-        $this->assertFileHasContent('<body>', $composerJson);
+        $this->assertFileHasContent('<body', $composerJson);
     }
 
     /** @test */


### PR DESCRIPTION
The starter kit export test has started failing because it was asserting that a `<body>` tag would be in the exported `welcome.blade.php`.

In `orchestra/testbench-core`, the `welcome` view was updated to be in line with the `laravel/laravel` skeleton repo which has `<body class="antialiased">`. 

This PR simply removes the `>` so it'll pass across versions.
