### PR TITLE
Fix parent and updated_by fields not being shallow augmented in API, sometimes causing recursion.

### DIFF
--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -4,6 +4,7 @@ namespace Statamic\Entries;
 
 use Statamic\Data\AbstractAugmented;
 use Statamic\Facades\Collection;
+use Statamic\Statamic;
 
 class AugmentedEntry extends AbstractAugmented
 {
@@ -46,7 +47,11 @@ class AugmentedEntry extends AbstractAugmented
 
     protected function updatedBy()
     {
-        return $this->data->lastModifiedBy();
+        $user = $this->data->lastModifiedBy();
+
+        return Statamic::isApiRoute()
+            ? optional($user)->toShallowAugmentedCollection()
+            : $user;
     }
 
     protected function updatedAt()

--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -66,7 +66,7 @@ class AugmentedEntry extends AbstractAugmented
 
     protected function parent()
     {
-        return $this->data->parent();
+        return $this->wrapValue(optional($this->data->parent())->id(), 'parent');
     }
 
     protected function mount()

--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -66,7 +66,11 @@ class AugmentedEntry extends AbstractAugmented
 
     protected function parent()
     {
-        return $this->wrapValue(optional($this->data->parent())->id(), 'parent');
+        $parent = $this->data->parent();
+
+        return Statamic::isApiRoute()
+            ? optional($parent)->toShallowAugmentedCollection()
+            : $parent;
     }
 
     protected function mount()

--- a/src/Taxonomies/AugmentedTerm.php
+++ b/src/Taxonomies/AugmentedTerm.php
@@ -3,6 +3,7 @@
 namespace Statamic\Taxonomies;
 
 use Statamic\Data\AbstractAugmented;
+use Statamic\Statamic;
 
 class AugmentedTerm extends AbstractAugmented
 {
@@ -38,7 +39,11 @@ class AugmentedTerm extends AbstractAugmented
 
     protected function updatedBy()
     {
-        return $this->data->lastModifiedBy();
+        $user = $this->data->lastModifiedBy();
+
+        return Statamic::isApiRoute()
+            ? optional($user)->toShallowAugmentedCollection()
+            : $user;
     }
 
     protected function updatedAt()


### PR DESCRIPTION
Fixes #6332

This makes `parent` use shallow augmentation, just like you'd expect from any other "entries" fieldtypes. This prevents the recursive situation, since the parent would be shallow, and now missing the field that would trigger the recursion in the first place.

I also applied this treatment to `updated_by` which should have been shallow augmenting, like you'd get with regular "users" fields.

I'm not super happy with the "if in api" checks here, but it's not the end of the world.

For context, I avoided shallow augmenting _always_ because when using in Antlers etc, we want the whole object, not a shallow array.