### PR TITLE
Fix root page validation error logic

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -489,7 +489,7 @@ class EntriesController extends CpController
         // If there's no parent selected, the entry will be at end of the top level, which is fine.
         // If the entry being edited is not the root, then we don't have anything to worry about.
         // If the parent is the root, that's fine, and is handled during the tree update later.
-        if (! $parent || ! $entry->isRoot()) {
+        if (! $parent || ! $entry->page()->isRoot()) {
             return;
         }
 


### PR DESCRIPTION
The "isRoot" should have been called on the corresponding page. Calling it on the entry determines if is the root localization. We needed to check if it's the root page in the tree.

Fixes #7026 
