### PR TITLE
Reset view paths after request

### DIFF
--- a/src/Http/Middleware/AddViewPaths.php
+++ b/src/Http/Middleware/AddViewPaths.php
@@ -8,15 +8,40 @@ use Statamic\Statamic;
 
 class AddViewPaths
 {
+    private $paths;
+    private $hints;
+    private $amp;
+    private $site;
+
     public function handle($request, Closure $next)
     {
-        $finder = view()->getFinder();
-        $amp = Statamic::isAmpRequest();
-        $site = Site::current()->handle();
-        $originalPaths = $finder->getPaths();
-        $originalHints = $finder->getHints();
+        $this->update();
 
-        $paths = collect($originalPaths)->flatMap(function ($path) use ($site, $amp) {
+        $response = $next($request);
+
+        $this->restore();
+
+        return $response;
+    }
+
+    private function update()
+    {
+        $this->finder = view()->getFinder();
+        $this->amp = Statamic::isAmpRequest();
+        $this->site = Site::current()->handle();
+        $this->paths = $this->finder->getPaths();
+        $this->hints = $this->finder->getHints();
+
+        $this->updatePaths();
+        $this->updateHints();
+    }
+
+    private function updatePaths()
+    {
+        $amp = $this->amp;
+        $site = $this->site;
+
+        $paths = collect($this->paths)->flatMap(function ($path) use ($site, $amp) {
             return [
                 $amp ? $path.'/'.$site.'/amp' : null,
                 $path.'/'.$site,
@@ -25,24 +50,26 @@ class AddViewPaths
             ];
         })->filter()->values()->all();
 
-        $finder->setPaths($paths);
+        $this->finder->setPaths($paths);
+    }
 
-        foreach ($originalHints as $namespace => $paths) {
+    private function updateHints()
+    {
+        foreach ($this->hints as $namespace => $paths) {
             foreach ($paths as $path) {
-                $finder->prependNamespace($namespace, $path.'/'.$site);
+                $this->finder->prependNamespace($namespace, $path.'/'.$this->site);
             }
         }
+    }
 
-        $response = $next($request);
+    private function restore()
+    {
+        $this->finder->setPaths($this->paths);
 
-        $finder->setPaths($originalPaths);
-
-        foreach ($originalHints as $namespace => $paths) {
+        foreach ($this->hints as $namespace => $paths) {
             foreach ($paths as $path) {
-                $finder->replaceNamespace($namespace, $path);
+                $this->finder->replaceNamespace($namespace, $path);
             }
         }
-
-        return $response;
     }
 }

--- a/tests/Http/Middleware/AddViewPathsTest.php
+++ b/tests/Http/Middleware/AddViewPathsTest.php
@@ -34,9 +34,11 @@ class AddViewPathsTest extends TestCase
 
         $request = $this->createRequest($requestUrl);
 
-        (new AddViewPaths())->handle($request, fn () => new Response());
+        (new AddViewPaths())->handle($request, function () use ($expectedPaths) {
+            $this->assertEquals($expectedPaths, view()->getFinder()->getPaths());
 
-        $this->assertEquals($expectedPaths, view()->getFinder()->getPaths());
+            return new Response;
+        });
     }
 
     /**
@@ -56,9 +58,11 @@ class AddViewPathsTest extends TestCase
 
         $request = $this->createRequest($requestUrl);
 
-        (new AddViewPaths())->handle($request, fn () => new Response());
+        (new AddViewPaths())->handle($request, function () use ($expectedPaths) {
+            $this->assertEquals($expectedPaths, array_get(view()->getFinder()->getHints(), 'foo'));
 
-        $this->assertEquals($expectedPaths, array_get(view()->getFinder()->getHints(), 'foo'));
+            return new Response;
+        });
     }
 
     private function setCurrentSiteBasedOnUrl($requestUrl)

--- a/tests/Http/Middleware/AddViewPathsTest.php
+++ b/tests/Http/Middleware/AddViewPathsTest.php
@@ -33,12 +33,16 @@ class AddViewPathsTest extends TestCase
         $this->setCurrentSiteBasedOnUrl($requestUrl);
 
         $request = $this->createRequest($requestUrl);
+        $handled = false;
 
-        (new AddViewPaths())->handle($request, function () use ($expectedPaths) {
+        (new AddViewPaths())->handle($request, function () use ($expectedPaths, &$handled) {
             $this->assertEquals($expectedPaths, view()->getFinder()->getPaths());
+            $handled = true;
 
             return new Response;
         });
+
+        $this->assertTrue($handled);
     }
 
     /**
@@ -57,12 +61,16 @@ class AddViewPathsTest extends TestCase
         $this->setCurrentSiteBasedOnUrl($requestUrl);
 
         $request = $this->createRequest($requestUrl);
+        $handled = false;
 
-        (new AddViewPaths())->handle($request, function () use ($expectedPaths) {
+        (new AddViewPaths())->handle($request, function () use ($expectedPaths, &$handled) {
             $this->assertEquals($expectedPaths, array_get(view()->getFinder()->getHints(), 'foo'));
+            $handled = true;
 
             return new Response;
         });
+
+        $this->assertTrue($handled);
     }
 
     private function setCurrentSiteBasedOnUrl($requestUrl)

--- a/tests/Http/Middleware/AddViewPathsTest.php
+++ b/tests/Http/Middleware/AddViewPathsTest.php
@@ -23,7 +23,7 @@ class AddViewPathsTest extends TestCase
             'french' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
         ]]);
 
-        view()->getFinder()->setPaths([
+        view()->getFinder()->setPaths($originalPaths = [
             '/path/to/views',
             '/path/to/other/views',
         ]);
@@ -43,6 +43,7 @@ class AddViewPathsTest extends TestCase
         });
 
         $this->assertTrue($handled);
+        $this->assertEquals($originalPaths, view()->getFinder()->getPaths());
     }
 
     /**
@@ -57,6 +58,7 @@ class AddViewPathsTest extends TestCase
         ]]);
 
         view()->getFinder()->replaceNamespace('foo', '/path/to/views');
+        $originalHints = view()->getFinder()->getHints()['foo'];
 
         $this->setCurrentSiteBasedOnUrl($requestUrl);
 
@@ -71,6 +73,7 @@ class AddViewPathsTest extends TestCase
         });
 
         $this->assertTrue($handled);
+        $this->assertEquals($originalHints, array_get(view()->getFinder()->getHints(), 'foo'));
     }
 
     private function setCurrentSiteBasedOnUrl($requestUrl)


### PR DESCRIPTION
Fixes statamic/ssg#116
Related statamic/ssg#119

This PR will reset the view paths and namespace hints after the request completes. This prevents them from leaking into other requests, for example in tests or in the SSG.

The tests are tweaked so that the assertion happens in the closure (simulating within the context of a request).

The middleware is also refactored so that the `handle` method is more readable.