### PR TITLE
Expand/collapse sets with a single click

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -7,8 +7,8 @@
         <div ref="content" hidden />
         <div class="replicator-set-header" :class="{'collapsed': collapsed, 'invalid': isInvalid }">
             <div class="item-move sortable-handle" data-drag-handle />
-            <div class="flex-1 p-1 replicator-set-header-inner" :class="{'flex items-center': collapsed}" @dblclick="toggleCollapsedState">
-                <label v-text="display || config.handle" class="text-xs whitespace-no-wrap mr-1"/>
+            <div class="flex-1 p-1 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
+                <label v-text="display || config.handle" class="text-xs whitespace-no-wrap mr-1 cursor-pointer"/>
                 <div
                     v-if="config.instructions"
                     v-show="!collapsed"
@@ -186,7 +186,7 @@ export default {
             }, 1);
         },
 
-         toggleCollapsedState() {
+        toggleCollapsedState(event) {
             if (this.collapsed) {
                 this.expand();
             } else {

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -186,7 +186,7 @@ export default {
             }, 1);
         },
 
-        toggleCollapsedState(event) {
+         toggleCollapsedState() {
             if (this.collapsed) {
                 this.expand();
             } else {

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -6,8 +6,8 @@
 
         <div class="replicator-set-header" :class="{ 'p-1': isReadOnly, 'collapsed': collapsed, 'invalid': isInvalid }">
             <div class="item-move sortable-handle" :class="sortableHandleClass" v-if="!isReadOnly"></div>
-            <div class="flex-1 p-1 replicator-set-header-inner" :class="{'flex items-center': collapsed}" @dblclick="toggleCollapsedState">
-                <label v-text="display || config.handle" class="text-xs whitespace-no-wrap mr-1"/>
+            <div class="flex-1 p-1 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
+                <label v-text="display || config.handle" class="text-xs whitespace-no-wrap mr-1 cursor-pointer"/>
                 <div
                     v-if="config.instructions"
                     v-show="!collapsed"
@@ -195,7 +195,7 @@ export default {
             this.updated('enabled', ! this.values.enabled);
         },
 
-        toggleCollapsedState() {
+        toggleCollapsedState(event) {  
             if (this.collapsed) {
                 this.expand();
             } else {

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -195,7 +195,7 @@ export default {
             this.updated('enabled', ! this.values.enabled);
         },
 
-        toggleCollapsedState(event) {  
+        toggleCollapsedState() {
             if (this.collapsed) {
                 this.expand();
             } else {


### PR DESCRIPTION
Appreciate you may not want to change this, but I thought I’d PR it just for the purposes of testing it out as a possibility.

This changes the expand/collapse event on the set label to a single rather than double click, and adds a pointer cursor on hover to make it clearer that it’s a clickable element.

FWIW I do think this would be a worthwhile tweak. Expanding/collapsing sets is faster and it doesn’t affect anything else as far as I can tell. The only negative is that it might take a little adjustment for people who are used to double-clicking.

Closes https://github.com/statamic/ideas/issues/865