### PR TITLE
Support custom date formats in route definitions

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -693,6 +693,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
 
         if ($this->hasDate()) {
             $data = $data->merge([
+                'date' => $this->date(),
                 'year' => $this->date()->format('Y'),
                 'month' => $this->date()->format('m'),
                 'day' => $this->date()->format('d'),

--- a/tests/Routing/UrlBuilderTest.php
+++ b/tests/Routing/UrlBuilderTest.php
@@ -64,6 +64,8 @@ class UrlBuilderTest extends TestCase
     public function it_builds_a_date_url()
     {
         $this->assertEquals('/blog/2015/01/02/post', $this->builder->build('/blog/{{ year }}/{{ month }}/{{ day }}/{{ slug }}'));
+        $this->assertEquals('/blog/1420156800/post', $this->builder->build('/blog/{{ date format="U" }}/{{ slug }}'));
+        $this->assertEquals('/blog/2-jan-15/post', $this->builder->build('/blog/{{ date format="j-M-y" }}/{{ slug }}'));
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds support for custom date formats in route definitions for a dated collection, based on discussion in https://github.com/statamic/cms/discussions/6248.

When defining a route pattern on a dated collection, Statamic already supports `year`, `month`, and `day` variables for generating date-based routes like `/blog/2015/01/02/post`. However, other date formats are not currently possible, like unix timestamps, month names, single-digit months or days, etc.

This adds an additional `date` property to the entry route data array with the full entry date Carbon instance to enable any other date format you can specify in Antlers using the `format` modifier. (e.g. `/blog/{{ date format="U" }}`)
