### PR TITLE
Fix namespaced view paths not being reset correctly

### DIFF
--- a/src/Http/Middleware/AddViewPaths.php
+++ b/src/Http/Middleware/AddViewPaths.php
@@ -56,9 +56,14 @@ class AddViewPaths
     private function updateHints()
     {
         foreach ($this->hints as $namespace => $paths) {
-            foreach ($paths as $path) {
-                $this->finder->prependNamespace($namespace, $path.'/'.$this->site);
-            }
+            $paths = collect($paths)->flatMap(function ($path) {
+                return [
+                    $path.'/'.$this->site,
+                    $path,
+                ];
+            })->values();
+
+            $this->finder->replaceNamespace($namespace, $paths->all());
         }
     }
 
@@ -67,9 +72,7 @@ class AddViewPaths
         $this->finder->setPaths($this->paths);
 
         foreach ($this->hints as $namespace => $paths) {
-            foreach ($paths as $path) {
-                $this->finder->replaceNamespace($namespace, $path);
-            }
+            $this->finder->replaceNamespace($namespace, $paths);
         }
     }
 }

--- a/tests/Http/Middleware/AddViewPathsTest.php
+++ b/tests/Http/Middleware/AddViewPathsTest.php
@@ -57,7 +57,10 @@ class AddViewPathsTest extends TestCase
             'french' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
         ]]);
 
-        view()->getFinder()->replaceNamespace('foo', '/path/to/views');
+        view()->getFinder()->replaceNamespace('foo', [
+            '/path/to/views',
+            '/path/to/other',
+        ]);
         $originalHints = view()->getFinder()->getHints()['foo'];
 
         $this->setCurrentSiteBasedOnUrl($requestUrl);
@@ -128,6 +131,8 @@ class AddViewPathsTest extends TestCase
                 [
                     '/path/to/views/english',
                     '/path/to/views',
+                    '/path/to/other/english',
+                    '/path/to/other',
                 ],
             ],
             'second site' => [
@@ -135,6 +140,8 @@ class AddViewPathsTest extends TestCase
                 [
                     '/path/to/views/french',
                     '/path/to/views',
+                    '/path/to/other/french',
+                    '/path/to/other',
                 ],
             ],
         ];


### PR DESCRIPTION
Fixes test failures that started appearing in SEO Pro.

In #7030, the paths were looping over and doing `replaceNamespace` on a single path. This was stomping over existing paths if a namespace had multiple paths.

This PR passes an array to `replaceNamespace`, and adjusts the tests to handle the multiple path scenario.