### PR TITLE
Fix lowercasing of asset folder names to match user's configuration

### DIFF
--- a/src/Actions/RenameAssetFolder.php
+++ b/src/Actions/RenameAssetFolder.php
@@ -35,9 +35,7 @@ class RenameAssetFolder extends Action
 
     public function run($folders, $values)
     {
-        $name = strtolower($values['name']);
-
-        return $folders->each->rename($name, true);
+        return $folders->each->rename($values['name'], true);
     }
 
     protected function fieldItems()

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -909,6 +909,12 @@ class Asset implements AssetContract, Augmentable, ArrayAccess, Arrayable, Conta
         return $this->disk()->filesystem()->readStream($this->path());
     }
 
+    /**
+     * Ensure safe filename string.
+     *
+     * @param  string  $string
+     * @return string
+     */
     private function getSafeFilename($string)
     {
         $replacements = [

--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -165,7 +165,7 @@ class AssetFolder implements Contract, Arrayable
             throw new \Exception('Folder cannot be moved to its own subfolder.');
         }
 
-        $name = $name ?? $this->basename();
+        $name = $this->getSafeBasename($name ?? $this->basename());
         $oldPath = $this->path();
         $newPath = Str::removeLeft(Path::tidy($parent.'/'.$name), '/');
 
@@ -183,6 +183,21 @@ class AssetFolder implements Contract, Arrayable
         $this->delete();
 
         return $folder;
+    }
+
+    /**
+     * Ensure safe basename string.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    private function getSafeBasename($string)
+    {
+        if (config('statamic.assets.lowercase')) {
+            $string = strtolower($string);
+        }
+
+        return (string) $string;
     }
 
     /**

--- a/src/Http/Controllers/CP/Assets/FoldersController.php
+++ b/src/Http/Controllers/CP/Assets/FoldersController.php
@@ -26,7 +26,9 @@ class FoldersController extends CpController
             ]);
         }
 
-        $path = strtolower($path); // Prevent case sensitivity collisions
+        if (config('statamic.assets.lowercase')) {
+            $path = strtolower($path);
+        }
 
         return $container->assetFolder($path)->save();
     }


### PR DESCRIPTION
A user recently pointed out that `'lowercase' => false` in `config/statamic/assets.php` only applied to asset filenames, not asset folder names. Folder names were always lowercased, but this should now match the user's configuration, as introduced in https://github.com/statamic/cms/pull/6031.