### PR TITLE
Update User Wizard

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -77,6 +77,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | User Wizard Invitation Email
+    |--------------------------------------------------------------------------
+    |
+    | When creating new users through the wizard in the control panel,
+    | you may choose whether to be able to send an invitation email.
+    | Setting to true will give the user the option. But setting
+    | it to false will disable the invitation option entirely.
+    |
+    */
+
+    'wizard_invitation' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Password Brokers
     |--------------------------------------------------------------------------
     |

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -12,6 +12,7 @@
         :can-assign-groups="{{ $str::bool($user->can('assign user groups')) }}"
         :activation-expiry="{{ $expiry }}"
         :separate-name-fields="{{ $str::bool($separateNameFields) }}"
+        :can-send-invitation="{{ $str::bool($canSendInvitation) }}"
     >
     </user-wizard>
 @stop

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -102,6 +102,7 @@ class UsersController extends CpController
             ],
             'expiry' => $expiry,
             'separateNameFields' => $blueprint->hasField('first_name'),
+            'canSendInvitation' => config('statamic.users.wizard_invitation'),
         ];
 
         if ($request->wantsJson()) {


### PR DESCRIPTION
This PR makes a few improvements to the user creation wizard.

1. You can disable the option to send an email invitation.

	```php
	// config/statamic/users.php
	
	'wizard_invitation' => false,
	```
	
	This will completely hide the last step where it asks if you want to send an email.

2. If you don't have permission to assign roles and groups (as per #6614) then that step will be hidden.

3. If you don't have group/role permissions, and you've disabled the invite, then you'd be left with a single step. In this case, the step navigation is hidden altogether.