### PR TITLE
Don't do replacements when not returning a simple response

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -3,6 +3,7 @@
 namespace Statamic\StaticCaching\Middleware;
 
 use Closure;
+use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
 use Statamic\Statamic;
 use Statamic\StaticCaching\Cacher;
@@ -61,14 +62,18 @@ class Cache
     {
         $cachedResponse = clone $response;
 
-        $this->getReplacers()->each(fn (Replacer $replacer) => $replacer->prepareResponseToCache($cachedResponse, $response));
+        if ($response instanceof Response) {
+            $this->getReplacers()->each(fn (Replacer $replacer) => $replacer->prepareResponseToCache($cachedResponse, $response));
+        }
 
         $this->cacher->cachePage($request, $cachedResponse);
     }
 
     private function makeReplacements($response)
     {
-        $this->getReplacers()->each(fn (Replacer $replacer) => $replacer->replaceInCachedResponse($response));
+        if ($response instanceof Response) {
+            $this->getReplacers()->each(fn (Replacer $replacer) => $replacer->replaceInCachedResponse($response));
+        }
     }
 
     private function getReplacers(): Collection


### PR DESCRIPTION
This fix will allow Inertia links to work without throwing a fatal error, as Inertia returns a JsonResponse.
There might be another way to control all this, since Inertia will send the header `x-inertia: true` which should affect the cached response so there's one for the normal rendered response and one for the json response.