### PR TITLE
Add config option to control generating asset preset manipulations on upload

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -70,6 +70,19 @@ return [
             // 'small' => ['w' => 200, 'h' => 200, 'q' => 75, 'fit' => 'crop'],
         ],
 
+        /*
+        |--------------------------------------------------------------------------
+        | Generate Image Manipulation Presets on upload
+        |--------------------------------------------------------------------------
+        |
+        | By default presets will be automatically generated on upload, ensuring the
+        | cached image is already available on the first page load with the asset.
+        | You can turn off this behaviour (for example if you have a lot of presets and
+        | not all should be applied to every asset).
+        |
+        */
+        'generate_presets_on_upload' => true,
+
     ],
 
     /*

--- a/config/assets.php
+++ b/config/assets.php
@@ -62,7 +62,7 @@ return [
         |
         | Rather than specifying your manipulation params in your templates with
         | the glide tag, you may define them here and reference their handles.
-        | They will also be automatically generated when you upload assets.
+        | They may also be automatically generated when you upload assets.
         |
         */
 
@@ -72,15 +72,15 @@ return [
 
         /*
         |--------------------------------------------------------------------------
-        | Generate Image Manipulation Presets on upload
+        | Generate Image Manipulation Presets on Upload
         |--------------------------------------------------------------------------
         |
-        | By default presets will be automatically generated on upload, ensuring the
-        | cached image is already available on the first page load with the asset.
-        | You can turn off this behaviour (for example if you have a lot of presets and
-        | not all should be applied to every asset).
+        | By default, presets will be automatically generated on upload, ensuring
+        | the cached images are available when they are first used. You may opt
+        | out of this behavior here and have the presets generated on demand.
         |
         */
+
         'generate_presets_on_upload' => true,
 
     ],

--- a/src/Listeners/GeneratePresetImageManipulations.php
+++ b/src/Listeners/GeneratePresetImageManipulations.php
@@ -29,6 +29,10 @@ class GeneratePresetImageManipulations implements ShouldQueue
      */
     public function subscribe($events)
     {
+        if (! config('statamic.assets.image_manipulation.generate_presets_on_upload', true)) {
+            return;
+        }
+
         $events->listen(AssetReuploaded::class, self::class.'@handle');
         $events->listen(AssetUploaded::class, self::class.'@handle');
     }


### PR DESCRIPTION
We use asset generation presets a lot, however when you specify them all manipulations are generated for every assets on upload, even though we only require specific presets for certain outputs of images. So you end up with a filesystem full of generations that are never required.

It would be useful to be able to specify which presets are automatically generated (even on a collection/blueprint basis), but as a stop gap I've added a config that lets you opt out of generating them at all.

If there is a better way or approach let me know and I'll update the PR.