### PR TITLE
Add Type Declaration to schedule method in AddonServiceProvider

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -539,7 +539,7 @@ abstract class AddonServiceProvider extends ServiceProvider
         Statamic::externalStyle($url);
     }
 
-    protected function schedule($schedule)
+    protected function schedule(Schedule $schedule)
     {
         //
     }


### PR DESCRIPTION
When developing addon I discovered that the method "schedule" in AddonServiceProvider doesn't have type casting.

This matter was discussed in this thread:

Closes https://github.com/statamic/ideas/issues/912