### PR TITLE
Prevent adding date to non-dated collections

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -630,13 +630,18 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
 
     public function makeLocalization($site)
     {
-        return Facades\Entry::make()
+        $localization = Facades\Entry::make()
             ->collection($this->collection)
             ->origin($this)
             ->locale($site)
             ->published($this->published)
-            ->slug($this->slug())
-            ->date($this->date());
+            ->slug($this->slug());
+
+        if ($this->collection()->dated()) {
+            $localization->date($this->date());
+        }
+
+        return $localization;
     }
 
     public function supplementTaxonomies()


### PR DESCRIPTION
Only add the date to new localizations if the collection is dated. Fixes #7085, Fixes #2296.