### PR TITLE
Allows localization variable to be saved as false.

### DIFF
--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -31,8 +31,11 @@ class FieldTransformer
             unset($field['width']);
         }
 
+        $sites = config('statamic.sites.sites');
+        $multisite = count($sites) > 1;
+
         if (Arr::get($field, 'localizable', false) === false) {
-            unset($field['localizable']);
+            if (!$multisite) unset($field['localizable']);
         }
 
         return array_filter([

--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -35,7 +35,9 @@ class FieldTransformer
         $multisite = count($sites) > 1;
 
         if (Arr::get($field, 'localizable', false) === false) {
-            if (!$multisite) unset($field['localizable']);
+            if (! $multisite) {
+                unset($field['localizable']);
+            }
         }
 
         return array_filter([

--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -4,6 +4,7 @@ namespace Statamic\Fields;
 
 use Facades\Statamic\Fields\FieldtypeRepository;
 use Statamic\Facades\Fieldset;
+use Statamic\Facades\Site;
 use Statamic\Support\Arr;
 
 class FieldTransformer
@@ -31,13 +32,8 @@ class FieldTransformer
             unset($field['width']);
         }
 
-        $sites = config('statamic.sites.sites');
-        $multisite = count($sites) > 1;
-
-        if (Arr::get($field, 'localizable', false) === false) {
-            if (! $multisite) {
-                unset($field['localizable']);
-            }
+        if (Arr::get($field, 'localizable', false) === false && ! Site::hasMultiple()) {
+            unset($field['localizable']);
         }
 
         return array_filter([


### PR DESCRIPTION
The localisation variable is always reset as true when updating blueprints. If you have a field that is not localizable and update the blueprint for any reason, the field is sent in the PATCH request with `localizable: false` which is then unset by this code. This means if the field has been localizable before then it can't be changed to non-localizable... this causes an issue as slugs are default localizable even when multisite is not enabled.

This code checks if multisite is enabled, and prevents the field from being unset. This fixes #7082, fixes #4471 and continues to allow the localizable field to be unset on single sites so their blueprints remain unchanged. On multi-sites, each blueprint will be updated the next time they are saved, and will explicitly say if fields are localizable or not by adding `localizable: false` to each one, and allow fields to be saved on non-localizable from the control panel.