### PR TITLE
Generate-Presets - catch exception on bad images so command can finish

### DIFF
--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -109,7 +109,11 @@ class AssetsGeneratePresets extends Command
                     ? 'dispatch'
                     : (method_exists(Dispatcher::class, 'dispatchSync') ? 'dispatchSync' : 'dispatchNow');
 
-                GeneratePresetImageManipulation::$dispatchMethod($asset, $preset);
+                try {
+                    GeneratePresetImageManipulation::$dispatchMethod($asset, $preset);
+                } catch (\Exception $e) {
+                    $this->error($asset.' '.$e->getMessage());
+                }    
 
                 $bar->advance();
             }

--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -113,7 +113,7 @@ class AssetsGeneratePresets extends Command
                     GeneratePresetImageManipulation::$dispatchMethod($asset, $preset);
                 } catch (\Exception $e) {
                     $this->error($asset.' '.$e->getMessage());
-                }    
+                }
 
                 $bar->advance();
             }


### PR DESCRIPTION
Allow the generate-presets command to continue upon error as described in issue https://github.com/statamic/cms/issues/6965

Closes #6965