### PR TITLE
Use parent localization when resolving link

### DIFF
--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -41,7 +41,7 @@ class Link extends Fieldtype
             return null;
         }
 
-        $redirect = ResolveRedirect::resolve($value, $this->field->parent());
+        $redirect = ResolveRedirect::resolve($value, $this->field->parent(), true);
 
         return $redirect === 404 ? null : $redirect;
     }

--- a/src/Routing/ResolveRedirect.php
+++ b/src/Routing/ResolveRedirect.php
@@ -28,13 +28,7 @@ class ResolveRedirect
 
         if (Str::startsWith($redirect, 'entry::')) {
             $id = Str::after($redirect, 'entry::');
-            $entry = Facades\Entry::find($id);
-            if ($localize) {
-                $site = $parent instanceof Localization ? $parent->locale() : Site::current()->handle();
-                $redirect = optional(optional($entry)->in($site) ?? $entry)->url() ?? 404;
-            } else {
-                $redirect = optional($entry)->url() ?? 404;
-            }
+            $redirect = optional($this->findEntry($id, $parent, $localize))->url() ?? 404;
         }
 
         if (Str::startsWith($redirect, 'asset::')) {
@@ -43,6 +37,23 @@ class ResolveRedirect
         }
 
         return is_numeric($redirect) ? (int) $redirect : $redirect;
+    }
+
+    private function findEntry($id, $parent, $localize)
+    {
+        if (! ($entry = Facades\Entry::find($id))) {
+            return null;
+        }
+
+        if (! $localize) {
+            return $entry;
+        }
+
+        $site = $parent instanceof Localization
+            ? $parent->locale()
+            : Site::current()->handle();
+
+        return $entry->in($site) ?? $entry;
     }
 
     private function firstChildUrl($parent)

--- a/tests/Feature/GraphQL/Fieldtypes/LinkFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/LinkFieldtypeTest.php
@@ -32,7 +32,7 @@ class LinkFieldtypeTest extends FieldtypeTestCase
             ],
         ]);
 
-        ResolveRedirect::shouldReceive('resolve')->once()->with('/hardcoded', $entry)->andReturn('/hardcoded');
+        ResolveRedirect::shouldReceive('resolve')->once()->with('/hardcoded', $entry, true)->andReturn('/hardcoded');
 
         $this->assertGqlEntryHas('link', ['link' => '/hardcoded']);
     }
@@ -47,7 +47,7 @@ class LinkFieldtypeTest extends FieldtypeTestCase
             ],
         ]);
 
-        ResolveRedirect::shouldReceive('resolve')->once()->with('entry::123', $entry)->andReturn('/the-entry-url');
+        ResolveRedirect::shouldReceive('resolve')->once()->with('entry::123', $entry, true)->andReturn('/the-entry-url');
 
         $this->assertGqlEntryHas('link', ['link' => '/the-entry-url']);
     }
@@ -62,7 +62,7 @@ class LinkFieldtypeTest extends FieldtypeTestCase
             ],
         ]);
 
-        ResolveRedirect::shouldReceive('resolve')->once()->with('@child', $entry)->andReturn('/the-first-child');
+        ResolveRedirect::shouldReceive('resolve')->once()->with('@child', $entry, true)->andReturn('/the-first-child');
 
         $this->assertGqlEntryHas('link', ['link' => '/the-first-child']);
     }
@@ -77,7 +77,7 @@ class LinkFieldtypeTest extends FieldtypeTestCase
             ],
         ]);
 
-        ResolveRedirect::shouldReceive('resolve')->once()->with('entry::unknown', $entry)->andReturn(404);
+        ResolveRedirect::shouldReceive('resolve')->once()->with('entry::unknown', $entry, true)->andReturn(404);
 
         $this->assertGqlEntryHas('link', ['link' => null]);
     }

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -14,7 +14,7 @@ class LinkTest extends TestCase
     public function it_augments_to_url()
     {
         ResolveRedirect::shouldReceive('resolve')
-            ->with('entry::test', $parent = new Entry)
+            ->with('entry::test', $parent = new Entry, true)
             ->once()
             ->andReturn('/the-redirect');
 
@@ -31,7 +31,7 @@ class LinkTest extends TestCase
         // invalid entries come back from the ResolveRedirect class as a 404 integer
 
         ResolveRedirect::shouldReceive('resolve')
-            ->with('entry::test', $parent = new Entry)
+            ->with('entry::test', $parent = new Entry, true)
             ->once()
             ->andReturn(404);
 

--- a/tests/Routing/ResolveRedirectTest.php
+++ b/tests/Routing/ResolveRedirectTest.php
@@ -145,6 +145,19 @@ class ResolveRedirectTest extends TestCase
     }
 
     /** @test */
+    public function it_resolves_references_to_entries_localized()
+    {
+        $resolver = new ResolveRedirect;
+
+        $parentEntry = Mockery::mock(Entry::class);
+        $frenchEntry = Mockery::mock(Entry::class)->shouldReceive('url')->once()->andReturn('/le-entry')->getMock();
+        $defaultEntry = Mockery::mock(Entry::class)->shouldReceive('in')->once()->andReturn($frenchEntry)->getMock();
+        Facades\Entry::shouldReceive('find')->with('123')->once()->andReturn($defaultEntry);
+
+        $this->assertEquals('/le-entry', $resolver('entry::123', $parentEntry, true));
+    }
+
+    /** @test */
     public function it_resolves_references_to_assets()
     {
         $resolver = new ResolveRedirect;
@@ -170,7 +183,7 @@ class ResolveRedirectTest extends TestCase
     {
         $resolve = $this->partialMock(ResolveRedirect::class);
 
-        $resolve->shouldReceive('resolve')->once()->with('foo', 'bar')->andReturn('hello');
+        $resolve->shouldReceive('resolve')->once()->with('foo', 'bar', false)->andReturn('hello');
 
         $this->assertEquals('hello', $resolve('foo', 'bar'));
     }

--- a/tests/Routing/ResolveRedirectTest.php
+++ b/tests/Routing/ResolveRedirectTest.php
@@ -158,6 +158,20 @@ class ResolveRedirectTest extends TestCase
     }
 
     /** @test */
+    public function it_resolves_references_to_entries_localized_with_fallback()
+    {
+        $resolver = new ResolveRedirect;
+
+        $parentEntry = Mockery::mock(Entry::class);
+        $entry = Mockery::mock(Entry::class);
+        $entry->shouldReceive('in')->once()->andReturn(null);
+        $entry->shouldReceive('url')->once()->andReturn('/the-entry');
+        Facades\Entry::shouldReceive('find')->with('123')->once()->andReturn($entry);
+
+        $this->assertEquals('/the-entry', $resolver('entry::123', $parentEntry, true));
+    }
+
+    /** @test */
     public function it_resolves_references_to_assets()
     {
         $resolver = new ResolveRedirect;


### PR DESCRIPTION
Fixes #3764 as suggested by @kesse. 

I added fallback to the original entry, in case the localization does not exist.