### PR TITLE
Fix localized entries are not added to collection structure with `propagate: true`

### DIFF
--- a/src/Http/Controllers/CP/Collections/LocalizeEntryController.php
+++ b/src/Http/Controllers/CP/Collections/LocalizeEntryController.php
@@ -14,39 +14,11 @@ class LocalizeEntryController extends CpController
 
         $localized = $entry->makeLocalization($site = $request->site);
 
-        $this->addToStructure($collection, $entry, $localized);
-
         $localized->store(['user' => User::fromUser($request->user())]);
 
         return [
             'handle' => $site,
             'url' => $localized->editUrl(),
         ];
-    }
-
-    private function addToStructure($collection, $entry, $localized)
-    {
-        // If it's orderable (linear - a max depth of 1) then don't add it.
-        if ($collection->orderable()) {
-            return;
-        }
-
-        // Collection not structured? Don't add it.
-        if (! $structure = $collection->structure()) {
-            return;
-        }
-
-        $tree = $structure->in($localized->locale());
-        $parent = optional($entry->parent())->in($localized->locale());
-
-        $localized->afterSave(function ($localized) use ($parent, $tree) {
-            if (! $parent || $parent->isRoot()) {
-                $tree->append($localized);
-            } else {
-                $tree->appendTo($parent->id(), $localized);
-            }
-
-            $tree->save();
-        });
     }
 }


### PR DESCRIPTION
This PR contains a fix for collections with `propagate: true` which localized entries are not being added to the collection structure.