### PR TITLE
Move JS super permission check

### DIFF
--- a/resources/js/components/Permission.js
+++ b/resources/js/components/Permission.js
@@ -10,7 +10,7 @@ class Permission {
     }
 
     has(permission) {
-        return this.all().includes(permission);
+        return this.all().includes(permission) || this.all().includes('super');
     }
 }
 

--- a/resources/js/components/fieldtypes/assets/Asset.js
+++ b/resources/js/components/fieldtypes/assets/Asset.js
@@ -42,8 +42,7 @@ export default {
         },
 
         canDownload() {
-            return Statamic.$permissions.has('super')
-                || Statamic.$permissions.has(`view ${this.container} assets`)
+            return Statamic.$permissions.has(`view ${this.container} assets`);
         },
 
         thumbnail() {


### PR DESCRIPTION
In `Statamic.$permissions.has(permission)` it should check for super permissions rather than needing to also manually do `.has('super')`.

References #7100
