### PR TITLE
Allow addons to set the fieldset namespace

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -154,6 +154,11 @@ abstract class AddonServiceProvider extends ServiceProvider
      */
     protected $translations = true;
 
+    /**
+     * @var string
+     */
+    protected $fieldsetNamespace;
+
     public function boot()
     {
         Statamic::booted(function () {
@@ -599,7 +604,10 @@ abstract class AddonServiceProvider extends ServiceProvider
             return $this;
         }
 
-        Fieldset::addNamespace($this->getAddon()->slug(), $path);
+        Fieldset::addNamespace(
+            $this->fieldsetNamespace ?? $this->getAddon()->slug(),
+            $path
+        );
 
         return $this;
     }

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -137,6 +137,11 @@ abstract class AddonServiceProvider extends ServiceProvider
     /**
      * @var string
      */
+    protected $fieldsetNamespace;
+
+    /**
+     * @var string
+     */
     protected $viewNamespace;
 
     /**
@@ -153,11 +158,6 @@ abstract class AddonServiceProvider extends ServiceProvider
      * @var bool
      */
     protected $translations = true;
-
-    /**
-     * @var string
-     */
-    protected $fieldsetNamespace;
 
     public function boot()
     {


### PR DESCRIPTION
Now that fieldsets can be referenced (like views), we might need to override the namespace (like we can w/ views).

IMO, we should only have one `$namespace` property, but I didn't want to break the existing `$viewNamespace` property.

If you'd me to add code to do so, let me know.