### PR TITLE
Return null if a collection does not exist instead of throwing an error

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -131,6 +131,11 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
                             : $this->get('blueprint');
                     }
 
+                    // With PHP <= 8.0 the Nullsafe operator could be used instead
+                    if (is_null($this->collection())) {
+                        return null;
+                    }
+
                     return $this->collection()->entryBlueprint($blueprint, $this);
                 });
             })


### PR DESCRIPTION
We have been running into the issue, that the collection could not be found inside a listing.

So instead of returning null for a collection (which might not exist anymore), in the actual implementation, a Server Error might occur and the listing will not show up.

This might be an edge case, but this little part does make our code more stable against invalid data inside listings.