### PR TITLE
Harden cpUrl method

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -257,7 +257,11 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
             return null;
         }
 
-        return cp_route($route, [$this->collectionHandle(), $id]);
+        if (! $collectionHandle = $this->collectionHandle()) {
+            return null;
+        }
+
+        return cp_route($route, [$collectionHandle, $id]);
     }
 
     public function apiUrl()


### PR DESCRIPTION
This might be another edgecase:

With invalid data, you might run into the problem that your listing breaks, as the collection handle might not exist.

This PR does catch this error early and does avoid a server error and does harden the code base against invalid data.