### PR TITLE
Add http auth to static warm

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -28,7 +28,7 @@ class StaticWarm extends Command
     use RunsInPlease;
     use EnhancesCommands;
 
-    protected $signature = 'statamic:static:warm {--queue : Queue the requests}';
+    protected $signature = 'statamic:static:warm {--queue : Queue the requests} {--u=  : HTTP authentication user} {--p=  : HTTP authentication password}';
 
     protected $description = 'Warms the static cache by visiting all URLs';
 
@@ -66,7 +66,10 @@ class StaticWarm extends Command
 
     private function warm(): void
     {
-        $client = new Client(['verify' => ! $this->laravel->isLocal()]);
+        $client = new Client([
+            'verify' => ! $this->laravel->isLocal(),
+            'auth' => $this->option('u') && $this->option('p') ? [$this->option('u'), $this->option('p')] : null
+        ]);
 
         $this->output->newLine();
         $this->line('Compiling URLs...');

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -28,7 +28,7 @@ class StaticWarm extends Command
     use RunsInPlease;
     use EnhancesCommands;
 
-    protected $signature = 'statamic:static:warm {--queue : Queue the requests} {--u=  : HTTP authentication user} {--p=  : HTTP authentication password}';
+    protected $signature = 'statamic:static:warm {--queue : Queue the requests} {--u= : HTTP authentication user} {--p= : HTTP authentication password}';
 
     protected $description = 'Warms the static cache by visiting all URLs';
 

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -28,7 +28,11 @@ class StaticWarm extends Command
     use RunsInPlease;
     use EnhancesCommands;
 
-    protected $signature = 'statamic:static:warm {--queue : Queue the requests} {--u= : HTTP authentication user} {--p= : HTTP authentication password}';
+    protected $signature = 'statamic:static:warm
+        {--queue : Queue the requests}
+        {--user= : HTTP authentication user}
+        {--password= : HTTP authentication password}
+    ';
 
     protected $description = 'Warms the static cache by visiting all URLs';
 
@@ -68,8 +72,8 @@ class StaticWarm extends Command
     {
         $client = new Client([
             'verify' => ! $this->laravel->isLocal(),
-            'auth' => $this->option('u') && $this->option('p')
-                ? [$this->option('u'), $this->option('p')]
+            'auth' => $this->option('user') && $this->option('password')
+                ? [$this->option('user'), $this->option('password')]
                 : null
         ]);
 

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -30,8 +30,8 @@ class StaticWarm extends Command
 
     protected $signature = 'statamic:static:warm
         {--queue : Queue the requests}
-        {--user= : HTTP authentication user}
-        {--password= : HTTP authentication password}
+        {--u|user= : HTTP authentication user}
+        {--p|password= : HTTP authentication password}
     ';
 
     protected $description = 'Warms the static cache by visiting all URLs';

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -68,7 +68,9 @@ class StaticWarm extends Command
     {
         $client = new Client([
             'verify' => ! $this->laravel->isLocal(),
-            'auth' => $this->option('u') && $this->option('p') ? [$this->option('u'), $this->option('p')] : null
+            'auth' => $this->option('u') && $this->option('p')
+                ? [$this->option('u'), $this->option('p')]
+                : null
         ]);
 
         $this->output->newLine();

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -74,7 +74,7 @@ class StaticWarm extends Command
             'verify' => ! $this->laravel->isLocal(),
             'auth' => $this->option('user') && $this->option('password')
                 ? [$this->option('user'), $this->option('password')]
-                : null
+                : null,
         ]);
 
         $this->output->newLine();


### PR DESCRIPTION
**Problem:**
Staging systems are often behind a HTTP basic authentication. Calling the current static warm command on a site behind HTTP basic authentication (e.g. from a CI job) produces a "401 Authorization Required" error.

**Solution:**
This pull request adds the possibility to pass the authentication credentials via the parameters `--u` (HTTP authentication user) and `--p` (HTTP authentication password) to the static warm command.