### PR TITLE
Fix invalid slug validation when using `max_depth: 1`

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -714,7 +714,7 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
             return null;
         }
 
-        if ($structure = $this->structure()) {
+        if (($structure = $this->structure()) && ! $this->collection()->orderable()) {
             return $structure->entryUri($this);
         }
 


### PR DESCRIPTION
Fixes #7066. 

The structure will return `null` for `->entryUri()` uri if the `id` for the entry is not set yet. For an ordered collection (`max_depth = 1`) you don't need to ask the structure for the uri though.

For an alternative solution, see #7134.