### PR TITLE
Fix invalid slug validation when using max_depth: 1

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -212,9 +212,11 @@ class EntriesController extends CpController
 
         $entry->slug($this->resolveSlug($request));
 
-        if ($collection->structure() && ! $collection->orderable()) {
+        if ($structure = $collection->structure()) {
             $tree = $entry->structure()->in($entry->locale());
+        }
 
+        if ($structure && ! $collection->orderable()) {
             $this->validateParent($entry, $tree, $parent);
 
             $entry->afterSave(function ($entry) use ($parent, $tree) {

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -364,16 +364,19 @@ class EntriesController extends CpController
             $entry->date($this->toCarbonInstanceForSaving($request->date));
         }
 
-        if (($structure = $collection->structure()) && ! $collection->orderable()) {
+        if ($structure = $collection->structure()) {
             $tree = $structure->in($site->handle());
-            $parent = $values['parent'] ?? null;
-            $entry->afterSave(function ($entry) use ($parent, $tree) {
-                if ($parent && optional($tree->page($parent))->isRoot()) {
-                    $parent = null;
-                }
 
-                $tree->appendTo($parent, $entry)->save();
-            });
+            if (! $collection->orderable()) {
+                $parent = $values['parent'] ?? null;
+                $entry->afterSave(function ($entry) use ($parent, $tree) {
+                    if ($parent && optional($tree->page($parent))->isRoot()) {
+                        $parent = null;
+                    }
+
+                    $tree->appendTo($parent, $entry)->save();
+                });
+            }
         }
 
         $this->validateUniqueUri($entry, $tree ?? null, $parent ?? null);

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -366,17 +366,17 @@ class EntriesController extends CpController
 
         if ($structure = $collection->structure()) {
             $tree = $structure->in($site->handle());
+        }
 
-            if (! $collection->orderable()) {
-                $parent = $values['parent'] ?? null;
-                $entry->afterSave(function ($entry) use ($parent, $tree) {
-                    if ($parent && optional($tree->page($parent))->isRoot()) {
-                        $parent = null;
-                    }
+        if ($structure && ! $collection->orderable()) {
+            $parent = $values['parent'] ?? null;
+            $entry->afterSave(function ($entry) use ($parent, $tree) {
+                if ($parent && optional($tree->page($parent))->isRoot()) {
+                    $parent = null;
+                }
 
-                    $tree->appendTo($parent, $entry)->save();
-                });
-            }
+                $tree->appendTo($parent, $entry)->save();
+            });
         }
 
         $this->validateUniqueUri($entry, $tree ?? null, $parent ?? null);


### PR DESCRIPTION
Fixes #7066.

Solved by getting the tree for an orderable collection too.

This is an alternative to #7133.