### PR TITLE
CP - Image Direct URLs - Override image generation and the cache

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -57,6 +57,23 @@ return [
 
         /*
         |--------------------------------------------------------------------------
+        | CP - access the images directly instead of going through the above cache
+        |--------------------------------------------------------------------------
+        |
+        | Override the above SAVED_CACHED_IMAGES setting for the CP and access the
+        | images directly instead of going through the cache.  You will need to
+        | run `php please glide:generate-presets` to generate the images.  Then
+        | symlink the public/img folder to the glide storage folder.  Images are
+        | expected to be to be present in the glide storage folder and will not be
+        | generated on the fly.
+        */
+
+        'image_direct_urls' => false,
+        'image_direct_path' => '/img/',
+
+
+        /*
+        |--------------------------------------------------------------------------
         | Image Manipulation Presets
         |--------------------------------------------------------------------------
         |


### PR DESCRIPTION
This PR enables users to access the CP thumbnails directly via URL instead of going through the CP image cache or image generation.   Currently there is at least a 450ms penalty and high CPU usage to using the SAVED_IMAGE_CACHE method whether it is true or false.  This reduces image fetching to 5-10ms and adds minimal stress to the server.

It will require users to have their images already generated using `php please glide:generate-presets` and having them located in a public location like public/img or have a symlink in public to the default storage folder that generate-presets stores its images (`storage/statamic/glide/containers/assets/`).   The images will need to be present and they won't be generated on the fly.  

More discussion in issue https://github.com/statamic/cms/issues/7096
