### PR TITLE
Fix search on Users Listing Table when storing users in the database & using separate first/last name fields

### DIFF
--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -49,7 +49,15 @@ class UsersController extends CpController
                 return Search::index('users')->ensureExists()->search($search);
             }
 
-            $query->where('email', 'like', '%'.$search.'%')->orWhere('name', 'like', '%'.$search.'%');
+            $query
+                ->where('email', 'like', '%'.$search.'%')
+                ->when(User::blueprint()->hasField('first_name'), function ($query) use ($search) {
+                    $query
+                        ->orWhere('first_name', 'like', '%'.$search.'%')
+                        ->orWhere('last_name', 'like', '%'.$search.'%');
+                }, function ($query) use ($search) {
+                    $query->orWhere('name', 'like', '%'.$search.'%');
+                });
         }
 
         return $query;


### PR DESCRIPTION
This pull request fixes an issue on the Users Listing Table when storing users in the database & using separate columns for first & last name.

## How to reproduce

1. Setup a Statamic site with users in the database (now that I think of it users could probably be flat-file for this issue too)
2. Make first & last names into separate columns, instead of one field as per the default
3. On the Users Listing Table, attempt to search for a user
4. See the error

Apologies for lack of test repository, I don't have any time to do that right now.

## Error

```"SQLSTATE[42S22]: Column not found: 1054 Unknown column 'name' in 'where clause' (SQL: select count(*) as aggregate from `users` where `email` like %dev% or `name` like %dev%)"```