### PR TITLE
Improve loading speed for updater page

### DIFF
--- a/resources/js/components/updater/Release.vue
+++ b/resources/js/components/updater/Release.vue
@@ -19,7 +19,7 @@
             </div>
         </div>
         <div class="card-body">
-            <div v-html="release.body"></div>
+            <div v-html="body"></div>
         </div>
 
         <confirmation-modal
@@ -66,6 +66,14 @@ export default {
             return this.confirmationPrompt.type === 'downgrade'
                 ? __('Are you sure you want to downgrade to :version?', attrs)
                 : __('Are you sure you want to update to :version?', attrs)
+        },
+
+        body() {
+            return markdown(this.release.body)
+                .replaceAll('[new]', '<span class="label" style="background: #5bc0de;">NEW</span>')
+                .replaceAll('[fix]', '<span class="label" style="background: #5cb85c;">FIX</span>')
+                .replaceAll('[break]', '<span class="label" style="background: #d9534f;">BREAK</span>')
+                .replaceAll('[na]', '<span class="label" style="background: #e8e8e8;">N/A</span>')
         }
     },
 

--- a/resources/js/components/updater/Updater.vue
+++ b/resources/js/components/updater/Updater.vue
@@ -132,11 +132,11 @@
             },
 
             latestVersion() {
-                return this.latestRelease.version;
+                return this.latestRelease && this.latestRelease.version;
             },
 
             canUpdateToLatestVersion() {
-                return this.latestVersion.canUpdate && this.showActions && ! this.onLatestVersion;
+                return this.latestVersion && this.latestVersion.canUpdate && this.showActions && ! this.onLatestVersion;
             }
         },
 

--- a/resources/js/components/updater/Updater.vue
+++ b/resources/js/components/updater/Updater.vue
@@ -140,11 +140,8 @@
             }
         },
 
-        mounted() {
-            this.getChangelog();
-        },
-
         created() {
+            this.getChangelog();
             this.$events.$on('composer-finished', this.composerFinished);
         },
 

--- a/src/Updater/Changelog.php
+++ b/src/Updater/Changelog.php
@@ -4,7 +4,6 @@ namespace Statamic\Updater;
 
 use Carbon\Carbon;
 use Facades\Statamic\Marketplace\Marketplace;
-use Statamic\Updater\Presenters\GithubReleasePresenter;
 
 abstract class Changelog
 {
@@ -40,7 +39,7 @@ abstract class Changelog
                 'latest' => $index === 0,
                 'licensed' => $this->isLicensed($release['version']),
                 'date' => Carbon::parse($release['date'])->format(config('statamic.cp.date_format')),
-                'body' => (string) new GithubReleasePresenter($release['changelog']),
+                'body' => $release['changelog'],
             ];
         });
     }

--- a/src/Updater/Changelog.php
+++ b/src/Updater/Changelog.php
@@ -29,10 +29,14 @@ abstract class Changelog
      */
     public function get()
     {
-        return Marketplace::releases($this->item())->map(function ($release, $index) {
+        $type = null;
+
+        return Marketplace::releases($this->item())->map(function ($release, $index) use (&$type) {
+            $type = $type === 'downgrade' ? $type : $this->parseReleaseType($release['version'], $index);
+
             return (object) [
                 'version' => $release['version'],
-                'type' => $this->parseReleaseType($release['version'], $index),
+                'type' => $type,
                 'latest' => $index === 0,
                 'licensed' => $this->isLicensed($release['version']),
                 'date' => Carbon::parse($release['date'])->format(config('statamic.cp.date_format')),

--- a/src/Updater/Presenters/GithubReleasePresenter.php
+++ b/src/Updater/Presenters/GithubReleasePresenter.php
@@ -5,6 +5,7 @@ namespace Statamic\Updater\Presenters;
 use Statamic\Support\Html;
 use Statamic\Support\Str;
 
+/** @deprecated */
 class GithubReleasePresenter
 {
     /**

--- a/tests/Composer/ChangelogTests.php
+++ b/tests/Composer/ChangelogTests.php
@@ -46,7 +46,7 @@ trait ChangelogTests
 
         collect($contents)->each(function ($release) {
             $this->assertEquals('2018: November 6th', $release->date);
-            $this->assertContainsHtml($release->body);
+            $this->assertIsString($release->body);
         });
     }
 


### PR DESCRIPTION
I've been noticing for a while that the updater page takes a long time to load. The same goes for the updater badge. Also the updater page doesn't show a loading indicator. This PR fixes / improves these issues.

Most of the loading time (several seconds each) was spent parsing the markdown in `GithubReleasePresenter@toHtml()` and determining if a version was a 'upgrade', 'current' or 'downgrade' version in `Changelog@parseReleaseType()`.

Changes:

* Parse markdown on the frontend
* Remember the release type, everything after the first 'downgrade' must be a downgrade too*
* Start loading the changelog in the Vue `created()` method instead of waiting for `mounted()`
* Fix a JS error that prevented the loading indicator from rendering

\* This assumes that the API returns the releases sorted, latest release first. Which seems to be the case.
