### PR TITLE
Prevent error when creating entry while using multisite

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -754,8 +754,8 @@ export default {
         window.history.replaceState({}, document.title, document.location.href.replace('created=true', ''));
 
         this.selectedOrigin = this.originBehavior === 'active'
-            ? this.localizations.find(l => l.active).handle
-            : this.localizations.find(l => l.root).handle;
+            ? this.localizations.find(l => l.active)?.handle
+            : this.localizations.find(l => l.root)?.handle;
     },
 
     unmounted() {


### PR DESCRIPTION
Fixes #7141

Use a nullsafe operator since the error is because the `this.localizations.find()` returns null in both cases.

The `this.selectedOrigin` property is only used on the edit form, so we don't care if it's null on the create form.
