### PR TITLE
Set default value to empty string if null

### DIFF
--- a/src/View/Antlers/Language/Runtime/LiteralReplacementManager.php
+++ b/src/View/Antlers/Language/Runtime/LiteralReplacementManager.php
@@ -37,7 +37,7 @@ class LiteralReplacementManager
             return $name;
         }
 
-        self::$regions[$name] = $default;
+        self::$regions[$name] = $default ?? '';
 
         return $name;
     }


### PR DESCRIPTION
This is to prevent deprecation messages on str_replace if the default value is "null" instead of an empty string