### PR TITLE
Antlers: makes value resolution "lazy"

### DIFF
--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -798,10 +798,7 @@ class Environment
                 $i += 1;
                 continue;
             } elseif ($currentNode instanceof LogicGroup) {
-                $restore = $this->isEvaluatingTruthValue;
-                $this->isEvaluatingTruthValue = false;
-                $stack[] = $this->adjustValue($this->getValue($currentNode), $currentNode);
-                $this->isEvaluatingTruthValue = $restore;
+                $stack[] = $currentNode;
                 continue;
             } elseif ($currentNode instanceof NullCoalescenceGroup) {
                 $stack[] = $this->adjustValue($this->evaluateNullCoalescence($currentNode), $currentNode);
@@ -929,13 +926,12 @@ class Environment
         if (count($stack) == 3) {
             $left = $stack[0];
             $rightNode = $stack[2];
-            $right = $this->getValue($rightNode);
             $operand = $stack[1];
 
             if ($operand instanceof LeftAssignmentOperator) {
                 $varName = $this->nameOf($left);
 
-                $right = $this->checkForFieldValue($right);
+                $right = $this->checkForFieldValue($this->getValue($rightNode));
 
                 $this->dataRetriever->setRuntimeValue($varName, $this->data, $right);
                 $lastPath = $this->dataRetriever->lastPath();
@@ -949,7 +945,7 @@ class Environment
             } elseif ($operand instanceof AdditionAssignmentOperator) {
                 $varName = $this->nameOf($left);
                 $curVal = $this->checkForFieldValue($this->scopeValue($varName));
-                $right = $this->checkForFieldValue($right);
+                $right = $this->checkForFieldValue($this->getValue($rightNode));
 
                 if (is_string($curVal) && is_string($right)) {
                     // Allows for addition assignment to act
@@ -982,7 +978,7 @@ class Environment
             } elseif ($operand instanceof DivisionAssignmentOperator) {
                 $varName = $this->nameOf($left);
                 $curVal = $this->checkForFieldValue($this->numericScopeValue($varName));
-                $right = $this->checkForFieldValue($right);
+                $right = $this->checkForFieldValue($this->getValue($rightNode));
 
                 $this->assertNumericValue($curVal);
                 $this->assertNumericValue($right);
@@ -1001,7 +997,7 @@ class Environment
             } elseif ($operand instanceof ModulusAssignmentOperator) {
                 $varName = $this->nameOf($left);
                 $curVal = $this->checkForFieldValue($this->numericScopeValue($varName));
-                $right = $this->checkForFieldValue($right);
+                $right = $this->checkForFieldValue($this->getValue($rightNode));
 
                 $this->assertNumericValue($curVal);
                 $this->assertNumericValue($right);
@@ -1019,7 +1015,7 @@ class Environment
             } elseif ($operand instanceof MultiplicationAssignmentOperator) {
                 $varName = $this->nameOf($left);
                 $curVal = $this->checkForFieldValue($this->numericScopeValue($varName));
-                $right = $this->checkForFieldValue($right);
+                $right = $this->checkForFieldValue($this->getValue($rightNode));
 
                 $this->assertNumericValue($curVal);
                 $this->assertNumericValue($right);
@@ -1037,7 +1033,7 @@ class Environment
             } elseif ($operand instanceof SubtractionAssignmentOperator) {
                 $varName = $this->nameOf($left);
                 $curVal = $this->checkForFieldValue($this->numericScopeValue($varName));
-                $right = $this->checkForFieldValue($right);
+                $right = $this->checkForFieldValue($this->getValue($rightNode));
 
                 $this->assertNumericValue($curVal);
                 $this->assertNumericValue($right);
@@ -1060,7 +1056,7 @@ class Environment
                 }
 
                 if ($leftValue != false) {
-                    return $this->getValue($right);
+                    return $this->getValue($rightNode);
                 } else {
                     return null;
                 }

--- a/src/View/Antlers/Language/Runtime/Sandbox/LanguageOperatorManager.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/LanguageOperatorManager.php
@@ -76,6 +76,10 @@ class LanguageOperatorManager
         $value = null;
 
         if ($operator == LanguageOperatorRegistry::ARR_PLUCK) {
+            if ($a === null) {
+                return [];
+            }
+
             $tmpValue = Arr::pluck($a, $b);
             $value = [];
 

--- a/tests/Antlers/Runtime/LogicGroupTest.php
+++ b/tests/Antlers/Runtime/LogicGroupTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Antlers\Runtime;
+
+use Exception;
+use Statamic\Tags\Tags;
+use Tests\Antlers\ParserTestCase;
+
+class LogicGroupTest extends ParserTestCase
+{
+    public function test_gatekeeper_right_side_is_lazy()
+    {
+        $template = '{{ thing ?= (stuff = "abc") }}--{{ stuff }}';
+
+        $result = $this->renderString($template, [
+            'thing' => false
+        ]);
+
+        $this->assertSame('--', $result);
+    }
+}

--- a/tests/Antlers/Sandbox/LanguageOperatorTest.php
+++ b/tests/Antlers/Sandbox/LanguageOperatorTest.php
@@ -61,4 +61,9 @@ EOT;
 
         $this->assertSame('123345', $this->renderString('{{ merged = a merge b }}{{ value }}{{ /merged }}', ['a' => $a, 'b' => $b]));
     }
+
+    public function test_pluck_on_variable_that_doesnt_exist()
+    {
+        $this->assertSame('', $this->renderString('{{ doesnt_exist pluck("title") }}'));
+    }
 }


### PR DESCRIPTION
This PR closes #7148 

The first fix just checks to make sure that the `pluck` operator doesn't call the internal `Arr::pluck` when the incoming value is `null`.

The second fix makes the evaluation of values "lazy", so that the following only evaluates the tag when value is truthy:

```antlers
{{ undefined_variable ?= {mytag} }}
```

```php
<?php

namespace App\Tags;

use Statamic\Tags\Tags;

class Mytag extends Tags
{
    public function index()
    {
        dump('tag is executed');

        return 'test';
    }
}
```

This lazy evaluation also extends to logic groups, so the following will no longer prematurely set the `test` variable:

```antlers
{{ var_exists ?= (test = "testing") }}

{{ test }}
```

Test cases have been provided for both items 👍