### PR TITLE
Show YouTube Shorts in video fieldtype preview

### DIFF
--- a/resources/js/components/fieldtypes/VideoFieldtype.vue
+++ b/resources/js/components/fieldtypes/VideoFieldtype.vue
@@ -58,7 +58,9 @@ export default {
             let embed_url = this.data;
 
             if (embed_url.includes('youtube')) {
-                embed_url = embed_url.replace('watch?v=', 'embed/');
+                embed_url = embed_url.includes('shorts/')
+                    ? embed_url.replace('shorts/', 'embed/')
+                    : embed_url.replace('watch?v=', 'embed/');
             }
 
             if (embed_url.includes('youtu.be')) {
@@ -82,7 +84,7 @@ export default {
         },
 
         isUrl() {
-            let regex = new RegExp('^(https?|ftp)://[^\s/$.?#].[^\s]*$', 'i')
+            let regex = new RegExp('^(https?|ftp):\/\/[^\s/$.?#].*$', 'i')
 
             return regex.test(this.data);
         },


### PR DESCRIPTION
This pull request allows for YouTube Shorts to be previewed within the Video fieldtype, in the same way you can with a 'normal' YouTube video.

<img width="866" alt="image" src="https://user-images.githubusercontent.com/19637309/204917541-aa7ea9b1-ebbd-43c6-9bba-057cadee7a51.png">

I had to make a change to the regex expression to allow for Shorts URLs to be previewed (credit to @JohnathonKoster for figuring out why the regex wasn't working in the first place 😅 )