### PR TITLE
Overwrite greeting in activation mail

### DIFF
--- a/src/Notifications/ActivateAccount.php
+++ b/src/Notifications/ActivateAccount.php
@@ -8,6 +8,7 @@ use Statamic\Auth\Passwords\PasswordReset as PasswordResetManager;
 class ActivateAccount extends PasswordReset
 {
     public static $subject;
+    public static $greeting;
     public static $body;
 
     public static function subject($subject = null)
@@ -17,6 +18,15 @@ class ActivateAccount extends PasswordReset
         }
 
         static::$subject = $subject;
+    }
+
+    public static function greeting($greeting = null)
+    {
+        if (is_null($greeting)) {
+            return static::$greeting;
+        }
+
+        static::$greeting = $greeting;
     }
 
     public static function body($body = null)
@@ -38,6 +48,7 @@ class ActivateAccount extends PasswordReset
     {
         return (new MailMessage)
             ->subject(static::$subject ?? __('statamic::messages.activate_account_notification_subject'))
+            ->greeting(static::$greeting ?? __('Hello!'))
             ->line(static::$body ?? __('statamic::messages.activate_account_notification_body'))
             ->action(__('Activate Account'), PasswordResetManager::url($this->token, PasswordResetManager::BROKER_ACTIVATIONS));
     }

--- a/src/Notifications/ActivateAccount.php
+++ b/src/Notifications/ActivateAccount.php
@@ -48,7 +48,7 @@ class ActivateAccount extends PasswordReset
     {
         return (new MailMessage)
             ->subject(static::$subject ?? __('statamic::messages.activate_account_notification_subject'))
-            ->greeting(static::$greeting ?? __('Hello!'))
+            ->greeting(static::$greeting)
             ->line(static::$body ?? __('statamic::messages.activate_account_notification_body'))
             ->action(__('Activate Account'), PasswordResetManager::url($this->token, PasswordResetManager::BROKER_ACTIVATIONS));
     }


### PR DESCRIPTION
This PR enables to overwrite the greeting of the activation mail of the user.

Currently, you can invite the user via the control panel (cp/users/create). But I need to invite 30 users to my application and I want to personalize the invitation mail:

<img width="834" alt="image" src="https://user-images.githubusercontent.com/14092921/205035285-b5cd0633-6e41-449d-96c6-e84202c42ea0.png">
