### PR TITLE
Support adding computed values to multiple collections at once

### DIFF
--- a/src/Data/StoresScopedComputedFieldCallbacks.php
+++ b/src/Data/StoresScopedComputedFieldCallbacks.php
@@ -4,17 +4,17 @@ namespace Statamic\Data;
 
 use Closure;
 use Illuminate\Support\Collection;
-use Statamic\Support\Str;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 trait StoresScopedComputedFieldCallbacks
 {
     protected $computedFieldCallbacks;
 
     /**
-     * @param string|array $scopes
-     * @param string $field
-     * @param Closure $callback
+     * @param  string|array  $scopes
+     * @param  string  $field
+     * @param  Closure  $callback
      */
     public function computed($scopes, string $field, Closure $callback)
     {

--- a/src/Data/StoresScopedComputedFieldCallbacks.php
+++ b/src/Data/StoresScopedComputedFieldCallbacks.php
@@ -5,14 +5,22 @@ namespace Statamic\Data;
 use Closure;
 use Illuminate\Support\Collection;
 use Statamic\Support\Str;
+use Statamic\Support\Arr;
 
 trait StoresScopedComputedFieldCallbacks
 {
     protected $computedFieldCallbacks;
 
-    public function computed(string $scope, string $field, Closure $callback)
+    /**
+     * @param string|array $scopes
+     * @param string $field
+     * @param Closure $callback
+     */
+    public function computed($scopes, string $field, Closure $callback)
     {
-        $this->computedFieldCallbacks["$scope.$field"] = $callback;
+        foreach (Arr::wrap($scopes) as $scope) {
+            $this->computedFieldCallbacks["$scope.$field"] = $callback;
+        }
     }
 
     public function getComputedCallbacks(string $scope): Collection

--- a/tests/Data/StoresScopedComputedFieldCallbacksTest.php
+++ b/tests/Data/StoresScopedComputedFieldCallbacksTest.php
@@ -35,6 +35,24 @@ class StoresScopedComputedFieldCallbacksTest extends TestCase
 
         $this->assertEquals([], $repository->getComputedCallbacks('products')->all());
     }
+
+    /** @test */
+    public function it_can_store_scoped_computed_callbacks_for_multiple_scopes()
+    {
+        $repository = new FakeRepositoryWithScopedCallbacks;
+
+        $repository->computed(['events', 'articles'], 'some_field', $closure = function ($item, $value) {
+            //
+        });
+
+        $this->assertEquals([
+            'some_field' => $closure,
+        ], $repository->getComputedCallbacks('events')->all());
+
+        $this->assertEquals([
+            'some_field' => $closure,
+        ], $repository->getComputedCallbacks('articles')->all());
+    }
 }
 
 class FakeRepositoryWithScopedCallbacks


### PR DESCRIPTION
This PR makes a small tweak that allows adding the same computed values to multiple collections at once. So instead of:

```php
$callback = function ($entry, $value) {
    //
};
Collection::computed('pages', 'extract', $callback);
Collection::computed('articles', 'extract', $callback);
```

You can just do:

```php
Collection::computed(['pages', 'articles'], 'extract', function ($entry, $value) {
    //
});
```