### PR TITLE
Allow searchables transformers to be a class to prevent serialisation error

### DIFF
--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -175,7 +175,7 @@ class Searchables
             if (! $transformers[$field] instanceof Closure) {
 
                 if (class_exists($transformers[$field])) {
-                    $transformedValue = app()->make($transformers[$field])->handle($field, $value);
+                    return [$field => app()->make($transformers[$field])->handle($field, $value)];
                 }
 
                 return;

--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -173,7 +173,13 @@ class Searchables
 
             if (! $transformers[$field] instanceof Closure) {
                 if (class_exists($transformers[$field])) {
-                    return [$field => app()->make($transformers[$field])->handle($field, $value)];
+                    $transformedValue = app()->make($transformers[$field])->handle($field, $value);
+
+                    if (is_array($transformedValue)) {
+                        return $transformedValue;
+                    }
+
+                    return [$field => $transformedValue];
                 }
 
                 return;

--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -182,7 +182,7 @@ class Searchables
                     return [$field => $transformedValue];
                 }
 
-                return;
+                return [$field => $value];
             }
 
             $transformedValue = $transformers[$field]($value);

--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -167,8 +167,18 @@ class Searchables
 
             return [$field => $value];
         })->flatMap(function ($value, $field) use ($transformers) {
-            if (! isset($transformers[$field]) || ! $transformers[$field] instanceof Closure) {
+
+            if (! isset($transformers[$field])) {
                 return [$field => $value];
+            }
+
+            if (! $transformers[$field] instanceof Closure) {
+
+                if (class_exists($transformers[$field])) {
+                    $transformedValue = app()->make($transformers[$field])->handle($field, $value);
+                }
+
+                return;
             }
 
             $transformedValue = $transformers[$field]($value);

--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -167,13 +167,11 @@ class Searchables
 
             return [$field => $value];
         })->flatMap(function ($value, $field) use ($transformers) {
-
             if (! isset($transformers[$field])) {
                 return [$field => $value];
             }
 
             if (! $transformers[$field] instanceof Closure) {
-
                 if (class_exists($transformers[$field])) {
                     return [$field => app()->make($transformers[$field])->handle($field, $value)];
                 }

--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -172,17 +172,17 @@ class Searchables
             }
 
             if (! $transformers[$field] instanceof Closure) {
-                if (class_exists($transformers[$field])) {
-                    $transformedValue = app()->make($transformers[$field])->handle($field, $value);
-
-                    if (is_array($transformedValue)) {
-                        return $transformedValue;
-                    }
-
-                    return [$field => $transformedValue];
+                if (! class_exists($transformers[$field])) {
+                    throw new \LogicException("Search transformer [{$transformers[$field]}] not found.");
                 }
 
-                return [$field => $value];
+                $transformedValue = app()->make($transformers[$field])->handle($field, $value);
+
+                if (is_array($transformedValue)) {
+                    return $transformedValue;
+                }
+
+                return [$field => $transformedValue];
             }
 
             $transformedValue = $transformers[$field]($value);

--- a/tests/Search/SearchablesTest.php
+++ b/tests/Search/SearchablesTest.php
@@ -371,7 +371,8 @@ class NotSearchable
 
 class SearchTransformerTest
 {
-    public function handle($field, $value) {
+    public function handle($field, $value)
+    {
         return strtoupper($value);
     }
 }

--- a/tests/Search/SearchablesTest.php
+++ b/tests/Search/SearchablesTest.php
@@ -454,7 +454,7 @@ class ArrayTestTransformer
     {
         return [
             $field => $value,
-            $field.'_upper' => strtoupper($value)
+            $field.'_upper' => strtoupper($value),
         ];
     }
 }

--- a/tests/Search/SearchablesTest.php
+++ b/tests/Search/SearchablesTest.php
@@ -299,6 +299,31 @@ class SearchablesTest extends TestCase
     }
 
     /** @test */
+    public function it_transforms_by_a_class_set_in_the_config_file()
+    {
+        config()->set('statamic.search.indexes.default', [
+            'fields' => [
+                'title',
+            ],
+            'transformers' => [
+                'title' => SearchTransformerTest::class,
+            ],
+        ]);
+
+        $index = app(\Statamic\Search\Comb\Index::class, [
+            'name' => 'default',
+            'config' => config('statamic.search.indexes.default'),
+        ]);
+
+        $searchable = EntryFactory::collection('test')->data(['title' => 'Hello'])->make();
+        $searchables = new Searchables($index);
+
+        $this->assertEquals([
+            'title' => 'HELLO',
+        ], $searchables->fields($searchable));
+    }
+
+    /** @test */
     public function if_a_transformer_returns_an_array_it_gets_combined_into_the_results()
     {
         config()->set('statamic.search.indexes.default', [
@@ -342,4 +367,11 @@ class SearchablesTest extends TestCase
 class NotSearchable
 {
     //
+}
+
+class SearchTransformerTest
+{
+    public function handle($field, $value) {
+        return strtoupper($value);
+    }
 }

--- a/tests/Search/SearchablesTest.php
+++ b/tests/Search/SearchablesTest.php
@@ -299,6 +299,27 @@ class SearchablesTest extends TestCase
     }
 
     /** @test */
+    public function it_uses_regular_value_if_theres_not_a_corresponding_transformer()
+    {
+        config()->set('statamic.search.indexes.default', [
+            'fields' => ['title'],
+            'transformers' => [],
+        ]);
+
+        $index = app(\Statamic\Search\Comb\Index::class, [
+            'name' => 'default',
+            'config' => config('statamic.search.indexes.default'),
+        ]);
+
+        $searchable = EntryFactory::collection('test')->data(['title' => 'Hello'])->make();
+        $searchables = new Searchables($index);
+
+        $this->assertEquals([
+            'title' => 'Hello',
+        ], $searchables->fields($searchable));
+    }
+
+    /** @test */
     public function it_transforms_by_a_class_set_in_the_config_file()
     {
         config()->set('statamic.search.indexes.default', [
@@ -321,6 +342,30 @@ class SearchablesTest extends TestCase
         $this->assertEquals([
             'title' => 'HELLO',
         ], $searchables->fields($searchable));
+    }
+
+    /** @test */
+    public function if_transformed_value_is_a_string_without_a_matching_class_it_throws_exception()
+    {
+        $this->expectExceptionMessage('Search transformer [foo] not found.');
+
+        config()->set('statamic.search.indexes.default', [
+            'fields' => [
+                'title',
+            ],
+            'transformers' => [
+                'title' => 'foo',
+            ],
+        ]);
+
+        $index = app(\Statamic\Search\Comb\Index::class, [
+            'name' => 'default',
+            'config' => config('statamic.search.indexes.default'),
+        ]);
+
+        $searchable = EntryFactory::collection('test')->data(['title' => 'Hello'])->make();
+        $searchables = new Searchables($index);
+        $searchables->fields($searchable);
     }
 
     /** @test */


### PR DESCRIPTION
If you specify a search transformer as a closure... eg:

```
            'transformers' => [
                'title' => function ($value) {
                    return strtoupper($value);
                },
            ],
```
and run `php artisan config:cache` then you are given a serialisation error.

@jacksleight has a great workaround here: https://github.com/statamic/ideas/issues/721#issuecomment-1334039830 but its not the immediate thing you reach for.

This PR allows you to specify a class to handle the transform, allowing serialisation to work, e.g.

```
            'transformers' => [
                'title' => \App\Transformers\MyTransformer::class,
            ],
```

Within the class we look for a `handle()` method and pass the `$field` and current `$value` to it. The developer can then return whatever they want to be added to the index.
