### PR TITLE
Handle edits within frontend fields

### DIFF
--- a/resources/views/extend/forms/fields/checkboxes.antlers.html
+++ b/resources/views/extend/forms/fields/checkboxes.antlers.html
@@ -1,15 +1,14 @@
-{{ foreach:options as="value|label" }}
+{{ foreach:options as="option|label" }}
     <label>
         <input
             type="checkbox"
             name="{{ handle }}[]"
-            value="{{ value }}"
+            value="{{ option }}"
             {{ if js_driver }}{{ js_attributes }}{{ /if }}
-            {{ if (old | in_array:value) }}checked{{ /if }}
-            {{ if ! old && value === default }}checked{{ /if }}
+            {{ if value|in_array:option }}checked{{ /if }}
             {{ if validate|contains:required }}required{{ /if }}
         >
-        {{ label !== null ? label : value }}
+        {{ label !== null ? label : option }}
     </label>
     {{ unless inline }}
         <br>

--- a/resources/views/extend/forms/fields/default.antlers.html
+++ b/resources/views/extend/forms/fields/default.antlers.html
@@ -1,7 +1,7 @@
 <input
-    type="text"
+    type="{{ input_type ?? 'text' }}"
     name="{{ handle }}"
-    value="{{ old ?? default}}"
+    value="{{ value }}"
     {{ if placeholder }}placeholder="{{ placeholder }}"{{ /if }}
     {{ if character_limit }}maxlength="{{ character_limit }}"{{ /if }}
     {{ if js_driver }}{{ js_attributes }}{{ /if }}

--- a/resources/views/extend/forms/fields/radio.antlers.html
+++ b/resources/views/extend/forms/fields/radio.antlers.html
@@ -1,15 +1,14 @@
-{{ foreach:options as="value|label" }}
+{{ foreach:options as="option|label" }}
     <label>
         <input
             type="radio"
             name="{{ handle }}"
-            value="{{ value }}"
+            value="{{ option }}"
             {{ if js_driver }}{{ js_attributes }}{{ /if }}
-            {{ if old === value }}checked{{ /if }}
-            {{ if ! old && value === default }}checked{{ /if }}
+            {{ if value == option }}checked{{ /if }}
             {{ if validate|contains:required }}required{{ /if }}
         >
-        {{ label !== null ? label : value }}
+        {{ label !== null ? label : option }}
     </label>
     {{ unless inline }}
         <br>

--- a/resources/views/extend/forms/fields/select.antlers.html
+++ b/resources/views/extend/forms/fields/select.antlers.html
@@ -13,9 +13,7 @@
             {{ /if }}
         </option>
     {{ /unless }}
-    {{ foreach:options as="value|label" }}
-        <option value="{{ value }}"{{ if old|in_array:value or old === value }} selected{{ /if }}{{ if ! old && default === value }} selected{{ /if }}>
-            {{ label !== null ? label : value }}
-        </option>
+    {{ foreach:options as="option|label" }}
+        <option value="{{ option }}"{{ if multiple }}{{ if value|in_array:option }} selected{{ /if }}{{ else }}{{ if option == value }} selected{{ /if }}{{ /if }}>
     {{ /foreach:options }}
 </select>

--- a/resources/views/extend/forms/fields/select.antlers.html
+++ b/resources/views/extend/forms/fields/select.antlers.html
@@ -15,5 +15,7 @@
     {{ /unless }}
     {{ foreach:options as="option|label" }}
         <option value="{{ option }}"{{ if multiple }}{{ if value|in_array:option }} selected{{ /if }}{{ else }}{{ if option == value }} selected{{ /if }}{{ /if }}>
+            {{ label !== null ? label : value }}
+        </option>
     {{ /foreach:options }}
 </select>

--- a/resources/views/extend/forms/fields/select.antlers.html
+++ b/resources/views/extend/forms/fields/select.antlers.html
@@ -15,7 +15,7 @@
     {{ /unless }}
     {{ foreach:options as="option|label" }}
         <option value="{{ option }}"{{ if multiple }}{{ if value|in_array:option }} selected{{ /if }}{{ else }}{{ if option == value }} selected{{ /if }}{{ /if }}>
-            {{ label !== null ? label : value }}
+            {{ label !== null ? label : option }}
         </option>
     {{ /foreach:options }}
 </select>

--- a/resources/views/extend/forms/fields/text.antlers.html
+++ b/resources/views/extend/forms/fields/text.antlers.html
@@ -1,7 +1,7 @@
 <input
     type="{{ input_type ?? 'text' }}"
     name="{{ handle }}"
-    value="{{ old ?? default }}"
+    value="{{ value }}"
     {{ if placeholder }}placeholder="{{ placeholder }}"{{ /if }}
     {{ if character_limit }}maxlength="{{ character_limit }}"{{ /if }}
     {{ if js_driver }}{{ js_attributes }}{{ /if }}

--- a/resources/views/extend/forms/fields/textarea.antlers.html
+++ b/resources/views/extend/forms/fields/textarea.antlers.html
@@ -6,5 +6,5 @@
     {{ if js_driver }}{{ js_attributes }}{{ /if }}
     {{ if validate|contains:required }}required{{ /if }}
 >
-    {{ old ?? default }}
+    {{ value }}
 </textarea>

--- a/resources/views/extend/forms/fields/toggle.antlers.html
+++ b/resources/views/extend/forms/fields/toggle.antlers.html
@@ -5,7 +5,7 @@
         name="{{ handle }}"
         value="1"
         {{ if js_driver }}{{ js_attributes }}{{ /if }}
-        {{ if old != '0' && value }}checked{{ /if }}
+        {{ if value && value !== '0' }}checked{{ /if }}
         {{ if validate|contains:required }}required{{ /if }}
     >
     {{ if inline_label }}

--- a/resources/views/extend/forms/fields/toggle.antlers.html
+++ b/resources/views/extend/forms/fields/toggle.antlers.html
@@ -5,7 +5,7 @@
         name="{{ handle }}"
         value="1"
         {{ if js_driver }}{{ js_attributes }}{{ /if }}
-        {{ if ! old && default }}checked{{ /if }}
+        {{ if old != '0' && value }}checked{{ /if }}
         {{ if validate|contains:required }}required{{ /if }}
     >
     {{ if inline_label }}

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -127,9 +127,16 @@ trait RendersForms
     {
         $errors = session('errors') ? session('errors')->getBag($errorBag) : new MessageBag;
 
+        $missing = str_random();
+        $old = old($field->handle(), $missing);
+        $value = $field->value() ?? $field->defaultValue();
+        $value = $old === $missing ? $value : $old;
+
         $data = array_merge($field->toArray(), [
             'error' => $errors->first($field->handle()) ?: null,
+            'default' => $field->value() ?? $field->defaultValue(),
             'old' => old($field->handle()),
+            'value' => $value,
         ]);
 
         if ($manipulateDataCallback instanceof Closure) {

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -134,7 +134,6 @@ trait RendersForms
 
         $data = array_merge($field->toArray(), [
             'error' => $errors->first($field->handle()) ?: null,
-            'default' => $field->value() ?? $field->defaultValue(),
             'old' => old($field->handle()),
             'value' => $value,
         ]);

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -129,8 +129,8 @@ trait RendersForms
 
         $missing = str_random();
         $old = old($field->handle(), $missing);
-        $value = $field->value() ?? $field->defaultValue();
-        $value = $old === $missing ? $value : $old;
+        $default = $field->value() ?? $field->defaultValue();
+        $value = $old === $missing ? $default : $old;
 
         $data = array_merge($field->toArray(), [
             'error' => $errors->first($field->handle()) ?: null,

--- a/tests/Tags/Concerns/RendersFormsTest.php
+++ b/tests/Tags/Concerns/RendersFormsTest.php
@@ -3,12 +3,15 @@
 namespace Tests\Tags\Concerns;
 
 use Statamic\Facades\Antlers;
+use Statamic\Fields\Field;
 use Statamic\Tags\Concerns;
 use Statamic\Tags\Tags;
 use Tests\TestCase;
 
 class RendersFormsTest extends TestCase
 {
+    const MISSING = 'field is missing from request';
+
     public function setUp(): void
     {
         parent::setUp();
@@ -88,6 +91,121 @@ EOT;
         $expected = '<select><option>One</option><option>Two</option></select><label><input type="checkbox">Option <a href="/link">with link</a> text or <span class="tailwind">style</span> class</label><label><input type="radio">Intentionally<a href="/link">tight</a>link or<span class="tailwind">style</span>class</label><textarea>Some <a href="/link">link</a> or <span class="tailwind">styled text</textarea><textarea><a href="/link">Start with</a> and end with a <a href="/link">link</a></textarea>';
 
         $this->assertEquals($expected, $this->tag->minifyFieldHtml($fields));
+    }
+
+    /**
+     * @test
+     * @dataProvider renderTextProvider
+     */
+    public function renders_text_fields($value, $default, $old, $expected)
+    {
+        $config = ['type' => 'text'];
+
+        if ($default) {
+            $config['default'] = $default;
+        }
+
+        $field = new Field('test', $config);
+        $field->setValue($value);
+
+        if ($old !== self::MISSING) {
+            session()->flashInput(['test' => $old]);
+            $this->get('/'); // create a request so the session works.
+        }
+
+        $rendered = $this->tag->getRenderableField($field);
+
+        $this->assertSame($expected, $rendered['value']);
+        $this->assertStringContainsString('value="'.$rendered['value'].'"', $rendered['field']);
+    }
+
+    public function renderTextProvider()
+    {
+        return [
+            'no value, missing' => ['value' => null, 'default' => null, 'old' => self::MISSING, 'expectedValue' => null],
+            'no value, filled' => ['value' => null, 'default' => null, 'old' => 'old', 'expectedValue' => 'old'],
+            'no value, empty' => ['value' => null, 'default' => null, 'old' => null, 'expectedValue' => null],
+
+            'value, missing' => ['value' => 'existing', 'default' => null, 'old' => self::MISSING, 'expectedValue' => 'existing'],
+            'value, filled' => ['value' => 'existing', 'default' => null, 'old' => 'old', 'expectedValue' => 'old'],
+            'value, empty' => ['value' => 'existing', 'default' => null, 'old' => null, 'expectedValue' => null],
+
+            'no value, default, missing' => ['value' => null, 'default' => 'default', 'old' => self::MISSING, 'expectedValue' => 'default'],
+            'no value, default, filled' => ['value' => null, 'default' => 'default', 'old' => 'old', 'expectedValue' => 'old'],
+            'no value, default, empty' => ['value' => null, 'default' => 'default', 'old' => null, 'expectedValue' => null],
+
+            'value, default, missing' => ['value' => 'existing', 'default' => 'default', 'old' => self::MISSING, 'expectedValue' => 'existing'],
+            'value, default, filled' => ['value' => 'existing', 'default' => 'default', 'old' => 'old', 'expectedValue' => 'old'],
+            'value, default, empty' => ['value' => 'existing', 'default' => 'default', 'old' => null, 'expectedValue' => null],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider renderToggleProvider
+     */
+    public function renders_toggles($value, $default, $old, $expected)
+    {
+        $config = ['type' => 'toggle'];
+
+        if ($default) {
+            $config['default'] = $default;
+        }
+
+        $field = new Field('test', $config);
+        $field->setValue($value);
+
+        if ($old !== self::MISSING) {
+            session()->flashInput(['test' => $old]);
+            $this->get('/'); // create a request so the session works.
+        }
+
+        $rendered = $this->tag->getRenderableField($field);
+
+        $this->assertSame($expected, (bool) $rendered['value']);
+
+        if ($expected) {
+            $this->assertStringContainsString('checked', $rendered['field']);
+        } else {
+            $this->assertStringNotContainsString('checked', $rendered['field']);
+        }
+    }
+
+    public function renderToggleProvider()
+    {
+        return [
+            'no value, missing' => ['value' => null, 'default' => null, 'old' => self::MISSING, 'expectedValue' => false],
+            'no value, checked' => ['value' => null, 'default' => null, 'old' => '1', 'expectedValue' => true],
+            'no value, unchecked' => ['value' => null, 'default' => null, 'old' => '0', 'expectedValue' => false],
+
+            'value true, missing' => ['value' => true, 'default' => null, 'old' => self::MISSING, 'expectedValue' => true],
+            'value true, checked' => ['value' => true, 'default' => null, 'old' => '1', 'expectedValue' => true],
+            'value true, unchecked' => ['value' => true, 'default' => null, 'old' => '0', 'expectedValue' => false],
+
+            'value false, missing' => ['value' => false, 'default' => null, 'old' => self::MISSING, 'expectedValue' => false],
+            'value false, checked' => ['value' => false, 'default' => null, 'old' => '1', 'expectedValue' => true],
+            'value false, unchecked' => ['value' => false, 'default' => null, 'old' => '0', 'expectedValue' => false],
+
+            'no value, default true, missing' => ['value' => null, 'default' => true, 'old' => self::MISSING, 'expectedValue' => true],
+            'no value, default true, checked' => ['value' => null, 'default' => true, 'old' => '1', 'expectedValue' => true],
+            'no value, default true, unchecked' => ['value' => null, 'default' => true, 'old' => '0', 'expectedValue' => false],
+
+            'no value, default false, missing' => ['value' => null, 'default' => false, 'old' => self::MISSING, 'expectedValue' => false],
+            'no value, default false, checked' => ['value' => null, 'default' => false, 'old' => '1', 'expectedValue' => true],
+            'no value, default false, unchecked' => ['value' => null, 'default' => false, 'old' => '0', 'expectedValue' => false],
+
+            'value true, default true, missing' => ['value' => true, 'default' => true, 'old' => self::MISSING, 'expectedValue' => true],
+            'value true, default true, checked' => ['value' => true, 'default' => true, 'old' => '1', 'expectedValue' => true],
+            'value true, default true, unchecked' => ['value' => true, 'default' => true, 'old' => '0', 'expectedValue' => false],
+
+            'value true, default false, missing' => ['value' => true, 'default' => false, 'old' => self::MISSING, 'expectedValue' => true],
+            'value true, default false, checked' => ['value' => true, 'default' => false, 'old' => '1', 'expectedValue' => true],
+            'value true, default false, unchecked' => ['value' => true, 'default' => false, 'old' => '0', 'expectedValue' => false],
+
+            'value false, default true, missing' => ['value' => false, 'default' => true, 'old' => self::MISSING, 'expectedValue' => false],
+            'value false, default true, checked' => ['value' => false, 'default' => true, 'old' => '1', 'expectedValue' => true],
+            'value false, default true, unchecked' => ['value' => false, 'default' => true, 'old' => '0', 'expectedValue' => false],
+        ];
     }
 }
 

--- a/tests/Tags/Concerns/RendersFormsTest.php
+++ b/tests/Tags/Concerns/RendersFormsTest.php
@@ -93,13 +93,9 @@ EOT;
         $this->assertEquals($expected, $this->tag->minifyFieldHtml($fields));
     }
 
-    /**
-     * @test
-     * @dataProvider renderTextProvider
-     */
-    public function renders_text_fields($value, $default, $old, $expected)
+    private function createField($type, $value, $default, $old)
     {
-        $config = ['type' => 'text'];
+        $config = ['type' => $type];
 
         if ($default) {
             $config['default'] = $default;
@@ -113,7 +109,16 @@ EOT;
             $this->get('/'); // create a request so the session works.
         }
 
-        $rendered = $this->tag->getRenderableField($field);
+        return $this->tag->getRenderableField($field);
+    }
+
+    /**
+     * @test
+     * @dataProvider renderTextProvider
+     */
+    public function renders_text_fields($value, $default, $old, $expected)
+    {
+        $rendered = $this->createField('text', $value, $default, $old);
 
         $this->assertSame($expected, $rendered['value']);
         $this->assertStringContainsString('value="'.$rendered['value'].'"', $rendered['field']);
@@ -146,21 +151,7 @@ EOT;
      */
     public function renders_toggles($value, $default, $old, $expected)
     {
-        $config = ['type' => 'toggle'];
-
-        if ($default) {
-            $config['default'] = $default;
-        }
-
-        $field = new Field('test', $config);
-        $field->setValue($value);
-
-        if ($old !== self::MISSING) {
-            session()->flashInput(['test' => $old]);
-            $this->get('/'); // create a request so the session works.
-        }
-
-        $rendered = $this->tag->getRenderableField($field);
+        $rendered = $this->createField('toggle', $value, $default, $old);
 
         $this->assertSame($expected, (bool) $rendered['value']);
 


### PR DESCRIPTION
This PR is related to #6400.

Up until now, front-end fields were only used for the "forms" feature where you only ever create items, not edit them. i.e. you only create submissions.

The fields that get rendered would only need to handle default values and old values.

Now with #6400, you'll need to render the fields but also be able to insert existing values.

This PR adds support for existing values.

- `value` is the smarter variable that'll account for the value itself, the previously submitted/old value, or default values.
- The `old`/`default` variables are no longer passed to the views, but stay there for backwards compatibility.
- A bunch of tests are added to make sure appropriate checkboxes are checked, options selected, fields filled, etc.