### PR TITLE
Fix handling for empty checkboxes fieldtype on front-end

### DIFF
--- a/resources/views/extend/forms/fields/checkboxes.antlers.html
+++ b/resources/views/extend/forms/fields/checkboxes.antlers.html
@@ -1,3 +1,4 @@
+<input type="hidden" name="{{ handle }}[]">
 {{ foreach:options as="option|label" }}
     <label>
         <input

--- a/tests/Tags/Concerns/RendersFormsTest.php
+++ b/tests/Tags/Concerns/RendersFormsTest.php
@@ -186,6 +186,7 @@ EOT;
         $rendered = $this->createField('toggle', $value, $default, $old);
 
         $this->assertSame($expected, (bool) $rendered['value']);
+        $this->assertStringContainsString('<input type="hidden" name="test" value="0">', $rendered['field']);
 
         if ($expected) {
             $this->assertStringContainsString('checked', $rendered['field']);

--- a/tests/Tags/Concerns/RendersFormsTest.php
+++ b/tests/Tags/Concerns/RendersFormsTest.php
@@ -354,6 +354,8 @@ EOT;
             ],
         ]);
 
+        $this->assertStringContainsString('<input type="hidden" name="test[]">', $rendered['field']);
+
         if ($expected) {
             $unexpected = array_diff(array_keys($options), $expected);
             foreach ($expected as $e) {
@@ -379,18 +381,22 @@ EOT;
             'no value, no default, missing' => ['value' => null, 'default' => null, 'old' => self::MISSING, 'expectedValue' => null],
             'no value, no default, selected' => ['value' => null, 'default' => null, 'old' => ['alfa'], 'expectedValue' => ['alfa']],
             'no value, no default, selected multiple' => ['value' => null, 'default' => null, 'old' => ['alfa', 'bravo'], 'expectedValue' => ['alfa', 'bravo']],
+            'no value, no default, selected none' => ['value' => null, 'default' => null, 'old' => [], 'expectedValue' => []],
 
             'value, no default, missing' => ['value' => ['alfa'], 'default' => null, 'old' => self::MISSING, 'expectedValue' => ['alfa']],
             'value, no default, selected' => ['value' => ['alfa'], 'default' => null, 'old' => ['bravo'], 'expectedValue' => ['bravo']],
             'value, no default, selected multiple' => ['value' => ['alfa'], 'default' => null, 'old' => ['bravo', 'charlie'], 'expectedValue' => ['bravo', 'charlie']],
+            'value, no default, selected none' => ['value' => ['alfa'], 'default' => null, 'old' => [], 'expectedValue' => []],
 
             'no value, default, missing' => ['value' => null, 'default' => ['alfa'], 'old' => self::MISSING, 'expectedValue' => ['alfa']],
             'no value, default, selected' => ['value' => null, 'default' => ['alfa'], 'old' => ['bravo'], 'expectedValue' => ['bravo']],
             'no value, default, selected multiple' => ['value' => null, 'default' => ['alfa'], 'old' => ['bravo', 'charlie'], 'expectedValue' => ['bravo', 'charlie']],
+            'no value, default, selected none' => ['value' => null, 'default' => ['alfa'], 'old' => [], 'expectedValue' => []],
 
             'value, default, missing' => ['value' => ['alfa'], 'default' => ['bravo'], 'old' => self::MISSING, 'expectedValue' => ['alfa']],
             'value, default, selected' => ['value' => ['alfa'], 'default' => ['bravo'], 'old' => ['charlie'], 'expectedValue' => ['charlie']],
             'value, default, selected multiple' => ['value' => ['alfa'], 'default' => ['bravo'], 'old' => ['charlie', 'delta'], 'expectedValue' => ['charlie', 'delta']],
+            'value, default, selected none' => ['value' => ['alfa'], 'default' => ['bravo'], 'old' => [], 'expectedValue' => []],
         ];
     }
 }


### PR DESCRIPTION
Continuation of #7178

Previously, if you uncheck all the boxes in a `checkboxes` field on the frontend, it would act like the field wasn't submitted at all, so the previous value would be used.

This PR adds a hidden field with an empty value. So if you uncheck all the options, an empty value still gets submitted, so the value will be updated to nothing, as expected.

Added a test to ensure that the hidden field is in the html.
Add equivalent test for toggle field while we're at it, which relies on the same behavior.

Again, this only matters for #6400 since at the moment front-end fields are only used for forms, which are create-only at the moment.