### PR TITLE
Add Bard Heading Shortcut to create Headings with custom link target

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -95,7 +95,6 @@ import {
     Blockquote,
     CodeBlock,
     HardBreak,
-    Heading,
     HorizontalRule,
     OrderedList,
     BulletList,
@@ -116,6 +115,7 @@ import Set from './Set';
 import Doc from './Doc';
 import BardSource from './Source.vue';
 import Link from './Link';
+import Heading from './Heading';
 import Image from './Image';
 import Small from './Small';
 import Subscript from './Subscript';

--- a/resources/js/components/fieldtypes/bard/Heading.js
+++ b/resources/js/components/fieldtypes/bard/Heading.js
@@ -1,0 +1,51 @@
+import { Heading as TipTapHeading } from "tiptap-extensions";
+import { textblockTypeInputRule } from 'tiptap-commands'
+
+/**
+ * Matches following attributes: [id]
+ *
+ * Example:
+ * ##{#my-heading} -> <h2 id="my-heading"></h2>
+ */
+
+const HEADING_INPUT_REGEX = /^(#{1,6})(?:\{#(.+)\})?\s/
+
+export default class Heading extends TipTapHeading {
+    get schema() {
+        return {
+            ...super.schema,
+            attrs: {
+                level: { default: 1 },
+                id: { default: null },
+            },
+            parseDOM: this.options.levels
+                .map(level => ({
+                    tag: `h${level}`,
+                    getAttrs: dom => ({
+                        level: level,
+                        id: dom.getAttribute('id'),
+                    }),
+                })),
+            toDOM: node => {
+                node.attrs.id = node.attrs.id;
+                return [`h${node.attrs.level}`, {
+                    id: node.attrs.id
+                }, 0];
+            }
+        };
+    }
+
+  inputRules({ type }) {
+    return [
+      textblockTypeInputRule(HEADING_INPUT_REGEX, type, match => {
+        let [, level, id] = match
+        level = level.length
+
+        return {
+          level,
+          id,
+        }
+      }),
+    ]
+  }
+}

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -4,11 +4,13 @@ namespace Statamic\Fieldtypes\Bard;
 
 use ProseMirrorToHtml\Marks\Link as DefaultLinkMark;
 use ProseMirrorToHtml\Nodes\Image as DefaultImageNode;
+use ProseMirrorToHtml\Nodes\Heading as DefaultHeadingNode;
 use ProseMirrorToHtml\Renderer;
 use Statamic\Fields\Field;
 use Statamic\Fields\Value;
 use Statamic\Fields\Values;
 use Statamic\Fieldtypes\Bard\ImageNode as CustomImageNode;
+use Statamic\Fieldtypes\Bard\HeadingNode as CustomHeadingNode;
 use Statamic\Fieldtypes\Bard\LinkMark as CustomLinkMark;
 use Statamic\Fieldtypes\Text;
 use Statamic\Support\Arr;
@@ -110,6 +112,7 @@ class Augmentor
 
         $renderer = (new Renderer)
             ->replaceNode(DefaultImageNode::class, $customImageNode)
+            ->replaceNode(DefaultHeadingNode::class, CustomHeadingNode::class)
             ->replaceMark(DefaultLinkMark::class, $customLinkMark)
             ->addNode(SetNode::class)
             ->addNodes(static::$customNodes)

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -3,14 +3,14 @@
 namespace Statamic\Fieldtypes\Bard;
 
 use ProseMirrorToHtml\Marks\Link as DefaultLinkMark;
-use ProseMirrorToHtml\Nodes\Image as DefaultImageNode;
 use ProseMirrorToHtml\Nodes\Heading as DefaultHeadingNode;
+use ProseMirrorToHtml\Nodes\Image as DefaultImageNode;
 use ProseMirrorToHtml\Renderer;
 use Statamic\Fields\Field;
 use Statamic\Fields\Value;
 use Statamic\Fields\Values;
-use Statamic\Fieldtypes\Bard\ImageNode as CustomImageNode;
 use Statamic\Fieldtypes\Bard\HeadingNode as CustomHeadingNode;
+use Statamic\Fieldtypes\Bard\ImageNode as CustomImageNode;
 use Statamic\Fieldtypes\Bard\LinkMark as CustomLinkMark;
 use Statamic\Fieldtypes\Text;
 use Statamic\Support\Arr;

--- a/src/Fieldtypes/Bard/HeadingNode.php
+++ b/src/Fieldtypes/Bard/HeadingNode.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Statamic\Fieldtypes\Bard;
+
+use ProseMirrorToHtml\Nodes\Node;
+
+class HeadingNode extends Node
+{
+    protected $nodeType = 'heading';
+
+    public function tag()
+    {
+        $attrs = [];
+        if (isset($this->node->attrs)) {
+            if (isset($this->node->attrs->id)) {
+                $attrs['id'] = $this->node->attrs->id;
+            }
+        }
+
+        return [
+            [
+                'tag' =>  "h{$this->node->attrs->level}",
+                'attrs' => $attrs,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR addresses [idea #289](https://github.com/statamic/ideas/issues/289).

This PR adds support to set a custom link target on Bard Headings using a shorthand syntax. I was thinking about adding automatically generated link targets for every heading, but this could have too much impact on existing sites. Instead, with the following shortcut, the user can optionally add a link target.

The input rule shortcut `##{#my-anchor}` gets converted into `<h2 id="my-anchor"></h2>`. This syntax is inspired by php [Markdown Extra to set attributes on certain elements](https://michelf.ca/projects/php-markdown/extra/#header-id).

I have also added a paste rule which parses the id of existing link targets when user pastes formatted html into the Bard Editor.

I'm happy for your feedback :) 

Here you can see the feature in action:

![2022-12-09 12 18 36](https://user-images.githubusercontent.com/1102712/206691152-939ea712-d3b3-44b3-816d-de0c643d1a10.gif)

