### PR TITLE
Ability to use separate queue for Static Cache warm

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -115,11 +115,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Queue name
+    | Warm Queue
     |--------------------------------------------------------------------------
     |
-    | Here you may define what queue should be used when adding warm requests.
+    | Here you may define the name of the queue that requests will be pushed
+    | onto when warming the static cache using the static:warm command.
     |
     */
-    'warm_queue_name' => 'default',
+
+    'warm_queue' => 'default',
+
 ];

--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -123,6 +123,6 @@ return [
     |
     */
 
-    'warm_queue' => 'default',
+    'warm_queue' => null,
 
 ];

--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -113,4 +113,13 @@ return [
         \Statamic\StaticCaching\Replacers\NoCacheReplacer::class,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Queue name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define what queue should be used when adding warm requests.
+    |
+    */
+    'warm_queue_name' => 'default',
 ];

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -85,10 +85,11 @@ class StaticWarm extends Command
         $this->output->newLine();
 
         if ($this->shouldQueue) {
-            $this->line('Queueing '.count($requests).' requests...');
+            $staticWarmQueue = env('STATAMIC_STATIC_WARM_QUEUE', 'default');
+            $this->line('Adding '.count($requests).' requests on queue "' . $staticWarmQueue . '"...');
 
             foreach ($requests as $request) {
-                StaticWarmJob::dispatch($request);
+                StaticWarmJob::dispatch($request)->onQueue($staticWarmQueue);
             }
         } else {
             $this->line('Visiting '.count($requests).' URLs...');

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -85,11 +85,11 @@ class StaticWarm extends Command
         $this->output->newLine();
 
         if ($this->shouldQueue) {
-            $staticWarmQueue = config('statamic.static_caching.warm_queue_name', 'default');
-            $this->line('Adding '.count($requests).' requests on queue "'.$staticWarmQueue.'"...');
+            $queue = config('statamic.static_caching.warm_queue', 'default');
+            $this->line('Adding '.count($requests).' requests on queue "'.$queue.'"...');
 
             foreach ($requests as $request) {
-                StaticWarmJob::dispatch($request)->onQueue($staticWarmQueue);
+                StaticWarmJob::dispatch($request)->onQueue($queue);
             }
         } else {
             $this->line('Visiting '.count($requests).' URLs...');

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -85,7 +85,7 @@ class StaticWarm extends Command
         $this->output->newLine();
 
         if ($this->shouldQueue) {
-            $staticWarmQueue = env('STATAMIC_STATIC_WARM_QUEUE', 'default');
+            $staticWarmQueue = config('statamic.static_caching.warm_queue_name', 'default');
             $this->line('Adding '.count($requests).' requests on queue "'.$staticWarmQueue.'"...');
 
             foreach ($requests as $request) {

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -86,7 +86,7 @@ class StaticWarm extends Command
 
         if ($this->shouldQueue) {
             $staticWarmQueue = env('STATAMIC_STATIC_WARM_QUEUE', 'default');
-            $this->line('Adding '.count($requests).' requests on queue "' . $staticWarmQueue . '"...');
+            $this->line('Adding '.count($requests).' requests on queue "'.$staticWarmQueue.'"...');
 
             foreach ($requests as $request) {
                 StaticWarmJob::dispatch($request)->onQueue($staticWarmQueue);

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -85,8 +85,8 @@ class StaticWarm extends Command
         $this->output->newLine();
 
         if ($this->shouldQueue) {
-            $queue = config('statamic.static_caching.warm_queue', 'default');
-            $this->line('Adding '.count($requests).' requests on queue "'.$queue.'"...');
+            $queue = config('statamic.static_caching.warm_queue');
+            $this->line(sprintf('Adding %s requests onto %squeue...', count($requests), $queue ? $queue.' ' : ''));
 
             foreach ($requests as $request) {
                 StaticWarmJob::dispatch($request)->onQueue($queue);


### PR DESCRIPTION
Having a big site with lots of entries, in my case 1000+, the cache warming using queue would fill the "default" queue making other more important jobs be really delayed. Adding this change would allow us to put the StaticWarm job on a separate queue and allows us to process the queue on a separate queue worker.

By changing `config/statamic/stache.php` and setting the key `warm_queue_name` to something else, jobs added to the warm queue with use this queue instead.

This will also fallback on default (current) behaviour so it should not be breaking anything.