### PR TITLE
Add ability to define default host in absoluteUrl of Site

### DIFF
--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -65,10 +65,10 @@ class Site implements Augmentable
         return $this->config['attributes'] ?? [];
     }
 
-    public function absoluteUrl()
+    public function absoluteUrl(string $defaultHost = null)
     {
         if (Str::startsWith($url = $this->url(), '/')) {
-            $url = Str::ensureLeft($url, request()->getSchemeAndHttpHost());
+            $url = Str::ensureLeft($url, $defaultHost ?? request()->getSchemeAndHttpHost());
         }
 
         return Str::removeRight($url, '/');


### PR DESCRIPTION
This is to add the ability for setting a default value for the host for the returned absolute url instead of only using the request host and scheme.