### PR TITLE
Ensure CacheServiceProvider honours 'permission'

### DIFF
--- a/src/Providers/CacheServiceProvider.php
+++ b/src/Providers/CacheServiceProvider.php
@@ -40,7 +40,8 @@ class CacheServiceProvider extends ServiceProvider
             Cache::extend('statamic', function () {
                 return Cache::repository(new FileStore(
                     $this->app['files'],
-                    $this->app['config']['cache.stores.file']['path']
+                    $this->app['config']['cache.stores.file']['path'],
+                    $this->app['config']['cache.stores.file']['permission']
                 ));
             });
 

--- a/src/Providers/CacheServiceProvider.php
+++ b/src/Providers/CacheServiceProvider.php
@@ -41,7 +41,7 @@ class CacheServiceProvider extends ServiceProvider
                 return Cache::repository(new FileStore(
                     $this->app['files'],
                     $this->app['config']['cache.stores.file']['path'],
-                    $this->app['config']['cache.stores.file']['permission']
+                    $this->app['config']['cache.stores.file']['permission'] ?? null
                 ));
             });
 


### PR DESCRIPTION
Laravel has a `$filePermission` parameter on `Illuminate\Cache\FileStore` [see here](https://github.com/laravel/framework/blob/1c10e4ff6dfca0761a6822eae2146a02edffde89/src/Illuminate/Cache/FileStore.php#L46), which allows allows a developer to control the filesystem permissions assigned to files created by Laravel within the cache.

Helpfully, this parameter can be set in `config/cache.php` and is used with configuring the cache [see here](https://github.com/laravel/framework/blob/1c10e4ff6dfca0761a6822eae2146a02edffde89/src/Illuminate/Cache/CacheManager.php#L158).

Statamic extends/overrides this driver but fails to honour the permission specified in config (and does this using a private method in the service provider, making it impossible to fix locally by extending the provider). 

This small PR fixes this inconsistency / oversight.