### PR TITLE
allow version ^6.0 of symfony/var-exporter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "statamic/stringy": "^3.1.2",
         "symfony/http-foundation": "^4.3.3 || ^5.1.4 || ^6.0",
         "symfony/lock": "^5.1",
-        "symfony/var-exporter": "^4.3 || ^5.1",
+        "symfony/var-exporter": "^4.3 || ^5.1 || ^6.0",
         "symfony/yaml": "^4.1 || ^5.1 || ^6.0",
         "ueberdosis/html-to-prosemirror": "^1.3",
         "ueberdosis/prosemirror-to-html": "^2.6",


### PR DESCRIPTION
Other packages are starting to require v6 of symfony components (including laravel). Ran into an issue when installing into an existing application.

[No major BC breaks listed](https://github.com/symfony/var-exporter/blob/6.2/CHANGELOG.md) so with unit tests passing this should be safe to upgrade.