### PR TITLE
Fix asset thumbnails/file-icons in entry listings and assets field

### DIFF
--- a/resources/js/components/assets/Browser/Thumbnail.vue
+++ b/resources/js/components/assets/Browser/Thumbnail.vue
@@ -3,13 +3,13 @@
     <div class="">
         <img v-if="asset.is_image"
             :src="asset.thumbnail"
-            class="asset-thumbnail rounded max-h-full max-w-full mx-auto rounded"
+            class="asset-thumbnail max-h-8 max-w-full mx-auto rounded"
             loading="lazy"
             :class="{'w-8 h-8 fit-cover': square}"
             />
         <img v-else-if="asset.is_svg"
             :src="asset.url"
-            class="asset-thumbnail rounded h-8 max-h-full max-w-full mx-auto rounded"
+            class="asset-thumbnail h-8 max-w-full mx-auto rounded"
             loading="lazy"
             />
         <file-icon v-else :extension="asset.extension" class="p-px asset-thumbnail rounded w-full h-full" />

--- a/resources/js/components/assets/Browser/Thumbnail.vue
+++ b/resources/js/components/assets/Browser/Thumbnail.vue
@@ -12,7 +12,7 @@
             class="asset-thumbnail h-8 max-w-full mx-auto rounded"
             loading="lazy"
             />
-        <file-icon v-else :extension="asset.extension" class="p-px asset-thumbnail rounded w-full h-full" />
+        <file-icon v-else :extension="asset.extension" class="p-px asset-thumbnail rounded w-8 h-8" />
     </div>
 
 </template>

--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -18,7 +18,7 @@
                     :alt="asset.basename"
                     v-if="isImage"
                 />
-                <file-icon :extension="asset.extension" v-else />
+                <file-icon :extension="asset.extension" v-else class="w-7 h-7" />
             </button>
             <button
                 v-if="showFilename"

--- a/resources/sass/core/utilities.scss
+++ b/resources/sass/core/utilities.scss
@@ -141,6 +141,10 @@
     object-fit: cover;
 }
 
+.max-h-8 {
+    max-height: 32px;
+}
+
 .ratio-4\:3 {
     padding-top: 75%;
 }

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -231,7 +231,7 @@ class Assets extends Fieldtype
             if ($isImage) {
                 $arr['thumbnail'] = cp_route('assets.thumbnails.show', [
                     'encoded_asset' => base64_encode($asset->id()),
-                    'size' => 'thumbnail',
+                    'size' => 'small',
                 ]);
             }
 


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/7192
Fixes https://github.com/statamic/cms/issues/7024

This PR fixes a couple of issues with asset thumbnails/file-icons.

## Thumbnail size in entry listings (https://github.com/statamic/cms/issues/7192)

The size has been changed from `thumbnail` to `small`, as `thumbnail` seems to return the full-size image.

## Asset thumbnails not showing in entry listings in Safari (https://github.com/statamic/cms/issues/7024)

I've found various mentions of Safari bugs around flexbox and children with percentage based max-height values, and that certainly seems to be what's causing this. Since both of the places where `<asset-thumbnail>` is used set `h-8` on the parent, changing the `max-h-full` to `max-h-8` doesn't affect the layout but does avoid the Safari bug(s).

I also removed the duplicate `rounded` class.

## Asset thumbnail file icon widths in entry listings

Icons were set to `w-full`, but that's `3xs` in an entry listing, leaving empty space either side:

![Screenshot 2022-12-10 at 15 34 21](https://user-images.githubusercontent.com/126740/206863798-0656834a-c0fb-4933-b213-d19ce9cc109b.png)

Giving them `w-8` instead fixes it:

![Screenshot 2022-12-10 at 15 34 12](https://user-images.githubusercontent.com/126740/206863803-a725cbc9-934d-4605-afed-3d6dcad03730.png)

## File icons in asset list fields in Safari

Stumbled on another Safari-only bug, the file icons are missing in asset list fields:

![Screenshot 2022-12-10 at 15 38 46](https://user-images.githubusercontent.com/126740/206863845-cfa8747e-4a39-4ed3-9a15-e046182f5481.png)

Giving them dimensions just like the thumbnails have fixed it:

![Screenshot 2022-12-10 at 15 39 03](https://user-images.githubusercontent.com/126740/206863864-da5619b3-aab6-4771-b37e-8dba535539cc.png)
