### PR TITLE
Improve support:details command with information about Stache and Static Caching

### DIFF
--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -28,9 +28,9 @@ class SupportDetails extends Command
         $this->line(sprintf('<info>Statamic</info> %s %s', Statamic::version(), Statamic::pro() ? 'Pro' : 'Solo'));
         $this->line('<info>Laravel</info> '.Application::VERSION);
         $this->line('<info>PHP</info> '.phpversion());
-	$this->line(sprintf('<info>Stache Watcher</info> %s', config('statamic.stache.watcher') ? 'Enabled' : 'Disabled'));
-	$this->line(sprintf('<info>Static Caching</info> %s', config('statamic.static_caching.strategy') ?: 'None'));
-	$this->addons();
+	    $this->line(sprintf('<info>Stache Watcher</info> %s', config('statamic.stache.watcher') ? 'Enabled' : 'Disabled'));
+	    $this->line(sprintf('<info>Static Caching</info> %s', config('statamic.static_caching.strategy') ?: 'None'));
+	    $this->addons();
         return static::SUCCESS;
     }
 

--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -28,8 +28,9 @@ class SupportDetails extends Command
         $this->line(sprintf('<info>Statamic</info> %s %s', Statamic::version(), Statamic::pro() ? 'Pro' : 'Solo'));
         $this->line('<info>Laravel</info> '.Application::VERSION);
         $this->line('<info>PHP</info> '.phpversion());
-        $this->addons();
-
+	$this->line(sprintf('<info>Stache Watcher</info> %s', config('statamic.stache.watcher') ? 'Enabled' : 'Disabled'));
+	$this->line(sprintf('<info>Static Caching</info> %s', config('statamic.static_caching.strategy') ?: 'None'));
+	$this->addons();
         return static::SUCCESS;
     }
 

--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -29,7 +29,7 @@ class SupportDetails extends Command
         $this->line('<info>Laravel</info> '.Application::VERSION);
         $this->line('<info>PHP</info> '.phpversion());
         $this->line(sprintf('<info>Stache Watcher</info> %s', config('statamic.stache.watcher') ? 'Enabled' : 'Disabled'));
-        $this->line(sprintf('<info>Static Caching</info> %s', config('statamic.static_caching.strategy') ?: 'None'));
+        $this->line(sprintf('<info>Static Caching</info> %s', config('statamic.static_caching.strategy') ?: 'Disabled'));
         $this->addons();
 
         return static::SUCCESS;

--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -31,7 +31,7 @@ class SupportDetails extends Command
         $this->line(sprintf('<info>Stache Watcher</info> %s', config('statamic.stache.watcher') ? 'Enabled' : 'Disabled'));
         $this->line(sprintf('<info>Static Caching</info> %s', config('statamic.static_caching.strategy') ?: 'None'));
         $this->addons();
-        
+
         return static::SUCCESS;
     }
 

--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -31,6 +31,7 @@ class SupportDetails extends Command
         $this->line(sprintf('<info>Stache Watcher</info> %s', config('statamic.stache.watcher') ? 'Enabled' : 'Disabled'));
         $this->line(sprintf('<info>Static Caching</info> %s', config('statamic.static_caching.strategy') ?: 'None'));
         $this->addons();
+        
         return static::SUCCESS;
     }
 

--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -28,9 +28,9 @@ class SupportDetails extends Command
         $this->line(sprintf('<info>Statamic</info> %s %s', Statamic::version(), Statamic::pro() ? 'Pro' : 'Solo'));
         $this->line('<info>Laravel</info> '.Application::VERSION);
         $this->line('<info>PHP</info> '.phpversion());
-	    $this->line(sprintf('<info>Stache Watcher</info> %s', config('statamic.stache.watcher') ? 'Enabled' : 'Disabled'));
-	    $this->line(sprintf('<info>Static Caching</info> %s', config('statamic.static_caching.strategy') ?: 'None'));
-	    $this->addons();
+        $this->line(sprintf('<info>Stache Watcher</info> %s', config('statamic.stache.watcher') ? 'Enabled' : 'Disabled'));
+        $this->line(sprintf('<info>Static Caching</info> %s', config('statamic.static_caching.strategy') ?: 'None'));
+        $this->addons();
         return static::SUCCESS;
     }
 

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -181,6 +181,8 @@ class AppServiceProvider extends ServiceProvider
             'Version' => fn () => Statamic::version().' '.(Statamic::pro() ? '<fg=yellow;options=bold>PRO</>' : 'Solo'),
             'Antlers' => config('statamic.antlers.version'),
             'Addons' => $addons->count(),
+	    'Stache Watcher' => config('statamic.stache.watcher') ? 'Enabled' : 'Disabled',
+	    'Static Caching' => config('statamic.static_caching.strategy') ?: 'None',
         ]);
 
         foreach ($addons as $addon) {

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -181,8 +181,8 @@ class AppServiceProvider extends ServiceProvider
             'Version' => fn () => Statamic::version().' '.(Statamic::pro() ? '<fg=yellow;options=bold>PRO</>' : 'Solo'),
             'Antlers' => config('statamic.antlers.version'),
             'Addons' => $addons->count(),
-	    'Stache Watcher' => config('statamic.stache.watcher') ? 'Enabled' : 'Disabled',
-	    'Static Caching' => config('statamic.static_caching.strategy') ?: 'None',
+            'Stache Watcher' => config('statamic.stache.watcher') ? 'Enabled' : 'Disabled',
+            'Static Caching' => config('statamic.static_caching.strategy') ?: 'None',
         ]);
 
         foreach ($addons as $addon) {

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -182,7 +182,7 @@ class AppServiceProvider extends ServiceProvider
             'Antlers' => config('statamic.antlers.version'),
             'Addons' => $addons->count(),
             'Stache Watcher' => config('statamic.stache.watcher') ? 'Enabled' : 'Disabled',
-            'Static Caching' => config('statamic.static_caching.strategy') ?: 'None',
+            'Static Caching' => config('statamic.static_caching.strategy') ?: 'Disabled',
         ]);
 
         foreach ($addons as $addon) {


### PR DESCRIPTION
Adds additional details about whether the Stache Watcher is enabled and which Static Caching strategy is bein used to the output of the `php please support:details` command. Works with the new `artisan about` command (Laravel 9+) and prior versions.

Before:
```
Statamic
Addons: 0
Antlers: regex
Version: 3.3.x-dev PRO
```

After:
```
Statamic
Addons: 0
Antlers: regex
Stache Watcher: Disabled
Static Caching: None
Version: 3.3.x-dev PRO
```