### PR TITLE
Fix utility route authorization

### DIFF
--- a/src/CP/Utilities/UtilityRepository.php
+++ b/src/CP/Utilities/UtilityRepository.php
@@ -49,12 +49,14 @@ class UtilityRepository
             $this->all()->each(function ($utility) {
                 if ($utility->action()) {
                     Route::get($utility->slug(), $utility->action())
+                        ->middleware("can:access {$utility->handle()} utility")
                         ->name($utility->slug());
                 }
 
                 if ($routeClosure = $utility->routes()) {
                     Route::name($utility->slug().'.')
                         ->prefix($utility->slug())
+                        ->middleware("can:access {$utility->handle()} utility")
                         ->group(function () use ($routeClosure) {
                             $routeClosure(Route::getFacadeRoot());
                         });

--- a/src/Http/Controllers/CP/Utilities/UpdateSearchController.php
+++ b/src/Http/Controllers/CP/Utilities/UpdateSearchController.php
@@ -8,13 +8,6 @@ use Statamic\Http\Controllers\CP\CpController;
 
 class UpdateSearchController extends CpController
 {
-    public function index()
-    {
-        return view('statamic::utilities.search', [
-            'indexes' => Search::indexes(),
-        ]);
-    }
-
     public function update(Request $request)
     {
         $indexes = collect($request->validate([


### PR DESCRIPTION
Fixes #7209

Currently authorization only removed the items from the navs. This PR adds it to the routes themselves to make them inaccessible.

Aside: I also noticed that the search page no longer uses the controller method so I removed that.