### PR TITLE
Close color picker on save

### DIFF
--- a/resources/js/components/fieldtypes/ColorFieldtype.vue
+++ b/resources/js/components/fieldtypes/ColorFieldtype.vue
@@ -22,7 +22,7 @@ export default {
     },
 
     mounted() {
-        const pickr = new Pickr({
+        const pickr = new Pickr ({
             el: this.$el,
             disabled: this.isReadOnly,
             lockOpacity: this.config.lock_opacity,

--- a/resources/js/components/fieldtypes/ColorFieldtype.vue
+++ b/resources/js/components/fieldtypes/ColorFieldtype.vue
@@ -22,7 +22,7 @@ export default {
     },
 
     mounted() {
-        const pickr = new Pickr ({
+        const pickr = new Pickr({
             el: this.$el,
             disabled: this.isReadOnly,
             lockOpacity: this.config.lock_opacity,
@@ -65,6 +65,7 @@ export default {
                 // Color was manually cleared
                 this.update(null);
             }
+            pickr.hide();
         });
     }
 


### PR DESCRIPTION
The color picker closes when you hit Clear but not when you hit Save, which is kind of odd and means you then have to click again (outside the picker) or hit Escape to close it.

The PR hides the picker when you hit Save.