### PR TITLE
GitHub workflow for when PRs arent editable

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -56,7 +56,7 @@ jobs:
               if (!pullRequest.maintainerCanModify) {
                 console.log('PR not owned by statamic and does not have maintainer edits enabled');
 
-                await github.issues.createComment({
+                await github.rest.issues.createComment({
                   issue_number: pullNumber,
                   owner: 'statamic',
                   repo,

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,75 @@
+name: Pull Requests
+
+# Credit: https://github.com/github/docs/blob/main/.github/workflows/notify-when-maintainers-cannot-edit.yaml
+#         https://github.com/laravel/.github/blob/main/.github/workflows/pull-requests.yml
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  notify-when-maintainers-cannot-edit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const repo = context.repo.repo;
+
+            const query = `
+              query($number: Int!) {
+                repository(owner: "statamic", name: "${repo}") {
+                  pullRequest(number: $number) {
+                    headRepositoryOwner {
+                      login
+                    }
+                    maintainerCanModify
+                    state
+                  }
+                }
+              }
+            `;
+
+            const pullNumber = context.issue.number;
+            const variables = { number: pullNumber };
+
+            try {
+              console.log(`Check for maintainer edit access ...`);
+              const result = await github.graphql(query, variables);
+              console.log(JSON.stringify(result, null, 2));
+              const pullRequest = result.repository.pullRequest;
+
+              if (pullRequest.headRepositoryOwner.login === 'statamic') {
+                console.log('PR owned by statamic');
+                return;
+              }
+
+              if (pullRequest.state !== 'OPEN') {
+                 console.log('PR has already been closed or merged');
+                 return;
+              }
+
+              if (!pullRequest.maintainerCanModify) {
+                console.log('PR not owned by statamic and does not have maintainer edits enabled');
+
+                await github.issues.createComment({
+                  issue_number: pullNumber,
+                  owner: 'statamic',
+                  repo,
+                  body: "Thanks for submitting a PR!\n\nIn order to review and merge PRs most efficiently, we require that all PRs grant maintainer edit access before we review them. For information on how to do this, [see the relevant GitHub documentation](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork). Additionally, GitHub doesn't allow maintainer permissions from organization accounts. Please resubmit this PR from a personal GitHub account with maintainer permissions enabled."
+                });
+
+                await github.rest.pulls.update({
+                  pull_number: pullNumber,
+                  owner: 'statamic',
+                  repo,
+                  state: 'closed'
+                });
+              }
+            } catch(e) {
+              console.log(e);
+            }

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  notify-when-maintainers-cannot-edit:
+  uneditable:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6


### PR DESCRIPTION
We often like to make small (or sometimes not so small) modifications to PRs without needing to ask the submitter to make it themselves. It's easier that way.

If a PR is opened from an account where we don't have maintainer permissions, we can't make those edits, and it's very frustrating. Typically it's when the fork is on an organization account.

This PR adds a GitHub action workflow that will close the PR and leave a comment asking the user to resubmit it from an account with appropriate permissions enabled.

It's basically a copy of what Laravel does. See laravel/framework#41839
