### PR TITLE
Fix default preferences not being tracked with git integration

### DIFF
--- a/config/git.php
+++ b/config/git.php
@@ -101,6 +101,7 @@ return [
         resource_path('fieldsets'),
         resource_path('forms'),
         resource_path('users'),
+        resource_path('preferences.yaml'),
         storage_path('forms'),
     ],
 

--- a/src/Events/Concerns/ListensForContentEvents.php
+++ b/src/Events/Concerns/ListensForContentEvents.php
@@ -51,6 +51,7 @@ trait ListensForContentEvents
         \Statamic\Events\UserGroupDeleted::class,
         \Statamic\Events\UserGroupSaved::class,
         \Statamic\Events\UserSaved::class,
+        \Statamic\Events\DefaultPreferencesSaved::class,
         \Statamic\Events\DuplicateIdRegenerated::class,
     ];
 }

--- a/src/Events/DefaultPreferencesSaved.php
+++ b/src/Events/DefaultPreferencesSaved.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Events;
+
+use Statamic\Contracts\Git\ProvidesCommitMessage;
+
+class DefaultPreferencesSaved extends Event implements ProvidesCommitMessage
+{
+    public function commitMessage()
+    {
+        return __('Default preferences saved', [], config('statamic.git.locale'));
+    }
+}

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -148,7 +148,7 @@ class Git
      */
     protected function gitProcessForPath($path)
     {
-        return is_link($path)
+        return is_link($path) || is_file($path)
             ? GitProcess::create($path)->fromParent()
             : GitProcess::create($path);
     }

--- a/src/Preferences/DefaultPreferences.php
+++ b/src/Preferences/DefaultPreferences.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Preferences;
 
+use Statamic\Events\DefaultPreferencesSaved;
 use Statamic\Facades\File;
 use Statamic\Facades\YAML;
 
@@ -40,6 +41,8 @@ class DefaultPreferences
     public function save()
     {
         File::put($this->path, YAML::dump($this->preferences));
+
+        DefaultPreferencesSaved::dispatch();
 
         return true;
     }

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -217,6 +217,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Updates\AddUniqueSlugValidation::class,
         Updates\AddGraphQLPermission::class,
         Updates\AddAssignRolesAndGroupsPermissions::class,
+        Updates\AddDefaultPreferencesToGitConfig::class,
     ];
 
     public function register()

--- a/src/UpdateScripts/AddDefaultPreferencesToGitConfig.php
+++ b/src/UpdateScripts/AddDefaultPreferencesToGitConfig.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Statamic\UpdateScripts;
+
+use Statamic\Facades\File;
+use Statamic\Support\Str;
+
+class AddDefaultPreferencesToGitConfig extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('3.3.62');
+    }
+
+    public function update()
+    {
+        if (! File::exists($path = config_path('statamic/git.php'))) {
+            return;
+        }
+
+        $config = File::get($path);
+
+        $addBelow = <<<'EOT'
+        resource_path('forms'),
+        resource_path('users'),
+EOT;
+
+        $replacement = <<<'EOT'
+        resource_path('forms'),
+        resource_path('users'),
+        resource_path('preferences.yaml'),
+EOT;
+
+        if (Str::contains($config, $replacement) || ! Str::contains($config, $addBelow)) {
+            return;
+        }
+
+        $config = str_replace($addBelow, $replacement, $config);
+
+        File::put($path, $config);
+    }
+}

--- a/tests/Git/GitEventTest.php
+++ b/tests/Git/GitEventTest.php
@@ -361,6 +361,16 @@ class GitEventTest extends TestCase
     }
 
     /** @test */
+    public function it_commits_when_default_user_preferences_are_saved()
+    {
+        Git::shouldReceive('dispatchCommit')->with('Default preferences saved')->once();
+
+        Facades\Preference::default()->set('foo', 'bar')->save();
+
+        Facades\File::delete(resource_path('preferences.yaml'));
+    }
+
+    /** @test */
     public function it_commits_when_asset_container_is_saved_and_deleted()
     {
         Git::shouldReceive('dispatchCommit')->with('Asset container saved')->once();


### PR DESCRIPTION
When we added default preferences in https://github.com/statamic/cms/pull/6642, I never thought to track changes to the `resources/preferences.yaml` file as a git path for our git integration feature. This PR adds/fixes this for new apps.