### PR TITLE
Locale preference should fall back to role and default before app config

### DIFF
--- a/src/Http/Middleware/CP/Localize.php
+++ b/src/Http/Middleware/CP/Localize.php
@@ -3,13 +3,13 @@
 namespace Statamic\Http\Middleware\CP;
 
 use Closure;
-use Statamic\Facades\User;
+use Statamic\Facades\Preference;
 
 class Localize
 {
     public function handle($request, Closure $next)
     {
-        $locale = User::current()->getPreference('locale') ?? app()->getLocale();
+        $locale = Preference::get('locale') ?? app()->getLocale();
 
         // Make locale config with dashes backwards compatible, as they should be underscores.
         $locale = str_replace('-', '_', $locale);


### PR DESCRIPTION
Currently if you set `locale` as a preference in a role or `preferences.yaml` it is ignored.