### PR TITLE
Fix Duplicator not respecting collections without slugs

### DIFF
--- a/src/Actions/DuplicateEntry.php
+++ b/src/Actions/DuplicateEntry.php
@@ -36,8 +36,11 @@ class DuplicateEntry extends Action
                 ->collection($original->collection())
                 ->blueprint($original->blueprint()->handle())
                 ->published(false)
-                ->slug($slug)
                 ->data($data);
+
+            if ($original->collection()->requiresSlugs()) {
+                $entry->slug($slug);
+            }
 
             if ($original->hasDate()) {
                 $entry->date($original->date());

--- a/tests/Actions/DuplicateEntryTest.php
+++ b/tests/Actions/DuplicateEntryTest.php
@@ -106,12 +106,14 @@ class DuplicateEntryTest extends TestCase
         $alfaDuplicate = Entry::query()->where('duplicated_from', 'alfa-id')->first();
 
         $this->assertNull($alfaDuplicate->slug());
-        $this->assertStringMatchesFormat('%s-%s-%s-%s-%s.md', basename($alfaDuplicate->initialPath()));
+        $this->assertNotEquals('alfa-id', $id = $alfaDuplicate->id());
+        $this->assertEquals($id.'.md', basename($alfaDuplicate->path()));
 
         $charlieDuplicate = Entry::query()->where('duplicated_from', 'charlie-id')->first();
 
         $this->assertNull($charlieDuplicate->slug());
-        $this->assertStringMatchesFormat('%s-%s-%s-%s-%s.md', basename($charlieDuplicate->initialPath()));
+        $this->assertNotEquals('charlie-id', $id = $charlieDuplicate->id());
+        $this->assertEquals($id.'.md', basename($charlieDuplicate->path()));
     }
 
     private function entryData()

--- a/tests/Actions/DuplicateEntryTest.php
+++ b/tests/Actions/DuplicateEntryTest.php
@@ -84,6 +84,36 @@ class DuplicateEntryTest extends TestCase
         $this->assertFalse((new DuplicateEntry)->authorizeBulk($userWithoutPermission, $items));
     }
 
+    /** @test */
+    public function it_respects_the_collection_not_requiring_slugs()
+    {
+        Collection::make('test')->requiresSlugs(false)->save();
+        EntryFactory::id('alfa-id')->collection('test')->data(['title' => 'Alfa'])->create();
+        EntryFactory::id('bravo-id')->collection('test')->data(['title' => 'Bravo'])->create();
+        EntryFactory::id('charlie-id')->collection('test')->data(['title' => 'Charlie'])->create();
+
+        $this->assertEquals([
+            ['slug' => null, 'published' => true, 'data' => ['title' => 'Alfa']],
+            ['slug' => null, 'published' => true, 'data' => ['title' => 'Bravo']],
+            ['slug' => null, 'published' => true, 'data' => ['title' => 'Charlie']],
+        ], $this->entryData());
+
+        (new DuplicateEntry)->run(collect([
+            Entry::find('alfa-id'),
+            Entry::find('charlie-id'),
+        ]), collect());
+
+        $alfaDuplicate = Entry::query()->where('duplicated_from', 'alfa-id')->first();
+
+        $this->assertNull($alfaDuplicate->slug());
+        $this->assertStringMatchesFormat('%s-%s-%s-%s-%s.md', basename($alfaDuplicate->initialPath()));
+
+        $charlieDuplicate = Entry::query()->where('duplicated_from', 'charlie-id')->first();
+
+        $this->assertNull($charlieDuplicate->slug());
+        $this->assertStringMatchesFormat('%s-%s-%s-%s-%s.md', basename($charlieDuplicate->initialPath()));
+    }
+
     private function entryData()
     {
         return Entry::all()->map(fn ($entry) => [


### PR DESCRIPTION
This pull request fixes #7166 by only setting slugs on duplicated entries if the collection has the 'Requires Slugs' toggle enabled.

Previously, it would generate filenames like `1.md` when you duplicate entries on a collection where the setting wasn't enabled. 

This was happening because of [the code that generates the title & slug](https://github.com/statamic/cms/blob/3.3/src/Actions/DuplicateEntry.php#L80) for the duplicated entry... in normal cases you'd get `the-slug-1.md` but because there was no slug, it just generated the number.