### PR TITLE
Order results by name (Collection & Taxonomy fieldtypes)

### DIFF
--- a/src/Fieldtypes/Collections.php
+++ b/src/Fieldtypes/Collections.php
@@ -29,7 +29,7 @@ class Collections extends Relationship
 
     public function getIndexItems($request)
     {
-        return Collection::all()->map(function ($collection) {
+        return Collection::all()->sortBy('title')->map(function ($collection) {
             return [
                 'id' => $collection->handle(),
                 'title' => $collection->title(),

--- a/src/Fieldtypes/Taxonomies.php
+++ b/src/Fieldtypes/Taxonomies.php
@@ -29,7 +29,7 @@ class Taxonomies extends Relationship
 
     public function getIndexItems($request)
     {
-        return Taxonomy::all()->map(function ($taxonomy) {
+        return Taxonomy::all()->sortBy('title')->map(function ($taxonomy) {
             return [
                 'id' => $taxonomy->handle(),
                 'title' => $taxonomy->title(),


### PR DESCRIPTION
This pull request closes #6908 by ordering the list of collections/taxonomies alphabetically by name.