### PR TITLE
Remove sound effects on Nav drag & drop interactions

### DIFF
--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -60,10 +60,6 @@
 
         </div>
 
-        <audio ref="soundDrop">
-            <source :src="soundDropUrl" type="audio/mp3">
-        </audio>
-
     </div>
 </template>
 
@@ -100,7 +96,6 @@ export default {
             saving: false,
             pages: [],
             treeData: [],
-            soundDropUrl: this.$config.get('resourceUrl') + '/audio/click.mp3',
         }
     },
 
@@ -161,7 +156,6 @@ export default {
             tree = tree || this.$refs.tree;
 
             this.pages = tree.getPureData();
-            this.$refs.soundDrop.play();
             this.$emit('changed');
         },
 


### PR DESCRIPTION
Lots of people have requested a setting to turn this off, and it seems like such a trivial, niche thing to make a setting for. Let's just get rid of it. I originally intended to have lots of sound effects but it never really seemed worth the effort.