### PR TITLE
Fix focus console error when there are no inputs

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -252,10 +252,10 @@ Statamic.app({
             // Fix autofocus issues in Safari and Firefox
             setTimeout(() => {
                 const inputs = document.querySelectorAll('input[autofocus]');
+                for (let input of inputs) {
+                    input.blur();
+                }
                 if (inputs.length) {
-                    for (let input of inputs) {
-                        input.blur();
-                    }
                     inputs[0].focus();
                 }
             }, 100);

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -252,10 +252,12 @@ Statamic.app({
             // Fix autofocus issues in Safari and Firefox
             setTimeout(() => {
                 const inputs = document.querySelectorAll('input[autofocus]');
-                for (let input of inputs) {
-                    input.blur();
+                if (inputs.length) {
+                    for (let input of inputs) {
+                        input.blur();
+                    }
+                    inputs[0].focus();
                 }
-                inputs[0].focus();
             }, 100);
         }
     }


### PR DESCRIPTION
Simple fix for a console error when there are no inputs on a CP view (such as the Dashboard).

```
Uncaught TypeError: can't access property "focus", e[0] is undefined
    fixAutofocus app.js:254
    setTimeout handler*fixAutofocus app.js:243
    mounted app.js:195
    VueJS 7
    start Statamic.js:87
    <anonymous> dashboard:438
app.js:254:22
```

When the input list is empty (such as the Dashboard), the `inputs` list has nothing at index 0. This tweak just runs the focus command if the `inputs` NodeList has a length (see [#7242](https://github.com/statamic/cms/pull/7242)).