### PR TITLE
Pass items into actions

### DIFF
--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -14,10 +14,23 @@ abstract class Action implements Arrayable
 
     protected static $binding = 'actions';
 
+    protected $items;
     protected $confirm = true;
     protected $dangerous = false;
     protected $fields = [];
     protected $context = [];
+
+    public function __construct()
+    {
+        $this->items = collect();
+    }
+
+    public function items($items)
+    {
+        $this->items = collect($items);
+
+        return $this;
+    }
 
     public function visibleTo($item)
     {

--- a/src/Actions/ActionRepository.php
+++ b/src/Actions/ActionRepository.php
@@ -23,6 +23,7 @@ class ActionRepository
     public function for($item, $context = [])
     {
         return $this->all()
+            ->each->items([$item])
             ->each->context($context)
             ->filter->visibleTo($item)
             ->filter->authorize(User::current(), $item)
@@ -32,6 +33,7 @@ class ActionRepository
     public function forBulk($items, $context = [])
     {
         return $this->all()
+            ->each->items($items)
             ->each->context($context)
             ->filter->visibleToBulk($items)
             ->filter->authorizeBulk(User::current(), $items)

--- a/src/Actions/RenameAsset.php
+++ b/src/Actions/RenameAsset.php
@@ -50,6 +50,7 @@ class RenameAsset extends Action
                 'validate' => 'required', // TODO: Better filename validation
                 'classes' => 'mousetrap',
                 'focus' => true,
+                'placeholder' => $this->items->containsOneItem() ? $this->items->first()->filename() : null,
             ],
         ];
     }

--- a/src/Http/Controllers/CP/ActionController.php
+++ b/src/Http/Controllers/CP/ActionController.php
@@ -19,13 +19,13 @@ abstract class ActionController extends CpController
 
         $context = $data['context'] ?? [];
 
-        $action = Action::get($request->action)->context($context);
+        $items = $this->getSelectedItems(collect($data['selections']), $context);
+
+        $action = Action::get($request->action)->context($context)->items($items);
 
         $validation = $action->fields()->validator();
 
         $request->replace($request->values)->validate($validation->rules());
-
-        $items = $this->getSelectedItems(collect($data['selections']), $context);
 
         $unauthorized = $items->reject(function ($item) use ($action) {
             return $action->authorize(User::current(), $item);


### PR DESCRIPTION
Closes statamic/ideas#881

Required for #6040 so the `files` fieldtype can pass along the respective `container` depending on what asset you're reuploading.

This also closes statamic/ideas#337 which is a perfect use case for this feature addition.
