### PR TITLE
Added PHP version check when decoding config data

### DIFF
--- a/src/Http/Controllers/CP/Fieldtypes/RelationshipFieldtypeController.php
+++ b/src/Http/Controllers/CP/Fieldtypes/RelationshipFieldtypeController.php
@@ -42,7 +42,12 @@ class RelationshipFieldtypeController extends CpController
 
     protected function fieldtype($request)
     {
-        $config = json_decode(mb_convert_encoding(base64_decode($request->config), 'UTF-8', mb_list_encodings()), true);
+        $phpVersion = (int) str_replace('.', '', phpversion());
+        if ($phpVersion <= 810) {
+            $config = json_decode(utf8_encode(base64_decode($request->config)), true);
+        } else {
+            $config = json_decode(mb_convert_encoding(base64_decode($request->config), 'UTF-8', mb_list_encodings()), true);
+        }
 
         return Fieldtype::find($config['type'])->setField(
             new Field('relationship', $config)

--- a/src/Http/Controllers/CP/Fieldtypes/RelationshipFieldtypeController.php
+++ b/src/Http/Controllers/CP/Fieldtypes/RelationshipFieldtypeController.php
@@ -42,8 +42,7 @@ class RelationshipFieldtypeController extends CpController
 
     protected function fieldtype($request)
     {
-        $phpVersion = (int) str_replace('.', '', phpversion());
-        if ($phpVersion <= 810) {
+        if (PHP_VERSION_ID < 801020) {
             $config = json_decode(utf8_encode(base64_decode($request->config)), true);
         } else {
             $config = json_decode(mb_convert_encoding(base64_decode($request->config), 'UTF-8', mb_list_encodings()), true);


### PR DESCRIPTION
As mentioned some people experiencing a bug on PHP 8.1.0. I've added a check for PHP 8.1.0 or lower to use the old decoding method.