### PR TITLE
Fix: ChangePassword field label

### DIFF
--- a/resources/js/components/users/ChangePassword.vue
+++ b/resources/js/components/users/ChangePassword.vue
@@ -11,7 +11,7 @@
         <div class="publish-fields p-2 pb-0 w-96">
             <form-group
                 handle="password"
-                :display="__('Password')"
+                :display="__('New Password')"
                 v-model="password"
                 :errors="errors.password"
                 class="p-0 mb-3"


### PR DESCRIPTION
In the absence of a "Current Password", some may confuse the field "Password" as a "Current Password" field. Renaming the field to "New Password" would avoid any confusion.

PS: i would ideally like to have a "Current Password" field in addition to "New Password" & "Password Confirmation"