### PR TITLE
Antlers: improve switch operator parsing

### DIFF
--- a/src/View/Antlers/Language/Parser/LanguageParser.php
+++ b/src/View/Antlers/Language/Parser/LanguageParser.php
@@ -982,11 +982,25 @@ class LanguageParser
                     $wrapperSemanticGroup = $next->scope->nodes[0];
 
                     if (empty($wrapperSemanticGroup->nodes) || $wrapperSemanticGroup->nodes[0] instanceof LogicGroup == false) {
-                        throw ErrorFactory::makeSyntaxError(
-                            AntlersErrorCodes::TYPE_UNEXPECTED_SWITCH_START_VALUE_NO_SEMANTIC_VALUE,
-                            $token,
-                            'Unexpected input while parsing [T_SWITCH_GROUP].'
-                        );
+                        $shouldError = true;
+
+                        if (! empty($wrapperSemanticGroup->nodes)) {
+                            $firstNode = $wrapperSemanticGroup->nodes[0];
+
+                            if ($firstNode instanceof  ArrayNode && $firstNode->hasModifiers()) {
+                                $shouldError = false;
+                            } else if ($firstNode instanceof VariableNode) {
+                                $shouldError = false;
+                            }
+                        }
+
+                        if ($shouldError) {
+                            throw ErrorFactory::makeSyntaxError(
+                                AntlersErrorCodes::TYPE_UNEXPECTED_SWITCH_START_VALUE_NO_SEMANTIC_VALUE,
+                                $token,
+                                'Unexpected input while parsing [T_SWITCH_GROUP].'
+                            );
+                        }
                     }
 
                     $firstCondition = $wrapperSemanticGroup->nodes;

--- a/tests/Antlers/Runtime/ConditionLogicTest.php
+++ b/tests/Antlers/Runtime/ConditionLogicTest.php
@@ -231,6 +231,20 @@ EOT;
         $this->assertSame('Result: Default', $this->renderString($template, ['value' => 23]));
     }
 
+    public function test_switch_operator_with_simplified_conditions()
+    {
+        $template = <<<'EOT'
+{{
+    switch (
+        (['doc', 'docx'] | in_array(filetype)) => 'word.svg',
+        () => 'default.svg'
+    )
+}}
+EOT;
+
+        $this->assertSame('word.svg', $this->renderString($template, ['filetype' => 'doc']));
+    }
+
     public function test_deferred_expressions_are_evaluated_correctly_from_ternary_conditions_relaxed()
     {
         (new class extends Tags


### PR DESCRIPTION
This PR makes it easier to utilize the `switch` operator by relaxing the parsing:

After this change, the following will now "just work":

```antlers
{{
    switch (
        (['doc', 'docx'] | in_array(filetype)) => 'word.svg',
        () => 'default.svg'
    )
}}
```

Currently it will produce a parsing error.