### PR TITLE
Require password to change password in CP

### DIFF
--- a/resources/js/components/users/ChangePassword.vue
+++ b/resources/js/components/users/ChangePassword.vue
@@ -11,6 +11,14 @@
         <div class="publish-fields p-2 pb-0 w-96">
             <form-group
                 handle="password"
+                :display="__('Current Password')"
+                v-model="currentPassword"
+                :errors="errors.current_password"
+                class="p-0 mb-3"
+                :config="{ input_type: this.inputType }"
+            />
+            <form-group
+                handle="password"
                 :display="__('Password')"
                 v-model="password"
                 :errors="errors.password"
@@ -48,6 +56,7 @@ export default {
             saving: false,
             error: null,
             errors: {},
+            currentPassword: null,
             password: null,
             confirmation: null,
             reveal: false
@@ -78,6 +87,7 @@ export default {
             this.saving = true;
 
             this.$axios.patch(this.saveUrl, {
+                current_password: this.currentPassword,
                 password: this.password,
                 password_confirmation: this.confirmation
             }).then(response => {
@@ -85,6 +95,7 @@ export default {
                 this.$refs.popper.close();
                 this.saving = false;
                 this.password = null;
+                this.currentPassword = null;
                 this.confirmation = null;
             }).catch(e => {
                 if (e.response && e.response.status === 422) {

--- a/resources/lang/cs/validation.php
+++ b/resources/lang/cs/validation.php
@@ -17,6 +17,7 @@ return [
     'between.array' => 'Musí být mezi :min a :max položkami.',
     'boolean' => 'Musí být true nebo false.',
     'confirmed' => 'Potvrzení se neshoduje.',
+    'current_password' => 'Současné heslo není spravné.',
     'date' => 'Není platné datum.',
     'date_format' => 'Nesouhlasí s formátem :format.',
     'different' => 'Musí být rozdílné.',

--- a/resources/lang/da/validation.php
+++ b/resources/lang/da/validation.php
@@ -17,6 +17,7 @@ return [
     'between.array' => 'Skal have mellem :min og :max værdier.',
     'boolean' => 'Skal være sandt eller falsk.',
     'confirmed' => 'Bekræftelsen stemmer ikke overens.',
+    'current_password' => 'Das Passwort ist falsch.',
     'date' => 'Ikke en gyldig dato.',
     'date_format' => 'Matcher ikke formatet :format .',
     'different' => 'Dette felt og :other skal være anderledes.',

--- a/resources/lang/de_CH/validation.php
+++ b/resources/lang/de_CH/validation.php
@@ -17,6 +17,7 @@ return [
     'between.array' => 'Muss zwischen :min und :max Element haben.',
     'boolean' => 'Muss wahr oder falsch sein.',
     'confirmed' => 'Bestätigung stimmt nicht überein.',
+    'current_password' => 'Das Passwort ist falsch.',
     'date' => 'Kein gültiges Datum.',
     'date_format' => 'Entspricht nicht dem Format :format .',
     'different' => 'Dieses Feld und :other müssen unterschiedlich sein.',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -31,6 +31,7 @@ return [
     ],
     'boolean'              => 'Must be true or false.',
     'confirmed'            => 'Confirmation does not match.',
+    'current_password'     => 'The password is incorrect.',
     'date'                 => 'Not a valid date.',
     'date_format'          => 'Does not match the format :format.',
     'different'            => 'This field and :other must be different.',

--- a/resources/lang/es/validation.php
+++ b/resources/lang/es/validation.php
@@ -30,6 +30,7 @@ return [
     ],
     'boolean'              => 'Debe ser verdadero o falso.',
     'confirmed'            => 'La confirmación no coincide.',
+    'current_password'     => 'La contraseña es incorrecta.',
     'date'                 => 'No es una fecha válida.',
     'date_format'          => 'No coincide con el formato :format.',
     'different'            => 'Este campo y :other deben ser diferentes.',

--- a/resources/lang/fr/validation.php
+++ b/resources/lang/fr/validation.php
@@ -17,6 +17,7 @@ return [
     'between.array' => 'Doit avoir entre :min et :max éléments.',
     'boolean' => 'Doit être vrai ou faux.',
     'confirmed' => 'La confirmation ne correspond pas.',
+    'current_password' => 'Le mot de passe est incorrect.',
     'date' => 'Date non valide',
     'date_format' => 'Ne correspond pas au format :format.',
     'different' => 'Ce champ et :other doivent être différents.',

--- a/resources/lang/id/validation.php
+++ b/resources/lang/id/validation.php
@@ -17,6 +17,7 @@ return [
     'between.array' => 'Harus memiliki antara :min dan :max item.',
     'boolean' => 'Harus benar atau salah.',
     'confirmed' => 'Konfirmasi tidak cocok.',
+    'current_password' => 'Kata sandi salah.',
     'date' => 'Bukan tanggal yang valid.',
     'date_format' => 'Tidak sesuai dengan format :format.',
     'different' => 'Bidang ini dan :other harus berbeda.',

--- a/resources/lang/it/validation.php
+++ b/resources/lang/it/validation.php
@@ -17,6 +17,7 @@ return [
     'between.array' => 'Deve contenere tra :min e :max elementi.',
     'boolean' => 'Deve essere vero o falso.',
     'confirmed' => 'La conferma non corrisponde.',
+    'current_password' => 'Password non valida.',
     'date' => 'Non è una data valida',
     'date_format' => 'Non corrisponde al formato :format.',
     'different' => 'Questo campo e :other devono essere diversi.',

--- a/resources/lang/ms/validation.php
+++ b/resources/lang/ms/validation.php
@@ -31,6 +31,7 @@ return [
     ],
     'boolean'              => 'Mesti betul atau salah.',
     'confirmed'            => 'Pengesahan tidak sepadan dengan e-mel',
+    'current_password'     => 'Katalaluan anda adalah salah.',
     'date'                 => 'Bukan tarikh yang sah.',
     'date_format'          => 'Tidak sepadan dengan format :format.',
     'different'            => 'Bidang ini dan :other mestilah berbeza.',

--- a/resources/lang/nb/validation.php
+++ b/resources/lang/nb/validation.php
@@ -17,6 +17,7 @@ return [
     'between.array' => 'Må ha mellom :min og :max elementer.',
     'boolean' => 'Må være sann eller usann.',
     'confirmed' => 'Bekreftelsen stemmer ikke overens.',
+    'current_password' => 'Oppgitt passord er feil.',
     'date' => 'Datoen er ugyldig.',
     'date_format' => 'Stemmer ikke overens med formatet :format.',
     'different' => 'Dette feltet og :other må være forskjellige.',

--- a/resources/lang/nl/validation.php
+++ b/resources/lang/nl/validation.php
@@ -17,6 +17,7 @@ return [
     'between.array' => 'Moet minimaal tussen de :min en :max items bevatten.',
     'boolean' => 'Moet true of false zijn.',
     'confirmed' => 'De bevestiging komt niet overeen.',
+    'current_password' => 'Huidig wachtwoord is onjuist.',
     'date' => 'Geen geldige datum.',
     'date_format' => 'Voldoet niet aan het :format formaat.',
     'different' => 'Dit veld en :other moeten verschillend zijn.',

--- a/resources/lang/pl/validation.php
+++ b/resources/lang/pl/validation.php
@@ -17,6 +17,7 @@ return [
     'between.array' => 'Musi mieć pomiędzy :min a :max elementów.',
     'boolean' => 'Musi mieć wartość logiczną prawda albo fałsz.',
     'confirmed' => 'Potwierdzenie pola nie zgadza się.',
+    'current_password' => 'Hasło jest nieprawidłowe.',
     'date' => 'Nieprawidłowa data.',
     'date_format' => 'Nie jest w formacie :format .',
     'different' => 'To pole oraz :other muszą się różnić.',

--- a/resources/lang/pt/validation.php
+++ b/resources/lang/pt/validation.php
@@ -17,6 +17,7 @@ return [
     'between.array' => 'deverá conter entre :min - :max elementos.',
     'boolean' => 'deverá conter o valor verdadeiro ou falso.',
     'confirmed' => 'a confirmação não coincide.',
+    'current_password' => 'A palavra-passe está incorreta.',
     'date' => 'não contém uma data válida.',
     'date_format' => 'não respeita o formato :format.',
     'different' => 'este campo e :other deverão conter valores diferentes.',

--- a/resources/lang/pt_BR/validation.php
+++ b/resources/lang/pt_BR/validation.php
@@ -19,6 +19,7 @@ return [
     ],
     'boolean' => 'Deve ser verdadeiro ou falso.',
     'confirmed' => 'A confirmação não corresponde.',
+    'current_password' => 'A senha está incorreta.',
     'date' => 'Não é uma data válida.',
     'date_format' => 'Não corresponde ao formato :format.',
     'different' => 'Este campo e :other devem ser diferentes.',

--- a/resources/lang/ru/validation.php
+++ b/resources/lang/ru/validation.php
@@ -31,6 +31,7 @@ return [
     ],
     'boolean'              => 'Поле :attribute должно иметь значение логического типа.',
     'confirmed'            => 'Поле :attribute не совпадает с подтверждением.',
+    'current_password'     => 'Неверный пароль.',
     'date'                 => 'Поле :attribute не является датой.',
     'date_format'          => 'Поле :attribute не соответствует формату :format.',
     'different'            => 'Поля :attribute и :other должны различаться.',

--- a/resources/lang/sl/validation.php
+++ b/resources/lang/sl/validation.php
@@ -17,6 +17,7 @@ return [
     'between.array' => 'Vsebovati mora med :min in :max postavkami.',
     'boolean' => 'Mora biti resnično ali napačno.',
     'confirmed' => 'Potrditev se ne ujema.',
+    'current_password' => 'Geslo ni veljavno.',
     'date' => 'Ni veljaven datum.',
     'date_format' => 'Ne ustreza obliki :format .',
     'different' => 'To polje in :other morata biti drugačna.',

--- a/resources/lang/sv/validation.php
+++ b/resources/lang/sv/validation.php
@@ -29,6 +29,7 @@ return [
     'between.array' => 'Måste ha mellan :min och :max artiklar.',
     'boolean' => 'Måste vara sant eller falskt.',
     'confirmed' => 'Bekräftelsen stämmer inte.',
+    'current_password' => 'Lösenordet är felaktigt.',
     'date' => 'Inte ett giltigt datum.',
     'date_format' => 'Matchar inte formatet :format .',
     'different' => 'Detta fält och :other måste vara olika.',

--- a/resources/lang/zh_CN/validation.php
+++ b/resources/lang/zh_CN/validation.php
@@ -31,6 +31,7 @@ return [
     ],
     'boolean'              => '必须为真或假。',
     'confirmed'            => '确认不匹配。',
+    'current_password'     => '密码错误。',
     'date'                 => '无效日期',
     'date_format'          => '与格式 :format 不匹配',
     'different'            => '此字段和 :other 必须不同。',

--- a/resources/lang/zh_TW/validation.php
+++ b/resources/lang/zh_TW/validation.php
@@ -31,6 +31,7 @@ return [
     ],
     'boolean'              => '必須為 true 或 false。',
     'confirmed'            => '確認欄位不相符。',
+    'current_password'     => '密码错误。',
     'date'                 => '不是有效的日期。',
     'date_format'          => '不符合格式 :format。',
     'different'            => '此欄位必須與 :other 不同',

--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -17,6 +17,7 @@ class PasswordController extends CpController
         $this->authorize('editPassword', $user);
 
         $request->validate([
+            'current_password' => ['required', 'current_password'],
             'password' => ['required', 'confirmed', PasswordDefaults::rules()],
         ]);
 


### PR DESCRIPTION
This adds a "current password" field to the popover for changing your own password within the CP. This provides more security as well as avoiding confusion as to whether the password field is the current password or new password field, as described in #7277.

Replaces #7277
