### PR TITLE
Added handling for Inertia caching and accepted query params

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -31,6 +31,9 @@ return [
         'half' => [
             'driver' => 'application',
             'expiry' => null,
+            'accepted_query_params' => [
+                // 'page',
+            ],
         ],
 
         'full' => [

--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -3,6 +3,7 @@
 namespace Statamic\StaticCaching\Cachers;
 
 use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Statamic\Facades\Site;
@@ -74,12 +75,15 @@ abstract class AbstractCacher implements Cacher
 
     /**
      * @param  mixed  $content
-     * @return string
+     * @return array|string
      */
     protected function normalizeContent($content)
     {
         if ($content instanceof Response) {
             $content = $content->content();
+        }
+        if ($content instanceof JsonResponse) {
+            $content = $content->getData(true);
         }
 
         return $content;

--- a/src/StaticCaching/Cachers/ApplicationCacher.php
+++ b/src/StaticCaching/Cachers/ApplicationCacher.php
@@ -40,7 +40,7 @@ class ApplicationCacher extends AbstractCacher
 
         // Append query string to URL.
         if (! empty($query)) {
-            $url .= '?' . http_build_query($query);
+            $url .= '?'.http_build_query($query);
         }
 
         return $url;


### PR DESCRIPTION
Follow up from #7075

This will allow Inertia request to be cached separately when using the application driver (half measure).

Furthermore, you can adjust what query params will be taken into account when caching a response, by setting `accepted_query_params` for the half measure strategy - by default all query params are accepted.
This is a handy way to allow caching to ignore any GTM query params.