### PR TITLE
Use proper YAML facade casing

### DIFF
--- a/src/Fieldtypes/Yaml.php
+++ b/src/Fieldtypes/Yaml.php
@@ -25,7 +25,7 @@ class Yaml extends Fieldtype
     public function preProcess($data)
     {
         if (is_array($data)) {
-            return count($data) > 0 ? \Statamic\Facades\Yaml::dump($data) : '';
+            return count($data) > 0 ? \Statamic\Facades\YAML::dump($data) : '';
         }
 
         return $data;
@@ -34,7 +34,7 @@ class Yaml extends Fieldtype
     public function process($data)
     {
         if (substr_count($data, "\n") > 0 || substr_count($data, ': ') > 0) {
-            $data = \Statamic\Facades\Yaml::parse($data);
+            $data = \Statamic\Facades\YAML::parse($data);
         }
 
         if (empty($data)) {


### PR DESCRIPTION
Like on line 53, these two ocurrences need to be uppercase.

Otherwise we were getting: 

```
Class "Statamic\Facades\Yaml" not found {"userId":"52b99608-2348-4081-998d-edea911298e9","exception":"[object] (Error(code: 0): Class \"Statamic\\Facades\\Yaml\" not found at /home/spnefro/public_html/vendor/statamic/cms/src/Fieldtypes/
```