### PR TITLE
PHP 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [7.4, 8.0, 8.1, 8.2]
         laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "league/glide": "^1.1 || ^2.0",
         "maennchen/zipstream-php": "^2.2",
         "michelf/php-smartypants": "^1.8.1",
+        "nesbot/carbon": "^2.62.1",
         "pixelfear/composer-dist-plugin": "^0.1.4",
         "rebing/graphql-laravel": "^6.5 || ^8.0",
         "spatie/blink": "^1.1.2",

--- a/src/Assets/Attributes.php
+++ b/src/Assets/Attributes.php
@@ -3,7 +3,6 @@
 namespace Statamic\Assets;
 
 use Facades\Statamic\Assets\ExtractInfo;
-use Statamic\Imaging\ImageGenerator;
 use Statamic\Support\Arr;
 
 class Attributes
@@ -12,14 +11,6 @@ class Attributes
      * @var Asset
      */
     private $asset;
-
-    /**
-     * @param $generator ImageGenerator
-     */
-    public function __construct(ImageGenerator $generator)
-    {
-        $this->generator = $generator;
-    }
 
     public function asset(Asset $asset)
     {

--- a/src/Auth/Protect/Protectors/Password/Controller.php
+++ b/src/Auth/Protect/Protectors/Password/Controller.php
@@ -8,6 +8,7 @@ use Statamic\View\View;
 class Controller extends BaseController
 {
     protected $tokenData;
+    protected $password;
 
     public function show()
     {

--- a/src/CP/Columns.php
+++ b/src/CP/Columns.php
@@ -68,7 +68,7 @@ class Columns extends Collection
             ->keyBy(function ($column, $key) use ($preferred) {
                 $preferredKey = array_search($column->field(), $preferred ?? []);
 
-                return $preferredKey !== false ? '_'.$preferredKey : $key + 1;
+                return $preferredKey !== false ? $preferredKey : $key + 10000;
             })
             ->sortKeys()
             ->map(function ($column) use ($preferred) {

--- a/src/CP/Navigation/Nav.php
+++ b/src/CP/Navigation/Nav.php
@@ -100,7 +100,7 @@ class Nav
      */
     public function build()
     {
-        return $this->built = $this
+        return $this
             ->makeDefaultItems()
             ->buildExtensions()
             ->buildChildren()

--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -20,6 +20,7 @@ class NavItem
     protected $authorization;
     protected $active;
     protected $view;
+    protected $attributes;
 
     /**
      * Get or set name.

--- a/src/Http/Middleware/AddViewPaths.php
+++ b/src/Http/Middleware/AddViewPaths.php
@@ -12,6 +12,7 @@ class AddViewPaths
     private $hints;
     private $amp;
     private $site;
+    private $finder;
 
     public function handle($request, Closure $next)
     {

--- a/src/Http/Resources/API/TreeResource.php
+++ b/src/Http/Resources/API/TreeResource.php
@@ -13,6 +13,7 @@ class TreeResource extends JsonResource
     protected $depth;
     protected $site;
     protected $query;
+    protected $maxDepth;
 
     /**
      * Set selected fields.

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -394,7 +394,7 @@ class Statamic
             return false;
         }
 
-        return Str::startsWith(Arr::get(request()->server(), 'argv.1'), ['queue:', 'horizon:']);
+        return Str::startsWith(Arr::get(request()->server(), 'argv.1') ?? '', ['queue:', 'horizon:']);
     }
 
     private static function createVersionedAssetPath($name, $path, $extension)

--- a/src/View/Antlers/Language/Nodes/Structures/PhpExecutionNode.php
+++ b/src/View/Antlers/Language/Nodes/Structures/PhpExecutionNode.php
@@ -7,4 +7,6 @@ use Statamic\View\Antlers\Language\Nodes\AbstractNode;
 class PhpExecutionNode extends AbstractNode
 {
     public $isEchoNode = false;
+    public $rawStart = '';
+    public $rawEnd = '';
 }

--- a/src/View/Antlers/Parser.php
+++ b/src/View/Antlers/Parser.php
@@ -54,6 +54,7 @@ class Parser implements ParserContract
     protected $variableLoopRegex;
     protected $variableRegex;
     protected $variableTagRegex;
+    protected $ignoreRegex;
 
     // Extractions
     protected $extractions = [

--- a/tests/API/CacherTest.php
+++ b/tests/API/CacherTest.php
@@ -19,6 +19,8 @@ class CacherTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $collection;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Actions/DuplicateAssetTest.php
+++ b/tests/Actions/DuplicateAssetTest.php
@@ -17,6 +17,8 @@ class DuplicateAssetTest extends TestCase
     use PreventSavingStacheItemsToDisk;
     use FakesRoles;
 
+    private $container;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -38,6 +38,8 @@ class AssetTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $container;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Assets/AttributesTest.php
+++ b/tests/Assets/AttributesTest.php
@@ -13,6 +13,8 @@ use Tests\TestCase;
 
 class AttributesTest extends TestCase
 {
+    private $attributes;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Assets/DimensionsTest.php
+++ b/tests/Assets/DimensionsTest.php
@@ -13,6 +13,8 @@ namespace Tests\Assets;
 
  class DimensionsTest extends TestCase
  {
+     private $dimensions;
+
      public function setUp(): void
      {
          parent::setUp();

--- a/tests/Assets/ExtractInfoTest.php
+++ b/tests/Assets/ExtractInfoTest.php
@@ -9,6 +9,8 @@ use Tests\TestCase;
 
 class ExtractInfoTest extends TestCase
 {
+    private $container;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Auth/Protect/FallbackProtectorTest.php
+++ b/tests/Auth/Protect/FallbackProtectorTest.php
@@ -8,6 +8,8 @@ use Tests\TestCase;
 
 class FallbackProtectorTest extends TestCase
 {
+    private $protector;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Auth/Protect/ProtectionTest.php
+++ b/tests/Auth/Protect/ProtectionTest.php
@@ -16,6 +16,8 @@ class ProtectionTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $protection;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -109,6 +111,8 @@ class ProtectionTest extends TestCase
         app(ProtectorManager::class)->extend('test', function ($app) use ($state) {
             return new class($state) extends Protector
             {
+                private $state;
+
                 public function __construct($state)
                 {
                     $this->state = $state;

--- a/tests/Auth/RoleRepositoryTest.php
+++ b/tests/Auth/RoleRepositoryTest.php
@@ -10,6 +10,8 @@ use Tests\TestCase;
 
 class RoleRepositoryTest extends TestCase
 {
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/CP/ColumnsTest.php
+++ b/tests/CP/ColumnsTest.php
@@ -8,6 +8,8 @@ use Tests\TestCase;
 
 class ColumnsTest extends TestCase
 {
+    private $columns;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Composer/ComposerJsonTest.php
+++ b/tests/Composer/ComposerJsonTest.php
@@ -9,6 +9,10 @@ use Tests\TestCase;
 
 class ComposerJsonTest extends TestCase
 {
+    private $files;
+    private $path;
+    private $backupPath;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Composer/ComposerLockBackupTest.php
+++ b/tests/Composer/ComposerLockBackupTest.php
@@ -9,15 +9,14 @@ use Statamic\Console\Composer\Lock;
  */
 class ComposerLockBackupTest extends \PHPUnit\Framework\TestCase
 {
+    protected $lockPath = './composer.lock';
+    protected $customLockPath = './custom/composer.lock';
+    protected $backupLockPath = './storage/statamic/updater/composer.lock.bak';
+    protected $customBackupLockPath = './custom/storage/statamic/updater/composer.lock.bak';
+
     public function setUp(): void
     {
         parent::setUp();
-
-        $this->lockPath = './composer.lock';
-        $this->customLockPath = './custom/composer.lock';
-
-        $this->backupLockPath = './storage/statamic/updater/composer.lock.bak';
-        $this->customBackupLockPath = './custom/storage/statamic/updater/composer.lock.bak';
 
         $this->removeLockFiles();
     }

--- a/tests/Composer/ComposerLockTest.php
+++ b/tests/Composer/ComposerLockTest.php
@@ -12,6 +12,10 @@ use Tests\TestCase;
 
 class ComposerLockTest extends TestCase
 {
+    private $files;
+    private $lockPath;
+    private $previousLockPath;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Composer/ComposerTest.php
+++ b/tests/Composer/ComposerTest.php
@@ -10,6 +10,8 @@ use Tests\TestCase;
 
 class ComposerTest extends TestCase
 {
+    private $files;
+
     public function setUp(): void
     {
         $this->markTestSkippedInWindows();

--- a/tests/Console/Commands/MakeActionTest.php
+++ b/tests/Console/Commands/MakeActionTest.php
@@ -10,6 +10,8 @@ class MakeActionTest extends TestCase
 {
     use Concerns\CleansUpGeneratedPaths;
 
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Console/Commands/MakeAddonTest.php
+++ b/tests/Console/Commands/MakeAddonTest.php
@@ -10,6 +10,8 @@ class MakeAddonTest extends TestCase
 {
     use Concerns\CleansUpGeneratedPaths;
 
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Console/Commands/MakeFieldtypeTest.php
+++ b/tests/Console/Commands/MakeFieldtypeTest.php
@@ -10,6 +10,8 @@ class MakeFieldtypeTest extends TestCase
 {
     use Concerns\CleansUpGeneratedPaths;
 
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Console/Commands/MakeFilterTest.php
+++ b/tests/Console/Commands/MakeFilterTest.php
@@ -10,6 +10,8 @@ class MakeFilterTest extends TestCase
 {
     use Concerns\CleansUpGeneratedPaths;
 
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Console/Commands/MakeModifierTest.php
+++ b/tests/Console/Commands/MakeModifierTest.php
@@ -10,6 +10,8 @@ class MakeModifierTest extends TestCase
 {
     use Concerns\CleansUpGeneratedPaths;
 
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Console/Commands/MakeScopeTest.php
+++ b/tests/Console/Commands/MakeScopeTest.php
@@ -10,6 +10,8 @@ class MakeScopeTest extends TestCase
 {
     use Concerns\CleansUpGeneratedPaths;
 
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Console/Commands/MakeTagTest.php
+++ b/tests/Console/Commands/MakeTagTest.php
@@ -10,6 +10,8 @@ class MakeTagTest extends TestCase
 {
     use Concerns\CleansUpGeneratedPaths;
 
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Console/Commands/MakeUserTest.php
+++ b/tests/Console/Commands/MakeUserTest.php
@@ -8,6 +8,8 @@ use Tests\TestCase;
 
 class MakeUserTest extends TestCase
 {
+    private $files;
+
     public function tearDown(): void
     {
         $path = __DIR__.'/../../__fixtures__/users';

--- a/tests/Console/Commands/MakeWidgetTest.php
+++ b/tests/Console/Commands/MakeWidgetTest.php
@@ -10,6 +10,8 @@ class MakeWidgetTest extends TestCase
 {
     use Concerns\CleansUpGeneratedPaths;
 
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Data/Assets/AssetQueryBuilderTest.php
+++ b/tests/Data/Assets/AssetQueryBuilderTest.php
@@ -13,6 +13,8 @@ class AssetQueryBuilderTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $container;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Data/AugmentedTest.php
+++ b/tests/Data/AugmentedTest.php
@@ -13,6 +13,9 @@ use Tests\TestCase;
 
 class AugmentedTest extends TestCase
 {
+    private $thing;
+    private $blueprintThing;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Data/DataRepositoryTest.php
+++ b/tests/Data/DataRepositoryTest.php
@@ -15,6 +15,8 @@ class DataRepositoryTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $data;
+
     // Mocking method_exists, courtesy of https://stackoverflow.com/a/37928161
     public static $functions;
 

--- a/tests/Data/HasAugmentedInstanceTest.php
+++ b/tests/Data/HasAugmentedInstanceTest.php
@@ -29,6 +29,8 @@ class HasAugmentedInstanceTest extends TestCase
         {
             use HasAugmentedInstance;
 
+            private $mock;
+
             public function __construct($mock)
             {
                 $this->mock = $mock;
@@ -66,6 +68,8 @@ class HasAugmentedInstanceTest extends TestCase
         {
             use HasAugmentedInstance;
 
+            private $mock;
+
             public function __construct($mock)
             {
                 $this->mock = $mock;
@@ -96,6 +100,8 @@ class HasAugmentedInstanceTest extends TestCase
         {
             use HasAugmentedInstance;
 
+            private $mock;
+
             public function __construct($mock)
             {
                 $this->mock = $mock;
@@ -123,6 +129,8 @@ class HasAugmentedInstanceTest extends TestCase
         $thing = new class($mock) implements ArrayAccess
         {
             use HasAugmentedInstance;
+
+            private $mock;
 
             public function __construct($mock)
             {

--- a/tests/Data/Structures/CollectionStructureTest.php
+++ b/tests/Data/Structures/CollectionStructureTest.php
@@ -16,6 +16,10 @@ use Statamic\Structures\Tree;
 
 class CollectionStructureTest extends StructureTestCase
 {
+    private $collection;
+    private $entryQueryBuilder;
+    private $queryBuilderGetReturnValue;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Data/Structures/CollectionTreeTest.php
+++ b/tests/Data/Structures/CollectionTreeTest.php
@@ -16,6 +16,8 @@ class CollectionTreeTest extends TestCase
     use PreventSavingStacheItemsToDisk;
     use UnlinksPaths;
 
+    private $directory;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Data/Structures/StructureRepositoryTest.php
+++ b/tests/Data/Structures/StructureRepositoryTest.php
@@ -11,6 +11,8 @@ use Tests\TestCase;
 
 class StructureRepositoryTest extends TestCase
 {
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Data/Taxonomies/ViewsTest.php
+++ b/tests/Data/Taxonomies/ViewsTest.php
@@ -16,6 +16,10 @@ class ViewsTest extends TestCase
     use FakesViews;
     use PreventSavingStacheItemsToDisk;
 
+    private $blogEntry;
+    private $frenchBlogEntry;
+    private $blogCollection;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Data/TracksLastModifiedTest.php
+++ b/tests/Data/TracksLastModifiedTest.php
@@ -8,6 +8,9 @@ use Tests\TestCase;
 
 class TracksLastModifiedTest extends TestCase
 {
+    private $entry;
+    private $user;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Fakes/Composer/FakeComposer.php
+++ b/tests/Fakes/Composer/FakeComposer.php
@@ -8,6 +8,8 @@ use Statamic\Support\Str;
 
 class FakeComposer
 {
+    private $files;
+
     public function __construct()
     {
         $this->files = app(Filesystem::class);

--- a/tests/FakesViews.php
+++ b/tests/FakesViews.php
@@ -7,6 +7,10 @@ use Illuminate\View\View;
 
 trait FakesViews
 {
+    protected $fakeView;
+    protected $fakeViewFinder;
+    protected $fakeViewFactory;
+
     public function withFakeViews()
     {
         $originalFactory = $this->app['view'];

--- a/tests/Feature/Assets/BrowserTest.php
+++ b/tests/Feature/Assets/BrowserTest.php
@@ -14,6 +14,8 @@ class BrowserTest extends TestCase
     use FakesRoles;
     use PreventSavingStacheItemsToDisk;
 
+    private $tempDir;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Feature/Assets/StoreAssetTest.php
+++ b/tests/Feature/Assets/StoreAssetTest.php
@@ -15,6 +15,8 @@ class StoreAssetTest extends TestCase
     use FakesRoles;
     use PreventSavingStacheItemsToDisk;
 
+    private $container;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Feature/Entries/EntryRevisionsTest.php
+++ b/tests/Feature/Entries/EntryRevisionsTest.php
@@ -21,6 +21,9 @@ class EntryRevisionsTest extends TestCase
     use FakesRoles;
     use PreventSavingStacheItemsToDisk;
 
+    private $dir;
+    private $collection;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Feature/Entries/ReorderEntriesTest.php
+++ b/tests/Feature/Entries/ReorderEntriesTest.php
@@ -16,6 +16,9 @@ class ReorderEntriesTest extends TestCase
     use FakesRoles;
     use PreventSavingStacheItemsToDisk;
 
+    private $structure;
+    private $collection;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Feature/GraphQL/ResolvesValuesTest.php
+++ b/tests/Feature/GraphQL/ResolvesValuesTest.php
@@ -19,6 +19,8 @@ class ResolvesValuesTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $blueprint;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Fields/BlueprintRepositoryTest.php
+++ b/tests/Fields/BlueprintRepositoryTest.php
@@ -12,6 +12,8 @@ use Tests\TestCase;
 
 class BlueprintRepositoryTest extends TestCase
 {
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Fields/FieldRepositoryTest.php
+++ b/tests/Fields/FieldRepositoryTest.php
@@ -11,6 +11,8 @@ use Tests\TestCase;
 
 class FieldRepositoryTest extends TestCase
 {
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Fields/FieldsetRepositoryTest.php
+++ b/tests/Fields/FieldsetRepositoryTest.php
@@ -12,6 +12,8 @@ use Tests\TestCase;
 
 class FieldsetRepositoryTest extends TestCase
 {
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Fields/ValueTest.php
+++ b/tests/Fields/ValueTest.php
@@ -158,6 +158,8 @@ class DummyAugmentable implements \Statamic\Contracts\Data\Augmentable
 {
     use \Statamic\Data\HasAugmentedData;
 
+    private $id;
+
     public function __construct($id)
     {
         $this->id = $id;

--- a/tests/Fields/ValuesTest.php
+++ b/tests/Fields/ValuesTest.php
@@ -21,6 +21,8 @@ class ValuesTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $fieldtype;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -257,6 +259,8 @@ class ValuesTest extends TestCase
 class FakeFieldtypeThatAugmentsToMockedBuilder extends Fieldtype
 {
     protected static $handle = 'test';
+
+    private $builder;
 
     public function __construct($builder)
     {

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -11,6 +11,11 @@ class FilesystemAdapterTest extends TestCase
 {
     use FilesystemAdapterTests;
 
+    private $tempDir;
+    private $baseDir;
+    private $outsideRoot;
+    private $filesystem;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Filesystem/FilesystemAdapterTests.php
+++ b/tests/Filesystem/FilesystemAdapterTests.php
@@ -8,6 +8,8 @@ use Statamic\Support\FileCollection;
 
 trait FilesystemAdapterTests
 {
+    private $adapter;
+
     /** @test */
     public function it_makes_a_file_collection()
     {

--- a/tests/Filesystem/FlysystemAdapterTest.php
+++ b/tests/Filesystem/FlysystemAdapterTest.php
@@ -11,6 +11,9 @@ class FlysystemAdapterTest extends TestCase
 {
     use FilesystemAdapterTests;
 
+    private $tempDir;
+    private $filesystem;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/FluentlyGetsAndSetsTest.php
+++ b/tests/FluentlyGetsAndSetsTest.php
@@ -7,6 +7,8 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class FluentlyGetsAndSetsTest extends TestCase
 {
+    private $entry;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -89,8 +91,10 @@ class Entry
 {
     use FluentlyGetsAndSets;
 
+    public $title;
+    public $route;
+    public $url;
     protected $blueprint;
-
     protected $publishedBy = 'Jesse';
 
     public function blueprint($blueprint = null)

--- a/tests/Git/GitProcessTest.php
+++ b/tests/Git/GitProcessTest.php
@@ -12,6 +12,8 @@ class GitProcessTest extends TestCase
 {
     use Concerns\PreparesTempRepos;
 
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Git/GitTest.php
+++ b/tests/Git/GitTest.php
@@ -16,6 +16,8 @@ class GitTest extends TestCase
 {
     use Concerns\PreparesTempRepos;
 
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Listeners/UpdateAssetReferencesTest.php
+++ b/tests/Listeners/UpdateAssetReferencesTest.php
@@ -14,6 +14,10 @@ class UpdateAssetReferencesTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $container;
+    private $assetHoff;
+    private $assetNorris;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Listeners/UpdateTermReferencesTest.php
+++ b/tests/Listeners/UpdateTermReferencesTest.php
@@ -11,6 +11,10 @@ class UpdateTermReferencesTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $topics;
+    private $termHoff;
+    private $termNorris;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Markdown/ManagerTest.php
+++ b/tests/Markdown/ManagerTest.php
@@ -10,6 +10,8 @@ use UnexpectedValueException;
 
 class ManagerTest extends TestCase
 {
+    private $parserClass;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Markdown/ParserTest.php
+++ b/tests/Markdown/ParserTest.php
@@ -7,6 +7,10 @@ use Tests\TestCase;
 
 class ParserTest extends TestCase
 {
+    private $parser;
+    private $smileyExtension;
+    private $frownyExtension;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/OAuth/ProviderTest.php
+++ b/tests/OAuth/ProviderTest.php
@@ -11,6 +11,8 @@ class ProviderTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $tempDir;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Preferences/DefaultPreferencesTest.php
+++ b/tests/Preferences/DefaultPreferencesTest.php
@@ -8,6 +8,8 @@ use Tests\TestCase;
 
 class DefaultPreferencesTest extends TestCase
 {
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Preferences/PrecedenceTest.php
+++ b/tests/Preferences/PrecedenceTest.php
@@ -13,6 +13,8 @@ class PrecedenceTest extends TestCase
 {
     use FakesRoles;
 
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Revisions/RepositoryTest.php
+++ b/tests/Revisions/RepositoryTest.php
@@ -9,6 +9,8 @@ use Tests\TestCase;
 
 class RepositoryTest extends TestCase
 {
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Routing/RouterMixinTest.php
+++ b/tests/Routing/RouterMixinTest.php
@@ -12,6 +12,8 @@ use Tests\TestCase;
 
 class RouterMixinTest extends TestCase
 {
+    private $router;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Sites/SitesTest.php
+++ b/tests/Sites/SitesTest.php
@@ -9,6 +9,8 @@ use Tests\TestCase;
 
 class SitesTest extends TestCase
 {
+    private $sites;
+
     protected function resolveApplicationConfiguration($app)
     {
         parent::resolveApplicationConfiguration($app);

--- a/tests/Stache/AggregateStoreTest.php
+++ b/tests/Stache/AggregateStoreTest.php
@@ -9,6 +9,8 @@ use Tests\TestCase;
 
 class AggregateStoreTest extends TestCase
 {
+    private $store;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/BasicStoreTest.php
+++ b/tests/Stache/BasicStoreTest.php
@@ -11,6 +11,9 @@ use Tests\TestCase;
 
 class BasicStoreTest extends TestCase
 {
+    private $tempDir;
+    private $store;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -87,6 +90,9 @@ class TestBasicStore extends BasicStore
 
 class TestBasicStoreItem
 {
+    private $id;
+    private $data;
+
     public function __construct($id, $data)
     {
         $this->id = $id;

--- a/tests/Stache/FeatureTest.php
+++ b/tests/Stache/FeatureTest.php
@@ -17,6 +17,8 @@ use Tests\TestCase;
 
 class FeatureTest extends TestCase
 {
+    private $stache;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Repositories/AssetContainerRepositoryTest.php
+++ b/tests/Stache/Repositories/AssetContainerRepositoryTest.php
@@ -12,6 +12,9 @@ use Tests\TestCase;
 
 class AssetContainerRepositoryTest extends TestCase
 {
+    private $directory;
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Repositories/CollectionRepositoryTest.php
+++ b/tests/Stache/Repositories/CollectionRepositoryTest.php
@@ -14,6 +14,9 @@ use Tests\TestCase;
 
 class CollectionRepositoryTest extends TestCase
 {
+    private $directory;
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Repositories/CollectionTreeRepositoryTest.php
+++ b/tests/Stache/Repositories/CollectionTreeRepositoryTest.php
@@ -11,6 +11,9 @@ use Tests\TestCase;
 
 class CollectionTreeRepositoryTest extends TestCase
 {
+    private $store;
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Repositories/EntryRepositoryTest.php
+++ b/tests/Stache/Repositories/EntryRepositoryTest.php
@@ -20,6 +20,10 @@ class EntryRepositoryTest extends TestCase
 {
     use UnlinksPaths;
 
+    private $stache;
+    private $directory;
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Repositories/GlobalRepositoryTest.php
+++ b/tests/Stache/Repositories/GlobalRepositoryTest.php
@@ -12,6 +12,9 @@ use Tests\TestCase;
 
 class GlobalRepositoryTest extends TestCase
 {
+    private $directory;
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Repositories/NavTreeRepositoryTest.php
+++ b/tests/Stache/Repositories/NavTreeRepositoryTest.php
@@ -10,6 +10,9 @@ use Tests\TestCase;
 
 class NavTreeRepositoryTest extends TestCase
 {
+    private $store;
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Repositories/NavigationRepositoryTest.php
+++ b/tests/Stache/Repositories/NavigationRepositoryTest.php
@@ -13,6 +13,9 @@ use Tests\TestCase;
 
 class NavigationRepositoryTest extends TestCase
 {
+    private $directory;
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Repositories/TaxonomyRepositoryTest.php
+++ b/tests/Stache/Repositories/TaxonomyRepositoryTest.php
@@ -14,6 +14,9 @@ use Tests\TestCase;
 
 class TaxonomyRepositoryTest extends TestCase
 {
+    private $directory;
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Repositories/UserRepositoryTest.php
+++ b/tests/Stache/Repositories/UserRepositoryTest.php
@@ -11,6 +11,8 @@ use Tests\TestCase;
 
 class UserRepositoryTest extends TestCase
 {
+    private $repo;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/StacheTest.php
+++ b/tests/Stache/StacheTest.php
@@ -12,6 +12,8 @@ use Statamic\Stache\Stores\EntriesStore;
 
 class StacheTest extends TestCase
 {
+    protected $stache;
+
     public function setUp(): void
     {
         $this->stache = new Stache;

--- a/tests/Stache/StoreTest.php
+++ b/tests/Stache/StoreTest.php
@@ -13,6 +13,8 @@ use Tests\TestCase;
 
 class StoreTest extends TestCase
 {
+    private $store;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Stores/AssetContainersStoreTest.php
+++ b/tests/Stache/Stores/AssetContainersStoreTest.php
@@ -15,6 +15,9 @@ use Tests\TestCase;
 
 class AssetContainersStoreTest extends TestCase
 {
+    private $tempDir;
+    private $store;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Stores/CollectionTreeStoreTest.php
+++ b/tests/Stache/Stores/CollectionTreeStoreTest.php
@@ -15,6 +15,9 @@ use Tests\TestCase;
 
 class CollectionTreeStoreTest extends TestCase
 {
+    private $tempDir;
+    private $store;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Stores/CollectionsStoreTest.php
+++ b/tests/Stache/Stores/CollectionsStoreTest.php
@@ -14,6 +14,9 @@ use Tests\TestCase;
 
 class CollectionsStoreTest extends TestCase
 {
+    private $tempDir;
+    private $store;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Stores/EntriesStoreTest.php
+++ b/tests/Stache/Stores/EntriesStoreTest.php
@@ -17,6 +17,9 @@ class EntriesStoreTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $parent;
+    private $directory;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Stores/GlobalsStoreTest.php
+++ b/tests/Stache/Stores/GlobalsStoreTest.php
@@ -14,6 +14,9 @@ use Tests\TestCase;
 
 class GlobalsStoreTest extends TestCase
 {
+    private $tempDir;
+    private $store;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Stores/NavTreeStoreTest.php
+++ b/tests/Stache/Stores/NavTreeStoreTest.php
@@ -14,6 +14,9 @@ use Tests\TestCase;
 
 class NavTreeStoreTest extends TestCase
 {
+    private $tempDir;
+    private $store;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Stores/NavigationStoreTest.php
+++ b/tests/Stache/Stores/NavigationStoreTest.php
@@ -13,6 +13,9 @@ use Tests\TestCase;
 
 class NavigationStoreTest extends TestCase
 {
+    private $tempDir;
+    private $store;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Stores/TaxonomiesStoreTest.php
+++ b/tests/Stache/Stores/TaxonomiesStoreTest.php
@@ -13,6 +13,9 @@ use Tests\TestCase;
 
 class TaxonomiesStoreTest extends TestCase
 {
+    private $tempDir;
+    private $store;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Stores/TermsStoreTest.php
+++ b/tests/Stache/Stores/TermsStoreTest.php
@@ -13,6 +13,9 @@ class TermsStoreTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $parent;
+    private $directory;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/Stores/UsersStoreTest.php
+++ b/tests/Stache/Stores/UsersStoreTest.php
@@ -12,6 +12,9 @@ use Tests\TestCase;
 
 class UsersStoreTest extends TestCase
 {
+    private $tempDir;
+    private $store;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Stache/TraverserTest.php
+++ b/tests/Stache/TraverserTest.php
@@ -15,6 +15,9 @@ use Tests\TestCase;
 
 class TraverserTest extends TestCase
 {
+    private $tempDir;
+    private $traverser;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/StarterKits/Concerns/BacksUpSite.php
+++ b/tests/StarterKits/Concerns/BacksUpSite.php
@@ -27,7 +27,7 @@ trait BacksUpSite
 
         if ($files->exists($backupPath)) {
             $files->cleanDirectory($basePath);
-            $files->copyDirectory($backupPath, $basePath, true);
+            $files->copyDirectory($backupPath, $basePath);
             $files->deleteDirectory($backupPath);
         }
     }

--- a/tests/StarterKits/ExportTest.php
+++ b/tests/StarterKits/ExportTest.php
@@ -13,6 +13,7 @@ class ExportTest extends TestCase
     protected $files;
     protected $configPath;
     protected $exportPath;
+    protected $postInstallHookPath;
 
     public function setUp(): void
     {

--- a/tests/StaticCaching/FullMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/FullMeasureStaticCachingTest.php
@@ -17,6 +17,8 @@ class FullMeasureStaticCachingTest extends TestCase
     use FakesViews;
     use PreventSavingStacheItemsToDisk;
 
+    private $dir;
+
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);

--- a/tests/Tags/Collection/CollectionTest.php
+++ b/tests/Tags/Collection/CollectionTest.php
@@ -21,6 +21,12 @@ class CollectionTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $music;
+    private $art;
+    private $books;
+    private $foods;
+    private $collectionTag;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -27,6 +27,8 @@ class EntriesTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $collection;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Tags/Concerns/QueriesConditionsTest.php
+++ b/tests/Tags/Concerns/QueriesConditionsTest.php
@@ -17,6 +17,8 @@ class QueriesConditionsTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $collection;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -517,7 +519,7 @@ class QueriesConditionsTest extends TestCase
         $class = new class($value)
         {
             use QueriesConditions;
-            protected $parameters;
+            protected $params;
 
             public function __construct($value)
             {
@@ -550,7 +552,7 @@ class QueriesConditionsTest extends TestCase
         $class = new class($values)
         {
             use QueriesConditions;
-            protected $parameters;
+            protected $params;
 
             public function __construct($values)
             {
@@ -583,7 +585,7 @@ class QueriesConditionsTest extends TestCase
         $class = new class($values)
         {
             use QueriesConditions;
-            protected $parameters;
+            protected $params;
 
             public function __construct($values)
             {
@@ -610,7 +612,7 @@ class QueriesConditionsTest extends TestCase
         $class = new class($value)
         {
             use QueriesConditions;
-            protected $parameters;
+            protected $params;
 
             public function __construct($value)
             {
@@ -639,7 +641,7 @@ class QueriesConditionsTest extends TestCase
         $class = new class($value)
         {
             use QueriesConditions;
-            protected $parameters;
+            protected $params;
 
             public function __construct($value)
             {

--- a/tests/Tags/Concerns/RendersAttributesTest.php
+++ b/tests/Tags/Concerns/RendersAttributesTest.php
@@ -9,6 +9,8 @@ use Tests\TestCase;
 
 class RendersAttributesTest extends TestCase
 {
+    private $tag;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Tags/Concerns/RendersFormsTest.php
+++ b/tests/Tags/Concerns/RendersFormsTest.php
@@ -13,6 +13,8 @@ class RendersFormsTest extends TestCase
 {
     const MISSING = 'field is missing from request';
 
+    private $tag;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Tags/ContextTest.php
+++ b/tests/Tags/ContextTest.php
@@ -9,6 +9,11 @@ use Tests\TestCase;
 
 class ContextTest extends TestCase
 {
+    private $value;
+    private $antlersValue;
+    private $nonAntlersValue;
+    private $context;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Tags/Form/FormTestCase.php
+++ b/tests/Tags/Form/FormTestCase.php
@@ -43,6 +43,8 @@ abstract class FormTestCase extends TestCase
         ],
     ];
 
+    private $customFieldBlueprintHandle;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Tags/GetContentTagTest.php
+++ b/tests/Tags/GetContentTagTest.php
@@ -13,6 +13,9 @@ class GetContentTagTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    private $one;
+    private $two;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Tags/ParametersTest.php
+++ b/tests/Tags/ParametersTest.php
@@ -10,6 +10,11 @@ use Tests\TestCase;
 
 class ParametersTest extends TestCase
 {
+    private $params;
+    private $value;
+    private $antlersValue;
+    private $nonAntlersValue;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Tokens/TokenRepositoryTest.php
+++ b/tests/Tokens/TokenRepositoryTest.php
@@ -12,6 +12,8 @@ use Tests\TestCase;
 
 class TokenRepositoryTest extends TestCase
 {
+    private $tokens;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/UpdateScripts/UpdateScriptTest.php
+++ b/tests/UpdateScripts/UpdateScriptTest.php
@@ -15,6 +15,10 @@ use Tests\TestCase;
 
 class UpdateScriptTest extends TestCase
 {
+    private $files;
+    private $lockPath;
+    private $previousLockPath;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/View/Antlers/EngineTests.php
+++ b/tests/View/Antlers/EngineTests.php
@@ -9,6 +9,9 @@ use Statamic\View\Antlers\Engine;
 
 trait EngineTests
 {
+    private $engine;
+    private $files;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/View/Antlers/ParserTests.php
+++ b/tests/View/Antlers/ParserTests.php
@@ -2475,6 +2475,8 @@ EOT;
 
 class NonArrayableObject
 {
+    protected $data;
+
     public function __construct($data)
     {
         $this->data = $data;


### PR DESCRIPTION
This adds PHP 8.2 support. 

There were only a few little issues. The main one was that carbon needed to be updated to a version that supported 8.2. https://github.com/laravel/framework/pull/44374

Everything else was really just concerning deprecation warnings. The majority was due to missing properties.

Running PHPUnit with `convertDeprecationsToExceptions="true"` now completely passes except for one test.

The failing test is due to a deprecation warning within `webonyx/graphql-php`. I tried PRing a tiny fix but it was rejected. Oh well. https://github.com/webonyx/graphql-php/pull/1280

I tried upgrading `laravel-graphql` to the next version just to test it (which uses v15 of graphql-php) and makes everything pass again, without any code changes on our side. It's not released yet, though. https://github.com/rebing/graphql-laravel/pull/953