### PR TITLE
Pass searchable into search transformers to empower indexing

### DIFF
--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -167,25 +167,25 @@ class Searchables
             }
 
             return [$field => $value];
-        })->flatMap(function ($value, $field) use ($transformers) {
+        })->flatMap(function ($value, $field) use ($transformers, $searchable) {
             if (! $transformer = $transformers[$field] ?? null) {
                 return [$field => $value];
             }
 
-            $value = $this->transformValue($transformer, $field, $value);
+            $value = $this->transformValue($transformer, $field, $value, $searchable);
 
             return is_array($value) ? $value : [$field => $value];
         })->all();
     }
 
-    private function transformValue($transformer, $field, $value)
+    private function transformValue($transformer, $field, $value, $searchable)
     {
         if ($transformer instanceof Closure) {
-            return $transformer($value);
+            return $transformer($value, $searchable);
         }
 
         try {
-            return app($transformer)->handle($value, $field);
+            return app($transformer)->handle($value, $field, $searchable);
         } catch (BindingResolutionException $e) {
             throw new \LogicException("Search transformer [{$transformer}] not found.");
         }

--- a/tests/Search/SearchablesTest.php
+++ b/tests/Search/SearchablesTest.php
@@ -4,8 +4,10 @@ namespace Tests\Search;
 
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Assert;
 use Statamic\Assets\AssetCollection;
 use Statamic\Auth\UserCollection;
+use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Entries\EntryCollection;
 use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
@@ -279,7 +281,11 @@ class SearchablesTest extends TestCase
                 'title',
             ],
             'transformers' => [
-                'title' => function ($value) {
+                'title' => function ($value, $searchable) {
+                    $this->assertEquals('Hello', $value);
+                    $this->assertInstanceOf(EntryContract::class, $searchable);
+                    $this->assertEquals('a', $searchable->id());
+
                     return strtoupper($value);
                 },
             ],
@@ -290,7 +296,7 @@ class SearchablesTest extends TestCase
             'config' => config('statamic.search.indexes.default'),
         ]);
 
-        $searchable = EntryFactory::collection('test')->data(['title' => 'Hello'])->make();
+        $searchable = EntryFactory::collection('test')->id('a')->data(['title' => 'Hello'])->make();
         $searchables = new Searchables($index);
 
         $this->assertEquals([
@@ -336,7 +342,7 @@ class SearchablesTest extends TestCase
             'config' => config('statamic.search.indexes.default'),
         ]);
 
-        $searchable = EntryFactory::collection('test')->data(['title' => 'Hello'])->make();
+        $searchable = EntryFactory::collection('test')->id('a')->data(['title' => 'Hello'])->make();
         $searchables = new Searchables($index);
 
         $this->assertEquals([
@@ -442,8 +448,13 @@ class NotSearchable
 
 class BasicTestTransformer
 {
-    public function handle($value)
+    public function handle($value, $field, $searchable)
     {
+        Assert::assertEquals('Hello', $value);
+        Assert::assertEquals('title', $field);
+        Assert::assertInstanceOf(EntryContract::class, $searchable);
+        Assert::assertEquals('a', $searchable->id());
+
         return strtoupper($value);
     }
 }


### PR DESCRIPTION
Hi

Currently, indexing a Bard field which is not saved as HTML is quite hard because the value will be passed as structured array and not as rendered HTML.

Until https://github.com/statamic/cms/pull/6318 will be merged, I solved it by just passing the searchable as additional parameter into all transformer calls (closure and the new instances handle methods).

By doing this, we can index a Bard field easily by just additionally getting the augmented value if needed.

Example:

```php

class ContentTransformer
{
    public function handle($value, $field, $searchable)
    {
        if (! $value) {
            return null;
        }

        $augmentedValue = $searchable->augmentedValue('content');

        return $this->extractTextFromHtml($augmentedValue);
    }
}
```

I think this really empowers the indexing in other cases together with the new Transformer classes from https://github.com/statamic/cms/pull/7177.
