### PR TITLE
Pass array of roles into `user_roles` tag

### DIFF
--- a/src/Tags/UserRoles.php
+++ b/src/Tags/UserRoles.php
@@ -13,7 +13,11 @@ class UserRoles extends Tags
     {
         $roles = Role::all();
 
-        if (! $handles = $this->params->explode('handle')) {
+        if (! is_array($handles = $this->params->get('handle'))) {
+            $handles = $this->params->explode('handle');
+        }
+
+        if (empty($handles)) {
             return $roles->values();
         }
 

--- a/tests/Tags/UserRolesTagTest.php
+++ b/tests/Tags/UserRolesTagTest.php
@@ -49,6 +49,7 @@ class UserRolesTagTest extends TestCase
         Role::make()->handle('test3')->title('Test 3')->save();
 
         $this->assertEquals('test2|test3|', $this->tag('{{ user_roles handle="test2|test3" }}{{ handle }}|{{ /user_roles }}'));
+        $this->assertEquals('test2|test3|', $this->tag('{{ user_roles :handle="roles" }}{{ handle }}|{{ /user_roles }}', ['roles' => ['test2', 'test3']]));
     }
 
     /** @test */

--- a/tests/Tags/UserRolesTagTest.php
+++ b/tests/Tags/UserRolesTagTest.php
@@ -56,6 +56,7 @@ class UserRolesTagTest extends TestCase
     public function it_outputs_no_results_when_finding_multiple_roles()
     {
         $this->assertEquals('nothing', $this->tag('{{ user_roles handle="test2|test3" }}{{ if no_results }}nothing{{ else }}something{{ /if }}{{ /user_roles }}'));
+        $this->assertEquals('nothing', $this->tag('{{ user_roles :handle="roles" }}{{ if no_results }}nothing{{ else }}something{{ /if }}{{ /user_roles }}', ['roles' => ['test2', 'test3']]));
     }
 
     private function tag($tag, $data = [])


### PR DESCRIPTION
Was helping someone on discord and had to write this:

```
    {{ user }}
        {{ user_roles handle="{roles | join('|')}" }}
            {{ title }}
        {{ /user_roles }}
    {{ /user }}
```

and thought that this would be nicer:

```
    {{ user }}
        {{ user_roles :handle="roles" }}
            {{ title }}
        {{ /user_roles }}
    {{ /user }}
```