### PR TITLE
Fix revealer fields disappearing on save

### DIFF
--- a/resources/js/components/fieldtypes/RevealerFieldtype.vue
+++ b/resources/js/components/fieldtypes/RevealerFieldtype.vue
@@ -50,6 +50,11 @@ export default {
     watch: {
         fieldPath(fieldPath) {
             this.$store.commit(`publish/${this.storeName}/setRevealerField`, fieldPath);
+        },
+        value(value, oldValue) {
+            if (!value && oldValue) {
+                this.buttonReveal();   
+            }
         }
     },
 


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/7306

I assume this was caused by https://github.com/statamic/cms/pull/6842, as after update the revealer field is no longer `true` so the conditional fields get hidden again.

This PR fixes it by watching for a new `false` value and re-calling `buttonReveal()` if the current value is `true`. I suspect there might a better way to fix this within the publish container itself, rather than updating and the immediately reverting the value, but that's a bit beyond me.