### PR TITLE
Update cached origin of localized descendants when saving entries (wip)

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -341,7 +341,25 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
                 });
         }
 
+        $this->updateCacheOfLocalizedDescendants($this);
+
         return true;
+    }
+
+    private function updateCacheOfLocalizedDescendants(Entry $parent)
+    {
+        if ($parent->descendants()->count() === 0) {
+            return;
+        }
+
+        $directDescendants = $parent->descendants()->filter(function ($descendant) use ($parent) {
+            return $descendant->origin()->id() === $parent->id();
+        });
+        $directDescendants->each(function ($descendant) use ($parent) {
+            $descendant->origin($parent);
+            Facades\Entry::save($descendant);
+            $this->updateCacheOfLocalizedDescendants($descendant);
+        });
     }
 
     public function taxonomize()


### PR DESCRIPTION
This pull request is a fix for #6714 but I am not sure if it's the right solution.

And: I cannot get the included test to fail due to the fact that during the test the origin entries are kept in memory and never contain the outdated data when loaded from cache. The test is marked as incomplete for now.

Thanks for any feedback! Cheers


