### PR TITLE
Update cached origin of localized descendants when saving entries (wip)

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -341,7 +341,25 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
                 });
         }
 
+        $this->updateCacheOfLocalizedDescendants($this);
+
         return true;
+    }
+
+    protected function updateCacheOfLocalizedDescendants(Entry $parent)
+    {
+        if ($parent->descendants()->count() === 0) {
+            return;
+        }
+
+        $directDescendants = $parent->descendants()->filter(function ($descendant) use ($parent) {
+            return $descendant->origin()->id() === $parent->id();
+        });
+        $directDescendants->each(function ($descendant) use ($parent) {
+            $descendant->origin($parent);
+            Facades\Entry::save($descendant);
+            $this->updateCacheOfLocalizedDescendants($descendant);
+        });
     }
 
     public function taxonomize()

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -367,6 +367,59 @@ class EntryTest extends TestCase
     }
 
     /** @test */
+    public function it_updates_the_origin_of_descendants_when_saving_an_entry_with_localizations()
+    {
+        Facades\Site::setConfig([
+            'default' => 'en',
+            'sites' => [
+                'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+                'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+                'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
+            ],
+        ]);
+
+        $collection = (new Collection)
+            ->handle('articles')
+            ->propagate(false)
+            ->sites(['en', 'fr', 'de'])
+            ->save();
+
+        $entryEn = (new Entry)
+            ->id('en')
+            ->locale('en')
+            ->collection($collection)
+            ->data(['description' => 'Description from en']);
+        $entryEn->save();
+
+        $entryFr = $entryEn->makeLocalization('fr');
+        $entryEn->addLocalization($entryFr); // todo: necessary to call this because $entryEn::$localizations is already cached and does not get/recognize new localizations. should be called in Entry::makeLocalization() ?
+        $entryFr->save();
+
+        $entryDe = $entryFr->makeLocalization('de');
+        $entryFr->addLocalization($entryDe);
+        $entryDe->save();
+
+        $this->assertEquals('Description from en', $entryEn->values()->get('description'));
+        $this->assertEquals('Description from en', $entryFr->value('description'));
+        $this->assertEquals('Description from en', $entryDe->value('description'));
+
+        $entryEn->data(['description' => 'Description from en modified'])->save();
+
+        // todo: how to get fresh entry objects from stache so that the origin entries are reloaded from cache as well. warming stache does not work...
+        $this->markTestIncomplete('Incomplete: Reload objects from cache/stache to simulate a new request.');
+
+//        Facades\Stache::warm();
+
+//        $entryEn = Facades\Entry::find($entryEn->id());
+//        $entryFr = Facades\Entry::find($entryFr->id());
+//        $entryDe = Facades\Entry::find($entryDe->id());
+
+//        $this->assertEquals('Description from en modified', $entryEn->values()->get('description'));
+//        $this->assertEquals('Description from en modified', $entryFr->value('description'));
+//        $this->assertEquals('Description from en modified', $entryDe->value('description'));
+    }
+
+    /** @test */
     public function it_gets_custom_computed_data()
     {
         Facades\Collection::computed('articles', 'description', function ($entry) {


### PR DESCRIPTION
This pull request includes a potential fix for https://github.com/statamic/cms/issues/6714 but I am not sure if it's the right solution.

> Localized entries contain a reference to the origin entry via Entry::origin(). When saving an entry with localized descendants, the origin of these descendants does not get updated. It still contains the old data before the save (in the cache).

The solution here recursively updates the origin of all localized descendants when saving an entry.

The included test is marked as incomplete: I cannot get it to fail due to the fact that during the test the origin entries are kept in memory and never contain the outdated data when loaded from cache.

Thanks for any feedback! Cheers