### PR TITLE
Create multiple list items when pasting multiple lines

### DIFF
--- a/resources/js/components/fieldtypes/ListFieldtype.vue
+++ b/resources/js/components/fieldtypes/ListFieldtype.vue
@@ -47,7 +47,7 @@
                     :placeholder="`${__('Add an item')}...`"
                     @keydown.enter.prevent="addItem"
                     @blur="newItemInputBlurred"
-                    @paste="pasteItem"
+                    @paste="newItemInputPaste"
                     @focus="editItem(data.length)"
                     @keyup.up="previousItem"
                 />
@@ -132,7 +132,7 @@ export default {
             });
         },
 
-        pasteItem(event) {
+        newItemInputPaste(event) {
             if (this.newItem !== '') {
                 return;
             }

--- a/resources/js/components/fieldtypes/ListFieldtype.vue
+++ b/resources/js/components/fieldtypes/ListFieldtype.vue
@@ -47,6 +47,7 @@
                     :placeholder="`${__('Add an item')}...`"
                     @keydown.enter.prevent="addItem"
                     @blur="newItemInputBlurred"
+                    @paste="pasteItem"
                     @focus="editItem(data.length)"
                     @keyup.up="previousItem"
                 />
@@ -129,6 +130,23 @@ export default {
             this.$nextTick(function () {
                 this.focusItem();
             });
+        },
+
+        pasteItem(event) {
+            if (this.newItem !== '') {
+                return;
+            }
+
+            const value = event.clipboardData.getData('text');
+            if (!value.includes("\n")) {
+                return;                
+            }
+            
+            value.split("\n").forEach((item) => {
+                this.data.push(this.newSortableValue(item));
+            });
+
+            event.preventDefault();
         },
 
         newItemInputBlurred() {


### PR DESCRIPTION
This PR is a small UX enhancement that will create multiple new items when pasting multiple lines into the list fieldtype:

https://user-images.githubusercontent.com/126740/211869797-0d8dffaf-1cb0-462b-8d29-a82865fb79d8.mp4

Will only kick in when pasting into the new item, and the new item is blank, and the pasted value contains line breaks.