### PR TITLE
Check previous host for preserving iframe scroll

### DIFF
--- a/resources/js/components/live-preview/LivePreview.vue
+++ b/resources/js/components/live-preview/LivePreview.vue
@@ -122,7 +122,7 @@ export default {
             keybinding: null,
             token: null,
             target: 0,
-            previousHost: null
+            previousUrl: null
         }
     },
 

--- a/resources/js/components/live-preview/LivePreview.vue
+++ b/resources/js/components/live-preview/LivePreview.vue
@@ -122,6 +122,7 @@ export default {
             keybinding: null,
             token: null,
             target: 0,
+            previousHost: null
         }
     },
 

--- a/resources/js/components/live-preview/UpdatesIframe.js
+++ b/resources/js/components/live-preview/UpdatesIframe.js
@@ -14,11 +14,12 @@ export default {
                 return;
             }
 
-            let urlHost = new URL(url).host;
+            let iframeUrl = new URL(url);
+            let cleanUrl = iframeUrl.host + iframeUrl.pathname;
 
-            let isSameOrigin = url.startsWith('/') || new URL(url).host === window.location.host;
+            let isSameOrigin = url.startsWith('/') || iframeUrl.host === window.location.host;
 
-            let preserveScroll = isSameOrigin && urlHost === this.previousHost;
+            let preserveScroll = isSameOrigin && (cleanUrl === this.previousUrl || this.previousUrl === null);
 
             let scroll = preserveScroll ? [
                 container.firstChild.contentWindow.scrollX ?? 0,
@@ -37,7 +38,7 @@ export default {
                 iframeContentWindow.addEventListener('load', iframeScrollUpdate, true);
             }
 
-            this.previousHost = urlHost;
+            this.previousUrl = cleanUrl;
         },
 
         setIframeAttributes(iframe) {

--- a/resources/js/components/live-preview/UpdatesIframe.js
+++ b/resources/js/components/live-preview/UpdatesIframe.js
@@ -14,16 +14,20 @@ export default {
                 return;
             }
 
+            let urlHost = new URL(url).host;
+
             let isSameOrigin = url.startsWith('/') || new URL(url).host === window.location.host;
 
-            let scroll = isSameOrigin ? [
+            let preserveScroll = isSameOrigin && urlHost === this.previousHost;
+
+            let scroll = preserveScroll ? [
                 container.firstChild.contentWindow.scrollX ?? 0,
                 container.firstChild.contentWindow.scrollY ?? 0
             ] : null;
 
             container.replaceChild(iframe, container.firstChild);
 
-            if (isSameOrigin) {
+            if (preserveScroll) {
                 let iframeContentWindow = iframe.contentWindow;
                 const iframeScrollUpdate = (event) => {
                     iframeContentWindow.scrollTo(...scroll);
@@ -32,6 +36,8 @@ export default {
                 iframeContentWindow.addEventListener('DOMContentLoaded', iframeScrollUpdate, true);
                 iframeContentWindow.addEventListener('load', iframeScrollUpdate, true);
             }
+
+            this.previousHost = new URL(url).host;
         },
 
         setIframeAttributes(iframe) {

--- a/resources/js/components/live-preview/UpdatesIframe.js
+++ b/resources/js/components/live-preview/UpdatesIframe.js
@@ -37,7 +37,7 @@ export default {
                 iframeContentWindow.addEventListener('load', iframeScrollUpdate, true);
             }
 
-            this.previousHost = new URL(url).host;
+            this.previousHost = urlHost;
         },
 
         setIframeAttributes(iframe) {


### PR DESCRIPTION
This PR fixes #7300.

This bug occurs when you're using multi-site with different host names.
While in live preview switching sites will break when you go back to the original site that you used to access the control panel.

I added a previous host attribute that gets set every time the iframe is updated.
To check if the scroll needs to be preserved we also need to check if the current host matches the previous host. 