### PR TITLE
Fix default time problem on creating new entry

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -286,10 +286,6 @@ class EntriesController extends CpController
             'published' => $collection->defaultPublishState(),
         ])->merge($fields->values());
 
-        if ($collection->dated()) {
-            $values['date'] = substr(now()->toDateTimeString(), 0, 10);
-        }
-
         $viewData = [
             'title' => $collection->createLabel(),
             'actions' => [


### PR DESCRIPTION
When I was creating a new entry in a collection with enabled Publish Dates, the default time was always 00:00. this happened when I make `time` enabled on `date` field, so it would contains Date + Time, not only date. In these lines, you've limited the date value to 10 characters, so it only includes `YYYY-MM-DD` and misses the time. (It should include 19 characters: `YYYY-MM-DD HH:MM:SS`).

I wonder why these lines exist, when the "date" field is always there and sets its own value.