### PR TITLE
Hide empty sections in final rendering of CP nav

### DIFF
--- a/src/CP/Navigation/NavBuilder.php
+++ b/src/CP/Navigation/NavBuilder.php
@@ -843,6 +843,7 @@ class NavBuilder
         // Collect and order each section's items...
         $built = collect($sections)
             ->reject(fn ($items, $section) => $this->withHidden ? false : Arr::get($manipulations, "{$section}.action") === '@hide')
+            ->filter(fn ($items) => $items || $this->withHidden)
             ->map(function ($items, $section) {
                 return collect($this->sectionsWithReorderedItems)->contains($section)
                     ? collect($items)->sortBy(fn ($item) => $item->order())->values()

--- a/tests/CP/Navigation/NavPreferencesTest.php
+++ b/tests/CP/Navigation/NavPreferencesTest.php
@@ -1485,6 +1485,39 @@ class NavPreferencesTest extends TestCase
     }
 
     /** @test */
+    public function it_hides_section_when_all_items_are_moved_out_of_section()
+    {
+        Facades\CP\Nav::extend(function ($nav) {
+            $nav->name('SEO Settings')
+                ->section('SEO Pro')
+                ->url('/cp/seo-pro');
+        });
+
+        $defaultSections = ['Top Level', 'Content', 'Fields', 'Tools', 'Users', 'SEO Pro'];
+
+        $this->assertEquals($defaultSections, $this->buildDefaultNav()->keys()->all());
+
+        $nav = $this->buildNavWithPreferences([
+            'top_level' => [
+                'seo_pro::seo_settings' => '@move',
+            ],
+        ]);
+
+        $navWithHidden = $this->buildNavWithPreferences([
+            'top_level' => [
+                'seo_pro::seo_settings' => '@move',
+            ],
+        ], true);
+
+        // Since we moved the SEO item to top level, it should hide SEO section by default...
+        $this->assertEquals(['Top Level', 'Content', 'Fields', 'Tools', 'Users'], $nav->keys()->all());
+
+        // But still show empty section when `withHidden` flag is true, so that user can re-add items to this core/extended section...
+        $this->assertEquals(['Top Level', 'Content', 'Fields', 'Tools', 'Users', 'SEO Pro'], $navWithHidden->keys()->all());
+        $this->assertTrue($navWithHidden->get('SEO Pro')->isEmpty());
+    }
+
+    /** @test */
     public function it_can_handle_a_bunch_of_useless_config_without_erroring()
     {
         $this->markTestSkipped();

--- a/tests/CP/Navigation/NavTest.php
+++ b/tests/CP/Navigation/NavTest.php
@@ -486,9 +486,21 @@ class NavTest extends TestCase
     {
         $this->actingAs(tap(User::make()->makeSuper())->save());
 
+        Nav::testSection('Visible Item');
         Nav::testSection('Hidden Item')->hidden(true);
 
-        $this->assertNull($this->build()->get('Test Section')->first());
+        $this->assertCount(1, $this->build()->get('Test Section'));
+        $this->assertEquals('Visible Item', $this->build()->get('Test Section')->first()->display());
+    }
+
+    /** @test */
+    public function it_doesnt_build_sections_containing_only_hidden_items()
+    {
+        $this->actingAs(tap(User::make()->makeSuper())->save());
+
+        Nav::testSection('Hidden Item')->hidden(true);
+
+        $this->assertNull($this->build()->get('Test Section'));
     }
 
     /** @test */
@@ -510,13 +522,15 @@ class NavTest extends TestCase
     {
         $this->actingAs(tap(User::make()->makeSuper())->save());
 
+        Nav::testSection('Visible Item');
         Nav::testSection('Hidden Item')->hidden(true);
 
         // Calling `withHidden()` should clone the instance, so that we don't update the singleton bound to the facade
-        $this->assertCount(1, Nav::build(true, true)->pluck('items', 'display')->get('Test Section'));
+        $this->assertCount(2, Nav::build(true, true)->pluck('items', 'display')->get('Test Section'));
 
         // Which means this should hide the hidden item again
-        $this->assertNull($this->build()->get('Test Section')->first());
+        $this->assertCount(1, $this->build()->get('Test Section'));
+        $this->assertEquals('Visible Item', $this->build()->get('Test Section')->first()->display());
     }
 
     /** @test */


### PR DESCRIPTION
Hide empty section headings from CP nav sidebar when section contains no items. 

For example, maybe a user drags the last item out of a section, then there's no use showing it in the final rendered nav. (But still show the section in the nav preferences UI, so that the user can re-add items back into that core / addon extended section.)

![CleanShot 2023-01-16 at 15 33 28](https://user-images.githubusercontent.com/5187394/212761611-6e2c08e2-c9f6-416c-b562-0d215e609b3a.png)