### PR TITLE
Antlers: Corrects memory leak

### DIFF
--- a/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
+++ b/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
@@ -199,6 +199,13 @@ class GlobalRuntimeState
      */
     public static $peekCallbacks = [];
 
+    /**
+     * Indicates if data should be removed.
+     *
+     * @var bool
+     */
+    public static $garbageCollect = true;
+
     public static function resetGlobalState()
     {
         self::$containsLayout = false;
@@ -207,6 +214,7 @@ class GlobalRuntimeState
         self::$environmentId = StringUtilities::uuidv4();
         self::$yieldCount = 0;
         self::$yieldStacks = [];
+        self::$garbageCollect = true;
 
         StackReplacementManager::clearStackState();
         LiteralReplacementManager::resetLiteralState();

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -446,6 +446,12 @@ class NodeProcessor
      */
     public function setData($data)
     {
+        if (GlobalRuntimeState::$garbageCollect) {
+            unset($this->data);
+            $this->data = [];
+            GlobalRuntimeState::$garbageCollect = false;
+        }
+
         if ($this->scopeLock) {
             return $this;
         }


### PR DESCRIPTION
This PR fixes #7360 by resolving a memory leak that occurs when the Runtime parser is repeatedly called within the same process.