### PR TITLE
Antlers: Cleanup additional data between Runtime parser invocations

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -448,7 +448,17 @@ class NodeProcessor
     {
         if (GlobalRuntimeState::$garbageCollect) {
             unset($this->data);
+            unset($this->previousAssignments);
+            unset($this->runtimeAssignments);
+            unset($this->canHandleInterpolations);
+            unset($this->interpolationCache);
+            unset($this->lockedData);
             $this->data = [];
+            $this->previousAssignments = [];
+            $this->runtimeAssignments = [];
+            $this->canHandleInterpolations = [];
+            $this->interpolationCache = [];
+            $this->lockedData = [];
             GlobalRuntimeState::$garbageCollect = false;
         }
 

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -447,12 +447,6 @@ class NodeProcessor
     public function setData($data)
     {
         if (GlobalRuntimeState::$garbageCollect) {
-            unset($this->data);
-            unset($this->previousAssignments);
-            unset($this->runtimeAssignments);
-            unset($this->canHandleInterpolations);
-            unset($this->interpolationCache);
-            unset($this->lockedData);
             $this->data = [];
             $this->previousAssignments = [];
             $this->runtimeAssignments = [];


### PR DESCRIPTION
This PR fixes #7366 by resetting more data between parser invocations within the same process. This PR expands on the concept from #7361 and utilizes the garbage collection flag to ensure that previous assignments, interpolation cache, locked data, etc. is also cleared from memory.

In the linked issue, the randomized behavior will happen if the blog post page is generated first, leaving its assignment in memory before the index page is generated.