### PR TITLE
Fix user blueprint fallback defaults

### DIFF
--- a/src/Auth/UserRepository.php
+++ b/src/Auth/UserRepository.php
@@ -8,6 +8,7 @@ use Statamic\Data\StoresComputedFieldCallbacks;
 use Statamic\Events\UserBlueprintFound;
 use Statamic\Facades\Blueprint;
 use Statamic\OAuth\Provider;
+use Statamic\Statamic;
 
 abstract class UserRepository implements RepositoryContract
 {
@@ -57,11 +58,18 @@ abstract class UserRepository implements RepositoryContract
     public function blueprint()
     {
         $blueprint = Blueprint::find('user') ?? Blueprint::makeFromFields([
-            'email' => ['type' => 'text', 'input_type' => 'email', 'display' => 'Email Address', 'listable' => true],
             'name' => ['type' => 'text', 'display' => 'Name', 'listable' => true],
-            'roles' => ['type' => 'user_roles', 'mode' => 'select', 'width' => 50, 'listable' => true],
-            'groups' => ['type' => 'user_groups', 'mode' => 'select', 'width' => 50, 'listable' => true],
         ])->setHandle('user');
+
+        $blueprint->ensureField('email', ['type' => 'text', 'input_type' => 'email', 'display' => 'Email Address', 'listable' => true]);
+
+        if (Statamic::pro()) {
+            $blueprint->ensureField('roles', ['type' => 'user_roles', 'mode' => 'select', 'width' => 50, 'listable' => true]);
+            $blueprint->ensureField('groups', ['type' => 'user_groups', 'mode' => 'select', 'width' => 50, 'listable' => true]);
+        } else {
+            $blueprint->removeField('roles');
+            $blueprint->removeField('groups');
+        }
 
         UserBlueprintFound::dispatch($blueprint);
 

--- a/tests/Auth/UserContractTests.php
+++ b/tests/Auth/UserContractTests.php
@@ -375,6 +375,86 @@ trait UserContractTests
     }
 
     /** @test */
+    public function it_provides_email_field_fallback_in_blueprint()
+    {
+        $blueprint = Blueprint::make();
+        Blueprint::shouldReceive('find')->with('user')->andReturn($blueprint);
+
+        $this->assertTrue($this->user()->blueprint()->hasField('email'));
+        $this->assertEquals('Email Address', $this->user()->blueprint()->fields()->get('email')->display());
+        $this->assertEquals('email', $this->user()->blueprint()->fields()->get('email')->get('input_type'));
+    }
+
+    /** @test */
+    public function it_allows_email_field_customizations_in_blueprint()
+    {
+        $blueprint = Blueprint::makeFromFields(['email' => ['display' => 'Custom Email Display']]);
+        Blueprint::shouldReceive('find')->with('user')->andReturn($blueprint);
+
+        $this->assertTrue($this->user()->blueprint()->hasField('email'));
+        $this->assertEquals('Custom Email Display', $this->user()->blueprint()->fields()->get('email')->display());
+        $this->assertEquals('email', $this->user()->blueprint()->fields()->get('email')->get('input_type'));
+    }
+
+    /** @test */
+    public function it_provides_roles_and_groups_field_fallbacks_in_blueprint()
+    {
+        $blueprint = Blueprint::make();
+        Blueprint::shouldReceive('find')->with('user')->andReturn($blueprint);
+
+        $this->assertTrue($this->user()->blueprint()->hasField('roles'));
+        $this->assertEquals('Roles', $this->user()->blueprint()->fields()->get('roles')->display());
+        $this->assertEquals('user_roles', $this->user()->blueprint()->fields()->get('roles')->type());
+
+        $this->assertTrue($this->user()->blueprint()->hasField('groups'));
+        $this->assertEquals('Groups', $this->user()->blueprint()->fields()->get('groups')->display());
+        $this->assertEquals('user_groups', $this->user()->blueprint()->fields()->get('groups')->type());
+    }
+
+    /** @test */
+    public function it_allows_roles_and_groups_field_customizations_in_blueprint()
+    {
+        $blueprint = Blueprint::makeFromFields([
+            'roles' => ['display' => 'Custom Roles Display'],
+            'groups' => ['display' => 'Custom Groups Display'],
+        ]);
+        Blueprint::shouldReceive('find')->with('user')->andReturn($blueprint);
+
+        $this->assertTrue($this->user()->blueprint()->hasField('roles'));
+        $this->assertEquals('Custom Roles Display', $this->user()->blueprint()->fields()->get('roles')->display());
+        $this->assertEquals('user_roles', $this->user()->blueprint()->fields()->get('roles')->type());
+
+        $this->assertTrue($this->user()->blueprint()->hasField('groups'));
+        $this->assertEquals('Custom Groups Display', $this->user()->blueprint()->fields()->get('groups')->display());
+        $this->assertEquals('user_groups', $this->user()->blueprint()->fields()->get('groups')->type());
+    }
+
+    /** @test */
+    public function it_removes_roles_and_groups_field_fallbacks_in_blueprint_when_pro_is_disabled()
+    {
+        config(['statamic.editions.pro' => false]);
+        $blueprint = Blueprint::make();
+        Blueprint::shouldReceive('find')->with('user')->andReturn($blueprint);
+
+        $this->assertFalse($this->user()->blueprint()->hasField('roles'));
+        $this->assertFalse($this->user()->blueprint()->hasField('groups'));
+    }
+
+    /** @test */
+    public function it_removes_roles_and_groups_event_when_explicitly_defined_in_blueprint_when_pro_is_disabled()
+    {
+        config(['statamic.editions.pro' => false]);
+        $blueprint = Blueprint::makeFromFields([
+            'roles' => ['display' => 'Custom Roles Display'],
+            'groups' => ['display' => 'Custom Groups Display'],
+        ]);
+        Blueprint::shouldReceive('find')->with('user')->andReturn($blueprint);
+
+        $this->assertFalse($this->user()->blueprint()->hasField('roles'));
+        $this->assertFalse($this->user()->blueprint()->hasField('groups'));
+    }
+
+    /** @test */
     public function converts_to_array()
     {
         Role::shouldReceive('all')->andReturn(collect([

--- a/tests/Tags/User/ProfileFormTest.php
+++ b/tests/Tags/User/ProfileFormTest.php
@@ -73,8 +73,8 @@ EOT
         preg_match_all('/<label>.+<\/label><input.+>/U', $output, $actual);
 
         $expected = [
-            '<label>Email Address</label><input type="email" name="email" value="test@example.com">',
             '<label>Name</label><input type="text" name="name" value="Test User">',
+            '<label>Email Address</label><input type="email" name="email" value="test@example.com">',
         ];
 
         $this->assertEquals($expected, $actual[0]);
@@ -102,6 +102,7 @@ EOT
 
         $expected = [
             '<label>Full Name</label><input type="text" name="name" value="Test User">',
+            '<label>Email Address</label><input type="email" name="email" value="test@example.com">',
             '<label>Phone Number</label><input type="text" name="phone" value="12345">',
             '<label>Over 18 years of age?</label><input type="text" name="age" value="" required>',
         ];
@@ -276,6 +277,10 @@ EOT
                         'type' => 'text',
                         'display' => 'Full Name',
                     ],
+                ],
+                [
+                    'handle' => 'email', // Field is included by default, but we're just implying field order here.
+                    'field' => [],
                 ],
                 [
                     'handle' => 'password', // Field already exists, but we're defining custom validation rules.


### PR DESCRIPTION
- [x] Provide fallbacks for `email`, `roles`, and `groups` when not explicitly defined in user blueprint.
    - Fixes #7359
- [x] Ensure we remove `roles` and `groups` from user blueprint when pro is disabled.
    - When doing this PR, I found that `roles` and `groups` fields were showing on the profile edit form of a fresh statamic/statamic install, even with pro disabled. These being pro features, it should be safe to remove these fields if pro is disabled.
- [x] Update docs.
    - References https://github.com/statamic/docs/pull/986