### PR TITLE
Antlers: Resolves an issue where assignments can leak under some circumstances

### DIFF
--- a/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
+++ b/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
@@ -199,13 +199,6 @@ class GlobalRuntimeState
      */
     public static $peekCallbacks = [];
 
-    /**
-     * Indicates if data should be removed.
-     *
-     * @var bool
-     */
-    public static $garbageCollect = true;
-
     public static function resetGlobalState()
     {
         self::$containsLayout = false;
@@ -214,7 +207,6 @@ class GlobalRuntimeState
         self::$environmentId = StringUtilities::uuidv4();
         self::$yieldCount = 0;
         self::$yieldStacks = [];
-        self::$garbageCollect = true;
 
         StackReplacementManager::clearStackState();
         LiteralReplacementManager::resetLiteralState();

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -447,18 +447,20 @@ class NodeProcessor
     public function setData($data)
     {
         if (GlobalRuntimeState::$garbageCollect) {
-            $this->data = [];
-            $this->previousAssignments = [];
-            $this->runtimeAssignments = [];
-            $this->canHandleInterpolations = [];
-            $this->interpolationCache = [];
-            $this->lockedData = [];
+            $this->scopeLock = false;
             GlobalRuntimeState::$garbageCollect = false;
         }
 
         if ($this->scopeLock) {
             return $this;
         }
+
+        $this->data = [];
+        $this->previousAssignments = [];
+        $this->runtimeAssignments = [];
+        $this->canHandleInterpolations = [];
+        $this->interpolationCache = [];
+        $this->lockedData = [];
 
         if ((is_array($data) == false && (is_object($data) && ($data instanceof Arrayable) == false)) ||
             is_string($data)) {

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -95,13 +95,6 @@ class NodeProcessor
     protected $bufferOverwrites = [];
 
     /**
-     * Indicates if the runtime is holding a lock to prevent scope manipulation.
-     *
-     * @var bool
-     */
-    protected $scopeLock = false;
-
-    /**
      * Indicates if the current runtime instance is evaluating an interpolated document.
      *
      * @var bool
@@ -446,15 +439,6 @@ class NodeProcessor
      */
     public function setData($data)
     {
-        if (GlobalRuntimeState::$garbageCollect) {
-            $this->scopeLock = false;
-            GlobalRuntimeState::$garbageCollect = false;
-        }
-
-        if ($this->scopeLock) {
-            return $this;
-        }
-
         $this->data = [];
         $this->previousAssignments = [];
         $this->runtimeAssignments = [];
@@ -493,10 +477,6 @@ class NodeProcessor
      */
     protected function pushScope(AntlersNode $node, $data)
     {
-        if ($this->scopeLock) {
-            return;
-        }
-
         $this->popScopes[$node->refId] = 1;
         $this->data[] = $data;
     }
@@ -664,10 +644,6 @@ class NodeProcessor
      */
     private function updateCurrentScope($data)
     {
-        if ($this->scopeLock) {
-            return;
-        }
-
         $dataLen = count($this->data);
 
         if ($dataLen == 0) {
@@ -2299,7 +2275,6 @@ class NodeProcessor
      */
     protected function addLoopIterationVariables($loop)
     {
-        $this->scopeLock = false;
         $index = 0;
         $total = count($loop);
         $lastIndex = $total - 1;
@@ -2347,8 +2322,6 @@ class NodeProcessor
         }
 
         $this->data = $curData;
-
-        $this->scopeLock = false;
 
         $prev = null;
 


### PR DESCRIPTION
This PR resolves an additional issue related to #7366  (this comment: https://github.com/statamic/cms/issues/7366#issuecomment-1399021786)

This PR subtly adjusts the garbage collection logic to enforce a clean variable state when transitioning between requests. If garbage collection is required, any held locks on the current processor instance are forcefully removed. Each time the `setData` method is called, the processor will reset its internal state and rely on the merging data behavior elsewhere.

A new test has also been included that will catch this going forward, and will fail if the changes are reverted 👍