### PR TITLE
Eloquent user login timestamps - change approach to check guard being used

### DIFF
--- a/src/Auth/SetLastLoginTimestamp.php
+++ b/src/Auth/SetLastLoginTimestamp.php
@@ -3,15 +3,17 @@
 namespace Statamic\Auth;
 
 use Illuminate\Auth\Events\Login;
-use Statamic\Contracts\Auth\User as StatamicUser;
 use Statamic\Facades\User;
 
 class SetLastLoginTimestamp
 {
     public function handle(Login $event)
     {
-        if ($event->user instanceof StatamicUser) {
-            User::fromUser($event->user)->setLastLogin(now());
+        $guards = collect(config('statamic.users.guards'))->values()->unique()->all();
+        if (in_array($event->guard, $guards)) {
+            if ($user = User::fromUser($event->user)) {
+                $user->setLastLogin(now());
+            }
         }
     }
 }


### PR DESCRIPTION
A different approach than #4823.

Instead of checking the user model that we are logging in, check the guard that is being used to ensure it's one of the ones defined for Statamic to use. The User::fromUser method already carries out the other checks needed, so defer to it and just check if we get a value for $user returned.

Fixes: #4030 