### PR TITLE
Ensure taxonomies parent has a proper collection when resolving augmentation

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -99,6 +99,7 @@ class Terms extends Relationship
             && $parent
             && $parent instanceof Entry
             && $this->field->handle() === $this->taxonomies()[0]
+            && $parent->collection() !== null
             && $parent->collection()->taxonomies()->map->handle()->contains($this->field->handle());
 
         if ($shouldQueryCollection) {


### PR DESCRIPTION
When adding taxonomy terms to a navigation entry, solving the augmentation will result in a `null` error call as `Statamic\Structures\Page` doesn't have a collection