### PR TITLE
Add toggle for `sometimes` rule in validation builder

### DIFF
--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -2,12 +2,24 @@
 
     <div class="w-full">
 
-        <div class="form-group publish-field select-fieldtype field-w-full">
-            <label class="publish-field-label">{{ __('Required') }}</label>
-            <div class="help-block -mt-1">
-                <p>{{ __('messages.field_validation_required_instructions') }}</p>
+        <div class="flex">
+
+            <div class="form-group publish-field select-fieldtype field-w-full">
+                <label class="publish-field-label">{{ __('Required') }}</label>
+                <div class="help-block -mt-1">
+                    <p>{{ __('messages.field_validation_required_instructions') }}</p>
+                </div>
+                <toggle-input v-model="isRequired" />
             </div>
-            <toggle-input v-model="isRequired" />
+
+            <div class="form-group publish-field select-fieldtype field-w-full">
+                <label class="publish-field-label">{{ __('Sometimes') }}</label>
+                <div class="help-block -mt-1">
+                    <p>{{ __('messages.field_validation_sometimes_instructions') }}</p>
+                </div>
+                <toggle-input v-model="sometimesValidate" />
+            </div>
+
         </div>
 
         <div class="form-group publish-field select-fieldtype field-w-full">
@@ -106,6 +118,7 @@ export default {
     data() {
         return {
             isRequired: false,
+            sometimesValidate: false,
             rules: [],
             selectedLaravelRule: null,
             customRule: null,
@@ -113,6 +126,7 @@ export default {
     },
 
     computed: {
+
         laravelVersion() {
             return this.$store.state.statamic.config.laravelVersion;
         },
@@ -162,14 +176,24 @@ export default {
 
             return rule.example || false;
         },
+
     },
 
     watch: {
+
         isRequired(value) {
             if (value === true) {
-                this.ensureRequired();
+                this.ensureToggleableRule('required');
             } else {
                 this.remove('required');
+            }
+        },
+
+        sometimesValidate(value) {
+            if (value === true) {
+                this.ensureToggleableRule('sometimes');
+            } else {
+                this.remove('sometimes');
             }
         },
 
@@ -178,6 +202,7 @@ export default {
 
             this.$emit('updated', value);
         },
+
     },
 
     created() {
@@ -185,6 +210,7 @@ export default {
     },
 
     methods: {
+
         getInitial() {
             this.rules = this.config.validate
                 ? this.explodeRules(this.config.validate)
@@ -195,6 +221,7 @@ export default {
             this.selectedLaravelRule = null;
             this.customRule = null;
             this.isRequired = this.rules.includes('required');
+            this.sometimesValidate = this.rules.includes('sometimes');
         },
 
         explodeRules(rules) {
@@ -213,9 +240,9 @@ export default {
             return rule;
         },
 
-        ensureRequired() {
-            if (! this.rules.includes('required')) {
-                this.rules.unshift('required');
+        ensureToggleableRule(rule) {
+            if (! this.rules.includes(rule)) {
+                this.rules.unshift(rule);
             }
         },
 

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -72,6 +72,7 @@ return [
     'field_synced_with_origin' => 'Synced with origin. Click or edit the field to desync.',
     'field_validation_advanced_instructions' => 'Add more advanced validation to this field.',
     'field_validation_required_instructions' => 'Control whether or not this field is required.',
+    'field_validation_sometimes_instructions' => 'Only validate when this field is visible or submitted.',
     'fields_always_save_instructions' => 'Always save field value, regardless of how field conditions are evaluated.',
     'fields_blueprints_description' => 'Blueprints define the fields for content structures like collections, taxonomies, users, and forms.',
     'fields_default_instructions' => 'Set the default value.',


### PR DESCRIPTION
This PR adds a toggle for laravel's `sometimes` rule to our validation builder.

![CleanShot 2023-01-27 at 10 47 42](https://user-images.githubusercontent.com/5187394/215128456-7100379b-460c-4ba5-b535-fe9828e185d1.png)

Though we document the sometimes rule [here](https://statamic.dev/conditional-fields#validation), this UX will help users discover this functionality, which is very helpful to those using [conditional fields](https://statamic.dev/conditional-fields).

![CleanShot 2023-01-27 at 10 49 18](https://user-images.githubusercontent.com/5187394/215128965-2bba82d6-2740-4e5a-a8ce-82e9de70566d.png)

