### PR TITLE
Auto-focus search input when opening selectors in Bard link or standalone link fieldtype

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -48,7 +48,7 @@
                             <div class="relative w-full">
 
                                 <div class="data-list-header">
-                                    <data-list-search v-model="searchQuery" />
+                                    <data-list-search ref="search" v-model="searchQuery" />
 
                                     <template v-if="! hasSelections">
                                         <button v-if="canCreateFolders" class="btn-flat btn-icon-only ml-2" @click="creatingFolder = true">
@@ -320,6 +320,7 @@ export default {
         maxFiles: Number,
         initialEditingAssetId: String,
         autoselectUploads: Boolean,
+        autofocusSearch: Boolean,
     },
 
     data() {
@@ -456,6 +457,12 @@ export default {
         parameters(after, before) {
             if (JSON.stringify(before) === JSON.stringify(after)) return;
             this.loadAssets();
+        },
+
+        initializing(isInitializing, wasInitializing) {
+            if (wasInitializing && this.autofocusSearch) {
+                this.$nextTick(() => this.$refs.search.focus());
+            }
         },
 
         loading(loading) {

--- a/resources/js/components/assets/Selector.vue
+++ b/resources/js/components/assets/Selector.vue
@@ -12,6 +12,7 @@
                     :restrict-folder-navigation="restrictFolderNavigation"
                     :max-files="maxFiles"
                     :autoselect-uploads="true"
+                    :autofocus-search="true"
                     @selections-updated="selectionsUpdated"
                     @asset-doubleclicked="select">
 

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -122,6 +122,7 @@
             :columns="[{ label: __('Title'), field: 'title' }]"
             :max-items="1"
             :site="bard.site"
+            :search="true"
             @loading="isLoading = $event"
             @item-data-updated="entrySelected"
         />


### PR DESCRIPTION
This pull request fixes #7413