### PR TITLE
Fix preferences listing errors when using Eloquent users

### DIFF
--- a/resources/views/nav/index.blade.php
+++ b/resources/views/nav/index.blade.php
@@ -59,7 +59,7 @@
                     </div>
                 </td>
                 <td class="text-right text-2xs text-grey-50">
-                    @if (auth()->user()->hasPreference('nav'))
+                    @if (Statamic\Facades\User::current()->hasPreference('nav'))
                         {{ __('Modified') }}
                     @endif
                 </td>

--- a/resources/views/preferences/index.blade.php
+++ b/resources/views/preferences/index.blade.php
@@ -59,7 +59,7 @@
                     </div>
                 </td>
                 <td class="text-right text-2xs text-grey-50">
-                    @if (!empty(auth()->user()->preferences()))
+                    @if (!empty(Statamic\Facades\User::current()->preferences()))
                         {{ __('Modified') }}
                     @endif
                 </td>


### PR DESCRIPTION
When using Eloquent users, we don't want to call preference-related methods on the Eloquent model directly, but rather on the Statamic user instance.

Fixes #7423