### PR TITLE
Fix GraphQL nested fields

### DIFF
--- a/src/Fields/Values.php
+++ b/src/Fields/Values.php
@@ -8,10 +8,12 @@ use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use IteratorAggregate;
 use JsonSerializable;
+use Statamic\Contracts\GraphQL\ResolvesValues as ResolvesGqlValues;
+use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\Compare;
 use Traversable;
 
-class Values implements ArrayAccess, Arrayable, IteratorAggregate, JsonSerializable
+class Values implements ArrayAccess, Arrayable, IteratorAggregate, JsonSerializable, ResolvesGqlValues
 {
     protected $instance;
 
@@ -115,5 +117,25 @@ class Values implements ArrayAccess, Arrayable, IteratorAggregate, JsonSerializa
     public function jsonSerialize()
     {
         return $this->all();
+    }
+
+    public function resolveGqlValue($field)
+    {
+        $value = $this->$field;
+
+        if ($value instanceof Value) {
+            $value = $value->value();
+        }
+
+        if ($value instanceof Builder) {
+            $value = $value->get();
+        }
+
+        return $value;
+    }
+
+    public function resolveRawGqlValue($field)
+    {
+        return $this->raw($field);
     }
 }

--- a/src/Fields/Values.php
+++ b/src/Fields/Values.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use IteratorAggregate;
 use JsonSerializable;
 use Statamic\Contracts\GraphQL\ResolvesValues as ResolvesGqlValues;
-use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\Compare;
 use Traversable;
 
@@ -121,17 +120,7 @@ class Values implements ArrayAccess, Arrayable, IteratorAggregate, JsonSerializa
 
     public function resolveGqlValue($field)
     {
-        $value = $this->$field;
-
-        if ($value instanceof Value) {
-            $value = $value->value();
-        }
-
-        if ($value instanceof Builder) {
-            $value = $value->get();
-        }
-
-        return $value;
+        return $this->$field;
     }
 
     public function resolveRawGqlValue($field)

--- a/src/GraphQL/Types/GridItemType.php
+++ b/src/GraphQL/Types/GridItemType.php
@@ -3,9 +3,7 @@
 namespace Statamic\GraphQL\Types;
 
 use Rebing\GraphQL\Support\Type;
-use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\GraphQL;
-use Statamic\Fields\Value;
 
 class GridItemType extends Type
 {
@@ -19,23 +17,19 @@ class GridItemType extends Type
 
     public function fields(): array
     {
-        return $this->fieldtype->fields()->toGql()
+        $fields = $this->fieldtype->fields()->toGql();
+
+        return $fields
             ->merge([
                 'id' => [
                     'type' => GraphQL::string(),
                 ],
             ])
-            ->map(function ($field) {
-                $field['resolve'] = function ($row, $args, $context, $info) {
-                    $value = $row[$info->fieldName];
-
-                    $value = $value instanceof Value ? $value->value() : $value;
-
-                    if ($value instanceof Builder) {
-                        $value = $value->get();
-                    }
-
-                    return $value;
+            ->map(function ($field) use ($fields) {
+                $field['resolve'] = function ($row, $args, $context, $info) use ($fields) {
+                    return ($resolver = $fields[$info->fieldName]['resolve'] ?? null)
+                         ? $resolver($row, $args, $context, $info)
+                         : $row[$info->fieldName];
                 };
 
                 return $field;

--- a/src/GraphQL/Types/ReplicatorSetType.php
+++ b/src/GraphQL/Types/ReplicatorSetType.php
@@ -2,9 +2,7 @@
 
 namespace Statamic\GraphQL\Types;
 
-use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\GraphQL;
-use Statamic\Fields\Value;
 
 class ReplicatorSetType extends \Rebing\GraphQL\Support\Type
 {
@@ -20,7 +18,9 @@ class ReplicatorSetType extends \Rebing\GraphQL\Support\Type
 
     public function fields(): array
     {
-        return $this->fieldtype->fields($this->handle)->toGql()
+        $fields = $this->fieldtype->fields($this->handle)->toGql();
+
+        return $fields
             ->merge([
                 'id' => [
                     'type' => GraphQL::string(),
@@ -29,17 +29,11 @@ class ReplicatorSetType extends \Rebing\GraphQL\Support\Type
                     'type' => GraphQL::nonNull(GraphQL::string()),
                 ],
             ])
-            ->map(function ($field) {
-                $field['resolve'] = function ($row, $args, $context, $info) {
-                    $value = $row[$info->fieldName];
-
-                    $value = $value instanceof Value ? $value->value() : $value;
-
-                    if ($value instanceof Builder) {
-                        $value = $value->get();
-                    }
-
-                    return $value;
+            ->map(function ($field) use ($fields) {
+                $field['resolve'] = function ($row, $args, $context, $info) use ($fields) {
+                    return ($resolver = $fields[$info->fieldName]['resolve'] ?? null)
+                        ? $resolver($row, $args, $context, $info)
+                        : $row[$info->fieldName];
                 };
 
                 return $field;

--- a/tests/Feature/GraphQL/Fieldtypes/BardFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/BardFieldtypeTest.php
@@ -33,7 +33,7 @@ class BardFieldtypeTest extends TestCase
                     'meal' => [
                         'fields' => [
                             ['handle' => 'food', 'field' => ['type' => 'text']],
-                            ['handle' => 'drink', 'field' => ['type' => 'markdown']],
+                            ['handle' => 'drink', 'field' => ['type' => 'markdown']], // using markdown to show nested fields are resolved using their fieldtype.
                         ],
                     ],
                     'car' => [

--- a/tests/Feature/GraphQL/Fieldtypes/BardFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/BardFieldtypeTest.php
@@ -33,7 +33,7 @@ class BardFieldtypeTest extends TestCase
                     'meal' => [
                         'fields' => [
                             ['handle' => 'food', 'field' => ['type' => 'text']],
-                            ['handle' => 'drink', 'field' => ['type' => 'text']],
+                            ['handle' => 'drink', 'field' => ['type' => 'markdown']],
                         ],
                     ],
                     'car' => [
@@ -54,7 +54,7 @@ class BardFieldtypeTest extends TestCase
             'title' => 'Main Post',
             'things' => [
                 ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'first text']]],
-                ['type' => 'set', 'attrs' => ['id' => '1', 'values' => ['type' => 'meal', 'food' => 'burger', 'drink' => 'coke']]],
+                ['type' => 'set', 'attrs' => ['id' => '1', 'values' => ['type' => 'meal', 'food' => 'burger', 'drink' => 'coke _zero_']]],
                 ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'second text']]],
                 ['type' => 'set', 'attrs' => ['id' => '2', 'values' => ['type' => 'car', 'make' => 'toyota', 'model' => 'corolla']]],
                 ['type' => 'set', 'attrs' => ['values' => ['type' => 'meal', 'food' => 'salad', 'drink' => 'water']]], // id intentionally omitted
@@ -77,6 +77,7 @@ class BardFieldtypeTest extends TestCase
                     type
                     food
                     drink
+                    drink_md: drink(format: "markdown")
                 }
                 ... on Set_Things_Car {
                     id
@@ -99,10 +100,10 @@ GQL;
                     'title' => 'Main Post',
                     'things' => [
                         ['type' => 'text', 'text' => '<p>first text</p>'],
-                        ['id' => '1', 'type' => 'meal', 'food' => 'burger', 'drink' => 'coke'],
+                        ['id' => '1', 'type' => 'meal', 'food' => 'burger', 'drink' => "<p>coke <em>zero</em></p>\n", 'drink_md' => 'coke _zero_'],
                         ['type' => 'text', 'text' => '<p>second text</p>'],
                         ['id' => '2', 'type' => 'car', 'make' => 'toyota', 'model' => 'corolla'],
-                        ['id' => null, 'type' => 'meal', 'food' => 'salad', 'drink' => 'water'],
+                        ['id' => null, 'type' => 'meal', 'food' => 'salad', 'drink' => "<p>water</p>\n", 'drink_md' => 'water'],
                         ['type' => 'text', 'text' => '<p>last text</p>'],
                     ],
                 ],

--- a/tests/Feature/GraphQL/Fieldtypes/GridFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/GridFieldtypeTest.php
@@ -32,7 +32,7 @@ class GridFieldtypeTest extends TestCase
                 'fields' => [
                     ['handle' => 'food', 'field' => ['type' => 'text']],
                     ['handle' => 'drink', 'field' => ['type' => 'markdown']], // using markdown to show nested fields are resolved using their fieldtype.
-                    ['handle' => 'stuff', 'field' => ['type' => 'entries']],
+                    ['handle' => 'stuff', 'field' => ['type' => 'entries']], // using entries to query builders get resolved
                 ],
             ],
         ]);

--- a/tests/Feature/GraphQL/Fieldtypes/GridFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/GridFieldtypeTest.php
@@ -31,7 +31,7 @@ class GridFieldtypeTest extends TestCase
                 'type' => 'grid',
                 'fields' => [
                     ['handle' => 'food', 'field' => ['type' => 'text']],
-                    ['handle' => 'drink', 'field' => ['type' => 'text']],
+                    ['handle' => 'drink', 'field' => ['type' => 'markdown']],
                     ['handle' => 'stuff', 'field' => ['type' => 'entries']],
                 ],
             ],
@@ -50,7 +50,7 @@ class GridFieldtypeTest extends TestCase
         EntryFactory::collection('blog')->id('1')->data([
             'title' => 'Main Post',
             'meals' => [
-                ['id' => '1', 'food' => 'burger', 'drink' => 'coke'],
+                ['id' => '1', 'food' => 'burger', 'drink' => 'coke _zero_'],
                 ['food' => 'salad', 'drink' => 'water', 'stuff' => ['stuff1']], // id intentionally omitted
             ],
         ])->create();
@@ -66,6 +66,7 @@ class GridFieldtypeTest extends TestCase
                 id
                 food
                 drink
+                drink_md: drink(format: "markdown")
                 stuff {
                     title
                 }
@@ -83,8 +84,8 @@ GQL;
                 'entry' => [
                     'title' => 'Main Post',
                     'meals' => [
-                        ['id' => '1', 'food' => 'burger', 'drink' => 'coke', 'stuff' => []],
-                        ['id' => null, 'food' => 'salad', 'drink' => 'water', 'stuff' => [['title' => 'One']]],
+                        ['id' => '1', 'food' => 'burger', 'drink' => "<p>coke <em>zero</em></p>\n", 'drink_md' => 'coke _zero_', 'stuff' => []],
+                        ['id' => null, 'food' => 'salad', 'drink' => "<p>water</p>\n", 'drink_md' => 'water', 'stuff' => [['title' => 'One']]],
                     ],
                 ],
             ]]);

--- a/tests/Feature/GraphQL/Fieldtypes/GridFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/GridFieldtypeTest.php
@@ -31,7 +31,7 @@ class GridFieldtypeTest extends TestCase
                 'type' => 'grid',
                 'fields' => [
                     ['handle' => 'food', 'field' => ['type' => 'text']],
-                    ['handle' => 'drink', 'field' => ['type' => 'markdown']],
+                    ['handle' => 'drink', 'field' => ['type' => 'markdown']], // using markdown to show nested fields are resolved using their fieldtype.
                     ['handle' => 'stuff', 'field' => ['type' => 'entries']],
                 ],
             ],

--- a/tests/Feature/GraphQL/Fieldtypes/ReplicatorFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/ReplicatorFieldtypeTest.php
@@ -33,7 +33,7 @@ class ReplicatorFieldtypeTest extends TestCase
                     'meal' => [
                         'fields' => [
                             ['handle' => 'food', 'field' => ['type' => 'text']],
-                            ['handle' => 'drink', 'field' => ['type' => 'text']],
+                            ['handle' => 'drink', 'field' => ['type' => 'markdown']],
                         ],
                     ],
                     'car' => [
@@ -60,7 +60,7 @@ class ReplicatorFieldtypeTest extends TestCase
         EntryFactory::collection('blog')->id('1')->data([
             'title' => 'Main Post',
             'things' => [
-                ['id' => '1', 'type' => 'meal', 'food' => 'burger', 'drink' => 'coke'],
+                ['id' => '1', 'type' => 'meal', 'food' => 'burger', 'drink' => 'coke _zero_'],
                 ['id' => '2', 'type' => 'car', 'make' => 'toyota', 'model' => 'corolla', 'trims' => ['trim1']],
                 ['type' => 'meal', 'food' => 'salad', 'drink' => 'water'], // id intentionally omitted
             ],
@@ -79,6 +79,7 @@ class ReplicatorFieldtypeTest extends TestCase
                     type
                     food
                     drink
+                    drink_md: drink(format: "markdown")
                 }
                 ... on Set_Things_Car {
                     id
@@ -103,9 +104,9 @@ GQL;
                 'entry' => [
                     'title' => 'Main Post',
                     'things' => [
-                        ['id' => '1', 'type' => 'meal', 'food' => 'burger', 'drink' => 'coke'],
+                        ['id' => '1', 'type' => 'meal', 'food' => 'burger', 'drink' => "<p>coke <em>zero</em></p>\n", 'drink_md' => 'coke _zero_'],
                         ['id' => '2', 'type' => 'car', 'make' => 'toyota', 'model' => 'corolla', 'trims' => [['title' => 'Trim One']]],
-                        ['id' => null, 'type' => 'meal', 'food' => 'salad', 'drink' => 'water'],
+                        ['id' => null, 'type' => 'meal', 'food' => 'salad', 'drink' => "<p>water</p>\n", 'drink_md' => 'water'],
                     ],
                 ],
             ]]);

--- a/tests/Feature/GraphQL/Fieldtypes/ReplicatorFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/ReplicatorFieldtypeTest.php
@@ -40,7 +40,7 @@ class ReplicatorFieldtypeTest extends TestCase
                         'fields' => [
                             ['handle' => 'make', 'field' => ['type' => 'text']],
                             ['handle' => 'model', 'field' => ['type' => 'text']],
-                            ['handle' => 'trims', 'field' => ['type' => 'entries']],
+                            ['handle' => 'trims', 'field' => ['type' => 'entries']], // using entries to query builders get resolved
                         ],
                     ],
                 ],

--- a/tests/Feature/GraphQL/Fieldtypes/ReplicatorFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/ReplicatorFieldtypeTest.php
@@ -33,7 +33,7 @@ class ReplicatorFieldtypeTest extends TestCase
                     'meal' => [
                         'fields' => [
                             ['handle' => 'food', 'field' => ['type' => 'text']],
-                            ['handle' => 'drink', 'field' => ['type' => 'markdown']],
+                            ['handle' => 'drink', 'field' => ['type' => 'markdown']], // using markdown to show nested fields are resolved using their fieldtype.
                         ],
                     ],
                     'car' => [


### PR DESCRIPTION
This fixes an issue where nested fields (fields inside replicator, grid, bard) get resolved too early.

e.g. If you have a markdown field, you're able to ask for it as markdown.

```graphql
description(format: "markdown") // returns markdown
```

But if you were asking for a markdown field inside a replicator set, it would have resolved to html within the set, and by the time it got to the markdown field, it wouldn't be able to give you raw markdown.

```graphql
... on Set_Replicator_MySet {
  description(format: "markdown") // returns html
}
```

This fixes it by using the corresponding field's resolver, instead of doing it within the set.

Todo:

- [x] Tests
- [x] Bard
- [x] Grid