### PR TITLE
Fix Bard backwards compatibility

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -230,7 +230,7 @@ class Bard extends Replicator
             $value = $this->convertLegacyData($value);
         }
 
-        $value = $this->handleLegacyTiptap($value);
+        $value = $this->convertLegacyTiptap($value);
 
         return (new Augmentor($this))->augment($value, $shallow);
     }
@@ -341,7 +341,7 @@ class Bard extends Replicator
             $value = $this->convertLegacyData($value);
         }
 
-        $value = $this->handleLegacyTiptap($value);
+        $value = $this->convertLegacyTiptap($value);
 
         if ($this->config('inline')) {
             // Root should be text, if it's not this must be a block field converted
@@ -483,7 +483,7 @@ class Bard extends Replicator
         })->all();
     }
 
-    protected function handleLegacyTiptap($value)
+    protected function convertLegacyTiptap($value)
     {
         if (is_string($value)) {
             return $value;
@@ -495,7 +495,7 @@ class Bard extends Replicator
             }
 
             if (is_array($item)) {
-                return $this->handleLegacyTiptap($item);
+                return $this->convertLegacyTiptap($item);
             }
 
             if ($key === 'type') {

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -230,6 +230,8 @@ class Bard extends Replicator
             $value = $this->convertLegacyData($value);
         }
 
+        $value = $this->handleLegacyTiptap($value);
+
         return (new Augmentor($this))->augment($value, $shallow);
     }
 
@@ -338,6 +340,8 @@ class Bard extends Replicator
         } elseif ($this->isLegacyData($value)) {
             $value = $this->convertLegacyData($value);
         }
+
+        $value = $this->handleLegacyTiptap($value);
 
         if ($this->config('inline')) {
             // Root should be text, if it's not this must be a block field converted
@@ -476,6 +480,29 @@ class Bard extends Replicator
                     ],
                 ],
             ];
+        })->all();
+    }
+
+    protected function handleLegacyTiptap($value)
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        return collect($value)->map(function ($item, $key) {
+            if (is_array($item) && ($item['type'] ?? null) === 'set') {
+                return $item;
+            }
+
+            if (is_array($item)) {
+                return $this->handleLegacyTiptap($item);
+            }
+
+            if ($key === 'type') {
+                return Str::camel($item);
+            }
+
+            return $item;
         })->all();
     }
 

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -130,6 +130,91 @@ class BardTest extends TestCase
     }
 
     /** @test */
+    public function it_augments_tiptap_v1_snake_case_types_to_v2_camel_case_types()
+    {
+        $data = [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'This is ',
+                    ],
+                    [
+                        'type' => 'text',
+                        'marks' => [
+                            ['type' => 'bold'],
+                        ],
+                        'text' => 'bold',
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => ' text.',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'set',
+                'attrs' => [
+                    'id' => '123',
+                    'values' => [
+                        'type' => 'my_set',
+                        'text' => 'test',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'bullet_list',
+                'content' => [
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'type' => 'text',
+                                        'text' => 'This is a list item.',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $expected = [
+            [
+                'type' => 'text',
+                'text' => '<p>This is <strong>bold</strong> text.</p>',
+            ],
+            [
+                'id' => '123',
+                'type' => 'my_set',
+                'text' => 'test',
+            ],
+            [
+                'type' => 'text',
+                'text' => '<ul><li><p>This is a list item.</p></li></ul>',
+            ],
+        ];
+
+        $augmented = $this->bard([
+            'sets' => [
+                'my_set' => [
+                    'fields' => [
+                        ['handle' => 'text', 'field' => ['type' => 'text']],
+                    ],
+                ],
+            ],
+        ])->augment($data);
+
+        $this->assertEveryItemIsInstanceOf(Values::class, $augmented);
+        $this->assertEquals($expected, collect($augmented)->toArray());
+    }
+
+    /** @test */
     public function it_augments_to_html_when_there_are_no_sets()
     {
         $data = [
@@ -704,6 +789,117 @@ EOT;
         $expected = '[{"type":"paragraph","content":[{"type":"text","text":"This is block text."}]}]';
 
         $this->assertEquals($expected, $this->bard(['inline' => true, 'sets' => null])->preProcess($data));
+    }
+
+    /** @test */
+    public function it_converts_tiptap_v1_snake_case_types_to_v2_camel_case_types()
+    {
+        $data = [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'This is ',
+                    ],
+                    [
+                        'type' => 'text',
+                        'marks' => [
+                            ['type' => 'bold'],
+                        ],
+                        'text' => 'bold',
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => ' text.',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'set',
+                'attrs' => [
+                    'id' => '123',
+                    'values' => [
+                        'type' => 'my_set',
+                        'text' => 'test',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'bullet_list',
+                'content' => [
+                    [
+                        'type' => 'list_item',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'type' => 'text',
+                                        'text' => 'This is a list item.',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $expected = [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'This is ',
+                    ],
+                    [
+                        'type' => 'text',
+                        'marks' => [
+                            ['type' => 'bold'],
+                        ],
+                        'text' => 'bold',
+                    ],
+                    [
+                        'type' => 'text',
+                        'text' => ' text.',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'set',
+                'attrs' => [
+                    'id' => '123',
+                    'values' => [
+                        'type' => 'my_set',
+                        'text' => 'test',
+                    ],
+                    'enabled' => true,
+                ],
+            ],
+            [
+                'type' => 'bulletList',
+                'content' => [
+                    [
+                        'type' => 'listItem',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'content' => [
+                                    [
+                                        'type' => 'text',
+                                        'text' => 'This is a list item.',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, json_decode($this->bard()->preProcess($data), true));
     }
 
     private function bard($config = [])


### PR DESCRIPTION
Fixes #7421

Rather than needing to update any content, this will adjust the `snake_case` types to `camelCase`, as per the tiptap v1/v2 upgrade guide.

If you open an entry in the cp and hit save, all the types will be updated in that entry.