### PR TITLE
Prevent Countable Error in Terms.php

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -264,9 +264,9 @@ class Terms extends Relationship
             }
 
             $blueprints = $taxonomy->termBlueprints();
-            
+
             $taxonomies = is_countable($taxonomies) ? $taxonomies : [$taxonomies];
-            
+
             return $blueprints->map(function ($blueprint) use ($taxonomy, $taxonomies, $blueprints) {
                 return [
                     'title' => $this->getCreatableTitle($taxonomy, $blueprint, count($taxonomies), $blueprints->count()),

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -264,7 +264,9 @@ class Terms extends Relationship
             }
 
             $blueprints = $taxonomy->termBlueprints();
-
+            
+            $taxonomies = is_countable($taxonomies) ? $taxonomies : [$taxonomies];
+            
             return $blueprints->map(function ($blueprint) use ($taxonomy, $taxonomies, $blueprints) {
                 return [
                     'title' => $this->getCreatableTitle($taxonomy, $blueprint, count($taxonomies), $blueprints->count()),


### PR DESCRIPTION
I would really really like to tell you how to reproduce this error - unfortunately this only happens in one of my projects, and it is a project that I started with a very early version of V3. I did update it over time and I am on the latest version, and it is a multisite project.

If you would prefer, I could try to make a branch of this project where I strip it down to the minimum needed content for this error to occur and put it up somewhere for inspection.

What happens is the following: when editing some Collection entries with Taxonomies, right at the point where I made the proposed change in the file, `$taxonomies` is not an array, but a simple string (the handle of the taxonomy in question). That of course throws the error "count(): Argument #1 ($value) must be of type Countable|array, string given" (because of the `count($taxonomies)` a few lines further down) - and my clients can't update their content anymore.

I know adding this line does nothing for most users - but it would help me a tremendous amount. 

Thanks for considering it, Sebastian