### PR TITLE
Updated Dutch translation

### DIFF
--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -44,7 +44,7 @@
     "Affected files": "Betreffende bestanden",
     "After": "Na",
     "After Saving": "Na opslaan",
-    "Alias Item": "Item uitlijnen",
+    "Alias Item": "Gealiast item",
     "Align Center": "Centreren",
     "Align Justify": "Uitrekken",
     "Align Left": "Links uitlijnen",


### PR DESCRIPTION
The translation was a bit off. 'Item uitlijnen' is the translation of 'align item' and not of 'alias item'. 

Still thanks to @oakeddev for the translations!

