### PR TITLE
Fix create entry form not redirecting on save

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -566,7 +566,7 @@ export default {
                     }
 
                     this.quickSave = false;
-                }).catch(e => {});
+                }).catch(e => console.error(e));
         },
 
         confirmPublish() {

--- a/resources/js/components/publish/HasHiddenFields.js
+++ b/resources/js/components/publish/HasHiddenFields.js
@@ -30,6 +30,8 @@ export default {
     methods: {
 
         resetValuesFromResponse(responseValues) {
+            if (!responseValues) return this.values;
+
             let preserveFields = ['id'].concat(this.revealerFields);
             let originalValues = new Values(this.values, this.jsonSubmittingFields);
             let newValues = new Values(responseValues, this.jsonSubmittingFields);

--- a/resources/js/components/publish/Values.js
+++ b/resources/js/components/publish/Values.js
@@ -3,7 +3,7 @@ import { data_get } from  '../../bootstrap/globals.js'
 import { data_set } from  '../../bootstrap/globals.js'
 import isObject from 'underscore/modules/isObject.js'
 
-export default class {
+export default class Values {
     constructor(values, jsonFields) {
         this.values = clone(values);
 


### PR DESCRIPTION
Fixes #7441
The issue said 3.4, but it was actually introduced in 3.3.66. I'll fix it separately for 3.4 too, though.

This PR:
- Fixes the error that prevented the redirect. It had to do with merging undefined response values since we don't get those on the create form.
- The save action would swallow any errors, making it look like there wasn't a problem. It'll now log the error.
- Added a name to the Values class, purely to make stack traces easier to read. An instance of Values would show up as `_default`. Now it says `Values`.
