### PR TITLE
Fix custom Bard extension type attributes

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -490,7 +490,7 @@ class Bard extends Replicator
         }
 
         return collect($value)->map(function ($item, $key) {
-            if (is_array($item) && ($item['type'] ?? null) === 'set') {
+            if (is_array($item) && $key === 'attrs') {
                 return $item;
             }
 

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -902,6 +902,21 @@ EOT;
         $this->assertEquals($expected, json_decode($this->bard()->preProcess($data), true));
     }
 
+    /** @test */
+    public function it_doesnt_convert_custom_type_attrs_to_camel_case()
+    {
+        $data = [
+            [
+                'type' => 'myCustomNode',
+                'attrs' => [
+                    'type' => 'my_custom_type_attr',
+                ],
+            ],
+        ];
+
+        $this->assertEquals($data, json_decode($this->bard()->preProcess($data), true));
+    }
+
     private function bard($config = [])
     {
         return (new Bard)->setField(new Field('test', array_merge(['type' => 'bard', 'sets' => ['one' => []]], $config)));


### PR DESCRIPTION
Run into a small issue with https://github.com/statamic/cms/pull/7433 and custom Bard extensions.

If your extension has a `type` _attribute_ it is also converted to camel case, even though only the node names need to be converted. This isn't a problem for the `type` values within set attributes as sets are skipped in the loop.

This PR fixes that by instead of just skipping sets it now skips all `attrs` arrays.