### PR TITLE
Support wildcard (*) in stache querybuilder `where` queries

### DIFF
--- a/src/Query/ResolveValue.php
+++ b/src/Query/ResolveValue.php
@@ -10,10 +10,10 @@ class ResolveValue
 {
     public function __invoke($item, $name)
     {
-        $nameExploded = explode('->', $name);
+        $this->nameExploded = explode('->', $name);
 
-        while (! empty($nameExploded)) {
-            $name = array_shift($nameExploded);
+        while (! empty($this->nameExploded)) {
+            $name = array_shift($this->nameExploded);
             $item = $this->resolveItemPartValue($item, $name);
 
             if (is_null($item)) {
@@ -36,6 +36,14 @@ class ResolveValue
     private function getItemPartValue($item, $name)
     {
         if (is_array($item)) {
+            if ($name === '*' && ! empty($this->nameExploded)) {
+                foreach ($item as $value) {
+                    if ($this->resolveItemPartValue($value, $this->nameExploded[0])) {
+                        return $value;
+                    }
+                }
+            }
+
             return $item[$name] ?? null;
         }
 

--- a/src/Query/ResolveValue.php
+++ b/src/Query/ResolveValue.php
@@ -24,21 +24,21 @@ class ResolveValue
         return $item;
     }
 
-    private function resolveItemPartValue($item, $name)
+    private function resolveItemPartValue($item, $name, $wildcardDepth = 0)
     {
-        $value = $this->getItemPartValue($item, $name);
+        $value = $this->getItemPartValue($item, $name, $wildcardDepth);
 
         return $value instanceof QueryableValue
             ? $value->toQueryableValue()
             : $value;
     }
 
-    private function getItemPartValue($item, $name)
+    private function getItemPartValue($item, $name, $wildcardDepth)
     {
         if (is_array($item)) {
             if ($name === '*' && ! empty($this->nameExploded)) {
                 foreach ($item as $value) {
-                    if ($this->resolveItemPartValue($value, $this->nameExploded[0])) {
+                    if ($this->resolveItemPartValue($value, $this->nameExploded[$wildcardDepth], $wildcardDepth + 1)) {
                         return $value;
                     }
                 }

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -507,7 +507,7 @@ class EntryQueryBuilderTest extends TestCase
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'content' => ['x' => ['value' => 1]]])->create();
         EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'content' => ['y' => ['value' => 2]]])->create();
-        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'content' => ['z' => ['value' => 3]]])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'content' => ['z' => ['x' => ['y' => ['value' => 2]]]]])->create();
         EntryFactory::id('4')->slug('post-4')->collection('posts')->data(['title' => 'Post 4', 'content' => ['a' => ['x' => ['value' => 2]]]])->create();
         EntryFactory::id('5')->slug('post-5')->collection('posts')->data(['title' => 'Post 5', 'content' => ['b' => ['value' => 1]]])->create();
         // the following two entries use scalars for the content field to test that they get successfully ignored.
@@ -529,6 +529,12 @@ class EntryQueryBuilderTest extends TestCase
 
         $this->assertCount(1, $entries);
         $this->assertEquals(['Post 4'], $entries->map->title->all());
+
+        // ensure we can use multiple wildcards
+        $entries = Entry::query()->where('content->*->x->*->value', 2)->get();
+
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Post 3'], $entries->map->title->all());
 
         // ensure it only works on array level elements
         $entries = Entry::query()->where('content->value->*', 1)->get();

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -508,7 +508,7 @@ class EntryQueryBuilderTest extends TestCase
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'content' => ['x' => ['value' => 1]]])->create();
         EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'content' => ['y' => ['value' => 2]]])->create();
         EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'content' => ['z' => ['value' => 3]]])->create();
-        EntryFactory::id('4')->slug('post-4')->collection('posts')->data(['title' => 'Post 4', 'content' => ['a' => ['value' => 2]]])->create();
+        EntryFactory::id('4')->slug('post-4')->collection('posts')->data(['title' => 'Post 4', 'content' => ['a' => ['x' => ['value' => 2]]]])->create();
         EntryFactory::id('5')->slug('post-5')->collection('posts')->data(['title' => 'Post 5', 'content' => ['b' => ['value' => 1]]])->create();
         // the following two entries use scalars for the content field to test that they get successfully ignored.
         EntryFactory::id('6')->slug('post-6')->collection('posts')->data(['title' => 'Post 6', 'content' => 'string'])->create();
@@ -523,6 +523,12 @@ class EntryQueryBuilderTest extends TestCase
 
         $this->assertCount(5, $entries);
         $this->assertEquals(['Post 2', 'Post 3', 'Post 4', 'Post 6', 'Post 7'], $entries->map->title->all());
+
+        // ensure we can use multiple wildcards
+        $entries = Entry::query()->where('content->*->*->value', 2)->get();
+
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Post 4'], $entries->map->title->all());
 
         // ensure it only works on array level elements
         $entries = Entry::query()->where('content->value->*', 1)->get();


### PR DESCRIPTION
One thing I find myself reaching for a lot, and that has also been asked for on Discord a few times, is the ability to query inside replicator type fields (indexed arrays) for a subfield value.

At the moment you can do the following:

```
$query->where('replicator_field->0->sub_field', 1)
->orWhere('replicator_field->1->sub_field', 1);
```

Obviously this falls apart when you dont know the length of your replicator field, or becomes unwieldy when you have lots of items in your replicator as you have to write lots of orWheres()

The PR attempts to resolve this by supporting wildcard searches (*) in where queries.

So the query above would become:

```
$query->where('replicator_field->*->sub_field', 1);
```

As far as I can tell, compatibility with eloquent will not be possible for this feature, so it would be file-driver only.

You'll see from the code I've restricted this to arrays only, though you may want to widen the scope once you see it in action. I've also tried to accommodate multiple wildcards... eg 

```
$query->where('replicator_field->*->sub_field->*->value', 1);
```