### PR TITLE
Fix `orWhereJsonLength()` method in the QueryBuilders

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -271,9 +271,9 @@ abstract class Builder implements Contract
         return $this;
     }
 
-    public function orWhereJsonLength($column, $operator, $value)
+    public function orWhereJsonLength($column, $operator, $value = null)
     {
-        return $this->whereJsonLength($column, $operator, $value = null, 'or');
+        return $this->whereJsonLength($column, $operator, $value, 'or');
     }
 
     public function whereNull($column, $boolean = 'and', $not = false)

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -181,9 +181,9 @@ abstract class EloquentQueryBuilder implements Builder
         return $this;
     }
 
-    public function orWhereJsonLength($column, $operator, $value)
+    public function orWhereJsonLength($column, $operator, $value = null)
     {
-        return $this->whereJsonLength($column, $operator, $value = null, 'or');
+        return $this->whereJsonLength($column, $operator, $value, 'or');
     }
 
     public function whereNull($column, $boolean = 'and', $not = false)

--- a/tests/Data/Assets/AssetQueryBuilderTest.php
+++ b/tests/Data/Assets/AssetQueryBuilderTest.php
@@ -411,13 +411,13 @@ class AssetQueryBuilderTest extends TestCase
         Asset::find('test::a.jpg')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-2']])->save();
         Asset::find('test::b.txt')->data(['test_taxonomy' => ['taxonomy-3']])->save();
         Asset::find('test::c.txt')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-3']])->save();
-        Asset::find('test::d.jpg')->data(['test_taxonomy' => ['taxonomy-3', 'taxonomy-4']])->save();
+        Asset::find('test::d.jpg')->data(['test_taxonomy' => ['taxonomy-3', 'taxonomy-4', 'taxonomy-5']])->save();
         Asset::find('test::e.jpg')->data(['test_taxonomy' => ['taxonomy-5']])->save();
 
-        $assets = $this->container->queryAssets()->whereJsonLength('test_taxonomy', 1)->get();
+        $assets = $this->container->queryAssets()->whereJsonLength('test_taxonomy', 1)->orWhereJsonLength('test_taxonomy', 3)->get();
 
-        $this->assertCount(2, $assets);
-        $this->assertEquals(['b', 'e'], $assets->map->filename()->all());
+        $this->assertCount(3, $assets);
+        $this->assertEquals(['b', 'e', 'd'], $assets->map->filename()->all());
     }
 
     /** @test **/

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -449,13 +449,13 @@ class EntryQueryBuilderTest extends TestCase
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'test_taxonomy' => ['taxonomy-1', 'taxonomy-2']])->create();
         EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'test_taxonomy' => ['taxonomy-3']])->create();
         EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'test_taxonomy' => ['taxonomy-1', 'taxonomy-3']])->create();
-        EntryFactory::id('4')->slug('post-4')->collection('posts')->data(['title' => 'Post 4', 'test_taxonomy' => ['taxonomy-3', 'taxonomy-4']])->create();
+        EntryFactory::id('4')->slug('post-4')->collection('posts')->data(['title' => 'Post 4', 'test_taxonomy' => ['taxonomy-3', 'taxonomy-4', 'taxonomy-5']])->create();
         EntryFactory::id('5')->slug('post-5')->collection('posts')->data(['title' => 'Post 5', 'test_taxonomy' => ['taxonomy-5']])->create();
 
-        $entries = Entry::query()->whereJsonLength('test_taxonomy', 1)->get();
+        $entries = Entry::query()->whereJsonLength('test_taxonomy', 1)->orWhereJsonLength('test_taxonomy', 3)->get();
 
-        $this->assertCount(2, $entries);
-        $this->assertEquals(['Post 2', 'Post 5'], $entries->map->title->all());
+        $this->assertCount(3, $entries);
+        $this->assertEquals(['Post 2', 'Post 5', 'Post 4'], $entries->map->title->all());
     }
 
     /** @test **/

--- a/tests/Data/Taxonomies/TermQueryBuilderTest.php
+++ b/tests/Data/Taxonomies/TermQueryBuilderTest.php
@@ -575,13 +575,13 @@ class TermQueryBuilderTest extends TestCase
         Term::make('1')->taxonomy('tags')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-2']])->save();
         Term::make('2')->taxonomy('tags')->data(['test_taxonomy' => ['taxonomy-3']])->save();
         Term::make('3')->taxonomy('tags')->data(['test_taxonomy' => ['taxonomy-1', 'taxonomy-3']])->save();
-        Term::make('4')->taxonomy('tags')->data(['test_taxonomy' => ['taxonomy-3', 'taxonomy-4']])->save();
+        Term::make('4')->taxonomy('tags')->data(['test_taxonomy' => ['taxonomy-3', 'taxonomy-4', 'taxonomy-5']])->save();
         Term::make('5')->taxonomy('tags')->data(['test_taxonomy' => ['taxonomy-5']])->save();
 
-        $entries = Term::query()->whereJsonLength('test_taxonomy', 1)->get();
+        $entries = Term::query()->whereJsonLength('test_taxonomy', 1)->orWhereJsonLength('test_taxonomy', 3)->get();
 
-        $this->assertCount(2, $entries);
-        $this->assertEquals(['2', '5'], $entries->map->slug()->all());
+        $this->assertCount(3, $entries);
+        $this->assertEquals(['2', '5', '4'], $entries->map->slug()->all());
     }
 
     /** @test */

--- a/tests/Search/QueryBuilderTest.php
+++ b/tests/Search/QueryBuilderTest.php
@@ -449,23 +449,6 @@ class QueryBuilderTest extends TestCase
     }
 
     /** @test **/
-    public function results_are_found_using_or_where_json_length()
-    {
-        $items = collect([
-            ['reference' => 'a', 'test_taxonomy' => ['taxonomy-1', 'taxonomy-2']],
-            ['reference' => 'b', 'test_taxonomy' => ['taxonomy-3']],
-            ['reference' => 'c', 'test_taxonomy' => ['taxonomy-1', 'taxonomy-3']],
-            ['reference' => 'd', 'test_taxonomy' => ['taxonomy-3', 'taxonomy-4']],
-            ['reference' => 'e', 'test_taxonomy' => ['taxonomy-5']],
-        ]);
-
-        $results = (new FakeQueryBuilder($items))->withoutData()->whereJsonLength('test_taxonomy', 1)->get();
-
-        $this->assertCount(2, $results);
-        $this->assertEquals(['b', 'e'], $results->map->reference->all());
-    }
-
-    /** @test **/
     public function results_are_found_using_multiple_wheres()
     {
         $items = collect([

--- a/tests/Search/QueryBuilderTest.php
+++ b/tests/Search/QueryBuilderTest.php
@@ -438,6 +438,23 @@ class QueryBuilderTest extends TestCase
             ['reference' => 'a', 'test_taxonomy' => ['taxonomy-1', 'taxonomy-2']],
             ['reference' => 'b', 'test_taxonomy' => ['taxonomy-3']],
             ['reference' => 'c', 'test_taxonomy' => ['taxonomy-1', 'taxonomy-3']],
+            ['reference' => 'd', 'test_taxonomy' => ['taxonomy-3', 'taxonomy-4', 'taxonomy-5']],
+            ['reference' => 'e', 'test_taxonomy' => ['taxonomy-5']],
+        ]);
+
+        $results = (new FakeQueryBuilder($items))->withoutData()->whereJsonLength('test_taxonomy', 1)->orWhereJsonLength('test_taxonomy', 3)->get();
+
+        $this->assertCount(3, $results);
+        $this->assertEquals(['b', 'e', 'd'], $results->map->reference->all());
+    }
+
+    /** @test **/
+    public function results_are_found_using_or_where_json_length()
+    {
+        $items = collect([
+            ['reference' => 'a', 'test_taxonomy' => ['taxonomy-1', 'taxonomy-2']],
+            ['reference' => 'b', 'test_taxonomy' => ['taxonomy-3']],
+            ['reference' => 'c', 'test_taxonomy' => ['taxonomy-1', 'taxonomy-3']],
             ['reference' => 'd', 'test_taxonomy' => ['taxonomy-3', 'taxonomy-4']],
             ['reference' => 'e', 'test_taxonomy' => ['taxonomy-5']],
         ]);


### PR DESCRIPTION
Fixes #7460. Both in `Statamic\Query\Builder` and `Statamic\Query\EloquentQueryBuilder`.