### PR TITLE
Cache result of schema call to avoid duplication

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -15,6 +15,7 @@ abstract class EloquentQueryBuilder implements Builder
 {
     protected $builder;
     protected $columns;
+    protected $schemas;
 
     protected $operators = [
         '=' => 'Equals',
@@ -33,6 +34,7 @@ abstract class EloquentQueryBuilder implements Builder
     public function __construct(EloquentBuilder $builder)
     {
         $this->builder = $builder;
+        $this->schemas = collect();
     }
 
     public function __call($method, $args)
@@ -394,7 +396,13 @@ abstract class EloquentQueryBuilder implements Builder
             // exception. Stripping out invalid columns is fine here. They
             // will still be sent through and used for augmentation.
             $model = $this->builder->getModel();
-            $schema = $model->getConnection()->getSchemaBuilder()->getColumnListing($model->getTable());
+            $table = $model->getTable();
+
+            if (! $schema = $this->schemas->get($table)) {
+                $schema = $model->getConnection()->getSchemaBuilder()->getColumnListing($table);
+                $this->schemas->put($table, $schame);
+            }
+
             $selected = array_intersect($schema, $columns);
         }
 

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -400,7 +400,7 @@ abstract class EloquentQueryBuilder implements Builder
 
             if (! $schema = $this->schemas->get($table)) {
                 $schema = $model->getConnection()->getSchemaBuilder()->getColumnListing($table);
-                $this->schemas->put($table, $schame);
+                $this->schemas->put($table, $schema);
             }
 
             $selected = array_intersect($schema, $columns);

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -397,7 +397,7 @@ abstract class EloquentQueryBuilder implements Builder
             $model = $this->builder->getModel();
             $table = $model->getTable();
 
-            Blink::once("eloquent-schema-{$table}", function () use ($model, $table) {
+            $schema = Blink::once("eloquent-schema-{$table}", function () use ($model, $table) {
                 return $model->getConnection()->getSchemaBuilder()->getColumnListing($table);
             });
 


### PR DESCRIPTION
As noted over in https://github.com/statamic/eloquent-driver/issues/110

The call to get the schema can result in lots of duplicate queries - so let's store the result of the call. As Eloquent Query Builders are singletons this approach should be ok - if I've misunderstood that then I can update it to `Blink` them instead.