### PR TITLE
Fix queue worker state issues around assets and stache indexes

### DIFF
--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -134,6 +134,7 @@ abstract class Index
 
     public function clear()
     {
+        $this->loaded = false;
         $this->items = null;
 
         Cache::forget($this->cacheKey());

--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -4,6 +4,7 @@ namespace Statamic\Stache\Indexes;
 
 use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\Stache;
+use Statamic\Statamic;
 
 abstract class Index
 {
@@ -65,6 +66,10 @@ abstract class Index
         }
 
         $this->loaded = true;
+
+        if (Statamic::isWorker()) {
+            $this->loaded = false;
+        }
 
         debugbar()->addMessage("Loading index: {$this->store->key()}/{$this->name}", 'stache');
 

--- a/src/Stache/Stores/ContainerAssetsStore.php
+++ b/src/Stache/Stores/ContainerAssetsStore.php
@@ -4,6 +4,7 @@ namespace Statamic\Stache\Stores;
 
 use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\AssetContainer;
+use Statamic\Statamic;
 use Statamic\Support\Str;
 
 class ContainerAssetsStore extends ChildStore
@@ -53,7 +54,7 @@ class ContainerAssetsStore extends ChildStore
 
     public function paths()
     {
-        if ($this->paths) {
+        if ($this->paths && ! Statamic::isWorker()) {
             return $this->paths;
         }
 


### PR DESCRIPTION
This one came from a support email, though we found it's very much related to #5501, among a few other issues.

Closes #5501
References #2993
References #6592

## The problem

If you upload an asset to an entry and try to get the asset value in a long-running queue worker, it'll find the asset just fine the first time, but not if you upload a new image and try to get the new asset a second time. This is mostly because the stache index is built/loaded only once per request, which breaks down in queue worker scenarios without a typical request lifecycle.

## To reproduce

1. Create an `EntrySaved` listener that dumps rendered html to log/ray/etc...

	```php
	public function handle($event)
	{
	    $this->entry = $event->entry;
	
	    $html = (new \Statamic\View\View)
	        ->template('articles/show')
	        ->with($this->entry->toAugmentedCollection()->map->value()->all())
	        ->render();
	
	    ray()->text($html);
	}
	```

2. In that view's template, make sure you're rendering the entry's asset field value...

	```antlers
	{{ hero }}
	    <img src="{{ url }}" alt="{{ alt }}" />
	{{ /hero }}
	```

3. Configure a proper redis queue connection...

	```
	QUEUE_CONNECTION=redis
	```

4. Start your queue worker...

	```bash
	php artisan queue:work --tries=1
	```

5. Upload an image to your entry and save.
	- You should see the template with the full `<img src="your-image-path.jpg">` being dumped.

6. Without restarting queue worker, upload a new image to your entry and save.
	- You would expect to see the template with the new `<img src="your-new-image-path.jpg">` being dumped,
	- But it is not there 😱