### PR TITLE
Adding support for the Vite::asset method

### DIFF
--- a/src/Tags/Vite.php
+++ b/src/Tags/Vite.php
@@ -3,6 +3,7 @@
 namespace Statamic\Tags;
 
 use Illuminate\Foundation\Vite as LaravelVite;
+use Illuminate\Support\Arr;
 
 class Vite extends Tags
 {
@@ -13,6 +14,13 @@ class Vite extends Tags
      */
     public function index()
     {
+        $asset = $this->params->explode('asset');
+
+        if ($asset) {
+            return app(LaravelVite::class)
+                ->asset(Arr::first($asset));
+        }
+
         if (! $src = $this->params->explode('src')) {
             throw new \Exception('Please provide a source file.');
         }

--- a/src/Tags/Vite.php
+++ b/src/Tags/Vite.php
@@ -3,7 +3,6 @@
 namespace Statamic\Tags;
 
 use Illuminate\Foundation\Vite as LaravelVite;
-use Illuminate\Support\Arr;
 
 class Vite extends Tags
 {
@@ -14,13 +13,6 @@ class Vite extends Tags
      */
     public function index()
     {
-        $asset = $this->params->explode('asset');
-
-        if ($asset) {
-            return app(LaravelVite::class)
-                ->asset(Arr::first($asset));
-        }
-
         if (! $src = $this->params->explode('src')) {
             throw new \Exception('Please provide a source file.');
         }
@@ -33,5 +25,22 @@ class Vite extends Tags
             ->useBuildDirectory($directory)
             ->useHotFile($hot ? base_path($hot) : null)
             ->toHtml();
+    }
+
+    /**
+     * The {{ vite:asset src="" }} tag.
+     *
+     * @return string
+     */
+    public function asset()
+    {
+        if (! $src = $this->params->get('src')) {
+            throw new \Exception('Please provide a source file.');
+        }
+
+        $buildDirectory = $this->params->get('buildDirectory', null);
+
+        return app(LaravelVite::class)
+                ->asset($src, $buildDirectory);
     }
 }

--- a/src/Tags/Vite.php
+++ b/src/Tags/Vite.php
@@ -38,9 +38,12 @@ class Vite extends Tags
             throw new \Exception('Please provide a source file.');
         }
 
-        $buildDirectory = $this->params->get('buildDirectory', null);
+        $directory = $this->params->get('directory', 'build');
+        $hot = $this->params->get('hot');
 
         return app(LaravelVite::class)
-                ->asset($src, $buildDirectory);
+            ->useBuildDirectory($directory)
+            ->useHotFile($hot ? base_path($hot) : null)
+            ->asset($src);
     }
 }


### PR DESCRIPTION
The Vite::asset (https://laravel.com/docs/9.x/vite#blade-processing-static-assets) method wasn't made available yet in Statamic Antlers.

I have extended the Vite Tag with a asset attribute to have the ability to load assets now.

Example usage: 

```html
{{ vite src="resources/css/app.scss" }}
{{ vite src="resources/js/site.js" }}


<img src="{{ vite asset="resources/images/logo.svg" }}" />
```