### PR TITLE
Update popover position when opening it

### DIFF
--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -86,6 +86,7 @@ export default {
         open() {
             this.isOpen = true;
             this.escBinding = this.$keys.bind('esc', e => this.close())
+            this.popper && this.popper.update();
         },
         close() {
             this.isOpen = false;


### PR DESCRIPTION
The menu was rendered offscreen. This fix makes sure the position for the menu is recalculated before showing it.

Fixes #7457
Fixes #7427