### PR TITLE
Custom Bard button active and visible callbacks

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -547,12 +547,18 @@ export default {
         },
 
         buttonIsActive(button) {
+            if (button.hasOwnProperty('isActive')) {
+                return button.isActive(this.editor, button.args);
+            }
             const nameProperty = button.hasOwnProperty('activeName') ? 'activeName' : 'name';
             const name = button[nameProperty];
             return this.editor.isActive(name, button.args);
         },
 
         buttonIsVisible(button) {
+            if (button.hasOwnProperty('isVisible')) {
+                return button.isVisible(this.editor, button.args);
+            }
             if (! button.hasOwnProperty('visibleWhenActive')) return true;
             return this.editor.isActive(button.visibleWhenActive, button.args);
         },


### PR DESCRIPTION
I'm working on a Bard extension that adds a button that sets an attribute on a node, however I only want the button to be visible when a relevant node is focused.

Currently this is not possible, because when the `visibleWhenActive` type is checked the `args` are also passed. This means that when checking if the button should be visible the element in question must already have the attribute set, which it wont as the purpose of the button is to set the attribute.

I considered adding a new `visibleWhenActiveArgs` property, but that felt a bit clumsy and some people could have even more complex requirements.

Instead this PR implements optional `isActive` and `isVisible` button callbacks, so that extensions can use their own completely custom logic to determine if the buttons should be visible or active, giving the most flexibility. 

I've put together a test extension that demonstrates the current issue and how this change allows it to work: https://gist.github.com/jacksleight/10ce4f5f90f3c1e75912f773164a91f8