### PR TITLE
Fix search issues

### DIFF
--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -100,6 +100,10 @@ class BrowserController extends CpController
 
         $assets = $query->paginate(request('perPage'));
 
+        if ($container->hasSearchIndex()) {
+            $assets->setCollection($assets->getCollection()->map->getSearchable());
+        }
+
         return new SearchedAssetsCollection($assets);
     }
 }

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -49,6 +49,10 @@ class EntriesController extends CpController
 
         $entries = $query->paginate(request('perPage'));
 
+        if (request('search') && $collection->hasSearchIndex()) {
+            $entries->setCollection($entries->getCollection()->map->getSearchable());
+        }
+
         return (new Entries($entries))
             ->blueprint($collection->entryBlueprint())
             ->columnPreferenceKey("collections.{$collection->handle()}.columns")

--- a/src/Search/PlainResult.php
+++ b/src/Search/PlainResult.php
@@ -31,4 +31,9 @@ class PlainResult extends Result
     {
         return new AugmentedData($this, $this->result);
     }
+
+    public function setSupplement($key, $value)
+    {
+        $this->result[$key] = $value;
+    }
 }

--- a/src/Search/PlainResult.php
+++ b/src/Search/PlainResult.php
@@ -32,6 +32,11 @@ class PlainResult extends Result
         return new AugmentedData($this, $this->result);
     }
 
+    public function get($key, $fallback = null)
+    {
+        return $this->result[$key] ?? $fallback;
+    }
+
     public function setSupplement($key, $value)
     {
         $this->result[$key] = $value;

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -45,12 +45,12 @@ abstract class QueryBuilder extends BaseQueryBuilder
         $results = $this->getSearchResults($this->query);
 
         if (! $this->withData) {
-            return collect($results)
+            return $this->collect($results)
                 ->map(fn ($result) => new PlainResult($result))
                 ->each(fn (Result $result, $i) => $result->setIndex($this->index)->setScore($results[$i]['search_score'] ?? null));
         }
 
-        return collect($results)->groupBy(function ($result) {
+        return $this->collect($results)->groupBy(function ($result) {
             return Str::before($result['reference'], '::');
         })->flatMap(function ($results, $prefix) {
             $results = $results->keyBy('reference');

--- a/src/Search/Result.php
+++ b/src/Search/Result.php
@@ -130,7 +130,7 @@ class Result implements Contract, ContainsQueryableValues
         return $this->searchable->getCpSearchResultBadge();
     }
 
-    public function supplement($key, $value)
+    public function setSupplement($key, $value)
     {
         $this->searchable->setSupplement($key, $value);
     }

--- a/src/Search/Result.php
+++ b/src/Search/Result.php
@@ -130,6 +130,11 @@ class Result implements Contract, ContainsQueryableValues
         return $this->searchable->getCpSearchResultBadge();
     }
 
+    public function get($key, $fallback = null)
+    {
+        return $this->searchable->get($key, $fallback);
+    }
+
     public function setSupplement($key, $value)
     {
         $this->searchable->setSupplement($key, $value);


### PR DESCRIPTION
- A couple of issues occur because a regular `Collection` is returned from the search query builder but should be a `DataCollection` like it was in 3.3. This prevented supplementing from working in the `search:results` tag. Additionally, supplementing wasn't being performed correctly in the Result classes.
  Fixes #7475

- When using search indexes in collections, taxonomies, or asset containers, and performing a search in the CP, you'd run into errors due to passing Result classes to our resource, but they were expecting Entry/Term/Asset instances. We now map back to those classes appropriately.
  Fixes #7474

- Added a `get` method to the Result class, which was being used by `DataCollection@multisort` method which fixes an error when using the `sort` param on the `search:results` tag.