### PR TITLE
Make the `nocache` tag work well with multiple query parameters

### DIFF
--- a/src/StaticCaching/NoCache/Controller.php
+++ b/src/StaticCaching/NoCache/Controller.php
@@ -4,12 +4,17 @@ namespace Statamic\StaticCaching\NoCache;
 
 use Illuminate\Http\Request;
 use Statamic\StaticCaching\Replacers\NoCacheReplacer;
+use Statamic\Support\Str;
 
 class Controller
 {
     public function __invoke(Request $request, Session $session)
     {
         $url = $request->input('url'); // todo: maybe strip off query params?
+
+        if (Str::contains($url, '?')) {
+            $url = Str::before($url, '?').'?'.Request::normalizeQueryString(Str::after($url, '?'));
+        }
 
         $session = $session->setUrl($url)->restore();
 

--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -5,7 +5,9 @@ namespace Statamic\StaticCaching\NoCache;
 use Facades\Statamic\View\Cascade;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Request;
 use Statamic\Facades\Data;
+use Statamic\Support\Str;
 
 class Session
 {
@@ -20,7 +22,7 @@ class Session
 
     public function __construct($url)
     {
-        $this->url = $url;
+        $this->setUrl($url);
         $this->regions = new Collection;
     }
 
@@ -31,6 +33,10 @@ class Session
 
     public function setUrl(string $url)
     {
+        if (Str::contains($url, '?')) {
+            $url = Str::before($url, '?').'?'.Request::normalizeQueryString(Str::after($url, '?'));
+        }
+
         $this->url = $url;
 
         return $this;

--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -5,9 +5,7 @@ namespace Statamic\StaticCaching\NoCache;
 use Facades\Statamic\View\Cascade;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Request;
 use Statamic\Facades\Data;
-use Statamic\Support\Str;
 
 class Session
 {
@@ -22,7 +20,7 @@ class Session
 
     public function __construct($url)
     {
-        $this->setUrl($url);
+        $this->url = $url;
         $this->regions = new Collection;
     }
 
@@ -33,10 +31,6 @@ class Session
 
     public function setUrl(string $url)
     {
-        if (Str::contains($url, '?')) {
-            $url = Str::before($url, '?').'?'.Request::normalizeQueryString(Str::after($url, '?'));
-        }
-
         $this->url = $url;
 
         return $this;

--- a/tests/StaticCaching/FileCacherTest.php
+++ b/tests/StaticCaching/FileCacherTest.php
@@ -74,8 +74,8 @@ class FileCacherTest extends TestCase
         ]);
 
         $this->assertEquals(
-            'test/path/foo/bar/baz/qux_a=b&c=d.html',
-            $cacher->getFilePath('http://domain.com/foo/bar/baz/qux?a=b&c=d')
+            'test/path/foo/bar/baz/qux_c=d&a=b.html',
+            $cacher->getFilePath('http://domain.com/foo/bar/baz/qux?c=d&a=b')
         );
 
         $this->assertEquals(

--- a/tests/StaticCaching/NoCacheSessionTest.php
+++ b/tests/StaticCaching/NoCacheSessionTest.php
@@ -73,18 +73,6 @@ class NoCacheSessionTest extends TestCase
     }
 
     /** @test */
-    public function it_normalizes_the_query_string()
-    {
-        $session = new Session('/foo?c=3&b=2&a=1');
-
-        $this->assertEquals('/foo?a=1&b=2&c=3', $session->url());
-
-        $session = tap(new Session(''), function($session) { $session->setUrl('/foo?c=3&b=2&a=1'); });
-
-        $this->assertEquals('/foo?a=1&b=2&c=3', $session->url());
-    }
-
-    /** @test */
     public function it_writes()
     {
         // Testing that the cache key used is unique to the url.
@@ -98,15 +86,11 @@ class NoCacheSessionTest extends TestCase
             ->with('nocache::session.'.md5('/foo'), Mockery::any())
             ->once();
 
-        Cache::shouldReceive('forever')
-            ->with('nocache::session.'.md5('/foo?a=1&b=2'), Mockery::any())
-            ->twice();
-
         // ...and that the urls are tracked in the cache.
 
         Cache::shouldReceive('get')
             ->with('nocache::urls', [])
-            ->times(4)
+            ->times(2)
             ->andReturn([], ['/']);
 
         Cache::shouldReceive('forever')
@@ -117,23 +101,11 @@ class NoCacheSessionTest extends TestCase
             ->with('nocache::urls', ['/', '/foo'])
             ->once();
 
-        Cache::shouldReceive('forever')
-            ->with('nocache::urls', ['/', '/foo?a=1&b=2'])
-            ->twice();
-
         tap(new Session('/'), function ($session) {
             $session->pushRegion('test', [], '.html');
         })->write();
 
         tap(new Session('/foo'), function ($session) {
-            $session->pushRegion('test', [], '.html');
-        })->write();
-
-        tap(new Session('/foo?a=1&b=2'), function ($session) {
-            $session->pushRegion('test', [], '.html');
-        })->write();
-
-        tap(new Session('/foo?b=2&a=1'), function ($session) {
             $session->pushRegion('test', [], '.html');
         })->write();
     }

--- a/tests/StaticCaching/NoCacheSessionTest.php
+++ b/tests/StaticCaching/NoCacheSessionTest.php
@@ -140,12 +140,12 @@ class NoCacheSessionTest extends TestCase
     /** @test */
     public function a_singleton_is_bound_in_the_container()
     {
-        $this->get('/test?foo=bar');
+        $this->get('/test?foo=bar&bar=baz');
 
         $session = $this->app->make(Session::class);
 
         $this->assertInstanceOf(Session::class, $session);
-        $this->assertEquals('http://localhost/test?foo=bar', $session->url());
+        $this->assertEquals('http://localhost/test?foo=bar&bar=baz', $session->url());
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #7465.

Static Caching gets the URI from the current request using `Illuminate\Http\Request@getUri()`. This method sorts the query parameters alphabetically under the hood, see  [Request::getUri() returns parameters in wrong order #30844](https://github.com/laravel/framework/issues/30844). So for example `/?foo=bar&bar=baz` will become `/?bar=baz&foo=bar`.

The issue happens because `Statamic\StaticCaching\NoCache\Controller` just takes the posted URL as is, without normalizing the query string. So the URL won't match the URL for the saved Session because the order of the parameters differ.

This PR normalizes the query string in the `Controller` too.
