### PR TITLE
Use the `ignore_query_string` setting when handling `nocache` Sessions

### DIFF
--- a/src/StaticCaching/NoCache/Controller.php
+++ b/src/StaticCaching/NoCache/Controller.php
@@ -9,7 +9,11 @@ class Controller
 {
     public function __invoke(Request $request, Session $session)
     {
-        $url = $request->input('url'); // todo: maybe strip off query params?
+        $url = $request->input('url');
+
+        if (config('statamic.static_caching.ignore_query_strings', false)) {
+            $url = explode('?', $url)[0];
+        }
 
         $session = $session->setUrl($url)->restore();
 

--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -35,11 +35,11 @@ class ServiceProvider extends LaravelServiceProvider
 
         $this->app->singleton(Session::class, function ($app) {
             $uri = $app['request']->getUri();
-            
+
             if (config('statamic.static_caching.ignore_query_strings', false)) {
                 $uri = explode('?', $uri)[0];
             }
-            
+
             return new Session($uri);
         });
 

--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -34,7 +34,13 @@ class ServiceProvider extends LaravelServiceProvider
         });
 
         $this->app->singleton(Session::class, function ($app) {
-            return new Session($app['request']->getUri());
+            $uri = $app['request']->getUri();
+            
+            if (config('statamic.static_caching.ignore_query_strings', false)) {
+                $uri = explode('?', $uri)[0];
+            }
+            
+            return new Session($uri);
         });
 
         $this->app->bind(UrlExcluder::class, function ($app) {

--- a/tests/StaticCaching/NoCacheSessionTest.php
+++ b/tests/StaticCaching/NoCacheSessionTest.php
@@ -149,6 +149,19 @@ class NoCacheSessionTest extends TestCase
     }
 
     /** @test */
+    public function it_ignores_the_query_string()
+    {
+        config(['statamic.static_caching.ignore_query_strings' => true]);
+
+        $this->get('/test?foo=bar');
+
+        $session = $this->app->make(Session::class);
+
+        $this->assertInstanceOf(Session::class, $session);
+        $this->assertEquals('http://localhost/test', $session->url());
+    }
+
+    /** @test */
     public function it_writes_session_if_a_nocache_tag_is_used()
     {
         $this->withStandardFakeViews();


### PR DESCRIPTION
Fixes #7487.