### PR TITLE
[4.x] Drop support for PHP 7 and Laravel 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,24 +13,15 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2]
-        laravel: [8.*, 9.*]
+        php: [8.0, 8.1, 8.2]
+        laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
-          - laravel: 8.*
-          - laravel: 9.*
-          - os: windows-latest
-            php: 7.4
-            laravel: 8.*
-            stability: prefer-stable
           - os: windows-latest
             php: 8.1
             laravel: 9.*
             stability: prefer-stable
-        exclude:
-          - laravel: 9.*
-            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -48,30 +39,6 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
-
-      - name: Set PHP 7.4 Mockery
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require "mockery/mockery >=1.2.3" --no-interaction --no-update
-        if: matrix.php >= 7.4 && matrix.php <8.0
-
-      - name: Set PHP 8 Mockery
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require "mockery/mockery >=1.3.3" --no-interaction --no-update
-        if: matrix.php >= 8.0
-
-      - name: Set PHP 8.1 Testbench
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer require "orchestra/testbench ^6.22.0" --no-interaction --no-update
-        if: matrix.laravel == '8.*' && matrix.php >= 8.1
 
       - name: Install dependencies
         uses: nick-invision/retry@v2

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "facade/ignition-contracts": "^1.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "james-heinrich/getid3": "^1.9.21",
-        "laravel/framework": "^8.48.0 || ^9.0",
+        "laravel/framework": "^9.0",
         "laravel/helpers": "^1.1",
         "league/commonmark": "^1.5 || ^2.2",
         "league/csv": "^9.0",
@@ -38,8 +38,8 @@
     "require-dev": {
         "fakerphp/faker": "~1.10",
         "google/cloud-translate": "^1.6",
-        "mockery/mockery": "^1.2.3",
-        "orchestra/testbench": "^6.18 || ^7.0"
+        "mockery/mockery": "^1.3.3",
+        "orchestra/testbench": "^7.0"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
This drops support for PHP 7.4 and Laravel 8.

At the moment, Laravel 9 is the only supported version on the master (4.x) branch.

Laravel 10 support is planned for 4.0 but will be added in a separate PR.