### PR TITLE
Preventing access of undefined array key

### DIFF
--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -214,7 +214,7 @@ class Comb
     private function setHaystack(array $data)
     {
         reset($data);
-        $firstKey = array_keys($data)[0];
+        $firstKey = array_keys($data)[0] ?? null;
         reset($data);
 
         if (! is_numeric($firstKey)) {


### PR DESCRIPTION
This addresses the attempted access of an undefined array key when a search index is empty. An Exception with the message "Empty haystack." will now be thrown rather than the more cryptic message "Undefined array key 0".