### PR TITLE
Fix underline in Bard not outputting any HTML tags

### DIFF
--- a/src/Providers/BardServiceProvider.php
+++ b/src/Providers/BardServiceProvider.php
@@ -44,6 +44,7 @@ class BardServiceProvider extends ServiceProvider
             'tableRow' => new \Tiptap\Nodes\TableRow(),
             'text' => new \Tiptap\Nodes\Text(),
             'textAlign' => new \Tiptap\Extensions\TextAlign(['types' => ['heading', 'paragraph']]),
+            'underline' => new \Tiptap\Marks\Underline(),
         ]);
     }
 }


### PR DESCRIPTION
Currently the Underline mark does not get registered in Bard.
This causes the underline setting not to output any HTML tags.
This PR adds the underline mark to the `BardServiceProvider` so the HTML tags get rendered correctly.
