### PR TITLE
[4.x] Replace dmuploader jQuery plugin in Uploader

### DIFF
--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -1,5 +1,6 @@
 <script>
-import 'dm-file-uploader';
+import { Upload } from './upload';
+import uniqid from 'uniqid';
 
 export default {
 
@@ -12,6 +13,7 @@ export default {
 
         return h('div', { on: {
             'dragenter': this.dragenter,
+            'dragover': this.dragover,
             'dragleave': this.dragleave,
             'drop': this.drop,
         }}, [
@@ -56,17 +58,12 @@ export default {
 
 
     mounted() {
-        if (this.enabled) {
-            this.bindUploader();
-        }
+        this.$refs.nativeFileField.addEventListener('change', this.addNativeFileFieldSelections);
     },
 
 
-    // Using beforeDestroy instead of destroy, since the destroy hook didn't seem to
-    // get called at all sometimes when using `npm run production`. Works fine when
-    // using `npm run dev`. beforeDestroy works fine in both cases. ¯\_(ツ)_/¯
     beforeDestroy() {
-        $(this.$el).unbind().removeData();
+        this.$refs.nativeFileField.removeEventListener('change', this.addNativeFileFieldSelections);
     },
 
 
@@ -74,80 +71,32 @@ export default {
 
         uploads(uploads) {
             this.$emit('updated', uploads);
-        },
-
-        extraData(data) {
-            $(this.$el).data('dmUploader').settings.extraData = data;
-        },
+        }
 
     },
 
 
     methods: {
 
-        /**
-         * Open the native file browser
-         */
         browse() {
-            $(this.$refs.nativeFileField).click();
+            this.$refs.nativeFileField.click();
         },
 
-        /**
-         * Bind the uploader plugin to the DOM
-         */
-        bindUploader() {
-            $(this.$el).dmUploader({
-                url: this.url,
-
-                extraData: this.extraData,
-
-                onNewFile: (id, file) => {
-                    this.uploads.push({
-                        id: id,
-                        basename: file.name,
-                        extension: file.name.split('.').pop(),
-                        percent: 0,
-                        errorMessage: null
-                    });
-                },
-
-                onUploadProgress: (id, percent) => {
-                    let upload = _(this.uploads).findWhere({ id });
-                    upload.percent = percent;
-                    this.$emit('progress', upload, this.uploads);
-                },
-
-                onUploadSuccess: (id, response) => {
-                    this.$emit('upload-complete', response.data, this.uploads);
-
-                    let index = _(this.uploads).findIndex({ id });
-                    this.uploads.splice(index, 1);
-                },
-
-                onUploadError: (id, errMsg, response) => {
-                    let upload = _(this.uploads).findWhere({ id });
-
-                    if (response.responseJSON) {
-                        errMsg = response.responseJSON.message;
-                    } 
-
-                    if (! errMsg) {
-                        if (response.status === 413) {
-                            errMsg = __('Upload failed. The file is larger than is allowed by your server.');
-                        } else {
-                            errMsg = __('Upload failed. The file might be larger than is allowed by your server.');
-                        }
-                    }
-
-                    upload.errorMessage = errMsg;
-
-                    this.$emit('error', upload, this.uploads);
-                }
-            });
+        addNativeFileFieldSelections(e) {
+            for (let i = 0; i < e.target.files.length; i++) {
+                this.addFile(e.target.files[i]);
+            }
         },
 
         dragenter(e) {
+            e.stopPropagation();
+            e.preventDefault();
             this.dragging = true;
+        },
+
+        dragover(e) {
+            e.stopPropagation();
+            e.preventDefault();
         },
 
         dragleave(e) {
@@ -158,8 +107,91 @@ export default {
         },
 
         drop(e) {
+            e.stopPropagation();
+            e.preventDefault();
             this.dragging = false;
-        }
+
+            for (let i = 0; i < e.dataTransfer.files.length; i++) {
+                this.addFile(e.dataTransfer.files[i]);
+            }
+        },
+
+        addFile(file) {
+            if (! this.enabled) return;
+
+            const id = uniqid();
+            const upload = this.makeUpload(id, file);
+
+            this.uploads.push({
+                id,
+                basename: file.name,
+                extension: file.name.split('.').pop(),
+                percent: 0,
+                errorMessage: null
+            });
+
+            upload.upload().then(response => {
+                const json = JSON.parse(response.data);
+                response.status === 200
+                    ? this.handleUploadSuccess(id, json)
+                    : this.handleUploadError(id, status, json);
+            });
+        },
+
+        findUpload(id) {
+            return this.uploads.find(u => u.id === id);
+        },
+
+        findUploadIndex(id) {
+            return this.uploads.findIndex(u => u.id === id);
+        },
+
+        makeUpload(id, file) {
+            const upload = new Upload({
+                url: this.url,
+                form: this.makeFormData(file),
+                headers: {
+                    Accept: 'application/json'
+                }
+            });
+
+            upload.on('progress', progress => {
+                this.findUpload(id).percent = progress * 100;
+            });
+
+            return upload;
+        },
+
+        makeFormData(file) {
+            const form = new FormData();
+
+            form.append('file', file);
+
+            for (let key in this.extraData) {
+                form.append(key, this.extraData[key]);
+            }
+
+            return form;
+        },
+
+        handleUploadSuccess(id, response) {
+            this.$emit('upload-complete', response.data, this.uploads);
+            this.uploads.splice(this.findUploadIndex(id), 1);
+        },
+
+        handleUploadError(id, status, response) {
+            const upload = this.findUpload(id);
+            let msg = response.message;
+            if (! msg) {
+                if (status === 413) {
+                    msg = __('Upload failed. The file is larger than is allowed by your server.');
+                } else {
+                    msg = __('Upload failed. The file might be larger than is allowed by your server.');
+                }
+            }
+            upload.errorMessage = msg;
+            this.$emit('error', upload, this.uploads);
+        },
     }
 
 }

--- a/resources/js/components/assets/upload.ts
+++ b/resources/js/components/assets/upload.ts
@@ -1,0 +1,347 @@
+import { IncomingMessage } from 'http';
+import FormDataNode, { SubmitOptions } from 'form-data';
+
+export interface UploadOptions {
+  form: Record<string, string | Blob> | FormData | FormDataNode;
+  url: string;
+  headers?: Record<string, string>;
+  withCredentials?: boolean;
+}
+
+export interface UploadResponse {
+  data?: string | ArrayBuffer | Blob;
+  xhr?: XMLHttpRequest;
+  status?: Number;
+  headers?: Record<string, string | string[] | undefined>;
+}
+
+export type UploadState =
+  | 'new'
+  | 'started'
+  | 'failed'
+  | 'successful'
+  | 'aborted';
+
+export type UploadStateChangeEventListener = (
+  this: Upload,
+  state: UploadState
+) => void;
+export type UploadProgressEventListener = (
+  this: Upload,
+  progress: number
+) => void;
+export type UploadErrorEventListener = (this: Upload) => void;
+
+type UploadEventListenerUnion =
+  | UploadStateChangeEventListener
+  | UploadErrorEventListener
+  | UploadProgressEventListener;
+
+interface UploadEvents {
+  state: Set<UploadStateChangeEventListener>;
+  error: Set<UploadErrorEventListener>;
+  progress: Set<UploadProgressEventListener>;
+}
+
+export class Upload {
+  private events: UploadEvents = {
+    state: new Set(),
+    error: new Set(),
+    progress: new Set(),
+  };
+
+  private form: Record<string, string | Blob> | FormData | FormDataNode;
+  private url: string;
+  private headers?: Record<string, string>;
+  private xhr?: XMLHttpRequest;
+  private withCredentials?: boolean = false;
+
+  private _uploadedBytes = 0;
+  private _totalBytes = 0;
+  private _state: UploadState = 'new';
+
+  constructor(options: UploadOptions) {
+    if (!options) {
+      throw new Error('Options are required.');
+    }
+
+    if (!options.url || typeof options.url !== 'string') {
+      throw new Error('Destination URL is missing or invalid.');
+    }
+
+    this.form = options.form;
+    this.url = options.url;
+    this.headers = options.headers;
+    this.withCredentials = options.withCredentials;
+  }
+
+  /**
+   * POSTs the form.
+   */
+  upload(): Promise<UploadResponse> {
+    return new Promise<UploadResponse>((resolve, reject) => {
+      // Check if we're running in a browser.
+      if (
+        typeof window !== 'undefined' &&
+        typeof XMLHttpRequest !== 'undefined'
+      ) {
+        this.xhr = new XMLHttpRequest();
+
+        if (this.withCredentials) {
+          this.xhr.withCredentials = true;
+        }
+
+        this.xhr.open('POST', this.url, true);
+
+        if (typeof this.headers === 'object') {
+          for (const headerName of Object.keys(this.headers)) {
+            this.xhr.setRequestHeader(headerName, this.headers[headerName]);
+          }
+        }
+
+        this.xhr.addEventListener('loadstart', () => {
+          this.setState('started');
+        });
+
+        if (this.xhr.upload) {
+          this.xhr.upload.addEventListener('progress', e => {
+            if (this._totalBytes !== e.total) {
+              this.setTotalBytes(e.total);
+            }
+            this.setUploadedBytes(e.loaded);
+          });
+        }
+
+        this.xhr.addEventListener('load', () => {
+          if (this.xhr) {
+            this.setUploadedBytes(this.totalBytes);
+            this.setState('successful');
+
+            const response: UploadResponse = {};
+            const lines = this.xhr
+              .getAllResponseHeaders()
+              .replace(/\r/g, '')
+              .split('\n');
+            const headers: Record<string, string> = {};
+            for (const line of lines) {
+              const split = line.split(':');
+              if (split.length != 2) {
+                continue;
+              }
+              headers[split[0].trim()] = split[1].trim();
+            }
+            response.headers = headers;
+            response.status = this.xhr.status;
+            response.xhr = this.xhr;
+
+            switch (this.xhr.responseType) {
+              case 'json':
+                response.data = JSON.stringify(this.xhr.response);
+                break;
+              default:
+                response.data = this.xhr.response;
+            }
+
+            resolve(response);
+          }
+        });
+
+        this.xhr.addEventListener('error', () => {
+          this.setState('failed');
+          this.emit('error');
+          reject();
+        });
+
+        this.xhr.addEventListener('abort', () => {
+          this.setState('aborted');
+        });
+
+        if (this.form instanceof FormData) {
+          this.xhr.send(this.form);
+        } else {
+          const form = this.form as Record<string, string | Blob>;
+          const formData = new FormData();
+          for (const key of Object.keys(this.form)) {
+            formData.set(key, form[key]);
+          }
+          this.xhr.send(formData);
+        }
+      } else {
+        const callback = (error: Error | null, res: IncomingMessage) => {
+          if (error) {
+            this.setState('failed');
+            this.emit('error');
+
+            reject();
+          } else {
+            this.setUploadedBytes(this.totalBytes);
+            this.setState('successful');
+
+            let body = '';
+            res.on('readable', () => {
+              const chunk = res.read();
+              if (chunk) {
+                body += chunk;
+              }
+            });
+            res.on('end', () => {
+              const response: UploadResponse = {};
+              response.data = body;
+              response.headers = res.headers;
+              resolve(response);
+            });
+          }
+        };
+
+        const url = new URL(this.url);
+        const options: SubmitOptions = {
+          hostname: url.hostname,
+          port: url.port,
+          path: url.pathname,
+          method: 'POST',
+          headers: this.headers,
+        };
+
+        let formData: FormDataNode;
+
+        if (this.form instanceof FormDataNode) {
+          formData = this.form;
+        } else {
+          const form = this.form as Record<string, string | Blob>;
+          formData = new FormDataNode();
+          for (const key of Object.keys(this.form)) {
+            formData.append(key, form[key]);
+          }
+        }
+
+        formData.getLength((error: Error | null, length: number) => {
+          this.setTotalBytes(length);
+        });
+
+        formData.on('data', chunk => {
+          if (this.state === 'new') {
+            this.setState('started');
+          }
+
+          if (chunk.hasOwnProperty('length')) {
+            this.increaseUploadedBytes(chunk.length as number);
+          }
+        });
+
+        formData.submit(options, callback);
+      }
+    });
+  }
+
+  abort(): void {
+    this.xhr?.abort();
+  }
+
+  get uploadedBytes(): number {
+    return this._uploadedBytes;
+  }
+
+  private setUploadedBytes(value: number) {
+    this._uploadedBytes = value;
+    this.emit('progress', this.progress);
+  }
+
+  private increaseUploadedBytes(value: number) {
+    this._uploadedBytes += value;
+    this.emit('progress', this.progress);
+  }
+
+  get totalBytes(): number {
+    return this._totalBytes;
+  }
+
+  private setTotalBytes(value: number) {
+    this._totalBytes = value;
+    this.emit('progress', this.progress);
+  }
+
+  /**
+   * Current upload progress. A float between 0 and 1.
+   */
+  get progress(): number {
+    return this._totalBytes === 0 ? 0 : this._uploadedBytes / this._totalBytes;
+  }
+
+  get state(): UploadState {
+    return this._state;
+  }
+
+  private setState(value: UploadState) {
+    const oldState = this._state;
+    this._state = value;
+    if (oldState !== this._state) {
+      this.emit('state', this._state);
+    }
+  }
+
+  /**
+   * Adds a listener for a progress event.
+   * @param eventType Event type. (progress)
+   * @param listener Listener function.
+   */
+  on(eventType: 'progress', listener: UploadProgressEventListener): void;
+
+  /**
+   * Adds a listener for an error event.
+   * @param eventType Event type. (error)
+   * @param listener Listener function.
+   */
+  on(eventType: 'error', listener: UploadErrorEventListener): void;
+
+  /**
+   * Adds a listener for a state change event.
+   * @param eventType Event type. (state)
+   * @param listener Listener function.
+   */
+  on(eventType: 'state', listener: UploadStateChangeEventListener): void;
+
+  /**
+   * Adds a listener for a given event.
+   * @param eventType Event type.
+   * @param listener Listener function.
+   */
+  on(eventType: keyof UploadEvents, listener: UploadEventListenerUnion): void {
+    this.events[eventType].add(listener as any);
+  }
+
+  /**
+   * Removes a listener for a progress event.
+   * @param eventType Event type. (progress)
+   * @param listener Listener function.
+   */
+  off(eventType: 'progress', listener: UploadProgressEventListener): void;
+
+  /**
+   * Removes a listener for an error event.
+   * @param eventType Event type. (error)
+   * @param listener Listener function.
+   */
+  off(eventType: 'error', listener: UploadErrorEventListener): void;
+
+  /**
+   * Removes a listener for a state change event.
+   * @param eventType Event type. (state)
+   * @param listener Listener function.
+   */
+  off(eventType: 'state', listener: UploadStateChangeEventListener): void;
+
+  /**
+   * Removes a listener for a given event.
+   * @param eventType Event type.
+   * @param listener Listener function.
+   */
+  off(eventType: keyof UploadEvents, listener: UploadEventListenerUnion): void {
+    this.events[eventType].delete(listener as any);
+  }
+
+  private emit(eventType: keyof UploadEvents, ...args: any[]) {
+    for (const listener of this.events[eventType]) {
+      (listener as any).apply(this, args);
+    }
+  }
+}


### PR DESCRIPTION
We're removing jQuery in an upcoming PR. This is one of the largest parts of our codebase that still uses jQuery.

This PR replaces `dmuploader` with `upload`.

At the moment there is a local version of the `upload` package until https://github.com/mat-sz/upload/pull/7 is merged and released. I'm assuming it will be accepted because it's such a tiny change. When it's released, `upload.ts` can be deleted, `upload` can be required in `package.json`, and the import will change to point to the npm package.

Also, intentionally not removing `dm-file-uploder` from `package.json` in this PR. I'll do it in #7504. I'm sure there would be a merge conflict in package-lock.json.