### PR TITLE
Add missing dropcursor when dragging Bard sets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tiptap/extension-code": "^2.0.0-beta.217",
         "@tiptap/extension-code-block-lowlight": "^2.0.0-beta.217",
         "@tiptap/extension-document": "^2.0.0-beta.217",
+        "@tiptap/extension-dropcursor": "^2.0.0-beta.217",
         "@tiptap/extension-gapcursor": "^2.0.0-beta.217",
         "@tiptap/extension-hard-break": "^2.0.0-beta.217",
         "@tiptap/extension-heading": "^2.0.0-beta.217",
@@ -2755,6 +2756,19 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0-beta.209"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "2.0.0-beta.217",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.0.0-beta.217.tgz",
+      "integrity": "sha512-+HkLmLBKSAJB987KM6z/pxsE+QMr7wZJiTSJv4JSTQnSjKwyJIHbfYNvNgWZo0k9MSncmLGhd/c4TFxYJZ762w==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0-beta.209",
+        "@tiptap/pm": "^2.0.0-beta.209"
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
@@ -19105,6 +19119,12 @@
       "version": "2.0.0-beta.217",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.0.0-beta.217.tgz",
       "integrity": "sha512-CDCTutbVO1Ub7QUULPCYILl2px48ezCX2kxbspQZzPD7nMoYZNmUMZ8gRJvVDdnSpMNlEl7oNnCAU7uC/lny/A==",
+      "requires": {}
+    },
+    "@tiptap/extension-dropcursor": {
+      "version": "2.0.0-beta.217",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.0.0-beta.217.tgz",
+      "integrity": "sha512-+HkLmLBKSAJB987KM6z/pxsE+QMr7wZJiTSJv4JSTQnSjKwyJIHbfYNvNgWZo0k9MSncmLGhd/c4TFxYJZ762w==",
       "requires": {}
     },
     "@tiptap/extension-floating-menu": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tiptap/extension-code": "^2.0.0-beta.217",
     "@tiptap/extension-code-block-lowlight": "^2.0.0-beta.217",
     "@tiptap/extension-document": "^2.0.0-beta.217",
+    "@tiptap/extension-dropcursor": "^2.0.0-beta.217",
     "@tiptap/extension-gapcursor": "^2.0.0-beta.217",
     "@tiptap/extension-hard-break": "^2.0.0-beta.217",
     "@tiptap/extension-heading": "^2.0.0-beta.217",

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -84,6 +84,7 @@ import BulletList from '@tiptap/extension-bullet-list';
 import CharacterCount from '@tiptap/extension-character-count';
 import Code from '@tiptap/extension-code';
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import Dropcursor from '@tiptap/extension-dropcursor';
 import Gapcursor from '@tiptap/extension-gapcursor';
 import HardBreak from '@tiptap/extension-hard-break';
 import Heading from '@tiptap/extension-heading';
@@ -578,6 +579,7 @@ export default {
             let exts = [
                 CharacterCount.configure({ limit: this.config.character_limit }),
                 ...(this.inputIsInline ? [DocumentInline] : [DocumentBlock, HardBreak]),
+                Dropcursor,
                 Gapcursor,
                 History,
                 Paragraph,


### PR DESCRIPTION
Since `3.4` no cursor is shown anymore at the drop position when a set is dragged within a Bard Editor.

This PR adds the missing extension [@tiptap/extension-dropcursor](https://tiptap.dev/api/extensions/dropcursor).

![2023-02-10 23 59 40](https://user-images.githubusercontent.com/1102712/218218512-864421a5-ed14-4d24-9280-6f886d98ad78.gif)
