### PR TITLE
Avoid a Firefox Bug which makes inputs/textareas in draggable Bard Nodes unselectable

### DIFF
--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -179,7 +179,12 @@ export default {
             this.updateAttributes({ src: this.actualSrc });
         },
 
-    }
+    },
 
+    updated() {
+        // This is a workaround to avoid Firefox's inability to select inputs/textareas when the
+        // parent element is set to draggable: https://bugzilla.mozilla.org/show_bug.cgi?id=739071
+        this.$el.setAttribute('draggable', false);
+    }
 }
 </script>

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -211,6 +211,12 @@ export default {
             return `${prefix}.${this.index}.attrs.values.${field.handle}`;
         },
 
+    },
+
+    updated() {
+        // This is a workaround to avoid Firefox's inability to select inputs/textareas when the
+        // parent element is set to draggable: https://bugzilla.mozilla.org/show_bug.cgi?id=739071
+        this.$el.setAttribute('draggable', false);
     }
 }
 </script>


### PR DESCRIPTION
Fixes #7447 

This adds a workround to avoid a Firefox Browser Bug [739071](https://bugzilla.mozilla.org/show_bug.cgi?id=739071). It seems before 3.4 the attribute `draggable=true` was not there, maybe something changed in tiptap 2.0 or ProseMirror.

Source: https://github.com/ueberdosis/tiptap/issues/1668