### PR TITLE
Remove redundant code in Taxonomy tag

### DIFF
--- a/src/Tags/Taxonomy/Taxonomy.php
+++ b/src/Tags/Taxonomy/Taxonomy.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\Tags\Taxonomy;
 
-use Statamic\Facades\Site;
-use Statamic\Support\Arr;
 use Statamic\Tags\Concerns;
 use Statamic\Tags\Tags;
 

--- a/src/Tags/Taxonomy/Taxonomy.php
+++ b/src/Tags/Taxonomy/Taxonomy.php
@@ -30,10 +30,6 @@ class Taxonomy extends Tags
     {
         $terms = $this->terms()->get();
 
-        $site = Arr::getFirst($this->params, ['site', 'locale'], Site::current()->handle());
-
-        $terms = $terms->map->in($site);
-
         return $this->output($terms);
     }
 


### PR DESCRIPTION
As mentioned [here](https://github.com/statamic/cms/discussions/7515) there are issues using paginate and the taxonomy tag, which is due to it calling map on a paginator instead of a collection.

Looking at the code, the map is actually no longer needed as the `querySite` function in `Tags\Taxonomy\Terms.php` already handles the site limiting.