### PR TITLE
Fix Bard Set Popover flickering

### DIFF
--- a/resources/sass/components/fieldtypes/bard.scss
+++ b/resources/sass/components/fieldtypes/bard.scss
@@ -194,11 +194,6 @@
     color: $color_red;
 }
 
-.bard-set .popover-container:not(.popover-open) .popover{
-    inset: 0 !important;
-    transform: none !important;
-}
-
 /* The set selection options for each text block
   ========================================================================== */
 


### PR DESCRIPTION
Fixes flickering issue when closing a Popover in a Bard Set. See third screenshot in #7427

![215457578-b1d352b1-060f-4709-8c10-e3d0a93adf9d](https://user-images.githubusercontent.com/1102712/218566801-249f6a48-34ae-4f77-afc8-904e079c8a85.gif)

This issue comes from https://github.com/statamic/cms/pull/6043/commits/0aa425d9c2729c0a74254ff932ec195b033b5449, but I was unable to find out why @wiebkevogel was overriding the default styles from Popover.

Without those `!important` overrides everything seems working as it should.