### PR TITLE
Fix docs URL on Updater page

### DIFF
--- a/resources/views/updater/index.blade.php
+++ b/resources/views/updater/index.blade.php
@@ -75,7 +75,7 @@
 
         @include('statamic::partials.docs-callout', [
             'topic' => __('Updates'),
-            'url' => 'updates'
+            'url' => Statamic::docsUrl('updating')
         ])
 
     @endif


### PR DESCRIPTION
Links to a relative URL of `updates` which of course leads nowhere. Replacing with `Statamic::docsUrl('updating')`