### PR TITLE
Display actual time in past revision history

### DIFF
--- a/resources/js/components/revision-history/History.vue
+++ b/resources/js/components/revision-history/History.vue
@@ -25,7 +25,7 @@
                 v-for="group in revisions"
                 :key="group.day"
             >
-                <h6 class="revision-date" v-text="$moment.unix(group.day).format('LL')" />
+                <h6 class="revision-date" v-text="$moment.unix(group.day).isBefore($moment().startOf('day')) ? $moment.unix(group.day).format('LL') : __('Today')" />
                 <div class="revision-list">
                     <revision
                         v-for="revision in group.revisions"

--- a/resources/js/components/revision-history/Revision.vue
+++ b/resources/js/components/revision-history/Revision.vue
@@ -16,7 +16,7 @@
                 <div class="flex-1">
                     <div class="revision-author text-grey-70 text-2xs">
                         <template v-if="revision.user">{{ revision.user.name || revision.user.email }} &ndash;</template>
-                        {{ date.fromNow() }}
+                        {{ date.isBefore($moment().startOf('day')) ? date.format('LT') : date.fromNow() }}
                     </div>
                 </div>
 


### PR DESCRIPTION
The revison history panel uses the relative `date.fromNow()` method to display the revision time, but for revisions older than today this is always something like "25 days ago", so they're all the same.

This PR changes it so that revisions older than today show the actual time, which is a little more informative.

From this:

![Screenshot 2023-02-15 at 17 30 56](https://user-images.githubusercontent.com/126740/219108279-fa76785d-dcdd-4e11-b905-0f0a5770986d.png)

To this:

![Screenshot 2023-02-15 at 17 31 53](https://user-images.githubusercontent.com/126740/219108309-33173025-dfe5-40bc-a894-4b44ffae6bc3.png)