### PR TITLE
Fix CP Nav preferences builder when top level section is empty

### DIFF
--- a/src/CP/Navigation/NavBuilder.php
+++ b/src/CP/Navigation/NavBuilder.php
@@ -177,6 +177,7 @@ class NavBuilder
             ->map(fn ($item) => $item->section())
             ->unique()
             ->keyBy(fn ($section) => NavItem::snakeCase($section))
+            ->prepend('Top Level', 'top_level')
             ->all();
 
         return $this;

--- a/tests/CP/Navigation/NavTest.php
+++ b/tests/CP/Navigation/NavTest.php
@@ -656,6 +656,21 @@ class NavTest extends TestCase
         $this->assertCount(1, $this->build()->get('Jedi')->map->display());
     }
 
+    /** @test */
+    public function it_ensures_top_level_section_is_always_built_when_building_with_hidden()
+    {
+        $this->actingAs(tap(User::make()->makeSuper())->save());
+
+        Nav::extend(function ($nav) {
+            $nav->remove('Top Level', 'Dashboard'); // Remove default top level dashboard item
+        });
+
+        $nav = Nav::build(true, true)->pluck('items', 'display');
+
+        $this->assertTrue($nav->has('Top Level'));
+        $this->assertCount(0, $nav->get('Top Level'));
+    }
+
     protected function build()
     {
         return Nav::build()->pluck('items', 'display');


### PR DESCRIPTION
If you remove all top level nav items (ie. `Dashboard`) using the PHP API...

```php
\Statamic\Facades\CP\Nav::extend(function ($nav) {
    $nav->remove('Top Level', 'Dashboard');
});
```

It completely borks the CP Nav preferences builder GUI, and assumes that the first section should be considered top level items...

![CleanShot 2023-02-15 at 20 56 42](https://user-images.githubusercontent.com/5187394/219247834-4b57b7d9-f703-4397-a58f-147fbe7eba60.png)

This PR fixes that...

![CleanShot 2023-02-15 at 20 57 28](https://user-images.githubusercontent.com/5187394/219247902-7e0fe9e4-7924-450b-bad5-52c188f72e46.png)