### PR TITLE
[4.x] Container Queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
       "devDependencies": {
         "@babel/preset-env": "^7.20.2",
         "@rollup/plugin-inject": "^5.0.3",
+        "@tailwindcss/container-queries": "^0.1.0",
         "@tailwindcss/typography": "^0.5.9",
         "@vitejs/plugin-vue2": "^2.2.0",
         "autoprefixer": "^10.4.0",
@@ -4480,6 +4481,15 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/container-queries": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.0.tgz",
+      "integrity": "sha512-t1GeJ9P8ual160BvKy6Y1sG7bjChArMaK6iRXm3ZYjZGN2FTzmqb5ztsTDb9AsTSJD4NMHtsnaI2ielrXEk+hw==",
+      "dev": true,
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -20937,6 +20947,13 @@
       "requires": {
         "@sinonjs/commons": "^2.0.0"
       }
+    },
+    "@tailwindcss/container-queries": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.0.tgz",
+      "integrity": "sha512-t1GeJ9P8ual160BvKy6Y1sG7bjChArMaK6iRXm3ZYjZGN2FTzmqb5ztsTDb9AsTSJD4NMHtsnaI2ielrXEk+hw==",
+      "dev": true,
+      "requires": {}
     },
     "@tailwindcss/typography": {
       "version": "0.5.9",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",
     "@rollup/plugin-inject": "^5.0.3",
+    "@tailwindcss/container-queries": "^0.1.0",
     "@tailwindcss/typography": "^0.5.9",
     "@vitejs/plugin-vue2": "^2.2.0",
     "autoprefixer": "^10.4.0",

--- a/resources/css/components/fieldtypes/assets.css
+++ b/resources/css/components/fieldtypes/assets.css
@@ -68,11 +68,3 @@
     display: none;
     .bard-set-solo & { display: block; }
 }
-
-
-
-/* Responsive Wangjangling
-  ========================================================================== */
-
-/*  hide the 'or drag to upload' text when too narrow */
-.assets-fieldtype .narrow .assets-fieldtype-picker .drag-drop-text { display: none; }

--- a/resources/css/components/fieldtypes/datetime.css
+++ b/resources/css/components/fieldtypes/datetime.css
@@ -34,20 +34,6 @@
 
 .date-time-container {
 	@apply flex;
-
-	.time-container {
-		@apply ml-2;
-	}
-}
-
-/*  Make date and time and fields sit one above the other */
-/*  when it's too narrow for them to sit side by side. */
-.date-time-container.narrow {
-    @apply block;
-
-    .time-container {
-        @apply mt-2 ml-0;
-    }
 }
 
 /*  Dear sweet baby Jesus please forgive me for this brittle selector */

--- a/resources/css/components/publish.css
+++ b/resources/css/components/publish.css
@@ -77,7 +77,7 @@ code.parent-url {
 }
 
 .publish-field {
-    position: relative;
+    @apply relative;
 }
 
 .publish-field-label {
@@ -108,16 +108,6 @@ code.parent-url {
     top: 0;
     z-index: 1000;
 }
-
-.field-w-1\/4 { @apply w-1/4; }
-.field-w-1\/3 { @apply w-1/3; }
-.field-w-1\/2 { @apply w-1/2; }
-.field-w-2\/3 { @apply w-2/3; }
-.field-w-3\/4 { @apply w-3/4; }
-.field-w-full { @apply w-full; }
-
-/*  When the wrapper gets narrow enough, the fields should all become full width. */
-.publish-fields-narrow .publish-field { width: 100%; }
 
 .publish-section:not(:empty) {
     @apply shadow bg-white rounded-md w-full;

--- a/resources/js/bootstrap/components.js
+++ b/resources/js/bootstrap/components.js
@@ -7,7 +7,7 @@ import ComposerOutput from '../components/ComposerOutput.vue';
 import Container from '../components/publish/Container.vue';
 import PublishForm from '../components/publish/PublishForm.vue';
 import Fields from '../components/publish/Fields.vue';
-import FieldsContainer from '../components/publish/FieldsContainer.vue';
+import FieldsContainer from '../components/publish/FieldsContainer.vue'; // deprecated
 import Field from '../components/publish/Field.vue';
 import FieldMeta from '../components/publish/FieldMeta.vue';
 import ConfigureSections from '../components/configure/Sections.vue';

--- a/resources/js/bootstrap/globals.js
+++ b/resources/js/bootstrap/globals.js
@@ -54,15 +54,15 @@ export function clone(value) {
 
 export function tailwind_width_class(width) {
     const widths = {
-        25: '1/4',
-        33: '1/3',
-        50: '1/2',
-        66: '2/3',
-        75: '3/4',
-        100: 'full'
+        25: 'w-full @lg:w-1/4',
+        33: 'w-full @lg:w-1/3',
+        50: 'w-full @lg:w-1/2',
+        66: 'w-full @lg:w-2/3',
+        75: 'w-full @lg:w-3/4',
+        100: 'w-full'
     };
 
-    return `w-${widths[width] || 'full'}`;
+    return `${widths[width] || 'w-full'}`;
 }
 
 export function markdown(value) {

--- a/resources/js/components/assets/Folder/Folder.vue
+++ b/resources/js/components/assets/Folder/Folder.vue
@@ -12,7 +12,7 @@
                 v-html="'&times'" />
         </div>
 
-        <publish-fields-container>
+        <div class="publish-fields @container">
 
             <form-group
                 v-if="!initialDirectory"
@@ -33,7 +33,7 @@
                 />
             </div>
 
-        </publish-fields-container>
+        </div>
 
     </modal>
 

--- a/resources/js/components/blueprints/RegularField.vue
+++ b/resources/js/components/blueprints/RegularField.vue
@@ -111,9 +111,9 @@ export default {
         },
 
         widthClass() {
-            if (! this.isSectionExpanded) return 'blueprint-section-field-w-full';
+            if (! this.isSectionExpanded) return 'w-full';
 
-            return `blueprint-section-field-${tailwind_width_class(this.width)}`;
+            return `${tailwind_width_class(this.width)}`;
         },
 
         localizable: {

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -1,6 +1,6 @@
 <template>
 
-    <div class="blueprint-section"
+    <div class="blueprint-section @container"
         :class="{
             'w-full md:w-1/2': !isEditing && !isSingle,
             'w-full': isEditing || isSingle

--- a/resources/js/components/fields/ImportSettings.vue
+++ b/resources/js/components/fields/ImportSettings.vue
@@ -23,7 +23,7 @@
 
         <div class="card">
 
-            <publish-fields-container>
+            <div class="publish-fields @container">
 
                 <form-group
                     handle="fieldset"
@@ -42,7 +42,7 @@
                     @input="updateField('prefix', $event)"
                 />
 
-            </publish-fields-container>
+            </div>
         </div>
     </div>
 

--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -1,6 +1,5 @@
 <template>
-    <element-container @resized="containerWidth = $event.width">
-    <div class="datetime">
+    <div class="datetime @container">
 
         <button type="button" class="btn flex mb-2 md:mb-0 items-center pl-3" v-if="!isReadOnly && config.inline === false && !hasDate" @click="addDate" tabindex="0">
             <svg-icon name="calendar" class="w-4 h-4 mr-2"></svg-icon>
@@ -8,8 +7,7 @@
     	</button>
 
         <div v-if="hasDate || config.inline"
-            class="date-time-container"
-            :class="{ 'narrow': isNarrow }"
+            class="date-time-container flex-col @xs:flex-row"
         >
 
             <div class="flex-1 date-container">
@@ -36,8 +34,7 @@
                         <!-- Date range inputs -->
                         <div
                             v-if="isRange"
-                            class="w-full flex items-center"
-                            :class="{ 'flex-col': isNarrow }"
+                            class="w-full flex items-start @md:items-center flex-col @md:flex-row"
                         >
                             <div class="input-group">
                                 <div class="input-group-prepend flex items-center" v-if="!config.inline">
@@ -53,7 +50,8 @@
                                 </div>
                             </div>
 
-                            <svg-icon name="micro-arrow-right" class="w-6 h-6 my-1 mx-2 text-gray-700" />
+                            <svg-icon name="micro-arrow-right" class="w-6 h-6 my-1 mx-2 text-gray-700 hidden @md:block" />
+                            <svg-icon name="micro-arrow-right" class="w-3.5 h-3.5 my-2 mx-2.5 rotate-90 text-gray-700 @md:hidden" />
 
                             <div class="input-group">
                                 <div class="input-group-prepend flex items-center" v-if="!config.inline">
@@ -88,7 +86,7 @@
                 </v-date-picker>
             </div>
 
-            <div v-if="config.time_enabled && !isRange" class="time-container time-fieldtype">
+            <div v-if="config.time_enabled && !isRange" class="time-container mt-2 @xs:ml-2 @xs:mt-0 time-fieldtype">
 				<time-fieldtype
                     v-if="hasTime"
                     ref="time"
@@ -168,10 +166,6 @@ export default {
 
         displayFormat() {
             return this.meta.displayFormat;
-        },
-
-        isNarrow() {
-            return this.containerWidth <= 320;
         },
 
     },

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -1,6 +1,5 @@
 <template>
-    <element-container @resized="containerWidth = $event.width">
-    <div :class="{ 'narrow': containerWidth < 500, 'really-narrow': containerWidth < 280, 'extremely-narrow': containerWidth < 180 }">
+    <div class="@container">
 
         <uploader
             ref="uploader"
@@ -41,8 +40,8 @@
                         <button type="button" class="upload-text-button" @click.prevent="uploadFile">
                             {{ __('Upload file') }}
                         </button>
-                        <span v-if="soloAsset" class="drag-drop-text" v-text="__('or drag & drop here to replace.')"></span>
-                        <span v-else class="drag-drop-text" v-text="__('or drag & drop here.')"></span>
+                        <span v-if="soloAsset" class="drag-drop-text hidden @md:inline" v-text="__('or drag & drop here to replace.')"></span>
+                        <span v-else class="drag-drop-text hidden @md:inline" v-text="__('or drag & drop here.')"></span>
                     </p>
                 </div>
 
@@ -184,7 +183,6 @@ export default {
             uploads: [],
             innerDragging: false,
             displayMode: 'grid',
-            containerWidth: null,
         };
     },
 

--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -14,7 +14,7 @@
             </div>
         </div>
 
-        <publish-fields-container>
+        <div class="publish-fields @container">
             <set-field
                 v-for="field in fields"
                 v-show="showField(field, fieldPath(field.handle))"
@@ -33,7 +33,7 @@
                 @focus="$emit('focus')"
                 @blur="$emit('blur')"
             />
-        </publish-fields-container>
+        </div>
     </div>
 
 </template>

--- a/resources/js/components/fieldtypes/replicator/Field.vue
+++ b/resources/js/components/fieldtypes/replicator/Field.vue
@@ -119,7 +119,7 @@ export default {
             return [
                 'form-group publish-field',
                 `${this.field.type}-fieldtype`,
-                `field-${tailwind_width_class(this.field.width)}`,
+                `${tailwind_width_class(this.field.width)}`,
                 this.isReadOnly ? 'read-only-field' : '',
                 this.field.classes || '',
                 { 'has-error': this.hasError || this.hasNestedError }

--- a/resources/js/components/nav/ItemEditor.vue
+++ b/resources/js/components/nav/ItemEditor.vue
@@ -13,7 +13,7 @@
             </div>
 
             <div class="flex-1 overflow-auto p-6">
-                <div class="publish-fields publish-fields-narrow">
+                <div class="publish-fields">
 
                 <div class="publish-field mb-8" :class="{ 'has-error': validateDisplay }">
                     <div class="field-inner">

--- a/resources/js/components/nav/SectionEditor.vue
+++ b/resources/js/components/nav/SectionEditor.vue
@@ -13,7 +13,7 @@
             </div>
 
             <div class="flex-1 overflow-auto p-6">
-                <div class="publish-fields publish-fields-narrow">
+                <div class="publish-fields">
 
                 <div class="publish-field mb-8" :class="{ 'has-error': validate }">
                     <div class="field-inner">

--- a/resources/js/components/publish/Field.vue
+++ b/resources/js/components/publish/Field.vue
@@ -181,7 +181,7 @@ export default {
                 'form-group publish-field',
                 `publish-field__` + this.config.handle,
                 `${this.config.component || this.config.type}-fieldtype`,
-                `field-${tailwind_width_class(this.config.width)}`,
+                `${tailwind_width_class(this.config.width)}`,
                 this.isReadOnly ? 'read-only-field' : '',
                 this.config.classes || '',
                 { 'has-error': this.hasError || this.hasNestedError }

--- a/resources/js/components/publish/Fields.vue
+++ b/resources/js/components/publish/Fields.vue
@@ -1,6 +1,6 @@
 <template>
 
-    <publish-fields-container>
+    <div class="publish-fields @container">
 
         <publish-field
             v-for="field in fields"
@@ -22,7 +22,7 @@
             @blur="$emit('blur', field.handle)"
         />
 
-    </publish-fields-container>
+    </div>
 
 </template>
 

--- a/resources/js/components/publish/FieldsContainer.vue
+++ b/resources/js/components/publish/FieldsContainer.vue
@@ -1,19 +1,9 @@
 <template>
-
-    <element-container @resized="width = $event.width">
-        <div class="publish-fields" :class="{ 'publish-fields-narrow': width <= 600 }">
-            <slot />
-        </div>
-    </element-container>
-
+    <!--
+        This component is deprecated.
+        You can replace any instance of it with <div class="publish-fields @container">...</div>.
+    -->
+    <div class="publish-fields @container">
+        <slot />
+    </div>
 </template>
-
-<script>
-export default {
-    data() {
-        return {
-            width: null
-        }
-    }
-}
-</script>

--- a/resources/js/components/roles/PublishForm.vue
+++ b/resources/js/components/roles/PublishForm.vue
@@ -6,7 +6,7 @@
                 <h1 v-text="initialTitle || __('Create Role')" />
             </header>
 
-            <publish-fields-container class="card p-0 mb-6 configure-section">
+            <div class="card p-0 mb-6 configure-section publish-fields @container">
 
                 <form-group
                     handle="title"
@@ -42,7 +42,7 @@
                     v-model="isSuper"
                 />
 
-            </publish-fields-container>
+            </div>
 
             <div v-if="!isSuper">
                 <div class="mt-6 content" v-for="group in permissions" :key="group.handle">

--- a/resources/js/components/user-groups/PublishForm.vue
+++ b/resources/js/components/user-groups/PublishForm.vue
@@ -1,7 +1,7 @@
 <template>
 
         <div>
-            <publish-fields-container class="card p-0 mb-6">
+            <div class="card p-0 mb-6 publish-fields @container">
 
                 <form-group
                     :display="__('Title')"
@@ -48,7 +48,7 @@
                     <small class="help-block text-red mt-2 mb-0" v-if="errors.roles" v-text="errors.roles[0]" />
                 </div>
 
-            </publish-fields-container>
+            </div>
             <div class="py-4 border-t flex justify-between">
                 <a :href="action" class="btn" v-text="__('Cancel') "/>
                 <button type="submit" class="btn-primary" @click="save">{{ __('Save') }}</button>

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -256,17 +256,15 @@ class Str extends \Illuminate\Support\Str
     public static function tailwindWidthClass($width)
     {
         $widths = [
-            25 => '1/4',
-            33 => '1/3',
-            50 => '1/2',
-            66 => '2/3',
-            75 => '3/4',
-            100 => 'full',
+            25 => 'w-full @lg:w-1/4',
+            33 => 'w-full @lg:w-1/3',
+            50 => 'w-full @lg:w-1/2',
+            66 => 'w-full @lg:w-2/3',
+            75 => 'w-full @lg:w-3/4',
+            100 => 'w-full',
         ];
 
-        $class = $widths[$width] ?? 'full';
-
-        return "w-$class";
+        return $widths[$width] ?? 'w-full';
     }
 
     /**

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -159,6 +159,7 @@ module.exports = {
         },
     },
     plugins: [
+        require('@tailwindcss/container-queries'),
         require('@tailwindcss/typography'),
     ],
     important: true,

--- a/tests/Support/StrTest.php
+++ b/tests/Support/StrTest.php
@@ -152,11 +152,11 @@ class StrTest extends TestCase
     /** @test */
     public function it_makes_tailwind_width_classes()
     {
-        $this->assertEquals('w-1/4', Str::tailwindWidthClass(25));
-        $this->assertEquals('w-1/3', Str::tailwindWidthClass(33));
-        $this->assertEquals('w-1/2', Str::tailwindWidthClass(50));
-        $this->assertEquals('w-2/3', Str::tailwindWidthClass(66));
-        $this->assertEquals('w-3/4', Str::tailwindWidthClass(75));
+        $this->assertEquals('w-full @lg:w-1/4', Str::tailwindWidthClass(25));
+        $this->assertEquals('w-full @lg:w-1/3', Str::tailwindWidthClass(33));
+        $this->assertEquals('w-full @lg:w-1/2', Str::tailwindWidthClass(50));
+        $this->assertEquals('w-full @lg:w-2/3', Str::tailwindWidthClass(66));
+        $this->assertEquals('w-full @lg:w-3/4', Str::tailwindWidthClass(75));
         $this->assertEquals('w-full', Str::tailwindWidthClass(100));
         $this->assertEquals('w-full', Str::tailwindWidthClass('foo'));
     }


### PR DESCRIPTION
This PR adds Tailwind's new Container Queries plugin and allows us to remove a number of `ElementContainer` components that use a JavaScript resize watcher to make CSS layout adjustments. This should decrease memory usage in the CP and give us more control of fieldtype styles that can find themselves in all sorts of odd sizes and spaces.

The `<fields-container>` component is now deprecated and you may replace any instance of it with a simple `<div class="publish-fields @container">` HTML element.