### PR TITLE
Antlers: allow single array values in parameter

### DIFF
--- a/tests/Antlers/Runtime/ParametersTest.php
+++ b/tests/Antlers/Runtime/ParametersTest.php
@@ -289,4 +289,23 @@ EOT;
             ],
         ]));
     }
+
+    public function test_single_array_values_inside_parameters()
+    {
+        (new class extends Tags
+        {
+            protected static $handle = 'test';
+
+            public function index()
+            {
+                return $this->params->get('param');
+            }
+        })::register();
+
+        $template = <<<'EOT'
+{{ test :param="[123]" }}{{ index}}:{{ value }}{{ /test }}
+EOT;
+
+        $this->assertSame('0:123', $this->renderString($template, [], true));
+    }
 }


### PR DESCRIPTION
This PR fixes #7560 by adding an additional check when it decides if it should resolve parameter values using the normal data manager, or pass it off to a full Antlers parser instance.

The following will now Just Work ™️

```antlers

{{ tag_name :parameter="[1234]" }}

```

Note: I can create a new PR specifically targeting 3.4 if you need me too