### PR TITLE
Scope modifier resolve values value

### DIFF
--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -5,6 +5,7 @@ namespace Statamic\Support;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr as IlluminateArr;
+use Statamic\Fields\Value;
 use Statamic\Fields\Values;
 
 class Arr extends IlluminateArr
@@ -51,6 +52,10 @@ class Arr extends IlluminateArr
         }
 
         return collect($array)->map(function ($value) use ($scope) {
+            if ($value instanceof Value) {
+                $value = $value->value();
+            }
+
             if ($value instanceof Arrayable) {
                 $value = $value->toArray();
             }

--- a/tests/Modifiers/ScopeTest.php
+++ b/tests/Modifiers/ScopeTest.php
@@ -8,6 +8,7 @@ use Statamic\Contracts\Data\Augmentable;
 use Statamic\Data\HasAugmentedData;
 use Statamic\Fields\Blueprint;
 use Statamic\Fields\Fieldtype;
+use Statamic\Fields\Value;
 use Statamic\Modifiers\Modify;
 use Tests\TestCase;
 
@@ -87,6 +88,32 @@ class ScopeTest extends TestCase
         ];
 
         $this->assertEquals($expected, $this->modify($arr, 'test'));
+    }
+
+    /** @test */
+    public function it_resolves_values_value_when_adding_scope()
+    {
+        $arr = [
+            new Value([ 'title' => 'One' ]),
+            new Value([ 'title' => 'Two' ]),
+        ];
+
+        $expected = [
+            [
+                'title' => 'One',
+                'article' => [
+                    'title' => 'One',
+                ],
+            ],
+            [
+                'title' => 'Two',
+                'article' => [
+                    'title' => 'Two',
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $this->modify($arr, 'article'));
     }
 
     public function modify($arr, $scope)


### PR DESCRIPTION
This PR fixes #7575 by resolving `Value` objects inside the `addScope` method.

The PR https://github.com/statamic/cms/pull/7436/files adjusted how the results of tag assignments are augmented. Overall, I think the changes in that PR make sense since it leaves things like `Value` alone until the last possible minute, which is more inline with other variable behavior.

This PR adds a check to the `addScope` method to resolve the values of `Value` objects, so things like this will now work (in a real setup these would come from entries/relationship fieldtypes):

```php
<?php

use Statamic\Support\Arr;
use Statamic\Fields\Value;

$arr = [
    new Value(['title' => 'One' ]),
    new Value(['title' => 'Two' ]),
];

Arr::addScope($arr, 'article');
```
