### PR TITLE
Fix read only dynamic mode array fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/ArrayFieldtype.vue
+++ b/resources/js/components/fieldtypes/ArrayFieldtype.vue
@@ -44,7 +44,7 @@
                             <th class="grid-drag-handle-header" v-if="!isReadOnly"></th>
                             <th class="w-1/4">{{ keyHeader }}</th>
                             <th class="">{{ valueHeader }}</th>
-                            <th class="row-controls"></th>
+                            <th class="row-controls" v-if="!isReadOnly"></th>
                         </tr>
                     </thead>
 
@@ -63,7 +63,7 @@
                                 <td>
                                     <input type="text" class="input-text" v-model="element.value" :readonly="isReadOnly" />
                                 </td>
-                                <td class="row-controls">
+                                <td class="row-controls" v-if="!isReadOnly">
                                     <a @click="deleteOrConfirm(index)" class="inline opacity-25 text-lg antialiased hover:opacity-75">&times;</a>
                                 </td>
                             </tr>
@@ -71,7 +71,7 @@
                     </sortable-list>
                 </table>
 
-                <button class="btn" @click="addValue" :disabled="atMax">
+                <button class="btn" @click="addValue" :disabled="atMax" v-if="!isReadOnly">
                     {{ addButton }}
                 </button>
 


### PR DESCRIPTION
The dynamic mode array fieldtype will let you add and remove items when it's set to read only.

This PR fixes that by hiding the add and remove buttons.

Before:

![Screenshot 2023-02-20 at 12 47 47](https://user-images.githubusercontent.com/126740/220113074-025e915b-3cc7-4819-9c6a-b21054d2a4d1.png)

After:

![Screenshot 2023-02-20 at 12 47 59](https://user-images.githubusercontent.com/126740/220113092-58cfcdfc-43b6-40b7-8ce9-b6e2131a8e94.png)
