### PR TITLE
Refactor randomness out of test

### DIFF
--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -91,7 +91,6 @@ class Environment
     protected $interpolationKeys = [];
     protected $assignments = [];
     protected $dataManagerInterpolations = [];
-    protected $evaluatedModifiers = false;
 
     /**
      * @var LanguageOperatorManager|null
@@ -311,8 +310,6 @@ class Environment
      */
     public function evaluate($nodes)
     {
-        $this->evaluatedModifiers = false;
-
         if (count($nodes) == 0) {
             return null;
         }
@@ -1252,14 +1249,7 @@ class Environment
      */
     private function applyModifiers($value, ModifierChainNode $modifierChain)
     {
-        $this->evaluatedModifiers = true;
-
         return ModifierManager::evaluate($value, $this, $modifierChain, $this->data);
-    }
-
-    public function getDidEvaluateModifiers()
-    {
-        return $this->evaluatedModifiers;
     }
 
     /**

--- a/tests/Antlers/Runtime/LoopTest.php
+++ b/tests/Antlers/Runtime/LoopTest.php
@@ -153,32 +153,24 @@ EOT;
         $this->assertTrue($isPaired);
     }
 
-    public function test_runtime_does_not_attempt_evaluate_modifiers_twice()
+    public function test_modified_value_is_used_each_iteration()
     {
-        mt_srand(1234);
-
         $data = [
-            'widths' => [
-                '25',
-                '50',
-                '75',
-            ],
+            'items' => ['a', 'b', 'c'],
         ];
 
+        // without mirroring modifier in closing tag
         $template = <<<'EOT'
-{{ loop from="1" to="10" }}<{{ value }}><{{ widths | shuffle | limit:1 }}width-{{ value }}{{ /widths }}><{{ value }}>{{ unless last }}|{{ /unless}}{{ /loop }}
+{{ loop from="1" to="3" }}<{{ value }}{{ items | limit:1 }}{{ value }}{{ /items }}{{ value }}>{{ /loop }}
 EOT;
 
-        $expected = <<<'EXPECTED'
-<1><width-75><1>|<2><width-75><2>|<3><width-50><3>|<4><width-75><4>|<5><width-25><5>|<6><width-75><6>|<7><width-75><7>|<8><width-50><8>|<9><width-50><9>|<10><width-50><10>
-EXPECTED;
+        $expected = '<1a1><2a2><3a3>'; // only "a" should be output in each iteration since limit:1 is used.
 
         $this->assertSame($expected, $this->renderString($template, $data, true));
 
-        mt_srand(1234);
-
+        // mirror modifiers in closing tag
         $template = <<<'EOT'
-{{ loop from="1" to="10" }}<{{ value }}><{{ widths | shuffle | limit:1 }}width-{{ value }}{{ /widths | shuffle | limit:1 }}><{{ value }}>{{ unless last }}|{{ /unless }}{{ /loop }}
+{{ loop from="1" to="3" }}<{{ value }}{{ items | limit:1 }}{{ value }}{{ /items | limit:1 }}{{ value }}>{{ /loop }}
 EOT;
 
         $this->assertSame($expected, $this->renderString($template, $data, true));


### PR DESCRIPTION
Replaces #7583

It turns out the issue in #5828 wasn't that the modifier was being called multiple times. It had more to do with the modified `value` not being used on subsequent iterations.

I wrote this test while on the commit where the original test was added, and confirmed that it broke without the original fix, and passed when adding it. That fix has since been refactored, and now still passes.

The replaced test is also simplified just so there's less to grok.

Also removed some leftover stuff that was introduced along at the same time as the test, but is no longer used.