### PR TITLE
Tag parameters prioritized over variable assignments

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1441,6 +1441,13 @@ class NodeProcessor
                                 $this->runtimeAssignments,
                                 GlobalRuntimeState::$tracedRuntimeAssignments
                             );
+
+                            foreach ($tagParameters as $paramName => $paramValue) {
+                                if (array_key_exists($paramName, GlobalRuntimeState::$tracedRuntimeAssignments)) {
+                                    GlobalRuntimeState::$tracedRuntimeAssignments[$paramName] = $paramValue;
+                                    $tagActiveData[$paramName] = $paramValue;
+                                }
+                            }
                         }
                         /** @var Tags $tag */
                         $tag = $this->loader->load($tagToLoad, [

--- a/tests/Antlers/Sandbox/VariableAssignmentTest.php
+++ b/tests/Antlers/Sandbox/VariableAssignmentTest.php
@@ -1062,4 +1062,60 @@ EOT;
 
         $this->assertSame('<Zero><One><Two><Three><Four>', trim($this->renderString($template)));
     }
+
+    public function test_tag_parameters_take_priority_over_custom_variable_assignments()
+    {
+        $this->withFakeViews();
+        $partial = <<<'PARTIAL'
+Partial: {{ myVar }}
+PARTIAL;
+
+        $this->viewShouldReturnRaw('test', $partial);
+
+        $template = <<<'TEMPLATE'
+{{ myVar = 'Hello, world!'; }}
+{{ partial:test /}}
+After: {{ myVar }}
+TEMPLATE;
+
+        $expected = <<<'EXP'
+Partial: Hello, world!
+After: Hello, world!
+EXP;
+
+        $this->assertSame($expected, trim($this->renderString($template, [], true)));
+
+        $template = <<<'TEMPLATE'
+{{ myVar = 'Hello, world!'; }}
+{{ partial:test myVar="I was changed!" /}}
+After: {{ myVar }}
+TEMPLATE;
+
+        $expected = <<<'EXP'
+Partial: I was changed!
+After: I was changed!
+EXP;
+
+        $this->assertSame($expected, trim($this->renderString($template, [], true)));
+
+        $partial = <<<'PARTIAL'
+Partial: {{ myVar }}
+{{ myVar = 'I was changed a lot!'; }}
+PARTIAL;
+
+        $this->viewShouldReturnRaw('test', $partial);
+        $template = <<<'TEMPLATE'
+{{ myVar = 'Hello, world!'; }}
+{{ partial:test myVar="I was changed!" /}}
+After: {{ myVar }}
+TEMPLATE;
+
+        $expected = <<<'EXP'
+Partial: I was changed!
+
+After: I was changed a lot!
+EXP;
+
+        $this->assertSame($expected, trim($this->renderString($template, [], true)));
+    }
 }


### PR DESCRIPTION
This PR resolves the tag parameters not taking precedence issue described in #7587 

Before this PR, the value of `my_param` inside the partial's scope would be stuck at "Hello, world!":

```antlers
{{ my_param = "Hello, world!" }}


{{ partial:test my_param="Howdy!" }}
```

With this PR it would now be set to the value provided by the parameter.