### PR TITLE
Fix save issue when slug starts with extension

### DIFF
--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -197,7 +197,7 @@ class CollectionEntriesStore extends ChildStore
 
         while (true) {
             $ext = '.'.$item->fileExtension();
-            $filename = Str::before($basePath, $ext);
+            $filename = Str::beforeLast($basePath, $ext);
             $suffix = $num ? ".$num" : '';
             $path = "{$filename}{$suffix}{$ext}";
 


### PR DESCRIPTION
This fixes an issue where if you give an entry a slug that starts with the file extension, it will wipe out the slug.

It only happens in dated collections.

For example, if you have a slug of `foo` it would save `2023-02-22.foo.md`.
But if you have a slug of `mdfoo` it would save `2023-02-22.md`.

This is because it was looking for `.md` in the string and getting everything before it, which was just the date.
This is fixed by doing `Str::beforeLast` instead of just `before` so it finds the final `.md`.
