### PR TITLE
Antlers: Allow creation of new array elements

### DIFF
--- a/src/View/Antlers/Language/Runtime/PathDataManager.php
+++ b/src/View/Antlers/Language/Runtime/PathDataManager.php
@@ -356,14 +356,18 @@ class PathDataManager
     public function setRuntimeValue(VariableReference $path, &$data, $value)
     {
         // Run through the getData routine to build up the dynamic path.
-        $this->getData($path, $data);
+        $result = $this->getDataWithExistence($path, $data);
         $lastPath = $this->lastPath();
+
+        if ($result[0] === false && mb_strlen($lastPath) > 0) {
+            $lastPath = $path->originalContent;
+        }
 
         if (Str::contains($lastPath, '{method:')) {
             throw new VariableAccessException('Cannot set method value with path: "'.$path->originalContent.'"');
         }
 
-        Arr::set($data, $this->lastPath(), $value);
+        Arr::set($data, $lastPath, $value);
     }
 
     /**

--- a/tests/Antlers/Runtime/ArraysTest.php
+++ b/tests/Antlers/Runtime/ArraysTest.php
@@ -376,4 +376,48 @@ EOT;
 
         $this->assertSame('<dance><party>', trim($this->renderString($template)));
     }
+
+    public function test_creation_of_new_array_elements()
+    {
+        $template = <<<'EOT'
+{{ the_array = ['One', 'Two'] }}
+One: {{ the_array.0 }}
+Two: {{ the_array.1 }}
+{{ the_array.2 = 'Three'; }}
+One: {{ the_array.0 }}
+Two: {{ the_array.1 }}
+Three: {{ the_array.2 }}
+{{ the_array = [] }}
+One: {{ the_array.0 }}
+Two: {{ the_array.1 }}
+Three: {{ the_array.2 }}
+{{ the_array.a.deeply.nested.path = 'One!'; }}
+{{ the_array.a.deeply.nested.more = 'Two!'; }}
+{{ the_array.a.deeply.nested.even_more = 'Three!'; }}
+One: {{ the_array.a.deeply.nested.path }}
+Two: {{ the_array.a.deeply.nested.more }}
+Three: {{ the_array.a.deeply.nested.even_more }}
+EOT;
+
+        $expected = <<<'EOT'
+One: One
+Two: Two
+
+One: One
+Two: Two
+Three: Three
+
+One: 
+Two: 
+Three: 
+
+
+
+One: One!
+Two: Two!
+Three: Three!
+EOT;
+
+        $this->assertSame($expected, trim($this->renderString($template)));
+    }
 }


### PR DESCRIPTION
This PR closes #7593 by allowing the creation of new nested array elements:

```antlers
{{ the_array = ['One', 'Two']; }}

{{ the_array.2 = 'Three'; }}

{{ the_array }}
    {{ value }}
{{ /the_array }}
```

will now output `One Two Three`. Current behavior is that the `{{ the_array.2 = 'Three'; }}` will just clobber all of the existing data. Still on the fence about the idea, but also figured it shouldn't get rid of all existing data, either.

The following syntax is still not supported:

```antlers
{{ the_array[] = 'Three'; }}
```