### PR TITLE
Antlers: Corrects updating nested value changes being lost after calling tags

### DIFF
--- a/src/View/Antlers/Language/Nodes/Paths/VariableReference.php
+++ b/src/View/Antlers/Language/Nodes/Paths/VariableReference.php
@@ -44,6 +44,11 @@ class VariableReference
     public $isFinal = false;
 
     /**
+     * @var VariableReference|null
+     */
+    private $cachedRoot = null;
+
+    /**
      * Determines if the provided path is a complex variable path or not.
      *
      * @return bool
@@ -66,6 +71,21 @@ class VariableReference
         }
 
         return false;
+    }
+
+    public function getRoot(): VariableReference
+    {
+        if ($this->cachedRoot == null) {
+            $this->cachedRoot = new VariableReference();
+
+            if (count($this->pathParts) == 0) {
+                return $this->cachedRoot;
+            }
+
+            $this->cachedRoot->pathParts[] = $this->pathParts[0];
+        }
+
+        return $this->cachedRoot;
     }
 
     /**

--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -932,6 +932,12 @@ class Environment
 
                 $this->dataRetriever->setRuntimeValue($varName, $this->data, $right);
                 $lastPath = $this->dataRetriever->lastPath();
+
+                if (count($varName->pathParts) > 1) {
+                    $right = $this->dataRetriever->getData($varName->getRoot(), $this->data);
+                    $lastPath = $varName->pathParts[0]->name;
+                }
+
                 $this->assignments[$lastPath] = $right;
 
                 if (array_key_exists($lastPath, GlobalRuntimeState::$tracedRuntimeAssignments)) {
@@ -969,7 +975,15 @@ class Environment
                     $this->data,
                     $newVal
                 );
-                $this->assignments[$this->dataRetriever->lastPath()] = $newVal;
+
+                $lastPath = $this->dataRetriever->lastPath();
+
+                if (count($varName->pathParts) > 1) {
+                    $newVal = $this->dataRetriever->getData($varName->getRoot(), $this->data);
+                    $lastPath = $varName->pathParts[0]->name;
+                }
+
+                $this->assignments[$lastPath] = $newVal;
 
                 return null;
             } elseif ($operand instanceof DivisionAssignmentOperator) {
@@ -988,7 +1002,15 @@ class Environment
                     $this->data,
                     $assignValue
                 );
-                $this->assignments[$this->dataRetriever->lastPath()] = $assignValue;
+
+                $lastPath = $this->dataRetriever->lastPath();
+
+                if (count($varName->pathParts) > 1) {
+                    $assignValue = $this->dataRetriever->getData($varName->getRoot(), $this->data);
+                    $lastPath = $varName->pathParts[0]->name;
+                }
+
+                $this->assignments[$lastPath] = $assignValue;
 
                 return null;
             } elseif ($operand instanceof ModulusAssignmentOperator) {
@@ -1006,7 +1028,15 @@ class Environment
                     $this->data,
                     $assignValue
                 );
-                $this->assignments[$this->dataRetriever->lastPath()] = $assignValue;
+
+                $lastPath = $this->dataRetriever->lastPath();
+
+                if (count($varName->pathParts) > 1) {
+                    $assignValue = $this->dataRetriever->getData($varName->getRoot(), $this->data);
+                    $lastPath = $varName->pathParts[0]->name;
+                }
+
+                $this->assignments[$lastPath] = $assignValue;
 
                 return null;
             } elseif ($operand instanceof MultiplicationAssignmentOperator) {
@@ -1024,7 +1054,15 @@ class Environment
                     $this->data,
                     $assignValue
                 );
-                $this->assignments[$this->dataRetriever->lastPath()] = $assignValue;
+
+                $lastPath = $this->dataRetriever->lastPath();
+
+                if (count($varName->pathParts) > 1) {
+                    $assignValue = $this->dataRetriever->getData($varName->getRoot(), $this->data);
+                    $lastPath = $varName->pathParts[0]->name;
+                }
+
+                $this->assignments[$lastPath] = $assignValue;
 
                 return null;
             } elseif ($operand instanceof SubtractionAssignmentOperator) {
@@ -1042,7 +1080,15 @@ class Environment
                     $this->data,
                     $assignValue
                 );
-                $this->assignments[$this->dataRetriever->lastPath()] = $assignValue;
+
+                $lastPath = $this->dataRetriever->lastPath();
+
+                if (count($varName->pathParts) > 1) {
+                    $assignValue = $this->dataRetriever->getData($varName->getRoot(), $this->data);
+                    $lastPath = $varName->pathParts[0]->name;
+                }
+
+                $this->assignments[$lastPath] = $assignValue;
 
                 return null;
             } elseif ($operand instanceof ConditionalVariableFallbackOperator) {

--- a/tests/Antlers/Sandbox/VariableAssignmentTest.php
+++ b/tests/Antlers/Sandbox/VariableAssignmentTest.php
@@ -5,6 +5,7 @@ namespace Tests\Antlers\Sandbox;
 use Facades\Tests\Factories\EntryFactory;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Taxonomy;
+use Statamic\View\Antlers\Language\Utilities\StringUtilities;
 use Tests\Antlers\ParserTestCase;
 use Tests\FakesViews;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -1061,5 +1062,58 @@ EOT;
 EOT;
 
         $this->assertSame('<Zero><One><Two><Three><Four>', trim($this->renderString($template)));
+    }
+
+    public function test_updated_arrays_are_not_reset_by_tags()
+    {
+        Collection::make('pages')->routes(['en' => '{slug}'])->save();
+        EntryFactory::collection('pages')->id('1')->slug('one')->data(['title' => 'One', 'template' => 'template'])->create();
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+
+
+        $template = <<<'EOT'
+{{ the_array = ['One', 10, 30, 40, 50, 60]; }}
+Value: {{ the_array.0 }}
+{{ the_array.0 = 'Two'; }}
+{{ the_array.1 *= 5; }}
+{{ the_array.2 -= 5; }}
+{{ the_array.3 %= 2; }}
+{{ the_array.4 /= 5; }}
+{{ the_array.5 += 10; }}
+Value: {{ the_array.0 }}
+{{ loop from="0" to="3" }}{{ index }}{{ /loop }}
+Value0: {{ the_array.0 }}
+Value1: {{ the_array.1 }}
+Value2: {{ the_array.2 }}
+Value3: {{ the_array.3 }}
+Value4: {{ the_array.4 }}
+Value5: {{ the_array.5 }}
+EOT;
+
+        $this->viewShouldReturnRaw('template', $template);
+
+        $responseOne = $this->get('one')->assertOk();
+
+        $expected = <<<'EXPECTED'
+Value: One
+
+
+
+
+
+
+Value: Two
+0123
+Value0: Two
+Value1: 50
+Value2: 25
+Value3: 0
+Value4: 10
+Value5: 70
+EXPECTED;
+
+        $this->assertSame($expected, StringUtilities::normalizeLineEndings(trim($responseOne->getContent())));
     }
 }


### PR DESCRIPTION
This PR fixes #7595 by pushing the updated state of the array back up through the scope. Currently it will push an internal variable similar to `the_array.0` (based on the nested path) when attempting updates, which leads to interesting results.

The following will now work correctly:

```antlers
{{ the_array = ['One', 10, 30, 40, 50, 60]; }}
Value: {{ the_array.0 }}
{{ the_array.0 = 'Two'; }}
{{ the_array.1 *= 5; }}
{{ the_array.2 -= 5; }}
{{ the_array.3 %= 2; }}
{{ the_array.4 /= 5; }}
{{ the_array.5 += 10; }}
Value: {{ the_array.0 }}
{{ loop from="0" to="3" }}{{ index }}{{ /loop }}
Value0: {{ the_array.0 }}
Value1: {{ the_array.1 }}
Value2: {{ the_array.2 }}
Value3: {{ the_array.3 }}
Value4: {{ the_array.4 }}
Value5: {{ the_array.5 }}
```