### PR TITLE
Ensure custom logo is visible

### DIFF
--- a/resources/sass/components/global-header.scss
+++ b/resources/sass/components/global-header.scss
@@ -142,6 +142,7 @@
 }
 
 .global-header .white-label-logo {
+    width: 100%;
     max-height: 32px;
     max-width: 280px;
 }


### PR DESCRIPTION
This fixes an issue, where a custom logo wouldn't be visible in the CP global header.

```php
'custom_logo_url' => env('STATAMIC_CUSTOM_LOGO_URL', '/cp/logo.svg'),
```
**Before proposed change**
<img width="578" alt="Bildschirmfoto 2023-02-23 um 12 11 26" src="https://user-images.githubusercontent.com/23167701/220979998-fd0d1646-599c-4b17-ad9a-89fa1a06c9b4.png">

**After proposed change**
<img width="479" alt="Bildschirmfoto 2023-02-23 um 12 11 42" src="https://user-images.githubusercontent.com/23167701/220980065-292a2221-a067-4940-8f2d-e7f879237f50.png">
