### PR TITLE
[4.x] Test Windows using PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,11 @@ jobs:
         os: [ubuntu-latest]
         include:
           - os: windows-latest
-            php: 8.2
+            php: 8.1
             laravel: 9.*
             stability: prefer-stable
           - os: windows-latest
-            php: 8.2
+            php: 8.1
             laravel: 10.*
             stability: prefer-stable
         exclude:


### PR DESCRIPTION
For whatever reason, the "setup php" step takes over 3-4 minutes when using php 8.2. But for 8.1 it's only ~1 minute.

The PHP version doesn't _really_ matter. We're testing 8.2 elsewhere.

![CleanShot 2023-02-23 at 16 13 45](https://user-images.githubusercontent.com/105211/221031641-d7c9b39e-f5b8-4b45-a886-74929288dee5.png)

![CleanShot 2023-02-23 at 16 15 21](https://user-images.githubusercontent.com/105211/221031900-3fe98d02-4fa1-4dd0-8083-81e2964e1909.png)
