### PR TITLE
[4.x] Routing

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,18 +1,28 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Statamic\Http\Controllers\API\AssetsController;
+use Statamic\Http\Controllers\API\CollectionEntriesController;
+use Statamic\Http\Controllers\API\CollectionTreeController;
+use Statamic\Http\Controllers\API\FormsController;
+use Statamic\Http\Controllers\API\GlobalsController;
+use Statamic\Http\Controllers\API\NavigationTreeController;
+use Statamic\Http\Controllers\API\NotFoundController;
+use Statamic\Http\Controllers\API\TaxonomyTermEntriesController;
+use Statamic\Http\Controllers\API\TaxonomyTermsController;
+use Statamic\Http\Controllers\API\UsersController;
 
-Route::resource('collections.entries', 'CollectionEntriesController')->only('index', 'show');
-Route::resource('taxonomies.terms', 'TaxonomyTermsController')->only('index', 'show');
-Route::resource('taxonomies.terms.entries', 'TaxonomyTermEntriesController')->only('index');
-Route::resource('globals', 'GlobalsController')->only('index', 'show');
-Route::resource('forms', 'FormsController')->only('index', 'show');
-Route::resource('users', 'UsersController')->only('index', 'show');
+Route::resource('collections.entries', CollectionEntriesController::class)->only('index', 'show');
+Route::resource('taxonomies.terms', TaxonomyTermsController::class)->only('index', 'show');
+Route::resource('taxonomies.terms.entries', TaxonomyTermEntriesController::class)->only('index');
+Route::resource('globals', GlobalsController::class)->only('index', 'show');
+Route::resource('forms', FormsController::class)->only('index', 'show');
+Route::resource('users', UsersController::class)->only('index', 'show');
 
-Route::name('assets.index')->get('assets/{asset_container}', 'AssetsController@index');
-Route::name('assets.show')->get('assets/{asset_container}/{asset}', 'AssetsController@show')->where('asset', '.*');
+Route::name('assets.index')->get('assets/{asset_container}', [AssetsController::class, 'index']);
+Route::name('assets.show')->get('assets/{asset_container}/{asset}', [AssetsController::class, 'show'])->where('asset', '.*');
 
-Route::get('collections/{collection}/tree', 'CollectionTreeController@show');
-Route::get('navs/{nav}/tree', 'NavigationTreeController@show');
+Route::get('collections/{collection}/tree', [CollectionTreeController::class, 'show']);
+Route::get('navs/{nav}/tree', [NavigationTreeController::class, 'show']);
 
-Route::get('{path?}', 'NotFoundController')->where('path', '.*');
+Route::get('{path?}', NotFoundController::class)->where('path', '.*');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -119,124 +119,113 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
 
     Route::get('select-site/{handle}', [SelectSiteController::class, 'select']);
 
-    Route::group([], function () {
-        Route::resource('navigation', NavigationController::class);
+    Route::resource('navigation', NavigationController::class);
+    Route::get('navigation/{navigation}/blueprint', [NavigationBlueprintController::class, 'edit'])->name('navigation.blueprint.edit');
+    Route::patch('navigation/{navigation}/blueprint', [NavigationBlueprintController::class, 'update'])->name('navigation.blueprint.update');
+    Route::get('navigation/{navigation}/tree', [NavigationTreeController::class, 'index'])->name('navigation.tree.index');
+    Route::patch('navigation/{navigation}/tree', [NavigationTreeController::class, 'update'])->name('navigation.tree.update');
+    Route::post('navigation/{navigation}/pages', [NavigationPagesController::class, 'update'])->name('navigation.pages.update');
+    Route::get('navigation/{navigation}/pages/create', [NavigationPagesController::class, 'create'])->name('navigation.pages.create');
+    Route::get('navigation/{navigation}/pages/{edit}/edit', [NavigationPagesController::class, 'edit'])->name('navigation.pages.edit');
 
-        Route::get('navigation/{navigation}/blueprint', [NavigationBlueprintController::class, 'edit'])->name('navigation.blueprint.edit');
-        Route::patch('navigation/{navigation}/blueprint', [NavigationBlueprintController::class, 'update'])->name('navigation.blueprint.update');
-        Route::get('navigation/{navigation}/tree', [NavigationTreeController::class, 'index'])->name('navigation.tree.index');
-        Route::patch('navigation/{navigation}/tree', [NavigationTreeController::class, 'update'])->name('navigation.tree.update');
-        Route::post('navigation/{navigation}/pages', [NavigationPagesController::class, 'update'])->name('navigation.pages.update');
-        Route::get('navigation/{navigation}/pages/create', [NavigationPagesController::class, 'create'])->name('navigation.pages.create');
-        Route::get('navigation/{navigation}/pages/{edit}/edit', [NavigationPagesController::class, 'edit'])->name('navigation.pages.edit');
-    });
+    Route::resource('collections', CollectionsController::class);
+    Route::get('collections/{collection}/scaffold', [ScaffoldCollectionController::class, 'index'])->name('collections.scaffold');
+    Route::post('collections/{collection}/scaffold', [ScaffoldCollectionController::class, 'create'])->name('collections.scaffold.create');
+    Route::resource('collections.blueprints', CollectionBlueprintsController::class);
+    Route::post('collections/{collection}/blueprints/reorder', ReorderCollectionBlueprintsController::class)->name('collections.blueprints.reorder');
 
-    Route::group([], function () {
-        Route::resource('collections', CollectionsController::class);
-        Route::get('collections/{collection}/scaffold', [ScaffoldCollectionController::class, 'index'])->name('collections.scaffold');
-        Route::post('collections/{collection}/scaffold', [ScaffoldCollectionController::class, 'create'])->name('collections.scaffold.create');
-        Route::resource('collections.blueprints', CollectionBlueprintsController::class);
-        Route::post('collections/{collection}/blueprints/reorder', ReorderCollectionBlueprintsController::class)->name('collections.blueprints.reorder');
+    Route::get('collections/{collection}/tree', [CollectionTreeController::class, 'index'])->name('collections.tree.index');
+    Route::patch('collections/{collection}/tree', [CollectionTreeController::class, 'update'])->name('collections.tree.update');
 
-        Route::get('collections/{collection}/tree', [CollectionTreeController::class, 'index'])->name('collections.tree.index');
-        Route::patch('collections/{collection}/tree', [CollectionTreeController::class, 'update'])->name('collections.tree.update');
+    Route::group(['prefix' => 'collections/{collection}/entries'], function () {
+        Route::get('/', [EntriesController::class, 'index'])->name('collections.entries.index');
+        Route::post('actions', [EntryActionController::class, 'run'])->name('collections.entries.actions.run');
+        Route::post('actions/list', [EntryActionController::class, 'bulkActions'])->name('collections.entries.actions.bulk');
+        Route::get('create/{site}', [EntriesController::class, 'create'])->name('collections.entries.create');
+        Route::post('create/{site}/preview', [EntryPreviewController::class, 'create'])->name('collections.entries.preview.create');
+        Route::post('reorder', ReorderEntriesController::class)->name('collections.entries.reorder');
+        Route::post('{site}', [EntriesController::class, 'store'])->name('collections.entries.store');
 
-        Route::group(['prefix' => 'collections/{collection}/entries'], function () {
-            Route::get('/', [EntriesController::class, 'index'])->name('collections.entries.index');
-            Route::post('actions', [EntryActionController::class, 'run'])->name('collections.entries.actions.run');
-            Route::post('actions/list', [EntryActionController::class, 'bulkActions'])->name('collections.entries.actions.bulk');
-            Route::get('create/{site}', [EntriesController::class, 'create'])->name('collections.entries.create');
-            Route::post('create/{site}/preview', [EntryPreviewController::class, 'create'])->name('collections.entries.preview.create');
-            Route::post('reorder', ReorderEntriesController::class)->name('collections.entries.reorder');
-            Route::post('{site}', [EntriesController::class, 'store'])->name('collections.entries.store');
+        Route::group(['prefix' => '{entry}'], function () {
+            Route::get('/', [EntriesController::class, 'edit'])->name('collections.entries.edit');
+            Route::post('publish', [PublishedEntriesController::class, 'store'])->name('collections.entries.published.store');
+            Route::post('unpublish', [PublishedEntriesController::class, 'destroy'])->name('collections.entries.published.destroy');
+            Route::post('localize', LocalizeEntryController::class)->name('collections.entries.localize');
 
-            Route::group(['prefix' => '{entry}'], function () {
-                Route::get('/', [EntriesController::class, 'edit'])->name('collections.entries.edit');
-                Route::post('publish', [PublishedEntriesController::class, 'store'])->name('collections.entries.published.store');
-                Route::post('unpublish', [PublishedEntriesController::class, 'destroy'])->name('collections.entries.published.destroy');
-                Route::post('localize', LocalizeEntryController::class)->name('collections.entries.localize');
+            Route::resource('revisions', EntryRevisionsController::class, [
+                'as' => 'collections.entries',
+                'only' => ['index', 'store', 'show'],
+            ]);
 
-                Route::resource('revisions', EntryRevisionsController::class, [
-                    'as' => 'collections.entries',
-                    'only' => ['index', 'store', 'show'],
-                ]);
-
-                Route::post('restore-revision', RestoreEntryRevisionController::class)->name('collections.entries.restore-revision');
-                Route::post('preview', [EntryPreviewController::class, 'edit'])->name('collections.entries.preview.edit');
-                Route::get('preview', [EntryPreviewController::class, 'show'])->name('collections.entries.preview.popout');
-                Route::patch('/', [EntriesController::class, 'update'])->name('collections.entries.update');
-                Route::get('{slug}', fn ($collection, $entry, $slug) => redirect($entry->editUrl()));
-            });
+            Route::post('restore-revision', RestoreEntryRevisionController::class)->name('collections.entries.restore-revision');
+            Route::post('preview', [EntryPreviewController::class, 'edit'])->name('collections.entries.preview.edit');
+            Route::get('preview', [EntryPreviewController::class, 'show'])->name('collections.entries.preview.popout');
+            Route::patch('/', [EntriesController::class, 'update'])->name('collections.entries.update');
+            Route::get('{slug}', fn ($collection, $entry, $slug) => redirect($entry->editUrl()));
         });
     });
 
-    Route::group([], function () {
-        Route::resource('taxonomies', TaxonomiesController::class);
-        Route::resource('taxonomies.blueprints', TaxonomyBlueprintsController::class);
-        Route::post('taxonomies/{taxonomy}/blueprints/reorder', ReorderTaxonomyBlueprintsController::class)->name('taxonomies.blueprints.reorder');
+    Route::resource('taxonomies', TaxonomiesController::class);
+    Route::resource('taxonomies.blueprints', TaxonomyBlueprintsController::class);
+    Route::post('taxonomies/{taxonomy}/blueprints/reorder', ReorderTaxonomyBlueprintsController::class)->name('taxonomies.blueprints.reorder');
 
-        Route::group(['prefix' => 'taxonomies/{taxonomy}/terms'], function () {
-            Route::get('/', [TermsController::class, 'index'])->name('taxonomies.terms.index');
-            Route::post('actions', [TermActionController::class, 'run'])->name('taxonomies.terms.actions.run');
-            Route::post('actions/list', [TermActionController::class, 'bulkActions'])->name('taxonomies.terms.actions.bulk');
-            Route::get('create/{site}', [TermsController::class, 'create'])->name('taxonomies.terms.create');
-            Route::post('create/{site}/preview', [TermPreviewController::class, 'create'])->name('taxonomies.terms.preview.create');
-            Route::post('{site}', [TermsController::class, 'store'])->name('taxonomies.terms.store');
+    Route::group(['prefix' => 'taxonomies/{taxonomy}/terms'], function () {
+        Route::get('/', [TermsController::class, 'index'])->name('taxonomies.terms.index');
+        Route::post('actions', [TermActionController::class, 'run'])->name('taxonomies.terms.actions.run');
+        Route::post('actions/list', [TermActionController::class, 'bulkActions'])->name('taxonomies.terms.actions.bulk');
+        Route::get('create/{site}', [TermsController::class, 'create'])->name('taxonomies.terms.create');
+        Route::post('create/{site}/preview', [TermPreviewController::class, 'create'])->name('taxonomies.terms.preview.create');
+        Route::post('{site}', [TermsController::class, 'store'])->name('taxonomies.terms.store');
 
-            Route::group(['prefix' => '{term}/{site?}'], function () {
-                Route::get('/', [TermsController::class, 'edit'])->name('taxonomies.terms.edit');
-                Route::post('/', [PublishedTermsController::class, 'store'])->name('taxonomies.terms.published.store');
-                Route::delete('/', [PublishedTermsController::class, 'destroy'])->name('taxonomies.terms.published.destroy');
+        Route::group(['prefix' => '{term}/{site?}'], function () {
+            Route::get('/', [TermsController::class, 'edit'])->name('taxonomies.terms.edit');
+            Route::post('/', [PublishedTermsController::class, 'store'])->name('taxonomies.terms.published.store');
+            Route::delete('/', [PublishedTermsController::class, 'destroy'])->name('taxonomies.terms.published.destroy');
 
-                Route::resource('revisions', TermRevisionsController::class, [
-                    'as' => 'taxonomies.terms',
-                    'only' => ['index', 'store', 'show'],
-                ]);
+            Route::resource('revisions', TermRevisionsController::class, [
+                'as' => 'taxonomies.terms',
+                'only' => ['index', 'store', 'show'],
+            ]);
 
-                Route::post('restore-revision', RestoreTermRevisionController::class)->name('taxonomies.terms.restore-revision');
-                Route::post('preview', [TermPreviewController::class, 'edit'])->name('taxonomies.terms.preview.edit');
-                Route::get('preview', [TermPreviewController::class, 'show'])->name('taxonomies.terms.preview.popout');
-                Route::patch('/', [TermsController::class, 'update'])->name('taxonomies.terms.update');
-            });
+            Route::post('restore-revision', RestoreTermRevisionController::class)->name('taxonomies.terms.restore-revision');
+            Route::post('preview', [TermPreviewController::class, 'edit'])->name('taxonomies.terms.preview.edit');
+            Route::get('preview', [TermPreviewController::class, 'show'])->name('taxonomies.terms.preview.popout');
+            Route::patch('/', [TermsController::class, 'update'])->name('taxonomies.terms.update');
         });
     });
 
-    Route::group(['namespace' => 'Globals'], function () {
-        Route::get('globals', [GlobalsController::class, 'index'])->name('globals.index');
-        Route::get('globals/create', [GlobalsController::class, 'create'])->name('globals.create');
-        Route::post('globals', [GlobalsController::class, 'store'])->name('globals.store');
-        Route::get('globals/{global_set}/edit', [GlobalsController::class, 'edit'])->name('globals.edit');
-        Route::patch('globals/{global_set}', [GlobalsController::class, 'update'])->name('globals.update');
-        Route::delete('globals/{global_set}', [GlobalsController::class, 'destroy'])->name('globals.destroy');
+    Route::get('globals', [GlobalsController::class, 'index'])->name('globals.index');
+    Route::get('globals/create', [GlobalsController::class, 'create'])->name('globals.create');
+    Route::post('globals', [GlobalsController::class, 'store'])->name('globals.store');
+    Route::get('globals/{global_set}/edit', [GlobalsController::class, 'edit'])->name('globals.edit');
+    Route::patch('globals/{global_set}', [GlobalsController::class, 'update'])->name('globals.update');
+    Route::delete('globals/{global_set}', [GlobalsController::class, 'destroy'])->name('globals.destroy');
 
-        Route::get('globals/{global_set}', [GlobalVariablesController::class, 'edit'])->name('globals.variables.edit');
-        Route::patch('globals/{global_set}/variables', [GlobalVariablesController::class, 'update'])->name('globals.variables.update');
+    Route::get('globals/{global_set}', [GlobalVariablesController::class, 'edit'])->name('globals.variables.edit');
+    Route::patch('globals/{global_set}/variables', [GlobalVariablesController::class, 'update'])->name('globals.variables.update');
 
-        Route::get('globals/{global_set}/blueprint', [GlobalsBlueprintController::class, 'edit'])->name('globals.blueprint.edit');
-        Route::patch('globals/{global_set}/blueprint', [GlobalsBlueprintController::class, 'update'])->name('globals.blueprint.update');
-    });
+    Route::get('globals/{global_set}/blueprint', [GlobalsBlueprintController::class, 'edit'])->name('globals.blueprint.edit');
+    Route::patch('globals/{global_set}/blueprint', [GlobalsBlueprintController::class, 'update'])->name('globals.blueprint.update');
 
-    Route::group([], function () {
-        Route::resource('asset-containers', AssetContainersController::class);
-        Route::post('asset-containers/{asset_container}/folders', [FoldersController::class, 'store']);
-        Route::patch('asset-containers/{asset_container}/folders/{path}', [FoldersController::class, 'update'])->where('path', '.*');
-        Route::get('asset-containers/{asset_container}/blueprint', [AssetContainerBlueprintController::class, 'edit'])->name('asset-containers.blueprint.edit');
-        Route::patch('asset-containers/{asset_container}/blueprint', [AssetContainerBlueprintController::class, 'update'])->name('asset-containers.blueprint.update');
-        Route::post('assets/actions', [ActionController::class, 'run'])->name('assets.actions.run');
-        Route::post('assets/actions/list', [ActionController::class, 'bulkActions'])->name('assets.actions.bulk');
-        Route::get('assets/browse', [BrowserController::class, 'index'])->name('assets.browse.index');
-        Route::get('assets/browse/search/{asset_container}/{path?}', [BrowserController::class, 'search'])->where('path', '.*');
-        Route::post('assets/browse/folders/{asset_container}/actions', [FolderActionController::class, 'run'])->name('assets.folders.actions.run');
-        Route::get('assets/browse/folders/{asset_container}/{path?}', [BrowserController::class, 'folder'])->where('path', '.*');
-        Route::get('assets/browse/{asset_container}/{path?}/edit', [BrowserController::class, 'edit'])->where('path', '.*')->name('assets.browse.edit');
-        Route::get('assets/browse/{asset_container}/{path?}', [BrowserController::class, 'show'])->where('path', '.*')->name('assets.browse.show');
-        Route::get('assets-fieldtype', [FieldtypeController::class, 'index']);
-        Route::resource('assets', AssetsController::class)->parameters(['assets' => 'encoded_asset']);
-        Route::get('assets/{encoded_asset}/download', [AssetsController::class, 'download'])->name('assets.download');
-        Route::get('thumbnails/{encoded_asset}/{size?}/{orientation?}', [ThumbnailController::class, 'show'])->name('assets.thumbnails.show');
-        Route::get('svgs/{encoded_asset}', [SvgController::class, 'show'])->name('assets.svgs.show');
-        Route::get('pdfs/{encoded_asset}', [PdfController::class, 'show'])->name('assets.pdfs.show');
-    });
+    Route::resource('asset-containers', AssetContainersController::class);
+    Route::post('asset-containers/{asset_container}/folders', [FoldersController::class, 'store']);
+    Route::patch('asset-containers/{asset_container}/folders/{path}', [FoldersController::class, 'update'])->where('path', '.*');
+    Route::get('asset-containers/{asset_container}/blueprint', [AssetContainerBlueprintController::class, 'edit'])->name('asset-containers.blueprint.edit');
+    Route::patch('asset-containers/{asset_container}/blueprint', [AssetContainerBlueprintController::class, 'update'])->name('asset-containers.blueprint.update');
+    Route::post('assets/actions', [ActionController::class, 'run'])->name('assets.actions.run');
+    Route::post('assets/actions/list', [ActionController::class, 'bulkActions'])->name('assets.actions.bulk');
+    Route::get('assets/browse', [BrowserController::class, 'index'])->name('assets.browse.index');
+    Route::get('assets/browse/search/{asset_container}/{path?}', [BrowserController::class, 'search'])->where('path', '.*');
+    Route::post('assets/browse/folders/{asset_container}/actions', [FolderActionController::class, 'run'])->name('assets.folders.actions.run');
+    Route::get('assets/browse/folders/{asset_container}/{path?}', [BrowserController::class, 'folder'])->where('path', '.*');
+    Route::get('assets/browse/{asset_container}/{path?}/edit', [BrowserController::class, 'edit'])->where('path', '.*')->name('assets.browse.edit');
+    Route::get('assets/browse/{asset_container}/{path?}', [BrowserController::class, 'show'])->where('path', '.*')->name('assets.browse.show');
+    Route::get('assets-fieldtype', [FieldtypeController::class, 'index']);
+    Route::resource('assets', AssetsController::class)->parameters(['assets' => 'encoded_asset']);
+    Route::get('assets/{encoded_asset}/download', [AssetsController::class, 'download'])->name('assets.download');
+    Route::get('thumbnails/{encoded_asset}/{size?}/{orientation?}', [ThumbnailController::class, 'show'])->name('assets.thumbnails.show');
+    Route::get('svgs/{encoded_asset}', [SvgController::class, 'show'])->name('assets.svgs.show');
+    Route::get('pdfs/{encoded_asset}', [PdfController::class, 'show'])->name('assets.pdfs.show');
 
     Route::group(['prefix' => 'fields'], function () {
         Route::get('/', [FieldsController::class, 'index'])->name('fields.index');
@@ -250,13 +239,11 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
 
     Route::get('composer/check', [ComposerOutputController::class, 'check']);
 
-    Route::group(['namespace' => 'Updater'], function () {
-        Route::get('updater', [UpdaterController::class, 'index'])->name('updater');
-        Route::get('updater/count', [UpdaterController::class, 'count']);
-        Route::get('updater/{product}', [UpdateProductController::class, 'show'])->name('updater.product');
-        Route::get('updater/{product}/changelog', [UpdateProductController::class, 'changelog']);
-        Route::post('updater/{product}/install', [UpdateProductController::class, 'install']);
-    });
+    Route::get('updater', [UpdaterController::class, 'index'])->name('updater');
+    Route::get('updater/count', [UpdaterController::class, 'count']);
+    Route::get('updater/{product}', [UpdateProductController::class, 'show'])->name('updater.product');
+    Route::get('updater/{product}/changelog', [UpdateProductController::class, 'changelog']);
+    Route::post('updater/{product}/install', [UpdateProductController::class, 'install']);
 
     Route::group(['prefix' => 'duplicates'], function () {
         Route::get('/', [DuplicatesController::class, 'index'])->name('duplicates');
@@ -268,29 +255,25 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
     Route::post('addons/uninstall', [AddonsController::class, 'uninstall']);
     Route::post('addons/editions', AddonEditionsController::class);
 
-    Route::group([], function () {
-        Route::post('forms/actions', [ActionController::class, 'run'])->name('forms.actions.run');
-        Route::post('forms/actions/list', [ActionController::class, 'bulkActions'])->name('forms.actions.bulk');
-        Route::post('forms/{form}/submissions/actions', [SubmissionActionController::class, 'run'])->name('forms.submissions.actions.run');
-        Route::post('forms/{form}/submissions/actions/list', [SubmissionActionController::class, 'bulkActions'])->name('forms.submissions.actions.bulk');
-        Route::resource('forms', FormsController::class);
-        Route::resource('forms.submissions', FormSubmissionsController::class);
-        Route::get('forms/{form}/export/{type}', [FormExportController::class, 'export'])->name('forms.export');
-        Route::get('forms/{form}/blueprint', [FormBlueprintController::class, 'edit'])->name('forms.blueprint.edit');
-        Route::patch('forms/{form}/blueprint', [FormBlueprintController::class, 'update'])->name('forms.blueprint.update');
-    });
+    Route::post('forms/actions', [ActionController::class, 'run'])->name('forms.actions.run');
+    Route::post('forms/actions/list', [ActionController::class, 'bulkActions'])->name('forms.actions.bulk');
+    Route::post('forms/{form}/submissions/actions', [SubmissionActionController::class, 'run'])->name('forms.submissions.actions.run');
+    Route::post('forms/{form}/submissions/actions/list', [SubmissionActionController::class, 'bulkActions'])->name('forms.submissions.actions.bulk');
+    Route::resource('forms', FormsController::class);
+    Route::resource('forms.submissions', FormSubmissionsController::class);
+    Route::get('forms/{form}/export/{type}', [FormExportController::class, 'export'])->name('forms.export');
+    Route::get('forms/{form}/blueprint', [FormBlueprintController::class, 'edit'])->name('forms.blueprint.edit');
+    Route::patch('forms/{form}/blueprint', [FormBlueprintController::class, 'update'])->name('forms.blueprint.update');
 
-    Route::group([], function () {
-        Route::post('users/actions', [UserActionController::class, 'run'])->name('users.actions.run');
-        Route::post('users/actions/list', [UserActionController::class, 'bulkActions'])->name('users.actions.bulk');
-        Route::get('users/blueprint', [UserBlueprintController::class, 'edit'])->name('users.blueprint.edit');
-        Route::patch('users/blueprint', [UserBlueprintController::class, 'update'])->name('users.blueprint.update');
-        Route::resource('users', UsersController::class);
-        Route::patch('users/{user}/password', [PasswordController::class, 'update'])->name('users.password.update');
-        Route::get('account', AccountController::class)->name('account');
-        Route::resource('user-groups', UserGroupsController::class);
-        Route::resource('roles', RolesController::class);
-    });
+    Route::post('users/actions', [UserActionController::class, 'run'])->name('users.actions.run');
+    Route::post('users/actions/list', [UserActionController::class, 'bulkActions'])->name('users.actions.bulk');
+    Route::get('users/blueprint', [UserBlueprintController::class, 'edit'])->name('users.blueprint.edit');
+    Route::patch('users/blueprint', [UserBlueprintController::class, 'update'])->name('users.blueprint.update');
+    Route::resource('users', UsersController::class);
+    Route::patch('users/{user}/password', [PasswordController::class, 'update'])->name('users.password.update');
+    Route::get('account', AccountController::class)->name('account');
+    Route::resource('user-groups', UserGroupsController::class);
+    Route::resource('roles', RolesController::class);
 
     Route::post('user-exists', UserWizardController::class)->name('user.exists');
 
@@ -304,7 +287,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::get('graphiql', [GraphQLController::class, 'graphiql'])->name('graphql.graphiql');
     }
 
-    Route::group(['prefix' => 'fieldtypes', 'namespace' => 'Fieldtypes'], function () {
+    Route::group(['prefix' => 'fieldtypes'], function () {
         Route::get('relationship', [RelationshipFieldtypeController::class, 'index'])->name('relationship.index');
         Route::post('relationship/data', [RelationshipFieldtypeController::class, 'data'])->name('relationship.data');
         Route::get('relationship/filters', [RelationshipFieldtypeController::class, 'filters'])->name('relationship.filters');
@@ -317,7 +300,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::resource('templates', TemplatesController::class);
     });
 
-    Route::group(['prefix' => 'preferences', 'as' => 'preferences.', 'namespace' => 'Preferences'], function () {
+    Route::group(['prefix' => 'preferences', 'as' => 'preferences.'], function () {
         Route::get('/', [PreferenceController::class, 'index'])->name('index');
         Route::get('edit', [UserPreferenceController::class, 'edit'])->name('user.edit');
         Route::patch('/', [UserPreferenceController::class, 'update'])->name('user.update');
@@ -332,7 +315,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::post('js', [PreferenceController::class, 'store'])->name('store');
         Route::delete('js/{key}', [PreferenceController::class, 'destroy'])->name('destroy');
 
-        Route::group(['prefix' => 'nav', 'as' => 'nav.', 'namespace' => 'Nav'], function () {
+        Route::group(['prefix' => 'nav', 'as' => 'nav.'], function () {
             Route::get('/', [NavController::class, 'index'])->name('index');
             Route::get('edit', [UserNavController::class, 'edit'])->name('user.edit');
             Route::patch('/', [UserNavController::class, 'update'])->name('user.update');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -2,266 +2,356 @@
 
 use Illuminate\Support\Facades\Route;
 use Statamic\Facades\Utility;
+use Statamic\Http\Controllers\CP\AddonEditionsController;
+use Statamic\Http\Controllers\CP\AddonsController;
+use Statamic\Http\Controllers\CP\API\TemplatesController;
+use Statamic\Http\Controllers\CP\Assets\ActionController;
+use Statamic\Http\Controllers\CP\Assets\AssetContainerBlueprintController;
+use Statamic\Http\Controllers\CP\Assets\AssetContainersController;
+use Statamic\Http\Controllers\CP\Assets\AssetsController;
+use Statamic\Http\Controllers\CP\Assets\BrowserController;
+use Statamic\Http\Controllers\CP\Assets\FieldtypeController;
+use Statamic\Http\Controllers\CP\Assets\FolderActionController;
+use Statamic\Http\Controllers\CP\Assets\FoldersController;
+use Statamic\Http\Controllers\CP\Assets\PdfController;
+use Statamic\Http\Controllers\CP\Assets\SvgController;
+use Statamic\Http\Controllers\CP\Assets\ThumbnailController;
+use Statamic\Http\Controllers\CP\Auth\CsrfTokenController;
+use Statamic\Http\Controllers\CP\Auth\ExtendSessionController;
+use Statamic\Http\Controllers\CP\Auth\ForgotPasswordController;
+use Statamic\Http\Controllers\CP\Auth\LoginController;
+use Statamic\Http\Controllers\CP\Auth\ResetPasswordController;
+use Statamic\Http\Controllers\CP\Auth\UnauthorizedController;
+use Statamic\Http\Controllers\CP\Collections\CollectionBlueprintsController;
+use Statamic\Http\Controllers\CP\Collections\CollectionsController;
+use Statamic\Http\Controllers\CP\Collections\CollectionTreeController;
+use Statamic\Http\Controllers\CP\Collections\EntriesController;
+use Statamic\Http\Controllers\CP\Collections\EntryActionController;
+use Statamic\Http\Controllers\CP\Collections\EntryPreviewController;
+use Statamic\Http\Controllers\CP\Collections\EntryRevisionsController;
+use Statamic\Http\Controllers\CP\Collections\LocalizeEntryController;
+use Statamic\Http\Controllers\CP\Collections\PublishedEntriesController;
+use Statamic\Http\Controllers\CP\Collections\ReorderCollectionBlueprintsController;
+use Statamic\Http\Controllers\CP\Collections\ReorderEntriesController;
+use Statamic\Http\Controllers\CP\Collections\RestoreEntryRevisionController;
+use Statamic\Http\Controllers\CP\Collections\ScaffoldCollectionController;
+use Statamic\Http\Controllers\CP\ComposerOutputController;
+use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Http\Controllers\CP\DashboardController;
+use Statamic\Http\Controllers\CP\DuplicatesController;
+use Statamic\Http\Controllers\CP\Fields\BlueprintController;
+use Statamic\Http\Controllers\CP\Fields\FieldsController;
+use Statamic\Http\Controllers\CP\Fields\FieldsetController;
+use Statamic\Http\Controllers\CP\Fields\FieldtypesController;
+use Statamic\Http\Controllers\CP\Fields\MetaController;
+use Statamic\Http\Controllers\CP\Fieldtypes\FilesFieldtypeController;
+use Statamic\Http\Controllers\CP\Fieldtypes\MarkdownFieldtypeController;
+use Statamic\Http\Controllers\CP\Fieldtypes\RelationshipFieldtypeController;
+use Statamic\Http\Controllers\CP\Forms\FormBlueprintController;
+use Statamic\Http\Controllers\CP\Forms\FormExportController;
+use Statamic\Http\Controllers\CP\Forms\FormsController;
+use Statamic\Http\Controllers\CP\Forms\FormSubmissionsController;
+use Statamic\Http\Controllers\CP\Forms\SubmissionActionController;
+use Statamic\Http\Controllers\CP\Globals\GlobalsBlueprintController;
+use Statamic\Http\Controllers\CP\Globals\GlobalsController;
+use Statamic\Http\Controllers\CP\Globals\GlobalVariablesController;
+use Statamic\Http\Controllers\CP\GraphQLController;
+use Statamic\Http\Controllers\CP\Navigation\NavigationBlueprintController;
+use Statamic\Http\Controllers\CP\Navigation\NavigationController;
+use Statamic\Http\Controllers\CP\Navigation\NavigationPagesController;
+use Statamic\Http\Controllers\CP\Navigation\NavigationTreeController;
+use Statamic\Http\Controllers\CP\Preferences\DefaultPreferenceController;
+use Statamic\Http\Controllers\CP\Preferences\Nav\DefaultNavController;
+use Statamic\Http\Controllers\CP\Preferences\Nav\NavController;
+use Statamic\Http\Controllers\CP\Preferences\Nav\RoleNavController;
+use Statamic\Http\Controllers\CP\Preferences\Nav\UserNavController;
+use Statamic\Http\Controllers\CP\Preferences\PreferenceController;
+use Statamic\Http\Controllers\CP\Preferences\RolePreferenceController;
+use Statamic\Http\Controllers\CP\Preferences\UserPreferenceController;
+use Statamic\Http\Controllers\CP\SearchController;
+use Statamic\Http\Controllers\CP\SelectSiteController;
+use Statamic\Http\Controllers\CP\SessionTimeoutController;
+use Statamic\Http\Controllers\CP\StartPageController;
+use Statamic\Http\Controllers\CP\Taxonomies\PublishedTermsController;
+use Statamic\Http\Controllers\CP\Taxonomies\ReorderTaxonomyBlueprintsController;
+use Statamic\Http\Controllers\CP\Taxonomies\RestoreTermRevisionController;
+use Statamic\Http\Controllers\CP\Taxonomies\TaxonomiesController;
+use Statamic\Http\Controllers\CP\Taxonomies\TaxonomyBlueprintsController;
+use Statamic\Http\Controllers\CP\Taxonomies\TermActionController;
+use Statamic\Http\Controllers\CP\Taxonomies\TermPreviewController;
+use Statamic\Http\Controllers\CP\Taxonomies\TermRevisionsController;
+use Statamic\Http\Controllers\CP\Taxonomies\TermsController;
+use Statamic\Http\Controllers\CP\Updater\UpdateProductController;
+use Statamic\Http\Controllers\CP\Updater\UpdaterController;
+use Statamic\Http\Controllers\CP\Users\AccountController;
+use Statamic\Http\Controllers\CP\Users\PasswordController;
+use Statamic\Http\Controllers\CP\Users\RolesController;
+use Statamic\Http\Controllers\CP\Users\UserActionController;
+use Statamic\Http\Controllers\CP\Users\UserBlueprintController;
+use Statamic\Http\Controllers\CP\Users\UserGroupsController;
+use Statamic\Http\Controllers\CP\Users\UsersController;
+use Statamic\Http\Controllers\CP\Users\UserWizardController;
+use Statamic\Http\Controllers\CP\Utilities\UtilitiesController;
 use Statamic\Http\Middleware\RequireStatamicPro;
 use Statamic\Statamic;
 
-Route::group(['prefix' => 'auth', 'namespace' => 'Auth'], function () {
-    Route::get('login', 'LoginController@showLoginForm')->name('login');
-    Route::post('login', 'LoginController@login');
-    Route::get('logout', 'LoginController@logout')->name('logout');
+Route::group(['prefix' => 'auth'], function () {
+    Route::get('login', [LoginController::class, 'showLoginForm'])->name('login');
+    Route::post('login', [LoginController::class, 'login']);
+    Route::get('logout', [LoginController::class, 'logout'])->name('logout');
 
-    Route::get('password/reset', 'ForgotPasswordController@showLinkRequestForm')->name('password.request');
-    Route::post('password/email', 'ForgotPasswordController@sendResetLinkEmail')->name('password.email');
-    Route::get('password/reset/{token}', 'ResetPasswordController@showResetForm')->name('password.reset');
-    Route::post('password/reset', 'ResetPasswordController@reset')->name('password.reset.action');
+    Route::get('password/reset', [ForgotPasswordController::class, 'showLinkRequestForm'])->name('password.request');
+    Route::post('password/email', [ForgotPasswordController::class, 'sendResetLinkEmail'])->name('password.email');
+    Route::get('password/reset/{token}', [ResetPasswordController::class, 'showResetForm'])->name('password.reset');
+    Route::post('password/reset', [ResetPasswordController::class, 'reset'])->name('password.reset.action');
 
-    Route::get('token', 'CsrfTokenController')->name('token');
-    Route::get('extend', 'ExtendSessionController')->name('extend');
+    Route::get('token', CsrfTokenController::class)->name('token');
+    Route::get('extend', ExtendSessionController::class)->name('extend');
 
-    Route::get('unauthorized', 'UnauthorizedController')->name('unauthorized');
+    Route::get('unauthorized', UnauthorizedController::class)->name('unauthorized');
 });
 
 Route::middleware('statamic.cp.authenticated')->group(function () {
     Statamic::additionalCpRoutes();
 
-    Route::get('/', 'StartPageController')->name('index');
-    Route::get('dashboard', 'DashboardController@index')->name('dashboard');
+    Route::get('/', StartPageController::class)->name('index');
+    Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
-    Route::get('select-site/{handle}', 'SelectSiteController@select');
+    Route::get('select-site/{handle}', [SelectSiteController::class, 'select']);
 
-    Route::group(['namespace' => 'Navigation'], function () {
-        Route::resource('navigation', 'NavigationController');
+    Route::group([], function () {
+        Route::resource('navigation', NavigationController::class);
 
-        Route::get('navigation/{navigation}/blueprint', 'NavigationBlueprintController@edit')->name('navigation.blueprint.edit');
-        Route::patch('navigation/{navigation}/blueprint', 'NavigationBlueprintController@update')->name('navigation.blueprint.update');
-        Route::get('navigation/{navigation}/tree', 'NavigationTreeController@index')->name('navigation.tree.index');
-        Route::patch('navigation/{navigation}/tree', 'NavigationTreeController@update')->name('navigation.tree.update');
-        Route::post('navigation/{navigation}/pages', 'NavigationPagesController@update')->name('navigation.pages.update');
-        Route::get('navigation/{navigation}/pages/create', 'NavigationPagesController@create')->name('navigation.pages.create');
-        Route::get('navigation/{navigation}/pages/{edit}/edit', 'NavigationPagesController@edit')->name('navigation.pages.edit');
+        Route::get('navigation/{navigation}/blueprint', [NavigationBlueprintController::class, 'edit'])->name('navigation.blueprint.edit');
+        Route::patch('navigation/{navigation}/blueprint', [NavigationBlueprintController::class, 'update'])->name('navigation.blueprint.update');
+        Route::get('navigation/{navigation}/tree', [NavigationTreeController::class, 'index'])->name('navigation.tree.index');
+        Route::patch('navigation/{navigation}/tree', [NavigationTreeController::class, 'update'])->name('navigation.tree.update');
+        Route::post('navigation/{navigation}/pages', [NavigationPagesController::class, 'update'])->name('navigation.pages.update');
+        Route::get('navigation/{navigation}/pages/create', [NavigationPagesController::class, 'create'])->name('navigation.pages.create');
+        Route::get('navigation/{navigation}/pages/{edit}/edit', [NavigationPagesController::class, 'edit'])->name('navigation.pages.edit');
     });
 
-    Route::group(['namespace' => 'Collections'], function () {
-        Route::resource('collections', 'CollectionsController');
-        Route::get('collections/{collection}/scaffold', 'ScaffoldCollectionController@index')->name('collections.scaffold');
-        Route::post('collections/{collection}/scaffold', 'ScaffoldCollectionController@create')->name('collections.scaffold.create');
-        Route::resource('collections.blueprints', 'CollectionBlueprintsController');
-        Route::post('collections/{collection}/blueprints/reorder', 'ReorderCollectionBlueprintsController')->name('collections.blueprints.reorder');
+    Route::group([], function () {
+        Route::resource('collections', CollectionsController::class);
+        Route::get('collections/{collection}/scaffold', [ScaffoldCollectionController::class, 'index'])->name('collections.scaffold');
+        Route::post('collections/{collection}/scaffold', [ScaffoldCollectionController::class, 'create'])->name('collections.scaffold.create');
+        Route::resource('collections.blueprints', CollectionBlueprintsController::class);
+        Route::post('collections/{collection}/blueprints/reorder', ReorderCollectionBlueprintsController::class)->name('collections.blueprints.reorder');
 
-        Route::get('collections/{collection}/tree', 'CollectionTreeController@index')->name('collections.tree.index');
-        Route::patch('collections/{collection}/tree', 'CollectionTreeController@update')->name('collections.tree.update');
+        Route::get('collections/{collection}/tree', [CollectionTreeController::class, 'index'])->name('collections.tree.index');
+        Route::patch('collections/{collection}/tree', [CollectionTreeController::class, 'update'])->name('collections.tree.update');
 
         Route::group(['prefix' => 'collections/{collection}/entries'], function () {
-            Route::get('/', 'EntriesController@index')->name('collections.entries.index');
-            Route::post('actions', 'EntryActionController@run')->name('collections.entries.actions.run');
-            Route::post('actions/list', 'EntryActionController@bulkActions')->name('collections.entries.actions.bulk');
-            Route::get('create/{site}', 'EntriesController@create')->name('collections.entries.create');
-            Route::post('create/{site}/preview', 'EntryPreviewController@create')->name('collections.entries.preview.create');
-            Route::post('reorder', 'ReorderEntriesController')->name('collections.entries.reorder');
-            Route::post('{site}', 'EntriesController@store')->name('collections.entries.store');
+            Route::get('/', [EntriesController::class, 'index'])->name('collections.entries.index');
+            Route::post('actions', [EntryActionController::class, 'run'])->name('collections.entries.actions.run');
+            Route::post('actions/list', [EntryActionController::class, 'bulkActions'])->name('collections.entries.actions.bulk');
+            Route::get('create/{site}', [EntriesController::class, 'create'])->name('collections.entries.create');
+            Route::post('create/{site}/preview', [EntryPreviewController::class, 'create'])->name('collections.entries.preview.create');
+            Route::post('reorder', ReorderEntriesController::class)->name('collections.entries.reorder');
+            Route::post('{site}', [EntriesController::class, 'store'])->name('collections.entries.store');
 
             Route::group(['prefix' => '{entry}'], function () {
-                Route::get('/', 'EntriesController@edit')->name('collections.entries.edit');
-                Route::post('publish', 'PublishedEntriesController@store')->name('collections.entries.published.store');
-                Route::post('unpublish', 'PublishedEntriesController@destroy')->name('collections.entries.published.destroy');
-                Route::post('localize', 'LocalizeEntryController')->name('collections.entries.localize');
+                Route::get('/', [EntriesController::class, 'edit'])->name('collections.entries.edit');
+                Route::post('publish', [PublishedEntriesController::class, 'store'])->name('collections.entries.published.store');
+                Route::post('unpublish', [PublishedEntriesController::class, 'destroy'])->name('collections.entries.published.destroy');
+                Route::post('localize', LocalizeEntryController::class)->name('collections.entries.localize');
 
-                Route::resource('revisions', 'EntryRevisionsController', [
+                Route::resource('revisions', EntryRevisionsController::class, [
                     'as' => 'collections.entries',
                     'only' => ['index', 'store', 'show'],
                 ]);
 
-                Route::post('restore-revision', 'RestoreEntryRevisionController')->name('collections.entries.restore-revision');
-                Route::post('preview', 'EntryPreviewController@edit')->name('collections.entries.preview.edit');
-                Route::get('preview', 'EntryPreviewController@show')->name('collections.entries.preview.popout');
-                Route::patch('/', 'EntriesController@update')->name('collections.entries.update');
+                Route::post('restore-revision', RestoreEntryRevisionController::class)->name('collections.entries.restore-revision');
+                Route::post('preview', [EntryPreviewController::class, 'edit'])->name('collections.entries.preview.edit');
+                Route::get('preview', [EntryPreviewController::class, 'show'])->name('collections.entries.preview.popout');
+                Route::patch('/', [EntriesController::class, 'update'])->name('collections.entries.update');
                 Route::get('{slug}', fn ($collection, $entry, $slug) => redirect($entry->editUrl()));
             });
         });
     });
 
-    Route::group(['namespace' => 'Taxonomies'], function () {
-        Route::resource('taxonomies', 'TaxonomiesController');
-        Route::resource('taxonomies.blueprints', 'TaxonomyBlueprintsController');
-        Route::post('taxonomies/{taxonomy}/blueprints/reorder', 'ReorderTaxonomyBlueprintsController')->name('taxonomies.blueprints.reorder');
+    Route::group([], function () {
+        Route::resource('taxonomies', TaxonomiesController::class);
+        Route::resource('taxonomies.blueprints', TaxonomyBlueprintsController::class);
+        Route::post('taxonomies/{taxonomy}/blueprints/reorder', ReorderTaxonomyBlueprintsController::class)->name('taxonomies.blueprints.reorder');
 
         Route::group(['prefix' => 'taxonomies/{taxonomy}/terms'], function () {
-            Route::get('/', 'TermsController@index')->name('taxonomies.terms.index');
-            Route::post('actions', 'TermActionController@run')->name('taxonomies.terms.actions.run');
-            Route::post('actions/list', 'TermActionController@bulkActions')->name('taxonomies.terms.actions.bulk');
-            Route::get('create/{site}', 'TermsController@create')->name('taxonomies.terms.create');
-            Route::post('create/{site}/preview', 'TermPreviewController@create')->name('taxonomies.terms.preview.create');
-            Route::post('{site}', 'TermsController@store')->name('taxonomies.terms.store');
+            Route::get('/', [TermsController::class, 'index'])->name('taxonomies.terms.index');
+            Route::post('actions', [TermActionController::class, 'run'])->name('taxonomies.terms.actions.run');
+            Route::post('actions/list', [TermActionController::class, 'bulkActions'])->name('taxonomies.terms.actions.bulk');
+            Route::get('create/{site}', [TermsController::class, 'create'])->name('taxonomies.terms.create');
+            Route::post('create/{site}/preview', [TermPreviewController::class, 'create'])->name('taxonomies.terms.preview.create');
+            Route::post('{site}', [TermsController::class, 'store'])->name('taxonomies.terms.store');
 
             Route::group(['prefix' => '{term}/{site?}'], function () {
-                Route::get('/', 'TermsController@edit')->name('taxonomies.terms.edit');
-                Route::post('/', 'PublishedTermsController@store')->name('taxonomies.terms.published.store');
-                Route::delete('/', 'PublishedTermsController@destroy')->name('taxonomies.terms.published.destroy');
+                Route::get('/', [TermsController::class, 'edit'])->name('taxonomies.terms.edit');
+                Route::post('/', [PublishedTermsController::class, 'store'])->name('taxonomies.terms.published.store');
+                Route::delete('/', [PublishedTermsController::class, 'destroy'])->name('taxonomies.terms.published.destroy');
 
-                Route::resource('revisions', 'TermRevisionsController', [
+                Route::resource('revisions', TermRevisionsController::class, [
                     'as' => 'taxonomies.terms',
                     'only' => ['index', 'store', 'show'],
                 ]);
 
-                Route::post('restore-revision', 'RestoreTermRevisionController')->name('taxonomies.terms.restore-revision');
-                Route::post('preview', 'TermPreviewController@edit')->name('taxonomies.terms.preview.edit');
-                Route::get('preview', 'TermPreviewController@show')->name('taxonomies.terms.preview.popout');
-                Route::patch('/', 'TermsController@update')->name('taxonomies.terms.update');
+                Route::post('restore-revision', RestoreTermRevisionController::class)->name('taxonomies.terms.restore-revision');
+                Route::post('preview', [TermPreviewController::class, 'edit'])->name('taxonomies.terms.preview.edit');
+                Route::get('preview', [TermPreviewController::class, 'show'])->name('taxonomies.terms.preview.popout');
+                Route::patch('/', [TermsController::class, 'update'])->name('taxonomies.terms.update');
             });
         });
     });
 
     Route::group(['namespace' => 'Globals'], function () {
-        Route::get('globals', 'GlobalsController@index')->name('globals.index');
-        Route::get('globals/create', 'GlobalsController@create')->name('globals.create');
-        Route::post('globals', 'GlobalsController@store')->name('globals.store');
-        Route::get('globals/{global_set}/edit', 'GlobalsController@edit')->name('globals.edit');
-        Route::patch('globals/{global_set}', 'GlobalsController@update')->name('globals.update');
-        Route::delete('globals/{global_set}', 'GlobalsController@destroy')->name('globals.destroy');
+        Route::get('globals', [GlobalsController::class, 'index'])->name('globals.index');
+        Route::get('globals/create', [GlobalsController::class, 'create'])->name('globals.create');
+        Route::post('globals', [GlobalsController::class, 'store'])->name('globals.store');
+        Route::get('globals/{global_set}/edit', [GlobalsController::class, 'edit'])->name('globals.edit');
+        Route::patch('globals/{global_set}', [GlobalsController::class, 'update'])->name('globals.update');
+        Route::delete('globals/{global_set}', [GlobalsController::class, 'destroy'])->name('globals.destroy');
 
-        Route::get('globals/{global_set}', 'GlobalVariablesController@edit')->name('globals.variables.edit');
-        Route::patch('globals/{global_set}/variables', 'GlobalVariablesController@update')->name('globals.variables.update');
+        Route::get('globals/{global_set}', [GlobalVariablesController::class, 'edit'])->name('globals.variables.edit');
+        Route::patch('globals/{global_set}/variables', [GlobalVariablesController::class, 'update'])->name('globals.variables.update');
 
-        Route::get('globals/{global_set}/blueprint', 'GlobalsBlueprintController@edit')->name('globals.blueprint.edit');
-        Route::patch('globals/{global_set}/blueprint', 'GlobalsBlueprintController@update')->name('globals.blueprint.update');
+        Route::get('globals/{global_set}/blueprint', [GlobalsBlueprintController::class, 'edit'])->name('globals.blueprint.edit');
+        Route::patch('globals/{global_set}/blueprint', [GlobalsBlueprintController::class, 'update'])->name('globals.blueprint.update');
     });
 
-    Route::group(['namespace' => 'Assets'], function () {
-        Route::resource('asset-containers', 'AssetContainersController');
-        Route::post('asset-containers/{asset_container}/folders', 'FoldersController@store');
-        Route::patch('asset-containers/{asset_container}/folders/{path}', 'FoldersController@update')->where('path', '.*');
-        Route::get('asset-containers/{asset_container}/blueprint', 'AssetContainerBlueprintController@edit')->name('asset-containers.blueprint.edit');
-        Route::patch('asset-containers/{asset_container}/blueprint', 'AssetContainerBlueprintController@update')->name('asset-containers.blueprint.update');
-        Route::post('assets/actions', 'ActionController@run')->name('assets.actions.run');
-        Route::post('assets/actions/list', 'ActionController@bulkActions')->name('assets.actions.bulk');
-        Route::get('assets/browse', 'BrowserController@index')->name('assets.browse.index');
-        Route::get('assets/browse/search/{asset_container}/{path?}', 'BrowserController@search')->where('path', '.*');
-        Route::post('assets/browse/folders/{asset_container}/actions', 'FolderActionController@run')->name('assets.folders.actions.run');
-        Route::get('assets/browse/folders/{asset_container}/{path?}', 'BrowserController@folder')->where('path', '.*');
-        Route::get('assets/browse/{asset_container}/{path?}/edit', 'BrowserController@edit')->where('path', '.*')->name('assets.browse.edit');
-        Route::get('assets/browse/{asset_container}/{path?}', 'BrowserController@show')->where('path', '.*')->name('assets.browse.show');
-        Route::get('assets-fieldtype', 'FieldtypeController@index');
-        Route::resource('assets', 'AssetsController')->parameters(['assets' => 'encoded_asset']);
-        Route::get('assets/{encoded_asset}/download', 'AssetsController@download')->name('assets.download');
-        Route::get('thumbnails/{encoded_asset}/{size?}/{orientation?}', 'ThumbnailController@show')->name('assets.thumbnails.show');
-        Route::get('svgs/{encoded_asset}', 'SvgController@show')->name('assets.svgs.show');
-        Route::get('pdfs/{encoded_asset}', 'PdfController@show')->name('assets.pdfs.show');
+    Route::group([], function () {
+        Route::resource('asset-containers', AssetContainersController::class);
+        Route::post('asset-containers/{asset_container}/folders', [FoldersController::class, 'store']);
+        Route::patch('asset-containers/{asset_container}/folders/{path}', [FoldersController::class, 'update'])->where('path', '.*');
+        Route::get('asset-containers/{asset_container}/blueprint', [AssetContainerBlueprintController::class, 'edit'])->name('asset-containers.blueprint.edit');
+        Route::patch('asset-containers/{asset_container}/blueprint', [AssetContainerBlueprintController::class, 'update'])->name('asset-containers.blueprint.update');
+        Route::post('assets/actions', [ActionController::class, 'run'])->name('assets.actions.run');
+        Route::post('assets/actions/list', [ActionController::class, 'bulkActions'])->name('assets.actions.bulk');
+        Route::get('assets/browse', [BrowserController::class, 'index'])->name('assets.browse.index');
+        Route::get('assets/browse/search/{asset_container}/{path?}', [BrowserController::class, 'search'])->where('path', '.*');
+        Route::post('assets/browse/folders/{asset_container}/actions', [FolderActionController::class, 'run'])->name('assets.folders.actions.run');
+        Route::get('assets/browse/folders/{asset_container}/{path?}', [BrowserController::class, 'folder'])->where('path', '.*');
+        Route::get('assets/browse/{asset_container}/{path?}/edit', [BrowserController::class, 'edit'])->where('path', '.*')->name('assets.browse.edit');
+        Route::get('assets/browse/{asset_container}/{path?}', [BrowserController::class, 'show'])->where('path', '.*')->name('assets.browse.show');
+        Route::get('assets-fieldtype', [FieldtypeController::class, 'index']);
+        Route::resource('assets', AssetsController::class)->parameters(['assets' => 'encoded_asset']);
+        Route::get('assets/{encoded_asset}/download', [AssetsController::class, 'download'])->name('assets.download');
+        Route::get('thumbnails/{encoded_asset}/{size?}/{orientation?}', [ThumbnailController::class, 'show'])->name('assets.thumbnails.show');
+        Route::get('svgs/{encoded_asset}', [SvgController::class, 'show'])->name('assets.svgs.show');
+        Route::get('pdfs/{encoded_asset}', [PdfController::class, 'show'])->name('assets.pdfs.show');
     });
 
-    Route::group(['prefix' => 'fields', 'namespace' => 'Fields'], function () {
-        Route::get('/', 'FieldsController@index')->name('fields.index');
-        Route::post('edit', 'FieldsController@edit')->name('fields.edit');
-        Route::post('update', 'FieldsController@update')->name('fields.update');
-        Route::get('field-meta', 'MetaController@show');
-        Route::resource('fieldsets', 'FieldsetController');
-        Route::get('blueprints', 'BlueprintController@index')->name('blueprints.index');
-        Route::get('fieldtypes', 'FieldtypesController@index');
+    Route::group(['prefix' => 'fields'], function () {
+        Route::get('/', [FieldsController::class, 'index'])->name('fields.index');
+        Route::post('edit', [FieldsController::class, 'edit'])->name('fields.edit');
+        Route::post('update', [FieldsController::class, 'update'])->name('fields.update');
+        Route::get('field-meta', [MetaController::class, 'show']);
+        Route::resource('fieldsets', FieldsetController::class);
+        Route::get('blueprints', [BlueprintController::class, 'index'])->name('blueprints.index');
+        Route::get('fieldtypes', [FieldtypesController::class, 'index']);
     });
 
-    Route::get('composer/check', 'ComposerOutputController@check');
+    Route::get('composer/check', [ComposerOutputController::class, 'check']);
 
     Route::group(['namespace' => 'Updater'], function () {
-        Route::get('updater', 'UpdaterController@index')->name('updater');
-        Route::get('updater/count', 'UpdaterController@count');
-        Route::get('updater/{product}', 'UpdateProductController@show')->name('updater.product');
-        Route::get('updater/{product}/changelog', 'UpdateProductController@changelog');
-        Route::post('updater/{product}/install', 'UpdateProductController@install');
+        Route::get('updater', [UpdaterController::class, 'index'])->name('updater');
+        Route::get('updater/count', [UpdaterController::class, 'count']);
+        Route::get('updater/{product}', [UpdateProductController::class, 'show'])->name('updater.product');
+        Route::get('updater/{product}/changelog', [UpdateProductController::class, 'changelog']);
+        Route::post('updater/{product}/install', [UpdateProductController::class, 'install']);
     });
 
     Route::group(['prefix' => 'duplicates'], function () {
-        Route::get('/', 'DuplicatesController@index')->name('duplicates');
-        Route::post('regenerate', 'DuplicatesController@regenerate')->name('duplicates.regenerate');
+        Route::get('/', [DuplicatesController::class, 'index'])->name('duplicates');
+        Route::post('regenerate', [DuplicatesController::class, 'regenerate'])->name('duplicates.regenerate');
     });
 
-    Route::get('addons', 'AddonsController@index')->name('addons.index');
-    Route::post('addons/install', 'AddonsController@install');
-    Route::post('addons/uninstall', 'AddonsController@uninstall');
-    Route::post('addons/editions', 'AddonEditionsController');
+    Route::get('addons', [AddonsController::class, 'index'])->name('addons.index');
+    Route::post('addons/install', [AddonsController::class, 'install']);
+    Route::post('addons/uninstall', [AddonsController::class, 'uninstall']);
+    Route::post('addons/editions', AddonEditionsController::class);
 
-    Route::group(['namespace' => 'Forms'], function () {
-        Route::post('forms/actions', 'ActionController@run')->name('forms.actions.run');
-        Route::post('forms/actions/list', 'ActionController@bulkActions')->name('forms.actions.bulk');
-        Route::post('forms/{form}/submissions/actions', 'SubmissionActionController@run')->name('forms.submissions.actions.run');
-        Route::post('forms/{form}/submissions/actions/list', 'SubmissionActionController@bulkActions')->name('forms.submissions.actions.bulk');
-        Route::resource('forms', 'FormsController');
-        Route::resource('forms.submissions', 'FormSubmissionsController');
-        Route::get('forms/{form}/export/{type}', 'FormExportController@export')->name('forms.export');
-        Route::get('forms/{form}/blueprint', 'FormBlueprintController@edit')->name('forms.blueprint.edit');
-        Route::patch('forms/{form}/blueprint', 'FormBlueprintController@update')->name('forms.blueprint.update');
+    Route::group([], function () {
+        Route::post('forms/actions', [ActionController::class, 'run'])->name('forms.actions.run');
+        Route::post('forms/actions/list', [ActionController::class, 'bulkActions'])->name('forms.actions.bulk');
+        Route::post('forms/{form}/submissions/actions', [SubmissionActionController::class, 'run'])->name('forms.submissions.actions.run');
+        Route::post('forms/{form}/submissions/actions/list', [SubmissionActionController::class, 'bulkActions'])->name('forms.submissions.actions.bulk');
+        Route::resource('forms', FormsController::class);
+        Route::resource('forms.submissions', FormSubmissionsController::class);
+        Route::get('forms/{form}/export/{type}', [FormExportController::class, 'export'])->name('forms.export');
+        Route::get('forms/{form}/blueprint', [FormBlueprintController::class, 'edit'])->name('forms.blueprint.edit');
+        Route::patch('forms/{form}/blueprint', [FormBlueprintController::class, 'update'])->name('forms.blueprint.update');
     });
 
-    Route::group(['namespace' => 'Users'], function () {
-        Route::post('users/actions', 'UserActionController@run')->name('users.actions.run');
-        Route::post('users/actions/list', 'UserActionController@bulkActions')->name('users.actions.bulk');
-        Route::get('users/blueprint', 'UserBlueprintController@edit')->name('users.blueprint.edit');
-        Route::patch('users/blueprint', 'UserBlueprintController@update')->name('users.blueprint.update');
-        Route::resource('users', 'UsersController');
-        Route::patch('users/{user}/password', 'PasswordController@update')->name('users.password.update');
-        Route::get('account', 'AccountController')->name('account');
-        Route::resource('user-groups', 'UserGroupsController');
-        Route::resource('roles', 'RolesController');
+    Route::group([], function () {
+        Route::post('users/actions', [UserActionController::class, 'run'])->name('users.actions.run');
+        Route::post('users/actions/list', [UserActionController::class, 'bulkActions'])->name('users.actions.bulk');
+        Route::get('users/blueprint', [UserBlueprintController::class, 'edit'])->name('users.blueprint.edit');
+        Route::patch('users/blueprint', [UserBlueprintController::class, 'update'])->name('users.blueprint.update');
+        Route::resource('users', UsersController::class);
+        Route::patch('users/{user}/password', [PasswordController::class, 'update'])->name('users.password.update');
+        Route::get('account', AccountController::class)->name('account');
+        Route::resource('user-groups', UserGroupsController::class);
+        Route::resource('roles', RolesController::class);
     });
 
-    Route::post('user-exists', 'Users\UserWizardController')->name('user.exists');
+    Route::post('user-exists', UserWizardController::class)->name('user.exists');
 
-    Route::get('search', 'SearchController')->name('search');
+    Route::get('search', SearchController::class)->name('search');
 
-    Route::get('utilities', 'Utilities\UtilitiesController@index')->name('utilities.index');
+    Route::get('utilities', [UtilitiesController::class, 'index'])->name('utilities.index');
     Utility::routes();
 
     if (config('statamic.graphql.enabled')) {
-        Route::get('graphql', 'GraphQLController@index')->name('graphql.index');
-        Route::get('graphiql', 'GraphQLController@graphiql')->name('graphql.graphiql');
+        Route::get('graphql', [GraphQLController::class, 'index'])->name('graphql.index');
+        Route::get('graphiql', [GraphQLController::class, 'graphiql'])->name('graphql.graphiql');
     }
 
     Route::group(['prefix' => 'fieldtypes', 'namespace' => 'Fieldtypes'], function () {
-        Route::get('relationship', 'RelationshipFieldtypeController@index')->name('relationship.index');
-        Route::post('relationship/data', 'RelationshipFieldtypeController@data')->name('relationship.data');
-        Route::get('relationship/filters', 'RelationshipFieldtypeController@filters')->name('relationship.filters');
-        Route::post('markdown', 'MarkdownFieldtypeController@preview')->name('markdown.preview');
-        Route::post('files/upload', 'FilesFieldtypeController@upload')->name('files.upload');
+        Route::get('relationship', [RelationshipFieldtypeController::class, 'index'])->name('relationship.index');
+        Route::post('relationship/data', [RelationshipFieldtypeController::class, 'data'])->name('relationship.data');
+        Route::get('relationship/filters', [RelationshipFieldtypeController::class, 'filters'])->name('relationship.filters');
+        Route::post('markdown', [MarkdownFieldtypeController::class, 'preview'])->name('markdown.preview');
+        Route::post('files/upload', [FilesFieldtypeController::class, 'upload'])->name('files.upload');
     });
 
-    Route::group(['prefix' => 'api', 'as' => 'api.', 'namespace' => 'API'], function () {
-        Route::resource('addons', 'AddonsController');
-        Route::resource('templates', 'TemplatesController');
+    Route::group(['prefix' => 'api', 'as' => 'api.'], function () {
+        Route::resource('addons', AddonsController::class);
+        Route::resource('templates', TemplatesController::class);
     });
 
     Route::group(['prefix' => 'preferences', 'as' => 'preferences.', 'namespace' => 'Preferences'], function () {
-        Route::get('/', 'PreferenceController@index')->name('index');
-        Route::get('edit', 'UserPreferenceController@edit')->name('user.edit');
-        Route::patch('/', 'UserPreferenceController@update')->name('user.update');
+        Route::get('/', [PreferenceController::class, 'index'])->name('index');
+        Route::get('edit', [UserPreferenceController::class, 'edit'])->name('user.edit');
+        Route::patch('/', [UserPreferenceController::class, 'update'])->name('user.update');
 
         Route::middleware([RequireStatamicPro::class, 'can:manage preferences'])->group(function () {
-            Route::get('roles/{role}/edit', 'RolePreferenceController@edit')->name('role.edit');
-            Route::patch('roles/{role}', 'RolePreferenceController@update')->name('role.update');
-            Route::get('default/edit', 'DefaultPreferenceController@edit')->name('default.edit');
-            Route::patch('default', 'DefaultPreferenceController@update')->name('default.update');
+            Route::get('roles/{role}/edit', [RolePreferenceController::class, 'edit'])->name('role.edit');
+            Route::patch('roles/{role}', [RolePreferenceController::class, 'update'])->name('role.update');
+            Route::get('default/edit', [DefaultPreferenceController::class, 'edit'])->name('default.edit');
+            Route::patch('default', [DefaultPreferenceController::class, 'update'])->name('default.update');
         });
 
-        Route::post('js', 'PreferenceController@store')->name('store');
-        Route::delete('js/{key}', 'PreferenceController@destroy')->name('destroy');
+        Route::post('js', [PreferenceController::class, 'store'])->name('store');
+        Route::delete('js/{key}', [PreferenceController::class, 'destroy'])->name('destroy');
 
         Route::group(['prefix' => 'nav', 'as' => 'nav.', 'namespace' => 'Nav'], function () {
-            Route::get('/', 'NavController@index')->name('index');
-            Route::get('edit', 'UserNavController@edit')->name('user.edit');
-            Route::patch('/', 'UserNavController@update')->name('user.update');
-            Route::delete('/', 'UserNavController@destroy')->name('user.destroy');
+            Route::get('/', [NavController::class, 'index'])->name('index');
+            Route::get('edit', [UserNavController::class, 'edit'])->name('user.edit');
+            Route::patch('/', [UserNavController::class, 'update'])->name('user.update');
+            Route::delete('/', [UserNavController::class, 'destroy'])->name('user.destroy');
 
             Route::middleware([RequireStatamicPro::class, 'can:manage preferences'])->group(function () {
-                Route::get('roles/{role}/edit', 'RoleNavController@edit')->name('role.edit');
-                Route::patch('roles/{role}', 'RoleNavController@update')->name('role.update');
-                Route::delete('roles/{role}', 'RoleNavController@destroy')->name('role.destroy');
-                Route::get('default/edit', 'DefaultNavController@edit')->name('default.edit');
-                Route::patch('default', 'DefaultNavController@update')->name('default.update');
-                Route::delete('default', 'DefaultNavController@destroy')->name('default.destroy');
+                Route::get('roles/{role}/edit', [RoleNavController::class, 'edit'])->name('role.edit');
+                Route::patch('roles/{role}', [RoleNavController::class, 'update'])->name('role.update');
+                Route::delete('roles/{role}', [RoleNavController::class, 'destroy'])->name('role.destroy');
+                Route::get('default/edit', [DefaultNavController::class, 'edit'])->name('default.edit');
+                Route::patch('default', [DefaultNavController::class, 'update'])->name('default.update');
+                Route::delete('default', [DefaultNavController::class, 'destroy'])->name('default.destroy');
             });
         });
     });
 
-    Route::get('session-timeout', 'SessionTimeoutController')->name('session.timeout');
+    Route::get('session-timeout', SessionTimeoutController::class)->name('session.timeout');
 
     Route::view('/playground', 'statamic::playground')->name('playground');
 
-    Route::get('{segments}', 'CpController@pageNotFound')->where('segments', '.*')->name('404');
+    Route::get('{segments}', [CpController::class, 'pageNotFound'])->where('segments', '.*')->name('404');
 });

--- a/routes/glide.php
+++ b/routes/glide.php
@@ -4,13 +4,14 @@ use Illuminate\Support\Facades\Route;
 use Statamic\Facades\Glide;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
+use Statamic\Http\Controllers\GlideController;
 
 Site::all()->map(function ($site) {
     return URL::makeRelative($site->url());
 })->unique()->each(function ($sitePrefix) {
     Route::group(['prefix' => $sitePrefix.'/'.Glide::route()], function () {
-        Route::get('/asset/{container}/{path?}', 'GlideController@generateByAsset')->where('path', '.*');
-        Route::get('/http/{url}/{filename?}', 'GlideController@generateByUrl');
-        Route::get('{path}', 'GlideController@generateByPath')->where('path', '.*');
+        Route::get('/asset/{container}/{path?}', [GlideController::class, 'generateByAsset'])->where('path', '.*');
+        Route::get('/http/{url}/{filename?}', [GlideController::class, 'generateByUrl']);
+        Route::get('{path}', [GlideController::class, 'generateByPath'])->where('path', '.*');
     });
 });

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -26,7 +26,6 @@ if (config('statamic.cp.enabled')) {
         Route::middleware('statamic.cp')
             ->name('statamic.cp.')
             ->prefix(config('statamic.cp.route'))
-            ->namespace('Statamic\Http\Controllers\CP')
             ->group(__DIR__.'/cp.php');
     });
 }

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -31,8 +31,7 @@ if (config('statamic.cp.enabled')) {
 }
 
 if (Glide::shouldServeByHttp()) {
-    Route::namespace('Statamic\Http\Controllers')
-        ->group(__DIR__.'/glide.php');
+    require __DIR__.'/glide.php';
 }
 
 Route::middleware(config('statamic.routes.middleware', 'web'))

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -34,5 +34,4 @@ if (Glide::shouldServeByHttp()) {
 }
 
 Route::middleware(config('statamic.routes.middleware', 'web'))
-    ->namespace('Statamic\Http\Controllers')
     ->group(__DIR__.'/web.php');

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -16,7 +16,6 @@ if (config('statamic.api.enabled')) {
         Route::middleware(config('statamic.api.middleware'))
             ->name('statamic.api.')
             ->prefix(config('statamic.api.route'))
-            ->namespace('Statamic\Http\Controllers\API')
             ->group(__DIR__.'/api.php');
     });
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,43 +1,53 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Statamic\Auth\Protect\Protectors\Password\Controller as PasswordProtectController;
 use Statamic\Facades\OAuth;
+use Statamic\Http\Controllers\ActivateAccountController;
+use Statamic\Http\Controllers\ForgotPasswordController;
+use Statamic\Http\Controllers\FormController;
+use Statamic\Http\Controllers\FrontendController;
+use Statamic\Http\Controllers\ResetPasswordController;
+use Statamic\Http\Controllers\UserController;
+use Statamic\Http\Middleware\AuthGuard;
+use Statamic\Http\Middleware\CP\AuthGuard as CPAuthGuard;
 use Statamic\Statamic;
+use Statamic\StaticCaching\NoCache\Controller as NoCacheController;
 
 Route::name('statamic.')->group(function () {
     Route::group(['prefix' => config('statamic.routes.action')], function () {
-        Route::post('forms/{form}', 'FormController@submit')->name('forms.submit');
+        Route::post('forms/{form}', [FormController::class, 'submit'])->name('forms.submit');
 
-        Route::get('protect/password', '\Statamic\Auth\Protect\Protectors\Password\Controller@show')->name('protect.password.show');
-        Route::post('protect/password', '\Statamic\Auth\Protect\Protectors\Password\Controller@store')->name('protect.password.store');
+        Route::get('protect/password', [PasswordProtectController::class, 'show'])->name('protect.password.show');
+        Route::post('protect/password', [PasswordProtectController::class, 'store'])->name('protect.password.store');
 
-        Route::group(['prefix' => 'auth', 'middleware' => [\Statamic\Http\Middleware\AuthGuard::class]], function () {
-            Route::post('login', 'UserController@login')->name('login');
-            Route::get('logout', 'UserController@logout')->name('logout');
-            Route::post('register', 'UserController@register')->name('register');
-            Route::post('profile', 'UserController@profile')->name('profile');
-            Route::post('password', 'UserController@password')->name('password');
+        Route::group(['prefix' => 'auth', 'middleware' => [AuthGuard::class]], function () {
+            Route::post('login', [UserController::class, 'login'])->name('login');
+            Route::get('logout', [UserController::class, 'logout'])->name('logout');
+            Route::post('register', [UserController::class, 'register'])->name('register');
+            Route::post('profile', [UserController::class, 'profile'])->name('profile');
+            Route::post('password', [UserController::class, 'password'])->name('password');
 
-            Route::post('password/email', 'ForgotPasswordController@sendResetLinkEmail')->name('password.email');
-            Route::get('password/reset/{token}', 'ResetPasswordController@showResetForm')->name('password.reset');
-            Route::post('password/reset', 'ResetPasswordController@reset')->name('password.reset.action');
+            Route::post('password/email', [ForgotPasswordController::class, 'sendResetLinkEmail'])->name('password.email');
+            Route::get('password/reset/{token}', [ResetPasswordController::class, 'showResetForm'])->name('password.reset');
+            Route::post('password/reset', [ResetPasswordController::class, 'reset'])->name('password.reset.action');
         });
 
-        Route::group(['prefix' => 'auth', 'middleware' => [\Statamic\Http\Middleware\CP\AuthGuard::class]], function () {
-            Route::get('activate/{token}', 'ActivateAccountController@showResetForm')->name('account.activate');
-            Route::post('activate', 'ActivateAccountController@reset')->name('account.activate.action');
+        Route::group(['prefix' => 'auth', 'middleware' => [CPAuthGuard::class]], function () {
+            Route::get('activate/{token}', [ActivateAccountController::class, 'showResetForm'])->name('account.activate');
+            Route::post('activate', [ActivateAccountController::class, 'reset'])->name('account.activate.action');
         });
 
         Statamic::additionalActionRoutes();
     });
 
     Route::prefix(config('statamic.routes.action'))
-        ->post('nocache', '\Statamic\StaticCaching\NoCache\Controller')
+        ->post('nocache', NoCacheController::class)
         ->withoutMiddleware('App\Http\Middleware\VerifyCsrfToken');
 
     if (OAuth::enabled()) {
-        Route::get(config('statamic.oauth.routes.login'), 'OAuthController@redirectToProvider')->name('oauth.login');
-        Route::get(config('statamic.oauth.routes.callback'), 'OAuthController@handleProviderCallback')->name('oauth.callback');
+        Route::get(config('statamic.oauth.routes.login'), [OAuthController::class, 'redirectToProvider'])->name('oauth.login');
+        Route::get(config('statamic.oauth.routes.callback'), [OAuthController::class, 'handleProviderCallback'])->name('oauth.callback');
     }
 });
 
@@ -48,7 +58,7 @@ if (config('statamic.routes.enabled')) {
      * Front-end
      * All front-end website requests go through a single controller method.
      */
-    Route::any('/{segments?}', 'FrontendController@index')
+    Route::any('/{segments?}', [FrontendController::class, 'index'])
         ->where('segments', Statamic::frontendRouteSegmentRegex())
         ->name('statamic.site');
 }

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -129,6 +129,11 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected $routes = [];
 
     /**
+     * @var string|null
+     */
+    protected $routeNamespace;
+
+    /**
      * Map of group name => Middlewares to apply.
      *
      * @var array<string, class-string[]>
@@ -421,6 +426,11 @@ abstract class AddonServiceProvider extends ServiceProvider
         return $this;
     }
 
+    protected function routeNamespace()
+    {
+        return $this->routeNamespace;
+    }
+
     /**
      * Register routes from the root of the site.
      *
@@ -430,7 +440,7 @@ abstract class AddonServiceProvider extends ServiceProvider
     public function registerWebRoutes($routes)
     {
         Statamic::pushWebRoutes(function () use ($routes) {
-            Route::namespace('\\'.$this->namespace().'\\Http\\Controllers')->group($routes);
+            Route::namespace($this->routeNamespace())->group($routes);
         });
     }
 
@@ -443,7 +453,7 @@ abstract class AddonServiceProvider extends ServiceProvider
     public function registerCpRoutes($routes)
     {
         Statamic::pushCpRoutes(function () use ($routes) {
-            Route::namespace('\\'.$this->namespace().'\\Http\\Controllers')->group($routes);
+            Route::namespace($this->routeNamespace())->group($routes);
         });
     }
 
@@ -456,7 +466,7 @@ abstract class AddonServiceProvider extends ServiceProvider
     public function registerActionRoutes($routes)
     {
         Statamic::pushActionRoutes(function () use ($routes) {
-            Route::namespace('\\'.$this->namespace().'\\Http\\Controllers')
+            Route::namespace($this->routeNamespace())
                 ->prefix($this->getAddon()->slug())
                 ->group($routes);
         });

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -462,39 +462,6 @@ abstract class AddonServiceProvider extends ServiceProvider
         });
     }
 
-    /**
-     * Register a route group.
-     *
-     * @param  string|Closure  $routes  Either the path to a routes file, or a closure containing routes.
-     * @param  array  $attributes  Additional attributes to be applied to the route group.
-     * @return void
-     */
-    protected function registerRouteGroup($routes, array $attributes = [])
-    {
-        if (is_string($routes)) {
-            $routes = function () use ($routes) {
-                require $routes;
-            };
-        }
-
-        Statamic::routes(function () use ($attributes, $routes) {
-            Route::group($this->routeGroupAttributes($attributes), $routes);
-        });
-    }
-
-    /**
-     * The attributes to be applied to the route group.
-     *
-     * @param  array  $overrides  Any additional attributes.
-     * @return array
-     */
-    protected function routeGroupAttributes($overrides = [])
-    {
-        return array_merge($overrides, [
-            'namespace' => $this->getAddon()->namespace(),
-        ]);
-    }
-
     protected function bootMiddleware()
     {
         foreach ($this->middlewareGroups as $group => $middleware) {


### PR DESCRIPTION
### Route namespaces have been removed

Previously, if you were to push routes to cp, web, or actions, it would assume you wanted them in a certain namespace. Now you're on your own.

For example:

```php
use App\Http\Controllers\ExampleController;

Statamic::pushCpRoutes(function () {
  Route::get('alfa', 'ExampleController@method');
  // before: Statamic\Http\Controllers\CP\ExampleController@method
  // after: ExampleController@method

  Route::get('bravo', ExampleController::class);
  // before: Statamic\Http\Controllers\App\Http\Controllers\ExampleController@__invoke
  // after: App\Http\Controllers\ExampleController@__invoke

  Route::get('charlie', [ExampleController::class, 'method']);
  // before: App\Http\Controllers\ExampleController@method
  // after: App\Http\Controllers\ExampleController@method
  // This array syntax worked fine before.

  Route::get('delta', [ExampleController::class, '__invoke']);
  // before: App\Http\Controllers\ExampleController@__invoke
  // after: App\Http\Controllers\ExampleController@__invoke
  // This array syntax worked fine before, but it's silly to need to point to __invoke.
});
```

Addon route namespaces have also been removed for the same reasons. If you _want_ to set the namespace, you can add a property (or method) to your service provider.

```php
protected $routeNamespace = 'MyAddon\Http\Controllers';

// or

protected function routeNamespace()
{
    return 'MyAddon\Http\Controllers';
}

// or wrap your routes

Route::namespace('MyAddon\Http\Controllers')->group(function () {
    Route::get(...);
});
```

Closes #3048

### Housekeeping

We now use properly imported class names or tuple syntax instead of just strings in our routes files. This has no functionality change.

```diff
+use Path\To\AlfaController;
+use Path\To\BravoController;

-Route::get('alfa', 'AlfaController@show');
+Route::get('alfa', [AlfaController::class, 'show']);

-Route::get('bravo', 'BravoController');
+Route::get('bravo', BravoController::class);
```

We've removed `registerRouteGroup` and `routeGroupAttributes` from `AddonServiceProvider` since they were never used. Leftovers from pre-3.0.0. Searching GitHub, no one used them.