### PR TITLE
Add current_layout variable

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -57,6 +57,7 @@ class View
     {
         return array_merge($this->cascade(), $this->data, [
             'current_template' => $this->template(),
+            'current_layout' => $this->layout(),
         ]);
     }
 


### PR DESCRIPTION
We have `current_template`. This adds `current_layout`.

(`template` and `layout` are only available if the entry has them in their data. `current_template` was explicitly added.)

From #7615