### PR TITLE
Also auto-publish assets when using Vite

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -627,7 +627,7 @@ abstract class AddonServiceProvider extends ServiceProvider
             return $this;
         }
 
-        if (empty($this->scripts) && empty($this->stylesheets)) {
+        if (empty($this->scripts) && empty($this->stylesheets) && empty($this->vite)) {
             return $this;
         }
 


### PR DESCRIPTION
This pull request fixes an issue where CSS/JS assets wouldn't be auto-published by Statamic when running the `php artisan statamic:install` command if the assets were configured using Vite.

Vite was introduced in #6869.

I've just ran into this issue after tagging a release for one of my addons with Vite & installing it into a fresh site. I can workaround it for now by overriding the method. 