### PR TITLE
Search: Allows for search queries containing "+"

### DIFF
--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -528,7 +528,7 @@ class Comb
 
             // loop over each query chunk
             foreach ($params['chunks'] as $j => $chunk) {
-                $escaped_chunk = str_replace('#', '\#', $chunk);
+                $escaped_chunk = preg_quote($chunk, '#');
                 $regex = [
                     'whole' => '#^'.$escaped_chunk.'$#i',
                     'partial' => '#'.$escaped_chunk.'#i',
@@ -1043,7 +1043,7 @@ class Comb
         $length = $this->snippet_length;
 
         $escaped_chunks = collect($chunks)
-            ->map(fn ($chunk) => str_replace('#', '\#', $chunk))
+            ->map(fn ($chunk) => preg_quote($chunk, '#'))
             ->join('|');
         $regex = '#(.*?)('.$escaped_chunks.')(.{0,'.$length.'}(?:\s|$))#i';
         if (! preg_match_all($regex, $value, $matches, PREG_SET_ORDER)) {

--- a/tests/Search/CombTest.php
+++ b/tests/Search/CombTest.php
@@ -60,6 +60,21 @@ EOT;
         $this->assertEquals($expected, collect($results['data'] ?? [])->pluck('snippets.content')->all());
     }
 
+    /**
+     * @test
+     */
+    public function it_can_search_for_plus_signs()
+    {
+        $comb = new Comb([
+            ['content' => '+Content']
+        ]);
+
+        $result = $comb->lookUp('+');
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertSame(1, $result['info']['total_results']);
+    }
+
     public function searchesProvider()
     {
         return [


### PR DESCRIPTION
This PR fixes #7163 to allow for search strings containing `+`. The changes in this PR remove the manual regex escaping, and instead uses `preg_quote` function with the `#` delimiter set.