### PR TITLE
Antlers: Corrects oversight with arrays appearing in the "tag name spot"

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -506,6 +506,10 @@ class NodeProcessor
      */
     private function shouldProcessAsTag(AntlersNode $node)
     {
+        if ($node->pathReference == null && $node->name != null && Str::startsWith($node->name->name, '[')) {
+            return false;
+        }
+
         if ($node->pathReference != null) {
             if ($node->pathReference->isStrictTagReference) {
                 return true;

--- a/tests/Antlers/Runtime/ArraysTest.php
+++ b/tests/Antlers/Runtime/ArraysTest.php
@@ -420,4 +420,9 @@ EOT;
 
         $this->assertSame($expected, trim($this->renderString($template)));
     }
+
+    public function test_arrays_as_the_tag_name()
+    {
+        $this->assertSame('array', $this->renderString('{{ [1, 2, 3, 4] | type_of }}', [], true));
+    }
 }


### PR DESCRIPTION
This PR corrects an issue that occurs when arrays are the _first_ thing inside the Antlers tag while chaining modifiers. These changes allow for the following example in the documentation to Just Work™️:

```antlers
{{ [1, 2, 3] | type_of }}     -> array
```
