### PR TITLE
[4.x] Draggable fixes

### DIFF
--- a/resources/css/components/blueprints.css
+++ b/resources/css/components/blueprints.css
@@ -22,7 +22,7 @@
 }
 
 .blueprint-section-field {
-    @apply relative mb-2 px-1 z-10 outline-none;
+    @apply relative mb-2 px-1 z-10 outline-none text-sm;
 
     .blueprint-section-field-inner {
         @apply relative border rounded bg-gray-200 shadow-sm flex outline-none z-10;

--- a/resources/css/components/column-picker.css
+++ b/resources/css/components/column-picker.css
@@ -19,7 +19,6 @@
         }
 
         /*  Drag interaction */
-        &.draggable-mirror,
         &.draggable-source--is-dragging {
             /*  @apply bg-white; */
             cursor: grabbing;

--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -67,10 +67,6 @@
     tr.draggable-source--is-dragging td {
         @apply bg-gray-100;
     }
-
-    .draggable-mirror {
-        @apply bg-white border-t border-b shadow;
-    }
 }
 
 .table-fieldtype-table .row-controls {

--- a/resources/css/components/items.css
+++ b/resources/css/components/items.css
@@ -18,4 +18,9 @@
             @apply border-red bg-red-lighter text-red;
         }
     }
+
+    /*  Drag interaction */
+    &.draggable-source--is-dragging {
+        opacity: 0.5;
+    }
 }

--- a/resources/css/components/items.css
+++ b/resources/css/components/items.css
@@ -18,9 +18,4 @@
             @apply border-red bg-red-lighter text-red;
         }
     }
-
-    /*  Drag interaction */
-    &.draggable-source--is-dragging {
-        opacity: 0.5;
-    }
 }

--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -141,10 +141,6 @@
         }
 	}
 
-	.sortable-row.draggable-mirror {
-		display: none;
-	}
-
     .date-index-field {
         @apply whitespace-nowrap;
     }

--- a/resources/js/components/blueprints/RegularField.vue
+++ b/resources/js/components/blueprints/RegularField.vue
@@ -111,9 +111,9 @@ export default {
         },
 
         widthClass() {
-            if (! this.isSectionExpanded) return 'w-full';
+            if (! this.isSectionExpanded) return 'blueprint-section-field-w-full';
 
-            return `${tailwind_width_class(this.width)}`;
+            return `blueprint-section-field-${tailwind_width_class(this.width)}`;
         },
 
         localizable: {

--- a/resources/js/components/blueprints/Sections.vue
+++ b/resources/js/components/blueprints/Sections.vue
@@ -120,7 +120,7 @@ export default {
             sortableFields = new Sortable(document.querySelectorAll('.blueprint-section-draggable-zone'), {
                 draggable: '.blueprint-section-field',
                 handle: '.blueprint-drag-handle',
-                mirror: { constrainDimensions: true },
+                mirror: { constrainDimensions: true, appendTo: 'body' },
                 plugins: [Plugins.SwapAnimation]
             }).on('sortable:stop', e => {
                 if (e.newContainer.parentElement.classList.contains('blueprint-add-section-button')) {

--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -16,7 +16,7 @@
                 :vertical="true"
                 item-class="column-picker-item"
                 handle-class="column-picker-item"
-                append-to=".popover-content"
+                :mirror="false"
             >
                 <div class="outline-none text-left px-2 py-2">
                     <h6 v-text="__('Displayed Columns')" class="p-2"/>

--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -33,6 +33,7 @@
         <sortable-list
             :value="rows"
             :vertical="true"
+            :mirror="false"
             item-class="sortable-row"
             handle-class="table-drag-handle"
             @input="$emit('reordered', $event)"

--- a/resources/js/components/fieldtypes/TableFieldtype.vue
+++ b/resources/js/components/fieldtypes/TableFieldtype.vue
@@ -32,6 +32,7 @@
                         :vertical="true"
                         item-class="sortable-row"
                         handle-class="table-drag-handle"
+                        :mirror="false"
                         @dragstart="$emit('focus')"
                         @dragend="$emit('blur')"
                     >

--- a/resources/js/components/fieldtypes/grid/Stacked.vue
+++ b/resources/js/components/fieldtypes/grid/Stacked.vue
@@ -13,6 +13,8 @@
         :vertical="true"
         :item-class="sortableItemClass"
         :handle-class="sortableHandleClass"
+        append-to="body"
+        constrain-dimensions
         @dragstart="$emit('focus')"
         @dragend="$emit('blur')"
         @input="(rows) => $emit('sorted', rows)"

--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -1,7 +1,7 @@
 <template>
 
     <div
-        class="shadow-sm mb-4 rounded border"
+        class="replicator-set shadow-sm mb-4 rounded border"
         :class="[sortableItemClass, { 'opacity-50': isExcessive }]"
     >
 
@@ -14,7 +14,7 @@
             </div>
         </div>
 
-        <div class="publish-fields @container">
+        <div class="replicator-set-body">
             <set-field
                 v-for="field in fields"
                 v-show="showField(field, fieldPath(field.handle))"

--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -14,7 +14,7 @@
             </div>
         </div>
 
-        <div class="replicator-set-body">
+        <div class="replicator-set-body publish-fields">
             <set-field
                 v-for="field in fields"
                 v-show="showField(field, fieldPath(field.handle))"

--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -5,8 +5,8 @@
         :class="[sortableItemClass, { 'opacity-50': isExcessive }]"
     >
 
-        <div class="replicator-set-header" :class="{ [sortableHandleClass]: grid.isReorderable }">
-            <div class="item-move cursor-grab sortable-handle" data-drag-handle />
+        <div class="replicator-set-header">
+            <div class="item-move cursor-grab sortable-handle" :class="{ [sortableHandleClass]: grid.isReorderable }" />
             <div class="py-2 pl-2 replicator-set-header-inner flex justify-end items-end w-full">
                 <button v-if="canDelete" class="flex self-end group items-center" @click="$emit('removed', index)" :aria-label="__('Delete Row')">
                     <svg-icon name="trash" class="w-4 h-4 text-gray-600 group-hover:text-gray-900" />

--- a/resources/js/components/fieldtypes/grid/Table.vue
+++ b/resources/js/components/fieldtypes/grid/Table.vue
@@ -22,6 +22,7 @@
             :vertical="true"
             :item-class="sortableItemClass"
             :handle-class="sortableHandleClass"
+            append-to="body"
             @dragstart="$emit('focus')"
             @dragend="$emit('blur')"
             @input="(rows) => $emit('sorted', rows)"

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -35,6 +35,7 @@
             :vertical="true"
             :item-class="sortableItemClass"
             :handle-class="sortableHandleClass"
+            append-to="body"
             constrain-dimensions
             @input="sorted($event)"
             @dragstart="$emit('focus')"

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -35,7 +35,7 @@
             </div>
         </div>
 
-        <div class="replicator-set-body" v-show="!collapsed">
+        <div class="replicator-set-body publish-fields" v-show="!collapsed">
             <set-field
                 v-for="field in fields"
                 v-show="showField(field, fieldPath(field))"

--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -268,7 +268,7 @@ export default {
                 const val = [...this.value];
                 val.splice(e.newIndex, 0, val.splice(e.oldIndex, 1)[0]);
                 this.update(val);
-            })
+            }).on('mirror:create', e => e.cancel());
         },
 
         itemCreated(item) {

--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -256,7 +256,7 @@ export default {
             this.sortable = new Sortable(this.$refs.items, {
                 draggable: '.item',
                 handle: '.item-move',
-                mirror: { constrainDimensions: true, xAxis: false },
+                mirror: { constrainDimensions: true, xAxis: false, appendTo: 'body' },
                 swapAnimation: { vertical: true },
                 plugins: [Plugins.SwapAnimation],
                 delay: 200
@@ -268,7 +268,7 @@ export default {
                 const val = [...this.value];
                 val.splice(e.newIndex, 0, val.splice(e.oldIndex, 1)[0]);
                 this.update(val);
-            }).on('mirror:create', e => e.cancel());
+            });
         },
 
         itemCreated(item) {

--- a/resources/js/components/sortable/SortableList.vue
+++ b/resources/js/components/sortable/SortableList.vue
@@ -26,6 +26,10 @@ export default {
         handleClass: {
             default: 'sortable-handle',
         },
+        mirror: {
+            type: Boolean,
+            default: true
+        },
         appendTo: {
             default: null,
         },
@@ -101,6 +105,10 @@ export default {
         this.$on('hook:destroyed', () => {
             sortable.destroy()
         })
+
+        if (this.mirror === false) {
+            sortable.on('mirror:create', (e) => e.cancel());
+        }
     }
 
 }


### PR DESCRIPTION
Fix some issues where drag mirrors wouldn't be positioned correctly, since #7557 causes `.@container` classes to create new stacking contexts. Items with `position: fixed` inside one of these become relative to the container rather than the `body` (e.g. drag mirrors).

Also makes minor fixes to grid in stacked mode looking/acting more like replicator.