### PR TITLE
[4.x] Remove tooltip element

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -44,8 +44,6 @@
 
             <keyboard-shortcuts-modal></keyboard-shortcuts-modal>
 
-            <tooltip :pointer="true"></tooltip>
-
             <portal-targets></portal-targets>
 
             <portal-target name="live-preview"></portal-target>


### PR DESCRIPTION
`vue-js-popover` was removed in #7637 but I forgot to remove this element along with it.
