### PR TITLE
Use the referer link to redirect correctly for OAuth logins

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -13,7 +13,7 @@
             <div class="login-oauth-providers">
                 @foreach ($providers as $provider)
                     <div class="provider mb-1">
-                        <a href="{{ $provider->loginUrl() }}?redirect={{ parse_url(cp_route('index'))['path'] }}" class="btn block btn-primary">
+                        <a href="{{ $provider->loginUrl() }}?redirect={{ $referer }}" class="btn block btn-primary">
                             {{ __('Log in with :provider', ['provider' => $provider->label()]) }}
                         </a>
                     </div>

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -33,7 +33,7 @@ class OAuthController
 
     protected function successRedirectUrl()
     {
-        $default = '/';
+        $default = cp_route('index');
 
         $previous = session('_previous.url');
 
@@ -43,6 +43,9 @@ class OAuthController
 
         parse_str($query, $query);
 
-        return array_get($query, 'redirect', $default);
+        $referer = array_get($query, 'redirect', $default);
+
+        // Only use the referer, if it's a url to the control panel.
+        return Str::contains($referer, '/'.config('statamic.cp.route')) ? $referer : $default;
     }
 }

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -33,7 +33,7 @@ class OAuthController
 
     protected function successRedirectUrl()
     {
-        $default = cp_route('index');
+        $default = '/';
 
         $previous = session('_previous.url');
 
@@ -43,9 +43,6 @@ class OAuthController
 
         parse_str($query, $query);
 
-        $referer = array_get($query, 'redirect', $default);
-
-        // Only use the referer, if it's a url to the control panel.
-        return Str::contains($referer, '/'.config('statamic.cp.route')) ? $referer : $default;
+        return array_get($query, 'redirect', $default);
     }
 }


### PR DESCRIPTION
Closes #7654

This PR fixes the redirect to the previous page for all OAuth logins.

---

As pointed out by Jason, the return url logic is already available in the `$referer` variable.