### PR TITLE
Add config to enable/disable broadcasting

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'enabled' => true,
+
+];

--- a/src/Providers/BroadcastServiceProvider.php
+++ b/src/Providers/BroadcastServiceProvider.php
@@ -30,7 +30,7 @@ class BroadcastServiceProvider extends ServiceProvider
 
     protected function enabled()
     {
-        return in_array(
+        return config('statamic.broadcasting.enabled') && in_array(
             \App\Providers\BroadcastServiceProvider::class,
             array_keys($this->app->getLoadedProviders())
         );


### PR DESCRIPTION
Provide a new config `statamic.broadcasting.enabled` that allows you to enable/disable broadcasting by the CP. Currently it checks for providers but this doesn't work when you are wanting to use them elsewhere in your app and not in Statamic's CP.

Partially fixes: #7573 

It would be good to extend this config to include the Socketi options the issue raises, but I didnt know how you'd want to approach that.

