### PR TITLE
Implement `AssetContainer::__toString()`

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -626,4 +626,9 @@ class AssetContainer implements AssetContainerContract, Augmentable, ArrayAccess
     {
         return Facades\AssetContainer::{$method}(...$parameters);
     }
+
+    public function __toString()
+    {
+        return $this->handle();
+    }
 }


### PR DESCRIPTION
Collection, taxonomy and blueprint objects can all be cast to a string, returning their handles.

This PR adds the same to asset containers.