### PR TITLE
Handle missing Bard set id

### DIFF
--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -155,7 +155,7 @@ class Augmentor
 
             $values = $this->fieldtype->fields($set['type'])->addValues($set)->{$augmentMethod}()->values()->all();
 
-            return array_merge($values, ['id' => $set['id'], 'type' => $set['type']]);
+            return array_merge($values, ['id' => $set['id'] ?? null, 'type' => $set['type']]);
         })->all();
     }
 


### PR DESCRIPTION
Added in #7279, the IDs that get added to Bard/Replicator would be output on the frontend.

However, if you just upgraded from 3.3, for example, and your Bard set didn't have an ID, you'd get an error "undefined array key id".

This PR will fall back to null if the id is missing. This behavior was already in place for Replicator.
