### PR TITLE
Ignore redirects when warming static cache

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -179,7 +179,7 @@ class StaticWarm extends Command
                 return null;
             }
 
-            return $entry->absoluteUrl();
+            return $entry->absoluteUrlWithoutRedirect();
         })->filter();
 
         $this->line("\x1B[1A\x1B[2K<info>[✔]</info> Entries");


### PR DESCRIPTION
Warming the cache via the `static:warm` command could result in some failing requests if there are redirect-only entries:

```bash
Visiting 78 URLs...
[✗] /a/redirect → cURL error 3:  (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for /a/redirect
…
```

This PR fixes this issue by using `absoluteUrlWithoutRedirect()` instead of `absoluteUrl()` when collecting entry URLs.