### PR TITLE
skip removeEntryFromStructure if no collection has been found

### DIFF
--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -128,9 +128,9 @@ class CollectionEntriesStore extends ChildStore
     {
         [$collection, $site] = $this->extractAttributesFromPath($path);
 
-        $collection = Collection::findByHandle($collection);
-
-        $this->removeEntryFromStructure($collection, $id);
+        if ($collection = Collection::findByHandle($collection)) {
+            $this->removeEntryFromStructure($collection, $id);
+        }
     }
 
     protected function removeEntryFromStructure($collection, $id)


### PR DESCRIPTION
This fixes an issue  
```
Call to a member function hasStructure() on null {"exception":"[object] (Error(code: 0): Call to
a member function hasStructure() on null at /usr/share/nginx/html/releases/149/vendor/statamic/cms/src/Stache/Stores/CollectionEntries
Store.php:138)
```