### PR TITLE
Add a lock to the static caching middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "spatie/blink": "^1.1.2",
         "statamic/stringy": "^3.1.2",
         "symfony/http-foundation": "^4.3.3 || ^5.1.4 || ^6.0",
-        "symfony/lock": "^5.1",
+        "symfony/lock": "^5.4",
         "symfony/var-exporter": "^4.3 || ^5.1 || ^6.0",
         "symfony/yaml": "^4.1 || ^5.1 || ^6.0",
         "ueberdosis/tiptap-php": "^1.1",

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -5,10 +5,13 @@ namespace Statamic\StaticCaching\Middleware;
 use Closure;
 use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
+use Statamic\Facades\File;
 use Statamic\Statamic;
 use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\NoCache\Session;
 use Statamic\StaticCaching\Replacer;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\FlockStore;
 
 class Cache
 {
@@ -37,6 +40,12 @@ class Cache
      */
     public function handle($request, Closure $next)
     {
+        $lock = $this->createLock($request);
+
+        while (! $lock->acquire()) {
+            sleep(1);
+        }
+
         if ($this->canBeCached($request) && $this->cacher->hasCachedPage($request)) {
             $response = response($this->cacher->getCachedPage($request));
 
@@ -48,6 +57,8 @@ class Cache
         $response = $next($request);
 
         if ($this->shouldBeCached($request, $response)) {
+            $lock->acquire(true);
+
             $this->makeReplacementsAndCacheResponse($request, $response);
 
             $this->nocache->write();
@@ -113,5 +124,16 @@ class Cache
         }
 
         return true;
+    }
+
+    private function createLock($request)
+    {
+        File::makeDirectory($dir = storage_path('statamic/static-caching-locks'));
+
+        $locks = new LockFactory(new FlockStore($dir));
+
+        $key = $this->cacher->getUrl($request);
+
+        return $locks->createLock($key);
     }
 }

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -134,6 +134,6 @@ class Cache
 
         $key = $this->cacher->getUrl($request);
 
-        return $locks->createLock($key);
+        return $locks->createLock($key, 30);
     }
 }

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -8,9 +8,11 @@ use Illuminate\Support\Collection;
 use Statamic\Facades\File;
 use Statamic\Statamic;
 use Statamic\StaticCaching\Cacher;
+use Statamic\StaticCaching\Cachers\NullCacher;
 use Statamic\StaticCaching\NoCache\Session;
 use Statamic\StaticCaching\Replacer;
 use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\NoLock;
 use Symfony\Component\Lock\Store\FlockStore;
 
 class Cache
@@ -128,6 +130,10 @@ class Cache
 
     private function createLock($request)
     {
+        if ($this->cacher instanceof NullCacher) {
+            return new NoLock;
+        }
+
         File::makeDirectory($dir = storage_path('statamic/static-caching-locks'));
 
         $locks = new LockFactory(new FlockStore($dir));


### PR DESCRIPTION
Fixes #7033

I wasn't quite able to reproduce the html stomping over the top of each other exactly like in the issue however I was able to reproduce a race condition.

Using Spatie's fork package, I did a handful of requests to the same page, and then invalidated that page somewhere in the middle of them. They happen at the same time, which simulates a race condition.

1. request (loads the cached page) ✅
2. request (loads the cached page) ✅
3. invalidate the page (e.g. like a client hitting save) ✅
4. request (notices the page isn't cached, so it loads a fresh page) ✅
5. request (also notices the page isn't cached, so loads a fresh page, again) ❌

Request 4 is what you'd expect. The page has just been invalidated so you should see a fresh version. This request should also cache the page.

Request 5 is the issue though. Since request 4 should have cached the page, request 5 should see what request 4 did. The problem is that request 4 might not have finished writing to the cache when request 5 checked if it was cached, so it tries to load a fresh page _and_ cache it once it's done.

I'm not going to commit a test to this repo because it's a mess and really slow. It's in [this gist](https://gist.github.com/jasonvarga/6dfce8958581e55f6f829b2490d1ca89) if anyone is curious, or if we need to see/run it in the future. This test got the job done, at least.

---

This PR fixes the issue by "locking" that URL until the cache has been written.
If another request hits the same page, it will wait until it's unlocked before trying to serve it.

Todo:
- [x] Fix error when static caching is disabled. Probably just avoid locking somehow when it's disabled.