### PR TITLE
Use the previousUrl from the session to redirect correctly

### DIFF
--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -136,7 +136,7 @@ class LoginController extends CpController
 
     protected function getReferrer()
     {
-        $referrer = url()->previous();
+        $referrer = session()->previousUrl();
 
         return $referrer === cp_route('unauthorized') ? cp_route('index') : $referrer;
     }


### PR DESCRIPTION
This PR uses the previous url from the session instead of the url helper to redirect after the login.

Those two work a little different under the hood. The url helper does check the request header for the referer, which might lead to a wrong redirect. 

```php
// Not equal
session()->previousUrl() !== url()->previous()
```

In my test example, we do come from github.com and am visiting a protected route on Statamic afterwards. 

We would expect the referer to be a statamic url, instead of github.com. I hope those tests show clearly how url()->previous() and session()->previousUrl() do work differently. 

_Those failing tests are on purpose, to show the behaviour cleary. Those should be reverted afterwards of course._