### PR TITLE
[4.x] Show less info in JS

### DIFF
--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\View\Composers;
 
 use Facades\Statamic\Fields\FieldtypeRepository;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 use Statamic\Facades\CP\Toast;
 use Statamic\Facades\Preference;
@@ -18,20 +19,42 @@ class JavascriptComposer
 
     public function compose(View $view)
     {
-        $user = User::current();
-        $licenses = app('Statamic\Licensing\LicenseManager');
+        $variables = $this->commonVariables();
 
-        Statamic::provideToScript([
-            'version' => Statamic::version(),
-            'laravelVersion' => app()->version(),
+        if (Gate::allows('access cp')) {
+            $variables = array_merge($variables, $this->protectedVariables());
+        }
+
+        Statamic::provideToScript($variables);
+    }
+
+    private function commonVariables()
+    {
+        return [
             'csrfToken' => csrf_token(),
             'cpUrl' => cp_route('index'),
             'cpRoot' => str_start(config('statamic.cp.route'), '/'),
             'urlPath' => Str::after(request()->getRequestUri(), config('statamic.cp.route').'/'),
             'resourceUrl' => Statamic::cpAssetUrl(),
-            'locales' => config('statamic.system.locales'),
             'flash' => Statamic::flash(),
             'toasts' => Toast::toArray(),
+            'translationLocale' => app('translator')->locale(),
+            'translations' => app('translator')->toJson(),
+            'locale' => config('app.locale'),
+            'asciiReplaceExtraSymbols' => $replaceSymbols = config('statamic.system.ascii_replace_extra_symbols'),
+            'charmap' => ASCII::charsArray($replaceSymbols),
+        ];
+    }
+
+    private function protectedVariables()
+    {
+        $user = User::current();
+        $licenses = app('Statamic\Licensing\LicenseManager');
+
+        return [
+            'version' => Statamic::version(),
+            'laravelVersion' => app()->version(),
+            'locales' => config('statamic.system.locales'),
             'ajaxTimeout' => config('statamic.system.ajax_timeout'),
             'googleDocsViewer' => config('statamic.assets.google_docs_viewer'),
             'focalPointEditorEnabled' => config('statamic.assets.focal_point_editor'),
@@ -39,18 +62,13 @@ class JavascriptComposer
             'paginationSize' => config('statamic.cp.pagination_size'),
             'paginationSizeOptions' => config('statamic.cp.pagination_size_options'),
             'alwaysShowFilters' => config('statamic.cp.always_show_filters'),
-            'translationLocale' => app('translator')->locale(),
-            'translations' => app('translator')->toJson(),
             'sites' => $this->sites(),
             'selectedSite' => Site::selected()->handle(),
             'preloadableFieldtypes' => FieldtypeRepository::preloadable()->keys(),
             'livePreview' => config('statamic.live_preview'),
-            'locale' => config('app.locale'),
             'permissions' => $this->permissions($user),
             'hasLicenseBanner' => $licenses->invalid() || $licenses->requestFailed(),
-            'asciiReplaceExtraSymbols' => $replaceSymbols = config('statamic.system.ascii_replace_extra_symbols'),
-            'charmap' => ASCII::charsArray($replaceSymbols),
-        ]);
+        ];
     }
 
     protected function sites()

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -514,7 +514,7 @@ abstract class AddonServiceProvider extends ServiceProvider
             $path => public_path("vendor/{$name}/js/{$filename}.js"),
         ], $this->getAddon()->slug());
 
-        Statamic::script($name, "{$filename}.js?v={$version}");
+        Statamic::script($name, "{$filename}.js?v=".md5($version));
     }
 
     public function registerVite($config)
@@ -559,7 +559,7 @@ abstract class AddonServiceProvider extends ServiceProvider
             $path => public_path("vendor/{$name}/css/{$filename}.css"),
         ], $this->getAddon()->slug());
 
-        Statamic::style($name, "{$filename}.css?v={$version}");
+        Statamic::style($name, "{$filename}.css?v=".md5($version));
     }
 
     public function registerExternalStylesheet(string $url)


### PR DESCRIPTION
- Place JS vars that don't really need to be visible outside of the CP behind a gate check. For example, the Statamic version number doesn't need to be seen on the login page.
- Obfuscate version numbers in non-Vite JS/CSS cache busting query params.
