### PR TITLE
[4.x] Popper to Floating UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "statamic",
       "dependencies": {
-        "@popperjs/core": "^2.5.3",
+        "@floating-ui/dom": "^1.2.5",
         "@shopify/draggable": "^1.0.0-beta.8",
         "@simonwep/pickr": "^1.7.4",
         "@tiptap/core": "^2.0.0-beta.217",
@@ -1778,16 +1778,16 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.3.1.tgz",
-      "integrity": "sha512-ensKY7Ub59u16qsVIFEo2hwTCqZ/r9oZZFh51ivcLGHfUwTn8l1Xzng8RJUe91H/UP8PeqeBronAGx0qmzwk2g=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.4.tgz",
+      "integrity": "sha512-SQOeVbMwb1di+mVWWJLpsUTToKfqVNioXys011beCAhyOIFtS+GQoW4EQSneuxzmQKddExDwQ+X0hLl4lJJaSQ=="
     },
     "node_modules/@floating-ui/dom": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.1.10.tgz",
-      "integrity": "sha512-4kAVoogvQm2N0XE0G6APQJuCNuErjOfPW8Ux7DFxh8+AfugWflwVJ5LDlHOwrwut7z/30NUvdtHzQ3zSip4EzQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.5.tgz",
+      "integrity": "sha512-+sAUfpQ3Frz+VCbPCqj+cZzvEESy3fjSeT/pDWkYCWOBXYNNKZfuVsHuv8/JO2zze8+Eb/Q7a6hZVgzS81fLbQ==",
       "dependencies": {
-        "@floating-ui/core": "^0.3.0"
+        "@floating-ui/core": "^1.2.4"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -6471,6 +6471,19 @@
       },
       "peerDependencies": {
         "vue": "^2.6.10"
+      }
+    },
+    "node_modules/floating-vue/node_modules/@floating-ui/core": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.3.1.tgz",
+      "integrity": "sha512-ensKY7Ub59u16qsVIFEo2hwTCqZ/r9oZZFh51ivcLGHfUwTn8l1Xzng8RJUe91H/UP8PeqeBronAGx0qmzwk2g=="
+    },
+    "node_modules/floating-vue/node_modules/@floating-ui/dom": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.1.10.tgz",
+      "integrity": "sha512-4kAVoogvQm2N0XE0G6APQJuCNuErjOfPW8Ux7DFxh8+AfugWflwVJ5LDlHOwrwut7z/30NUvdtHzQ3zSip4EzQ==",
+      "dependencies": {
+        "@floating-ui/core": "^0.3.0"
       }
     },
     "node_modules/follow-redirects": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "frontend-build": "vite build -c vite-frontend.config.js"
   },
   "dependencies": {
-    "@popperjs/core": "^2.5.3",
+    "@floating-ui/dom": "^1.2.5",
     "@shopify/draggable": "^1.0.0-beta.8",
     "@simonwep/pickr": "^1.7.4",
     "@tiptap/core": "^2.0.0-beta.217",

--- a/resources/css/components/popover.css
+++ b/resources/css/components/popover.css
@@ -31,6 +31,7 @@
 .popover-container {
     position: relative;
     z-index: 9999;
+    pointer-events: none;
 }
 
 /*  When open */

--- a/resources/css/components/popover.css
+++ b/resources/css/components/popover.css
@@ -30,6 +30,7 @@
 
 .popover-container {
     position: relative;
+    z-index: 9999;
 }
 
 /*  When open */

--- a/resources/css/components/popover.css
+++ b/resources/css/components/popover.css
@@ -7,10 +7,8 @@
     visibility: hidden;
     z-index: 999;
     position: absolute;
-    top: auto;
-    bottom: auto;
-    left: auto;
-    right: auto;
+    top: 0;
+    left: 0;
 
     &::before {
         content: '';

--- a/resources/js/components/DropdownList.vue
+++ b/resources/js/components/DropdownList.vue
@@ -1,5 +1,5 @@
 <template>
-    <popover class="dropdown-list" :disabled="disabled" :placement="placement" :autoclose="autoclose" :fixed="fixed">
+    <popover class="dropdown-list" :disabled="disabled" :placement="placement" :autoclose="autoclose">
         <template #trigger>
             <slot name="trigger">
                 <button class="rotating-dots-button" :aria-label="__('Open Dropdown')">
@@ -21,10 +21,6 @@ export default {
         placement: {
             type: String,
             default: 'bottom-end'
-        },
-        fixed: {
-            type: Boolean,
-            default: false
         },
         autoclose: {
             type: Boolean,

--- a/resources/js/components/DropdownList.vue
+++ b/resources/js/components/DropdownList.vue
@@ -1,5 +1,5 @@
 <template>
-    <popover class="dropdown-list" :disabled="disabled" :placement="placement" :scroll="scroll" :autoclose="autoclose" :strategy="strategy">
+    <popover class="dropdown-list" :disabled="disabled" :placement="placement" :autoclose="autoclose" :fixed="fixed">
         <template #trigger>
             <slot name="trigger">
                 <button class="rotating-dots-button" :aria-label="__('Open Dropdown')">
@@ -22,7 +22,7 @@ export default {
             type: String,
             default: 'bottom-end'
         },
-        scroll: {
+        fixed: {
             type: Boolean,
             default: false
         },
@@ -30,11 +30,7 @@ export default {
             type: Boolean,
             default: false
         }
-    },
-    computed: {
-        strategy() {
-            return this.scroll ? 'fixed' : 'absolute';
-        }
     }
+
 }
 </script>

--- a/resources/js/components/FavoriteCreator.vue
+++ b/resources/js/components/FavoriteCreator.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <popover v-if="isNotYetFavorited" ref="popper" placement="auto-end" :offset="[28, 10]">
+        <popover v-if="isNotYetFavorited" ref="popper" placement="bottom-end" :offset="[10, 28]">
             <template slot="trigger">
                 <button @click="shown" slot="reference" class="h-6 w-6 block outline-none p-1 text-gray hover:text-gray-800" v-tooltip="__('Pin to Favorites')" :aria-label="__('Pin to Favorites')">
                     <svg-icon name="pin"></svg-icon>

--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -62,12 +62,15 @@ export default {
     },
 
     computed: {
+
         portalTargetName() {
             return this.portalTarget ? this.portalTarget.name : null;
         },
+
         targetClass() {
             return this.$vnode.data.staticClass;
         }
+
     },
 
     created() {
@@ -79,6 +82,7 @@ export default {
     },
 
     methods: {
+
         computePosition() {
             computePosition(this.$refs.trigger, this.$refs.popover, {
                 placement: this.placement,
@@ -87,15 +91,17 @@ export default {
                     flip(), // If you place it on the right, and there's not enough room, it'll flip to the left, etc.
                     shift({ padding: 5 }), // If it'll end up positioned offscreen, it'll shift it enough to display it fully.
                 ],
-            }).then(({ x, y, strategy }) => {
+            }).then(({ x, y }) => {
                 Object.assign(this.$refs.popover.style, {
                     transform: `translate(${Math.round(x)}px, ${Math.round(y)}px)`, // Round to avoid blurry text
                 });
             });
         },
+
         toggle() {
             this.isOpen ? this.close() : this.open();
         },
+
         open() {
             if (this.disabled) return;
 
@@ -105,32 +111,32 @@ export default {
                 this.cleanupAutoUpdater = autoUpdate(this.$refs.trigger, this.$refs.popover, this.computePosition);
             });
         },
+
         clickawayClose() {
-            if (this.clickaway) {
-                this.close();
-            }
+            if (this.clickaway) this.close();
         },
+
         close() {
-            if (!this.isOpen) return;
+            if (! this.isOpen) return;
 
             this.isOpen = false;
-            if (this.escBinding) {
-                this.escBinding.destroy();
-            }
             this.$emit('closed');
             this.cleanupAutoUpdater();
+
+            if (this.escBinding) this.escBinding.destroy();
         },
+
         leave() {
-            if (this.autoclose) {
-                this.close();
-            }
+            if (this.autoclose) this.close();
         },
+
         createPortalTarget() {
             let key = `popover-${this._uid}`;
             let portalTarget = { key, name: key };
             this.$root.portals.push(portalTarget);
             this.portalTarget = portalTarget;
         },
+
         destroyPortalTarget() {
             const i = _.findIndex(this.$root.portals, (portal) => portal.key === this.portalTarget.key);
             this.$root.portals.splice(i, 1);

--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -12,7 +12,7 @@
             <div :class="`${isOpen ? 'popover-open' : ''}`">
                 <div ref="popover" class="popover" v-if="!disabled">
                     <div class="popover-content bg-white shadow-popover rounded-md">
-                        <slot :close="close" :after-closed="afterClosed" />
+                        <slot :close="close" />
                     </div>
                 </div>
             </div>
@@ -59,7 +59,6 @@ export default {
         return {
             isOpen: false,
             escBinding: null,
-            closedCallbacks: [],
             cleanupAutoUpdater: null,
             portalTarget: null,
         }
@@ -130,13 +129,6 @@ export default {
             if (this.autoclose) {
                 this.close();
             }
-        },
-        destroyPopper() {
-            // run any after-closed callbacks
-            this.closedCallbacks.forEach(callback => callback());
-        },
-        afterClosed(callback) {
-            this.closedCallbacks.push(callback);
         },
         createPortalTarget() {
             let key = `popover-${this._uid}`;

--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -103,6 +103,8 @@ export default {
             this.isOpen ? this.close() : this.open();
         },
         open() {
+            if (this.disabled) return;
+
             this.isOpen = true;
             this.escBinding = this.$keys.bind('esc', e => this.close());
             this.$nextTick(() => {

--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -50,9 +50,6 @@ export default {
             type: String,
             default: 'bottom-end',
         },
-        fixed: {
-            type: Boolean
-        },
     },
 
     data() {
@@ -85,7 +82,6 @@ export default {
         computePosition() {
             computePosition(this.$refs.trigger, this.$refs.popover, {
                 placement: this.placement,
-                strategy: this.fixed ? 'fixed' : 'absolute',
                 middleware: [
                     offset({ mainAxis: this.offset[0], crossAxis: this.offset[1] }),
                     flip(), // If you place it on the right, and there's not enough room, it'll flip to the left, etc.
@@ -93,7 +89,6 @@ export default {
                 ],
             }).then(({ x, y, strategy }) => {
                 Object.assign(this.$refs.popover.style, {
-                    position: strategy,
                     transform: `translate(${Math.round(x)}px, ${Math.round(y)}px)`, // Round to avoid blurry text
                 });
             });

--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -123,7 +123,7 @@
                                         <td />
 
                                         <th class="actions-column" :colspan="columns.length">
-                                            <dropdown-list placement="left-start" scroll v-if="folderActions(folder).length">
+                                            <dropdown-list fixed placement="left-start" v-if="folderActions(folder).length">
                                                 <!-- TODO: Folder edit -->
                                                 <!-- <dropdown-item :text="__('Edit')" @click="editedFolderPath = folder.path" /> -->
 
@@ -158,7 +158,7 @@
                                 </template>
 
                                 <template slot="actions" slot-scope="{ row: asset }">
-                                    <dropdown-list placement="left-start" scroll>
+                                    <dropdown-list placement="left-start" fixed>
                                         <dropdown-item :text="__(canEdit ? 'Edit' : 'View')" @click="edit(asset.id)" />
                                         <div class="divider" v-if="asset.actions.length" />
                                         <data-list-inline-actions

--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -123,7 +123,7 @@
                                         <td />
 
                                         <th class="actions-column" :colspan="columns.length">
-                                            <dropdown-list fixed placement="left-start" v-if="folderActions(folder).length">
+                                            <dropdown-list placement="left-start" v-if="folderActions(folder).length">
                                                 <!-- TODO: Folder edit -->
                                                 <!-- <dropdown-item :text="__('Edit')" @click="editedFolderPath = folder.path" /> -->
 
@@ -158,7 +158,7 @@
                                 </template>
 
                                 <template slot="actions" slot-scope="{ row: asset }">
-                                    <dropdown-list placement="left-start" fixed>
+                                    <dropdown-list placement="left-start">
                                         <dropdown-item :text="__(canEdit ? 'Edit' : 'View')" @click="edit(asset.id)" />
                                         <div class="divider" v-if="asset.actions.length" />
                                         <data-list-inline-actions

--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -6,7 +6,7 @@
                     <a :href="collection.entries_url">{{ collection.title }}</a>
                 </template>
                 <template slot="actions" slot-scope="{ row: collection, index }">
-                    <dropdown-list scroll placement="left-start">
+                    <dropdown-list placement="left-start">
                         <dropdown-item :text="__('View')" :redirect="collection.entries_url" />
                         <dropdown-item v-if="collection.url" :text="__('Visit URL')" :external-link="collection.url"  />
                         <dropdown-item v-if="collection.editable" :text="__('Edit Collection')" :redirect="collection.edit_url" />

--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -1,5 +1,5 @@
 <template>
-    <popover ref="popover" scroll strategy="fixed">
+    <popover ref="popover" fixed>
 
         <template slot="trigger">
             <button

--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -1,5 +1,5 @@
 <template>
-    <popover ref="popover" fixed>
+    <popover ref="popover">
 
         <template slot="trigger">
             <button

--- a/resources/js/components/data-list/FieldFilter.vue
+++ b/resources/js/components/data-list/FieldFilter.vue
@@ -63,7 +63,6 @@ export default {
         config: Object,
         values: Object,
         badges: Object,
-        popoverClosed: Function
     },
 
     data() {
@@ -142,15 +141,15 @@ export default {
         this.reset();
 
         this.$refs.fieldSelect.$refs.search.focus();
-
-        this.popoverClosed(() => {
-            if (! this.badges[this.field]) {
-                this.resetAll();
-            }
-        });
     },
 
     methods: {
+
+        popoverClosed() {
+            if (! this.badges[this.field]) {
+                this.resetAll();
+            }
+        },
 
         reset() {
             if (this.field) this.$emit('changed', this.initialValues);

--- a/resources/js/components/data-list/Filters.vue
+++ b/resources/js/components/data-list/Filters.vue
@@ -3,7 +3,7 @@
         <div class="flex flex-wrap px-3 border-b pt-2">
 
             <!-- Field filter (requires custom selection UI) -->
-            <popover v-if="fieldFilter" scroll strategy="fixed">
+            <popover v-if="fieldFilter" fixed placement="bottom-start">
                 <template slot="trigger">
                     <button class="filter-badge filter-badge-control mr-2 mb-2" @click="resetFilterPopover">
                         {{ __('Field') }}
@@ -39,7 +39,7 @@
             </popover>
 
             <!-- Standard non-field filters -->
-            <popover v-if="standardFilters.length" v-for="filter in standardFilters" :key="filter.handle" scroll strategy="fixed">
+            <popover v-if="standardFilters.length" v-for="filter in standardFilters" :key="filter.handle" fixed placement="bottom-start">
                 <template slot="trigger">
                     <button class="filter-badge filter-badge-control mr-2 mb-2">
                         {{ filter.title }}

--- a/resources/js/components/data-list/Filters.vue
+++ b/resources/js/components/data-list/Filters.vue
@@ -3,7 +3,7 @@
         <div class="flex flex-wrap px-3 border-b pt-2">
 
             <!-- Field filter (requires custom selection UI) -->
-            <popover v-if="fieldFilter" fixed placement="bottom-start" :clickaway="false" @closed="fieldFilterClosed">
+            <popover v-if="fieldFilter" placement="bottom-start" :clickaway="false" @closed="fieldFilterClosed">
                 <template slot="trigger">
                     <button class="filter-badge filter-badge-control mr-2 mb-2" @click="resetFilterPopover">
                         {{ __('Field') }}
@@ -38,7 +38,7 @@
             </popover>
 
             <!-- Standard non-field filters -->
-            <popover v-if="standardFilters.length" v-for="filter in standardFilters" :key="filter.handle" fixed placement="bottom-start">
+            <popover v-if="standardFilters.length" v-for="filter in standardFilters" :key="filter.handle" placement="bottom-start">
                 <template slot="trigger">
                     <button class="filter-badge filter-badge-control mr-2 mb-2">
                         {{ filter.title }}

--- a/resources/js/components/data-list/Filters.vue
+++ b/resources/js/components/data-list/Filters.vue
@@ -3,14 +3,14 @@
         <div class="flex flex-wrap px-3 border-b pt-2">
 
             <!-- Field filter (requires custom selection UI) -->
-            <popover v-if="fieldFilter" fixed placement="bottom-start">
+            <popover v-if="fieldFilter" fixed placement="bottom-start" :clickaway="false" @closed="fieldFilterClosed">
                 <template slot="trigger">
                     <button class="filter-badge filter-badge-control mr-2 mb-2" @click="resetFilterPopover">
                         {{ __('Field') }}
                         <svg-icon name="chevron-down-xs" class="w-2 h-2 mx-2" />
                     </button>
                 </template>
-                <template #default="{ close: closePopover, afterClosed: afterPopoverClosed }">
+                <template #default="{ close: closePopover }">
                     <div class="flex flex-col text-left w-64">
                         <div class="filter-fields text-sm">
                             <field-filter
@@ -18,7 +18,6 @@
                                 :config="fieldFilter"
                                 :values="activeFilters.fields || {}"
                                 :badges="fieldFilterBadges"
-                                :popover-closed="afterPopoverClosed"
                                 @changed="$emit('filter-changed', {handle: 'fields', values: $event})"
                                 @cleared="creating = false"
                                 @closed="closePopover"
@@ -196,7 +195,11 @@ export default {
         resetFilterPopover() {
             this.creating = false;
 
-            this.$refs.fieldFilter.resetInitialValues();
+            setTimeout(() => this.$refs.fieldFilter?.resetInitialValues(), 100); // wait for popover to appear
+        },
+
+        fieldFilterClosed() {
+            this.$refs.fieldFilter.popoverClosed();
         },
 
         removeFieldFilter(handle) {

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -99,7 +99,7 @@
                                 <div class="slug-index-field" :title="entry.slug">{{ entry.slug }}</div>
                             </template>
                             <template slot="actions" slot-scope="{ row: entry, index }">
-                                <dropdown-list placement="left-start" scroll>
+                                <dropdown-list placement="left-start">
                                     <dropdown-item :text="__('View')" :external-link="entry.permalink" v-if="entry.viewable && entry.permalink" />
                                     <dropdown-item :text="__('Edit')" :redirect="entry.edit_url" v-if="entry.editable" />
                                     <div class="divider" v-if="entry.actions.length" />

--- a/resources/js/components/taxonomies/Listing.vue
+++ b/resources/js/components/taxonomies/Listing.vue
@@ -6,7 +6,7 @@
                     <a :href="taxonomy.terms_url">{{ taxonomy.title }}</a>
                 </template>
                 <template slot="actions" slot-scope="{ row: taxonomy, index }">
-                    <dropdown-list placement="left-start" scroll>
+                    <dropdown-list placement="left-start">
                         <dropdown-item :text="__('Edit')" :redirect="taxonomy.edit_url" />
                         <dropdown-item :text="__('Edit Blueprints')" :redirect="taxonomy.blueprints_url" />
                         <dropdown-item

--- a/resources/js/components/terms/Listing.vue
+++ b/resources/js/components/terms/Listing.vue
@@ -93,7 +93,7 @@
                             <span class="font-mono text-2xs">{{ term.slug }}</span>
                         </template>
                         <template slot="actions" slot-scope="{ row: term, index }">
-                            <dropdown-list placement="left-start" fixed>
+                            <dropdown-list placement="left-start">
                                 <dropdown-item :text="__('View')" :redirect="term.permalink" />
                                 <dropdown-item :text="__('Edit')" :redirect="term.edit_url" />
                                 <div class="divider" />

--- a/resources/js/components/terms/Listing.vue
+++ b/resources/js/components/terms/Listing.vue
@@ -93,7 +93,7 @@
                             <span class="font-mono text-2xs">{{ term.slug }}</span>
                         </template>
                         <template slot="actions" slot-scope="{ row: term, index }">
-                            <dropdown-list placement="left-start" scroll>
+                            <dropdown-list placement="left-start" fixed>
                                 <dropdown-item :text="__('View')" :redirect="term.permalink" />
                                 <dropdown-item :text="__('Edit')" :redirect="term.edit_url" />
                                 <div class="divider" />

--- a/resources/js/components/users/Listing.vue
+++ b/resources/js/components/users/Listing.vue
@@ -101,7 +101,7 @@
                             </div>
                         </template>
                         <template slot="actions" slot-scope="{ row: user, index }">
-                            <dropdown-list placement="left-start" scroll>
+                            <dropdown-list placement="right-start" fixed>
                                 <dropdown-item :text="__('Edit')" :redirect="user.edit_url" v-if="user.editable" />
                                 <dropdown-item :text="__('View')" :redirect="user.edit_url" v-else />
                                 <data-list-inline-actions

--- a/resources/js/components/users/Listing.vue
+++ b/resources/js/components/users/Listing.vue
@@ -101,7 +101,7 @@
                             </div>
                         </template>
                         <template slot="actions" slot-scope="{ row: user, index }">
-                            <dropdown-list placement="right-start" fixed>
+                            <dropdown-list placement="right-start">
                                 <dropdown-item :text="__('Edit')" :redirect="user.edit_url" v-if="user.editable" />
                                 <dropdown-item :text="__('View')" :redirect="user.edit_url" v-else />
                                 <data-list-inline-actions


### PR DESCRIPTION
Continuation of #7637

- Swap `@popperjs/core` for `@floating-ui/dom` (Popper.js was renamed to Floating UI)
- The "scroll" feature is now automatically on via the `autoUpdate` feature of floating-ui. There's not really a situation where you wouldn't want it on. If you scroll, the open popover should maintain its appropriate position.
- Popover now portals its contents to the end of the page, within the "stacks on stacks" flow. This way it will appear on top of other things appropriately and fixes any clipping issues.
- Remove the `scroll` prop from `DropdownList` and `Popover`. They were kinda combined but didn't make sense for them to be.
- Remove the `strategy` prop. Now that we're portalling to the end of the page, the strategy is irrelevant. The default strategy (absolute) will always be positioned from the viewport.
- The `offset` prop now accepts the pixels in a more logical floating-ui way. The "mainAxis" is first, and "crossAxis" is second. If you're placing the popover under or above, then the y axis is first. Left or right, the x axis is first.
- Removed the confusing "after close" callbacks on the popover, introduced in #6654. The field filter component was the only thing using it, and have changed that to use the closed event added since then.
