### PR TITLE
[4.x] Sortable list tweaks

### DIFF
--- a/resources/js/components/fieldtypes/ListFieldtype.vue
+++ b/resources/js/components/fieldtypes/ListFieldtype.vue
@@ -6,6 +6,7 @@
                 :vertical="true"
                 item-class="sortable-row"
                 handle-class="sortable-handle"
+                :mirror="false"
                 @dragstart="$emit('focus')"
                 @dragend="$emit('blur')"
             >

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -38,7 +38,7 @@
                     item-class="sortable-item"
                     handle-class="sortable-item"
                     :value="items"
-                    :delay="75"
+                    :distance="5"
                     @input="input"
                 >
                     <div class="vs__selected-options-outside flex flex-wrap">

--- a/resources/js/components/sortable/SortableList.vue
+++ b/resources/js/components/sortable/SortableList.vue
@@ -44,7 +44,11 @@ export default {
         },
         delay: {
             type: Number,
-            default: 200
+            default: 0
+        },
+        distance: {
+            type: Number,
+            default: 0
         },
         disabled: {
             type: Boolean,
@@ -59,6 +63,7 @@ export default {
                 draggable: `.${CSS.escape(this.itemClass)}`,
                 handle: `.${CSS.escape(this.handleClass)}`,
                 delay: this.delay,
+                distance: this.distance,
                 swapAnimation: { vertical: this.vertical, horizontal: !this.vertical },
                 plugins: [Plugins.SwapAnimation],
                 mirror: {


### PR DESCRIPTION
The `SortableList` component has changed the default delay from 200ms to 0. This makes interactions feel much snappier.

The `delay` was initially added to prevent unintentional drags. For example, if the thing you are sorting is also clickable, sometimes your mouse isn't 100% still when you click, making it consider it a drag. If you want to handle this situation, you can set the prop to what you need.

However, you should probably use the new `distance` prop instead of delay. This will consider it a drag after you've moved the mouse that many pixels. It's a better interaction than delay, which is needing to hold down the mouse for that long before it's considered a drag.

The relationship fieldtype's select mode lets you drag the options. This PR changes the delay to distance. As mentioned above, clicking the x on the item would sometimes register as a drag.

This PR also removes the drag mirror from the list fieldtype to be consistent with other vertically sortable lists (grid, table, etc)