### PR TITLE
Support additional columns in collection widget

### DIFF
--- a/resources/js/components/entries/Widget.vue
+++ b/resources/js/components/entries/Widget.vue
@@ -47,11 +47,12 @@ export default {
 
     props: {
         collection: String,
+        additionalColumns: Array,
     },
 
     data() {
         return {
-            cols: [{ label: "Title", field: "title", visible: true }],
+            cols: [{ label: "Title", field: "title", visible: true }, ...this.additionalColumns],
             listingKey: 'entries',
             requestUrl: cp_url(`collections/${this.collection}/entries`),
         }

--- a/resources/views/widgets/collection.blade.php
+++ b/resources/views/widgets/collection.blade.php
@@ -18,6 +18,7 @@
     </div>
     <collection-widget
         collection="{{ $collection->handle() }}"
+        :additional-columns="{{ $columns->toJson() }}"
         :filters="{{ $filters->toJson() }}"
         initial-sort-column="{{ $sortColumn }}"
         initial-sort-direction="{{ $sortDirection }}"

--- a/src/Widgets/Collection.php
+++ b/src/Widgets/Collection.php
@@ -33,7 +33,7 @@ class Collection extends Widget
         $columns = $blueprint
             ->columns()
             ->only($this->config('fields', []))
-            ->map(fn ($column) => $column->sortable(false))
+            ->map(fn ($column) => $column->sortable(false)->visible(true))
             ->values();
 
         return view('statamic::widgets.collection', [

--- a/src/Widgets/Collection.php
+++ b/src/Widgets/Collection.php
@@ -29,6 +29,12 @@ class Collection extends Widget
 
         [$sortColumn, $sortDirection] = $this->parseSort($collection);
 
+        $blueprint = $collection->entryBlueprint();
+        $columns = $blueprint
+            ->columns()
+            ->only($this->config('fields', []))
+            ->values();
+
         return view('statamic::widgets.collection', [
             'collection' => $collection,
             'filters' => Scope::filters('entries', [
@@ -40,6 +46,7 @@ class Collection extends Widget
             'limit' => $this->config('limit', 5),
             'sortColumn' => $sortColumn,
             'sortDirection' => $sortDirection,
+            'columns' => $columns,
         ]);
     }
 

--- a/src/Widgets/Collection.php
+++ b/src/Widgets/Collection.php
@@ -33,6 +33,7 @@ class Collection extends Widget
         $columns = $blueprint
             ->columns()
             ->only($this->config('fields', []))
+            ->map(fn ($column) => $column->sortable(false))
             ->values();
 
         return view('statamic::widgets.collection', [


### PR DESCRIPTION
Closes https://github.com/statamic/ideas/issues/961

![Screenshot 2023-03-24 at 12 40 32](https://user-images.githubusercontent.com/126740/227523844-5985009f-f009-4b7b-b687-dbca1b7955c1.png)

I called the Vue prop `additionalColumns` because `columns` conflicts with the listing mixin.