### PR TITLE
[4.x] Assorted fixes

### DIFF
--- a/resources/js/components/DropdownItem.vue
+++ b/resources/js/components/DropdownItem.vue
@@ -11,6 +11,8 @@ export default {
 
     props: ['text', 'redirect', 'externalLink'],
 
+    inject: ['popover'],
+
     computed: {
 
         href() {
@@ -32,7 +34,7 @@ export default {
 
             this.$emit('click', $event);
 
-            this.$parent.close();
+            this.popover.vm.close();
         },
 
     }

--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -9,6 +9,7 @@
             :to="portalTargetName"
             :target-class="`popover-container ${targetClass || ''}`"
         >
+        <provider :variables="provide">
             <div :class="`${isOpen ? 'popover-open' : ''}`" v-on-clickaway="clickawayClose">
                 <div ref="popover" class="popover" v-if="!disabled">
                     <div class="popover-content bg-white shadow-popover rounded-md">
@@ -16,6 +17,7 @@
                     </div>
                 </div>
             </div>
+        </provider>
         </portal>
 
     </div>
@@ -24,10 +26,15 @@
 <script>
 import { mixin as clickaway } from 'vue-clickaway';
 import { computePosition, flip, shift, offset, autoUpdate } from '@floating-ui/dom';
+import Provider from './live-preview/Provider.vue';
 
 export default {
 
     mixins: [ clickaway ],
+
+    components: {
+        Provider,
+    },
 
     props: {
         autoclose: {
@@ -58,6 +65,9 @@ export default {
             escBinding: null,
             cleanupAutoUpdater: null,
             portalTarget: null,
+            provide: {
+                popover: this.makeProvide(),
+            },
         }
     },
 
@@ -141,6 +151,14 @@ export default {
         destroyPortalTarget() {
             const i = _.findIndex(this.$root.portals, (portal) => portal.key === this.portalTarget.key);
             this.$root.portals.splice(i, 1);
+        },
+
+        makeProvide() {
+            const provide = {};
+            Object.defineProperties(provide, {
+                vm: { get: () => this },
+            });
+            return provide;
         }
     }
 }

--- a/resources/js/components/nav/Branch.vue
+++ b/resources/js/components/nav/Branch.vue
@@ -3,19 +3,19 @@
     <div class="flex">
         <div class="page-move w-6" />
         <div class="flex items-center flex-1 p-2 ml-2 text-xs leading-normal">
-            <div class="flex items-center flex-1" :class="{ 'opacity-50': isHidden || isInHiddenTab }">
-                <template v-if="! isTab">
+            <div class="flex items-center flex-1" :class="{ 'opacity-50': isHidden || isInHiddenSection }">
+                <template v-if="! isSection">
                     <i v-if="isAlreadySvg" class="w-4 h-4 mr-2" v-html="icon"></i>
                     <svg-icon v-else class="w-4 h-4 mr-2" :name="icon" />
                 </template>
 
                 <a
                     @click="$emit('edit', $event)"
-                    :class="{ 'text-sm font-medium': isTab }"
+                    :class="{ 'text-sm font-medium': isSection }"
                     v-text="__(item.text)" />
 
                 <button
-                    v-if="hasChildren && !isTab"
+                    v-if="hasChildren && !isSection"
                     class="p-2 text-gray-600 hover:text-gray-700 transition duration-100 outline-none flex"
                     :class="{ '-rotate-90': !isOpen }"
                     @click="$emit('toggle-open')"
@@ -36,13 +36,13 @@
             <div class="pr-2 flex items-center">
                 <slot name="branch-icon" :branch="item" />
 
-                <svg-icon v-if="isRenamedTab" class="inline-block w-4 h-4 text-gray-500" name="content-writing" v-tooltip="__('Renamed Tab')" />
-                <svg-icon v-else-if="isHidden" class="inline-block w-4 h-4 text-gray-500" name="hidden" v-tooltip="isTab ? __('Hidden Tab') : __('Hidden Item')" />
+                <svg-icon v-if="isRenamedSection" class="inline-block w-4 h-4 text-gray-500" name="content-writing" v-tooltip="__('Renamed Section')" />
+                <svg-icon v-else-if="isHidden" class="inline-block w-4 h-4 text-gray-500" name="hidden" v-tooltip="isSection ? __('Hidden Section') : __('Hidden Item')" />
                 <svg-icon v-else-if="isPinnedAlias" class="inline-block w-4 h-4 text-gray-500" name="pin" v-tooltip="__('Pinned Item')" />
                 <svg-icon v-else-if="isAlias" class="inline-block w-4 h-4 text-gray-500" name="duplicate-ids" v-tooltip="__('Alias Item')" />
                 <svg-icon v-else-if="isMoved" class="inline-block w-4 text-gray-500" name="flip-vertical" v-tooltip="__('Moved Item')" />
                 <svg-icon v-else-if="isModified" class="inline-block w-4 h-4 text-gray-500" name="content-writing" v-tooltip="__('Modified Item')" />
-                <svg-icon v-else-if="isCustom" class="inline-block w-4 text-gray-500" name="user-edit" v-tooltip="isTab ? __('Custom Tab') : __('Custom Item')" />
+                <svg-icon v-else-if="isCustom" class="inline-block w-4 text-gray-500" name="user-edit" v-tooltip="isSection ? __('Custom Section') : __('Custom Item')" />
 
                 <dropdown-list class="ml-4">
                     <slot name="branch-options"
@@ -65,13 +65,13 @@ export default {
 
     props: {
         item: Object,
-        parentTab: Object,
+        parentSection: Object,
         depth: Number,
         root: Boolean,
         vm: Object,
         isOpen: Boolean,
         hasChildren: Boolean,
-        disableTabs: Boolean,
+        disableSections: Boolean,
         topLevel: Boolean,
     },
 
@@ -83,8 +83,8 @@ export default {
 
     computed: {
 
-        isTab() {
-            if (this.disableTabs) {
+        isSection() {
+            if (this.disableSections) {
                 return false;
             }
 
@@ -103,16 +103,16 @@ export default {
             return this.icon.startsWith('<svg');
         },
 
-        isRenamedTab() {
-            return this.isTab && this.item.text !== data_get(this.item, 'config.display_original');
+        isRenamedSection() {
+            return this.isSection && this.item.text !== data_get(this.item, 'config.display_original');
         },
 
         isHidden() {
             return data_get(this.item, 'manipulations.action') === '@hide';
         },
 
-        isInHiddenTab() {
-            return data_get(this.parentTab, 'manipulations.action') === '@hide';
+        isInHiddenSection() {
+            return data_get(this.parentSection, 'manipulations.action') === '@hide';
         },
 
         isPinnedAlias() {

--- a/resources/js/components/nav/ItemEditor.vue
+++ b/resources/js/components/nav/ItemEditor.vue
@@ -12,34 +12,39 @@
                     v-html="'&times'" />
             </div>
 
-            <div class="flex-1 overflow-auto p-6">
-                <div class="publish-fields">
+            <div class="flex-1 overflow-auto">
+                <div class="px-2">
+                    <div class="publish-fields @container">
 
-                <div class="publish-field mb-8" :class="{ 'has-error': validateDisplay }">
-                    <div class="field-inner">
-                        <label class="text-sm font-medium mb-2">{{ __('Display') }} <span class="text-red-500">*</span></label>
-                        <text-input v-model="config.display" :focus="true" />
-                        <div v-if="validateDisplay" class="help-block text-red-500 mt-2"><p>{{ __('statamic::validation.required') }}</p></div>
-                    </div>
-                </div>
-
-                <div class="publish-field mb-8" :class="{ 'has-error': validateUrl }">
-                    <div class="field-inner">
-                        <label class="text-sm font-medium mb-2">{{ __('URL') }} <span class="text-red-500">*</span></label>
-                        <div class="help-block -mt-2">
-                            <p v-text="__('Enter any internal or external URL.')"></p>
+                        <div class="form-group publish-field w-full" :class="{ 'has-error': validateDisplay }">
+                            <div class="field-inner">
+                                <label class="text-sm font-medium mb-2">{{ __('Display') }} <span class="text-red-500">*</span></label>
+                                <text-input v-model="config.display" :focus="true" />
+                                <div v-if="validateDisplay" class="help-block text-red-500 mt-2"><p>{{ __('statamic::validation.required') }}</p></div>
+                            </div>
                         </div>
-                        <text-input v-model="config.url" />
-                        <div v-if="validateUrl" class="help-block text-red-500 mt-2"><p>{{ __('statamic::validation.required') }}</p></div>
+
+                        <div class="form-group publish-field w-full" :class="{ 'has-error': validateUrl }">
+                            <div class="field-inner">
+                                <label class="text-sm font-medium mb-2">{{ __('URL') }} <span class="text-red-500">*</span></label>
+                                <div class="help-block -mt-2">
+                                    <p v-text="__('Enter any internal or external URL.')"></p>
+                                </div>
+                                <text-input v-model="config.url" />
+                                <div v-if="validateUrl" class="help-block text-red-500 mt-2"><p>{{ __('statamic::validation.required') }}</p></div>
+                            </div>
+                        </div>
+
                     </div>
                 </div>
 
-                <button
-                    class="btn-primary w-full mt-6"
-                    :class="{ 'opacity-50': false }"
-                    :disabled="false"
-                    @click="save"
-                    v-text="__('Save')" />
+                <div class="p-6">
+                    <button
+                        class="btn-primary w-full"
+                        :class="{ 'opacity-50': false }"
+                        :disabled="false"
+                        @click="save"
+                        v-text="__('Save')" />
                 </div>
             </div>
 

--- a/resources/js/components/nav/SectionEditor.vue
+++ b/resources/js/components/nav/SectionEditor.vue
@@ -4,7 +4,7 @@
         <div slot-scope="{ close }" class="bg-white h-full flex flex-col">
 
             <div class="bg-gray-200 px-6 py-2 border-b border-gray-300 text-lg font-medium flex items-center justify-between">
-                {{ creating ? __('Add Tab') : __('Edit Tab') }}
+                {{ creating ? __('Add Section') : __('Edit Section') }}
                 <button
                     type="button"
                     class="btn-close"
@@ -19,7 +19,7 @@
                         <div class="form-group publish-field w-full" :class="{ 'has-error': validate }">
                             <div class="field-inner">
                                 <label class="text-sm font-medium mb-2">{{ __('Display') }} <span class="text-red-500">*</span></label>
-                                <text-input v-model="tab" :focus="true" />
+                                <text-input v-model="section" :focus="true" />
                                 <div v-if="validate" class="help-block text-red-500 mt-2"><p>{{ __('statamic::validation.required') }}</p></div>
                             </div>
                         </div>
@@ -48,12 +48,12 @@ export default {
 
     props: {
         creating: false,
-        tabItem: {},
+        sectionItem: {},
     },
 
     data() {
         return {
-            tab: data_get(this.tabItem, 'text') || '',
+            section: data_get(this.sectionItem, 'text') || '',
             saveKeyBinding: null,
             validate: false,
         }
@@ -75,12 +75,12 @@ export default {
         save() {
             this.validate = false;
 
-            if (! this.tab) {
+            if (! this.section) {
                 this.validate = true;
                 return;
             }
 
-            this.$emit('updated', this.tab, this.tabItem);
+            this.$emit('updated', this.section, this.sectionItem);
         },
 
     },

--- a/resources/js/components/nav/TabEditor.vue
+++ b/resources/js/components/nav/TabEditor.vue
@@ -12,23 +12,27 @@
                     v-html="'&times'" />
             </div>
 
-            <div class="flex-1 overflow-auto p-6">
-                <div class="publish-fields">
+            <div class="flex-1 overflow-auto">
+                <div class="px-2">
+                    <div class="publish-fields @container">
 
-                <div class="publish-field mb-8" :class="{ 'has-error': validate }">
-                    <div class="field-inner">
-                        <label class="text-sm font-medium mb-2">{{ __('Display') }} <span class="text-red-500">*</span></label>
-                        <text-input v-model="tab" :focus="true" />
-                        <div v-if="validate" class="help-block text-red-500 mt-2"><p>{{ __('statamic::validation.required') }}</p></div>
+                        <div class="form-group publish-field w-full" :class="{ 'has-error': validate }">
+                            <div class="field-inner">
+                                <label class="text-sm font-medium mb-2">{{ __('Display') }} <span class="text-red-500">*</span></label>
+                                <text-input v-model="tab" :focus="true" />
+                                <div v-if="validate" class="help-block text-red-500 mt-2"><p>{{ __('statamic::validation.required') }}</p></div>
+                            </div>
+                        </div>
+
                     </div>
                 </div>
-
-                <button
-                    class="btn-primary w-full mt-6"
-                    :class="{ 'opacity-50': false }"
-                    :disabled="false"
-                    @click="save"
-                    v-text="__('Save')" />
+                <div class="p-6">
+                    <button
+                        class="btn-primary w-full"
+                        :class="{ 'opacity-50': false }"
+                        :disabled="false"
+                        @click="save"
+                        v-text="__('Save')" />
                 </div>
             </div>
 

--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -28,6 +28,7 @@
                     :meta="meta"
                     :errors="errors"
                     :localized-fields="localizedFields"
+                    class="px-2"
                     @updated="values = $event"
                 >
                     <div slot-scope="{ container, setFieldMeta }">

--- a/resources/js/components/updater/Updater.vue
+++ b/resources/js/components/updater/Updater.vue
@@ -5,7 +5,7 @@
                 <span v-text="name" />
                 <span v-if="currentVersion" class="font-normal text-gray-700 ml-2">{{ currentVersion }}</span>
             </h1>
-            <button v-if="!onLatestVersion" class="btn-primary ml-4" @click="this.modalOpen = true">{{ __('Update') }}</button>
+            <button v-if="!onLatestVersion" class="btn-primary ml-4" @click="modalOpen = true">{{ __('Update') }}</button>
             <div v-if="onLatestVersion" v-text="__('Up to date')" />
         </div>
 


### PR DESCRIPTION
- Consistent spacing in pane-style forms. (Nav item editor, CP section and item editor)
- Revert section/tab find/replace within nav components. Those "sections" are still "sections".
- Popover provides an object containing itself, so children (in a portal) can reference it. Then use use that to close the popover from within dropdown list. Now that the DropdownItem is within a portal, $parent was not what it used to be, which caused an error.
- Fix error when clicking the topmost "Update" button in the updater.
