### PR TITLE
[4.x] Fixes

### DIFF
--- a/resources/css/components/fieldtypes/replicator.css
+++ b/resources/css/components/fieldtypes/replicator.css
@@ -64,6 +64,10 @@
 .replicator-fieldtype {
     @apply py-6 px-0 bg-gray-200 border-t border-b;
 
+    &:first-child {
+        @apply border-t-0;
+    }
+
     > .field-inner {
         @apply ml-6;
     }

--- a/resources/js/components/Slugify.vue
+++ b/resources/js/components/Slugify.vue
@@ -42,8 +42,11 @@ export default {
             if (to !== this.slug) this.shouldSlugify = false;
         },
 
-        slug(slug) {
-            this.$emit('slugified', slug);
+        slug: {
+            immediate: true,
+            handler(slug) {
+                this.$emit('slugified', slug);
+            }
         }
 
     },

--- a/resources/js/components/blueprints/Fields.vue
+++ b/resources/js/components/blueprints/Fields.vue
@@ -111,18 +111,14 @@ export default {
         fieldtypeSelected(field) {
             this.isSelectingNewFieldtype = false;
 
-            const handle = field.type;
-
             const pending = {
                 _id: uniqid(),
                 type: 'inline',
                 fieldtype: field.type,
                 icon: field.icon,
-                handle,
                 config: {
                     ...field,
                     isNew: true,
-                    handle
                 }
             };
 

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -155,7 +155,7 @@ export default {
         makeSectionsSortable() {
             if (sortableSections) sortableSections.destroy();
 
-            sortableSections = new Sortable(document.querySelectorAll('.blueprint-sections'), {
+            sortableSections = new Sortable(this.$el.querySelectorAll('.blueprint-sections'), {
                 draggable: '.blueprint-section',
                 handle: '.blueprint-section-drag-handle',
                 mirror: { constrainDimensions: true, appendTo: 'body' },

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -210,13 +210,15 @@ export default {
 
         getStatusTooltip(entry) {
             if (entry.status === 'published') {
-                return __('messages.status_published_with_date', {date: entry.date})
+                return entry.collection.dated
+                    ? __('messages.status_published_with_date', {date: entry.date})
+                    : null; // The label is sufficient.
             } else if (entry.status === 'scheduled') {
                 return __('messages.status_scheduled_with_date', {date: entry.date})
             } else if (entry.status === 'expired') {
                 return __('messages.status_expired_with_date', {date: entry.date})
             } else if (entry.status === 'draft') {
-                return __('Draft');
+                return null; // The label is sufficient.
             }
         },
 

--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -209,8 +209,9 @@ export default {
             // and id keys. This will be 'field_n' etc, where n would be the total root
             // level, grid, or set fields depending on the event listener location.
             let field = {
-                display: `${fieldtype.title} ${__('Field')}`,
                 type: fieldtype.handle,
+                display: `${fieldtype.title} ${__('Field')}`,
+                handle: null, // The handle will be generated from the display by the "slug" fieldtype.
                 icon: fieldtype.icon,
                 instructions: null,
                 localizable: false,

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -62,11 +62,7 @@
 
                         <publish-sections
                             :sections="blueprint.tabs[0].sections"
-
-                            @updated="(handle, value) => {
-                                updateField(handle, value, setFieldValue);
-                                if (handle === 'handle') isHandleModified = true
-                            }"
+                            @updated="(handle, value) => updateField(handle, value, setFieldValue)"
                             @meta-updated="setFieldMeta"
                         />
 
@@ -138,7 +134,6 @@ export default {
             error: null,
             errors: {},
             editedFields: clone(this.overrides),
-            isHandleModified: true,
             activeTab: 'settings',
             storeName: 'base',
             fieldtype: null,
@@ -192,19 +187,6 @@ export default {
     },
 
     created() {
-        // For new fields, we'll slugify the display name into the field name.
-        // If they edit the handle, we'll stop.
-        if (this.config.isNew && !this.config.isMeta) {
-            this.isHandleModified = false;
-
-            this.$watch('values.display', function(display) {
-                if (! this.isHandleModified) {
-                    const handle = this.$slugify(display, '_');
-                    this.updateField('handle', handle);
-                }
-            });
-        }
-
         this.load();
     },
 

--- a/resources/js/components/fieldsets/EditForm.vue
+++ b/resources/js/components/fieldsets/EditForm.vue
@@ -125,10 +125,10 @@ export default {
         },
 
         makeSortable() {
-            new Sortable(this.$el.querySelector('.blueprint-tab-draggable-zone'), {
-                draggable: '.blueprint-tab-field',
+            new Sortable(this.$el.querySelector('.blueprint-section-draggable-zone'), {
+                draggable: '.blueprint-section-field',
                 handle: '.blueprint-drag-handle',
-                mirror: { constrainDimensions: true },
+                mirror: { constrainDimensions: true, appendTo: 'body' },
                 plugins: [Plugins.SwapAnimation]
             }).on('sortable:stop', e => {
                 this.fieldset.fields.splice(e.newIndex, 0, this.fieldset.fields.splice(e.oldIndex, 1)[0]);

--- a/resources/js/components/fieldsets/EditForm.vue
+++ b/resources/js/components/fieldsets/EditForm.vue
@@ -10,15 +10,20 @@
             </div>
         </header>
 
-        <div class="publish-form card p-0 mb-10">
-
-            <div class="form-group">
-                <label class="block">{{ __('Title') }}</label>
-                <small class="help-block">{{ __('messages.fieldsets_title_instructions') }}</small>
-                <div v-if="errors.title">
-                    <small class="help-block text-red-500" v-for="(error, i) in errors.title" :key="i" v-text="error" />
+        <div class="publish-form card p-0 @container mb-8">
+            <div class="publish-fields">
+                <div class="form-group w-full">
+                    <div class="field-inner">
+                        <label class="block">{{ __('Title') }}</label>
+                        <small class="help-block -mt-2">{{ __('messages.fieldsets_title_instructions') }}</small>
+                        <div v-if="errors.title">
+                            <small class="help-block text-red-500" v-for="(error, i) in errors.title" :key="i" v-text="error" />
+                        </div>
+                    </div>
+                    <div>
+                        <input type="text" name="title" class="input-text" v-model="fieldset.title" autofocus="autofocus">
+                    </div>
                 </div>
-                <input type="text" name="title" class="input-text" v-model="fieldset.title" autofocus="autofocus">
             </div>
 
         </div>

--- a/resources/js/components/fieldsets/EditForm.vue
+++ b/resources/js/components/fieldsets/EditForm.vue
@@ -32,7 +32,7 @@
             <h2 v-text="__('Fields')" />
         </div>
 
-        <div class="card" :class="{ 'pt-2': !fields.length }">
+        <div class="card @container" :class="{ 'pt-2': !fields.length }">
             <fields
                 :fields="fieldset.fields"
                 :editing-field="editingField"

--- a/resources/js/components/fieldtypes/replicator/AddSetButton.vue
+++ b/resources/js/components/fieldtypes/replicator/AddSetButton.vue
@@ -1,7 +1,7 @@
 <template>
 
     <div class="replicator-set-picker">
-        <set-picker :sets="groups" :placement="last ? 'bottom-start' : 'auto'" @added="addSet">
+        <set-picker :sets="groups" :placement="last ? 'bottom-start' : 'bottom'" @added="addSet">
             <template #trigger>
                 <div class="text-center">
                     <button :class="{ 'btn-round flex items-center justify-center': last }" @click="addSetButtonClicked">

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -100,6 +100,7 @@ class FieldsController extends CpController
                 'from' => 'display',
                 'separator' => '_',
                 'validate' => 'required|not_in:'.implode(',', $reserved),
+                'show_regenerate' => true,
             ],
             'instructions' => [
                 'display' => __('Instructions'),

--- a/src/Http/Resources/CP/Entries/ListedEntry.php
+++ b/src/Http/Resources/CP/Entries/ListedEntry.php
@@ -43,7 +43,7 @@ class ListedEntry extends JsonResource
 
             'permalink' => $entry->absoluteUrl(),
             'edit_url' => $entry->editUrl(),
-            'collection' => $entry->collection()->toArray(),
+            'collection' => array_merge($entry->collection()->toArray(), ['dated' => $entry->collection()->dated()]),
             'viewable' => User::current()->can('view', $entry),
             'editable' => User::current()->can('edit', $entry),
             'actions' => Action::for($entry, ['collection' => $collection->handle()]),


### PR DESCRIPTION
A handful of fixes.

- Fix fields not being draggable when opening a bard/replicator. 
	Closes #7800 
- Fix weird padding around the title field for the fieldset builder.
- Fix fields not being draggable in the fieldset builder.
- Fix fieldset builder field widths not kicking in when using something other than 100%.
- Make the slugify component slugify immediately. e.g. if the source has a value, it'll immediately set the slug. Previously it would wait for you to do a keystroke in the source field.
- Fix double slugification logic in the field settings form, causing the handle to stop slugifying after a moment. The handle field uses the slug fieldtype now, so let the fieldtype do its job.
	Closes #7783 
- Add the regenerate button to handle field in the field settings form. It was made opt-in in #7773. We're opting in.
- Fix double border when a replicator is at the start of a section.
	Closes #7762 
- Fix "Published on ," tooltip.
	Closes #7705
