### PR TITLE
[4.x] Bard set picker fixes

### DIFF
--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -119,6 +119,10 @@ export default {
             this.$nextTick(() => {
                 this.cleanupAutoUpdater = autoUpdate(this.$refs.trigger.firstChild, this.$refs.popover, this.computePosition);
                 this.$emit('opened');
+
+                this.$refs.popover.addEventListener('transitionend', () => {
+                    this.$emit('opened');
+                }, { once: true });
             });
         },
 

--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -93,6 +93,8 @@ export default {
     methods: {
 
         computePosition() {
+            if (! this.$refs.trigger) return;
+
             computePosition(this.$refs.trigger.firstChild, this.$refs.popover, {
                 placement: this.placement,
                 middleware: [

--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -93,7 +93,7 @@ export default {
     methods: {
 
         computePosition() {
-            computePosition(this.$refs.trigger, this.$refs.popover, {
+            computePosition(this.$refs.trigger.firstChild, this.$refs.popover, {
                 placement: this.placement,
                 middleware: [
                     offset({ mainAxis: this.offset[0], crossAxis: this.offset[1] }),
@@ -117,7 +117,7 @@ export default {
             this.isOpen = true;
             this.escBinding = this.$keys.bind('esc', e => this.close());
             this.$nextTick(() => {
-                this.cleanupAutoUpdater = autoUpdate(this.$refs.trigger, this.$refs.popover, this.computePosition);
+                this.cleanupAutoUpdater = autoUpdate(this.$refs.trigger.firstChild, this.$refs.popover, this.computePosition);
                 this.$emit('opened');
             });
         },
@@ -131,6 +131,7 @@ export default {
             if (this.$refs.popover.contains(e.target) || this.$el.contains(e.target)) return;
 
             this.close();
+            this.$emit('clicked-away', e);
         },
 
         close() {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -51,10 +51,31 @@
                     :editor="editor" />
             </bubble-menu>
 
-            <floating-menu class="bard-set-selector" :editor="editor" :tippy-options="{ offset: calcFloatingOffset, zIndex: 6 }" :should-show="shouldShowSetButton" v-if="editor">
-                <set-picker :sets="groupConfigs" @added="addSet">
+            <floating-menu
+                class="bard-set-selector"
+                :editor="editor"
+                :should-show="shouldShowSetButton"
+                :is-showing="showAddSetButton"
+                v-if="editor"
+                v-slot="{ x, y }"
+                @shown="showAddSetButton = true"
+                @hidden="showAddSetButton = false"
+            >
+                <set-picker
+                    v-if="showAddSetButton"
+                    :sets="groupConfigs"
+                    @added="addSet"
+                    @clicked-away="clickedAwayFromSetPicker"
+                >
                     <template #trigger>
-                        <button type="button" class="btn-round group flex items-center justify-center" :aria-label="__('Add Set')" v-tooltip="__('Add Set')" @click="addSetButtonClicked">
+                        <button
+                            type="button"
+                            class="btn-round group flex items-center justify-center absolute top-[-6px] -left-9 z-1"
+                            :style="{ transform: `translate(${x}px, ${y}px)` }"
+                            :aria-label="__('Add Set')"
+                            v-tooltip="__('Add Set')"
+                            @click="addSetButtonClicked"
+                        >
                             <svg-icon name="micro-plus" class="w-3 h-3 text-gray-800 group-hover:text-black" />
                         </button>
                     </template>
@@ -81,7 +102,8 @@
 <script>
 import uniqid from 'uniqid';
 import reduce from 'underscore/modules/reduce';
-import { BubbleMenu, Editor, EditorContent, FloatingMenu } from '@tiptap/vue-2';
+import { BubbleMenu, Editor, EditorContent } from '@tiptap/vue-2';
+import { FloatingMenu } from './FloatingMenu';
 import Blockquote from '@tiptap/extension-blockquote';
 import Bold from '@tiptap/extension-bold';
 import BulletList from '@tiptap/extension-bullet-list';
@@ -154,6 +176,7 @@ export default {
             invalid: false,
             pageHeader: null,
             escBinding: null,
+            showAddSetButton: false,
             provide: {
                 bard: this.makeBardProvide(),
                 storeName: this.storeName
@@ -303,7 +326,10 @@ export default {
                 // blur event immediately. We need to make sure that the newly focused element is outside
                 // of Bard. We use a timeout because activeElement only exists after the blur event.
                 setTimeout(() => {
-                    if (!this.$el.contains(document.activeElement)) this.$emit('blur');
+                    if (!this.$el.contains(document.activeElement)) {
+                        this.$emit('blur');
+                        this.showAddSetButton = false;
+                    }
                 }, 1);
             },
             onUpdate: () => {
@@ -478,11 +504,6 @@ export default {
 
             const isActive = view.hasFocus() && empty && isRootDepth && isEmptyTextBlock;
             return this.setConfigs.length && (this.config.always_show_set_button || isActive);
-        },
-
-        calcFloatingOffset({ reference }) {
-            let x = reference.x + reference.width + 20;
-            return [0, -x];
         },
 
         initToolbarButtons() {
@@ -692,7 +713,12 @@ export default {
             if (this.setConfigs.length === 1) {
                 this.addSet(this.setConfigs[0].handle);
             }
-        }
+        },
+
+        clickedAwayFromSetPicker($event) {
+            if (this.$el.contains($event.target)) return;
+            this.showAddSetButton = false;
+        },
 
     }
 }

--- a/resources/js/components/fieldtypes/bard/FloatingMenu.js
+++ b/resources/js/components/fieldtypes/bard/FloatingMenu.js
@@ -1,0 +1,71 @@
+import { FloatingMenuPlugin } from './FloatingMenuPlugin'
+
+export const FloatingMenu = {
+    name: 'FloatingMenu',
+
+    props: {
+        editor: {
+            type: Object,
+            required: true,
+        },
+        shouldShow: {
+            type: Function,
+            default: null,
+        },
+        isShowing: {
+            type: Boolean,
+        }
+    },
+
+    data() {
+        return {
+            show: false,
+            x: 0,
+            y: 0
+        }
+    },
+
+    watch: {
+        editor: {
+            immediate: true,
+            handler(editor) {
+                if (!editor) return;
+
+                this.$nextTick(() => {
+                    editor.registerPlugin(FloatingMenuPlugin({
+                        pluginKey: 'floatingMenu',
+                        editor,
+                        vm: this,
+                        element: this.$el,
+                        shouldShow: this.shouldShow,
+                    }))
+                })
+            },
+        },
+
+        isShowing(showing) {
+            // Depending on the action, sometimes the menu visibility is modified from the
+            // parent (e.g. on blur) and sometimes from the menu itself (e.g.) when moving the cursor.
+            this.show = showing;
+        },
+
+        show(shown) {
+            if (shown) {
+                this.$emit('shown');
+            } else {
+                this.$emit('hidden');
+            }
+        }
+    },
+
+    render() {
+        return this.$scopedSlots.default({
+            x: this.x,
+            y: this.y,
+        });
+    },
+
+    beforeDestroy() {
+        this.editor.unregisterPlugin(this.pluginKey)
+    },
+}

--- a/resources/js/components/fieldtypes/bard/FloatingMenuPlugin.js
+++ b/resources/js/components/fieldtypes/bard/FloatingMenuPlugin.js
@@ -1,0 +1,67 @@
+import { posToDOMRect } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+
+class FloatingMenuView {
+    constructor({
+        editor, element, view, shouldShow, vm
+    }) {
+        this.editor = editor
+        this.element = element
+        this.view = view
+        this.vm = vm
+        this.shouldShow = shouldShow
+
+        this.editor.on('focus', this.focusHandler)
+    }
+
+    focusHandler = () => {
+        this.update(this.editor.view)
+    }
+
+    update(view, oldState) {
+        const { state } = view
+        const { doc, selection } = state
+        const { from, to } = selection
+        const isSame = oldState && oldState.doc.eq(doc) && oldState.selection.eq(selection)
+
+        if (isSame) return;
+
+        const shouldShow = this.shouldShow?.({
+            editor: this.editor,
+            view,
+            state,
+            oldState,
+        })
+
+        if (!shouldShow) return this.hide();
+
+        // The dimension from posToDOMRect are relative to the window.
+        // But since bard is inside a @container which creates a new stacking
+        // context, we need the dimensions relative to the bard editor.
+        const { top: selectionTop, left: selectionLeft } = posToDOMRect(view, from, to);
+        const { top: editorTop, left: editorLeft } = this.editor.options.element.getBoundingClientRect();
+        this.vm.x = Math.round(selectionLeft-editorLeft);
+        this.vm.y = Math.round(selectionTop-editorTop);
+
+        this.show();
+    }
+
+    show() {
+        this.vm.show = true;
+    }
+
+    hide() {
+        this.vm.show = false;
+    }
+
+    destroy() {
+        this.editor.off('focus', this.focusHandler)
+    }
+}
+
+export const FloatingMenuPlugin = (options) => {
+    return new Plugin({
+        key: new PluginKey(options.pluginKey),
+        view: view => new FloatingMenuView({ view, ...options }),
+    })
+}

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -174,11 +174,8 @@ export default {
         },
 
         opened() {
-            // Focus the search input. For some reason the page jumps to the top
-            // when it gets focus, so we need to scroll back to where we were.
-            const scrollPosition = window.scrollY;
+            // setTimeout(() => this.$refs.search.focus(), 150);
             this.$refs.search.focus();
-            window.scrollTo(0, scrollPosition);
 
             if (this.sets.length === 1) {
                 this.selectedGroupHandle = this.sets[0].handle;

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -8,6 +8,7 @@
         @opened="opened"
         @closed="closed"
         @click="triggerWasClicked"
+        @clicked-away="$emit('clicked-away', $event)"
     >
         <template #trigger>
             <slot name="trigger" />


### PR DESCRIPTION
Fixes #7810 

Uses a local customized version of the FloatingMenu tiptap plugin, so we can have more control over the position of the button. This doesn't require tippy, it simply sets the coordinates of the button.