### PR TITLE
[4.x] Fix taggable fieldtype not being deletable

### DIFF
--- a/resources/js/components/fieldtypes/TagsFieldtype.vue
+++ b/resources/js/components/fieldtypes/TagsFieldtype.vue
@@ -32,6 +32,7 @@
                     item-class="sortable-item"
                     handle-class="sortable-item"
                     :value="value"
+                    :distance="10"
                     @input="update"
                 >
                     <div class="vs__selected-options-outside flex flex-wrap">


### PR DESCRIPTION
Since #7755 if you have a clickable thing _inside_ a draggable thing, you'll need to give the draggable thing a distance otherwise it'll think you're trying to drag it.

This adds a little distance so you can click the x on the tag.

Fixes #7814
