### PR TITLE
[4.x] Fix replicator

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -378,12 +378,12 @@ class Bard extends Replicator
     {
         $values = parent::preProcessRow($row['attrs']['values'], $index);
 
-        unset($values['_id']);
+        $generatedId = Arr::pull($values, '_id');
 
         return [
             'type' => 'set',
             'attrs' => [
-                'id' => $row['attrs']['id'] ?? str_random(8),
+                'id' => $row['attrs']['id'] ?? $generatedId,
                 'enabled' => $row['attrs']['enabled'] ?? true,
                 'values' => Arr::except($values, 'enabled'),
             ],

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -521,7 +521,7 @@ class Bard extends Replicator
             return $item['type'] === 'set';
         })->mapWithKeys(function ($set) {
             $values = $set['attrs']['values'];
-            $config = $this->config("sets.{$values['type']}.fields", []);
+            $config = Arr::get($this->flattenedSetsConfig(), "{$values['type']}.fields", []);
 
             return [$set['attrs']['id'] => (new Fields($config))->addValues($values)->meta()->put('_', '_')];
         })->toArray();

--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -149,7 +149,7 @@ class Augmentor
         $augmentMethod = $shallow ? 'shallowAugment' : 'augment';
 
         return $value->map(function ($set) use ($augmentMethod) {
-            if (! $this->fieldtype->config("sets.{$set['type']}.fields")) {
+            if (! Arr::get($this->fieldtype->flattenedSetsConfig(), "{$set['type']}.fields")) {
                 return $set;
             }
 

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -177,7 +177,7 @@ class Replicator extends Fieldtype
         return collect($values)->reject(function ($set, $key) {
             return array_get($set, 'enabled', true) === false;
         })->map(function ($set) use ($shallow) {
-            if (! $this->config("sets.{$set['type']}.fields")) {
+            if (! Arr::get($this->flattenedSetsConfig(), "{$set['type']}.fields")) {
                 return $set;
             }
 

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -222,7 +222,7 @@ class Replicator extends Fieldtype
         ];
     }
 
-    protected function flattenedSetsConfig()
+    public function flattenedSetsConfig()
     {
         $sets = collect($this->config('sets'));
 

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -108,7 +108,7 @@ class Replicator extends Fieldtype
     public function fields($set)
     {
         return new Fields(
-            $this->flattenedSetsConfig()[$set]['fields'],
+            Arr::get($this->flattenedSetsConfig(), "$set.fields"),
             $this->field()->parent(),
             $this->field()
         );
@@ -226,10 +226,10 @@ class Replicator extends Fieldtype
     {
         $sets = collect($this->config('sets'));
 
-        // If the first set has a "fields" key, it would be the legacy format.
+        // If the first set doesn't have a nested "set" key, it would be the legacy format.
         // We'll put it in a "main" group so it's compatible with the new format.
         // This also happens in the "sets" fieldtype.
-        if (Arr::has($sets->first(), 'fields')) {
+        if (! Arr::has($sets->first(), 'sets')) {
             $sets = collect([
                 'main' => [
                     'sets' => $sets->all(),

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -108,7 +108,7 @@ class Replicator extends Fieldtype
     public function fields($set)
     {
         return new Fields(
-            $this->config("sets.$set.fields"),
+            $this->flattenedSetsConfig()[$set]['fields'],
             $this->field()->parent(),
             $this->field()
         );
@@ -192,7 +192,7 @@ class Replicator extends Fieldtype
     public function preload()
     {
         $existing = collect($this->field->value())->mapWithKeys(function ($set) {
-            $config = $this->config("sets.{$set['type']}.fields", []);
+            $config = $this->flattenedSetsConfig()[$set['type']]['fields'];
 
             return [$set['_id'] => (new Fields($config))->addValues($set)->meta()->put('_', '_')];
         })->toArray();

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -21,9 +21,9 @@ class Sets extends Fieldtype
     {
         $sets = collect($sets);
 
-        // If the first set has a "fields" key, it would be the legacy format.
+        // If the first set doesn't have a "sets" key, it would be the legacy format.
         // We'll put it in a "main" group so it's compatible with the new format.
-        if (Arr::has($sets->first(), 'fields')) {
+        if (! Arr::has($sets->first(), 'sets')) {
             $sets = collect([
                 'main' => [
                     'display' => __('Main'),

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -571,35 +571,20 @@ class BardTest extends TestCase
         ]);
     }
 
-    /** @test */
-    public function it_preloads_preprocessed_default_values()
+    /**
+     * @test
+     *
+     * @dataProvider groupedSetsProvider
+     */
+    public function it_preloads($areSetsGrouped)
     {
-        $field = (new Field('test', [
-            'type' => 'bard',
-            'sets' => [
-                'group_one' => [
-                    'sets' => [
-                        'main' => [
-                            'fields' => [
-                                ['handle' => 'things', 'field' => ['type' => 'array']],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ]))->setValue('[]'); // what an empty value would get preprocessed into.
-
-        $expected = [
-            'things' => [],
-        ];
-
-        $this->assertEquals($expected, $field->fieldtype()->preload()['defaults']['main']);
-    }
-
-    /** @test */
-    public function it_preloads_new_meta_with_preprocessed_values()
-    {
-        RowId::shouldReceive('generate')->andReturn('random1', 'random2');
+        RowId::shouldReceive('generate')->andReturn(
+            'random-string-1',
+            'random-string-2',
+            'random-string-3',
+            'random-string-4',
+            'random-string-5',
+        );
 
         // For this test, use a grid field with min_rows.
         // It doesn't have to be, but it's a fieldtype that would
@@ -608,45 +593,113 @@ class BardTest extends TestCase
 
         $field = (new Field('test', [
             'type' => 'bard',
-            'sets' => [
-                'group_one' => [
-                    'sets' => [
-                        'main' => [
-                            'fields' => [
-                                [
-                                    'handle' => 'things',
-                                    'field' => [
-                                        'type' => 'grid',
-                                        'min_rows' => 2,
-                                        'fields' => [
-                                            ['handle' => 'one', 'field' => ['type' => 'text']],
-                                        ],
-                                    ],
+            'sets' => $this->groupSets($areSetsGrouped, [
+                'main' => [
+                    'fields' => [
+                        [
+                            'handle' => 'a_text_field',
+                            'field' => [
+                                'type' => 'text',
+                                'default' => 'the default',
+                            ],
+                        ],
+                        [
+                            'handle' => 'a_grid_field',
+                            'field' => [
+                                'type' => 'grid',
+                                'min_rows' => 2,
+                                'fields' => [
+                                    ['handle' => 'one', 'field' => ['type' => 'text', 'default' => 'default in nested']],
                                 ],
                             ],
                         ],
                     ],
                 ],
+            ]),
+        ]))->setValue([
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    ['type' => 'text', 'text' => 'This is text.'],
+                ],
             ],
-        ]))->setValue('[]'); // what an empty value would get preprocessed into.
+            [
+                'type' => 'set',
+                'attrs' => [
+                    'values' => [
+                        'type' => 'main',
+                        'a_text_field' => 'hello',
+                        'a_grid_field' => [
+                            ['one' => 'foo'],
+                            ['one' => 'bar'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
-        $expected = [
-            '_' => '_',
-            'things' => [ // this array is the preloaded meta for the grid field
+        // The preload method expects the field to already be preprocessed.
+        // This will add stuff like set/row IDs to *existing* values, but not
+        // to any "new" or "default" values. That'll be handled by the fieldtype.
+        // During this preprocess step, the 2 nested grid rows, and the 1 replicator
+        // set will be assigned the first 3 random-string-n IDs.
+        $field = $field->preProcess();
+
+        $meta = $field->fieldtype()->preload();
+
+        // Assert about the "existing" sub-array.
+        // This is meta data for subfields of existing sets.
+        $this->assertCount(1, $meta['existing']);
+        $this->assertArrayHasKey('random-string-3', $meta['existing']); // The set ID assigned during preprocess.
+        $this->assertEquals([
+            '_' => '_', // An empty key to enforce an object in JavaScript.
+            'a_text_field' => null, // the text field doesn't have meta data.
+            'a_grid_field' => [ // this array is the preloaded meta for the grid field
                 'defaults' => [
-                    'one' => null, // default value for the text field
+                    'one' => 'default in nested', // default value for the text field
                 ],
                 'new' => [
                     'one' => null, // meta for the text field
                 ],
                 'existing' => [
-                    'random1' => ['one' => null],
-                    'random2' => ['one' => null],
+                    'random-string-1' => ['one' => null],
+                    'random-string-2' => ['one' => null],
                 ],
             ],
-        ];
+        ], $meta['existing']['random-string-3']);
 
-        $this->assertEquals($expected, $field->fieldtype()->preload()['new']['main']);
+        // Assert about the "defaults" sub-array.
+        // These are the initial values used for subfields when a new set is added.
+        $this->assertCount(1, $meta['defaults']);
+        $this->assertArrayHasKey('main', $meta['defaults']);
+        $this->assertEquals([
+            'a_text_field' => 'the default',
+            'a_grid_field' => [
+                ['_id' => 'random-string-4', 'one' => 'default in nested'],
+                ['_id' => 'random-string-5', 'one' => 'default in nested'],
+            ],
+        ], $meta['defaults']['main']);
+
+        // Assert about the "new" sub-array.
+        // This is meta data for subfields when a new set is added.
+        $this->assertCount(1, $meta['new']);
+        $this->assertArrayHasKey('main', $meta['new']);
+        $this->assertEquals([
+            '_' => '_', // An empty key to enforce an object in JavaScript.
+            'a_text_field' => null, // the text field doesn't have meta data.
+            'a_grid_field' => [ // this array is the preloaded meta for the grid field
+                'defaults' => [
+                    'one' => 'default in nested', // default value for the text field
+                ],
+                'new' => [
+                    'one' => null, // meta for the text field
+                ],
+                'existing' => [
+                    'random-string-4' => ['one' => null],
+                    'random-string-5' => ['one' => null],
+                ],
+            ],
+        ], $meta['new']['main']);
     }
 
     /** @test */
@@ -947,5 +1000,24 @@ EOT;
     private function bard($config = [])
     {
         return (new Bard)->setField(new Field('test', array_merge(['type' => 'bard', 'sets' => ['one' => []]], $config)));
+    }
+
+    public function groupedSetsProvider()
+    {
+        return [
+            'grouped sets (new)' => [true],
+            'ungrouped sets (old)' => [false],
+        ];
+    }
+
+    private function groupSets($shouldGroup, $sets)
+    {
+        if (! $shouldGroup) {
+            return $sets;
+        }
+
+        return [
+            'group_one' => ['sets' => $sets],
+        ];
     }
 }


### PR DESCRIPTION
Fixes #7768 

Improves the "preloading" test to test for more things, in both Bard and Replicator.
Improves the test to handle old and new set configs.