### PR TITLE
[4.x] UI fixes

### DIFF
--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -16,7 +16,7 @@
 }
 
 .data-list-bulk-actions {
-	@apply bg-white absolute w-full py-2 z-10;
+	@apply bg-white absolute w-full py-2 z-1;
 	padding-left: 56px;
 }
 
@@ -141,7 +141,7 @@
 /* Sticky Meta Columns */
 .data-table {
     thead th.checkbox-column {
-        @apply p-0 pr-2 sticky -left-px;
+        @apply p-0 pr-2 sticky z-1 -left-px;
         background-image: linear-gradient(to right, theme(colors.gray.100) 70%, theme(colors.gray.100 / 0%) 100%);
         width: 45px;
         min-width: 45px;
@@ -167,11 +167,11 @@
     }
 
     tbody tr.row-selected .checkbox-column {
-        background-image: linear-gradient(to left, theme(colors.gray.200) 70%, theme(colors.gray.200 / 0%) 100%);
+        background-image: linear-gradient(to right, theme(colors.gray.200) 70%, theme(colors.gray.200 / 0%) 100%);
     }
 
     tbody tr.row-selected .actions-column {
-        background-image: linear-gradient(to right, theme(colors.gray.200) 70%, theme(colors.gray.200 / 0%) 100%);
+        background-image: linear-gradient(to left, theme(colors.gray.200) 70%, theme(colors.gray.200 / 0%) 100%);
     }
 
     tbody tr:hover .checkbox-column {

--- a/resources/js/components/data-list/BulkActions.vue
+++ b/resources/js/components/data-list/BulkActions.vue
@@ -1,7 +1,7 @@
 <template>
 
     <div v-if="showAlways || hasSelections" class="data-list-bulk-actions">
-        <div class="input-group input-group-sm relative z-10">
+        <div class="input-group input-group-sm relative">
             <div class="input-group-prepend">
                 <div class="text-gray-700 hidden md:inline-block"
                     v-text="__n(`:count item selected|:count items selected`, selections.length)" />

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -75,11 +75,11 @@ class CollectionsController extends CpController
 
         $columns = $blueprint
             ->columns()
-            ->prepend(Column::make('status')
+            ->put('status', Column::make('status')
                 ->listable(true)
                 ->visible(true)
                 ->defaultVisibility(true)
-                ->sortable(false), 'status')
+                ->sortable(false))
             ->setPreferred("collections.{$collection->handle()}.columns")
             ->rejectUnlisted()
             ->values();


### PR DESCRIPTION
- Fixes the 'select all' checkbox not appearing over the bulk actions bar.
- Fixes inverted gradients on selected rows.
- Puts the status column at the end instead of the start by default. Closes #7834 