### PR TITLE
[4.x] Use floating ui to position select options

### DIFF
--- a/resources/js/components/fieldtypes/IconFieldtype.vue
+++ b/resources/js/components/fieldtypes/IconFieldtype.vue
@@ -4,7 +4,7 @@
             ref="input"
             class="w-full"
             append-to-body
-            :calculate-position="withPopper"
+            :calculate-position="positionOptions"
             clearable
             :name="name"
             :disabled="config.disabled || isReadOnly"
@@ -74,7 +74,7 @@ export default {
             }
         },
 
-        withPopper(dropdownList, component, { width }) {
+        positionOptions(dropdownList, component, { width }) {
             dropdownList.style.width = width
 
             computePosition(component.$refs.toggle, dropdownList, {

--- a/resources/js/components/fieldtypes/IconFieldtype.vue
+++ b/resources/js/components/fieldtypes/IconFieldtype.vue
@@ -37,9 +37,9 @@
 </template>
 
 <script>
-import { createPopper } from '@popperjs/core'
-export default {
+import { computePosition, offset } from '@floating-ui/dom';
 
+export default {
 
     mixins: [Fieldtype],
 
@@ -75,22 +75,20 @@ export default {
         },
 
         withPopper(dropdownList, component, { width }) {
-
             dropdownList.style.width = width
 
-            const popper = createPopper(component.$refs.toggle, dropdownList, {
-                placement: 'bottom-start',
-                modifiers: [
-                    {
-                        name: 'offset',
-                        options: {
-                            offset: [0, -1],
-                        },
-                    },
-                ],
-            })
-
-            return () => popper.destroy()
+            computePosition(component.$refs.toggle, dropdownList, {
+                placement: 'bottom',
+                middleware: [
+                    offset({ mainAxis: 0, crossAxis: -1 }),
+                ]
+            }).then(({ x, y }) => {
+                Object.assign(dropdownList.style, {
+                    // Round to avoid blurry text
+                    left: `${Math.round(x)}px`,
+                    top: `${Math.round(y)}px`,
+                });
+            });
         },
     }
 };

--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -3,6 +3,8 @@
         <v-select
             ref="input"
             class="flex-1"
+            append-to-body
+            :calculate-position="positionOptions"
             :name="name"
             :clearable="config.clearable"
             :disabled="config.disabled || isReadOnly || (config.multiple && limitReached)"
@@ -63,6 +65,7 @@
 
 <script>
 import HasInputOptions from './HasInputOptions.js'
+import { computePosition, offset } from '@floating-ui/dom';
 
 export default {
 
@@ -145,7 +148,24 @@ export default {
                     this.update(null);
                 }
             }
-        }
+        },
+
+        positionOptions(dropdownList, component, { width }) {
+            dropdownList.style.width = width
+
+            computePosition(component.$refs.toggle, dropdownList, {
+                placement: 'bottom',
+                middleware: [
+                    offset({ mainAxis: 0, crossAxis: -1 }),
+                ]
+            }).then(({ x, y }) => {
+                Object.assign(dropdownList.style, {
+                    // Round to avoid blurry text
+                    left: `${Math.round(x)}px`,
+                    top: `${Math.round(y)}px`,
+                });
+            });
+        },
     }
 };
 </script>


### PR DESCRIPTION
- Uses floating-ui instead of popper in icon fieldtype, continuation of #7841. We don't explicitly require popper-js anymore.
- Position the regular `select` fieldtype the same way, since it would have the same problem.
