### PR TITLE
[4.x] Fix unnecessary navigate-away dialog

### DIFF
--- a/resources/js/components/Slugify.vue
+++ b/resources/js/components/Slugify.vue
@@ -42,11 +42,8 @@ export default {
             if (to !== this.slug) this.shouldSlugify = false;
         },
 
-        slug: {
-            immediate: true,
-            handler(slug) {
-                this.$emit('slugified', slug);
-            }
+        slug(slug) {
+            this.$emit('slugified', slug);
         }
 
     },

--- a/resources/js/components/fieldtypes/ColorFieldtype.vue
+++ b/resources/js/components/fieldtypes/ColorFieldtype.vue
@@ -33,7 +33,7 @@ export default {
 
     data () {
         return {
-            color: this.config.default
+            color: this.value
         }
     },
 
@@ -57,10 +57,7 @@ export default {
                 : null;
         }
 
-    },
+    }
 
-    mounted() {
-        this.color = this.value
-    },
 };
 </script>


### PR DESCRIPTION
There were a couple of fieldtypes unintentionally causing the "are you sure you want to leave" dialog because they updated data.

- Color fieldtype was setting the value on mount. Adjusted it so it sets it within the data. The default value fallback is already handled in PHP.
- The slug syncing immediately was incorrect behavior introduced in #7806 in order to fix #7783. I've reverted this behavior, and 7783 remains fixed. (Although you don't see a handle until you edit the display. Can address that separately.)