### PR TITLE
[4.x] Fix Replicator set pickers not closing when opening a second one

### DIFF
--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -1,7 +1,7 @@
 <template>
     <div :class="{'popover-open': isOpen}" @mouseleave="leave">
 
-        <div @click.stop="toggle" ref="trigger" aria-haspopup="true" :aria-expanded="isOpen" v-if="$scopedSlots.default">
+        <div @click="toggle" ref="trigger" aria-haspopup="true" :aria-expanded="isOpen" v-if="$scopedSlots.default">
             <slot name="trigger"></slot>
         </div>
 
@@ -51,6 +51,10 @@ export default {
             type: String,
             default: 'bottom-end',
         },
+        stopPropagation: {
+            type: Boolean,
+            default: true
+        },
     },
 
     data() {
@@ -92,7 +96,9 @@ export default {
             });
         },
 
-        toggle() {
+        toggle(e) {
+            if (this.stopPropagation) e.stopPropagation();
+
             this.isOpen ? this.close() : this.open();
         },
 

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -5,6 +5,7 @@
         class="set-picker"
         placement="bottom-start"
         :disabled="!hasMultipleSets"
+        :stop-propagation="false"
         @opened="opened"
         @closed="closed"
         @click="triggerWasClicked"


### PR DESCRIPTION
Fixes #7861

Caused by #7844. Stopping propogation on popovers caused v-on-clickaway to not work when you clicked another popover trigger button.

Funnily, I told Jack not to bother adding a prop in #7844 because you'll probably want propagation stopped most of the time. Well we've found one case where we need it, so here's the prop.
