### PR TITLE
[4.x] Fix some container related padding issues

### DIFF
--- a/resources/css/components/publish.css
+++ b/resources/css/components/publish.css
@@ -77,7 +77,11 @@ code.parent-url {
 }
 
 .publish-section-header {
-    @apply px-3 @sm:px-4 @lg:px-6 pt-4 pb-3 border-b border-gray-400 bg-gray-100 rounded-t-lg;
+    @apply border-b border-gray-400 bg-gray-100 rounded-t-lg;
+}
+
+.publish-section-header-inner {
+    @apply px-3 @sm:px-4 @lg:px-6 pt-4 pb-3;
 }
 
 .publish-sidebar {

--- a/resources/css/components/publish.css
+++ b/resources/css/components/publish.css
@@ -77,7 +77,7 @@ code.parent-url {
 }
 
 .publish-section-header {
-    @apply px-5 pt-4 pb-3 border-b border-gray-400 bg-gray-100 rounded-t-lg;
+    @apply px-3 @sm:px-4 @lg:px-6 pt-4 pb-3 border-b border-gray-400 bg-gray-100 rounded-t-lg;
 }
 
 .publish-sidebar {

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -35,7 +35,7 @@
                     </dropdown-list>
                 </div>
             </div>
-            <div class="replicator-set-body" v-if="!collapsed && index !== undefined">
+            <div class="replicator-set-body publish-fields @container" v-if="!collapsed && index !== undefined">
                 <set-field
                     v-for="field in fields"
                     v-show="showField(field, fieldPath(field))"

--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -14,7 +14,7 @@
             </div>
         </div>
 
-        <div class="replicator-set-body publish-fields">
+        <div class="replicator-set-body publish-fields @container">
             <set-field
                 v-for="field in fields"
                 v-show="showField(field, fieldPath(field.handle))"

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -32,7 +32,7 @@
                 </div>
             </div>
 
-            <div class="replicator-set-body publish-fields" v-show="!collapsed">
+            <div class="replicator-set-body publish-fields @container" v-show="!collapsed">
                 <set-field
                     v-for="field in fields"
                     v-show="showField(field, fieldPath(field))"

--- a/resources/js/components/publish/Fields.vue
+++ b/resources/js/components/publish/Fields.vue
@@ -1,6 +1,6 @@
 <template>
 
-    <div class="publish-fields">
+    <div class="publish-fields @container">
 
         <publish-field
             v-for="field in fields"

--- a/resources/js/components/publish/Fields.vue
+++ b/resources/js/components/publish/Fields.vue
@@ -1,6 +1,6 @@
 <template>
 
-    <div class="publish-fields @container">
+    <div class="publish-fields">
 
         <publish-field
             v-for="field in fields"

--- a/resources/js/components/publish/Sections.vue
+++ b/resources/js/components/publish/Sections.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="publish-sections">
+    <div class="publish-sections @container">
         <div class="mb-8" v-for="(section, i) in sections" :key="i">
             <div class="card p-0">
                 <header class="publish-section-header" v-if="section.display">

--- a/resources/js/components/publish/Sections.vue
+++ b/resources/js/components/publish/Sections.vue
@@ -1,10 +1,12 @@
 <template>
-    <div class="publish-sections @container">
+    <div class="publish-sections">
         <div class="mb-8" v-for="(section, i) in sections" :key="i">
             <div class="card p-0">
-                <header class="publish-section-header" v-if="section.display">
-                    <label v-text="section.display" class="text-base font-semibold" />
-                    <div class="help-block" v-if="section.instructions"><p v-html="$options.filters.markdown(section.instructions)" /></div>
+                <header class="publish-section-header @container" v-if="section.display">
+                    <div class="publish-section-header-inner">
+                        <label v-text="section.display" class="text-base font-semibold" />
+                        <div class="help-block" v-if="section.instructions"><p v-html="$options.filters.markdown(section.instructions)" /></div>
+                    </div>
                 </header>
                 <publish-fields
                     :fields="section.fields"


### PR DESCRIPTION
References https://github.com/statamic/cms/issues/7866


- Fixes the responsive padding in section headers
- Fixes field width breakpoints within nested containers, like in replicator, bard, and grid.
	e.g. At what point they become 100%. Previously they would only become 100% based on the top level section. But since a replicator set, for example, would have additional side padding, the fields would be smaller. Now they will become 100% at a more expected point.
- Fixes nested fields immediately becoming 100% and sometimes overflowing when you started to drag a replicator or grid (stacked) row.