### PR TITLE
Fix field dragging in blueprints

### DIFF
--- a/resources/js/components/blueprints/Sections.vue
+++ b/resources/js/components/blueprints/Sections.vue
@@ -39,8 +39,6 @@ import BlueprintSection from './Section.vue';
 import {Sortable, Plugins} from '@shopify/draggable';
 import CanDefineLocalizable from '../fields/CanDefineLocalizable';
 
-let sortableSections, sortableFields;
-
 export default {
 
     mixins: [CanDefineLocalizable],
@@ -74,13 +72,20 @@ export default {
 
     data() {
         return {
-            sections: this.initialSections
+            sections: this.initialSections,
+            sortableSections: null,
+            sortableFields: null,
         }
     },
 
     mounted() {
         this.ensureSection();
         this.makeSortable();
+    },
+
+    beforeDestroy() {
+        if (this.sortableSections) this.sortableSections.destroy();
+        if (this.sortableFields) this.sortableFields.destroy();
     },
 
     watch: {
@@ -101,9 +106,9 @@ export default {
         },
 
         makeSectionsSortable() {
-            if (sortableSections) sortableSections.destroy();
+            if (this.sortableSections) this.sortableSections.destroy();
 
-            sortableSections = new Sortable(this.$refs.sections, {
+            this.sortableSections = new Sortable(this.$refs.sections, {
                 draggable: '.blueprint-section',
                 handle: '.blueprint-section-drag-handle',
                 mirror: { constrainDimensions: true },
@@ -115,9 +120,9 @@ export default {
         },
 
         makeFieldsSortable() {
-            if (sortableFields) sortableFields.destroy();
+            if (this.sortableFields) this.sortableFields.destroy();
 
-            sortableFields = new Sortable(this.$el.querySelectorAll('.blueprint-section-draggable-zone'), {
+            this.sortableFields = new Sortable(this.$el.querySelectorAll('.blueprint-section-draggable-zone'), {
                 draggable: '.blueprint-section-field',
                 handle: '.blueprint-drag-handle',
                 mirror: { constrainDimensions: true },


### PR DESCRIPTION
Continues from #7799

While #7799 fixed the dragging when editing a fieldset, it was still a little broken when in the blueprint builder.

If you open a bard field, close it, instead of it being a bit derpy, now the dragging just doesn't work at all.

This PR makes it work.

What seemed to happen was that setting the variable outside the component would make it reused across components. So when you open the blueprint builder, it sets the sortableFields, then you open the bard settings, it would see the variable, destroy it, and recreate a new sortable instance. Then when you closed the settings, dragging wouldn't work because it had been destroyed.

As a little bonus, this cleans up the sortable instances when the component is destroyed. 
