### PR TITLE
[4.x] Misc fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "statamic",
   "private": true,
   "scripts": {
-    "dev": "vite",
+    "dev": "rm -rf resources/dist/build && vite",
     "build": "vite build",
     "svgo": "svgo -f ./resources/svg/  -r",
     "test": "cross-env NODE_ENV=test jest --silent",

--- a/resources/css/components/blueprints.css
+++ b/resources/css/components/blueprints.css
@@ -32,7 +32,7 @@
         opacity: 0.5;
     }
 
-    &.draggable-mirror {
+    &.draggable-mirror .blueprint-section-field-inner {
         @apply shadow-lg;
     }
 }

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -123,6 +123,12 @@ export default {
         this.makeSortable();
     },
 
+    destroyed() {
+        if (this.sortableTabs) this.sortableTabs.destroy();
+        if (this.sortableSections) this.sortableSections.destroy();
+        if (this.sortableFields) this.sortableFields.destroy();
+    },
+
     methods: {
 
         ensureTab() {

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -159,7 +159,6 @@ export default {
                 draggable: '.blueprint-section',
                 handle: '.blueprint-section-drag-handle',
                 mirror: { constrainDimensions: true, appendTo: 'body' },
-                plugins: [Plugins.SwapAnimation]
             })
             .on('drag:start', e => this.lastInteractedTab = this.currentTab)
             .on('drag:stop', e => this.lastInteractedTab = null)
@@ -175,7 +174,6 @@ export default {
                 draggable: '.blueprint-section-field',
                 handle: '.blueprint-drag-handle',
                 mirror: { constrainDimensions: true, appendTo: 'body' },
-                plugins: [Plugins.SwapAnimation]
             })
             .on('drag:start', e => this.lastInteractedTab = this.currentTab)
             .on('drag:stop', e => this.lastInteractedTab = null)

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -44,8 +44,6 @@ import uniqid from 'uniqid';
 import Tab from './Tab.vue';
 import TabContent from './TabContent.vue';
 
-let sortableTabs, sortableSections, sortableFields;
-
 export default {
 
     components: {
@@ -106,6 +104,9 @@ export default {
             tabsAreScrolled: false,
             canScrollLeft: false,
             canScrollRight: false,
+            sortableTabs: null,
+            sortableSections: null,
+            sortableFields: null,
         }
     },
 
@@ -139,9 +140,9 @@ export default {
         },
 
         makeTabsSortable() {
-            if (sortableTabs) sortableTabs.destroy();
+            if (this.sortableTabs) this.sortableTabs.destroy();
 
-            sortableTabs = new Sortable(this.$refs.tabs, {
+            this.sortableTabs = new Sortable(this.$refs.tabs, {
                 draggable: '.blueprint-tab',
                 mirror: { constrainDimensions: true },
                 swapAnimation: { horizontal: true },
@@ -153,9 +154,9 @@ export default {
         },
 
         makeSectionsSortable() {
-            if (sortableSections) sortableSections.destroy();
+            if (this.sortableSections) this.sortableSections.destroy();
 
-            sortableSections = new Sortable(this.$el.querySelectorAll('.blueprint-sections'), {
+            this.sortableSections = new Sortable(this.$el.querySelectorAll('.blueprint-sections'), {
                 draggable: '.blueprint-section',
                 handle: '.blueprint-section-drag-handle',
                 mirror: { constrainDimensions: true, appendTo: 'body' },
@@ -168,9 +169,9 @@ export default {
 
 
         makeFieldsSortable() {
-            if (sortableFields) sortableFields.destroy();
+            if (this.sortableFields) this.sortableFields.destroy();
 
-            sortableFields = new Sortable(this.$el.querySelectorAll('.blueprint-section-draggable-zone'), {
+            this.sortableFields = new Sortable(this.$el.querySelectorAll('.blueprint-section-draggable-zone'), {
                 draggable: '.blueprint-section-field',
                 handle: '.blueprint-drag-handle',
                 mirror: { constrainDimensions: true, appendTo: 'body' },

--- a/resources/js/components/fieldtypes/FieldDisplayFieldtype.vue
+++ b/resources/js/components/fieldtypes/FieldDisplayFieldtype.vue
@@ -52,6 +52,10 @@ export default {
 
     },
 
+    mounted() {
+        this.$refs.input.select();
+    },
+
     methods: {
 
         toggleHidden() {

--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -97,6 +97,10 @@ export default {
         this.$events.$off('localization.created', this.handleLocalizationCreated);
     },
 
+    mounted() {
+        if (this.config.required && !this.value) this.update(this.$refs.slugify.slug);
+    },
+
     methods: {
 
         handleLocalizationCreated({ store }) {

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -91,7 +91,6 @@ class FieldsController extends CpController
                 'display' => __('Display Label'),
                 'instructions' => __('statamic::messages.fields_display_instructions'),
                 'type' => 'field_display',
-                'autoselect' => true,
             ],
             'handle' => [
                 'display' => __('Handle'),


### PR DESCRIPTION
- Delete build directory before running dev. This prevents the annoying situation where you might have compiled production assets from testing earlier on, and you haven't run `npm run dev` yet, and you're wondering why your assets are outdated. Because the now out-of-date production assets are being used.

- Slug fieldtype will immediately update if it's required and empty. See #7857
- 
- Remove swap animations from blueprint fields and sections. When fields are side by side (e.g. if you make the fields not full width) they still animate vertically, which is really weird. Now it just feels snappier anyway.

- Fix fields not being draggable after opening a bard/replicator field settings. Same as #7870 
 
- Fix border around padding in blueprint field when dragging. Notice how the shadow goes around the padding and not the item itself.
	![CleanShot 2023-04-07 at 15 52 24](https://user-images.githubusercontent.com/105211/230672323-b0b2df4c-a525-4278-8b2a-dd3b734f7901.png)

- Autoselect the display field when opening field settings. This stopped happening when the custom display fieldtype was introduced.
