### PR TITLE
Merge user attributes if found by oauth id or email

### DIFF
--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -34,11 +34,10 @@ class Provider
 
     public function findOrCreateUser($socialite): StatamicUser
     {
-        if ($user = User::findByOAuthId($this->name, $socialite->getId())) {
-            return $user;
-        }
-
-        if ($user = User::findByEmail($socialite->getEmail())) {
+        if (
+            ($user = User::findByOAuthId($this->name, $socialite->getId())) ||
+            ($user = User::findByEmail($socialite->getEmail()))
+        ) {
             return $this->mergeUser($user, $socialite);
         }
 


### PR DESCRIPTION
This fixes #7882 by merging user data attributes when the user is found via an OAuth ID.