### PR TITLE
Focal Point Editor: Correctly set bg for images with ( ) in their name

### DIFF
--- a/resources/js/components/assets/Editor/FocalPointPreviewFrame.vue
+++ b/resources/js/components/assets/Editor/FocalPointPreviewFrame.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="frame-image" ref="frame" :style="{ backgroundImage: `url(${encodeURI(imageUrl)})`, backgroundPosition: backgroundPosition, transform: `scale(${z})`, transformOrigin: transformOrigin }"
+    <div class="frame-image" ref="frame" :style="{ backgroundImage: `url('${encodeURI(imageUrl)}')`, backgroundPosition: backgroundPosition, transform: `scale(${z})`, transformOrigin: transformOrigin }"
     />
 </template>
 


### PR DESCRIPTION
Fixes #6959.