### PR TITLE
Use Localize middleware in frontend user and nocache controllers

### DIFF
--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -155,7 +155,7 @@ class UserController extends Controller
 
         $validator = Validator::make($request->all(), [
             'current_password' => ['required', 'current_password'],
-            'password' => ['required', 'confirmed', PasswordDefaults::rules()],
+            'password'         => ['required', 'confirmed', PasswordDefaults::rules()],
         ]);
 
         if ($validator->fails()) {

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -20,6 +20,11 @@ class UserController extends Controller
 
     private $request;
 
+    public function __construct()
+    {
+        $this->middleware(\Statamic\Http\Middleware\Localize::class);
+    }
+
     public function login(Request $request)
     {
         $validator = Validator::make($request->all(), [
@@ -150,7 +155,7 @@ class UserController extends Controller
 
         $validator = Validator::make($request->all(), [
             'current_password' => ['required', 'current_password'],
-            'password'         => ['required', 'confirmed', PasswordDefaults::rules()],
+            'password' => ['required', 'confirmed', PasswordDefaults::rules()],
         ]);
 
         if ($validator->fails()) {

--- a/src/StaticCaching/NoCache/Controller.php
+++ b/src/StaticCaching/NoCache/Controller.php
@@ -3,11 +3,17 @@
 namespace Statamic\StaticCaching\NoCache;
 
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller as BaseController;
 use Statamic\StaticCaching\Replacers\NoCacheReplacer;
 use Statamic\Support\Str;
 
-class Controller
+class Controller extends BaseController
 {
+    public function __construct()
+    {
+        $this->middleware(\Statamic\Http\Middleware\Localize::class);
+    }
+
     public function __invoke(Request $request, Session $session)
     {
         $url = $request->input('url');


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/7890
Fixes https://github.com/statamic/cms/issues/7893

Only implements the Localize middlewear rather than the full `statamic.web` group. Could be done in the routes file but I just copied the approach from the `FrontendController` class.