### PR TITLE
Make Livewire work with full measure static caching

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -225,6 +225,10 @@ class FileCacher extends AbstractCacher
         for (const meta of document.querySelectorAll('meta[content="$csrfPlaceholder"]')) {
             meta.content = data.csrf;
         }
+        
+        if (window.hasOwnProperty('livewire_token')) {
+            window.livewire_token = data.csrf
+        }
 
         document.dispatchEvent(new CustomEvent('statamic:nocache.replaced'));
     });


### PR DESCRIPTION
This PR makes it possible to use Livewire together with full measure static caching. It ensures that the `STATAMIC_CSRF_TOKEN` placeholder is replaced when the cached page is loaded.

## Why this is needed
Statamic replaces all token occurrences in the `CsrfTokenReplacer`:

https://github.com/statamic/cms/blob/509bd70b4e36c6c409c53e5537c2c9d32a4bdf24/src/StaticCaching/Replacers/CsrfTokenReplacer.php#L29-L33

So Livewire doesn't have a valid token to work with:

<img width="198" alt="CleanShot 2023-04-12 at 14 08 49@2x" src="https://user-images.githubusercontent.com/23167701/231546449-602a5c46-fc62-4ae0-b61d-7114b6106bc0.png">

Which results in this error when interacting with the Livewire component after a cached page is loaded:

<img width="447" alt="CleanShot 2023-04-12 at 14 13 14@2x" src="https://user-images.githubusercontent.com/23167701/231547346-e9b0bb28-88d9-4fe7-b075-554d742ab89f.png">

With this PR, the `livewire_token` is replaced and the error is gone:

<img width="319" alt="CleanShot 2023-04-12 at 14 10 35@2x" src="https://user-images.githubusercontent.com/23167701/231546710-1c8b8613-5f9f-41cd-ac29-2bb2f3b17fa8.png">
