### PR TITLE
Pass existing user into OAuth callback

### DIFF
--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -74,7 +74,7 @@ class Provider
 
     public function mergeUser($user, $socialite): StatamicUser
     {
-        collect($this->userData($socialite))->each(fn ($value, $key) => $user->set($key, $value));
+        collect($this->userData($socialite, $user))->each(fn ($value, $key) => $user->set($key, $value));
 
         $user->save();
 
@@ -83,10 +83,10 @@ class Provider
         return $user;
     }
 
-    public function userData($socialite)
+    public function userData($socialite, $existingUser = null)
     {
         if ($this->userDataCallback) {
-            return call_user_func($this->userDataCallback, $socialite);
+            return call_user_func($this->userDataCallback, $socialite, $existingUser);
         }
 
         return ['name' => $socialite->getName()];

--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -95,11 +95,15 @@ class Provider
     public function withUserData(Closure $callback)
     {
         $this->userDataCallback = $callback;
+
+        return $this;
     }
 
     public function withUser(Closure $callback)
     {
         $this->userCallback = $callback;
+
+        return $this;
     }
 
     public function loginUrl()


### PR DESCRIPTION
Prompted by #7883, this passes along the existing user (if one exists) to the `withUserData` callback, so within your callback you can more provide data appropriate to first vs. subsequent logins. See #3269

```php
OAuth::provider('github')
     ->withUserData(fn ($socialiteUser, $statamicUser) => [
        'name' => $socialiteUser->getName(),
        'created_at' => optional($statamicUser)->created_at ?? now()->format('Y-m-d'),
    ]);
```

Also makes the methods fluent so you can combine both methods in your service provider if you want.

```diff
-OAuth::provider('github')->withUserData(...);
-OAuth::provider('github')->withUser(...);
+OAuth::provider('github')
+  ->withUserData(...)
+  ->withUser(...)
```