### PR TITLE
[4.x] Move Column Customizer into a Modal for better long list management

### DIFF
--- a/resources/css/components/column-picker.css
+++ b/resources/css/components/column-picker.css
@@ -1,9 +1,5 @@
-.column-picker {
-
-}
-
 .column-picker-item {
-    @apply text-sm outline-none flex items-center select-none h-full;
+    @apply text-sm outline-none flex items-center select-none;
 
     &.sortable {
         @apply rounded bg-white border;

--- a/resources/css/components/modal.css
+++ b/resources/css/components/modal.css
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .vm--modal {
-    @apply rounded-lg overflow-scroll !important;
+    @apply rounded-lg !important;
 }
 
 .vm--overlay {

--- a/resources/css/components/modal.css
+++ b/resources/css/components/modal.css
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .vm--modal {
-    @apply rounded-lg !important;
+    @apply rounded-lg overflow-scroll !important;
 }
 
 .vm--overlay {

--- a/resources/js/components/Modal.vue
+++ b/resources/js/components/Modal.vue
@@ -16,7 +16,7 @@ export default {
 
     props: {
         adaptive: { type: Boolean, default: true },
-        draggable: { type: Boolean, default: false },
+        draggable: { default: false },
         clickToClose: { type: Boolean, default: false },
         shiftY: { type: Number, default: 0.1 },
         focusTrap: {type: Boolean, default: true},

--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -106,7 +106,7 @@ export default {
         setLocalColumns() {
             this.selectedColumns = this.sharedState.columns.filter(column => column.visible);
             let hiddenColumns = this.sharedState.columns.filter(column => ! column.visible);
-            this.hiddenColumns = _.sortBy(hiddenColumns, column => column.label);
+            this.hiddenColumns = _.sortBy(hiddenColumns, column => column.label.toLowerCase());
         },
 
         setSharedStateColumns() {
@@ -124,7 +124,7 @@ export default {
             toArray.push(fromArray[currentIndex]);
             fromArray.splice(currentIndex, 1);
 
-            this.hiddenColumns = _.sortBy(this.hiddenColumns, column => column.label);
+            this.hiddenColumns = _.sortBy(this.hiddenColumns, column => column.label.toLowerCase());
         },
 
         save() {

--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -8,58 +8,61 @@
             <svg-icon name="light/settings-horizontal" class="w-4 h-4" />
         </button>
 
-        <modal v-if="open" name="column-picker" @closed="open = false" adaptive draggable=".modal-drag-handle" click-to-close>
+        <modal v-if="open" name="column-picker" @closed="open = false" draggable=".modal-drag-handle" click-to-close>
+            <div class="flex flex-col h-full">
 
-            <header class="modal-drag-handle p-4 bg-gray-200 border-b flex items-center justify-between cursor-grab active:cursor-grabbing">
-                <h2>{{ __('Customize Columns') }}</h2>
-                <button class="btn-close" @click="open = false" :aria-label="__('Close Editor')">&times;</button>
-            </header>
+                <header class="modal-drag-handle p-4 bg-gray-200 border-b flex items-center justify-between cursor-grab active:cursor-grabbing">
+                    <h2>{{ __('Customize Columns') }}</h2>
+                    <button class="btn-close" @click="open = false" :aria-label="__('Close Editor')">&times;</button>
+                </header>
 
-            <div class="column-picker flex rounded-t-md bg-gray-100 overflow-y-scroll h-screen-64">
+                <div class="flex grow min-h-0 rounded-t-md bg-gray-100">
+                    <!-- Available Columns -->
+                    <div class="outline-none text-left w-1/2 border-r flex flex-col">
+                        <header v-text="__('Available Columns')" class="border-b py-2 px-3 text-sm bg-white font-medium"/>
+                        <div class="flex flex-1 flex-col space-y-1 py-2 px-3 select-none shadow-inner overflow-y-scroll">
+                            <div class="column-picker-item" v-for="column in hiddenColumns" :key="column.field" v-if="hiddenColumns.length">
+                                <label class="flex items-center cursor-pointer">
+                                    <input type="checkbox" class="mr-2" v-model="column.visible" @change="columnToggled(column) "/>
+                                    {{ column.label }}
+                                </label>
+                            </div>
+                        </div>
+                    </div>
 
-                <!-- Available Columns -->
-                <div class="outline-none text-left w-1/2 border-r">
-                    <header v-text="__('Available Columns')" class="border-b py-2 px-3 text-sm bg-white font-medium"/>
-                    <div class="flex flex-col space-y-1 py-2 px-3 select-none shadow-inner">
-                        <div class="column-picker-item" v-for="column in hiddenColumns" :key="column.field" v-if="hiddenColumns.length">
-                            <label class="flex items-center cursor-pointer">
-                                <input type="checkbox" class="mr-2" v-model="column.visible" @change="columnToggled(column) "/>
-                                {{ column.label }}
-                            </label>
+                    <!-- Displayed Columns -->
+                    <div class="w-1/2 flex flex-col">
+                        <header v-text="__('Displayed Columns')" class="border-b px-3 py-2 text-sm bg-white rounded-tl-md font-medium flex-none"/>
+                        <div class="grow overflow-y-scroll shadow-inner">
+                            <sortable-list
+                                v-model="selectedColumns"
+                                :vertical="true"
+                                :distance="10"
+                                item-class="item"
+                                handle-class="item"
+                                append-to=".modal-body"
+                                constrain-dimensions
+                            >
+                                <div class="space-y-1 px-3 p-3 select-none">
+                                    <div class="item sortable cursor-grab" v-for="column in selectedColumns" :key="column.field">
+                                        <div class="item-move py-1">&nbsp;</div>
+                                        <div class="flex flex-1 ml-2 items-center p-0">
+                                            <input type="checkbox" class="mr-2" v-model="column.visible" @change="columnToggled(column)" :disabled="selectedColumns.length === 1" />
+                                            {{ column.label }}
+                                        </div>
+                                    </div>
+                                </div>
+                            </sortable-list>
                         </div>
                     </div>
                 </div>
 
-                <!-- Displayed Columns -->
-                <div class="w-1/2">
-                    <header v-text="__('Displayed Columns')" class="border-b px-3 py-2 text-sm bg-white rounded-tl-md font-medium"/>
-                    <sortable-list
-                        v-model="selectedColumns"
-                        :vertical="true"
-                        :distance="10"
-                        item-class="item"
-                        handle-class="item"
-                        append-to=".modal-body"
-                        constrain-dimensions
-                    >
-                        <div class="flex flex-col space-y-1 px-3 p-3 select-none shadow-inner">
-                            <div class="item sortable cursor-grab" v-for="column in selectedColumns" :key="column.field">
-                                <div class="item-move py-1">&nbsp;</div>
-                                <div class="flex flex-1 ml-2 items-center p-0">
-                                    <input type="checkbox" class="mr-2" v-model="column.visible" @change="columnToggled(column)" :disabled="selectedColumns.length === 1" />
-                                    {{ column.label }}
-                                </div>
-                            </div>
-                        </div>
-                    </sortable-list>
-                </div>
+                <footer class="px-3 py-2 border-t flex items-center justify-end" v-if="preferencesKey">
+                    <button class="btn" v-text="__('Reset')" @click="reset" :disabled="saving" />
+                    <button class="ml-3 btn-primary" v-text="__('Save')" @click="save" :disabled="saving" />
+                </footer>
+
             </div>
-
-            <footer class="px-3 py-2 border-t flex items-center justify-end" v-if="preferencesKey">
-                <button class="btn" v-text="__('Reset')" @click="reset" :disabled="saving" />
-                <button class="ml-3 btn-primary" v-text="__('Save')" @click="save" :disabled="saving" />
-            </footer>
-
         </modal>
     </div>
 </template>

--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -124,7 +124,7 @@ export default {
             toArray.push(fromArray[currentIndex]);
             fromArray.splice(currentIndex, 1);
 
-            this.hiddenColumns = _.sortBy(this.hiddenColumns, column => column.defaultOrder);
+            this.hiddenColumns = _.sortBy(this.hiddenColumns, column => column.label);
         },
 
         save() {

--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -40,6 +40,7 @@
                         item-class="item"
                         handle-class="item"
                         append-to=".modal-body"
+                        constrain-dimensions
                     >
                         <div class="flex flex-col space-y-1 px-3 p-3 select-none shadow-inner">
                             <div class="item sortable cursor-grab" v-for="column in selectedColumns" :key="column.field">

--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -152,7 +152,7 @@ export default {
             this.$preferences.remove(this.preferencesKey)
                 .then(response => {
                     this.saving = false;
-                    this.$refs.popover.close();
+                    this.open = false;
                     this.$toast.success(__('Columns have been reset to their defaults.'));
                 })
                 .catch(error => {

--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -8,9 +8,9 @@
             <svg-icon name="light/settings-horizontal" class="w-4 h-4" />
         </button>
 
-        <modal v-if="open" name="column-picker" @closed="open = false" adaptive draggable click-to-close>
+        <modal v-if="open" name="column-picker" @closed="open = false" adaptive draggable=".modal-drag-handle" click-to-close>
 
-            <header class="p-4 bg-gray-200 border-b flex items-center justify-between cursor-grab active:cursor-grabbing">
+            <header class="modal-drag-handle p-4 bg-gray-200 border-b flex items-center justify-between cursor-grab active:cursor-grabbing">
                 <h2>{{ __('Customize Columns') }}</h2>
                 <button class="btn-close" @click="open = false" :aria-label="__('Close Editor')">&times;</button>
             </header>


### PR DESCRIPTION
Closes https://github.com/statamic/cms/issues/7897

<img width="655" alt="CleanShot 2023-04-13 at 14 22 19@2x" src="https://user-images.githubusercontent.com/44739/231849429-988bbc4b-bc1f-41bd-ae8c-90dc83ff2e88.png">


- Moves the UI into a modal
- Sorts available columns alphabetically
- The `draggable` prop on the `modal` component can accept more than booleans.