### PR TITLE
Add Dutch passwords strings file

### DIFF
--- a/resources/lang/nl/passwords.php
+++ b/resources/lang/nl/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'reset' => 'Je wachtwoord is gereset.',
+    'sent' => 'We hebben een e-mail met een wachtwoordresetlink verstuurd.',
+    'throttled' => 'Wacht even voordat je het opnieuw probeert.',
+    'token' => 'Deze wachtwoordresettoken is niet geldig.',
+    'user' => "We kunnen geen gebruiker vinden met dat e-mailadres.",
+
+];


### PR DESCRIPTION
I wonder why this file is missing for every translation available. Could it be the CLI translate tool might need an update?

Anyways. This fixes it for Dutch.