### PR TITLE
[4.x] Fix set handle not synced with display

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -22,7 +22,7 @@
             <confirmation-modal
                 v-if="editingSection"
                 :title="editText"
-                @opened="$refs.displayInput.focus()"
+                @opened="$refs.displayInput.select()"
                 @confirm="editConfirmed"
                 @cancel="editCancelled"
             >

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -132,9 +132,9 @@ export default {
             }
         },
 
-        'section.display': function(display) {
-            if (this.handleSyncedWithDisplay) {
-                this.section.handle = this.$slugify(display, '_');
+        'editingSection.display': function(display) {
+            if (this.editingSection && this.handleSyncedWithDisplay) {
+                this.editingSection.handle = this.$slugify(display, '_');
             }
         }
 


### PR DESCRIPTION
- Fix handle not being synced with display field. Fixes #7891
- Select the display field instead of just focusing.
