### PR TITLE
Validate query builder orderBy arguments

### DIFF
--- a/src/Query/OrderBy.php
+++ b/src/Query/OrderBy.php
@@ -20,7 +20,7 @@ class OrderBy
         if (! in_array($direction, ['asc', 'desc'], true)) {
             throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
         }
-        
+
         $this->sort = $sort;
         $this->direction = $direction;
     }

--- a/src/Query/OrderBy.php
+++ b/src/Query/OrderBy.php
@@ -15,6 +15,12 @@ class OrderBy
      */
     public function __construct(string $sort, string $direction)
     {
+        $direction = strtolower($direction);
+
+        if (! in_array($direction, ['asc', 'desc'], true)) {
+            throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
+        }
+        
         $this->sort = $sort;
         $this->direction = $direction;
     }

--- a/src/Query/OrderBy.php
+++ b/src/Query/OrderBy.php
@@ -18,7 +18,7 @@ class OrderBy
         $direction = strtolower($direction);
 
         if (! in_array($direction, ['asc', 'desc'], true)) {
-            throw new InvalidArgumentException('Order direction must be "asc" or "desc".');
+            throw new \InvalidArgumentException('Order direction must be "asc" or "desc".');
         }
 
         $this->sort = $sort;


### PR DESCRIPTION
On the current version doing the following query will be silently ignored:

```php
Entry::query()->where('collection', 'news')->orderBy('date', 'DESC')->get()

Entry::query()->where('collection', 'news')->orderBy('date', 'something_invalid')->get()
```

This pull request add some validation to alert developers when a wrong value is passed to the query builder `orderBy` method.

This replicate Laravel's behavior: https://github.com/laravel/framework/blob/a24b75e81812f3d01e20182227a29b284eb712ce/src/Illuminate/Database/Query/Builder.php#L2295