### PR TITLE
Simplify Bard's CSS with a decoration plugin

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -251,233 +251,192 @@
 
 
 /* Typography
-   -
-   Selectors are specific so they don't cascade into the sets, which
-   all sit inline within the rest of the elements.
    ========================================================================== */
 .bard-fieldtype .ProseMirror {
     outline: 0;
-}
 
-.bard-fieldtype .ProseMirror > {
-    p {
+    p.bard-node {
         @apply text-gray-800;
         word-break: break-all;
         word-break: break-word;
-
         line-height: 1.7;
         text-size-adjust: 100%;
-    }
-
-
-    blockquote,
-    ol,
-    p,
-    ul {
         margin-top: 0;
         margin-bottom: .85em;
+        color: red !important;
+    }
 
-        b,
-        strong { font-weight: 700; }
+    b:has(.bard-mark),
+    strong:has(.bard-mark) {
+        font-weight: 700;
+    }
 
-        em, i { font-style: italic }
+    em:has(.bard-mark),
+    i:has(.bard-mark) {
+        font-style: italic
+    }
 
-        a {
-            @apply text-blue underline break-words;
-        }
+    a:has(.bard-mark) {
+        @apply text-blue underline break-words;
+        color: purple !important;
 
-        a:active,
-        a:focus,
-        a:hover {
+        &:active,
+        &:focus,
+        &:hover {
             outline: 0;
             text-decoration: underline;
         }
-
-        img {
-            border: 0;
-            max-width: 100%;
-        }
     }
 
-    blockquote,
-    blockquote ol li,
-    blockquote ul li,
-    ol li,
-    ul li {
-        > p {
-            margin-top: 0;
-            margin-bottom: .85em;
-        }
+    img.bard-node {
+        border: 0;
+        max-width: 100%;
     }
 
-    hr {
+    hr.bard-node {
         @apply bg-gray-600;
         height: 4px;
         padding: 0;
         margin: 1.7em 0;
         overflow: hidden;
         border: none;
+
+        &:after,
+        &:before {
+            display: table;
+            content: " ";
+        }
+
+        &:after {
+            clear: both
+        }
     }
 
-    hr:after,
-    hr:before {
-        display: table;
-        content: " ";
-    }
-
-    hr:after {
-        clear: both
-    }
-
-    h1, h2, h3, h4, h5, h6 {
+    h1.bard-node,
+    h2.bard-node,
+    h3.bard-node,
+    h4.bard-node,
+    h5.bard-node,
+    h6.bard-node {
         margin-top: 1.275em;
         margin-bottom: .85em;
-        font-weight: 700
+        font-weight: 700;
+
+        &:first-child {
+            margin-top: 0;
+        }
     }
 
-    h1 { font-size: 2em }
+    h1.bard-node {
+        font-size: 2em;
+    }
 
-    h2 { font-size: 1.75em }
+    h2.bard-node {
+        font-size: 1.75em;
+    }
 
-    h3 { font-size: 1.5em }
+    h3.bard-node {
+        font-size: 1.5em;
+    }
 
-    h4 { font-size: 1.25em }
+    h4.bard-node {
+        font-size: 1.25em;
+    }
 
-    h5 { font-size: 1em }
+    h5.bard-node {
+        font-size: 1em;
+    }
 
-    h6 {
+    h6.bard-node {
         font-size: 1em;
         @apply text-gray-700;
     }
 
-    h1:first-child,
-    h2:first-child,
-    h3:first-child,
-    h4:first-child,
-    h5:first-child,
-    h6:first-child {
-        margin-top: 0;
-    }
-
-    ul,
-    blockquote ul,
-    .tableWrapper table ul {
+    ul.bard-node {
         list-style-type: disc;
+
+        ul.bard-node {
+            list-style-type: circle;
+        }
     }
 
-    ol,
-    blockquote ol,
-    .tableWrapper table ol {
+    ol.bard-node {
         list-style-type: decimal;
+
+        ol.bard-node {
+            list-style-type: decimal;
+        }
     }
 
-    ol,
-    ul,
-    blockquote ol,
-    blockquote ul {
+    ol.bard-node,
+    ul.bard-node {
         padding: 0;
         margin: 0;
         margin-bottom: .85em;
         padding-left: 2em;
+
+        ol.bard-node,
+        ul.bard-node {
+            margin-bottom: 0;
+        }
     }
 
-    .tableWrapper table ol,
-    .tableWrapper table ul {
-        padding: 0;
-        margin: 0;
-        padding-left: 2em;
-    }
-
-    ol ol,
-    ol ul,
-    ul ol,
-    ul ul {
-        margin-top: 0;
-        margin-bottom: 0;
-        padding-left: 2em;
-    }
-
-    ul ul {
-        list-style-type: circle;
-    }
-
-    ol ol {
-        list-style-type: decimal;
-    }
-
-    ul ol {
-        list-style-type: decimal;
-    }
-
-    ol ul {
-        list-style-type: circle;
-    }
-
-    blockquote {
+    blockquote.bard-node {
         @apply text-gray-800 border-l-4 border-blue px-4;
         margin: 0 0 .85em;
+
+        &:first-child {
+            margin-top: 0;
+        }
+
+        &:last-child {
+            margin-bottom: 0;
+        }
     }
 
-    blockquote:first-child {
-        margin-top: 0;
-    }
-
-    blockquote:last-child {
-        margin-bottom: 0;
-    }
-
-    .tableWrapper table,
-    blockquote > .tableWrapper table,
-    ol li > .tableWrapper table,
-    ul li > .tableWrapper table {
+    .tableWrapper.bard-node > table {
         @apply w-full overflow-hidden m-0 mb-4 bg-white text-sm ;
         border-collapse: collapse;
         table-layout: fixed;
 
-        th {
+        th.bard-node {
             @apply font-bold text-left bg-gray-200;
         }
 
-        td, th {
+        td.bard-node,
+        th.bard-node {
             @apply border align-top relative py-1 px-2;
             min-width: 1em;
-        }
-
-        .selectedCell {
-            @apply relative;
-
-            &:after {
-                @apply bg-gray-400 absolute inset-0 pointer-events-none opacity-25;
-                content: '';
+            p.bard-node,
+            ol.bard-node,
+            ul.bard-node {
+                margin-bottom: 0;
             }
-        }
-
-        a {
-            @apply text-blue underline break-words;
-        }
-
-        a:active,
-        a:focus,
-        a:hover {
-            outline: 0;
-            text-decoration: underline;
+            &.selectedCell {
+                @apply relative;
+    
+                &:after {
+                    @apply bg-gray-400 absolute inset-0 pointer-events-none opacity-25;
+                    content: '';
+                }
+            }
         }
     }
 
-    p > code {
+    code:has(.bard-mark) {
         @apply font-mono bg-gray-400 rounded-sm text-xs relative;
         padding: 2px 4px;
         top: -1px;
     }
 
-    pre {
+    pre.bard-node {
         margin-bottom: .85em;
+        > code {
+            @apply font-mono bg-gray-400 text-xs p-4 block w-full rounded;
+            line-height: 1.8;
+        }
     }
 
-    pre code {
-        @apply font-mono bg-gray-400 text-xs p-4 block w-full rounded;
-        line-height: 1.8;
-    }
 }
 
 /* Placeholder

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -263,7 +263,6 @@
         text-size-adjust: 100%;
         margin-top: 0;
         margin-bottom: .85em;
-        color: red !important;
     }
 
     b:has(.bard-mark),
@@ -278,7 +277,6 @@
 
     a:has(.bard-mark) {
         @apply text-blue underline break-words;
-        color: purple !important;
 
         &:active,
         &:focus,

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -265,17 +265,17 @@
         margin-bottom: .85em;
     }
 
-    b:has(.bard-mark),
-    strong:has(.bard-mark) {
+    b .bard-mark,
+    strong .bard-mark {
         font-weight: 700;
     }
 
-    em:has(.bard-mark),
-    i:has(.bard-mark) {
+    em .bard-mark,
+    i .bard-mark {
         font-style: italic
     }
 
-    a:has(.bard-mark) {
+    a .bard-mark {
         @apply text-blue underline break-words;
 
         &:active,
@@ -421,7 +421,7 @@
         }
     }
 
-    code:has(.bard-mark) {
+    code .bard-mark {
         @apply font-mono bg-gray-400 rounded-sm text-xs relative;
         padding: 2px 4px;
         top: -1px;

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -221,7 +221,8 @@
         @apply px-6 py-16 flex flex-col;
         min-height: calc(100vh - 120px);
 
-        > p > code, > pre code {
+        code .bard-mark,
+        pre.bard-node > code {
             @apply bg-gray-300;
         }
 

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -139,6 +139,7 @@ import { Set } from './Set'
 import { Small } from './Small';
 import { Image } from './Image';
 import { Link } from './Link';
+import { CssHelper } from './CssHelper';
 import LinkToolbarButton from './LinkToolbarButton.vue';
 import ManagesSetMeta from '../replicator/ManagesSetMeta';
 import { availableButtons, addButtonHtml } from '../bard/buttons';
@@ -614,6 +615,7 @@ export default {
         getExtensions() {
             let exts = [
                 CharacterCount.configure({ limit: this.config.character_limit }),
+                CssHelper,
                 ...(this.inputIsInline ? [DocumentInline] : [DocumentBlock, HardBreak]),
                 Dropcursor,
                 Gapcursor,

--- a/resources/js/components/fieldtypes/bard/CssHelper.js
+++ b/resources/js/components/fieldtypes/bard/CssHelper.js
@@ -1,0 +1,30 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+export const CssHelper = Extension.create({
+
+    name: 'cssHelper',
+
+    addProseMirrorPlugins() {
+        return [
+            new Plugin({
+                key: new PluginKey('cssHelper'),
+                props: {
+                    decorations(state) {
+                        const decorations = [];
+                        state.doc.descendants((node, pos) => {
+                            if (node.type.name !== 'text') {
+                                decorations.push(Decoration.node(pos, pos + node.nodeSize, { class: 'bard-node' }));
+                            } else if (node.marks.length) {
+                                decorations.push(Decoration.inline(pos, pos + node.nodeSize, { class: 'bard-mark' }));
+                            }
+                        });
+                        return DecorationSet.create(state.doc, decorations);
+                    }
+                },
+            }),
+        ]
+    },
+
+})


### PR DESCRIPTION
This is more of an idea really, but I thought I’d PR it since I’d written the code when trying it out. Targets master as it might fit with the other v4 stuff (and it could be breaking for people who've implemented custom CSS).

This PR replaces the descendant selector method of styling Bard text elements with a custom decorator plugin that adds bard-specific classes to those elements instead, removing the need to rely on the hierarchy and still preventing the styles from leaking into sets and other custom views within the editor.

This has a couple of advantages:

1. The code needed to style nested elements of different types is much simpler and more robust. I've submitted a couple of PRs related to this in the past, but there's still the odd gap (eg. headings inside blockquotes and tables)
2. When extending Bard, content within custom text-based nodes can just rely on the built-in styles, rather than duplicating things. Full disclosure: I have to do that in Texstyle to make some current/future things work, and I'd really love to remove that bloat.

The plugin works by adding a `.bard-node` class to node elements, and a `span.bard-mark` inside mark elements (unfortunately I don’t think ProseMirror supports decorating mark elements directly). These additions are entirely internal and do not affect the value of the Bard field. Even if you copy the content out to another app the extra classes/elements aren’t included.

Saying that, this would obviously need thorough testing, and there could well be something I’ve overlooked.