### PR TITLE
[4.x] Focal point editor fixes

### DIFF
--- a/resources/css/components/focal-point.css
+++ b/resources/css/components/focal-point.css
@@ -3,14 +3,8 @@
    ========================================================================== */
 
 .focal-point {
-    position: fixed;
-    z-index: 10000;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    @apply absolute inset-0 bg-gray-800;
     border: 5px solid #394045;
-    @apply bg-gray-800;
 }
 
 .focal-point-toolbox {

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -166,24 +166,20 @@
 
         </template>
 
-        <portal name="asset-editor">
-            <div>
-            <focal-point-editor
-                v-if="showFocalPointEditor && isFocalPointEditorEnabled"
-                :data="values.focus"
-                :image="asset.preview"
-                @selected="selectFocalPoint"
-                @closed="closeFocalPointEditor" />
+        <editor-actions
+            v-if="actions.length"
+            :id="id"
+            :actions="actions"
+            :url="actionUrl"
+            @started="actionStarted"
+            @completed="actionCompleted" />
 
-            <editor-actions
-                v-if="actions.length"
-                :id="id"
-                :actions="actions"
-                :url="actionUrl"
-                @started="actionStarted"
-                @completed="actionCompleted" />
-            </div>
-        </portal>
+        <focal-point-editor
+            v-if="showFocalPointEditor && isFocalPointEditorEnabled"
+            :data="values.focus"
+            :image="asset.preview"
+            @selected="selectFocalPoint"
+            @closed="closeFocalPointEditor" />
 
     </div>
 

--- a/resources/js/components/assets/Editor/FocalPointEditor.vue
+++ b/resources/js/components/assets/Editor/FocalPointEditor.vue
@@ -1,5 +1,6 @@
 <template>
 
+    <portal name="focal-point">
     <div class="focal-point">
         <div class="focal-point-toolbox card p-0">
             <div class="p-4">
@@ -46,6 +47,7 @@
             <focal-point-preview-frame v-if="imageDimensions" :x="x" :y="y" :z="z" :image-url="image" :image-dimensions="imageDimensions" />
         </div>
     </div>
+    </portal>
 
 </template>
 

--- a/resources/js/components/assets/Editor/FocalPointEditor.vue
+++ b/resources/js/components/assets/Editor/FocalPointEditor.vue
@@ -107,8 +107,8 @@ export default {
             var imageW = rect.width;
             var imageH = rect.height;
 
-            var offsetX = e.pageX - rect.left;
-            var offsetY = e.pageY - rect.top;
+            var offsetX = e.clientX - rect.left;
+            var offsetY = e.clientY - rect.top;
 
             this.x = ((offsetX/imageW)*100).toFixed();
             this.y = ((offsetY/imageH)*100).toFixed();


### PR DESCRIPTION
- Fix offset issue. Using `e.pageY` included scroll position. `e.clientY` doesn't. Something must have changed in our portals etc. Closes #7929
- Move portal inside focal point component. It's not needed around the actions since they are all just their own portals.
- Simplify css. fixed and z-index not necessary.
