### PR TITLE
[4.x] Fix processing completly `null` date fieldtype values

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -193,7 +193,7 @@ class Date extends Fieldtype
 
     public function process($data)
     {
-        if (is_null($data['date'])) {
+        if (is_null($data) || is_null($data['date'])) {
             return null;
         }
 

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -126,9 +126,10 @@ class UserController extends Controller
             return $this->userProfileFailure($validator->errors());
         }
 
-        $values = $fields->process()->values()
+        $values = $fields
             ->only(array_keys($values))
-            ->except(['email', 'password', 'groups', 'roles', 'super']);
+            ->except(['email', 'password', 'groups', 'roles', 'super'])
+            ->process()->values();
 
         if ($request->email) {
             $user->email($request->email);


### PR DESCRIPTION
Rob ran into a `trying to access array offset on value of type null` error when using the `user:profile_form` tag in v4.

Turns out the date fieldtype's process method has been updated to expect an array with a `date` key, but it's possible for the value passed to simply be `null` if you have a date field in your user blueprint, implement the `user:profile_form`, but don't include that field in the form.

This PR fixes that by also checking that `$data` isn't null.

Related to this, it probably makes sense to only process values that are actually submitted through the  `user:profile_form`, rather than also processing a bunch of nulls. So this PR also moves the field filtering to before the process call in `UserController::profile()`.