### PR TITLE
Fix bard link extension is stripping out the domain part when pasting a url

### DIFF
--- a/resources/js/components/fieldtypes/bard/Link.js
+++ b/resources/js/components/fieldtypes/bard/Link.js
@@ -55,7 +55,7 @@ export const Link = Mark.create({
     addPasteRules() {
         return [
             markPasteRule({
-                find: /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g,
+                find: /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_+.~#?&//=]*)/g,
                 type: this.type,
                 getAttributes: url => ({
                     href: url[0]


### PR DESCRIPTION
Fixes #7813 