### PR TITLE
Make `absolute_url` available in Nav tag

### DIFF
--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -140,6 +140,7 @@ class Structure extends Tags
                 'is_current'  => ! is_null($url) && rtrim($url, '/') === rtrim($this->currentUrl, '/'),
                 'is_parent'   => ! is_null($url) && $this->siteAbsoluteUrl !== $absoluteUrl && URL::isAncestorOf($this->currentUrl, $url),
                 'is_external' => URL::isExternal((string) $absoluteUrl),
+                'absolute_url' => $absoluteUrl,
             ]);
         })->filter()->values();
 

--- a/tests/Tags/StructureTagTest.php
+++ b/tests/Tags/StructureTagTest.php
@@ -388,7 +388,6 @@ EOT;
     {
         $this->createCollectionAndNav();
 
-        // The html uses <i> tags (could be any tag, but i is short) to prevent whitespace comparison issues in the assertion.
         $template = <<<'EOT'
 <ul>
 {{ nav:test }}
@@ -416,10 +415,7 @@ EOT;
 </ul>
 EOT;
 
-        $this->assertXmlStringEqualsXmlString($expected, (string) Antlers::parse($template, [
-            'foo' => 'bar', // to test that cascade is inherited.
-            'title' => 'outer title', // to test that cascade the page's data takes precedence over the cascading data.
-        ]));
+        $this->assertXmlStringEqualsXmlString($expected, (string) Antlers::parse($template));
     }
 
     private function makeNav($tree)

--- a/tests/Tags/StructureTagTest.php
+++ b/tests/Tags/StructureTagTest.php
@@ -8,7 +8,6 @@ use Statamic\Facades\Antlers;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Nav;
-use Statamic\Facades\Site;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 


### PR DESCRIPTION
This pull request makes an `{{ absolute_url }}` variable available when using the Nav tag.

## Example

```antlers
{{ nav:footer_links }}
    <a href="{{ absolute_url }}">{{ title }}</a>
{{ /nav:footer_links }}
```

## Use case

There's probably lots of use cases for this but our particular one is that the header & footer HTML generated by Statamic will be fed into a third-party integration so the URLs output in the header & footer need to be absolute URLs.