### PR TITLE
[4.x] Date fieldtype improvements

### DIFF
--- a/resources/css/components/fieldtypes/datetime.css
+++ b/resources/css/components/fieldtypes/datetime.css
@@ -36,9 +36,9 @@
 	@apply flex;
 }
 
-/*  Dear sweet baby Jesus please forgive me for this brittle selector */
-.date-time-container .date-container > span > .vc-popover-content-wrapper {
-	left: -50px !important;
+/* Remove style from datepicker in popover since the popover has them. */
+.popover-content .vc-container {
+    @apply border-none bg-none;
 }
 
 /* Time Field

--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -139,9 +139,6 @@ export default {
                 modelConfig: { type: 'string', mask: this.format },
                 updateOnInput: false,
                 value: this.datePickerValue,
-
-                // probably no longer needed
-                popover: { visibility: 'focus' },
             };
         },
 

--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -6,9 +6,6 @@
     		{{ __('Add Date') }}
     	</button>
 
-        <pre>{{ value }}</pre>
-
-
         <div v-if="hasDate || config.inline"
             class="date-time-container flex flow-col @sm:flex-row"
             :class="config.time_seconds_enabled ? 'space-x-1' : 'space-x-3'"

--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -91,7 +91,6 @@
 			</div>
         </div>
     </div>
-    </element-container>
 
 </template>
 

--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -14,6 +14,8 @@
                 :is="pickerComponent"
                 v-bind="pickerProps"
                 @input="setDate"
+                @focus="focusedField = $event"
+                @blur="focusedField = null"
             />
 
             <div v-if="config.time_enabled && !isRange" class="time-container @xs:ml-2 @xs:mt-0 time-fieldtype">

--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -13,27 +13,8 @@
             class="date-time-container flex flow-col @sm:flex-row"
             :class="config.time_seconds_enabled ? 'space-x-1' : 'space-x-3'"
         >
-
-            <SinglePopover
-                v-if="isSingle && usesPopover"
-                v-bind="pickerProps"
-                @input="setDate"
-            />
-
-            <SingleInline
-                v-if="isSingle && isInline"
-                v-bind="pickerProps"
-                @input="setDate"
-            />
-
-            <RangePopover
-                v-if="isRange && usesPopover"
-                v-bind="pickerProps"
-                @input="setDate"
-            />
-
-            <RangeInline
-                v-if="isRange && isInline"
+            <component
+                :is="pickerComponent"
                 v-bind="pickerProps"
                 @input="setDate"
             />
@@ -83,6 +64,14 @@ export default {
     },
 
     computed: {
+
+        pickerComponent() {
+            if (this.isRange) {
+                return this.usesPopover ? 'RangePopover' : 'RangeInline';
+            }
+
+            return this.usesPopover ? 'SinglePopover' : 'SingleInline';
+        },
 
         hasDate() {
             return this.config.required || this.value.date;

--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -12,24 +12,7 @@
         >
 
             <div class="flex-1 date-container">
-                <v-date-picker
-                    :attributes="attrs"
-                    :class="{ 'w-full': !config.inline }"
-                    :columns="$screens({ default: 1, lg: config.columns })"
-                    :is-expanded="name === 'date' || config.full_width"
-                    :is-range="isRange"
-                    :is-required="config.required"
-                    :locale="$config.get('locale').replace('_', '-')"
-                    :masks="{ input: [displayFormat] }"
-                    :min-date="config.earliest_date.date"
-                    :max-date="config.latest_date.date"
-                    :model-config="modelConfig"
-                    :popover="{ visibility: 'focus' }"
-                    :rows="$screens({ default: 1, lg: config.rows })"
-                    :update-on-input="false"
-                    :value="datePickerValue"
-                    @input="setDate"
-                >
+                <v-date-picker v-bind="datePickerBindings" v-on="datePickerEvents">
                     <template v-if="!config.inline" v-slot="{ inputValue, inputEvents }">
                         <!-- Date range inputs -->
                         <div
@@ -171,6 +154,32 @@ export default {
             // we expect. The time is handled separately by the nested time fieldtype.
             // https://github.com/statamic/cms/pull/6688
             return this.value.date+'T00:00:00';
+        },
+
+        datePickerBindings() {
+            return {
+                attributes: this.attrs,
+                class: { 'w-full': !this.config.inline },
+                columns: this.$screens({ default: 1, lg: this.config.columns }),
+                isExpanded: this.name === 'date' || this.config.full_width,
+                isRange: this.isRange,
+                isRequired: this.config.required,
+                locale: this.$config.get('locale').replace('_', '-'),
+                masks: { input: [this.displayFormat] },
+                minDate: this.config.earliest_date.date,
+                maxDate: this.config.latest_date.date,
+                modelConfig: this.modelConfig,
+                popover: { visibility: 'focus' },
+                rows: this.$screens({ default: 1, lg: this.config.rows }),
+                updateOnInput: false,
+                value: this.datePickerValue,
+            };
+        },
+
+        datePickerEvents() {
+            return {
+                input: this.setDate
+            };
         },
 
         format() {

--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -140,10 +140,6 @@ export default {
                 updateOnInput: false,
                 value: this.datePickerValue,
 
-
-                // merge separately
-                class: { 'w-full': !this.config.inline }, // move to the "Popover" versions
-
                 // probably no longer needed
                 popover: { visibility: 'focus' },
             };

--- a/resources/js/components/fieldtypes/date/Picker.js
+++ b/resources/js/components/fieldtypes/date/Picker.js
@@ -1,0 +1,6 @@
+export default {
+    props: {
+        isReadOnly: { type: Boolean, default: false },
+        bindings: { type: Object },
+    }
+}

--- a/resources/js/components/fieldtypes/date/RangeInline.vue
+++ b/resources/js/components/fieldtypes/date/RangeInline.vue
@@ -1,0 +1,18 @@
+<template>
+
+    <v-date-picker
+        v-bind="{ ...bindings, isRange: true }"
+        @input="$emit('input', $event)"
+    />
+
+</template>
+
+<script>
+import Picker from './Picker';
+
+export default {
+
+    mixins: [Picker],
+
+}
+</script>

--- a/resources/js/components/fieldtypes/date/RangeInline.vue
+++ b/resources/js/components/fieldtypes/date/RangeInline.vue
@@ -1,9 +1,12 @@
 <template>
 
-    <v-date-picker
-        v-bind="pickerBindings"
-        @input="$emit('input', $event)"
-    />
+    <div class="relative">
+        <v-date-picker
+            v-bind="pickerBindings"
+            @input="$emit('input', $event)"
+        />
+        <div class="absolute inset-0 z-1 cursor-not-allowed" v-if="isReadOnly" />
+    </div>
 
 </template>
 

--- a/resources/js/components/fieldtypes/date/RangeInline.vue
+++ b/resources/js/components/fieldtypes/date/RangeInline.vue
@@ -1,7 +1,7 @@
 <template>
 
     <v-date-picker
-        v-bind="{ ...bindings, isRange: true }"
+        v-bind="pickerBindings"
         @input="$emit('input', $event)"
     />
 
@@ -13,6 +13,18 @@ import Picker from './Picker';
 export default {
 
     mixins: [Picker],
+
+    computed: {
+
+        pickerBindings() {
+            return {
+                ...this.bindings,
+                isRange: true,
+                disabledDates: this.isReadOnly ? { weekdays: [1, 2, 3, 4, 5, 6, 7] } : null
+            }
+        },
+
+    }
 
 }
 </script>

--- a/resources/js/components/fieldtypes/date/RangePopover.vue
+++ b/resources/js/components/fieldtypes/date/RangePopover.vue
@@ -2,54 +2,81 @@
 
     <div>
 
-        <v-date-picker
-            ref="picker"
-            v-bind="{...bindings, isRange: true}"
-            @input="$emit('input', $event)"
-        />
-
+        <v-portal :disabled="!open" :to="portalTarget">
+            <v-date-picker
+                ref="picker"
+                v-bind="{...bindings, isRange: true}"
+                v-show="open"
+                @input="dateSelected"
+            />
+        </v-portal>
 
         <div
             class="w-full flex items-start @md:items-center flex-col @md:flex-row"
         >
-            <div class="input-group">
-                <div class="input-group-prepend flex items-center">
-                    <svg-icon name="light/calendar" class="w-4 h-4" />
-                </div>
-                <div class="input-text border border-gray-500 border-l-0" :class="{ 'read-only': isReadOnly }">
-                    <input
-                        class="input-text-minimal p-0 bg-transparent leading-none"
-                        :value="startInputValue"
-                        v-on="startInputEvents"
-                    />
-                        <!-- :value="inputValue.start"
-                        :readonly="isReadOnly"
-                        @focus="focusedField = $event.target"
-                        @blur="focusedField = null"
-                        v-on="!isReadOnly && inputEvents.start" -->
-                </div>
-            </div>
+
+            <popover
+                ref="startPopover"
+                placement="bottom-start"
+                @opened="startPopoverOpened"
+                @closed="startPopoverClosed"
+            >
+                <template #trigger>
+                    <div class="input-group">
+                        <div class="input-group-prepend flex items-center">
+                            <svg-icon name="light/calendar" class="w-4 h-4" />
+                        </div>
+                        <div class="input-text border border-gray-500 border-l-0" :class="{ 'read-only': isReadOnly }">
+                            <input
+                                class="input-text-minimal p-0 bg-transparent leading-none"
+                                :value="startInputValue"
+                                v-on="startInputEvents"
+                            />
+                                <!-- :value="inputValue.start"
+                                :readonly="isReadOnly"
+                                @focus="focusedField = $event.target"
+                                @blur="focusedField = null"
+                                v-on="!isReadOnly && inputEvents.start" -->
+                        </div>
+                    </div>
+                </template>
+                <portal-target :name="startPortalTarget" />
+                start popover
+            </popover>
 
             <svg-icon name="micro/arrow-right" class="w-6 h-6 my-1 mx-2 text-gray-700 hidden @md:block" />
             <svg-icon name="micro/arrow-right" class="w-3.5 h-3.5 my-2 mx-2.5 rotate-90 text-gray-700 @md:hidden" />
 
-            <div class="input-group">
-                <div class="input-group-prepend flex items-center">
-                    <svg-icon name="light/calendar" class="w-4 h-4" />
-                </div>
-                <div class="input-text border border-gray-500 border-l-0" :class="{ 'read-only': isReadOnly }">
-                    <input
-                        class="input-text-minimal p-0 bg-transparent leading-none"
-                        :value="endInputValue"
-                        v-on="endInputEvents"
-                    />
-                        <!-- :value="inputValue.end"
-                        :readonly="isReadOnly"
-                        @focus="focusedField = $event.target"
-                        @blur="focusedField = null"
-                        v-on="!isReadOnly && inputEvents.end" -->
-                </div>
-            </div>
+
+            <popover
+                ref="endPopover"
+                placement="bottom-start"
+                @opened="endPopoverOpened"
+                @closed="endPopoverClosed"
+            >
+                <template #trigger>
+                    <div class="input-group">
+                        <div class="input-group-prepend flex items-center">
+                            <svg-icon name="light/calendar" class="w-4 h-4" />
+                        </div>
+                        <div class="input-text border border-gray-500 border-l-0" :class="{ 'read-only': isReadOnly }">
+                            <input
+                                class="input-text-minimal p-0 bg-transparent leading-none"
+                                :value="endInputValue"
+                                v-on="endInputEvents"
+                            />
+                                <!-- :value="inputValue.end"
+                                :readonly="isReadOnly"
+                                @focus="focusedField = $event.target"
+                                @blur="focusedField = null"
+                                v-on="!isReadOnly && inputEvents.end" -->
+                        </div>
+                    </div>
+                </template>
+                <portal-target :name="endPortalTarget" />
+                end popover
+            </popover>
+
         </div>
 
     </div>
@@ -65,46 +92,105 @@ export default {
 
     data() {
         return {
-            mounted: false,
+            startOpen: false,
+            endOpen: false,
+            picker: null,
+            portalTarget: null,
+            startPortalTarget: `date-picker-start-${this._uid}`,
+            endPortalTarget: `date-picker-end-${this._uid}`,
+            startInputValue: null,
+            endInputValue: null,
         }
     },
 
     computed: {
 
-        startInputValue() {
-            return this.mounted ? this.$refs.picker.inputValues[0] : null;
-        },
-
-        endInputValue() {
-            return this.mounted ? this.$refs.picker.inputValues[1] : null;
+        open() {
+            return this.startOpen || this.endOpen;
         },
 
         startInputEvents() {
-            if (!this.mounted) return;
-
             return {
                 // Handle changing the date when typing.
-                change: (e) => this.$refs.picker.onInputUpdate(e.target.value, true, { formatInput: true }),
+                change: (e) => this.picker.onInputUpdate(e.target.value, true, { formatInput: true }),
                 // Allows hitting escape to cancel any changes.
-                keyup: (e) => this.$refs.picker.onInputKeyup(e),
+                keyup: (e) => this.picker.onInputKeyup(e),
             };
         },
 
         endInputEvents() {
-            if (!this.mounted) return;
-
             return {
                 // Handle changing the date when typing.
-                change: (e) => this.$refs.picker.onInputUpdate(e.target.value, false, { formatInput: true }),
+                change: (e) => this.picker.onInputUpdate(e.target.value, false, { formatInput: true }),
                 // Allows hitting escape to cancel any changes.
-                keyup: (e) => this.$refs.picker.onInputKeyup(e),
+                keyup: (e) => this.picker.onInputKeyup(e),
             };
         }
 
     },
 
+    watch: {
+
+        'bindings.value': function () {
+            this.$nextTick(() => this.updateInputValues());
+        },
+
+    },
+
     mounted() {
-        this.mounted = true;
+        this.$nextTick(() => {
+            this.resetPicker();
+            this.updateInputValues();
+        });
+    },
+
+    methods: {
+
+        startPopoverOpened() {
+            if (this.endOpen) this.$refs.endPopover.close();
+
+            this.startOpen = true;
+            this.portalTarget = this.startPortalTarget;
+            this.$nextTick(() => this.resetPicker());
+        },
+
+        startPopoverClosed() {
+            this.startOpen = false;
+            this.portalTarget = null;
+            this.$nextTick(() => this.resetPicker());
+        },
+
+        endPopoverOpened() {
+            if (this.startOpen) this.$refs.startPopover.close();
+
+            this.endOpen = true;
+            this.portalTarget = this.endPortalTarget;
+            this.$nextTick(() => this.resetPicker());
+        },
+
+        endPopoverClosed() {
+            this.endOpen = false;
+            this.portalTarget = null;
+            this.$nextTick(() => this.resetPicker());
+        },
+
+        updateInputValues() {
+            this.startInputValue = this.picker.inputValues[0];
+            this.endInputValue = this.picker.inputValues[1];
+        },
+
+        dateSelected(date) {
+            this.$emit('input', date)
+            this.$nextTick(() => {
+                this.$refs.startPopover.close()
+                this.$refs.endPopover.close()
+            });
+        },
+
+        resetPicker() {
+            this.picker = this.$refs.picker;
+        }
+
     }
 
 }

--- a/resources/js/components/fieldtypes/date/RangePopover.vue
+++ b/resources/js/components/fieldtypes/date/RangePopover.vue
@@ -1,0 +1,111 @@
+<template>
+
+    <div>
+
+        <v-date-picker
+            ref="picker"
+            v-bind="{...bindings, isRange: true}"
+            @input="$emit('input', $event)"
+        />
+
+
+        <div
+            class="w-full flex items-start @md:items-center flex-col @md:flex-row"
+        >
+            <div class="input-group">
+                <div class="input-group-prepend flex items-center">
+                    <svg-icon name="light/calendar" class="w-4 h-4" />
+                </div>
+                <div class="input-text border border-gray-500 border-l-0" :class="{ 'read-only': isReadOnly }">
+                    <input
+                        class="input-text-minimal p-0 bg-transparent leading-none"
+                        :value="startInputValue"
+                        v-on="startInputEvents"
+                    />
+                        <!-- :value="inputValue.start"
+                        :readonly="isReadOnly"
+                        @focus="focusedField = $event.target"
+                        @blur="focusedField = null"
+                        v-on="!isReadOnly && inputEvents.start" -->
+                </div>
+            </div>
+
+            <svg-icon name="micro/arrow-right" class="w-6 h-6 my-1 mx-2 text-gray-700 hidden @md:block" />
+            <svg-icon name="micro/arrow-right" class="w-3.5 h-3.5 my-2 mx-2.5 rotate-90 text-gray-700 @md:hidden" />
+
+            <div class="input-group">
+                <div class="input-group-prepend flex items-center">
+                    <svg-icon name="light/calendar" class="w-4 h-4" />
+                </div>
+                <div class="input-text border border-gray-500 border-l-0" :class="{ 'read-only': isReadOnly }">
+                    <input
+                        class="input-text-minimal p-0 bg-transparent leading-none"
+                        :value="endInputValue"
+                        v-on="endInputEvents"
+                    />
+                        <!-- :value="inputValue.end"
+                        :readonly="isReadOnly"
+                        @focus="focusedField = $event.target"
+                        @blur="focusedField = null"
+                        v-on="!isReadOnly && inputEvents.end" -->
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+</template>
+
+<script>
+import Picker from './Picker';
+
+export default {
+
+    mixins: [Picker],
+
+    data() {
+        return {
+            mounted: false,
+        }
+    },
+
+    computed: {
+
+        startInputValue() {
+            return this.mounted ? this.$refs.picker.inputValues[0] : null;
+        },
+
+        endInputValue() {
+            return this.mounted ? this.$refs.picker.inputValues[1] : null;
+        },
+
+        startInputEvents() {
+            if (!this.mounted) return;
+
+            return {
+                // Handle changing the date when typing.
+                change: (e) => this.$refs.picker.onInputUpdate(e.target.value, true, { formatInput: true }),
+                // Allows hitting escape to cancel any changes.
+                keyup: (e) => this.$refs.picker.onInputKeyup(e),
+            };
+        },
+
+        endInputEvents() {
+            if (!this.mounted) return;
+
+            return {
+                // Handle changing the date when typing.
+                change: (e) => this.$refs.picker.onInputUpdate(e.target.value, false, { formatInput: true }),
+                // Allows hitting escape to cancel any changes.
+                keyup: (e) => this.$refs.picker.onInputKeyup(e),
+            };
+        }
+
+    },
+
+    mounted() {
+        this.mounted = true;
+    }
+
+}
+</script>

--- a/resources/js/components/fieldtypes/date/RangePopover.vue
+++ b/resources/js/components/fieldtypes/date/RangePopover.vue
@@ -34,11 +34,9 @@
                                 :readonly="isReadOnly"
                                 :value="startInputValue"
                                 v-on="startInputEvents"
+                                @focus="$emit('focus', $event.target)"
+                                @blur="$emit('blur')"
                             />
-                                <!-- :value="inputValue.start"
-                                @focus="focusedField = $event.target"
-                                @blur="focusedField = null"
-                                v-on="!isReadOnly && inputEvents.start" -->
                         </div>
                     </div>
                 </template>
@@ -68,11 +66,9 @@
                                 :readonly="isReadOnly"
                                 :value="endInputValue"
                                 v-on="endInputEvents"
+                                @focus="$emit('focus', $event.target)"
+                                @blur="$emit('blur')"
                             />
-                                <!-- :value="inputValue.end"
-                                @focus="focusedField = $event.target"
-                                @blur="focusedField = null"
-                                v-on="!isReadOnly && inputEvents.end" -->
                         </div>
                     </div>
                 </template>

--- a/resources/js/components/fieldtypes/date/RangePopover.vue
+++ b/resources/js/components/fieldtypes/date/RangePopover.vue
@@ -5,7 +5,7 @@
         <v-portal :disabled="!open" :to="portalTarget">
             <v-date-picker
                 ref="picker"
-                v-bind="{...bindings, isRange: true}"
+                v-bind="pickerBindings"
                 v-show="open"
                 @input="dateSelected"
             />
@@ -19,6 +19,7 @@
                 ref="startPopover"
                 placement="bottom-start"
                 class="w-full"
+                :disabled="isReadOnly"
                 @opened="startPopoverOpened"
                 @closed="startPopoverClosed"
             >
@@ -30,11 +31,11 @@
                         <div class="input-text border border-gray-500 border-l-0" :class="{ 'read-only': isReadOnly }">
                             <input
                                 class="input-text-minimal p-0 bg-transparent leading-none"
+                                :readonly="isReadOnly"
                                 :value="startInputValue"
                                 v-on="startInputEvents"
                             />
                                 <!-- :value="inputValue.start"
-                                :readonly="isReadOnly"
                                 @focus="focusedField = $event.target"
                                 @blur="focusedField = null"
                                 v-on="!isReadOnly && inputEvents.start" -->
@@ -52,6 +53,7 @@
                 ref="endPopover"
                 placement="bottom-start"
                 class="w-full"
+                :disabled="isReadOnly"
                 @opened="endPopoverOpened"
                 @closed="endPopoverClosed"
             >
@@ -63,11 +65,11 @@
                         <div class="input-text border border-gray-500 border-l-0" :class="{ 'read-only': isReadOnly }">
                             <input
                                 class="input-text-minimal p-0 bg-transparent leading-none"
+                                :readonly="isReadOnly"
                                 :value="endInputValue"
                                 v-on="endInputEvents"
                             />
                                 <!-- :value="inputValue.end"
-                                :readonly="isReadOnly"
                                 @focus="focusedField = $event.target"
                                 @blur="focusedField = null"
                                 v-on="!isReadOnly && inputEvents.end" -->
@@ -104,6 +106,14 @@ export default {
     },
 
     computed: {
+
+        pickerBindings() {
+            return {
+                ...this.bindings,
+                isRange: true,
+                disabledDates: this.isReadOnly ? { weekdays: [1, 2, 3, 4, 5, 6, 7] } : null
+            }
+        },
 
         open() {
             return this.startOpen || this.endOpen;

--- a/resources/js/components/fieldtypes/date/RangePopover.vue
+++ b/resources/js/components/fieldtypes/date/RangePopover.vue
@@ -1,6 +1,6 @@
 <template>
 
-    <div>
+    <div class="w-full">
 
         <v-portal :disabled="!open" :to="portalTarget">
             <v-date-picker
@@ -18,6 +18,7 @@
             <popover
                 ref="startPopover"
                 placement="bottom-start"
+                class="w-full"
                 @opened="startPopoverOpened"
                 @closed="startPopoverClosed"
             >
@@ -50,6 +51,7 @@
             <popover
                 ref="endPopover"
                 placement="bottom-start"
+                class="w-full"
                 @opened="endPopoverOpened"
                 @closed="endPopoverClosed"
             >

--- a/resources/js/components/fieldtypes/date/RangePopover.vue
+++ b/resources/js/components/fieldtypes/date/RangePopover.vue
@@ -41,7 +41,6 @@
                     </div>
                 </template>
                 <portal-target :name="startPortalTarget" />
-                start popover
             </popover>
 
             <svg-icon name="micro/arrow-right" class="w-6 h-6 my-1 mx-2 text-gray-700 hidden @md:block" />
@@ -74,7 +73,6 @@
                     </div>
                 </template>
                 <portal-target :name="endPortalTarget" />
-                end popover
             </popover>
 
         </div>

--- a/resources/js/components/fieldtypes/date/SingleInline.vue
+++ b/resources/js/components/fieldtypes/date/SingleInline.vue
@@ -1,9 +1,12 @@
 <template>
 
-    <v-date-picker
-        v-bind="pickerBindings"
-        @input="$emit('input', $event)"
-    />
+    <div class="relative">
+        <v-date-picker
+            v-bind="pickerBindings"
+            @input="$emit('input', $event)"
+        />
+        <div class="absolute inset-0 z-1 cursor-not-allowed" v-if="isReadOnly" />
+    </div>
 
 </template>
 

--- a/resources/js/components/fieldtypes/date/SingleInline.vue
+++ b/resources/js/components/fieldtypes/date/SingleInline.vue
@@ -1,7 +1,7 @@
 <template>
 
     <v-date-picker
-        v-bind="bindings"
+        v-bind="pickerBindings"
         @input="$emit('input', $event)"
     />
 
@@ -13,6 +13,17 @@ import Picker from './Picker';
 export default {
 
     mixins: [Picker],
+
+    computed: {
+
+        pickerBindings() {
+            return {
+                ...this.bindings,
+                disabledDates: this.isReadOnly ? { weekdays: [1, 2, 3, 4, 5, 6, 7] } : null
+            }
+        },
+
+    }
 
 }
 </script>

--- a/resources/js/components/fieldtypes/date/SingleInline.vue
+++ b/resources/js/components/fieldtypes/date/SingleInline.vue
@@ -1,0 +1,18 @@
+<template>
+
+    <v-date-picker
+        v-bind="bindings"
+        @input="$emit('input', $event)"
+    />
+
+</template>
+
+<script>
+import Picker from './Picker';
+
+export default {
+
+    mixins: [Picker],
+
+}
+</script>

--- a/resources/js/components/fieldtypes/date/SinglePopover.vue
+++ b/resources/js/components/fieldtypes/date/SinglePopover.vue
@@ -14,6 +14,7 @@
         <popover
             ref="popover"
             placement="bottom-start"
+            :disabled="isReadOnly"
             @opened="popoverStateChanged(true)"
             @closed="popoverStateChanged(false)"
         >
@@ -25,14 +26,13 @@
                     <div class="input-text border border-gray-500 border-l-0" :class="{ 'read-only': isReadOnly }">
                         <input
                             class="input-text-minimal p-0 bg-transparent leading-none"
+                            :readonly="isReadOnly"
                             :value="inputValue"
                             v-on="inputEvents"
                         />
                             <!-- :value="inputValue"
-                            :readonly="isReadOnly"
                             @focus="focusedField = $event.target"
-                            @blur="focusedField = null"
-                            v-on="!isReadOnly && inputEvents" -->
+                            @blur="focusedField = null" -->
                     </div>
                 </div>
             </template>

--- a/resources/js/components/fieldtypes/date/SinglePopover.vue
+++ b/resources/js/components/fieldtypes/date/SinglePopover.vue
@@ -1,0 +1,70 @@
+<template>
+
+    <div>
+
+        <v-date-picker
+            ref="picker"
+            v-bind="bindings"
+            @input="$emit('input', $event)"
+        />
+
+        <div class="input-group">
+            <div class="input-group-prepend flex items-center">
+                <svg-icon name="light/calendar" class="w-4 h-4" />
+            </div>
+            <div class="input-text border border-gray-500 border-l-0" :class="{ 'read-only': isReadOnly }">
+                <input
+                    class="input-text-minimal p-0 bg-transparent leading-none"
+                    :value="inputValue"
+                    v-on="inputEvents"
+                />
+                    <!-- :value="inputValue"
+                    :readonly="isReadOnly"
+                    @focus="focusedField = $event.target"
+                    @blur="focusedField = null"
+                    v-on="!isReadOnly && inputEvents" -->
+            </div>
+        </div>
+
+    </div>
+
+</template>
+
+<script>
+import Picker from './Picker';
+
+export default {
+
+    mixins: [Picker],
+
+    data() {
+        return {
+            mounted: false,
+        }
+    },
+
+    computed: {
+
+        inputValue() {
+            return this.mounted ? this.$refs.picker.inputValues[0] : null;
+        },
+
+        inputEvents() {
+            if (!this.mounted) return;
+
+            return {
+                // Handle changing the date when typing.
+                change: (e) => this.$refs.picker.onInputUpdate(e.target.value, true, { formatInput: true }),
+                // Allows hitting escape to cancel any changes.
+                keyup: (e) => this.$refs.picker.onInputKeyup(e),
+            };
+        }
+
+    },
+
+    mounted() {
+        this.mounted = true;
+    }
+
+}
+</script>

--- a/resources/js/components/fieldtypes/date/SinglePopover.vue
+++ b/resources/js/components/fieldtypes/date/SinglePopover.vue
@@ -93,7 +93,7 @@ export default {
 
         dateSelected(date) {
             this.$emit('input', date)
-            this.$nextTick(() => this.$refs.popover.close());
+            this.$nextTick(() => this.$refs.popover?.close());
         },
 
         resetPicker() {

--- a/resources/js/components/fieldtypes/date/SinglePopover.vue
+++ b/resources/js/components/fieldtypes/date/SinglePopover.vue
@@ -29,10 +29,9 @@
                             :readonly="isReadOnly"
                             :value="inputValue"
                             v-on="inputEvents"
+                            @focus="$emit('focus', $event.target)"
+                            @blur="$emit('blur')"
                         />
-                            <!-- :value="inputValue"
-                            @focus="focusedField = $event.target"
-                            @blur="focusedField = null" -->
                     </div>
                 </div>
             </template>

--- a/resources/js/components/fieldtypes/date/SinglePopover.vue
+++ b/resources/js/components/fieldtypes/date/SinglePopover.vue
@@ -1,6 +1,6 @@
 <template>
 
-    <div>
+    <div class="w-full">
 
         <v-portal :disabled="!open" :to="portalTarget">
             <v-date-picker


### PR DESCRIPTION
Fixes #7964

This PR basically swaps out v-calendar's built in popover logic for our own, which already handles portaling and stacking contexts.

- Split the UI logic into sub components. (Single w/popover, single inline, range w/popovers, range inline)
- Rather than using v-calendar's popover mode, they are all technically inline modes, but when we want popovers, we wrap it with our own popovers.
	- The date pickers are always on the page, so the inputs can be hooked up to them and use their very helpful built in logic. e.g. if you type an incorrect date like 2023-1-3 it'll change it to 2023-01-03.
	- When the popovers are closed, the date picker needs to still be there (but hidden) so the input field continues to work.
	- When the popovers are open, the date picker gets portalled into the popover.
	- Whe the datepicker goes in/out of a portal, the component is recreated, which is why the`$ref` is being tracked in a property and not used directly.
- Turns out read only mode wasn't hooked up for inline modes. Huh. Now they are!
	- I disabled every day in the v-calendar config so every date is unselectable.
	- Disabling days only prevents you from selecting, but you can still navigate through months/years so I added an invisible overlay to prevent clicks.