### PR TITLE
[4.x] Revert stopping propagation of Popover clicks

### DIFF
--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -51,10 +51,6 @@ export default {
             type: String,
             default: 'bottom-end',
         },
-        stopPropagation: {
-            type: Boolean,
-            default: true
-        },
     },
 
     data() {
@@ -97,8 +93,6 @@ export default {
         },
 
         toggle(e) {
-            if (this.stopPropagation) e.stopPropagation();
-
             this.isOpen ? this.close() : this.open();
         },
 

--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -218,23 +218,29 @@
                                         v-for="(asset, index) in assets"
                                         :key="asset.id"
                                         :class="{ 'selected': isSelected(asset.id) }"
-                                        @click="toggleSelection(asset.id, index, $event)"
-                                        @dblclick="$emit('edit-asset', asset)"
                                     >
-                                        <div class="asset-thumb-container">
-                                            <div class="asset-thumb">
-                                                <img v-if="asset.is_image" :src="asset.thumbnail" loading="lazy" :class="{'p-4 h-full w-full': asset.extension === 'svg'}" />
-                                                <file-icon
-                                                    v-else
-                                                    :extension="asset.extension"
-                                                    class="p-4 h-full w-full"
-                                                />
+                                        <div
+                                            class="w-full"
+                                            @click.stop="toggleSelection(asset.id, index, $event)"
+                                            @dblclick.stop="$emit('edit-asset', asset)"
+                                        >
+                                            <div class="asset-thumb-container">
+                                                <div class="asset-thumb">
+                                                    <img v-if="asset.is_image" :src="asset.thumbnail" loading="lazy" :class="{'p-4 h-full w-full': asset.extension === 'svg'}" />
+                                                    <file-icon
+                                                        v-else
+                                                        :extension="asset.extension"
+                                                        class="p-4 h-full w-full"
+                                                    />
+                                                </div>
+                                            </div>
+                                            <div class="asset-meta">
+                                                <div class="asset-filename px-2 py-1 text-center" v-text="asset.basename" :title="asset.basename" />
                                             </div>
                                         </div>
-                                        <div class="asset-meta">
-                                            <div class="asset-filename px-2 py-1 text-center" v-text="asset.basename" :title="asset.basename" />
-                                        </div>
-                                        <dropdown-list class="absolute top-1 right-2 opacity-0 group-hover:opacity-100">
+                                        <dropdown-list
+                                            class="absolute top-1 right-2 opacity-0 group-hover:opacity-100"
+                                        >
                                              <dropdown-item :text="__(canEdit ? 'Edit' : 'View')" @click="edit(asset.id)" />
                                              <div class="divider" v-if="asset.actions.length" />
                                              <data-list-inline-actions

--- a/resources/js/components/data-list/Filters.vue
+++ b/resources/js/components/data-list/Filters.vue
@@ -3,7 +3,7 @@
         <div class="flex flex-wrap px-3 border-b pt-2">
 
             <!-- Field filter (requires custom selection UI) -->
-            <popover v-if="fieldFilter" placement="bottom-start" :stop-propagation="false" @closed="fieldFilterClosed">
+            <popover v-if="fieldFilter" placement="bottom-start" @closed="fieldFilterClosed">
                 <template slot="trigger">
                     <button class="filter-badge filter-badge-control mr-2 mb-2" @click="resetFilterPopover">
                         {{ __('Field') }}
@@ -38,7 +38,7 @@
             </popover>
 
             <!-- Standard non-field filters -->
-            <popover v-if="standardFilters.length" v-for="filter in standardFilters" :key="filter.handle" placement="bottom-start" :stop-propagation="false">
+            <popover v-if="standardFilters.length" v-for="filter in standardFilters" :key="filter.handle" placement="bottom-start">
                 <template slot="trigger">
                     <button class="filter-badge filter-badge-control mr-2 mb-2">
                         {{ filter.title }}

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -5,7 +5,6 @@
         class="set-picker"
         placement="bottom-start"
         :disabled="!hasMultipleSets"
-        :stop-propagation="false"
         @opened="opened"
         @closed="closed"
         @click="triggerWasClicked"


### PR DESCRIPTION
First, a background. 😂 

- In #7844, we disabled propagation of clicks on the popover trigger element to fix #7840.
- Stopping propagation like this prevented v-on-clickaway from working, which caused the following issues:
	- #7861.
		- Fixed in #7862 by adding a prop.
	- #7898
		- Fixed in #7907 by using that prop.
	- If you have a dropdown list open, and you open a second, the first one stays open. (This PR fixes that)

So, this PR reverts stopping propagation since it caused more problems.

Instead, this fixes the original #7840 issue in a different way. Rather than the entire asset tile be clickable (including the twirldown), just wrap the clickable bits in a new div, attach the handlers to that, and let the twirldown sit on top.

Visually:

```
Tile (click handlers here)
    Dropdown
    Image
    Filename
```
becomes
```
Tile
    Dropdown
    Wrapper (click handlers here)
        Image
        Filename
```

Now since the twirldown is not a child, when you click it, the event won't bubble up causing the asset to be selected.