### PR TITLE
Adds support for checking if section names exist

### DIFF
--- a/src/View/Antlers/Language/Runtime/ConditionProcessor.php
+++ b/src/View/Antlers/Language/Runtime/ConditionProcessor.php
@@ -31,10 +31,18 @@ class ConditionProcessor
 
     public function process(ConditionNode $node, $data)
     {
+        $condValueToRestore = $this->processor->getIsConditionProcessor();
+
         foreach ($node->logicBranches as $branch) {
             if ($branch->head->name->name == 'else') {
                 return $branch;
             } else {
+                // Let the processor know that it is being used
+                // to help process a condition. Some tags are
+                // handled internally by the processor, and
+                // they may want to change their behavior.
+                $this->processor->setIsConditionProcessor(true);
+
                 $parser = new LanguageParser();
                 $environment = new Environment();
                 $environment->setProcessor($this->processor);
@@ -68,10 +76,14 @@ class ConditionProcessor
                 $result = $environment->evaluateBool(self::$branchCache[$branch->head->content]);
 
                 if ($result === true) {
+                    $this->processor->setIsConditionProcessor($condValueToRestore);
+
                     return $branch;
                 }
             }
         }
+
+        $this->processor->setIsConditionProcessor($condValueToRestore);
 
         return null;
     }

--- a/src/View/Antlers/Language/Runtime/LiteralReplacementManager.php
+++ b/src/View/Antlers/Language/Runtime/LiteralReplacementManager.php
@@ -9,6 +9,7 @@ class LiteralReplacementManager
     protected static $regions = [];
     protected static $replacements = [];
     protected static $globalReplacement = [];
+    protected static $registeredSections = [];
     protected static $retargeted = [];
 
     public static function resetLiteralState()
@@ -17,6 +18,7 @@ class LiteralReplacementManager
         self::$replacements = [];
         self::$globalReplacement = [];
         self::$retargeted = [];
+        self::$registeredSections = [];
     }
 
     public static function registerRegion($name, $section, $default)
@@ -42,8 +44,24 @@ class LiteralReplacementManager
         return $name;
     }
 
+    /**
+     * Tests if a section name bas been registered with the manager.
+     *
+     * @param  string  $name The section name.
+     * @return bool
+     */
+    public static function hasRegisteredSectionName($name)
+    {
+        return in_array($name, self::$registeredSections);
+    }
+
     public static function registerRegionReplacement($name, $tagMethod, $string)
     {
+        // Keep a record of all the section names we've registered.
+        if (! in_array($tagMethod, self::$registeredSections)) {
+            self::$registeredSections[] = $tagMethod;
+        }
+
         $name = '__literalReplacement::_'.md5($name);
 
         $string = (string) $string;

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -110,6 +110,13 @@ class NodeProcessor
     protected $isProvidingParameterContent = false;
 
     /**
+     * Indicates if the processor is helping to evaluate conditions.
+     *
+     * @var bool
+     */
+    protected $isConditionalProcessor = false;
+
+    /**
      * @var RuntimeConfiguration|null
      */
     protected $runtimeConfiguration = null;
@@ -265,6 +272,24 @@ class NodeProcessor
         $this->isInterpolationProcessor = $isInterpolation;
 
         return $this;
+    }
+
+    /**
+     * Sets whether the NodeProcessor is processing conditions.
+     *
+     * @param  bool  $isCondition The value.
+     * @return $this
+     */
+    public function setIsConditionProcessor($isCondition)
+    {
+        $this->isConditionalProcessor = $isCondition;
+
+        return $this;
+    }
+
+    public function getIsConditionProcessor()
+    {
+        return $this->isConditionalProcessor;
     }
 
     /**
@@ -839,6 +864,7 @@ class NodeProcessor
         $processor = new NodeProcessor($this->loader, $this->envDetails);
         $processor->allowPhp($this->allowPhp);
         $processor->setRuntimeAssignments($this->runtimeAssignments);
+        $processor->setIsConditionProcessor($this->isConditionalProcessor);
 
         if ($this->antlersParser != null) {
             $processor->setAntlersParserInstance($this->antlersParser);
@@ -1111,6 +1137,7 @@ class NodeProcessor
                                     $callback($this);
                                 }
                             }
+
                             continue;
                         }
                     }
@@ -1155,6 +1182,7 @@ class NodeProcessor
                     }
 
                     $buffer .= $this->evaluateAntlersPhpNode($node);
+
                     continue;
                 }
 
@@ -1207,6 +1235,7 @@ class NodeProcessor
                         }
 
                         $buffer .= $registeredStack;
+
                         continue;
                     } elseif (($node->name->name == 'push' || $node->name->name == 'prepend') && $node->isClosedBy != null) {
                         $currentData = $this->getActiveData();
@@ -1226,6 +1255,7 @@ class NodeProcessor
                         if ($this->isTracingEnabled()) {
                             $this->runtimeConfiguration->traceManager->traceOnExit($node, $stackContent);
                         }
+
                         continue;
                     }
 
@@ -1243,6 +1273,7 @@ class NodeProcessor
                         if ($this->isTracingEnabled()) {
                             $this->runtimeConfiguration->traceManager->traceOnExit($node, null);
                         }
+
                         continue;
                     } else {
                         if ($result instanceof ExecutionBranch) {
@@ -1338,6 +1369,7 @@ class NodeProcessor
                             $recursiveParent->activeDepth -= 1;
                             RecursiveNodeManager::releaseRecursiveNode($node);
                         }
+
                         continue;
                     }
 
@@ -1345,6 +1377,7 @@ class NodeProcessor
                         if ($this->isTracingEnabled()) {
                             $this->runtimeConfiguration->traceManager->traceOnExit($node, null);
                         }
+
                         continue;
                     }
 
@@ -1382,6 +1415,7 @@ class NodeProcessor
                             if ($this->isTracingEnabled()) {
                                 $this->runtimeConfiguration->traceManager->traceOnExit($node, null);
                             }
+
                             continue;
                         }
 
@@ -1521,6 +1555,12 @@ class NodeProcessor
                         RuntimeParser::pushNodeCache($node->runtimeContent, $node->children);
 
                         if ($node->name->name == 'yield') {
+                            // If the current processor instance is a conditional processor, we
+                            // will simply return whether the section has been registered.
+                            if ($this->isConditionalProcessor) {
+                                return LiteralReplacementManager::hasRegisteredSectionName($tagMethod);
+                            }
+
                             GlobalRuntimeState::$yieldCount += 1;
                             // Wrap it in a partial thing.
                             $wrapName = 'section:'.$tagMethod.'__yield'.GlobalRuntimeState::$yieldCount;
@@ -1677,6 +1717,7 @@ class NodeProcessor
                         if ($this->isTracingEnabled()) {
                             $this->runtimeConfiguration->traceManager->traceOnExit($node, $results);
                         }
+
                         continue;
                     }
 
@@ -1863,6 +1904,7 @@ class NodeProcessor
                             if ($this->isTracingEnabled()) {
                                 $this->runtimeConfiguration->traceManager->traceOnExit($node, $val);
                             }
+
                             continue;
                         }
                     } else {
@@ -1940,6 +1982,7 @@ class NodeProcessor
 
                                         if ($varValue == 'void::'.GlobalRuntimeState::$environmentId) {
                                             $this->data = $lockData;
+
                                             continue;
                                         }
 
@@ -2058,6 +2101,7 @@ class NodeProcessor
 
                     if ($this->isInterpolationProcessor && is_array($val)) {
                         $buffer = $val;
+
                         continue;
                     }
 
@@ -2183,6 +2227,7 @@ class NodeProcessor
                             }
 
                             $this->data = $lockData;
+
                             continue;
                         }
                     }

--- a/tests/Antlers/Runtime/YieldTest.php
+++ b/tests/Antlers/Runtime/YieldTest.php
@@ -401,4 +401,33 @@ EOT;
 
         $this->assertSame(StringUtilities::normalizeLineEndings($expected), $this->renderString($template, $data, true));
     }
+
+    public function test_yield_can_be_used_inside_conditions()
+    {
+        $template = <<<'EOT'
+{{ if {yield:section_name} }}
+Hello, universe!
+{{ /if }}
+EOT;
+
+        $this->assertSame('', trim($this->renderString($template, [], true)));
+
+        $template = <<<'EOT'
+{{ section:section_name }}Some content.{{ /section:section_name }}
+
+{{ if {yield:section_name} }}
+Hello, universe!
+{{ /if }}
+EOT;
+
+        $this->assertSame('Hello, universe!', trim($this->renderString($template, [], true)));
+
+        $template = <<<'EOT'
+{{ if {yield:section_name} }}
+Hello, universe!
+{{ /if }}
+EOT;
+
+        $this->assertSame('', trim($this->renderString($template, [], true)));
+    }
 }


### PR DESCRIPTION
This PR allows users to check if a section has been defined inside a condition (behavior outlined in #1193).

This check only works _after_ the `section` tag has been used, and is not "lazy". The following will now work:

In a template:

```antlers
{{ section:sidebar }}
  <h2>Sidebar: {{ title }}</h2>
{{ /section:sidebar }}
````

In the layout:

```antlers
{{ if {yield:sidebar} }}
  Do something only if the sidebar section has been registered.
{{ /if }}
```