### PR TITLE
[4.x] Fix select field option positioning

### DIFF
--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -65,7 +65,7 @@
 
 <script>
 import HasInputOptions from './HasInputOptions.js'
-import { computePosition, offset } from '@floating-ui/dom';
+import { computePosition, offset, flip } from '@floating-ui/dom';
 
 export default {
 
@@ -157,6 +157,7 @@ export default {
                 placement: 'bottom',
                 middleware: [
                     offset({ mainAxis: 0, crossAxis: -1 }),
+                    flip(),
                 ]
             }).then(({ x, y }) => {
                 Object.assign(dropdownList.style, {

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -72,7 +72,7 @@
 
 <script>
 import { SortableList, SortableItem } from '../../sortable/Sortable';
-import { computePosition, offset } from '@floating-ui/dom';
+import { computePosition, offset, flip } from '@floating-ui/dom';
 
 export default {
 
@@ -160,6 +160,7 @@ export default {
                 placement: 'bottom',
                 middleware: [
                     offset({ mainAxis: 0, crossAxis: -1 }),
+                    flip(),
                 ]
             }).then(({ x, y }) => {
                 Object.assign(dropdownList.style, {


### PR DESCRIPTION
Fixes #7958

Flips the options on the select field when they'd appear out of the screen. (In the select fieldtype and relationship field in select mode.)
