### PR TITLE
[4.x] Fix nav item editor

### DIFF
--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -65,7 +65,7 @@
                 <div class="card p-4 content w-full">
                     <div class="flex flex-wrap w-full">
                         <a :href="editUrl" class="w-full lg:w-1/2 p-4 flex items-start hover:bg-gray-200 rounded-md group">
-                            <svg-icon name="hammer-wrench" class="h-8 w-8 mr-4 text-gray-800" />
+                            <svg-icon name="light/hammer-wrench" class="h-8 w-8 mr-4 text-gray-800" />
                             <div class="flex-1 mb-4 md:mb-0 md:mr-6">
                                 <h3 class="mb-2 text-blue">{{ __('Configure Navigation') }} &rarr;</h3>
                                 <p>{{ __('messages.navigation_configure_settings_intro') }}</p>
@@ -79,14 +79,14 @@
                             </div>
                         </a>
                         <a @click="linkEntries()" v-if="hasCollections" class="w-full lg:w-1/2 p-4 flex items-start hover:bg-gray-200 rounded-md group">
-                            <svg-icon name="hierarchy-files" class="h-8 w-8 mr-4 text-gray-800" />
+                            <svg-icon name="light/hierarchy-files" class="h-8 w-8 mr-4 text-gray-800" />
                             <div class="flex-1 mb-4 md:mb-0 md:mr-6">
                                 <h3 class="mb-2 text-blue">{{ __('Link to Entry') }} &rarr;</h3>
                                  <p>{{ __('messages.navigation_link_to_entry_instructions') }}</p>
                             </div>
                         </a>
                         <a :href="docs_url('navigation')" class="w-full lg:w-1/2 p-4 flex items-start hover:bg-gray-200 rounded-md group">
-                            <svg-icon name="book-pages" class="h-8 w-8 mr-4 text-gray-800" />
+                            <svg-icon name="light/book-pages" class="h-8 w-8 mr-4 text-gray-800" />
                             <div class="flex-1 mb-4 md:mb-0 md:mr-6">
                                 <h3 class="mb-2 text-blue">{{ __('Read the Documentation') }} &rarr;</h3>
                                  <p>{{ __('messages.navigation_documentation_instructions') }}</p>

--- a/resources/js/components/publish/Field.vue
+++ b/resources/js/components/publish/Field.vue
@@ -40,7 +40,7 @@
                     :class="{ flex: syncable && !isSynced }"
                     @click="$emit('synced')"
                 >
-                    <svg-icon name="hyperlink-broken" class="h-4 w-4 mr-1.5 mb-1 text-gray-600"
+                    <svg-icon name="light/hyperlink-broken" class="h-4 w-4 mr-1.5 mb-1 text-gray-600"
                         v-tooltip.top="__('messages.field_desynced_from_origin')" />
                 </button>
             </label>

--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -3,14 +3,14 @@
     <stack narrow name="page-tree-linker" :before-close="shouldClose" @closed="$emit('closed')">
         <div slot-scope="{ close }" class="bg-gray-100 h-full flex flex-col">
 
-            <div class="bg-gray-200 px-6 py-2 mb-4 border-b shadow-md text-lg font-medium flex items-center justify-between">
+            <header class="bg-white pl-6 pr-3 py-2 mb-4 border-b shadow-md text-lg font-medium flex items-center justify-between">
                 {{ headerText }}
                 <button
                     type="button"
                     class="btn-close"
                     @click="confirmClose(close)"
                     v-html="'&times'" />
-            </div>
+            </header>
 
             <div v-if="loading" class="flex-1 overflow-auto relative">
                 <div class="absolute inset-0 z-10 bg-white bg-opacity-75 flex items-center justify-center text-center">

--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -1,9 +1,9 @@
 <template>
 
     <stack narrow name="page-tree-linker" :before-close="shouldClose" @closed="$emit('closed')">
-        <div slot-scope="{ close }" class="bg-white h-full flex flex-col">
+        <div slot-scope="{ close }" class="bg-gray-100 h-full flex flex-col">
 
-            <div class="bg-gray-200 px-6 py-2 border-b border-gray-300 text-lg font-medium flex items-center justify-between">
+            <div class="bg-gray-200 px-6 py-2 mb-4 border-b shadow-md text-lg font-medium flex items-center justify-between">
                 {{ headerText }}
                 <button
                     type="button"
@@ -18,7 +18,7 @@
                 </div>
             </div>
 
-            <div v-else class="flex-1 overflow-auto">
+            <div v-if="!loading" class="flex-1 overflow-auto px-1">
 
                 <publish-container
                     ref="container"
@@ -36,8 +36,9 @@
                             <loading-graphic text="" />
                         </div>
 
-                        <publish-fields
-                            :fields="fields"
+
+                        <publish-sections
+                            :sections="adjustedBlueprint.tabs[0].sections"
                             :syncable="type == 'entry'"
                             :syncable-fields="syncableFields"
                             @updated="setFieldValue"
@@ -50,15 +51,18 @@
                     </div>
                 </publish-container>
 
-                <div class="p-6">
-                    <button @click="submit" class="btn-primary w-full">{{ __('Submit') }}</button>
+            </div>
 
-                    <div class="text-xs mt-4" v-if="type === 'entry'">
-                        <a :href="editEntryUrl" target="_blank" class="flex items-center justify-center text-blue hover:text-blue underline">
-                            <svg-icon name="light/external-link" class="w-4 h-4 mr-2" />
-                            {{ __('Edit Entry') }}
-                        </a>
-                    </div>
+            <div v-if="!loading" class="bg-gray-200 p-4 border-t flex items-center justify-between flex-row-reverse">
+                <div>
+                    <button @click="confirmClose(close)" class="btn mr-2">{{ __('Cancel') }}</button>
+                    <button @click="submit" class="btn-primary">{{ __('Submit') }}</button>
+                </div>
+                <div v-if="type === 'entry'">
+                    <a :href="editEntryUrl" target="_blank" class="text-xs flex items-center justify-center text-blue hover:text-blue underline mr-4">
+                        <svg-icon name="light/external-link" class="w-4 h-4 mr-2" />
+                        {{ __('Edit Entry') }}
+                    </a>
                 </div>
 
             </div>
@@ -106,19 +110,37 @@ export default {
         },
 
         adjustedBlueprint() {
-            function isMissingField(fields, handle) {
-                return ! fields.some(field => field.handle === handle);
+            function getFields(blueprint) {
+                return _.chain(blueprint.tabs[0].sections)
+                    .map(sections => sections.fields)
+                    .flatten(true)
+                    .value();
             }
-            function hasField(fields, handle) {
-                return ! isMissingField(fields, handle);
+            function isMissingField(blueprint, handle) {
+                return ! getFields(blueprint).some(field => field.handle === handle);
+            }
+            function hasField(blueprint, handle) {
+                return ! isMissingField(blueprint, handle);
+            }
+            function getField(handle) {
+                for (let sectionIndex = 0; sectionIndex < blueprint.tabs[0].sections.length; sectionIndex++) {
+                    const section = blueprint.tabs[0].sections[sectionIndex];
+                    for (let fieldIndex = 0; fieldIndex < section.fields.length; fieldIndex++) {
+                        const field = section.fields[fieldIndex];
+                        if (field.handle === handle) {
+                            return { section: sectionIndex, field: fieldIndex };
+                        }
+                    }
+                }
+
+                return { section: null, field: null };
             }
 
             // This UI only supports the first tab
             const blueprint = clone(this.blueprint);
-            const fields = blueprint.tabs[0].sections[0].fields;
 
-            if (this.type == 'url' && isMissingField(fields, 'url')) {
-                fields.unshift({
+            if (this.type == 'url' && isMissingField(blueprint, 'url')) {
+                blueprint.tabs[0].sections[0].fields.unshift({
                     handle: 'url',
                     type: 'text',
                     display: __('URL'),
@@ -128,27 +150,21 @@ export default {
 
             // Remove the "url" field if it's been added to the blueprint by the user.
             // URL fields only make sense for URL type pages. Entries will have their own URLs.
-            if (this.type == 'entry' && hasField(fields, 'url')) {
-                fields.splice(fields.indexOf(fields.find(field => field.handle === 'url')), 1);
+            if (this.type == 'entry' && hasField(blueprint, 'url')) {
+                const {section, field} = getField('url');
+                blueprint.tabs[0].sections[section].fields.splice(field, 1);
             }
 
-            if (isMissingField(fields, 'title')) {
-                fields.unshift({
+            if (isMissingField(blueprint, 'title')) {
+                blueprint.tabs[0].sections[0].fields.unshift({
                     handle: 'title',
                     type: 'text',
                     display: __('Title')
                 });
             }
 
-            return { ...blueprint, tabs: [{ fields }] };
+            return blueprint;
         },
-
-        fields() {
-            return _.chain(this.adjustedBlueprint.tabs)
-                .map(tab => tab.fields)
-                .flatten(true)
-                .value();
-        }
     },
 
     watch: {


### PR DESCRIPTION
Add support for multiple sections in nav items. Closes #7968 

![CleanShot 2023-04-24 at 17 56 58](https://user-images.githubusercontent.com/105211/234125521-c47fb38c-825b-434f-a112-445bb5ca70db.png)

If your blueprint has a `title` and/or `url` field, they'll remain where you placed them.
If they're missing, they'll get prepended to the first section.
This is the same behavior as before, except before we only assumed a single section.

This also makes the field area scrollable, but the header and footer with the buttons stay fixed.

It looks okay here but potentially a little weird on a full size page with only a couple of fields. 🤔  Maybe I should scrap the buttons-at-the-bottom change. I was trying to copy the asset editor.

![CleanShot 2023-04-25 at 16 02 21](https://user-images.githubusercontent.com/105211/234389987-a4b9b0e4-3834-4452-806b-42c4021e5180.png)


(Also fixes some icons)