### PR TITLE
Antlers: Processes assignments from within associative arrays/maps.

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -2096,6 +2096,7 @@ class NodeProcessor
                                     $processor->setAntlersParserInstance($this->antlersParser);
                                     $processor->setData($evalData);
                                     $processor->cascade($this->cascade);
+                                    $processor->setRuntimeAssignments($this->runtimeAssignments);
 
                                     if ($this->runtimeConfiguration != null) {
                                         $processor->setRuntimeConfiguration($this->runtimeConfiguration);
@@ -2104,7 +2105,15 @@ class NodeProcessor
 
                                     $buffer .= $this->measureBufferAppend($node, $this->modifyBufferAppend($assocOutput));
 
+                                    $runtimeAssignmentsToProcess = $processor->getRuntimeAssignments();
+
                                     $this->popScope($node->refId);
+
+                                    if (! empty($runtimeAssignmentsToProcess)) {
+                                        $this->data = $lockData;
+                                        $this->processAssignments($runtimeAssignmentsToProcess);
+                                        $lockData = $this->data;
+                                    }
                                 } else {
                                     if (! $executedParamModifiers || $tagCallbackResult != null) {
                                         $val = $this->addLoopIterationVariables($val);

--- a/tests/Antlers/Sandbox/VariableAssignmentTest.php
+++ b/tests/Antlers/Sandbox/VariableAssignmentTest.php
@@ -1115,4 +1115,19 @@ EXPECTED;
 
         $this->assertSame($expected, StringUtilities::normalizeLineEndings(trim($responseOne->getContent())));
     }
+
+    public function test_assignments_are_processed_after_associative_arrays()
+    {
+        $template = <<<'EOT'
+{{ _value = 'One'; }}
+
+{{ data }}
+    {{ _value = 'Two'; }}
+{{ /data }}
+
+The value: {{ _value }}.
+EOT;
+
+        $this->assertSame('The value: Two.', trim($this->renderString($template, ['data' => ['foo' => 'bar']])));
+    }
 }


### PR DESCRIPTION
This PR fixes #7796 by processing assignments when leaving an associative array/map tag pair.

The issue mentions the `{{ user }} {{ /user }}` pair, but upon further investigation you can trigger this behavior with any associative array.