### PR TITLE
[4.x] Fix blueprint error when section is missing fields

### DIFF
--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -111,7 +111,7 @@ trait ManagesBlueprints
             'display' => $section->display(),
             'instructions' => $section->instructions(),
         ]) + [
-            'fields' => collect($section->contents()['fields'])->map(function ($field, $i) use ($tab, $sectionIndex) {
+            'fields' => collect($section->contents()['fields'] ?? [])->map(function ($field, $i) use ($tab, $sectionIndex) {
                 return array_merge(FieldTransformer::toVue($field), ['_id' => $tab->handle().'-'.$sectionIndex.'-'.$i]);
             })->all(),
         ];


### PR DESCRIPTION
Make sure the blueprint sections will parse when the sections contain no fields.

Fixes #7993