### PR TITLE
Move Bard content styling to dedicated class name

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -221,10 +221,6 @@
         @apply px-6 py-16 flex flex-col;
         min-height: calc(100vh - 120px);
 
-        > p > code, > pre code {
-            @apply bg-gray-300;
-        }
-
         /*  To remove min height from nested bard fields inside bard in fullscreen mode. */
         * > .ProseMirror {
             min-height: auto;
@@ -232,6 +228,12 @@
 
         &:focus {
             @apply ring-0;
+        }
+    }
+    
+    & > .bard-editor > div > .bard-content > {
+        p > code, > pre code {
+            @apply bg-gray-300;
         }
     }
 
@@ -259,7 +261,7 @@
     outline: 0;
 }
 
-.bard-fieldtype .ProseMirror > {
+.bard-fieldtype .bard-content > {
     p {
         @apply text-gray-800;
         word-break: break-all;

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -231,8 +231,9 @@
         }
     }
     
-    & > .bard-editor > div > .bard-content > {
-        p > code, > pre code {
+    .bard-content:not(.bard-content *) > {
+        p > code,
+        pre code {
             @apply bg-gray-300;
         }
     }

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -231,7 +231,7 @@
         }
     }
     
-    .bard-content:not(.bard-content *) > {
+    .bard-content:not(.bard-set *) > {
         p > code,
         pre code {
             @apply bg-gray-300;

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -583,6 +583,7 @@ export default {
                 editable: !this.readOnly,
                 enableInputRules: this.config.enable_input_rules,
                 enablePasteRules: this.config.enable_paste_rules,
+                editorProps: { attributes: { class: 'bard-content' }},
                 onFocus: () => this.$emit('focus'),
                 onBlur: () => {
                     // Since clicking into a field inside a set would also trigger a blur, we can't just emit the


### PR DESCRIPTION
This is a simpler (and cut-down) alternative to https://github.com/statamic/cms/pull/7926. It doesn’t introduce a decorator plugin or restructure the CSS in any significant way.

What this does do is move the Bard content styling to a new `bard-content` class, separate from the `ProseMirror` class. This allows custom Bard nodes that contain text content to use all the built-in styles by simply applying that class, without also inheriting all the container styling that comes with the `ProseMirror` class.

Would be really handy and allow me to simplify a bunch of custom stuff 🙂 .

Targets master.