### PR TITLE
[4.x] Enforce PR title format

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,10 @@
+name: Pull Request Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+steps:
+  - uses: deepakputhraya/action-pr-title@master
+    with:
+      regex: '^\[(?:3\.\d+|[4-9]\d?\.x|\d{2,}\.x)\]\s'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
-  title:
+  pr-title:
     runs-on: ubuntu-latest
     steps:
       - uses: deepakputhraya/action-pr-title@master

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   title:
+    runs-on: ubuntu-latest
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
-steps:
-  - uses: deepakputhraya/action-pr-title@master
-    with:
-      regex: '^\[(?:3\.\d+|[4-9]\d?\.x|\d{2,}\.x)\]\s'
+jobs:
+  title:
+    steps:
+      - uses: deepakputhraya/action-pr-title@master
+        with:
+          regex: '^\[(?:3\.\d+|[4-9]\d?\.x|\d{2,}\.x)\]\s'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
-          regex: '^\[\d+\.x)\]\s'
+          regex: '^\[\d+\.x\]\s'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
-          regex: '^\[(?:3\.\d+|[4-9]\d?\.x|\d{2,}\.x)\]\s'
+          regex: '^\[\d+\.x)\]\s'


### PR DESCRIPTION
PR titles should have the version line as the prefix.

Opening this because I missed manually renaming one before merging. Now the git log makes me sad. 😢 

![CleanShot 2023-04-25 at 15 12 37](https://user-images.githubusercontent.com/105211/234379203-a859f659-f556-4ce4-891c-daa01b4edda4.png)

The regex just allows `[n.x]` and won't bother with the rule on 3.x. We'll just prefix on 4.x onwards.
