### PR TITLE
[4.x] Fix double popover opened event

### DIFF
--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -103,7 +103,6 @@ export default {
             this.escBinding = this.$keys.bind('esc', e => this.close());
             this.$nextTick(() => {
                 this.cleanupAutoUpdater = autoUpdate(this.$refs.trigger.firstChild, this.$refs.popover, this.computePosition);
-                this.$emit('opened');
 
                 this.$refs.popover.addEventListener('transitionend', () => {
                     this.$emit('opened');


### PR DESCRIPTION
Fixes #7998

The double event caused two sets of keybindings to be registered in [SetPicker](https://github.com/statamic/cms/blob/d5808454ed7bc8d1e0d090317d2c8164cbb34a5f/resources/js/components/fieldtypes/replicator/SetPicker.vue#L180).

When closing the picker, only one set of keybindings were unbound. The second one remained, so when you hit enter within Bard, it was as if you were selecting from the set picker again.
