### PR TITLE
Only show Copy Asset URL action for public containers

### DIFF
--- a/src/Actions/CopyAssetUrl.php
+++ b/src/Actions/CopyAssetUrl.php
@@ -15,7 +15,7 @@ class CopyAssetUrl extends Action
 
     public function visibleTo($item)
     {
-        return $item instanceof Asset;
+        return $item instanceof Asset && $item->absoluteUrl();
     }
 
     public function visibleToBulk($items)


### PR DESCRIPTION
Fixes second part of #7552
