### PR TITLE
[4.x] Fix losing super when editing self user in cp

### DIFF
--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -199,7 +199,7 @@ class UsersController extends CpController
             $blueprint->ensureField('groups', ['visibility' => 'read_only']);
         }
 
-        if (User::current()->isSuper() && User::current() != $user) {
+        if (User::current()->isSuper() && User::current()->id() !== $user->id()) {
             $blueprint->ensureField('super', ['type' => 'toggle']);
         }
 
@@ -251,7 +251,7 @@ class UsersController extends CpController
             $user->set($key, $value);
         }
 
-        if (User::current()->isSuper() && User::current() != $user) {
+        if (User::current()->isSuper() && User::current()->id() !== $user->id()) {
             $user->super = $request->super;
         }
 


### PR DESCRIPTION
Fixes small bug introduced by #7716, where if you edit your own super user in the CP, it would lose `super: true` and you'd get kicked out.