### PR TITLE
Support `min_files` on asset field type

### DIFF
--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -10,6 +10,7 @@ return [
     'assets.config.container' => 'Choose which asset container to use for this field.',
     'assets.config.folder' => 'The folder to begin browsing in.',
     'assets.config.max_files' => 'The maximum number of selectable assets.',
+    'assets.config.min_files' => 'The minimum number of selectable assets.',
     'assets.config.mode' => 'Choose your preferred layout style.',
     'assets.config.restrict' => 'Prevent users from navigating to other folders.',
     'assets.config.show_filename' => 'Show the filename next to the preview image.',

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -77,6 +77,13 @@ class Assets extends Fieldtype
                 'type' => 'integer',
                 'width' => 50,
             ],
+            'min_files' => [
+                'display' => __('Min Files'),
+                'instructions' => __('statamic::fieldtypes.assets.config.min_files'),
+                'min' => 1,
+                'type' => 'integer',
+                'width' => 50,
+            ],
         ];
     }
 
@@ -107,8 +114,6 @@ class Assets extends Fieldtype
 
     public function process($data)
     {
-        $max_files = (int) $this->config('max_files');
-
         $values = collect($data)->map(function ($id) {
             return Asset::find($id)->path();
         });
@@ -188,6 +193,10 @@ class Assets extends Fieldtype
 
         if ($max = $this->config('max_files')) {
             $rules[] = 'max:'.$max;
+        }
+
+        if ($min = $this->config('min_files')) {
+            $rules[] = 'min:'.$min;
         }
 
         return $rules;

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -40,7 +40,6 @@ class Assets extends Fieldtype
                 'type' => 'asset_container',
                 'max_items' => 1,
                 'mode' => 'select',
-                'width' => 50,
                 'default' => AssetContainer::all()->count() == 1 ? AssetContainer::all()->first()->handle() : null,
             ],
             'folder' => [


### PR DESCRIPTION
Closes: https://github.com/statamic/ideas/issues/980

This PR adds support for `min_files` on the asset field type.

Ideally it would require you to enter a lower value than max_fields (if present), but I couldn't see any way to add validation rules to config fields.

(I also removed a variable declaration on max_files that wasnt being used)