### PR TITLE
[4.x] Fix Reference Error when using bard toolbar link button

### DIFF
--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -300,7 +300,7 @@ export default {
         autofocus() {
             if (this.linkType === 'url') {
                 this.$nextTick(() => {
-                    setTimout(() => {
+                    setTimeout(() => {
                         this.$refs.urlInput.focus();
                     }, 50);
                 });


### PR DESCRIPTION
This PR is resolving a ReferenceError that was being thrown when using the link Button in Bard toolbar due to a typo 🪄