### PR TITLE
[4.x] Fix relationship selector search autofocus

### DIFF
--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -217,7 +217,7 @@ export default {
 
         initialRequest() {
             return this.request().then(() => {
-                if (this.search) this.$refs.filters.$refs.search.focus();
+                if (this.search) this.$refs.search.focus();
             });
         },
 


### PR DESCRIPTION
This PR fixes an issue where autofocus of the search input was not working when opening the relationship selector. 