### PR TITLE
[4.x] Improve column resizing UI in Bard table

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -524,3 +524,22 @@
         cursor: grab;
     }
 }
+
+/* Bard Table
+  ========================================================================== */
+
+.bard-fieldtype .ProseMirror {
+    &.resize-cursor {
+        @apply cursor-col-resize;
+    }
+
+    .tableWrapper {
+        @apply overflow-x-auto;
+    }
+
+    table .column-resize-handle {
+        @apply absolute top-0 bottom-0 pointer-events-none bg-blue-200;
+        width: 3px;
+        right: -2px;
+    }
+}


### PR DESCRIPTION
* This commit improves the ui when resizing columns in Bard tables. As before, using the column size values in frontend is up to the user.
* Fixes #8020. The PR is targeting V4 but can be backported to 3.4, as the issue already existed there.

![2023-04-29 14 34 17](https://user-images.githubusercontent.com/1102712/235302811-d5c13875-300b-4f9d-923e-eb6e0d24fdaa.gif)
