### PR TITLE
[4.x] Minor modal fixes

### DIFF
--- a/resources/js/components/assets/Folder/Folder.vue
+++ b/resources/js/components/assets/Folder/Folder.vue
@@ -1,11 +1,11 @@
 <template>
 
-    <modal name="folder-editor">
+    <modal name="folder-editor" :focusTrap="false">
 
         <div class="flex items-center justify-between px-6 py-4 bg-gray-200 border-b text-center">
             {{ modalTitle }}
             <button type="button"
-                tabindex="-1"
+                tabindex="0"
                 class="btn-close"
                 aria-label="Close"
                 @click="cancel"

--- a/resources/js/components/modals/KeyboardShortcutsModal.vue
+++ b/resources/js/components/modals/KeyboardShortcutsModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <modal v-if="open" name="keyboard-shortcuts" width="380" height="auto" :adaptive="true" @closed="open = false" v-on-clickaway="close">
+    <modal v-if="open" name="keyboard-shortcuts" width="380" height="auto" :adaptive="true" @closed="open = false" :clickToClose="close">
         <h1 class="p-4 bg-gray-200 border-b text-center">
             {{ __('Keyboard Shortcuts') }}
         </h1>


### PR DESCRIPTION
This PR fixes some minor modal issues:
* The Keyboard Shortcut Modal cannot be closed when clicked away.
* The _Create Folder_ Modal input field was losing focus. I have disabled the `focusTrap` property for this modal to avoid the `v-modal` from focusing on the first input/button element.
