### PR TITLE
[4.x] Fix date field issues

### DIFF
--- a/resources/js/components/fieldtypes/date/RangePopover.vue
+++ b/resources/js/components/fieldtypes/date/RangePopover.vue
@@ -40,7 +40,7 @@
                         </div>
                     </div>
                 </template>
-                <portal-target :name="startPortalTarget" />
+                <portal-target :name="startPortalTarget" @change="resetPicker" />
             </popover>
 
             <svg-icon name="micro/arrow-right" class="w-6 h-6 my-1 mx-2 text-gray-700 hidden @md:block" />
@@ -72,7 +72,7 @@
                         </div>
                     </div>
                 </template>
-                <portal-target :name="endPortalTarget" />
+                <portal-target :name="endPortalTarget" @change="resetPicker" />
             </popover>
 
         </div>
@@ -157,13 +157,11 @@ export default {
 
             this.startOpen = true;
             this.portalTarget = this.startPortalTarget;
-            this.$nextTick(() => this.resetPicker());
         },
 
         startPopoverClosed() {
             this.startOpen = false;
             this.portalTarget = null;
-            this.$nextTick(() => this.resetPicker());
         },
 
         endPopoverOpened() {
@@ -171,13 +169,11 @@ export default {
 
             this.endOpen = true;
             this.portalTarget = this.endPortalTarget;
-            this.$nextTick(() => this.resetPicker());
         },
 
         endPopoverClosed() {
             this.endOpen = false;
             this.portalTarget = null;
-            this.$nextTick(() => this.resetPicker());
         },
 
         updateInputValues() {

--- a/resources/js/components/fieldtypes/date/RangePopover.vue
+++ b/resources/js/components/fieldtypes/date/RangePopover.vue
@@ -119,8 +119,11 @@ export default {
             return {
                 // Handle changing the date when typing.
                 change: (e) => this.picker.onInputUpdate(e.target.value, true, { formatInput: true }),
-                // Allows hitting escape to cancel any changes.
-                keyup: (e) => this.picker.onInputKeyup(e),
+                // Allows hitting escape to cancel any changes, and close the popover.
+                keyup: (e) => {
+                    this.picker.onInputKeyup(e);
+                    if (e.key === 'Escape') this.$refs.startPopover.close();
+                }
             };
         },
 
@@ -128,8 +131,11 @@ export default {
             return {
                 // Handle changing the date when typing.
                 change: (e) => this.picker.onInputUpdate(e.target.value, false, { formatInput: true }),
-                // Allows hitting escape to cancel any changes.
-                keyup: (e) => this.picker.onInputKeyup(e),
+                // Allows hitting escape to cancel any changes, and close the popover.
+                keyup: (e) => {
+                    this.picker.onInputKeyup(e);
+                    if (e.key === 'Escape') this.$refs.endPopover.close();
+                }
             };
         }
 

--- a/resources/js/components/fieldtypes/date/RangePopover.vue
+++ b/resources/js/components/fieldtypes/date/RangePopover.vue
@@ -184,8 +184,8 @@ export default {
         dateSelected(date) {
             this.$emit('input', date)
             this.$nextTick(() => {
-                this.$refs.startPopover.close()
-                this.$refs.endPopover.close()
+                this.$refs.startPopover?.close()
+                this.$refs.endPopover?.close()
             });
         },
 

--- a/resources/js/components/fieldtypes/date/SinglePopover.vue
+++ b/resources/js/components/fieldtypes/date/SinglePopover.vue
@@ -15,8 +15,8 @@
             ref="popover"
             placement="bottom-start"
             :disabled="isReadOnly"
-            @opened="popoverStateChanged(true)"
-            @closed="popoverStateChanged(false)"
+            @opened="open = true"
+            @closed="open = false"
         >
             <template #trigger>
                 <div class="input-group">
@@ -35,7 +35,7 @@
                     </div>
                 </div>
             </template>
-            <portal-target :name="portalTarget" />
+            <portal-target :name="portalTarget" @change="resetPicker" />
         </popover>
 
     </div>
@@ -80,11 +80,6 @@ export default {
     },
 
     methods: {
-
-        popoverStateChanged(open) {
-            this.open = open;
-            this.$nextTick(() => this.resetPicker());
-        },
 
         updateInputValue() {
             this.inputValue = this.picker.inputValues[0];

--- a/resources/js/components/fieldtypes/date/SinglePopover.vue
+++ b/resources/js/components/fieldtypes/date/SinglePopover.vue
@@ -64,8 +64,11 @@ export default {
             return {
                 // Handle changing the date when typing.
                 change: (e) => this.picker.onInputUpdate(e.target.value, true, { formatInput: true }),
-                // Allows hitting escape to cancel any changes.
-                keyup: (e) => this.picker.onInputKeyup(e),
+                // Allows hitting escape to cancel any changes, and close the popover.
+                keyup: (e) => {
+                    this.picker.onInputKeyup(e);
+                    if (e.key === 'Escape') this.$refs.popover?.close();
+                }
             }
         },
 


### PR DESCRIPTION
- Use portal-target change as the hook for updating the picker.
- Prevent error when clearing out range field.
- Let escape key close the popovers.

Fixes #8026


Context:

#8004 broke it, which meant that the date field components were relying on that first event, not the one after transition end. 
When resetPicker was called, there was no picker in the dom yet, so refs were empty. Changing to the portal-target changed event luckily allowed us to reset the picker when it will definitely be there.