### PR TITLE
[4.x] Fix bard buttons setting reorder

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardButtonsSettingFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardButtonsSettingFieldtype.vue
@@ -118,7 +118,7 @@ export default {
                 distance: 10
             }).on('sortable:stop', e => {
                 this.buttons.splice(e.newIndex, 0, this.buttons.splice(e.oldIndex, 1)[0]);
-            });
+            }).on('mirror:create', (e) => e.cancel());
         },
 
         toggleButton(name) {
@@ -132,9 +132,3 @@ export default {
     }
 };
 </script>
-
-<style scoped>
-.draggable-mirror {
-    display: none;
-}
-</style>

--- a/resources/js/components/fieldtypes/bard/BardButtonsSettingFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardButtonsSettingFieldtype.vue
@@ -115,7 +115,7 @@ export default {
                 mirror: { constrainDimensions: true, xAxis: true, appendTo: 'body' },
                 swapAnimation: { horizontal: true },
                 plugins: [Plugins.SwapAnimation],
-                delay: 20
+                distance: 10
             }).on('sortable:stop', e => {
                 this.buttons.splice(e.newIndex, 0, this.buttons.splice(e.oldIndex, 1)[0]);
             });

--- a/resources/js/components/fieldtypes/bard/BardButtonsSettingFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardButtonsSettingFieldtype.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-import { Sortable } from '@shopify/draggable';
+import {Sortable, Plugins} from '@shopify/draggable';
 import { availableButtons, addButtonHtml } from './buttons';
 
 export default {
@@ -112,7 +112,10 @@ export default {
         initSortable() {
             new Sortable(this.$refs.buttons, {
                 draggable: 'button',
-                delay: 200
+                mirror: { constrainDimensions: true, xAxis: true, appendTo: 'body' },
+                swapAnimation: { horizontal: true },
+                plugins: [Plugins.SwapAnimation],
+                delay: 20
             }).on('sortable:stop', e => {
                 this.buttons.splice(e.newIndex, 0, this.buttons.splice(e.oldIndex, 1)[0]);
             });
@@ -129,3 +132,9 @@ export default {
     }
 };
 </script>
+
+<style scoped>
+.draggable-mirror {
+    display: none;
+}
+</style>


### PR DESCRIPTION
Lowers the sortable delay so you don't have to wait 2 seconds before reordering. Also adds swap animation.

Closes #8041.