### PR TITLE
Allow Specifying Username Key in Config

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -138,4 +138,17 @@ return [
         'web' => 'web',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Username Key
+    |--------------------------------------------------------------------------
+    |
+    | By default, Statamic will use `email` as key. However,
+    | if you want to use a different auth guard, which needs
+    | a different key you can customize it here.
+    |
+    */
+
+    'usernameKey' => 'email',
+
 ];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -38,8 +38,8 @@
 
             <div class="mb-4">
                 <label class="mb-1" for="input-email">{{ __('Email') }}</label>
-                <input type="text" class="input-text input-text" name="email" value="{{ old('email') }}" autofocus id="input-email">
-                @if ($hasError('email'))<div class="text-red text-xs mt-1">{{ $errors->first('email') }}</div>@endif
+                <input type="text" class="input-text input-text" name="{{$usernameKey}}" value="{{ old($usernameKey) }}" autofocus id="input-{{$usernameKey}}">
+                @if ($hasError($usernameKey))<div class="text-red text-xs mt-1">{{ $errors->first($usernameKey) }}</div>@endif
             </div>
 
             <div class="mb-4">

--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -39,6 +39,7 @@ class LoginController extends CpController
             'providers' => $enabled ? OAuth::providers() : [],
             'referer' => $this->getReferrer($request),
             'hasError' => $this->hasError(),
+            'usernameKey' => $this->username(),
         ];
 
         $view = view('statamic::auth.login', $data);
@@ -143,7 +144,7 @@ class LoginController extends CpController
 
     public function username()
     {
-        return 'email';
+        return config('statamic.users.usernameKey', 'email');
     }
 
     private function hasError()


### PR DESCRIPTION
This PR allows the developers to configure the username key used for the CP login. This is useful, if a different auth guard with a different username key is used.