### PR TITLE
[4.x] Remove array fieldtype mirror

### DIFF
--- a/resources/js/components/fieldtypes/ArrayFieldtype.vue
+++ b/resources/js/components/fieldtypes/ArrayFieldtype.vue
@@ -53,6 +53,7 @@
                         :vertical="true"
                         item-class="sortable-row"
                         handle-class="sortable-handle"
+                        :mirror="false"
                     >
                         <tbody>
                             <tr class="sortable-row" v-for="(element, index) in data" :key="element._id">


### PR DESCRIPTION
Fixes #8039

It removes the drag mirror just like other table-based fieldtypes. We just missed the array fieldtype.
