### PR TITLE
[4.x] Replicator and Bard sets fieldtype improvements and fixes

### DIFF
--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -22,6 +22,7 @@
                 <svg-icon name="add" class="w-3 h-3" />
             </button>
         </div>
+        <button v-if="!singleTab && tabs.length === 0" class="btn" @click="addAndEditTab" v-text="addTabText" />
         <tab-content
             v-for="tab in tabs"
             ref="tabContent"

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Fieldtypes;
 
-use Statamic\CP\FieldtypeFactory;
 use Statamic\Fields\Fieldset;
 use Statamic\Fields\FieldTransformer;
 use Statamic\Fields\Fieldtype;

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -20,6 +20,10 @@ class Sets extends Fieldtype
     {
         $sets = collect($sets);
 
+        if ($sets->isEmpty()) {
+            return [];
+        }
+
         // If the first set doesn't have a "sets" key, it would be the legacy format.
         // We'll put it in a "main" group so it's compatible with the new format.
         if (! Arr::has($sets->first(), 'sets')) {
@@ -61,6 +65,10 @@ class Sets extends Fieldtype
     public function preProcessConfig($sets)
     {
         $sets = collect($sets);
+
+        if ($sets->isEmpty()) {
+            return [];
+        }
 
         // If the first set doesn't have a "sets" key, it would be the legacy format.
         // We'll put it in a "main" group so it's compatible with the new format.

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -119,39 +119,4 @@ class Sets extends Fieldtype
         })
         ->all();
     }
-
-    private function moveOutNameKey($fields)
-    {
-        $processed = [];
-
-        foreach ($fields as $field) {
-            $handle = $field['handle'];
-            unset($field['handle']);
-            $processed[$handle] = $this->recursivelyProcess($field);
-        }
-
-        return $processed;
-    }
-
-    private function recursivelyProcess($config)
-    {
-        // Get the fieldtype for this field
-        $type = $config['type'];
-        $config_fieldtype = FieldtypeFactory::create($type);
-
-        // Get the fieldtype's config fieldset
-        $fieldset = $config_fieldtype->getConfigFieldset();
-
-        // Process all the fields in the fieldset
-        foreach ($fieldset->fieldtypes() as $field) {
-            // Ignore if the field isn't in the config
-            if (! in_array($field->getName(), array_keys($config))) {
-                continue;
-            }
-
-            $config[$field->getName()] = $field->process($config[$field->getName()]);
-        }
-
-        return Fieldset::cleanFieldForSaving($config);
-    }
 }

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -63,9 +63,9 @@ class Sets extends Fieldtype
     {
         $sets = collect($sets);
 
-        // If the first set has a "fields" key, it would be the legacy format.
+        // If the first set doesn't have a "sets" key, it would be the legacy format.
         // We'll put it in a "main" group so it's compatible with the new format.
-        if (Arr::has($sets->first(), 'fields')) {
+        if (! Arr::has($sets->first(), 'sets')) {
             $sets = collect([
                 'main' => [
                     'sets' => $sets->all(),

--- a/tests/Fieldtypes/ReplicatorTest.php
+++ b/tests/Fieldtypes/ReplicatorTest.php
@@ -12,20 +12,16 @@ use Tests\TestCase;
 
 class ReplicatorTest extends TestCase
 {
-    /** @test */
-    public function it_preprocesses_the_values()
+    /**
+     * @test
+     *
+     * @dataProvider groupedSetsProvider
+     */
+    public function it_preprocesses_with_empty_value($areSetsGrouped)
     {
-        RowId::shouldReceive('generate')->twice()->andReturn('random-string-1', 'random-string-2');
-
-        FieldRepository::shouldReceive('find')
-            ->with('testfieldset.numbers')
-            ->andReturnUsing(function () {
-                return new Field('numbers', ['type' => 'integer']);
-            });
-
         $field = (new Field('test', [
             'type' => 'replicator',
-            'sets' => [
+            'sets' => $this->groupSets($areSetsGrouped, [
                 'one' => [
                     'fields' => [
                         ['handle' => 'numbers', 'field' => 'testfieldset.numbers'], // test field reference
@@ -38,7 +34,43 @@ class ReplicatorTest extends TestCase
                         ['handle' => 'food', 'field' => ['type' => 'text']], // test inline field
                     ],
                 ],
-            ],
+            ]),
+        ]));
+
+        $this->assertSame([], $field->preProcess()->value());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider groupedSetsProvider
+     */
+    public function it_preprocesses_the_values($areSetsGrouped)
+    {
+        RowId::shouldReceive('generate')->twice()->andReturn('random-string-1', 'random-string-2');
+
+        FieldRepository::shouldReceive('find')
+            ->with('testfieldset.numbers')
+            ->andReturnUsing(function () {
+                return new Field('numbers', ['type' => 'integer']);
+            });
+
+        $field = (new Field('test', [
+            'type' => 'replicator',
+            'sets' => $this->groupSets($areSetsGrouped, [
+                'one' => [
+                    'fields' => [
+                        ['handle' => 'numbers', 'field' => 'testfieldset.numbers'], // test field reference
+                        ['handle' => 'words', 'field' => ['type' => 'text']], // test inline field
+                    ],
+                ],
+                'two' => [
+                    'fields' => [
+                        ['handle' => 'age', 'field' => 'testfieldset.numbers'], // test field reference
+                        ['handle' => 'food', 'field' => ['type' => 'text']], // test inline field
+                    ],
+                ],
+            ]),
         ]))->setValue([
             [
                 'type' => 'one',

--- a/tests/Fieldtypes/SetsTest.php
+++ b/tests/Fieldtypes/SetsTest.php
@@ -1,0 +1,390 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use Statamic\Fields\ConfigField;
+use Statamic\Fields\Field;
+use Tests\TestCase;
+
+class SetsTest extends TestCase
+{
+    /** @test */
+    public function it_preprocesses_with_groups()
+    {
+        $field = (new Field('test', [
+            'type' => 'sets',
+        ]))->setValue([
+            'alfa' => [
+                'display' => 'Alfa',
+                'instructions' => 'Alfa instructions',
+                'icon' => 'alfa-icon',
+                'sets' => [
+                    'one' => [
+                        'display' => 'One',
+                        'instructions' => 'One instructions',
+                        'icon' => 'one-icon',
+                        'fields' => [
+                            ['handle' => 'field_one', 'field' => ['type' => 'text']],
+                        ],
+                    ],
+                ],
+            ],
+            // This one has the minimum required keys so that we can check that they get filled with nulls instead of erroring.
+            'bravo' => [
+                'sets' => [
+                    'two' => [
+                        'fields' => [
+                            ['handle' => 'field_two', 'field' => ['type' => 'text']],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals([
+            [
+                '_id' => 'group-alfa',
+                'handle' => 'alfa',
+                'display' => 'Alfa',
+                'instructions' => 'Alfa instructions',
+                'icon' => 'alfa-icon',
+                'sections' => [
+                    [
+                        '_id' => 'group-alfa-section-one',
+                        'handle' => 'one',
+                        'display' => 'One',
+                        'instructions' => 'One instructions',
+                        'icon' => 'one-icon',
+                        'fields' => [
+                            [
+                                '_id' => 'group-alfa-section-one-0',
+                                'handle' => 'field_one',
+                                'type' => 'inline',
+                                'fieldtype' => 'text',
+                                'icon' => 'text',
+                                'config' => [
+                                    'type' => 'text',
+                                    'width' => 100,
+                                    'localizable' => false,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                '_id' => 'group-bravo',
+                'handle' => 'bravo',
+                'display' => null,
+                'instructions' => null,
+                'icon' => null,
+                'sections' => [
+                    [
+                        '_id' => 'group-bravo-section-two',
+                        'handle' => 'two',
+                        'display' => null,
+                        'instructions' => null,
+                        'icon' => null,
+                        'fields' => [
+                            [
+                                '_id' => 'group-bravo-section-two-0',
+                                'handle' => 'field_two',
+                                'type' => 'inline',
+                                'fieldtype' => 'text',
+                                'icon' => 'text',
+                                'config' => [
+                                    'type' => 'text',
+                                    'width' => 100,
+                                    'localizable' => false,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $field->preProcess()->value());
+    }
+
+    /** @test */
+    public function it_preprocesses_without_groups()
+    {
+        $field = (new Field('test', [
+            'type' => 'sets',
+        ]))->setValue([
+            'one' => [
+                'display' => 'One',
+                'instructions' => 'One instructions',
+                'icon' => 'one-icon',
+                'fields' => [
+                    ['handle' => 'field_one', 'field' => ['type' => 'text']],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals([
+            [
+                '_id' => 'group-main',
+                'handle' => 'main',
+                'display' => 'Main',
+                'instructions' => null,
+                'icon' => null,
+                'sections' => [
+                    [
+                        '_id' => 'group-main-section-one',
+                        'handle' => 'one',
+                        'display' => 'One',
+                        'instructions' => 'One instructions',
+                        'icon' => 'one-icon',
+                        'fields' => [
+                            [
+                                '_id' => 'group-main-section-one-0',
+                                'handle' => 'field_one',
+                                'type' => 'inline',
+                                'fieldtype' => 'text',
+                                'icon' => 'text',
+                                'config' => [
+                                    'type' => 'text',
+                                    'width' => 100,
+                                    'localizable' => false,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $field->preProcess()->value());
+    }
+
+    /** @test */
+    public function it_preprocesses_with_empty_value()
+    {
+        $field = (new Field('test', [
+            'type' => 'sets',
+        ]));
+
+        $this->assertEquals([], $field->preProcess()->value());
+    }
+
+    /** @test */
+    public function it_preprocesses_for_config_with_groups()
+    {
+        $field = (new ConfigField('test', [
+            'type' => 'sets',
+        ]))->setValue([
+            'alfa' => [
+                'display' => 'Alfa',
+                'instructions' => 'Alfa instructions',
+                'icon' => 'alfa-icon',
+                'sets' => [
+                    'one' => [
+                        'display' => 'One',
+                        'instructions' => 'One instructions',
+                        'icon' => 'one-icon',
+                        'fields' => [
+                            ['handle' => 'field_one', 'field' => ['type' => 'text']],
+                        ],
+                    ],
+                ],
+            ],
+            // This one has the minimum required keys so that we can check that they get filled with nulls instead of erroring.
+            'bravo' => [
+                'sets' => [
+                    'two' => [
+                        'fields' => [
+                            ['handle' => 'field_two', 'field' => ['type' => 'text']],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals([
+            [
+                'handle' => 'alfa',
+                'display' => 'Alfa',
+                'instructions' => 'Alfa instructions',
+                'icon' => 'alfa-icon',
+                'sets' => [
+                    [
+                        'id' => 'one',
+                        'handle' => 'one',
+                        'display' => 'One',
+                        'instructions' => 'One instructions',
+                        'icon' => 'one-icon',
+                        'fields' => [
+                            [
+                                'display' => 'Field One',
+                                'handle' => 'field_one',
+                                'type' => 'text',
+                                'input_type' => 'text',
+                                'placeholder' => null,
+                                'default' => null,
+                                'character_limit' => 0,
+                                'prepend' => null,
+                                'append' => null,
+                                'antlers' => false,
+                                'component' => 'text',
+                                'prefix' => null,
+                                'instructions' => null,
+                                'required' => false,
+                                'visibility' => 'visible',
+                                'read_only' => false,
+                                'always_save' => false,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'handle' => 'bravo',
+                'sets' => [
+                    [
+                        'id' => 'two',
+                        'handle' => 'two',
+                        'fields' => [
+                            [
+                                'display' => 'Field Two',
+                                'handle' => 'field_two',
+                                'type' => 'text',
+                                'input_type' => 'text',
+                                'placeholder' => null,
+                                'default' => null,
+                                'character_limit' => 0,
+                                'prepend' => null,
+                                'append' => null,
+                                'antlers' => false,
+                                'component' => 'text',
+                                'prefix' => null,
+                                'instructions' => null,
+                                'required' => false,
+                                'visibility' => 'visible',
+                                'read_only' => false,
+                                'always_save' => false,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $field->preProcess()->value());
+    }
+
+    /** @test */
+    public function it_preprocesses_for_config_without_groups()
+    {
+        $field = (new ConfigField('test', [
+            'type' => 'sets',
+        ]))->setValue([
+            'one' => [
+                'display' => 'One',
+                'instructions' => 'One instructions',
+                'icon' => 'one-icon',
+                'fields' => [
+                    ['handle' => 'field_one', 'field' => ['type' => 'text']],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals([
+            [
+                'handle' => 'main',
+                'sets' => [
+                    [
+                        'id' => 'one',
+                        'handle' => 'one',
+                        'display' => 'One',
+                        'instructions' => 'One instructions',
+                        'icon' => 'one-icon',
+                        'fields' => [
+                            [
+                                'display' => 'Field One',
+                                'handle' => 'field_one',
+                                'type' => 'text',
+                                'input_type' => 'text',
+                                'placeholder' => null,
+                                'default' => null,
+                                'character_limit' => 0,
+                                'prepend' => null,
+                                'append' => null,
+                                'antlers' => false,
+                                'component' => 'text',
+                                'prefix' => null,
+                                'instructions' => null,
+                                'required' => false,
+                                'visibility' => 'visible',
+                                'read_only' => false,
+                                'always_save' => false,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $field->preProcess()->value());
+    }
+
+    /** @test */
+    public function it_preprocesses_for_config_with_empty_value()
+    {
+        $field = (new ConfigField('test', [
+            'type' => 'sets',
+        ]));
+
+        $this->assertEquals([], $field->preProcess()->value());
+    }
+
+    /** @test */
+    public function it_processes()
+    {
+        $field = (new Field('test', [
+            'type' => 'sets',
+        ]))->setValue([
+            [
+                'handle' => 'alfa',
+                'display' => 'Alfa',
+                'instructions' => 'Alfa instructions',
+                'icon' => 'alfa-icon',
+                'sections' => [
+                    [
+                        'handle' => 'one',
+                        'display' => 'One',
+                        'instructions' => 'One Instructions',
+                        'icon' => 'one-icon',
+                        'fields' => [
+                            [
+                                'handle' => 'field_one',
+                                'type' => 'inline',
+                                'config' => [
+                                    'type' => 'text',
+                                    'foo' => 'bar',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame([
+            'alfa' => [
+                'display' => 'Alfa',
+                'instructions' => 'Alfa instructions',
+                'icon' => 'alfa-icon',
+                'sets' => [
+                    'one' => [
+                        'display' => 'One',
+                        'instructions' => 'One Instructions',
+                        'icon' => 'one-icon',
+                        'fields' => [
+                            [
+                                'handle' => 'field_one',
+                                'field' => [
+                                    'type' => 'text',
+                                    'foo' => 'bar',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $field->process()->value());
+    }
+}


### PR DESCRIPTION
- Prevent the sets fieldtype from adding a group when empty. This fixes #8042.
- Added tests for the sets fieldtype to cover this issue, plus more just because.
- I started writing more replicator tests thinking that's where the issue was, so I'm including those anyway. Doesn't hurt to have more coverage.
- Bring back the add tab button that I incorrectly removed in 4bebfde38b9332f7a3572beeb652e7967dd40f8f. Now that it's possible to have no tabs again, you need the button to add one.