### PR TITLE
Add `insecure` flag to skip ssl verification when warming static cache

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -173,7 +173,7 @@ class StaticWarm extends Command
 
     protected function shouldVerifySsl(): bool
     {
-        if($this->option('insecure')) {
+        if ($this->option('insecure')) {
             return false;
         }
 

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -32,6 +32,7 @@ class StaticWarm extends Command
         {--queue : Queue the requests}
         {--u|user= : HTTP authentication user}
         {--p|password= : HTTP authentication password}
+        {--insecure : Skip SSL verification}
     ';
 
     protected $description = 'Warms the static cache by visiting all URLs';
@@ -71,7 +72,7 @@ class StaticWarm extends Command
     private function warm(): void
     {
         $client = new Client([
-            'verify' => ! $this->laravel->isLocal(),
+            'verify' => ! $this->option('insecure') && ! $this->laravel->isLocal(),
             'auth' => $this->option('user') && $this->option('password')
                 ? [$this->option('user'), $this->option('password')]
                 : null,

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -171,7 +171,7 @@ class StaticWarm extends Command
             ->values();
     }
 
-    protected function shouldVerifySsl(): bool
+    private function shouldVerifySsl(): bool
     {
         if ($this->option('insecure')) {
             return false;

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -72,7 +72,7 @@ class StaticWarm extends Command
     private function warm(): void
     {
         $client = new Client([
-            'verify' => ! $this->option('insecure') && ! $this->laravel->isLocal(),
+            'verify' => $this->shouldVerifySsl(),
             'auth' => $this->option('user') && $this->option('password')
                 ? [$this->option('user'), $this->option('password')]
                 : null,
@@ -169,6 +169,15 @@ class StaticWarm extends Command
             })
             ->sort()
             ->values();
+    }
+
+    protected function shouldVerifySsl(): bool
+    {
+        if($this->option('insecure')) {
+            return false;
+        }
+
+        return ! $this->laravel->isLocal();
     }
 
     protected function entryUris(): Collection


### PR DESCRIPTION
This PR adds an `--insecure` flag to the `static:warm` command to skip SSL verification. The `--insecure` option is useful to warm the static cache even when running Statamic with self-signed certs (e.g. behind a reverse proxy).