### PR TITLE
Fix vimeo unlisted videos in video fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/VideoFieldtype.vue
+++ b/resources/js/components/fieldtypes/VideoFieldtype.vue
@@ -69,7 +69,7 @@ export default {
 
             if (embed_url.includes('vimeo')) {
                 embed_url = embed_url.replace('/vimeo.com', '/player.vimeo.com/video');
-                if (embed_url.split('/').length > 4) {
+                if (embed_url.split('/').length > 5) {
                     let hash = embed_url.substr(embed_url.lastIndexOf('/') + 1);
                     embed_url = embed_url.substr(0, embed_url.lastIndexOf('/')) + '?h=' + hash.replace('?', '&');
                 }

--- a/resources/js/components/fieldtypes/VideoFieldtype.vue
+++ b/resources/js/components/fieldtypes/VideoFieldtype.vue
@@ -69,6 +69,10 @@ export default {
 
             if (embed_url.includes('vimeo')) {
                 embed_url = embed_url.replace('/vimeo.com', '/player.vimeo.com/video');
+                if (embed_url.split('/').length > 4) {
+                    let hash = embed_url.substr(embed_url.lastIndexOf('/') + 1);
+                    embed_url = embed_url.substr(0, embed_url.lastIndexOf('/')) + '?h=' + hash.replace('?', '&');
+                }
             }
 
             // Make sure additional query parameters are included.


### PR DESCRIPTION
Related to: https://github.com/statamic/cms/pull/6413
Fixes: https://github.com/statamic/cms/issues/8053

Vimeo unlisted urls are shared in the format: https://vimeo.com/x/y but when embedded need to be https://player.vimeo.com/x?h=y

This PR makes that happen.