### PR TITLE
[4.x] Fix date filter

### DIFF
--- a/resources/js/components/data-list/Filters.vue
+++ b/resources/js/components/data-list/Filters.vue
@@ -11,7 +11,7 @@
                     </button>
                 </template>
                 <template #default="{ close: closePopover }">
-                    <div class="flex flex-col text-left w-64">
+                    <div class="flex flex-col text-left min-w-[18rem]">
                         <div class="filter-fields text-sm">
                             <field-filter
                                 ref="fieldFilter"

--- a/resources/js/components/fieldtypes/date/RangeInline.vue
+++ b/resources/js/components/fieldtypes/date/RangeInline.vue
@@ -1,6 +1,6 @@
 <template>
 
-    <div class="relative">
+    <div class="relative w-full">
         <v-date-picker
             v-bind="pickerBindings"
             @input="$emit('input', $event)"

--- a/resources/js/components/fieldtypes/date/SingleInline.vue
+++ b/resources/js/components/fieldtypes/date/SingleInline.vue
@@ -1,6 +1,6 @@
 <template>
 
-    <div class="relative">
+    <div class="relative w-full">
         <v-date-picker
             v-bind="pickerBindings"
             @input="$emit('input', $event)"

--- a/src/Query/Scopes/Filters/Fields/Date.php
+++ b/src/Query/Scopes/Filters/Fields/Date.php
@@ -19,6 +19,8 @@ class Date extends FieldtypeFilter
             ],
             'value' => [
                 'type' => 'date',
+                'inline' => true,
+                'full_width' => true,
                 'required' => 'true',
                 'if' => [
                     'operator' => 'not empty',


### PR DESCRIPTION
Fixes #8055

The actual issue is that when you clicked a date in the datepicker, since it's not "inside" the filter popover due to it being portaled away, it would think you're clicking away from the filter popover, and close it before the date has a chance to register. (Or something along those lines. :smile:)

The real fix is something along the lines of tweaking the clickawayClose logic to ignore clicks inside nested popovers. But it's a bit complicated since they're not actually nested in the DOM.

- Fix full width inline date pickers. The missing w-full class would prevent the calendars from stretching the full width, even when used as a regular publish field.
- Use an inline date picker in the filter to workaround the popover issue.
- make the min width of the field filter popover just a bit wider than a calendar, otherwise it would stick over the edge.
