### PR TITLE
[4.x] Fix fields not being droppable onto new sections

### DIFF
--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -114,6 +114,7 @@ export default {
 
         tabs(tabs) {
             this.$emit('updated', tabs);
+            this.makeSortable();
         }
 
     },


### PR DESCRIPTION
Fixes #8063 

This fixes the issue by reinitializing the sortable when the tabs are changed.

[Same technique as used in v3](https://github.com/statamic/cms/blob/70f91a03adb2119e2d3b366d2c85916fd11d8a72/resources/js/components/blueprints/Sections.vue#L95) but accidentally left out during the blueprint revamp.