### PR TITLE
Antlers: Prevent `isConditionProcessor` from leaking on else branches

### DIFF
--- a/src/View/Antlers/Language/Runtime/ConditionProcessor.php
+++ b/src/View/Antlers/Language/Runtime/ConditionProcessor.php
@@ -35,6 +35,8 @@ class ConditionProcessor
 
         foreach ($node->logicBranches as $branch) {
             if ($branch->head->name->name == 'else') {
+                $this->processor->setIsConditionProcessor($condValueToRestore);
+
                 return $branch;
             } else {
                 // Let the processor know that it is being used

--- a/tests/Antlers/Runtime/YieldTest.php
+++ b/tests/Antlers/Runtime/YieldTest.php
@@ -430,4 +430,28 @@ EOT;
 
         $this->assertSame('', trim($this->renderString($template, [], true)));
     }
+
+    public function test_condition_blocks_do_not_leak_their_condition_state()
+    {
+        $template = <<<'EOT'
+{{ if false }}
+    {{# It doesn't matter whats inside here #}}
+{{ else }}
+    Else Statement.
+{{ /if }}
+
+{{ section:seo_body }}Content{{ section:seo_body }}
+
+{{ yield:seo_body }}
+EOT;
+
+        $expected = <<<'EXPECTED'
+Else Statement.
+
+
+Content
+EXPECTED;
+
+        $this->assertSame($expected, trim($this->renderString($template, [], true)));
+    }
 }


### PR DESCRIPTION
This PR resolves #8066 by fixing a state leak when a condition contains an `else` clause that is evaluated.

For example, if you had the following template:

```antlers
{{ if false }}
    {{# It doesn't matter whats inside here #}}
{{ else }}
    Else Statement.
{{ /if }}

{{ section:seo_body }}Content{{ section:seo_body }}

{{ yield:seo_body }}
```

The site would return `1`. However, if you changed the condition to `true` so the `else` block is not hit, the bugged behavior will go away.

