### PR TITLE
[4.x] Fix missing gap cursor in Bard fullscreen mode

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -223,11 +223,6 @@
         @apply px-6 py-16;
         min-height: calc(100vh - 120px);
 
-        /*  To remove min height from nested bard fields inside bard in fullscreen mode. */
-        * > .ProseMirror {
-            min-height: auto;
-        }
-
         &:focus {
             @apply ring-0;
         }

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -220,7 +220,7 @@
     }
 
     & > .bard-editor > div > .ProseMirror {
-        @apply px-6 py-16 flex flex-col;
+        @apply px-6 py-16;
         min-height: calc(100vh - 120px);
 
         /*  To remove min height from nested bard fields inside bard in fullscreen mode. */


### PR DESCRIPTION
This PR removes the flexbox which caused unnessary spacing and broke the gap cursor. It didn't seem to be necessary, since everything still works without it. Fixes #8069

This also removes an unnecessary min-height reset now that the selector applying the min-height in the first place is more specific since #7938.
