### PR TITLE
[4.x] Sortable consistency

### DIFF
--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -37,7 +37,7 @@
                             <sortable-list
                                 v-model="selectedColumns"
                                 :vertical="true"
-                                :distance="10"
+                                :distance="5"
                                 item-class="item"
                                 handle-class="item"
                                 append-to=".modal-body"

--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -78,7 +78,7 @@
                 <sortable-list
                     item-class="sortable-item"
                     handle-class="sortable-item"
-                    distance="10"
+                    distance="5"
                     :mirror="false"
                     v-model="rules"
                 >
@@ -98,6 +98,11 @@
 
 </template>
 
+<style scoped>
+    .draggable-source--is-dragging {
+        @apply opacity-75 bg-transparent border-dashed
+    }
+</style>
 
 <script>
 import RULES from './Rules.js';

--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -78,6 +78,8 @@
                 <sortable-list
                     item-class="sortable-item"
                     handle-class="sortable-item"
+                    distance="10"
+                    :mirror="false"
                     v-model="rules"
                 >
                     <div class="vs__selected-options-outside flex flex-wrap outline-none">

--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -43,8 +43,16 @@
                     <div class="text-sm text-gray-700 text-left py-2 px-4" v-text="__('No options to choose from.')" />
                 </template>
                 <template #footer="{ deselect }" v-if="config.multiple">
+                    <sortable-list
+                        item-class="sortable-item"
+                        handle-class="sortable-item"
+                        :value="value"
+                        :distance="5"
+                        :mirror="false"
+                        @input="update"
+                    >
                     <div class="vs__selected-options-outside flex flex-wrap">
-                        <span v-for="option in selectedOptions" :key="option.value" class="vs__selected mt-2">
+                        <span v-for="option in selectedOptions" :key="option.value" class="vs__selected mt-2 sortable-item">
                             <div v-if="config.label_html" v-html="option.label"></div>
                             <template v-else>{{ option.label }}</template>
                             <button v-if="!readOnly" @click="deselect(option)" type="button" :aria-label="__('Deselect option')" class="vs__deselect">
@@ -55,6 +63,7 @@
                             </button>
                         </span>
                     </div>
+                    </sortable-list>
                 </template>
         </v-select>
         <div class="text-xs ml-2 mt-3" :class="limitIndicatorColor" v-if="config.max_items">
@@ -63,13 +72,25 @@
     </div>
 </template>
 
+<style scoped>
+    .draggable-source--is-dragging {
+        @apply opacity-75 bg-transparent border-dashed
+    }
+</style>
+
 <script>
 import HasInputOptions from './HasInputOptions.js'
 import { computePosition, offset, flip } from '@floating-ui/dom';
+import { SortableList } from '../sortable/Sortable';
+
 
 export default {
 
     mixins: [Fieldtype, HasInputOptions],
+
+    components: {
+        SortableList
+    },
 
     computed: {
         selectedOptions() {

--- a/resources/js/components/fieldtypes/TagsFieldtype.vue
+++ b/resources/js/components/fieldtypes/TagsFieldtype.vue
@@ -32,7 +32,8 @@
                     item-class="sortable-item"
                     handle-class="sortable-item"
                     :value="value"
-                    :distance="10"
+                    :distance="5"
+                    :mirror="false"
                     @input="update"
                 >
                     <div class="vs__selected-options-outside flex flex-wrap">
@@ -47,6 +48,12 @@
             </template>
     </v-select>
 </template>
+
+<style scoped>
+    .draggable-source--is-dragging {
+        @apply opacity-75 bg-transparent border-dashed
+    }
+</style>
 
 <script>
 import HasInputOptions from './HasInputOptions.js'

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -62,7 +62,7 @@
                         @dragend="$emit('blur')"
                         :constrain-dimensions="true"
                         :disabled="isReadOnly"
-                        :distance="10"
+                        :distance="5"
                         :animate="false"
                         append-to="body"
                     >
@@ -88,7 +88,7 @@
                                 handle-class="asset-row"
                                 :vertical="true"
                                 :disabled="isReadOnly"
-                                :distance="10"
+                                :distance="5"
                                 :mirror="false"
                             >
                                 <tbody ref="assets">

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -41,6 +41,7 @@
                     handle-class="sortable-item"
                     :value="items"
                     :distance="5"
+                    :mirror="false"
                     @input="input"
                 >
                     <div class="vs__selected-options-outside flex flex-wrap">
@@ -62,9 +63,6 @@
 </template>
 
 <style scoped>
-    .draggable-mirror {
-        display: none !important;
-    }
     .draggable-source--is-dragging {
         @apply opacity-75 bg-transparent border-dashed
     }


### PR DESCRIPTION
- Fixes issue where you can't remove a validation rule. Added distance prop otherwise it'll think you're dragging when you try to click the x.
- Makes all the "taggable" fields behave the same. No drag mirror, semi-transparent dashed border source.
- Lets the `select` fieldtype's options be sortable.
- Makes the sortable distances all use 5px instead of 10px all over the place.