### PR TITLE
[4.x] Support random sorting of entries in GraphQL

### DIFF
--- a/src/GraphQL/Queries/EntriesQuery.php
+++ b/src/GraphQL/Queries/EntriesQuery.php
@@ -82,6 +82,11 @@ class EntriesQuery extends Query
                 [$sort, $order] = explode(' ', $sort);
             }
 
+            if ($sort === 'random') {
+                $query->inRandomOrder($order);
+                return;
+            }
+
             $query->orderBy($sort, $order);
         }
     }

--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -10,6 +10,7 @@ abstract class Builder extends BaseBuilder
 {
     protected $store;
     protected $randomize = false;
+    protected $randomizeSeed = null;
 
     public function __construct(Store $store)
     {
@@ -50,9 +51,10 @@ abstract class Builder extends BaseBuilder
         return $keys->slice($this->offset, $this->limit);
     }
 
-    public function inRandomOrder()
+    public function inRandomOrder($seed = null)
     {
         $this->randomize = true;
+        $this->randomizeSeed = $seed;
 
         return $this;
     }
@@ -60,7 +62,7 @@ abstract class Builder extends BaseBuilder
     protected function orderKeys($keys)
     {
         if ($this->randomize) {
-            return $keys->shuffle();
+            return $keys->shuffle($this->randomizeSeed);
         }
 
         if (empty($this->orderBys)) {


### PR DESCRIPTION
I am submitting this merge request to introduce a new feature that allows random sorting of GraphQL queries. This enhancement will enable users to retrieve entries in a randomized order, making it easier to, well, display random results. This is an extension of the already existing `sort` attribute. 

It further extends the `Builder` to pass a seed to the `shuffle` function, that already supports seeds.

This is related to this idea: https://github.com/statamic/ideas/issues/757