### PR TITLE
[4.x] Include URL in Live Preview post message

### DIFF
--- a/resources/js/components/live-preview/UpdatesIframe.js
+++ b/resources/js/components/live-preview/UpdatesIframe.js
@@ -13,6 +13,7 @@ const postMessageToIframe = (container, url, payload) => {
 
     container.firstChild.contentWindow.postMessage({
         name: 'statamic.preview.updated',
+        url,
         ...payload
     }, targetOrigin);
 }


### PR DESCRIPTION
The normal live preview refresh uses a random string in the URL to prevent caching on each update, but if you're using the post message method and the fetch API to grab the updated page you don't currently have access to the URL with the new random string in it.

You can generate your own version, but since Statamic is already generating one it would be handy if you could just use that.

This PR includes the updated live preview URL in the post message data, so that your frontend code can use it, something like:

```js
window.addEventListener('message', async (event) => {
    if (event.data.name === 'statamic.preview.updated') {
        const text = await fetch(event.data.url).then((res) => res.text());
        // ...
    }
});
```