### PR TITLE
[4.x] Use different approach to reset stack stacking context

### DIFF
--- a/resources/css/components/stacks.css
+++ b/resources/css/components/stacks.css
@@ -9,12 +9,13 @@
 
     .vue-portal-target {
         @apply pointer-events-auto; /* allow clicks that we disabled above */
+        isolation: isolate;
     }
 }
 
 .stacks-on-stacks {
     .stack-container {
-        @apply absolute inset-0 z-1;
+        @apply absolute inset-0;
         transition: left .3s ease;
     }
 


### PR DESCRIPTION
Reverts the change in #8073, which caused #8082, as well as popovers not being visibile within stacks.

This resets the stacking context on _all_ of the top level portal targets rather than just on stacks.
Resetting on just the stack caused it to sit above other portal targets, like popovers.

This continues to fix #8082.
Fixes #8082.
Fixes dropdown lists / popovers not being visible.
