### PR TITLE
[4.x] Remove empty css file

### DIFF
--- a/resources/css/cp.css
+++ b/resources/css/cp.css
@@ -69,7 +69,6 @@
 @import "components/fieldtypes/table";
 @import "components/fieldtypes/tags";
 @import "components/fieldtypes/textarea";
-@import "components/fieldtypes/time";
 @import "components/fieldtypes/width";
 @import "components/fieldtypes/video";
 @import "components/fieldtypes/yaml";


### PR DESCRIPTION
The last statement was removed in #8094. Now it's empty and Vite complains about that.
