### PR TITLE
Only show set alt field column only if needsAlt

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -30,7 +30,7 @@
             </button>
             <div v-text="asset.size" class="hidden @xs:inline asset-filesize text-xs text-gray-600 px-2" />
         </td>
-        <td class="w-24" v-if="showSetAlt">
+        <td class="w-24" v-if="showSetAlt && needsAlt">
             <button
                 class="asset-set-alt text-blue px-4 text-sm hover:text-black"
                 @click="edit"


### PR DESCRIPTION
The table column for the "Set alt" button is outputting with a width of `w-24` even if it doesn't need an alt tag, this causes the image to be squashed and the red click area in my screenshot below to be inactive (the button isn't outputted inside the cell but it's parent td is):  

<img width="600" alt="statamic-td-fix" src="https://github.com/bengs/cms/assets/20150565/245e75c2-38e2-4dca-ba64-6297ee2bc11c">
