### PR TITLE
[4.x] Fix imported Bard button config override

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardButtonsSettingFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardButtonsSettingFieldtype.vue
@@ -43,9 +43,12 @@ export default {
         buttons: {
             deep: true,
             handler(buttons) {
-                this.data = buttons
+                const enabledButtonNames = buttons
                     .filter(button => button.enabled)
                     .map(button => button.name);
+                if (JSON.stringify(enabledButtonNames) !== JSON.stringify(this.data)) {
+                    this.data = enabledButtonNames;
+                }
             }
         },
 


### PR DESCRIPTION
When you import a Bard field from a fieldset the `buttons` list is always saved as an override, even if it hasn't been changed from the default list in the source field. This means changes to the source field's buttons are never reflected in the imported fields even when no override was intended.

This happens because the `buttons` watcher is triggered during `initButtons()` and that always updates `data`. This PR fixes that by checking if the list of buttons are actually different before updating `data`.