### PR TITLE
[4.x] New addons use Vite

### DIFF
--- a/src/Console/Commands/stubs/addon/package.json.stub
+++ b/src/Console/Commands/stubs/addon/package.json.stub
@@ -1,17 +1,12 @@
 {
     "private": true,
     "scripts": {
-        "dev": "mix",
-        "development": "mix",
-        "watch": "mix watch",
-        "watch-poll": "mix watch -- --watch-options-poll=1000",
-        "hot": "mix watch --hot",
-        "production": "mix --production"
+        "dev": "vite",
+        "build": "vite build"
     },
     "devDependencies": {
-        "cross-env": "^7.0",
-        "laravel-mix": "^6.0",
-        "vue": "^2.6.11",
-        "vue-loader": "^15.9.8"
+        "@vitejs/plugin-vue2": "^2.2.0",
+        "laravel-vite-plugin": "^0.7.2",
+        "vite": "^4.0.0"
     }
 }

--- a/src/Console/Commands/stubs/addon/vite.config.js.stub
+++ b/src/Console/Commands/stubs/addon/vite.config.js.stub
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+import vue from '@vitejs/plugin-vue2';
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            input: [
+                'resources/js/addon.js',
+                // 'resources/css/addon.css'
+            ],
+            publicDirectory: 'resources/dist',
+        }),
+        vue(),
+    ],
+});

--- a/src/Console/Commands/stubs/addon/webpack.mix.js.stub
+++ b/src/Console/Commands/stubs/addon/webpack.mix.js.stub
@@ -1,3 +1,0 @@
-let mix = require('laravel-mix');
-
-mix.js('resources/js/addon.js', 'dist/js').vue();

--- a/tests/Console/Commands/MakeAddonTest.php
+++ b/tests/Console/Commands/MakeAddonTest.php
@@ -105,10 +105,11 @@ class MakeAddonTest extends TestCase
 
         // Fieldtype stuff
         $this->assertFileExists(base_path('addons/hasselhoff/knight-rider/package.json'));
-        $this->assertFileExists(base_path('addons/hasselhoff/knight-rider/webpack.mix.js'));
+        $this->assertFileExists(base_path('addons/hasselhoff/knight-rider/vite.config.js'));
         $this->assertFileExists(base_path('addons/hasselhoff/knight-rider/src/Fieldtypes/KnightRider.php'));
         $this->assertFileExists(base_path('addons/hasselhoff/knight-rider/resources/js/addon.js'));
         $this->assertFileExists(base_path('addons/hasselhoff/knight-rider/resources/js/components/fieldtypes/KnightRider.vue'));
+        $this->assertDirectoryExists(base_path('addons/hasselhoff/knight-rider/resources/dist'));
     }
 
     /** @test */


### PR DESCRIPTION
When using make:fieldtype, it will now use Vite instead of Mix.
