### PR TITLE
[4.x] Fix link fieldtype's options appearing behind things.

### DIFF
--- a/resources/js/components/fieldtypes/IconFieldtype.vue
+++ b/resources/js/components/fieldtypes/IconFieldtype.vue
@@ -37,11 +37,11 @@
 </template>
 
 <script>
-import { computePosition, offset } from '@floating-ui/dom';
+import PositionsSelectOptions from '../../mixins/PositionsSelectOptions';
 
 export default {
 
-    mixins: [Fieldtype],
+    mixins: [Fieldtype, PositionsSelectOptions],
 
     computed: {
         options() {
@@ -72,23 +72,6 @@ export default {
             } else {
                 this.update(null);
             }
-        },
-
-        positionOptions(dropdownList, component, { width }) {
-            dropdownList.style.width = width
-
-            computePosition(component.$refs.toggle, dropdownList, {
-                placement: 'bottom',
-                middleware: [
-                    offset({ mainAxis: 0, crossAxis: -1 }),
-                ]
-            }).then(({ x, y }) => {
-                Object.assign(dropdownList.style, {
-                    // Round to avoid blurry text
-                    left: `${Math.round(x)}px`,
-                    top: `${Math.round(y)}px`,
-                });
-            });
         },
     }
 };

--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -5,9 +5,12 @@
         <div class="w-40 mr-4">
             <v-select
                 v-model="option"
+                append-to-body
+                :calculate-position="positionOptions"
                 :options="options"
                 :clearable="false"
                 :reduce="(option) => option.value"
+
             >
                 <template #option="{ label }">
                   {{ __(label) }}
@@ -49,9 +52,11 @@
 </template>
 
 <script>
+import PositionsSelectOptions from '../../mixins/PositionsSelectOptions';
+
 export default {
 
-    mixins: [Fieldtype],
+    mixins: [Fieldtype, PositionsSelectOptions],
 
     data() {
 

--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -80,13 +80,13 @@
 
 <script>
 import HasInputOptions from './HasInputOptions.js'
-import { computePosition, offset, flip } from '@floating-ui/dom';
 import { SortableList } from '../sortable/Sortable';
+import PositionsSelectOptions from '../../mixins/PositionsSelectOptions';
 
 
 export default {
 
-    mixins: [Fieldtype, HasInputOptions],
+    mixins: [Fieldtype, HasInputOptions, PositionsSelectOptions],
 
     components: {
         SortableList
@@ -169,24 +169,6 @@ export default {
                     this.update(null);
                 }
             }
-        },
-
-        positionOptions(dropdownList, component, { width }) {
-            dropdownList.style.width = width
-
-            computePosition(component.$refs.toggle, dropdownList, {
-                placement: 'bottom',
-                middleware: [
-                    offset({ mainAxis: 0, crossAxis: -1 }),
-                    flip(),
-                ]
-            }).then(({ x, y }) => {
-                Object.assign(dropdownList.style, {
-                    // Round to avoid blurry text
-                    left: `${Math.round(x)}px`,
-                    top: `${Math.round(y)}px`,
-                });
-            });
         },
     }
 };

--- a/resources/js/components/fieldtypes/TemplateFieldtype.vue
+++ b/resources/js/components/fieldtypes/TemplateFieldtype.vue
@@ -23,11 +23,12 @@
 </template>
 
 <script>
-import { computePosition, offset, flip } from '@floating-ui/dom';
+import PositionsSelectOptions from '../../mixins/PositionsSelectOptions';
+
 
 export default {
 
-    mixins: [Fieldtype],
+    mixins: [Fieldtype, PositionsSelectOptions],
 
     data: function() {
         return {
@@ -80,26 +81,6 @@ export default {
             this.options = options;
             this.loading = false;
         });
-    },
-
-    methods: {
-        positionOptions(dropdownList, component, { width }) {
-            dropdownList.style.width = width
-
-            computePosition(component.$refs.toggle, dropdownList, {
-                placement: 'bottom',
-                middleware: [
-                    offset({ mainAxis: 0, crossAxis: -1 }),
-                    flip(),
-                ]
-            }).then(({ x, y }) => {
-                Object.assign(dropdownList.style, {
-                    // Round to avoid blurry text
-                    left: `${Math.round(x)}px`,
-                    top: `${Math.round(y)}px`,
-                });
-            });
-        }
     }
 
 };

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -69,10 +69,12 @@
 </style>
 
 <script>
+import PositionsSelectOptions from '../../../mixins/PositionsSelectOptions';
 import { SortableList, SortableItem } from '../../sortable/Sortable';
-import { computePosition, offset, flip } from '@floating-ui/dom';
 
 export default {
+
+    mixins: [PositionsSelectOptions],
 
     components: {
         SortableList,
@@ -149,24 +151,6 @@ export default {
             }
 
             this.$emit('input', items);
-        },
-
-        positionOptions(dropdownList, component, { width }) {
-            dropdownList.style.width = width
-
-            computePosition(component.$refs.toggle, dropdownList, {
-                placement: 'bottom',
-                middleware: [
-                    offset({ mainAxis: 0, crossAxis: -1 }),
-                    flip(),
-                ]
-            }).then(({ x, y }) => {
-                Object.assign(dropdownList.style, {
-                    // Round to avoid blurry text
-                    left: `${Math.round(x)}px`,
-                    top: `${Math.round(y)}px`,
-                });
-            });
         },
 
     }

--- a/resources/js/mixins/PositionsSelectOptions.js
+++ b/resources/js/mixins/PositionsSelectOptions.js
@@ -1,0 +1,27 @@
+import { computePosition, offset, flip } from '@floating-ui/dom';
+
+export default {
+
+    methods: {
+
+        positionOptions(dropdownList, component, { width }) {
+            dropdownList.style.width = width
+
+            computePosition(component.$refs.toggle, dropdownList, {
+                placement: 'bottom',
+                middleware: [
+                    offset({ mainAxis: 0, crossAxis: -1 }),
+                    flip(),
+                ]
+            }).then(({ x, y }) => {
+                Object.assign(dropdownList.style, {
+                    // Round to avoid blurry text
+                    left: `${Math.round(x)}px`,
+                    top: `${Math.round(y)}px`,
+                });
+            });
+        }
+
+    }
+
+}


### PR DESCRIPTION
- Move positioning logic to a mixin
- Apply to link fieldtype. Fixes #8123
