### PR TITLE
[4.x] Invalid Avatar URL falls back to initials

### DIFF
--- a/resources/js/components/Avatar.vue
+++ b/resources/js/components/Avatar.vue
@@ -1,8 +1,8 @@
 <template>
 
     <div class="rounded-full overflow-hidden" v-tooltip="user.name">
-        <img v-if="user.avatar" :src="user.avatar.permalink || user.avatar" class="block" />
-        <div v-else class="text-center flex items-center justify-center h-full w-full bg-pink text-white"><span>{{ initials }}</span></div>
+        <img v-if="useAvatar" :src="avatarSrc" class="block" @error="hasAvatarError = true" />
+        <div v-if="useInitials" class="text-center flex items-center justify-center h-full w-full bg-pink text-white"><span>{{ initials }}</span></div>
     </div>
 
 </template>
@@ -14,10 +14,34 @@ export default {
         user: Object
     },
 
+    data() {
+        return {
+            hasAvatarError: false,
+        }
+    },
+
     computed: {
 
         initials() {
             return this.user.initials || '?';
+        },
+
+        useAvatar() {
+            return this.hasAvatar && !this.hasAvatarError;
+        },
+
+        hasAvatar() {
+            return !! this.user.avatar;
+        },
+
+        avatarSrc() {
+            if (! this.hasAvatar) return null;
+
+            return this.user.avatar.permalink || this.user.avatar;
+        },
+
+        useInitials() {
+            return ! this.hasAvatar || this.hasAvatarError;
         }
 
     }


### PR DESCRIPTION
Closes statamic/collaboration#81

When an avatar URL ends up with a 404 or some other type of error, fall back to using the initials rather than a broken image.
