### PR TITLE
[4.x] Fix icon fieldtype default

### DIFF
--- a/src/Fieldtypes/Icon.php
+++ b/src/Fieldtypes/Icon.php
@@ -77,7 +77,7 @@ class Icon extends Fieldtype
 
         $folder = $this->config(
             'folder',
-            $hasConfiguredDirectory ? null : 'default' // Only apply a default folder if using Statamic icons.
+            $hasConfiguredDirectory ? null : 'regular' // Only apply a default folder if using Statamic icons.
         );
 
         $path = Path::tidy($directory.'/'.$folder);


### PR DESCRIPTION
When using the icon fieldtype and you don't select your own custom directory, it's supposed to show the `regular` set of Statamic CP icons.

When the icon fieldtype was introduced, they were in a `default` directory. The default icons were moved to `regular` in #7854 but we didn't update this line.

This fixes the icon fieldtype showing nothing if you were to use the uncustomized config. (It still doesn't let you use them on the frontend.)
