### PR TITLE
[4.x] Adjust a couple of fieldtype translations

### DIFF
--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -210,7 +210,7 @@ export default {
             // level, grid, or set fields depending on the event listener location.
             let field = {
                 type: fieldtype.handle,
-                display: `${fieldtype.title} ${__('Field')}`,
+                display: __(':title Field', {title: fieldtype.title}),
                 handle: null, // The handle will be generated from the display by the "slug" fieldtype.
                 icon: fieldtype.icon,
                 instructions: null,

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -11,7 +11,7 @@
                 {{ values.display || config.display || config.handle }}
                 <small class="badge-pill bg-gray-100 ml-4 border text-xs text-gray-700 font-medium leading-none flex items-center">
                     <svg-icon class="h-4 w-4 mr-2 inline-block text-gray-700" :name="`light/${fieldtype.icon}`"></svg-icon>
-                    {{ fieldtype.title }} {{ __('Fieldtype') }}
+                    {{ fieldtype.title }}
                 </small>
             </h1>
             <button

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -8,6 +8,7 @@
     ":count\/:max selected": ":count\/:max выбрано",
     ":file uploaded": ":file загружен",
     ":start-:end of :total": ":start-:end из :total",
+    ":title Field": ":title Поле",
     "A blueprint with that name already exists.": "Чертёж с таким именем уже существует.",
     "A fieldset with that name already exists.": "Набор полей с таким именем уже существует.",
     "A valid blueprint is required.": "Требуется действительный чертёж.",

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -8,7 +8,7 @@
     ":count\/:max selected": ":count\/:max выбрано",
     ":file uploaded": ":file загружен",
     ":start-:end of :total": ":start-:end из :total",
-    ":title Field": ":title Поле",
+    ":title Field": "Поле :title",
     "A blueprint with that name already exists.": "Чертёж с таким именем уже существует.",
     "A fieldset with that name already exists.": "Набор полей с таким именем уже существует.",
     "A valid blueprint is required.": "Требуется действительный чертёж.",


### PR DESCRIPTION
This addresses #8134 

Remove "Fieldtype" suffix in fieldtype settings header to simplify translation.
![image](https://github.com/statamic/cms/assets/105211/ad70f98b-680c-4d27-bb09-4bc18aad1a43)
![image](https://github.com/statamic/cms/assets/105211/7e58be7c-3c1e-4590-bcc9-b2281c801818)

Use translation with placeholder rather than concatenation.
e.g. Some languages would say "Markdown field" and some say an equivalent of "Field Markdown". By using a single translation, it can be adjusted appropriately, as with the included Russian translation in this PR.
