### PR TITLE
[4.x] Add border to colour option in ColorFieldtype.vue

### DIFF
--- a/resources/js/components/fieldtypes/ColorFieldtype.vue
+++ b/resources/js/components/fieldtypes/ColorFieldtype.vue
@@ -22,7 +22,7 @@
                     <div v-if="config.swatches.length" class="grid grid-cols-4 gap-3">
                         <div
                             v-for="swatch in config.swatches"
-                            class="w-10 h-10 inline-block cursor-pointer rounded flex"
+                            class="w-10 h-10 inline-block cursor-pointer rounded flex border border-gray-400"
                             :style="{ 'background-color': swatch }"
                             @click="() => { update(swatch); closePopover(); }"
                         >


### PR DESCRIPTION
When adding a pure white color swatch, it has no border or shadow and is indistinguishable from the white background of the popover. A border has been added in line with the surrounding styles