### PR TITLE
[4.x] Update error display in starter kit export

### DIFF
--- a/src/StarterKits/Exporter.php
+++ b/src/StarterKits/Exporter.php
@@ -33,7 +33,7 @@ class Exporter
         $this->exportPath = $absolutePath;
 
         if (! $this->files->exists($this->exportPath)) {
-            throw new StarterKitException("Path [$exportPath] does not exist.");
+            throw new StarterKitException("Path [$this->exportPath] does not exist.");
         }
 
         if (! $this->files->exists(base_path('starter-kit.yaml'))) {


### PR DESCRIPTION
The $exportPath variable isnt defined as its scoped to $this