### PR TITLE
[4.x] Fix 404 response status view cascade hydration

### DIFF
--- a/src/Exceptions/NotFoundHttpException.php
+++ b/src/Exceptions/NotFoundHttpException.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Exceptions;
 
+use Facades\Statamic\View\Cascade;
 use Statamic\Statamic;
 use Statamic\View\View;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException as SymfonyException;
@@ -21,10 +22,13 @@ class NotFoundHttpException extends SymfonyException
 
     protected function contents()
     {
+        Cascade::hydrated(function ($cascade) {
+            $cascade->set('response_code', 404);
+        });
+
         return app(View::class)
             ->template('errors.404')
             ->layout($this->layout())
-            ->with(['response_code' => 404])
             ->render();
     }
 

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Facades\Statamic\CP\LivePreview;
+use Facades\Statamic\View\Cascade;
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
@@ -631,6 +632,8 @@ class FrontendTest extends TestCase
         $this->viewShouldReturnRaw('errors.404', 'Not found {{ response_code }} {{ site:handle }}');
 
         $this->get('unknown')->assertNotFound()->assertSee('Not found 404 en');
+
+        $this->assertEquals(404, Cascade::get('response_code'));
 
         // todo: test cascade vars are in the debugbar
     }


### PR DESCRIPTION
When working on tests for https://github.com/statamic/seo-pro/pull/268, we noticed that though 404 status codes were in the view context, they weren't being properly hydrated to `View\Cascade` (which we use in the SEO Pro blade directive specifically when rendering blade components). This PR fixes that.