### PR TITLE
[4.x] Fix suggestable condition fields

### DIFF
--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -68,7 +68,7 @@ export default {
 
     provide() {
         return {
-            conditions: this.makeConditionsProvider(),
+            suggestableConditionFieldsProvider: this.makeConditionsProvider(),
         }
     },
 

--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -41,7 +41,7 @@
 
         <tabs
             :single-tab="!useTabs"
-            :initial-tabs="blueprint.tabs"
+            :initial-tabs="tabs"
             @updated="tabsUpdated"
         />
 
@@ -72,28 +72,14 @@ export default {
     data() {
         return {
             blueprint: this.initializeBlueprint(),
-            tabs: [],
             errors: {}
         }
     },
 
     computed: {
 
-        suggestableConditionFields() {
-            let fields = this.blueprint.tabs.reduce((fields, tab) => {
-                return fields.concat(tab.sections.reduce((fields, section) => {
-                    let sectionFields = section.fields.reduce((fields, field) => {
-                        return fields.concat(
-                            field.type === 'import'
-                                ? this.getFieldsFromImportedFieldset(field.fieldset, field.prefix)
-                                : [field.handle]
-                        );
-                    }, []);
-                    return fields.concat(sectionFields);
-                }, []));
-            }, []);
-
-            return _.unique(fields);
+        tabs() {
+            return this.blueprint.tabs;
         }
 
     },
@@ -110,10 +96,6 @@ export default {
     },
 
     watch: {
-
-        tabs(tabs) {
-            this.blueprint.tabs = tabs;
-        },
 
         blueprint: {
             deep: true,
@@ -135,7 +117,7 @@ export default {
         },
 
         tabsUpdated(tabs) {
-            this.tabs = tabs;
+            this.blueprint.tabs = tabs;
         },
 
         save() {

--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -85,11 +85,18 @@ export default {
         suggestableConditionFields() {
             let fields = this.blueprint.tabs.reduce((fields, tab) => {
                 return fields.concat(tab.sections.reduce((fields, section) => {
-                    return fields.concat(section.fields.map(field => field.handle));
+                    let sectionFields = section.fields.reduce((fields, field) => {
+                        return fields.concat(
+                            field.type === 'import'
+                                ? this.getFieldsFromImportedFieldset(field.fieldset, field.prefix)
+                                : [field.handle]
+                        );
+                    }, []);
+                    return fields.concat(sectionFields);
                 }, []));
             }, []);
 
-            return fields
+            return _.unique(fields);
         }
 
     },
@@ -156,6 +163,12 @@ export default {
                 suggestableFields: { get: () => this.suggestableConditionFields },
             });
             return provide;
+        },
+
+        getFieldsFromImportedFieldset(fieldset, prefix) {
+            return Statamic.$config.get(`fieldsets.${fieldset}.fields`, [])
+                .map(field => field.handle)
+                .map(handle => prefix ? `${prefix}${handle}` : handle);
         }
 
     }

--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -66,12 +66,32 @@ export default {
         isFormBlueprint: { type: Boolean, default: false },
     },
 
+    provide() {
+        return {
+            conditions: this.makeConditionsProvider(),
+        }
+    },
+
     data() {
         return {
             blueprint: this.initializeBlueprint(),
             tabs: [],
             errors: {}
         }
+    },
+
+    computed: {
+
+        suggestableConditionFields() {
+            let fields = this.blueprint.tabs.reduce((fields, tab) => {
+                return fields.concat(tab.sections.reduce((fields, section) => {
+                    return fields.concat(section.fields.map(field => field.handle));
+                }, []));
+            }, []);
+
+            return fields
+        }
+
     },
 
     created() {
@@ -128,6 +148,14 @@ export default {
             this.$toast.success(__('Saved'));
             this.errors = {};
             this.$dirty.remove('blueprints');
+        },
+
+        makeConditionsProvider() {
+            const provide = {};
+            Object.defineProperties(provide, {
+                suggestableFields: { get: () => this.suggestableConditionFields },
+            });
+            return provide;
         }
 
     }

--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -134,7 +134,7 @@ export default {
             this.$toast.success(__('Saved'));
             this.errors = {};
             this.$dirty.remove('blueprints');
-        },
+        }
 
     }
 

--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -167,7 +167,13 @@ export default {
 
         getFieldsFromImportedFieldset(fieldset, prefix) {
             return Statamic.$config.get(`fieldsets.${fieldset}.fields`, [])
-                .map(field => field.handle)
+                .reduce((fields, field) => {
+                    return fields.concat(
+                        field.type === 'import'
+                            ? this.getFieldsFromImportedFieldset(field.fieldset, field.prefix)
+                            : [field.handle]
+                    );
+                }, [])
                 .map(handle => prefix ? `${prefix}${handle}` : handle);
         }
 

--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -50,9 +50,12 @@
 </template>
 
 <script>
+import SuggestsConditionalFields from './SuggestsConditionalFields';
 import Tabs from './Tabs.vue';
 
 export default {
+
+    mixins: [SuggestsConditionalFields],
 
     components: {
         Tabs,
@@ -64,12 +67,6 @@ export default {
         showTitle: Boolean,
         useTabs: { type: Boolean, default: true },
         isFormBlueprint: { type: Boolean, default: false },
-    },
-
-    provide() {
-        return {
-            suggestableConditionFieldsProvider: this.makeConditionsProvider(),
-        }
     },
 
     data() {
@@ -156,26 +153,6 @@ export default {
             this.errors = {};
             this.$dirty.remove('blueprints');
         },
-
-        makeConditionsProvider() {
-            const provide = {};
-            Object.defineProperties(provide, {
-                suggestableFields: { get: () => this.suggestableConditionFields },
-            });
-            return provide;
-        },
-
-        getFieldsFromImportedFieldset(fieldset, prefix) {
-            return Statamic.$config.get(`fieldsets.${fieldset}.fields`, [])
-                .reduce((fields, field) => {
-                    return fields.concat(
-                        field.type === 'import'
-                            ? this.getFieldsFromImportedFieldset(field.fieldset, field.prefix)
-                            : [field.handle]
-                    );
-                }, [])
-                .map(handle => prefix ? `${prefix}${handle}` : handle);
-        }
 
     }
 

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -88,7 +88,9 @@ export default {
 
     mixins: [CanDefineLocalizable],
 
-    inject: ['conditions'],
+    inject: {
+        conditions: { default: null }
+    },
 
     components: {
         Fields,
@@ -121,7 +123,7 @@ export default {
 
     computed: {
         suggestableConditionFields() {
-            return this.conditions.suggestableFields;
+            return this.conditions?.suggestableFields || [];
         }
     },
 

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -89,7 +89,7 @@ export default {
     mixins: [CanDefineLocalizable],
 
     inject: {
-        conditions: { default: null }
+        suggestableConditionFieldsProvider: { default: null }
     },
 
     components: {
@@ -123,7 +123,7 @@ export default {
 
     computed: {
         suggestableConditionFields() {
-            return this.conditions?.suggestableFields || [];
+            return this.suggestableConditionFieldsProvider?.suggestableFields || [];
         }
     },
 

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -88,6 +88,8 @@ export default {
 
     mixins: [CanDefineLocalizable],
 
+    inject: ['conditions'],
+
     components: {
         Fields,
     },
@@ -119,7 +121,7 @@ export default {
 
     computed: {
         suggestableConditionFields() {
-            return this.section.fields.map(field => field.handle);
+            return this.conditions.suggestableFields;
         }
     },
 

--- a/resources/js/components/blueprints/SuggestsConditionalFields.js
+++ b/resources/js/components/blueprints/SuggestsConditionalFields.js
@@ -1,0 +1,33 @@
+export default {
+
+    provide() {
+        return {
+            suggestableConditionFieldsProvider: this.makeConditionsProvider(),
+        }
+    },
+
+    methods: {
+
+        makeConditionsProvider() {
+            const provide = {};
+            Object.defineProperties(provide, {
+                suggestableFields: { get: () => this.suggestableConditionFields },
+            });
+            return provide;
+        },
+
+        getFieldsFromImportedFieldset(fieldset, prefix) {
+            return Statamic.$config.get(`fieldsets.${fieldset}.fields`, [])
+                .reduce((fields, field) => {
+                    return fields.concat(
+                        field.type === 'import'
+                            ? this.getFieldsFromImportedFieldset(field.fieldset, field.prefix)
+                            : [field.handle]
+                    );
+                }, [])
+                .map(handle => prefix ? `${prefix}${handle}` : handle);
+        }
+
+    }
+
+}

--- a/resources/js/components/blueprints/SuggestsConditionalFields.js
+++ b/resources/js/components/blueprints/SuggestsConditionalFields.js
@@ -6,6 +6,30 @@ export default {
         }
     },
 
+    computed: {
+
+        fieldsForConditionSuggestions() {
+            return this.tabs.reduce((fields, tab) => {
+                return fields.concat(tab.sections.reduce((fields, section) => {
+                    return fields.concat(section.fields);
+                }, []));
+            }, []);
+        },
+
+        suggestableConditionFields() {
+            let fields = this.fieldsForConditionSuggestions.reduce((fields, field) => {
+                return fields.concat(
+                    field.type === 'import'
+                        ? this.getFieldsFromImportedFieldset(field.fieldset, field.prefix)
+                        : [field.handle]
+                );
+            }, []);
+
+            return _.unique(fields);
+        },
+
+    },
+
     methods: {
 
         makeConditionsProvider() {

--- a/resources/js/components/field-conditions/Builder.vue
+++ b/resources/js/components/field-conditions/Builder.vue
@@ -31,6 +31,8 @@
                 :key="condition._id"
                 class="flex flex-wrap items-center py-4 border-t"
             >
+                <div v-if="index === 0" class="help-block" v-text="__('messages.field_conditions_field_instructions')" />
+
                 <v-select
                     ref="fieldSelect"
                     v-model="conditions[index].field"

--- a/resources/js/components/fieldsets/EditForm.vue
+++ b/resources/js/components/fieldsets/EditForm.vue
@@ -141,7 +141,7 @@ export default {
             }).on('sortable:stop', e => {
                 this.fieldset.fields.splice(e.newIndex, 0, this.fieldset.fields.splice(e.oldIndex, 1)[0]);
             });
-        },
+        }
 
     },
 

--- a/resources/js/components/fieldsets/EditForm.vue
+++ b/resources/js/components/fieldsets/EditForm.vue
@@ -54,8 +54,11 @@
 <script>
 import Fields from '../blueprints/Fields.vue';
 import {Sortable, Plugins} from '@shopify/draggable';
+import SuggestsConditionalFields from '../blueprints/SuggestsConditionalFields';
 
 export default {
+
+    mixins: [SuggestsConditionalFields],
 
     components: {
         Fields
@@ -148,17 +151,6 @@ export default {
             });
         },
 
-        getFieldsFromImportedFieldset(fieldset, prefix) {
-            return Statamic.$config.get(`fieldsets.${fieldset}.fields`, [])
-                .reduce((fields, field) => {
-                    return fields.concat(
-                        field.type === 'import'
-                            ? this.getFieldsFromImportedFieldset(field.fieldset, field.prefix)
-                            : [field.handle]
-                    );
-                }, [])
-                .map(handle => prefix ? `${prefix}${handle}` : handle);
-        }
     },
 
     created() {

--- a/resources/js/components/fieldsets/EditForm.vue
+++ b/resources/js/components/fieldsets/EditForm.vue
@@ -142,7 +142,6 @@ export default {
                 this.fieldset.fields.splice(e.newIndex, 0, this.fieldset.fields.splice(e.oldIndex, 1)[0]);
             });
         }
-
     },
 
     created() {

--- a/resources/js/components/fieldsets/EditForm.vue
+++ b/resources/js/components/fieldsets/EditForm.vue
@@ -87,16 +87,8 @@ export default {
             }
         },
 
-        suggestableConditionFields() {
-            let fields = this.fieldset.fields.reduce((fields, field) => {
-                return fields.concat(
-                    field.type === 'import'
-                        ? this.getFieldsFromImportedFieldset(field.fieldset, field.prefix)
-                        : [field.handle]
-                );
-            }, []);
-
-            return _.unique(fields);
+        fieldsForConditionSuggestions() {
+            return this.fields;
         }
 
     },

--- a/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
@@ -32,17 +32,52 @@ export default {
         Tabs
     },
 
+    provide() {
+        return {
+            conditions: this.makeConditionsProvider(),
+        }
+    },
+
     data() {
         return {
             tabs: this.value
         }
     },
 
+    computed: {
+
+        suggestableConditionFields() {
+            let fields = this.tabs.reduce((fields, tab) => {
+                return fields.concat(tab.sections.reduce((fields, section) => {
+                    let sectionFields = section.fields.reduce((fields, field) => {
+                        return fields.concat(
+                            field.type === 'import'
+                                ? this.getFieldsFromImportedFieldset(field.fieldset, field.prefix)
+                                : [field.handle]
+                        );
+                    }, []);
+                    return fields.concat(sectionFields);
+                }, []));
+            }, []);
+
+            return _.unique(fields);
+        }
+
+    },
+
     methods: {
 
         tabsUpdated(tabs) {
             this.update(tabs);
-        }
+        },
+
+        makeConditionsProvider() {
+            const provide = {};
+            Object.defineProperties(provide, {
+                suggestableFields: { get: () => this.suggestableConditionFields },
+            });
+            return provide;
+        },
 
     }
 

--- a/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
@@ -43,7 +43,7 @@ export default {
 
         tabsUpdated(tabs) {
             this.update(tabs);
-        },
+        }
 
     }
 

--- a/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
@@ -34,7 +34,7 @@ export default {
 
     provide() {
         return {
-            conditions: this.makeConditionsProvider(),
+            suggestableConditionFieldsProvider: this.makeConditionsProvider(),
         }
     },
 

--- a/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
@@ -22,20 +22,15 @@
 </template>
 
 <script>
+import SuggestsConditionalFields from '../../blueprints/SuggestsConditionalFields';
 import Tabs from '../../blueprints/Tabs.vue';
 
 export default {
 
-    mixins: [Fieldtype],
+    mixins: [Fieldtype, SuggestsConditionalFields],
 
     components: {
         Tabs
-    },
-
-    provide() {
-        return {
-            suggestableConditionFieldsProvider: this.makeConditionsProvider(),
-        }
     },
 
     data() {
@@ -69,14 +64,6 @@ export default {
 
         tabsUpdated(tabs) {
             this.update(tabs);
-        },
-
-        makeConditionsProvider() {
-            const provide = {};
-            Object.defineProperties(provide, {
-                suggestableFields: { get: () => this.suggestableConditionFields },
-            });
-            return provide;
         },
 
     }

--- a/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
@@ -39,27 +39,6 @@ export default {
         }
     },
 
-    computed: {
-
-        suggestableConditionFields() {
-            let fields = this.tabs.reduce((fields, tab) => {
-                return fields.concat(tab.sections.reduce((fields, section) => {
-                    let sectionFields = section.fields.reduce((fields, field) => {
-                        return fields.concat(
-                            field.type === 'import'
-                                ? this.getFieldsFromImportedFieldset(field.fieldset, field.prefix)
-                                : [field.handle]
-                        );
-                    }, []);
-                    return fields.concat(sectionFields);
-                }, []));
-            }, []);
-
-            return _.unique(fields);
-        }
-
-    },
-
     methods: {
 
         tabsUpdated(tabs) {

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -73,6 +73,7 @@ return [
     'entry_origin_instructions' => 'The new localization will inherit values from the entry in the selected site.',
     'expect_root_instructions' => 'Consider the first page in the tree a "root" or "home" page.',
     'field_conditions_always_save_instructions' => 'Always save field value, even if field is hidden.',
+    'field_conditions_field_instructions' => 'You may enter any field handle. You are not limited to the options in the dropdown.',
     'field_conditions_instructions' => 'When to show or hide this field.',
     'field_desynced_from_origin' => 'Desynced from origin. Click to sync and revert to the origin\'s value.',
     'field_synced_with_origin' => 'Synced with origin. Click or edit the field to desync.',


### PR DESCRIPTION
- Makes fields from the entire blueprint available in the suggestions.
	- Fixes #8155
	- Fixes #6151
- Allows fields from imported fieldsets (recursively!) to appear in that dropdown.
- Wire up field suggestions in the fieldset editor.
	- Fixes #841
- In some cases, you don't get *all* the available fields in the dropdown. For example, if you're in the fieldset editor, it only knows about fields in that fieldset. But you're still able to type fields in the blueprint, or other potential fieldsets. Added an instructional line explaining you can type any field handle.