### PR TITLE
[4.x] Fix path for SVG copy icon in the Updater popover

### DIFF
--- a/resources/js/components/CodeBlock.vue
+++ b/resources/js/components/CodeBlock.vue
@@ -3,7 +3,7 @@
         <div class="flex items-center bg-gray-800 py-3 px-4 rounded-md">
             <pre class="flex-1 p-0 m-0 leading-6"><code class="bg-transparent p-0 text-gray-400 leading-none" v-text="text" /></pre>
             <button v-if="copyable" class="flex" v-tooltip="__('Copy')" @click="copy">
-                <svg-icon name="entries" class="w-4 h-4 text-white" />
+                <svg-icon name="light/entries" class="w-4 h-4 text-white" />
             </button>
         </div>
     </div>


### PR DESCRIPTION
Before:
<img width="596" alt="CleanShot 2023-05-17 at 6 41 34@2x" src="https://github.com/statamic/cms/assets/3824203/036af7d9-5752-42a1-93f7-01f58baa287e">
After:
<img width="596" alt="CleanShot 2023-05-17 at 6 39 48@2x" src="https://github.com/statamic/cms/assets/3824203/a946f1ac-2d4e-42a6-b5d9-30b75f64521b">
