### PR TITLE
[4.x] Fix margins disappearing in Replicator when hitting max items

### DIFF
--- a/resources/css/components/fieldtypes/replicator.css
+++ b/resources/css/components/fieldtypes/replicator.css
@@ -61,6 +61,10 @@
     transform: translateX(-4px);
 }
 
+.replicator-set-picker.between .replicator-set-picker-button-wrapper {
+    @apply h-5;
+}
+
 .replicator-set.has-error > .replicator-set-header label {
     @apply text-red-500;
 }

--- a/resources/js/components/fieldtypes/replicator/AddSetButton.vue
+++ b/resources/js/components/fieldtypes/replicator/AddSetButton.vue
@@ -4,7 +4,7 @@
         <set-picker :sets="groups" @added="addSet">
             <template #trigger>
                 <div class="replicator-set-picker-button-wrapper">
-                    <button class="btn-round flex items-center justify-center" :class="{ 'h-5 w-5': ! last }" @click="addSetButtonClicked">
+                    <button v-if="enabled" class="btn-round flex items-center justify-center" :class="{ 'h-5 w-5': ! last }" @click="addSetButtonClicked">
                         <svg-icon name="micro/plus"
                             :class="{
                                 'w-3 h-3 text-gray-800 group-hover:text-black': last,
@@ -32,6 +32,7 @@ export default {
         groups: Array,
         index: Number,
         last: Boolean,
+        enabled: { type: Boolean, default: true },
     },
 
     methods: {

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -92,8 +92,7 @@
             </div>
         </sortable-list>
 
-        <add-set-button
-            v-if="canAddSet"
+        <add-set-button v-if="canAddSet"
             class="mt-3"
             :last="true"
             :groups="groupConfigs"

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -79,19 +79,21 @@
                     @blur="blurred"
                     @previews-updated="updateSetPreviews(set._id, $event)"
                 >
-                    <template v-slot:picker v-if="canAddSet">
+                    <template v-slot:picker>
                         <add-set-button
                             class="between"
                             :groups="groupConfigs"
                             :sets="setConfigs"
                             :index="index"
+                            :enabled="canAddSet"
                             @added="addSet" />
                     </template>
                 </replicator-set>
             </div>
         </sortable-list>
 
-        <add-set-button v-if="canAddSet"
+        <add-set-button
+            v-if="canAddSet"
             class="mt-3"
             :last="true"
             :groups="groupConfigs"


### PR DESCRIPTION
Fixes #8138

This PR maintains the spacing between replicator sets by keeping the divs there with a fixed size. The button inside those divs will disappear conditionally instead. When the button is hidden, the div will stick around as a sizer.
