### PR TITLE
[4.x] Fix fullscreen mode buttons in Grid and Replicator

### DIFF
--- a/resources/js/components/fieldtypes/grid/Stacked.vue
+++ b/resources/js/components/fieldtypes/grid/Stacked.vue
@@ -1,7 +1,7 @@
 <template>
 <div>
     <div class="flex justify-end absolute top-3 right-3 @md:right-6" v-if="! grid.fullScreenMode">
-        <button @click="grid.toggleFullScreen" class="btn btn-icon flex items-center" v-tooltip="__('Toggle Fullscreen Mode')">
+        <button v-if="allowFullscreen" @click="grid.toggleFullScreen" class="btn btn-icon flex items-center" v-tooltip="__('Toggle Fullscreen Mode')">
             <svg-icon name="expand-bold" class="h-3.5 px-0.5 text-gray-750" v-show="! grid.fullScreenMode" />
             <svg-icon name="shrink-all" class="h-3.5 px-0.5 text-gray-750" v-show="grid.fullScreenMode" />
         </button>

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -33,7 +33,7 @@
                 <button @click="collapseAll" class="btn btn-icon flex items-center" v-tooltip="__('Collapse Sets')" v-if="config.collapse !== 'accordion' && value.length > 0">
                     <svg-icon name="arrows-horizontal-collapse" class="h-3.5 px-0.5 text-gray-750" />
                 </button>
-                <button @click="fullScreenMode = !fullScreenMode" class="btn btn-icon flex items-center" v-tooltip="__('Toggle Fullscreen Mode')">
+                <button v-if="config.fullscreen" @click="fullScreenMode = !fullScreenMode" class="btn btn-icon flex items-center" v-tooltip="__('Toggle Fullscreen Mode')">
                     <svg-icon name="expand-bold" class="h-3.5 px-0.5 text-gray-750" v-show="! fullScreenMode" />
                     <svg-icon name="shrink-all" class="h-3.5 px-0.5 text-gray-750" v-show="fullScreenMode" />
                 </button>

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -74,7 +74,7 @@ return [
     'form.title' => 'Form',
     'grid.config.add_row' => 'Customize the label of the "Add Row" button.',
     'grid.config.fields' => 'Each field becomes a column in the grid table.',
-    'grid.config.fullscreen' => 'Enable toggle for fullscreen mode',
+    'grid.config.fullscreen' => 'Enable toggle for fullscreen mode.',
     'grid.config.max_rows' => 'Set a maximum number of creatable rows.',
     'grid.config.min_rows' => 'Set a minimum number of creatable rows.',
     'grid.config.mode' => 'Choose your preferred layout style.',

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -120,6 +120,7 @@ return [
     'replicator.config.collapse.accordion' => 'Only allow one set to be expanded at a time',
     'replicator.config.collapse.disabled' => 'All sets expanded by default',
     'replicator.config.collapse.enabled' => 'All sets collapsed by default',
+    'replicator.config.fullscreen' => 'Enable toggle for fullscreen mode.',
     'replicator.config.max_sets' => 'Set a maximum number of sets.',
     'replicator.config.previews' => 'Show a preview of the content inside a set while collapsed.',
     'replicator.config.sets' => 'Sets are configurable blocks of fields that be created and reordered as desired.',

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -48,6 +48,12 @@ class Replicator extends Fieldtype
                         'instructions' => __('statamic::fieldtypes.replicator.config.max_sets'),
                         'type' => 'integer',
                     ],
+                    'fullscreen' => [
+                        'display' => __('Allow Fullscreen Mode'),
+                        'instructions' => __('statamic::fieldtypes.replicator.config.fullscreen'),
+                        'type' => 'toggle',
+                        'default' => true,
+                    ],
                 ],
             ],
             [


### PR DESCRIPTION
- Add fullscreen option to Replicator.
- Hook up fullscreen option to button in Grid stacked mode.

Fixes #8137
