### PR TITLE
[4.x] Export tiptap/vue-2

### DIFF
--- a/resources/js/components/Bard.js
+++ b/resources/js/components/Bard.js
@@ -1,4 +1,5 @@
 import * as core from '@tiptap/core';
+import * as vue2 from '@tiptap/vue-2';
 import * as state from '@tiptap/pm/state';
 import * as model from '@tiptap/pm/model';
 import * as view from '@tiptap/pm/view';
@@ -26,6 +27,7 @@ class Bard {
     get tiptap() {
         return {
             core,
+            vue2,
             pm: {
                 state,
                 model,


### PR DESCRIPTION
This PR exports @tiptap/vue-2 so it can be used in custom Bard extensions.