### PR TITLE
[4.x] Respect line breaks in automagic form mails

### DIFF
--- a/resources/views/forms/automagic-email.antlers.html
+++ b/resources/views/forms/automagic-email.antlers.html
@@ -19,7 +19,7 @@
             {{ value | json }}
 
         {{ else }}
-            {{ value }}
+            {{ value | nl2br }}
         {{ /if }}
 
     {{ /if }}


### PR DESCRIPTION
This simple PR ensures that the automagic form mails respect line breaks of textarea fields. Hacked on it with @jesseleite on the way back home from Flat Camp.