### PR TITLE
[4.x] Change hydrate methods from private to protected

### DIFF
--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -109,7 +109,7 @@ class Cascade
         return $this;
     }
 
-    private function hydrateVariables()
+    protected function hydrateVariables()
     {
         foreach ($this->contextualVariables() as $key => $value) {
             $this->set($key, $value);
@@ -118,7 +118,7 @@ class Cascade
         return $this;
     }
 
-    private function hydrateSegments()
+    protected function hydrateSegments()
     {
         $path = $this->site->relativePath($this->request->url());
 
@@ -135,7 +135,7 @@ class Cascade
         return $this;
     }
 
-    private function hydrateGlobals()
+    protected function hydrateGlobals()
     {
         foreach (GlobalSet::all() as $global) {
             if (! $global->existsIn($this->site->handle())) {
@@ -156,7 +156,7 @@ class Cascade
         return $this;
     }
 
-    private function hydrateContent()
+    protected function hydrateContent()
     {
         if (! $this->content) {
             return $this;


### PR DESCRIPTION
Hi there,

I hope this message finds you well. I have been working with Statamic extensively and have noticed that in large websites with numerous global sets, the hydration of all these global sets to a view can result in unnecessary performance overhead.

This way I can bind my extended version of Cascade class and extend the hydrateGlobals method where I can exclude some globals that I don't need in the view!

I believe this enhancement will greatly benefit users working with large Statamic websites that utilize the Control Panel extensively. It aligns with the goal of optimizing performance without compromising functionality.


Thank you!