### PR TITLE
[4.x] Fix date validation

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -372,6 +372,10 @@ class Date extends Fieldtype
 
     private function preProcessSingleValidatable($value)
     {
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
         if (! $value || ! $value['date']) {
             return null;
         }

--- a/src/Validation/DateFieldtype.php
+++ b/src/Validation/DateFieldtype.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Validation;
 
+use Carbon\Carbon;
 use DateTime;
 use Statamic\Support\Arr;
 
@@ -16,6 +17,10 @@ class DateFieldtype
 
     public function __invoke($value)
     {
+        if (is_null($value) || $value instanceof Carbon) {
+            return;
+        }
+
         if (! is_array($value)) {
             return __('statamic::validation.array');
         }

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -483,6 +483,13 @@ class DateTest extends TestCase
                 ['date' => '2012-01-29', 'time' => null],
                 '2012-01-29 00:00:00',
             ],
+            // A carbon instance would be passed in if it was already processed.
+            // e.g. if it was nested inside a Replicator.
+            'carbon instance' => [
+                [],
+                Carbon::parse('2012-01-29'),
+                '2012-01-29 00:00:00',
+            ],
         ];
     }
 
@@ -560,6 +567,11 @@ class DateTest extends TestCase
             'valid date' => [
                 [],
                 ['date' => '2012-01-29', 'time' => null],
+                [],
+            ],
+            'null' => [
+                [],
+                null,
                 [],
             ],
             'not an array' => [


### PR DESCRIPTION
Fixes #8185

This prevents overzealous validation errors.
Nulls are fine, which happens if the date isn't submitted at all, like it if was hidden conditionally.
Carbon instances are returned early, which happens if a date field is inside a Replicator.
