### PR TITLE
[4.x] Fix custom fieldtype SVGs

### DIFF
--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -36,7 +36,7 @@ export default {
     },
     methods: {
         handleIcon() {
-            if (this.name.includes('<svg')) {
+            if (this.name.startsWith('<svg')) {
                 return this.svgIcon = this.name;
             }
 

--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -1,5 +1,6 @@
 <template>
-    <component v-if="icon" :is="icon" />
+    <component v-if="iconComponent" :is="iconComponent" />
+    <span v-else-if="svgIcon" v-html="svgIcon" />
 </template>
 
 <script>
@@ -21,17 +22,25 @@ export default {
     },
     data() {
         return {
-            icon: this.evaluateIcon(),
+            iconComponent: null,
+            svgIcon: null,
         }
+    },
+    mounted() {
+        this.handleIcon()
     },
     watch: {
         name() {
-            this.icon = this.evaluateIcon();
-        }
+            this.handleIcon();
+        },
     },
     methods: {
-        evaluateIcon() {
-            return defineAsyncComponent(() => {
+        handleIcon() {
+            if (this.name.includes('<svg')) {
+                return this.svgIcon = this.name;
+            }
+
+            return this.iconComponent = defineAsyncComponent(() => {
                 const [set, file] = splitIcon(this.name);
                 return import(`./../../svg/icons/${set}/${file}.svg`)
                     .catch(e => {

--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -1,6 +1,5 @@
 <template>
-    <component v-if="iconComponent" :is="iconComponent" />
-    <span v-else-if="svgIcon" v-html="svgIcon" />
+    <component v-if="icon" :is="icon" />
 </template>
 
 <script>
@@ -22,25 +21,23 @@ export default {
     },
     data() {
         return {
-            iconComponent: null,
-            svgIcon: null,
+            icon: this.evaluateIcon(),
         }
-    },
-    mounted() {
-        this.handleIcon()
     },
     watch: {
         name() {
-            this.handleIcon();
+            this.icon = this.evaluateIcon();
         },
     },
     methods: {
-        handleIcon() {
+        evaluateIcon() {
             if (this.name.startsWith('<svg')) {
-                return this.svgIcon = this.name;
+                return defineAsyncComponent(() => {
+                    return new Promise(resolve => resolve({ template: this.name }));
+                });
             }
 
-            return this.iconComponent = defineAsyncComponent(() => {
+            return defineAsyncComponent(() => {
                 const [set, file] = splitIcon(this.name);
                 return import(`./../../svg/icons/${set}/${file}.svg`)
                     .catch(e => {

--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -27,7 +27,7 @@ export default {
     watch: {
         name() {
             this.icon = this.evaluateIcon();
-        },
+        }
     },
     methods: {
         evaluateIcon() {

--- a/resources/js/components/blueprints/RegularField.vue
+++ b/resources/js/components/blueprints/RegularField.vue
@@ -5,7 +5,7 @@
             <div class="blueprint-drag-handle w-4 border-r"></div>
             <div class="flex flex-1 items-center justify-between">
                 <div class="flex items-center flex-1 pr-4 py-2 pl-2">
-                    <svg-icon class="text-gray-800 mr-2 h-4 w-4 flex-none" :name="`light/${field.icon}`" v-tooltip="tooltipText" default="light/generic-field" />
+                    <svg-icon class="text-gray-800 mr-2 h-4 w-4 flex-none" :name="field.icon.includes('<svg') ? field.icon : `light/${field.icon}`" v-tooltip="tooltipText" default="light/generic-field" />
                     <a class="break-all" v-text="labelText" @click="$emit('edit')" />
                     <svg-icon name="light/hyperlink" v-if="isReferenceField" class="text-gray-600 text-3xs ml-2 h-4 w-4" v-tooltip="__('Imported from fieldset') + ': ' + field.field_reference" />
                 </div>

--- a/resources/js/components/blueprints/RegularField.vue
+++ b/resources/js/components/blueprints/RegularField.vue
@@ -5,7 +5,7 @@
             <div class="blueprint-drag-handle w-4 border-r"></div>
             <div class="flex flex-1 items-center justify-between">
                 <div class="flex items-center flex-1 pr-4 py-2 pl-2">
-                    <svg-icon class="text-gray-800 mr-2 h-4 w-4 flex-none" :name="field.icon.includes('<svg') ? field.icon : `light/${field.icon}`" v-tooltip="tooltipText" default="light/generic-field" />
+                    <svg-icon class="text-gray-800 mr-2 h-4 w-4 flex-none" :name="field.icon.startsWith('<svg') ? field.icon : `light/${field.icon}`" v-tooltip="tooltipText" default="light/generic-field" />
                     <a class="break-all" v-text="labelText" @click="$emit('edit')" />
                     <svg-icon name="light/hyperlink" v-if="isReferenceField" class="text-gray-600 text-3xs ml-2 h-4 w-4" v-tooltip="__('Imported from fieldset') + ': ' + field.field_reference" />
                 </div>

--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -24,7 +24,7 @@
                             <button class="bg-white border border-gray-500 flex items-center group w-full rounded hover:border-gray-600 shadow-sm hover:shadow-md pr-3"
                                 @click="select(fieldtype)">
                                 <div class="p-2 flex items-center border-r border-gray-500 group-hover:border-gray-600 bg-gray-200 rounded-l">
-                                    <svg-icon class="h-5 w-5 text-gray-800" :name="`light/${fieldtype.icon}`" default="light/generic-field"></svg-icon>
+                                    <svg-icon class="h-5 w-5 text-gray-800" :name="fieldtype.icon.includes('<svg') ? fieldtype.icon : `light/${fieldtype.icon}`" default="light/generic-field"></svg-icon>
                                 </div>
                                 <span class="pl-3 text-gray-800 text-md group-hover:text-gray-900">{{ fieldtype.text }}</span>
                             </button>

--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -24,7 +24,7 @@
                             <button class="bg-white border border-gray-500 flex items-center group w-full rounded hover:border-gray-600 shadow-sm hover:shadow-md pr-3"
                                 @click="select(fieldtype)">
                                 <div class="p-2 flex items-center border-r border-gray-500 group-hover:border-gray-600 bg-gray-200 rounded-l">
-                                    <svg-icon class="h-5 w-5 text-gray-800" :name="fieldtype.icon.includes('<svg') ? fieldtype.icon : `light/${fieldtype.icon}`" default="light/generic-field"></svg-icon>
+                                    <svg-icon class="h-5 w-5 text-gray-800" :name="fieldtype.icon.startsWith('<svg') ? fieldtype.icon : `light/${fieldtype.icon}`" default="light/generic-field"></svg-icon>
                                 </div>
                                 <span class="pl-3 text-gray-800 text-md group-hover:text-gray-900">{{ fieldtype.text }}</span>
                             </button>

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -10,7 +10,7 @@
             <h1 class="flex-1 flex items-center text-xl">
                 {{ values.display || config.display || config.handle }}
                 <small class="badge-pill bg-gray-100 ml-4 border text-xs text-gray-700 font-medium leading-none flex items-center">
-                    <svg-icon class="h-4 w-4 mr-2 inline-block text-gray-700" :name="`light/${fieldtype.icon}`"></svg-icon>
+                    <svg-icon class="h-4 w-4 mr-2 inline-block text-gray-700" :name="fieldtype.icon.startsWith('<svg') ? fieldtype.icon : `light/${fieldtype.icon}`"></svg-icon>
                     {{ fieldtype.title }}
                 </small>
             </h1>


### PR DESCRIPTION
This pull request attempts to fix #8129.

The issue was that SVG fieldtype icons weren't being shown in the blueprint/fieldset builders, it would simply fallback to the generic fieldtype icon.

This was happening due to the `SvgIcon` component expecting the `name` prop to be the path to an icon, rather than an SVG string.

I'm not 100% happy with this fix so feel free to close & tackle another way if you have another idea. 

Essentially, I've added a check into the `SvgIcon` component to check if the `name` prop (which could maybe become `icon`?) contains `<svg` & if it does, it'll use the SVG string as the icon, otherwise it'll fallback.

However, I also had to make changes to the `RegularField` and `FieldtypeSelector` components to check the same thing to `light/` is only prepended to the `name` prop if the icon is the path to an icon, rather than an actual SVG string.