### PR TITLE
[4.x] Fix asset selection request query length

### DIFF
--- a/resources/js/components/fieldtypes/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/MarkdownFieldtype.vue
@@ -476,7 +476,7 @@ export default {
             // We don't want to maintain the asset selections
             this.selectedAssets = [];
 
-            this.$axios.get(cp_url('assets-fieldtype'), { params: { assets } }).then(response => {
+            this.$axios.post(cp_url('assets-fieldtype'), { params: { assets } }).then(response => {
                 _(response.data).each((asset) => {
                     var alt = asset.values.alt || '';
                     var url = encodeURI('statamic://'+asset.reference);

--- a/resources/js/components/fieldtypes/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/MarkdownFieldtype.vue
@@ -476,7 +476,7 @@ export default {
             // We don't want to maintain the asset selections
             this.selectedAssets = [];
 
-            this.$axios.post(cp_url('assets-fieldtype'), { params: { assets } }).then(response => {
+            this.$axios.post(cp_url('assets-fieldtype'), { assets }).then(response => {
                 _(response.data).each((asset) => {
                     var alt = asset.values.alt || '';
                     var url = encodeURI('statamic://'+asset.reference);

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -388,7 +388,7 @@ export default {
             this.loading = true;
 
             this.$axios.post(cp_url('assets-fieldtype'), {
-                params: { assets }
+                assets
             }).then(response => {
                 this.assets = response.data;
                 this.loading = false;

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -387,7 +387,7 @@ export default {
 
             this.loading = true;
 
-            this.$axios.get(cp_url('assets-fieldtype'), {
+            this.$axios.post(cp_url('assets-fieldtype'), {
                 params: { assets }
             }).then(response => {
                 this.assets = response.data;

--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -163,7 +163,7 @@ export default {
             }
 
             this.$axios.post(cp_url('assets-fieldtype'), {
-                params: { assets: [id] }
+                assets: [id],
             }).then(response => {
                 this.setAsset(response.data[0]);
             });

--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -162,7 +162,7 @@ export default {
                 // return;
             }
 
-            this.$axios.get(cp_url('assets-fieldtype'), {
+            this.$axios.post(cp_url('assets-fieldtype'), {
                 params: { assets: [id] }
             }).then(response => {
                 this.setAsset(response.data[0]);

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -373,7 +373,7 @@ export default {
         },
 
         loadAssetData(url) {
-            this.$axios.get(cp_url('assets-fieldtype'), {
+            this.$axios.post(cp_url('assets-fieldtype'), {
                 params: { assets: [url] }
             }).then(response => {
                 this.selectItem('asset', response.data[0])

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -374,7 +374,7 @@ export default {
 
         loadAssetData(url) {
             this.$axios.post(cp_url('assets-fieldtype'), {
-                params: { assets: [url] }
+                assets: [url],
             }).then(response => {
                 this.selectItem('asset', response.data[0])
                 this.isLoading = false;

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -220,7 +220,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
     Route::get('assets/browse/folders/{asset_container}/{path?}', [BrowserController::class, 'folder'])->where('path', '.*');
     Route::get('assets/browse/{asset_container}/{path?}/edit', [BrowserController::class, 'edit'])->where('path', '.*')->name('assets.browse.edit');
     Route::get('assets/browse/{asset_container}/{path?}', [BrowserController::class, 'show'])->where('path', '.*')->name('assets.browse.show');
-    Route::get('assets-fieldtype', [FieldtypeController::class, 'index']);
+    Route::post('assets-fieldtype', [FieldtypeController::class, 'index']);
     Route::resource('assets', AssetsController::class)->parameters(['assets' => 'encoded_asset']);
     Route::get('assets/{encoded_asset}/download', [AssetsController::class, 'download'])->name('assets.download');
     Route::get('thumbnails/{encoded_asset}/{size?}/{orientation?}', [ThumbnailController::class, 'show'])->name('assets.thumbnails.show');


### PR DESCRIPTION
This pull request fixes #8208 by changing the `assets-fieldtype` route to use a POST request, rather than a GET route as the URL gets too long for browsers like Safari when you have lots of assets selected.

A similar issue was fixed a while back using the same solution: #4484