### PR TITLE
Improve entry status on entry stack picker 

### DIFF
--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -49,9 +49,12 @@
                             >
                                 <template slot="cell-title" slot-scope="{ row: entry }">
                                     <div class="flex items-center">
-                                        <div v-if="entry.published !== undefined" class="little-dot mr-2" :class="getStatusClass(entry)" />
+                                        <div class="little-dot mr-2" v-tooltip="getStatusLabel(entry)" :class="getStatusClass(entry)" v-if="! columnShowing('status')" />
                                         {{ entry.title }}
                                     </div>
+                                </template>
+                                <template slot="cell-status" slot-scope="{ row: entry }">
+                                    <div class="status-index-field select-none" v-tooltip="getStatusTooltip(entry)" :class="`status-${entry.status}`" v-text="getStatusLabel(entry)" />
                                 </template>
                                 <template slot="cell-url" slot-scope="{ row: entry }">
                                     <span class="text-2xs">{{ entry.url }}</span>
@@ -276,7 +279,37 @@ export default {
             } else {
                 return 'bg-gray-400';
             }
-        }
+        },
+
+        getStatusLabel(entry) {
+            if (entry.status === 'published') {
+                return __('Published');
+            } else if (entry.status === 'scheduled') {
+                return __('Scheduled');
+            } else if (entry.status === 'expired') {
+                return __('Expired');
+            } else if (entry.status === 'draft') {
+                return __('Draft');
+            }
+        },
+
+        getStatusTooltip(entry) {
+            if (entry.status === 'published') {
+                return entry.collection.dated
+                    ? __('messages.status_published_with_date', {date: entry.date})
+                    : null; // The label is sufficient.
+            } else if (entry.status === 'scheduled') {
+                return __('messages.status_scheduled_with_date', {date: entry.date})
+            } else if (entry.status === 'expired') {
+                return __('messages.status_expired_with_date', {date: entry.date})
+            } else if (entry.status === 'draft') {
+                return null; // The label is sufficient.
+            }
+        },
+
+        columnShowing(column) {
+            return this.columns.find(c => c.field === column && c.visible);
+        },
 
     }
 

--- a/src/Http/Resources/CP/Entries/Entries.php
+++ b/src/Http/Resources/CP/Entries/Entries.php
@@ -38,7 +38,7 @@ class Entries extends ResourceCollection
             ->defaultVisibility(true)
             ->sortable(false);
 
-        $columns->prepend($status, 'status');
+        $columns->push($status);
 
         if ($key = $this->columnPreferenceKey) {
             $columns->setPreferred($key);


### PR DESCRIPTION
This pull request makes some small improvements to the entry stack picker, notably the one used in Navigations when linking an entry, however this will likely address other areas where the entry stack picker is used.

Improvements:

* The Status column will use the new 'pill' status label
* When the Status column is not visible (eg. if you've hidden it on the collection's listing table), the entry status will be denoted by a dot on the entry title.
* The Status column will be shown as the last column before the 'Collection' column to match what happens on the Entry Listing Table.
  * Not sure if changing `prepend` to `push` here (and adding it to the end of the columns, instead of the start) will break something elsewhere?

Closes #8079