### PR TITLE
[4.x] Creating nav items: Change button label from Submit to Save

### DIFF
--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -56,7 +56,7 @@
             <div v-if="!loading" class="bg-gray-200 p-4 border-t flex items-center justify-between flex-row-reverse">
                 <div>
                     <button @click="confirmClose(close)" class="btn mr-2">{{ __('Cancel') }}</button>
-                    <button @click="submit" class="btn-primary">{{ __('Submit') }}</button>
+                    <button @click="submit" class="btn-primary">{{ __('Save') }}</button>
                 </div>
                 <div v-if="type === 'entry'">
                     <a :href="editEntryUrl" target="_blank" class="text-xs flex items-center justify-center text-blue hover:text-blue underline mr-4">


### PR DESCRIPTION
This PR changes the button label from 'Submit' to 'Save' on the stack that allows users to create nav items. 'Save' makes more sense (at least to me) than 'Submit' does as the button *saves* the information entered.

Very tiny PR 😆 

Closes #8060 - translations will already exist as 'Save' is used elsewhere within the CP.