### PR TITLE
[4.x] Fix utility handle to slug conversion

### DIFF
--- a/src/CP/Utilities/Utility.php
+++ b/src/CP/Utilities/Utility.php
@@ -40,7 +40,7 @@ class Utility
 
     public function slug()
     {
-        return Str::slug($this->handle);
+        return Str::slug(Str::replace('_', '-', $this->handle));
     }
 
     public function action($action = null)

--- a/src/CP/Utilities/UtilityRepository.php
+++ b/src/CP/Utilities/UtilityRepository.php
@@ -63,6 +63,11 @@ class UtilityRepository
         return $this->utilities->get($handle);
     }
 
+    public function findBySlug($slug)
+    {
+        return $this->utilities->first(fn ($utility) => $utility->slug() === $slug);
+    }
+
     public function routes()
     {
         $this->boot();

--- a/src/Facades/Utility.php
+++ b/src/Facades/Utility.php
@@ -12,6 +12,7 @@ use Statamic\CP\Utilities\UtilityRepository;
  * @method static mixed authorized()
  * @method static mixed find($handle)
  * @method static void routes()
+ * @method static void extend(\Closure $closure)
  *
  * @see \Statamic\CP\Utilities\UtilityRepository
  */

--- a/src/Http/Controllers/CP/Utilities/UtilitiesController.php
+++ b/src/Http/Controllers/CP/Utilities/UtilitiesController.php
@@ -17,7 +17,7 @@ class UtilitiesController extends CpController
 
     public function show(Request $request)
     {
-        $utility = Utility::find($this->getUtilityHandle($request));
+        $utility = Utility::findBySlug($this->getUtilityHandle($request));
 
         if ($view = $utility->view()) {
             return view($view, $utility->viewData($request));


### PR DESCRIPTION
Fixes inconsistency with how underscores are handled in utility slugs.

Also added a missing facade typehint.