### PR TITLE
[4.x] Misc fixes to read-only state on assets fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -8,7 +8,7 @@
             ></div>
             <button
                 class="w-7 h-7 cursor-pointer whitespace-nowrap flex items-center justify-center"
-                @click="edit"
+                @click="editOrOpen"
                 v-else
             >
                 <img
@@ -22,7 +22,7 @@
             </button>
             <button
                 v-if="showFilename"
-                @click="edit"
+                @click="editOrOpen"
                 class="flex items-center flex-1 ml-3 text-xs text-left truncate w-full"
                 :aria-label="__('Edit Asset')"
             >
@@ -33,7 +33,7 @@
         <td class="w-24" v-if="showSetAlt">
             <button
                 class="asset-set-alt text-blue px-4 text-sm hover:text-black"
-                @click="edit"
+                @click="editOrOpen"
                 v-if="needsAlt"
             >
                 {{ asset.values.alt ? "✅" : __("Set Alt") }}
@@ -65,6 +65,14 @@
 <script>
 import Asset from "./Asset";
 export default {
+
     mixins: [Asset],
+
+    methods: {
+        editOrOpen() {
+            return this.readOnly ? this.open() : this.edit();
+        }
+    },
+
 };
 </script>

--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -39,9 +39,8 @@
                 {{ asset.values.alt ? "✅" : __("Set Alt") }}
             </button>
         </td>
-        <td class="p-0 w-8 text-right align-middle">
+        <td class="p-0 w-8 text-right align-middle" v-if="!readOnly">
             <button
-                v-if="!readOnly"
                 class="flex items-center p-1 w-6 h-8 text-gray-600 hover:text-gray-900"
                 @click="remove"
                 :aria-label="__('Remove Asset')"

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -73,7 +73,7 @@
                                 :asset="asset"
                                 :read-only="isReadOnly"
                                 :show-filename="config.show_filename"
-                                :show-set-alt="config.show_set_alt"
+                                :show-set-alt="showSetAlt"
                                 @updated="assetUpdated"
                                 @removed="assetRemoved"
                                 @id-changed="idChanged(asset.id, $event)">
@@ -100,7 +100,7 @@
                                         :asset="asset"
                                         :read-only="isReadOnly"
                                         :show-filename="config.show_filename"
-                                        :show-set-alt="config.show_set_alt"
+                                        :show-set-alt="showSetAlt"
                                         @updated="assetUpdated"
                                         @removed="assetRemoved"
                                         @id-changed="idChanged(asset.id, $event)">
@@ -345,7 +345,11 @@ export default {
 
         isFullWidth() {
             return ! (this.config.width && this.config.width < 100)
-        }
+        },
+
+        showSetAlt() {
+            return this.config.show_set_alt && ! this.isReadOnly;
+        },
 
     },
 


### PR DESCRIPTION
This PR fixes the inability to click to view an asset when the assets fieldtype is read-only (ie. when viewing a form submission in cp), hides the 'set alt' option when read-only, and cleans up read-only styling a bit.

Before:

![CleanShot 2023-05-29 at 16 39 07](https://github.com/statamic/cms/assets/5187394/1d76a550-c343-4983-bef6-840da3a74099)

After:

![CleanShot 2023-05-29 at 16 39 44](https://github.com/statamic/cms/assets/5187394/d05d2790-520c-451f-bd4c-3508daefbda4)

Closes #6501.