### PR TITLE
[4.x] Fix searching with asset folder fieldtype

### DIFF
--- a/src/Fieldtypes/AssetFolder.php
+++ b/src/Fieldtypes/AssetFolder.php
@@ -25,10 +25,8 @@ class AssetFolder extends Relationship
                 return ['id' => $folder, 'title' => $folder];
             })
             ->prepend(['id' => '/', 'title' => '/'])
-            ->when($request->search, function ($folders) use ($request) {
-                return $folders->filter(function ($folder) use ($request) {
-                    return str_contains($folder['title'], $request->search);
-                });
+            ->when($request->search, function ($folders, $search) {
+                return $folders->filter(fn ($folder) => str_contains($folder['title'], $search));
             })
             ->values();
     }

--- a/src/Fieldtypes/AssetFolder.php
+++ b/src/Fieldtypes/AssetFolder.php
@@ -25,6 +25,11 @@ class AssetFolder extends Relationship
                 return ['id' => $folder, 'title' => $folder];
             })
             ->prepend(['id' => '/', 'title' => '/'])
+            ->when($request->search, function ($folders) use ($request) {
+                return $folders->filter(function ($folder) use ($request) {
+                    return str_contains($folder['title'], $request->search);
+                });
+            })
             ->values();
     }
 }


### PR DESCRIPTION
This pull request implements searching on the Asset Folder fieldtype, used when setting a folder on an Asset field in a blueprint.

In the stack, the search bar would appear but actually trying to use it wouldn't work. This PR implements the logic to make search working.

There's no related issue for this one, just something I noticed when working on a site.