### PR TITLE
[4.x] Fix `user:can` tag in blade

### DIFF
--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -413,16 +413,18 @@ class UserTags extends Tags
     public function can()
     {
         if (! $user = User::current()) {
-            return;
+            return $this->parser ? null : false;
         }
 
         $permissions = Arr::wrap($this->params->explode(['permission', 'do']));
 
         foreach ($permissions as $permission) {
             if ($user->can($permission)) {
-                return $this->parse();
+                return $this->parser ? $this->parse() : true;
             }
         }
+
+        return $this->parser ? null : false;
     }
 
     /**


### PR DESCRIPTION
Fixes: https://github.com/statamic/cms/issues/8217

This PR fixes the user:can tag in blade calls, eg `Statamic::tag('user:can')... ` by checking for the presence of $this->parser as suggested by Jason.