### PR TITLE
Fix asset grid folder dropdown

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -188,7 +188,7 @@
                                         <div class="asset-meta flex items-center">
                                             <div class="asset-filename text-center w-full px-2 py-1" v-text="folder.basename" :title="folder.basename" />
                                         </div>
-                                        <dropdown-list autoclose v-if="folderActions(folder).length" class="absolute top-1 right-2 opacity-0 group-hover:opacity-100">
+                                        <dropdown-list v-if="folderActions(folder).length" class="absolute top-1 right-2 opacity-0 group-hover:opacity-100">
                                              <data-list-inline-actions
                                                  :item="folder.path"
                                                  :url="folderActionUrl"


### PR DESCRIPTION
It's not currently possible to access asset grid folder actions as the dropdown closes when you hover over the menu:

https://github.com/statamic/cms/assets/126740/6b696859-6862-4502-87b8-f498ffb3b22b

This PR fixes that by removing the `autoclose` attribute, which matches how the other dropdown-lists are configured.