### PR TITLE
[4.x] Fix asset grid button visibility

### DIFF
--- a/resources/js/components/DropdownList.vue
+++ b/resources/js/components/DropdownList.vue
@@ -1,5 +1,12 @@
 <template>
-    <popover class="dropdown-list" :disabled="disabled" :placement="placement" :autoclose="autoclose">
+    <popover
+        class="dropdown-list"
+        :class="{ 'opacity-0 group-hover:opacity-100': hoverable, 'opacity-100': hoverable && open }"
+        :disabled="disabled"
+        :placement="placement"
+        :autoclose="autoclose"
+        @opened="open = true"
+        @closed="open = false">
         <template #trigger>
             <slot name="trigger">
                 <button class="rotating-dots-button" :aria-label="__('Open Dropdown')">
@@ -25,7 +32,16 @@ export default {
         autoclose: {
             type: Boolean,
             default: false
+        },
+        hoverable: {
+            type: Boolean,
+            default: false
         }
+    },
+    data() {
+        return {
+            open: false,
+        };
     },
     computed: {
         strategy() {

--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -188,7 +188,7 @@
                                         <div class="asset-meta flex items-center">
                                             <div class="asset-filename text-center w-full px-2 py-1" v-text="folder.basename" :title="folder.basename" />
                                         </div>
-                                        <dropdown-list autoclose v-if="folderActions(folder).length" class="absolute top-1 right-2 opacity-0 group-hover:opacity-100">
+                                        <dropdown-list autoclose v-if="folderActions(folder).length" class="absolute top-1 right-2" hoverable>
                                              <data-list-inline-actions
                                                  :item="folder.path"
                                                  :url="folderActionUrl"
@@ -225,7 +225,8 @@
                                             </div>
                                         </div>
                                         <dropdown-list
-                                            class="absolute top-1 right-2 opacity-0 group-hover:opacity-100"
+                                            class="absolute top-1 right-2"
+                                            hoverable
                                         >
                                              <dropdown-item :text="__(canEdit ? 'Edit' : 'View')" @click="edit(asset.id)" />
                                              <div class="divider" v-if="asset.actions.length" />


### PR DESCRIPTION
The asset grid action buttons only appear on group hover, however they disappear when you hover over the menu as that's in a portal target outside of the group:

https://github.com/statamic/cms/assets/126740/8f63062c-4679-4bfe-af53-d2aeb427b52a

This PR fixes that by moving the show/hide classes into the dropdown-list component and then including an additional show class all the time the popover is open:

https://github.com/statamic/cms/assets/126740/4f2acdb2-a9da-45c7-8aa7-5adc6257fd24

Not too sure on the prop name `hoverable`, there might be a better option.