### PR TITLE
[4.x] Fix asset grid button visibility

### DIFF
--- a/resources/js/components/DropdownList.vue
+++ b/resources/js/components/DropdownList.vue
@@ -1,5 +1,5 @@
 <template>
-    <popover class="dropdown-list" :disabled="disabled" :placement="placement" :autoclose="autoclose">
+    <popover class="dropdown-list" :disabled="disabled" :placement="placement" :autoclose="autoclose" @opened="$emit('opened')" @closed="$emit('closed')">
         <template #trigger>
             <slot name="trigger">
                 <button class="rotating-dots-button" :aria-label="__('Open Dropdown')">

--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -188,7 +188,12 @@
                                         <div class="asset-meta flex items-center">
                                             <div class="asset-filename text-center w-full px-2 py-1" v-text="folder.basename" :title="folder.basename" />
                                         </div>
-                                        <dropdown-list v-if="folderActions(folder).length" class="absolute top-1 right-2 opacity-0 group-hover:opacity-100">
+                                        <dropdown-list v-if="folderActions(folder).length"
+                                            class="absolute top-1 right-2 opacity-0 group-hover:opacity-100"
+                                            :class="{ 'opacity-100': actionOpened === folder.path }"
+                                            @opened="actionOpened = folder.path"
+                                            @closed="actionOpened = null"
+                                        >
                                              <data-list-inline-actions
                                                  :item="folder.path"
                                                  :url="folderActionUrl"
@@ -226,6 +231,9 @@
                                         </div>
                                         <dropdown-list
                                             class="absolute top-1 right-2 opacity-0 group-hover:opacity-100"
+                                            :class="{ 'opacity-100': actionOpened === asset.id }"
+                                            @opened="actionOpened = asset.id"
+                                            @closed="actionOpened = null"
                                         >
                                              <dropdown-item :text="__(canEdit ? 'Edit' : 'View')" @click="edit(asset.id)" />
                                              <div class="divider" v-if="asset.actions.length" />
@@ -350,7 +358,8 @@ export default {
             actionUrl: null,
             folderActionUrl: null,
             shifting: false,
-            lastItemClicked: null
+            lastItemClicked: null,
+            actionOpened: null,
         }
     },
 


### PR DESCRIPTION
Show the dropdown trigger if its opened by tracking the state using events (which should probably have been there anyway).

Replaces #8230
