### PR TITLE
[4.x] Adds a new classes modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -328,6 +328,11 @@ class CoreModifiers extends Modifier
             ->all();
     }
 
+    public function classes($value)
+    {
+        return Arr::toCssClasses($value);
+    }
+
     public function className($value)
     {
         return get_class($value);

--- a/tests/Modifiers/ClassesTest.php
+++ b/tests/Modifiers/ClassesTest.php
@@ -15,7 +15,6 @@ class ClassesTest extends TestCase
     {
         $this->assertSame('one two', $this->modify(['one' => true, 'two' => true])->fetch());
         $this->assertSame('one', $this->modify(['one' => true, 'two' => false])->fetch());
-
     }
 
     private function modify($value)

--- a/tests/Modifiers/ClassesTest.php
+++ b/tests/Modifiers/ClassesTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+/**
+ * @group array
+ */
+class ClassesTest extends TestCase
+{
+    /** @test */
+    public function it_conditionally_applies_class_names(): void
+    {
+        $this->assertSame('one two', $this->modify(['one' => true, 'two' => true])->fetch());
+        $this->assertSame('one', $this->modify(['one' => true, 'two' => false])->fetch());
+
+    }
+
+    private function modify($value)
+    {
+        return Modify::value($value)->classes();
+    }
+}


### PR DESCRIPTION
This PR adds a new `classes` modifier that wraps Laravel's `Arr::toCssClasses` helper method.

Which lets us write the following:

```antlers
<div class="something {{ ['danger' => isDanger, 'success' => otherValue] | classes }}">

</div>
```
