### PR TITLE
[4.x] Fix searching users when a search index is present

### DIFF
--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -80,7 +80,9 @@ class UsersController extends CpController
     protected function searchUsers($search, $query, $useIndex = true)
     {
         if ($useIndex && Search::indexes()->has('users')) {
-            return Search::index('users')->ensureExists()->search($search);
+            $results = Search::index('users')->ensureExists()->search($search);
+            $results->setCollection($results->getCollection()->map->getSearchable());
+            return $results;
         }
 
         $query->where(function ($query) use ($search) {


### PR DESCRIPTION
Since previous updates change searching to return a search document rather than the specific result, searching for users in the CP while having a search index of `users` has been broken.

This PR maps the search result back to a user entity.

Fixes: #7680