### PR TITLE
[4.x] Ensure to pass replacements so `unique_user_value works` as expected

### DIFF
--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -301,9 +301,9 @@ class Fields
         return Validator::make()->fields($this);
     }
 
-    public function validate($extraRules = [], $customMessages = [])
+    public function validate($extraRules = [], $customMessages = [], $replacements = [])
     {
-        return $this->validator()->withRules($extraRules)->withMessages($customMessages)->validate();
+        return $this->validator()->withRules($extraRules)->withMessages($customMessages)->withReplacements($replacements)->validate();
     }
 
     public function toGql()

--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -301,9 +301,9 @@ class Fields
         return Validator::make()->fields($this);
     }
 
-    public function validate($extraRules = [], $customMessages = [], $replacements = [])
+    public function validate($extraRules = [], $customMessages = [])
     {
-        return $this->validator()->withRules($extraRules)->withMessages($customMessages)->withReplacements($replacements)->validate();
+        return $this->validator()->withRules($extraRules)->withMessages($customMessages)->validate();
     }
 
     public function toGql()

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -243,7 +243,7 @@ class UsersController extends CpController
 
         $fields = $user->blueprint()->fields()->except(['password'])->addValues($request->all());
 
-        $fields->validate(['email' => 'required|unique_user_value:'.$user->id()]);
+        $fields->validate(['email' => 'required|unique_user_value:{id}'], [], ['id' => $user->id()]);
 
         $values = $fields->process()->values()->except(['email', 'groups', 'roles']);
 

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -243,7 +243,10 @@ class UsersController extends CpController
 
         $fields = $user->blueprint()->fields()->except(['password'])->addValues($request->all());
 
-        $fields->validate(['email' => 'required|unique_user_value:{id}'], [], ['id' => $user->id()]);
+        $fields
+            ->validator()
+            ->withReplacements(['id' => $user->id()])
+            ->validate(['email' => 'required|unique_user_value:{id}']);
 
         $values = $fields->process()->values()->except(['email', 'groups', 'roles']);
 

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -245,8 +245,9 @@ class UsersController extends CpController
 
         $fields
             ->validator()
+            ->withRules(['email' => 'required|unique_user_value:{id}'])
             ->withReplacements(['id' => $user->id()])
-            ->validate(['email' => 'required|unique_user_value:{id}']);
+            ->validate();
 
         $values = $fields->process()->values()->except(['email', 'groups', 'roles']);
 

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -117,7 +117,9 @@ class UserController extends Controller
         $fields = $fields->addValues($values);
 
         $fieldRules = $fields->validator()->withRules([
-            'email' => ['required', 'email', 'unique_user_value:'.$user->id()],
+            'email' => ['required', 'email', 'unique_user_value:{id}'],
+        ])->withReplacements([
+            'id' => $user->id(),
         ])->rules();
 
         $validator = Validator::make($values, $fieldRules);


### PR DESCRIPTION
This PR updates the Validator class validate() method to allow passing a parameter for `replacements`.
It also ensures that user id is passed as a replacement value when editing through the CP or through a profile form update.

Fixes: #8085