### PR TITLE
[4.x] Make eloquent 'like' queries case insensitive

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -104,6 +104,7 @@ abstract class EloquentQueryBuilder implements Builder
 
         if (lower($operator) == 'like') {
             $this->builder->whereRaw('LOWER('.$this->column($column).') LIKE ?', strtolower($value), $boolean);
+
             return $this;
         }
 

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -102,7 +102,7 @@ abstract class EloquentQueryBuilder implements Builder
             return $this->whereNested($column, $boolean);
         }
 
-        if (lower($operator) == 'like') {
+        if (strtolower($operator) == 'like') {
             $this->builder->whereRaw('LOWER('.$this->column($column).') LIKE ?', strtolower($value), $boolean);
 
             return $this;

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -102,6 +102,11 @@ abstract class EloquentQueryBuilder implements Builder
             return $this->whereNested($column, $boolean);
         }
 
+        if (lower($operator) == 'like') {
+            $this->builder->whereRaw('LOWER('.$this->column($column).') LIKE ?', strtolower($value), $boolean);
+            return $this;
+        }
+
         $this->builder->where($this->column($column), $operator, $value, $boolean);
 
         return $this;


### PR DESCRIPTION
I've been trying to work out the best approach for issues like https://github.com/statamic/eloquent-driver/issues/137 and https://github.com/statamic/cms/issues/8227 which come from JSON fields being case sensitive in MySQL. 

The only approach I can find that is not database engine specific seems to be `LOWER()`-ing the fields, but that may not work for all languages, accents etc. 

For want of a better solution, we should run with it for now.

This will only fix ->where('x', 'like', 'y%') type queries, it wont affect straight ->where() or ->whereIn() etc

Fixes: https://github.com/statamic/cms/issues/8227 https://github.com/statamic/eloquent-driver/issues/137