### PR TITLE
[4.x] Reduce computed value callback calls

### DIFF
--- a/src/Data/ContainsComputedData.php
+++ b/src/Data/ContainsComputedData.php
@@ -6,7 +6,7 @@ trait ContainsComputedData
 {
     protected $withComputedData = true;
 
-    public function computedFields()
+    public function computedKeys()
     {
         if (! method_exists($this, 'getComputedCallbacks')) {
             return collect();

--- a/src/Data/ContainsComputedData.php
+++ b/src/Data/ContainsComputedData.php
@@ -6,6 +6,15 @@ trait ContainsComputedData
 {
     protected $withComputedData = true;
 
+    public function computedFields()
+    {
+        if (! method_exists($this, 'getComputedCallbacks')) {
+            return collect();
+        }
+
+        return $this->getComputedCallbacks()->keys();
+    }
+
     public function computedData()
     {
         if (! method_exists($this, 'getComputedCallbacks')) {

--- a/src/Data/HasOrigin.php
+++ b/src/Data/HasOrigin.php
@@ -6,6 +6,21 @@ trait HasOrigin
 {
     protected $origin;
 
+    public function keys()
+    {
+        $originFallbackKeys = method_exists($this, 'getOriginFallbackValues') ? $this->getOriginFallbackValues()->keys() : collect();
+
+        $originKeys = $this->hasOrigin() ? $this->origin()->keys() : collect();
+
+        $computedFields = method_exists($this, 'computedFields') ? $this->computedFields() : [];
+
+        return collect()
+            ->merge($originFallbackKeys)
+            ->merge($originKeys)
+            ->merge($this->data->keys())
+            ->merge($computedFields);
+    }
+
     public function values()
     {
         $originFallbackValues = method_exists($this, 'getOriginFallbackValues') ? $this->getOriginFallbackValues() : collect();

--- a/src/Data/HasOrigin.php
+++ b/src/Data/HasOrigin.php
@@ -12,13 +12,13 @@ trait HasOrigin
 
         $originKeys = $this->hasOrigin() ? $this->origin()->keys() : collect();
 
-        $computedFields = method_exists($this, 'computedFields') ? $this->computedFields() : [];
+        $computedKeys = method_exists($this, 'computedKeys') ? $this->computedKeys() : [];
 
         return collect()
             ->merge($originFallbackKeys)
             ->merge($originKeys)
             ->merge($this->data->keys())
-            ->merge($computedFields);
+            ->merge($computedKeys);
     }
 
     public function values()

--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -10,7 +10,7 @@ class AugmentedEntry extends AbstractAugmented
 {
     public function keys()
     {
-        return $this->data->values()->keys()
+        return $this->data->keys()
             ->merge($this->data->supplements()->keys())
             ->merge($this->commonKeys())
             ->merge($this->blueprintFields()->keys())

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -481,6 +481,25 @@ class EntryTest extends TestCase
     }
 
     /** @test */
+    public function it_only_evaluates_computed_data_closures_when_getting_values()
+    {
+        $count = 0;
+        Facades\Collection::computed('articles', 'description', function ($entry) use (&$count) {
+            $count++;
+
+            return $entry->get('title').' AND MORE!';
+        });
+
+        $articleEntry = (new Entry)->collection(tap(Collection::make('articles'))->save())->data(['title' => 'Pop Rocks']);
+
+        $this->assertEquals(0, $count);
+        $this->assertEquals(['title', 'description'], $articleEntry->keys()->all());
+
+        $this->assertEquals(['title' => 'Pop Rocks', 'description' => 'Pop Rocks AND MORE!'], $articleEntry->values()->all());
+        $this->assertEquals(1, $count);
+    }
+
+    /** @test */
     public function it_gets_the_url_from_the_collection()
     {
         Facades\Site::setConfig(['default' => 'en', 'sites' => [

--- a/tests/Data/Structures/AugmentedPageTest.php
+++ b/tests/Data/Structures/AugmentedPageTest.php
@@ -55,9 +55,9 @@ class AugmentedPageTest extends AugmentedTestCase
         ])->setNamespace('navs')->setHandle('pages');
 
         $entry = Mockery::mock(Entry::class);
-        $entry->shouldReceive('values')->andReturn(collect([
-            'one' => 'two',
-            'three' => 'four',
+        $entry->shouldReceive('keys')->andReturn(collect([
+            'one',
+            'three',
         ]));
         $entry->shouldReceive('supplements')->andReturn(collect([
             'alfa' => 'bravo',
@@ -169,11 +169,11 @@ class AugmentedPageTest extends AugmentedTestCase
         ])->setNamespace('navs')->setHandle('pages');
 
         $entry = Mockery::mock(Entry::class);
-        $entry->shouldReceive('values')->andReturn(collect([
-            'title' => 'The Entry Title',
-            'one' => 'two',
-            'three' => 'four',
-            'five' => 'six',
+        $entry->shouldReceive('keys')->andReturn(collect([
+            'title',
+            'one',
+            'three',
+            'five',
         ]));
         $entry->shouldReceive('supplements')->andReturn(collect());
         $entry->shouldReceive('value')->with('title')->andReturn('The Entry Title');


### PR DESCRIPTION
I’ve noticed that when using computed values the same callbacks are being called 17 times during a single page load, which is unexpected and seems unnecessary. I know the docs recommend caching computed values when using external APIs or performing other expensive tasks, but even when doing something simple calling the same function that many times isn’t ideal.

This is happening because:

* `AugmentedEntry::keys()` calls `$this->data->values()` which results in all computed callbacks being called
* `AbstractAugmented::get()` calls `$this->keys()` every time a [data method value is fetched](https://github.com/statamic/cms/blob/4.x/src/Data/AbstractAugmented.php#L59)

This results in all computed callbacks being called every time any data method value is fetched.

This PR aims to fix this by making the following changes:

* Adds a new `ContainsComputedData::computedFields()` method that just returns the field names
* Adds a new `HasOrigin::keys()` method that uses the new `computedFields()` method and only returns keys
* Uses the new `keys()` method in `AugmentedEntry::keys()`

In my testing this reduces the callback calls from 17 down to 2 (once for the URI check and once for the view rendering).

I’ve updated two tests to match the new behaviour, hopefully the changes I’ve made to those are correct.

Closes https://github.com/statamic/cms/issues/7931