### PR TITLE
[4.x] Adds support for start time to full YouTube links when using the embed_url modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -3024,6 +3024,10 @@ class CoreModifiers extends Modifier
 
         if (Str::contains($url, 'youtube.com/watch?v=')) {
             $url = str_replace('watch?v=', 'embed/', $url);
+
+            if (Str::contains($url, '&t=')) {
+                $url = str_replace('&t=', '?start=', $url);
+            }
         }
 
         if (Str::contains($url, 'youtube.com')) {

--- a/tests/Modifiers/EmbedUrlTest.php
+++ b/tests/Modifiers/EmbedUrlTest.php
@@ -61,6 +61,12 @@ class EmbedUrlTest extends TestCase
             $this->embed('https://youtu.be/s72r_wu_NVY?t=559'),
             'It transforms the start time parameter of shortened sharing links'
         );
+
+        $this->assertEquals(
+            'https://www.youtube-nocookie.com/embed/hyJ7CBs_2RQ?start=2',
+            $this->embed(('https://www.youtube.com/watch?v=hyJ7CBs_2RQ&t=2')),
+            'It transforms the start time parameter of full youtube links'
+        );
     }
 
     public function embed($url)


### PR DESCRIPTION
This PR fixes #8249 by adding support for the start time parameter to full YouTube links, such as this one:

```
https://www.youtube.com/watch?v=hyJ7CBs_2RQ&t=2
```

After the changes in the PR, the generated embed URL will now become:

```
https://www.youtube-nocookie.com/embed/hyJ7CBs_2RQ?start=2
```