### PR TITLE
[4.x] Add Nullsafe operator to visibleColumns

### DIFF
--- a/src/Http/Resources/CP/Concerns/HasRequestedColumns.php
+++ b/src/Http/Resources/CP/Concerns/HasRequestedColumns.php
@@ -23,7 +23,7 @@ trait HasRequestedColumns
 
         return collect($requested)
             ->filter(fn ($field) => $columns->has($field))
-            ->map(fn ($field) => $columns->get($field)->visible(true))
+            ->map(fn ($field) => $columns->get($field)?->visible(true))
             ->merge($columns->except($requested))
             ->values();
     }


### PR DESCRIPTION
Please don't ask what we did :-D

Under some circumstances, if you users do have listing preferences contain fields, which do not contain anymore, this will throw a 500 error in "stack listings". 

This PR fixes that behaviour, so if a users has a field in his personal settings that does not exist anymore, the listing will simply ignore it.