### PR TITLE
[4.x] Open CP nav item when it has any active child

### DIFF
--- a/resources/views/partials/nav-main.blade.php
+++ b/resources/views/partials/nav-main.blade.php
@@ -14,7 +14,7 @@
                                 <a href="{{ $item->url() }}" {{ $item->attributes() }}>
                                     <i>{!! $item->icon() !!}</i><span>{{ __($item->name()) }}</span>
                                 </a>
-                                @if ($item->children() && $item->isActive())
+                                @if ($item->children() && ($item->isActive() || $item->hasActiveChild()))
                                     <ul>
                                         @foreach ($item->children() as $child)
                                             <li class="{{ $child->isActive() ? 'current' : '' }}">

--- a/resources/views/partials/nav-mobile.blade.php
+++ b/resources/views/partials/nav-mobile.blade.php
@@ -13,7 +13,7 @@
                             <a href="{{ $item->url() }}">
                                 <i>{!! $item->icon() !!}</i><span>{{ __($item->name()) }}</span>
                             </a>
-                            @if ($item->children() && $item->isActive())
+                            @if ($item->children() && ($item->isActive() || $item->hasActiveChild()))
                                 <ul>
                                     @foreach ($item->children() as $child)
                                         <li class="{{ $child->isActive() ? 'current' : '' }}">

--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\CP\Navigation;
 
+use Illuminate\Support\Collection;
 use Statamic\Facades\CP\Nav;
 use Statamic\Statamic;
 use Statamic\Support\Html;
@@ -324,6 +325,16 @@ class NavItem
         $pattern = preg_quote(config('statamic.cp.route'), '#').'/'.$this->active;
 
         return preg_match('#'.$pattern.'#', request()->decodedPath()) === 1;
+    }
+
+    /**
+     * Get whether the nav item has a currently active child.
+     *
+     * @return bool
+     */
+    public function hasActiveChild()
+    {
+        return $this->children() instanceof Collection && $this->children()->first(fn ($item) => $item->isActive()) !== null;
     }
 
     /**


### PR DESCRIPTION
Now that the CP nav can be customised I would like to group collections/taxonomies by subject rather than type, so instead of this:

```
- Collections
  - Blog
- Taxonomies
  - Blog Categories
```

I can just have this:

```
- Blog
  - Categories
```

Which is totally possible!

The only problem is the nav hierarchy no longer matches the URL hierarchy, so when you click on `Blog > Categories` the `Blog` section closes and `Categories` is no longer visible.

This PR aims to resolve that by adding a `NavItem::hasActiveChild()` method, so that items can remain open when they have active children but aren't active themselves.

I see `NavItem::children()` can sometimes return a closure. I didn't want to mess with resolving children if it's not necessary, so I'm checking if it's a collection first. That may not be the best approach, I'm not sure, but it seems to work for this use-case.