### PR TITLE
[4.x] Add custom sort field methods to Collection

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -158,6 +158,11 @@ class Collection implements Contract, AugmentableContract, ArrayAccess, Arrayabl
             ->args(func_get_args());
     }
 
+    public function customSortField()
+    {
+        return $this->sortField;
+    }
+
     public function sortDirection($dir = null)
     {
         return $this
@@ -183,6 +188,11 @@ class Collection implements Contract, AugmentableContract, ArrayAccess, Arrayabl
                 return 'asc';
             })
             ->args(func_get_args());
+    }
+
+    public function customSortDirection()
+    {
+        return $this->sortDirection;
     }
 
     public function title($title = null)

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -381,18 +381,26 @@ class CollectionTest extends TestCase
         $alpha = new Collection;
         $this->assertEquals('title', $alpha->sortField());
         $this->assertEquals('asc', $alpha->sortDirection());
+        $this->assertNull($alpha->customSortField());
+        $this->assertNull($alpha->customSortDirection());
 
         $dated = (new Collection)->dated(true);
         $this->assertEquals('date', $dated->sortField());
         $this->assertEquals('desc', $dated->sortDirection());
+        $this->assertNull($dated->customSortField());
+        $this->assertNull($dated->customSortDirection());
 
         $ordered = (new Collection)->structureContents(['max_depth' => 1]);
         $this->assertEquals('order', $ordered->sortField());
         $this->assertEquals('asc', $ordered->sortDirection());
+        $this->assertNull($ordered->customSortField());
+        $this->assertNull($ordered->customSortDirection());
 
         $datedAndOrdered = (new Collection)->dated(true)->structureContents(['max_depth' => 1]);
         $this->assertEquals('order', $datedAndOrdered->sortField());
         $this->assertEquals('asc', $datedAndOrdered->sortDirection());
+        $this->assertNull($datedAndOrdered->customSortField());
+        $this->assertNull($datedAndOrdered->customSortDirection());
 
         $alpha->structureContents(['max_depth' => 99]);
         $this->assertEquals('title', $alpha->sortField());
@@ -401,7 +409,33 @@ class CollectionTest extends TestCase
         $this->assertEquals('date', $dated->sortField());
         $this->assertEquals('desc', $dated->sortDirection());
 
-        // TODO: Ability to control sort direction
+        // Custom sort field and direction should override any other logic.
+        foreach ([$alpha, $dated, $ordered, $datedAndOrdered] as $collection) {
+            $collection->sortField('foo');
+            $this->assertEquals('foo', $collection->sortField());
+            $this->assertEquals('asc', $collection->sortDirection());
+            $this->assertEquals('foo', $collection->customSortField());
+            $this->assertNull($collection->customSortDirection());
+            $collection->sortDirection('desc');
+            $this->assertEquals('desc', $collection->sortDirection());
+            $this->assertEquals('desc', $collection->customSortDirection());
+        }
+    }
+
+    /** @test */
+    public function setting_custom_sort_field_will_set_the_sort_direction_to_asc_when_not_explicitly_set()
+    {
+        // Use a date collection to test this because its default sort direction is desc.
+
+        $dated = (new Collection)->dated(true);
+        $this->assertEquals('date', $dated->sortField());
+        $this->assertEquals('desc', $dated->sortDirection());
+        $this->assertNull($dated->customSortField());
+
+        $dated->sortField('foo');
+        $this->assertEquals('foo', $dated->sortField());
+        $this->assertEquals('asc', $dated->sortDirection());
+        $this->assertEquals('foo', $dated->customSortField());
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds `customSortField` and `customSortDirection` getter methods to the collection class.

It's needed by the Eloquent driver.

These methods will get the explicitly defined sort field/direction values. The regular `sortField` and `sortDirection` methods have logic in them to handle fallbacks. The Eloquent driver needs the actual explicit values without the fallbacks.

statamic/eloquent-driver#161
