### PR TITLE
[4.x] Invalidate Stache status index value on date

### DIFF
--- a/src/Stache/Indexes/Entries/Status.php
+++ b/src/Stache/Indexes/Entries/Status.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Statamic\Stache\Indexes\Entries;
+
+use Illuminate\Support\Carbon;
+use Statamic\Facades\Entry;
+use Statamic\Stache\Indexes\Value;
+
+class Status extends Value
+{
+    private $recentlyUpdated = false;
+
+    public function getItemValue($entry)
+    {
+        $status = $entry->status();
+
+        return $status.'::'.$this->getExpiration($entry, $status);
+    }
+
+    private function getExpiration($entry, $status)
+    {
+        if (! $this->isDated()) {
+            return;
+        }
+
+        // Past date behavior is private (eg. events that disappear after they happen)
+        if ($status === 'published' && $this->collection()->pastDateBehavior() === 'private') {
+            return $entry->date()->timestamp;
+        }
+
+        // When future date behavior is private (eg. scheduled blog posts)
+        if ($status === 'scheduled' && $this->collection()->futureDateBehavior() === 'private') {
+            return $entry->date()->timestamp;
+        }
+    }
+
+    public function load()
+    {
+        if ($this->loaded) {
+            return $this;
+        }
+
+        parent::load();
+
+        $this->items = collect($this->items)->map(function ($value, $id) {
+            [$status, $expiration] = explode('::', $value);
+
+            if ($newStatus = $this->updateItemIfNecessary($expiration, $id)) {
+                $status = $newStatus;
+            }
+
+            return $status;
+        })->all();
+
+        return $this;
+    }
+
+    public function update()
+    {
+        parent::update();
+
+        $this->recentlyUpdated = true;
+
+        return $this;
+    }
+
+    private function collection()
+    {
+        return $this->store->collection();
+    }
+
+    private function isDated()
+    {
+        return $this->collection()->dated();
+    }
+
+    private function updateItemIfNecessary($expiration, $id)
+    {
+        if (! $this->isDated() || $this->recentlyUpdated || ! $expiration) {
+            return;
+        }
+
+        if (Carbon::createFromTimestamp($expiration)->isPast()) {
+            $this->updateItem($entry = Entry::find($id));
+
+            return $entry->status();
+        }
+    }
+}

--- a/src/Stache/Indexes/Entries/Status.php
+++ b/src/Stache/Indexes/Entries/Status.php
@@ -86,4 +86,9 @@ class Status extends Value
             return $entry->status();
         }
     }
+
+    public function items()
+    {
+        return parent::items()->map(fn ($item) => explode('::', $item)[0]);
+    }
 }

--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -20,7 +20,7 @@ class CollectionEntriesStore extends ChildStore
 {
     protected $collection;
 
-    protected function collection()
+    public function collection()
     {
         return $this->collection ?? Collection::findByHandle($this->childKey);
     }
@@ -157,6 +157,7 @@ class CollectionEntriesStore extends ChildStore
             'site' => Indexes\Site::class,
             'origin' => Indexes\Origin::class,
             'parent' => Indexes\Parents::class,
+            'status' => Indexes\Entries\Status::class,
         ]);
 
         if (! $collection = Collection::findByHandle($this->childKey())) {


### PR DESCRIPTION
Replaces #5089
Closes #2217

This is more of the direction I had in mind. This will save the status along with a timestamp of when the value should "expire". When loading the index, it'll loop over them, see if any timestamps are expired, then update them.

This obviously only solves the problem for the Stache. For Eloquent, we'd need to think of a different solution.
I still think the real solution is to scrap querying by `status` and instead put the logic in the query itself. (e.g. where date is in past, and published is true, etc). But that's a bigger job and likely a breaking change.

This should solve what @aerni needed (scheduled entries), and what @Buffalom brought up (expired entries).

Todo:
- [x] Tests are failing, so clearly it's not right. Figure that out. 😄 
- [ ] Maybe add tracking of when last update was, to prevent the loop-on-load happening on _every_ request. i.e. maybe throttle them to every 5 minutes, configurable.