### PR TITLE
[4.x] Enable sorting by last login, hide un-sortable arrows

### DIFF
--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -18,7 +18,7 @@
                     @click.prevent="changeSortColumn(column.field)"
                 >
                     <span v-text="column.label" />
-                    <svg :class="[sharedState.sortDirection, {'opacity-100 pointer-events-none': sharedState.sortColumn === column.field}]" height="8" width="8" viewBox="0 0 10 6.5" class="ml-1 opacity-0 group-hover:opacity-100">
+                    <svg v-if="column.sortable" :class="[sharedState.sortDirection, {'opacity-100 pointer-events-none': sharedState.sortColumn === column.field}]" height="8" width="8" viewBox="0 0 10 6.5" class="ml-1 opacity-0 group-hover:opacity-100">
                         <path d="M9.9,1.4L5,6.4L0,1.4L1.4,0L5,3.5L8.5,0L9.9,1.4z" fill="currentColor"/>
                     </svg>
                 </th>

--- a/src/Http/Resources/CP/Users/Users.php
+++ b/src/Http/Resources/CP/Users/Users.php
@@ -55,7 +55,6 @@ class Users extends ResourceCollection
         $columns->put('last_login',
             Column::make('last_login')
                 ->label(__('Last Login'))
-                ->sortable(false)
                 ->defaultOrder($columns->max('defaultOrder') + 1)
         );
 


### PR DESCRIPTION
This PR makes two small tweaks to the users listing/sorting:

1. Enables sorting by last login (this seems to work fine as far as I can tell and would be a useful addition)
2. Hides the sort arrows that appear on hover for un-sortable columns like roles (this was confusing a client)