### PR TITLE
[4.x] Fix "undefined array key" error when using Glide with assets

### DIFF
--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -85,18 +85,14 @@ class GlideController extends Controller
      * Generate a manipulated image by an asset reference.
      *
      * @param  string  $ref
+     * @param  string  $path 
      * @return mixed
      *
      * @throws \Exception
      */
-    public function generateByAsset($encoded)
+    public function generateByAsset($container, $path)
     {
         $this->validateSignature();
-
-        $decoded = base64_decode($encoded);
-
-        // The string before the first slash is the container
-        [$container, $path] = explode('/', $decoded, 2);
 
         throw_unless($container = AssetContainer::find($container), new NotFoundHttpException);
 


### PR DESCRIPTION
This change fixes the "Undefined array key 1" exception when using Glide to generate images from assets.

An example URL which would have this problem would be `https://mycompany.com/img/asset/mycontainer/myimage.png?w=100`