### PR TITLE
[4.x] Fix glide Undefined Array Key 1

### DIFF
--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -104,8 +104,8 @@ class GlideController extends Controller
     /**
      * Generate an image.
      *
-     * @param $type
-     * @param $item
+     * @param  $type
+     * @param  $item
      * @return mixed
      */
     private function generateBy($type, $item)

--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -89,14 +89,9 @@ class GlideController extends Controller
      *
      * @throws \Exception
      */
-    public function generateByAsset($encoded)
+    public function generateByAsset($container, $path)
     {
         $this->validateSignature();
-
-        $decoded = base64_decode($encoded);
-
-        // The string before the first slash is the container
-        [$container, $path] = explode('/', $decoded, 2);
 
         throw_unless($container = AssetContainer::find($container), new NotFoundHttpException);
 

--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -84,7 +84,8 @@ class GlideController extends Controller
     /**
      * Generate a manipulated image by an asset reference.
      *
-     * @param  string  $ref
+     * @param  string  $container
+     * @param  string  $path
      * @return mixed
      *
      * @throws \Exception


### PR DESCRIPTION
Generating a Glide image from an asset causes an "undefined array key 1" error. This is due to the route being passed in as two parameters instead of the expected single parameter. This update adds a second parameter and allows the full path to be processed and the images generated correctly.