### PR TITLE
[4.x] Add replicator_preview toggle to Blueprint editor

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -90,6 +90,7 @@ return [
     'fields_instructions_position_instructions' => 'Show instructions above or below the field.',
     'fields_listable_instructions' => 'Control the listing column visibility.',
     'fields_visibility_instructions' => 'Control field visibility on publish forms.',
+    'fields_replicator_preview_instructions' => 'Control preview visibility in Replicator/Bard sets.',
     'fieldset_import_fieldset_instructions' => 'The fieldset to be imported.',
     'fieldset_import_prefix_instructions' => 'The prefix that should be applied to each field when they are imported. eg. hero_',
     'fieldset_intro' => 'Fieldsets are an optional companion to blueprints, acting as reusable partials that can be used within blueprints.',

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -146,6 +146,13 @@ class FieldsController extends CpController
                 'default' => 'visible',
                 'type' => 'select',
             ],
+            'replicator_preview' => [
+                'display' => __('Preview'),
+                'instructions' => __('statamic::messages.fields_replicator_preview_instructions'),
+                'type' => 'toggle',
+                'validate' => 'boolean',
+                'default' => true,
+            ],
             'duplicate' => [
                 'display' => __('Duplicate'),
                 'instructions' => __('statamic::messages.fields_duplicate_instructions'),


### PR DESCRIPTION
Just noticed there's no toggle for `replicator_preview` in the Blueprint editor.

This PR adds it.