### PR TITLE
[4.x] Asset image tile wouldn't show checkerboard background on svg images

### DIFF
--- a/resources/css/components/assets.css
+++ b/resources/css/components/assets.css
@@ -98,7 +98,7 @@
     .asset-thumb {
         @apply flex justify-center items-center;
         > img, > svg, > .svg-img {
-            @apply max-h-full max-w-full absolute;
+            @apply w-full h-full max-h-full max-w-full;
         }
     }
 


### PR DESCRIPTION
The checkerboard background in grid view on an asset image tile wouldn't show since the img was absolute-ly positioned. 

Removed the absolute position and made the checkerboard div use full width and height.

<img width="1487" alt="Screenshot 2023-06-14 at 12 09 33 PM" src="https://github.com/statamic/cms/assets/63021431/482f0e5d-7692-45ae-a263-7b4d7c10f26c">