### PR TITLE
[4.x] Add option to collections to always use search index on entry listing

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -43,6 +43,7 @@ class Collection implements Contract, AugmentableContract, ArrayAccess, Arrayabl
     protected $propagate = false;
     protected $blueprints = [];
     protected $searchIndex;
+    protected $alwaysUseSearchIndex = false;
     protected $dated = false;
     protected $sortField;
     protected $sortDirection;
@@ -475,6 +476,16 @@ class Collection implements Contract, AugmentableContract, ArrayAccess, Arrayabl
     public function hasSearchIndex()
     {
         return $this->searchIndex() !== null;
+    }
+
+    public function alwaysUseSearchIndex($index = null)
+    {
+        return $this
+            ->fluentlyGetOrSet('alwaysUseSearchIndex')
+            ->getter(function ($value) {
+                return $value ? $this->hasSearchIndex() : false;
+            })
+            ->args(func_get_args());
     }
 
     public function fileData()

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -48,7 +48,7 @@ class EntriesController extends CpController
 
         $entries = $query->paginate(request('perPage'));
 
-        if (request('search') && $collection->hasSearchIndex()) {
+        if ($collection->alwaysUseSearchIndex() || (request('search') && $collection->hasSearchIndex())) {
             $entries->setCollection($entries->getCollection()->map->getSearchable());
         }
 
@@ -72,7 +72,7 @@ class EntriesController extends CpController
             $query->where('title', 'like', '%'.$search.'%');
         }
 
-        return $query;
+        return $collection->alwaysUseSearchIndex() ? $collection->searchIndex()->ensureExists()->query() : $query;
     }
 
     public function edit(Request $request, $collection, $entry)

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -48,6 +48,7 @@ class CollectionsStore extends BasicStore
             ->layout(array_get($data, 'layout'))
             ->cascade(array_get($data, 'inject', []))
             ->searchIndex(array_get($data, 'search_index'))
+            ->alwaysUseSearchIndex(array_get($data, 'always_use_search_index'))
             ->revisionsEnabled(array_get($data, 'revisions', false))
             ->defaultPublishState($this->getDefaultPublishState($data))
             ->originBehavior(array_get($data, 'origin_behavior', 'select'))


### PR DESCRIPTION
This could maybe be named better but for an add-on I'm working on to speed up entry listings by deferring to a search provider I'd like to always use the search index for listings, not just when a search term has been entered. 

This means more work integrating with the search provider as you need to make a query builder, but it can dramatically improve the response time of listings.

If youre not happy adding it as a collection variable, another option would be to check for a specific key in the search index config? 