### PR TITLE
[4.x] Incremental Stache warming

### DIFF
--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -19,7 +19,7 @@ class Install extends Command
      *
      * @var string
      */
-    protected $signature = 'statamic:install';
+    protected $signature = 'statamic:install {--no-cache-clear}';
 
     /**
      * The console command description.
@@ -101,7 +101,9 @@ class Install extends Command
 
     protected function clearCache()
     {
-        $this->call('cache:clear');
+        if (! $this->option('no-cache-clear')) {
+            $this->call('cache:clear');
+        }
 
         return $this;
     }

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -97,7 +97,7 @@ class CollectionsStore extends BasicStore
 
     public function handleFileChanges()
     {
-        if ($this->fileChangesHandled || ! config('statamic.stache.watcher')) {
+        if (! $this->forceHandleChanges && ($this->fileChangesHandled || ! config('statamic.stache.watcher'))) {
             return;
         }
 

--- a/src/Stache/Stores/ContainerAssetsStore.php
+++ b/src/Stache/Stores/ContainerAssetsStore.php
@@ -19,7 +19,7 @@ class ContainerAssetsStore extends ChildStore
     public function handleFileChanges()
     {
         // We only want to act on any file changes one time per store.
-        if ($this->fileChangesHandled) {
+        if ($this->fileChangesHandled && ! $this->forceHandleChanges) {
             return;
         }
 

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -133,7 +133,7 @@ class TaxonomyTermsStore extends ChildStore
 
     public function handleFileChanges()
     {
-        if ($this->fileChangesHandled || ! config('statamic.stache.watcher')) {
+        if (! $this->forceHandleChanges && ($this->fileChangesHandled || ! config('statamic.stache.watcher'))) {
             return;
         }
 


### PR DESCRIPTION
At the moment, whenever you run `composer install`, the `statamic:install` command would clear the cache.
In a deployment, this would allow the Stache to be rebuilt from scratch.

Sometimes that's a bit heavy handed, especially on sites with lots of content. You're forced to update the Stache from scratch on every deployment, potentially causing CPU spikes.

This PR allows you to avoid clearing the entire cache after a `composer install`. Then, the `stache:warm` command will also now notice file changes.

Now you can maintain your cache across deployments, keep the Stache watcher disabled, and the `stache:warm` command will apply any file changes appropriately.
