### PR TITLE
[4.x] Fix LinkMark to resolve entries in correct locale

### DIFF
--- a/src/Fieldtypes/Bard/LinkMark.php
+++ b/src/Fieldtypes/Bard/LinkMark.php
@@ -3,8 +3,8 @@
 namespace Statamic\Fieldtypes\Bard;
 
 use Statamic\Entries\Entry;
-use Statamic\Facades\Site;
 use Statamic\Facades\Data;
+use Statamic\Facades\Site;
 use Statamic\Support\Str;
 use Tiptap\Marks\Link;
 
@@ -58,8 +58,8 @@ class LinkMark extends Link
             return '';
         }
 
-        if($item instanceof Entry){
-            return $item->in(Site::current()->handle())?->url() ?? $item->url();
+        if ($item instanceof Entry) {
+            return ($item->in(Site::current()->handle()) ?? $item)->url();
         }
 
         return $item->url();

--- a/src/Fieldtypes/Bard/LinkMark.php
+++ b/src/Fieldtypes/Bard/LinkMark.php
@@ -3,6 +3,7 @@
 namespace Statamic\Fieldtypes\Bard;
 
 use Statamic\Entries\Entry;
+use Statamic\Facades\Site;
 use Statamic\Facades\Data;
 use Statamic\Support\Str;
 use Tiptap\Marks\Link;

--- a/src/Fieldtypes/Bard/LinkMark.php
+++ b/src/Fieldtypes/Bard/LinkMark.php
@@ -56,6 +56,10 @@ class LinkMark extends Link
             return '';
         }
 
+        if($item instanceof Entry){
+            return $item->in(Site::current()->handle())?->url() ?? $item->url();
+        }
+
         return $item->url();
     }
 }

--- a/src/Fieldtypes/Bard/LinkMark.php
+++ b/src/Fieldtypes/Bard/LinkMark.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Fieldtypes\Bard;
 
-use Statamic\Entries\Entry;
+use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\Data;
 use Statamic\Facades\Site;
 use Statamic\Support\Str;

--- a/src/Fieldtypes/Bard/LinkMark.php
+++ b/src/Fieldtypes/Bard/LinkMark.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fieldtypes\Bard;
 
+use Statamic\Entries\Entry;
 use Statamic\Facades\Data;
 use Statamic\Support\Str;
 use Tiptap\Marks\Link;


### PR DESCRIPTION
Hello everyone,

I'd like to address an issue through a brief user story.

Imagine you're working on the multisite configuration control panel, and your task is to create a new entry. You start by adding content to the 'en-de' site. Within that content, you include a Link Mark that points to another entry within the 'en-de' site.

Now, let's say you localize the content for the 'en-us' site and inherit the content. The problem arises when the link still directs users to the 'en-de' site, instead of switching to the corresponding 'en-us' site. This behavior seems counterintuitive since visitors expect a seamless transition to the appropriate locale by simply clicking on a link.

To improve this, I propose implementing a mechanism that attempts to locate and resolve the entry in the correct locale if it exists.

I welcome your thoughts and feedback on this matter.

Thank you!