### PR TITLE
[4.x] Antlers: relaxes generic comparisons

### DIFF
--- a/src/View/Antlers/Language/Runtime/ConditionProcessor.php
+++ b/src/View/Antlers/Language/Runtime/ConditionProcessor.php
@@ -77,7 +77,7 @@ class ConditionProcessor
 
                 $result = $environment->evaluateBool(self::$branchCache[$branch->head->content]);
 
-                if ($result === true) {
+                if ($result == true) {
                     $this->processor->setIsConditionProcessor($condValueToRestore);
 
                     return $branch;

--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -382,7 +382,8 @@ class Environment
         }
 
         if (is_numeric($result)) {
-            $value = $result >= 1;
+            // Updated to be != 0 to be consistent with PHP behavior.
+            $value = $result != 0;
             $this->unlock();
 
             return $value;

--- a/tests/Antlers/Sandbox/ConditionalsTest.php
+++ b/tests/Antlers/Sandbox/ConditionalsTest.php
@@ -136,4 +136,13 @@ EOT;
         ]);
         $this->assertSame('inner truth', $result);
     }
+
+    public function test_numeric_values_inside_conditions()
+    {
+        $this->assertSame('Yes', $this->renderString('{{ if -1 }}Yes{{ else }}No{{ /if }}'));
+        $this->assertSame('Yes', $this->renderString('{{ if 1 }}Yes{{ else }}No{{ /if }}'));
+        $this->assertSame('Yes', $this->renderString('{{ if 1.0 }}Yes{{ else }}No{{ /if }}'));
+        $this->assertSame('No', $this->renderString('{{ if 0 }}Yes{{ else }}No{{ /if }}'));
+        $this->assertSame('No', $this->renderString('{{ if 0.0 }}Yes{{ else }}No{{ /if }}'));
+    }
 }


### PR DESCRIPTION
This PR resolves #8325 by relaxing the general comparisons. The root cause of the problem described in the linked issue is that eventually a comparison like `1 === true` would be performed, which returns `false`.

This internal comparison is now a loose comparison, and the logic surrounding numeric values is now consistent with regular PHP.