### PR TITLE
[4.x] Forgot password link is available with OAuth

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -58,7 +58,7 @@
     </div>
     </login>
 </div>
-@if (! $oauth)
+@if ($emailLoginEnabled)
     <div class="w-full text-center mt-4">
         <a href="{{ cp_route('password.request') }}" class="forgot-password-link text-sm opacity-75 hover:opacity-100">
             {{ __('Forgot password?') }}


### PR DESCRIPTION
Fixes #8329

Currently the link is hidden when OAuth is enabled. This PR flips the logic so that it is hidden when the email login is disabled.
