### PR TITLE
[4.x] Move downloadUrl logic into Asset class

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -524,7 +524,7 @@ class Asset implements AssetContract, Augmentable, ArrayAccess, Arrayable, Conta
      * 
      * @return string
      */
-    public function downloadUrl()
+    public function cpDownloadUrl()
     {
         return cp_route('assets.download', base64_encode($this->id()));
     }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -520,6 +520,16 @@ class Asset implements AssetContract, Augmentable, ArrayAccess, Arrayable, Conta
     }
 
     /**
+     * Get the file download url.
+     * 
+     * @return string
+     */
+    public function downloadUrl()
+    {
+        return cp_route('assets.download', base64_encode($this->id()));
+    }
+
+    /**
      * Get the file extension of the asset.
      *
      * @return string

--- a/src/Http/Resources/CP/Assets/Asset.php
+++ b/src/Http/Resources/CP/Assets/Asset.php
@@ -19,7 +19,7 @@ class Asset extends JsonResource
             'reference' => $this->reference(),
             'permalink' => $this->absoluteUrl(),
             'extension' => $this->extension(),
-            'downloadUrl' => cp_route('assets.download', base64_encode($this->id())),
+            'downloadUrl' => $this->downloadUrl(),
             'size' => Str::fileSizeForHumans($this->size()),
             'lastModified' => $this->lastModified()->inPreferredFormat(),
             'lastModifiedRelative' => $this->lastModified()->diffForHumans(),

--- a/src/Http/Resources/CP/Assets/Asset.php
+++ b/src/Http/Resources/CP/Assets/Asset.php
@@ -19,7 +19,7 @@ class Asset extends JsonResource
             'reference' => $this->reference(),
             'permalink' => $this->absoluteUrl(),
             'extension' => $this->extension(),
-            'downloadUrl' => $this->downloadUrl(),
+            'downloadUrl' => $this->cpDownloadUrl(),
             'size' => Str::fileSizeForHumans($this->size()),
             'lastModified' => $this->lastModified()->inPreferredFormat(),
             'lastModifiedRelative' => $this->lastModified()->diffForHumans(),


### PR DESCRIPTION
This PR simplifies the AssetResource by moving the logic into the asset class itself.

This is really helpful if you need to manipulate the download url for assets.