### PR TITLE
[4.x] Allow arrays to be passed to `user_groups` tag

### DIFF
--- a/src/Tags/UserGroups.php
+++ b/src/Tags/UserGroups.php
@@ -13,7 +13,11 @@ class UserGroups extends Tags
     {
         $groups = UserGroup::all();
 
-        if (! $handles = $this->params->explode('handle')) {
+        if (! is_array($handles = $this->params->get('handle'))) {
+            $handles = $this->params->explode('handle');
+        }
+
+        if (empty($handles)) {
             return $groups->values();
         }
 

--- a/tests/Tags/UserGroupsTagTest.php
+++ b/tests/Tags/UserGroupsTagTest.php
@@ -49,12 +49,14 @@ class UserGroupsTagTest extends TestCase
         UserGroup::make()->handle('test3')->title('Test 3')->save();
 
         $this->assertEquals('test2|test3|', $this->tag('{{ user_groups handle="test2|test3" }}{{ handle }}|{{ /user_groups }}'));
+        $this->assertEquals('test2|test3|', $this->tag('{{ user_groups :handle="groups" }}{{ handle }}|{{ /user_groups }}', ['groups' => ['test2', 'test3']]));
     }
 
     /** @test */
     public function it_outputs_no_results_when_finding_multiple_groups()
     {
         $this->assertEquals('nothing', $this->tag('{{ user_groups handle="test2|test3" }}{{ if no_results }}nothing{{ else }}something{{ /if }}{{ /user_groups }}'));
+        $this->assertEquals('nothing', $this->tag('{{ user_groups :handle="groups" }}{{ if no_results }}nothing{{ else }}something{{ /if }}{{ /user_groups }}', ['groups' => ['test2', 'test3']]));
     }
 
     private function tag($tag, $data = [])


### PR DESCRIPTION
I noticed when helping someone on Discord that Erin had added support for passing an array of roles to `user_roles`, so we should allow the same for `user_groups`.

Ref: https://github.com/statamic/cms/pull/7328