### PR TITLE
[4.x] Antlers profiler: fixes division by zero

### DIFF
--- a/src/View/Debugbar/AntlersProfiler/PerformanceTracer.php
+++ b/src/View/Debugbar/AntlersProfiler/PerformanceTracer.php
@@ -100,7 +100,10 @@ class PerformanceTracer implements RuntimeTracerContract
 
             $item->clientTotalTime = $item->getTotalExecutionTime();
             $item->clientSelfTime = $item->getSelfExecutionTime();
-            $item->percentOfExecutionTime = round(($item->totalElapsedTime / $this->totalElapsedTime) * 100, 2);
+
+            if ($this->totalElapsedTime > 0) {
+                $item->percentOfExecutionTime = round(($item->totalElapsedTime / $this->totalElapsedTime) * 100, 2);
+            }
 
             $item->clientSelfTimeDisplay = $item->getSelfExecutionTimeDisplay();
             $item->clientTotalTimeDisplay = $item->getTotalExecutionTimeDisplay();


### PR DESCRIPTION
Fixes a division by zero error that can happen if something fails early and causes the total execution time to be `0`.

This bug causes exceptions within tags/modifiers to become less visible/harder to track down.