### PR TITLE
[4.x] Prevent processing Antlers comments within the profiler

### DIFF
--- a/src/View/Debugbar/AntlersProfiler/PerformanceTracer.php
+++ b/src/View/Debugbar/AntlersProfiler/PerformanceTracer.php
@@ -220,6 +220,10 @@ class PerformanceTracer implements RuntimeTracerContract
             return;
         }
 
+        if ($node->isComment) {
+            return;
+        }
+
         $file = $this->massageFilePath(GlobalRuntimeState::$currentExecutionFile);
         $fullPath = $this->normalizePath(GlobalRuntimeState::$currentExecutionFile);
         $this->antlersNodesObserved += 1;
@@ -315,6 +319,10 @@ class PerformanceTracer implements RuntimeTracerContract
 
     public function onExit(AbstractNode $node, $runtimeContent)
     {
+        if ($node instanceof AntlersNode && $node->isComment) {
+            return;
+        }
+
         if ($node->isVirtual) {
             return;
         }


### PR DESCRIPTION
Prevents comments from making their way into the profiler's logic, which will cause issues as they will not have a `$name` property.