### PR TITLE
[4.x] Adds is_external_url modifer

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1277,6 +1277,17 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Returns true if the string is an external URL.
+     *
+     * @param $value
+     * @return bool
+     */
+    public function isUrlExternal($value)
+    {
+        return Str::isUrl($value) && URL::isExternal($value);
+    }
+
+    /**
      * Determines if the date on a weekday.
      *
      * @param $value

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1282,7 +1282,7 @@ class CoreModifiers extends Modifier
      * @param $value
      * @return bool
      */
-    public function isUrlExternal($value)
+    public function isExternalUrl($value)
     {
         return Str::isUrl($value) && URL::isExternal($value);
     }


### PR DESCRIPTION
This is a handy modifier to have access to within Antlers to help determine if a link is external - and if so, can conditionally add `target="_blank"` to an anchor, such as:
```antlers
<a href="{{ link }}" {{ if link | is_url_external }} target="_blank" {{ /if }}>{{ label }}</a>
```
If this is something that is of use, happy to do a PR for docs to update those too.