### PR TITLE
[4.x] Add setting to disable Antlers profiler

### DIFF
--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -194,6 +194,6 @@ class ViewServiceProvider extends ServiceProvider
 
     private function profilerEnabled()
     {
-        return debugbar()->isEnabled() && ! Statamic::isCpRoute();
+        return debugbar()->isEnabled() && config('statamic.antlers.debugbar', true) && ! Statamic::isCpRoute();
     }
 }


### PR DESCRIPTION
This allows you to add `'debugbar' => false` to your `config/statamic/antlers.php` file to disable it. It's enabled by default.

Looks like there could be an issue sometimes that breaks debugbar (#8352), so this setting would at least let you disable the Antlers part so the rest of Debugbar can continue working.