### PR TITLE
[4.x] Make contains modifier handle array needles 

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -407,6 +407,10 @@ class CoreModifiers extends Modifier
         $needle = $this->getFromContext($context, $params);
 
         if (is_array($haystack)) {
+            if (is_array($needle)) {
+                return count(array_intersect($haystack, $needle)) > 0;
+            }
+
             if (Arr::isAssoc($haystack)) {
                 return Arr::exists($haystack, $needle);
             }
@@ -1274,17 +1278,6 @@ class CoreModifiers extends Modifier
     public function isUrl($value)
     {
         return Str::isUrl($value);
-    }
-
-    /**
-     * Returns true if the string is an external URL.
-     *
-     * @param $value
-     * @return bool
-     */
-    public function isExternalUrl($value)
-    {
-        return Str::isUrl($value) && URL::isExternal($value);
     }
 
     /**

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1281,6 +1281,17 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Returns true if the string is an external URL.
+     *
+     * @param $value
+     * @return bool
+     */
+    public function isExternalUrl($value)
+    {
+        return Str::isUrl($value) && URL::isExternal($value);
+    }
+
+    /**
      * Determines if the date on a weekday.
      *
      * @param $value

--- a/src/Tags/Concerns/QueriesConditions.php
+++ b/src/Tags/Concerns/QueriesConditions.php
@@ -135,11 +135,19 @@ trait QueriesConditions
 
     protected function queryContainsCondition($query, $field, $value)
     {
+        if (is_array($value)) {
+            return $query->whereJsonContains($field, $value);
+        }
+
         return $query->where($field, 'like', "%{$value}%");
     }
 
     protected function queryDoesntContainCondition($query, $field, $value)
     {
+        if (is_array($value)) {
+            return $query->whereJsonDoesntContain($field, $value);
+        }
+
         return $query->where($field, 'not like', "%{$value}%");
     }
 

--- a/tests/Modifiers/ContainsTest.php
+++ b/tests/Modifiers/ContainsTest.php
@@ -73,6 +73,24 @@ class ContainsTest extends TestCase
         $this->assertFalse($modified);
     }
 
+    /** @test */
+    public function it_returns_true_if_needle_array_found_in_array(): void
+    {
+        $haystack = ['bacon', 'bread', 'tomato'];
+
+        $modified = $this->modify($haystack, ['delicious'], ['delicious' => ['bacon', 'bread'], 'gross' => 'broccoli']);
+        $this->assertTrue($modified);
+    }
+
+    /** @test */
+    public function it_returns_false_if_needle_array_not_found_in_array(): void
+    {
+        $haystack = ['bacon', 'bread', 'tomato'];
+
+        $modified = $this->modify($haystack, ['gross'], ['delicious' => 'bacon', 'gross' => ['broccoli']]);
+        $this->assertFalse($modified);
+    }
+
     private function modify($value, array $params, array $context)
     {
         return Modify::value($value)->context($context)->contains($params)->fetch();

--- a/tests/Tags/Concerns/QueriesConditionsTest.php
+++ b/tests/Tags/Concerns/QueriesConditionsTest.php
@@ -101,6 +101,28 @@ class QueriesConditionsTest extends TestCase
     }
 
     /** @test */
+    public function it_filters_by_contains_condition_when_needle_and_data_are_arrays()
+    {
+        $this->makeEntry('dog')->set('array_field', ['one', 'two', 'three'])->save();
+        $this->makeEntry('cat')->set('array_field', ['four', 'five', 'six'])->save();
+        $this->makeEntry('tiger')->set('array_field', ['seven', 'eight', 'nine'])->save();
+
+        $this->assertCount(3, $this->getEntries());
+        $this->assertCount(1, $this->getEntries(['array_field:contains' => ['four', 'ten']]));
+    }
+
+    /** @test */
+    public function it_filters_by_doesnt_contain_condition_when_needle_and_data_are_arrays()
+    {
+        $this->makeEntry('dog')->set('array_field', ['one', 'two', 'three'])->save();
+        $this->makeEntry('cat')->set('array_field', ['four', 'five', 'six'])->save();
+        $this->makeEntry('tiger')->set('array_field', ['seven', 'eight', 'nine'])->save();
+
+        $this->assertCount(3, $this->getEntries());
+        $this->assertCount(2, $this->getEntries(['array_field:doesnt_contain' => ['four', 'ten']]));
+    }
+
+    /** @test */
     public function it_filters_by_in_condition()
     {
         $this->makeEntry('dog')->set('type', 'canine')->save();


### PR DESCRIPTION
Sometimes you need to compare arrays to arrays, and it would be nice if the `contains` modifier was smart enough to handle it.

This PR updates that modifier to check if the intersect count between the 2 arrays is greater than zero, and if so it's true. This allows you to do things like:

`{{ collection:pages array_field:contains="this|or|that" }}`

or

`{{ my_value | contains("this|or|that") }}`

Which people seem to assume should work (judging by discord).

I thought it better to do it this way rather than a new modifier.

You could argue it should be a strict comparison, where the intersect count needs to match the needle count, but this approach matches whereJsonContains, and I've updated the queriesConditions contains method too.