### PR TITLE
[4.x] Antlers Profiler: Refactors & reduces client-side data

### DIFF
--- a/src/View/Debugbar/AntlersProfiler/PerformanceObject.php
+++ b/src/View/Debugbar/AntlersProfiler/PerformanceObject.php
@@ -21,9 +21,7 @@ class PerformanceObject
     public $children = [];
     public $parent = null;
     public $childMap = [];
-    public $nodeContent = '';
     public $escapedNodeContent = '';
-    public $sourceContent = '';
     public $escapedSourceContent = '';
     public $isNodeObject = false;
     public $executionCount = 0;
@@ -32,7 +30,6 @@ class PerformanceObject
     public $line = 0;
     public $percentOfExecutionTime = 0;
     public $isConditionNode = false;
-    public $bufferOutput = '';
     public $escapedBufferOutput = '';
     public $isCloseOutput = false;
     public $clientTotalTime = 0;
@@ -155,5 +152,39 @@ class PerformanceObject
         }
 
         return $this->getTotalExecutionTime() - $this->getChildExecutionTime();
+    }
+
+    public function toArray($includeChildren = true)
+    {
+        $children = [];
+
+        if ($includeChildren) {
+            foreach ($this->children as $child) {
+                $children[] = $child->toArray();
+            }
+        }
+
+        return [
+            'escapedNodeContent' => $this->escapedNodeContent,
+            'escapedBufferOutput' => $this->escapedBufferOutput,
+            'escapedSourceContent' => $this->escapedSourceContent,
+            'path' => $this->path,
+            'fullPath' => $this->fullPath,
+            'editorLink' => $this->editorLink,
+            'isNodeObject' => $this->isNodeObject,
+            'executionCount' => $this->executionCount,
+            'totalElapsedTime' => $this->totalElapsedTime,
+            'isHot' => $this->isHot,
+            'isTag' => $this->isTag,
+            'isCloseOutput' => $this->isCloseOutput,
+            'cumulativeMemorySamples' => $this->cumulativeMemorySamples,
+            'executionTimeCategory' => $this->executionTimeCategory,
+            'sampleTime' => $this->sampleTime,
+            'children' => $children,
+            'line' => $this->line,
+            'clientSelfTimeDisplay' => $this->clientSelfTimeDisplay,
+            'clientTotalTimeDisplay' => $this->clientTotalTimeDisplay,
+            'percentOfExecutionTime' => $this->percentOfExecutionTime,
+        ];
     }
 }

--- a/src/View/Debugbar/AntlersProfiler/PerformanceTracer.php
+++ b/src/View/Debugbar/AntlersProfiler/PerformanceTracer.php
@@ -264,13 +264,19 @@ class PerformanceTracer implements RuntimeTracerContract
             $performanceItem->isTag = $node->isTagNode;
             $performanceItem->isConditionNode = in_array($node->name->name, self::$conditions);
 
-            $content = $node->content;
+            $contentNode = $node;
 
             if ($node->originalNode != null) {
-                $content = $node->originalNode->content;
+                $contentNode = $node->originalNode;
             }
 
-            $performanceItem->escapedNodeContent = e($node->rawStart.' '.trim($content).' '.$node->rawEnd);
+            $content = $contentNode->rawStart.' '.trim($contentNode->content).' '.$contentNode->rawEnd;
+
+            if (count($contentNode->interpolationRegions) > 0) {
+                $content = $contentNode->getNodeDocumentText();
+            }
+
+            $performanceItem->escapedNodeContent = e($content);
             $performanceItem->escapedSourceContent = e($node->runtimeContent);
 
             $performanceItem->isNodeObject = true;

--- a/src/View/Debugbar/AntlersProfiler/PerformanceTracer.php
+++ b/src/View/Debugbar/AntlersProfiler/PerformanceTracer.php
@@ -108,13 +108,10 @@ class PerformanceTracer implements RuntimeTracerContract
             $item->clientSelfTimeDisplay = $item->getSelfExecutionTimeDisplay();
             $item->clientTotalTimeDisplay = $item->getTotalExecutionTimeDisplay();
 
-            $item->escapedNodeContent = e($item->nodeContent);
             $item->executionTimeCategory = PerformanceCategory::getCategory($item->totalElapsedTime);
         }
 
         foreach ($this->sourceViewObjects as $item) {
-            $item->escapedNodeContent = e($item->nodeContent);
-
             if (! $item->isNodeObject) {
                 continue;
             }
@@ -123,7 +120,6 @@ class PerformanceTracer implements RuntimeTracerContract
             if (array_key_exists($item->nodeRefId, $this->nodePerformanceItems)) {
                 $reference = $this->nodePerformanceItems[$item->nodeRefId];
 
-                $item->nodeContent = $reference->nodeContent;
                 $item->escapedNodeContent = $reference->escapedNodeContent;
                 $item->clientSelfTime = $reference->clientSelfTime;
                 $item->clientTotalTime = $reference->clientTotalTime;
@@ -153,7 +149,6 @@ class PerformanceTracer implements RuntimeTracerContract
             $rootItem->path = $file;
             $rootItem->isNodeObject = false;
             $rootItem->children = $reportItems;
-            $rootItem->escapedNodeContent = e($rootItem->nodeContent);
             $rootItem->clientSelfTimeDisplay = $rootItem->getTotalExecutionTimeDisplay();
             $rootItem->clientTotalTimeDisplay = $rootItem->getTotalExecutionTimeDisplay();
 
@@ -166,7 +161,7 @@ class PerformanceTracer implements RuntimeTracerContract
                 $rootItem->totalElapsedTime += $item->getTotalExecutionTime();
             }
 
-            $report[] = $rootItem;
+            $report[] = $rootItem->toArray();
         }
 
         return $report;
@@ -232,14 +227,12 @@ class PerformanceTracer implements RuntimeTracerContract
             $outputClosing = new PerformanceObject($this->firstSampleTime);
             $outputClosing->nodeRefId = $node->refId;
 
-            $outputClosing->bufferOutput = $node->rawStart.$node->content.$node->rawEnd;
-            $outputClosing->escapedBufferOutput = e($outputClosing->bufferOutput);
+            $outputClosing->escapedBufferOutput = e($node->rawStart.$node->content.$node->rawEnd);
             $outputClosing->path = $file;
             $outputClosing->fullPath = $fullPath;
             $outputClosing->isCloseOutput = true;
             $outputClosing->isNodeObject = true;
 
-            $outputClosing->sourceContent = trim($node->runtimeContent);
             $outputClosing->escapedSourceContent = e($node->runtimeContent);
             $this->sourceViewObjects[] = $outputClosing;
             $this->currentDepth -= 1;
@@ -252,13 +245,11 @@ class PerformanceTracer implements RuntimeTracerContract
         if ($node->isClosedBy != null) {
             $openNode = new PerformanceObject($this->firstSampleTime);
             $openNode->nodeRefId = $node->refId;
-            $openNode->bufferOutput = $node->rawStart.$node->content.$node->rawEnd;
-            $openNode->escapedBufferOutput = e($openNode->bufferOutput);
+            $openNode->escapedBufferOutput = e($node->rawStart.$node->content.$node->rawEnd);
             $openNode->isNodeObject = true;
             $openNode->path = $file;
             $openNode->fullPath = $fullPath;
 
-            $openNode->sourceContent = trim($node->runtimeContent);
             $openNode->escapedSourceContent = e($node->runtimeContent);
 
             $this->sourceViewRefIdMapping[$node->refId] = $openNode;
@@ -279,8 +270,7 @@ class PerformanceTracer implements RuntimeTracerContract
                 $content = $node->originalNode->content;
             }
 
-            $performanceItem->nodeContent = $node->rawStart.' '.trim($content).' '.$node->rawEnd;
-            $performanceItem->sourceContent = trim($node->runtimeContent);
+            $performanceItem->escapedNodeContent = e($node->rawStart.' '.trim($content).' '.$node->rawEnd);
             $performanceItem->escapedSourceContent = e($node->runtimeContent);
 
             $performanceItem->isNodeObject = true;
@@ -334,8 +324,7 @@ class PerformanceTracer implements RuntimeTracerContract
         if ($node instanceof LiteralNode) {
             if (! array_key_exists($node->refId, $this->sourceViewObjects)) {
                 $literalObject = new PerformanceObject($this->firstSampleTime);
-                $literalObject->bufferOutput = $runtimeContent;
-                $literalObject->escapedBufferOutput = e($literalObject->bufferOutput);
+                $literalObject->escapedBufferOutput = e($runtimeContent);
                 $literalObject->path = $this->massageFilePath(GlobalRuntimeState::$currentExecutionFile);
                 $literalObject->fullPath = $this->normalizePath(GlobalRuntimeState::$currentExecutionFile);
                 $this->sourceViewObjects[] = $literalObject;
@@ -370,21 +359,18 @@ class PerformanceTracer implements RuntimeTracerContract
                 $outContent = $runtimeContent;
 
                 if (Str::contains($node->content, 'template_content')) {
-                    $outContent = '/*REPLACED_CONTENT*/';
+                    $outContent = '****REPLACED_CONTENT****';
                     $this->triggeredTemplateContent = $this->nodePerformanceItems[$node->refId]->path;
                 }
 
-                $outObject->bufferOutput = $outContent;
-                $outObject->escapedBufferOutput = e($outObject->bufferOutput);
-                $outObject->nodeContent = $this->nodePerformanceItems[$node->refId]->nodeContent;
-                $outObject->escapedNodeContent = e($outObject->nodeContent);
+                $outObject->escapedBufferOutput = e($outContent);
+                $outObject->escapedNodeContent = $this->nodePerformanceItems[$node->refId]->escapedNodeContent;
                 $outObject->isNodeObject = true;
                 $outObject->totalElapsedTime = $elapsed;
                 $outObject->clientTotalTimeDisplay = $outObject->getTotalExecutionTimeDisplay();
                 $outObject->path = $this->nodePerformanceItems[$node->refId]->path;
                 $outObject->fullPath = $this->nodePerformanceItems[$node->refId]->fullPath;
 
-                $outObject->sourceContent = trim($node->runtimeContent);
                 $outObject->escapedSourceContent = e($node->runtimeContent);
 
                 $this->sourceViewObjects[] = $outObject;

--- a/src/View/Debugbar/AntlersProfiler/resources/widget.js
+++ b/src/View/Debugbar/AntlersProfiler/resources/widget.js
@@ -103,12 +103,6 @@
 
         render: function () {
             this.bindAttr('data', function (data) {
-                data.performance_items_array = Object.keys(data.performance_items).map(function (key) {
-                    return data.performance_items[key];
-                }).filter(function (item) {
-                    return item.depth == 0;
-                });
-
                 var debugWarningLabel = '';
 
                 if (data.had_active_debug_sessions) {
@@ -412,7 +406,7 @@
                         field: 'clientDisplay',
                         formatter: function (cell) {
                             var data = cell.getData();
-                            var contents = !data.isNodeObject ? data.path : data.nodeContent;
+                            var contents = !data.isNodeObject ? data.path : data.escapedNodeContent;
 
                             contents = truncateString(contents, 100);
 
@@ -608,7 +602,7 @@
                     btnNodeGraph.classList.add('antlers-trace-button-active');
                     btnSourceGraph.classList.remove('antlers-trace-button-active');
 
-                    callTable.replaceData(data.performance_items_array);
+                    callTable.replaceData(data.performance_items);
                     callTable.showColumn('path');
                 });
 


### PR DESCRIPTION
Fixes #8352 

This PR makes the following changes:

* Removes all unescaped content to reduce the amount of data, and to prevent issues with json encoding
* Begins filtering node samples when the sample count exceeds 1,000 (these samples power the graph)
* Dramatically reduces the amount of data sent to the client that is required to power the current views/reporting