### PR TITLE
[4.x] Fix wrong page title on edit form page

### DIFF
--- a/resources/js/components/collections/EditForm.vue
+++ b/resources/js/components/collections/EditForm.vue
@@ -15,7 +15,7 @@
             <header class="mb-6">
                 <breadcrumb :url="url" :title="values.title" />
                 <div class="flex items-center">
-                    <h1 class="flex-1" v-text="__('Configure Collection')" />
+                    <h1 class="flex-1" v-text="__('Configure Form')" />
                     <button type="submit" class="btn-primary" @click="submit">{{ __('Save') }}</button>
                 </div>
             </header>


### PR DESCRIPTION
This pull request fixes a small issue where the page title for the edit form page was incorrect.

Fixes #8350