### PR TITLE
[4.x] Change visibility of FileStore path method

### DIFF
--- a/src/Extensions/FileStore.php
+++ b/src/Extensions/FileStore.php
@@ -8,7 +8,7 @@ use Statamic\Support\Str;
 
 class FileStore extends LaravelFileStore implements Store
 {
-    protected function path($key)
+    public function path($key)
     {
         if (! Str::startsWith($key, 'stache::')) {
             return parent::path($key);


### PR DESCRIPTION
Laravel 10.14.0 changed the visibility of the `path` method to public.

We had an overridden that method, but it was protected. The difference in visibilities caused an error.

This PR changes the visibility to match.

Fixes #8364
