### PR TITLE
[4.x] Remove bottom margin on a Section field type publish form when no instructions are present

### DIFF
--- a/resources/css/components/fieldtypes/section.css
+++ b/resources/css/components/fieldtypes/section.css
@@ -26,6 +26,10 @@
     .read-only-overlay {
         display: none;
     }
+
+    label:last-child {
+        @apply mb-0 !important; /* Removes spacing under label when there are no instructions to display */
+    }
 }
 
 .bard-fieldtype .section-fieldtype {


### PR DESCRIPTION
Just creating a slightly neater appearance for a section without instructions.

When a Section has no instructions, the mb-2 of the label remains, and the spacing is unbalanced:
<img width="390" alt="image" src="https://github.com/statamic/cms/assets/1491079/c847400f-8ede-4e9b-9855-f3bb31bbfb75">

This PR resolves that:
<img width="474" alt="image" src="https://github.com/statamic/cms/assets/1491079/4dfccb81-df7f-481d-845a-f1849e2b007b">

