### PR TITLE
[4.x] Avoid Pint fixing on forks

### DIFF
--- a/.github/workflows/pint-fix.yml
+++ b/.github/workflows/pint-fix.yml
@@ -11,21 +11,19 @@ permissions:
 jobs:
   fix-php-code-styling:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'statamic'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        if: github.repository_owner == 'statamic'
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.PINT }}
 
       - name: Fix PHP code style issues
-        if: github.repository_owner == 'statamic'
         uses: aglipanci/laravel-pint-action@1.0.0
 
       - name: Commit changes
-        if: github.repository_owner == 'statamic'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Fix styling

--- a/.github/workflows/pint-fix.yml
+++ b/.github/workflows/pint-fix.yml
@@ -15,14 +15,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        if: github.repository_owner == 'statamic'
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.PINT }}
 
       - name: Fix PHP code style issues
+        if: github.repository_owner == 'statamic'
         uses: aglipanci/laravel-pint-action@1.0.0
 
       - name: Commit changes
+        if: github.repository_owner == 'statamic'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Fix styling

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -18,7 +18,7 @@ use Statamic\Tags\FluentTag;
 use Stringy\StaticStringy;
 
 class Statamic
- {
+{
     const CORE_SLUG = 'statamic';
     const PACKAGE = 'statamic/cms';
 

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -18,7 +18,7 @@ use Statamic\Tags\FluentTag;
 use Stringy\StaticStringy;
 
 class Statamic
-{
+ {
     const CORE_SLUG = 'statamic';
     const PACKAGE = 'statamic/cms';
 


### PR DESCRIPTION
See #8310

The "fix" workflow requires a personal access token. On forks, they wouldn't have that token, and I definitely don't want to require it. At the moment on forks you get a "workflow failed" error/email because of the missing token.

This will prevent the job from running in the workflow.
There's no way at the moment to have a workflow be ignored completely on a fork.
