### PR TITLE
[4.x] Fix taxonomy term filtering inconsistencies between Tag and API

### DIFF
--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -7,9 +7,12 @@ use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Entry;
 use Statamic\Http\Resources\API\EntryResource;
 use Statamic\Support\Str;
+use Statamic\Tags\Concerns\QueriesTaxonomyTerms;
 
 class CollectionEntriesController extends ApiController
 {
+    use QueriesTaxonomyTerms;
+
     protected $resourceConfigKey = 'collections';
     protected $routeResourceKey = 'collection';
     protected $filterPublished = true;
@@ -60,17 +63,11 @@ class CollectionEntriesController extends ApiController
 
     protected function applyTaxonomyFilter($query, $filter, $terms)
     {
-        [$_, $taxonomy, $condition] = array_pad(explode(':', $filter), 3, null);
+        [$_, $taxonomy, $modifier] = array_pad(explode(':', $filter), 3, null);
 
-        $terms = collect(explode(',', $terms))->map(fn ($term) => "$taxonomy::$term");
+        $values = collect(explode(',', $terms))->map(fn ($term) => "$taxonomy::$term");
 
-        if ($condition === 'in') {
-            $query->whereTaxonomyIn($terms->all());
-        } elseif ($condition === 'not_in') {
-            $query->whereTaxonomyNotIn($terms->all());
-        } else {
-            $terms->each(fn ($term) => $query->whereTaxonomy($term));
-        }
+        $this->queryTaxonomyTerms($query, $modifier, $values);
     }
 
     private function abortIfInvalid($entry, $collection)

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -5,7 +5,6 @@ namespace Statamic\Tags\Collection;
 use Closure;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as IlluminateCollection;
-use InvalidArgumentException;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Entries\EntryCollection;
 use Statamic\Facades\Collection;
@@ -21,7 +20,8 @@ class Entries
     use Concerns\QueriesScopes,
         Concerns\QueriesOrderBys,
         Concerns\GetsQueryResults,
-        Concerns\GetsQuerySelectKeys;
+        Concerns\GetsQuerySelectKeys,
+        Concerns\QueriesTaxonomyTerms;
     use Concerns\QueriesConditions {
         queryableConditionParams as traitQueryableConditionParams;
     }
@@ -305,7 +305,7 @@ class Entries
             return $key === 'taxonomy' || Str::startsWith($key, 'taxonomy:');
         })->each(function ($values, $param) use ($query) {
             $taxonomy = substr($param, 9);
-            [$taxonomy, $modifier] = array_pad(explode(':', $taxonomy), 2, 'any');
+            [$taxonomy, $modifier] = array_pad(explode(':', $taxonomy), 2, null);
 
             if (Compare::isQueryBuilder($values)) {
                 $values = $values->get();
@@ -327,19 +327,7 @@ class Entries
                 return Str::contains($term, '::') ? $term : $taxonomy.'::'.$term;
             });
 
-            if ($modifier === 'all') {
-                $values->each(function ($value) use ($query) {
-                    $query->whereTaxonomy($value);
-                });
-            } elseif ($modifier === 'not') {
-                $query->whereTaxonomyNotIn($values->all());
-            } elseif ($modifier === 'any') {
-                $query->whereTaxonomyIn($values->all());
-            } else {
-                throw new InvalidArgumentException(
-                    'Unknown taxonomy query modifier ['.$modifier.']. Valid values are "any", "not", and "all".'
-                );
-            }
+            $this->queryTaxonomyTerms($query, $modifier, $values);
         });
     }
 

--- a/src/Tags/Concerns/QueriesTaxonomyTerms.php
+++ b/src/Tags/Concerns/QueriesTaxonomyTerms.php
@@ -20,7 +20,7 @@ trait QueriesTaxonomyTerms
             $values->each(fn ($value) => $query->whereTaxonomy($value));
         } else {
             throw new InvalidArgumentException(
-                'Unknown taxonomy query modifier ['.$modifier.']. Valid values are "in", "any", "not_in", "not", and "all".'
+                'Unknown taxonomy query modifier ['.$modifier.']. Valid values are "any", "not", and "all".'
             );
         }
     }

--- a/src/Tags/Concerns/QueriesTaxonomyTerms.php
+++ b/src/Tags/Concerns/QueriesTaxonomyTerms.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Statamic\Tags\Concerns;
+
+use InvalidArgumentException;
+
+trait QueriesTaxonomyTerms
+{
+    protected function queryTaxonomyTerms($query, $modifier, $value)
+    {
+        $values = collect($value);
+
+        $modifier ??= 'any';
+
+        if (in_array($modifier, ['in', 'any'])) {
+            $query->whereTaxonomyIn($values->all());
+        } elseif (in_array($modifier, ['not_in', 'not'])) {
+            $query->whereTaxonomyNotIn($values->all());
+        } elseif ($modifier === 'all') {
+            $values->each(fn ($value) => $query->whereTaxonomy($value));
+        } else {
+            throw new InvalidArgumentException(
+                'Unknown taxonomy query modifier ['.$modifier.']. Valid values are "in", "any", "not_in", "not", and "all".'
+            );
+        }
+    }
+}

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -497,6 +497,13 @@ class EntriesTest extends TestCase
 
         // Ensure in logic intersects properly across multiple taxonomies
         $this->assertEquals([1], $this->getEntryIds(['taxonomy:tags:in' => 'rad|meh', 'taxonomy:categories:in' => 'news']));
+
+        // Passing IDs into generic taxonomy param
+        $this->assertEquals([1, 3], $this->getEntryIds(['taxonomy' => 'tags::rad']));
+        $this->assertEquals([1, 3, 4], $this->getEntryIds(['taxonomy' => 'tags::rad|tags::meh']));
+        $this->assertEquals([1, 3, 4], $this->getEntryIds(['taxonomy' => 'tags::rad|tags::meh|categories::news']));
+        $this->assertEquals([1], $this->getEntryIds(['taxonomy::all' => 'tags::rad|categories::news'])); // modifier still expected to be 3rd segment
+        $this->assertEquals([1], $this->getEntryIds(['taxonomy' => 'tags::rad|tags::meh', 'taxonomy:categories' => 'news'])); // mix and match
     }
 
     /** @test */

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -503,7 +503,7 @@ class EntriesTest extends TestCase
     public function it_throws_an_exception_when_using_an_unknown_taxonomy_query_modifier()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown taxonomy query modifier [xyz]. Valid values are "in", "any", "not_in", "not", and "all".');
+        $this->expectExceptionMessage('Unknown taxonomy query modifier [xyz]. Valid values are "any", "not", and "all".');
 
         $this->getEntries(['taxonomy:tags:xyz' => 'test']);
     }

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -513,7 +513,7 @@ class EntriesTest extends TestCase
     public function it_throws_an_exception_when_using_an_unknown_taxonomy_query_modifier()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown taxonomy query modifier [xyz]. Valid values are "any", "not", and "all".');
+        $this->expectExceptionMessage('Unknown taxonomy query modifier [xyz]. Valid values are "in", "any", "not_in", "not", and "all".');
 
         $this->getEntries(['taxonomy:tags:xyz' => 'test']);
     }

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -66,12 +66,19 @@ class EntriesTest extends TestCase
 
         $params = Parameters::make($params, new Context);
 
-        return (new Entries($params))->get();
+        $entries = (new Entries($params))->get();
+
+        // If paginated result set...
+        if (method_exists($entries, 'items')) {
+            $entries = $entries->items();
+        }
+
+        return $entries;
     }
 
     protected function getEntryIds($params = [])
     {
-        return collect($this->getEntries($params)->items())->map->id()->all();
+        return collect($this->getEntries($params))->map->id()->all();
     }
 
     /** @test */
@@ -450,29 +457,7 @@ class EntriesTest extends TestCase
     }
 
     /** @test */
-    public function it_filters_by_a_single_taxonomy_term()
-    {
-        $this->makeEntry('1')->data(['tags' => ['rad']])->save();
-        $this->makeEntry('2')->data(['tags' => ['rad']])->save();
-        $this->makeEntry('3')->data(['tags' => ['meh']])->save();
-
-        $this->assertEquals([1, 2], $this->getEntries(['taxonomy:tags' => 'rad'])->map->slug()->all());
-        $this->assertEquals([1, 2], $this->getEntries(['taxonomy:tags' => TermCollection::make([Term::make('rad')->taxonomy('tags')])])->map->slug()->all());
-    }
-
-    /** @test */
-    public function it_filters_out_a_single_taxonomy_term()
-    {
-        $this->makeEntry('1')->data(['tags' => ['rad']])->save();
-        $this->makeEntry('2')->data(['tags' => ['rad']])->save();
-        $this->makeEntry('3')->data(['tags' => ['meh']])->save();
-
-        $this->assertEquals([1, 2], $this->getEntries(['taxonomy:tags:not' => 'meh'])->map->slug()->all());
-        $this->assertEquals([1, 2], $this->getEntries(['taxonomy:tags:not' => TermCollection::make([Term::make('meh')->taxonomy('tags')])])->map->slug()->all());
-    }
-
-    /** @test */
-    public function it_filters_out_multiple_taxonomy_terms()
+    public function it_filters_by_taxonomy_terms()
     {
         $this->makeEntry('1')->data(['tags' => ['rad'], 'categories' => ['news']])->save();
         $this->makeEntry('2')->data(['tags' => ['awesome'], 'categories' => ['events']])->save();
@@ -480,33 +465,38 @@ class EntriesTest extends TestCase
         $this->makeEntry('4')->data(['tags' => ['meh']])->save();
         $this->makeEntry('5')->data([])->save();
 
-        $this->assertEquals([4, 5], $this->getEntries(['taxonomy:tags:not' => 'rad|awesome'])->map->slug()->all());
-        $this->assertEquals([4, 5], $this->getEntries(['taxonomy:tags:not' => ['rad', 'awesome']])->map->slug()->all());
-        $this->assertEquals([2, 5], $this->getEntries(['taxonomy:tags:not' => 'rad|meh'])->map->slug()->all());
-        $this->assertEquals([2, 5], $this->getEntries(['taxonomy:tags:not' => ['rad', 'meh']])->map->slug()->all());
+        // Where term in
+        $this->assertEquals([1, 3], $this->getEntryIds(['taxonomy:tags:in' => 'rad']));
+        $this->assertEquals([1, 3], $this->getEntryIds(['taxonomy:tags:any' => 'rad']));
+        $this->assertEquals([1, 3], $this->getEntryIds(['taxonomy:tags' => 'rad'])); // shorthand
 
-        // Ensure `whereIn` and `whereNot` logic intersect results properly.
-        $this->assertEquals([1, 3], $this->getEntries(['taxonomy:tags' => ['rad', 'meh'], 'taxonomy:tags:not' => ['meh']])->map->slug()->all());
-    }
+        // Where any of these terms in
+        $this->assertEquals([1, 3, 4], $this->getEntryIds(['taxonomy:tags:in' => 'rad|meh']));
+        $this->assertEquals([1, 3, 4], $this->getEntryIds(['taxonomy:tags:in' => ['rad', 'meh']]));
+        $this->assertEquals([1, 3, 4], $this->getEntryIds(['taxonomy:tags:any' => 'rad|meh']));
+        $this->assertEquals([1, 3, 4], $this->getEntryIds(['taxonomy:tags:any' => ['rad', 'meh']]));
+        $this->assertEquals([1, 3, 4], $this->getEntryIds(['taxonomy:tags' => 'rad|meh'])); // shorthand
+        $this->assertEquals([1, 3, 4], $this->getEntryIds(['taxonomy:tags' => ['rad', 'meh']])); // shorthand
 
-    /** @test */
-    public function it_filters_by_in_multiple_taxonomy_terms()
-    {
-        $this->makeEntry('1')->data(['tags' => ['rad'], 'categories' => ['news']])->save();
-        $this->makeEntry('2')->data(['tags' => ['awesome'], 'categories' => ['events']])->save();
-        $this->makeEntry('3')->data(['tags' => ['rad', 'awesome']])->save();
-        $this->makeEntry('4')->data(['tags' => ['meh']])->save();
+        // Where term not in
+        $this->assertEquals([2, 4, 5], $this->getEntryIds(['taxonomy:tags:not_in' => 'rad']));
+        $this->assertEquals([2, 4, 5], $this->getEntryIds(['taxonomy:tags:not' => 'rad']));
 
-        $this->assertEquals([3], $this->getEntries(['taxonomy:tags:all' => 'rad|awesome'])->map->slug()->all());
-        $this->assertEquals([3], $this->getEntries(['taxonomy:tags:all' => ['rad', 'awesome']])->map->slug()->all());
-        $this->assertEquals([1], $this->getEntries(['taxonomy:tags' => 'rad', 'taxonomy:categories' => 'news'])->map->slug()->all());
-        $this->assertEquals(0, $this->getEntries(['taxonomy:tags' => 'rad', 'taxonomy:categories' => 'events'])->count());
-        $this->assertEquals([1, 3, 4], $this->getEntries(['taxonomy:tags' => 'rad|meh'])->map->slug()->all());
-        $this->assertEquals([1, 3, 4], $this->getEntries(['taxonomy:tags' => ['rad', 'meh']])->map->slug()->all());
-        $this->assertEquals([1, 2, 3], $this->getEntries(['taxonomy' => 'tags::rad|categories::events'])->map->slug()->all());
-        $this->assertEquals([1, 2, 3], $this->getEntries(['taxonomy' => ['tags::rad', 'categories::events']])->map->slug()->all());
-        $this->assertEquals([3], $this->getEntries(['taxonomy' => 'tags::rad|tags::meh', 'taxonomy:tags' => 'awesome'])->map->slug()->all());
-        $this->assertEquals([2], $this->getEntries(['taxonomy' => 'tags::meh|categories::events', 'taxonomy:tags' => 'awesome'])->map->slug()->all());
+        // Where terms not in
+        $this->assertEquals([4, 5], $this->getEntryIds(['taxonomy:tags:not_in' => 'rad|awesome']));
+        $this->assertEquals([4, 5], $this->getEntryIds(['taxonomy:tags:not_in' => ['rad', 'awesome']]));
+        $this->assertEquals([4, 5], $this->getEntryIds(['taxonomy:tags:not' => 'rad|awesome']));
+        $this->assertEquals([4, 5], $this->getEntryIds(['taxonomy:tags:not' => ['rad', 'awesome']]));
+
+        // Where all of these terms in
+        $this->assertEquals([3], $this->getEntryIds(['taxonomy:tags:all' => 'rad|awesome']));
+        $this->assertEquals([3], $this->getEntryIds(['taxonomy:tags:all' => ['rad', 'awesome']]));
+
+        // Ensure in and not logic intersect properly
+        $this->assertEquals([1, 3], $this->getEntryIds(['taxonomy:tags:in' => 'rad|meh', 'taxonomy:tags:not' => 'meh']));
+
+        // Ensure in logic intersects properly across multiple taxonomies
+        $this->assertEquals([1], $this->getEntryIds(['taxonomy:tags:in' => 'rad|meh', 'taxonomy:categories:in' => 'news']));
     }
 
     /** @test */
@@ -527,6 +517,17 @@ class EntriesTest extends TestCase
 
         $this->assertEquals([1, 2, 3], $this->getEntries(['taxonomy:tags' => ''])->map->slug()->all());
         $this->assertEquals([1, 2, 3], $this->getEntries(['taxonomy:tags' => '|'])->map->slug()->all());
+        $this->assertEquals([1, 2, 3], $this->getEntries(['taxonomy:tags' => []])->map->slug()->all());
+    }
+
+    /** @test */
+    public function it_accepts_a_term_collection_to_filter_by_taxonomy()
+    {
+        $this->makeEntry('1')->data(['tags' => ['rad']])->save();
+        $this->makeEntry('2')->data(['tags' => ['rad']])->save();
+        $this->makeEntry('3')->data(['tags' => ['meh']])->save();
+
+        $this->assertEquals([1, 2], $this->getEntries(['taxonomy:tags' => TermCollection::make([Term::make('rad')->taxonomy('tags')])])->map->slug()->all());
     }
 
     /** @test */


### PR DESCRIPTION
(In the [REST API docs for filtering](https://statamic.dev/rest-api#filtering), you're told you can use all the same conditions "available to the collection tag"...

![CleanShot 2023-07-06 at 22 16 34](https://github.com/statamic/cms/assets/5187394/96a2128c-e41c-4bbe-b91f-1989c1505ebf)

If you follow that link through to [Taxonomy Conditions](https://statamic.dev/conditions#taxonomy-conditions), you're told that you can use the following "query modifiers"...

![CleanShot 2023-07-06 at 22 18 37](https://github.com/statamic/cms/assets/5187394/6c13f5f0-6030-48cd-97a6-afd9408ad306)

We noticed through a customer email that the REST API's taxonomy filtering was inconsistent with the collection's taxonomy filtering, despite being documented that way. This PR aims to fix these inconsistencies.

## Todo

- [x] Normalize taxonomy filtering between collection tag and REST API.
    - You can see in the implementation that we support `in` and `not_in` aliases, for the purpose of backwards compatibility with [#6615](https://github.com/statamic/cms/pull/6615), despite that functionality never being mentioned directly in the [REST API docs](https://statamic.dev/rest-api#filtering).
- [x] Normalize and flesh out test assertions for collection tag and REST API.
- [x] Fix incorrect shorthand default from `all` to `any` on REST API side.
    - The default has always been documented as `any` (see above screenshots), with no mention of how the shorthand default works in [#6615](https://github.com/statamic/cms/pull/6615), so we decided to consider this a 'fix', hoping that nobody was relying on undocumented broken functionality.