### PR TITLE
[4.x] Bring back the password reset for non-OAuth sites

### DIFF
--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -35,7 +35,7 @@ class LoginController extends CpController
         $data = [
             'title' => __('Log in'),
             'oauth' => $enabled = OAuth::enabled(),
-            'emailLoginEnabled' => $enabled ? config('statamic.oauth.email_login_enabled') : false,
+            'emailLoginEnabled' => $enabled ? config('statamic.oauth.email_login_enabled') : true,
             'providers' => $enabled ? OAuth::providers() : [],
             'referer' => $this->getReferrer($request),
             'hasError' => $this->hasError(),


### PR DESCRIPTION
[This PR](https://github.com/statamic/cms/pull/4625) moved the emailLoginEnabled check into an OAuth only situation. If you don't have OAuth enabled, you only have email, and [this bit here](https://github.com/statamic/cms/blob/4.x/resources/views/auth/login.blade.php#L61-L67) will never render. 