### PR TITLE
[4.x] Optimize Replicator Field loading performance for nested sets

### DIFF
--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -146,7 +146,11 @@ class Fields
 
     public function toPublishArray()
     {
-        return $this->fields->values()->map->toPublishArray()->all();
+        $blink = md5(json_encode($this->fields));
+
+        return Blink::once($blink, function () {
+            return $this->fields->values()->map->toPublishArray()->all();
+        });
     }
 
     public function addValues(array $values)

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -206,6 +206,7 @@ class Replicator extends Fieldtype
             $meta = Blink::once($metaHash, function () use ($config, $set) {
                 return (new Fields($config))->addValues($set)->meta();
             });
+
             return [$set['_id'] => $meta->put('_', '_')];
         })->toArray();
 


### PR DESCRIPTION
Fixes #8395 

This commit adds Blink caches to avoid redundant method calls when importing same fields in a nested replicator context.

Regular loading speed of the mentioned entry: 3.6s
With this PR: 289ms 🚀

I’m leaving this PR as a draft, because I’m not so happy with the code. So feel free to nitpick or use it as an idea.