### PR TITLE
[4.x] Add support for Collections and QueryBuilders to `random` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1709,6 +1709,14 @@ class CoreModifiers extends Modifier
      */
     public function random($value)
     {
+        if (Compare::isQueryBuilder($value)) {
+            $value = $value->get();
+        }
+
+        if ($value instanceof Collection) {
+            $value = $value->all();
+        }
+
         return array_random($value);
     }
 

--- a/src/Query/OrderedQueryBuilder.php
+++ b/src/Query/OrderedQueryBuilder.php
@@ -28,6 +28,13 @@ class OrderedQueryBuilder implements Builder
         return $this->forwardCallTo($this->builder, 'orderBy', func_get_args());
     }
 
+    public function inRandomOrder()
+    {
+        $this->ordered = true;
+
+        return $this->forwardCallTo($this->builder, 'inRandomOrder', func_get_args());
+    }
+
     public function get($columns = ['*'])
     {
         $results = $this->builder->get($columns);

--- a/tests/Modifiers/RandomTest.php
+++ b/tests/Modifiers/RandomTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Illuminate\Support\Collection;
+use Mockery;
+use Statamic\Contracts\Query\Builder;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class RandomTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @group array
+     */
+    public function it_returns_one_random_item_from_an_array(): void
+    {
+        $orderOfCeremony = [
+            'Sonic',
+            'Knuckles',
+            'Tails',
+        ];
+
+        srand(1234);
+
+        $modified = $this->modify($orderOfCeremony);
+        $expected = $this->modify($orderOfCeremony);
+        $this->assertEquals($expected, $modified);
+    }
+
+    /**
+     * @test
+     *
+     * @group array
+     */
+    public function it_returns_one_random_item_from_a_collection(): void
+    {
+        $orderOfCeremony = collect([
+            'Sonic',
+            'Knuckles',
+            'Tails',
+        ]);
+
+        srand(1234);
+
+        $modified = $this->modify($orderOfCeremony);
+        $expected = $this->modify($orderOfCeremony);
+        $this->assertEquals($expected, $modified);
+    }
+
+    /** @test */
+    public function it_returns_one_random_item_from_a_query_builder()
+    {
+        $builder = Mockery::mock(Builder::class);
+        $builder->shouldReceive('get')->andReturn(Collection::make([
+            'Sonic',
+            'Knuckles',
+            'Tails',
+        ]));
+
+        srand(1234);
+        $modified = $this->modify($builder);
+        $expected = $this->modify($builder);
+        $this->assertEquals($expected, $modified);
+    }
+
+    private function modify($value)
+    {
+        return Modify::value($value)->random()->fetch();
+    }
+}

--- a/tests/Query/OrderedQueryBuilderTest.php
+++ b/tests/Query/OrderedQueryBuilderTest.php
@@ -63,7 +63,7 @@ class OrderedQueryBuilderTest extends TestCase
     public function it_wont_order_the_items_after_getting_them_if_the_builder_is_manually_ordered()
     {
         $builder = $this->mock(Builder::class);
-        $builder->shouldReceive('orderBy')->with('title')->andReturnSelf();
+        $builder->shouldReceive('orderBy')->with('title')->once()->andReturnSelf();
         $builder->shouldReceive('get')->once()->andReturn(collect([
             ['id' => '3'],
             ['id' => '1'],

--- a/tests/Query/OrderedQueryBuilderTest.php
+++ b/tests/Query/OrderedQueryBuilderTest.php
@@ -80,6 +80,26 @@ class OrderedQueryBuilderTest extends TestCase
     }
 
     /** @test */
+    public function it_wont_order_the_items_after_getting_them_if_the_builder_is_manually_randomly_ordered()
+    {
+        $builder = $this->mock(Builder::class);
+        $builder->shouldReceive('inRandomOrder')->once()->andReturnSelf();
+        $builder->shouldReceive('get')->once()->andReturn(collect([
+            ['id' => '3'],
+            ['id' => '1'],
+            ['id' => '2'],
+        ]));
+
+        $results = (new OrderedQueryBuilder($builder, [2, 3, 1]))->inRandomOrder()->get();
+
+        $this->assertEquals([
+            ['id' => '3'],
+            ['id' => '1'],
+            ['id' => '2'],
+        ], $results->all());
+    }
+
+    /** @test */
     public function it_wont_order_the_items_when_using_pagination()
     {
         // This will just be a known limitation.


### PR DESCRIPTION
I noticed you couldn't randomize assets due to lack of QueryBuilder and/or Collection support.