### PR TITLE
[4.x] Caches sections and stacks when used inside cache tags

### DIFF
--- a/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
+++ b/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
@@ -209,6 +209,8 @@ class GlobalRuntimeState
      */
     public static $peekCallbacks = [];
 
+    public static $isCacheEnabled = false;
+
     public static function resetGlobalState()
     {
         self::$containsLayout = false;

--- a/src/View/Antlers/Language/Runtime/LiteralReplacementManager.php
+++ b/src/View/Antlers/Language/Runtime/LiteralReplacementManager.php
@@ -12,6 +12,29 @@ class LiteralReplacementManager
     protected static $registeredSections = [];
     protected static $retargeted = [];
 
+    public static $cachedSections = [];
+
+    public static function clearCachedSections()
+    {
+        self::$cachedSections = [];
+    }
+
+    public static function getCachedSections()
+    {
+        return self::$cachedSections;
+    }
+
+    public static function restoreCachedSections($cachedSections)
+    {
+        foreach ($cachedSections as $section) {
+            self::registerRegionReplacement(
+                $section[0],
+                $section[1],
+                $section[2]
+            );
+        }
+    }
+
     public static function resetLiteralState()
     {
         self::$regions = [];

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -240,4 +240,11 @@ class Cascade
     {
         return $this->sections;
     }
+
+    public function clearSections()
+    {
+        $this->sections = collect();
+
+        return $this;
+    }
 }

--- a/src/View/State/CachesOutput.php
+++ b/src/View/State/CachesOutput.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Statamic\View\State;
+
+interface CachesOutput
+{
+}

--- a/src/View/State/StateManager.php
+++ b/src/View/State/StateManager.php
@@ -25,7 +25,7 @@ class StateManager
      */
     public static function track($class)
     {
-        if (class_implements($class, ResetsState::class)) {
+        if (in_array(ResetsState::class, class_implements($class))) {
             self::$resetsState[$class] = 1;
         }
     }


### PR DESCRIPTION
This PR fixes #8399 by also caching the string results of `section` and `stack` tag calls when used inside `cache` tags.

It does this by checking if the tag implements a new `CachesOutput` interface (to help make the implementation a bit more generic - anyone wanting to leverage this feature can implement this on their own. Implementors would be responsible for implementing similar logic to the Core cache tag, however).

Cached section/stack content is stored as a new cache entry. The key of this is based off the existing cache key logic.