### PR TITLE
[4.x] Reset Live-Preview viewport size back to responsive

### DIFF
--- a/resources/js/components/live-preview/LivePreview.vue
+++ b/resources/js/components/live-preview/LivePreview.vue
@@ -251,7 +251,11 @@ export default {
         setIframeAttributes(iframe) {
             iframe.setAttribute('frameborder', '0');
             iframe.setAttribute('class', this.previewDevice ? 'device' : 'responsive');
-            if (this.previewDevice) iframe.setAttribute('style', `width: ${this.previewDeviceWidth}; height: ${this.previewDeviceHeight}`);
+            if (this.previewDevice) {
+                iframe.setAttribute('style', `width: ${this.previewDeviceWidth}; height: ${this.previewDeviceHeight}`);
+            } else {
+                iframe.removeAttribute('style');
+            }
         },
 
         close() {


### PR DESCRIPTION
This PR resolves https://github.com/statamic/cms/issues/8224 by:

- reset the styles attribute if no preview device was found (responsive mode)