### PR TITLE
[4.x] SVG tag sanitization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "ext-json": "*",
         "ajthinking/archetype": "^1.0.3",
         "composer/composer": "^1.10.22 || ^2.2.12",
+        "enshrined/svg-sanitize": "^0.16.0",
         "facade/ignition-contracts": "^1.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "james-heinrich/getid3": "^1.9.21",

--- a/src/Tags/Svg.php
+++ b/src/Tags/Svg.php
@@ -92,6 +92,7 @@ class Svg extends Tags
         }
 
         $sanitizer = new Sanitizer;
+        $sanitizer->removeXMLTag(! Str::startsWith($svg, '<?xml'));
         $sanitizer->setAllowedAttrs($this->getAllowedAttrs());
         $sanitizer->setAllowedTags($this->getAllowedTags());
 

--- a/src/Tags/Svg.php
+++ b/src/Tags/Svg.php
@@ -2,6 +2,9 @@
 
 namespace Statamic\Tags;
 
+use enshrined\svgSanitize\data\AllowedAttributes;
+use enshrined\svgSanitize\data\AllowedTags;
+use enshrined\svgSanitize\Sanitizer;
 use Statamic\Facades\File;
 use Statamic\Facades\URL;
 use Statamic\Support\Str;
@@ -47,11 +50,13 @@ class Svg extends Tags
             $svg = $this->setTitleAndDesc($svg);
         }
 
-        return str_replace(
+        $svg = str_replace(
             '<svg',
             collect(['<svg', $attributes])->filter()->implode(' '),
             $svg
         );
+
+        return $this->sanitize($svg);
     }
 
     private function setTitleAndDesc($svg)
@@ -78,5 +83,58 @@ class Svg extends Tags
         }
 
         return $doc->saveHTML();
+    }
+
+    private function sanitize($svg)
+    {
+        if ($this->params->bool('sanitize') === false) {
+            return $svg;
+        }
+
+        $sanitizer = new Sanitizer;
+        $sanitizer->setAllowedAttrs($this->getAllowedAttrs());
+        $sanitizer->setAllowedTags($this->getAllowedTags());
+
+        return $sanitizer->sanitize($svg);
+    }
+
+    private function getAllowedAttrs()
+    {
+        $attrs = $this->params->explode('allow_attrs', []);
+
+        return new class($attrs) extends AllowedAttributes
+        {
+            private static $attrs = [];
+
+            public function __construct($attrs)
+            {
+                self::$attrs = $attrs;
+            }
+
+            public static function getAttributes()
+            {
+                return array_merge(parent::getAttributes(), self::$attrs);
+            }
+        };
+    }
+
+    private function getAllowedTags()
+    {
+        $tags = $this->params->explode('allow_tags', []);
+
+        return new class($tags) extends AllowedTags
+        {
+            private static $tags = [];
+
+            public function __construct($tags)
+            {
+                self::$tags = $tags;
+            }
+
+            public static function getTags()
+            {
+                return array_merge(parent::getTags(), self::$tags);
+            }
+        };
     }
 }

--- a/tests/Tags/SvgTagTest.php
+++ b/tests/Tags/SvgTagTest.php
@@ -4,6 +4,7 @@ namespace Tests\Tags;
 
 use Illuminate\Support\Facades\File;
 use Statamic\Facades\Parse;
+use Statamic\View\Antlers\Language\Utilities\StringUtilities;
 use Tests\TestCase;
 
 class SvgTagTest extends TestCase
@@ -17,7 +18,10 @@ class SvgTagTest extends TestCase
 
     private function tag($tag)
     {
-        return Parse::template($tag, []);
+        $output = Parse::template($tag, []);
+
+        // Normalize whitespace and line breaks for testing ease.
+        return trim(StringUtilities::normalizeLineEndings($output));
     }
 
     /** @test */
@@ -31,5 +35,71 @@ class SvgTagTest extends TestCase
     public function it_renders_svg_with_additional_params()
     {
         $this->assertStringStartsWith('<svg class="mb-2" xmlns="', $this->tag('{{ svg src="users" class="mb-2" }}'));
+    }
+
+    /** @test */
+    public function it_sanitizes()
+    {
+        File::put(resource_path('xss.svg'), <<<'SVG'
+<svg>
+    <path onload="loadxss" onclick="clickxss"></path>
+    <script>alert("xss")</script>
+    <foreignObject></foreignObject>
+    <mesh></mesh>
+</svg>
+SVG);
+
+        $this->assertEquals(<<<'SVG'
+<svg>
+  <path></path>
+</svg>
+SVG,
+            $this->tag('{{ svg src="xss" sanitize="true" }}')
+        );
+
+        $this->assertEquals(<<<'SVG'
+<svg>
+  <path onclick="clickxss"></path>
+  <foreignObject></foreignObject>
+  <mesh></mesh>
+</svg>
+SVG,
+            $this->tag('{{ svg src="xss" sanitize="true" allow_tags="mesh|foreignObject" allow_attrs="onclick" }}')
+        );
+    }
+
+    /** @test */
+    public function sanitizing_doesnt_add_xml_tag()
+    {
+        // Thes sanitizer package adds an xml tag by default.
+        // We want to make sure if there wasn't one to begin with, it doesn't add one.
+
+        $svg = <<<'SVG'
+<svg>
+  <path></path>
+</svg>
+SVG;
+
+        File::put(resource_path('xmltag.svg'), $svg);
+
+        $this->assertEquals($svg, $this->tag('{{ svg src="xmltag" sanitize="true" }}'));
+    }
+
+    /** @test */
+    public function sanitizing_doesnt_remove_an_xml_tag()
+    {
+        // Thes sanitizer package adds an xml tag by default.
+        // We want to make sure that we haven't configured it to remove it if we wanted it there to begin with.
+
+        $svg = <<<'SVG'
+<?xml version="1.0" encoding="UTF-8"?>
+<svg>
+  <path></path>
+</svg>
+SVG;
+
+        File::put(resource_path('xmltag.svg'), $svg);
+
+        $this->assertEquals($svg, $this->tag('{{ svg src="xmltag" sanitize="true" }}'));
     }
 }


### PR DESCRIPTION
This PR adds a `sanitize` param to the `svg` tag battle potential XSS issues.

It uses https://github.com/darylldoyle/svg-sanitizer which is a PHP implementation of the popular DOMPurify library. https://github.com/cure53/DOMPurify

The svg tag will now let you add `sanitize="true"` and will trigger the sanitization.

``` antlers
{{ svg src="..." sanitize="true" }}
```

```xml
<svg><path onclick="foo">...</path><script>alert('foo')</script></svg>
```

```xml
<svg><path>....</path></svg>
```

You may specify additional attributes or tags to be allowed through the sanitizer:

```antlers
{{ svg src="..." sanitize="true" allow_attrs="onclick|onload" allow_tags="mesh|foreignObject" }}
```

We are leaving it as opt-in otherwise it would be a breaking change. In Statamic 5 we will make it sanitize by default.
