### PR TITLE
[4.x] Fix mapping of search results in entries fieldtype

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -117,11 +117,7 @@ class Entries extends Relationship
 
         $entries = $request->boolean('paginate', true) ? $query->paginate() : $query->get();
 
-        if ($entries->getCollection()->first() instanceof Result) {
-            $entries->setCollection($entries->getCollection()->map->getSearchable());
-        }
-
-        return $entries;
+        return $entries->map(fn ($item) => $item instanceof Result ? $item->getSearchable() : $item);
     }
 
     public function getResourceCollection($request, $items)


### PR DESCRIPTION
In #8253 we introduced the ability for the entries fieldtype to use the appropriate search index. If the search query builder is used, it returned `Result` instances which needed to be mapped over. The way the code was written was only applicable to when it was a paginator. For the `select` mode, you don't get a paginator, and you ran into the error.

This PR changes it to map those result instances in a more compatible way.

Fixes #8411

