### PR TITLE
[4.x] Fix a typo in zh_CN.json

### DIFF
--- a/resources/lang/zh_CN.json
+++ b/resources/lang/zh_CN.json
@@ -557,7 +557,7 @@
     "or": "或",
     "or drag & drop to upload.": "或拖放以上传。",
     "Orderable": "可排序",
-    "Ordered List": "订购清单",
+    "Ordered List": "有序列表",
     "Ordering": "排序",
     "Origin": "起源",
     "Other": "其他",


### PR DESCRIPTION
订购清单 means shopping list, and 有序列表 is for ordered list