### PR TITLE
[4.x] Maintain paginator in entries fieldtype

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -115,9 +115,11 @@ class Entries extends Relationship
             $query->orderBy($sort, $this->getSortDirection($request));
         }
 
-        $entries = $request->boolean('paginate', true) ? $query->paginate() : $query->get();
+        $results = ($paginate = $request->boolean('paginate', true)) ? $query->paginate() : $query->get();
 
-        return $entries->map(fn ($item) => $item instanceof Result ? $item->getSearchable() : $item);
+        $items = $results->map(fn ($item) => $item instanceof Result ? $item->getSearchable() : $item);
+
+        return $paginate ? $results->setCollection($items) : $items;
     }
 
     public function getResourceCollection($request, $items)


### PR DESCRIPTION
Third time's a charm.

Fixes #8419
Caused by #8414, which was fixing #8411, caused by #8253.

Simply calling `map` on the paginator _did_ correctly map the Result instances, but it also returned the underlying collection. The paginator needed to be returned.
