### PR TITLE
[4.x] Change from dot syntax to named-key access for scoped access in Alpine JS driver

### DIFF
--- a/src/Forms/JsDrivers/Alpine.php
+++ b/src/Forms/JsDrivers/Alpine.php
@@ -85,7 +85,7 @@ class Alpine extends AbstractJsDriver
     protected function getAlpineXDataKey($fieldHandle, $alpineScope)
     {
         return is_string($alpineScope)
-            ? "{$alpineScope}.{$fieldHandle}"
+            ? "{$alpineScope}['{$fieldHandle}']"
             : $fieldHandle;
     }
 

--- a/tests/Tags/Form/FormCreateAlpineTest.php
+++ b/tests/Tags/Form/FormCreateAlpineTest.php
@@ -293,7 +293,7 @@ EOT
         ];
 
         $this->assertFieldRendersHtml(['<input type="text" name="name" value="" x-model="name">'], $config, [], ['js' => 'alpine']);
-        $this->assertFieldRendersHtml(['<input type="text" name="name" value="" x-model="my_form.name">'], $config, [], ['js' => 'alpine:my_form']);
+        $this->assertFieldRendersHtml(['<input type="text" name="name" value="" x-model="my_form[\'name\']">'], $config, [], ['js' => 'alpine:my_form']);
     }
 
     /** @test */
@@ -307,7 +307,7 @@ EOT
         ];
 
         $this->assertFieldRendersHtml(['<textarea name="comment" rows="5" x-model="comment"></textarea>'], $config, [], ['js' => 'alpine']);
-        $this->assertFieldRendersHtml(['<textarea name="comment" rows="5" x-model="my_form.comment"></textarea>'], $config, [], ['js' => 'alpine:my_form']);
+        $this->assertFieldRendersHtml(['<textarea name="comment" rows="5" x-model="my_form[\'comment\']"></textarea>'], $config, [], ['js' => 'alpine:my_form']);
     }
 
     /** @test */
@@ -329,9 +329,9 @@ EOT
         $this->assertFieldRendersHtml(['<input type="checkbox" name="fav_animals[]" value="rat" x-model="fav_animals">'], $config, [], ['js' => 'alpine']);
         $this->assertFieldRendersHtml(['<input type="checkbox" name="fav_animals[]" value="armadillo" x-model="fav_animals">'], $config, [], ['js' => 'alpine']);
 
-        $this->assertFieldRendersHtml(['<input type="checkbox" name="fav_animals[]" value="cat" x-model="my_form.fav_animals">'], $config, [], ['js' => 'alpine:my_form']);
-        $this->assertFieldRendersHtml(['<input type="checkbox" name="fav_animals[]" value="rat" x-model="my_form.fav_animals">'], $config, [], ['js' => 'alpine:my_form']);
-        $this->assertFieldRendersHtml(['<input type="checkbox" name="fav_animals[]" value="armadillo" x-model="my_form.fav_animals">'], $config, [], ['js' => 'alpine:my_form']);
+        $this->assertFieldRendersHtml(['<input type="checkbox" name="fav_animals[]" value="cat" x-model="my_form[\'fav_animals\']">'], $config, [], ['js' => 'alpine:my_form']);
+        $this->assertFieldRendersHtml(['<input type="checkbox" name="fav_animals[]" value="rat" x-model="my_form[\'fav_animals\']">'], $config, [], ['js' => 'alpine:my_form']);
+        $this->assertFieldRendersHtml(['<input type="checkbox" name="fav_animals[]" value="armadillo" x-model="my_form[\'fav_animals\']">'], $config, [], ['js' => 'alpine:my_form']);
     }
 
     /** @test */
@@ -353,9 +353,9 @@ EOT
         $this->assertFieldRendersHtml(['<input type="radio" name="fav_animal" value="rat" x-model="fav_animal">'], $config, [], ['js' => 'alpine']);
         $this->assertFieldRendersHtml(['<input type="radio" name="fav_animal" value="armadillo" x-model="fav_animal">'], $config, [], ['js' => 'alpine']);
 
-        $this->assertFieldRendersHtml(['<input type="radio" name="fav_animal" value="cat" x-model="my_form.fav_animal">'], $config, [], ['js' => 'alpine:my_form']);
-        $this->assertFieldRendersHtml(['<input type="radio" name="fav_animal" value="rat" x-model="my_form.fav_animal">'], $config, [], ['js' => 'alpine:my_form']);
-        $this->assertFieldRendersHtml(['<input type="radio" name="fav_animal" value="armadillo" x-model="my_form.fav_animal">'], $config, [], ['js' => 'alpine:my_form']);
+        $this->assertFieldRendersHtml(['<input type="radio" name="fav_animal" value="cat" x-model="my_form[\'fav_animal\']">'], $config, [], ['js' => 'alpine:my_form']);
+        $this->assertFieldRendersHtml(['<input type="radio" name="fav_animal" value="rat" x-model="my_form[\'fav_animal\']">'], $config, [], ['js' => 'alpine:my_form']);
+        $this->assertFieldRendersHtml(['<input type="radio" name="fav_animal" value="armadillo" x-model="my_form[\'fav_animal\']">'], $config, [], ['js' => 'alpine:my_form']);
     }
 
     /** @test */
@@ -385,7 +385,7 @@ EOT
         $this->assertFieldRendersHtml($expected, $config, [], ['js' => 'alpine']);
 
         $expectedScoped = [
-            '<select name="favourite_animal" x-model="my_form.favourite_animal">',
+            '<select name="favourite_animal" x-model="my_form[\'favourite_animal\']">',
             '<option value>Please select...</option>',
             '<option value="cat">Cat</option>',
             '<option value="armadillo">Armadillo</option>',
@@ -409,7 +409,7 @@ EOT
         ];
 
         $this->assertFieldRendersHtml('<input type="file" name="cat_selfie" x-model="cat_selfie">', $config, [], ['js' => 'alpine']);
-        $this->assertFieldRendersHtml('<input type="file" name="cat_selfie" x-model="my_form.cat_selfie">', $config, [], ['js' => 'alpine:my_form']);
+        $this->assertFieldRendersHtml('<input type="file" name="cat_selfie" x-model="my_form[\'cat_selfie\']">', $config, [], ['js' => 'alpine:my_form']);
     }
 
     /** @test */
@@ -423,7 +423,7 @@ EOT
         ];
 
         $this->assertFieldRendersHtml('<input type="text" name="custom" value="" x-model="custom">', $config, [], ['js' => 'alpine']);
-        $this->assertFieldRendersHtml('<input type="text" name="custom" value="" x-model="my_form.custom">', $config, [], ['js' => 'alpine:my_form']);
+        $this->assertFieldRendersHtml('<input type="text" name="custom" value="" x-model="my_form[\'custom\']">', $config, [], ['js' => 'alpine:my_form']);
     }
 
     private function jsonEncode($data)


### PR DESCRIPTION
The Alpine Data Keys are accessed using a dot-syntax when using [scoped data](https://statamic.dev/tags/form-create#scoping-your-alpine-data).

If a form's data is:
```js
{
    name: '',
    name_-_dash: ''
}
```

Then `data.name` works as expected.

However, `data.name_-_dash` is not correct.

The issue is that Statamic _does_ allow the dash in a field handle (and in fact, allows very invalid handles to be saved, including spaces, special characters, etc).

While manually removing the invalid character manually works, it is not always that simple to instruct clients to make sure the handle - which is automatically generated for them - doesn't include a dash. While removing the dash *is* a simple step, it's also an extra human-responsible step that can go wrong. 

A more permanent (and less human-responsible) solution should be implemented.

This PR changes the Alpine JS Driver's definition for data access to resolves the issue, and allows dashes in a field handle **however only when using scoped data**.

This would mean data is accessed using `data['name_-_dash"]` which is correct.

The benefit of this is that the Statamic CP Blueprint editor can continue working as it currently does **but only with scoped data** - and the accessing of data is corrected for this use case.

This is only a half fix though. If you do not use scoped data, you're out of luck.

There are two more permanent solutions:
1. Update the Blueprint builder for *Forms* only to not allow dashes (or any other JS-invalid characters - currently there's no validation) in handles (both with the Slugify generation, and validation of the slug), or
2. Change the policy to always used scoped data with the Alpine driver

Both of these bigger than just a simple fix and are a bit opinionated, but happy to chat further about how we've seen the Alpine JS driver used and work towards a more permanent fix.

Given this is only a half-fix, I appreciate it may not be accepted... but also is a bandaid fix to the issue too especially if using more complex forms and Alpine setups.