### PR TITLE
[4.x] User Role filter to account for eloquent database users.

### DIFF
--- a/src/Query/Scopes/Filters/UserRole.php
+++ b/src/Query/Scopes/Filters/UserRole.php
@@ -30,7 +30,19 @@ class UserRole extends Filter
         if ($values['role'] === 'super') {
             $query->where('super', true);
         } else {
-            $query->where('roles/'.$values['role'], true);
+            if(config('statamic.users.repository') == 'eloquent') {
+                $tableName = config('statamic.users.tables.role_user', 'role_user');
+                $userIds = DB::connection(config('statamic.users.database'))
+                    ->table($tableName)
+                    ->where('role_id', $values['role'])
+                    ->distinct('user_id')
+                    ->pluck('user_id')
+                    ->toArray();
+                    
+                $query->whereIn('id', $userIds);
+            } else {
+                $query->where('roles/'.$values['role'], true);
+            }
         }
     }
 

--- a/src/Query/Scopes/Filters/UserRole.php
+++ b/src/Query/Scopes/Filters/UserRole.php
@@ -30,7 +30,7 @@ class UserRole extends Filter
         if ($values['role'] === 'super') {
             $query->where('super', true);
         } else {
-            if(config('statamic.users.repository') == 'eloquent') {
+            if (config('statamic.users.repository') === 'eloquent') {
                 $tableName = config('statamic.users.tables.role_user', 'role_user');
                 $userIds = DB::connection(config('statamic.users.database'))
                     ->table($tableName)


### PR DESCRIPTION
Hey!

Came across the following problem in the control panel when using the role filter on the user index page.

```Illuminate\Database\QueryException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'roles/admin' in 'where clause' (SQL: select count(*) as aggregate from `users` where `roles/admin` = 1)```

I've added a check which looks for the current repository being used by Statamic in this filter specifically and then adjusts the query accordingly.

It feels a little verbose, so if anyone has any suggestions on how to do this better let me know!