### PR TITLE
[4.x] Add "Show Word Count" option to the Bard fieldtype

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -163,7 +163,7 @@
 }
 
 .bard-footer-toolbar {
-    @apply bg-white shadow-none text-gray-700 rounded-b border-t text-xs p-2 grid grid-flow-col;
+    @apply bg-white shadow-none text-gray-700 rounded-b border-t text-xs p-2 flex items-center justify-between;
     padding: 8px 12px;
 
     .bard-fullscreen & {

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -163,7 +163,7 @@
 }
 
 .bard-footer-toolbar {
-    @apply bg-white shadow-none text-gray-700 rounded-b border-t text-xs p-2 flex items-center justify-between;
+    @apply bg-white shadow-none text-gray-700 rounded-b border-t text-xs p-2 grid grid-flow-col;
     padding: 8px 12px;
 
     .bard-fullscreen & {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -87,12 +87,10 @@
             <editor-content :editor="editor" v-show="!showSource" :id="fieldId" />
             <bard-source :html="htmlWithReplacedLinks" v-if="showSource" />
         </div>
-        <div class="bard-footer-toolbar" v-if="editor && numFooterToolbarStats">
-            <div v-if="config.reading_time">{{ readingTime }} {{ __('Reading Time') }}</div>
-            <div v-if="numFooterToolbarStats == 2 && config.reading_time" />
-            <div v-if="config.word_count">{{ __('Word Count') }} {{ editor.storage.characterCount.words() }}</div>
-            <div v-if="numFooterToolbarStats == 2 && !config.reading_time" />
-            <div v-if="config.character_limit">{{ editor.storage.characterCount.characters() }}/{{ config.character_limit }}</div>
+        <div v-if="editor && numBardFooterToolbarStats" :class="bardFooterToolbarClasses" >
+            <div v-if="config.reading_time" class="text-left">{{ readingTime }} {{ __('Reading Time') }}</div>
+            <div v-if="config.word_count" :class="wordCountClasses">{{ __('Word Count') }} {{ editor.storage.characterCount.words() }}</div>
+            <div v-if="config.character_limit" :class="characterCountClasses">{{ editor.storage.characterCount.characters() }}/{{ config.character_limit }}</div>
         </div>
     </div>
 </div>
@@ -217,8 +215,28 @@ export default {
             }
         },
 
-        numFooterToolbarStats() {
+        numBardFooterToolbarStats() {
             return (this.config.reading_time ? 1 : 0) + (this.config.word_count ? 1 : 0) + (this.config.character_limit ? 1 : 0);
+        },
+
+        bardFooterToolbarClasses() {
+            return "bard-footer-toolbar grid-cols-" + this.numBardFooterToolbarStats;
+        },
+
+        wordCountClasses() {
+            if (this.numBardFooterToolbarStats == 3) {
+                return "text-center";
+            }
+
+            if (this.numBardFooterToolbarStats && this.config.reading_time) {
+                return "text-right";
+            } else {
+                return "text-left";
+            }
+        },
+
+        characterCountClasses() {
+            return this.numBardFooterToolbarStats == 1 ? "text-left" : "text-right";
         },
 
         isFirstCreation() {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -87,10 +87,10 @@
             <editor-content :editor="editor" v-show="!showSource" :id="fieldId" />
             <bard-source :html="htmlWithReplacedLinks" v-if="showSource" />
         </div>
-        <div v-if="editor && numBardFooterToolbarStats" :class="bardFooterToolbarClasses" >
-            <div v-if="config.reading_time" class="text-left">{{ readingTime }} {{ __('Reading Time') }}</div>
-            <div v-if="config.word_count" :class="wordCountClasses">{{ __('Word Count') }} {{ editor.storage.characterCount.words() }}</div>
-            <div v-if="config.character_limit" :class="characterCountClasses">{{ editor.storage.characterCount.characters() }}/{{ config.character_limit }}</div>
+        <div class="bard-footer-toolbar" v-if="editor && (config.reading_time || config.character_limit || config.word_count)">
+            <div v-if="config.reading_time">{{ readingTime }} {{ __('Reading Time') }}</div>
+            <div v-else />
+            <div v-if="config.character_limit || config.word_count" v-text="characterAndWordCountText" />
         </div>
     </div>
 </div>
@@ -215,28 +215,22 @@ export default {
             }
         },
 
-        numBardFooterToolbarStats() {
-            return (this.config.reading_time ? 1 : 0) + (this.config.word_count ? 1 : 0) + (this.config.character_limit ? 1 : 0);
-        },
+        characterAndWordCountText() {
+            const showWordCount = this.config.word_count;
+            const wordCount = this.editor.storage.characterCount.words();
+            const wordCountText = `${__n(':count word|:count words', wordCount)}`;
+            const charLimit = this.config.character_limit;
+            const showCharLimit = charLimit > 0;
+            const charCount = this.editor.storage.characterCount.characters();
 
-        bardFooterToolbarClasses() {
-            return "bard-footer-toolbar grid-cols-" + this.numBardFooterToolbarStats;
-        },
-
-        wordCountClasses() {
-            if (this.numBardFooterToolbarStats == 3) {
-                return "text-center";
+            // If both are enabled, show a more verbose combined string.
+            if (showCharLimit && showWordCount) {
+                return `${wordCountText}, ${__(':count/:total characters', { count: charCount, total: charLimit })}`;
             }
 
-            if (this.numBardFooterToolbarStats && this.config.reading_time) {
-                return "text-right";
-            } else {
-                return "text-left";
-            }
-        },
-
-        characterCountClasses() {
-            return this.numBardFooterToolbarStats == 1 ? "text-left" : "text-right";
+            // Otherwise show one or the other.
+            if (showCharLimit) return `${charCount}/${charLimit}`;
+            if (showWordCount) return wordCountText;
         },
 
         isFirstCreation() {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -89,7 +89,9 @@
         </div>
         <div class="bard-footer-toolbar" v-if="editor && (config.reading_time || config.word_count || config.character_limit)">
             <div v-if="config.reading_time">{{ readingTime }} {{ __('Reading Time') }}</div>
+            <div v-if="numFooterToolbarStats == 2 && config.reading_time" />
             <div v-if="config.word_count">{{ __('Word Count') }} {{ editor.storage.characterCount.words() }}</div>
+            <div v-if="numFooterToolbarStats == 2 && !config.reading_time" />
             <div v-if="config.character_limit">{{ editor.storage.characterCount.characters() }}/{{ config.character_limit }}</div>
         </div>
     </div>
@@ -213,6 +215,10 @@ export default {
 
                 return moment.utc(duration.asMilliseconds()).format("mm:ss");
             }
+        },
+
+        numFooterToolbarStats() {
+            return (this.config.reading_time ? 1 : 0) + (this.config.word_count ? 1 : 0) + (this.config.character_limit ? 1 : 0);
         },
 
         isFirstCreation() {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -89,7 +89,7 @@
         </div>
         <div class="bard-footer-toolbar" v-if="editor && (config.reading_time || config.word_count || config.character_limit)">
             <div v-if="config.reading_time">{{ readingTime }} {{ __('Reading Time') }}</div>
-            <div v-if="config.word_count">{{ wordCount }}</div>
+            <div v-if="config.word_count">{{ __('Word Count') }} {{ editor.storage.characterCount.words() }}</div>
             <div v-if="config.character_limit">{{ editor.storage.characterCount.characters() }}/{{ config.character_limit }}</div>
         </div>
     </div>
@@ -213,12 +213,6 @@ export default {
 
                 return moment.utc(duration.asMilliseconds()).format("mm:ss");
             }
-        },
-
-        wordCount() {
-            var count = this.editor.storage.characterCount.words();
-            var units = ( count == 1 ) ? __('Word') : __('Words');
-            return count + " " + units;
         },
 
         isFirstCreation() {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -87,7 +87,7 @@
             <editor-content :editor="editor" v-show="!showSource" :id="fieldId" />
             <bard-source :html="htmlWithReplacedLinks" v-if="showSource" />
         </div>
-        <div class="bard-footer-toolbar" v-if="editor && (config.reading_time || config.word_count || config.character_limit)">
+        <div class="bard-footer-toolbar" v-if="editor && numFooterToolbarStats">
             <div v-if="config.reading_time">{{ readingTime }} {{ __('Reading Time') }}</div>
             <div v-if="numFooterToolbarStats == 2 && config.reading_time" />
             <div v-if="config.word_count">{{ __('Word Count') }} {{ editor.storage.characterCount.words() }}</div>

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -87,10 +87,9 @@
             <editor-content :editor="editor" v-show="!showSource" :id="fieldId" />
             <bard-source :html="htmlWithReplacedLinks" v-if="showSource" />
         </div>
-        <div class="bard-footer-toolbar" v-if="editor && (config.reading_time || config.character_limit)">
+        <div class="bard-footer-toolbar" v-if="editor && (config.reading_time || config.word_count || config.character_limit)">
             <div v-if="config.reading_time">{{ readingTime }} {{ __('Reading Time') }}</div>
-            <div v-else />
-
+            <div v-if="config.word_count">{{ wordCount }}</div>
             <div v-if="config.character_limit">{{ editor.storage.characterCount.characters() }}/{{ config.character_limit }}</div>
         </div>
     </div>
@@ -214,6 +213,12 @@ export default {
 
                 return moment.utc(duration.asMilliseconds()).format("mm:ss");
             }
+        },
+
+        wordCount() {
+            var count = this.editor.storage.characterCount.words();
+            var units = ( count == 1 ) ? __('Word') : __('Words');
+            return count + " " + units;
         },
 
         isFirstCreation() {

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -38,6 +38,7 @@ return [
     'bard.config.section.editor.instructions' => 'Configure the editor\'s appearance and general behavior.',
     'bard.config.section.links.instructions' => 'Configure how links are handled in this instance of Bard.',
     'bard.config.section.sets.instructions' => 'Configure blocks of fields that can be inserted anywhere in your Bard content.',
+    'bard.config.word_count' => 'Show the word count at the bottom of the field.',
     'bard.title' => 'Bard',
     'button_group.title' => 'Button Group',
     'checkboxes.config.inline' => 'Show the checkboxes in a row.',

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -84,6 +84,12 @@ class Bard extends Replicator
                         'type' => 'toggle',
                         'default' => false,
                     ],
+                    'word_count' => [
+                        'display' => __('Show Word Count'),
+                        'instructions' => __('statamic::fieldtypes.bard.config.word_count'),
+                        'type' => 'toggle',
+                        'default' => false,
+                    ],
                     'fullscreen' => [
                         'display' => __('Allow Fullscreen Mode'),
                         'instructions' => __('statamic::fieldtypes.bard.config.fullscreen'),


### PR DESCRIPTION
This PR adds a "Show Word Count" option to the Bard fieldtype.  If enabled, the word count is displayed at the bottom of the Bard field, between the reading time and character limit.