### PR TITLE
[4.x] Fix ranged date validation

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -369,7 +369,7 @@ class Date extends Fieldtype
             return $this->preProcessSingleValidatable($value);
         }
 
-        if (isset($value['start'])) {
+        if (! $value || isset($value['start'])) {
             // It was already processed.
             return $value;
         }

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -365,11 +365,15 @@ class Date extends Fieldtype
             ]);
         }
 
+        if ($value === null) {
+            return null;
+        }
+
         if ($this->config('mode', 'single') === 'single') {
             return $this->preProcessSingleValidatable($value);
         }
 
-        if (! $value || isset($value['start'])) {
+        if (isset($value['start'])) {
             // It was already processed.
             return $value;
         }
@@ -383,7 +387,7 @@ class Date extends Fieldtype
             return $value;
         }
 
-        if (! $value || ! $value['date']) {
+        if (! $value['date']) {
             return null;
         }
 

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -543,6 +543,11 @@ class DateTest extends TestCase
                 ['date' => null],
                 null,
             ],
+            'hidden date in range mode' => [
+                ['mode' => 'range'],
+                null,
+                null,
+            ],
             'both dates null' => [
                 ['mode' => 'range'],
                 ['date' => ['start' => null, 'end' => null]],

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -468,6 +468,11 @@ class DateTest extends TestCase
         // This only contains valid values. Invalid ones would throw a validation exception, tested in "it_validates" below.
 
         return [
+            'null' => [
+                [],
+                null,
+                null,
+            ],
             'null date when not required' => [
                 [],
                 ['date' => null, 'time' => null],
@@ -530,6 +535,11 @@ class DateTest extends TestCase
         // This only contains valid values. Invalid ones would throw a validation exception, tested in "it_validates" below.
 
         return [
+            'null' => [
+                ['mode' => 'range'],
+                null,
+                null,
+            ],
             'valid date range' => [
                 ['mode' => 'range'],
                 ['date' => ['start' => '2012-01-29', 'end' => '2012-01-30']],
@@ -541,11 +551,6 @@ class DateTest extends TestCase
             'null date in range mode' => [
                 ['mode' => 'range'],
                 ['date' => null],
-                null,
-            ],
-            'hidden date in range mode' => [
-                ['mode' => 'range'],
-                null,
                 null,
             ],
             'both dates null' => [


### PR DESCRIPTION
Fixes #8187

This is a follow up for #8205 which not completely fixed the issue. 

If a ranged date was not shown, it tried to access an array on null, causing an error on save.