### PR TITLE
[4.x] Handle nocache tag error

### DIFF
--- a/src/StaticCaching/NoCache/RegionNotFound.php
+++ b/src/StaticCaching/NoCache/RegionNotFound.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Statamic\StaticCaching\NoCache;
+
+class RegionNotFound extends \Exception
+{
+    private $region;
+
+    public function __construct($region)
+    {
+        $this->region = $region;
+        parent::__construct("Region [{$region}] not found.");
+    }
+
+    public function getRegion()
+    {
+        return $this->region;
+    }
+}

--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -46,7 +46,11 @@ class Session
 
     public function region(string $key): Region
     {
-        return $this->regions[$key];
+        if ($region = $this->regions[$key] ?? null) {
+            return $region;
+        }
+
+        throw new RegionNotFound($key);
     }
 
     public function pushRegion($contents, $context, $extension): StringRegion


### PR DESCRIPTION
Fixes #6781

This PR introduces adds error handling to the replacement step when serving a statically cache page.

When attempting to replace a region, and the region isn't in the cache for whatever reason, instead of throwing an error it will now just regenerate the page as if it was uncached.

The reason for the region not being in the cache is still a bit of a mystery. Maybe a race condition? Not sure.
