### PR TITLE
[4.x] Implement `ContainsQueryableValues` on users

### DIFF
--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -17,6 +17,7 @@ use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Contracts\GraphQL\ResolvesValues as ResolvesValuesContract;
+use Statamic\Contracts\Query\ContainsQueryableValues;
 use Statamic\Contracts\Search\Searchable as SearchableContract;
 use Statamic\Data\ContainsComputedData;
 use Statamic\Data\HasAugmentedInstance;
@@ -34,7 +35,7 @@ use Statamic\Search\Searchable;
 use Statamic\Statamic;
 use Statamic\Support\Str;
 
-abstract class User implements UserContract, Authenticatable, CanResetPasswordContract, Augmentable, AuthorizableContract, ResolvesValuesContract, HasLocalePreference, ArrayAccess, Arrayable, SearchableContract
+abstract class User implements UserContract, Authenticatable, CanResetPasswordContract, Augmentable, AuthorizableContract, ResolvesValuesContract, HasLocalePreference, ArrayAccess, Arrayable, SearchableContract, ContainsQueryableValues
 {
     use Authorizable, Notifiable, CanResetPassword, HasAugmentedInstance, TracksQueriedColumns, TracksQueriedRelations, HasAvatar, ResolvesValues, ContainsComputedData, Searchable;
 
@@ -297,5 +298,20 @@ abstract class User implements UserContract, Authenticatable, CanResetPasswordCo
     protected function getComputedCallbacks()
     {
         return Facades\User::getComputedCallbacks();
+    }
+
+    public function getQueryableValue(string $field)
+    {
+        if (method_exists($this, $method = Str::camel($field))) {
+            return $this->{$method}();
+        }
+
+        $value = $this->get($field);
+
+        if (! $field = $this->blueprint()->field($field)) {
+            return $value;
+        }
+
+        return $field->fieldtype()->toQueryableValue($value);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/8454 by implementing `ContainsQueryableValues` on the base User class.