### PR TITLE
[4.x] Use term live preview url instead of hard coded URL

### DIFF
--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -104,7 +104,7 @@
                                     <div class="p-4 flex items-center -mx-2" v-if="showLivePreviewButton || showVisitUrlButton">
                                         <button
                                             class="flex items-center justify-center btn-flat w-full mx-2 px-2"
-                                            v-if="isBase"
+                                            v-if="showLivePreviewButton"
                                             @click="openLivePreview">
                                             <svg-icon name="light/synchronize" class="h-4 w-4 mr-2" />
                                             <span>{{ __('Live Preview') }}</span>
@@ -343,7 +343,7 @@ export default {
         },
 
         livePreviewUrl() {
-            return _.findWhere(this.localizations, { active: true }).url + '/preview';
+            return _.findWhere(this.localizations, { active: true }).livePreviewUrl;
         },
 
         showLivePreviewButton() {


### PR DESCRIPTION
The taxonomy term publish form should use the live preview URL provided on the localisation rather than using its own hard coded url. It should also use the showLivePreviewButton() function to determine whether to show the button or not.

This allows devs to bind their own version of LocalizedTerm and change the live preview target if required.

Fixes #8443