### PR TITLE
[4.x] Fix error handling for recent curl bug

### DIFF
--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -139,11 +139,9 @@ class Outpost
             return $this->cacheAndReturnValidationResponse($e);
         } elseif ($code == 429) {
             return $this->cacheAndReturnRateLimitResponse($e);
-        } elseif ($code >= 500 && $code < 600) {
-            return $this->cacheAndReturnErrorResponse($e);
         }
 
-        throw $e;
+        return $this->cacheAndReturnErrorResponse($e);
     }
 
     private function cacheAndReturnValidationResponse($e)
@@ -167,7 +165,7 @@ class Outpost
     {
         Log::debug('Error contacting Outpost: '.$e->getMessage());
 
-        return $this->cacheResponse(now()->addMinutes(5), ['error' => 500]);
+        return $this->cacheResponse(now()->addMinutes(5), ['error' => $e->getCode()]);
     }
 
     private function cache()

--- a/tests/Licensing/OutpostTest.php
+++ b/tests/Licensing/OutpostTest.php
@@ -118,14 +118,14 @@ class OutpostTest extends TestCase
     }
 
     /** @test */
-    public function it_caches_a_timed_out_request_for_5_minutes_and_treats_it_like_a_500_error()
+    public function it_caches_a_timed_out_request_for_5_minutes()
     {
         $outpost = $this->outpostWithResponse(
-            new ConnectException('', new Request('POST', '/v3/query'))
+            $e = new ConnectException('', new Request('POST', '/v3/query'))
         );
 
         $expectedResponse = [
-            'error' => 500,
+            'error' => $e->getCode(),
             'expiry' => now()->addMinutes(5)->timestamp,
             'payload' => $outpost->payload(),
         ];


### PR DESCRIPTION
Users are reporting 500 errors when trying to visit /cp due to a recent curl bug introduced on July 19th(?). This PR improves exception handling in Outpost class to more gracefully handle errors like this.

References: https://github.com/statamic/cms/discussions/8471