### PR TITLE
Add support for `whereHas()` and `whereRelation()` to entry and user query builders

### DIFF
--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -350,6 +350,11 @@ abstract class Fieldtype implements Arrayable
         return $this->relationship;
     }
 
+    public function relationshipQueryBuilder()
+    {
+        return false;
+    }
+
     public function toQueryableValue($value)
     {
         return $value;

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -352,4 +352,12 @@ class Entries extends Relationship
             ? collect([$augmented])
             : $augmented->whereAnyStatus()->get();
     }
+
+    public function relationshipQueryBuilder()
+    {
+        $collections = $this->config('collections');
+
+        return Entry::query()
+                ->when($collections, fn ($query) => $query->whereIn('collection', $collections));
+    }
 }

--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -197,4 +197,9 @@ class Users extends Relationship
     {
         return new UserFilter($this);
     }
+
+    public function relationshipQueryBuilder()
+    {
+        return User::query();
+    }
 }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -13,6 +13,8 @@ use Statamic\Extensions\Pagination\LengthAwarePaginator;
 
 abstract class Builder implements Contract
 {
+    use Traits\QueriesRelationships;
+
     protected $columns;
     protected $limit;
     protected $offset = 0;

--- a/src/Query/Traits/QueriesRelationships.php
+++ b/src/Query/Traits/QueriesRelationships.php
@@ -19,7 +19,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \Statamic\Query\Builder|static
      *
-     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      */
     public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
     {

--- a/src/Query/Traits/QueriesRelationships.php
+++ b/src/Query/Traits/QueriesRelationships.php
@@ -185,7 +185,7 @@ trait QueriesRelationships
     }
 
     /**
-     * Get the blueprints avaialble to this query builder
+     * Get the blueprints available to this query builder
      *
      * @return \Illuminate\Support\Collection
      */
@@ -195,7 +195,7 @@ trait QueriesRelationships
     }
 
     /**
-     * Get the "has relation" base query instance.
+     * Get the query builder and field for the relation we are querying (if they exist)
      *
      * @param  string  $relation
      * @return \Statamic\Query\Builder

--- a/src/Query/Traits/QueriesRelationships.php
+++ b/src/Query/Traits/QueriesRelationships.php
@@ -4,8 +4,6 @@ namespace Statamic\Query\Traits;
 
 use Closure;
 use InvalidArgumentException;
-use Statamic\Facades;
-use Statamic\Fieldtypes;
 
 trait QueriesRelationships
 {

--- a/src/Query/Traits/QueriesRelationships.php
+++ b/src/Query/Traits/QueriesRelationships.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Statamic\Query\Traits;
+
+use Closure;
+use InvalidArgumentException;
+use Statamic\Facades;
+use Statamic\Fieldtypes;
+
+trait QueriesRelationships
+{
+    /**
+     * Add a relationship count / exists condition to the query.
+     *
+     * @param  string  $relation
+     * @param  string  $operator
+     * @param  int  $count
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
+     * @return \Statamic\Query\Builder|static
+     *
+     * @throws \RuntimeException
+     */
+    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    {
+        [$relationQueryBuilder, $relationField] = $this->getRelationQueryBuilderAndField($relation);
+
+        if (! $callback) {
+            return $this->whereJsonLength($relation, $operator, $count, $boolean);
+        }
+
+        $ids = $relationQueryBuilder
+            ->where($callback)
+            ->get(['id'])
+            ->map(fn ($item) => $item->id())
+            ->all();
+
+        $maxItems = $relationField->config()['max_items'] ?? 0;
+
+        if ($maxItems == 1) {
+            return $this->whereIn($relation, $ids);
+        }
+
+        if (empty($ids)) {
+            return $this->whereJsonContains($relation, ['']);
+        }
+
+        return $this->where(function ($subquery) use ($relation, $ids) {
+            foreach ($ids as $count => $id) {
+                $subquery->{$count == 0 ? 'whereJsonContains' : 'orWhereJsonContains'}($relation, [$id]);
+            }
+        });
+    }
+
+    /**
+     * Add a relationship count / exists condition to the query with an "or".
+     *
+     * @param  string  $relation
+     * @param  string  $operator
+     * @param  int  $count
+     * @return \Statamic\Query\Builder|static
+     */
+    public function orHas($relation, $operator = '>=', $count = 1)
+    {
+        return $this->has($relation, $operator, $count, 'or');
+    }
+
+    /**
+     * Add a relationship count / exists condition to the query.
+     *
+     * @param  string  $relation
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
+     * @return \Statamic\Query\Builder|static
+     */
+    public function doesntHave($relation, $boolean = 'and', Closure $callback = null)
+    {
+        return $this->{$boolean == 'and' ? 'where' : 'orwhere'}(function ($subquery) use ($relation, $callback) {
+            return $subquery->whereNull($relation)
+                ->orHas($relation, '<', 1, 'and', $callback);
+        });
+    }
+
+    /**
+     * Add a relationship count / exists condition to the query with an "or".
+     *
+     * @param  string  $relation
+     * @return \Statamic\Query\Builder|static
+     */
+    public function orDoesntHave($relation)
+    {
+        return $this->doesntHave($relation, 'or');
+    }
+
+    /**
+     * Add a relationship count / exists condition to the query with where clauses.
+     *
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
+     * @return \Statamic\Query\Builder|static
+     */
+    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    {
+        return $this->has($relation, $operator, $count, 'and', $callback);
+    }
+
+    /**
+     * Add a relationship count / exists condition to the query with where clauses and an "or".
+     *
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
+     * @return \Statamic\Query\Builder|static
+     */
+    public function orWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    {
+        return $this->has($relation, $operator, $count, 'or', $callback);
+    }
+
+    /**
+     * Add a relationship count / exists condition to the query with where clauses.
+     *
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
+     * @return \Statamic\Query\Builder|static
+     */
+    public function whereDoesntHave($relation, Closure $callback = null)
+    {
+        return $this->doesntHave($relation, 'and', $callback);
+    }
+
+    /**
+     * Add a relationship count / exists condition to the query with where clauses and an "or".
+     *
+     * @param  string  $relation
+     * @param  \Closure|null  $callback
+     * @return \Statamic\Query\Builder|static
+     */
+    public function orWhereDoesntHave($relation, Closure $callback = null)
+    {
+        return $this->doesntHave($relation, 'or', $callback);
+    }
+
+    /**
+     * Add a basic where clause to a relationship query.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return \Statamic\Query\Builder|static
+     */
+    public function whereRelation($relation, $column, $operator = null, $value = null)
+    {
+        return $this->whereHas($relation, function ($query) use ($column, $operator, $value) {
+            if ($column instanceof Closure) {
+                $column($query);
+            } else {
+                $query->where($column, $operator, $value);
+            }
+        });
+    }
+
+    /**
+     * Add an "or where" clause to a relationship query.
+     *
+     * @param  string  $relation
+     * @param  \Closure|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return \Statamic\Query\Builder|static
+     */
+    public function orWhereRelation($relation, $column, $operator = null, $value = null)
+    {
+        return $this->orWhereHas($relation, function ($query) use ($column, $operator, $value) {
+            if ($column instanceof Closure) {
+                $column($query);
+            } else {
+                $query->where($column, $operator, $value);
+            }
+        });
+    }
+
+    /**
+     * Get the blueprints avaialble to this query builder
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getBlueprintsForRelations()
+    {
+        return collect();
+    }
+
+    /**
+     * Get the "has relation" base query instance.
+     *
+     * @param  string  $relation
+     * @return \Statamic\Query\Builder
+     */
+    protected function getRelationQueryBuilderAndField($relation)
+    {
+        $relationField = $this->getBlueprintsForRelations()
+            ->flatMap(function ($blueprint) use ($relation) {
+                return $blueprint->fields()->all()->map(function ($field) use ($relation) {
+                    if ($field->handle() == $relation && $field->fieldtype()->isRelationship()) {
+                        return $field;
+                    }
+                })
+                    ->filter()
+                    ->values();
+            })
+            ->filter()
+            ->first();
+
+        if (! $relationField) {
+            throw new InvalidArgumentException("Relation {$relation} does not exist");
+        }
+
+        $queryBuilder = $relationField->fieldtype()->relationshipQueryBuilder();
+
+        if (! $queryBuilder) {
+            throw new InvalidArgumentException("Relation {$relation} does not support subquerying");
+        }
+
+        return [$queryBuilder, $relationField];
+    }
+}

--- a/src/Stache/Query/EntryQueryBuilder.php
+++ b/src/Stache/Query/EntryQueryBuilder.php
@@ -131,4 +131,27 @@ class EntryQueryBuilder extends Builder implements QueryBuilder
             return $this->getWhereColumnKeysFromStore($collection, ['column' => $column]);
         });
     }
+
+    protected function getBlueprintsForRelations()
+    {
+        $wheres = collect($this->wheres);
+
+        $collections = $wheres->where('column', 'collection')
+            ->flatMap(function ($where) {
+                return $where['values'] ?? [$where['value']] ?? [];
+            })
+            ->unique();
+
+        if (! $collections->count()) {
+            $collections = Facades\Collection::all();
+        }
+
+        return $collections->flatMap(function ($collectionHandle) {
+            if ($collection = Facades\Collection::find($collectionHandle)) {
+                return $collection->entryBlueprints();
+            }
+        })
+            ->filter()
+            ->unique();
+    }
 }

--- a/src/Stache/Query/EntryQueryBuilder.php
+++ b/src/Stache/Query/EntryQueryBuilder.php
@@ -146,10 +146,12 @@ class EntryQueryBuilder extends Builder implements QueryBuilder
             $collections = Facades\Collection::all();
         }
 
-        return $collections->flatMap(function ($collectionHandle) {
-            if ($collection = Facades\Collection::find($collectionHandle)) {
-                return $collection->entryBlueprints();
+        return $collections->flatMap(function ($collection) {
+            if (is_string($collection)) {
+                $collection = Facades\Collection::find($collection);
             }
+
+            return $collection ? $collection->entryBlueprints() : false;
         })
             ->filter()
             ->unique();

--- a/src/Stache/Query/UserQueryBuilder.php
+++ b/src/Stache/Query/UserQueryBuilder.php
@@ -3,6 +3,7 @@
 namespace Statamic\Stache\Query;
 
 use Statamic\Auth\UserCollection;
+use Statamic\Facades\User;
 
 class UserQueryBuilder extends Builder
 {
@@ -49,5 +50,10 @@ class UserQueryBuilder extends Builder
 
             return [$orderBy->sort => $items];
         });
+    }
+
+    protected function getBlueprintsForRelations()
+    {
+        return collect([User::make()->blueprint()]);
     }
 }

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -664,4 +664,104 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertCount(2, $entries);
         $this->assertEquals(['Post 2', 'Post 3'], $entries->map->title->all());
     }
+
+    /** @test **/
+    public function entries_are_found_using_where_has_when_max_items_1()
+    {
+        $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries', 'max_items' => 1]]);
+        Blueprint::shouldReceive('in')->with('collections/posts')->andReturn(collect(['posts' => $blueprint]));
+
+        $this->createDummyCollectionAndEntries();
+
+        Entry::find(1)
+            ->merge([
+                'entries_field' => 2
+            ])
+            ->save();
+
+        Entry::find(3)
+            ->merge([
+                'entries_field' => 1
+            ])
+            ->save();
+
+        $entries = Entry::query()->whereHas('entries_field', function ($subquery) {
+            $subquery->where('title', 'Post 2');
+        })
+            ->get();
+
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Post 1'], $entries->map->title->all());
+
+        $entries = Entry::query()->whereDoesntHave('entries_field', function ($subquery) {
+            $subquery->where('title', 'Post 2');
+        })
+            ->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 2', 'Post 3'], $entries->map->title->all());
+    }
+
+    /** @test **/
+    public function entries_are_found_using_where_has_when_max_items_not_1()
+    {
+        $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries']]);
+        Blueprint::shouldReceive('in')->with('collections/posts')->andReturn(collect(['posts' => $blueprint]));
+
+        $this->createDummyCollectionAndEntries();
+
+        Entry::find(1)
+            ->merge([
+                'entries_field' => [2, 1]
+            ])
+            ->save();
+
+        Entry::find(3)
+            ->merge([
+                'entries_field' => [1, 2]
+            ])
+            ->save();
+
+        $entries = Entry::query()->whereHas('entries_field', function ($subquery) {
+            $subquery->where('title', 'Post 2');
+        })
+            ->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 1', 'Post 3'], $entries->map->title->all());
+
+        $entries = Entry::query()->whereDoesntHave('entries_field', function ($subquery) {
+            $subquery->where('title', 'Post 2');
+        })
+            ->get();
+
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Post 2'], $entries->map->title->all());
+    }
+
+    /** @test **/
+    public function entries_are_found_using_where_relation()
+    {
+        $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries']]);
+        Blueprint::shouldReceive('in')->with('collections/posts')->andReturn(collect(['posts' => $blueprint]));
+
+        $this->createDummyCollectionAndEntries();
+
+        Entry::find(1)
+            ->merge([
+                'entries_field' => [2, 1]
+            ])
+            ->save();
+
+        Entry::find(3)
+            ->merge([
+                'entries_field' => [1, 2]
+            ])
+            ->save();
+
+        $entries = Entry::query()->whereRelation('entries_field', 'title', 'Post 2')->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 1', 'Post 3'], $entries->map->title->all());
+    }
 }

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -685,6 +685,11 @@ class EntryQueryBuilderTest extends TestCase
             ])
             ->save();
 
+        $entries = Entry::query()->whereHas('entries_field')->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 1', 'Post 3'], $entries->map->title->all());
+
         $entries = Entry::query()->whereHas('entries_field', function ($subquery) {
             $subquery->where('title', 'Post 2');
         })
@@ -721,6 +726,11 @@ class EntryQueryBuilderTest extends TestCase
                 'entries_field' => [1, 2]
             ])
             ->save();
+
+        $entries = Entry::query()->whereHas('entries_field')->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 1', 'Post 3'], $entries->map->title->all());
 
         $entries = Entry::query()->whereHas('entries_field', function ($subquery) {
             $subquery->where('title', 'Post 2');

--- a/tests/Data/Users/UserQueryBuilderTest.php
+++ b/tests/Data/Users/UserQueryBuilderTest.php
@@ -2,6 +2,10 @@
 
 namespace Tests\Data\Users;
 
+use Facades\Tests\Factories\EntryFactory;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
 use Statamic\Facades\User;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -207,5 +211,92 @@ class UserQueryBuilderTest extends TestCase
 
         $this->assertCount(1, $users);
         $this->assertEquals(['Gandalf'], $users->map->name->all());
+    }
+
+    /** @test **/
+    public function users_are_found_using_where_has_when_max_items_1()
+    {
+        $this->createDummyCollectionAndEntries();
+
+        $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries', 'max_items' => 1]]);
+        Blueprint::shouldReceive('find')->with('user')->andReturn($blueprint);
+
+        User::make()->email('gandalf@precious.com')->data(['name' => 'Gandalf', 'entries_field' => 2])->save();
+        User::make()->email('smeagol@precious.com')->data(['name' => 'Smeagol'])->save();
+        User::make()->email('frodo@precious.com')->data(['name' => 'Frodo', 'entries_field' => 1])->save();
+
+        $entries = User::query()->whereHas('entries_field', function ($subquery) {
+            $subquery->where('title', 'Post 2');
+        })
+            ->get();
+
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Gandalf'], $entries->map->name->all());
+
+        $entries = User::query()->whereDoesntHave('entries_field', function ($subquery) {
+            $subquery->where('title', 'Post 2');
+        })
+            ->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Smeagol', 'Frodo'], $entries->map->name->all());
+    }
+
+    /** @test **/
+    public function users_are_found_using_where_has_when_max_items_not_1()
+    {
+        $this->createDummyCollectionAndEntries();
+
+        $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries']]);
+        Blueprint::shouldReceive('find')->with('user')->andReturn($blueprint);
+
+        User::make()->email('gandalf@precious.com')->data(['name' => 'Gandalf', 'entries_field' => [2, 1]])->save();
+        User::make()->email('smeagol@precious.com')->data(['name' => 'Smeagol'])->save();
+        User::make()->email('frodo@precious.com')->data(['name' => 'Frodo', 'entries_field' => [1, 2]])->save();
+
+        $users = User::query()->whereHas('entries_field', function ($subquery) {
+            $subquery->where('title', 'Post 2');
+        })
+            ->get();
+
+        $this->assertCount(2, $users);
+        $this->assertEquals(['Gandalf', 'Frodo'], $users->map->name->all());
+
+        $users = User::query()->whereDoesntHave('entries_field', function ($subquery) {
+            $subquery->where('title', 'Post 2');
+        })
+            ->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals(['Smeagol'], $users->map->name->all());
+    }
+
+    /** @test **/
+    public function users_are_found_using_where_relation()
+    {
+        $this->createDummyCollectionAndEntries();
+
+        $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries']]);
+        Blueprint::shouldReceive('find')->with('user')->andReturn($blueprint);
+
+        User::make()->email('gandalf@precious.com')->data(['name' => 'Gandalf', 'entries_field' => [2, 1]])->save();
+        User::make()->email('smeagol@precious.com')->data(['name' => 'Smeagol'])->save();
+        User::make()->email('frodo@precious.com')->data(['name' => 'Frodo', 'entries_field' => [1, 2]])->save();
+
+        $users = User::query()->whereRelation('entries_field', 'title', 'Post 2')->get();
+
+        $this->assertCount(2, $users);
+        $this->assertEquals(['Gandalf', 'Frodo'], $users->map->name->all());
+    }
+
+    private function createDummyCollectionAndEntries()
+    {
+        Collection::make('posts')->save();
+
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'author' => 'John Doe'])->create();
+        $entry = EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'author' => 'John Doe'])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3', 'author' => 'John Doe'])->create();
+
+        return $entry;
     }
 }


### PR DESCRIPTION
This PR adds support for queries in the format:

```php
        $entries = Entry::query()->whereHas('entries_field', function ($subquery) {
            $subquery->where('title', 'Post 2');
        })

        $entries = Entry::query()->whereHas('entries_field');

        $entries = Entry::query()->whereRelation('entries_field', 'title', 'Post 2');
```

I've added support to both Entry and User query builders, but as it's a trait it can be easily added to other query builders if required. The query builder just needs to provide the appropriate blueprints through the getBlueprintsForRelations method.

The logic going on behind the scenes is to loop over the blueprint(s) and get the first relationship field type that has the same handle as the relation name being asked for. We then use the appropriate Facade to do another query to match the ids we want, and then do a check on the relationship field for those ids, this is provided by a new relationshipQueryBuilder() method on the fieldtype (currently only applied to entries and user fields, this would need to be extended).

It doesn't currently support queries in the format:

```php
         Entry::query()->whereHas('entries_field', function ($query) {
                  $query->where('content', 'like', 'code%');
        }, '>=', 10)
```

And an InvalidArgumentException is thrown if this is attempted.

Looking forward to hearing your thoughts on this.