### PR TITLE
[4.x] Hide heading when there are no unlisted addons

### DIFF
--- a/resources/views/updater/index.blade.php
+++ b/resources/views/updater/index.blade.php
@@ -42,36 +42,40 @@
             </table>
         </div>
 
-        <h6 class="mt-8">{{ __('Addons') }}</h6>
-        <div class="card p-0 mt-2">
-            <table class="data-table">
-                @foreach ($addons as $addon)
-                <tr>
-                    <td class="w-64"><a href="{{ route('statamic.cp.updater.product', $addon -> slug()) }}"
-                            class="text-blue font-bold mr-2">{{ $addon -> name() }}</a>
-                    <td>{{ $addon -> version() }}</td>
-                    @if ($count = $addon->changelog()->availableUpdatesCount())
-                    <td class="text-right"><span
-                            class="badge-sm bg-green-600 btn-xs">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
-                    @else
-                    <td class="text-right">{{ __('Up to date') }}</td>
-                    @endif
-                </tr>
-                @endforeach
-            </table>
-        </div>
-
-        <h6 class="mt-8">{{ __('Unlisted Addons') }}</h6>
-        <div class="card p-0 mt-2">
-            <table class="data-table">
-                @foreach ($unlistedAddons as $addon)
+        @if($addons->count())
+            <h6 class="mt-8">{{ __('Addons') }}</h6>
+            <div class="card p-0 mt-2">
+                <table class="data-table">
+                    @foreach ($addons as $addon)
                     <tr>
-                        <td class="w-64">{{ $addon->name() }}</td>
-                        <td>{{ $addon->version() }}</td>
+                        <td class="w-64"><a href="{{ route('statamic.cp.updater.product', $addon -> slug()) }}"
+                                class="text-blue font-bold mr-2">{{ $addon -> name() }}</a>
+                        <td>{{ $addon -> version() }}</td>
+                        @if ($count = $addon->changelog()->availableUpdatesCount())
+                        <td class="text-right"><span
+                                class="badge-sm bg-green-600 btn-xs">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
+                        @else
+                        <td class="text-right">{{ __('Up to date') }}</td>
+                        @endif
                     </tr>
-                @endforeach
-            </table>
-        </div>
+                    @endforeach
+                </table>
+            </div>
+        @endif
+
+        @if($unlistedAddons->count())
+            <h6 class="mt-8">{{ __('Unlisted Addons') }}</h6>
+            <div class="card p-0 mt-2">
+                <table class="data-table">
+                    @foreach ($unlistedAddons as $addon)
+                        <tr>
+                            <td class="w-64">{{ $addon->name() }}</td>
+                            <td>{{ $addon->version() }}</td>
+                        </tr>
+                    @endforeach
+                </table>
+            </div>
+        @endif
 
         @include('statamic::partials.docs-callout', [
             'topic' => __('Updates'),

--- a/resources/views/updater/index.blade.php
+++ b/resources/views/updater/index.blade.php
@@ -42,26 +42,24 @@
             </table>
         </div>
 
-        @if($addons->count())
-            <h6 class="mt-8">{{ __('Addons') }}</h6>
-            <div class="card p-0 mt-2">
-                <table class="data-table">
-                    @foreach ($addons as $addon)
-                    <tr>
-                        <td class="w-64"><a href="{{ route('statamic.cp.updater.product', $addon -> slug()) }}"
-                                class="text-blue font-bold mr-2">{{ $addon -> name() }}</a>
-                        <td>{{ $addon -> version() }}</td>
-                        @if ($count = $addon->changelog()->availableUpdatesCount())
-                        <td class="text-right"><span
-                                class="badge-sm bg-green-600 btn-xs">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
-                        @else
-                        <td class="text-right">{{ __('Up to date') }}</td>
-                        @endif
-                    </tr>
-                    @endforeach
-                </table>
-            </div>
-        @endif
+        <h6 class="mt-8">{{ __('Addons') }}</h6>
+        <div class="card p-0 mt-2">
+            <table class="data-table">
+                @foreach ($addons as $addon)
+                <tr>
+                    <td class="w-64"><a href="{{ route('statamic.cp.updater.product', $addon -> slug()) }}"
+                            class="text-blue font-bold mr-2">{{ $addon -> name() }}</a>
+                    <td>{{ $addon -> version() }}</td>
+                    @if ($count = $addon->changelog()->availableUpdatesCount())
+                    <td class="text-right"><span
+                            class="badge-sm bg-green-600 btn-xs">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
+                    @else
+                    <td class="text-right">{{ __('Up to date') }}</td>
+                    @endif
+                </tr>
+                @endforeach
+            </table>
+        </div>
 
         @if($unlistedAddons->count())
             <h6 class="mt-8">{{ __('Unlisted Addons') }}</h6>


### PR DESCRIPTION
This pull request fixes a small thing I just noticed... when you're on a site with no addons or no unlisted addons, the sections still show on the Updater page but they're just empty.

![image](https://github.com/statamic/cms/assets/19637309/598b66f4-a1de-4062-94e0-8cd1ff8ee9cf)

This PR just hides the sections if there's no addons/unlisted addons to show in the list.