### PR TITLE
Cache Utility: Don't show Stache 'Size' label when there is no size

### DIFF
--- a/resources/views/utilities/cache.blade.php
+++ b/resources/views/utilities/cache.blade.php
@@ -39,7 +39,9 @@
             </div>
             <div class="text-sm text-gray flex">
                 <div class="mr-4 badge-pill-sm"><span class="text-gray-800 font-medium">{{ __('Records') }}:</span> {{ $stache['records'] }}</div>
-                <div class="mr-4 badge-pill-sm"><span class="text-gray-800 font-medium">{{ __('Size') }}:</span> {{ $stache['size'] }}</div>
+                @if($stache['size'])
+                    <div class="mr-4 badge-pill-sm"><span class="text-gray-800 font-medium">{{ __('Size') }}:</span> {{ $stache['size'] }}</div>
+                @endif
                 @if ($stache['time'])
                     <div class="mr-4 badge-pill-sm"><span class="text-gray-800 font-medium">{{ __('Build time') }}:</span> {{ $stache['time'] }}</div>
                 @endif

--- a/src/Http/Controllers/CP/Utilities/CacheController.php
+++ b/src/Http/Controllers/CP/Utilities/CacheController.php
@@ -24,12 +24,13 @@ class CacheController extends CpController
 
     protected function getStacheStats()
     {
+        $size = Stache::fileSize();
         $time = Stache::buildTime();
         $built = Stache::buildDate();
 
         return [
             'records' => Stache::fileCount(),
-            'size' => Str::fileSizeForHumans(Stache::fileSize()),
+            'size' => $size ? Str::fileSizeForHumans($size) : null,
             'time' => $time ? Str::timeForHumans($time) : __('Refresh'),
             'rebuilt' => $built ? $built->diffForHumans() : __('Refresh'),
         ];


### PR DESCRIPTION
This pull request makes a small change to the Cache Utility in the Control Panel, to hide the "Size" label when there is no size.

This PR was prompted by a help thread [on Discord](https://discord.com/channels/489818810157891584/1127611808140775544/1127611808140775544) a few weeks ago where someone mentioned that the size for the Stache was showing as 0. This was happening due to them using the Redis cache driver, rather than the file cache driver, which is the only one (I think) that lets us derive the total file size.

I didn't implement `if cache driver is file, then show` logic but did it around if the value was `null` since I think `Stache::fileSize()` will give us a number otherwise.