### PR TITLE
[4.x] Warm URLs after invalidating them

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -64,6 +64,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Warm after Invalidation
+    |--------------------------------------------------------------------------
+    |
+    | When configured, Statamic will automatically warm the static cache after
+    | invalidating content. It'll use your invalidation rules to determine
+    | which pages should be warmed.
+    |
+    */
+
+    'warm_after_invalidation' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Invalidation Rules
     |--------------------------------------------------------------------------
     |

--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -2,10 +2,12 @@
 
 namespace Statamic\StaticCaching\Cachers;
 
+use GuzzleHttp\Client;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Statamic\Facades\Site;
+use Statamic\Facades\URL;
 use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\UrlExcluder;
 use Statamic\Support\Str;
@@ -293,5 +295,20 @@ abstract class AbstractCacher implements Cacher
             $path.$query,
             $parsed['scheme'].'://'.$parsed['host'],
         ];
+    }
+
+    public function warmUrl(string $url): void
+    {
+        // TODO: use same parameters as the StaticWarm command?
+        $client = new Client();
+
+        $client->get(URL::tidy(Str::start($url, config('app.url').'/')));
+    }
+
+    public function warmUrls(array $urls): void
+    {
+        collect($urls)
+            ->filter(fn ($url) => Str::contains($url, '*'))
+            ->each(fn ($url) => $this->warmUrl($url));
     }
 }

--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -2,10 +2,10 @@
 
 namespace Statamic\StaticCaching\Cachers;
 
-use GuzzleHttp\Client;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Http;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\StaticCaching\Cacher;
@@ -299,10 +299,9 @@ abstract class AbstractCacher implements Cacher
 
     public function warmUrl(string $url): void
     {
-        // TODO: use same parameters as the StaticWarm command?
-        $client = new Client();
-
-        $client->get(URL::tidy(Str::start($url, config('app.url').'/')));
+        Http::when(! app()->isLocal(), function ($http) {
+            $http->withoutVerifying();
+        })->get(URL::tidy(Str::start($url, config('app.url').'/')));
     }
 
     public function warmUrls(array $urls): void

--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\StaticCaching;
 
+use GuzzleHttp\Client;
 use Statamic\Contracts\Assets\Asset;
 use Statamic\Contracts\Entries\Collection;
 use Statamic\Contracts\Entries\Entry;
@@ -9,11 +10,14 @@ use Statamic\Contracts\Forms\Form;
 use Statamic\Contracts\Globals\GlobalSet;
 use Statamic\Contracts\Structures\Nav;
 use Statamic\Contracts\Taxonomies\Term;
+use Statamic\Facades\URL;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class DefaultInvalidator implements Invalidator
 {
     protected $cacher;
+
     protected $rules;
 
     public function __construct(Cacher $cacher, $rules = [])
@@ -48,15 +52,19 @@ class DefaultInvalidator implements Invalidator
     protected function invalidateFormUrls($form)
     {
         $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "forms.{$form->handle()}.urls")
+            $rules = Arr::get($this->rules, "forms.{$form->handle()}.urls")
         );
+
+        $this->warmUrls($rules);
     }
 
     protected function invalidateAssetUrls($asset)
     {
         $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "assets.{$asset->container()->handle()}.urls")
+            $rules = Arr::get($this->rules, "assets.{$asset->container()->handle()}.urls")
         );
+
+        $this->warmUrls($rules);
     }
 
     protected function invalidateEntryUrls($entry)
@@ -64,54 +72,68 @@ class DefaultInvalidator implements Invalidator
         $entry->descendants()->push($entry)->each(function ($entry) {
             if (! $entry->isRedirect() && $url = $entry->absoluteUrl()) {
                 $this->cacher->invalidateUrl(...$this->splitUrlAndDomain($url));
+                $this->warmUrl($url);
             }
         });
 
         $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "collections.{$entry->collectionHandle()}.urls")
+            $rules = Arr::get($this->rules, "collections.{$entry->collectionHandle()}.urls")
         );
+
+        $this->warmUrls($rules);
     }
 
     protected function invalidateTermUrls($term)
     {
         if ($url = $term->absoluteUrl()) {
             $this->cacher->invalidateUrl(...$this->splitUrlAndDomain($url));
+            $this->warmUrl($term->absoluteUrl());
 
             $term->taxonomy()->collections()->each(function ($collection) use ($term) {
                 if ($url = $term->collection($collection)->absoluteUrl()) {
                     $this->cacher->invalidateUrl(...$this->splitUrlAndDomain($url));
+                    $this->warmUrl($url);
                 }
             });
         }
 
         $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "taxonomies.{$term->taxonomyHandle()}.urls")
+            $rules = Arr::get($this->rules, "taxonomies.{$term->taxonomyHandle()}.urls")
         );
+
+        $this->warmUrls($rules);
     }
 
     protected function invalidateNavUrls($nav)
     {
         $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "navigation.{$nav->handle()}.urls")
+            $rules = Arr::get($this->rules, "navigation.{$nav->handle()}.urls")
         );
+
+        $this->warmUrls($rules);
     }
 
     protected function invalidateGlobalUrls($set)
     {
         $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "globals.{$set->handle()}.urls")
+            $rules = Arr::get($this->rules, "globals.{$set->handle()}.urls")
         );
+
+        $this->warmUrls($rules);
     }
 
     protected function invalidateCollectionUrls($collection)
     {
         if ($url = $collection->absoluteUrl()) {
             $this->cacher->invalidateUrl(...$this->splitUrlAndDomain($url));
+            $this->warmUrl($url);
         }
 
         $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "collections.{$collection->handle()}.urls")
+            $rules = Arr::get($this->rules, "collections.{$collection->handle()}.urls")
         );
+
+        $this->warmUrls($rules);
     }
 
     private function splitUrlAndDomain(string $url)
@@ -122,5 +144,20 @@ class DefaultInvalidator implements Invalidator
             Arr::get($parsed, 'path', '/'),
             $parsed['scheme'].'://'.$parsed['host'],
         ];
+    }
+
+    private function warmUrl(string $url): void
+    {
+        // TODO: use same parameters as the StaticWarm command?
+        $client = new Client();
+
+        $client->get(URL::tidy(Str::start($url, config('app.url').'/')));
+    }
+
+    private function warmUrls(array $urls): void
+    {
+        collect($urls)
+            ->filter(fn ($url) => Str::contains($url, '*'))
+            ->each(fn ($url) => $this->warmUrl($url));
     }
 }

--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -52,7 +52,9 @@ class DefaultInvalidator implements Invalidator
             $rules = Arr::get($this->rules, "forms.{$form->handle()}.urls")
         );
 
-        $this->cacher->warmUrls($rules);
+        if (config('statamic.static_caching.warm_after_invalidation')) {
+            $this->cacher->warmUrls($rules);
+        }
     }
 
     protected function invalidateAssetUrls($asset)
@@ -61,7 +63,9 @@ class DefaultInvalidator implements Invalidator
             $rules = Arr::get($this->rules, "assets.{$asset->container()->handle()}.urls")
         );
 
-        $this->cacher->warmUrls($rules);
+        if (config('statamic.static_caching.warm_after_invalidation')) {
+            $this->cacher->warmUrls($rules);
+        }
     }
 
     protected function invalidateEntryUrls($entry)
@@ -69,7 +73,10 @@ class DefaultInvalidator implements Invalidator
         $entry->descendants()->push($entry)->each(function ($entry) {
             if (! $entry->isRedirect() && $url = $entry->absoluteUrl()) {
                 $this->cacher->invalidateUrl(...$this->splitUrlAndDomain($url));
-                $this->cacher->warmUrl($url);
+
+                if (config('statamic.static_caching.warm_after_invalidation')) {
+                    $this->cacher->warmUrl($url);
+                }
             }
         });
 
@@ -77,19 +84,27 @@ class DefaultInvalidator implements Invalidator
             $rules = Arr::get($this->rules, "collections.{$entry->collectionHandle()}.urls")
         );
 
-        $this->cacher->warmUrls($rules);
+        if (config('statamic.static_caching.warm_after_invalidation')) {
+            $this->cacher->warmUrls($rules);
+        }
     }
 
     protected function invalidateTermUrls($term)
     {
         if ($url = $term->absoluteUrl()) {
             $this->cacher->invalidateUrl(...$this->splitUrlAndDomain($url));
-            $this->cacher->warmUrl($term->absoluteUrl());
+
+            if (config('statamic.static_caching.warm_after_invalidation')) {
+                $this->cacher->warmUrl($term->absoluteUrl());
+            }
 
             $term->taxonomy()->collections()->each(function ($collection) use ($term) {
                 if ($url = $term->collection($collection)->absoluteUrl()) {
                     $this->cacher->invalidateUrl(...$this->splitUrlAndDomain($url));
-                    $this->cacher->warmUrl($url);
+
+                    if (config('statamic.static_caching.warm_after_invalidation')) {
+                        $this->cacher->warmUrl($url);
+                    }
                 }
             });
         }
@@ -98,7 +113,9 @@ class DefaultInvalidator implements Invalidator
             $rules = Arr::get($this->rules, "taxonomies.{$term->taxonomyHandle()}.urls")
         );
 
-        $this->cacher->warmUrls($rules);
+        if (config('statamic.static_caching.warm_after_invalidation')) {
+            $this->cacher->warmUrls($rules);
+        }
     }
 
     protected function invalidateNavUrls($nav)
@@ -107,7 +124,9 @@ class DefaultInvalidator implements Invalidator
             $rules = Arr::get($this->rules, "navigation.{$nav->handle()}.urls")
         );
 
-        $this->cacher->warmUrls($rules);
+        if (config('statamic.static_caching.warm_after_invalidation')) {
+            $this->cacher->warmUrls($rules);
+        }
     }
 
     protected function invalidateGlobalUrls($set)
@@ -116,21 +135,28 @@ class DefaultInvalidator implements Invalidator
             $rules = Arr::get($this->rules, "globals.{$set->handle()}.urls")
         );
 
-        $this->cacher->warmUrls($rules);
+        if (config('statamic.static_caching.warm_after_invalidation')) {
+            $this->cacher->warmUrls($rules);
+        }
     }
 
     protected function invalidateCollectionUrls($collection)
     {
         if ($url = $collection->absoluteUrl()) {
             $this->cacher->invalidateUrl(...$this->splitUrlAndDomain($url));
-            $this->cacher->warmUrl($url);
+
+            if (config('statamic.static_caching.warm_after_invalidation')) {
+                $this->cacher->warmUrl($url);
+            }
         }
 
         $this->cacher->invalidateUrls(
             $rules = Arr::get($this->rules, "collections.{$collection->handle()}.urls")
         );
 
-        $this->cacher->warmUrls($rules);
+        if (config('statamic.static_caching.warm_after_invalidation')) {
+            $this->cacher->warmUrls($rules);
+        }
     }
 
     private function splitUrlAndDomain(string $url)

--- a/tests/StaticCaching/DefaultInvalidatorTest.php
+++ b/tests/StaticCaching/DefaultInvalidatorTest.php
@@ -14,8 +14,9 @@ use Statamic\Contracts\Taxonomies\Taxonomy;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\DefaultInvalidator as Invalidator;
+use Tests\TestCase;
 
-class DefaultInvalidatorTest extends \PHPUnit\Framework\TestCase
+class DefaultInvalidatorTest extends TestCase
 {
     public function tearDown(): void
     {

--- a/tests/StaticCaching/DefaultInvalidatorTest.php
+++ b/tests/StaticCaching/DefaultInvalidatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\StaticCaching;
 
+use Illuminate\Support\Facades\Config;
 use Mockery;
 use Statamic\Contracts\Assets\Asset;
 use Statamic\Contracts\Assets\AssetContainer;
@@ -18,8 +19,17 @@ use Tests\TestCase;
 
 class DefaultInvalidatorTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('statamic.static_caching.warm_after_invalidation', true);
+    }
+
     public function tearDown(): void
     {
+        parent::tearDown();
+
         Mockery::close();
     }
 

--- a/tests/StaticCaching/DefaultInvalidatorTest.php
+++ b/tests/StaticCaching/DefaultInvalidatorTest.php
@@ -38,6 +38,7 @@ class DefaultInvalidatorTest extends \PHPUnit\Framework\TestCase
     {
         $cacher = tap(Mockery::mock(Cacher::class), function ($cacher) {
             $cacher->shouldReceive('invalidateUrls')->once()->with(['/page/one', '/page/two']);
+            $cacher->shouldReceive('warmUrls')->once()->with(['/page/one', '/page/two']);
         });
 
         $container = tap(Mockery::mock(AssetContainer::class), function ($m) {
@@ -68,6 +69,8 @@ class DefaultInvalidatorTest extends \PHPUnit\Framework\TestCase
         $cacher = tap(Mockery::mock(Cacher::class), function ($cacher) {
             $cacher->shouldReceive('invalidateUrl')->with('/my/test/collection', 'http://test.com')->once();
             $cacher->shouldReceive('invalidateUrls')->once()->with(['/blog/one', '/blog/two']);
+            $cacher->shouldReceive('warmUrl')->with('http://test.com/my/test/collection')->once();
+            $cacher->shouldReceive('warmUrls')->once()->with(['/blog/one', '/blog/two']);
         });
 
         $collection = tap(Mockery::mock(Collection::class), function ($m) {
@@ -95,6 +98,8 @@ class DefaultInvalidatorTest extends \PHPUnit\Framework\TestCase
         $cacher = tap(Mockery::mock(Cacher::class), function ($cacher) {
             $cacher->shouldReceive('invalidateUrl')->with('/my/test/entry', 'http://test.com')->once();
             $cacher->shouldReceive('invalidateUrls')->once()->with(['/blog/one', '/blog/two']);
+            $cacher->shouldReceive('warmUrl')->with('http://test.com/my/test/entry')->once();
+            $cacher->shouldReceive('warmUrls')->once()->with(['/blog/one', '/blog/two']);
         });
 
         $entry = tap(Mockery::mock(Entry::class), function ($m) {
@@ -124,6 +129,8 @@ class DefaultInvalidatorTest extends \PHPUnit\Framework\TestCase
         $cacher = tap(Mockery::mock(Cacher::class), function ($cacher) {
             $cacher->shouldReceive('invalidateUrl')->never();
             $cacher->shouldReceive('invalidateUrls')->once()->with(['/blog/one', '/blog/two']);
+            $cacher->shouldReceive('warmUrl')->never();
+            $cacher->shouldReceive('warmUrls')->once()->with(['/blog/one', '/blog/two']);
         });
 
         $entry = tap(Mockery::mock(Entry::class), function ($m) {
@@ -154,6 +161,8 @@ class DefaultInvalidatorTest extends \PHPUnit\Framework\TestCase
             $cacher->shouldReceive('invalidateUrl')->with('/my/test/term', 'http://test.com')->once();
             $cacher->shouldReceive('invalidateUrl')->with('/my/collection/tags/term', 'http://test.com')->once();
             $cacher->shouldReceive('invalidateUrls')->once()->with(['/tags/one', '/tags/two']);
+            $cacher->shouldReceive('warmUrl')->with('http://test.com/my/collection/tags/term')->twice();
+            $cacher->shouldReceive('warmUrls')->once()->with(['/tags/one', '/tags/two']);
         });
 
         $collection = Mockery::mock(Collection::class);
@@ -188,6 +197,7 @@ class DefaultInvalidatorTest extends \PHPUnit\Framework\TestCase
     {
         $cacher = tap(Mockery::mock(Cacher::class), function ($cacher) {
             $cacher->shouldReceive('invalidateUrls')->once()->with(['/one', '/two']);
+            $cacher->shouldReceive('warmUrls')->once()->with(['/one', '/two']);
         });
 
         $nav = tap(Mockery::mock(Nav::class), function ($m) {
@@ -213,6 +223,7 @@ class DefaultInvalidatorTest extends \PHPUnit\Framework\TestCase
     {
         $cacher = tap(Mockery::mock(Cacher::class), function ($cacher) {
             $cacher->shouldReceive('invalidateUrls')->once()->with(['/one', '/two']);
+            $cacher->shouldReceive('warmUrls')->once()->with(['/one', '/two']);
         });
 
         $set = tap(Mockery::mock(GlobalSet::class), function ($m) {
@@ -238,6 +249,7 @@ class DefaultInvalidatorTest extends \PHPUnit\Framework\TestCase
     {
         $cacher = tap(Mockery::mock(Cacher::class), function ($cacher) {
             $cacher->shouldReceive('invalidateUrls')->once()->with(['/one', '/two']);
+            $cacher->shouldReceive('warmUrls')->once()->with(['/one', '/two']);
         });
 
         $form = tap(Mockery::mock(Form::class), function ($m) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -115,6 +115,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         ]);
 
         $app['config']->set('statamic.search.indexes.default.driver', 'null');
+        $app['config']->set('statamic.static_caching.warm_after_invalidation', false);
 
         $viewPaths = $app['config']->get('view.paths');
         $viewPaths[] = __DIR__.'/__fixtures__/views/';


### PR DESCRIPTION
This pull request implements statamic/ideas#877, by warming URLs after they're invalidated by content updates.

Right now, when you update an entry/term/nav/etc in the Control Panel, the relevant page(s) will be invalidated from the static cache. Then, you need to wait for the next person to request that page for it to be cached again.

This PR makes it Statamic will automatically warm the page(s) right after invalidating them.

In addition to the entry/term URL, this PR will also take into account any invalidation URLs configured in your `static_caching` config file (apart from those with wildcards).

## To Do

* [x] Write tests
* [x] Make warming opt-in (which should fix the failing tests)