### PR TITLE
[4.x] Use site in create entry button on collection tree view

### DIFF
--- a/resources/js/components/collections/View.vue
+++ b/resources/js/components/collections/View.vue
@@ -182,7 +182,7 @@ export default {
         title: { type: String, required: true },
         handle: { type: String, required: true },
         canCreate: { type: Boolean, required: true },
-        createUrl: { type: String, required: true },
+        createUrls: { type: Object, required: true },
         createLabel: { type: String, required: true },
         blueprints: { type: Array, required: true },
         breadcrumbUrl: { type: String, required: true },
@@ -243,6 +243,10 @@ export default {
             }
             countChildren(this.entryBeingDeleted);
             return children;
+        },
+
+        createUrl() {
+            return this.createUrls[this.site];
         }
 
     },

--- a/resources/views/collections/show.blade.php
+++ b/resources/views/collections/show.blade.php
@@ -9,7 +9,7 @@
         handle="{{ $collection->handle() }}"
         breadcrumb-url="{{ cp_route('collections.index') }}"
         :can-create="@can('create', ['Statamic\Contracts\Entries\Entry', $collection]) true @else false @endcan"
-        create-url="{{ cp_route('collections.entries.create', [$collection->handle(), $site]) }}"
+        :create-urls='@json($createUrls)'
         create-label="{{ $collection->createLabel() }}"
         :blueprints='@json($blueprints)'
         sort-column="{{ $collection->sortField() }}"

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -105,6 +105,9 @@ class CollectionsController extends CpController
                     'name' => $site->name(),
                 ];
             })->values()->all(),
+            'createUrls' => $collection->sites()
+                ->mapWithKeys(fn ($site) => [$site => cp_route('collections.entries.create', [$collection->handle(), $site])])
+                ->all(),
         ];
 
         if ($collection->queryEntries()->count() === 0) {


### PR DESCRIPTION
Fixes #8473

The url was hard coded to the first site. This PR passes in URLs for each site in PHP and uses them based on which site you have selected in JS.
