### PR TITLE
[4.x] Allow relative urls as preview targets

### DIFF
--- a/src/Http/Controllers/CP/PreviewController.php
+++ b/src/Http/Controllers/CP/PreviewController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\CP;
 
 use Facades\Statamic\CP\LivePreview;
 use Illuminate\Http\Request;
+use Statamic\Facades\URL;
 
 class PreviewController extends CpController
 {
@@ -40,7 +41,7 @@ class PreviewController extends CpController
 
     private function getPreviewUrl($data, $target, $token)
     {
-        $url = $data->previewTargets()[$target]['url'];
+        $url = URL::makeAbsolute($data->previewTargets()[$target]['url']);
 
         return vsprintf('%s%slive-preview=%s&token=%s', [
             $url,


### PR DESCRIPTION
Revised version of https://github.com/statamic/cms/pull/8474 (as suggested by @jasonvarga [here](https://github.com/statamic/cms/pull/8474#issuecomment-1648493499))

This pull request allows the preview target to be a relative URL. The URL can be either hardcoded or by using `{url}`.

E.g.

```yaml
preview_targets:
  -
    label: 'Custom Target'
    url: '/cp/custom-preview-target'
    refresh: true
  -
    label: 'URL'
    url: '{url}'
    refresh: true
````