### PR TITLE
[4.x] Allow `query_scopes` on the form field type

### DIFF
--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -73,6 +73,7 @@ return [
     'entries.title' => 'Entries',
     'float.title' => 'Float',
     'form.config.max_items' => 'Set a maximum number of selectable forms.',
+    'form.config.query_scopes' => 'Choose which query scopes should be applied when retrieving selectable forms.',
     'form.title' => 'Form',
     'grid.config.add_row' => 'Customize the label of the "Add Row" button.',
     'grid.config.fields' => 'Each field becomes a column in the grid table.',

--- a/src/Forms/Fieldtype.php
+++ b/src/Forms/Fieldtype.php
@@ -31,6 +31,11 @@ class Fieldtype extends Relationship
                 'instructions' => __('statamic::fieldtypes.form.config.max_items'),
                 'min' => 1,
             ],
+            'query_scopes' => [
+                'display' => __('Query Scopes'),
+                'instructions' => __('statamic::fieldtypes.form.config.query_scopes'),
+                'type' => 'taggable',
+            ],
         ];
     }
 
@@ -61,13 +66,19 @@ class Fieldtype extends Relationship
 
     public function getIndexItems($request)
     {
-        return Facades\Form::all()->map(function ($form) {
-            return [
-                'id' => $form->handle(),
-                'title' => $form->title(),
-                'submissions' => $form->submissions()->count(),
-            ];
-        })->values();
+        $query = Facades\Form::query();
+
+        $this->applyIndexQueryScopes($query, $request->all());
+
+        return $query->get()
+            ->map(function ($form) {
+                return [
+                    'id' => $form->handle(),
+                    'title' => $form->title(),
+                    'submissions' => $form->submissions()->count(),
+                ];
+            })
+            ->values();
     }
 
     public function augmentValue($value)


### PR DESCRIPTION
Following on from https://github.com/statamic/cms/pull/8456
It would be good to apply query scopes to forms as well.

Closes https://github.com/statamic/ideas/issues/841