### PR TITLE
[4.x] Fix incorrect doctype in `Submission` contract

### DIFF
--- a/src/Contracts/Forms/Submission.php
+++ b/src/Contracts/Forms/Submission.php
@@ -47,7 +47,7 @@ interface Submission extends Arrayable
      * Get or set the data.
      *
      * @param  array|null  $data
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
     public function data($data = null);
 


### PR DESCRIPTION
This pull request fixes an incorrect doctype in the `Submission` contract, where it was saying the return type for the `data` method was an array but it's actually a `Collection` now.

Fixes #8375