### PR TITLE
Reset page in asset browser when searching

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -482,7 +482,11 @@ export default {
                 : this.path;
 
             this.$emit('navigated', this.container, path);
-        }
+        },
+
+        searchQuery() {
+            this.page = 1;
+        },
 
     },
 


### PR DESCRIPTION
This pull request fixes #8370 by resetting the page in the asset browser when the user types in a search query. 

I've set `page = 1` in a watcher since if I did it in the `loadAssets`, it would prevent paginating between pages of search results.