### PR TITLE
[4.x] Handle separate first & last name fields in User fieldtype

### DIFF
--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -14,9 +14,7 @@ use Statamic\Support\Arr;
 class Users extends Relationship
 {
     protected $statusIcons = false;
-
     protected $formComponent = 'user-publish-form';
-
     protected $canEdit = true;
 
     protected $formComponentProps = [
@@ -57,6 +55,11 @@ class Users extends Relationship
                         'instructions' => __('statamic::messages.fields_default_instructions'),
                         'type' => 'users',
                     ],
+                    'query_scopes' => [
+                        'display' => __('Query Scopes'),
+                        'instructions' => __('statamic::fieldtypes.users.config.query_scopes'),
+                        'type' => 'taggable',
+                    ],
                 ],
             ],
         ];
@@ -95,6 +98,8 @@ class Users extends Relationship
         if ($request->exclusions) {
             $query->whereNotIn('id', $request->exclusions);
         }
+
+        $this->applyIndexQueryScopes($query, $request->all());
 
         $query
             ->when(User::blueprint()->hasField('first_name'), function ($query) {

--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -101,14 +101,11 @@ class Users extends Relationship
 
         $this->applyIndexQueryScopes($query, $request->all());
 
-        $query
-            ->when(User::blueprint()->hasField('first_name'), function ($query) {
-                $query
-                    ->selectRaw('CONCAT(first_name, " ", last_name) as name')
-                    ->orderBy('name');
-            }, function ($query) {
-                $query->orderBy('name');
-            });
+        $query->when(
+            User::blueprint()->hasField('first_name'),
+            fn ($query) => $query->orderBy('first_name')->orderBy('last_name'),
+            fn ($query) => $query->orderBy('name')
+        );
 
         $userFields = function ($user) {
             return [


### PR DESCRIPTION
This pull request fixes an issue where you couldn't have separate first & last name columns for users in the database when using the User fieldtype. The fieldtype would error out due to no `name` field existing for the `->orderBy('name')` part of the query.

Fixes #8353.