### PR TITLE
[4.x] Add 'Parent' column to entries fieldtype

### DIFF
--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -22,6 +22,9 @@
                         <path d="M9.9,1.4L5,6.4L0,1.4L1.4,0L5,3.5L8.5,0L9.9,1.4z" fill="currentColor"/>
                     </svg>
                 </th>
+                <th class="parent-column" v-if="type === 'entries' && rows[0]?.collection.hasStructure">
+                    {{ __('Parent') }}
+                </th>
                 <th class="type-column" v-if="type">
                     <template v-if="type === 'entries'">{{ __('Collection') }}</template>
                     <template v-if="type === 'terms'">{{ __('Taxonomy') }}</template>
@@ -64,6 +67,9 @@
                     >
                         <table-field :handle="column.field" :value="row[column.value || column.field]" :values="row" :fieldtype="column.fieldtype" :key="column.field" />
                     </slot>
+                </td>
+                <td class="parent-column" v-if="type === 'entries' && row.collection.hasStructure">
+                    {{ row.parent?.title }}
                 </td>
                 <td class="type-column" v-if="type">
                     <span v-if="type === 'entries' || type === 'terms'" class="rounded px-1 py-px text-2xs uppercase bg-gray-200 text-gray">

--- a/src/Http/Resources/CP/Entries/ListedEntry.php
+++ b/src/Http/Resources/CP/Entries/ListedEntry.php
@@ -9,6 +9,7 @@ use Statamic\Facades\User;
 class ListedEntry extends JsonResource
 {
     protected $blueprint;
+
     protected $columns;
 
     public function blueprint($blueprint)
@@ -43,10 +44,14 @@ class ListedEntry extends JsonResource
 
             'permalink' => $entry->absoluteUrl(),
             'edit_url' => $entry->editUrl(),
-            'collection' => array_merge($entry->collection()->toArray(), ['dated' => $entry->collection()->dated()]),
+            'collection' => array_merge($entry->collection()->toArray(), [
+                'dated' => $entry->collection()->dated(),
+                'hasStructure' => $entry->collection()->hasStructure(),
+            ]),
             'viewable' => User::current()->can('view', $entry),
             'editable' => User::current()->can('edit', $entry),
             'actions' => Action::for($entry, ['collection' => $collection->handle()]),
+            'parent' => $entry->parent()?->toShallowAugmentedCollection(),
         ];
     }
 


### PR DESCRIPTION
This pull request adds a 'Parent' column to the Entries fieldtype when it's opened in a stack.

At the moment, if you have a collection's structured and looks like this:

* Home
* Locations
    * Location 1
        * Apartments
        * Amenities
        * Gallery
    * Location 2
        * Apartments
        * Amenities
        * Gallery

Then, when you open the entries fieldtype in a stack, it's hard to identify which 'Apartments' entry you're selecting. Sometimes you have to select in the stack, then open it up, check if it's the right one, then remove it and try again. It's painful and I'm surprised we haven't had a client complain yet 😅 

This PR fixes that issue by adding a 'Parent' column to the entries fieldtype results, when the collection has a structure.

<img width="1071" alt="image" src="https://github.com/statamic/cms/assets/19637309/28849b0e-487e-4639-920a-be7fe10e0846">

*^ screenshot from my sandbox site - the entries don't match the use case I just explained but I'm sure you can make sense of it*

Fixes #4187