### PR TITLE
[4.x] Ignore processing GIFs on file upload

### DIFF
--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -21,6 +21,10 @@ abstract class Uploader
 
     private function processSourceFile(UploadedFile $file): string
     {
+        if (in_array($file->getExtension(), ['gif', 'svg'])) {
+            return $file->getRealPath();
+        }
+
         if (! $preset = $this->preset()) {
             return $file->getRealPath();
         }

--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -21,7 +21,7 @@ abstract class Uploader
 
     private function processSourceFile(UploadedFile $file): string
     {
-        if ($file->getExtension() === 'gif') {
+        if ($file->getMimeType() === 'image/gif') {
             return $file->getRealPath();
         }
 

--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -21,7 +21,7 @@ abstract class Uploader
 
     private function processSourceFile(UploadedFile $file): string
     {
-        if (in_array($file->getExtension(), ['gif', 'svg'])) {
+        if ($file->getExtension() === 'gif') {
             return $file->getRealPath();
         }
 


### PR DESCRIPTION
This pull request fixes an issue where GIFs would be processed on file upload (if the asset container had a `source_preset` set) and would become static.

Meaning cool GIFs like this:

![working-gif](https://github.com/statamic/cms/assets/19637309/11b66867-e43e-4d8f-adfe-dec0aafb5fa0)

Would turn into this: 😞 

![image](https://github.com/statamic/cms/assets/19637309/9019efd5-cd77-49a0-9d94-7d62b98e1a52)

---

Related: studio1902/statamic-peak#321