### PR TITLE
[4.x] Force lowercase on operator in query builder

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -152,7 +152,7 @@ abstract class Builder implements Contract
     {
         $loweredOperator = strtolower($operator);
 
-        if ($useDefault || ! isset($this->operators[$loweredOperator])) {
+        if ($useDefault) {
             return [$operator, '='];
         } elseif ($this->invalidOperatorAndValue($operator, $value)) {
             throw new InvalidArgumentException('Illegal operator and value combination.');

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -154,7 +154,7 @@ abstract class Builder implements Contract
 
         if ($useDefault) {
             return [$operator, '='];
-        } elseif ($this->invalidOperatorAndValue($operator, $value)) {
+        } elseif ($this->invalidOperatorAndValue($loweredOperator, $value)) {
             throw new InvalidArgumentException('Illegal operator and value combination.');
         }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -158,7 +158,7 @@ abstract class Builder implements Contract
             throw new InvalidArgumentException('Illegal operator and value combination.');
         }
 
-        return [$value, $operator];
+        return [$value, $loweredOperator];
     }
 
     protected function invalidOperatorAndValue($operator, $value)

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -156,7 +156,7 @@ abstract class Builder implements Contract
             throw new InvalidArgumentException('Illegal operator and value combination.');
         }
 
-        return [$value, $operator];
+        return [$value, strtolower($operator)];
     }
 
     protected function invalidOperatorAndValue($operator, $value)

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -150,9 +150,9 @@ abstract class Builder implements Contract
 
     public function prepareValueAndOperator($value, $operator, $useDefault = false)
     {
-        $operator = strtolower($operator);
+        $loweredOperator = strtolower($operator);
 
-        if ($useDefault || ! isset($this->operators[$operator])) {
+        if ($useDefault || ! isset($this->operators[$loweredOperator])) {
             return [$operator, '='];
         } elseif ($this->invalidOperatorAndValue($operator, $value)) {
             throw new InvalidArgumentException('Illegal operator and value combination.');

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -150,13 +150,15 @@ abstract class Builder implements Contract
 
     public function prepareValueAndOperator($value, $operator, $useDefault = false)
     {
-        if ($useDefault) {
+        $operator = strtolower($operator);
+
+        if ($useDefault || ! isset($this->operators[$operator])) {
             return [$operator, '='];
         } elseif ($this->invalidOperatorAndValue($operator, $value)) {
             throw new InvalidArgumentException('Illegal operator and value combination.');
         }
 
-        return [$value, strtolower($operator)];
+        return [$value, $operator];
     }
 
     protected function invalidOperatorAndValue($operator, $value)


### PR DESCRIPTION
@duncanmcclean found a great bug that I'm not sure how we didn't catch before.

```
$query->where('field', 'LIKE', '%y%')
```

was failing as there is no matching operator due to it expecting a lowercase like.

It does raise the question as to whether we should throw an error when there is no matching operator?