### PR TITLE
[4.x] Improve nested field ids and focus behavior of some fieldtypes

### DIFF
--- a/resources/js/components/fieldtypes/FieldDisplayFieldtype.vue
+++ b/resources/js/components/fieldtypes/FieldDisplayFieldtype.vue
@@ -4,8 +4,9 @@
     <div class="flex items-center">
         <div class="input-group">
             <input
-                ref="input"
-                class="input-text"
+            ref="input"
+            class="input-text"
+                :id="fieldId"
                 :name="name"
                 :value="value"
                 type="text"

--- a/resources/js/components/fieldtypes/FieldDisplayFieldtype.vue
+++ b/resources/js/components/fieldtypes/FieldDisplayFieldtype.vue
@@ -4,8 +4,8 @@
     <div class="flex items-center">
         <div class="input-group">
             <input
-            ref="input"
-            class="input-text"
+                ref="input"
+                class="input-text"
                 :id="fieldId"
                 :name="name"
                 :value="value"

--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -60,7 +60,9 @@ export default {
         },
 
         fieldId() {
-            return 'field_'+this.config.handle;
+            let prefix = this.fieldPathPrefix ? this.fieldPathPrefix+'_' : '';
+
+            return prefix+'field_'+this.config.handle;
         }
     },
 

--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -60,7 +60,7 @@ export default {
         },
 
         fieldId() {
-            let prefix = this.fieldPathPrefix ? this.fieldPathPrefix+'_' : '';
+            let prefix = this.fieldPathPrefix ? this.fieldPathPrefix+'.' : '';
 
             return prefix+'field_'+this.config.handle;
         }

--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -2,6 +2,7 @@
     <div class="flex">
         <v-select
             ref="input"
+            :input-id="fieldId"
             class="flex-1"
             append-to-body
             :calculate-position="positionOptions"

--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -19,6 +19,7 @@
             :value="selectedOptions"
             :create-option="(value) => ({ value, label: value })"
             @input="vueSelectUpdated"
+            @focus="$emit('focus')"
             @search:focus="$emit('focus')"
             @search:blur="$emit('blur')">
                 <template #selected-option-container v-if="config.multiple"><i class="hidden"></i></template>

--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -14,6 +14,7 @@
                 :isReadOnly="isReadOnly"
                 :append="config.show_regenerate && value"
                 :name="slug"
+                :id="fieldId"
                 @focus="$emit('focus')"
                 @blur="$emit('blur')"
             >

--- a/resources/js/components/fieldtypes/ToggleFieldtype.vue
+++ b/resources/js/components/fieldtypes/ToggleFieldtype.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="toggle-fieldtype-wrapper">
-        <toggle-input :value="value" @input="update" :read-only="isReadOnly" />
+        <toggle-input :value="value" @input="update" :read-only="isReadOnly" :id="fieldId" />
         <label v-if="config.inline_label" class="inline-label" v-html="$options.filters.markdown(config.inline_label)"></label>
     </div>
 </template>

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -344,6 +344,10 @@ export default {
         this.pageHeader = document.querySelector('.global-header');
 
         this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
+
+        document.querySelector(`label[for="${this.fieldId}"]`).addEventListener('click', () => {
+            this.editor.commands.focus();
+        });
     },
 
     beforeDestroy() {

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -196,6 +196,10 @@ export default {
 
     mounted() {
         this.initToolbarButtons();
+
+        document.querySelector(`label[for="${this.fieldId}"]`).addEventListener('click', () => {
+            this.codemirror.focus();
+        });
     },
 
     methods: {

--- a/resources/js/components/fieldtypes/replicator/Field.vue
+++ b/resources/js/components/fieldtypes/replicator/Field.vue
@@ -2,7 +2,7 @@
 
     <div class="p-4 m-0 @container" :class="classes">
 
-        <label class="block" v-if="showLabel">
+        <label class="block" :for="fieldId" v-if="showLabel">
             <span v-if="showLabelText">{{ display }}</span>
             <i class="required" v-if="field.required">*</i>
             <span v-if="isReadOnly" class="text-gray-500 font-normal text-2xs mx-1" v-text="__('Read Only')" />
@@ -134,6 +134,11 @@ export default {
 
         showLabelText() {
             return !this.field.hide_display;
+        },
+
+        fieldId() {
+            let prefix = this.fieldPath ? this.fieldPath+'.' : '';
+            return prefix+'field_'+this.field.handle;
         }
 
     }

--- a/resources/js/components/publish/Field.vue
+++ b/resources/js/components/publish/Field.vue
@@ -162,6 +162,7 @@ export default {
         },
 
         fieldId() {
+            console.log(this.fieldPathPrefix)
             return 'field_'+this.config.handle;
         },
 

--- a/resources/js/components/publish/Field.vue
+++ b/resources/js/components/publish/Field.vue
@@ -162,7 +162,6 @@ export default {
         },
 
         fieldId() {
-            console.log(this.fieldPathPrefix)
             return 'field_'+this.config.handle;
         },
 


### PR DESCRIPTION
Fields inside Bard, Replicator, and other nestable fieldtypes were creating duplicate HTML IDs which caused issued with the wrong input being focused.

This PR addresses that by prefixing field IDs with `fieldPathPrefix` if set.

It also sets the `fieldId` on a number of fieldtypes that didn't have it set, which allows the fields to be focused by clicking on their respective labels.

Closes #6616.