### PR TITLE
[4.x] Add `query_scopes` and searching to the form fieldtype

### DIFF
--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -73,6 +73,7 @@ return [
     'entries.title' => 'Entries',
     'float.title' => 'Float',
     'form.config.max_items' => 'Set a maximum number of selectable forms.',
+    'form.config.query_scopes' => 'Choose which query scopes should be applied when retrieving selectable forms.',
     'form.title' => 'Form',
     'grid.config.add_row' => 'Customize the label of the "Add Row" button.',
     'grid.config.fields' => 'Each field becomes a column in the grid table.',

--- a/src/Forms/Fieldtype.php
+++ b/src/Forms/Fieldtype.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Forms;
 
-use Statamic\Data\DataCollection;
 use Statamic\CP\Column;
+use Statamic\Data\DataCollection;
 use Statamic\Facades;
 use Statamic\Facades\GraphQL;
 use Statamic\Fieldtypes\Relationship;

--- a/src/Forms/Fieldtype.php
+++ b/src/Forms/Fieldtype.php
@@ -31,6 +31,11 @@ class Fieldtype extends Relationship
                 'instructions' => __('statamic::fieldtypes.form.config.max_items'),
                 'min' => 1,
             ],
+            'query_scopes' => [
+                'display' => __('Query Scopes'),
+                'instructions' => __('statamic::fieldtypes.form.config.query_scopes'),
+                'type' => 'taggable',
+            ],
         ];
     }
 
@@ -61,13 +66,19 @@ class Fieldtype extends Relationship
 
     public function getIndexItems($request)
     {
-        return Facades\Form::all()->map(function ($form) {
-            return [
-                'id' => $form->handle(),
-                'title' => $form->title(),
-                'submissions' => $form->submissions()->count(),
-            ];
-        })->values();
+        $query = Facades\Form::query();
+
+        $this->applyIndexQueryScopes($query, $request->all());
+
+        return $query->get()
+            ->map(function ($form) {
+                return [
+                    'id' => $form->handle(),
+                    'title' => $form->title(),
+                    'submissions' => $form->submissions()->count(),
+                ];
+            })
+            ->values();
     }
 
     public function augmentValue($value)


### PR DESCRIPTION
Replaces https://github.com/statamic/cms/pull/8494 and actually works this time.

This time I've passed the items as a DataCollection into the ItemQueryBuilder which allows querying of the data. Along the way I noticed searching wasn't enabled, even though in Stack view there is a search field, so I hooked that up too. Not sure most people have enough forms to justify searching, but better for the search input to work than not.

I've also done all the usual checks for pagination etc that other relationship fields also do.

Closes https://github.com/statamic/ideas/issues/841