### PR TITLE
[4.x] Tweak the UpdatesBadge component to only update the count when the response is a number

### DIFF
--- a/resources/js/components/UpdatesBadge.vue
+++ b/resources/js/components/UpdatesBadge.vue
@@ -25,7 +25,7 @@
                 let params = clearCache ? {'clearCache': clearCache} : {};
 
                 this.$axios.get(cp_url('updater/count'), params).then(response => {
-                    this.count = response.data;
+                    this.count = !isNaN(response.data) ? response.data : 0;
                 });
             }
         }


### PR DESCRIPTION
Currently when the "updater/count" route returns anything, it is added to the badge - even if the response is not a number (meaning you can get some weird badge appearances).

Working on two factor challenges for the CP and if the challenge is due to be triggered, it can result in HTML being returned as part of this call, making the badge appear as a a huge slab of HTML.

This update updates the UpdatesBadge component to only update the internal `count` when the response is able to be parsed as a number. Otherwise, it will be set to zero (i.e. hide the badge).