### PR TITLE
[4.x] Match user searching in users list and user field type

### DIFF
--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -101,7 +101,7 @@ class Users extends Relationship
                     $query
                         ->where('email', 'like', '%'.$search.'%')
                         ->when(User::blueprint()->hasField('first_name'), function ($query) use ($search) {
-                            foreach (explode(' ', $query) as $word) {
+                            foreach (explode(' ', $search) as $word) {
                                 $query
                                     ->orWhere('first_name', 'like', '%'.$word.'%')
                                     ->orWhere('last_name', 'like', '%'.$word.'%');

--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -5,10 +5,12 @@ namespace Statamic\Fieldtypes;
 use Illuminate\Support\Collection;
 use Statamic\CP\Column;
 use Statamic\Facades\GraphQL;
+use Statamic\Facades\Search;
 use Statamic\Facades\User;
 use Statamic\GraphQL\Types\UserType;
 use Statamic\Query\OrderedQueryBuilder;
 use Statamic\Query\Scopes\Filters\Fields\User as UserFilter;
+use Statamic\Search\Result;
 use Statamic\Support\Arr;
 
 class Users extends Relationship
@@ -92,7 +94,23 @@ class Users extends Relationship
         $query = User::query();
 
         if ($search = $request->search) {
-            $query->where('name', 'like', '%'.$search.'%');
+            if (Search::indexes()->has('users')) {
+                $query = Search::index('users')->ensureExists()->search($search);
+            } else {
+                $query->where(function ($query) use ($search) {
+                    $query
+                        ->where('email', 'like', '%'.$search.'%')
+                        ->when(User::blueprint()->hasField('first_name'), function ($query) use ($search) {
+                            foreach (explode(' ', $query) as $word) {
+                                $query
+                                    ->orWhere('first_name', 'like', '%'.$word.'%')
+                                    ->orWhere('last_name', 'like', '%'.$word.'%');
+                            }
+                        }, function ($query) use ($search) {
+                            $query->orWhere('name', 'like', '%'.$search.'%');
+                        });
+                });
+            }
         }
 
         if ($request->exclusions) {
@@ -101,13 +119,11 @@ class Users extends Relationship
 
         $this->applyIndexQueryScopes($query, $request->all());
 
-        $query->when(
-            User::blueprint()->hasField('first_name'),
-            fn ($query) => $query->orderBy('first_name')->orderBy('last_name'),
-            fn ($query) => $query->orderBy('name')
-        );
-
         $userFields = function ($user) {
+            if ($user instanceof Result) {
+                $user = $user->getSearchable();
+            }
+
             return [
                 'id' => $user->id(),
                 'title' => $user->name(),

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -92,7 +92,7 @@ class UsersController extends CpController
             $query
                 ->where('email', 'like', '%'.$search.'%')
                 ->when(User::blueprint()->hasField('first_name'), function ($query) use ($search) {
-                    foreach (explode(' ', $query) as $word) {
+                    foreach (explode(' ', $search) as $word) {
                         $query
                             ->orWhere('first_name', 'like', '%'.$word.'%')
                             ->orWhere('last_name', 'like', '%'.$word.'%');

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -92,9 +92,11 @@ class UsersController extends CpController
             $query
                 ->where('email', 'like', '%'.$search.'%')
                 ->when(User::blueprint()->hasField('first_name'), function ($query) use ($search) {
-                    $query
-                        ->orWhere('first_name', 'like', '%'.$search.'%')
-                        ->orWhere('last_name', 'like', '%'.$search.'%');
+                    foreach (explode(' ', $query) as $word) {
+                        $query
+                            ->orWhere('first_name', 'like', '%'.$word.'%')
+                            ->orWhere('last_name', 'like', '%'.$word.'%');
+                    }
                 }, function ($query) use ($search) {
                     $query->orWhere('name', 'like', '%'.$search.'%');
                 });


### PR DESCRIPTION
Following on from the comments here https://github.com/statamic/cms/issues/8353#issuecomment-1662522741

Apply word by word searching to the user list in the CP when its a first_name, last_name set up in the blueprint

Match the same logic from the main CP listing to the user field type.

Closes #8353 