### PR TITLE
[4.x] Add is_svg to augmented assets

### DIFF
--- a/src/Assets/AugmentedAsset.php
+++ b/src/Assets/AugmentedAsset.php
@@ -23,6 +23,7 @@ class AugmentedAsset extends AbstractAugmented
                 'is_audio',
                 'is_previewable',
                 'is_image',
+                'is_svg',
                 'is_video',
                 'blueprint',
                 'edit_url',


### PR DESCRIPTION
Fixes: https://github.com/statamic/cms/issues/8546 by adding `is_svg` to the variables provided by Augmented Asset