### PR TITLE
[4.x] Add `RevisionSaving` event

### DIFF
--- a/src/Events/RevisionSaving.php
+++ b/src/Events/RevisionSaving.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class RevisionSaving extends Event
+{
+    public $revision;
+
+    public function __construct($revision)
+    {
+        $this->revision = $revision;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Revisions/Revision.php
+++ b/src/Revisions/Revision.php
@@ -8,6 +8,7 @@ use Statamic\Contracts\Revisions\Revision as Contract;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Events\RevisionDeleted;
 use Statamic\Events\RevisionSaved;
+use Statamic\Events\RevisionSaving;
 use Statamic\Facades;
 use Statamic\Facades\Revision as Revisions;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
@@ -130,6 +131,10 @@ class Revision implements Contract, Arrayable
 
     public function save()
     {
+        if (RevisionSaving::dispatch($this) === false) {
+            return false;
+        }
+
         Revisions::save($this);
 
         RevisionSaved::dispatch($this);


### PR DESCRIPTION
As detailed [here](https://github.com/statamic/ideas/issues/1028) you can't currently stop a Revision from saving, which isn't ideal if you want to add some extra logic.

So this PR adds a `RevisionSaving` event, similar to `EntrySaving`.

Closes https://github.com/statamic/ideas/issues/1028