### PR TITLE
[4.x] Prevent using different globals and variables directories

### DIFF
--- a/src/Globals/Variables.php
+++ b/src/Globals/Variables.php
@@ -74,7 +74,7 @@ class Variables implements Contract, Localization, Augmentable, ResolvesValuesCo
     public function path()
     {
         return vsprintf('%s/%s%s.%s', [
-            rtrim(Stache::store('globals')->directory(), '/'),
+            rtrim(Stache::store('global-variables')->directory(), '/'),
             Site::hasMultiple() ? $this->locale().'/' : '',
             $this->handle(),
             'yaml',

--- a/src/Stache/Stores/GlobalsStore.php
+++ b/src/Stache/Stores/GlobalsStore.php
@@ -4,6 +4,7 @@ namespace Statamic\Stache\Stores;
 
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Path;
+use Statamic\Facades\Stache;
 use Statamic\Facades\YAML;
 use Statamic\Support\Arr;
 use Symfony\Component\Finder\SplFileInfo;
@@ -13,6 +14,15 @@ class GlobalsStore extends BasicStore
     public function key()
     {
         return 'globals';
+    }
+
+    public function paths()
+    {
+        if ($this->directory !== Stache::store('global-variables')->directory()) {
+            throw new \Exception('The [globals] and [global-variables] Stache stores must share the same directory.');
+        }
+
+        return parent::paths();
     }
 
     public function getItemFilter(SplFileInfo $file)


### PR DESCRIPTION
#8343 introduced the ability for the global variables to be in a different store/repository from the global sets themselves.

This PR addresses an oversight that when you have a single site, and different directories configured, that the variables won't be found since they're stored in the global set's file. Rather than actually "fix" it, this will just throw an exception if you configure them to have different directories. The previous PR was more geared towards usage with the Eloquent driver, which will still be possible. 

In Statamic v5 we may consider just _always_ having the global variables live in their own files (like you get when using multisite).

(This PR also adjusts the path to point to the global variables store directory, even though the exception enforces it's the same as globals. 🤪)
