### PR TITLE
[4.x] REST API Globals return resolved relations

### DIFF
--- a/src/Http/Resources/API/GlobalSetResource.php
+++ b/src/Http/Resources/API/GlobalSetResource.php
@@ -7,6 +7,8 @@ use Statamic\Statamic;
 
 class GlobalSetResource extends JsonResource
 {
+    private static $relations = false;
+
     /**
      * Transform the resource into an array.
      *
@@ -15,18 +17,28 @@ class GlobalSetResource extends JsonResource
      */
     public function toArray($request)
     {
-        $with = $this->resource->blueprint()
-            ->fields()->all()
-            ->filter->isRelationship()->keys()->all();
-
-        return $this->resource
+        $collection = $this->resource
             ->toAugmentedCollection()
             ->merge([
                 'handle' => $this->resource->handle(),
                 'api_url' => Statamic::apiRoute('globals.show', [$this->resource->handle()]),
-            ])
-            ->withRelations($with)
+            ]);
+
+        if (static::$relations) {
+            $with = $this->resource->blueprint()
+                ->fields()->all()
+                ->filter->isRelationship()->keys()->all();
+
+            $collection->withRelations($with);
+        }
+
+        return $collection
             ->withShallowNesting()
             ->toArray();
+    }
+
+    public static function withRelations()
+    {
+        static::$relations = true;
     }
 }

--- a/src/Http/Resources/API/GlobalSetResource.php
+++ b/src/Http/Resources/API/GlobalSetResource.php
@@ -7,6 +7,7 @@ use Statamic\Statamic;
 
 class GlobalSetResource extends JsonResource
 {
+    /** @deprecated */
     private static $relations = false;
 
     /**
@@ -37,6 +38,7 @@ class GlobalSetResource extends JsonResource
             ->toArray();
     }
 
+    /** @deprecated */
     public static function withRelations()
     {
         static::$relations = true;

--- a/src/Http/Resources/API/GlobalSetResource.php
+++ b/src/Http/Resources/API/GlobalSetResource.php
@@ -15,12 +15,17 @@ class GlobalSetResource extends JsonResource
      */
     public function toArray($request)
     {
+        $with = $this->resource->blueprint()
+            ->fields()->all()
+            ->filter->isRelationship()->keys()->all();
+
         return $this->resource
             ->toAugmentedCollection()
             ->merge([
                 'handle' => $this->resource->handle(),
                 'api_url' => Statamic::apiRoute('globals.show', [$this->resource->handle()]),
             ])
+            ->withRelations($with)
             ->withShallowNesting()
             ->toArray();
     }


### PR DESCRIPTION
This resolves: https://github.com/statamic/cms/issues/8462

Calling the REST API for globals resolves any given relationship, so it behaves the same as other API endpoints (entries, …).

**This is a breaking change** since it changes the behaviour of the public facing API of Statamic.