### PR TITLE
[4.x] Fire globalset save and saving events when saving variables

### DIFF
--- a/src/Globals/Variables.php
+++ b/src/Globals/Variables.php
@@ -15,6 +15,8 @@ use Statamic\Data\ExistsAsFile;
 use Statamic\Data\HasAugmentedInstance;
 use Statamic\Data\HasOrigin;
 use Statamic\Data\TracksQueriedRelations;
+use Statamic\Events\GlobalSetSaved;
+use Statamic\Events\GlobalSetSaving;
 use Statamic\Events\GlobalVariablesBlueprintFound;
 use Statamic\Events\GlobalVariablesCreated;
 use Statamic\Events\GlobalVariablesDeleted;
@@ -130,6 +132,11 @@ class Variables implements Contract, Localization, Augmentable, ResolvesValuesCo
             if (GlobalVariablesSaving::dispatch($this) === false) {
                 return false;
             }
+
+            // @deprecated
+            if (GlobalSetSaving::dispatch($this->globalSet()) === false) {
+                return false;
+            }
         }
 
         Facades\GlobalVariables::save($this);
@@ -144,6 +151,9 @@ class Variables implements Contract, Localization, Augmentable, ResolvesValuesCo
             }
 
             GlobalVariablesSaved::dispatch($this);
+
+            // @deprecated
+            GlobalSetSaved::dispatch($this->globalSet());
         }
 
         return $this;


### PR DESCRIPTION
It seems I inadvertently introduced a breaking change with the global set variables split. Sorry.

If you were listening for the GlobalSetSaved/Saving events you no longer get them when variables are being saved through the CP. To avoid it being a breaking change we should fire these events when a variable is saved.

I've marked them as deprecated which feels like the right approach.

Fixes #8559