### PR TITLE
[4.x] Fix globals save event

### DIFF
--- a/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
+++ b/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
@@ -104,7 +104,7 @@ class GlobalVariablesController extends CpController
 
         $set->data($values);
 
-        $set->save();
+        $set->globalSet()->addLocalization($set)->save();
 
         return response('', 204);
     }

--- a/tests/Feature/Globals/UpdateGlobalVariablesTest.php
+++ b/tests/Feature/Globals/UpdateGlobalVariablesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Globals;
+
+use Facades\Tests\Factories\GlobalFactory;
+use Illuminate\Support\Facades\Event;
+use Statamic\Events\GlobalSetSaved;
+use Statamic\Events\GlobalVariablesSaved;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\GlobalSet;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class UpdateGlobalVariablesTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    /** @test */
+    public function it_denies_access_if_you_dont_have_permission()
+    {
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = User::make()->assignRole('test')->save();
+        $global = GlobalFactory::handle('test')->create();
+
+        $this
+            ->from('/original')
+            ->actingAs($user)
+            ->patch($global->in('en')->editUrl())
+            ->assertRedirect('/original')
+            ->assertSessionHas('error');
+    }
+
+    /** @test */
+    public function global_variables_get_updated()
+    {
+        $blueprint = Blueprint::make()->setContents(['fields' => [
+            ['handle' => 'foo', 'field' => ['type' => 'text']],
+        ]]);
+        Blueprint::partialMock();
+        Blueprint::shouldReceive('find')->with('globals.test')->andReturn($blueprint);
+        $this->setTestRoles(['test' => ['access cp', 'edit test globals']]);
+        $user = tap(User::make()->assignRole('test')->makeSuper())->save();
+        $global = GlobalFactory::handle('test')->data(['foo' => 'bar'])->create();
+
+        Event::fake(); // Fake after initial global has been created so its event isn't tracked.
+
+        $this->assertCount(1, GlobalSet::all());
+
+        $this
+            ->from('/here')
+            ->actingAs($user)
+            ->patchJson($global->in('en')->updateUrl(), ['foo' => 'baz'])
+            ->assertSuccessful();
+
+        $this->assertCount(1, GlobalSet::all());
+        $global = GlobalSet::find('test')->in('en');
+        $this->assertEquals('baz', $global->foo);
+
+        Event::assertDispatched(GlobalVariablesSaved::class, function ($event) {
+            return $event->variables->handle() === 'test'
+                && $event->variables->data()->all() === ['foo' => 'baz'];
+        });
+
+        Event::assertDispatched(GlobalSetSaved::class, function ($event) {
+            return $event->globals->handle() === 'test'
+                && $event->globals->in('en')->data()->all() === ['foo' => 'baz'];
+        });
+    }
+}


### PR DESCRIPTION
Fixes #8559
Replaces #8561

Prior to #8343 when you save global variables in the CP, the GlobalSetSaved (etc) events would be dispatched. That PR made it so that when you save the variables, only the variable events got dispatched - logically. But that was a breaking change.

This PR makes it so that when you save the variables form, it'll still save the global set and dispatch the original events. This fixes the breaking change.
