### PR TITLE
[4.x] Guzzle proxy support

### DIFF
--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -66,7 +66,7 @@ class Outpost
             'timeout' => self::REQUEST_TIMEOUT,
             'proxy' => [
                     'http' => env('APP_HTTP_PROXY', null),
-                    'https' => env('APP_HTTPS_PROXY', null)
+                    'https' => env('APP_HTTPS_PROXY', null),
             ],
         ]);
 

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -67,7 +67,7 @@ class Outpost
             'proxy' => [
                     'http' => env('APP_HTTP_PROXY', null),
                     'https' => env('APP_HTTPS_PROXY', null)
-            ]
+            ],
         ]);
 
         return json_decode($response->getBody()->getContents(), true);

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -65,8 +65,8 @@ class Outpost
             'json' => $this->payload(),
             'timeout' => self::REQUEST_TIMEOUT,
             'proxy' => [
-                    'http' => env('APP_HTTP_PROXY', null),
-                    'https' => env('APP_HTTPS_PROXY', null),
+                'http' => env('APP_HTTP_PROXY', null),
+                'https' => env('APP_HTTPS_PROXY', null),
             ],
         ]);
 

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -64,6 +64,10 @@ class Outpost
             'headers' => ['accept' => 'application/json'],
             'json' => $this->payload(),
             'timeout' => self::REQUEST_TIMEOUT,
+            'proxy' => [
+                    'http' => env('APP_HTTP_PROXY', null),
+                    'https' => env('APP_HTTPS_PROXY', null)
+            ]
         ]);
 
         return json_decode($response->getBody()->getContents(), true);

--- a/src/Marketplace/Client.php
+++ b/src/Marketplace/Client.php
@@ -57,7 +57,7 @@ class Client
                 'query' => $params,
                 'proxy' => [
                     'http' => env('APP_HTTP_PROXY', null),
-                    'https' => env('APP_HTTPS_PROXY', null)
+                    'https' => env('APP_HTTPS_PROXY', null),
                 ],
             ]);
 

--- a/src/Marketplace/Client.php
+++ b/src/Marketplace/Client.php
@@ -57,7 +57,7 @@ class Client
                 'query' => $params,
                 'proxy' => [
                     'http' => env('APP_HTTP_PROXY', null),
-                    'https' => env('APP_HTTPS_PROXY', null)
+                    'https' => env('APP_HTTPS_PROXY', null),
                 ]
             ]);
 

--- a/src/Marketplace/Client.php
+++ b/src/Marketplace/Client.php
@@ -55,6 +55,10 @@ class Client
             $response = Guzzle::request('GET', $endpoint, [
                 'verify' => $this->verifySsl,
                 'query' => $params,
+                'proxy' => [
+                    'http' => env('APP_HTTP_PROXY', null),
+                    'https' => env('APP_HTTPS_PROXY', null)
+                ]
             ]);
 
             $json = json_decode($response->getBody(), true);

--- a/src/Marketplace/Client.php
+++ b/src/Marketplace/Client.php
@@ -57,8 +57,8 @@ class Client
                 'query' => $params,
                 'proxy' => [
                     'http' => env('APP_HTTP_PROXY', null),
-                    'https' => env('APP_HTTPS_PROXY', null),
-                ]
+                    'https' => env('APP_HTTPS_PROXY', null)
+                ],
             ]);
 
             $json = json_decode($response->getBody(), true);


### PR DESCRIPTION
Right now, Guzzle only supports using the default Linux/Windows proxy environment variables when running from the CLI.

This means inside our corporate network we are unable to run any `composer` commands or use the CMS 'Addons' or 'Updates' pages without `cURL` errors from Guzzle.

The only "bug" with this setup, is that if the `APP_HTTP_PROXY` environment variable is set, but not `APP_HTTPS_PROXY`, the request fails; it seems having even a null key value pair in the `proxy` array causes it to try both.