### PR TITLE
[4.x] Fix Bard set picker position

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -159,7 +159,7 @@
 }
 
 .bard-add-set-button {
-    @apply flex items-center justify-center absolute -left-6 top-[-6px] @xl/bard:-left-8 z-1;
+    @apply flex items-center justify-center absolute -left-4 top-[-6px] z-1;
 }
 
 .bard-footer-toolbar {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -58,7 +58,7 @@
                 :should-show="shouldShowSetButton"
                 :is-showing="showAddSetButton"
                 v-if="editor"
-                v-slot="{ x, y }"
+                v-slot="{ y }"
                 @shown="showAddSetButton = true"
                 @hidden="showAddSetButton = false"
             >
@@ -72,7 +72,7 @@
                         <button
                             type="button"
                             class="btn-round group bard-add-set-button"
-                            :style="{ transform: `translate(${x}px, ${y}px)` }"
+                            :style="{ transform: `translateY(${y}px)` }"
                             :aria-label="__('Add Set')"
                             v-tooltip="__('Add Set')"
                             @click="addSetButtonClicked"

--- a/resources/js/components/fieldtypes/bard/FloatingMenuPlugin.js
+++ b/resources/js/components/fieldtypes/bard/FloatingMenuPlugin.js
@@ -38,9 +38,8 @@ class FloatingMenuView {
         // The dimension from posToDOMRect are relative to the window.
         // But since bard is inside a @container which creates a new stacking
         // context, we need the dimensions relative to the bard editor.
-        const { top: selectionTop, left: selectionLeft } = posToDOMRect(view, from, to);
-        const { top: editorTop, left: editorLeft } = this.editor.options.element.getBoundingClientRect();
-        this.vm.x = Math.round(selectionLeft-editorLeft);
+        const { top: selectionTop } = posToDOMRect(view, from, to);
+        const { top: editorTop } = this.editor.options.element.getBoundingClientRect();
         this.vm.y = Math.round(selectionTop-editorTop);
 
         this.show();


### PR DESCRIPTION
Fixes #8557. Reverts the dynamic positioning of the button on the x-axis introduced in https://github.com/statamic/cms/pull/7818.

Fixes overlapping text, when the `Always Show Set Button` option is enabled:

![2023-08-11 15 09 26](https://github.com/statamic/cms/assets/1102712/863927fe-ad71-421c-8a88-3542cbdc6f52)

Fixes set picker position when changing text alignment, although not sure if that was the intended reason for adding that feature.

![2023-08-11 15 03 44](https://github.com/statamic/cms/assets/1102712/a646e1f8-16be-4aad-95c4-14b01655f2d4)
