### PR TITLE
[4.x] Make the views field handle reserved

### DIFF
--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -83,6 +83,7 @@ class FieldsController extends CpController
             'status',
             'unless',
             'value', // todo: can be removed when https://github.com/statamic/cms/issues/2495 is resolved
+            'views',
         ];
 
         $fields = collect([


### PR DESCRIPTION
Closes #8575

The `views` variable is used in the cascade to keep track of any view specific variables - stuff you put the in the front-matter of a view file.
