### PR TITLE
[4.x] Register/export set and field related components

### DIFF
--- a/resources/js/bootstrap/fieldtypes.js
+++ b/resources/js/bootstrap/fieldtypes.js
@@ -57,6 +57,8 @@ import ToggleIndexFieldtype from '../components/fieldtypes/ToggleIndexFieldtype.
 import WidthFieldtype from '../components/fieldtypes/WidthFieldtype.vue';
 import VideoFieldtype from '../components/fieldtypes/VideoFieldtype.vue';
 import YamlFieldtype from '../components/fieldtypes/YamlFieldtype.vue';
+import SetPicker from '../components/fieldtypes/replicator/SetPicker.vue';
+import SetField from '../components/fieldtypes/replicator/Field.vue';
 
 Vue.component('select-input', Select);
 Vue.component('text-input', Text);
@@ -113,6 +115,8 @@ Vue.component('toggle-fieldtype-index', ToggleIndexFieldtype);
 Vue.component('width-fieldtype', WidthFieldtype);
 Vue.component('video-fieldtype', VideoFieldtype);
 Vue.component('yaml-fieldtype', YamlFieldtype);
+Vue.component('set-picker', SetPicker);
+Vue.component('set-field', SetField);
 
 
 Vue.component('revealer-fieldtype', RevealerFieldtype);

--- a/resources/js/bootstrap/mixins.js
+++ b/resources/js/bootstrap/mixins.js
@@ -4,11 +4,13 @@ import Fieldtype from '../components/fieldtypes/Fieldtype.vue'
 import IndexFieldtype from '../components/fieldtypes/IndexFieldtype.vue'
 import BardToolbarButton from '../components/fieldtypes/bard/ToolbarButton.vue'
 import Listing from '../components/Listing.vue'
+import * as FieldConditions from '../components/field-conditions/FieldConditions.js';
 
 window.Fieldtype = Fieldtype;
 window.IndexFieldtype = IndexFieldtype;
 window.BardToolbarButton = BardToolbarButton;
 window.Listing = Listing;
+window.FieldConditions = FieldConditions;
 
 Vue.mixin({
     methods: {


### PR DESCRIPTION
This PR registers/exports some Vue components related to sets and field conditions, so they can be used by addons. They are:

* The `<set-picker>` component
* The `<set-field>` component
* The `FieldConditions` mixin