### PR TITLE
[4.x] Improve Bard invalid content error reporting

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -17,7 +17,7 @@
     }
 }
 
-.bard-editor .bard-invalid {
+.bard-editor .bard-error {
     @apply p-2 @lg:px-4 bg-red-100 text-red-500 text-xs whitespace-nowrap;
 }
 

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -83,7 +83,7 @@
                 </set-picker>
             </floating-menu>
 
-            <div class="bard-invalid" v-if="invalid" v-html="__('Invalid content')"></div>
+            <div class="bard-invalid" v-if="invalid" v-html="invalid"></div>
             <editor-content :editor="editor" v-show="!showSource" :id="fieldId" />
             <bard-source :html="htmlWithReplacedLinks" v-if="showSource" />
         </div>
@@ -627,11 +627,30 @@ export default {
                         try {
                             state.schema.nodeFromJSON(content);
                         } catch (error) {
-                            this.invalid = true;
+                            const invalid = this.invalidMessage(error);
+                            if (invalid) {
+                                this.invalid = invalid;
+                            } else {
+                                this.invalid = __('Something went wrong');
+                                console.error(error);
+                            }
                         }
                     }
                 }
             });
+        },
+
+        invalidMessage(error) {
+            let match;
+            if (match = error.message.match(/^There is no mark type ([\w]+) in this schema$/)) {
+                return __('Invalid content, check :type button/extension is enabled', { type: match[1] });
+            } else if (match = error.message.match(/^Unknown node type: ([\w]+)$/)) {
+                return __('Invalid content, check :type button/extension is enabled', { type: match[1] });
+            } else if (match = error.message.match(/^Invalid text node in JSON$/)) {
+                return __('Invalid content, text values must be strings');
+            } else if (match = error.message.match(/^Empty text nodes are not allowed$/)) {
+                return __('Invalid content, text values cannot be empty');
+            }
         },
 
         valueToContent(value) {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -649,11 +649,12 @@ export default {
                 return __(messages[error.message]);
             }
             let match;
-            if (match = error.message.match(/^Unknown (?:node|mark) type: $/)) {
-                return __('Invalid content, nodes and marks must have a type');
-            }
-            if (match = error.message.match(/^(?:There is no|Unknown) (?:node|mark) type:? (\w+)/)) {
-                return __('Invalid content, :type button/extension is not enabled', { type: match[1] });
+            if (match = error.message.match(/^(?:There is no|Unknown) (?:node|mark) type:? (\w*)(?: in this schema)?$/)) {
+                if (match[1]) {
+                    return __('Invalid content, :type button/extension is not enabled', { type: match[1] });
+                } else {
+                    return __('Invalid content, nodes and marks must have a type');
+                }
             }
         },
 

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -645,9 +645,11 @@ export default {
                 'Invalid text node in JSON': 'Invalid content, text values must be strings',
                 'Empty text nodes are not allowed': 'Invalid content, text values cannot be empty',
             };
+
             if (messages[error.message]) {
                 return __(messages[error.message]);
             }
+
             let match;
             if (match = error.message.match(/^(?:There is no|Unknown) (?:node|mark) type:? (\w*)(?: in this schema)?$/)) {
                 if (match[1]) {


### PR DESCRIPTION
The goal of this PR is to improve the error reporting when Bard encounters invalid content:

![Screenshot 2023-08-14 at 17 50 28](https://github.com/statamic/cms/assets/126740/20ff2ecb-912b-4488-b489-c21194a76fb4)

Now friendlier and hopefully more useful messages are displayed for some of the most common issues, which could occur if a field's configuration is changed after content has been added or if content has been imported manually:

![Screenshot 2023-08-15 at 10 01 28](https://github.com/statamic/cms/assets/126740/ae55f857-1cac-41a5-b8ba-7e885558e76e)

Possible messages are:

* Invalid content, [type] button/extension is not enabled
* Invalid content, nodes and marks must have a type
* Invalid content, text values cannot be empty
* Invalid content, text values must be strings

Other errors will just just output the usual "Something went wrong" message with the full error logged to the console:

![Screenshot 2023-08-14 at 17 53 05](https://github.com/statamic/cms/assets/126740/9cff601c-754c-4dbb-8c1c-3ea9e68fa0b3)

Or in some instances it is possible for the editor to completely fail to load due to errors being thrown outside of the `onCreate` call. If that happens the error will appear in the console as normal.