### PR TITLE
[4.x] Ensure User::hasRole() checks group roles too

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -145,9 +145,9 @@ class User extends BaseUser
 
     public function hasRole($role)
     {
-        return $this->roles()->has(
-            is_string($role) ? $role : $role->handle()
-        );
+        $role = is_string($role) ? $role : $role->handle();
+
+        return $this->roles()->has($role) || $this->groups()->flatMap(fn ($group) => $group->roles())->has($role);
     }
 
     public function groups($groups = null)

--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -196,7 +196,7 @@ class User extends BaseUser
     {
         $role = $role instanceof RoleContract ? $role->handle() : $role;
 
-        return $this->roles()->has($role);
+        return $this->roles()->has($role) || $this->groups()->flatMap(fn ($group) => $group->roles())->has($role);
     }
 
     public function addToGroup($group)

--- a/tests/Auth/PermissibleContractTests.php
+++ b/tests/Auth/PermissibleContractTests.php
@@ -107,6 +107,7 @@ trait PermissibleContractTests
             }
         };
 
+        RoleAPI::shouldReceive('find')->with('a')->andReturn($roleA);
         RoleAPI::shouldReceive('find')->with('b')->andReturn($roleB);
         RoleAPI::shouldReceive('find')->with('c')->andReturn($roleC);
         RoleAPI::shouldReceive('all')->andReturn(collect([$roleA, $roleB, $roleC, $roleD])); // the stache calls this when getting a user. unrelated to test.
@@ -187,7 +188,8 @@ trait PermissibleContractTests
         $this->assertFalse($user->hasRole('b'));
 
         $groupA = (new UserGroup)->handle('some_group')->assignRole($roleA);
-        $groupA->save();
+        UserGroupAPI::shouldReceive('find')->with('some_group')->andReturn($groupA);
+        UserGroupAPI::shouldReceive('all')->andReturn(collect([$groupA])); // the stache calls this when getting a user. unrelated to test.
 
         $user->addToGroup($groupA);
         $user->save();


### PR DESCRIPTION
I mentioned this in the comments of https://github.com/statamic/cms/pull/6131 and forgot to loop back to it.

When checking if a user has a role (`$user->hasRole('x')`), should it not also check the user's group for that role too, seeing as groups can also be associated with roles. Otherwise the burden is on the developer to check for this and it may not be apparent to most people.

I see you are merging group permissions with user permissions when checking for `hasPermission()`, so this feels like a natural evolution of that.

As always, please push back on this if I've misunderstood the intention.