### PR TITLE
[4.x] Fix slugify error

### DIFF
--- a/resources/js/plugins/slugify.js
+++ b/resources/js/plugins/slugify.js
@@ -7,7 +7,7 @@ export default {
             const sites = Statamic.$config.get('sites');
             const site = sites.find(site => site.handle === selectedSite);
             lang = lang ?? site?.lang ?? Statamic.$config.get('lang');
-            const custom = Statamic.$config.get(`charmap.${lang}`) ?? undefined;
+            const custom = Statamic.$config.get(`charmap.${lang}`) ?? {};
 
             // Remove apostrophes in all languages
             custom["'"] = "";


### PR DESCRIPTION
Fixes #8582
Introduced in #8524

If you happen to have a language that the ASCII package doesn't support, then we were trying to set a property on undefined when an empty object would have worked.
