### PR TITLE
[4.x] Pint updates

### DIFF
--- a/src/CP/Utilities/CoreUtilities.php
+++ b/src/CP/Utilities/CoreUtilities.php
@@ -10,6 +10,7 @@ use Statamic\Http\Controllers\CP\Utilities\GitController;
 use Statamic\Http\Controllers\CP\Utilities\PhpInfoController;
 use Statamic\Http\Controllers\CP\Utilities\UpdateSearchController;
 use Statamic\Statamic;
+
 use function Statamic\trans as __;
 
 class CoreUtilities


### PR DESCRIPTION
Run `pint` with the newer version. It now extracts function imports.
