### PR TITLE
[4.x] Fix alignment of menu icon in global-header.blade.php

### DIFF
--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -1,6 +1,6 @@
 <div class="global-header">
     <div class="lg:min-w-xl pl-2 md:pl-6 h-full flex items-center">
-        <button class="nav-toggle hidden md:block ml-1 shrink-0" @click="toggleNav" aria-label="{{ __('Toggle Nav') }}">@cp_svg('icons/light/burger')</button>
+        <button class="nav-toggle hidden md:flex ml-1 shrink-0" @click="toggleNav" aria-label="{{ __('Toggle Nav') }}">@cp_svg('icons/light/burger')</button>
         <button class="nav-toggle md:hidden ml-1 shrink-0" @click="toggleMobileNav" v-if="! mobileNavOpen" aria-label="{{ __('Toggle Mobile Nav') }}">@cp_svg('icons/light/burger')</button>
         <button class="nav-toggle md:hidden ml-1 shrink-0" @click="toggleMobileNav" v-else v-cloak aria-label="{{ __('Toggle Mobile Nav') }}">@cp_svg('icons/light/close')</button>
         <a href="{{ route('statamic.cp.index') }}" class="flex items-end">


### PR DESCRIPTION
I'm sorry, I realize this is an obnoxiously-small PR, but my eye cannot unsee this misaligned icon. 😅 One-word patch, changing from an `md:block` to `md:flex`.

![image](https://github.com/statamic/cms/assets/13950848/b5b3ff2f-6ff4-4ec5-a615-170518da8b58)
