### PR TITLE
[4.x] Implement Stringable for LocalizedTerm

### DIFF
--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -3,6 +3,7 @@
 namespace Statamic\Taxonomies;
 
 use ArrayAccess;
+use Stringable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Carbon;
@@ -33,7 +34,7 @@ use Statamic\Search\Searchable;
 use Statamic\Statamic;
 use Statamic\Support\Str;
 
-class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, ResolvesValuesContract, ArrayAccess, Arrayable, ContainsQueryableValues, SearchableContract
+class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, ResolvesValuesContract, ArrayAccess, Arrayable, ContainsQueryableValues, SearchableContract, Stringable
 {
     use Revisable, Routable, Publishable, HasAugmentedInstance, TracksQueriedColumns, TracksQueriedRelations, TracksLastModified, ContainsSupplementalData, ResolvesValues, Searchable;
 
@@ -514,5 +515,9 @@ class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, Reso
     public function getCpSearchResultBadge()
     {
         return $this->taxonomy()->title();
+    }
+
+    public function __toString(): string {
+        return $this->title();
     }
 }

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -517,7 +517,8 @@ class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, Reso
         return $this->taxonomy()->title();
     }
 
-    public function __toString(): string {
-        return $this->title();
+    public function __toString(): string
+    {
+        return $this->title() ?? '';
     }
 }

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -3,7 +3,6 @@
 namespace Statamic\Taxonomies;
 
 use ArrayAccess;
-use Stringable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Carbon;
@@ -33,6 +32,7 @@ use Statamic\Routing\Routable;
 use Statamic\Search\Searchable;
 use Statamic\Statamic;
 use Statamic\Support\Str;
+use Stringable;
 
 class LocalizedTerm implements Term, Responsable, Augmentable, Protectable, ResolvesValuesContract, ArrayAccess, Arrayable, ContainsQueryableValues, SearchableContract, Stringable
 {


### PR DESCRIPTION
Allows grouping by taxonomy terms in collections, fixing the `Object of class Statamic\Taxonomies\LocalizedTerm could not be converted to string` error

Example code which this fixes:

```hbs
{{ collection:articles as="articles" }}
   {{ articles group_by="article_category" }}
      {{ groups }}
        <h2>{{ group }}</h2>
        {{ items }}
          {{ partial src="partials/article" }}
        {{ /items }}
      {{ /groups }}
   {{ /articles }}
{{ /collection:articles }}