### PR TITLE
[4.x] Make uploader synchronous

### DIFF
--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -129,7 +129,7 @@ export default {
                 extension: file.name.split('.').pop(),
                 percent: 0,
                 errorMessage: null,
-                upload
+                instance: upload
             });
         },
 
@@ -175,7 +175,7 @@ export default {
             const upload = this.uploads[0];
             const id = upload.id;
 
-            upload.upload.upload().then(response => {
+            upload.instance.upload().then(response => {
                 const json = JSON.parse(response.data);
                 response.status === 200
                     ? this.handleUploadSuccess(id, json)

--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -71,6 +71,7 @@ export default {
 
         uploads(uploads) {
             this.$emit('updated', uploads);
+            this.processUploadQueue();
         }
 
     },
@@ -127,14 +128,8 @@ export default {
                 basename: file.name,
                 extension: file.name.split('.').pop(),
                 percent: 0,
-                errorMessage: null
-            });
-
-            upload.upload().then(response => {
-                const json = JSON.parse(response.data);
-                response.status === 200
-                    ? this.handleUploadSuccess(id, json)
-                    : this.handleUploadError(id, status, json);
+                errorMessage: null,
+                upload
             });
         },
 
@@ -172,6 +167,20 @@ export default {
             }
 
             return form;
+        },
+
+        processUploadQueue() {
+            if (this.uploads.length === 0) return;
+
+            const upload = this.uploads[0];
+            const id = upload.id;
+
+            upload.upload.upload().then(response => {
+                const json = JSON.parse(response.data);
+                response.status === 200
+                    ? this.handleUploadSuccess(id, json)
+                    : this.handleUploadError(id, status, json);
+            });
         },
 
         handleUploadSuccess(id, response) {


### PR DESCRIPTION
Uploading asynchronously appears to cause a race condition. Technically its still there, e.g. if someone else uploads at the same time as you, but this helps.

Fixes #8587
