### PR TITLE
[4.x] replace hard coded text with i18n

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -21,7 +21,7 @@
             </div>
 
             @if($emailLoginEnabled)
-                <div class="text-center text-sm text-gray-700 py-6">&mdash; or &mdash;</div>
+                <div class="text-center text-sm text-gray-700 py-6">&mdash; {{ __('or') }} &mdash;</div>
 
                 <div class="login-with-email" v-if="! showEmailLogin">
                     <a class="btn w-full" @click.prevent="showEmailLogin = true">


### PR DESCRIPTION
When using Oauth, there's some hard coded text in the form that our client has been complaining about ;) There's already translations of `or` in translation files, so it'd be a shame not to use them.