### PR TITLE
[4.x] Add a way to determine which entry saved event was the initiator

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -336,6 +336,18 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
 
         $this->ancestors()->each(fn ($entry) => Blink::forget('entry-descendants-'.$entry->id()));
 
+        $stack = Blink::get('entry-event-initiator-'.$this->root()->id()) ?? collect();
+
+        $initiator = $stack->first() ?? $this;
+
+        $initiatorIsAncestor = $this->ancestors()->contains(function ($entry) use ($initiator) {
+            return $entry->id() === $initiator->id();
+        });
+
+        if ($stack->isEmpty() || $initiatorIsAncestor) {
+            $stack->push($this);
+        }
+
         $this->directDescendants()->each->save();
 
         $this->taxonomize();
@@ -361,6 +373,9 @@ class Entry implements Contract, Augmentable, Responsable, Localization, Protect
                     $this->makeLocalization($siteHandle)->save();
                 });
         }
+
+        $stack->pop();
+        Blink::put('entry-event-initiator-'.$this->root()->id(), $stack);
 
         return true;
     }

--- a/src/Entries/InitiatorStack.php
+++ b/src/Entries/InitiatorStack.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Statamic\Entries;
+
+use Statamic\Contracts\Entries\Entry;
+use Statamic\Facades\Blink;
+
+class InitiatorStack
+{
+    private $entry;
+    private $key;
+    private $stack;
+
+    public function entry($entry)
+    {
+        $this->entry = $entry;
+        $this->key = 'entry-event-initiator-'.$entry->root()->id();
+        $this->stack = Blink::get($this->key) ?? collect();
+
+        return $this;
+    }
+
+    public function push()
+    {
+        $initiator = $this->stack->first() ?? $this->entry;
+
+        $initiatorIsAncestor = $this->entry
+            ->ancestors()
+            ->contains(fn ($entry) => $entry->id() === $initiator->id());
+
+        if ($this->stack->isEmpty() || $initiatorIsAncestor) {
+            $this->stack->push($this->entry);
+            Blink::put($this->key, $this->stack);
+        }
+
+        return $this;
+    }
+
+    public function initiator(): ?Entry
+    {
+        return $this->stack->first();
+    }
+
+    public function pop()
+    {
+        $this->stack->pop();
+    }
+}

--- a/src/Events/EntrySaved.php
+++ b/src/Events/EntrySaved.php
@@ -20,4 +20,9 @@ class EntrySaved extends Event implements ProvidesCommitMessage
     {
         return __('Entry saved', [], config('statamic.git.locale'));
     }
+
+    public function isInitiator()
+    {
+        return $this->entry->id() === $this->initiator->id();
+    }
 }

--- a/src/Events/EntrySaved.php
+++ b/src/Events/EntrySaved.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Events;
 
+use Facades\Statamic\Entries\InitiatorStack;
 use Statamic\Contracts\Git\ProvidesCommitMessage;
-use Statamic\Facades\Blink;
 
 class EntrySaved extends Event implements ProvidesCommitMessage
 {
@@ -13,7 +13,7 @@ class EntrySaved extends Event implements ProvidesCommitMessage
     public function __construct($entry)
     {
         $this->entry = $entry;
-        $this->initiator = (Blink::get('entry-event-initiator-'.$entry->root()->id()) ?? collect())->first();
+        $this->initiator = InitiatorStack::entry($entry)->initiator();
     }
 
     public function commitMessage()

--- a/src/Events/EntrySaved.php
+++ b/src/Events/EntrySaved.php
@@ -3,14 +3,17 @@
 namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
+use Statamic\Facades\Blink;
 
 class EntrySaved extends Event implements ProvidesCommitMessage
 {
     public $entry;
+    public $initiator;
 
     public function __construct($entry)
     {
         $this->entry = $entry;
+        $this->initiator = (Blink::get('entry-event-initiator-'.$entry->root()->id()) ?? collect())->first();
     }
 
     public function commitMessage()

--- a/tests/Search/UpdateItemIndexesTest.php
+++ b/tests/Search/UpdateItemIndexesTest.php
@@ -4,8 +4,8 @@ namespace Tests\Search;
 
 use Mockery;
 use Statamic\Contracts\Search\Searchable;
-use Statamic\Events\EntryDeleted;
-use Statamic\Events\EntrySaved;
+use Statamic\Events\UserDeleted;
+use Statamic\Events\UserSaved;
 use Statamic\Facades\Search;
 use Statamic\Search\UpdateItemIndexes;
 use Tests\TestCase;
@@ -19,7 +19,7 @@ class UpdateItemIndexesTest extends TestCase
 
         Search::shouldReceive('updateWithinIndexes')->with($item)->once();
 
-        $event = new EntrySaved($item);
+        $event = new UserSaved($item);
 
         $listener = new UpdateItemIndexes;
 
@@ -33,7 +33,7 @@ class UpdateItemIndexesTest extends TestCase
 
         Search::shouldReceive('deleteFromIndexes')->with($item)->once();
 
-        $event = new EntryDeleted($item);
+        $event = new UserDeleted($item);
 
         $listener = new UpdateItemIndexes;
 


### PR DESCRIPTION
See https://github.com/statamic/cms/discussions/8588

This PR adds an `isInitial()` method on the `EntrySaved` event.

When you save an entry, if it has any localizations, they'll also get saved since #8505.

Depending on the use, you might only care about the one that was initially saved.

For example, if you wanted to send a notification when an entry is saved, you might not care that its localizations were also updated. But maybe you are updating some third party content, in which case you would care.

```php
Event::listen(function (EntrySaved $event) {
  if ($event->isInitial()) {
    $this->sendNotification();
  } else {
    // It's just a localization that happened to get saved. Don't send notification.
  }
});
```