### PR TITLE
[4.x] Ensure Dropdown List Remains Anchored on Resize

### DIFF
--- a/resources/js/mixins/PositionsSelectOptions.js
+++ b/resources/js/mixins/PositionsSelectOptions.js
@@ -1,27 +1,33 @@
-import { computePosition, offset, flip } from '@floating-ui/dom';
+import { computePosition, offset, flip, autoUpdate } from '@floating-ui/dom';
 
 export default {
-
     methods: {
+        positionOptions(dropdownList, component, {width}) {
+            dropdownList.style.width = width;
 
-        positionOptions(dropdownList, component, { width }) {
-            dropdownList.style.width = width
-
-            computePosition(component.$refs.toggle, dropdownList, {
-                placement: 'bottom',
-                middleware: [
-                    offset({ mainAxis: 0, crossAxis: -1 }),
-                    flip(),
-                ]
-            }).then(({ x, y }) => {
-                Object.assign(dropdownList.style, {
+            function updatePosition() {
+                computePosition(component.$refs.toggle, dropdownList, {
+                    placement: 'bottom',
+                    middleware: [
+                        offset({mainAxis: 0, crossAxis: -1}),
+                        flip(),
+                    ]
+                }).then(({x, y}) => {
                     // Round to avoid blurry text
-                    left: `${Math.round(x)}px`,
-                    top: `${Math.round(y)}px`,
+                    Object.assign(dropdownList.style, {
+                        left: `${Math.round(x)}px`,
+                        top: `${Math.round(y)}px`,
+                    });
                 });
-            });
+            }
+
+            const cleanup = autoUpdate(
+                component.$refs.toggle,
+                dropdownList,
+                updatePosition
+            );
+
+            this.$once('hook:destroyed', cleanup);
         }
-
     }
-
 }


### PR DESCRIPTION
Fixes #8316

- Implemented the `autoUpdate()` function from the Floating UI library to ensure the dropdown list remains anchored to the select input, especially when its size changes due to filtering.
- Addressed the issue where the dropdown list would float above the select input on smaller screens or when the list becomes shorter.