### PR TITLE
[4.x] Rename method

### DIFF
--- a/src/Events/EntrySaved.php
+++ b/src/Events/EntrySaved.php
@@ -21,7 +21,7 @@ class EntrySaved extends Event implements ProvidesCommitMessage
         return __('Entry saved', [], config('statamic.git.locale'));
     }
 
-    public function isInitiator()
+    public function isInitial()
     {
         return $this->entry->id() === $this->initiator->id();
     }


### PR DESCRIPTION
Continuation of #8605

I merged the PR before pushing up the method rename commit. Oops.

The method should be `isInitial()` as per the other PR description.
