### PR TITLE
[4.x] Set 'restrict' to false in ReplaceAsset action

### DIFF
--- a/src/Actions/ReplaceAsset.php
+++ b/src/Actions/ReplaceAsset.php
@@ -63,7 +63,7 @@ class ReplaceAsset extends Action
                 'max_files' => 1,
                 'validate' => 'required',
                 'mode' => 'list',
-                'restrict' => true,
+                'restrict' => false,
                 'allow_uploads' => true,
                 'show_filename' => true,
             ],


### PR DESCRIPTION
Fixes #8590

To allow users to select other folders to replace an asset, the restriction should be set to false.