### PR TITLE
[4.x] Fix data loss when reordering sets with revealer fields

### DIFF
--- a/resources/js/components/fieldtypes/RevealerFieldtype.vue
+++ b/resources/js/components/fieldtypes/RevealerFieldtype.vue
@@ -54,7 +54,9 @@ export default {
     watch: {
         fieldPath(fieldPath, oldFieldPath) {
             this.$store.commit(`publish/${this.storeName}/unsetRevealerField`, oldFieldPath);
-            this.$store.commit(`publish/${this.storeName}/setRevealerField`, fieldPath);
+            this.$nextTick(() => {
+                this.$store.commit(`publish/${this.storeName}/setRevealerField`, fieldPath);
+            });
         }
     },
 

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -407,7 +407,9 @@ export default {
 
         fieldPathPrefix(fieldPathPrefix, oldFieldPathPrefix) {
             this.$store.commit(`publish/${this.storeName}/unsetFieldSubmitsJson`, oldFieldPathPrefix);
-            this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, fieldPathPrefix);
+            this.$nextTick(() => {
+                this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, fieldPathPrefix);
+            });
         },
 
         fullScreenMode() {


### PR DESCRIPTION
I _think_ this fixes https://github.com/statamic/cms/issues/8615. Be great if anyone who's run into that can test.

The issue seems to be caused by a race condition when unsetting/setting the revealer fields in the store. When you move a set it will affect the field paths of multiple sets, so there will be multiple unset/set calls which could get mixed up. This defers the set calls to the next tick to ensure they run after everything has been unset (hopefully).