### PR TITLE
[4.x] Set initial and maximum scale to prevent auto zoom on iOS devices

### DIFF
--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -1,6 +1,6 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-<meta name="viewport" content="width=device-width">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 <meta name="robots" content="noindex,nofollow">
 
 <title>@yield('title', $title ?? __('Here')) ‹ {{ Statamic::pro() ? config('statamic.cp.custom_cms_name', 'Statamic') : 'Statamic' }}</title>


### PR DESCRIPTION
Prevent annoying auto zoom on iOS devices inside the CP when focusing or selecting form elements.

**Note:** This change still allows the user to zoom in manually, because the option "user-scalable=0" is **not** set.

Auto zoom problem on iOS:

https://github.com/statamic/cms/assets/21835310/ca7c725e-d4e8-4aec-ab4c-abdba062610f

