### PR TITLE
[4.x] Fix asset & term reference updaters when using new set groups blueprint config

### DIFF
--- a/src/Data/DataReferenceUpdater.php
+++ b/src/Data/DataReferenceUpdater.php
@@ -170,7 +170,7 @@ abstract class DataReferenceUpdater
         collect($sets)->each(function ($set, $setKey) use ($dottedKey, $field) {
             $dottedPrefix = "{$dottedKey}.{$setKey}.attrs.values.";
             $setHandle = Arr::get($set, 'attrs.values.type');
-            $fields = Arr::get($field->config(), "sets.{$setHandle}.fields");
+            $fields = Arr::get($field->fieldtype()->flattenedSetsConfig(), "{$setHandle}.fields");
 
             if ($setHandle && $fields) {
                 $this->recursivelyUpdateFields((new Fields($fields))->all(), $dottedPrefix);

--- a/src/Data/DataReferenceUpdater.php
+++ b/src/Data/DataReferenceUpdater.php
@@ -125,7 +125,7 @@ abstract class DataReferenceUpdater
         collect($sets)->each(function ($set, $setKey) use ($dottedKey, $field) {
             $dottedPrefix = "{$dottedKey}.{$setKey}.";
             $setHandle = Arr::get($set, 'type');
-            $fields = Arr::get($field->config(), "sets.{$setHandle}.fields");
+            $fields = Arr::get($field->fieldtype()->flattenedSetsConfig(), "{$setHandle}.fields");
 
             if ($setHandle && $fields) {
                 $this->recursivelyUpdateFields((new Fields($fields))->all(), $dottedPrefix);

--- a/tests/Listeners/UpdateAssetReferencesTest.php
+++ b/tests/Listeners/UpdateAssetReferencesTest.php
@@ -428,6 +428,92 @@ class UpdateAssetReferencesTest extends TestCase
                     'field' => [
                         'type' => 'replicator',
                         'sets' => [
+                            'group_one' => [
+                                'sets' => [
+                                    'set_one' => [
+                                        'fields' => [
+                                            [
+                                                'handle' => 'product',
+                                                'field' => [
+                                                    'type' => 'assets',
+                                                    'container' => 'test_container',
+                                                    'max_files' => 1,
+                                                ],
+                                            ],
+                                            [
+                                                'handle' => 'pics',
+                                                'field' => [
+                                                    'type' => 'assets',
+                                                    'container' => 'test_container',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                    'set_two' => [
+                                        'fields' => [
+                                            [
+                                                'handle' => 'not_asset',
+                                                'field' => [
+                                                    'type' => 'text',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry = tap(Facades\Entry::make()->collection($collection)->data([
+            'reppy' => [
+                [
+                    'type' => 'set_one',
+                    'product' => 'norris.jpg',
+                    'pics' => ['hoff.jpg', 'norris.jpg'],
+                ],
+                [
+                    'type' => 'set_two',
+                    'not_asset' => 'not an asset',
+                ],
+                [
+                    'type' => 'set_one',
+                    'product' => 'hoff.jpg',
+                    'pics' => ['hoff.jpg', 'norris.jpg', 'lee.jpg'],
+                ],
+            ],
+        ]))->save();
+
+        $this->assertEquals('norris.jpg', Arr::get($entry->data(), 'reppy.0.product'));
+        $this->assertEquals(['hoff.jpg', 'norris.jpg'], Arr::get($entry->data(), 'reppy.0.pics'));
+        $this->assertEquals('not an asset', Arr::get($entry->data(), 'reppy.1.not_asset'));
+        $this->assertEquals('hoff.jpg', Arr::get($entry->data(), 'reppy.2.product'));
+        $this->assertEquals(['hoff.jpg', 'norris.jpg', 'lee.jpg'], Arr::get($entry->data(), 'reppy.2.pics'));
+
+        $this->assetNorris->path('content/norris.jpg')->save();
+        $this->assetHoff->delete();
+
+        $this->assertEquals('content/norris.jpg', Arr::get($entry->fresh()->data(), 'reppy.0.product'));
+        $this->assertEquals(['content/norris.jpg'], Arr::get($entry->fresh()->data(), 'reppy.0.pics'));
+        $this->assertEquals('not an asset', Arr::get($entry->fresh()->data(), 'reppy.1.not_asset'));
+        $this->assertFalse(Arr::has($entry->fresh()->data(), 'reppy.2.product'));
+        $this->assertEquals(['content/norris.jpg', 'lee.jpg'], Arr::get($entry->fresh()->data(), 'reppy.2.pics'));
+    }
+
+    /** @test */
+    public function it_updates_nested_asset_fields_within_legacy_replicator_configs()
+    {
+        $collection = tap(Facades\Collection::make('articles'))->save();
+
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                [
+                    'handle' => 'reppy',
+                    'field' => [
+                        'type' => 'replicator',
+                        'sets' => [
                             'set_one' => [
                                 'fields' => [
                                     [

--- a/tests/Listeners/UpdateTermReferencesTest.php
+++ b/tests/Listeners/UpdateTermReferencesTest.php
@@ -360,6 +360,92 @@ class UpdateTermReferencesTest extends TestCase
                     'field' => [
                         'type' => 'replicator',
                         'sets' => [
+                            'group_one' => [
+                                'sets' => [
+                                    'set_one' => [
+                                        'fields' => [
+                                            [
+                                                'handle' => 'favourite',
+                                                'field' => [
+                                                    'type' => 'terms',
+                                                    'taxonomies' => ['topics'],
+                                                    'max_items' => 1,
+                                                ],
+                                            ],
+                                            [
+                                                'handle' => 'favourites',
+                                                'field' => [
+                                                    'type' => 'terms',
+                                                    'taxonomies' => ['topics'],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                    'set_two' => [
+                                        'fields' => [
+                                            [
+                                                'handle' => 'not_term',
+                                                'field' => [
+                                                    'type' => 'text',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry = tap(Facades\Entry::make()->collection($collection)->data([
+            'reppy' => [
+                [
+                    'type' => 'set_one',
+                    'favourite' => 'norris',
+                    'favourites' => ['hoff', 'norris'],
+                ],
+                [
+                    'type' => 'set_two',
+                    'not_term' => 'not a term',
+                ],
+                [
+                    'type' => 'set_one',
+                    'favourite' => 'hoff',
+                    'favourites' => ['hoff', 'norris', 'lee'],
+                ],
+            ],
+        ]))->save();
+
+        $this->assertEquals('norris', Arr::get($entry->data(), 'reppy.0.favourite'));
+        $this->assertEquals(['hoff', 'norris'], Arr::get($entry->data(), 'reppy.0.favourites'));
+        $this->assertEquals('not a term', Arr::get($entry->data(), 'reppy.1.not_term'));
+        $this->assertEquals('hoff', Arr::get($entry->data(), 'reppy.2.favourite'));
+        $this->assertEquals(['hoff', 'norris', 'lee'], Arr::get($entry->data(), 'reppy.2.favourites'));
+
+        $this->termNorris->slug('norris-new')->save();
+        $this->termHoff->delete();
+
+        $this->assertEquals('norris-new', Arr::get($entry->fresh()->data(), 'reppy.0.favourite'));
+        $this->assertEquals(['norris-new'], Arr::get($entry->fresh()->data(), 'reppy.0.favourites'));
+        $this->assertEquals('not a term', Arr::get($entry->fresh()->data(), 'reppy.1.not_term'));
+        $this->assertFalse(Arr::has($entry->fresh()->data(), 'reppy.2.favourite'));
+        $this->assertEquals(['norris-new', 'lee'], Arr::get($entry->fresh()->data(), 'reppy.2.favourites'));
+    }
+
+    /** @test */
+    public function it_updates_nested_term_fields_within_legacy_replicator_configs()
+    {
+        $collection = tap(Facades\Collection::make('articles'))->save();
+
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                [
+                    'handle' => 'reppy',
+                    'field' => [
+                        'type' => 'replicator',
+                        'sets' => [
                             'set_one' => [
                                 'fields' => [
                                     [


### PR DESCRIPTION
Found a regression in 4.x where the newer style set groups in replicators and bards were not properly handled in our asset/term reference updater logic.

- [x] Fix for replicators
- [x] Fix for bards

Fixes #8415