### PR TITLE
Add timezone to parse timestamp format correctly

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -343,7 +343,7 @@ class Date extends Fieldtype
         try {
             return Carbon::createFromFormat($this->saveFormat(), $value)->tz($this->timezone());
         } catch (InvalidFormatException|InvalidArgumentException $e) {
-            return Carbon::parse($value);
+            return Carbon::parse($value)->tz($this->timezone());
         }
     }
 

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Fieldtypes;
 
-use Carbon\Exceptions\InvalidFormatException;
 use Illuminate\Support\Carbon;
+use DateTimeZone;
 use InvalidArgumentException;
 use Statamic\Exceptions\ValidationException;
 use Statamic\Facades\GraphQL;
@@ -341,7 +341,7 @@ class Date extends Fieldtype
     private function parseSaved($value)
     {
         try {
-            return Carbon::createFromFormat($this->saveFormat(), $value);
+            return Carbon::createFromFormat($this->saveFormat(), $value)->tz($this->timezone());
         } catch (InvalidFormatException|InvalidArgumentException $e) {
             return Carbon::parse($value);
         }
@@ -410,5 +410,10 @@ class Date extends Fieldtype
             'start' => Carbon::createFromFormat(self::DEFAULT_DATE_FORMAT, $value['start'])->startOfDay(),
             'end' => Carbon::createFromFormat(self::DEFAULT_DATE_FORMAT, $value['end'])->startOfDay(),
         ];
+    }
+
+    private function timezone()
+    {
+        return new DateTimeZone(config('app.timezone'));
     }
 }

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -2,13 +2,14 @@
 
 namespace Tests\Fieldtypes;
 
-use Illuminate\Support\Carbon;
-use Illuminate\Validation\ValidationException;
-use Statamic\Facades\Preference;
+use DateTimeZone;
+use Tests\TestCase;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fields;
 use Statamic\Fieldtypes\Date;
-use Tests\TestCase;
+use Illuminate\Support\Carbon;
+use Statamic\Facades\Preference;
+use Illuminate\Validation\ValidationException;
 
 class DateTest extends TestCase
 {
@@ -69,6 +70,33 @@ class DateTest extends TestCase
                 '2012 Jan 04 15:32:54',
             ],
         ];
+    }
+
+    /** @test */
+    public function it_augments_a_timestamp_to_the_correct_timezone()
+    {
+        // Timestamp for: Mon Aug 28 2023 05:20:00 GMT+0000
+        $timestamp = '1693200000';
+        
+        // No Timezone. Stays the same
+        $value = $this->fieldtype(['format' => 'U', 'time_enabled' => true])->preProcess($timestamp);
+        $this->assertEquals("05:20", $value['time']);
+        
+        
+        config()->set('app.timezone', 'Europe/Berlin');
+        
+        // As Europe/Berlin is +2, 07:20:00 should be returned insted of 05:20
+        $value = $this->fieldtype(['format' => 'U', 'time_enabled' => true])->preProcess($timestamp);
+        $this->assertEquals("07:20", $value['time']);
+        
+        // Test the date to make sure nothing fancy is going on.
+        $this->assertEquals("2023-08-28", $value['date']);
+
+        // If the value can't be parsed, it will use `parse` instead of `createFromFormat`. Let's test that this works as well.
+        // createFromFormat will fail if we parse a carbon object, but `parse` can work with it:
+        $timestamp = Carbon::createFromTimestamp('1693200000');
+        $value = $this->fieldtype(['format' => 'U', 'time_enabled' => true])->preProcess($timestamp);
+        $this->assertEquals("07:20", $value['time']);
     }
 
     /** @test */


### PR DESCRIPTION
We are saving dates as Unix Timestamp. This can be done by specifying `U` as Format. 

If displaying the datetime after saving it, the hours might be wrong, as the timestamp cannot be parsed correctly without the timezone information. 
This timezone issue does only appear, if the time is enabled.

**This PR add's the timezone to the `parseSaved` method.**

[x] Timestamp will be saved as GMT time
[x] Timestamp will be parsed and displayed correctly in the defined timezone
[ ] Test that a default datetime will be saved correctly
[ ] Test that a default datetime will be displayed correctly