### PR TITLE
[4.x] Add timezone to parse timestamp format correctly

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Fieldtypes;
 
-use DateTimeZone;
 use Carbon\Exceptions\InvalidFormatException;
+use DateTimeZone;
 use Illuminate\Support\Carbon;
 use InvalidArgumentException;
 use Statamic\Exceptions\ValidationException;

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fieldtypes;
 
+use DateTimeZone;
 use Carbon\Exceptions\InvalidFormatException;
 use Illuminate\Support\Carbon;
 use InvalidArgumentException;
@@ -341,9 +342,9 @@ class Date extends Fieldtype
     private function parseSaved($value)
     {
         try {
-            return Carbon::createFromFormat($this->saveFormat(), $value);
+            return Carbon::createFromFormat($this->saveFormat(), $value)->tz($this->timezone());
         } catch (InvalidFormatException|InvalidArgumentException $e) {
-            return Carbon::parse($value);
+            return Carbon::parse($value)->tz($this->timezone());
         }
     }
 
@@ -410,5 +411,10 @@ class Date extends Fieldtype
             'start' => Carbon::createFromFormat(self::DEFAULT_DATE_FORMAT, $value['start'])->startOfDay(),
             'end' => Carbon::createFromFormat(self::DEFAULT_DATE_FORMAT, $value['end'])->startOfDay(),
         ];
+    }
+
+    private function timezone()
+    {
+        return new DateTimeZone(config('app.timezone'));
     }
 }

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -82,21 +82,20 @@ class DateTest extends TestCase
         $value = $this->fieldtype(['format' => 'U', 'time_enabled' => true])->preProcess($timestamp);
         $this->assertEquals("05:20", $value['time']);
 
-
         config()->set('app.timezone', 'Europe/Berlin');
 
         // As Europe/Berlin is +2, 07:20:00 should be returned insted of 05:20
         $value = $this->fieldtype(['format' => 'U', 'time_enabled' => true])->preProcess($timestamp);
-        $this->assertEquals("07:20", $value['time']);
+        $this->assertEquals('07:20', $value['time']);
 
         // Test the date to make sure nothing fancy is going on.
-        $this->assertEquals("2023-08-28", $value['date']);
+        $this->assertEquals('2023-08-28', $value['date']);
 
         // If the value can't be parsed, it will use `parse` instead of `createFromFormat`. Let's test that this works as well.
         // createFromFormat will fail if we parse a carbon object, but `parse` can work with it:
         $timestamp = Carbon::createFromTimestamp('1693200000');
         $value = $this->fieldtype(['format' => 'U', 'time_enabled' => true])->preProcess($timestamp);
-        $this->assertEquals("07:20", $value['time']);
+        $this->assertEquals('07:20', $value['time']);
     }
 
     /** @test */

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Fieldtypes;
 
+use DateTimeZone;
 use Illuminate\Support\Carbon;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\Preference;
@@ -69,6 +70,33 @@ class DateTest extends TestCase
                 '2012 Jan 04 15:32:54',
             ],
         ];
+    }
+
+    /** @test */
+    public function it_augments_a_timestamp_to_the_correct_timezone()
+    {
+        // Timestamp for: Mon Aug 28 2023 05:20:00 GMT+0000
+        $timestamp = '1693200000';
+
+        // No Timezone. Stays the same
+        $value = $this->fieldtype(['format' => 'U', 'time_enabled' => true])->preProcess($timestamp);
+        $this->assertEquals("05:20", $value['time']);
+
+
+        config()->set('app.timezone', 'Europe/Berlin');
+
+        // As Europe/Berlin is +2, 07:20:00 should be returned insted of 05:20
+        $value = $this->fieldtype(['format' => 'U', 'time_enabled' => true])->preProcess($timestamp);
+        $this->assertEquals("07:20", $value['time']);
+
+        // Test the date to make sure nothing fancy is going on.
+        $this->assertEquals("2023-08-28", $value['date']);
+
+        // If the value can't be parsed, it will use `parse` instead of `createFromFormat`. Let's test that this works as well.
+        // createFromFormat will fail if we parse a carbon object, but `parse` can work with it:
+        $timestamp = Carbon::createFromTimestamp('1693200000');
+        $value = $this->fieldtype(['format' => 'U', 'time_enabled' => true])->preProcess($timestamp);
+        $this->assertEquals("07:20", $value['time']);
     }
 
     /** @test */

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Fieldtypes;
 
-use DateTimeZone;
 use Illuminate\Support\Carbon;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\Preference;
@@ -80,7 +79,7 @@ class DateTest extends TestCase
 
         // No Timezone. Stays the same
         $value = $this->fieldtype(['format' => 'U', 'time_enabled' => true])->preProcess($timestamp);
-        $this->assertEquals("05:20", $value['time']);
+        $this->assertEquals('05:20', $value['time']);
 
         config()->set('app.timezone', 'Europe/Berlin');
 


### PR DESCRIPTION
We are saving dates as Unix Timestamp. This can be done by specifying U as Format.

If displaying the datetime after saving it, the hours might be wrong, as the timestamp cannot be parsed correctly without the timezone information.
This timezone issue does only appear, if the time is enabled.

This PR add's the timezone to the parseSaved method.

- [x] Timestamp will be saved as GMT time
- [x] Timestamp will be parsed and displayed correctly in the defined timezone
- [x] Test that a default datetime will be saved correctly
- [x] Test that a default datetime will be displayed correctly