### PR TITLE
[4.x] Add duration field to GraphQL AssetInterface

### DIFF
--- a/src/Assets/AugmentedAsset.php
+++ b/src/Assets/AugmentedAsset.php
@@ -150,7 +150,9 @@ class AugmentedAsset extends AbstractAugmented
 
     protected function duration()
     {
-        return round($this->data->duration() ?? 0);
+        return ($duration = $this->data->duration())
+            ? round($duration)
+            : null;
     }
 
     protected function durationSeconds()

--- a/src/GraphQL/Types/AssetInterface.php
+++ b/src/GraphQL/Types/AssetInterface.php
@@ -99,6 +99,9 @@ class AssetInterface extends InterfaceType
             'ratio' => [
                 'type' => GraphQL::float(),
             ],
+            'duration' => [
+                'type' => GraphQL::float(),
+            ],
         ];
 
         foreach (GraphQL::getExtraTypeFields(static::NAME) as $field => $closure) {

--- a/tests/Feature/GraphQL/AssetTest.php
+++ b/tests/Feature/GraphQL/AssetTest.php
@@ -175,6 +175,7 @@ GQL;
         width
         orientation
         ratio
+        duration
         ... on Asset_Test {
             potato
         }
@@ -219,6 +220,7 @@ GQL;
                     'orientation' => 'portrait',
                     'ratio' => 0.5,
                     'potato' => 'baked',
+                    'duration' => null,
                 ],
             ]]);
     }


### PR DESCRIPTION
Adds duration as a float field for `AssetInterface` when using GraphQL. Duration is available when working with an augmented asset so I think it makes sense to also make it available for GraphQL queries. We're currently using the `addField` method to add this on a site where it's needed.