### PR TITLE
[4.x] Fire `EntryBlueprintFound` before creating

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\CP\Breadcrumbs;
+use Statamic\Events\EntryBlueprintFound;
 use Statamic\Exceptions\BlueprintNotFoundException;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Entry;
@@ -273,7 +274,14 @@ class EntriesController extends CpController
             $blueprint->ensureFieldHasConfig('author', ['visibility' => 'read_only']);
         }
 
-        $values = Entry::make()->collection($collection)->values()->all();
+        $entry = Entry::make()
+            ->collection($collection);
+
+        EntryBlueprintFound::dispatch($blueprint, $entry);
+
+        $values = $entry
+            ->values()
+            ->all();
 
         if ($collection->hasStructure() && $request->parent) {
             $values['parent'] = $request->parent;


### PR DESCRIPTION
This PR fires the EntryBlueprintFound on the 'create' screen of the CP, allowing you to programatically set default values for fields using an event listener.

You can see this has been asked for in a few places, e.g. https://github.com/statamic/ideas/issues/964

You can then add a listener like follows:

```php
<?php

namespace App\Listeners;

use Statamic\Events\EntryBlueprintFound;
use Statamic\Facades\Entry;

class EntryBlueprintListener
{
    public function handle(EntryBlueprintFound $event)
    {
        if ($event->entry && is_null(Entry::find($event->entry->id()))) {
            
            $event->entry->merge([
                'title' => 'This value was set in the listener',
            ]);
            
        }
    }
}
```

Which lets you modify the default values:
<img width="1178" alt="Screenshot 2023-08-29 at 13 53 14" src="https://github.com/statamic/cms/assets/51899/b3550958-d721-404a-b441-f1d1e85c4a73">

Obviously title's can have their default values in other ways, but where this becomes really useful is when you want to have default replicator or grid values.