### PR TITLE
[4.x] Set end range date to end of day

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -212,13 +212,20 @@ class Date extends Fieldtype
 
         return [
             'start' => $this->processDateTime($date['start']),
-            'end' => $this->processDateTime($date['end']),
+            'end' => $this->processDateTimeEndOfDay($date['end']),
         ];
     }
 
     private function processDateTime($value)
     {
         $date = Carbon::parse($value);
+
+        return $this->formatAndCast($date, $this->saveFormat());
+    }
+
+    private function processDateTimeEndOfDay($value)
+    {
+        $date = Carbon::parse($value)->endOfDay();
 
         return $this->formatAndCast($date, $this->saveFormat());
     }

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -182,6 +182,11 @@ class DateTest extends TestCase
                 ['date' => ['start' => '2012-08-29', 'end' => '2013-09-27'], 'time' => null],
                 ['start' => '2012--08--29', 'end' => '2013--09--27'],
             ],
+            'range with format containing time has end date at end of day' => [
+                ['mode' => 'range', 'format' => 'Y-m-d H:i:s'],
+                ['date' => ['start' => '2012-08-29', 'end' => '2013-09-27'], 'time' => null],
+                ['start' => '2012-08-29 00:00:00', 'end' => '2013-09-27 23:59:59'],
+            ],
         ];
     }
 


### PR DESCRIPTION
The Date Fieldtype is flexible and you can decide the format, in which you want to save dates.

In some edge cases, the end format won't represent the end of the day, as some formats to save seconds by default, which might lead to unexpected results.

This PR does set the datetime to the end of the day, before converting it to the end of day. 

In our cases it's important, as we work with a Unix timestamp (Format U). In that case, the start and end range are different, event if it's the same day. 

Example
```
// Format `y-m-d`
// start => 30.08.2023
// end => 30.08.2023

// Format `U` actual behaviour
// start => 1693346400 // hour: 0, minute: 0, seconds: 0
// end => 1693346400 // hour: 0, minute: 0, seconds: 0

// Format `U` with PR
// start => 1693346400 // hour: 0, minute: 0, seconds: 0
// end => 1693432799 // hour: 23 minute: 59, seconds: 59
```