### PR TITLE
[4.x] Add option to exclude entries from static cache

### DIFF
--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -33,6 +33,7 @@ class DataResponse implements Responsable
 
         $this
             ->protect()
+            ->handleStaticCaching()
             ->handleDraft()
             ->handlePrivateEntries()
             ->adjustResponseType()
@@ -85,6 +86,15 @@ class DataResponse implements Responsable
         app(Protection::class)
             ->setData($this->data)
             ->protect();
+
+        return $this;
+    }
+
+    protected function handleStaticCaching()
+    {
+        if ($this->data->static_caching == false) {
+            $this->headers['X-Statamic-No-Cache'] = true;
+        }
 
         return $this;
     }

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -92,7 +92,9 @@ class DataResponse implements Responsable
 
     protected function handleStaticCaching()
     {
-        if ($this->data->static_caching == false) {
+        $ignoreStaticCaching = preg_match_all('/"static_caching":(false|"false")/', $this->data->values()->toJson());
+
+        if ($ignoreStaticCaching) {
             $this->headers['X-Statamic-No-Cache'] = true;
         }
 

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -133,6 +133,11 @@ class Cache
             return false;
         }
 
+        // Entries with `static_caching: false` should not be cached.
+        if ($response->headers->has('X-Statamic-No-Cache')) {
+            return false;
+        }
+
         if ($response->getStatusCode() !== 200 || $response->getContent() == '') {
             return false;
         }


### PR DESCRIPTION
I found myself needing to exclude an entry from the static cache. Adding the URL to the static caching exclude array always felt unintuitive and doesn't work well in an environment where clients add/remove pages themselves. All I want is a simple toggle on an entry to determine whether a page should be cached. Or use a computed field for more advanced use cases.

This PR adds an `X-Statamic-No-Cache` header if `static_caching: false` is set on the entry. It is a super simple and powerful implementation that lets you exclude entries in a more dynamic way.