### PR TITLE
[4.x] Reticulate Splines sleep for half a second

### DIFF
--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -572,7 +572,7 @@ EOT;
         $this->console->info('Reticulating splines...');
 
         if (config('app.env') !== 'testing') {
-            usleep(100000)
+            usleep(500000)
         }
 
         return $this;

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -572,7 +572,7 @@ EOT;
         $this->console->info('Reticulating splines...');
 
         if (config('app.env') !== 'testing') {
-            sleep(2);
+            usleep(100000)
         }
 
         return $this;

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -572,7 +572,7 @@ EOT;
         $this->console->info('Reticulating splines...');
 
         if (config('app.env') !== 'testing') {
-            usleep(500000)
+            usleep(500000);
         }
 
         return $this;


### PR DESCRIPTION
When you install starter kits more than once, the reticulating splines sleep step of 2 seconds can become a bit tiring. My proposal is to change it to 500000 microseconds which is .5 seconds. 

I didn't create an issue cuz this is so tiny. Feel free to close of course (as I can imagine this seems very picky).