### PR TITLE
[4.x] Create CollectionTree and NavTree contracts and bindings

### DIFF
--- a/src/Contracts/Structures/CollectionTree.php
+++ b/src/Contracts/Structures/CollectionTree.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Statamic\Contracts\Structures;
+
+interface CollectionTree
+{
+}

--- a/src/Contracts/Structures/NavTree.php
+++ b/src/Contracts/Structures/NavTree.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Statamic\Contracts\Structures;
+
+interface NavTree
+{
+}

--- a/src/Stache/Repositories/CollectionTreeRepository.php
+++ b/src/Stache/Repositories/CollectionTreeRepository.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Stache\Repositories;
 
+use Statamic\Contracts\Structures\CollectionTree as TreeContract;
 use Statamic\Stache\Stache;
+use Statamic\Structures\CollectionTree;
 
 class CollectionTreeRepository extends NavTreeRepository
 {
@@ -10,5 +12,12 @@ class CollectionTreeRepository extends NavTreeRepository
     {
         $this->stache = $stache;
         $this->store = $stache->store('collection-trees');
+    }
+
+    public static function bindings()
+    {
+        return [
+            TreeContract::class => CollectionTree::class,
+        ];
     }
 }

--- a/src/Stache/Repositories/NavTreeRepository.php
+++ b/src/Stache/Repositories/NavTreeRepository.php
@@ -2,9 +2,11 @@
 
 namespace Statamic\Stache\Repositories;
 
+use Statamic\Contracts\Structures\NavTree as TreeContract;
 use Statamic\Contracts\Structures\NavTreeRepository as Contract;
 use Statamic\Contracts\Structures\Tree;
 use Statamic\Stache\Stache;
+use Statamic\Structures\NavTree;
 
 class NavTreeRepository implements Contract
 {
@@ -38,6 +40,8 @@ class NavTreeRepository implements Contract
 
     public static function bindings()
     {
-        return [];
+        return [
+            TreeContract::class => NavTree::class,
+        ];
     }
 }

--- a/src/Structures/CollectionStructure.php
+++ b/src/Structures/CollectionStructure.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Structures;
 
+use Statamic\Contracts\Structures\CollectionTree;
 use Statamic\Contracts\Structures\CollectionTreeRepository;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
@@ -58,7 +59,7 @@ class CollectionStructure extends Structure
 
     public function newTreeInstance()
     {
-        return new CollectionTree;
+        return app(CollectionTree::class);
     }
 
     public function validateTree(array $tree, string $locale): array

--- a/src/Structures/CollectionTree.php
+++ b/src/Structures/CollectionTree.php
@@ -3,6 +3,7 @@
 namespace Statamic\Structures;
 
 use Facades\Statamic\Structures\CollectionTreeDiff;
+use Statamic\Contracts\Structures\CollectionTree as TreeContract;
 use Statamic\Contracts\Structures\CollectionTreeRepository;
 use Statamic\Events\CollectionTreeDeleted;
 use Statamic\Events\CollectionTreeSaved;
@@ -11,7 +12,7 @@ use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
 
-class CollectionTree extends Tree
+class CollectionTree extends Tree implements TreeContract
 {
     public function structure()
     {

--- a/src/Structures/Nav.php
+++ b/src/Structures/Nav.php
@@ -3,6 +3,7 @@
 namespace Statamic\Structures;
 
 use Statamic\Contracts\Structures\Nav as Contract;
+use Statamic\Contracts\Structures\NavTree;
 use Statamic\Contracts\Structures\NavTreeRepository;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Events\NavBlueprintFound;
@@ -88,7 +89,7 @@ class Nav extends Structure implements Contract
 
     public function newTreeInstance()
     {
-        return new NavTree;
+        return app(NavTree::class);
     }
 
     public function in($site)

--- a/src/Structures/NavTree.php
+++ b/src/Structures/NavTree.php
@@ -3,6 +3,7 @@
 namespace Statamic\Structures;
 
 use Facades\Statamic\Structures\BranchIds;
+use Statamic\Contracts\Structures\NavTree as TreeContract;
 use Statamic\Contracts\Structures\NavTreeRepository;
 use Statamic\Events\NavTreeDeleted;
 use Statamic\Events\NavTreeSaved;
@@ -11,7 +12,7 @@ use Statamic\Facades\Nav;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
 
-class NavTree extends Tree
+class NavTree extends Tree implements TreeContract
 {
     public function structure()
     {


### PR DESCRIPTION
As reported over in https://github.com/statamic/eloquent-driver/issues/198 if you have a split config of file based collections and eloquent collection trees then creating a new collection (tree) throws an error. I've worked around this [here](https://github.com/statamic/eloquent-driver/pull/199) but it's not the ideal solution.

Instead we should have a contract for `CollectionTree` and bind it to the repository in the same pattern used elsewhere. Would you consider this a breaking change? Im not sure.

While we're at it, we should do the same for `NavTree` as the same issue will exist there.