### PR TITLE
[4.x] Use Laravel url helper instead to get the site url

### DIFF
--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -238,10 +238,6 @@ class URL
      */
     public function getSiteUrl()
     {
-        if (app()->runningInConsole()) {
-            return config('app.url');
-        }
-
         $rootUrl = url()->to('/');
 
         return Str::ensureRight($rootUrl, '/');

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -242,7 +242,7 @@ class URL
             return config('app.url');
         }
 
-        $rootUrl = app('request')->root();
+        $rootUrl = url()->to('/');
 
         return Str::ensureRight($rootUrl, '/');
     }

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -118,6 +118,55 @@ class UrlTest extends TestCase
         ];
     }
 
+    /** @test */
+    public function gets_site_url()
+    {
+        $this->assertEquals('http://absolute-url-resolved-from-request.com/', URL::getSiteUrl());
+
+        \Illuminate\Support\Facades\URL::forceScheme('https');
+        $this->assertEquals('https://absolute-url-resolved-from-request.com/', URL::getSiteUrl());
+
+        \Illuminate\Support\Facades\URL::forceScheme('http');
+        $this->assertEquals('http://absolute-url-resolved-from-request.com/', URL::getSiteUrl());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider absoluteProvider
+     **/
+    public function it_makes_urls_absolute($url, $expected, $forceScheme = false)
+    {
+        if ($forceScheme) {
+            \Illuminate\Support\Facades\URL::forceScheme($forceScheme);
+        }
+
+        $this->assertSame($expected, URL::makeAbsolute($url));
+    }
+
+    public function absoluteProvider()
+    {
+        return [
+            ['http://example.com', 'http://example.com'],
+            ['http://example.com/', 'http://example.com/'],
+            ['/', 'http://absolute-url-resolved-from-request.com/'],
+            ['/foo', 'http://absolute-url-resolved-from-request.com/foo'],
+            ['/foo/', 'http://absolute-url-resolved-from-request.com/foo/'],
+
+            ['http://example.com', 'http://example.com', 'https'], // absolute url provided, so scheme is left alone.
+            ['http://example.com/', 'http://example.com/', 'https'], // absolute url provided, so scheme is left alone.
+            ['/', 'https://absolute-url-resolved-from-request.com/', 'https'],
+            ['/foo', 'https://absolute-url-resolved-from-request.com/foo', 'https'],
+            ['/foo/', 'https://absolute-url-resolved-from-request.com/foo/', 'https'],
+
+            ['https://example.com', 'https://example.com', 'http'], // absolute url provided, so scheme is left alone.
+            ['https://example.com/', 'https://example.com/', 'http'], // absolute url provided, so scheme is left alone.
+            ['/', 'http://absolute-url-resolved-from-request.com/', 'http'],
+            ['/foo', 'http://absolute-url-resolved-from-request.com/foo', 'http'],
+            ['/foo/', 'http://absolute-url-resolved-from-request.com/foo/', 'http'],
+        ];
+    }
+
     /**
      * @test
      *


### PR DESCRIPTION
Closes https://github.com/statamic/cms/issues/8180

In some cases, if for example working with a proxy or common if using Docker, you might need to force a scheme via:
`\Illuminate\Support\Facades\URL::forceScheme('https');`

In that case, it might happen that the live preview can't be shown, as the page has been loaded via `https`, but the live preview will be requested via `http`. This is a common cors problem.

The issue starts it's journey right here:
https://github.com/statamic/cms/blob/9f324a57aba71fad79049012da138684da29210a/src/Http/Controllers/CP/PreviewController.php#L44

The Statamic URL Facade uses the request to determine the root url:
https://github.com/statamic/cms/blob/9f324a57aba71fad79049012da138684da29210a/src/Facades/Endpoint/URL.php#L245

If calling `root` directly on the request, the forced scheme will be ignored.

**Solution**
Using the Laravel `url()` helper as done in this PR. 

Under the hood, the url helper does respect the forceScheme setting
https://github.com/laravel/framework/blob/4989e6de076688ade265e2f1970ab6f0c1b60fcb/src/Illuminate/Routing/UrlGenerator.php#L226

but is doing nothing more than then using `request->root()` to get the url.
https://github.com/laravel/framework/blob/4989e6de076688ade265e2f1970ab6f0c1b60fcb/src/Illuminate/Routing/UrlGenerator.php#L593

As the behaviour is nearly the same, I think there shouldn't be any breaking changes.