### PR TITLE
[4.x] Add config setting so CSV submission export can use field `display` instead of `handle`

### DIFF
--- a/config/forms.php
+++ b/config/forms.php
@@ -57,4 +57,16 @@ return [
 
     'csv_delimiter' => ',',
 
+    /*
+    |--------------------------------------------------------------------------
+    | CSV Export Headings
+    |--------------------------------------------------------------------------
+    |
+    | If true Statamic will use the field handles for headings
+    | if false Statamic will use the field display for headings
+    |
+    */
+
+    'csv_use_handles_for_headings' => true,
+
 ];

--- a/config/forms.php
+++ b/config/forms.php
@@ -62,11 +62,13 @@ return [
     | CSV Export Headings
     |--------------------------------------------------------------------------
     |
-    | If true Statamic will use the field handles for headings
-    | if false Statamic will use the field display for headings
+    | The values to be used in the csv export header rows.
+    | Can be the field handle or the field display text.
+    |
+    | Supported values: "handle", "display"
     |
     */
 
-    'csv_use_handles_for_headings' => true,
+    'csv_headers' => 'handle',
 
 ];

--- a/src/Forms/Exporters/CsvExporter.php
+++ b/src/Forms/Exporters/CsvExporter.php
@@ -40,9 +40,11 @@ class CsvExporter extends AbstractExporter
      */
     private function insertHeaders()
     {
-        $headers = $this->form()->fields()->keys()->all();
-
-        $headers[] = 'date';
+        if (config('statamic.forms.csv_use_handles_for_headings', true)) {
+            $headers = array_merge($this->form()->fields()->keys()->all(), ['date']);
+        } else {
+            $headers = array_merge($this->form()->fields()->map->display()->values()->all(), [__('Date')]);
+        }
 
         $this->writer->insertOne($headers);
     }

--- a/src/Forms/Exporters/CsvExporter.php
+++ b/src/Forms/Exporters/CsvExporter.php
@@ -40,11 +40,12 @@ class CsvExporter extends AbstractExporter
      */
     private function insertHeaders()
     {
-        if (config('statamic.forms.csv_use_handles_for_headings', true)) {
-            $headers = array_merge($this->form()->fields()->keys()->all(), ['date']);
-        } else {
-            $headers = array_merge($this->form()->fields()->map->display()->values()->all(), [__('Date')]);
-        }
+        $key = config('statamic.forms.csv_headers', 'handle');
+
+        $headers = $this->form()->fields()
+            ->map(fn ($field) => $key === 'display' ? $field->display() : $field->handle())
+            ->push($key === 'display' ? __('Date') : 'date')
+            ->values()->all();
 
         $this->writer->insertOne($headers);
     }


### PR DESCRIPTION
This PR adds a config setting `statamic.forms.csv_use_handles_for_headings` which when false uses the fields `display` value instead of the `handle` when exporting CSV submissions.