### PR TITLE
[4.x] Fix list item focus infinite loop

### DIFF
--- a/resources/js/components/fieldtypes/ListFieldtype.vue
+++ b/resources/js/components/fieldtypes/ListFieldtype.vue
@@ -21,7 +21,7 @@
                                 v-model="element.value"
                                 :readonly="isReadOnly"
                                 @blur="focused = false"
-                                @focus="editItem(index)"
+                                @focus="editItem(index, true)"
                                 @keydown.enter.prevent="nextItem"
                                 @keyup.up="previousItem"
                                 @keyup.down="nextItem"
@@ -116,9 +116,11 @@ export default {
             this.data.splice(index, 1);
         },
 
-        editItem(index) {
+        editItem(index, alreadyFocused) {
             this.editing = index;
-            this.$refs.listItem[index].focus();
+            if (! alreadyFocused) {
+                this.$refs.listItem[index].focus();
+            }
         },
 
         newItemInputPaste(event) {

--- a/resources/js/components/fieldtypes/ListFieldtype.vue
+++ b/resources/js/components/fieldtypes/ListFieldtype.vue
@@ -21,7 +21,7 @@
                                 v-model="element.value"
                                 :readonly="isReadOnly"
                                 @blur="focused = false"
-                                @focus="editItem(index, true)"
+                                @focus="editItemWithoutFocusing(index)"
                                 @keydown.enter.prevent="nextItem"
                                 @keyup.up="previousItem"
                                 @keyup.down="nextItem"
@@ -116,11 +116,13 @@ export default {
             this.data.splice(index, 1);
         },
 
-        editItem(index, alreadyFocused) {
+        editItem(index) {
+            this.editItemWithoutFocusing(index);
+            this.$refs.listItem[index].focus();
+        },
+
+        editItemWithoutFocusing(index) {
             this.editing = index;
-            if (! alreadyFocused) {
-                this.$refs.listItem[index].focus();
-            }
         },
 
         newItemInputPaste(event) {


### PR DESCRIPTION
Focusing a list field type was causing an infinite loop and maximum call stack js error, highlighted by #8672.
The fix is to not focus inside editItem when called by a focus state.

I opted for this approach after I tried checking the element focus state using document.activeElement but I couldn't get it to work consistently.

Fixes: https://github.com/statamic/cms/issues/8672