### PR TITLE
[4.x] Fix Bard inside Bard addEventListener error

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -345,11 +345,11 @@ export default {
 
         this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
 
-        // this.$nextTick(() => {
+        this.$nextTick(() => {
             document.querySelector(`label[for="${this.fieldId}"]`).addEventListener('click', () => {
                 this.editor.commands.focus();
             });
-        // });
+        });
     },
 
     beforeDestroy() {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -345,9 +345,11 @@ export default {
 
         this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
 
-        document.querySelector(`label[for="${this.fieldId}"]`).addEventListener('click', () => {
-            this.editor.commands.focus();
-        });
+        // this.$nextTick(() => {
+            document.querySelector(`label[for="${this.fieldId}"]`).addEventListener('click', () => {
+                this.editor.commands.focus();
+            });
+        // });
     },
 
     beforeDestroy() {


### PR DESCRIPTION
I noticed that when you have a Bard field inside a Bard field you get this error in the console on page load:

![Screenshot 2023-09-07 at 18 04 36](https://github.com/statamic/cms/assets/126740/ec931247-30b6-4f4f-abe2-3e408efe677a)

This is caused by the `document.querySelector()` call in the mounted method. It looks as though that can somehow fire before the label has actually been added to the DOM, resulting in the query returning null. This doesn't seem to happen for top-level Bards.

This PR fixes it by delaying that call until the next tick.