### PR TITLE
[4.x] Undo pint changes

### DIFF
--- a/src/Assets/AssetReferenceUpdater.php
+++ b/src/Assets/AssetReferenceUpdater.php
@@ -53,7 +53,7 @@ class AssetReferenceUpdater extends DataReferenceUpdater
         $fields
             ->filter(function ($field) {
                 return $field->type() === 'assets'
-                    && $this->container === $this->getConfiguredAssetsFieldContainer($field);
+                    && $this->getConfiguredAssetsFieldContainer($field) === $this->container;
             })
             ->each(function ($field) use ($dottedPrefix) {
                 $field->get('max_files') === 1
@@ -76,7 +76,7 @@ class AssetReferenceUpdater extends DataReferenceUpdater
         $fields
             ->filter(function ($field) {
                 return $field->type() === 'link'
-                    && $this->container === $field->get('container');
+                    && $field->get('container') === $this->container;
             })
             ->each(function ($field) use ($dottedPrefix) {
                 $this->updateStatamicUrlsInLinkValue($field, $dottedPrefix);
@@ -97,7 +97,7 @@ class AssetReferenceUpdater extends DataReferenceUpdater
         $fields
             ->filter(function ($field) {
                 return $field->type() === 'bard'
-                    && $this->container === $field->get('container');
+                    && $field->get('container') === $this->container;
             })
             ->each(function ($field) use ($dottedPrefix) {
                 $field->get('save_html') === true
@@ -120,7 +120,7 @@ class AssetReferenceUpdater extends DataReferenceUpdater
         $fields
             ->filter(function ($field) {
                 return $field->type() === 'markdown'
-                    && $this->container === $field->get('container');
+                    && $field->get('container') === $this->container;
             })
             ->each(function ($field) use ($dottedPrefix) {
                 $this->updateStatamicUrlsInStringValue($field, $dottedPrefix);

--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -95,7 +95,7 @@ class AssetRepository implements Contract
     public function findByPath(string $path)
     {
         return $this->all()->filter(function ($asset) use ($path) {
-            return $path === $asset->resolvedPath();
+            return $asset->resolvedPath() === $path;
         })->first();
     }
 
@@ -122,7 +122,7 @@ class AssetRepository implements Contract
 
         $cache->add($asset->path());
 
-        if (($originalPath = $asset->getOriginal('path')) !== $asset->path()) {
+        if ($asset->path() !== ($originalPath = $asset->getOriginal('path'))) {
             $originalId = $asset->container()->handle().'::'.$originalPath;
             $store->delete($store->getItem($originalId));
             $cache->forget($originalPath);

--- a/src/Auth/UserProvider.php
+++ b/src/Auth/UserProvider.php
@@ -33,7 +33,7 @@ class UserProvider implements UserProviderContract
             return null;
         }
 
-        return ($token === $user->getRememberToken()) ? $user : null;
+        return ($user->getRememberToken() === $token) ? $user : null;
     }
 
     /**

--- a/src/CP/Navigation/Nav.php
+++ b/src/CP/Navigation/Nav.php
@@ -53,8 +53,8 @@ class Nav
     public function findOrCreate($section, $name)
     {
         $item = collect($this->items)->first(function ($item) use ($section, $name) {
-            return $section === $item->section()
-                && $name === $item->display()
+            return $item->section() === $section
+                && $item->display() === $name
                 && ! $item->isChild();
         });
 
@@ -73,8 +73,8 @@ class Nav
         $this->items = collect($this->items)
             ->reject(function ($item) use ($section, $name) {
                 return $name
-                    ? $section === $item->section() && $name === $item->display()
-                    : $section === $item->section();
+                    ? $item->section() === $section && $item->display() === $name
+                    : $item->section() === $section;
             })
             ->all();
 

--- a/src/CP/Navigation/NavBuilder.php
+++ b/src/CP/Navigation/NavBuilder.php
@@ -407,7 +407,7 @@ class NavBuilder
         $displayNew = $this->sectionsManipulations[$sectionKey]['display'];
 
         collect($this->items)
-            ->filter(fn ($item) => $displayOriginal === $item->section())
+            ->filter(fn ($item) => $item->section() === $displayOriginal)
             ->each(fn ($item) => $item->preserveCurrentId()->section($displayNew));
 
         $this->sections[$sectionKey] = $displayNew;
@@ -457,7 +457,7 @@ class NavBuilder
 
         // Get unconfigured item IDs...
         $unconfiguredItemIds = collect($this->items)
-            ->filter(fn ($item) => $section === $item->section())
+            ->filter(fn ($item) => $item->section() === $section)
             ->map
             ->id();
 

--- a/src/CP/Utilities/UtilityRepository.php
+++ b/src/CP/Utilities/UtilityRepository.php
@@ -65,7 +65,7 @@ class UtilityRepository
 
     public function findBySlug($slug)
     {
-        return $this->utilities->first(fn ($utility) => $slug === $utility->slug());
+        return $this->utilities->first(fn ($utility) => $utility->slug() === $slug);
     }
 
     public function routes()

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -265,7 +265,7 @@ class StaticWarm extends Command
 
         $routes = collect(app('router')->getRoutes()->getRoutes())
             ->filter(function (Route $route) use ($action) {
-                return $action === $route->getActionName() && ! Str::contains($route->uri(), '{');
+                return $route->getActionName() === $action && ! Str::contains($route->uri(), '{');
             })
             ->map(function (Route $route) {
                 return URL::tidy(Str::start($route->uri(), config('app.url').'/'));

--- a/src/Exceptions/Concerns/RendersControlPanelExceptions.php
+++ b/src/Exceptions/Concerns/RendersControlPanelExceptions.php
@@ -31,7 +31,7 @@ trait RendersControlPanelExceptions
 
         // If we're already there, there'd be a redirect loop, so we'll
         // send them to a page that tells them they're unauthorized.
-        if ($target === request()->getUri()) {
+        if (request()->getUri() === $target) {
             return cp_route('unauthorized');
         }
 

--- a/src/Facades/Endpoint/Pattern.php
+++ b/src/Facades/Endpoint/Pattern.php
@@ -79,7 +79,7 @@ class Pattern
      */
     public function startsWith($haystack, $needle)
     {
-        return $needle === substr($haystack, 0, strlen($needle));
+        return substr($haystack, 0, strlen($needle)) === $needle;
     }
 
     /**

--- a/src/Fieldtypes/Assets/DimensionsRule.php
+++ b/src/Fieldtypes/Assets/DimensionsRule.php
@@ -121,6 +121,6 @@ class DimensionsRule implements Rule
 
         $precision = 1 / (max($width, $height) + 1);
 
-        return $precision < abs($numerator / $denominator - $width / $height);
+        return abs($numerator / $denominator - $width / $height) > $precision;
     }
 }

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -300,7 +300,7 @@ class Form implements Arrayable, Augmentable, FormContract
     public function submission($id)
     {
         return $this->submissions()->filter(function ($submission) use ($id) {
-            return $id === $submission->id();
+            return $submission->id() === $id;
         })->first();
     }
 

--- a/src/Http/Controllers/CP/Assets/ThumbnailController.php
+++ b/src/Http/Controllers/CP/Assets/ThumbnailController.php
@@ -177,7 +177,7 @@ class ThumbnailController extends Controller
         $maxWidth = Config::get('statamic.assets.thumbnails.max_width');
         $maxHeight = Config::get('statamic.assets.thumbnails.max_height');
 
-        if ($maxWidth > $this->asset->width() && $maxHeight > $this->asset->height()) {
+        if ($this->asset->width() < $maxWidth && $this->asset->height() < $maxHeight) {
             return;
         }
 

--- a/src/Http/Controllers/CP/Collections/CollectionTreeController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionTreeController.php
@@ -76,7 +76,7 @@ class CollectionTreeController extends CpController
                 : $page->parent()->pages()->all();
 
             $siblings = $siblings->reject(function ($sibling) use ($id) {
-                return $id === $sibling->reference();
+                return $sibling->reference() === $id;
             });
 
             $uris = $siblings->map->uri();

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -483,7 +483,7 @@ class EntriesController extends CpController
 
     private function validateParent($entry, $tree, $parent)
     {
-        if ($parent == $entry->id()) {
+        if ($entry->id() == $parent) {
             throw ValidationException::withMessages(['parent' => __('statamic::validation.parent_cannot_be_itself')]);
         }
 
@@ -497,7 +497,7 @@ class EntriesController extends CpController
         // There will always be a next page since we couldn't have got this far with a single page.
         $nextTopLevelPage = $tree->pages()->all()->skip(1)->first();
 
-        if ($parent === $nextTopLevelPage->id() || $nextTopLevelPage->pages()->all()->count() > 0) {
+        if ($nextTopLevelPage->id() === $parent || $nextTopLevelPage->pages()->all()->count() > 0) {
             throw ValidationException::withMessages(['parent' => __('statamic::validation.parent_causes_root_children')]);
         }
     }

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -280,7 +280,7 @@ class TermsController extends CpController
 
         // If the term is *not* being created in the default site, we'll copy all the
         // appropriate values into the default localization since it needs to exist.
-        if ($defaultSite !== $site->handle()) {
+        if ($site->handle() !== $defaultSite) {
             $term
                 ->in($defaultSite)
                 ->published($published)

--- a/src/Http/Middleware/DeleteTemporaryFileUploads.php
+++ b/src/Http/Middleware/DeleteTemporaryFileUploads.php
@@ -11,7 +11,7 @@ class DeleteTemporaryFileUploads
     {
         $lottery = [2, 100];
 
-        if ($lottery[0] >= random_int(1, $lottery[1])) {
+        if (random_int(1, $lottery[1]) <= $lottery[0]) {
             $this->deleteFilesOverAnHourOld();
         }
 

--- a/src/Http/Middleware/HandleToken.php
+++ b/src/Http/Middleware/HandleToken.php
@@ -22,7 +22,7 @@ class HandleToken
     {
         $lottery = [2, 100];
 
-        if ($lottery[0] >= random_int(1, $lottery[1])) {
+        if (random_int(1, $lottery[1]) <= $lottery[0]) {
             Token::collectGarbage();
         }
     }

--- a/src/Marketplace/Marketplace.php
+++ b/src/Marketplace/Marketplace.php
@@ -44,7 +44,7 @@ class Marketplace
         }
 
         $addon = Addon::all()->first(function ($addon) use ($slug) {
-            return $slug === $addon->slug();
+            return $addon->slug() === $slug;
         });
 
         if ($addon) {

--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -660,7 +660,7 @@ class Comb
                     $output_length++;
                 }
 
-                if (is_null($this->limit) || ($this->limit && $this->limit > count($categorized_output[$item['category']]))) {
+                if (is_null($this->limit) || ($this->limit && count($categorized_output[$item['category']]) < $this->limit)) {
                     array_push($categorized_output[$item['category']], $item);
                 }
             }
@@ -671,7 +671,7 @@ class Comb
             // or trim outputs to limit if it was set
 
             // if we do not want more results than the limit
-            if ($this->enable_too_many_results && $this->limit < count($output)) {
+            if ($this->enable_too_many_results && count($output) > $this->limit) {
                 throw new TooManyResults('Too many results found.');
             }
 
@@ -885,7 +885,7 @@ class Comb
                     array_push($parts['disallowed'], substr($word, 1));
                 } elseif (strpos($word, '+') === 0 && strlen($word) >= $this->min_word_characters + 1) {
                     array_push($parts['required'], substr($word, 1));
-                } elseif ($this->min_word_characters <= strlen($word)) {
+                } elseif (strlen($word) >= $this->min_word_characters) {
                     array_push($parts['chunks'], $word);
                 }
             }
@@ -1063,7 +1063,7 @@ class Comb
             $before = $surplus.$before;
             $surplus = '';
             $half = floor(($length - Str::length($chunk)) / 2);
-            if ($half > Str::length($after)) {
+            if (Str::length($after) < $half) {
                 $snippet = $chunk.$after;
                 $snippet = Str::safeTruncateReverse($before, $length - Str::length($snippet)).$snippet;
             } else {

--- a/src/Stache/Repositories/EntryRepository.php
+++ b/src/Stache/Repositories/EntryRepository.php
@@ -60,7 +60,7 @@ class EntryRepository implements RepositoryContract
             return null;
         }
 
-        if ($uri !== $entry->uri()) {
+        if ($entry->uri() !== $uri) {
             return null;
         }
 

--- a/src/Stache/Repositories/GlobalVariablesRepository.php
+++ b/src/Stache/Repositories/GlobalVariablesRepository.php
@@ -35,7 +35,7 @@ class GlobalVariablesRepository implements RepositoryContract
     {
         return $this
             ->all()
-            ->filter(fn ($variable) => $handle == Str::before($variable->id(), '::'))
+            ->filter(fn ($variable) => Str::before($variable->id(), '::') == $handle)
             ->values();
     }
 

--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -30,7 +30,7 @@ class CollectionEntriesStore extends ChildStore
         $dir = str_finish($this->directory(), '/');
         $relative = Path::tidy($file->getPathname());
 
-        if ($dir == substr($relative, 0, strlen($dir))) {
+        if (substr($relative, 0, strlen($dir)) == $dir) {
             $relative = substr($relative, strlen($dir));
         }
 

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -31,7 +31,7 @@ class TaxonomyTermsStore extends ChildStore
         $dir = str_finish($this->directory(), '/');
         $relative = $file->getPathname();
 
-        if ($dir == substr($relative, 0, strlen($dir))) {
+        if (substr($relative, 0, strlen($dir)) == $dir) {
             $relative = substr($relative, strlen($dir));
         }
 

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -297,11 +297,11 @@ abstract class Tree implements Contract, Localization
     {
         $parent = optional($this->find($entry)->parent());
 
-        if ($target === $parent->id() || $parent->isRoot() && is_null($target)) {
+        if ($parent->id() === $target || $parent->isRoot() && is_null($target)) {
             return $this;
         }
 
-        if ($this->structure()->expectsRoot() && $target === Arr::get($this->tree, '0.'.$this->idKey())) {
+        if ($this->structure()->expectsRoot() && Arr::get($this->tree, '0.'.$this->idKey()) === $target) {
             throw new \Exception('Root page cannot have children');
         }
 

--- a/src/Tags/Concerns/GetsQuerySelectKeys.php
+++ b/src/Tags/Concerns/GetsQuerySelectKeys.php
@@ -12,7 +12,7 @@ trait GetsQuerySelectKeys
             return null;
         }
 
-        if (($shallow = array_search('@shallow', $selected)) !== false) {
+        if (false !== ($shallow = array_search('@shallow', $selected))) {
             unset($selected[$shallow]);
             $selected = array_merge($selected, $item->shallowAugmentedArrayKeys());
         }

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -140,7 +140,7 @@ class LocalizedTerm implements Arrayable, ArrayAccess, Augmentable, ContainsQuer
 
     protected function isDefaultLocale()
     {
-        return $this->locale === $this->defaultLocale();
+        return $this->defaultLocale() === $this->locale;
     }
 
     public function hasOrigin()

--- a/src/Translator/Commands/Stats.php
+++ b/src/Translator/Commands/Stats.php
@@ -81,7 +81,7 @@ class Stats extends Command
 
         if ($minWords = $input->getOption('min-words')) {
             $rows = $rows->filter(function ($item) use ($minWords) {
-                return ($minWords - 1) <= substr_count($item['string'], ' ');
+                return substr_count($item['string'], ' ') >= ($minWords - 1);
             });
         }
 

--- a/src/UpdateScripts/Manager.php
+++ b/src/UpdateScripts/Manager.php
@@ -46,7 +46,7 @@ class Manager
         $oldLockFile = Lock::file(UpdateScript::BACKUP_PATH)->overridePackageVersion($package, $oldVersion);
 
         $scripts = $this->getRegisteredScripts($console)->filter(function ($script) use ($package) {
-            return $package === $script->package();
+            return $script->package() === $package;
         });
 
         $scripts = $this->runUpdatableScripts($scripts, $oldLockFile, $newLockFile);

--- a/src/Validation/DateFieldtype.php
+++ b/src/Validation/DateFieldtype.php
@@ -124,7 +124,7 @@ class DateFieldtype
 
         $date = DateTime::createFromFormat('!'.$format, $value);
 
-        return $date && $value == $date->format($format);
+        return $date && $date->format($format) == $value;
     }
 
     private function timeEnabled()

--- a/src/Validation/TimeFieldtype.php
+++ b/src/Validation/TimeFieldtype.php
@@ -31,6 +31,6 @@ class TimeFieldtype implements InvokableRule
 
         $date = DateTime::createFromFormat('!'.$format, $value);
 
-        return $date && $value == $date->format($format);
+        return $date && $date->format($format) == $value;
     }
 }

--- a/src/View/Antlers/Language/Analyzers/RecursiveParentAnalyzer.php
+++ b/src/View/Antlers/Language/Analyzers/RecursiveParentAnalyzer.php
@@ -46,7 +46,7 @@ class RecursiveParentAnalyzer
 
                     if ($subNode instanceof AntlersNode && $subNode->isClosedBy != null) {
                         if ($node->isNestedRecursive) {
-                            if ($node->name->name == trim($subNode->content)) {
+                            if (trim($subNode->content) == $node->name->name) {
                                 $lastNode = $subNode;
                                 break;
                             }

--- a/src/View/Antlers/Language/Analyzers/TagPairAnalyzer.php
+++ b/src/View/Antlers/Language/Analyzers/TagPairAnalyzer.php
@@ -218,7 +218,7 @@ class TagPairAnalyzer
                             // Here we will check some details on the candidate node to
                             // determine what the "priority" of this node is.
                             if ($refOpen != $refClose) {
-                                if ($refRuntimeNodeCount <= count($candidateNode->runtimeNodes)) {
+                                if (count($candidateNode->runtimeNodes) >= $refRuntimeNodeCount) {
                                     continue;
                                 }
                             }

--- a/src/View/Antlers/Language/Nodes/Paths/VariableReference.php
+++ b/src/View/Antlers/Language/Nodes/Paths/VariableReference.php
@@ -62,7 +62,7 @@ class VariableReference
         foreach ($this->pathParts as $part) {
             if ($part instanceof PathNode) {
                 // Handle the case of variable.5
-                if ($part->name == intval($part->name)) {
+                if (intval($part->name) == $part->name) {
                     return true;
                 }
             } elseif ($part instanceof VariableReference) {

--- a/src/View/Antlers/Language/Parser/AntlersNodeParser.php
+++ b/src/View/Antlers/Language/Parser/AntlersNodeParser.php
@@ -450,7 +450,7 @@ class AntlersNodeParser
                     }
                 }
 
-                if ($charCount <= $i + 1) {
+                if ($i + 1 >= $charCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_UNEXPECTED_END_OF_INPUT,
                         $node,
@@ -460,7 +460,7 @@ class AntlersNodeParser
 
                 $peek = null;
 
-                if ($charCount > $i + 1) {
+                if ($i + 1 < $charCount) {
                     $peek = $chars[$i + 1];
                 }
 
@@ -499,7 +499,7 @@ class AntlersNodeParser
             if ($hasFoundName && $current == DocumentParser::String_EscapeCharacter) {
                 $peek = null;
 
-                if ($charCount > $i + 1) {
+                if ($i + 1 < $charCount) {
                     $peek = $chars[$i + 1];
                 }
 
@@ -567,7 +567,7 @@ class AntlersNodeParser
                 $parameterNode->value = $content;
                 $parameterNode->startPosition = $node->relativePositionFromOffset($startAt, $nameStart);
 
-                if ($charCount < $i + 1) {
+                if ($i + 1 > $charCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_UNEXPECTED_EOI_WHILE_PARSING_NODE_PARAMETER,
                         $node,

--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -230,7 +230,7 @@ class DocumentParser
 
                 $peek = null;
 
-                if ($this->inputLen > $this->currentIndex + 2) {
+                if ($this->currentIndex + 2 < $this->inputLen) {
                     $peek = $this->peek($this->currentIndex + 2);
                 }
 
@@ -272,7 +272,7 @@ class DocumentParser
             }
 
             if ($this->cur == self::AtChar && $this->next != null && $this->next == self::LeftBrace) {
-                if ($this->inputLen <= $this->currentIndex + 2) {
+                if ($this->currentIndex + 2 >= $this->inputLen) {
                     $this->currentContent[] = $this->next;
                     $this->dumpLiteralNode($this->currentIndex + 1);
                     break;
@@ -447,7 +447,7 @@ class DocumentParser
                 }
 
                 if ($this->lastAntlersNode != null && $this->lastAntlersNode instanceof PhpExecutionNode == false && $this->lastAntlersNode->isComment) {
-                    if ($indexCount > $i + 1) {
+                    if ($i + 1 < $indexCount) {
                         $nextAntlersStart = $this->antlersStartIndex[$i + 1];
 
                         if ($nextAntlersStart < $this->lastAntlersNode->endPosition->offset) {
@@ -523,11 +523,11 @@ class DocumentParser
 
                     // Skip processing potential nodes that are inside the last node.
                     if ($startCandidate->isBefore($this->lastAntlersNode->endPosition)) {
-                        if ($indexCount > $i + 1) {
+                        if ($i + 1 < $indexCount) {
                             $nextAntlersStart = $this->antlersStartIndex[$i + 1];
 
                             if ($nextAntlersStart < $this->lastAntlersNode->endPosition->offset) {
-                                if ($indexCount > $i + 2) {
+                                if ($i + 2 < $indexCount) {
                                     $nextAntlersStart = $this->antlersStartIndex[$i + 2];
                                 } else {
                                     $literalStart = $this->lastAntlersNode->endPosition->offset + 1;
@@ -547,14 +547,14 @@ class DocumentParser
                                 }
                             }
                         } else {
-                            if ($lastIndex != $i + 1) {
+                            if ($i + 1 != $lastIndex) {
                                 continue;
                             }
                         }
                     }
                 }
 
-                if ($indexCount > $i + 1) {
+                if ($i + 1 < $indexCount) {
                     $nextAntlersStart = $this->antlersStartIndex[$i + 1];
                     $literalStartIndex = $this->lastAntlersEndIndex + 1;
 
@@ -592,7 +592,7 @@ class DocumentParser
                         }
                     }
 
-                    if ($lastIndex == $i + 1 && ($nextAntlersStart <= $this->lastAntlersEndIndex)) {
+                    if ($i + 1 == $lastIndex && ($nextAntlersStart <= $this->lastAntlersEndIndex)) {
                         // In this scenario, we will create the last trailing literal node and break.
                         $thisOffset = $this->currentChunkOffset;
                         $content = StringUtilities::substr($this->content, $literalStartIndex);
@@ -1088,7 +1088,7 @@ class DocumentParser
             $this->startIndex + $this->seedOffset
         );
 
-        if ($this->inputLen < $index + 3) {
+        if ($index + 3 > $this->inputLen) {
             throw ErrorFactory::makeSyntaxError(
                 AntlersErrorCodes::TYPE_UNEXPECTED_EOI_WHILE_MANIFESTING_ANTLERS_NODE,
                 $node,
@@ -1142,7 +1142,7 @@ class DocumentParser
             $this->startIndex + $this->seedOffset
         );
 
-        if ($this->inputLen < $index + 2) {
+        if ($index + 2 > $this->inputLen) {
             throw ErrorFactory::makeSyntaxError(
                 AntlersErrorCodes::TYPE_UNEXPECTED_EOI_WHILE_MANIFESTING_ANTLERS_NODE,
                 $node,

--- a/src/View/Antlers/Language/Parser/LanguageParser.php
+++ b/src/View/Antlers/Language/Parser/LanguageParser.php
@@ -302,7 +302,7 @@ class LanguageParser
                 $prevNode = $newTokens[count($newTokens) - 1];
             }
 
-            if ($nodeCount > $i + 1) {
+            if ($i + 1 < $nodeCount) {
                 $next = $tokens[$i + 1];
             }
 
@@ -382,7 +382,7 @@ class LanguageParser
             } elseif ($thisNode instanceof VariableNode && $prevNode instanceof MethodInvocationNode) {
                 $this->cleanVariableForMethodInvocation($thisNode);
 
-                if ($nodeCount < $i + 1) {
+                if ($i + 1 > $nodeCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_METHOD_CALL_MISSING_ARG_GROUP,
                         $thisNode,
@@ -423,7 +423,7 @@ class LanguageParser
 
                 continue;
             } elseif ($thisNode instanceof InlineBranchSeparator && $prevNode instanceof MethodInvocationNode) {
-                if ($nodeCount < $i + 1) {
+                if ($i + 1 > $nodeCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_METHOD_CALL_MISSING_METHOD,
                         $thisNode,
@@ -433,7 +433,7 @@ class LanguageParser
 
                 $next = $tokens[$i + 1];
 
-                if ($nodeCount < $i + 2) {
+                if ($i + 2 > $nodeCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_METHOD_CALL_MISSING_ARG_GROUP,
                         $thisNode,
@@ -475,7 +475,7 @@ class LanguageParser
 
                 continue;
             } elseif ($thisNode instanceof MethodInvocationNode) {
-                if ($nodeCount < $i + 1) {
+                if ($i + 1 > $nodeCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_METHOD_CALL_MISSING_METHOD,
                         $thisNode,
@@ -486,7 +486,7 @@ class LanguageParser
                 /** @var VariableNode $methodNode */
                 $methodNode = $tokens[$i + 1];
 
-                if ($nodeCount < $i + 2) {
+                if ($i + 2 > $nodeCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_INVALID_METHOD_CALL_ARG_GROUP,
                         $thisNode,
@@ -561,7 +561,7 @@ class LanguageParser
             }
 
             if ($thisNode instanceof LanguageOperatorConstruct) {
-                if ($nodeCount <= $i + 1) {
+                if ($i + 1 >= $nodeCount) {
                     // Convert it into a variable type node.
                     $tokens[$i] = $this->convertOperatorToVarNode($thisNode);
 
@@ -614,7 +614,7 @@ class LanguageParser
             $thisToken = $tokens[$i];
 
             if ($thisToken instanceof TupleListStart) {
-                if ($tokenCount <= $i + 1) {
+                if ($i + 1 >= $tokenCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_UNEXPECTED_EOI_PARSING_TUPLE_LIST,
                         $thisToken,
@@ -701,7 +701,7 @@ class LanguageParser
                         );
                     }
 
-                    if ($targetGroupLength != count($valueNodeCandidate->nodes)) {
+                    if (count($valueNodeCandidate->nodes) != $targetGroupLength) {
                         throw ErrorFactory::makeSyntaxError(
                             AntlersErrorCodes::TYPE_VALUE_NAME_LENGTH_MISMATCH_TUPLE_LIST,
                             $peek,
@@ -780,7 +780,7 @@ class LanguageParser
             $thisToken = $tokens[$i];
 
             if ($this->isOperatorType($thisToken)) {
-                if ($tokenCount <= $i + 1) {
+                if ($i + 1 >= $tokenCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_UNEXPECTED_OPERATOR,
                         $thisToken,
@@ -835,7 +835,7 @@ class LanguageParser
 
             if ($token instanceof LanguageOperatorConstruct) {
                 if ($token->content == LanguageOperatorRegistry::ARR_ORDERBY) {
-                    if ($tokenCount <= $i + 1) {
+                    if ($i + 1 >= $tokenCount) {
                         throw ErrorFactory::makeSyntaxError(
                             AntlersErrorCodes::TYPE_UNEXPECTED_EOI_PARSING_ORDER_GROUP,
                             $token,
@@ -888,7 +888,7 @@ class LanguageParser
 
                     continue;
                 } elseif ($token->content == LanguageOperatorRegistry::ARR_GROUPBY) {
-                    if ($tokenCount <= $i + 1) {
+                    if ($i + 1 >= $tokenCount) {
                         throw ErrorFactory::makeSyntaxError(
                             AntlersErrorCodes::TYPE_UNEXPECTED_EOI_WHILE_PARSING_GROUP_BY,
                             $token,
@@ -925,7 +925,7 @@ class LanguageParser
                     $newTokens[] = $token;
                     $newTokens[] = $groupFields;
 
-                    if ($tokenCount > $i + 2 && $tokenCount > $i + 3) {
+                    if ($i + 2 < $tokenCount && $i + 3 < $tokenCount) {
                         $peekOne = $tokens[$i + 2];
                         $peekTwo = $tokens[$i + 3];
 
@@ -951,7 +951,7 @@ class LanguageParser
 
                     continue;
                 } elseif ($token->content == LanguageOperatorRegistry::STRUCT_SWITCH) {
-                    if ($tokenCount <= $i + 1) {
+                    if ($i + 1 >= $tokenCount) {
                         if ($token->originalAbstractNode instanceof VariableNode == false) {
                             throw ErrorFactory::makeSyntaxError(
                                 AntlersErrorCodes::TYPE_UNEXPECTED_EOI_WHILE_PARSING_SWITCH_GROUP,
@@ -1081,7 +1081,7 @@ class LanguageParser
                                 continue;
                             }
 
-                            if ($subTokenCount > $c + 1) {
+                            if ($c + 1 < $subTokenCount) {
                                 $next = $subTokens[$c + 1];
                             }
 
@@ -1101,7 +1101,7 @@ class LanguageParser
 
                                 $switchGroup->cases[] = $newCase;
 
-                                if ($subTokenCount > $c + 3) {
+                                if ($c + 3 < $subTokenCount) {
                                     if ($subTokens[$c + 3] instanceof ArgSeparator == false) {
                                         throw ErrorFactory::makeSyntaxError(
                                             AntlersErrorCodes::TYPE_PARSER_INVALID_SWITCH_TOKEN,
@@ -1126,7 +1126,7 @@ class LanguageParser
 
                     continue;
                 } elseif ($token->content == LanguageOperatorRegistry::ARR_MAKE) {
-                    if ($tokenCount <= $i + 1) {
+                    if ($i + 1 >= $tokenCount) {
                         throw ErrorFactory::makeSyntaxError(
                             AntlersErrorCodes::TYPE_ARR_MAKE_MISSING_TARGET,
                             $token,
@@ -1223,12 +1223,12 @@ class LanguageParser
 
             $next = null;
 
-            if ($nodeCount > $i + 1) {
+            if ($i + 1 < $nodeCount) {
                 $next = $nodes[$i + 1];
             }
 
             if ($next instanceof ScopeAssignmentOperator) {
-                if ($nodeCount <= $i + 2) {
+                if ($i + 2 >= $nodeCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_ARR_MAKE_MISSING_ARR_KEY_PAIR_VALUE,
                         $next,
@@ -1307,7 +1307,7 @@ class LanguageParser
 
             $next = null;
 
-            if ($nodeCount > $i + 1) {
+            if ($i + 1 < $nodeCount) {
                 $next = $nodes[$i + 1];
             }
 
@@ -1346,7 +1346,7 @@ class LanguageParser
 
                 $next = null;
 
-                if ($nodeCount > $i + 1) {
+                if ($i + 1 < $nodeCount) {
                     $next = $nodes[$i + 1];
                 }
 
@@ -1419,7 +1419,7 @@ class LanguageParser
 
             $next = null;
 
-            if ($nodeCount > $i + 1) {
+            if ($i + 1 < $nodeCount) {
                 $next = $nodes[$i + 1];
             }
 
@@ -1485,7 +1485,7 @@ class LanguageParser
 
             $next = null;
 
-            if ($nodeCount > $i + 1) {
+            if ($i + 1 < $nodeCount) {
                 $next = $nodes[$i + 1];
             }
 
@@ -1495,7 +1495,7 @@ class LanguageParser
 
                 continue;
             } elseif ($next instanceof InlineBranchSeparator) {
-                if ($nodeCount <= $i + 2) {
+                if ($i + 2 >= $nodeCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_ARG_UNEXPECTED_NAMED_ARGUMENT,
                         $thisNode,
@@ -1524,7 +1524,7 @@ class LanguageParser
 
                 $argGroup->args[] = $namedArgument;
 
-                if ($nodeCount > $i + 3 && $nodes[$i + 3] instanceof ArgSeparator) {
+                if ($i + 3 < $nodeCount && $nodes[$i + 3] instanceof ArgSeparator) {
                     $i += 3;
                 } else {
                     $i += 2;
@@ -1631,7 +1631,7 @@ class LanguageParser
 
                 $this->assertOperandRight($nodes, $i);
 
-                if ($nodeCount <= $i + 1) {
+                if ($i + 1 >= $nodeCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_UNEXPECTED_EOI_WHILE_REDUCING_NEGATION_OPERATORS,
                         $node,
@@ -1714,7 +1714,7 @@ class LanguageParser
      */
     private function assertOperandRight($tokens, $i)
     {
-        if ((count($tokens) - 1) < $i + 1) {
+        if ($i + 1 > (count($tokens) - 1)) {
             throw ErrorFactory::makeSyntaxError(
                 AntlersErrorCodes::TYPE_UNEXPECTED_END_OF_INPUT,
                 $tokens[$i], 'Unexpected end of input; expecting operand for operator '.TypeLabeler::getPrettyTypeName($tokens[$i]).' near "'.LineRetriever::getNearText($tokens[$i]).'".');
@@ -1825,7 +1825,7 @@ class LanguageParser
                     );
                 }
 
-                if ($tokenCount <= $i + 1) {
+                if ($i + 1 >= $tokenCount) {
                     $lastNodeText = '';
 
                     if ($i > 0) {
@@ -2018,7 +2018,7 @@ class LanguageParser
             if ($thisNode instanceof MethodInvocationNode) {
                 // Check to see if we should continue.
                 $doContinue = false;
-                if ($nodeLen > $i + 1) {
+                if ($i + 1 < $nodeLen) {
                     for ($j = $i + 1; $j < $nodeLen; $j++) {
                         $checkNode = $nodes[$j];
 
@@ -2049,7 +2049,7 @@ class LanguageParser
                 $targetNodes[] = $thisNode;
 
                 // Scan forwards to collect all chained calls.
-                if ($nodeLen > $i + 1 && $nodes[$i + 1] instanceof MethodInvocationNode) {
+                if ($i + 1 < $nodeLen && $nodes[$i + 1] instanceof MethodInvocationNode) {
                     $skipTo = $i;
 
                     for ($j = $i + 1; $j < $nodeLen; $j++) {
@@ -2112,7 +2112,7 @@ class LanguageParser
                     $applyModifiersToNode->modifierChain = new ModifierChainNode();
                 }
 
-                if ($tokenCount <= $i + 1) {
+                if ($i + 1 >= $tokenCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_UNEXPECTED_EOI_WHILE_PARSING_MODIFIER_DETAILS,
                         $node,
@@ -2326,7 +2326,7 @@ class LanguageParser
 
         for ($i = 0; $i < $tokenCount; $i++) {
             if ($tokens[$i] instanceof ModifierValueSeparator || $tokens[$i] instanceof InlineBranchSeparator) {
-                if ($tokenCount <= $i + 1) {
+                if ($i + 1 >= $tokenCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_MODIFIER_UNEXPECTED_END_OF_VALUE_LIST,
                         null,
@@ -2459,7 +2459,7 @@ class LanguageParser
             $thisToken = $tokens[$i];
 
             if ($thisToken instanceof AssignmentOperatorNodeContract) {
-                if ($tokenCount > $i + 2) {
+                if ($i + 2 < $tokenCount) {
                     $peek = $tokens[$i + 2];
 
                     if ($peek instanceof StatementSeparatorNode == false) {
@@ -2509,7 +2509,7 @@ class LanguageParser
             } else {
                 $groupNodes[] = $tokens[$i];
 
-                if ($tokenCount <= $i + 1) {
+                if ($i + 1 >= $tokenCount) {
                     $semanticGroup = new SemanticGroup();
                     $semanticGroup->nodes = $groupNodes;
                     $groups[] = $semanticGroup;
@@ -2532,7 +2532,7 @@ class LanguageParser
             if ($node instanceof NullCoalesceOperator) {
                 $left = array_pop($newTokens);
 
-                if ($tokenCount <= $i + 1) {
+                if ($i + 1 >= $tokenCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_UNEXPECTED_EOI_WHILE_PARSING_NULL_COALESCENCE_GROUP,
                         $node,
@@ -2705,7 +2705,7 @@ class LanguageParser
             if ($token instanceof LogicalNegationOperator) {
                 $negationCount = $this->countTypeRight($tokens, $i, LogicalNegationOperator::class);
 
-                if (count($negatedGroupedTokens) == 0 && $negationCount == count($tokens)) {
+                if (count($negatedGroupedTokens) == 0 && count($tokens) == $negationCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_UNEXPECTED_LOGIC_NEGATION_OPERATOR,
                         $token,
@@ -2803,7 +2803,7 @@ class LanguageParser
             $token = $negatedGroupedTokens[$i];
 
             if ($token instanceof LogicGroupBegin) {
-                if ($negatedTokenCount <= $i + 1) {
+                if ($i + 1 >= $negatedTokenCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_UNEXPECTED_EOI_WHILE_PARSING_LOGIC_GROUP_END_DUE_TO_NEGATION,
                         $token,
@@ -2876,7 +2876,7 @@ class LanguageParser
                 $end = $node;
                 break;
             } elseif ($node instanceof LogicGroupBegin) {
-                if ($nodeCount <= $i + 1) {
+                if ($i + 1 >= $nodeCount) {
                     throw ErrorFactory::makeSyntaxError(
                         AntlersErrorCodes::TYPE_UNEXPECTED_EOI_WHILE_PARSING_LOGIC_GROUP_END,
                         $node,
@@ -2911,7 +2911,7 @@ class LanguageParser
         if (count($subNodes) >= 2 && $subNodes[1] instanceof ScopeAssignmentOperator) {
             $logicalGroup = new ScopedLogicGroup();
 
-            if ($nodeCount > $i + 2 && $nodes[$i + 1] instanceof VariableNode && $nodes[$i + 2] instanceof StringValueNode) {
+            if ($i + 2 < $nodeCount && $nodes[$i + 1] instanceof VariableNode && $nodes[$i + 2] instanceof StringValueNode) {
                 /** @var VariableNode $candidateVarNode */
                 $candidateVarNode = $nodes[$i + 1];
 

--- a/src/View/Antlers/Language/Parser/PathParser.php
+++ b/src/View/Antlers/Language/Parser/PathParser.php
@@ -135,7 +135,7 @@ class PathParser
                 $this->prev = '';
             }
 
-            if ($this->inputLength > $this->currentIndex + 1) {
+            if ($this->currentIndex + 1 < $this->inputLength) {
                 $this->next = $this->chars[$this->currentIndex + 1];
             }
 
@@ -369,7 +369,7 @@ class PathParser
                 $prev = $this->chars[$i - 1];
             }
 
-            if ($this->inputLength > $i + 1) {
+            if ($i + 1 < $this->inputLength) {
                 $next = $this->chars[$i + 1];
             }
 

--- a/src/View/Antlers/Language/Runtime/Debugging/GlobalDebugManager.php
+++ b/src/View/Antlers/Language/Runtime/Debugging/GlobalDebugManager.php
@@ -305,7 +305,7 @@ class GlobalDebugManager
         $path = Str::finish($path, '/');
 
         if ($handle = opendir($path)) {
-            while (($entry = readdir($handle)) !== false) {
+            while (false !== ($entry = readdir($handle))) {
                 if ($entry != '.' && $entry != '..') {
                     $paths[] = $path.$entry;
                 }

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -873,7 +873,7 @@ class NodeProcessor
             $thisNode = $nodes[$i];
 
             if ($thisNode instanceof StatementSeparatorNode) {
-                if ($nodeCount <= $i + 1) {
+                if ($i + 1 >= $nodeCount) {
                     return true;
                 }
 
@@ -1728,7 +1728,7 @@ class NodeProcessor
                                             $potentialVariableCollisionName = $tagParameters[$paramName];
 
                                             if (array_key_exists($potentialVariableCollisionName, $beforeAssignments) && array_key_exists($potentialVariableCollisionName, $tagAssocOutput)) {
-                                                if ($tagAssocOutput[$potentialVariableCollisionName] == $this->data[count($this->data) - 1][$potentialVariableCollisionName]) {
+                                                if ($this->data[count($this->data) - 1][$potentialVariableCollisionName] == $tagAssocOutput[$potentialVariableCollisionName]) {
                                                     unset($this->runtimeAssignments[$potentialVariableCollisionName]);
                                                     $adjustedScope = true;
                                                 }
@@ -2302,7 +2302,7 @@ class NodeProcessor
 
                                         $processor->setRuntimeAssignments($runtimeAssignments);
 
-                                        if ($dataCount < count($this->data)) {
+                                        if (count($this->data) > $dataCount) {
                                             $this->popLoopScope();
                                         }
                                     }

--- a/src/View/Antlers/Language/Runtime/PathDataManager.php
+++ b/src/View/Antlers/Language/Runtime/PathDataManager.php
@@ -683,7 +683,7 @@ class PathDataManager
                 }
 
                 if (count($pathItem->pathParts) == 1 && is_numeric($pathItem->originalContent) &&
-                    $pathItem->originalContent == intval($pathItem->originalContent)) {
+                    intval($pathItem->originalContent) == $pathItem->originalContent) {
                     $numericIndex = intval($pathItem->originalContent);
 
                     if (array_key_exists($numericIndex, $this->reducedVar)) {

--- a/src/View/Antlers/Language/Runtime/Sandbox/TypeCoercion.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/TypeCoercion.php
@@ -6,9 +6,9 @@ class TypeCoercion
 {
     public static function coerceType($value)
     {
-        if ($value == intval($value)) {
+        if (intval($value) == $value) {
             return intval($value);
-        } elseif ($value == floatval($value)) {
+        } elseif (floatval($value) == $value) {
             return floatval($value);
         }
 

--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -409,7 +409,7 @@ class AssetFolderTest extends TestCase
         Event::assertDispatchedTimes(AssetFolderSaved::class, count($paths));
         foreach ($paths as $path) {
             Event::assertDispatched(AssetFolderDeleted::class, function (AssetFolderDeleted $event) use ($path) {
-                return $path === $event->folder->path();
+                return $event->folder->path() === $path;
             });
 
             Event::assertDispatched(AssetFolderSaved::class, function (AssetFolderSaved $event) use ($path) {
@@ -427,7 +427,7 @@ class AssetFolderTest extends TestCase
         Event::assertDispatchedTimes(AssetSaved::class, count($paths));
         foreach ($paths as $path) {
             Event::assertDispatched(AssetSaved::class, function (AssetSaved $event) use ($path) {
-                return $path === $event->asset->path();
+                return $event->asset->path() === $path;
             });
         }
     }
@@ -510,7 +510,7 @@ class AssetFolderTest extends TestCase
         Event::assertDispatchedTimes(AssetFolderSaved::class, count($paths));
         foreach ($paths as $path) {
             Event::assertDispatched(AssetFolderDeleted::class, function (AssetFolderDeleted $event) use ($path) {
-                return $path === $event->folder->path();
+                return $event->folder->path() === $path;
             });
         }
         $paths = ['newmove', 'newmove/sub', 'newmove/sub/subsub'];
@@ -530,7 +530,7 @@ class AssetFolderTest extends TestCase
         Event::assertDispatchedTimes(AssetSaved::class, count($paths));
         foreach ($paths as $path) {
             Event::assertDispatched(AssetSaved::class, function (AssetSaved $event) use ($path) {
-                return $path === $event->asset->path();
+                return $event->asset->path() === $path;
             });
         }
     }
@@ -595,7 +595,7 @@ class AssetFolderTest extends TestCase
         Event::assertDispatchedTimes(AssetFolderSaved::class, count($paths));
         foreach ($paths as $path) {
             Event::assertDispatched(AssetFolderDeleted::class, function (AssetFolderDeleted $event) use ($path) {
-                return $path === $event->folder->path();
+                return $event->folder->path() === $path;
             });
         }
         $paths = ['newmove', 'newmove/sub', 'newmove/sub/subsub'];
@@ -615,7 +615,7 @@ class AssetFolderTest extends TestCase
         Event::assertDispatchedTimes(AssetSaved::class, count($paths));
         foreach ($paths as $path) {
             Event::assertDispatched(AssetSaved::class, function (AssetSaved $event) use ($path) {
-                return $path === $event->asset->path();
+                return $event->asset->path() === $path;
             });
         }
     }
@@ -682,7 +682,7 @@ class AssetFolderTest extends TestCase
         Event::assertDispatchedTimes(AssetFolderSaved::class, count($paths));
         foreach ($paths as $path) {
             Event::assertDispatched(AssetFolderDeleted::class, function (AssetFolderDeleted $event) use ($path) {
-                return $path === $event->folder->path();
+                return $event->folder->path() === $path;
             });
         }
         $paths = ['NEWMOVE', 'NEWMOVE/sub', 'NEWMOVE/sub/subsub'];
@@ -702,7 +702,7 @@ class AssetFolderTest extends TestCase
         Event::assertDispatchedTimes(AssetSaved::class, count($paths));
         foreach ($paths as $path) {
             Event::assertDispatched(AssetSaved::class, function (AssetSaved $event) use ($path) {
-                return $path === $event->asset->path();
+                return $event->asset->path() === $path;
             });
         }
     }

--- a/tests/Feature/Collections/ViewCollectionListingTest.php
+++ b/tests/Feature/Collections/ViewCollectionListingTest.php
@@ -105,7 +105,7 @@ class ViewCollectionListingTest extends TestCase
             ->get(cp_route('collections.index'))
             ->assertSuccessful()
             ->assertViewHas('collections', function ($collections) {
-                return ['foo', 'bar'] === $collections->map->id->all();
+                return $collections->map->id->all() === ['foo', 'bar'];
             })
             ->assertDontSee('no-results');
     }

--- a/tests/Feature/Navigation/ViewNavigationListingTest.php
+++ b/tests/Feature/Navigation/ViewNavigationListingTest.php
@@ -26,7 +26,7 @@ class ViewNavigationListingTest extends TestCase
             ->visitIndex()
             ->assertSuccessful()
             ->assertViewHas('navs', function ($navs) {
-                return ['foo', 'bar'] === $navs->map->id->all();
+                return $navs->map->id->all() === ['foo', 'bar'];
             })
             ->assertDontSee('no-results');
     }
@@ -59,7 +59,7 @@ class ViewNavigationListingTest extends TestCase
             ->visitIndex()
             ->assertSuccessful()
             ->assertViewHas('navs', function ($navs) {
-                return ['bar'] === $navs->map->id->all();
+                return $navs->map->id->all() === ['bar'];
             })
             ->assertDontSee('no-results');
     }
@@ -79,7 +79,7 @@ class ViewNavigationListingTest extends TestCase
             ->visitIndex()
             ->assertSuccessful()
             ->assertViewHas('navs', function ($navs) {
-                return ['foo', 'bar'] === $navs->map->id->all();
+                return $navs->map->id->all() === ['foo', 'bar'];
             })
             ->assertDontSee('no-results');
     }

--- a/tests/Forms/SendEmailTest.php
+++ b/tests/Forms/SendEmailTest.php
@@ -36,8 +36,8 @@ class SendEmailTest extends TestCase
         Mail::assertSent(Email::class, 1);
 
         Mail::assertSent(function (Email $mail) use ($submission, $site) {
-            return $submission === $mail->getSubmission()
-                && $site === $mail->getSite()
+            return $mail->getSubmission() === $submission
+                && $mail->getSite() === $site
                 && $mail->getConfig() === [
                     'from' => 'first@sender.com',
                     'to' => 'first@recipient.com',

--- a/tests/Tags/Collection/CollectionTest.php
+++ b/tests/Tags/Collection/CollectionTest.php
@@ -574,7 +574,7 @@ class CollectionTest extends TestCase
     public function findEntryByTitle($title)
     {
         return Facades\Entry::all()->first(function ($entry) use ($title) {
-            return $title === $entry->get('title');
+            return $entry->get('title') === $title;
         });
     }
 


### PR DESCRIPTION
This reverts commit 8e5852f1e0d5c24d66dfc438fc3d06f16fa1c52d.

This was heavy handed, introduced by https://github.com/laravel/pint/pull/210 in Pint 1.13.0
Not a breaking change, but just unexpected and ugly.

It was fixed in 1.13.1 https://github.com/laravel/pint/pull/213
