### PR TITLE
[4.x] Add 'on' and 'off' autocomplete values to text field

### DIFF
--- a/src/Fieldtypes/Text.php
+++ b/src/Fieldtypes/Text.php
@@ -91,6 +91,8 @@ class Text extends Fieldtype
                             'name',
                             'new-password',
                             'nickname',
+                            'off',
+                            'on',
                             'organization',
                             'organization-title',
                             'photo',


### PR DESCRIPTION
Autocomplete is an excellent addition by Jeroen, this was actually on my todo list after we missed it on a recent project.

For some sites I also need to be able to set autocomplete='off' however, since otherwise the browser will automatically guess depending on the field name, which can be annoying.

Also added 'on' just to complete the spec, not sure what use cases there are for that one.