### PR TITLE
[5.x] Store Bard values as objects in publish store

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -1,772 +1,762 @@
 <template>
 
-<portal name="bard-fullscreen" :disabled="!fullScreenMode" :provide="provide">
-<!-- These wrappers allow any css that expected the field to
-     be within the context of a publish form to continue working
-     once it has been portaled out. -->
-<div :class="{ 'publish-fields': fullScreenMode }">
-<div :class="fullScreenMode && wrapperClasses">
-
-    <div
-        class="bard-fieldtype-wrapper"
-        :class="{'bard-fullscreen': fullScreenMode }"
-        ref="container"
-        @dragstart.stop="ignorePageHeader(true)"
-        @dragend="ignorePageHeader(false)"
-    >
-
-        <div class="bard-fixed-toolbar" v-if="!readOnly && showFixedToolbar">
-            <div class="flex flex-wrap flex-1 items-center no-select" v-if="toolbarIsFixed" :class="{'justify-center': fullScreenMode}">
-                <component
-                    v-for="button in visibleButtons(buttons)"
-                    :key="button.name"
-                    :is="button.component || 'BardToolbarButton'"
-                    :button="button"
-                    :active="buttonIsActive(button)"
-                    :config="config"
-                    :bard="_self"
-                    :editor="editor" />
-                    <button class="bard-toolbar-button" @click="showSource = !showSource" v-if="allowSource" v-tooltip="__('Show HTML Source')" :aria-label="__('Show HTML Source')">
-                        <svg-icon name="show-source" class="w-4 h-4 "/>
-                    </button>
-                    <button class="bard-toolbar-button" @click="toggleCollapseSets" v-tooltip="__('Expand/Collapse Sets')" :aria-label="__('Expand/Collapse Sets')" v-if="config.collapse !== 'accordion' && setConfigs.length > 0">
-                        <svg-icon name="expand-collapse-vertical-2" class="w-4 h-4" />
-                    </button>
-                    <button class="bard-toolbar-button" @click="toggleFullscreen" v-tooltip="__('Toggle Fullscreen Mode')" :aria-label="__('Toggle Fullscreen Mode')" v-if="config.fullscreen">
-                        <svg-icon name="arrows-shrink" class="w-4 h-4" v-show="fullScreenMode" />
-                        <svg-icon name="expand-bold" class="w-4 h-4" v-show="!fullScreenMode" />
-                    </button>
+    <portal name="bard-fullscreen" :disabled="!fullScreenMode" :provide="provide">
+    <!-- These wrappers allow any css that expected the field to
+         be within the context of a publish form to continue working
+         once it has been portaled out. -->
+    <div :class="{ 'publish-fields': fullScreenMode }">
+    <div :class="fullScreenMode && wrapperClasses">
+    
+        <div
+            class="bard-fieldtype-wrapper"
+            :class="{'bard-fullscreen': fullScreenMode }"
+            ref="container"
+            @dragstart.stop="ignorePageHeader(true)"
+            @dragend="ignorePageHeader(false)"
+        >
+    
+            <div class="bard-fixed-toolbar" v-if="!readOnly && showFixedToolbar">
+                <div class="flex flex-wrap flex-1 items-center no-select" v-if="toolbarIsFixed" :class="{'justify-center': fullScreenMode}">
+                    <component
+                        v-for="button in visibleButtons(buttons)"
+                        :key="button.name"
+                        :is="button.component || 'BardToolbarButton'"
+                        :button="button"
+                        :active="buttonIsActive(button)"
+                        :config="config"
+                        :bard="_self"
+                        :editor="editor" />
+                        <button class="bard-toolbar-button" @click="showSource = !showSource" v-if="allowSource" v-tooltip="__('Show HTML Source')" :aria-label="__('Show HTML Source')">
+                            <svg-icon name="show-source" class="w-4 h-4 "/>
+                        </button>
+                        <button class="bard-toolbar-button" @click="toggleCollapseSets" v-tooltip="__('Expand/Collapse Sets')" :aria-label="__('Expand/Collapse Sets')" v-if="config.collapse !== 'accordion' && setConfigs.length > 0">
+                            <svg-icon name="expand-collapse-vertical-2" class="w-4 h-4" />
+                        </button>
+                        <button class="bard-toolbar-button" @click="toggleFullscreen" v-tooltip="__('Toggle Fullscreen Mode')" :aria-label="__('Toggle Fullscreen Mode')" v-if="config.fullscreen">
+                            <svg-icon name="arrows-shrink" class="w-4 h-4" v-show="fullScreenMode" />
+                            <svg-icon name="expand-bold" class="w-4 h-4" v-show="!fullScreenMode" />
+                        </button>
+                </div>
+            </div>
+    
+            <div class="bard-editor @container/bard" :class="{ 'mode:read-only': readOnly, 'mode:minimal': ! showFixedToolbar, 'mode:inline': inputIsInline }" tabindex="0">
+                <bubble-menu class="bard-floating-toolbar" :editor="editor" :tippy-options="{ maxWidth: 'none', zIndex: 1000 }" v-if="editor && toolbarIsFloating && !readOnly">
+                    <component
+                        v-for="button in visibleButtons(buttons)"
+                        :key="button.name"
+                        :is="button.component || 'BardToolbarButton'"
+                        :button="button"
+                        :active="buttonIsActive(button)"
+                        :bard="_self"
+                        :config="config"
+                        :editor="editor" />
+                </bubble-menu>
+    
+                <floating-menu
+                    class="bard-set-selector"
+                    :editor="editor"
+                    :should-show="shouldShowSetButton"
+                    :is-showing="showAddSetButton"
+                    v-if="editor"
+                    v-slot="{ y }"
+                    @shown="showAddSetButton = true"
+                    @hidden="showAddSetButton = false"
+                >
+                    <set-picker
+                        v-if="showAddSetButton"
+                        :sets="groupConfigs"
+                        @added="addSet"
+                        @clicked-away="clickedAwayFromSetPicker"
+                    >
+                        <template #trigger>
+                            <button
+                                type="button"
+                                class="btn-round group bard-add-set-button"
+                                :style="{ transform: `translateY(${y}px)` }"
+                                :aria-label="__('Add Set')"
+                                v-tooltip="__('Add Set')"
+                                @click="addSetButtonClicked"
+                            >
+                                <svg-icon name="micro/plus" class="w-3 h-3 text-gray-800 group-hover:text-black" />
+                            </button>
+                        </template>
+                    </set-picker>
+                </floating-menu>
+    
+                <div class="bard-invalid" v-if="invalid" v-html="__('Invalid content')"></div>
+                <editor-content :editor="editor" v-show="!showSource" :id="fieldId" />
+                <bard-source :html="htmlWithReplacedLinks" v-if="showSource" />
+            </div>
+            <div class="bard-footer-toolbar" v-if="editor && (config.reading_time || config.character_limit || config.word_count)">
+                <div v-if="config.reading_time">{{ readingTime }} {{ __('Reading Time') }}</div>
+                <div v-else />
+                <div v-if="config.character_limit || config.word_count" v-text="characterAndWordCountText" />
             </div>
         </div>
-
-        <div class="bard-editor @container/bard" :class="{ 'mode:read-only': readOnly, 'mode:minimal': ! showFixedToolbar, 'mode:inline': inputIsInline }" tabindex="0">
-            <bubble-menu class="bard-floating-toolbar" :editor="editor" :tippy-options="{ maxWidth: 'none', zIndex: 1000 }" v-if="editor && toolbarIsFloating && !readOnly">
-                <component
-                    v-for="button in visibleButtons(buttons)"
-                    :key="button.name"
-                    :is="button.component || 'BardToolbarButton'"
-                    :button="button"
-                    :active="buttonIsActive(button)"
-                    :bard="_self"
-                    :config="config"
-                    :editor="editor" />
-            </bubble-menu>
-
-            <floating-menu
-                class="bard-set-selector"
-                :editor="editor"
-                :should-show="shouldShowSetButton"
-                :is-showing="showAddSetButton"
-                v-if="editor"
-                v-slot="{ y }"
-                @shown="showAddSetButton = true"
-                @hidden="showAddSetButton = false"
-            >
-                <set-picker
-                    v-if="showAddSetButton"
-                    :sets="groupConfigs"
-                    @added="addSet"
-                    @clicked-away="clickedAwayFromSetPicker"
-                >
-                    <template #trigger>
-                        <button
-                            type="button"
-                            class="btn-round group bard-add-set-button"
-                            :style="{ transform: `translateY(${y}px)` }"
-                            :aria-label="__('Add Set')"
-                            v-tooltip="__('Add Set')"
-                            @click="addSetButtonClicked"
-                        >
-                            <svg-icon name="micro/plus" class="w-3 h-3 text-gray-800 group-hover:text-black" />
-                        </button>
-                    </template>
-                </set-picker>
-            </floating-menu>
-
-            <div class="bard-invalid" v-if="invalid" v-html="__('Invalid content')"></div>
-            <editor-content :editor="editor" v-show="!showSource" :id="fieldId" />
-            <bard-source :html="htmlWithReplacedLinks" v-if="showSource" />
-        </div>
-        <div class="bard-footer-toolbar" v-if="editor && (config.reading_time || config.character_limit || config.word_count)">
-            <div v-if="config.reading_time">{{ readingTime }} {{ __('Reading Time') }}</div>
-            <div v-else />
-            <div v-if="config.character_limit || config.word_count" v-text="characterAndWordCountText" />
-        </div>
     </div>
-</div>
-</div>
-</portal>
-
-</template>
-
-<script>
-import uniqid from 'uniqid';
-import reduce from 'underscore/modules/reduce';
-import { BubbleMenu, Editor, EditorContent } from '@tiptap/vue-2';
-import { FloatingMenu } from './FloatingMenu';
-import Blockquote from '@tiptap/extension-blockquote';
-import Bold from '@tiptap/extension-bold';
-import BulletList from '@tiptap/extension-bullet-list';
-import CharacterCount from '@tiptap/extension-character-count';
-import Code from '@tiptap/extension-code';
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
-import Dropcursor from '@tiptap/extension-dropcursor';
-import Gapcursor from '@tiptap/extension-gapcursor';
-import HardBreak from '@tiptap/extension-hard-break';
-import Heading from '@tiptap/extension-heading';
-import History from '@tiptap/extension-history';
-import HorizontalRule from '@tiptap/extension-horizontal-rule';
-import Italic from '@tiptap/extension-italic';
-import ListItem from '@tiptap/extension-list-item';
-import OrderedList from '@tiptap/extension-ordered-list';
-import Paragraph from '@tiptap/extension-paragraph';
-import Placeholder from '@tiptap/extension-placeholder';
-import Strike from '@tiptap/extension-strike';
-import Subscript from '@tiptap/extension-subscript';
-import Superscript from '@tiptap/extension-superscript';
-import Table from '@tiptap/extension-table';
-import TableRow from '@tiptap/extension-table-row';
-import TableCell from '@tiptap/extension-table-cell';
-import TableHeader from '@tiptap/extension-table-header';
-import Text from '@tiptap/extension-text';
-import TextAlign from '@tiptap/extension-text-align';
-import Typography from '@tiptap/extension-typography';
-import Underline from '@tiptap/extension-underline';
-import BardSource from './Source.vue';
-import SetPicker from '../replicator/SetPicker.vue';
-import { DocumentBlock, DocumentInline } from './Document';
-import { Set } from './Set'
-import { Small } from './Small';
-import { Image } from './Image';
-import { Link } from './Link';
-import LinkToolbarButton from './LinkToolbarButton.vue';
-import ManagesSetMeta from '../replicator/ManagesSetMeta';
-import { availableButtons, addButtonHtml } from '../bard/buttons';
-import readTimeEstimate from 'read-time-estimate';
-import { lowlight } from 'lowlight/lib/common.js';
-import 'highlight.js/styles/github.css';
-
-export default {
-
-    mixins: [Fieldtype, ManagesSetMeta],
-
-    components: {
-        BubbleMenu,
-        BardSource,
-        BardToolbarButton,
-        SetPicker,
-        EditorContent,
-        FloatingMenu,
-        LinkToolbarButton,
-    },
-
-    inject: ['storeName'],
-
-    data() {
-        return {
-            editor: null,
-            html: null,
-            json: [],
-            showSource: false,
-            fullScreenMode: false,
-            buttons: [],
-            collapsed: this.meta.collapsed,
-            previews: this.meta.previews,
-            mounted: false,
-            invalid: false,
-            pageHeader: null,
-            escBinding: null,
-            showAddSetButton: false,
-            provide: {
-                bard: this.makeBardProvide(),
-                storeName: this.storeName
-            }
-        }
-    },
-
-    computed: {
-
-        allowSource() {
-            return this.config.allow_source === undefined ? true : this.config.allow_source;
+    </div>
+    </portal>
+    
+    </template>
+    
+    <script>
+    import uniqid from 'uniqid';
+    import reduce from 'underscore/modules/reduce';
+    import { BubbleMenu, Editor, EditorContent } from '@tiptap/vue-2';
+    import { FloatingMenu } from './FloatingMenu';
+    import Blockquote from '@tiptap/extension-blockquote';
+    import Bold from '@tiptap/extension-bold';
+    import BulletList from '@tiptap/extension-bullet-list';
+    import CharacterCount from '@tiptap/extension-character-count';
+    import Code from '@tiptap/extension-code';
+    import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+    import Dropcursor from '@tiptap/extension-dropcursor';
+    import Gapcursor from '@tiptap/extension-gapcursor';
+    import HardBreak from '@tiptap/extension-hard-break';
+    import Heading from '@tiptap/extension-heading';
+    import History from '@tiptap/extension-history';
+    import HorizontalRule from '@tiptap/extension-horizontal-rule';
+    import Italic from '@tiptap/extension-italic';
+    import ListItem from '@tiptap/extension-list-item';
+    import OrderedList from '@tiptap/extension-ordered-list';
+    import Paragraph from '@tiptap/extension-paragraph';
+    import Placeholder from '@tiptap/extension-placeholder';
+    import Strike from '@tiptap/extension-strike';
+    import Subscript from '@tiptap/extension-subscript';
+    import Superscript from '@tiptap/extension-superscript';
+    import Table from '@tiptap/extension-table';
+    import TableRow from '@tiptap/extension-table-row';
+    import TableCell from '@tiptap/extension-table-cell';
+    import TableHeader from '@tiptap/extension-table-header';
+    import Text from '@tiptap/extension-text';
+    import TextAlign from '@tiptap/extension-text-align';
+    import Typography from '@tiptap/extension-typography';
+    import Underline from '@tiptap/extension-underline';
+    import BardSource from './Source.vue';
+    import SetPicker from '../replicator/SetPicker.vue';
+    import { DocumentBlock, DocumentInline } from './Document';
+    import { Set } from './Set'
+    import { Small } from './Small';
+    import { Image } from './Image';
+    import { Link } from './Link';
+    import LinkToolbarButton from './LinkToolbarButton.vue';
+    import ManagesSetMeta from '../replicator/ManagesSetMeta';
+    import { availableButtons, addButtonHtml } from '../bard/buttons';
+    import readTimeEstimate from 'read-time-estimate';
+    import { lowlight } from 'lowlight/lib/common.js';
+    import 'highlight.js/styles/github.css';
+    
+    export default {
+    
+        mixins: [Fieldtype, ManagesSetMeta],
+    
+        components: {
+            BubbleMenu,
+            BardSource,
+            BardToolbarButton,
+            SetPicker,
+            EditorContent,
+            FloatingMenu,
+            LinkToolbarButton,
         },
-
-        toolbarIsFixed() {
-            return this.config.toolbar_mode === 'fixed';
-        },
-
-        toolbarIsFloating() {
-            return this.config.toolbar_mode === 'floating';
-        },
-
-        showFixedToolbar() {
-            return this.toolbarIsFixed && (this.visibleButtons.length > 0 || this.allowSource || this.hasExtraButtons)
-        },
-
-        hasExtraButtons() {
-            return this.allowSource || this.setConfigs.length > 0 || this.config.fullscreen;
-        },
-
-        readingTime() {
-            if (this.html) {
-                var stats = readTimeEstimate(this.html, 265, 12, 500, ['img', 'Image', 'bard-set']);
-                var duration = moment.duration(stats.duration, 'minutes');
-
-                return moment.utc(duration.asMilliseconds()).format("mm:ss");
-            }
-        },
-
-        characterAndWordCountText() {
-            const showWordCount = this.config.word_count;
-            const wordCount = this.editor.storage.characterCount.words();
-            const wordCountText = `${__n(':count word|:count words', wordCount)}`;
-            const charLimit = this.config.character_limit;
-            const showCharLimit = charLimit > 0;
-            const charCount = this.editor.storage.characterCount.characters();
-
-            // If both are enabled, show a more verbose combined string.
-            if (showCharLimit && showWordCount) {
-                return `${wordCountText}, ${__(':count/:total characters', { count: charCount, total: charLimit })}`;
-            }
-
-            // Otherwise show one or the other.
-            if (showCharLimit) return `${charCount}/${charLimit}`;
-            if (showWordCount) return wordCountText;
-        },
-
-        isFirstCreation() {
-            return !this.$config.get('bard.meta').hasOwnProperty(this.id);
-        },
-
-        id() {
-            return `${this.storeName}.${this.name}`;
-        },
-
-        setIndexes() {
-            let indexes = {}
-
-            this.json.forEach((item, i) => {
-                if (item.type === 'set') {
-                    indexes[item.attrs.id] = i;
-                }
-            });
-
-            return indexes;
-        },
-
-        storeState() {
-            if (! this.storeName) return undefined;
-
-            return this.$store.state.publish[this.storeName];
-        },
-
-        site() {
-            return this.storeState ? this.storeState.site : this.$config.get('selectedSite');
-        },
-
-        htmlWithReplacedLinks() {
-            return this.html.replaceAll(/\"statamic:\/\/(.*?)\"/g, (match, ref) => {
-                const linkData = this.meta.linkData[ref];
-                if (! linkData) {
-                    this.$toast.error(`${__('No link data found for')} ${ref}`);
-                    return '""';
-                }
-
-                return `"${linkData.permalink}"`;
-            });
-        },
-
-        setsWithErrors() {
-            if (! this.storeState) return [];
-
-            return Object.values(this.setIndexes).filter((setIndex) => {
-                const prefix = `${this.fieldPathPrefix || this.handle}.${setIndex}.`;
-
-                return Object.keys(this.storeState.errors).some(key => key.startsWith(prefix));
-            })
-        },
-
-        replicatorPreview() {
-            const stack = JSON.parse(this.value);
-            let text = '';
-            while (stack.length) {
-                const node = stack.shift();
-                if (node.type === 'text') {
-                    text += ` ${node.text || ''}`;
-                } else if (node.type === 'set') {
-                    const handle = node.attrs.values.type;
-                    const set = this.setConfigs.find(set => set.handle === handle);
-                    text += ` [${set ? set.display : handle}]`;
-                }
-                if (text.length > 150) {
-                    break;
-                }
-                if (node.content) {
-                    stack.unshift(...node.content);
+    
+        inject: ['storeName'],
+    
+        data() {
+            return {
+                editor: null,
+                html: null,
+                json: [],
+                showSource: false,
+                fullScreenMode: false,
+                buttons: [],
+                collapsed: this.meta.collapsed,
+                previews: this.meta.previews,
+                mounted: false,
+                invalid: false,
+                pageHeader: null,
+                escBinding: null,
+                showAddSetButton: false,
+                provide: {
+                    bard: this.makeBardProvide(),
+                    storeName: this.storeName
                 }
             }
-            return text;
         },
-
-        inputIsInline() {
-            return this.config.inline;
-        },
-
-        wrapperClasses() {
-            return `form-group publish-field publish-field__${this.handle} bard-fieldtype`;
-        },
-
-        setConfigs() {
-            return reduce(this.groupConfigs, (sets, group) => {
-                return sets.concat(group.sets);
-            }, []);
-        },
-
-        groupConfigs() {
-            return this.config.sets;
-        },
-
-    },
-
-    mounted() {
-        this.initToolbarButtons();
-        this.initEditor();
-
-        this.json = this.editor.getJSON().content;
-        this.html = this.editor.getHTML();
-
-        this.escBinding = this.$keys.bind('esc', this.closeFullscreen)
-
-        this.$nextTick(() => {
-            this.mounted = true;
-            if (this.config.collapse) this.collapseAll();
-        });
-
-        this.pageHeader = document.querySelector('.global-header');
-
-        this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
-
-        this.$nextTick(() => {
-            document.querySelector(`label[for="${this.fieldId}"]`).addEventListener('click', () => {
-                this.editor.commands.focus();
-            });
-        });
-    },
-
-    beforeDestroy() {
-        this.editor.destroy();
-        this.escBinding.destroy();
-
-        this.$store.commit(`publish/${this.storeName}/unsetFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
-    },
-
-    watch: {
-
-        json(json) {
-            if (!this.mounted) return;
-
-            // Prosemirror's JSON will include spaces between tags.
-            // For example (this is not the actual json)...
-            // "<p>One <b>two</b> three</p>" becomes ['OneSPACE', '<b>two</b>', 'SPACEthree']
-            // But, Laravel's TrimStrings middleware would remove them.
-            // Those spaces need to be there, otherwise it would be rendered as <p>One<b>two</b>three</p>
-            // To combat this, we submit the JSON string instead of an object.
-            this.updateDebounced(JSON.stringify(json));
-        },
-
-        value(value, oldValue) {
-            if (value === oldValue) return;
-
-            const oldContent = this.editor.getJSON();
-            const content = this.valueToContent(value);
-
-            if (JSON.stringify(content) !== JSON.stringify(oldContent)) {
-                this.editor.commands.clearContent()
-                this.editor.commands.setContent(content, true);
-            }
-        },
-
-        readOnly(readOnly) {
-            this.editor.setEditable(!this.readOnly);
-        },
-
-        collapsed(value) {
-            const meta = this.meta;
-            meta.collapsed = value;
-            this.updateMeta(meta);
-        },
-
-        previews: {
-            deep: true,
-            handler(value) {
-                if (JSON.stringify(this.meta.previews) === JSON.stringify(value)) {
-                    return
+    
+        computed: {
+    
+            allowSource() {
+                return this.config.allow_source === undefined ? true : this.config.allow_source;
+            },
+    
+            toolbarIsFixed() {
+                return this.config.toolbar_mode === 'fixed';
+            },
+    
+            toolbarIsFloating() {
+                return this.config.toolbar_mode === 'floating';
+            },
+    
+            showFixedToolbar() {
+                return this.toolbarIsFixed && (this.visibleButtons.length > 0 || this.allowSource || this.hasExtraButtons)
+            },
+    
+            hasExtraButtons() {
+                return this.allowSource || this.setConfigs.length > 0 || this.config.fullscreen;
+            },
+    
+            readingTime() {
+                if (this.html) {
+                    var stats = readTimeEstimate(this.html, 265, 12, 500, ['img', 'Image', 'bard-set']);
+                    var duration = moment.duration(stats.duration, 'minutes');
+    
+                    return moment.utc(duration.asMilliseconds()).format("mm:ss");
                 }
-                const meta = this.meta;
-                meta.previews = value;
-                this.updateMeta(meta);
-            }
-        },
-
-        fieldPathPrefix(fieldPathPrefix, oldFieldPathPrefix) {
-            this.$store.commit(`publish/${this.storeName}/unsetFieldSubmitsJson`, oldFieldPathPrefix);
-            this.$nextTick(() => {
-                this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, fieldPathPrefix);
-            });
-        },
-
-        fullScreenMode() {
-            this.initEditor();
-        }
-
-    },
-
-    methods: {
-        addSet(handle) {
-            const id = uniqid();
-            const values = Object.assign({}, { type: handle }, this.meta.defaults[handle]);
-
-            let previews = {};
-            Object.keys(this.meta.defaults[handle]).forEach(key => previews[key] = null);
-            this.previews = Object.assign({}, this.previews, { [id]: previews });
-
-            this.updateSetMeta(id, this.meta.new[handle]);
-
-            // Perform this in nextTick because the meta data won't be ready until then.
-            this.$nextTick(() => {
-                this.editor.commands.set({ id, values });
-            });
-        },
-
-        duplicateSet(old_id, attrs, pos) {
-            const id = uniqid();
-            const enabled = attrs.enabled;
-            const values = Object.assign({}, attrs.values);
-
-            let previews = Object.assign({}, this.previews[old_id]);
-            this.previews = Object.assign({}, this.previews, { [id]: previews });
-
-            this.updateSetMeta(id, this.meta.existing[old_id]);
-
-            // Perform this in nextTick because the meta data won't be ready until then.
-            this.$nextTick(() => {
-                this.editor.commands.setAt({ attrs: { id, enabled, values }, pos });
-            });
-        },
-
-        collapseSet(id) {
-            if (!this.collapsed.includes(id)) {
-                this.collapsed.push(id)
-            }
-        },
-
-        expandSet(id) {
-            if (this.config.collapse === 'accordion') {
-                this.collapsed = Object.keys(this.meta.existing).filter(v => v !== id);
-                return;
-            }
-
-            if (this.collapsed.includes(id)) {
-                var index = this.collapsed.indexOf(id);
-                this.collapsed.splice(index, 1);
-            }
-        },
-
-        collapseAll() {
-            this.collapsed = Object.keys(this.meta.existing);
-        },
-
-        expandAll() {
-            this.collapsed = [];
-        },
-
-        toggleCollapseSets() {
-            (this.collapsed.length === 0) ? this.collapseAll() : this.expandAll();
-        },
-
-        toggleFullscreen() {
-            this.fullScreenMode = !this.fullScreenMode;
-        },
-
-        closeFullscreen() {
-            this.fullScreenMode = false;
-        },
-
-        shouldShowSetButton({ view, state }) {
-            const { selection } = state;
-            const { $anchor, empty } = selection;
-            const isRootDepth = $anchor.depth === 1;
-            const isEmptyTextBlock = $anchor.parent.isTextblock && !$anchor.parent.type.spec.code && !$anchor.parent.textContent;
-            const isAroundInlineImage = state.selection.$to.nodeBefore?.type.name === 'image' || state.selection.$to.nodeAfter?.type.name === 'image'
-            const isActive = view.hasFocus() && empty && isRootDepth && isEmptyTextBlock && !isAroundInlineImage;
-            return this.setConfigs.length && (this.config.always_show_set_button || isActive);
-        },
-
-        initToolbarButtons() {
-            const selectedButtons = this.config.buttons || [
-                'h2', 'h3', 'bold', 'italic', 'unorderedlist', 'orderedlist', 'removeformat', 'quote', 'anchor', 'table'
-            ];
-
-            if (selectedButtons.includes('table')) {
-                selectedButtons.push(
-                    'deletetable',
-                    'addcolumnbefore',
-                    'addcolumnafter',
-                    'deletecolumn',
-                    'addrowbefore',
-                    'addrowafter',
-                    'deleterow',
-                    'togglecellmerge',
-                    'toggleheadercell'
-                );
-            }
-
-            // Get the configured buttons and swap them with corresponding objects
-            let buttons = selectedButtons.map(button => {
-                return _.findWhere(availableButtons(), { name: button.toLowerCase() }) || button;
-            });
-
-            // Let addons add, remove, or control the position of buttons.
-            this.$bard.buttonCallbacks.forEach(callback => {
-                // Since the developer uses the same callback to add buttons to the field itself, and for the
-                // button configurator, we need to make the button conditional when on the Bard fieldtype
-                // but not in the button configurator. So here we'll filter it out if it's not selected.
-                const buttonFn = (button) => selectedButtons.includes(button.name) ? button : null;
-
-                const addedButtons = callback(buttons, buttonFn);
-
-                // No return value means either they literally returned nothing, with the intention
-                // of manipulating the buttons object manually. Or, they used the button() and
-                // the button was not configured in the field so it was stripped out.
-                if (! addedButtons) return;
-
-                buttons = buttons.concat(
-                    Array.isArray(addedButtons) ? addedButtons : [addedButtons]
-                );
-            });
-
-            // Remove any nulls. This could happen if a developer-added button was not specified in this field's buttons array.
-            buttons = buttons.filter(button => !!button);
-
-            // Remove any non-objects. This would happen if you configure a button name that doesn't exist.
-            buttons = buttons.filter(button => typeof button != 'string');
-
-            // Generate fallback html for each button
-            buttons = addButtonHtml(buttons);
-
-            // Remove buttons that don't pass conditions.
-            // eg. only the insert asset button can be shown if a container has been set.
-            buttons = buttons.filter(button => {
-                return (button.condition) ? button.condition.call(null, this.config) : true;
-            });
-
-            if (_.findWhere(buttons, {name: 'table'})) {
-                buttons.push(
-                    { name: 'deletetable', text: __('Delete Table'), command: (editor) => editor.commands.deleteTable(), svg: 'delete-table', visibleWhenActive: 'table' },
-                    { name: 'addcolumnbefore', text: __('Add Column Before'), command: (editor) => editor.commands.addColumnBefore(), svg: 'add-col-before', visibleWhenActive: 'table' },
-                    { name: 'addcolumnafter', text: __('Add Column After'), command: (editor) => editor.commands.addColumnAfter(), svg: 'add-col-after', visibleWhenActive: 'table' },
-                    { name: 'deletecolumn', text: __('Delete Column'), command: (editor) => editor.commands.deleteColumn(), svg: 'delete-col', visibleWhenActive: 'table' },
-                    { name: 'addrowbefore', text: __('Add Row Before'), command: (editor) => editor.commands.addRowBefore(), svg: 'add-row-before', visibleWhenActive: 'table' },
-                    { name: 'addrowafter', text: __('Add Row After'), command: (editor) => editor.commands.addRowAfter(), svg: 'add-row-after', visibleWhenActive: 'table' },
-                    { name: 'deleterow', text: __('Delete Row'), command: (editor) => editor.commands.deleteRow(), svg: 'delete-row', visibleWhenActive: 'table' },
-                    { name: 'toggleheadercell', text: __('Toggle Header Cell'), command: (editor) => editor.commands.toggleHeaderCell(), svg: 'flip-vertical', visibleWhenActive: 'table' },
-                    { name: 'togglecellmerge', text: __('Merge Cells'), command: (editor) => editor.commands.mergeCells(), svg: 'combine-cells', visibleWhenActive: 'table' },
-                )
-            }
-
-            this.buttons = buttons;
-        },
-
-        buttonIsActive(button) {
-            if (button.hasOwnProperty('active')) {
-                return button.active(this.editor, button.args);
-            }
-            const nameProperty = button.hasOwnProperty('activeName') ? 'activeName' : 'name';
-            const name = button[nameProperty];
-            return this.editor.isActive(name, button.args);
-        },
-
-        buttonIsVisible(button) {
-            if (button.hasOwnProperty('visible')) {
-                return button.visible(this.editor, button.args);
-            }
-            if (! button.hasOwnProperty('visibleWhenActive')) return true;
-            return this.editor.isActive(button.visibleWhenActive, button.args);
-        },
-
-        visibleButtons(buttons) {
-            return buttons.filter(button => this.buttonIsVisible(button));
-        },
-
-        initEditor() {
-            if (this.editor) this.editor.destroy();
-
-            const content = this.valueToContent(clone(this.value));
-
-            this.editor = new Editor({
-                extensions: this.getExtensions(),
-                content: content,
-                editable: !this.readOnly,
-                enableInputRules: this.config.enable_input_rules,
-                enablePasteRules: this.config.enable_paste_rules,
-                editorProps: { attributes: { class: 'bard-content' }},
-                onFocus: () => this.$emit('focus'),
-                onBlur: () => {
-                    // Since clicking into a field inside a set would also trigger a blur, we can't just emit the
-                    // blur event immediately. We need to make sure that the newly focused element is outside
-                    // of Bard. We use a timeout because activeElement only exists after the blur event.
-                    setTimeout(() => {
-                        if (!this.$refs.container.contains(document.activeElement)) {
-                            this.$emit('blur');
-                            this.showAddSetButton = false;
-                        }
-                    }, 1);
-                },
-                onUpdate: () => {
-                    this.json = this.editor.getJSON().content;
-                    this.html = this.editor.getHTML();
-                },
-                onCreate: ({ editor }) => {
-                    const state = editor.view.state;
-                    if (content !== null && typeof content === 'object') {
-                        try {
-                            state.schema.nodeFromJSON(content);
-                        } catch (error) {
-                            this.invalid = true;
-                        }
+            },
+    
+            characterAndWordCountText() {
+                const showWordCount = this.config.word_count;
+                const wordCount = this.editor.storage.characterCount.words();
+                const wordCountText = `${__n(':count word|:count words', wordCount)}`;
+                const charLimit = this.config.character_limit;
+                const showCharLimit = charLimit > 0;
+                const charCount = this.editor.storage.characterCount.characters();
+    
+                // If both are enabled, show a more verbose combined string.
+                if (showCharLimit && showWordCount) {
+                    return `${wordCountText}, ${__(':count/:total characters', { count: charCount, total: charLimit })}`;
+                }
+    
+                // Otherwise show one or the other.
+                if (showCharLimit) return `${charCount}/${charLimit}`;
+                if (showWordCount) return wordCountText;
+            },
+    
+            isFirstCreation() {
+                return !this.$config.get('bard.meta').hasOwnProperty(this.id);
+            },
+    
+            id() {
+                return `${this.storeName}.${this.name}`;
+            },
+    
+            setIndexes() {
+                let indexes = {}
+    
+                this.json.forEach((item, i) => {
+                    if (item.type === 'set') {
+                        indexes[item.attrs.id] = i;
+                    }
+                });
+    
+                return indexes;
+            },
+    
+            storeState() {
+                if (! this.storeName) return undefined;
+    
+                return this.$store.state.publish[this.storeName];
+            },
+    
+            site() {
+                return this.storeState ? this.storeState.site : this.$config.get('selectedSite');
+            },
+    
+            htmlWithReplacedLinks() {
+                return this.html.replaceAll(/\"statamic:\/\/(.*?)\"/g, (match, ref) => {
+                    const linkData = this.meta.linkData[ref];
+                    if (! linkData) {
+                        this.$toast.error(`${__('No link data found for')} ${ref}`);
+                        return '""';
+                    }
+    
+                    return `"${linkData.permalink}"`;
+                });
+            },
+    
+            setsWithErrors() {
+                if (! this.storeState) return [];
+    
+                return Object.values(this.setIndexes).filter((setIndex) => {
+                    const prefix = `${this.fieldPathPrefix || this.handle}.${setIndex}.`;
+    
+                    return Object.keys(this.storeState.errors).some(key => key.startsWith(prefix));
+                })
+            },
+    
+            replicatorPreview() {
+                const stack = [...this.value];
+                let text = '';
+                while (stack.length) {
+                    const node = stack.shift();
+                    if (node.type === 'text') {
+                        text += ` ${node.text || ''}`;
+                    } else if (node.type === 'set') {
+                        const handle = node.attrs.values.type;
+                        const set = this.setConfigs.find(set => set.handle === handle);
+                        text += ` [${set ? set.display : handle}]`;
+                    }
+                    if (text.length > 150) {
+                        break;
+                    }
+                    if (node.content) {
+                        stack.unshift(...node.content);
                     }
                 }
+                return text;
+            },
+    
+            inputIsInline() {
+                return this.config.inline;
+            },
+    
+            wrapperClasses() {
+                return `form-group publish-field publish-field__${this.handle} bard-fieldtype`;
+            },
+    
+            setConfigs() {
+                return reduce(this.groupConfigs, (sets, group) => {
+                    return sets.concat(group.sets);
+                }, []);
+            },
+    
+            groupConfigs() {
+                return this.config.sets;
+            },
+    
+        },
+    
+        mounted() {
+            this.initToolbarButtons();
+            this.initEditor();
+    
+            this.json = this.editor.getJSON().content;
+            this.html = this.editor.getHTML();
+    
+            this.escBinding = this.$keys.bind('esc', this.closeFullscreen)
+    
+            this.$nextTick(() => {
+                this.mounted = true;
+                if (this.config.collapse) this.collapseAll();
+            });
+    
+            this.pageHeader = document.querySelector('.global-header');
+    
+            this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
+    
+            this.$nextTick(() => {
+                document.querySelector(`label[for="${this.fieldId}"]`).addEventListener('click', () => {
+                    this.editor.commands.focus();
+                });
             });
         },
-
-        valueToContent(value) {
-            // A json string is passed from PHP since that's what's submitted.
-            value = JSON.parse(value);
-
-            return value.length
-                ? { type: 'doc', content: value }
-                : null;
+    
+        beforeDestroy() {
+            this.editor.destroy();
+            this.escBinding.destroy();
+    
+            this.$store.commit(`publish/${this.storeName}/unsetFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
         },
-
-        getExtensions() {
-            let modeExts = this.inputIsInline ? [DocumentInline] : [DocumentBlock, HardBreak];
-            if (this.config.inline === 'break') {
-                modeExts.push(HardBreak.extend({
-                    addKeyboardShortcuts() {
-                        return {
-                            ...this.parent?.(),
-                            'Enter': () => this.editor.commands.setHardBreak(),
-                        }
+    
+        watch: {
+    
+            json(json) {
+                if (!this.mounted) return;
+    
+                this.updateDebounced(json);
+            },
+    
+            value(value, oldValue) {    
+                const oldContent = this.editor.getJSON();
+                const content = this.valueToContent(value);
+    
+                if (JSON.stringify(content) !== JSON.stringify(oldContent)) {
+                    this.editor.commands.clearContent()
+                    this.editor.commands.setContent(content, true);
+                }
+            },
+    
+            readOnly(readOnly) {
+                this.editor.setEditable(!this.readOnly);
+            },
+    
+            collapsed(value) {
+                const meta = this.meta;
+                meta.collapsed = value;
+                this.updateMeta(meta);
+            },
+    
+            previews: {
+                deep: true,
+                handler(value) {
+                    if (JSON.stringify(this.meta.previews) === JSON.stringify(value)) {
+                        return
+                    }
+                    const meta = this.meta;
+                    meta.previews = value;
+                    this.updateMeta(meta);
+                }
+            },
+    
+            fieldPathPrefix(fieldPathPrefix, oldFieldPathPrefix) {
+                this.$store.commit(`publish/${this.storeName}/unsetFieldSubmitsJson`, oldFieldPathPrefix);
+                this.$nextTick(() => {
+                    this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, fieldPathPrefix);
+                });
+            },
+    
+            fullScreenMode() {
+                this.initEditor();
+            }
+    
+        },
+    
+        methods: {
+            addSet(handle) {
+                const id = uniqid();
+                const values = Object.assign({}, { type: handle }, this.meta.defaults[handle]);
+    
+                let previews = {};
+                Object.keys(this.meta.defaults[handle]).forEach(key => previews[key] = null);
+                this.previews = Object.assign({}, this.previews, { [id]: previews });
+    
+                this.updateSetMeta(id, this.meta.new[handle]);
+    
+                // Perform this in nextTick because the meta data won't be ready until then.
+                this.$nextTick(() => {
+                    this.editor.commands.set({ id, values });
+                });
+            },
+    
+            duplicateSet(old_id, attrs, pos) {
+                const id = uniqid();
+                const enabled = attrs.enabled;
+                const values = Object.assign({}, attrs.values);
+    
+                let previews = Object.assign({}, this.previews[old_id]);
+                this.previews = Object.assign({}, this.previews, { [id]: previews });
+    
+                this.updateSetMeta(id, this.meta.existing[old_id]);
+    
+                // Perform this in nextTick because the meta data won't be ready until then.
+                this.$nextTick(() => {
+                    this.editor.commands.setAt({ attrs: { id, enabled, values }, pos });
+                });
+            },
+    
+            collapseSet(id) {
+                if (!this.collapsed.includes(id)) {
+                    this.collapsed.push(id)
+                }
+            },
+    
+            expandSet(id) {
+                if (this.config.collapse === 'accordion') {
+                    this.collapsed = Object.keys(this.meta.existing).filter(v => v !== id);
+                    return;
+                }
+    
+                if (this.collapsed.includes(id)) {
+                    var index = this.collapsed.indexOf(id);
+                    this.collapsed.splice(index, 1);
+                }
+            },
+    
+            collapseAll() {
+                this.collapsed = Object.keys(this.meta.existing);
+            },
+    
+            expandAll() {
+                this.collapsed = [];
+            },
+    
+            toggleCollapseSets() {
+                (this.collapsed.length === 0) ? this.collapseAll() : this.expandAll();
+            },
+    
+            toggleFullscreen() {
+                this.fullScreenMode = !this.fullScreenMode;
+            },
+    
+            closeFullscreen() {
+                this.fullScreenMode = false;
+            },
+    
+            shouldShowSetButton({ view, state }) {
+                const { selection } = state;
+                const { $anchor, empty } = selection;
+                const isRootDepth = $anchor.depth === 1;
+                const isEmptyTextBlock = $anchor.parent.isTextblock && !$anchor.parent.type.spec.code && !$anchor.parent.textContent;
+                const isAroundInlineImage = state.selection.$to.nodeBefore?.type.name === 'image' || state.selection.$to.nodeAfter?.type.name === 'image'
+                const isActive = view.hasFocus() && empty && isRootDepth && isEmptyTextBlock && !isAroundInlineImage;
+                return this.setConfigs.length && (this.config.always_show_set_button || isActive);
+            },
+    
+            initToolbarButtons() {
+                const selectedButtons = this.config.buttons || [
+                    'h2', 'h3', 'bold', 'italic', 'unorderedlist', 'orderedlist', 'removeformat', 'quote', 'anchor', 'table'
+                ];
+    
+                if (selectedButtons.includes('table')) {
+                    selectedButtons.push(
+                        'deletetable',
+                        'addcolumnbefore',
+                        'addcolumnafter',
+                        'deletecolumn',
+                        'addrowbefore',
+                        'addrowafter',
+                        'deleterow',
+                        'togglecellmerge',
+                        'toggleheadercell'
+                    );
+                }
+    
+                // Get the configured buttons and swap them with corresponding objects
+                let buttons = selectedButtons.map(button => {
+                    return _.findWhere(availableButtons(), { name: button.toLowerCase() }) || button;
+                });
+    
+                // Let addons add, remove, or control the position of buttons.
+                this.$bard.buttonCallbacks.forEach(callback => {
+                    // Since the developer uses the same callback to add buttons to the field itself, and for the
+                    // button configurator, we need to make the button conditional when on the Bard fieldtype
+                    // but not in the button configurator. So here we'll filter it out if it's not selected.
+                    const buttonFn = (button) => selectedButtons.includes(button.name) ? button : null;
+    
+                    const addedButtons = callback(buttons, buttonFn);
+    
+                    // No return value means either they literally returned nothing, with the intention
+                    // of manipulating the buttons object manually. Or, they used the button() and
+                    // the button was not configured in the field so it was stripped out.
+                    if (! addedButtons) return;
+    
+                    buttons = buttons.concat(
+                        Array.isArray(addedButtons) ? addedButtons : [addedButtons]
+                    );
+                });
+    
+                // Remove any nulls. This could happen if a developer-added button was not specified in this field's buttons array.
+                buttons = buttons.filter(button => !!button);
+    
+                // Remove any non-objects. This would happen if you configure a button name that doesn't exist.
+                buttons = buttons.filter(button => typeof button != 'string');
+    
+                // Generate fallback html for each button
+                buttons = addButtonHtml(buttons);
+    
+                // Remove buttons that don't pass conditions.
+                // eg. only the insert asset button can be shown if a container has been set.
+                buttons = buttons.filter(button => {
+                    return (button.condition) ? button.condition.call(null, this.config) : true;
+                });
+    
+                if (_.findWhere(buttons, {name: 'table'})) {
+                    buttons.push(
+                        { name: 'deletetable', text: __('Delete Table'), command: (editor) => editor.commands.deleteTable(), svg: 'delete-table', visibleWhenActive: 'table' },
+                        { name: 'addcolumnbefore', text: __('Add Column Before'), command: (editor) => editor.commands.addColumnBefore(), svg: 'add-col-before', visibleWhenActive: 'table' },
+                        { name: 'addcolumnafter', text: __('Add Column After'), command: (editor) => editor.commands.addColumnAfter(), svg: 'add-col-after', visibleWhenActive: 'table' },
+                        { name: 'deletecolumn', text: __('Delete Column'), command: (editor) => editor.commands.deleteColumn(), svg: 'delete-col', visibleWhenActive: 'table' },
+                        { name: 'addrowbefore', text: __('Add Row Before'), command: (editor) => editor.commands.addRowBefore(), svg: 'add-row-before', visibleWhenActive: 'table' },
+                        { name: 'addrowafter', text: __('Add Row After'), command: (editor) => editor.commands.addRowAfter(), svg: 'add-row-after', visibleWhenActive: 'table' },
+                        { name: 'deleterow', text: __('Delete Row'), command: (editor) => editor.commands.deleteRow(), svg: 'delete-row', visibleWhenActive: 'table' },
+                        { name: 'toggleheadercell', text: __('Toggle Header Cell'), command: (editor) => editor.commands.toggleHeaderCell(), svg: 'flip-vertical', visibleWhenActive: 'table' },
+                        { name: 'togglecellmerge', text: __('Merge Cells'), command: (editor) => editor.commands.mergeCells(), svg: 'combine-cells', visibleWhenActive: 'table' },
+                    )
+                }
+    
+                this.buttons = buttons;
+            },
+    
+            buttonIsActive(button) {
+                if (button.hasOwnProperty('active')) {
+                    return button.active(this.editor, button.args);
+                }
+                const nameProperty = button.hasOwnProperty('activeName') ? 'activeName' : 'name';
+                const name = button[nameProperty];
+                return this.editor.isActive(name, button.args);
+            },
+    
+            buttonIsVisible(button) {
+                if (button.hasOwnProperty('visible')) {
+                    return button.visible(this.editor, button.args);
+                }
+                if (! button.hasOwnProperty('visibleWhenActive')) return true;
+                return this.editor.isActive(button.visibleWhenActive, button.args);
+            },
+    
+            visibleButtons(buttons) {
+                return buttons.filter(button => this.buttonIsVisible(button));
+            },
+    
+            initEditor() {
+                if (this.editor) this.editor.destroy();
+    
+                const content = this.valueToContent(clone(this.value));
+    
+                this.editor = new Editor({
+                    extensions: this.getExtensions(),
+                    content: content,
+                    editable: !this.readOnly,
+                    enableInputRules: this.config.enable_input_rules,
+                    enablePasteRules: this.config.enable_paste_rules,
+                    editorProps: { attributes: { class: 'bard-content' }},
+                    onFocus: () => this.$emit('focus'),
+                    onBlur: () => {
+                        // Since clicking into a field inside a set would also trigger a blur, we can't just emit the
+                        // blur event immediately. We need to make sure that the newly focused element is outside
+                        // of Bard. We use a timeout because activeElement only exists after the blur event.
+                        setTimeout(() => {
+                            if (!this.$refs.container.contains(document.activeElement)) {
+                                this.$emit('blur');
+                                this.showAddSetButton = false;
+                            }
+                        }, 1);
                     },
-                }));
-            }
-            let exts = [
-                CharacterCount.configure({ limit: this.config.character_limit }),
-                ...modeExts,
-                Dropcursor,
-                Gapcursor,
-                History,
-                Paragraph,
-                Placeholder.configure({ placeholder: this.config.placeholder }),
-                Set.configure({ bard: this }),
-                Text
-            ];
-
-            if (this.config.smart_typography) {
-                exts.push(Typography);
-            }
-
-            let btns = this.buttons.map(button => button.name);
-
-            if (btns.includes('anchor')) exts.push(Link.configure({ vm: this }));
-            if (btns.includes('bold')) exts.push(Bold);
-            if (btns.includes('code')) exts.push(Code);
-            if (btns.includes('codeblock')) exts.push(CodeBlockLowlight.configure({ lowlight }));
-            if (btns.includes('horizontalrule')) exts.push(HorizontalRule);
-            if (btns.includes('image')) exts.push(Image.configure({ bard: this }));
-            if (btns.includes('italic')) exts.push(Italic);
-            if (btns.includes('quote')) exts.push(Blockquote);
-            if (btns.includes('orderedlist')) exts.push(OrderedList);
-            if (btns.includes('orderedlist') || btns.includes('unorderedlist')) exts.push(ListItem);
-            if (btns.includes('underline')) exts.push(Underline);
-            if (btns.includes('unorderedlist')) exts.push(BulletList);
-            if (btns.includes('small')) exts.push(Small);
-            if (btns.includes('strikethrough')) exts.push(Strike);
-            if (btns.includes('subscript')) exts.push(Subscript);
-            if (btns.includes('superscript')) exts.push(Superscript);
-
-            let levels = [];
-            if (btns.includes('h1')) levels.push(1);
-            if (btns.includes('h2')) levels.push(2);
-            if (btns.includes('h3')) levels.push(3);
-            if (btns.includes('h4')) levels.push(4);
-            if (btns.includes('h5')) levels.push(5);
-            if (btns.includes('h6')) levels.push(6);
-            if (levels.length) exts.push(Heading.configure({ levels }));
-
-            let alignments = [];
-            if (btns.includes('alignleft')) alignments.push('left');
-            if (btns.includes('aligncenter')) alignments.push('center');
-            if (btns.includes('alignright')) alignments.push('right');
-            if (btns.includes('alignjustify')) alignments.push('justify');
-            if (alignments.length) exts.push(TextAlign.configure({ types: ['heading', 'paragraph'], alignments }));
-
-            if (btns.includes('table')) {
-                exts.push(
-                    Table.configure({ resizable: true }),
-                    TableHeader,
-                    TableCell,
-                    TableRow,
-                );
-            }
-
-            this.$bard.extensionCallbacks.forEach((callback) => {
-                let returned = callback({ bard: this});
-                exts = exts.concat(
-                    Array.isArray(returned) ? returned : [returned]
-                );
-            });
-
-            this.$bard.extensionReplacementCallbacks.forEach(({ callback, name }) => {
-                let index = exts.findIndex(ext => ext.name === name);
-                if (index === -1) return;
-                let extension = exts[index];
-                let newExtension = callback({ bard: this, extension });
-                exts[index] = newExtension;
-            });
-
-            return exts;
-        },
-
-        updateSetPreviews(set, previews) {
-            this.previews[set] = previews;
-        },
-
-        ignorePageHeader(ignore) {
-            if (this.pageHeader) {
-                this.pageHeader.style['pointer-events'] = ignore ? 'none' : 'all';
-            }
-        },
-
-        makeBardProvide() {
-            const bard = {};
-            Object.defineProperties(bard, {
-                setConfigs: { get: () => this.setConfigs },
-                isReadOnly: { get: () => this.readOnly },
-            });
-            return bard;
-        },
-
-        addSetButtonClicked() {
-            if (this.setConfigs.length === 1) {
-                this.addSet(this.setConfigs[0].handle);
-            }
-        },
-
-        clickedAwayFromSetPicker($event) {
-            if (this.$el.contains($event.target)) return;
-            this.showAddSetButton = false;
-        },
-
+                    onUpdate: () => {
+                        this.json = this.editor.getJSON().content;
+                        this.html = this.editor.getHTML();
+                    },
+                    onCreate: ({ editor }) => {
+                        const state = editor.view.state;
+                        if (content !== null && typeof content === 'object') {
+                            try {
+                                state.schema.nodeFromJSON(content);
+                            } catch (error) {
+                                this.invalid = true;
+                            }
+                        }
+                    }
+                });
+            },
+    
+            valueToContent(value) {    
+                return value.length
+                    ? { type: 'doc', content: value }
+                    : null;
+            },
+    
+            getExtensions() {
+                let modeExts = this.inputIsInline ? [DocumentInline] : [DocumentBlock, HardBreak];
+                if (this.config.inline === 'break') {
+                    modeExts.push(HardBreak.extend({
+                        addKeyboardShortcuts() {
+                            return {
+                                ...this.parent?.(),
+                                'Enter': () => this.editor.commands.setHardBreak(),
+                            }
+                        },
+                    }));
+                }
+                let exts = [
+                    CharacterCount.configure({ limit: this.config.character_limit }),
+                    ...modeExts,
+                    Dropcursor,
+                    Gapcursor,
+                    History,
+                    Paragraph,
+                    Placeholder.configure({ placeholder: this.config.placeholder }),
+                    Set.configure({ bard: this }),
+                    Text
+                ];
+    
+                if (this.config.smart_typography) {
+                    exts.push(Typography);
+                }
+    
+                let btns = this.buttons.map(button => button.name);
+    
+                if (btns.includes('anchor')) exts.push(Link.configure({ vm: this }));
+                if (btns.includes('bold')) exts.push(Bold);
+                if (btns.includes('code')) exts.push(Code);
+                if (btns.includes('codeblock')) exts.push(CodeBlockLowlight.configure({ lowlight }));
+                if (btns.includes('horizontalrule')) exts.push(HorizontalRule);
+                if (btns.includes('image')) exts.push(Image.configure({ bard: this }));
+                if (btns.includes('italic')) exts.push(Italic);
+                if (btns.includes('quote')) exts.push(Blockquote);
+                if (btns.includes('orderedlist')) exts.push(OrderedList);
+                if (btns.includes('orderedlist') || btns.includes('unorderedlist')) exts.push(ListItem);
+                if (btns.includes('underline')) exts.push(Underline);
+                if (btns.includes('unorderedlist')) exts.push(BulletList);
+                if (btns.includes('small')) exts.push(Small);
+                if (btns.includes('strikethrough')) exts.push(Strike);
+                if (btns.includes('subscript')) exts.push(Subscript);
+                if (btns.includes('superscript')) exts.push(Superscript);
+    
+                let levels = [];
+                if (btns.includes('h1')) levels.push(1);
+                if (btns.includes('h2')) levels.push(2);
+                if (btns.includes('h3')) levels.push(3);
+                if (btns.includes('h4')) levels.push(4);
+                if (btns.includes('h5')) levels.push(5);
+                if (btns.includes('h6')) levels.push(6);
+                if (levels.length) exts.push(Heading.configure({ levels }));
+    
+                let alignments = [];
+                if (btns.includes('alignleft')) alignments.push('left');
+                if (btns.includes('aligncenter')) alignments.push('center');
+                if (btns.includes('alignright')) alignments.push('right');
+                if (btns.includes('alignjustify')) alignments.push('justify');
+                if (alignments.length) exts.push(TextAlign.configure({ types: ['heading', 'paragraph'], alignments }));
+    
+                if (btns.includes('table')) {
+                    exts.push(
+                        Table.configure({ resizable: true }),
+                        TableHeader,
+                        TableCell,
+                        TableRow,
+                    );
+                }
+    
+                this.$bard.extensionCallbacks.forEach((callback) => {
+                    let returned = callback({ bard: this});
+                    exts = exts.concat(
+                        Array.isArray(returned) ? returned : [returned]
+                    );
+                });
+    
+                this.$bard.extensionReplacementCallbacks.forEach(({ callback, name }) => {
+                    let index = exts.findIndex(ext => ext.name === name);
+                    if (index === -1) return;
+                    let extension = exts[index];
+                    let newExtension = callback({ bard: this, extension });
+                    exts[index] = newExtension;
+                });
+    
+                return exts;
+            },
+    
+            updateSetPreviews(set, previews) {
+                this.previews[set] = previews;
+            },
+    
+            ignorePageHeader(ignore) {
+                if (this.pageHeader) {
+                    this.pageHeader.style['pointer-events'] = ignore ? 'none' : 'all';
+                }
+            },
+    
+            makeBardProvide() {
+                const bard = {};
+                Object.defineProperties(bard, {
+                    setConfigs: { get: () => this.setConfigs },
+                    isReadOnly: { get: () => this.readOnly },
+                });
+                return bard;
+            },
+    
+            addSetButtonClicked() {
+                if (this.setConfigs.length === 1) {
+                    this.addSet(this.setConfigs[0].handle);
+                }
+            },
+    
+            clickedAwayFromSetPicker($event) {
+                if (this.$el.contains($event.target)) return;
+                this.showAddSetButton = false;
+            },
+    
+        }
     }
-}
-</script>
+    </script>
+    

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -2,8 +2,8 @@
 
 <portal name="bard-fullscreen" :disabled="!fullScreenMode" :provide="provide">
 <!-- These wrappers allow any css that expected the field to
-        be within the context of a publish form to continue working
-        once it has been portaled out. -->
+     be within the context of a publish form to continue working
+     once it has been portaled out. -->
 <div :class="{ 'publish-fields': fullScreenMode }">
 <div :class="fullScreenMode && wrapperClasses">
 

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -96,7 +96,7 @@
 </div>
 </div>
 </portal>
-    
+
 </template>
 
 <script>

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -1,762 +1,761 @@
 <template>
 
-    <portal name="bard-fullscreen" :disabled="!fullScreenMode" :provide="provide">
-    <!-- These wrappers allow any css that expected the field to
-         be within the context of a publish form to continue working
-         once it has been portaled out. -->
-    <div :class="{ 'publish-fields': fullScreenMode }">
-    <div :class="fullScreenMode && wrapperClasses">
-    
-        <div
-            class="bard-fieldtype-wrapper"
-            :class="{'bard-fullscreen': fullScreenMode }"
-            ref="container"
-            @dragstart.stop="ignorePageHeader(true)"
-            @dragend="ignorePageHeader(false)"
-        >
-    
-            <div class="bard-fixed-toolbar" v-if="!readOnly && showFixedToolbar">
-                <div class="flex flex-wrap flex-1 items-center no-select" v-if="toolbarIsFixed" :class="{'justify-center': fullScreenMode}">
-                    <component
-                        v-for="button in visibleButtons(buttons)"
-                        :key="button.name"
-                        :is="button.component || 'BardToolbarButton'"
-                        :button="button"
-                        :active="buttonIsActive(button)"
-                        :config="config"
-                        :bard="_self"
-                        :editor="editor" />
-                        <button class="bard-toolbar-button" @click="showSource = !showSource" v-if="allowSource" v-tooltip="__('Show HTML Source')" :aria-label="__('Show HTML Source')">
-                            <svg-icon name="show-source" class="w-4 h-4 "/>
-                        </button>
-                        <button class="bard-toolbar-button" @click="toggleCollapseSets" v-tooltip="__('Expand/Collapse Sets')" :aria-label="__('Expand/Collapse Sets')" v-if="config.collapse !== 'accordion' && setConfigs.length > 0">
-                            <svg-icon name="expand-collapse-vertical-2" class="w-4 h-4" />
-                        </button>
-                        <button class="bard-toolbar-button" @click="toggleFullscreen" v-tooltip="__('Toggle Fullscreen Mode')" :aria-label="__('Toggle Fullscreen Mode')" v-if="config.fullscreen">
-                            <svg-icon name="arrows-shrink" class="w-4 h-4" v-show="fullScreenMode" />
-                            <svg-icon name="expand-bold" class="w-4 h-4" v-show="!fullScreenMode" />
-                        </button>
-                </div>
-            </div>
-    
-            <div class="bard-editor @container/bard" :class="{ 'mode:read-only': readOnly, 'mode:minimal': ! showFixedToolbar, 'mode:inline': inputIsInline }" tabindex="0">
-                <bubble-menu class="bard-floating-toolbar" :editor="editor" :tippy-options="{ maxWidth: 'none', zIndex: 1000 }" v-if="editor && toolbarIsFloating && !readOnly">
-                    <component
-                        v-for="button in visibleButtons(buttons)"
-                        :key="button.name"
-                        :is="button.component || 'BardToolbarButton'"
-                        :button="button"
-                        :active="buttonIsActive(button)"
-                        :bard="_self"
-                        :config="config"
-                        :editor="editor" />
-                </bubble-menu>
-    
-                <floating-menu
-                    class="bard-set-selector"
-                    :editor="editor"
-                    :should-show="shouldShowSetButton"
-                    :is-showing="showAddSetButton"
-                    v-if="editor"
-                    v-slot="{ y }"
-                    @shown="showAddSetButton = true"
-                    @hidden="showAddSetButton = false"
-                >
-                    <set-picker
-                        v-if="showAddSetButton"
-                        :sets="groupConfigs"
-                        @added="addSet"
-                        @clicked-away="clickedAwayFromSetPicker"
-                    >
-                        <template #trigger>
-                            <button
-                                type="button"
-                                class="btn-round group bard-add-set-button"
-                                :style="{ transform: `translateY(${y}px)` }"
-                                :aria-label="__('Add Set')"
-                                v-tooltip="__('Add Set')"
-                                @click="addSetButtonClicked"
-                            >
-                                <svg-icon name="micro/plus" class="w-3 h-3 text-gray-800 group-hover:text-black" />
-                            </button>
-                        </template>
-                    </set-picker>
-                </floating-menu>
-    
-                <div class="bard-invalid" v-if="invalid" v-html="__('Invalid content')"></div>
-                <editor-content :editor="editor" v-show="!showSource" :id="fieldId" />
-                <bard-source :html="htmlWithReplacedLinks" v-if="showSource" />
-            </div>
-            <div class="bard-footer-toolbar" v-if="editor && (config.reading_time || config.character_limit || config.word_count)">
-                <div v-if="config.reading_time">{{ readingTime }} {{ __('Reading Time') }}</div>
-                <div v-else />
-                <div v-if="config.character_limit || config.word_count" v-text="characterAndWordCountText" />
+<portal name="bard-fullscreen" :disabled="!fullScreenMode" :provide="provide">
+<!-- These wrappers allow any css that expected the field to
+        be within the context of a publish form to continue working
+        once it has been portaled out. -->
+<div :class="{ 'publish-fields': fullScreenMode }">
+<div :class="fullScreenMode && wrapperClasses">
+
+    <div
+        class="bard-fieldtype-wrapper"
+        :class="{'bard-fullscreen': fullScreenMode }"
+        ref="container"
+        @dragstart.stop="ignorePageHeader(true)"
+        @dragend="ignorePageHeader(false)"
+    >
+
+        <div class="bard-fixed-toolbar" v-if="!readOnly && showFixedToolbar">
+            <div class="flex flex-wrap flex-1 items-center no-select" v-if="toolbarIsFixed" :class="{'justify-center': fullScreenMode}">
+                <component
+                    v-for="button in visibleButtons(buttons)"
+                    :key="button.name"
+                    :is="button.component || 'BardToolbarButton'"
+                    :button="button"
+                    :active="buttonIsActive(button)"
+                    :config="config"
+                    :bard="_self"
+                    :editor="editor" />
+                    <button class="bard-toolbar-button" @click="showSource = !showSource" v-if="allowSource" v-tooltip="__('Show HTML Source')" :aria-label="__('Show HTML Source')">
+                        <svg-icon name="show-source" class="w-4 h-4 "/>
+                    </button>
+                    <button class="bard-toolbar-button" @click="toggleCollapseSets" v-tooltip="__('Expand/Collapse Sets')" :aria-label="__('Expand/Collapse Sets')" v-if="config.collapse !== 'accordion' && setConfigs.length > 0">
+                        <svg-icon name="expand-collapse-vertical-2" class="w-4 h-4" />
+                    </button>
+                    <button class="bard-toolbar-button" @click="toggleFullscreen" v-tooltip="__('Toggle Fullscreen Mode')" :aria-label="__('Toggle Fullscreen Mode')" v-if="config.fullscreen">
+                        <svg-icon name="arrows-shrink" class="w-4 h-4" v-show="fullScreenMode" />
+                        <svg-icon name="expand-bold" class="w-4 h-4" v-show="!fullScreenMode" />
+                    </button>
             </div>
         </div>
+
+        <div class="bard-editor @container/bard" :class="{ 'mode:read-only': readOnly, 'mode:minimal': ! showFixedToolbar, 'mode:inline': inputIsInline }" tabindex="0">
+            <bubble-menu class="bard-floating-toolbar" :editor="editor" :tippy-options="{ maxWidth: 'none', zIndex: 1000 }" v-if="editor && toolbarIsFloating && !readOnly">
+                <component
+                    v-for="button in visibleButtons(buttons)"
+                    :key="button.name"
+                    :is="button.component || 'BardToolbarButton'"
+                    :button="button"
+                    :active="buttonIsActive(button)"
+                    :bard="_self"
+                    :config="config"
+                    :editor="editor" />
+            </bubble-menu>
+
+            <floating-menu
+                class="bard-set-selector"
+                :editor="editor"
+                :should-show="shouldShowSetButton"
+                :is-showing="showAddSetButton"
+                v-if="editor"
+                v-slot="{ y }"
+                @shown="showAddSetButton = true"
+                @hidden="showAddSetButton = false"
+            >
+                <set-picker
+                    v-if="showAddSetButton"
+                    :sets="groupConfigs"
+                    @added="addSet"
+                    @clicked-away="clickedAwayFromSetPicker"
+                >
+                    <template #trigger>
+                        <button
+                            type="button"
+                            class="btn-round group bard-add-set-button"
+                            :style="{ transform: `translateY(${y}px)` }"
+                            :aria-label="__('Add Set')"
+                            v-tooltip="__('Add Set')"
+                            @click="addSetButtonClicked"
+                        >
+                            <svg-icon name="micro/plus" class="w-3 h-3 text-gray-800 group-hover:text-black" />
+                        </button>
+                    </template>
+                </set-picker>
+            </floating-menu>
+
+            <div class="bard-invalid" v-if="invalid" v-html="__('Invalid content')"></div>
+            <editor-content :editor="editor" v-show="!showSource" :id="fieldId" />
+            <bard-source :html="htmlWithReplacedLinks" v-if="showSource" />
+        </div>
+        <div class="bard-footer-toolbar" v-if="editor && (config.reading_time || config.character_limit || config.word_count)">
+            <div v-if="config.reading_time">{{ readingTime }} {{ __('Reading Time') }}</div>
+            <div v-else />
+            <div v-if="config.character_limit || config.word_count" v-text="characterAndWordCountText" />
+        </div>
     </div>
-    </div>
-    </portal>
+</div>
+</div>
+</portal>
     
-    </template>
-    
-    <script>
-    import uniqid from 'uniqid';
-    import reduce from 'underscore/modules/reduce';
-    import { BubbleMenu, Editor, EditorContent } from '@tiptap/vue-2';
-    import { FloatingMenu } from './FloatingMenu';
-    import Blockquote from '@tiptap/extension-blockquote';
-    import Bold from '@tiptap/extension-bold';
-    import BulletList from '@tiptap/extension-bullet-list';
-    import CharacterCount from '@tiptap/extension-character-count';
-    import Code from '@tiptap/extension-code';
-    import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
-    import Dropcursor from '@tiptap/extension-dropcursor';
-    import Gapcursor from '@tiptap/extension-gapcursor';
-    import HardBreak from '@tiptap/extension-hard-break';
-    import Heading from '@tiptap/extension-heading';
-    import History from '@tiptap/extension-history';
-    import HorizontalRule from '@tiptap/extension-horizontal-rule';
-    import Italic from '@tiptap/extension-italic';
-    import ListItem from '@tiptap/extension-list-item';
-    import OrderedList from '@tiptap/extension-ordered-list';
-    import Paragraph from '@tiptap/extension-paragraph';
-    import Placeholder from '@tiptap/extension-placeholder';
-    import Strike from '@tiptap/extension-strike';
-    import Subscript from '@tiptap/extension-subscript';
-    import Superscript from '@tiptap/extension-superscript';
-    import Table from '@tiptap/extension-table';
-    import TableRow from '@tiptap/extension-table-row';
-    import TableCell from '@tiptap/extension-table-cell';
-    import TableHeader from '@tiptap/extension-table-header';
-    import Text from '@tiptap/extension-text';
-    import TextAlign from '@tiptap/extension-text-align';
-    import Typography from '@tiptap/extension-typography';
-    import Underline from '@tiptap/extension-underline';
-    import BardSource from './Source.vue';
-    import SetPicker from '../replicator/SetPicker.vue';
-    import { DocumentBlock, DocumentInline } from './Document';
-    import { Set } from './Set'
-    import { Small } from './Small';
-    import { Image } from './Image';
-    import { Link } from './Link';
-    import LinkToolbarButton from './LinkToolbarButton.vue';
-    import ManagesSetMeta from '../replicator/ManagesSetMeta';
-    import { availableButtons, addButtonHtml } from '../bard/buttons';
-    import readTimeEstimate from 'read-time-estimate';
-    import { lowlight } from 'lowlight/lib/common.js';
-    import 'highlight.js/styles/github.css';
-    
-    export default {
-    
-        mixins: [Fieldtype, ManagesSetMeta],
-    
-        components: {
-            BubbleMenu,
-            BardSource,
-            BardToolbarButton,
-            SetPicker,
-            EditorContent,
-            FloatingMenu,
-            LinkToolbarButton,
+</template>
+
+<script>
+import uniqid from 'uniqid';
+import reduce from 'underscore/modules/reduce';
+import { BubbleMenu, Editor, EditorContent } from '@tiptap/vue-2';
+import { FloatingMenu } from './FloatingMenu';
+import Blockquote from '@tiptap/extension-blockquote';
+import Bold from '@tiptap/extension-bold';
+import BulletList from '@tiptap/extension-bullet-list';
+import CharacterCount from '@tiptap/extension-character-count';
+import Code from '@tiptap/extension-code';
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import Dropcursor from '@tiptap/extension-dropcursor';
+import Gapcursor from '@tiptap/extension-gapcursor';
+import HardBreak from '@tiptap/extension-hard-break';
+import Heading from '@tiptap/extension-heading';
+import History from '@tiptap/extension-history';
+import HorizontalRule from '@tiptap/extension-horizontal-rule';
+import Italic from '@tiptap/extension-italic';
+import ListItem from '@tiptap/extension-list-item';
+import OrderedList from '@tiptap/extension-ordered-list';
+import Paragraph from '@tiptap/extension-paragraph';
+import Placeholder from '@tiptap/extension-placeholder';
+import Strike from '@tiptap/extension-strike';
+import Subscript from '@tiptap/extension-subscript';
+import Superscript from '@tiptap/extension-superscript';
+import Table from '@tiptap/extension-table';
+import TableRow from '@tiptap/extension-table-row';
+import TableCell from '@tiptap/extension-table-cell';
+import TableHeader from '@tiptap/extension-table-header';
+import Text from '@tiptap/extension-text';
+import TextAlign from '@tiptap/extension-text-align';
+import Typography from '@tiptap/extension-typography';
+import Underline from '@tiptap/extension-underline';
+import BardSource from './Source.vue';
+import SetPicker from '../replicator/SetPicker.vue';
+import { DocumentBlock, DocumentInline } from './Document';
+import { Set } from './Set'
+import { Small } from './Small';
+import { Image } from './Image';
+import { Link } from './Link';
+import LinkToolbarButton from './LinkToolbarButton.vue';
+import ManagesSetMeta from '../replicator/ManagesSetMeta';
+import { availableButtons, addButtonHtml } from '../bard/buttons';
+import readTimeEstimate from 'read-time-estimate';
+import { lowlight } from 'lowlight/lib/common.js';
+import 'highlight.js/styles/github.css';
+
+export default {
+
+    mixins: [Fieldtype, ManagesSetMeta],
+
+    components: {
+        BubbleMenu,
+        BardSource,
+        BardToolbarButton,
+        SetPicker,
+        EditorContent,
+        FloatingMenu,
+        LinkToolbarButton,
+    },
+
+    inject: ['storeName'],
+
+    data() {
+        return {
+            editor: null,
+            html: null,
+            json: [],
+            showSource: false,
+            fullScreenMode: false,
+            buttons: [],
+            collapsed: this.meta.collapsed,
+            previews: this.meta.previews,
+            mounted: false,
+            invalid: false,
+            pageHeader: null,
+            escBinding: null,
+            showAddSetButton: false,
+            provide: {
+                bard: this.makeBardProvide(),
+                storeName: this.storeName
+            }
+        }
+    },
+
+    computed: {
+
+        allowSource() {
+            return this.config.allow_source === undefined ? true : this.config.allow_source;
         },
-    
-        inject: ['storeName'],
-    
-        data() {
-            return {
-                editor: null,
-                html: null,
-                json: [],
-                showSource: false,
-                fullScreenMode: false,
-                buttons: [],
-                collapsed: this.meta.collapsed,
-                previews: this.meta.previews,
-                mounted: false,
-                invalid: false,
-                pageHeader: null,
-                escBinding: null,
-                showAddSetButton: false,
-                provide: {
-                    bard: this.makeBardProvide(),
-                    storeName: this.storeName
-                }
+
+        toolbarIsFixed() {
+            return this.config.toolbar_mode === 'fixed';
+        },
+
+        toolbarIsFloating() {
+            return this.config.toolbar_mode === 'floating';
+        },
+
+        showFixedToolbar() {
+            return this.toolbarIsFixed && (this.visibleButtons.length > 0 || this.allowSource || this.hasExtraButtons)
+        },
+
+        hasExtraButtons() {
+            return this.allowSource || this.setConfigs.length > 0 || this.config.fullscreen;
+        },
+
+        readingTime() {
+            if (this.html) {
+                var stats = readTimeEstimate(this.html, 265, 12, 500, ['img', 'Image', 'bard-set']);
+                var duration = moment.duration(stats.duration, 'minutes');
+
+                return moment.utc(duration.asMilliseconds()).format("mm:ss");
             }
         },
-    
-        computed: {
-    
-            allowSource() {
-                return this.config.allow_source === undefined ? true : this.config.allow_source;
-            },
-    
-            toolbarIsFixed() {
-                return this.config.toolbar_mode === 'fixed';
-            },
-    
-            toolbarIsFloating() {
-                return this.config.toolbar_mode === 'floating';
-            },
-    
-            showFixedToolbar() {
-                return this.toolbarIsFixed && (this.visibleButtons.length > 0 || this.allowSource || this.hasExtraButtons)
-            },
-    
-            hasExtraButtons() {
-                return this.allowSource || this.setConfigs.length > 0 || this.config.fullscreen;
-            },
-    
-            readingTime() {
-                if (this.html) {
-                    var stats = readTimeEstimate(this.html, 265, 12, 500, ['img', 'Image', 'bard-set']);
-                    var duration = moment.duration(stats.duration, 'minutes');
-    
-                    return moment.utc(duration.asMilliseconds()).format("mm:ss");
-                }
-            },
-    
-            characterAndWordCountText() {
-                const showWordCount = this.config.word_count;
-                const wordCount = this.editor.storage.characterCount.words();
-                const wordCountText = `${__n(':count word|:count words', wordCount)}`;
-                const charLimit = this.config.character_limit;
-                const showCharLimit = charLimit > 0;
-                const charCount = this.editor.storage.characterCount.characters();
-    
-                // If both are enabled, show a more verbose combined string.
-                if (showCharLimit && showWordCount) {
-                    return `${wordCountText}, ${__(':count/:total characters', { count: charCount, total: charLimit })}`;
-                }
-    
-                // Otherwise show one or the other.
-                if (showCharLimit) return `${charCount}/${charLimit}`;
-                if (showWordCount) return wordCountText;
-            },
-    
-            isFirstCreation() {
-                return !this.$config.get('bard.meta').hasOwnProperty(this.id);
-            },
-    
-            id() {
-                return `${this.storeName}.${this.name}`;
-            },
-    
-            setIndexes() {
-                let indexes = {}
-    
-                this.json.forEach((item, i) => {
-                    if (item.type === 'set') {
-                        indexes[item.attrs.id] = i;
-                    }
-                });
-    
-                return indexes;
-            },
-    
-            storeState() {
-                if (! this.storeName) return undefined;
-    
-                return this.$store.state.publish[this.storeName];
-            },
-    
-            site() {
-                return this.storeState ? this.storeState.site : this.$config.get('selectedSite');
-            },
-    
-            htmlWithReplacedLinks() {
-                return this.html.replaceAll(/\"statamic:\/\/(.*?)\"/g, (match, ref) => {
-                    const linkData = this.meta.linkData[ref];
-                    if (! linkData) {
-                        this.$toast.error(`${__('No link data found for')} ${ref}`);
-                        return '""';
-                    }
-    
-                    return `"${linkData.permalink}"`;
-                });
-            },
-    
-            setsWithErrors() {
-                if (! this.storeState) return [];
-    
-                return Object.values(this.setIndexes).filter((setIndex) => {
-                    const prefix = `${this.fieldPathPrefix || this.handle}.${setIndex}.`;
-    
-                    return Object.keys(this.storeState.errors).some(key => key.startsWith(prefix));
-                })
-            },
-    
-            replicatorPreview() {
-                const stack = [...this.value];
-                let text = '';
-                while (stack.length) {
-                    const node = stack.shift();
-                    if (node.type === 'text') {
-                        text += ` ${node.text || ''}`;
-                    } else if (node.type === 'set') {
-                        const handle = node.attrs.values.type;
-                        const set = this.setConfigs.find(set => set.handle === handle);
-                        text += ` [${set ? set.display : handle}]`;
-                    }
-                    if (text.length > 150) {
-                        break;
-                    }
-                    if (node.content) {
-                        stack.unshift(...node.content);
-                    }
-                }
-                return text;
-            },
-    
-            inputIsInline() {
-                return this.config.inline;
-            },
-    
-            wrapperClasses() {
-                return `form-group publish-field publish-field__${this.handle} bard-fieldtype`;
-            },
-    
-            setConfigs() {
-                return reduce(this.groupConfigs, (sets, group) => {
-                    return sets.concat(group.sets);
-                }, []);
-            },
-    
-            groupConfigs() {
-                return this.config.sets;
-            },
-    
+
+        characterAndWordCountText() {
+            const showWordCount = this.config.word_count;
+            const wordCount = this.editor.storage.characterCount.words();
+            const wordCountText = `${__n(':count word|:count words', wordCount)}`;
+            const charLimit = this.config.character_limit;
+            const showCharLimit = charLimit > 0;
+            const charCount = this.editor.storage.characterCount.characters();
+
+            // If both are enabled, show a more verbose combined string.
+            if (showCharLimit && showWordCount) {
+                return `${wordCountText}, ${__(':count/:total characters', { count: charCount, total: charLimit })}`;
+            }
+
+            // Otherwise show one or the other.
+            if (showCharLimit) return `${charCount}/${charLimit}`;
+            if (showWordCount) return wordCountText;
         },
-    
-        mounted() {
-            this.initToolbarButtons();
-            this.initEditor();
-    
-            this.json = this.editor.getJSON().content;
-            this.html = this.editor.getHTML();
-    
-            this.escBinding = this.$keys.bind('esc', this.closeFullscreen)
-    
-            this.$nextTick(() => {
-                this.mounted = true;
-                if (this.config.collapse) this.collapseAll();
+
+        isFirstCreation() {
+            return !this.$config.get('bard.meta').hasOwnProperty(this.id);
+        },
+
+        id() {
+            return `${this.storeName}.${this.name}`;
+        },
+
+        setIndexes() {
+            let indexes = {}
+
+            this.json.forEach((item, i) => {
+                if (item.type === 'set') {
+                    indexes[item.attrs.id] = i;
+                }
             });
-    
-            this.pageHeader = document.querySelector('.global-header');
-    
-            this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
-    
-            this.$nextTick(() => {
-                document.querySelector(`label[for="${this.fieldId}"]`).addEventListener('click', () => {
-                    this.editor.commands.focus();
-                });
+
+            return indexes;
+        },
+
+        storeState() {
+            if (! this.storeName) return undefined;
+
+            return this.$store.state.publish[this.storeName];
+        },
+
+        site() {
+            return this.storeState ? this.storeState.site : this.$config.get('selectedSite');
+        },
+
+        htmlWithReplacedLinks() {
+            return this.html.replaceAll(/\"statamic:\/\/(.*?)\"/g, (match, ref) => {
+                const linkData = this.meta.linkData[ref];
+                if (! linkData) {
+                    this.$toast.error(`${__('No link data found for')} ${ref}`);
+                    return '""';
+                }
+
+                return `"${linkData.permalink}"`;
             });
         },
-    
-        beforeDestroy() {
-            this.editor.destroy();
-            this.escBinding.destroy();
-    
-            this.$store.commit(`publish/${this.storeName}/unsetFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
+
+        setsWithErrors() {
+            if (! this.storeState) return [];
+
+            return Object.values(this.setIndexes).filter((setIndex) => {
+                const prefix = `${this.fieldPathPrefix || this.handle}.${setIndex}.`;
+
+                return Object.keys(this.storeState.errors).some(key => key.startsWith(prefix));
+            })
         },
-    
-        watch: {
-    
-            json(json) {
-                if (!this.mounted) return;
-    
-                this.updateDebounced(json);
-            },
-    
-            value(value, oldValue) {    
-                const oldContent = this.editor.getJSON();
-                const content = this.valueToContent(value);
-    
-                if (JSON.stringify(content) !== JSON.stringify(oldContent)) {
-                    this.editor.commands.clearContent()
-                    this.editor.commands.setContent(content, true);
+
+        replicatorPreview() {
+            const stack = [...this.value];
+            let text = '';
+            while (stack.length) {
+                const node = stack.shift();
+                if (node.type === 'text') {
+                    text += ` ${node.text || ''}`;
+                } else if (node.type === 'set') {
+                    const handle = node.attrs.values.type;
+                    const set = this.setConfigs.find(set => set.handle === handle);
+                    text += ` [${set ? set.display : handle}]`;
                 }
-            },
-    
-            readOnly(readOnly) {
-                this.editor.setEditable(!this.readOnly);
-            },
-    
-            collapsed(value) {
+                if (text.length > 150) {
+                    break;
+                }
+                if (node.content) {
+                    stack.unshift(...node.content);
+                }
+            }
+            return text;
+        },
+
+        inputIsInline() {
+            return this.config.inline;
+        },
+
+        wrapperClasses() {
+            return `form-group publish-field publish-field__${this.handle} bard-fieldtype`;
+        },
+
+        setConfigs() {
+            return reduce(this.groupConfigs, (sets, group) => {
+                return sets.concat(group.sets);
+            }, []);
+        },
+
+        groupConfigs() {
+            return this.config.sets;
+        },
+
+    },
+
+    mounted() {
+        this.initToolbarButtons();
+        this.initEditor();
+
+        this.json = this.editor.getJSON().content;
+        this.html = this.editor.getHTML();
+
+        this.escBinding = this.$keys.bind('esc', this.closeFullscreen)
+
+        this.$nextTick(() => {
+            this.mounted = true;
+            if (this.config.collapse) this.collapseAll();
+        });
+
+        this.pageHeader = document.querySelector('.global-header');
+
+        this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
+
+        this.$nextTick(() => {
+            document.querySelector(`label[for="${this.fieldId}"]`).addEventListener('click', () => {
+                this.editor.commands.focus();
+            });
+        });
+    },
+
+    beforeDestroy() {
+        this.editor.destroy();
+        this.escBinding.destroy();
+
+        this.$store.commit(`publish/${this.storeName}/unsetFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
+    },
+
+    watch: {
+
+        json(json) {
+            if (!this.mounted) return;
+
+            this.updateDebounced(json);
+        },
+
+        value(value, oldValue) {    
+            const oldContent = this.editor.getJSON();
+            const content = this.valueToContent(value);
+
+            if (JSON.stringify(content) !== JSON.stringify(oldContent)) {
+                this.editor.commands.clearContent()
+                this.editor.commands.setContent(content, true);
+            }
+        },
+
+        readOnly(readOnly) {
+            this.editor.setEditable(!this.readOnly);
+        },
+
+        collapsed(value) {
+            const meta = this.meta;
+            meta.collapsed = value;
+            this.updateMeta(meta);
+        },
+
+        previews: {
+            deep: true,
+            handler(value) {
+                if (JSON.stringify(this.meta.previews) === JSON.stringify(value)) {
+                    return
+                }
                 const meta = this.meta;
-                meta.collapsed = value;
+                meta.previews = value;
                 this.updateMeta(meta);
-            },
-    
-            previews: {
-                deep: true,
-                handler(value) {
-                    if (JSON.stringify(this.meta.previews) === JSON.stringify(value)) {
-                        return
-                    }
-                    const meta = this.meta;
-                    meta.previews = value;
-                    this.updateMeta(meta);
-                }
-            },
-    
-            fieldPathPrefix(fieldPathPrefix, oldFieldPathPrefix) {
-                this.$store.commit(`publish/${this.storeName}/unsetFieldSubmitsJson`, oldFieldPathPrefix);
-                this.$nextTick(() => {
-                    this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, fieldPathPrefix);
-                });
-            },
-    
-            fullScreenMode() {
-                this.initEditor();
             }
-    
         },
-    
-        methods: {
-            addSet(handle) {
-                const id = uniqid();
-                const values = Object.assign({}, { type: handle }, this.meta.defaults[handle]);
-    
-                let previews = {};
-                Object.keys(this.meta.defaults[handle]).forEach(key => previews[key] = null);
-                this.previews = Object.assign({}, this.previews, { [id]: previews });
-    
-                this.updateSetMeta(id, this.meta.new[handle]);
-    
-                // Perform this in nextTick because the meta data won't be ready until then.
-                this.$nextTick(() => {
-                    this.editor.commands.set({ id, values });
-                });
-            },
-    
-            duplicateSet(old_id, attrs, pos) {
-                const id = uniqid();
-                const enabled = attrs.enabled;
-                const values = Object.assign({}, attrs.values);
-    
-                let previews = Object.assign({}, this.previews[old_id]);
-                this.previews = Object.assign({}, this.previews, { [id]: previews });
-    
-                this.updateSetMeta(id, this.meta.existing[old_id]);
-    
-                // Perform this in nextTick because the meta data won't be ready until then.
-                this.$nextTick(() => {
-                    this.editor.commands.setAt({ attrs: { id, enabled, values }, pos });
-                });
-            },
-    
-            collapseSet(id) {
-                if (!this.collapsed.includes(id)) {
-                    this.collapsed.push(id)
-                }
-            },
-    
-            expandSet(id) {
-                if (this.config.collapse === 'accordion') {
-                    this.collapsed = Object.keys(this.meta.existing).filter(v => v !== id);
-                    return;
-                }
-    
-                if (this.collapsed.includes(id)) {
-                    var index = this.collapsed.indexOf(id);
-                    this.collapsed.splice(index, 1);
-                }
-            },
-    
-            collapseAll() {
-                this.collapsed = Object.keys(this.meta.existing);
-            },
-    
-            expandAll() {
-                this.collapsed = [];
-            },
-    
-            toggleCollapseSets() {
-                (this.collapsed.length === 0) ? this.collapseAll() : this.expandAll();
-            },
-    
-            toggleFullscreen() {
-                this.fullScreenMode = !this.fullScreenMode;
-            },
-    
-            closeFullscreen() {
-                this.fullScreenMode = false;
-            },
-    
-            shouldShowSetButton({ view, state }) {
-                const { selection } = state;
-                const { $anchor, empty } = selection;
-                const isRootDepth = $anchor.depth === 1;
-                const isEmptyTextBlock = $anchor.parent.isTextblock && !$anchor.parent.type.spec.code && !$anchor.parent.textContent;
-                const isAroundInlineImage = state.selection.$to.nodeBefore?.type.name === 'image' || state.selection.$to.nodeAfter?.type.name === 'image'
-                const isActive = view.hasFocus() && empty && isRootDepth && isEmptyTextBlock && !isAroundInlineImage;
-                return this.setConfigs.length && (this.config.always_show_set_button || isActive);
-            },
-    
-            initToolbarButtons() {
-                const selectedButtons = this.config.buttons || [
-                    'h2', 'h3', 'bold', 'italic', 'unorderedlist', 'orderedlist', 'removeformat', 'quote', 'anchor', 'table'
-                ];
-    
-                if (selectedButtons.includes('table')) {
-                    selectedButtons.push(
-                        'deletetable',
-                        'addcolumnbefore',
-                        'addcolumnafter',
-                        'deletecolumn',
-                        'addrowbefore',
-                        'addrowafter',
-                        'deleterow',
-                        'togglecellmerge',
-                        'toggleheadercell'
-                    );
-                }
-    
-                // Get the configured buttons and swap them with corresponding objects
-                let buttons = selectedButtons.map(button => {
-                    return _.findWhere(availableButtons(), { name: button.toLowerCase() }) || button;
-                });
-    
-                // Let addons add, remove, or control the position of buttons.
-                this.$bard.buttonCallbacks.forEach(callback => {
-                    // Since the developer uses the same callback to add buttons to the field itself, and for the
-                    // button configurator, we need to make the button conditional when on the Bard fieldtype
-                    // but not in the button configurator. So here we'll filter it out if it's not selected.
-                    const buttonFn = (button) => selectedButtons.includes(button.name) ? button : null;
-    
-                    const addedButtons = callback(buttons, buttonFn);
-    
-                    // No return value means either they literally returned nothing, with the intention
-                    // of manipulating the buttons object manually. Or, they used the button() and
-                    // the button was not configured in the field so it was stripped out.
-                    if (! addedButtons) return;
-    
-                    buttons = buttons.concat(
-                        Array.isArray(addedButtons) ? addedButtons : [addedButtons]
-                    );
-                });
-    
-                // Remove any nulls. This could happen if a developer-added button was not specified in this field's buttons array.
-                buttons = buttons.filter(button => !!button);
-    
-                // Remove any non-objects. This would happen if you configure a button name that doesn't exist.
-                buttons = buttons.filter(button => typeof button != 'string');
-    
-                // Generate fallback html for each button
-                buttons = addButtonHtml(buttons);
-    
-                // Remove buttons that don't pass conditions.
-                // eg. only the insert asset button can be shown if a container has been set.
-                buttons = buttons.filter(button => {
-                    return (button.condition) ? button.condition.call(null, this.config) : true;
-                });
-    
-                if (_.findWhere(buttons, {name: 'table'})) {
-                    buttons.push(
-                        { name: 'deletetable', text: __('Delete Table'), command: (editor) => editor.commands.deleteTable(), svg: 'delete-table', visibleWhenActive: 'table' },
-                        { name: 'addcolumnbefore', text: __('Add Column Before'), command: (editor) => editor.commands.addColumnBefore(), svg: 'add-col-before', visibleWhenActive: 'table' },
-                        { name: 'addcolumnafter', text: __('Add Column After'), command: (editor) => editor.commands.addColumnAfter(), svg: 'add-col-after', visibleWhenActive: 'table' },
-                        { name: 'deletecolumn', text: __('Delete Column'), command: (editor) => editor.commands.deleteColumn(), svg: 'delete-col', visibleWhenActive: 'table' },
-                        { name: 'addrowbefore', text: __('Add Row Before'), command: (editor) => editor.commands.addRowBefore(), svg: 'add-row-before', visibleWhenActive: 'table' },
-                        { name: 'addrowafter', text: __('Add Row After'), command: (editor) => editor.commands.addRowAfter(), svg: 'add-row-after', visibleWhenActive: 'table' },
-                        { name: 'deleterow', text: __('Delete Row'), command: (editor) => editor.commands.deleteRow(), svg: 'delete-row', visibleWhenActive: 'table' },
-                        { name: 'toggleheadercell', text: __('Toggle Header Cell'), command: (editor) => editor.commands.toggleHeaderCell(), svg: 'flip-vertical', visibleWhenActive: 'table' },
-                        { name: 'togglecellmerge', text: __('Merge Cells'), command: (editor) => editor.commands.mergeCells(), svg: 'combine-cells', visibleWhenActive: 'table' },
-                    )
-                }
-    
-                this.buttons = buttons;
-            },
-    
-            buttonIsActive(button) {
-                if (button.hasOwnProperty('active')) {
-                    return button.active(this.editor, button.args);
-                }
-                const nameProperty = button.hasOwnProperty('activeName') ? 'activeName' : 'name';
-                const name = button[nameProperty];
-                return this.editor.isActive(name, button.args);
-            },
-    
-            buttonIsVisible(button) {
-                if (button.hasOwnProperty('visible')) {
-                    return button.visible(this.editor, button.args);
-                }
-                if (! button.hasOwnProperty('visibleWhenActive')) return true;
-                return this.editor.isActive(button.visibleWhenActive, button.args);
-            },
-    
-            visibleButtons(buttons) {
-                return buttons.filter(button => this.buttonIsVisible(button));
-            },
-    
-            initEditor() {
-                if (this.editor) this.editor.destroy();
-    
-                const content = this.valueToContent(clone(this.value));
-    
-                this.editor = new Editor({
-                    extensions: this.getExtensions(),
-                    content: content,
-                    editable: !this.readOnly,
-                    enableInputRules: this.config.enable_input_rules,
-                    enablePasteRules: this.config.enable_paste_rules,
-                    editorProps: { attributes: { class: 'bard-content' }},
-                    onFocus: () => this.$emit('focus'),
-                    onBlur: () => {
-                        // Since clicking into a field inside a set would also trigger a blur, we can't just emit the
-                        // blur event immediately. We need to make sure that the newly focused element is outside
-                        // of Bard. We use a timeout because activeElement only exists after the blur event.
-                        setTimeout(() => {
-                            if (!this.$refs.container.contains(document.activeElement)) {
-                                this.$emit('blur');
-                                this.showAddSetButton = false;
-                            }
-                        }, 1);
-                    },
-                    onUpdate: () => {
-                        this.json = this.editor.getJSON().content;
-                        this.html = this.editor.getHTML();
-                    },
-                    onCreate: ({ editor }) => {
-                        const state = editor.view.state;
-                        if (content !== null && typeof content === 'object') {
-                            try {
-                                state.schema.nodeFromJSON(content);
-                            } catch (error) {
-                                this.invalid = true;
-                            }
+
+        fieldPathPrefix(fieldPathPrefix, oldFieldPathPrefix) {
+            this.$store.commit(`publish/${this.storeName}/unsetFieldSubmitsJson`, oldFieldPathPrefix);
+            this.$nextTick(() => {
+                this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, fieldPathPrefix);
+            });
+        },
+
+        fullScreenMode() {
+            this.initEditor();
+        }
+
+    },
+
+    methods: {
+        addSet(handle) {
+            const id = uniqid();
+            const values = Object.assign({}, { type: handle }, this.meta.defaults[handle]);
+
+            let previews = {};
+            Object.keys(this.meta.defaults[handle]).forEach(key => previews[key] = null);
+            this.previews = Object.assign({}, this.previews, { [id]: previews });
+
+            this.updateSetMeta(id, this.meta.new[handle]);
+
+            // Perform this in nextTick because the meta data won't be ready until then.
+            this.$nextTick(() => {
+                this.editor.commands.set({ id, values });
+            });
+        },
+
+        duplicateSet(old_id, attrs, pos) {
+            const id = uniqid();
+            const enabled = attrs.enabled;
+            const values = Object.assign({}, attrs.values);
+
+            let previews = Object.assign({}, this.previews[old_id]);
+            this.previews = Object.assign({}, this.previews, { [id]: previews });
+
+            this.updateSetMeta(id, this.meta.existing[old_id]);
+
+            // Perform this in nextTick because the meta data won't be ready until then.
+            this.$nextTick(() => {
+                this.editor.commands.setAt({ attrs: { id, enabled, values }, pos });
+            });
+        },
+
+        collapseSet(id) {
+            if (!this.collapsed.includes(id)) {
+                this.collapsed.push(id)
+            }
+        },
+
+        expandSet(id) {
+            if (this.config.collapse === 'accordion') {
+                this.collapsed = Object.keys(this.meta.existing).filter(v => v !== id);
+                return;
+            }
+
+            if (this.collapsed.includes(id)) {
+                var index = this.collapsed.indexOf(id);
+                this.collapsed.splice(index, 1);
+            }
+        },
+
+        collapseAll() {
+            this.collapsed = Object.keys(this.meta.existing);
+        },
+
+        expandAll() {
+            this.collapsed = [];
+        },
+
+        toggleCollapseSets() {
+            (this.collapsed.length === 0) ? this.collapseAll() : this.expandAll();
+        },
+
+        toggleFullscreen() {
+            this.fullScreenMode = !this.fullScreenMode;
+        },
+
+        closeFullscreen() {
+            this.fullScreenMode = false;
+        },
+
+        shouldShowSetButton({ view, state }) {
+            const { selection } = state;
+            const { $anchor, empty } = selection;
+            const isRootDepth = $anchor.depth === 1;
+            const isEmptyTextBlock = $anchor.parent.isTextblock && !$anchor.parent.type.spec.code && !$anchor.parent.textContent;
+            const isAroundInlineImage = state.selection.$to.nodeBefore?.type.name === 'image' || state.selection.$to.nodeAfter?.type.name === 'image'
+            const isActive = view.hasFocus() && empty && isRootDepth && isEmptyTextBlock && !isAroundInlineImage;
+            return this.setConfigs.length && (this.config.always_show_set_button || isActive);
+        },
+
+        initToolbarButtons() {
+            const selectedButtons = this.config.buttons || [
+                'h2', 'h3', 'bold', 'italic', 'unorderedlist', 'orderedlist', 'removeformat', 'quote', 'anchor', 'table'
+            ];
+
+            if (selectedButtons.includes('table')) {
+                selectedButtons.push(
+                    'deletetable',
+                    'addcolumnbefore',
+                    'addcolumnafter',
+                    'deletecolumn',
+                    'addrowbefore',
+                    'addrowafter',
+                    'deleterow',
+                    'togglecellmerge',
+                    'toggleheadercell'
+                );
+            }
+
+            // Get the configured buttons and swap them with corresponding objects
+            let buttons = selectedButtons.map(button => {
+                return _.findWhere(availableButtons(), { name: button.toLowerCase() }) || button;
+            });
+
+            // Let addons add, remove, or control the position of buttons.
+            this.$bard.buttonCallbacks.forEach(callback => {
+                // Since the developer uses the same callback to add buttons to the field itself, and for the
+                // button configurator, we need to make the button conditional when on the Bard fieldtype
+                // but not in the button configurator. So here we'll filter it out if it's not selected.
+                const buttonFn = (button) => selectedButtons.includes(button.name) ? button : null;
+
+                const addedButtons = callback(buttons, buttonFn);
+
+                // No return value means either they literally returned nothing, with the intention
+                // of manipulating the buttons object manually. Or, they used the button() and
+                // the button was not configured in the field so it was stripped out.
+                if (! addedButtons) return;
+
+                buttons = buttons.concat(
+                    Array.isArray(addedButtons) ? addedButtons : [addedButtons]
+                );
+            });
+
+            // Remove any nulls. This could happen if a developer-added button was not specified in this field's buttons array.
+            buttons = buttons.filter(button => !!button);
+
+            // Remove any non-objects. This would happen if you configure a button name that doesn't exist.
+            buttons = buttons.filter(button => typeof button != 'string');
+
+            // Generate fallback html for each button
+            buttons = addButtonHtml(buttons);
+
+            // Remove buttons that don't pass conditions.
+            // eg. only the insert asset button can be shown if a container has been set.
+            buttons = buttons.filter(button => {
+                return (button.condition) ? button.condition.call(null, this.config) : true;
+            });
+
+            if (_.findWhere(buttons, {name: 'table'})) {
+                buttons.push(
+                    { name: 'deletetable', text: __('Delete Table'), command: (editor) => editor.commands.deleteTable(), svg: 'delete-table', visibleWhenActive: 'table' },
+                    { name: 'addcolumnbefore', text: __('Add Column Before'), command: (editor) => editor.commands.addColumnBefore(), svg: 'add-col-before', visibleWhenActive: 'table' },
+                    { name: 'addcolumnafter', text: __('Add Column After'), command: (editor) => editor.commands.addColumnAfter(), svg: 'add-col-after', visibleWhenActive: 'table' },
+                    { name: 'deletecolumn', text: __('Delete Column'), command: (editor) => editor.commands.deleteColumn(), svg: 'delete-col', visibleWhenActive: 'table' },
+                    { name: 'addrowbefore', text: __('Add Row Before'), command: (editor) => editor.commands.addRowBefore(), svg: 'add-row-before', visibleWhenActive: 'table' },
+                    { name: 'addrowafter', text: __('Add Row After'), command: (editor) => editor.commands.addRowAfter(), svg: 'add-row-after', visibleWhenActive: 'table' },
+                    { name: 'deleterow', text: __('Delete Row'), command: (editor) => editor.commands.deleteRow(), svg: 'delete-row', visibleWhenActive: 'table' },
+                    { name: 'toggleheadercell', text: __('Toggle Header Cell'), command: (editor) => editor.commands.toggleHeaderCell(), svg: 'flip-vertical', visibleWhenActive: 'table' },
+                    { name: 'togglecellmerge', text: __('Merge Cells'), command: (editor) => editor.commands.mergeCells(), svg: 'combine-cells', visibleWhenActive: 'table' },
+                )
+            }
+
+            this.buttons = buttons;
+        },
+
+        buttonIsActive(button) {
+            if (button.hasOwnProperty('active')) {
+                return button.active(this.editor, button.args);
+            }
+            const nameProperty = button.hasOwnProperty('activeName') ? 'activeName' : 'name';
+            const name = button[nameProperty];
+            return this.editor.isActive(name, button.args);
+        },
+
+        buttonIsVisible(button) {
+            if (button.hasOwnProperty('visible')) {
+                return button.visible(this.editor, button.args);
+            }
+            if (! button.hasOwnProperty('visibleWhenActive')) return true;
+            return this.editor.isActive(button.visibleWhenActive, button.args);
+        },
+
+        visibleButtons(buttons) {
+            return buttons.filter(button => this.buttonIsVisible(button));
+        },
+
+        initEditor() {
+            if (this.editor) this.editor.destroy();
+
+            const content = this.valueToContent(clone(this.value));
+
+            this.editor = new Editor({
+                extensions: this.getExtensions(),
+                content: content,
+                editable: !this.readOnly,
+                enableInputRules: this.config.enable_input_rules,
+                enablePasteRules: this.config.enable_paste_rules,
+                editorProps: { attributes: { class: 'bard-content' }},
+                onFocus: () => this.$emit('focus'),
+                onBlur: () => {
+                    // Since clicking into a field inside a set would also trigger a blur, we can't just emit the
+                    // blur event immediately. We need to make sure that the newly focused element is outside
+                    // of Bard. We use a timeout because activeElement only exists after the blur event.
+                    setTimeout(() => {
+                        if (!this.$refs.container.contains(document.activeElement)) {
+                            this.$emit('blur');
+                            this.showAddSetButton = false;
+                        }
+                    }, 1);
+                },
+                onUpdate: () => {
+                    this.json = this.editor.getJSON().content;
+                    this.html = this.editor.getHTML();
+                },
+                onCreate: ({ editor }) => {
+                    const state = editor.view.state;
+                    if (content !== null && typeof content === 'object') {
+                        try {
+                            state.schema.nodeFromJSON(content);
+                        } catch (error) {
+                            this.invalid = true;
                         }
                     }
-                });
-            },
-    
-            valueToContent(value) {    
-                return value.length
-                    ? { type: 'doc', content: value }
-                    : null;
-            },
-    
-            getExtensions() {
-                let modeExts = this.inputIsInline ? [DocumentInline] : [DocumentBlock, HardBreak];
-                if (this.config.inline === 'break') {
-                    modeExts.push(HardBreak.extend({
-                        addKeyboardShortcuts() {
-                            return {
-                                ...this.parent?.(),
-                                'Enter': () => this.editor.commands.setHardBreak(),
-                            }
-                        },
-                    }));
                 }
-                let exts = [
-                    CharacterCount.configure({ limit: this.config.character_limit }),
-                    ...modeExts,
-                    Dropcursor,
-                    Gapcursor,
-                    History,
-                    Paragraph,
-                    Placeholder.configure({ placeholder: this.config.placeholder }),
-                    Set.configure({ bard: this }),
-                    Text
-                ];
-    
-                if (this.config.smart_typography) {
-                    exts.push(Typography);
-                }
-    
-                let btns = this.buttons.map(button => button.name);
-    
-                if (btns.includes('anchor')) exts.push(Link.configure({ vm: this }));
-                if (btns.includes('bold')) exts.push(Bold);
-                if (btns.includes('code')) exts.push(Code);
-                if (btns.includes('codeblock')) exts.push(CodeBlockLowlight.configure({ lowlight }));
-                if (btns.includes('horizontalrule')) exts.push(HorizontalRule);
-                if (btns.includes('image')) exts.push(Image.configure({ bard: this }));
-                if (btns.includes('italic')) exts.push(Italic);
-                if (btns.includes('quote')) exts.push(Blockquote);
-                if (btns.includes('orderedlist')) exts.push(OrderedList);
-                if (btns.includes('orderedlist') || btns.includes('unorderedlist')) exts.push(ListItem);
-                if (btns.includes('underline')) exts.push(Underline);
-                if (btns.includes('unorderedlist')) exts.push(BulletList);
-                if (btns.includes('small')) exts.push(Small);
-                if (btns.includes('strikethrough')) exts.push(Strike);
-                if (btns.includes('subscript')) exts.push(Subscript);
-                if (btns.includes('superscript')) exts.push(Superscript);
-    
-                let levels = [];
-                if (btns.includes('h1')) levels.push(1);
-                if (btns.includes('h2')) levels.push(2);
-                if (btns.includes('h3')) levels.push(3);
-                if (btns.includes('h4')) levels.push(4);
-                if (btns.includes('h5')) levels.push(5);
-                if (btns.includes('h6')) levels.push(6);
-                if (levels.length) exts.push(Heading.configure({ levels }));
-    
-                let alignments = [];
-                if (btns.includes('alignleft')) alignments.push('left');
-                if (btns.includes('aligncenter')) alignments.push('center');
-                if (btns.includes('alignright')) alignments.push('right');
-                if (btns.includes('alignjustify')) alignments.push('justify');
-                if (alignments.length) exts.push(TextAlign.configure({ types: ['heading', 'paragraph'], alignments }));
-    
-                if (btns.includes('table')) {
-                    exts.push(
-                        Table.configure({ resizable: true }),
-                        TableHeader,
-                        TableCell,
-                        TableRow,
-                    );
-                }
-    
-                this.$bard.extensionCallbacks.forEach((callback) => {
-                    let returned = callback({ bard: this});
-                    exts = exts.concat(
-                        Array.isArray(returned) ? returned : [returned]
-                    );
-                });
-    
-                this.$bard.extensionReplacementCallbacks.forEach(({ callback, name }) => {
-                    let index = exts.findIndex(ext => ext.name === name);
-                    if (index === -1) return;
-                    let extension = exts[index];
-                    let newExtension = callback({ bard: this, extension });
-                    exts[index] = newExtension;
-                });
-    
-                return exts;
-            },
-    
-            updateSetPreviews(set, previews) {
-                this.previews[set] = previews;
-            },
-    
-            ignorePageHeader(ignore) {
-                if (this.pageHeader) {
-                    this.pageHeader.style['pointer-events'] = ignore ? 'none' : 'all';
-                }
-            },
-    
-            makeBardProvide() {
-                const bard = {};
-                Object.defineProperties(bard, {
-                    setConfigs: { get: () => this.setConfigs },
-                    isReadOnly: { get: () => this.readOnly },
-                });
-                return bard;
-            },
-    
-            addSetButtonClicked() {
-                if (this.setConfigs.length === 1) {
-                    this.addSet(this.setConfigs[0].handle);
-                }
-            },
-    
-            clickedAwayFromSetPicker($event) {
-                if (this.$el.contains($event.target)) return;
-                this.showAddSetButton = false;
-            },
-    
-        }
+            });
+        },
+
+        valueToContent(value) {    
+            return value.length
+                ? { type: 'doc', content: value }
+                : null;
+        },
+
+        getExtensions() {
+            let modeExts = this.inputIsInline ? [DocumentInline] : [DocumentBlock, HardBreak];
+            if (this.config.inline === 'break') {
+                modeExts.push(HardBreak.extend({
+                    addKeyboardShortcuts() {
+                        return {
+                            ...this.parent?.(),
+                            'Enter': () => this.editor.commands.setHardBreak(),
+                        }
+                    },
+                }));
+            }
+            let exts = [
+                CharacterCount.configure({ limit: this.config.character_limit }),
+                ...modeExts,
+                Dropcursor,
+                Gapcursor,
+                History,
+                Paragraph,
+                Placeholder.configure({ placeholder: this.config.placeholder }),
+                Set.configure({ bard: this }),
+                Text
+            ];
+
+            if (this.config.smart_typography) {
+                exts.push(Typography);
+            }
+
+            let btns = this.buttons.map(button => button.name);
+
+            if (btns.includes('anchor')) exts.push(Link.configure({ vm: this }));
+            if (btns.includes('bold')) exts.push(Bold);
+            if (btns.includes('code')) exts.push(Code);
+            if (btns.includes('codeblock')) exts.push(CodeBlockLowlight.configure({ lowlight }));
+            if (btns.includes('horizontalrule')) exts.push(HorizontalRule);
+            if (btns.includes('image')) exts.push(Image.configure({ bard: this }));
+            if (btns.includes('italic')) exts.push(Italic);
+            if (btns.includes('quote')) exts.push(Blockquote);
+            if (btns.includes('orderedlist')) exts.push(OrderedList);
+            if (btns.includes('orderedlist') || btns.includes('unorderedlist')) exts.push(ListItem);
+            if (btns.includes('underline')) exts.push(Underline);
+            if (btns.includes('unorderedlist')) exts.push(BulletList);
+            if (btns.includes('small')) exts.push(Small);
+            if (btns.includes('strikethrough')) exts.push(Strike);
+            if (btns.includes('subscript')) exts.push(Subscript);
+            if (btns.includes('superscript')) exts.push(Superscript);
+
+            let levels = [];
+            if (btns.includes('h1')) levels.push(1);
+            if (btns.includes('h2')) levels.push(2);
+            if (btns.includes('h3')) levels.push(3);
+            if (btns.includes('h4')) levels.push(4);
+            if (btns.includes('h5')) levels.push(5);
+            if (btns.includes('h6')) levels.push(6);
+            if (levels.length) exts.push(Heading.configure({ levels }));
+
+            let alignments = [];
+            if (btns.includes('alignleft')) alignments.push('left');
+            if (btns.includes('aligncenter')) alignments.push('center');
+            if (btns.includes('alignright')) alignments.push('right');
+            if (btns.includes('alignjustify')) alignments.push('justify');
+            if (alignments.length) exts.push(TextAlign.configure({ types: ['heading', 'paragraph'], alignments }));
+
+            if (btns.includes('table')) {
+                exts.push(
+                    Table.configure({ resizable: true }),
+                    TableHeader,
+                    TableCell,
+                    TableRow,
+                );
+            }
+
+            this.$bard.extensionCallbacks.forEach((callback) => {
+                let returned = callback({ bard: this});
+                exts = exts.concat(
+                    Array.isArray(returned) ? returned : [returned]
+                );
+            });
+
+            this.$bard.extensionReplacementCallbacks.forEach(({ callback, name }) => {
+                let index = exts.findIndex(ext => ext.name === name);
+                if (index === -1) return;
+                let extension = exts[index];
+                let newExtension = callback({ bard: this, extension });
+                exts[index] = newExtension;
+            });
+
+            return exts;
+        },
+
+        updateSetPreviews(set, previews) {
+            this.previews[set] = previews;
+        },
+
+        ignorePageHeader(ignore) {
+            if (this.pageHeader) {
+                this.pageHeader.style['pointer-events'] = ignore ? 'none' : 'all';
+            }
+        },
+
+        makeBardProvide() {
+            const bard = {};
+            Object.defineProperties(bard, {
+                setConfigs: { get: () => this.setConfigs },
+                isReadOnly: { get: () => this.readOnly },
+            });
+            return bard;
+        },
+
+        addSetButtonClicked() {
+            if (this.setConfigs.length === 1) {
+                this.addSet(this.setConfigs[0].handle);
+            }
+        },
+
+        clickedAwayFromSetPicker($event) {
+            if (this.$el.contains($event.target)) return;
+            this.showAddSetButton = false;
+        },
+
     }
-    </script>
-    
+}
+</script>

--- a/resources/js/components/publish/HasHiddenFields.js
+++ b/resources/js/components/publish/HasHiddenFields.js
@@ -22,7 +22,14 @@ export default {
                 .keys()
                 .value();
 
-            return new Values(this.values, this.jsonSubmittingFields).except(omittableFields);
+            // Prosemirror's JSON will include spaces between tags.
+            // For example (this is not the actual json)...
+            // "<p>One <b>two</b> three</p>" becomes ['OneSPACE', '<b>two</b>', 'SPACEthree']
+            // But, Laravel's TrimStrings middleware would remove them.
+            // Those spaces need to be there, otherwise it would be rendered as <p>One<b>two</b>three</p>
+            // To combat this, we submit the JSON string instead of an object.
+
+            return new Values(this.values, this.jsonSubmittingFields).jsonEncode().except(omittableFields);
         },
 
     },

--- a/resources/js/components/publish/Values.js
+++ b/resources/js/components/publish/Values.js
@@ -25,24 +25,19 @@ export default class Values {
 
     get(dottedKey) {
         let decodedValues = new this.constructor(clone(this.values), this.jsonFields)
-            .jsonDecode()
             .values;
 
         return data_get(decodedValues, dottedKey);
     }
 
     set(dottedKey, value)  {
-        this.jsonDecode()
-            .setValue(dottedKey, value)
-            .jsonEncode();
+        this.setValue(dottedKey, value);
 
         return this;
     }
 
     except(dottedKeys) {
-        return this.jsonDecode()
-            .rejectValuesByKey(dottedKeys)
-            .jsonEncode()
+        return this.rejectValuesByKey(dottedKeys)
             .all();
     }
 

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -23,7 +23,9 @@ class Bard extends Replicator
     use Concerns\ResolvesStatamicUrls;
 
     protected $categories = ['text', 'structured'];
-    protected $defaultValue = '[]';
+
+    protected $defaultValue = [];
+
     protected $rules = [];
 
     protected function configFieldItems(): array
@@ -349,8 +351,8 @@ class Bard extends Replicator
 
     public function preProcess($value)
     {
-        if (empty($value) || $value === '[]') {
-            return '[]';
+        if (empty($value)) {
+            return [];
         }
 
         if (is_string($value)) {
@@ -384,7 +386,7 @@ class Bard extends Replicator
             }
 
             return $this->preProcessRow($row, $i);
-        })->toJson();
+        })->all();
     }
 
     protected function preProcessRow($row, $index)
@@ -528,7 +530,7 @@ class Bard extends Replicator
 
     public function preload()
     {
-        $value = json_decode($this->field->value(), true);
+        $value = $this->field->value();
 
         $existing = collect($value)->filter(function ($item) {
             return $item['type'] === 'set';


### PR DESCRIPTION
I've noticed a performance issue when you have a lot of Bard fields (eg. in a large page builder), which I think started with [this PR](https://github.com/statamic/cms/pull/7388).

## Problem

In that PR the way response values are merged back into the publish store changed, with them being passed through the `Values` object. In that class all `jsonSubmittingFields` are decoded/encoded every time a value is either fetched or set. Bard fields are `jsonSubmittingFields`.

The performance issue I've noticed occurs when you save an entry and remain on the page. The response values are merged back into the store, and all that JSON decoding/encoding can add a lot of overhead during which the page is unresponsive.

This gets slower for every additional field (of any type), since all `jsonSubmittingFields` are decoded every time `get` and `set` are called, and encoded every time `set` is called, which happens for every field.

## Solution

This PR offers a possible solution to this, although there could easily be something I've overlooked.

This PR changes the way Bard values are passed _from_ PHP and stored in the publish store. Instead of passing and storing them as encoded JSON strings they're stored as normal objects. This means that when new values are merged in no decoding/encoding is necessary. And it simplifies the Bard code a bit as well.

Of course the reason these fields are encoded as JSON is to avoid the Laravel trim strings middleware issue, so that does still need to happen somewhere. This now only happens when `visibleValues` is called by the publish form save methods. This means the `jsonSubmittingFields` are still sent as encoded JSON in the request (avoiding trim strings) but can be normal objects in the publish store.

## Notes

Like I say I could have missed something, but in my testing this does offer a decent performance improvement when there are a lot of Bard fields in the form.

Unfortunately this could be a breaking change for people who are accessing Bard field values through the publish store and expecting them to be JSON strings.