### PR TITLE
[4.x] Update ZipStream version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "league/commonmark": "^2.2",
         "league/csv": "^9.0",
         "league/glide": "^1.1 || ^2.0",
-        "maennchen/zipstream-php": "^2.2",
+        "maennchen/zipstream-php": "^2.2 || ^3.0",
         "michelf/php-smartypants": "^1.8.1",
         "nesbot/carbon": "^2.62.1",
         "pixelfear/composer-dist-plugin": "^0.1.4",


### PR DESCRIPTION
Latest version is v3 and if you have other packages that require it, installing Statamic downgrades this to v2.