### PR TITLE
[4.x] Prevent deletion of selection when filtering (Relationship-Fieldtype)

### DIFF
--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -31,7 +31,7 @@
                             :active-filter-badges="activeFilterBadges"
                             :active-count="activeFilterCount"
                             :search-query="searchQuery"
-                            @changed="filterChanged"
+                            @changed="filterChanged($event, false)"
                         />
                     </div>
                 </div>


### PR DESCRIPTION
Closes https://github.com/statamic/cms/issues/8631

With this we could prevent the selection from being removed after filtering. Maybe this is also a solution for you?