### PR TITLE
[4.x] Fix single digit month not working on whereMonth

### DIFF
--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -190,7 +190,7 @@ abstract class Builder extends BaseBuilder
                 return false;
             }
 
-            return $this->{$method}($value->format('m'), $where['value']);
+            return $this->{$method}($value->format('m'), sprintf('%02d', $where['value']));
         });
     }
 

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -117,6 +117,11 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertCount(3, $entries);
         $this->assertEquals(['Post 1', 'Post 2', 'Post 3'], $entries->map->title->all());
 
+        $entries = Entry::query()->whereMonth('test_date', 9)->get();
+
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Post 4'], $entries->map->title->all());
+
         $entries = Entry::query()->whereMonth('test_date', '<', 11)->get();
 
         $this->assertCount(1, $entries);


### PR DESCRIPTION
On query builder, when using the `whereMonth` method to check for equality in month, it currently only works with double-digit months.

This PR fixes the issue.
```PHP
// Before:
Entry::query()->whereMonth('date', 11)->get() // works
Entry::query()->whereMonth('date', 9)->get(); // does not work (does not provide the right result)

// After:
Entry::query()->whereMonth('date', 11)->get() // works
Entry::query()->whereMonth('date', 9)->get(); // works
```