### PR TITLE
[4.x] Allow for a honeypot field on `user:register` tag

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -77,6 +77,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Registration form honeypot field
+    |--------------------------------------------------------------------------
+    |
+    | When registering new users through the user:register_form tag,
+    | specify the field to act as a honeypot for bots
+    |
+    */
+
+    'registration_form_honeypot_field' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | User Wizard Invitation Email
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -90,6 +90,10 @@ class UserController extends Controller
         }
 
         try {
+            if ($honeypot = config('statamic.users.registration_form_honeypot_field')) {
+                throw_if(Arr::get($values, $honeypot), new SilentFormFailureException);
+            }
+
             throw_if(UserRegistering::dispatch($user) === false, new SilentFormFailureException);
         } catch (ValidationException $e) {
             return $this->userRegistrationFailure($e->errors());

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
@@ -91,7 +92,7 @@ class UserController extends Controller
 
         try {
             if ($honeypot = config('statamic.users.registration_form_honeypot_field')) {
-                throw_if(Arr::get($values, $honeypot), new SilentFormFailureException);
+                throw_if(Arr::get($request->input(), $honeypot), new SilentFormFailureException);
             }
 
             throw_if(UserRegistering::dispatch($user) === false, new SilentFormFailureException);

--- a/tests/Tags/User/RegisterFormTest.php
+++ b/tests/Tags/User/RegisterFormTest.php
@@ -392,4 +392,73 @@ EOT
 
         $this->assertArrayHasKey('_token', $form['params']);
     }
+
+    /** @test */
+    public function it_wont_register_user_when_honeypot_is_present()
+    {
+        $this->assertNull(User::findByEmail('san@holo.com'));
+        $this->assertFalse(auth()->check());
+
+        config()->set('statamic.users.registration_form_honeypot_field', 'honeypot');
+
+        $response = $this
+            ->post('/!/auth/register', [
+                'email' => 'san@holo.com',
+                'password' => 'chewbacca',
+                'password_confirmation' => 'chewbacca',
+                'honeypot' => 'falcon',
+            ])
+            ->assertSessionHasNoErrors()
+            ->assertLocation('/');
+
+        $this->assertNull(User::findByEmail('san@holo.com'));
+        $this->assertFalse(auth()->check());
+
+        $output = $this->tag(<<<'EOT'
+{{ user:register_form }}
+    <p class="success">{{ success }}</p>
+{{ /user:register_form }}
+EOT
+        );
+
+        preg_match_all('/<p class="success">(.+)<\/p>/U', $output, $success);
+
+        $this->assertEquals(['Registration successful.'], $success[1]);
+
+        config()->set('statamic.users.registration_form_honeypot_field', null);
+    }
+
+    /** @test */
+    public function it_will_register_user_when_honeypot_is_not_present()
+    {
+        $this->assertNull(User::findByEmail('san@holo.com'));
+        $this->assertFalse(auth()->check());
+
+        config()->set('statamic.users.registration_form_honeypot_field', 'honeypot');
+
+        $response = $this
+            ->post('/!/auth/register', [
+                'email' => 'san@holo.com',
+                'password' => 'chewbacca',
+                'password_confirmation' => 'chewbacca',
+            ])
+            ->assertSessionHasNoErrors()
+            ->assertLocation('/');
+
+        $this->assertNotNull(User::findByEmail('san@holo.com'));
+        $this->assertTrue(auth()->check());
+
+        $output = $this->tag(<<<'EOT'
+{{ user:register_form }}
+    <p class="success">{{ success }}</p>
+{{ /user:register_form }}
+EOT
+        );
+
+        preg_match_all('/<p class="success">(.+)<\/p>/U', $output, $success);
+
+        $this->assertEquals(['Registration successful.'], $success[1]);
+
+        config()->set('statamic.users.registration_form_honeypot_field', null);
+    }
 }


### PR DESCRIPTION
This PR adds a config `statamic.users.registration_form_honeypot_field` which when not null will be checked as a honeypot on the `user:register` submission.

Closes https://github.com/statamic/ideas/issues/1043