### PR TITLE
[4.x] Switch base kernel to `Illuminate\Foundation\Console\Kernel` for DDD compatibility

### DIFF
--- a/src/Console/Please/Kernel.php
+++ b/src/Console/Please/Kernel.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Console\Please;
 
-use App\Console\Kernel as ConsoleKernel;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use Statamic\Console\Please\Application as Please;
 use Statamic\Statamic;
 


### PR DESCRIPTION
Replace the use of `App\Console\Kernel` as the base kernel with `Illuminate\Foundation\Console\Kernel`. This resolves issues in larger projects following Domain-Driven Design (DDD), where the kernel may reside in a different namespace like `Infrastructure\Console\Kernel`.