### PR TITLE
[4.x] Improve post-save performance with many Bard and Revealer fields

### DIFF
--- a/resources/js/components/publish/HasHiddenFields.js
+++ b/resources/js/components/publish/HasHiddenFields.js
@@ -36,9 +36,7 @@ export default {
             let originalValues = new Values(this.values, this.jsonSubmittingFields);
             let newValues = new Values(responseValues, this.jsonSubmittingFields);
 
-            preserveFields.forEach(dottedKey => {
-                newValues.set(dottedKey, originalValues.get(dottedKey));
-            });
+            newValues.mergeDottedKeys(preserveFields, originalValues);
 
             return newValues.all();
         },

--- a/resources/js/components/publish/Values.js
+++ b/resources/js/components/publish/Values.js
@@ -39,6 +39,20 @@ export default class Values {
         return this;
     }
 
+    mergeDottedKeys(dottedKeys, values)  {
+        let decodedValues = new this.constructor(clone(values.values), values.jsonFields)
+            .jsonDecode()
+            .values;
+
+        this.jsonDecode();
+        dottedKeys.forEach(dottedKey => {
+            data_set(this.values, dottedKey, data_get(decodedValues, dottedKey));
+        });
+        this.jsonEncode();
+
+        return this;
+    }
+
     except(dottedKeys) {
         return this.jsonDecode()
             .rejectValuesByKey(dottedKeys)


### PR DESCRIPTION
This is a non-breaking companion  to https://github.com/statamic/cms/pull/8684.

Bard data is still stored as encoded JSON strings, the only change this makes is instead of decoding/encoding all Bard fields for every preserved Revealer field, this will decode once at the start and then encode once at the end. This makes a big difference when your entry data contains a lot of Bard and Revealer fields.

I've tried to implement this in the most minimal way without affecting any of the Values object's existing behaviour. I've added a new `mergeDottedKeys` method (there's probably a better name) in the Values object which will set multiple values at once based on the provided list of dotted keys. And updated HasHiddenFields to use this.