### PR TITLE
[4.x] Stop forcing max_items: 1 on form fields

### DIFF
--- a/src/Forms/Fieldtype.php
+++ b/src/Forms/Fieldtype.php
@@ -31,7 +31,6 @@ class Fieldtype extends Relationship
                 'display' => __('Max Items'),
                 'default' => 1,
                 'instructions' => __('statamic::fieldtypes.form.config.max_items'),
-                'min' => 1,
             ],
             'query_scopes' => [
                 'display' => __('Query Scopes'),


### PR DESCRIPTION
Closes #3809

Works fine with 1, more, or no max_items, as one would expect.