### PR TITLE
[4.x] Improve initial render speed of replicators with many sets

### DIFF
--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -71,6 +71,9 @@ export default {
         replicatorPreview: {
             immediate: true,
             handler(text) {
+                if (!this.config.replicator_preview) {
+                    return;
+                }
                 this.$emit('replicator-preview-updated', text);
             }
         }

--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -71,9 +71,6 @@ export default {
         replicatorPreview: {
             immediate: true,
             handler(text) {
-                if (!this.config.replicator_preview) {
-                    return;
-                }
                 this.$emit('replicator-preview-updated', text);
             }
         }

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -133,6 +133,7 @@ export default {
         return {
             focused: false,
             collapsed: clone(this.meta.collapsed),
+            previews: this.meta.previews,
             fullScreenMode: false,
             provide: {
                 storeName: this.storeName
@@ -141,10 +142,6 @@ export default {
     },
 
     computed: {
-
-        previews() {
-            return this.meta.previews;
-        },
 
         canAddSet() {
             if (this.isReadOnly) return false;
@@ -242,13 +239,7 @@ export default {
         },
 
         updateSetPreviews(id, previews) {
-            this.updateMeta({
-                ...this.meta,
-                previews: {
-                    ...this.meta.previews,
-                    [id]: previews,
-                },
-            });
+            this.previews[id] = previews;
         },
 
         collapseSet(id) {
@@ -312,6 +303,18 @@ export default {
 
         collapsed(collapsed) {
             this.updateMeta({ ...this.meta, collapsed: clone(collapsed) });
+        },
+
+        previews: {
+            deep: true,
+            handler(value) {
+                if (JSON.stringify(this.meta.previews) === JSON.stringify(value)) {
+                    return
+                }
+                const meta = this.meta;
+                meta.previews = value;
+                this.updateMeta(meta);
+            }
         },
 
     }

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -166,9 +166,7 @@ export default {
         },
 
         previewUpdated(handle, value) {
-            setTimeout(() => {
-                this.$emit('previews-updated', { ...this.previews, [handle]: value });
-            }, 0);
+            this.$emit('previews-updated', { ...this.previews, [handle]: value });
         },
 
         destroy() {


### PR DESCRIPTION
When you have a lot of replicator sets the initial render speed of the page can be very slow (see video below). I've been looking into this and think I've found the cause and a good fix, but first some background:

1. When a replicator is loaded `replicator-preview-updated` events are fired for every field within each set, which then calls the `Fieldtype.updateMeta()` method and updates the publish container.
2. There used to be a bug (https://github.com/statamic/cms/issues/5081) where only the last set would show a preview on page load. 
3. As far as I can tell this bug was caused by a race condition. Loads of `replicator-preview-updated` events would all be fired at once, but the publish container updates asynchronously so each subsequent event would overwrite the update from the previous one.
4. https://github.com/statamic/cms/pull/5096 fixed this issue by wrapping the preview updates in `setTimeout`, however unfortunately this change significantly slowed them down (if you console log in `Fieldtype.updateMeta()` you can see them coming in while the page is unresponsive).

This PR removes the `setTimeout` and fixes the issue another way, making the initial render much faster.

The fix uses the [same logic as Bard already uses](https://github.com/statamic/cms/blob/4.x/resources/js/components/fieldtypes/bard/BardFieldtype.vue#L398) for preview values. Instead of passing updates directly to `updateMeta()`, they're stored in the replicator component's state and a watcher is used instead. This results in a single call to `updateMeta()`, rather than one per set field.

## Demo

This is a demo with 100 replicator sets, each contains a single text field. Pay attention to the browser loading indicator and expand/collapse icons. The page is unresponsive until the rendering completes.

### Before

https://github.com/statamic/cms/assets/126740/ba634d60-300c-4b7e-928f-7ac41f9239f6

### After

https://github.com/statamic/cms/assets/126740/b8613c43-5093-4999-9fe7-241e37a6dcc1

## Note

I did notice that when Replicator makes similar changes to the collapsed meta values it first clones or copies from `this.meta`, whereas Bard just uses the existing object. I'm not sure if the clone is necessary or not. This code is copied directly from Bard so it does not do the clone currently, but it would probably make sense for all Bard and Replicator collapsed/previews updates to operate the same way.