### PR TITLE
[4.x] Antlers: Protections around updating view values 

### DIFF
--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -91,6 +91,7 @@ class Environment
     protected $interpolationKeys = [];
     protected $assignments = [];
     protected $dataManagerInterpolations = [];
+    private $protectedScopes = ['view'];
 
     /**
      * @var LanguageOperatorManager|null
@@ -964,10 +965,12 @@ class Environment
                     $lastPath = $varName->pathParts[0]->name;
                 }
 
-                $this->assignments[$lastPath] = $right;
+                if (! in_array($lastPath, $this->protectedScopes)) {
+                    $this->assignments[$lastPath] = $right;
 
-                if (array_key_exists($lastPath, GlobalRuntimeState::$tracedRuntimeAssignments)) {
-                    GlobalRuntimeState::$tracedRuntimeAssignments[$lastPath] = $right;
+                    if (array_key_exists($lastPath, GlobalRuntimeState::$tracedRuntimeAssignments)) {
+                        GlobalRuntimeState::$tracedRuntimeAssignments[$lastPath] = $right;
+                    }
                 }
 
                 return null;
@@ -1009,7 +1012,9 @@ class Environment
                     $lastPath = $varName->pathParts[0]->name;
                 }
 
-                $this->assignments[$lastPath] = $newVal;
+                if (! in_array($lastPath, $this->protectedScopes)) {
+                    $this->assignments[$lastPath] = $newVal;
+                }
 
                 return null;
             } elseif ($operand instanceof DivisionAssignmentOperator) {
@@ -1036,7 +1041,9 @@ class Environment
                     $lastPath = $varName->pathParts[0]->name;
                 }
 
-                $this->assignments[$lastPath] = $assignValue;
+                if (! in_array($lastPath, $this->protectedScopes)) {
+                    $this->assignments[$lastPath] = $assignValue;
+                }
 
                 return null;
             } elseif ($operand instanceof ModulusAssignmentOperator) {
@@ -1062,7 +1069,9 @@ class Environment
                     $lastPath = $varName->pathParts[0]->name;
                 }
 
-                $this->assignments[$lastPath] = $assignValue;
+                if (! in_array($lastPath, $this->protectedScopes)) {
+                    $this->assignments[$lastPath] = $assignValue;
+                }
 
                 return null;
             } elseif ($operand instanceof MultiplicationAssignmentOperator) {
@@ -1088,7 +1097,9 @@ class Environment
                     $lastPath = $varName->pathParts[0]->name;
                 }
 
-                $this->assignments[$lastPath] = $assignValue;
+                if (! in_array($lastPath, $this->protectedScopes)) {
+                    $this->assignments[$lastPath] = $assignValue;
+                }
 
                 return null;
             } elseif ($operand instanceof SubtractionAssignmentOperator) {
@@ -1114,7 +1125,9 @@ class Environment
                     $lastPath = $varName->pathParts[0]->name;
                 }
 
-                $this->assignments[$lastPath] = $assignValue;
+                if (! in_array($lastPath, $this->protectedScopes)) {
+                    $this->assignments[$lastPath] = $assignValue;
+                }
 
                 return null;
             } elseif ($operand instanceof ConditionalVariableFallbackOperator) {


### PR DESCRIPTION
This PR replaces #7635  and fixes #7633 by introducing an internal concept of protected scopes. Protected scopes will not have their values pushed up the Cascade, and their values will not be pushed down into further partial/template scopes (there is no user-land way to influence what is considered a protected scope).

With these changes, manual updates to the `view` array will be tossed away once the current template/partial goes out of scope.

Partials/templates having the frontmatter merged in from parent templates/partials has not been changed.
