### PR TITLE
[4.x] Add `orderByDesc` method to the query builder

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -73,6 +73,11 @@ abstract class Builder implements Contract
         return $this;
     }
 
+    public function orderByDesc($column)
+    {
+        return $this->orderBy($column, 'desc');
+    }
+
     abstract public function inRandomOrder();
 
     public function where($column, $operator = null, $value = null, $boolean = 'and')

--- a/tests/Data/Taxonomies/TermQueryBuilderTest.php
+++ b/tests/Data/Taxonomies/TermQueryBuilderTest.php
@@ -204,17 +204,6 @@ class TermQueryBuilderTest extends TestCase
 
         $terms = Term::query()->orderBy('test')->get();
         $this->assertEquals(['c', 'b', 'e', 'a', 'd'], $terms->map->slug()->all());
-    }
-
-    /** @test */
-    public function it_sorts_in_descending_order()
-    {
-        Taxonomy::make('tags')->save();
-        Term::make('a')->taxonomy('tags')->data(['test' => 4])->save();
-        Term::make('b')->taxonomy('tags')->data(['test' => 2])->save();
-        Term::make('c')->taxonomy('tags')->data(['test' => 1])->save();
-        Term::make('d')->taxonomy('tags')->data(['test' => 5])->save();
-        Term::make('e')->taxonomy('tags')->data(['test' => 3])->save();
 
         $terms = Term::query()->orderByDesc('test')->get();
         $this->assertEquals(['d', 'a', 'e', 'b', 'c'], $terms->map->slug()->all());

--- a/tests/Data/Taxonomies/TermQueryBuilderTest.php
+++ b/tests/Data/Taxonomies/TermQueryBuilderTest.php
@@ -206,6 +206,20 @@ class TermQueryBuilderTest extends TestCase
         $this->assertEquals(['c', 'b', 'e', 'a', 'd'], $terms->map->slug()->all());
     }
 
+    /** @test */
+    public function it_sorts_in_descending_order()
+    {
+        Taxonomy::make('tags')->save();
+        Term::make('a')->taxonomy('tags')->data(['test' => 4])->save();
+        Term::make('b')->taxonomy('tags')->data(['test' => 2])->save();
+        Term::make('c')->taxonomy('tags')->data(['test' => 1])->save();
+        Term::make('d')->taxonomy('tags')->data(['test' => 5])->save();
+        Term::make('e')->taxonomy('tags')->data(['test' => 3])->save();
+
+        $terms = Term::query()->orderByDesc('test')->get();
+        $this->assertEquals(['d', 'a', 'e', 'b', 'c'], $terms->map->slug()->all());
+    }
+
     /** @test **/
     public function terms_are_found_using_where_column()
     {


### PR DESCRIPTION
This pull request adds an `orderByDesc` method to the Statamic Query Builder, after I expected it to exist but it didn't (a method with the same name [exists in the Eloquent query builder](https://github.com/laravel/framework/blob/89171a265479075baf79a52ef06332a94f562ee5/src/Illuminate/Database/Query/Builder.php#L2338)).

`orderByDesc` simply uses the existing `orderBy` method under the hood. It's literally a really simple wrapper around it.

I've added a test to the `TermQueryBuilderTest` to cover it as that's the only test I could find that tests the existing `orderBy` method.