### PR TITLE
[4.x] Use default slug to get taxonomy entries count

### DIFF
--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -122,7 +122,7 @@ class TermRepository implements RepositoryContract
         $items = $this->store->store($term->taxonomyHandle())
             ->index('associations')
             ->items()
-            ->where('value', $term->slug());
+            ->where('value', $term->inDefaultLocale()->slug());
 
         if ($term instanceof LocalizedTerm) {
             $items = $items->where('site', $term->locale());

--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -122,7 +122,7 @@ class TermRepository implements RepositoryContract
         $items = $this->store->store($term->taxonomyHandle())
             ->index('associations')
             ->items()
-            ->where('value', $term->inDefaultLocale()->slug());
+            ->where('value', $term->slug());
 
         if ($term instanceof LocalizedTerm) {
             $items = $items->where('site', $term->locale());

--- a/tests/Feature/Taxonomies/TermEntriesTest.php
+++ b/tests/Feature/Taxonomies/TermEntriesTest.php
@@ -107,15 +107,15 @@ class TermEntriesTest extends TestCase
         Taxonomy::make('colors')->save();
         tap(Term::make()->taxonomy('colors'), function ($term) {
             $term->in('en')->slug('red')->data(['hex' => 'f00'])->save();
-            $term->in('fr')->slug('rouge')->data([])->save();
+            $term->in('fr')->slug('rouge')->save();
         });
         tap(Term::make()->taxonomy('colors'), function ($term) {
             $term->in('en')->slug('black')->data(['hex' => '000'])->save();
-            $term->in('fr')->slug('noir')->data([])->save();
+            $term->in('fr')->slug('noir')->save();
         });
         tap(Term::make()->taxonomy('colors'), function ($term) {
             $term->in('en')->slug('yellow')->data(['hex' => 'ff0'])->save();
-            $term->in('fr')->slug('jaune')->data([])->save();
+            $term->in('fr')->slug('jaune')->save();
         });
 
         Collection::make('animals')->taxonomies(['colors'])->save();
@@ -171,15 +171,15 @@ class TermEntriesTest extends TestCase
         Taxonomy::make('colors')->save();
         tap(Term::make()->taxonomy('colors'), function ($term) {
             $term->in('en')->slug('red')->data(['hex' => 'f00'])->save();
-            $term->in('fr')->slug('rouge')->data([])->save();
+            $term->in('fr')->slug('rouge')->save();
         });
         tap(Term::make()->taxonomy('colors'), function ($term) {
             $term->in('en')->slug('black')->data(['hex' => '000'])->save();
-            $term->in('fr')->slug('noir')->data([])->save();
+            $term->in('fr')->slug('noir')->save();
         });
         tap(Term::make()->taxonomy('colors'), function ($term) {
             $term->in('en')->slug('yellow')->data(['hex' => 'ff0'])->save();
-            $term->in('fr')->slug('jaune')->data([])->save();
+            $term->in('fr')->slug('jaune')->save();
         });
 
         $animals = tap(Collection::make('animals')->taxonomies(['colors']))->save();


### PR DESCRIPTION
This may be too simplistic a fix, but to get the correct entry count raised in https://github.com/statamic/cms/issues/4493 we could just make sure we query by the default locale.

Fixes https://github.com/statamic/cms/issues/4493