### PR TITLE
[4.x] make title in revision preview computed

### DIFF
--- a/resources/js/components/revision-history/Preview.vue
+++ b/resources/js/components/revision-history/Preview.vue
@@ -15,8 +15,13 @@ export default {
             readOnly: true,
             method: 'patch',
             action: 'update',
-            title: this.revision.attributes.data.title,
             itemUrl: `${document.location.pathname}/revisions/${this.revision.id}`,
+        }
+    },
+
+    computed: {
+        title() {
+            return this.revision.attributes.data?.title ?? '';
         }
     },
 


### PR DESCRIPTION
With this PR, the title is a computed property and makes the title optional.

In our case we use custom revisions, we only load the needed data to show the listing below (no title required).

![Bildschirmfoto 2023-09-20 um 15 02 15](https://github.com/statamic/cms/assets/38906163/6d57cd87-0aa2-4826-8852-0247d8bbfaeb)

As soon as you click on a revision, the data of that revision will be loaded. The loaded data can first be available, after the component has been created. The title is expected though at creation time, which does lead to an error.

The simple solution below fixes it, as the title is not required at creation time.

We are using the following serverside workaround at the moment, which does work but feels a little to special :-)

```php
(new Revision())
    ->id($content['name'] ?? $entryId)
    // More stuff
    ->attributes(['data' => ['title' => '']]); // As the frontend requires a title.
```