### PR TITLE
[4.x] Fix CSRF field related test failures

### DIFF
--- a/tests/Tags/Concerns/RendersFormsTest.php
+++ b/tests/Tags/Concerns/RendersFormsTest.php
@@ -28,7 +28,7 @@ class RendersFormsTest extends TestCase
         $output = $this->tag->formOpen('http://localhost:8000/submit');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost:8000/submit">', $output);
-        $this->assertStringContainsString('<input type="hidden" name="_token" value="">', $output);
+        $this->assertStringContainsString(csrf_field(), $output);
         $this->assertStringNotContainsString('<input type="hidden" name="_method"', $output);
     }
 
@@ -38,7 +38,7 @@ class RendersFormsTest extends TestCase
         $output = $this->tag->formOpen('http://localhost:8000/submit', 'DELETE');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost:8000/submit">', $output);
-        $this->assertStringContainsString('<input type="hidden" name="_token" value="">', $output);
+        $this->assertStringContainsString(csrf_field(), $output);
         $this->assertStringContainsString('<input type="hidden" name="_method" value="DELETE">', $output);
     }
 
@@ -55,7 +55,7 @@ class RendersFormsTest extends TestCase
             ->formOpen('http://localhost:8000/submit', 'DELETE');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost:8000/submit" class="mb-2" id="form">', $output);
-        $this->assertStringContainsString('<input type="hidden" name="_token" value="">', $output);
+        $this->assertStringContainsString(csrf_field(), $output);
         $this->assertStringContainsString('<input type="hidden" name="_method" value="DELETE">', $output);
     }
 

--- a/tests/Tags/Form/FormCreateTest.php
+++ b/tests/Tags/Form/FormCreateTest.php
@@ -23,7 +23,7 @@ class FormCreateTest extends FormTestCase
 
         foreach ($forms as $output) {
             $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/forms/contact">', $output);
-            $this->assertStringContainsString('<input type="hidden" name="_token" value="">', $output);
+            $this->assertStringContainsString(csrf_field(), $output);
             $this->assertStringEndsWith('</form>', $output);
         }
     }

--- a/tests/Tags/User/ForgotPasswordFormTest.php
+++ b/tests/Tags/User/ForgotPasswordFormTest.php
@@ -24,7 +24,7 @@ class ForgotPasswordFormTest extends TestCase
         $output = $this->tag('{{ user:forgot_password_form }}{{ /user:forgot_password_form }}');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/password/email">', $output);
-        $this->assertStringContainsString('<input type="hidden" name="_token" value="">', $output);
+        $this->assertStringContainsString(csrf_field(), $output);
         $this->assertStringEndsWith('</form>', $output);
     }
 

--- a/tests/Tags/User/LoginFormTest.php
+++ b/tests/Tags/User/LoginFormTest.php
@@ -23,7 +23,7 @@ class LoginFormTest extends TestCase
         $output = $this->tag('{{ user:login_form }}{{ /user:login_form }}');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/login">', $output);
-        $this->assertStringContainsString('<input type="hidden" name="_token" value="">', $output);
+        $this->assertStringContainsString(csrf_field(), $output);
         $this->assertStringEndsWith('</form>', $output);
     }
 

--- a/tests/Tags/User/PasswordFormTest.php
+++ b/tests/Tags/User/PasswordFormTest.php
@@ -25,7 +25,7 @@ class PasswordFormTest extends TestCase
         $output = $this->tag('{{ user:password_form }}{{ /user:password_form }}');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/password">', $output);
-        $this->assertStringContainsString('<input type="hidden" name="_token" value="">', $output);
+        $this->assertStringContainsString(csrf_field(), $output);
         $this->assertStringEndsWith('</form>', $output);
     }
 

--- a/tests/Tags/User/ProfileFormTest.php
+++ b/tests/Tags/User/ProfileFormTest.php
@@ -26,7 +26,7 @@ class ProfileFormTest extends TestCase
         $output = $this->tag('{{ user:profile_form }}{{ /user:profile_form }}');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/profile">', $output);
-        $this->assertStringContainsString('<input type="hidden" name="_token" value="">', $output);
+        $this->assertStringContainsString(csrf_field(), $output);
         $this->assertStringEndsWith('</form>', $output);
     }
 

--- a/tests/Tags/User/RegisterFormTest.php
+++ b/tests/Tags/User/RegisterFormTest.php
@@ -27,8 +27,8 @@ class RegisterFormTest extends TestCase
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/register">', $output);
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/register">', $aliased);
-        $this->assertStringContainsString('<input type="hidden" name="_token" value="">', $output);
-        $this->assertStringContainsString('<input type="hidden" name="_token" value="">', $aliased);
+        $this->assertStringContainsString(csrf_field(), $output);
+        $this->assertStringContainsString(csrf_field(), $aliased);
         $this->assertStringEndsWith('</form>', $output);
         $this->assertStringEndsWith('</form>', $aliased);
     }


### PR DESCRIPTION
Laravel 10.24.0 introduced some test failures due to another attribute being added to the csrf_field output.

See https://github.com/laravel/framework/pull/48371

This wasn't really a breaking change on their part. We should have just been asserting that csrf_field was output in html rather than checking the explicit html.
