### PR TITLE
[4.x] Wrap eloquent builder like column

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -103,7 +103,8 @@ abstract class EloquentQueryBuilder implements Builder
         }
 
         if (strtolower($operator) == 'like') {
-            $this->builder->whereRaw('LOWER('.$this->column($column).') LIKE ?', strtolower($value), $boolean);
+            $grammar = $this->builder->getConnection()->getQueryGrammar();
+            $this->builder->whereRaw('LOWER('.$grammar->wrap($this->column($column)).') LIKE ?', strtolower($value), $boolean);
 
             return $this;
         }


### PR DESCRIPTION
I introduced a bug in https://github.com/statamic/cms/pull/8243/files see:
https://cdn.discordapp.com/attachments/1153390699161587823/1154476994873012255/image.png

The column needs wrapped so that each eloquent grammar can make it work for their appropriate underlying engine.

Sorry.