### PR TITLE
[4.x] Fix static caching with Livewire 3

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -221,12 +221,14 @@ class FileCacher extends AbstractCacher
         for (const meta of document.querySelectorAll('meta[content="$csrfPlaceholder"]')) {
             meta.content = data.csrf;
         }
-        
+
+        for (const input of document.querySelectorAll('script[data-csrf="$csrfPlaceholder"]')) {
+            input.setAttribute('data-csrf', data.csrf);
+        }
+
         if (window.hasOwnProperty('livewire_token')) {
             window.livewire_token = data.csrf
         }
-
-        document.querySelector('script[data-csrf="STATAMIC_CSRF_TOKEN"]')?.setAttribute('data-csrf', data.csrf);
 
         if (window.hasOwnProperty('livewireScriptConfig')) {
             window.livewireScriptConfig.csrf = data.csrf

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -226,6 +226,12 @@ class FileCacher extends AbstractCacher
             window.livewire_token = data.csrf
         }
 
+        document.querySelector('script[data-csrf="STATAMIC_CSRF_TOKEN"]')?.setAttribute('data-csrf', data.csrf);
+
+        if (window.hasOwnProperty('livewireScriptConfig')) {
+            window.livewireScriptConfig.csrf = data.csrf
+        }
+
         document.dispatchEvent(new CustomEvent('statamic:nocache.replaced'));
     });
 })();


### PR DESCRIPTION
This PR makes Livewire 3 work with full-measure static caching. It's the equivalent of https://github.com/statamic/cms/pull/7894 which made Livewire 2 work with full-measure static caching.