### PR TITLE
[4.x] Impersonate should check on id() not full class

### DIFF
--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -23,7 +23,7 @@ class Impersonate extends Action
             return false;
         }
 
-        return $item instanceof UserContract && $item != User::current();
+        return $item instanceof UserContract && $item->id() != User::current()->id();
     }
 
     public function visibleToBulk($items)


### PR DESCRIPTION
As [reported here](https://github.com/statamic/cms/issues/8761) impersonate is allowing you to impersonate yourself when eloquent users are used.

Lets fix this by checking for an id() match only.

Fixes: https://github.com/statamic/cms/issues/8761