### PR TITLE
[4.x] Use 'autocomplete' attribute in the default Text-template

### DIFF
--- a/resources/views/extend/forms/fields/text.antlers.html
+++ b/resources/views/extend/forms/fields/text.antlers.html
@@ -4,6 +4,7 @@
     value="{{ value }}"
     {{ if placeholder }}placeholder="{{ placeholder }}"{{ /if }}
     {{ if character_limit }}maxlength="{{ character_limit }}"{{ /if }}
+    {{ if autocomplete }}autocomplete="{{ autocomplete }}"{{ /if }}
     {{ if js_driver }}{{ js_attributes }}{{ /if }}
     {{ if validate|contains:required }}required{{ /if }}
 >


### PR DESCRIPTION
Addition to PR https://github.com/statamic/cms/pull/8623: implemented autocomplete in the default text-field template for forms

Sorry I forgot to do this the first time! 🥴