### PR TITLE
[4.x] Antlers: Adds first-class support for sending custom variables to the layout

### DIFF
--- a/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
+++ b/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
@@ -192,6 +192,8 @@ class GlobalRuntimeState
     public static $prefixState = [];
 
     public static $containsLayout = false;
+    public static $shareVariablesTemplateTrigger = '';
+    public static $layoutVariables = [];
 
     public static $requiresRuntimeIsolation = false;
 
@@ -213,6 +215,8 @@ class GlobalRuntimeState
 
     public static function resetGlobalState()
     {
+        self::$shareVariablesTemplateTrigger = '';
+        self::$layoutVariables = [];
         self::$containsLayout = false;
         self::$tracedRuntimeAssignments = [];
         self::$traceTagAssignments = false;

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -435,6 +435,12 @@ class RuntimeParser implements Parser
             $bufferContent = str_replace(DocumentParser::getRightBraceEscape(), DocumentParser::RightBrace, $bufferContent);
         }
 
+
+        if (GlobalRuntimeState::$containsLayout && $this->view == GlobalRuntimeState::$shareVariablesTemplateTrigger) {
+            // Force the root runtime assignments to be merged into the global state.
+            GlobalRuntimeState::$layoutVariables = $this->nodeProcessor->getRuntimeAssignments();
+        }
+
         return new AntlersString($bufferContent, $this);
     }
 

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -435,7 +435,6 @@ class RuntimeParser implements Parser
             $bufferContent = str_replace(DocumentParser::getRightBraceEscape(), DocumentParser::RightBrace, $bufferContent);
         }
 
-
         if (GlobalRuntimeState::$containsLayout && $this->view == GlobalRuntimeState::$shareVariablesTemplateTrigger) {
             // Force the root runtime assignments to be merged into the global state.
             GlobalRuntimeState::$layoutVariables = $this->nodeProcessor->getRuntimeAssignments();

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -89,19 +89,23 @@ class View
 
         if ($this->shouldUseLayout()) {
             GlobalRuntimeState::$containsLayout = true;
-
             $contents = view($this->templateViewName(), $cascade);
 
             if (Str::endsWith($this->layoutViewPath(), Engine::EXTENSIONS)) {
                 $contents = $contents->withoutExtractions();
             }
 
+            GlobalRuntimeState::$shareVariablesTemplateTrigger = $contents->getPath();
+
             $contents = $contents->render();
             GlobalRuntimeState::$containsLayout = false;
+            GlobalRuntimeState::$shareVariablesTemplateTrigger = '';
 
-            $contents = view($this->layoutViewName(), array_merge($cascade, [
+            $contents = view($this->layoutViewName(), array_merge($cascade, GlobalRuntimeState::$layoutVariables, [
                 'template_content' => $contents,
             ]));
+
+            GlobalRuntimeState::$layoutVariables = [];
         } else {
             $contents = view($this->templateViewName(), $cascade);
         }


### PR DESCRIPTION
This PR closes #8772. Sharing of custom variables would previously work if you executed a tag towards the end of the template, but sharing variables with the layout in this way was always unintended behavior.

This seems to come up quite a bit, so this PR resolves this by automatically sharing custom variables with the layout, without needing to resort to hacks/workarounds. Only variables declared _inside_ the template file will be shared with the layout.