### PR TITLE
[4.x] Bard link email, phone and relationship options

### DIFF
--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -2,89 +2,92 @@
 
     <div class="bard-link-toolbar">
         <div>
-            <!-- Link type select -->
-            <div class="flex items-center px-4 py-2 border-b">
-
-                <button
-                    class="button-tab"
-                    v-for="visibleLinkType in visibleLinkTypes"
-                    :class="{active: visibleLinkType.type === linkType}"
-                    :for="visibleLinkType.type"
-                    :key="visibleLinkType.type"
-                    :id="visibleLinkType.type"
-                    @click="setLinkType(visibleLinkType.type)"
-                >
-                    {{ visibleLinkType.title }}
-                </button>
-            </div>
-
             <div class="px-4 py-4 border-b">
-                <div class="h-8 mb-4 p-2 bg-gray-100 text-gray-800 w-full border rounded shadow-inner placeholder:text-gray-600 flex items-center">
 
-                    <!-- URL input -->
-                    <input
-                        v-if="linkType === 'url'"
-                        v-model="url.url"
-                        type="text"
-                        ref="urlInput"
-                        class="input h-auto text-sm"
-                        placeholder="URL"
-                        @keydown.enter.prevent="commit"
-                    />
+                <div class="flex">
 
-                    <!-- Email input -->
-                    <input
-                        v-else-if="linkType === 'mailto'"
-                        v-model="urlData.mailto"
-                        type="text"
-                        ref="mailtoInput"
-                        class="input h-auto text-sm"
-                        placeholder="Email Address"
-                        @keydown.enter.prevent="commit"
-                    />
-
-                    <!-- Phone input -->
-                    <input
-                        v-else-if="linkType === 'tel'"
-                        v-model="urlData.tel"
-                        type="text"
-                        ref="telInput"
-                        class="input h-auto text-sm"
-                        placeholder="Phone Number"
-                        @keydown.enter.prevent="commit"
-                    />
-
-                    <!-- Data input -->
-                    <div
-                        v-else
-                        class="w-full flex items-center justify-between cursor-pointer"
-                        @click="openSelector"
-                    >
-
-                        <loading-graphic v-if="isLoading" :inline="true" />
-
-                        <div v-else class="flex-1 flex items-center mr-2 truncate">
-                            <img
-                                v-if="linkType === 'asset' && itemData.asset && itemData.isImage"
-                                :src="itemData.asset.thumbnail || itemData.asset.url"
-                                class="asset-thumbnail max-h-full max-w-full rounded w-6 h-6 mr-2 object-cover lazyloaded"
+                    <div class="h-8 mb-4 p-1 bg-gray-100 text-gray-800 border rounded shadow-inner flex items-center mr-1">
+                        <select
+                            class="input w-auto h-auto text-sm"
+                            v-model="linkType">
+                            <option
+                                v-for="visibleLinkType in visibleLinkTypes"
+                                :value="visibleLinkType.type"
                             >
-                            {{ displayValue }}
-                        </div>
-
-                        <button
-                        class="flex items-center"
-                            v-tooltip="`${__('Browse')}...`"
-                            :aria-label="`${__('Browse')}...`"
-                            @click="openSelector"
-                        >
-                            <svg-icon v-show="linkType === 'asset'" name="folder-image" class="h-4 w-4" />
-                            <svg-icon v-show="linkType !== 'asset'" name="folder-generic" class="h-4 w-4" />
-                        </button>
-
+                                {{ visibleLinkType.title }}
+                            </option>
+                        </select>
                     </div>
 
+                    <div class="h-8 mb-4 p-2 bg-gray-100 text-gray-800 w-full border rounded shadow-inner placeholder:text-gray-600 flex items-center">
+    
+                        <!-- URL input -->
+                        <input
+                            v-if="linkType === 'url'"
+                            v-model="url.url"
+                            type="text"
+                            ref="urlInput"
+                            class="input h-auto text-sm"
+                            placeholder="URL"
+                            @keydown.enter.prevent="commit"
+                        />
+    
+                        <!-- Email input -->
+                        <input
+                            v-else-if="linkType === 'mailto'"
+                            v-model="urlData.mailto"
+                            type="text"
+                            ref="mailtoInput"
+                            class="input h-auto text-sm"
+                            placeholder="Email Address"
+                            @keydown.enter.prevent="commit"
+                        />
+    
+                        <!-- Phone input -->
+                        <input
+                            v-else-if="linkType === 'tel'"
+                            v-model="urlData.tel"
+                            type="text"
+                            ref="telInput"
+                            class="input h-auto text-sm"
+                            placeholder="Phone Number"
+                            @keydown.enter.prevent="commit"
+                        />
+    
+                        <!-- Data input -->
+                        <div
+                            v-else
+                            class="w-full flex items-center justify-between cursor-pointer"
+                            @click="openSelector"
+                        >
+    
+                            <loading-graphic v-if="isLoading" :inline="true" />
+    
+                            <div v-else class="flex-1 flex items-center mr-2 truncate">
+                                <img
+                                    v-if="linkType === 'asset' && itemData.asset && itemData.isImage"
+                                    :src="itemData.asset.thumbnail || itemData.asset.url"
+                                    class="asset-thumbnail max-h-full max-w-full rounded w-6 h-6 mr-2 object-cover lazyloaded"
+                                >
+                                {{ displayValue }}
+                            </div>
+    
+                            <button
+                            class="flex items-center"
+                                v-tooltip="`${__('Browse')}...`"
+                                :aria-label="`${__('Browse')}...`"
+                                @click="openSelector"
+                            >
+                                <svg-icon v-show="linkType === 'asset'" name="folder-image" class="h-4 w-4" />
+                                <svg-icon v-show="linkType !== 'asset'" name="folder-generic" class="h-4 w-4" />
+                            </button>
+    
+                        </div>
+    
+                    </div>
+                    
                 </div>
+
 
                 <!-- Title attribute -->
                 <div class="h-8 mb-4 p-2 bg-gray-100 text-gray-800 w-full border rounded shadow-inner placeholder:text-gray-600 flex items-center" >
@@ -352,10 +355,6 @@ export default {
             this.targetBlank = attrs.href
                 ? attrs.target === '_blank'
                 : this.config.target_blank;
-        },
-
-        setLinkType(type) {
-            this.linkType = type;
         },
 
         autofocus() {

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -87,7 +87,7 @@
                 </div>
 
                 <!-- Title attribute -->
-                <div class="h-8 p-2 mb-4 bg-gray-100 text-gray-800 w-full border rounded shadow-inner placeholder:text-gray-600 flex items-center" >
+                <div class="h-8 mb-4 p-2 bg-gray-100 text-gray-800 w-full border rounded shadow-inner placeholder:text-gray-600 flex items-center" >
                     <input
                         type="text"
                         ref="input"

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -298,10 +298,10 @@ export default {
             deep: true,
             handler() {
                 if (this.linkType === 'email') {
-                    this.setUrl('email', `mailto:${this.urlData.email}`);
+                    this.setUrl('email', this.urlData.email ? `mailto:${this.urlData.email}` : null);
                 }
                 if (this.linkType === 'phone') {
-                    this.setUrl('phone', `tel:${this.urlData.phone}`);
+                    this.setUrl('phone', this.urlData.phone ? `tel:${this.urlData.phone}` : null);
                 }
             },
         },

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -309,8 +309,7 @@ export default {
         urlData: {
             deep: true,
             handler() {
-                const types = ['mailto', 'tel'];
-                if (!types.includes(this.linkType)) {
+                if (!['mailto', 'tel'].includes(this.linkType)) {
                     return;
                 }
                 this.setUrl(this.linkType, this.urlData[this.linkType]
@@ -470,7 +469,7 @@ export default {
                 return type;
             }
 
-            const matches = url.match(/^(mailto|tel):(.*)$/);
+            const matches = url ? url.match(/^(mailto|tel):(.*)$/) : null;
             if (matches) {
                 return matches[1];
             }
@@ -479,7 +478,7 @@ export default {
         },
 
         getUrlDataForUrl(url) {
-            const matches = url.match(/^(mailto|tel):(.*)$/);
+            const matches = url ? url.match(/^(mailto|tel):(.*)$/) : null;
             if (! matches) {
                 return null;
             }

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -6,9 +6,9 @@
 
                 <div class="flex">
 
-                    <div class="h-8 mb-4 p-1 bg-gray-100 text-gray-800 border rounded shadow-inner flex items-center mr-1">
+                    <div class="h-8 mb-4 bg-gray-100 text-gray-800 border rounded shadow-inner flex items-center mr-1">
                         <select
-                            class="input w-auto h-auto text-sm"
+                            class="input w-auto text-sm px-1"
                             v-model="linkType">
                             <option
                                 v-for="visibleLinkType in visibleLinkTypes"

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -34,10 +34,10 @@
 
                     <!-- Email input -->
                     <input
-                        v-else-if="linkType === 'email'"
-                        v-model="urlData.email"
+                        v-else-if="linkType === 'mailto'"
+                        v-model="urlData.mailto"
                         type="text"
-                        ref="emailInput"
+                        ref="mailtoInput"
                         class="input h-auto text-sm"
                         placeholder="Email Address"
                         @keydown.enter.prevent="commit"
@@ -45,10 +45,10 @@
 
                     <!-- Phone input -->
                     <input
-                        v-else-if="linkType === 'phone'"
-                        v-model="urlData.phone"
+                        v-else-if="linkType === 'tel'"
+                        v-model="urlData.tel"
                         type="text"
-                        ref="phoneInput"
+                        ref="telInput"
                         class="input h-auto text-sm"
                         placeholder="Phone Number"
                         @keydown.enter.prevent="commit"
@@ -203,8 +203,8 @@ export default {
                 { type: 'url', title: __('URL') },
                 { type: 'entry', title: __('Entry') },
                 { type: 'asset', title: __('Asset') },
-                { type: 'email', title: __('Email') },
-                { type: 'phone', title: __('Phone') },
+                { type: 'mailto', title: __('Email') },
+                { type: 'tel', title: __('Phone') },
             ],
             url: {},
             urlData: {},
@@ -236,10 +236,10 @@ export default {
                     return this.itemData.entry ? this.itemData.entry.title : null;
                 case 'asset':
                     return this.itemData.asset ? this.itemData.asset.basename : null;
-                case 'email':
-                    return this.urlData.email ? this.urlData.email : null;
-                case 'phone':
-                    return this.urlData.phone ? this.urlData.phone : null;
+                case 'mailto':
+                    return this.urlData.mailto ? this.urlData.mailto : null;
+                case 'tel':
+                    return this.urlData.tel ? this.urlData.tel : null;
             }
         },
 
@@ -309,12 +309,13 @@ export default {
         urlData: {
             deep: true,
             handler() {
-                if (this.linkType === 'email') {
-                    this.setUrl('email', this.urlData.email ? `mailto:${this.urlData.email}` : null);
+                const types = ['mailto', 'tel'];
+                if (!types.includes(this.linkType)) {
+                    return;
                 }
-                if (this.linkType === 'phone') {
-                    this.setUrl('phone', this.urlData.phone ? `tel:${this.urlData.phone}` : null);
-                }
+                this.setUrl(this.linkType, this.urlData[this.linkType]
+                    ? `${this.linkType}:${this.urlData[this.linkType]}`
+                    : null);
             },
         },
 
@@ -469,31 +470,21 @@ export default {
                 return type;
             }
 
-            try {
-                const data = new URL(url);
-                if (data.protocol === 'mailto:') {
-                    return 'email'; 
-                }
-                if (data.protocol === 'tel:') {
-                    return 'phone'; 
-                }
-            } catch (e) {}
+            const matches = url.match(/^(mailto|tel):(.*)$/);
+            if (matches) {
+                return matches[1];
+            }
 
             return 'url';
         },
 
         getUrlDataForUrl(url) {
-            try {
-                const data = new URL(url);
-                if (data.protocol === 'mailto:') {
-                    return data.pathname;
-                }
-                if (data.protocol === 'tel:') {
-                    return data.pathname;
-                }
-            } catch (e) {}
+            const matches = url.match(/^(mailto|tel):(.*)$/);
+            if (! matches) {
+                return null;
+            }
 
-            return null;
+            return matches[2];
         },
 
         getItemDataForUrl(url) {

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -87,13 +87,24 @@
                 </div>
 
                 <!-- Title attribute -->
-                <div class="h-8 p-2 bg-gray-100 text-gray-800 w-full border rounded shadow-inner placeholder:text-gray-600 flex items-center" >
+                <div class="h-8 p-2 mb-4 bg-gray-100 text-gray-800 w-full border rounded shadow-inner placeholder:text-gray-600 flex items-center" >
                     <input
                         type="text"
                         ref="input"
                         v-model="title"
                         class="input h-auto text-sm placeholder-gray-50"
                         :placeholder="`${__('Label')} (${__('Optional')})`"
+                    />
+                </div>
+
+                <!-- Rel attribute -->
+                <div class="h-8 p-2 bg-gray-100 text-gray-800 w-full border rounded shadow-inner placeholder:text-gray-600 flex items-center" >
+                    <input
+                        type="text"
+                        ref="input"
+                        v-model="rel"
+                        class="input h-auto text-sm placeholder-gray-50"
+                        :placeholder="`${__('Relationship')} (${__('Optional')})`"
                     />
                 </div>
 
@@ -199,6 +210,7 @@ export default {
             urlData: {},
             itemData: {},
             title: null,
+            rel: null,
             targetBlank: null,
             showAssetSelector: false,
             isLoading: false,
@@ -239,7 +251,7 @@ export default {
             return this.sanitizeLink(this.url[this.linkType]);
         },
 
-        rel() {
+        defaultRel() {
             let rel = [];
             if (this.config.link_noopener) rel.push('noopener');
             if (this.config.link_noreferrer) rel.push('noreferrer');
@@ -334,6 +346,9 @@ export default {
             this.itemData = { [this.linkType]: this.getItemDataForUrl(attrs.href) };
 
             this.title = attrs.title;
+            this.rel = attrs.href 
+                ? attrs.rel
+                : this.defaultRel;
             this.targetBlank = attrs.href
                 ? attrs.target === '_blank'
                 : this.config.target_blank;

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -394,7 +394,7 @@ export default {
             this.$emit('updated', {
                 href: this.href,
                 rel: this.rel,
-                target: this.targetBlank ? '_blank' : null,
+                target: (this.canHaveTarget && this.targetBlank) ? '_blank' : null,
                 title: this.title,
             });
         },

--- a/resources/js/components/fieldtypes/bard/LinkToolbarButton.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbarButton.vue
@@ -13,7 +13,7 @@
         </template>
         <template #default>
             <link-toolbar
-                class="w-80"
+                class="w-84"
                 ref="toolbar"
                 v-if="showingToolbar"
                 :link-attrs="linkAttrs"

--- a/src/Fieldtypes/Bard/LinkMark.php
+++ b/src/Fieldtypes/Bard/LinkMark.php
@@ -43,6 +43,13 @@ class LinkMark extends Link
                 },
             ],
             'title' => [],
+            'rel' => [
+                'renderHTML' => function ($attributes) {
+                    return [
+                        'rel' => $attributes->rel ?? '',
+                    ];
+                },
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR adds the following options to the Bard link panel:

* Email Type - Simplifies linking to `mailto:` URLs
* Phone Type - Simplifies linking to `tel:` URLs
* Relationship Field - Allows customisation of `rel` attributes per link

![Untitled](https://github.com/statamic/cms/assets/126740/837e5090-3de6-40c8-a323-ee0f30149226)

The relationship field exposes the `rel` value that's already generated by the field configuration, allowing you to add additional values and customise the default ones. This is the same way the open in new window field works.

The open in new window field is hidden and unset for email and phone links as I don't _think_ it would be relevant given that these links would always open in another application. Can change that if someone knows otherwise?

One UI thing I'm not sure about is how well the five type tabs will fit with other locales? I already had to bump up the width slightly.

Closes https://github.com/statamic/ideas/issues/700
Closes https://github.com/statamic/ideas/issues/579