### PR TITLE
[4.x] Add site to resolvePreviewTargetUrl options

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -905,6 +905,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
         }
 
         return (string) Antlers::parse($format, array_merge($this->routeData(), [
+            'site' => $this->site()->absoluteUrl(),
             'permalink' => $this->absoluteUrl(),
             'locale' => $this->locale(),
         ]));

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -905,7 +905,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
         }
 
         return (string) Antlers::parse($format, array_merge($this->routeData(), [
-            'site' => $this->site()->absoluteUrl(),
+            'site' => $this->site(),
             'permalink' => $this->absoluteUrl(),
             'locale' => $this->locale(),
         ]));


### PR DESCRIPTION
When creating alternate `preview_targets` in a setup where the site domain differs from the CMS (e.g. in headless mode) we need access to the absolute URL of the site in order to build a more complex preview structure besides the existing `permalink`, like for an overview page. In the current setup the page would need to be hardcoded:

```
preview_targets:
  -
    label: Entry
    url: '{permalink}'
  -
    label: Overview
    url: 'http://page.de{mount}'
```

With the proposed change it would be a bit more elegant:

```
preview_targets:
  -
    label: Entry
    url: '{permalink}'
  -
    label: Overview
    url: '{site}{mount}'
```