### PR TITLE
[4.x] Default to first collection's sort config in entries fieldtype

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -161,7 +161,7 @@ class Entries extends Relationship
         $column = $request->get('sort');
 
         if (! $column && ! $request->search) {
-            $column = 'title'; // todo: get from collection or config
+            $column = $this->getFirstCollectionFromRequest($request)->sortField();
         }
 
         return $column;
@@ -172,7 +172,7 @@ class Entries extends Relationship
         $order = $request->get('order', 'asc');
 
         if (! $request->sort && ! $request->search) {
-            // $order = 'asc'; // todo: get from collection or config
+            $order = $this->getFirstCollectionFromRequest($request)->sortDirection();
         }
 
         return $order;


### PR DESCRIPTION
Removes the 'to-do' in the sorting and defers to the sort preferences from the first collection in the request.

Closes https://github.com/statamic/cms/issues/8723