### PR TITLE
[4.x] Propagate save withEvents to the direct descendents on entry save

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -339,7 +339,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
 
         $stack = InitiatorStack::entry($this)->push();
 
-        $this->directDescendants()->each->save();
+        $this->directDescendants()->each->{$withEvents ? 'save' : 'saveQuietly'}();
 
         $this->taxonomize();
 


### PR DESCRIPTION
The save event in Entries does not honour the withEvents setting (set by saveQuietly) when saving descendants.

Fixes: https://github.com/statamic/cms/issues/8785