### PR TITLE
[4.x] Allow for HTML in create-first $button

### DIFF
--- a/resources/views/partials/create-first.blade.php
+++ b/resources/views/partials/create-first.blade.php
@@ -19,7 +19,7 @@
 
         @if ($can ?? $user->can('super'))
             @if($button ?? false)
-                {{ $button }}
+                {!! $button !!}
             @else
                 <a href="{{ $route ?? null }}" class="btn-primary btn-lg">{{ __("Create {$resource}") }}</a>
             @endif


### PR DESCRIPTION
This code block in `resources/views/partials/create-first.blade.php` has a slot-like option, for the `$button`: 

```php
@if ($can ?? $user->can('super'))
    @if($button ?? false)
        {{ $button }} // 👈 Currently escapes whatever gets passed in.
    @else
        <a href="{{ $route ?? null }}" class="btn-primary btn-lg">{{ __("Create {$resource}") }}</a>
    @endif
@endif
```

> Sidenote: I don't think this is currently available as an `x-component`, so it has to be passed in via `@include` parameters...but would be kinda nice to have this + other partials registered as components, to make this sort of thing easier & more robust. 

This code block seems to allow for a complete override of the $button, but...

- that's a bit gnarly to pass through as a parameter to an @include (since this can't be used as an x-component with slots), and 
- it's escaped, breaking HTML (ie, uses `{{ }}` instead of `{!! !!})` which prevents you from injecting an actual button.

This PR addresses the second point, by updating that line to use [Blade's un-escaped syntax](https://laravel.com/docs/10.x/blade#displaying-unescaped-data), to allow for proper (ie, HTML-based) overriding of button "slot".