### PR TITLE
[4.x] Fix toggle.css breaking out of toggle-container

### DIFF
--- a/resources/css/components/toggle.css
+++ b/resources/css/components/toggle.css
@@ -27,7 +27,7 @@
 }
 
 .toggle-container {
-    @apply bg-white cursor-pointer relative border;
+    @apply bg-white cursor-pointer relative border shrink-0;
     height: 22px;
     width: 46px;
     border-radius: 20px;


### PR DESCRIPTION
On Toggle fields with a tighter width, long inline labels can bump to multiple lines. That results in the `toggle-container` breaking, without a `shrink-0` applied to its CSS class. This PR applies that Tailwind class to the `toggle-container`.

**Before:**
![image](https://github.com/statamic/cms/assets/13950848/9f23aa69-d303-4896-b729-892441b2c12c)

**After:**
![image](https://github.com/statamic/cms/assets/13950848/f827c5b9-0445-423c-b95a-bb7f24179499)
