### PR TITLE
[4.x] Improve CollectionStructure performance

### DIFF
--- a/src/Structures/CollectionStructure.php
+++ b/src/Structures/CollectionStructure.php
@@ -135,15 +135,17 @@ class CollectionStructure extends Structure
 
     public function in($site)
     {
-        $tree = app(CollectionTreeRepository::class)->find($this->collection()->handle(), $site);
+        return Blink::once("collection-{$this->id()}-structure-in-{$site}", function () use ($site) {
+            $tree = app(CollectionTreeRepository::class)->find($this->collection()->handle(), $site);
 
-        if (! $tree && $this->existsIn($site)) {
-            $tree = $this->makeTree($site);
-        }
+            if (! $tree && $this->existsIn($site)) {
+                $tree = $this->makeTree($site);
+            }
 
-        return $tree;
+            return $tree;
+        });
     }
-
+    
     public function existsIn($site)
     {
         return $this->collection()->sites()->contains($site);

--- a/src/Structures/CollectionStructure.php
+++ b/src/Structures/CollectionStructure.php
@@ -145,7 +145,7 @@ class CollectionStructure extends Structure
             return $tree;
         });
     }
-    
+
     public function existsIn($site)
     {
         return $this->collection()->sites()->contains($site);

--- a/src/Structures/CollectionStructure.php
+++ b/src/Structures/CollectionStructure.php
@@ -135,7 +135,7 @@ class CollectionStructure extends Structure
 
     public function in($site)
     {
-        return Blink::once("collection-{$this->id()}-structure-in-{$site}", function () use ($site) {
+        return Blink::once("collection-structure-tree-{$this->handle()}-{$site}", function () use ($site) {
             $tree = app(CollectionTreeRepository::class)->find($this->collection()->handle(), $site);
 
             if (! $tree && $this->existsIn($site)) {

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -160,6 +160,7 @@ abstract class Tree implements Contract, Localization
         $this->cachedFlattenedPages = null;
 
         Blink::forget('collection-structure-flattened-pages-collection*');
+        Blink::forget('collection-structure-tree*');
 
         $this->repository()->save($this);
 
@@ -170,6 +171,8 @@ abstract class Tree implements Contract, Localization
 
     public function delete()
     {
+        Blink::forget('collection-structure-tree*');
+
         $this->repository()->delete($this);
 
         $this->dispatchDeletedEvent();


### PR DESCRIPTION
Improve performance when CollectionStructure::in is called multiple times for the same collection and site. This increases performance when warming the stache: #8744 

Closes #8744.