### PR TITLE
[4.x] Fix missing response from `afterRequestCompleted`

### DIFF
--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -130,7 +130,7 @@ export default {
                 if (this.shouldRequestFirstPage) return this.request();
                 this.loading = false;
                 this.initializing = false;
-                this.afterRequestCompleted();
+                this.afterRequestCompleted(response);
             }).catch(e => {
                 if (this.$axios.isCancel(e)) return;
                 this.loading = false;


### PR DESCRIPTION
The `Listing` mixin includes an `afterRequestCompleted` method that should receive the response object, but it's missing from the call. This PR adds it.