### PR TITLE
[4.x] Clean up Section fieldtype styles

### DIFF
--- a/resources/css/components/fieldtypes/section.css
+++ b/resources/css/components/fieldtypes/section.css
@@ -4,16 +4,20 @@
 
 .section-fieldtype {
     @apply border-t border-b bg-gray-200;
-    top: -1px; /*  Avoid adjacent borders just in case they're stacked */
+    @apply -mt-px; /*  Avoid adjacent borders just in case they're stacked */
 
     &.form-group {
         position: relative;
         &:first-child {
-            @apply rounded-t border-t-0;
+            @apply rounded-t-md border-t-0;
+        }
+
+        &:last-child {
+            @apply rounded-b-md mt-0;
         }
 
         .field-inner > label {
-            @apply uppercase text-sm font-bold mt-2;
+            @apply uppercase text-sm font-bold;
         }
     }
 
@@ -33,5 +37,13 @@
 }
 
 .bard-fieldtype .section-fieldtype {
-    top: 0;
+    @apply mt-0;
+}
+
+.publish-section-header + .publish-fields .section-fieldtype {
+    &.form-group {
+        &:first-child {
+            @apply rounded-t-none;
+        }
+    }
 }


### PR DESCRIPTION
This PR cleans up the styles of the `Section` fieldtype, by addressing a few bits that were just slightly off:

- Unequal space on top & bottom of the label/description—loosely related to #8371
- Corner radius was one step smaller (`.rounded` vs. `rounded-md`) than the ancestor `.card`.
- Pulled away from the bottom edge, due to `top:1px`; replaced with a negative `margin-top`.
- Immediate sections with a header get pulled up, breaking into the header's border.
- Fixes double-stacked borders, when sections are back to back. 
- Bottom radius not accounted for, when the section is at the end of a card.

Those last two were mostly to give a better foundation for addons (eg, [Group fieldtype](https://github.com/eminos/statamic-group)) that use sections to "contain" other fields. But still cleaner to have in core, without adding too much into the stylesheet.

Here's a quick kitchen sink setup, to show the before-and-after. Tweaked a few other things in the code after this was rendered, but the most noticeable changes are shown here:

![section-field-change](https://github.com/statamic/cms/assets/13950848/a04148ea-d549-4b58-920f-48479b43be96)

Lmk if you'd like to see any adjustments, and I'll take a crack at it. Thanks team!