### PR TITLE
[4.x] Clarify default field instructions/helper-text

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -81,7 +81,7 @@ return [
     'field_validation_required_instructions' => 'Control whether or not this field is required.',
     'field_validation_sometimes_instructions' => 'Only validate when this field is visible or submitted.',
     'fields_blueprints_description' => 'Blueprints define the fields for content structures like collections, taxonomies, users, and forms.',
-    'fields_default_instructions' => 'Set the default value.',
+    'fields_default_instructions' => 'Set a default value. Inserted whenever this field is empty, on **all** publishable forms.',
     'fields_display_instructions' => 'The field\'s label shown in the Control Panel.',
     'fields_duplicate_instructions' => 'Whether this field should be included when duplicating the item.',
     'fields_fieldsets_description' => 'Fieldsets are simple, flexible, and completely optional groupings of fields that help to organize reusable, pre-configured fields.',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -81,7 +81,7 @@ return [
     'field_validation_required_instructions' => 'Control whether or not this field is required.',
     'field_validation_sometimes_instructions' => 'Only validate when this field is visible or submitted.',
     'fields_blueprints_description' => 'Blueprints define the fields for content structures like collections, taxonomies, users, and forms.',
-    'fields_default_instructions' => 'Set a default value. Inserted whenever this field is empty, on **all** publishable forms.',
+    'fields_default_instructions' => 'The value to be inserted whenever this field is empty on all publish forms.',
     'fields_display_instructions' => 'The field\'s label shown in the Control Panel.',
     'fields_duplicate_instructions' => 'Whether this field should be included when duplicating the item.',
     'fields_fieldsets_description' => 'Fieldsets are simple, flexible, and completely optional groupings of fields that help to organize reusable, pre-configured fields.',


### PR DESCRIPTION
This tiny tweak originated in **[a Discord chat with Erin & Sam](https://discord.com/channels/489818810157891584/1159256773312655372/1159259733870518302)**. Currently, the `fields_default_instructions`—which is used for the helper text below `Default Value` on field definitions—reads as:

> Set the default value.

This PR tries to put a lil more meat on dem bones. 🍖 Proposing a change to:

> Set a default value. Inserted whenever this field is empty, on **all** publishable forms.

This is definitely a subjective thing, so won't hurt my feelings if you all decide to reject or edit...but this has bit me a couple of times, with how the setting actually works. Copying in a bit of that Discord convo linked above, for more context:

I tend to think of **_default_** as more of a _UI consideration_—ie, a default value to save the user some time in the GUI, by pre-populating the field _at time of creation_, with a commonly-used default. And what's actually happening, I would maybe consider more of a **_fallback_** that's typically handled _via code_—ie, a stand-in value, in the event that the user hasn't provided a value and the system _needs_ one, for whatever reason. 

The way Statamic actually works is kind of an interesting hybrid, IMHO...it's similar to the former, as it's purely a front-end thing (at least as far as I can tell...nothing seems to be happening server-side to "force" that default into place). But it has the persistence of the latter, as it always attempts to "re-insert" the default, including on _edit_ forms.

So as an example, say a user goes to **create** a new entry and clears the default value from the field. This saves as expected, with a null value. But if they return to **edit** that previously-saved entry—ie, any one that has a blank value in the field—the default value will be "quietly" re-entered via the CP GUI. And they might not realize that, causing confusion and/or problems when they unknowingly save a value into that field.

Again, totally realize this is mostly subjective semantics. TBH, would be nice to have both a `default` and a `fallback` to serve both purposes. But no biggie—just thought it might be beneficial for all, to have a slightly more descriptive rundown on how that works under the hood.