### PR TITLE
[4.x] GraphQL: Fix assets not resolving query builders

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -43,16 +43,17 @@ use Symfony\Component\Mime\MimeTypes;
 
 class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, ContainsQueryableValues, ResolvesValuesContract, SearchableContract
 {
-    use ContainsData, FluentlyGetsAndSets, HasAugmentedInstance, Searchable, TracksQueriedColumns;
+    use ContainsData, FluentlyGetsAndSets, HasAugmentedInstance,
+        Searchable,
+        TracksQueriedColumns, TracksQueriedRelations {
+            set as traitSet;
+            get as traitGet;
+            remove as traitRemove;
+            data as traitData;
+            merge as traitMerge;
+        }
     use ResolvesValues {
         resolveGqlValue as traitResolveGqlValue;
-    }
-    use TracksQueriedRelations {
-        set as traitSet;
-        get as traitGet;
-        remove as traitRemove;
-        data as traitData;
-        merge as traitMerge;
     }
 
     protected $container;

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -12,6 +12,7 @@ use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
+use Statamic\Contracts\GraphQL\ResolvesValues as ResolvesValuesContract;
 use Statamic\Contracts\Query\ContainsQueryableValues;
 use Statamic\Contracts\Search\Searchable as SearchableContract;
 use Statamic\Data\ContainsData;
@@ -24,6 +25,7 @@ use Statamic\Events\AssetReuploaded;
 use Statamic\Events\AssetSaved;
 use Statamic\Events\AssetUploaded;
 use Statamic\Exceptions\FileExtensionMismatch;
+use Statamic\GraphQL\ResolvesValues;
 use Statamic\Facades;
 use Statamic\Facades\AssetContainer as AssetContainerAPI;
 use Statamic\Facades\Image;
@@ -39,17 +41,19 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Mime\MimeTypes;
 
-class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, ContainsQueryableValues, SearchableContract
+class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, ContainsQueryableValues, SearchableContract, ResolvesValuesContract
 {
-    use ContainsData, FluentlyGetsAndSets, HasAugmentedInstance,
-        Searchable,
-        TracksQueriedColumns, TracksQueriedRelations {
-            set as traitSet;
-            get as traitGet;
-            remove as traitRemove;
-            data as traitData;
-            merge as traitMerge;
-        }
+    use ContainsData, FluentlyGetsAndSets, HasAugmentedInstance, Searchable, TracksQueriedColumns;
+    use TracksQueriedRelations {
+        set as traitSet;
+        get as traitGet;
+        remove as traitRemove;
+        data as traitData;
+        merge as traitMerge;
+    }
+    use ResolvesValues {
+        resolveGqlValue as traitResolveGqlValue;
+    }
 
     protected $container;
     protected $path;

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -25,13 +25,13 @@ use Statamic\Events\AssetReuploaded;
 use Statamic\Events\AssetSaved;
 use Statamic\Events\AssetUploaded;
 use Statamic\Exceptions\FileExtensionMismatch;
-use Statamic\GraphQL\ResolvesValues;
 use Statamic\Facades;
 use Statamic\Facades\AssetContainer as AssetContainerAPI;
 use Statamic\Facades\Image;
 use Statamic\Facades\Path;
 use Statamic\Facades\URL;
 use Statamic\Facades\YAML;
+use Statamic\GraphQL\ResolvesValues;
 use Statamic\Listeners\UpdateAssetReferences as UpdateAssetReferencesSubscriber;
 use Statamic\Search\Searchable;
 use Statamic\Statamic;
@@ -41,18 +41,18 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Mime\MimeTypes;
 
-class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, ContainsQueryableValues, SearchableContract, ResolvesValuesContract
+class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, ContainsQueryableValues, ResolvesValuesContract, SearchableContract
 {
     use ContainsData, FluentlyGetsAndSets, HasAugmentedInstance, Searchable, TracksQueriedColumns;
+    use ResolvesValues {
+        resolveGqlValue as traitResolveGqlValue;
+    }
     use TracksQueriedRelations {
         set as traitSet;
         get as traitGet;
         remove as traitRemove;
         data as traitData;
         merge as traitMerge;
-    }
-    use ResolvesValues {
-        resolveGqlValue as traitResolveGqlValue;
     }
 
     protected $container;

--- a/src/GraphQL/Types/AssetType.php
+++ b/src/GraphQL/Types/AssetType.php
@@ -5,7 +5,6 @@ namespace Statamic\GraphQL\Types;
 use Statamic\Contracts\Assets\Asset;
 use Statamic\Contracts\Assets\AssetContainer;
 use Statamic\Facades\GraphQL;
-use Statamic\Fields\Value;
 use Statamic\Support\Str;
 
 class AssetType extends \Rebing\GraphQL\Support\Type
@@ -50,13 +49,7 @@ class AssetType extends \Rebing\GraphQL\Support\Type
     private function resolver()
     {
         return function (Asset $asset, $args, $context, $info) {
-            $value = $asset->augmentedValue($info->fieldName);
-
-            if ($value instanceof Value) {
-                $value = $value->value();
-            }
-
-            return $value;
+            return $asset->resolveGqlValue($info->fieldName);
         };
     }
 }


### PR DESCRIPTION
Having terms on an Asset causes an almost an identical issues on Graphql (`User Error: expected iterable, but did not find one for field`) as was solved in #6379.

While I'm not entirely sure this is the correct approach I added the `ResolvesValues`-Trait to `Asset.php` and modified the resolve function. Otherwise simply adding the code ` if ($value instanceof Builder) { $value = $value->get();  }` in the resolver will also fix the issue.