### PR TITLE
[4.x] Remove requirement of orderable collection from next/prev tags

### DIFF
--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -73,8 +73,9 @@ class Entries
             $operator = '<';
         }
 
-        if ($collection->orderable() && $primaryOrderBy->sort === 'order') {
-            $query = $this->query()->where('order', $operator ?? '>', $currentEntry->order());
+        if ($primaryOrderBy->sort === 'order') {
+            throw_if(! $currentOrder = $currentEntry->order(), new \Exception('Current entry does not have an order'));
+            $query = $this->query()->where('order', $operator ?? '>', $currentOrder);
         } elseif ($collection->dated() && $primaryOrderBy->sort === 'date') {
             $query = $this->query()->where('date', $operator ?? '>', $currentEntry->date());
         } else {
@@ -97,8 +98,9 @@ class Entries
             $operator = '>';
         }
 
-        if ($collection->orderable() && $primaryOrderBy->sort === 'order') {
-            $query = $this->query()->where('order', $operator ?? '<', $currentEntry->order());
+        if ($primaryOrderBy->sort === 'order') {
+            throw_if(! $currentOrder = $currentEntry->order(), new \Exception('Current entry does not have an order'));
+            $query = $this->query()->where('order', $operator ?? '<', $currentOrder);
         } elseif ($collection->dated() && $primaryOrderBy->sort === 'date') {
             $query = $this->query()->where('date', $operator ?? '<', $currentEntry->date());
         } else {


### PR DESCRIPTION
At the moment, the `collection:next`/`prev` tags only work on dated or orderable collections. "Orderable" collections are ones with a structure set to max depth of 1.

This was because the "order" was ambiguous for multi-depth collections. A while ago in #4883 we made the decision for it to just assume the order is depth-first (how it looks if you read down the page while looking at the tree).

We never looped back and added support for that within the collection:next/prev tags.

This PR removes that requirement. If you want to sort by `order`, go for it. You can technically even sort a dated collection by order if you add an `order` field to each entry.

The default sort order of a multi-depth structured collection is `title`. Since we don't want to make it a breaking change, to get these tags to work, you'll need to add `sort="order"`. In Statamic 5 we will change the default sort order of a multi-depth structured collection to `order`.
