### PR TITLE
[4.x] Support additional CP thumbnail presets

### DIFF
--- a/config/cp.php
+++ b/config/cp.php
@@ -131,11 +131,11 @@ return [
     | Thumbnails
     |--------------------------------------------------------------------------
     |
-    | Here you may define additional CP asset thumbnail sizes.
+    | Here you may define additional CP asset thumbnail presets.
     |
     */
 
-    'thumbnail_sizes' => [
+    'thumbnail_presets' => [
         // 'medium' => 800,
     ],
 ];

--- a/config/cp.php
+++ b/config/cp.php
@@ -125,4 +125,17 @@ return [
     'custom_favicon_url' => env('STATAMIC_CUSTOM_FAVICON_URL', null),
 
     'custom_css_url' => env('STATAMIC_CUSTOM_CSS_URL', null),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Thumbnails
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define additional CP asset thumbnail sizes.
+    |
+    */
+
+    'thumbnail_sizes' => [
+        // 'medium' => 800,
+    ],
 ];

--- a/src/Imaging/Manager.php
+++ b/src/Imaging/Manager.php
@@ -79,11 +79,18 @@ class Manager
      */
     public function cpManipulationPresets()
     {
-        return [
-            'cp_thumbnail_small_landscape' => ['w' => '400', 'h' => '400', 'fit' => 'contain'],
-            'cp_thumbnail_small_portrait' => ['h' => '400', 'fit' => 'contain'],
-            'cp_thumbnail_small_square' => ['w' => '400', 'h' => '400'],
-        ];
+        $sizes = array_merge(
+            ['small' => 400],
+            config('statamic.cp.thumbnail_sizes', [])
+        );
+
+        return collect($sizes)
+            ->flatMap(fn ($size, $name) => [
+                "cp_thumbnail_{$name}_landscape" => ['w' => $size, 'h' => $size, 'fit' => 'contain'],
+                "cp_thumbnail_{$name}_portrait" => ['h' => $size, 'fit' => 'contain'],
+                "cp_thumbnail_{$name}_square" => ['w' => $size, 'h' => $size],
+            ])
+            ->all();
     }
 
     /**

--- a/src/Imaging/Manager.php
+++ b/src/Imaging/Manager.php
@@ -79,12 +79,12 @@ class Manager
      */
     public function cpManipulationPresets()
     {
-        $sizes = array_merge(
+        $presets = array_merge(
             ['small' => 400],
-            config('statamic.cp.thumbnail_sizes', [])
+            config('statamic.cp.thumbnail_presets', [])
         );
 
-        return collect($sizes)
+        return collect($presets)
             ->flatMap(fn ($size, $name) => [
                 "cp_thumbnail_{$name}_landscape" => ['w' => $size, 'h' => $size, 'fit' => 'contain'],
                 "cp_thumbnail_{$name}_portrait" => ['h' => $size, 'fit' => 'contain'],


### PR DESCRIPTION
I'm working on a project with a custom assets fieldtype that displays the preview image larger than 400px, so the default `small` thumbnail looks a bit fuzzy. The only alternative currently is to display the original file, but that could be huge.

This PR allows you to add extra CP thumbnail presets, for use by custom CP extensions/addons.

It does allow you to override the default `small` preset as well, as I couldn't really see any reason to prevent that. That could be useful if you just needed a slightly larger thumbnail and don't want to double up.

The config could make sense in either `assets` or `cp`. I went for `cp` but can change that if necessary.