### PR TITLE
[4.x] Fix error when saving entry where content is empty array

### DIFF
--- a/src/Yaml/Yaml.php
+++ b/src/Yaml/Yaml.php
@@ -103,7 +103,7 @@ class Yaml
      */
     public function dumpFrontMatter($data, $content = null)
     {
-        if ($content !== null && ! is_string($content)) {
+        if (! is_null($content) && ! is_string($content)) {
             $data['content'] = $content;
             $content = '';
         }

--- a/src/Yaml/Yaml.php
+++ b/src/Yaml/Yaml.php
@@ -103,7 +103,7 @@ class Yaml
      */
     public function dumpFrontMatter($data, $content = null)
     {
-        if ($content && ! is_string($content)) {
+        if ($content !== null && ! is_string($content)) {
             $data['content'] = $content;
             $content = '';
         }

--- a/src/Yaml/Yaml.php
+++ b/src/Yaml/Yaml.php
@@ -83,7 +83,7 @@ class Yaml
      */
     public function dump($data, $content = null)
     {
-        if ($content) {
+        if (! is_null($content)) {
             if (is_string($content)) {
                 return $this->dumpFrontMatter($data, $content);
             }

--- a/tests/Yaml/YamlTest.php
+++ b/tests/Yaml/YamlTest.php
@@ -60,7 +60,7 @@ EOT;
     }
 
     /** @test */
-    public function it_explicitly_dumps_front_matter_when_content_is_an_empty_array()
+    public function it_dumps_without_front_matter_when_content_is_an_empty_array()
     {
         $expected = <<<'EOT'
 foo: bar

--- a/tests/Yaml/YamlTest.php
+++ b/tests/Yaml/YamlTest.php
@@ -60,6 +60,18 @@ EOT;
     }
 
     /** @test */
+    public function it_explicitly_dumps_front_matter_when_content_is_an_empty_array()
+    {
+        $expected = <<<'EOT'
+foo: bar
+content: {  }
+
+EOT;
+
+        $this->assertEquals($expected, YAML::dump(['foo' => 'bar'], []));
+    }
+
+    /** @test */
     public function it_dumps_without_front_matter_when_content_is_null()
     {
         $expected = <<<'EOT'
@@ -110,6 +122,20 @@ content:
 EOT;
 
         $this->assertEquals($expected, YAML::dumpFrontMatter(['foo' => 'bar'], ['baz' => 'qux']));
+    }
+
+    /** @test */
+    public function it_explicitly_dumps_front_matter_including_content_when_its_an_empty_array()
+    {
+        $expected = <<<'EOT'
+---
+foo: bar
+content: {  }
+---
+
+EOT;
+
+        $this->assertEquals($expected, YAML::dumpFrontMatter(['foo' => 'bar'], []));
     }
 
     /** @test */


### PR DESCRIPTION
Solves an issue where you cannot save localized entries in a multisite when your content field is an empty replicator.