### PR TITLE
[4.x] Feature: Add inline label for Toggle when truthy

### DIFF
--- a/resources/js/components/fieldtypes/ToggleFieldtype.vue
+++ b/resources/js/components/fieldtypes/ToggleFieldtype.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="toggle-fieldtype-wrapper">
         <toggle-input :value="value" @input="update" :read-only="isReadOnly" :id="fieldId" />
-        <label v-if="config.inline_label" class="inline-label" v-html="$options.filters.markdown(config.inline_label)"></label>
+        <label v-if="inlineLabel" class="inline-label" v-html="$options.filters.markdown(inlineLabel)"></label>
     </div>
 </template>
 
@@ -10,6 +10,10 @@ export default {
     mixins: [Fieldtype],
 
     computed: {
+
+        inlineLabel(){
+            return this.value ? (this.config.inline_label_when_true || this.config.inline_label) : this.config.inline_label;
+        },
 
         replicatorPreview() {
             return (this.value ? '✓' : '✗') + ' ' + this.config.display;

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -176,6 +176,7 @@ return [
     'time.title' => 'Time',
     'toggle.title' => 'Toggle',
     'toggle.config.inline_label' => 'Set an inline label to be shown beside the toggle input.',
+    'toggle.config.inline_label_when_true' => 'Set an inline label to be shown when the toggle\'s value is true.',
     'user_groups.title' => 'User Groups',
     'user_roles.title' => 'User Roles',
     'users.title' => 'Users',

--- a/src/Fieldtypes/Toggle.php
+++ b/src/Fieldtypes/Toggle.php
@@ -24,6 +24,12 @@ class Toggle extends Fieldtype
                         'type' => 'text',
                         'default' => '',
                     ],
+                    'inline_label_when_true' => [
+                        'display' => __('Inline Label when True'),
+                        'instructions' => __('statamic::fieldtypes.toggle.config.inline_label_when_true'),
+                        'type' => 'text',
+                        'default' => '',
+                    ],
                     'default' => [
                         'display' => __('Default Value'),
                         'instructions' => __('statamic::messages.fields_default_instructions'),


### PR DESCRIPTION
This PR adds an optional `inline_label_when_true` field to the Toggle fieldtype's config, allowing for a separate inline label when the value of the Toggle is truthy. This is non-breaking/backwards compatible, as the existing `inline_label` is unchanged and used as the fallback within the Vue component. Here's what this change looks like, in each possible scenario:

![dynamic-toggle-kitchen-sink](https://github.com/statamic/cms/assets/13950848/35395383-0f48-4420-8388-29f6ead45c03)
