### PR TITLE
[4.x] Bug: Fix Section fieldtype first-child's top-margin

### DIFF
--- a/resources/css/components/fieldtypes/section.css
+++ b/resources/css/components/fieldtypes/section.css
@@ -9,11 +9,11 @@
     &.form-group {
         position: relative;
         &:first-child {
-            @apply rounded-t-md border-t-0;
+            @apply mt-0 rounded-t-md border-t-0;
         }
 
         &:last-child {
-            @apply rounded-b-md mt-0;
+            @apply rounded-b-md;
         }
 
         .field-inner > label {


### PR DESCRIPTION
Small bug from #8807; I had the `mt-0` in `last-child`...should have been `first-child`. **Sorry about that!** 
Blaming a hole in my kitchen sink—gave a false-positive of sorts, since the `last-child` was also the `first-child` in that example.

## Before and after:
![immediate-section-patch](https://github.com/statamic/cms/assets/13950848/1cc7391e-5a58-4ce4-8fb8-2296a1eb6e08)

## Updated kitchen sink:
![image](https://github.com/statamic/cms/assets/13950848/bdcf11e0-68f9-475d-b188-a9fd8d5803e6)
