### PR TITLE
[4.x] Fix assets being deleted when renaming snake_case folder to kebab-case.

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -357,7 +357,8 @@ class AssetContainer implements Arrayable, ArrayAccess, AssetContainerContract, 
 
         if ($folder !== null) {
             if ($recursive) {
-                $query->where('path', 'like', "{$folder}/%");
+                $like = str_replace('_', '\_', $folder).'/%';
+                $query->where('path', 'like', $like);
             } else {
                 $query->where('folder', $folder);
             }


### PR DESCRIPTION
Fixes #8825

When you rename a folder, it'll do these steps:
1. Move assets to new directory
2. Query for assets in the current directory
3. Delete those assets

The bug happens in step 2. There's a `->where('path', 'like', "$folder/%")` happening.
In a `like` clause syntax, an `_` means "any single character". So when we try to do `->where('path', 'like', 'my_folder/%')`, anything in `my-folder` (or even swapping any character like `myzfolder`) would get returned, and deleted in step 3.

This PR makes sure to escape the underscore in the passed path. The `like` behavior is correct.
