### PR TITLE
Only show status indicator in stack view if item has a status

### DIFF
--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -49,7 +49,7 @@
                             >
                                 <template slot="cell-title" slot-scope="{ row: entry }">
                                     <div class="flex items-center">
-                                        <div class="little-dot mr-2" v-tooltip="getStatusLabel(entry)" :class="getStatusClass(entry)" v-if="! columnShowing('status')" />
+                                        <div class="little-dot mr-2" v-tooltip="getStatusLabel(entry)" :class="getStatusClass(entry)" v-if="entry.status && ! columnShowing('status')" />
                                         {{ entry.title }}
                                     </div>
                                 </template>


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/8824 by checking we have a status to show when determining if the dot should be visible.

The form selector now looks like this:

<img width="847" alt="Screenshot 2023-10-12 at 08 49 02" src="https://github.com/statamic/cms/assets/51899/5afa8f64-6a0d-425f-bc58-4cf60bb90614">
