### PR TITLE
Update widget.js

### DIFF
--- a/src/View/Debugbar/AntlersProfiler/resources/widget.js
+++ b/src/View/Debugbar/AntlersProfiler/resources/widget.js
@@ -541,7 +541,7 @@
                     dataTree: true,
                     dataTreeStartExpanded: true,
                     dataTreeChildField: 'children',
-                    layout: 'responsive',
+                    responsiveLayout: true,
                     tooltips: true,
                     rowFormatter: function (row) {
                         var data = row.getData(),


### PR DESCRIPTION
Using debugbar in Statamic with Antlers profiling enabled currently creates a console warning:

```
Layout Error - invalid mode set, defaulting to 'fitData' : responsive
```

This seems to be because 'responsive' isn't a valid option, it's supposed to be `responsiveLayout: true` as per https://tabulator.info/docs/5.5/layout#responsive