### PR TITLE
[4.x] Supply field's config and form's handle to extraRenderableFieldData method

### DIFF
--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -355,7 +355,7 @@ abstract class Fieldtype implements Arrayable
         return $value;
     }
 
-    public function extraRenderableFieldData(): array
+    public function extraRenderableFieldData($form = null): array
     {
         return [];
     }

--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -355,7 +355,7 @@ abstract class Fieldtype implements Arrayable
         return $value;
     }
 
-    public function extraRenderableFieldData($form = null): array
+    public function extraRenderableFieldData($field, $form = null): array
     {
         return [];
     }

--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -355,7 +355,7 @@ abstract class Fieldtype implements Arrayable
         return $value;
     }
 
-    public function extraRenderableFieldData($field, $form = null): array
+    public function extraRenderableFieldData($config = [], $form = null): array
     {
         return [];
     }

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -66,7 +66,10 @@ class Tags extends BaseTags
         $data['sections'] = $this->getSections($this->sessionHandle(), $jsDriver);
         if (!empty($data['sections'])) {
             // fields have already been rendered in the sections: get from the sections to avoid a re-render
-            $data['fields'] = collect($data['sections'])->map(fn($section) => $section['fields'])->flatten(1);
+            $data['fields'] = collect($data['sections'])->map(fn($section) => $section['fields'])
+                ->flatten(1)
+                ->values()
+                ->all();
         } else {
             // render fields directly
             $data['fields'] = $this->getFields($this->sessionHandle(), $jsDriver);

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -64,7 +64,7 @@ class Tags extends BaseTags
         $jsDriver = $this->parseJsParamDriverAndOptions($this->params->get('js'), $form);
 
         $data['sections'] = $this->getSections($this->sessionHandle(), $jsDriver);
-        if (!empty($data['sections'])) {
+        if (! empty($data['sections'])) {
             // fields have already been rendered in the sections: get from the sections to avoid a re-render
             $data['fields'] = collect($data['sections'])->map(fn($section) => $section['fields'])
                 ->flatten(1)

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -64,7 +64,13 @@ class Tags extends BaseTags
         $jsDriver = $this->parseJsParamDriverAndOptions($this->params->get('js'), $form);
 
         $data['sections'] = $this->getSections($this->sessionHandle(), $jsDriver);
-        $data['fields'] = $this->getFields($this->sessionHandle(), $jsDriver);
+        if (!empty($data['sections'])) {
+            // fields have already been rendered in the sections: get from the sections to avoid a re-render
+            $data['fields'] = collect($data['sections'])->map(fn($section) => $section['fields'])->flatten(1);
+        } else {
+            // render fields directly
+            $data['fields'] = $this->getFields($this->sessionHandle(), $jsDriver);
+        }
         $data['honeypot'] = $form->honeypot();
 
         if ($jsDriver) {

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -66,7 +66,7 @@ class Tags extends BaseTags
         $data['sections'] = $this->getSections($this->sessionHandle(), $jsDriver);
         if (! empty($data['sections'])) {
             // fields have already been rendered in the sections: get from the sections to avoid a re-render
-            $data['fields'] = collect($data['sections'])->map(fn($section) => $section['fields'])
+            $data['fields'] = collect($data['sections'])->map(fn ($section) => $section['fields'])
                 ->flatten(1)
                 ->values()
                 ->all();

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -138,7 +138,7 @@ trait RendersForms
             'default' => $field->value() ?? $field->defaultValue(),
             'old' => old($field->handle()),
             'value' => $value,
-        ], $field->fieldtype()->extraRenderableFieldData(method_exists($this, 'form') ? $this->form()->handle() : null));
+        ], $field->fieldtype()->extraRenderableFieldData($field, method_exists($this, 'form') ? $this->form()->handle() : null));
 
         if ($manipulateDataCallback instanceof Closure) {
             $data = $manipulateDataCallback($data, $field);

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -138,7 +138,7 @@ trait RendersForms
             'default' => $field->value() ?? $field->defaultValue(),
             'old' => old($field->handle()),
             'value' => $value,
-        ], $field->fieldtype()->extraRenderableFieldData($field, method_exists($this, 'form') ? $this->form()->handle() : null));
+        ], $field->fieldtype()->extraRenderableFieldData($field->config(), method_exists($this, 'form') ? $this->form()->handle() : null));
 
         if ($manipulateDataCallback instanceof Closure) {
             $data = $manipulateDataCallback($data, $field);

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -138,7 +138,7 @@ trait RendersForms
             'default' => $field->value() ?? $field->defaultValue(),
             'old' => old($field->handle()),
             'value' => $value,
-        ], $field->fieldtype()->extraRenderableFieldData());
+        ], $field->fieldtype()->extraRenderableFieldData(method_exists($this, 'form') ? $this->form()->handle() : null));
 
         if ($manipulateDataCallback instanceof Closure) {
             $data = $manipulateDataCallback($data, $field);


### PR DESCRIPTION
The key tweak here is supplying the form's handle to the new `extraRenderableFieldData` method.

This allows the potential for form-specific calculations to take place within a custom fieldtype.

Further to this, to prevent fields being rendered multiple times, the Form tag has been tweaked to collect the `fields` from the sections, if the form rendered any, otherwise fall back to the older way of doing it. Without this tweak, the fields get rendered twice per form.