### PR TITLE
[4.x] Allow overwriting the column for `unique_user_value` validation

### DIFF
--- a/src/Validation/UniqueUserValue.php
+++ b/src/Validation/UniqueUserValue.php
@@ -8,10 +8,12 @@ class UniqueUserValue
 {
     public function validate($attribute, $value, $parameters, $validator)
     {
-        [$except] = array_pad($parameters, 1, null);
+        [$except, $column] = array_pad($parameters, 2, null);
+
+        $column = $column ?? $attribute;
 
         $existing = User::query()
-            ->where($attribute, $value)
+            ->where($column, $value)
             ->first();
 
         if (! $existing) {

--- a/src/Validation/UniqueUserValue.php
+++ b/src/Validation/UniqueUserValue.php
@@ -10,7 +10,7 @@ class UniqueUserValue
     {
         [$except, $column] = array_pad($parameters, 2, null);
 
-        $column = $column ?? $attribute;
+        $column ??= $attribute;
 
         $existing = User::query()
             ->where($column, $value)

--- a/tests/Validation/UniqueUserValueTest.php
+++ b/tests/Validation/UniqueUserValueTest.php
@@ -35,4 +35,15 @@ class UniqueUserValueTest extends TestCase
             ['email' => 'unique_user_value:123']
         )->passes());
     }
+
+    /** @test */
+    public function it_supports_overwriting_the_column()
+    {
+        User::make()->email('foo@bar.com')->save();
+
+        $this->assertTrue(Validator::make(
+            ['baz' => 'foo@bar.com'],
+            ['baz' => 'unique_user_value:null,email']
+        )->fails());
+    }
 }


### PR DESCRIPTION
Sometimes it's necessary to pass the column the `unique_user_value` validator validates on. For example when using Livewire Form Objects where the field handles get prefixed by `form.`.

Closes https://github.com/statamic/ideas/issues/1067.