### PR TITLE
[4.x] Fix missing replicator set previews

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -127,6 +127,12 @@ export default {
         }
     },
 
+    data() {
+        return {
+            fieldPreviews: this.previews,
+        }
+    },
+
     computed: {
 
         fields() {
@@ -166,7 +172,7 @@ export default {
         },
 
         previewUpdated(handle, value) {
-            this.$emit('previews-updated', { ...this.previews, [handle]: value });
+            this.$emit('previews-updated', this.fieldPreviews = { ...this.fieldPreviews, [handle]: value });
         },
 
         destroy() {


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/8839

The reason for this issue is that replicator passes the previews down to each set as a prop, but when the page loads and all fields trigger an update the prop isn't updated fast enough and each subsequent update wipes out the previews from the previous ones. The old `setTimeout` approach that the referenced PR changed avoided this.

The issue isn't specific to text fields, it could happen for any field, it's just that the last field to initialise would always win and text fields are so simple they usually initialise first. I replicated the same issue with toggle fields, and text fields that are last in the set.

This PR fixes it by storing a copy of the previews in the set component, so that it always has a complete set rather than relying on the prop value. I did try setting `immediate: true` on the replicator `previews` watcher as an alternative fix, but that didn't seem to work.

Theoretically this issue would apply to bard as well, however it doesn't because bard sets fetch their previews directly from the parent component's meta values, rather than relying on a prop being passed in.