### PR TITLE
[4.x] Allow keys to be specified on the nocache tag

### DIFF
--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -53,9 +53,9 @@ class Session
         throw new RegionNotFound($key);
     }
 
-    public function pushRegion($contents, $context, $extension): StringRegion
+    public function pushRegion($contents, $context, $extension, $key = ''): StringRegion
     {
-        $region = new StringRegion($this, trim($contents), $context, $extension);
+        $region = new StringRegion($this, trim($contents), $context, $extension, $key ?? '');
 
         return $this->regions[$region->key()] = $region;
     }

--- a/src/StaticCaching/NoCache/StringRegion.php
+++ b/src/StaticCaching/NoCache/StringRegion.php
@@ -7,13 +7,13 @@ class StringRegion extends Region
     protected $content;
     protected $extension;
 
-    public function __construct(Session $session, string $content, array $context, string $extension)
+    public function __construct(Session $session, string $content, array $context, string $extension, string $key = '')
     {
         $this->session = $session;
         $this->content = $content;
         $this->context = $this->filterContext($context);
         $this->extension = $extension;
-        $this->key = sha1($content.str_random());
+        $this->key = $key ?: sha1($content.str_random());
     }
 
     public function key(): string

--- a/src/StaticCaching/NoCache/Tags.php
+++ b/src/StaticCaching/NoCache/Tags.php
@@ -21,7 +21,7 @@ class Tags extends \Statamic\Tags\Tags
     {
         return $this
             ->nocache
-            ->pushRegion($this->content, $this->context->all(), 'antlers.html')
+            ->pushRegion($this->content, $this->context->all(), 'antlers.html', $this->params->get('key'))
             ->placeholder();
     }
 }


### PR DESCRIPTION
This PR adds support for keys on nocache tags...

`{{ nocache key="my_key" }}`

When used the key wont be randomly generated on each page load, which should go some way to mitigating the memory/views build up thats being reported here: https://github.com/statamic/cms/issues/7039

However if you are using a key it means the contents of the nocache tag can't be session or page load specific, it must be generalised data otherwise data leakage could potentially occur. Maybe its not enough to warn about that and this should be extended to not include session data when keys are specified?