### PR TITLE
[4.x] Remove double-render of fields in Form tag

### DIFF
--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -64,7 +64,16 @@ class Tags extends BaseTags
         $jsDriver = $this->parseJsParamDriverAndOptions($this->params->get('js'), $form);
 
         $data['sections'] = $this->getSections($this->sessionHandle(), $jsDriver);
-        $data['fields'] = $this->getFields($this->sessionHandle(), $jsDriver);
+        if (! empty($data['sections'])) {
+            // fields have already been rendered in the sections: get from the sections to avoid a re-render
+            $data['fields'] = collect($data['sections'])->map(fn ($section) => $section['fields'])
+                ->flatten(1)
+                ->values()
+                ->all();
+        } else {
+            // render fields directly
+            $data['fields'] = $this->getFields($this->sessionHandle(), $jsDriver);
+        }
         $data['honeypot'] = $form->honeypot();
 
         if ($jsDriver) {


### PR DESCRIPTION
In the Forms tag, when `create` is called, `getSections` and `getFields` are called to get the sections and fields respectively.

However, `getSections` already calls `getFields`. This results in `getFields` being called twice - meaning fields are being rendered twice.

This PR changes the behaviour of `create` and runs `getSections` first, as it currently does, and then checks to see if sections were returned - if so, it then extracts the fields from the sections (rather than calling `getFields` again). If there are no sections (i.e. think historical pre-section forms) then `getFields` is explicitly called.