### PR TITLE
[4.x] Add form reference to field during render

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\Type;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Lang;
 use Rebing\GraphQL\Support\Field as GqlField;
+use Statamic\Contracts\Forms\Form;
 use Statamic\Facades\GraphQL;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
@@ -20,7 +21,7 @@ class Field implements Arrayable
     protected $parent;
     protected $parentField;
     protected $validationContext;
-    protected $form;
+    protected ?Form $form = null;
 
     public function __construct($handle, array $config)
     {
@@ -411,14 +412,14 @@ class Field implements Arrayable
         return $this->fieldtype()->isRelationship();
     }
 
-    public function setForm($form)
+    public function setForm(Form $form)
     {
         $this->form = $form;
 
         return $this;
     }
 
-    public function form()
+    public function form(): ?Form
     {
         return $this->form;
     }

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -20,6 +20,7 @@ class Field implements Arrayable
     protected $parent;
     protected $parentField;
     protected $validationContext;
+    protected $form;
 
     public function __construct($handle, array $config)
     {
@@ -408,5 +409,17 @@ class Field implements Arrayable
     public function isRelationship(): bool
     {
         return $this->fieldtype()->isRelationship();
+    }
+
+    public function setForm($form)
+    {
+        $this->form = $form;
+
+        return $this;
+    }
+
+    public function form()
+    {
+        return $this->form;
     }
 }

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -240,7 +240,10 @@ class Tags extends BaseTags
      */
     protected function getFields($sessionHandle, $jsDriver, $fields = null)
     {
-        return collect($fields ?? $this->form()->fields())
+        $form = $this->form();
+
+        return collect($fields ?? $form->fields())
+            ->each(fn ($field) => $field->setForm($form))
             ->map(function ($field) use ($sessionHandle, $jsDriver) {
                 return $this->getRenderableField($field, $sessionHandle, function ($data, $field) use ($jsDriver) {
                     return $jsDriver

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -127,6 +127,10 @@ trait RendersForms
     {
         $errors = session('errors') ? session('errors')->getBag($errorBag) : new MessageBag;
 
+        if (method_exists($this, 'form')) {
+            $field->setForm($this->form());
+        }
+
         $missing = str_random();
         $old = old($field->handle(), $missing);
         $default = $field->value() ?? $field->defaultValue();

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -127,10 +127,6 @@ trait RendersForms
     {
         $errors = session('errors') ? session('errors')->getBag($errorBag) : new MessageBag;
 
-        if (method_exists($this, 'form')) {
-            $field->setForm($this->form());
-        }
-
         $missing = str_random();
         $old = old($field->handle(), $missing);
         $default = $field->value() ?? $field->defaultValue();

--- a/tests/Fields/FieldTest.php
+++ b/tests/Fields/FieldTest.php
@@ -6,6 +6,7 @@ use Facades\Statamic\Fields\FieldtypeRepository;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Value;
+use Statamic\Forms\Form;
 use Tests\TestCase;
 
 class FieldTest extends TestCase
@@ -617,5 +618,18 @@ class FieldTest extends TestCase
         $field = (new Field('test', ['type' => 'fieldtype']))->setValue('foo');
 
         $this->assertTrue($field->isRelationship());
+    }
+
+    /** @test */
+    public function it_gets_and_sets_the_form()
+    {
+        $field = new Field('test', ['type' => 'text']);
+
+        $this->assertNull($field->form());
+
+        $return = $field->setForm($form = new Form);
+
+        $this->assertEquals($field, $return);
+        $this->assertEquals($form, $field->form());
     }
 }


### PR DESCRIPTION
The `RendersForms` concern handles the rendering of fields. 

However within a field's context during render, the field has no knowledge of the form it is being used on.

This PR updates the `getRenderableField` method of `RendersForms` to add the form to the Field (only if the `form` method exists).

This can be useful to help give the fieldtype rendering context as to what form it is belonging to.

For a custom fieldtype, developers can use `$this->field()->form()` within their fieldtype to get the form instance.