### PR TITLE
[4.x] Fix navigation 'Save Changes' button state

### DIFF
--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -383,9 +383,9 @@ export default {
         },
 
         treeSaved(response) {
-            this.changed = false;
-
             this.replaceGeneratedIds(response.data.generatedIds);
+
+            this.changed = false;
         },
 
         replaceGeneratedIds(ids) {


### PR DESCRIPTION
This pull request fixes an issue I spotted where the 'Save Changes' button on navigations would take two clicks to clear the browser dirty state and disable the button.

Fixes #8859.