### PR TITLE
[4.x] Add autocreate_on_save option for indexes

### DIFF
--- a/config/search.php
+++ b/config/search.php
@@ -29,6 +29,7 @@ return [
             'driver' => 'local',
             'searchables' => 'all',
             'fields' => ['title'],
+            'autocreate_on_save' => true,
         ],
 
         // 'blog' => [


### PR DESCRIPTION
Statamic updates search indexes automatically, when an entry is saved. This includes creating a new index and filling it up completely, if none exists.

This is great for smaller sites, since one does not have to worry about the index at all - however, on larger sites with a lot of content and/or custom search indexers, that take a while to complete, this can end in a situation, where saving an entry is impossible due to the index creation.

This PR adds a `autocreate_on_save` option for indexes, which defaults to `true`.

* If `autocreate_on_save` is set to `true` then the current behaviour is preserved
* If `autocreate_on_save` is set to `false`, then the index will be updated, if it already exists but it will not be automatically created, should it not exist. If the option is enabled, the index has to be created using other means (e.g. manually via CLI, cronjob, ...)

---

Future outlook:

When this question originally was raised by my colleague, moving this work to a queue was also raised as an alternative. In my opinion, this would be a better solution altogether

![2023-10-18_12-18](https://github.com/statamic/cms/assets/3374170/a73127a2-5173-4bb0-a7c0-e2e6ed21267e)
