### PR TITLE
[4.x] Change "Manage Licenses" link on Licensing page

### DIFF
--- a/resources/views/licensing.blade.php
+++ b/resources/views/licensing.blade.php
@@ -118,7 +118,7 @@
 
         <div class="mt-10 py-4 border-t flex items-center">
             <a href="{{ $site->url() }}" target="_blank" class="btn btn-primary mr-4">{{ __('Edit Site') }}</a>
-            @if ($addToCartUrl) <a href="{{ $addToCartUrl }}" target="_blank" class="btn mr-4">{{ __('Buy Licenses') }}</a> @endif
+            @if ($manageLicensesUrl) <a href="{{ $manageLicensesUrl }}" target="_blank" class="btn mr-4">{{ __('Manage Licenses') }}</a> @endif
             <a href="{{ cp_route('utilities.licensing.refresh') }}" class="btn">{{ __('Sync') }}</a>
             <p class="ml-4 text-2xs text-gray">{{ __('statamic::messages.licensing_sync_instructions') }}</p>
         </div>

--- a/src/Http/Controllers/CP/LicensingController.php
+++ b/src/Http/Controllers/CP/LicensingController.php
@@ -15,7 +15,7 @@ class LicensingController extends CpController
             'addons' => $addons = $licenses->addons()->filter->existsOnMarketplace(),
             'unlistedAddons' => $licenses->addons()->reject->existsOnMarketplace(),
             'configCached' => app()->configurationIsCached(),
-            'addToCartUrl' => $this->addToCartUrl($site, $statamic, $addons),
+            'manageLicensesUrl' => $this->manageLicensesUrl($site),
         ]);
     }
 
@@ -28,19 +28,14 @@ class LicensingController extends CpController
             ->with('success', __('Data updated'));
     }
 
-    public function addToCartUrl($site, $statamic, $addons)
+    public function manageLicensesUrl($site): string
     {
-        return 'https://statamic.com/cart/bulk-add?'.http_build_query([
-            'site' => $site->key(),
-            'statamic' => ! $statamic->valid(),
-            'products' => $addons->reject->valid()->map->addon()->map(function ($addon) {
-                $product = $addon->marketplaceId();
-                if ($edition = $addon->edition()) {
-                    $product .= ':'.$edition;
-                }
+        $url = 'https://statamic.com/account/manage-licenses';
 
-                return $product;
-            })->implode(','),
-        ]);
+        if ($site->key()) {
+            $url .= "?site={$site->key()}";
+        }
+
+        return $url;
     }
 }


### PR DESCRIPTION
This pull request changes the URL the "Manage Licenses" button (previously called "Buy Licenses") points to - aligning with changes on statamic.com.