### PR TITLE
[4.x] Default to using the CP broker when multiple are available

### DIFF
--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -233,12 +233,20 @@ abstract class User implements Arrayable, ArrayAccess, Augmentable, Authenticata
     {
         $broker = config('statamic.users.passwords.'.PasswordReset::BROKER_RESETS);
 
+        if (is_array($broker)) {
+            $broker = $broker['cp'];
+        }
+
         return Password::broker($broker)->createToken($this);
     }
 
     public function generateActivateAccountToken()
     {
         $broker = config('statamic.users.passwords.'.PasswordReset::BROKER_ACTIVATIONS);
+
+        if (is_array($broker)) {
+            $broker = $broker['cp'];
+        }
 
         return Password::broker($broker)->createToken($this);
     }


### PR DESCRIPTION
As [reported here](https://github.com/statamic/cms/issues/8868) when you specify multiple guards copying the password reset token throws an error.

This PR fixes that by applying the same logic used elsewhere and checking if its an array and selecting the cp guard.

Closes https://github.com/statamic/cms/issues/8868