### PR TITLE
[4.x] Fix runtime behavior regression

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1756,7 +1756,11 @@ class NodeProcessor
                                 // Only revert to parseLoop behavior if the tag contains
                                 // parameters that are likely to dramatically change
                                 // the scope or overall output of the tag result.
-                                if ($node->hasScopeAdjustingParameters) {
+                                // We will also revert to parseLoop behavior if
+                                // the tag returns an associative array and
+                                // the tag has parameters with the same
+                                // name as modifiers for compatibility.
+                                if ($node->hasModifierParameters() && Arr::isAssoc($output) || $node->hasScopeAdjustingParameters) {
                                     $tagAssocOutput = $output;
                                     $output = Arr::assoc($output) ? (string) $tag->parse($output) : (string) $tag->parseLoop($this->addLoopIterationVariables($output));
                                     $tagCallbackResult = null;

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1755,8 +1755,8 @@ class NodeProcessor
 
                                 // Only revert to parseLoop behavior if the tag contains
                                 // parameters that are likely to dramatically change
-                                // the scope or overall output of the tag result
-                                if ($node->hasScopeAdjustingParameters) {
+                                // the scope or overall output of the tag result.
+                                if (Arr::isAssoc($output) || $node->hasScopeAdjustingParameters) {
                                     $tagAssocOutput = $output;
                                     $output = Arr::assoc($output) ? (string) $tag->parse($output) : (string) $tag->parseLoop($this->addLoopIterationVariables($output));
                                     $tagCallbackResult = null;


### PR DESCRIPTION
This PR fixes #8829.

An earlier PR #8818 introduced a behavior regression. While the behavior is *technically correct*, it doesn't play well with sites that were accidentally relying on the old behavior.

An example of where the old behavior before #8818 would apply incorrectly is when using the `asset` tag with the `url` parameter:

```antlers
{{ asset :url="image" }}
   {{# Do your thing. #}}
{{ /asset }}
```

Because `url` also matches a modifier name, the previous over-aggressive check would catch this tag and isolate its parsing/rendering. This PR re-introduces this old behavior when a tag returns an associative array, while preserving the corrected behavior #8818 was trying to achieve.

This behavior regression is incredibly difficult to track down and correct within sites using a page builder-type setup, where its not obvious what's being included when/by-what. I've verified it on a site (related to the attached issue), but it is highly likely to impact more.

New tests have also been added to catch this behavior, but there is the possibility that it doesn't account for *all* of the weird previous behavior of having the over-aggressive check apply to everything.

Note: Regardless of which action is taken (reverting #8818) or accepting this PR, there *will be* strange behavior in some scenarios until it can be resolved in a breaking-change version. The easier scenario/workaround to document is the workaround that would be required by reverting #8818:

```antlers
{{ _the_count = 1; }}

{{ collection:articles limit="3" as="oo_shiny" }}
    {{#
        This works because the runtime *can* trace the assignments across scope barriers.
        Even though the as will force a new renderer to be created, the runtime is still
        handling the iteration/looping itself, instead of the tag's parseLoop method.
    #}}
    {{ oo_shiny }}
        {{ _the_count += 1; }}
        Entry: {{ _the_count }}
    {{ /oo_shiny }}
{{ /collection:articles }}
```

That workaround is required when the tag does *not* return an associative array, but does have parameters that conflict with modifier names. This is probably the better course of action (instead of accidentally breaking behavior), but I did make an attempt to keep both things working 🙂

Note 2: Adding the ability to force isolation and opt-into the previous behavior would also be an option, but would also be a breaking change and require changes to a site's template (and would be confusing to explain *when* that should be done).