### PR TITLE
[4.x] Decrease the width of the link type selector

### DIFF
--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -2,7 +2,7 @@
     <div class="flex items-center">
 
         <!-- Link type selector -->
-        <div class="w-40 mr-4">
+        <div class="w-28 mr-4">
             <v-select
                 v-model="option"
                 append-to-body


### PR DESCRIPTION
On small screens the url subfield of the link field type gets comically small:

![image](https://github.com/statamic/cms/assets/3847288/54873ca6-7193-452a-b8c9-1a7aec92fe1c)

To resolve this we can decrease the width of the link type so that it better fits any of the current options in it (ie. URL, Entry, Asset):

![image](https://github.com/statamic/cms/assets/3847288/7c016ab0-e951-44e7-b175-41e92049a53c)
