### PR TITLE
[4.x] Add helper arg for addons to easily remove child item in core nav

### DIFF
--- a/src/CP/Navigation/Nav.php
+++ b/src/CP/Navigation/Nav.php
@@ -45,12 +45,13 @@ class Nav
     }
 
     /**
-     * Find or create nav item.
+     * Find nav item.
      *
      * @param  string  $section
      * @param  string  $name
+     * @return NavItem|null
      */
-    public function findOrCreate($section, $name)
+    public function find($section, $name)
     {
         $item = collect($this->items)->first(function ($item) use ($section, $name) {
             return $item->section() === $section
@@ -58,7 +59,19 @@ class Nav
                 && ! $item->isChild();
         });
 
-        return $item ?: $this->create($name)->section($section);
+        return $item;
+    }
+
+    /**
+     * Find or create nav item.
+     *
+     * @param  string  $section
+     * @param  string  $name
+     * @return NavItem
+     */
+    public function findOrCreate($section, $name)
+    {
+        return $this->find($section, $name) ?: $this->create($name)->section($section);
     }
 
     /**
@@ -66,10 +79,15 @@ class Nav
      *
      * @param  string  $section
      * @param  string|null  $name
+     * @param  string|null  $childName
      * @return $this
      */
-    public function remove($section, $name = null)
+    public function remove($section, $name = null, $childName = null)
     {
+        if ($childName) {
+            return $this->removeChildItem($section, $name, $childName);
+        }
+
         $this->items = collect($this->items)
             ->reject(function ($item) use ($section, $name) {
                 return $name
@@ -77,6 +95,29 @@ class Nav
                     : $item->section() === $section;
             })
             ->all();
+
+        return $this;
+    }
+
+    /**
+     * Remove nav item.
+     *
+     * @param  string  $section
+     * @param  string|null  $name
+     * @param  string|null  $childName
+     * @return $this
+     */
+    protected function removeChildItem($section, $name, $childName)
+    {
+        if (! $parent = $this->find($section, $name)) {
+            return $this;
+        }
+
+        if (! $children = $parent->resolveChildren()->children()) {
+            return $this;
+        }
+
+        $parent->children($children->reject(fn ($child) => $child->display() === $childName));
 
         return $this;
     }

--- a/tests/CP/Navigation/NavTest.php
+++ b/tests/CP/Navigation/NavTest.php
@@ -124,7 +124,7 @@ class NavTest extends TestCase
     }
 
     /** @test */
-    public function it_can_get_and_modify_an_existing_item()
+    public function it_can_find_and_modify_an_existing_item()
     {
         $this->actingAs(tap(User::make()->makeSuper())->save());
 
@@ -132,6 +132,27 @@ class NavTest extends TestCase
             ->url('/pit-droid')
             ->icon('<svg>...</svg>');
 
+        Nav::find('Droids', 'WAC-47')
+            ->url('/d-squad');
+
+        $item = $this->build()->get('Droids')->first();
+
+        $this->assertEquals('Droids', $item->section());
+        $this->assertEquals('WAC-47', $item->display());
+        $this->assertEquals('<svg>...</svg>', $item->icon());
+        $this->assertEquals('http://localhost/d-squad', $item->url());
+    }
+
+    /** @test */
+    public function it_can_find_and_modify_an_existing_item_using_magic_constructor()
+    {
+        $this->actingAs(tap(User::make()->makeSuper())->save());
+
+        Nav::droids('WAC-47')
+            ->url('/pit-droid')
+            ->icon('<svg>...</svg>');
+
+        // Callign the same constructor does a `findOrCreate()` under the hood...
         Nav::droids('WAC-47')
             ->url('/d-squad');
 


### PR DESCRIPTION
This PR adds ability for an addon to remove specific core nav item children more easily. For example, in our [Shopify rad pack addon](https://github.com/statamic-rad-pack/shopify), @ryanmitchell is wanting to remove the `Products` collection item from `Collections`, because that item is being listed as a child of the `Shopify` nav item instead.

### Before

```php
Nav::extend(function ($nav) {
    $collectionsNav = $nav->content('Collections');

    $children = $collectionsNav
        ->resolveChildren()
        ->children()
        ->reject(function ($item) {
            if (in_array($item->display(), ['Products', 'Variants'])) {
                return true;
            }
        });

    $collectionsNav->children($children);
});
```

### After

```php
Nav::extend(function ($nav) {
    $nav->remove('Content', 'Collections', 'Products');
    $nav->remove('Content', 'Collections', 'Variants');
});
```

## Todo

- [x] Add new helper arg to `remove()`
- [x] Update docs
  - https://github.com/statamic/docs/pull/1126
  - Of course, any addon using this new 3rd `remove()` param, would need to explicitly require whatever version of Statamic this is tagged in, since this is a new feature 👍 
    - Should min version requirement be mentioned in docs, @jasonvarga?