### PR TITLE
[4.x] Improve Entries fieldtype search index logic, and add option to define an explicit one.

### DIFF
--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -74,7 +74,7 @@ return [
     'entries.config.create' => 'Allow creation of new entries.',
     'entries.config.collections' => 'Choose which collections the user can select from.',
     'entries.config.query_scopes' => 'Choose which query scopes should be applied when retrieving selectable entries.',
-    'entries.config.search_index' => 'Choose which search index should be used when searching entries.',
+    'entries.config.search_index' => 'An appropriate search index will be used automatically where possible, but you may define an explicit one.',
     'entries.title' => 'Entries',
     'float.title' => 'Float',
     'form.config.max_items' => 'Set a maximum number of selectable forms.',

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -74,6 +74,7 @@ return [
     'entries.config.create' => 'Allow creation of new entries.',
     'entries.config.collections' => 'Choose which collections the user can select from.',
     'entries.config.query_scopes' => 'Choose which query scopes should be applied when retrieving selectable entries.',
+    'entries.config.search_index' => 'Choose which search index should be used when searching entries.',
     'entries.title' => 'Entries',
     'float.title' => 'Float',
     'form.config.max_items' => 'Set a maximum number of selectable forms.',

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -10,6 +10,7 @@ use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\GraphQL;
 use Statamic\Facades\Scope;
+use Statamic\Facades\Search;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Http\Resources\CP\Entries\Entries as EntriesResource;
@@ -90,6 +91,11 @@ class Entries extends Relationship
                         'instructions' => __('statamic::fieldtypes.entries.config.collections'),
                         'type' => 'collections',
                         'mode' => 'select',
+                    ],
+                    'search_index' => [
+                        'display' => __('Search Index'),
+                        'instructions' => __('statamic::fieldtypes.entries.config.search_index'),
+                        'type' => 'text',
                     ],
                     'query_scopes' => [
                         'display' => __('Query Scopes'),
@@ -186,7 +192,10 @@ class Entries extends Relationship
             $usingSearchIndex = false;
             $collections = collect($this->getConfiguredCollections());
 
-            if ($collections->count() == 1) {
+            if ($searchIndex = $this->config('search_index')) {
+                $query = Search::in($searchIndex)->ensureExists()->search($search);
+                $usingSearchIndex = true;
+            } elseif ($collections->count() == 1) {
                 $collection = Collection::findByHandle($collections->first());
                 if ($collection && $collection->hasSearchIndex()) {
                     $query = $collection->searchIndex()->ensureExists()->search($search);


### PR DESCRIPTION
Our use case is that we have an entries field type hooked up to several collections, and because it's multi-site, when we're on the Arabic site, we can't actually find the entry we need because all we can search on is title, which of course, are in arabic.

We'd love to be able to search by slug, and have a search index that includes slug so we can do that in the English site.

However, when multiple collections are configured on an Entries fieldtype, on a 'like' query on the title is performed.

This PR adds a `search_index` to the config then uses it, if it exists.