### PR TITLE
[4.x] Allow using Global Set variables in form email configs

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -203,7 +203,7 @@ class Email extends Mailable
         return collect($config)->map(function ($value) {
             $value = Parse::env($value); // deprecated
 
-            return (string) Antlers::parse($value, $this->submissionData);
+            return (string) Antlers::parse($value, array_merge($this->submissionData, $this->getGlobalsData()));
         });
     }
 }

--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -22,6 +22,7 @@ class Email extends Mailable
     protected $submissionData;
     protected $config;
     protected $site;
+    private $globalData;
 
     public function __construct(Submission $submission, array $config, Site $site)
     {
@@ -160,6 +161,10 @@ class Email extends Mailable
 
     private function getGlobalsData()
     {
+        if (! is_null($this->globalData)) {
+            return $this->globalData;
+        }
+
         $data = [];
 
         foreach (GlobalSet::all() as $global) {
@@ -172,7 +177,7 @@ class Email extends Mailable
             $data[$global->handle()] = $global->toAugmentedArray();
         }
 
-        return array_merge($data, $data['global'] ?? []);
+        return $this->globalData = array_merge($data, $data['global'] ?? []);
     }
 
     protected function addresses($addresses)

--- a/src/Forms/SendEmails.php
+++ b/src/Forms/SendEmails.php
@@ -6,8 +6,6 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Bus;
 use Statamic\Contracts\Forms\Submission;
-use Statamic\Facades\Antlers;
-use Statamic\Facades\GlobalSet;
 use Statamic\Sites\Site;
 
 class SendEmails

--- a/src/Forms/SendEmails.php
+++ b/src/Forms/SendEmails.php
@@ -6,6 +6,8 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Bus;
 use Statamic\Contracts\Forms\Submission;
+use Statamic\Facades\Antlers;
+use Statamic\Facades\GlobalSet;
 use Statamic\Sites\Site;
 
 class SendEmails


### PR DESCRIPTION
This pull request allows for using Global Set variables in form configs.

Closes #2635.

## Example

For example you could have a "Company Information" global with Name & Email fields. 

Then, when configuring form emails, you'd be able to reference the global set data just like you would in a normal Antlers template: `{{ company_information:email }}`

![CleanShot 2023-10-30 at 12 10 33](https://github.com/statamic/cms/assets/19637309/74296df8-9fb7-4a43-a0ca-a5021dcae8e6)
