### PR TITLE
[4.x] Refresh Live Preview when relationship items are updated

### DIFF
--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -53,6 +53,8 @@ export default {
         InlineEditForm
     },
 
+    inject: ['storeName'],
+
     props: {
         item: Object,
         config: Object,
@@ -83,6 +85,8 @@ export default {
             this.item.published = responseData.published;
             this.item.private = responseData.private;
             this.item.status = responseData.status;
+
+            this.$events.$emit(`live-preview.${this.storeName}.refresh`);
         },
 
     }

--- a/resources/js/components/live-preview/LivePreview.vue
+++ b/resources/js/components/live-preview/LivePreview.vue
@@ -215,6 +215,10 @@ export default {
         this.keybinding = this.$keys.bindGlobal('mod+shift+p', () => {
             this.previewing ? this.close() : this.$emit('opened-via-keyboard');
         });
+
+        this.$events.$on(`live-preview.${this.name}.refresh`, () => {
+            this.update();
+        });
     },
 
     beforeDestroy() {


### PR DESCRIPTION
This pull request fixes an issue with Live Preview when updating a relationship item (entry / taxonomy term / etc) that it wouldn't refresh the Live Preview.

![CleanShot 2023-10-30 at 16 25 21](https://github.com/statamic/cms/assets/19637309/0878022d-0183-44b4-b722-039de16bfcee)

Closes #1975.