### PR TITLE
[4.x] Ignore single smart quotes when slugifying string

### DIFF
--- a/resources/js/plugins/slugify.js
+++ b/resources/js/plugins/slugify.js
@@ -12,6 +12,9 @@ export default {
             // Remove apostrophes in all languages
             custom["'"] = "";
 
+            // Remove smart single quotes
+            custom["’"] = "";
+
             return getSlug(text, {
                 separator: glue || '-',
                 lang,


### PR DESCRIPTION
This pull request fixes a small issue where single smart quotes (`’`) weren't being stripped out when slugifying a string.

Example title: `GTA Online’s latest news: “huge map”`

Fixes #8844.