### PR TITLE
[4.x] Fixed issue when resetting columns on Entry Listing Table

### DIFF
--- a/src/Http/Resources/CP/Entries/Entries.php
+++ b/src/Http/Resources/CP/Entries/Entries.php
@@ -36,6 +36,7 @@ class Entries extends ResourceCollection
             ->listable(true)
             ->visible(true)
             ->defaultVisibility(true)
+            ->defaultOrder($columns->count() + 1)
             ->sortable(false);
 
         $columns->put('status', $status);


### PR DESCRIPTION
This pull request fixes an issue on the Entry Listing Table where the "Status" column is placed *before* the title & slug columns when resetting columns on the entry listing table.

Initially, when you load the Entry Listing Table without any preferences, it'll get all the fields set as visible. Then, when you "Reset" the columns in the `ColumnPicker` modal, it'll set the columns to those which are visible by default (`defaultVisibility`) and order by them by the column's `defaultOrder` setting.

This PR makes it so the "Status" column will be displayed as the last column in this scenario, fixing #8285.

Fixes #8285.