### PR TITLE
[4.x] Entries Fieldtype: Use columns from preferences

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -5,6 +5,7 @@ namespace Statamic\Fieldtypes;
 use Illuminate\Support\Collection as SupportCollection;
 use Statamic\Contracts\Data\Localization;
 use Statamic\Contracts\Entries\Entry as EntryContract;
+use Statamic\CP\Column;
 use Statamic\Exceptions\CollectionNotFoundException;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -375,6 +376,22 @@ class Entries extends Relationship
 
     public function getColumns()
     {
+        if (count($this->getConfiguredCollections()) === 1) {
+            $columns = $this->getBlueprint()->columns();
+
+            $status = Column::make('status')
+                ->listable(true)
+                ->visible(true)
+                ->defaultVisibility(true)
+                ->sortable(false);
+
+            $columns->put('status', $status);
+
+            $columns->setPreferred("collections.{$this->getConfiguredCollections()[0]}.columns");
+
+            return $columns->rejectUnlisted()->values();
+        }
+
         return $this->getBlueprint()->columns()->values()->all();
     }
 


### PR DESCRIPTION
This pull request makes a small quality-of-life improvement to the Entries Fieldtype. 

When a single collection is configured, the fieldtype will now show the user's preferred columns for the collection, rather than just the listable columns from the blueprint.

This means that the columns you configure on the collection's listing table will also be used when viewing its entries in the Entry Fieldtype stack selector.

Closes statamic/ideas#1052