### PR TITLE
[4.x] Glide tag - make absolute url transform apply only to current site url

### DIFF
--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -13,6 +13,7 @@ use Statamic\Facades\Config;
 use Statamic\Facades\Glide as GlideManager;
 use Statamic\Facades\Image;
 use Statamic\Facades\Path;
+use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Imaging\ImageGenerator;
 use Statamic\Support\Str;
@@ -199,7 +200,9 @@ class Glide extends Tags
             return;
         }
 
-        $url = ($this->params->bool('absolute', $this->useAbsoluteUrls())) ? URL::makeAbsolute($url) : URL::makeRelative($url);
+        if (Str::startsWith($url, Site::current()->absoluteUrl())) {
+            $url = ($this->params->bool('absolute', $this->useAbsoluteUrls())) ? URL::makeAbsolute($url) : URL::makeRelative($url);
+        }
 
         return $url;
     }


### PR DESCRIPTION
This resolves https://github.com/statamic/cms/issues/8637

The absolute URL transformation should only happen if the asset url is the current site.  Otherwise non-transformed assets will break when storing images on S3 or CDN storage providers.