### PR TITLE
[4.x] Support paste events in Taggable Fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/TagsFieldtype.vue
+++ b/resources/js/components/fieldtypes/TagsFieldtype.vue
@@ -15,13 +15,14 @@
         @search:focus="$emit('focus')"
         @search:blur="$emit('blur')">
             <template #selected-option-container><i class="hidden"></i></template>
-            <template #search="{ events, attributes }" v-if="config.multiple">
+            <template #search="{ events, attributes }">
                 <input
                     :placeholder="config.placeholder"
                     class="vs__search"
                     type="search"
                     v-on="events"
                     v-bind="attributes"
+                    @paste="onPaste"
                 >
             </template>
              <template #no-options>
@@ -71,6 +72,14 @@ export default {
     methods: {
         focus() {
             this.$refs.input.focus();
+        },
+
+        onPaste(event) {
+            const pastedValue = event.clipboardData.getData('text');
+
+            this.update([...this.value, ...pastedValue.split(',')]);
+
+            event.preventDefault();
         },
     },
 


### PR DESCRIPTION
This pull request adds support for paste events in the Taggable Fieldtype so you can simply paste a string like `one, two, three` into the input and it'll split it up into separate tags.

I've removed the `v-if="config.multiple"` check since that setting doesn't exist on this fieldtype and I needed to hook into the `<input>` for the paste event.

Closes #1649.