### PR TITLE
[4.x] Validate that Select & Button Group options have keys

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -175,7 +175,7 @@ return [
     'date_fieldtype_end_date_required' => 'End date is required.',
     'date_fieldtype_end_date_invalid' => 'Not a valid end date.',
     'code_fieldtype_rulers' => 'This is invalid.',
-    'options_require_keys' => 'Please ensure all options have keys.',
+    'options_require_keys' => 'All options must have keys.',
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -175,6 +175,7 @@ return [
     'date_fieldtype_end_date_required' => 'End date is required.',
     'date_fieldtype_end_date_invalid' => 'Not a valid end date.',
     'code_fieldtype_rulers' => 'This is invalid.',
+    'options_require_keys' => 'Please ensure all options have keys.',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Fieldtypes/ButtonGroup.php
+++ b/src/Fieldtypes/ButtonGroup.php
@@ -23,6 +23,13 @@ class ButtonGroup extends Fieldtype
                         'type' => 'array',
                         'value_header' => __('Label').' ('.__('Optional').')',
                         'add_button' => __('Add Option'),
+                        'validate' => [function ($attribute, $value, $fail) {
+                            $optionsWithoutKeys = collect($value)->keys()->filter(fn ($key) => empty($key));
+
+                            if ($optionsWithoutKeys->isNotEmpty()) {
+                                $fail(__('Please ensure all options have keys.'));
+                            }
+                        }],
                     ],
                     'default' => [
                         'display' => __('Default Value'),

--- a/src/Fieldtypes/ButtonGroup.php
+++ b/src/Fieldtypes/ButtonGroup.php
@@ -24,7 +24,7 @@ class ButtonGroup extends Fieldtype
                         'value_header' => __('Label').' ('.__('Optional').')',
                         'add_button' => __('Add Option'),
                         'validate' => [function ($attribute, $value, $fail) {
-                            $optionsWithoutKeys = collect($value)->keys()->filter(fn ($key) => empty($key) === 'null');
+                            $optionsWithoutKeys = collect($value)->keys()->filter(fn ($key) => empty($key) || $key === 'null');
 
                             if ($optionsWithoutKeys->isNotEmpty()) {
                                 $fail(__('Please ensure all options have keys.'));

--- a/src/Fieldtypes/ButtonGroup.php
+++ b/src/Fieldtypes/ButtonGroup.php
@@ -24,7 +24,7 @@ class ButtonGroup extends Fieldtype
                         'value_header' => __('Label').' ('.__('Optional').')',
                         'add_button' => __('Add Option'),
                         'validate' => [function ($attribute, $value, $fail) {
-                            $optionsWithoutKeys = collect($value)->keys()->filter(fn ($key) => empty($key));
+                            $optionsWithoutKeys = collect($value)->keys()->filter(fn ($key) => empty($key) === 'null');
 
                             if ($optionsWithoutKeys->isNotEmpty()) {
                                 $fail(__('Please ensure all options have keys.'));

--- a/src/Fieldtypes/ButtonGroup.php
+++ b/src/Fieldtypes/ButtonGroup.php
@@ -27,7 +27,7 @@ class ButtonGroup extends Fieldtype
                             $optionsWithoutKeys = collect($value)->keys()->filter(fn ($key) => empty($key) || $key === 'null');
 
                             if ($optionsWithoutKeys->isNotEmpty()) {
-                                $fail(__('Please ensure all options have keys.'));
+                                $fail(__('statamic::validation.options_require_keys'));
                             }
                         }],
                     ],

--- a/src/Fieldtypes/Select.php
+++ b/src/Fieldtypes/Select.php
@@ -9,7 +9,9 @@ class Select extends Fieldtype
     use HasSelectOptions;
 
     protected $categories = ['controls'];
+
     protected $selectableInForms = true;
+
     protected $indexComponent = 'tags';
 
     protected function configFieldItems(): array
@@ -25,6 +27,13 @@ class Select extends Fieldtype
                         'key_header' => __('Key'),
                         'value_header' => __('Label').' ('.__('Optional').')',
                         'add_button' => __('Add Option'),
+                        'validate' => [function ($attribute, $value, $fail) {
+                            $optionsWithoutKeys = collect($value)->keys()->filter(fn ($key) => empty($key));
+
+                            if ($optionsWithoutKeys->isNotEmpty()) {
+                                $fail(__('Please ensure all options have keys.'));
+                            }
+                        }],
                     ],
                     'taggable' => [
                         'display' => __('Allow additions'),

--- a/src/Fieldtypes/Select.php
+++ b/src/Fieldtypes/Select.php
@@ -28,7 +28,7 @@ class Select extends Fieldtype
                         'value_header' => __('Label').' ('.__('Optional').')',
                         'add_button' => __('Add Option'),
                         'validate' => [function ($attribute, $value, $fail) {
-                            $optionsWithoutKeys = collect($value)->keys()->filter(fn ($key) => empty($key));
+                            $optionsWithoutKeys = collect($value)->keys()->filter(fn ($key) => empty($key) || $key === 'null');
 
                             if ($optionsWithoutKeys->isNotEmpty()) {
                                 $fail(__('Please ensure all options have keys.'));

--- a/src/Fieldtypes/Select.php
+++ b/src/Fieldtypes/Select.php
@@ -9,9 +9,7 @@ class Select extends Fieldtype
     use HasSelectOptions;
 
     protected $categories = ['controls'];
-
     protected $selectableInForms = true;
-
     protected $indexComponent = 'tags';
 
     protected function configFieldItems(): array

--- a/src/Fieldtypes/Select.php
+++ b/src/Fieldtypes/Select.php
@@ -29,7 +29,7 @@ class Select extends Fieldtype
                             $optionsWithoutKeys = collect($value)->keys()->filter(fn ($key) => empty($key) || $key === 'null');
 
                             if ($optionsWithoutKeys->isNotEmpty()) {
-                                $fail(__('Please ensure all options have keys.'));
+                                $fail(__('statamic::validation.options_require_keys'));
                             }
                         }],
                     ],

--- a/tests/Fieldtypes/ButtonGroupTest.php
+++ b/tests/Fieldtypes/ButtonGroupTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Fieldtypes;
 
+use Facades\Statamic\Fields\FieldtypeRepository;
+use Illuminate\Validation\ValidationException;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\ButtonGroup;
 use Tests\TestCase;
@@ -15,5 +17,46 @@ class ButtonGroupTest extends TestCase
         $ft = new ButtonGroup;
 
         return $ft->setField(new Field('test', array_merge($config, ['type' => $ft->handle()])));
+    }
+
+    /** @test */
+    public function throws_a_validation_error_when_key_is_missing_from_option()
+    {
+        $fieldtype = FieldtypeRepository::find('button_group');
+        $blueprint = $fieldtype->configBlueprint();
+
+        $fields = $blueprint
+            ->fields()
+            ->addValues([
+                'options' => [
+                    'one' => 'One',
+                    'two' => 'Two',
+                    '' => 'Three',
+                ],
+            ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("Please ensure all options have keys.");
+
+        $fields->validate();
+    }
+
+    /** @test */
+    public function does_not_throw_a_validation_error_when_all_options_have_keys()
+    {
+        $fieldtype = FieldtypeRepository::find('button_group');
+        $blueprint = $fieldtype->configBlueprint();
+
+        $fields = $blueprint
+            ->fields()
+            ->addValues([
+                'options' => [
+                    'one' => 'One',
+                    'two' => 'Two',
+                    'three' => 'Three',
+                ],
+            ]);
+
+        $fields->validate();
     }
 }

--- a/tests/Fieldtypes/ButtonGroupTest.php
+++ b/tests/Fieldtypes/ButtonGroupTest.php
@@ -36,7 +36,7 @@ class ButtonGroupTest extends TestCase
             ]);
 
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Please ensure all options have keys.');
+        $this->expectExceptionMessage(__('statamic::validation.options_require_keys'));
 
         $fields->validate();
     }

--- a/tests/Fieldtypes/ButtonGroupTest.php
+++ b/tests/Fieldtypes/ButtonGroupTest.php
@@ -36,7 +36,7 @@ class ButtonGroupTest extends TestCase
             ]);
 
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage("Please ensure all options have keys.");
+        $this->expectExceptionMessage('Please ensure all options have keys.');
 
         $fields->validate();
     }

--- a/tests/Fieldtypes/ButtonGroupTest.php
+++ b/tests/Fieldtypes/ButtonGroupTest.php
@@ -49,7 +49,7 @@ class ButtonGroupTest extends TestCase
 
         $fields = $blueprint
             ->fields()
-            ->addValues([
+            ->addValues($values = [
                 'options' => [
                     'one' => 'One',
                     'two' => 'Two',
@@ -57,6 +57,6 @@ class ButtonGroupTest extends TestCase
                 ],
             ]);
 
-        $fields->validate();
+        $this->assertEquals($values, $fields->validate());
     }
 }

--- a/tests/Fieldtypes/SelectTest.php
+++ b/tests/Fieldtypes/SelectTest.php
@@ -2,7 +2,12 @@
 
 namespace Tests\Fieldtypes;
 
+use Facades\Statamic\Fields\FieldtypeRepository;
+use Illuminate\Validation\ValidationException;
+use Statamic\Facades\Blueprint;
 use Statamic\Fields\Field;
+use Statamic\Fields\Fields;
+use Statamic\Fields\Fieldtype;
 use Statamic\Fieldtypes\Select;
 use Tests\TestCase;
 
@@ -15,5 +20,46 @@ class SelectTest extends TestCase
         $ft = new Select;
 
         return $ft->setField(new Field('test', array_merge($config, ['type' => $ft->handle()])));
+    }
+
+    /** @test */
+    public function throws_a_validation_error_when_key_is_missing_from_option()
+    {
+        $fieldtype = FieldtypeRepository::find('select');
+        $blueprint = $fieldtype->configBlueprint();
+
+        $fields = $blueprint
+            ->fields()
+            ->addValues([
+                'options' => [
+                    'one' => 'One',
+                    'two' => 'Two',
+                    '' => 'Three',
+                ],
+            ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("Please ensure all options have keys.");
+
+        $fields->validate();
+    }
+
+    /** @test */
+    public function does_not_throw_a_validation_error_when_all_options_have_keys()
+    {
+        $fieldtype = FieldtypeRepository::find('select');
+        $blueprint = $fieldtype->configBlueprint();
+
+        $fields = $blueprint
+            ->fields()
+            ->addValues([
+                'options' => [
+                    'one' => 'One',
+                    'two' => 'Two',
+                    'three' => 'Three',
+                ],
+            ]);
+
+        $fields->validate();
     }
 }

--- a/tests/Fieldtypes/SelectTest.php
+++ b/tests/Fieldtypes/SelectTest.php
@@ -49,7 +49,7 @@ class SelectTest extends TestCase
 
         $fields = $blueprint
             ->fields()
-            ->addValues([
+            ->addValues($values = [
                 'options' => [
                     'one' => 'One',
                     'two' => 'Two',
@@ -57,6 +57,6 @@ class SelectTest extends TestCase
                 ],
             ]);
 
-        $fields->validate();
+        $this->assertEquals($values, $fields->validate());
     }
 }

--- a/tests/Fieldtypes/SelectTest.php
+++ b/tests/Fieldtypes/SelectTest.php
@@ -36,7 +36,7 @@ class SelectTest extends TestCase
             ]);
 
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Please ensure all options have keys.');
+        $this->expectExceptionMessage(__('statamic::validation.options_require_keys'));
 
         $fields->validate();
     }

--- a/tests/Fieldtypes/SelectTest.php
+++ b/tests/Fieldtypes/SelectTest.php
@@ -4,10 +4,7 @@ namespace Tests\Fieldtypes;
 
 use Facades\Statamic\Fields\FieldtypeRepository;
 use Illuminate\Validation\ValidationException;
-use Statamic\Facades\Blueprint;
 use Statamic\Fields\Field;
-use Statamic\Fields\Fields;
-use Statamic\Fields\Fieldtype;
 use Statamic\Fieldtypes\Select;
 use Tests\TestCase;
 
@@ -39,7 +36,7 @@ class SelectTest extends TestCase
             ]);
 
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage("Please ensure all options have keys.");
+        $this->expectExceptionMessage('Please ensure all options have keys.');
 
         $fields->validate();
     }


### PR DESCRIPTION
This pull request adds validation to the `options` config field on the Select & Button Group fieldtypes to ensure keys are always entered.

By validating that keys exist, we can ensure that there's no weird arrays like this get saved:

![CleanShot 2023-11-01 at 11 31 19](https://github.com/statamic/cms/assets/19637309/d23e3df4-28cc-42b4-9893-252a2ba6328c)

```yaml
options:
    option-value: 'Option Text'
    another-option-value: 'Another Option Value'
    '': Hallo
    Wat: null
```

Closes #346.