### PR TITLE
[4.x] Remove schema check on import users command

### DIFF
--- a/src/Console/Commands/ImportUsers.php
+++ b/src/Console/Commands/ImportUsers.php
@@ -4,7 +4,6 @@ namespace Statamic\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
-use Illuminate\Support\Facades\Schema;
 use Statamic\Auth\Eloquent\User as EloquentUser;
 use Statamic\Auth\File\User as FileUser;
 use Statamic\Auth\UserRepositoryManager;

--- a/src/Console/Commands/ImportUsers.php
+++ b/src/Console/Commands/ImportUsers.php
@@ -62,7 +62,7 @@ class ImportUsers extends Command
             return;
         }
 
-        if (! in_array(Schema::getColumnType('users', 'id'), ['guid', 'string'])) {
+        if (! in_array(Schema::getColumnType('users', $model->getKey()), ['char', 'guid', 'string'])) {
             $this->error('Your users table must use UUIDs for ids in order for this migration to run');
 
             return;

--- a/src/Console/Commands/ImportUsers.php
+++ b/src/Console/Commands/ImportUsers.php
@@ -62,12 +62,6 @@ class ImportUsers extends Command
             return;
         }
 
-        if (! in_array(Schema::getColumnType('users', $model->getKey()), ['char', 'guid', 'string'])) {
-            $this->error('Your users table must use UUIDs for ids in order for this migration to run');
-
-            return;
-        }
-
         app()->bind(UserContract::class, FileUser::class);
         app()->bind(UserRepositoryContract::class, FileRepository::class);
 


### PR DESCRIPTION
It seems MySQL 8 returns CHAR, instead of string for the column type, so we should allow that.
(Maybe its worth removing the column type check altogether?)

Also updated it to not assume id, but use $model->getKey()

Fixes: https://github.com/statamic/cms/issues/8907