### PR TITLE
[4.x] Make Link field arrayable

### DIFF
--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -3,13 +3,18 @@
 namespace Statamic\Fieldtypes;
 
 use Facades\Statamic\Routing\ResolveRedirect;
+use Statamic\Contracts\Assets\Asset as AssetContract;
+use Statamic\Contracts\Data\Localization;
 use Statamic\Contracts\Entries\Collection;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades;
+use Statamic\Facades\Asset;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Site;
+use Statamic\Fields\ArrayableString;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
+use Statamic\Structures\Page;
 use Statamic\Support\Str;
 
 class Link extends Fieldtype
@@ -46,9 +51,13 @@ class Link extends Fieldtype
             return null;
         }
 
-        $redirect = ResolveRedirect::resolve($value, $this->field->parent(), true);
+        if (is_null($item = $this->resolve($value))) {
+            return null;
+        }
 
-        return $redirect === 404 ? null : $redirect;
+        // $redirect = ResolveRedirect::resolve($value, $this->field->parent(), true);
+
+        return new ArrayableLink($item);
     }
 
     public function preload()
@@ -173,5 +182,85 @@ class Link extends Fieldtype
     private function showAssetOption()
     {
         return $this->config('container') !== null;
+    }
+
+    private function resolve($value): string|Entry|AssetContract|null
+    {
+        if ($value === '@child') {
+            return $this->firstChildUrl($this->field->parent());
+        }
+
+        if (Str::startsWith($value, 'entry::')) {
+            return $this->findEntry(
+                Str::after($value, 'entry::'),
+                $this->field->parent(),
+                true
+            );
+        }
+
+        if (Str::startsWith($value, 'asset::')) {
+            return Asset::find(Str::after($value, 'asset::'));
+        }
+
+        return $value;
+    }
+
+    private function findEntry($id, $parent, $localize)
+    {
+        if (! ($entry = Facades\Entry::find($id))) {
+            return null;
+        }
+
+        if (! $localize) {
+            return $entry;
+        }
+
+        $site = $parent instanceof Localization
+            ? $parent->locale()
+            : Site::current()->handle();
+
+        return $entry->in($site) ?? $entry;
+    }
+
+    private function firstChildUrl($parent)
+    {
+        if (! $parent || ! $parent instanceof Entry) {
+            throw new \Exception("Cannot resolve a page's child redirect without providing a page.");
+        }
+
+        if (! $parent instanceof Page && $parent instanceof Entry) {
+            $parent = $parent->page();
+        }
+
+        $children = $parent->isRoot()
+            ? $parent->structure()->in($parent->locale())->pages()->all()->slice(1, 1)
+            : $parent->pages()->all();
+
+        if ($children->isEmpty()) {
+            return 404;
+        }
+
+        return $children->first()->url();
+    }
+}
+
+class ArrayableLink extends ArrayableString
+{
+    public function value()
+    {
+        if (is_string($this->value)) {
+            return $this->value;
+        }
+
+        return $this->value->url();
+    }
+
+    public function toArray()
+    {
+        if (is_string($this->value)) {
+            return ['url' => $this->value];
+        }
+
+        return $this->value->toAugmentedArray();
     }
 }

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Fieldtypes;
 
-use Facades\Statamic\Routing\ResolveRedirect;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Data\Localization;
 use Statamic\Contracts\Entries\Collection;
@@ -54,8 +53,6 @@ class Link extends Fieldtype
         if (is_null($item = $this->resolve($value))) {
             return null;
         }
-
-        // $redirect = ResolveRedirect::resolve($value, $this->field->parent(), true);
 
         return new ArrayableLink($item);
     }
@@ -246,7 +243,11 @@ class Link extends Fieldtype
 
 class ArrayableLink extends ArrayableString
 {
-    public function value()
+    // public function value()
+    // {
+    // }
+
+    public function __toString()
     {
         if (is_string($this->value)) {
             return $this->value;

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -44,13 +44,11 @@ class Link extends Fieldtype
 
     public function augment($value)
     {
-        if (! $value) {
-            return new ArrayableLink(null);
-        }
-
-        $item = ResolveRedirect::item($value, $this->field->parent(), true);
-
-        return new ArrayableLink($item);
+        return new ArrayableLink(
+            $value
+                ? ResolveRedirect::item($value, $this->field->parent(), true)
+                : null
+        );
     }
 
     public function preload()

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -243,10 +243,6 @@ class Link extends Fieldtype
 
 class ArrayableLink extends ArrayableString
 {
-    // public function value()
-    // {
-    // }
-
     public function __toString()
     {
         if (is_string($this->value)) {

--- a/src/Fieldtypes/Link/ArrayableLink.php
+++ b/src/Fieldtypes/Link/ArrayableLink.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Statamic\Fieldtypes\Link;
+
+use Statamic\Fields\ArrayableString;
+
+class ArrayableLink extends ArrayableString
+{
+    public function __toString()
+    {
+        return (string) $this->url();
+    }
+
+    public function toArray()
+    {
+        if (is_string($this->value)) {
+            return ['url' => $this->value];
+        }
+
+        return $this->value?->toAugmentedArray();
+    }
+
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return $this->url(); // Use a string for backwards compatibility in the REST API, etc.
+    }
+
+    private function url()
+    {
+        if (is_string($this->value)) {
+            return $this->value;
+        }
+
+        return $this->value?->url();
+    }
+}

--- a/src/Fieldtypes/Link/ArrayableLink.php
+++ b/src/Fieldtypes/Link/ArrayableLink.php
@@ -13,11 +13,9 @@ class ArrayableLink extends ArrayableString
 
     public function toArray()
     {
-        if (is_string($this->value)) {
-            return ['url' => $this->value];
-        }
-
-        return $this->value?->toAugmentedArray();
+        return is_object($this->value)
+            ? $this->value->toAugmentedArray()
+            : ['url' => $this->url()];
     }
 
     #[\ReturnTypeWillChange]
@@ -28,10 +26,6 @@ class ArrayableLink extends ArrayableString
 
     private function url()
     {
-        if (is_string($this->value)) {
-            return $this->value;
-        }
-
-        return $this->value?->url();
+        return is_object($this->value) ? $this->value?->url() : $this->value;
     }
 }

--- a/src/Routing/ResolveRedirect.php
+++ b/src/Routing/ResolveRedirect.php
@@ -22,18 +22,33 @@ class ResolveRedirect
             return null;
         }
 
+        if (! $item = $this->item($redirect, $parent, $localize)) {
+            return 404;
+        }
+
+        return is_object($item) ? $item->url() : $item;
+    }
+
+    public function item($redirect, $parent = null, $localize = false)
+    {
+        if (is_null($redirect)) {
+            return null;
+        }
+
         if ($redirect === '@child') {
-            $redirect = $this->firstChildUrl($parent);
+            return $this->firstChild($parent);
         }
 
         if (Str::startsWith($redirect, 'entry::')) {
             $id = Str::after($redirect, 'entry::');
-            $redirect = optional($this->findEntry($id, $parent, $localize))->url() ?? 404;
+
+            return $this->findEntry($id, $parent, $localize);
         }
 
         if (Str::startsWith($redirect, 'asset::')) {
             $id = Str::after($redirect, 'asset::');
-            $redirect = optional(Facades\Asset::find($id))->url() ?? 404;
+
+            return Facades\Asset::find($id);
         }
 
         return is_numeric($redirect) ? (int) $redirect : $redirect;
@@ -56,7 +71,7 @@ class ResolveRedirect
         return $entry->in($site) ?? $entry;
     }
 
-    private function firstChildUrl($parent)
+    private function firstChild($parent)
     {
         if (! $parent || ! $parent instanceof Entry) {
             throw new \Exception("Cannot resolve a page's child redirect without providing a page.");
@@ -71,9 +86,9 @@ class ResolveRedirect
             : $parent->pages()->all();
 
         if ($children->isEmpty()) {
-            return 404;
+            return null;
         }
 
-        return $children->first()->url();
+        return $children->first();
     }
 }

--- a/tests/Feature/GraphQL/Fieldtypes/LinkFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/LinkFieldtypeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\GraphQL\Fieldtypes;
 
 use Facades\Statamic\Routing\ResolveRedirect;
+use Facades\Tests\Factories\EntryFactory;
 
 /** @group graphql */
 class LinkFieldtypeTest extends FieldtypeTestCase
@@ -17,8 +18,6 @@ class LinkFieldtypeTest extends FieldtypeTestCase
             ],
         ]);
 
-        ResolveRedirect::shouldReceive('resolve')->never();
-
         $this->assertGqlEntryHas('link', ['link' => null]);
     }
 
@@ -32,22 +31,20 @@ class LinkFieldtypeTest extends FieldtypeTestCase
             ],
         ]);
 
-        ResolveRedirect::shouldReceive('resolve')->once()->with('/hardcoded', $entry, true)->andReturn('/hardcoded');
-
         $this->assertGqlEntryHas('link', ['link' => '/hardcoded']);
     }
 
     /** @test */
     public function it_gets_an_entry()
     {
+        EntryFactory::collection('test')->id(2)->slug('the-entry-url')->create();
+
         $entry = $this->createEntryWithFields([
             'link' => [
-                'value' => 'entry::123',
+                'value' => 'entry::2',
                 'field' => ['type' => 'link'],
             ],
         ]);
-
-        ResolveRedirect::shouldReceive('resolve')->once()->with('entry::123', $entry, true)->andReturn('/the-entry-url');
 
         $this->assertGqlEntryHas('link', ['link' => '/the-entry-url']);
     }
@@ -76,8 +73,6 @@ class LinkFieldtypeTest extends FieldtypeTestCase
                 'field' => ['type' => 'link'],
             ],
         ]);
-
-        ResolveRedirect::shouldReceive('resolve')->once()->with('entry::unknown', $entry, true)->andReturn(404);
 
         $this->assertGqlEntryHas('link', ['link' => null]);
     }

--- a/tests/Feature/GraphQL/Fieldtypes/LinkFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/LinkFieldtypeTest.php
@@ -19,6 +19,8 @@ class LinkFieldtypeTest extends FieldtypeTestCase
             ],
         ]);
 
+        ResolveRedirect::shouldReceive('item')->never();
+
         $this->assertGqlEntryHas('link', ['link' => null]);
     }
 

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -8,13 +8,10 @@ use Statamic\Entries\Entry;
 use Statamic\Fields\ArrayableString;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Link;
-use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class LinkTest extends TestCase
 {
-    use PreventSavingStacheItemsToDisk;
-
     /** @test */
     public function it_augments_string_to_string()
     {

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -31,6 +31,7 @@ class LinkTest extends TestCase
         $augmented = $fieldtype->augment('/foo');
         $this->assertInstanceOf(ArrayableString::class, $augmented);
         $this->assertEquals('/foo', $augmented->value());
+        $this->assertEquals(['url' => '/foo'], $augmented->toArray());
     }
 
     /** @test */
@@ -38,6 +39,7 @@ class LinkTest extends TestCase
     {
         $entry = Mockery::mock(Entry::class);
         $entry->shouldReceive('url')->once()->andReturn('/the-entry-url');
+        $entry->shouldReceive('toAugmentedArray')->once()->andReturn('augmented entry array');
 
         ResolveRedirect::shouldReceive('item')
             ->with('entry::test', $parent = new Entry, true)
@@ -52,6 +54,7 @@ class LinkTest extends TestCase
         $this->assertInstanceOf(ArrayableString::class, $augmented);
         $this->assertEquals($entry, $augmented->value());
         $this->assertEquals('/the-entry-url', (string) $augmented);
+        $this->assertEquals('augmented entry array', $augmented->toArray());
     }
 
     /** @test */
@@ -69,6 +72,7 @@ class LinkTest extends TestCase
         $augmented = $fieldtype->augment('entry::invalid');
         $this->assertInstanceOf(ArrayableString::class, $augmented);
         $this->assertNull($augmented->value());
+        $this->assertEquals(['url' => null], $augmented->toArray());
     }
 
     /** @test */
@@ -76,6 +80,7 @@ class LinkTest extends TestCase
     {
         $asset = Mockery::mock(Asset::class);
         $asset->shouldReceive('url')->once()->andReturn('/the-asset-url');
+        $asset->shouldReceive('toAugmentedArray')->once()->andReturn('augmented asset array');
 
         ResolveRedirect::shouldReceive('item')
             ->with('asset::test', $parent = new Entry, true)
@@ -90,6 +95,7 @@ class LinkTest extends TestCase
         $this->assertInstanceOf(ArrayableString::class, $augmented);
         $this->assertEquals($asset, $augmented->value());
         $this->assertEquals('/the-asset-url', (string) $augmented);
+        $this->assertEquals('augmented asset array', $augmented->toArray());
     }
 
     /** @test */
@@ -107,6 +113,7 @@ class LinkTest extends TestCase
         $augmented = $fieldtype->augment('asset::invalid');
         $this->assertInstanceOf(ArrayableString::class, $augmented);
         $this->assertNull($augmented->value());
+        $this->assertEquals(['url' => null], $augmented->toArray());
     }
 
     /** @test */
@@ -123,5 +130,6 @@ class LinkTest extends TestCase
         $augmented = $fieldtype->augment(null);
         $this->assertInstanceOf(ArrayableString::class, $augmented);
         $this->assertNull($augmented->value());
+        $this->assertEquals(['url' => null], $augmented->toArray());
     }
 }

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -4,7 +4,6 @@ namespace Tests\Fieldtypes;
 
 use Facades\Statamic\Routing\ResolveRedirect;
 use Mockery;
-use Statamic\Contracts\Assets\Asset;
 use Statamic\Entries\Entry;
 use Statamic\Fields\ArrayableString;
 use Statamic\Fields\Field;
@@ -35,9 +34,9 @@ class LinkTest extends TestCase
     }
 
     /** @test */
-    public function it_augments_to_entry()
+    public function it_augments_reference_to_object()
     {
-        $entry = Mockery::mock(Entry::class);
+        $entry = Mockery::mock();
         $entry->shouldReceive('url')->once()->andReturn('/the-entry-url');
         $entry->shouldReceive('toAugmentedArray')->once()->andReturn('augmented entry array');
 
@@ -58,7 +57,7 @@ class LinkTest extends TestCase
     }
 
     /** @test */
-    public function it_augments_invalid_entry_to_null()
+    public function it_augments_invalid_object_to_null()
     {
         ResolveRedirect::shouldReceive('item')
             ->with('entry::invalid', $parent = new Entry, true)
@@ -70,47 +69,6 @@ class LinkTest extends TestCase
         $fieldtype = (new Link)->setField($field);
 
         $augmented = $fieldtype->augment('entry::invalid');
-        $this->assertInstanceOf(ArrayableString::class, $augmented);
-        $this->assertNull($augmented->value());
-        $this->assertEquals(['url' => null], $augmented->toArray());
-    }
-
-    /** @test */
-    public function it_augments_to_asset()
-    {
-        $asset = Mockery::mock(Asset::class);
-        $asset->shouldReceive('url')->once()->andReturn('/the-asset-url');
-        $asset->shouldReceive('toAugmentedArray')->once()->andReturn('augmented asset array');
-
-        ResolveRedirect::shouldReceive('item')
-            ->with('asset::test', $parent = new Entry, true)
-            ->once()
-            ->andReturn($asset);
-
-        $field = new Field('test', ['type' => 'link']);
-        $field->setParent($parent);
-        $fieldtype = (new Link)->setField($field);
-
-        $augmented = $fieldtype->augment('asset::test');
-        $this->assertInstanceOf(ArrayableString::class, $augmented);
-        $this->assertEquals($asset, $augmented->value());
-        $this->assertEquals('/the-asset-url', (string) $augmented);
-        $this->assertEquals('augmented asset array', $augmented->toArray());
-    }
-
-    /** @test */
-    public function it_augments_invalid_asset_to_null()
-    {
-        ResolveRedirect::shouldReceive('item')
-            ->with('asset::invalid', $parent = new Entry, true)
-            ->once()
-            ->andReturnNull();
-
-        $field = new Field('test', ['type' => 'link']);
-        $field->setParent($parent);
-        $fieldtype = (new Link)->setField($field);
-
-        $augmented = $fieldtype->augment('asset::invalid');
         $this->assertInstanceOf(ArrayableString::class, $augmented);
         $this->assertNull($augmented->value());
         $this->assertEquals(['url' => null], $augmented->toArray());

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -2,22 +2,54 @@
 
 namespace Tests\Fieldtypes;
 
+use Facades\Statamic\Fields\BlueprintRepository;
 use Facades\Statamic\Routing\ResolveRedirect;
 use Statamic\Entries\Entry;
+use Statamic\Facades;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Link;
 use Tests\TestCase;
 
 class LinkTest extends TestCase
 {
-    /** @test */
-    public function it_augments_to_url()
+    public function setup(): void
     {
-        ResolveRedirect::shouldReceive('resolve')
-            ->with('entry::test', $parent = new Entry, true)
-            ->once()
-            ->andReturn('/the-redirect');
+        parent::setUp();
 
+        $collection = tap(Facades\Collection::make('pages'))->routes('/{slug}')->save();
+
+        $blueprint = Facades\Blueprint::make('article')
+            ->setNamespace('collections.pages')
+            ->setContents([
+                'fields' => [
+                    [
+                        'handle' => 'link',
+                        'field' => [
+                            'type' => 'link',
+                            'collections' => ['pages'],
+                        ],
+                    ],
+                ],
+            ]);
+
+        BlueprintRepository::shouldReceive('in')->with('collections/pages')->andReturn(collect([$blueprint]));
+    }
+
+    /** @test */
+    public function it_augments_string_to_string()
+    {
+        $parent = tap(new Entry)->collection('pages')->slug('the-redirect')->id('test')->save();
+        $field = new Field('test', ['type' => 'link']);
+        $field->setParent($parent);
+        $fieldtype = (new Link)->setField($field);
+
+        $this->assertEquals('/foo', $fieldtype->augment('/foo'));
+    }
+
+    /** @test */
+    public function it_augments_entry_to_url()
+    {
+        $parent = tap(new Entry)->collection('pages')->slug('the-redirect')->id('test')->save();
         $field = new Field('test', ['type' => 'link']);
         $field->setParent($parent);
         $fieldtype = (new Link)->setField($field);
@@ -28,27 +60,18 @@ class LinkTest extends TestCase
     /** @test */
     public function it_augments_invalid_entry_to_null()
     {
-        // invalid entries come back from the ResolveRedirect class as a 404 integer
-
-        ResolveRedirect::shouldReceive('resolve')
-            ->with('entry::test', $parent = new Entry, true)
-            ->once()
-            ->andReturn(404);
-
+        $parent = tap(new Entry)->collection('pages')->slug('the-redirect')->id('test')->save();
         $field = new Field('test', ['type' => 'link']);
         $field->setParent($parent);
         $fieldtype = (new Link)->setField($field);
 
-        $this->assertNull($fieldtype->augment('entry::test'));
+        $this->assertNull($fieldtype->augment('entry::foo'));
     }
 
     /** @test */
     public function it_augments_null_to_null()
     {
-        // null could technically be passed to the ResolveRedirect class, where it would
-        // just return null, but we'll just avoid calling it for a little less overhead.
-        ResolveRedirect::shouldReceive('resolve')->never();
-
+        $parent = tap(new Entry)->collection('pages')->slug('the-redirect')->id('test')->save();
         $field = new Field('test', ['type' => 'link']);
         $field->setParent(new Entry);
         $fieldtype = (new Link)->setField($field);

--- a/tests/Routing/ResolveRedirectTest.php
+++ b/tests/Routing/ResolveRedirectTest.php
@@ -66,6 +66,7 @@ class ResolveRedirectTest extends TestCase
         $parent->shouldReceive('pages')->andReturn($children);
 
         $this->assertEquals('/parent/first-child', $resolver('@child', $parent));
+        $this->assertEquals($child, $resolver->item('@child', $parent));
     }
 
     /** @test */
@@ -87,6 +88,7 @@ class ResolveRedirectTest extends TestCase
         $parent->shouldReceive('page')->andReturn($parentPage);
 
         $this->assertEquals('/parent/first-child', $resolver('@child', $parent));
+        $this->assertEquals($child, $resolver->item('@child', $parent));
     }
 
     /** @test */
@@ -116,6 +118,7 @@ class ResolveRedirectTest extends TestCase
         $root->shouldReceive('structure')->andReturn($structure);
 
         $this->assertEquals('/parent/first-child', $resolver('@child', $root));
+        $this->assertEquals($child, $resolver->item('@child', $root));
     }
 
     /** @test */
@@ -131,6 +134,7 @@ class ResolveRedirectTest extends TestCase
         $parent->shouldReceive('pages')->andReturn($pages);
 
         $this->assertSame(404, $resolver('@child', $parent));
+        $this->assertSame(null, $resolver->item('@child', $parent));
     }
 
     /** @test */
@@ -139,9 +143,10 @@ class ResolveRedirectTest extends TestCase
         $resolver = new ResolveRedirect;
 
         $entry = Mockery::mock(Entry::class)->shouldReceive('url')->once()->andReturn('/the-entry')->getMock();
-        Facades\Entry::shouldReceive('find')->with('123')->once()->andReturn($entry);
+        Facades\Entry::shouldReceive('find')->with('123')->twice()->andReturn($entry);
 
         $this->assertEquals('/the-entry', $resolver('entry::123'));
+        $this->assertEquals($entry, $resolver->item('entry::123'));
     }
 
     /** @test */
@@ -151,10 +156,11 @@ class ResolveRedirectTest extends TestCase
 
         $parentEntry = Mockery::mock(Entry::class);
         $frenchEntry = Mockery::mock(Entry::class)->shouldReceive('url')->once()->andReturn('/le-entry')->getMock();
-        $defaultEntry = Mockery::mock(Entry::class)->shouldReceive('in')->once()->andReturn($frenchEntry)->getMock();
-        Facades\Entry::shouldReceive('find')->with('123')->once()->andReturn($defaultEntry);
+        $defaultEntry = Mockery::mock(Entry::class)->shouldReceive('in')->twice()->andReturn($frenchEntry)->getMock();
+        Facades\Entry::shouldReceive('find')->with('123')->twice()->andReturn($defaultEntry);
 
         $this->assertEquals('/le-entry', $resolver('entry::123', $parentEntry, true));
+        $this->assertEquals($frenchEntry, $resolver->item('entry::123', $parentEntry, true));
     }
 
     /** @test */
@@ -164,11 +170,12 @@ class ResolveRedirectTest extends TestCase
 
         $parentEntry = Mockery::mock(Entry::class);
         $entry = Mockery::mock(Entry::class);
-        $entry->shouldReceive('in')->once()->andReturn(null);
+        $entry->shouldReceive('in')->twice()->andReturn(null);
         $entry->shouldReceive('url')->once()->andReturn('/the-entry');
-        Facades\Entry::shouldReceive('find')->with('123')->once()->andReturn($entry);
+        Facades\Entry::shouldReceive('find')->with('123')->twice()->andReturn($entry);
 
         $this->assertEquals('/the-entry', $resolver('entry::123', $parentEntry, true));
+        $this->assertEquals($entry, $resolver->item('entry::123', $parentEntry, true));
     }
 
     /** @test */
@@ -177,9 +184,10 @@ class ResolveRedirectTest extends TestCase
         $resolver = new ResolveRedirect;
 
         $asset = Mockery::mock(Asset::class)->shouldReceive('url')->once()->andReturn('/assets/foo/bar/baz.jpg')->getMock();
-        Facades\Asset::shouldReceive('find')->with('foo::bar/baz.jpg')->once()->andReturn($asset);
+        Facades\Asset::shouldReceive('find')->with('foo::bar/baz.jpg')->twice()->andReturn($asset);
 
         $this->assertEquals('/assets/foo/bar/baz.jpg', $resolver('asset::foo::bar/baz.jpg'));
+        $this->assertEquals($asset, $resolver->item('asset::foo::bar/baz.jpg'));
     }
 
     /** @test */
@@ -187,9 +195,10 @@ class ResolveRedirectTest extends TestCase
     {
         $resolver = new ResolveRedirect;
 
-        Facades\Entry::shouldReceive('find')->with('123')->once()->andReturnNull();
+        Facades\Entry::shouldReceive('find')->with('123')->twice()->andReturnNull();
 
         $this->assertSame(404, $resolver('entry::123'));
+        $this->assertSame(null, $resolver->item('entry::123'));
     }
 
     /** @test */


### PR DESCRIPTION
We use the `Link` fieldtype, and we often want to use the `title` of whatever we're linking to. Right now the `link` field augments to the url so the `title` is lost.

This change makes the field "arrayable" so you can now do `{{ link_field:title }}`.