### PR TITLE
[4.x] Prevent root entries being deleted in listing view

### DIFF
--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -17,6 +17,8 @@ class Delete extends Action
     {
         switch (true) {
             case $item instanceof Contracts\Entries\Entry && $item->collection()->sites()->count() === 1:
+                return ! $item->page()?->isRoot();
+                break;
             case $item instanceof Contracts\Taxonomies\Term:
             case $item instanceof Contracts\Assets\Asset:
             case $item instanceof Contracts\Assets\AssetFolder:

--- a/src/Actions/DeleteMultisiteEntry.php
+++ b/src/Actions/DeleteMultisiteEntry.php
@@ -9,8 +9,11 @@ class DeleteMultisiteEntry extends Delete
 {
     public function visibleTo($item)
     {
-        return $item instanceof Entry
-            && $item->collection()->sites()->count() > 1;
+        if (! ($item instanceof Entry && $item->collection()->sites()->count() > 1)) {
+            return false;
+        }
+
+        return ! $item->page()?->isRoot();
     }
 
     public function fieldItems()


### PR DESCRIPTION
This PR prevents root entries from being deleted in listing views by not letting the delete actions be visible to these entries.

Before: (home is my root entry)
<img width="1176" alt="Screenshot 2023-11-02 at 07 43 46" src="https://github.com/statamic/cms/assets/51899/a97c2ba0-6693-4e6f-a6ea-d73183dbce91">

After: 
<img width="1186" alt="Screenshot 2023-11-02 at 07 43 22" src="https://github.com/statamic/cms/assets/51899/30a592dc-c700-4c8a-8ead-504ebc0e8f62">

Closes https://github.com/statamic/cms/issues/8794