### PR TITLE
[4.x] Fix missing translation of some user defined strings

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -3,7 +3,7 @@
         <div class="card overflow-hidden p-0" slot-scope="{ filteredRows: rows }">
             <data-list-table :rows="rows">
                 <template slot="cell-title" slot-scope="{ row: collection }">
-                    <a :href="collection.entries_url">{{ collection.title }}</a>
+                    <a :href="collection.entries_url">{{ __(collection.title) }}</a>
                 </template>
                 <template slot="actions" slot-scope="{ row: collection, index }">
                     <dropdown-list placement="left-start">

--- a/resources/js/components/collections/View.vue
+++ b/resources/js/components/collections/View.vue
@@ -7,7 +7,7 @@
             <breadcrumb :url="breadcrumbUrl" :title="__('Collections')" />
 
             <div class="flex items-center">
-                <h1 class="flex-1" v-text="title" />
+                <h1 class="flex-1" v-text="__(title)" />
 
                 <dropdown-list class="mr-2" v-if="!!this.$scopedSlots.twirldown">
                     <slot name="twirldown" />

--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -67,8 +67,8 @@
                 </td>
                 <td class="type-column" v-if="type">
                     <span v-if="type === 'entries' || type === 'terms'" class="rounded px-1 py-px text-2xs uppercase bg-gray-200 text-gray">
-                        <template v-if="type === 'entries'">{{ row.collection.title }}</template>
-                        <template v-if="type === 'terms'">{{ row.taxonomy.title }}</template>
+                        <template v-if="type === 'entries'">{{ __(row.collection.title) }}</template>
+                        <template v-if="type === 'terms'">{{ __(row.taxonomy.title) }}</template>
                     </span>
                 </td>
                 <th class="actions-column">

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -5,7 +5,7 @@
             <breadcrumb :url="globalsUrl" :title="__('Globals')" />
 
             <div class="flex items-center">
-                <h1 class="flex-1" v-text="title" />
+                <h1 class="flex-1" v-text="__(title)" />
 
                 <div class="pt-px text-2xs text-gray-600 ml-4 flex" v-if="! canEdit">
                     <svg-icon name="lock" class="w-4 mr-1 -mt-1" /> {{ __('Read Only') }}

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -28,7 +28,7 @@
             />
 
             <div class="flex items-center flex-1 justify-end">
-                <div v-if="item.collection" v-text="item.collection.title" class="text-4xs text-gray-600 uppercase whitespace-nowrap mr-2 hidden @sm:block" />
+                <div v-if="item.collection" v-text="__(item.collection.title)" class="text-4xs text-gray-600 uppercase whitespace-nowrap mr-2 hidden @sm:block" />
 
                 <div class="flex items-center" v-if="!readOnly">
                     <dropdown-list>

--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -6,7 +6,7 @@
             <breadcrumb :url="breadcrumbUrl" :title="__('Navigation')" />
 
             <div class="flex items-center">
-                <h1 class="flex-1" v-text="title" />
+                <h1 class="flex-1" v-text="__(title)" />
 
                 <dropdown-list class="mr-2">
                     <slot name="twirldown" />

--- a/resources/js/components/taxonomies/Listing.vue
+++ b/resources/js/components/taxonomies/Listing.vue
@@ -3,7 +3,7 @@
         <div class="card p-0" slot-scope="{ filteredRows: rows }">
             <data-list-table :rows="rows">
                 <template slot="cell-title" slot-scope="{ row: taxonomy }">
-                    <a :href="taxonomy.terms_url">{{ taxonomy.title }}</a>
+                    <a :href="taxonomy.terms_url">{{ __(taxonomy.title) }}</a>
                 </template>
                 <template slot="actions" slot-scope="{ row: taxonomy, index }">
                     <dropdown-list placement="left-start">

--- a/resources/js/components/user-groups/PublishForm.vue
+++ b/resources/js/components/user-groups/PublishForm.vue
@@ -5,7 +5,7 @@
         <header class="mb-3">
             <breadcrumb :url="cp_url('user-groups')" :title="__('User Groups')" />
             <div class="flex items-center">
-                <h1 class="flex-1" v-text="title" />
+                <h1 class="flex-1" v-text="__(title)" />
                     <dropdown-list class="mr-2" v-if="canEditBlueprint">
                         <dropdown-item :text="__('Edit Blueprint')" :redirect="actions.editBlueprint" />
                     </dropdown-list>


### PR DESCRIPTION
As noted in https://github.com/statamic/cms/issues/8913 there was a missing translation on the collection list.
I also noticed them in the relationship and data list components so I've translated them there too.

Closes https://github.com/statamic/cms/issues/8913
Closes #3638 