### PR TITLE
[4.x] Handle empty values in collection tag filters

### DIFF
--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -350,8 +350,8 @@ class Entries
 
     protected function queryableConditionParams()
     {
-        return $this->traitQueryableConditionParams()->reject(function ($value, $key) {
-            return Str::startsWith($key, 'taxonomy:');
-        });
+        return $this->traitQueryableConditionParams()
+            ->reject(fn ($value, $key) => Str::startsWith($key, 'taxonomy:'))
+            ->reject(fn ($value, $key) => $value === '');
     }
 }

--- a/src/Tags/Concerns/QueriesConditions.php
+++ b/src/Tags/Concerns/QueriesConditions.php
@@ -27,9 +27,9 @@ trait QueriesConditions
 
     protected function queryableConditionParams()
     {
-        return $this->params->filter(function ($value, $param) {
-            return Str::contains($param, ':');
-        });
+        return $this->params
+            ->filter(fn ($value, $param) => Str::contains($param, ':'))
+            ->reject(fn ($value, $param) => $value === '');
     }
 
     protected function isQueryingCondition($field)
@@ -125,37 +125,21 @@ trait QueriesConditions
 
     protected function queryIsCondition($query, $field, $value)
     {
-        if (is_null($value) || $value === '') {
-            return;
-        }
-
         return $query->where($field, $value);
     }
 
     protected function queryNotCondition($query, $field, $value)
     {
-        if (is_null($value) || $value === '') {
-            return;
-        }
-
         return $query->where($field, '!=', $value);
     }
 
     protected function queryContainsCondition($query, $field, $value)
     {
-        if (is_null($value) || $value === '') {
-            return;
-        }
-
         return $query->where($field, 'like', "%{$value}%");
     }
 
     protected function queryDoesntContainCondition($query, $field, $value)
     {
-        if (is_null($value) || $value === '') {
-            return;
-        }
-
         return $query->where($field, 'not like', "%{$value}%");
     }
 

--- a/src/Tags/Concerns/QueriesConditions.php
+++ b/src/Tags/Concerns/QueriesConditions.php
@@ -125,21 +125,37 @@ trait QueriesConditions
 
     protected function queryIsCondition($query, $field, $value)
     {
+        if (is_null($value) || $value === '') {
+            return;
+        }
+
         return $query->where($field, $value);
     }
 
     protected function queryNotCondition($query, $field, $value)
     {
+        if (is_null($value) || $value === '') {
+            return;
+        }
+
         return $query->where($field, '!=', $value);
     }
 
     protected function queryContainsCondition($query, $field, $value)
     {
+        if (is_null($value) || $value === '') {
+            return;
+        }
+
         return $query->where($field, 'like', "%{$value}%");
     }
 
     protected function queryDoesntContainCondition($query, $field, $value)
     {
+        if (is_null($value) || $value === '') {
+            return;
+        }
+
         return $query->where($field, 'not like', "%{$value}%");
     }
 

--- a/tests/Tags/Concerns/QueriesConditionsTest.php
+++ b/tests/Tags/Concerns/QueriesConditionsTest.php
@@ -61,6 +61,16 @@ class QueriesConditionsTest extends TestCase
     }
 
     /** @test */
+    public function it_does_not_filter_by_is_condition_when_value_is_empty()
+    {
+        $this->makeEntry('a')->set('author', 'john-doe')->save();
+        $this->makeEntry('b')->set('author', 'david-hasselhoff')->save();
+        $this->makeEntry('c')->set('author', 'josiah-bartlet')->save();
+
+        $this->assertCount(3, $this->getEntries(['author:is' => '']));
+    }
+
+    /** @test */
     public function it_filters_by_not_condition()
     {
         $this->makeEntry('dog')->set('title', 'Dog')->save();
@@ -79,6 +89,16 @@ class QueriesConditionsTest extends TestCase
     }
 
     /** @test */
+    public function it_does_not_filter_by_not_condition_when_value_is_empty()
+    {
+        $this->makeEntry('a')->set('author', 'john-doe')->save();
+        $this->makeEntry('b')->set('author', 'david-hasselhoff')->save();
+        $this->makeEntry('c')->set('author', 'josiah-bartlet')->save();
+
+        $this->assertCount(3, $this->getEntries(['author:not' => '']));
+    }
+
+    /** @test */
     public function it_filters_by_contains_condition()
     {
         $this->makeEntry('dog')->set('title', 'Dog Stories')->save();
@@ -90,6 +110,16 @@ class QueriesConditionsTest extends TestCase
     }
 
     /** @test */
+    public function it_does_not_filter_by_contains_condition_when_value_is_empty()
+    {
+        $this->makeEntry('dog')->set('title', 'Dog Stories')->save();
+        $this->makeEntry('cat')->set('title', 'Cat Fables')->save();
+        $this->makeEntry('tiger')->set('title', 'Tiger Tales')->save();
+
+        $this->assertCount(3, $this->getEntries(['title:contains' => '']));
+    }
+
+    /** @test */
     public function it_filters_by_doesnt_contain_condition()
     {
         $this->makeEntry('dog')->set('title', 'Dog Stories')->save();
@@ -98,6 +128,16 @@ class QueriesConditionsTest extends TestCase
 
         $this->assertCount(3, $this->getEntries());
         $this->assertCount(2, $this->getEntries(['title:doesnt_contain' => 'sto']));
+    }
+
+    /** @test */
+    public function it_does_not_filter_by_doesnt_contains_condition_when_value_is_empty()
+    {
+        $this->makeEntry('dog')->set('title', 'Dog Stories')->save();
+        $this->makeEntry('cat')->set('title', 'Cat Fables')->save();
+        $this->makeEntry('tiger')->set('title', 'Tiger Tales')->save();
+
+        $this->assertCount(3, $this->getEntries(['title:doesnt_contain' => '']));
     }
 
     /** @test */


### PR DESCRIPTION
This pull request attempts to improve the handling of empty values when using the `{{ collection }}` tag.

For example, when you're using the `{{ collection }}` tag and filtering with query parameters, if any of those query params don't have a value, the query will return no results which often times isn't what you want.

Instead, you'd want that particular filter to be ignored unless a value is present.

```antlers
<div>
    <h2>Filter articles:</h2>

    <form action="{{ current_uri }}" method="get">
        <select name="author">
            <option value="">All users</option>
            {{ users }}
                <option value="{{ id }}" {{ if get:author == id }} selected {{ /if }}>{{ name }}</option>
            {{ /users }}
        </select>

        <button type="submit">Search</button>
    </form>

    <ul>
        {{ collection:articles author:is="{ get:author }" }}
            <li><a href="{{ url }}">{{ title }}</a></li>
        {{ /collection:articles }}
    </ul>
</div>
````

I fixed this issue for the taxonomy filters way back in #2672. This PR fixes it for `:is`, `:not`, `:contains` and `:doesnt_contain` filters.

Fixes #3155.