### PR TITLE
[4.x] Hide publish action fields when saving

### DIFF
--- a/resources/js/components/entries/PublishActions.vue
+++ b/resources/js/components/entries/PublishActions.vue
@@ -18,48 +18,52 @@
                     <loading-graphic text="" />
                 </div>
 
-                <select-input
-                    class="mb-6"
-                    v-model="action"
-                    :options="options"
-                />
+                <template v-else>
 
-                <div v-if="action">
-
-                    <date-fieldtype
-                        v-if="action == 'schedule'"
+                    <select-input
                         class="mb-6"
-                        name="publishTime"
-                        :value="publishTime" />
-
-                    <textarea-input
-                        class="mb-6 text-sm"
-                        v-model="revisionMessage"
-                        :placeholder="__('Notes about this revision')"
-                        @keydown.enter="submit"
-                        :focus="true" />
-
-                    <button
-                        class="btn-primary w-full mb-6"
-                        v-text="submitButtonText"
-                        @click="submit"
+                        v-model="action"
+                        :options="options"
                     />
 
-                    <div class="text-gray text-xs flex mb-6">
-                        <div class="pt-px w-4 mr-2">
-                            <svg-icon name="info-circle" class="pt-px" />
+                    <div v-if="action">
+
+                        <date-fieldtype
+                            v-if="action == 'schedule'"
+                            class="mb-6"
+                            name="publishTime"
+                            :value="publishTime" />
+
+                        <textarea-input
+                            class="mb-6 text-sm"
+                            v-model="revisionMessage"
+                            :placeholder="__('Notes about this revision')"
+                            @keydown.enter="submit"
+                            :focus="true" />
+
+                        <button
+                            class="btn-primary w-full mb-6"
+                            v-text="submitButtonText"
+                            @click="submit"
+                        />
+
+                        <div class="text-gray text-xs flex mb-6">
+                            <div class="pt-px w-4 mr-2">
+                                <svg-icon name="info-circle" class="pt-px" />
+                            </div>
+                            <div class="flex-1" v-text="actionInfoText" />
                         </div>
-                        <div class="flex-1" v-text="actionInfoText" />
+
+                        <div class="text-gray text-xs flex mb-6 text-red-500" v-if="action === 'schedule'">
+                            <div class="pt-px w-4 mr-2">
+                                <svg-icon name="info-circle" class="pt-px" />
+                            </div>
+                            <div class="flex-1" v-text="__('messages.publish_actions_current_becomes_draft_because_scheduled')" />
+                        </div>
+
                     </div>
 
-                    <div class="text-gray text-xs flex mb-6 text-red-500" v-if="action === 'schedule'">
-                        <div class="pt-px w-4 mr-2">
-                            <svg-icon name="info-circle" class="pt-px" />
-                        </div>
-                        <div class="flex-1" v-text="__('messages.publish_actions_current_becomes_draft_because_scheduled')" />
-                    </div>
-
-                </div>
+                </template>
 
             </div>
         </div>

--- a/resources/js/components/entries/PublishActions.vue
+++ b/resources/js/components/entries/PublishActions.vue
@@ -20,48 +20,48 @@
 
                 <template v-else>
 
-                    <select-input
+                <select-input
+                    class="mb-6"
+                    v-model="action"
+                    :options="options"
+                />
+
+                <div v-if="action">
+
+                    <date-fieldtype
+                        v-if="action == 'schedule'"
                         class="mb-6"
-                        v-model="action"
-                        :options="options"
+                        name="publishTime"
+                        :value="publishTime" />
+
+                    <textarea-input
+                        class="mb-6 text-sm"
+                        v-model="revisionMessage"
+                        :placeholder="__('Notes about this revision')"
+                        @keydown.enter="submit"
+                        :focus="true" />
+
+                    <button
+                        class="btn-primary w-full mb-6"
+                        v-text="submitButtonText"
+                        @click="submit"
                     />
 
-                    <div v-if="action">
-
-                        <date-fieldtype
-                            v-if="action == 'schedule'"
-                            class="mb-6"
-                            name="publishTime"
-                            :value="publishTime" />
-
-                        <textarea-input
-                            class="mb-6 text-sm"
-                            v-model="revisionMessage"
-                            :placeholder="__('Notes about this revision')"
-                            @keydown.enter="submit"
-                            :focus="true" />
-
-                        <button
-                            class="btn-primary w-full mb-6"
-                            v-text="submitButtonText"
-                            @click="submit"
-                        />
-
-                        <div class="text-gray text-xs flex mb-6">
-                            <div class="pt-px w-4 mr-2">
-                                <svg-icon name="info-circle" class="pt-px" />
-                            </div>
-                            <div class="flex-1" v-text="actionInfoText" />
+                    <div class="text-gray text-xs flex mb-6">
+                        <div class="pt-px w-4 mr-2">
+                            <svg-icon name="info-circle" class="pt-px" />
                         </div>
-
-                        <div class="text-gray text-xs flex mb-6 text-red-500" v-if="action === 'schedule'">
-                            <div class="pt-px w-4 mr-2">
-                                <svg-icon name="info-circle" class="pt-px" />
-                            </div>
-                            <div class="flex-1" v-text="__('messages.publish_actions_current_becomes_draft_because_scheduled')" />
-                        </div>
-
+                        <div class="flex-1" v-text="actionInfoText" />
                     </div>
+
+                    <div class="text-gray text-xs flex mb-6 text-red-500" v-if="action === 'schedule'">
+                        <div class="pt-px w-4 mr-2">
+                            <svg-icon name="info-circle" class="pt-px" />
+                        </div>
+                        <div class="flex-1" v-text="__('messages.publish_actions_current_becomes_draft_because_scheduled')" />
+                    </div>
+
+                </div>
 
                 </template>
 

--- a/resources/js/components/entries/PublishActions.vue
+++ b/resources/js/components/entries/PublishActions.vue
@@ -20,48 +20,48 @@
 
                 <template v-else>
 
-                <select-input
-                    class="mb-6"
-                    v-model="action"
-                    :options="options"
-                />
-
-                <div v-if="action">
-
-                    <date-fieldtype
-                        v-if="action == 'schedule'"
+                    <select-input
                         class="mb-6"
-                        name="publishTime"
-                        :value="publishTime" />
-
-                    <textarea-input
-                        class="mb-6 text-sm"
-                        v-model="revisionMessage"
-                        :placeholder="__('Notes about this revision')"
-                        @keydown.enter="submit"
-                        :focus="true" />
-
-                    <button
-                        class="btn-primary w-full mb-6"
-                        v-text="submitButtonText"
-                        @click="submit"
+                        v-model="action"
+                        :options="options"
                     />
 
-                    <div class="text-gray text-xs flex mb-6">
-                        <div class="pt-px w-4 mr-2">
-                            <svg-icon name="info-circle" class="pt-px" />
-                        </div>
-                        <div class="flex-1" v-text="actionInfoText" />
-                    </div>
+                    <div v-if="action">
 
-                    <div class="text-gray text-xs flex mb-6 text-red-500" v-if="action === 'schedule'">
-                        <div class="pt-px w-4 mr-2">
-                            <svg-icon name="info-circle" class="pt-px" />
-                        </div>
-                        <div class="flex-1" v-text="__('messages.publish_actions_current_becomes_draft_because_scheduled')" />
-                    </div>
+                        <date-fieldtype
+                            v-if="action == 'schedule'"
+                            class="mb-6"
+                            name="publishTime"
+                            :value="publishTime" />
 
-                </div>
+                        <textarea-input
+                            class="mb-6 text-sm"
+                            v-model="revisionMessage"
+                            :placeholder="__('Notes about this revision')"
+                            @keydown.enter="submit"
+                            :focus="true" />
+
+                        <button
+                            class="btn-primary w-full mb-6"
+                            v-text="submitButtonText"
+                            @click="submit"
+                        />
+
+                        <div class="text-gray text-xs flex mb-6">
+                            <div class="pt-px w-4 mr-2">
+                                <svg-icon name="info-circle" class="pt-px" />
+                            </div>
+                            <div class="flex-1" v-text="actionInfoText" />
+                        </div>
+
+                        <div class="text-gray text-xs flex mb-6 text-red-500" v-if="action === 'schedule'">
+                            <div class="pt-px w-4 mr-2">
+                                <svg-icon name="info-circle" class="pt-px" />
+                            </div>
+                            <div class="flex-1" v-text="__('messages.publish_actions_current_becomes_draft_because_scheduled')" />
+                        </div>
+
+                    </div>
 
                 </template>
 


### PR DESCRIPTION
I noticed this visual glitch on a site of ours - when you click 'save' the revision publish action fields were still visible below the loading indicator. This PR means they are now hidden when saving.

Closes https://github.com/statamic/cms/issues/8798