### PR TITLE
[4.x] Handle unauthorized response in Inline Publish Form

### DIFF
--- a/resources/js/components/inputs/relationship/InlinePublishForm.vue
+++ b/resources/js/components/inputs/relationship/InlinePublishForm.vue
@@ -69,14 +69,20 @@ export default {
     methods: {
 
         getItem() {
-            this.$axios.get(this.itemUrl).then(response => {
-                for (const prop in this.componentProps) {
-                    const value = data_get(response.data, this.componentProps[prop]);
-                    this.$set(this.componentPropValues, prop, value);
-                }
+            this.$axios.get(this.itemUrl)
+                .then(response => {
+                    for (const prop in this.componentProps) {
+                        const value = data_get(response.data, this.componentProps[prop]);
+                        this.$set(this.componentPropValues, prop, value);
+                    }
 
-                this.loading = false;
-            });
+                    this.loading = false;
+                }).catch((error) => {
+                    if (error.response.status === 403) {
+                        this.$toast.error(__('This action is unauthorized.'));
+                        this.close();
+                    }
+                });
         },
 
         close() {

--- a/src/Policies/EntryPolicy.php
+++ b/src/Policies/EntryPolicy.php
@@ -26,10 +26,6 @@ class EntryPolicy
     {
         $user = User::fromUser($user);
 
-        if ($entry->slug === '2019-year-in-review') {
-            return false;
-        }
-
         if (! $this->userCanAccessSite($user, $entry->site())) {
             return false;
         }

--- a/src/Policies/EntryPolicy.php
+++ b/src/Policies/EntryPolicy.php
@@ -26,6 +26,10 @@ class EntryPolicy
     {
         $user = User::fromUser($user);
 
+        if ($entry->slug === '2019-year-in-review') {
+            return false;
+        }
+
         if (! $this->userCanAccessSite($user, $entry->site())) {
             return false;
         }


### PR DESCRIPTION
This pull request improves how unauthorised responses are handled with the Inline Publish Form that's part of the Relationship Fieldtype.

Previously, when you opened an item that you weren't authorized to edit, the stack would show as loading but nothing would actually happen. It would stay "loading" forever.

Now, the `InlinePublishForm` will handle the case where the user is unauthorized to edit the item and display a toast message.

Fixes #1435.