### PR TITLE
[4.x] Allow entries to be drafted without requiring validation

### DIFF
--- a/resources/js/components/entries/PublishActions.vue
+++ b/resources/js/components/entries/PublishActions.vue
@@ -205,6 +205,14 @@ export default {
 
         handleAxiosError(e) {
             this.saving = false;
+
+            if (e.response && e.response.status === 422) {
+                const { message, errors } = e.response.data;
+                this.$store.commit(`publish/${this.publishContainer}/setErrors`, errors);
+                this.$toast.error(message);
+                return;
+            }
+
             this.$toast.error(e || __('Something went wrong'));
         }
 

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -59,6 +59,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
     protected $titleFormats = [];
     protected $previewTargets = [];
     protected $autosave;
+    protected $draftWithoutValidation = false;
 
     public function __construct()
     {
@@ -850,5 +851,10 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
             'title' => $this->title(),
             'handle' => $this->handle(),
         ];
+    }
+
+    public function draftWithoutValidation($draftWithoutValidation = null)
+    {
+        return $this->fluentlyGetOrSet('draftWithoutValidation')->args(func_get_args());
     }
 }

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -189,14 +189,16 @@ class EntriesController extends CpController
             ->fields()
             ->addValues($data);
 
-        $fields
-            ->validator()
-            ->withRules(Entry::updateRules($collection, $entry))
-            ->withReplacements([
-                'id' => $entry->id(),
-                'collection' => $collection->handle(),
-                'site' => $entry->locale(),
-            ])->validate();
+        if ($fields->get('published')->value() || ! $collection->draftWithoutValidation()) {
+            $fields
+                ->validator()
+                ->withRules(Entry::updateRules($collection, $entry))
+                ->withReplacements([
+                    'id' => $entry->id(),
+                    'collection' => $collection->handle(),
+                    'site' => $entry->locale(),
+                ])->validate();
+        }
 
         $values = $fields->process()->values();
 
@@ -349,13 +351,15 @@ class EntriesController extends CpController
             ->fields()
             ->addValues($data);
 
-        $fields
-            ->validator()
-            ->withRules(Entry::createRules($collection, $site))
-            ->withReplacements([
-                'collection' => $collection->handle(),
-                'site' => $site->handle(),
-            ])->validate();
+        if ($fields->get('published')->value() || ! $collection->draftWithoutValidation()) {
+            $fields
+                ->validator()
+                ->withRules(Entry::createRules($collection, $site))
+                ->withReplacements([
+                    'collection' => $collection->handle(),
+                    'site' => $site->handle(),
+                ])->validate();
+        }
 
         $values = $fields->process()->values()->except(['slug', 'blueprint', 'published']);
 

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -189,7 +189,7 @@ class EntriesController extends CpController
             ->fields()
             ->addValues($data);
 
-        if ($fields->get('published')->value() || ! $collection->draftWithoutValidation()) {
+        if (($fields->get('published')->value() && ! $entry->revisionsEnabled()) || ! $collection->draftWithoutValidation()) {
             $fields
                 ->validator()
                 ->withRules(Entry::updateRules($collection, $entry))

--- a/src/Http/Controllers/CP/Collections/PublishedEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/PublishedEntriesController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
+use Statamic\Facades\Entry;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
@@ -12,6 +13,23 @@ class PublishedEntriesController extends CpController
     public function store(Request $request, $collection, $entry)
     {
         $this->authorize('publish', $entry);
+
+        if ($collection->draftWithoutValidation()) {
+            $fields = $entry
+                ->blueprint()
+                ->ensureField('published', ['type' => 'toggle'])
+                ->fields()
+                ->addValues($entry->data()->all());
+
+            $fields
+                ->validator()
+                ->withRules(Entry::updateRules($collection, $entry))
+                ->withReplacements([
+                    'id' => $entry->id(),
+                    'collection' => $collection->handle(),
+                    'site' => $entry->locale(),
+                ])->validate();
+        }
 
         $entry = $entry->publish([
             'message' => $request->message,

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -57,7 +57,8 @@ class CollectionsStore extends BasicStore
             ->taxonomies(array_get($data, 'taxonomies'))
             ->propagate(array_get($data, 'propagate'))
             ->previewTargets($this->normalizePreviewTargets(array_get($data, 'preview_targets', [])))
-            ->autosaveInterval(array_get($data, 'autosave'));
+            ->autosaveInterval(array_get($data, 'autosave'))
+            ->draftWithoutValidation(array_get($data, 'draft_without_validation', false));
 
         if ($dateBehavior = array_get($data, 'date_behavior')) {
             $collection


### PR DESCRIPTION
This PR adds a new opt-in collection configuration option `draft_without_validation` which allows unpublished entries to be created without applying any validation rules.

Validation rules continue to be applied when the entry is published, but while its in an unpublished state they will not be run.

This can be useful if you are populating content but haven't yet been supplied all the information, or you haven't yet received assets.

I've left this PR as a draft just to get your thoughts, if it's a direction you like I will work on test coverage.

There seems to be a similar idea here: https://github.com/statamic/ideas/issues/765