### PR TITLE
[4.x] Fix entries on the same date being ignored by collection previous/next tags

### DIFF
--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -28,19 +28,12 @@ class Entries
     }
 
     protected $ignoredParams = ['as'];
-
     protected $params;
-
     protected $collections;
-
     protected $site;
-
     protected $showPublished;
-
     protected $showUnpublished;
-
     protected $since;
-
     protected $until;
 
     public function __construct($params)

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -12,6 +12,7 @@ use Statamic\Facades\Collection;
 use Statamic\Facades\Compare;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
+use Statamic\Query\OrderBy;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Tags\Concerns;
@@ -71,6 +72,10 @@ class Entries
         $primaryOrderBy = $this->orderBys->first();
         $secondaryOrderBy = $this->orderBys->get(1);
 
+        if (! $secondaryOrderBy) {
+            $this->orderBys[] = new OrderBy('title', 'asc');
+        }
+
         $primaryOperator = $primaryOrderBy->direction === 'desc' ? '<' : '>';
         $secondaryOperator = $secondaryOrderBy?->direction === 'desc' ? '<' : '>';
 
@@ -95,6 +100,10 @@ class Entries
         $collection = $this->collections->first();
         $primaryOrderBy = $this->orderBys->first();
         $secondaryOrderBy = $this->orderBys->get(1);
+
+        if (! $secondaryOrderBy) {
+            $this->orderBys[] = new OrderBy('title', 'asc');
+        }
 
         $primaryOperator = $primaryOrderBy->direction === 'desc' ? '>' : '<';
         $secondaryOperator = $secondaryOrderBy?->direction === 'desc' ? '>' : '<';
@@ -130,6 +139,18 @@ class Entries
             : $this->next($currentEntry);
     }
 
+    public function newer($currentEntry)
+    {
+        $collection = $this->collections->first();
+        $primaryOrderBy = $this->orderBys->first();
+
+        throw_unless($collection->dated(), new \Exception('collection:newer requires a dated collection'));
+
+        return $primaryOrderBy->direction === 'asc'
+            ? $this->next($currentEntry)
+            : $this->previous($currentEntry);
+    }
+
     protected function queryPreviousNextByDate($currentEntry, string $primaryOperator, string $secondaryOperator): QueryBuilder
     {
         $primaryOrderBy = $this->orderBys->first();
@@ -154,18 +175,6 @@ class Entries
             )
             ->orderBy('date', $primaryOrderBy->direction)
             ->orderBy($secondaryOrderBy->sort, $secondaryOrderBy->direction);
-    }
-
-    public function newer($currentEntry)
-    {
-        $collection = $this->collections->first();
-        $primaryOrderBy = $this->orderBys->first();
-
-        throw_unless($collection->dated(), new \Exception('collection:newer requires a dated collection'));
-
-        return $primaryOrderBy->direction === 'asc'
-            ? $this->next($currentEntry)
-            : $this->previous($currentEntry);
     }
 
     protected function query()

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -29,19 +29,12 @@ class Entries
     }
 
     protected $ignoredParams = ['as'];
-
     protected $params;
-
     protected $collections;
-
     protected $site;
-
     protected $showPublished;
-
     protected $showUnpublished;
-
     protected $since;
-
     protected $until;
 
     public function __construct($params)

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -170,7 +170,7 @@ class Entries
         $previousOfSame = $this->query()
             ->where('date', $currentEntryDate)
             ->orderBy($secondaryOrderBy->sort, $secondaryOrderBy->direction)
-            ->where('title', $secondaryOperator, $currentEntry->get('title'))
+            ->where($secondaryOrderBy->sort, $secondaryOperator, $currentEntry->value($secondaryOrderBy->sort))
             ->get()
             ->pluck('id')
             ->toArray();

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -29,12 +29,19 @@ class Entries
     }
 
     protected $ignoredParams = ['as'];
+
     protected $params;
+
     protected $collections;
+
     protected $site;
+
     protected $showPublished;
+
     protected $showUnpublished;
+
     protected $since;
+
     protected $until;
 
     public function __construct($params)
@@ -68,16 +75,16 @@ class Entries
         throw_if($this->params->has('offset'), new \Exception('collection:next is not compatible with [offset] parameter'));
         throw_if($this->collections->count() > 1, new \Exception('collection:next is not compatible with multiple collections'));
 
+        if ($this->orderBys->count() === 1) {
+            $this->orderBys[] = new OrderBy('title', 'asc');
+        }
+
         $collection = $this->collections->first();
         $primaryOrderBy = $this->orderBys->first();
         $secondaryOrderBy = $this->orderBys->get(1);
 
-        if (! $secondaryOrderBy) {
-            $this->orderBys[] = new OrderBy('title', 'asc');
-        }
-
         $primaryOperator = $primaryOrderBy->direction === 'desc' ? '<' : '>';
-        $secondaryOperator = $secondaryOrderBy?->direction === 'desc' ? '<' : '>';
+        $secondaryOperator = $secondaryOrderBy->direction === 'desc' ? '<' : '>';
 
         if ($primaryOrderBy->sort === 'order') {
             throw_if(! $currentOrder = $currentEntry->order(), new \Exception('Current entry does not have an order'));
@@ -97,16 +104,16 @@ class Entries
         throw_if($this->params->has('offset'), new \Exception('collection:previous is not compatible with [offset] parameter'));
         throw_if($this->collections->count() > 1, new \Exception('collection:previous is not compatible with multiple collections'));
 
+        if ($this->orderBys->count() === 1) {
+            $this->orderBys[] = new OrderBy('title', 'asc');
+        }
+
         $collection = $this->collections->first();
         $primaryOrderBy = $this->orderBys->first();
         $secondaryOrderBy = $this->orderBys->get(1);
 
-        if (! $secondaryOrderBy) {
-            $this->orderBys[] = new OrderBy('title', 'asc');
-        }
-
         $primaryOperator = $primaryOrderBy->direction === 'desc' ? '>' : '<';
-        $secondaryOperator = $secondaryOrderBy?->direction === 'desc' ? '>' : '<';
+        $secondaryOperator = $secondaryOrderBy->direction === 'desc' ? '>' : '<';
 
         if ($primaryOrderBy->sort === 'order') {
             throw_if(! $currentOrder = $currentEntry->order(), new \Exception('Current entry does not have an order'));

--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -28,12 +28,19 @@ class Entries
     }
 
     protected $ignoredParams = ['as'];
+
     protected $params;
+
     protected $collections;
+
     protected $site;
+
     protected $showPublished;
+
     protected $showUnpublished;
+
     protected $since;
+
     protected $until;
 
     public function __construct($params)

--- a/tests/Tags/Collection/CollectionTest.php
+++ b/tests/Tags/Collection/CollectionTest.php
@@ -20,13 +20,9 @@ class CollectionTest extends TestCase
     use PreventSavingStacheItemsToDisk;
 
     private $music;
-
     private $art;
-
     private $books;
-
     private $foods;
-
     private $collectionTag;
 
     public function setUp(): void

--- a/tests/Tags/Collection/CollectionTest.php
+++ b/tests/Tags/Collection/CollectionTest.php
@@ -346,16 +346,13 @@ class CollectionTest extends TestCase
         $this->assertEquals(['Grape', 'Hummus', 'Fig'], $this->runTagAndGetTitles('newer')); // Alias of prev when date:desc
     }
 
-    /** @test */
+    /**
+     * @test
+     * https://github.com/statamic/cms/issues/1831
+     */
     public function it_can_get_previous_and_next_entries_in_a_dated_desc_collection_when_multiple_entries_share_the_same_date()
     {
         $this->foods->dated(true)->save();
-        Carbon::setTestNow(Carbon::parse('2019-04-10 13:00'));
-
-        // 1st January: Apple
-        // 5th February: Banana
-        // 5th February: Carrot
-        // 7th March: Danish
 
         $this->makeEntry($this->foods, 'a')->date('2023-01-01')->set('title', 'Apple')->save();
         $this->makeEntry($this->foods, 'b')->date('2023-02-05')->set('title', 'Banana')->save();
@@ -364,14 +361,9 @@ class CollectionTest extends TestCase
 
         $currentId = $this->findEntryByTitle('Carrot')->id();
 
-        $orderBy = 'date:desc|title:asc';
+        $orderBy = 'date:desc|title:desc';
 
         $this->setTagParameters(['in' => 'foods', 'current' => $currentId, 'order_by' => $orderBy, 'limit' => 1]);
-
-        // Carrot
-        // Prev: Banana
-        // 2nd prev: Apple
-        // Next: Danish
 
         $this->assertEquals(['Danish'], $this->runTagAndGetTitles('previous'));
         $this->assertEquals(['Banana'], $this->runTagAndGetTitles('next'));
@@ -419,16 +411,13 @@ class CollectionTest extends TestCase
         $this->assertEquals(['Carrot', 'Banana', 'Danish'], $this->runTagAndGetTitles('older')); // Alias of prev when date:desc
     }
 
-    /** @test */
+    /**
+     * @test
+     * https://github.com/statamic/cms/issues/1831
+     */
     public function it_can_get_previous_and_next_entries_in_a_dated_asc_collection_when_multiple_entries_share_the_same_date()
     {
         $this->foods->dated(true)->save();
-        Carbon::setTestNow(Carbon::parse('2019-04-10 13:00'));
-
-        // 1st January: Apple
-        // 5th February: Banana
-        // 5th February: Carrot
-        // 7th March: Danish
 
         $this->makeEntry($this->foods, 'a')->date('2023-01-01')->set('title', 'Apple')->save();
         $this->makeEntry($this->foods, 'b')->date('2023-02-05')->set('title', 'Banana')->save();
@@ -440,11 +429,6 @@ class CollectionTest extends TestCase
         $orderBy = 'date:asc|title:asc';
 
         $this->setTagParameters(['in' => 'foods', 'current' => $currentId, 'order_by' => $orderBy, 'limit' => 1]);
-
-        // Carrot
-        // Prev: Banana
-        // 2nd prev: Apple
-        // Next: Danish
 
         $this->assertEquals(['Banana'], $this->runTagAndGetTitles('previous'));
         $this->assertEquals(['Danish'], $this->runTagAndGetTitles('next'));

--- a/tests/Tags/Collection/CollectionTest.php
+++ b/tests/Tags/Collection/CollectionTest.php
@@ -366,7 +366,9 @@ class CollectionTest extends TestCase
         $this->setTagParameters(['in' => 'foods', 'current' => $currentId, 'order_by' => $orderBy, 'limit' => 1]);
 
         $this->assertEquals(['Danish'], $this->runTagAndGetTitles('previous'));
+        $this->assertEquals(['Danish'], $this->runTagAndGetTitles('newer')); // Alias of prev when date:desc
         $this->assertEquals(['Banana'], $this->runTagAndGetTitles('next'));
+        $this->assertEquals(['Banana'], $this->runTagAndGetTitles('older')); // Alias of next when date:desc
     }
 
     /** @test */
@@ -431,7 +433,9 @@ class CollectionTest extends TestCase
         $this->setTagParameters(['in' => 'foods', 'current' => $currentId, 'order_by' => $orderBy, 'limit' => 1]);
 
         $this->assertEquals(['Banana'], $this->runTagAndGetTitles('previous'));
+        $this->assertEquals(['Banana'], $this->runTagAndGetTitles('older')); // Alias of previous when date:desc
         $this->assertEquals(['Danish'], $this->runTagAndGetTitles('next'));
+        $this->assertEquals(['Danish'], $this->runTagAndGetTitles('newer')); // Alias of next when date:asc
     }
 
     /** @test */

--- a/tests/Tags/Collection/CollectionTest.php
+++ b/tests/Tags/Collection/CollectionTest.php
@@ -20,9 +20,13 @@ class CollectionTest extends TestCase
     use PreventSavingStacheItemsToDisk;
 
     private $music;
+
     private $art;
+
     private $books;
+
     private $foods;
+
     private $collectionTag;
 
     public function setUp(): void
@@ -343,6 +347,37 @@ class CollectionTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_previous_and_next_entries_in_a_dated_desc_collection_when_multiple_entries_share_the_same_date()
+    {
+        $this->foods->dated(true)->save();
+        Carbon::setTestNow(Carbon::parse('2019-04-10 13:00'));
+
+        // 1st January: Apple
+        // 5th February: Banana
+        // 5th February: Carrot
+        // 7th March: Danish
+
+        $this->makeEntry($this->foods, 'a')->date('2023-01-01')->set('title', 'Apple')->save();
+        $this->makeEntry($this->foods, 'b')->date('2023-02-05')->set('title', 'Banana')->save();
+        $this->makeEntry($this->foods, 'c')->date('2023-02-05')->set('title', 'Carrot')->save();
+        $this->makeEntry($this->foods, 'd')->date('2023-03-07')->set('title', 'Danish')->save();
+
+        $currentId = $this->findEntryByTitle('Carrot')->id();
+
+        $orderBy = 'date:desc|title:asc';
+
+        $this->setTagParameters(['in' => 'foods', 'current' => $currentId, 'order_by' => $orderBy, 'limit' => 1]);
+
+        // Carrot
+        // Prev: Banana
+        // 2nd prev: Apple
+        // Next: Danish
+
+        $this->assertEquals(['Danish'], $this->runTagAndGetTitles('previous'));
+        $this->assertEquals(['Banana'], $this->runTagAndGetTitles('next'));
+    }
+
+    /** @test */
     public function it_can_get_previous_and_next_entries_in_a_dated_asc_collection()
     {
         $this->foods->dated(true)->save();
@@ -382,6 +417,37 @@ class CollectionTest extends TestCase
         $this->assertEquals(['Fig', 'Hummus', 'Grape'], $this->runTagAndGetTitles('newer')); // Alias of next when date:desc
         $this->assertEquals(['Carrot', 'Banana', 'Danish'], $this->runTagAndGetTitles('previous'));
         $this->assertEquals(['Carrot', 'Banana', 'Danish'], $this->runTagAndGetTitles('older')); // Alias of prev when date:desc
+    }
+
+    /** @test */
+    public function it_can_get_previous_and_next_entries_in_a_dated_asc_collection_when_multiple_entries_share_the_same_date()
+    {
+        $this->foods->dated(true)->save();
+        Carbon::setTestNow(Carbon::parse('2019-04-10 13:00'));
+
+        // 1st January: Apple
+        // 5th February: Banana
+        // 5th February: Carrot
+        // 7th March: Danish
+
+        $this->makeEntry($this->foods, 'a')->date('2023-01-01')->set('title', 'Apple')->save();
+        $this->makeEntry($this->foods, 'b')->date('2023-02-05')->set('title', 'Banana')->save();
+        $this->makeEntry($this->foods, 'c')->date('2023-02-05')->set('title', 'Carrot')->save();
+        $this->makeEntry($this->foods, 'd')->date('2023-03-07')->set('title', 'Danish')->save();
+
+        $currentId = $this->findEntryByTitle('Carrot')->id();
+
+        $orderBy = 'date:asc|title:asc';
+
+        $this->setTagParameters(['in' => 'foods', 'current' => $currentId, 'order_by' => $orderBy, 'limit' => 1]);
+
+        // Carrot
+        // Prev: Banana
+        // 2nd prev: Apple
+        // Next: Danish
+
+        $this->assertEquals(['Banana'], $this->runTagAndGetTitles('previous'));
+        $this->assertEquals(['Danish'], $this->runTagAndGetTitles('next'));
     }
 
     /** @test */

--- a/tests/Tags/Collection/CollectionTest.php
+++ b/tests/Tags/Collection/CollectionTest.php
@@ -359,11 +359,12 @@ class CollectionTest extends TestCase
         $this->makeEntry($this->foods, 'c')->date('2023-02-05')->set('title', 'Carrot')->save();
         $this->makeEntry($this->foods, 'd')->date('2023-03-07')->set('title', 'Danish')->save();
 
-        $currentId = $this->findEntryByTitle('Carrot')->id();
-
-        $orderBy = 'date:desc|title:desc';
-
-        $this->setTagParameters(['in' => 'foods', 'current' => $currentId, 'order_by' => $orderBy, 'limit' => 1]);
+        $this->setTagParameters([
+            'in' => 'foods',
+            'current' => $this->findEntryByTitle('Carrot')->id(),
+            'order_by' => 'date:desc|title:desc',
+            'limit' => 1,
+        ]);
 
         $this->assertEquals(['Danish'], $this->runTagAndGetTitles('previous'));
         $this->assertEquals(['Danish'], $this->runTagAndGetTitles('newer')); // Alias of prev when date:desc
@@ -426,11 +427,12 @@ class CollectionTest extends TestCase
         $this->makeEntry($this->foods, 'c')->date('2023-02-05')->set('title', 'Carrot')->save();
         $this->makeEntry($this->foods, 'd')->date('2023-03-07')->set('title', 'Danish')->save();
 
-        $currentId = $this->findEntryByTitle('Carrot')->id();
-
-        $orderBy = 'date:asc|title:asc';
-
-        $this->setTagParameters(['in' => 'foods', 'current' => $currentId, 'order_by' => $orderBy, 'limit' => 1]);
+        $this->setTagParameters([
+            'in' => 'foods',
+            'current' => $this->findEntryByTitle('Carrot')->id(),
+            'order_by' => 'date:asc|title:asc',
+            'limit' => 1,
+        ]);
 
         $this->assertEquals(['Banana'], $this->runTagAndGetTitles('previous'));
         $this->assertEquals(['Banana'], $this->runTagAndGetTitles('older')); // Alias of previous when date:desc


### PR DESCRIPTION
This pull request fixes an issue where the `{{ collection:previous }}` and `{{ collection:next }}` tags would ignore other entries published on the same date. 

For example, say you had the following entries:

* 1st January: Article A
* 5th February: Article B
* 5th February: Article C
* 7th March: Article D

When you visited the "Article C" entry, the `{{ collection:previous }}` tag would have returned "Article A" as the previous entry and "Article B" would have been ignored.

Similarly, when you visited the "Article B" entry, the `{{ collection:next }}` tag would have returned "Article D" as the next entry and "Article C" would have been ignored. 

This PR fixes this issue by querying both entries _before/after the current entry's date_ **AND** those _on the same date where the title is greater/less than the current entry's title_.

To make this work, ensure you have two sorts configured on the previous/next collection tag. The first being the `date` field and the second being the secondary column you want to order by, in my case that's the `title`.

```antlers
{{ collection:previous in="articles" limit="1" sort="date:asc|title:asc" }}
    <a href="{{ url }}">
        {{ title }} ({{ date format="F j, Y" }})
    </a>
{{ /collection:previous }}
```

Fixes #1831.