### PR TITLE
[4.x] Fix slugify when using hyphens surrounded by spaces.

### DIFF
--- a/resources/js/plugins/slugify.js
+++ b/resources/js/plugins/slugify.js
@@ -15,6 +15,9 @@ export default {
             // Remove smart single quotes
             custom["’"] = "";
 
+            // Prevent `Block - Hero` turning into `block_-_hero`
+            custom[" - "] = " ";
+
             return getSlug(text, {
                 separator: glue || '-',
                 lang,


### PR DESCRIPTION
This pull request fixes a small issue with the `slugify` function:

* If you enter `Block - Hero` as a title
* `slugify` would generate `block_-_hero` as the slug
* With this fix, `slugify` will generate `block_hero` as the slug

Fixes #8749.