### PR TITLE
[4.x] Fix permissions for asset upload and folder creation buttons in CP

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -388,11 +388,11 @@ export default {
         },
 
         canUpload() {
-            return this.folder && this.container.allow_uploads;
+            return this.folder && this.container.allow_uploads && this.can('upload '+ this.container.id +' assets');
         },
 
         canCreateFolders() {
-            return this.folder && this.container.create_folders && ! this.restrictFolderNavigation;
+            return this.folder && this.container.create_folders && ! this.restrictFolderNavigation && this.can('upload '+ this.container.id +' assets');
         },
 
         parameters() {


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/8922.
The `Upload` and `Create Folder` buttons were showing in the Asset Browser for users who don't have permission to do said actions.
Creating folders in an asset container relies on the `upload {container} assets` permission and not the `configure asset containers` permissions [see here](https://github.com/statamic/cms/blob/4.x/src/Policies/AssetFolderPolicy.php#L9-L18).
Also disables the uploader component as a nice side-effect so it doesn't confuse users seeing the ability to drag and drop files.

