### PR TITLE
[4.x] Prevent ensuring fields on entries if they already exist

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -336,20 +336,22 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
 
     public function ensureEntryBlueprintFields($blueprint)
     {
-        $blueprint->ensureFieldPrepended('title', [
-            'type' => ($auto = $this->autoGeneratesTitles()) ? 'hidden' : 'text',
-            'required' => ! $auto,
-        ]);
+        if (! $blueprint->hasField('title')) {
+            $blueprint->ensureFieldPrepended('title', [
+                'type' => ($auto = $this->autoGeneratesTitles()) ? 'hidden' : 'text',
+                'required' => ! $auto,
+            ]);
+        }
 
-        if ($this->requiresSlugs()) {
+        if ($this->requiresSlugs() && ! $blueprint->hasField('slug')) {
             $blueprint->ensureField('slug', ['type' => 'slug', 'localizable' => true], 'sidebar');
         }
 
-        if ($this->dated()) {
+        if ($this->dated() && ! $blueprint->hasField('date')) {
             $blueprint->ensureField('date', ['type' => 'date', 'required' => true, 'default' => 'now'], 'sidebar');
         }
 
-        if ($this->hasStructure() && ! $this->orderable()) {
+        if ($this->hasStructure() && ! $this->orderable() && ! $blueprint->hasField('parent')) {
             $blueprint->ensureField('parent', [
                 'type' => 'entries',
                 'collections' => [$this->handle()],
@@ -360,6 +362,10 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
         }
 
         foreach ($this->taxonomies() as $taxonomy) {
+            if ($blueprint->hasField($taxonomy->handle())) {
+                continue;
+            }
+
             $blueprint->ensureField($taxonomy->handle(), [
                 'type' => 'terms',
                 'taxonomies' => [$taxonomy->handle()],


### PR DESCRIPTION
This pull request prevents fields from being ensured on entry blueprints if they already exist. Without this check, any changes you made to the config of any of the ensured fields would be overwritten the next time you save the blueprint.

I've added the check for this in `Collection` where we're ensuring them but happy to do something "upstream" (eg. in the `Blueprint` methods) if you'd rather go down that route.

Fixes #2743.