### PR TITLE
[4.x] Fix "Always Save" toggle not being saved when used on linked field

### DIFF
--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -227,9 +227,7 @@ export default {
         updateAlwaysSave(alwaysSave) {
             this.values.always_save = alwaysSave;
 
-            if (this.editedFields.indexOf('always_save') === -1) {
-                this.editedFields.push('always_save');
-            }
+            this.markFieldEdited('always_save');
         },
 
         markFieldEdited(handle) {

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -226,6 +226,10 @@ export default {
 
         updateAlwaysSave(alwaysSave) {
             this.values.always_save = alwaysSave;
+
+            if (this.editedFields.indexOf('always_save') === -1) {
+                this.editedFields.push('always_save');
+            }
         },
 
         markFieldEdited(handle) {


### PR DESCRIPTION
This pull request fixes an issue where the "Always Saved" toggle didn't save when it was set on a linked/reference field.

Fixes #8277.