### PR TITLE
[4.x] Add `mount` to augmented collection

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -849,6 +849,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
         return [
             'title' => $this->title(),
             'handle' => $this->handle(),
+            'mount' => $this->mount(),
         ];
     }
 }

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -846,10 +846,15 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
 
     public function augmentedArrayData()
     {
-        return [
+        $data = [
             'title' => $this->title(),
             'handle' => $this->handle(),
-            'mount' => $this->mount(),
         ];
+
+        if (! Statamic::isApiRoute()) {
+            $data['mount'] = $this->mount();
+        }
+
+        return $data;
     }
 }

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Data\Entries;
 
 use Facades\Statamic\Fields\BlueprintRepository;
+use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Event;
 use Statamic\Contracts\Data\Augmentable;
@@ -658,13 +659,15 @@ class CollectionTest extends TestCase
     /** @test */
     public function it_augments()
     {
-        $collection = (new Collection)->handle('test');
+        $mountedEntry = EntryFactory::collection('pages')->id('blog')->slug('blog')->data(['title' => 'Blog'])->create();
+
+        $collection = (new Collection)->mount('blog')->handle('test');
 
         $this->assertInstanceof(Augmentable::class, $collection);
-        $this->assertEquals([
-            'title' => 'Test',
-            'handle' => 'test',
-        ], $collection->toAugmentedArray());
+        $this->assertCount(3, $augmentedArray = $collection->toAugmentedArray());
+        $this->assertEquals('Test', $augmentedArray['title']);
+        $this->assertEquals('test', $augmentedArray['handle']);
+        $this->assertEquals('Blog', $augmentedArray['mount']->value()->get('title'));
     }
 
     /** @test */

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -667,7 +667,7 @@ class CollectionTest extends TestCase
         $this->assertCount(3, $augmentedArray = $collection->toAugmentedArray());
         $this->assertEquals('Test', $augmentedArray['title']);
         $this->assertEquals('test', $augmentedArray['handle']);
-        $this->assertEquals('Blog', $augmentedArray['mount']->value()->get('title'));
+        $this->assertEquals($mountedEntry, $augmentedArray['mount']->value());
     }
 
     /** @test */


### PR DESCRIPTION
This pull request makes a collection's mounted entry available when a `Collection` is augmented.

This will allow you to access a collection's mounted entry when on an entry "show" page:

```
Mounted to: <a href="{{ collection:mount:url }}">{{ collection:mount:title }}</a>
```

Fixes #3625.