### PR TITLE
[4.x] Slug Fieldtype: Allow targeting sibling fields inside a replicator

### DIFF
--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -30,6 +30,7 @@
 </template>
 
 <script>
+import { data_get } from '../../bootstrap/globals';
 import Fieldtype from './Fieldtype.vue';
 
 export default {
@@ -66,6 +67,12 @@ export default {
             if (! this.generate) return;
 
             const field = this.config.from || 'title';
+
+            if (this.fieldPathPrefix) {
+                let dottedPrefix = this.fieldPathPrefix.replace(new RegExp('\.'+this.handle+'$'), '');
+
+                return data_get(this.$store.state.publish[this.store].values, dottedPrefix + '.' + field);
+            }
 
             return this.$store.state.publish[this.store].values[field];
         },

--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -67,14 +67,14 @@ export default {
             if (! this.generate) return;
 
             const field = this.config.from || 'title';
+            let key = field;
 
             if (this.fieldPathPrefix) {
                 let dottedPrefix = this.fieldPathPrefix.replace(new RegExp('\.'+this.handle+'$'), '');
-
-                return data_get(this.$store.state.publish[this.store].values, dottedPrefix + '.' + field);
+                key = dottedPrefix + '.' + field;
             }
 
-            return this.$store.state.publish[this.store].values[field];
+            return data_get(this.$store.state.publish[this.store].values, key);
         },
 
         language() {


### PR DESCRIPTION
This pull request fixes an issue in the Slug Fieldtype. 

When used inside a Replicator Set, the Slug fieldtype previously couldn't "target" sibling fields, only fields in the root of the publish form.

Fixes #8881.