### PR TITLE
[4.x] Add ability to customize bard/replicator set icons directory

### DIFF
--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -5,11 +5,6 @@
 <script>
 import { defineAsyncComponent } from 'vue';
 
-const splitIcon = function(icon) {
-    if (! icon.includes('/')) icon = 'regular/' + icon;
-    return icon.split('/');
-}
-
 const fallbackIconImport = function() {
     return import('./../../svg/icons/regular/image.svg');
 }
@@ -18,6 +13,8 @@ export default {
     props: {
         name: String,
         default: String,
+        directory: String,
+        folder: String,
     },
     data() {
         return {
@@ -29,7 +26,9 @@ export default {
             this.icon = this.evaluateIcon();
         }
     },
+
     methods: {
+
         evaluateIcon() {
             if (this.name.startsWith('<svg')) {
                 return defineAsyncComponent(() => {
@@ -38,15 +37,31 @@ export default {
             }
 
             return defineAsyncComponent(() => {
-                const [set, file] = splitIcon(this.name);
-                return import(`./../../svg/icons/${set}/${file}.svg`)
+                console.log(this.getIconPath(this.name));
+                return import(this.getIconPath(this.name))
                     .catch(e => {
                         if (! this.default) return fallbackIconImport();
-                        const [set, file] = splitIcon(this.default);
-                        return import(`./../../svg/icons/${set}/${file}.svg`).catch(e => fallbackIconImport());
+                        return import(this.getIconPath(this.default)).catch(e => fallbackIconImport());
                     });
             });
-        }
+        },
+
+        getIconPath(name) {
+            return this.$config.get('test-path');
+            let directory = this.directory ? `./../../../../${this.directory}` : './../../svg/icons';
+            let folder = this.folder || 'regular';
+
+            // If a legacy `plump/icon` name string is passed instead of using dedicated folder
+            // prop, parse the folder and file from the icon name as we have always done.
+            if (name.includes('/')) {
+                folder = name.split('/')[0];
+                name = name.split('/')[1];
+            }
+
+            console.log(`${directory}/${folder}/${name}.svg`);
+            return `${directory}/${folder}/${name}.svg`;
+        },
+
     }
 }
 </script>

--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -4,24 +4,44 @@
 
 <script>
 import { defineAsyncComponent } from 'vue';
+import { data_get } from  '../bootstrap/globals.js'
 
 export default {
+
     props: {
         name: String,
         default: String,
+        customDirectory: String,
     },
+
     data() {
         return {
             icon: this.evaluateIcon(),
         }
     },
+
     watch: {
         name() {
             this.icon = this.evaluateIcon();
         }
     },
+
+    computed: {
+        customIcon() {
+            if (! this.customDirectory) return;
+
+            return data_get(this.$config.get('customSvgIcons') || {}, `${this.customDirectory}.${this.name}`);
+        },
+    },
+
     methods: {
         evaluateIcon() {
+            if (this.customIcon) {
+                return defineAsyncComponent(() => {
+                    return new Promise(resolve => resolve({ template: this.customIcon }));
+                });
+            }
+
             if (this.name.startsWith('<svg')) {
                 return defineAsyncComponent(() => {
                     return new Promise(resolve => resolve({ template: this.name }));

--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -5,15 +5,6 @@
 <script>
 import { defineAsyncComponent } from 'vue';
 
-const splitIcon = function(icon) {
-    if (! icon.includes('/')) icon = 'regular/' + icon;
-    return icon.split('/');
-}
-
-const fallbackIconImport = function() {
-    return import('./../../svg/icons/regular/image.svg');
-}
-
 export default {
     props: {
         name: String,
@@ -38,15 +29,27 @@ export default {
             }
 
             return defineAsyncComponent(() => {
-                const [set, file] = splitIcon(this.name);
+                const [set, file] = this.splitIcon(this.name);
+
                 return import(`./../../svg/icons/${set}/${file}.svg`)
                     .catch(e => {
-                        if (! this.default) return fallbackIconImport();
-                        const [set, file] = splitIcon(this.default);
-                        return import(`./../../svg/icons/${set}/${file}.svg`).catch(e => fallbackIconImport());
+                        if (! this.default) return this.fallbackIconImport();
+                        const [set, file] = this.splitIcon(this.default);
+                        return import(`./../../svg/icons/${set}/${file}.svg`).catch(e => this.fallbackIconImport());
                     });
             });
-        }
+        },
+
+        splitIcon(icon) {
+            if (! icon.includes('/')) icon = 'regular/' + icon;
+
+            return icon.split('/');
+        },
+
+        fallbackIconImport() {
+            return import('./../../svg/icons/regular/image.svg');
+        },
+
     }
 }
 </script>

--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -16,8 +16,12 @@ export default {
 
     data() {
         return {
-            icon: this.evaluateIcon(),
+            icon: null,
         }
+    },
+
+    created() {
+        this.$nextTick(() => this.icon = this.evaluateIcon());
     },
 
     watch: {
@@ -36,7 +40,7 @@ export default {
 
     methods: {
         evaluateIcon() {
-            if (this.directory) {
+            if (this.customIcon) {
                 return defineAsyncComponent(() => {
                     return new Promise(resolve => resolve({ template: this.customIcon }));
                 });

--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -20,8 +20,8 @@ export default {
         }
     },
 
-    created() {
-        this.$nextTick(() => this.icon = this.evaluateIcon());
+    mounted() {
+        this.icon = this.evaluateIcon();
     },
 
     watch: {

--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -34,7 +34,16 @@ export default {
         customIcon() {
             if (! this.directory) return;
 
-            return data_get(this.$config.get('customSvgIcons') || {}, `${this.directory}.${this.name}`);
+            let directory = this.directory;
+            let folder = null;
+            let file = this.name;
+
+            if (this.name.includes('/')) {
+                [folder, file] = this.name.split('/');
+                directory = directory+'/'+folder;
+            }
+
+            return data_get(this.$config.get('customSvgIcons') || {}, `${directory}.${file}`);
         },
     },
 

--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -11,7 +11,7 @@ export default {
     props: {
         name: String,
         default: String,
-        customDirectory: String,
+        directory: String,
     },
 
     data() {
@@ -28,15 +28,15 @@ export default {
 
     computed: {
         customIcon() {
-            if (! this.customDirectory) return;
+            if (! this.directory) return;
 
-            return data_get(this.$config.get('customSvgIcons') || {}, `${this.customDirectory}.${this.name}`);
+            return data_get(this.$config.get('customSvgIcons') || {}, `${this.directory}.${this.name}`);
         },
     },
 
     methods: {
         evaluateIcon() {
-            if (this.customIcon) {
+            if (this.directory) {
                 return defineAsyncComponent(() => {
                     return new Promise(resolve => resolve({ template: this.customIcon }));
                 });

--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -5,6 +5,11 @@
 <script>
 import { defineAsyncComponent } from 'vue';
 
+const splitIcon = function(icon) {
+    if (! icon.includes('/')) icon = 'regular/' + icon;
+    return icon.split('/');
+}
+
 const fallbackIconImport = function() {
     return import('./../../svg/icons/regular/image.svg');
 }
@@ -13,8 +18,6 @@ export default {
     props: {
         name: String,
         default: String,
-        directory: String,
-        folder: String,
     },
     data() {
         return {
@@ -26,9 +29,7 @@ export default {
             this.icon = this.evaluateIcon();
         }
     },
-
     methods: {
-
         evaluateIcon() {
             if (this.name.startsWith('<svg')) {
                 return defineAsyncComponent(() => {
@@ -37,31 +38,15 @@ export default {
             }
 
             return defineAsyncComponent(() => {
-                console.log(this.getIconPath(this.name));
-                return import(this.getIconPath(this.name))
+                const [set, file] = splitIcon(this.name);
+                return import(`./../../svg/icons/${set}/${file}.svg`)
                     .catch(e => {
                         if (! this.default) return fallbackIconImport();
-                        return import(this.getIconPath(this.default)).catch(e => fallbackIconImport());
+                        const [set, file] = splitIcon(this.default);
+                        return import(`./../../svg/icons/${set}/${file}.svg`).catch(e => fallbackIconImport());
                     });
             });
-        },
-
-        getIconPath(name) {
-            return this.$config.get('test-path');
-            let directory = this.directory ? `./../../../../${this.directory}` : './../../svg/icons';
-            let folder = this.folder || 'regular';
-
-            // If a legacy `plump/icon` name string is passed instead of using dedicated folder
-            // prop, parse the folder and file from the icon name as we have always done.
-            if (name.includes('/')) {
-                folder = name.split('/')[0];
-                name = name.split('/')[1];
-            }
-
-            console.log(`${directory}/${folder}/${name}.svg`);
-            return `${directory}/${folder}/${name}.svg`;
-        },
-
+        }
     }
 }
 </script>

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -7,7 +7,7 @@
                 <div class="blueprint-drag-handle blueprint-section-drag-handle w-4 border-r"></div>
                 <div class="p-2 flex-1 flex items-center">
                     <a class="flex items-center flex-1 group" @click="edit">
-                        <svg-icon v-if="section.icon" :name="section.icon" :custom-directory="iconPath" class="h-4 w-4 mr-2 text-gray-700 group-hover:text-blue-500" />
+                        <svg-icon v-if="section.icon" :name="section.icon" :directory="iconDirectory" class="h-4 w-4 mr-2 text-gray-700 group-hover:text-blue-500" />
                         <div class="mr-2" v-text="section.display" />
                     </a>
                     <button class="flex items-center text-gray-700 hover:text-gray-950 mr-3" @click="edit">
@@ -42,7 +42,7 @@
                     <div class="form-group w-full" v-if="showHandleField">
                         <label v-text="__('Icon')" />
                         <publish-field-meta
-                            :config="{ handle: 'icon', type: 'icon', directory: this.iconDirectory, folder: this.iconFolder }"
+                            :config="{ handle: 'icon', type: 'icon', directory: this.iconBaseDirectory, folder: this.iconSubFolder }"
                             :initial-value="editingSection.icon"
                             v-slot="{ meta, value, loading }"
                         >
@@ -127,22 +127,22 @@ export default {
             return this.suggestableConditionFieldsProvider?.suggestableFields || [];
         },
 
-        iconDirectory() {
+        iconBaseDirectory() {
             return this.$config.get('setIconsDirectory');
         },
 
-        iconFolder() {
+        iconSubFolder() {
             return this.$config.get('setIconsFolder');
         },
 
-        iconPath() {
-            let path = this.iconDirectory;
+        iconDirectory() {
+            let dir = this.iconBaseDirectory;
 
-            if (this.iconFolder) {
-                path = path+'/'+this.iconFolder;
+            if (this.iconSubFolder) {
+                dir = dir+'/'+this.iconSubFolder;
             }
 
-            return path;
+            return dir;
         },
 
     },

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -7,7 +7,7 @@
                 <div class="blueprint-drag-handle blueprint-section-drag-handle w-4 border-r"></div>
                 <div class="p-2 flex-1 flex items-center">
                     <a class="flex items-center flex-1 group" @click="edit">
-                        <svg-icon v-if="section.icon" :name="section.icon" :directory="iconDirectory" class="h-4 w-4 mr-2 text-gray-700 group-hover:text-blue-500" />
+                        <svg-icon :name="section.icon" :directory="iconDirectory" class="h-4 w-4 mr-2 text-gray-700 group-hover:text-blue-500" />
                         <div class="mr-2" v-text="section.display" />
                     </a>
                     <button class="flex items-center text-gray-700 hover:text-gray-950 mr-3" @click="edit">

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -42,7 +42,7 @@
                     <div class="form-group w-full" v-if="showHandleField">
                         <label v-text="__('Icon')" />
                         <publish-field-meta
-                            :config="{ handle: 'icon', type: 'icon', folder: 'plump' }"
+                            :config="{ handle: 'icon', type: 'icon', directory: this.iconDirectory, folder: this.iconFolder }"
                             :initial-value="editingSection.icon"
                             v-slot="{ meta, value, loading }"
                         >
@@ -122,9 +122,19 @@ export default {
     },
 
     computed: {
+
         suggestableConditionFields() {
             return this.suggestableConditionFieldsProvider?.suggestableFields || [];
-        }
+        },
+
+        iconDirectory() {
+            return this.$config.get('bard_set_icons_directory');
+        },
+
+        iconFolder() {
+            return this.$config.get('bard_set_icons_folder') || 'plump';
+        },
+
     },
 
     watch: {

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -128,11 +128,11 @@ export default {
         },
 
         iconDirectory() {
-            return this.$config.get('bard_set_icons_directory');
+            return this.$config.get('set_icons_directory');
         },
 
         iconFolder() {
-            return this.$config.get('bard_set_icons_folder') || 'plump';
+            return this.$config.get('set_icons_folder') || 'plump';
         },
 
     },

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -204,6 +204,8 @@ export default {
         },
 
         iconName(name) {
+            if (! name) return 'folder-generic';
+
             return this.iconSubFolder
                 ? this.iconSubFolder+'/'+name
                 : name;

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -7,7 +7,7 @@
                 <div class="blueprint-drag-handle blueprint-section-drag-handle w-4 border-r"></div>
                 <div class="p-2 flex-1 flex items-center">
                     <a class="flex items-center flex-1 group" @click="edit">
-                        <svg-icon class="h-4 w-4 mr-2 text-gray-700 group-hover:text-blue-500" :name="section.icon ? `plump/${section.icon}` : 'folder-generic'" />
+                        <div v-if="section.icon" v-html="section.icon" class="h-4 w-4 mr-2 text-gray-700 group-hover:text-blue-500" />
                         <div class="mr-2" v-text="section.display" />
                     </a>
                     <button class="flex items-center text-gray-700 hover:text-gray-950 mr-3" @click="edit">

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -128,11 +128,11 @@ export default {
         },
 
         iconDirectory() {
-            return this.$config.get('set_icons_directory');
+            return this.$config.get('setIconsDirectory');
         },
 
         iconFolder() {
-            return this.$config.get('set_icons_folder');
+            return this.$config.get('setIconsFolder');
         },
 
     },

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -7,7 +7,7 @@
                 <div class="blueprint-drag-handle blueprint-section-drag-handle w-4 border-r"></div>
                 <div class="p-2 flex-1 flex items-center">
                     <a class="flex items-center flex-1 group" @click="edit">
-                        <svg-icon :name="section.icon" :directory="iconDirectory" class="h-4 w-4 mr-2 text-gray-700 group-hover:text-blue-500" />
+                        <svg-icon :name="iconName(section.icon)" :directory="iconBaseDirectory" class="h-4 w-4 mr-2 text-gray-700 group-hover:text-blue-500" />
                         <div class="mr-2" v-text="section.display" />
                     </a>
                     <button class="flex items-center text-gray-700 hover:text-gray-950 mr-3" @click="edit">
@@ -135,16 +135,6 @@ export default {
             return this.$config.get('setIconsFolder');
         },
 
-        iconDirectory() {
-            let dir = this.iconBaseDirectory;
-
-            if (this.iconSubFolder) {
-                dir = dir+'/'+this.iconSubFolder;
-            }
-
-            return dir;
-        },
-
     },
 
     watch: {
@@ -211,7 +201,13 @@ export default {
 
         editCancelled() {
             this.editingSection = false;
-        }
+        },
+
+        iconName(name) {
+            return this.iconSubFolder
+                ? this.iconSubFolder+'/'+name
+                : name;
+        },
 
     }
 

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -132,7 +132,7 @@ export default {
         },
 
         iconFolder() {
-            return this.$config.get('set_icons_folder') || 'plump';
+            return this.$config.get('set_icons_folder');
         },
 
     },

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -7,7 +7,7 @@
                 <div class="blueprint-drag-handle blueprint-section-drag-handle w-4 border-r"></div>
                 <div class="p-2 flex-1 flex items-center">
                     <a class="flex items-center flex-1 group" @click="edit">
-                        <div v-if="section.icon" v-html="section.icon" class="h-4 w-4 mr-2 text-gray-700 group-hover:text-blue-500" />
+                        <svg-icon v-if="section.icon" :name="section.icon" :custom-directory="iconPath" class="h-4 w-4 mr-2 text-gray-700 group-hover:text-blue-500" />
                         <div class="mr-2" v-text="section.display" />
                     </a>
                     <button class="flex items-center text-gray-700 hover:text-gray-950 mr-3" @click="edit">
@@ -133,6 +133,16 @@ export default {
 
         iconFolder() {
             return this.$config.get('setIconsFolder');
+        },
+
+        iconPath() {
+            let path = this.iconDirectory;
+
+            if (this.iconFolder) {
+                path = path+'/'+this.iconFolder;
+            }
+
+            return path;
         },
 
     },

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -118,11 +118,11 @@ export default {
         },
 
         iconDirectory() {
-            return this.$config.get('bard_set_icons_directory');
+            return this.$config.get('set_icons_directory');
         },
 
         iconFolder() {
-            return this.$config.get('bard_set_icons_folder') || 'plump';
+            return this.$config.get('set_icons_folder') || 'plump';
         },
 
     },

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -167,6 +167,8 @@ export default {
         },
 
         iconName(name) {
+            if (! name) return null;
+
             return this.iconSubFolder
                 ? this.iconSubFolder+'/'+name
                 : name;

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -11,7 +11,7 @@
         @click="$emit('selected')"
         @mouseenter="$emit('mouseenter')"
     >
-        <div v-if="tab.icon" v-html="tab.icon" class="w-4 h-4 mr-1" />
+        <svg-icon v-if="tab.icon" :name="tab.icon" :custom-directory="iconPath" class="w-4 h-4 mr-1" />
 
         {{ tab.display }}
 
@@ -123,6 +123,16 @@ export default {
 
         iconFolder() {
             return this.$config.get('setIconsFolder');
+        },
+
+        iconPath() {
+            let path = this.iconDirectory;
+
+            if (this.iconFolder) {
+                path = path+'/'+this.iconFolder;
+            }
+
+            return path;
         },
 
     },

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -11,7 +11,7 @@
         @click="$emit('selected')"
         @mouseenter="$emit('mouseenter')"
     >
-        <svg-icon v-if="tab.icon" :name="tab.icon" :custom-directory="iconPath" class="w-4 h-4 mr-1" />
+        <svg-icon v-if="tab.icon" :name="tab.icon" :directory="iconDirectory" class="w-4 h-4 mr-1" />
 
         {{ tab.display }}
 
@@ -58,7 +58,7 @@
                 <div class="form-group w-full" v-if="showInstructions">
                     <label v-text="__('Icon')" />
                     <publish-field-meta
-                        :config="{ handle: 'icon', type: 'icon', directory: this.iconDirectory, folder: this.iconFolder }"
+                        :config="{ handle: 'icon', type: 'icon', directory: this.iconBaseDirectory, folder: this.iconSubFolder }"
                         :initial-value="icon"
                         v-slot="{ meta, value, loading }"
                     >
@@ -117,22 +117,22 @@ export default {
             return this.currentTab === this.tab._id;
         },
 
-        iconDirectory() {
+        iconBaseDirectory() {
             return this.$config.get('setIconsDirectory');
         },
 
-        iconFolder() {
+        iconSubFolder() {
             return this.$config.get('setIconsFolder');
         },
 
-        iconPath() {
-            let path = this.iconDirectory;
+        iconDirectory() {
+            let dir = this.iconBaseDirectory;
 
-            if (this.iconFolder) {
-                path = path+'/'+this.iconFolder;
+            if (this.iconSubFolder) {
+                dir = dir+'/'+this.iconSubFolder;
             }
 
-            return path;
+            return dir;
         },
 
     },

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -11,7 +11,7 @@
         @click="$emit('selected')"
         @mouseenter="$emit('mouseenter')"
     >
-        <svg-icon v-if="tab.icon" :name="tab.icon" :directory="iconDirectory" class="w-4 h-4 mr-1" />
+        <svg-icon :name="tab.icon" :directory="iconDirectory" class="w-4 h-4 mr-1" />
 
         {{ tab.display }}
 

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -122,7 +122,7 @@ export default {
         },
 
         iconFolder() {
-            return this.$config.get('set_icons_folder') || 'plump';
+            return this.$config.get('set_icons_folder');
         },
 
     },

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -118,11 +118,11 @@ export default {
         },
 
         iconDirectory() {
-            return this.$config.get('set_icons_directory');
+            return this.$config.get('setIconsDirectory');
         },
 
         iconFolder() {
-            return this.$config.get('set_icons_folder');
+            return this.$config.get('setIconsFolder');
         },
 
     },

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -11,7 +11,7 @@
         @click="$emit('selected')"
         @mouseenter="$emit('mouseenter')"
     >
-        <svg-icon v-if="tab.icon" :name="`plump/${tab.icon}`" class="w-4 h-4 mr-1" />
+        <div v-if="tab.icon" v-html="tab.icon" class="w-4 h-4 mr-1" />
 
         {{ tab.display }}
 

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -11,7 +11,7 @@
         @click="$emit('selected')"
         @mouseenter="$emit('mouseenter')"
     >
-        <svg-icon :name="tab.icon" :directory="iconDirectory" class="w-4 h-4 mr-1" />
+        <svg-icon v-if="tab.icon" :name="iconName(tab.icon)" :directory="iconBaseDirectory" class="w-4 h-4 mr-1" />
 
         {{ tab.display }}
 
@@ -125,16 +125,6 @@ export default {
             return this.$config.get('setIconsFolder');
         },
 
-        iconDirectory() {
-            let dir = this.iconBaseDirectory;
-
-            if (this.iconSubFolder) {
-                dir = dir+'/'+this.iconSubFolder;
-            }
-
-            return dir;
-        },
-
     },
 
     methods: {
@@ -174,7 +164,13 @@ export default {
 
         remove() {
             this.$emit('removed');
-        }
+        },
+
+        iconName(name) {
+            return this.iconSubFolder
+                ? this.iconSubFolder+'/'+name
+                : name;
+        },
 
     }
 

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -58,7 +58,7 @@
                 <div class="form-group w-full" v-if="showInstructions">
                     <label v-text="__('Icon')" />
                     <publish-field-meta
-                        :config="{ handle: 'icon', type: 'icon', folder: 'plump' }"
+                        :config="{ handle: 'icon', type: 'icon', directory: this.iconDirectory, folder: this.iconFolder }"
                         :initial-value="icon"
                         v-slot="{ meta, value, loading }"
                     >
@@ -115,6 +115,14 @@ export default {
 
         isActive() {
             return this.currentTab === this.tab._id;
+        },
+
+        iconDirectory() {
+            return this.$config.get('bard_set_icons_directory');
+        },
+
+        iconFolder() {
+            return this.$config.get('bard_set_icons_folder') || 'plump';
         },
 
     },

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -27,7 +27,7 @@
             <div class="p-1 max-h-[21rem] overflow-auto">
                 <div v-for="(item, i) in items" :key="item.handle" class="cursor-pointer rounded" :class="{ 'bg-gray-200': selectionIndex === i }" @mouseover="selectionIndex = i">
                     <div v-if="item.type === 'group'" @click="selectGroup(item.handle)" class="flex items-center group px-2 py-1.5 rounded-md">
-                        <svg-icon :name="item.icon" :directory="iconDirectory" class="h-9 w-9 rounded bg-white border border-gray-600 mr-2 p-2 text-gray-800" />
+                        <svg-icon :name="groupIconName(item.icon)" :directory="iconBaseDirectory" class="h-9 w-9 rounded bg-white border border-gray-600 mr-2 p-2 text-gray-800" />
                         <div class="flex-1">
                             <div class="text-md font-medium text-gray-800 truncate w-52">{{ __(item.display || item.handle) }}</div>
                             <div v-if="item.instructions" class="text-2xs text-gray-700 truncate w-52">{{ __(item.instructions) }}</div>
@@ -35,7 +35,7 @@
                         <svg-icon name="micro/chevron-right-thin" class="text-gray-600 group-hover:text-gray-800" />
                     </div>
                     <div v-if="item.type === 'set'" @click="addSet(item.handle)" class="flex items-center group px-2 py-1.5 rounded-md">
-                        <svg-icon :name="item.icon" :directory="iconDirectory" class="h-9 w-9 rounded bg-white border border-gray-600 mr-2 p-2 text-gray-800" />
+                        <svg-icon :name="setIconName(item.icon)" :directory="iconBaseDirectory" class="h-9 w-9 rounded bg-white border border-gray-600 mr-2 p-2 text-gray-800" />
                         <div class="flex-1">
                             <div class="text-md font-medium text-gray-800 truncate w-52">{{ __(item.display || item.handle) }}</div>
                             <div v-if="item.instructions" class="text-2xs text-gray-700 truncate w-52">{{ __(item.instructions) }}</div>
@@ -137,6 +137,14 @@ export default {
             return this.search && this.visibleSets.length === 0;
         },
 
+        iconBaseDirectory() {
+            return this.$config.get('setIconsDirectory');
+        },
+
+        iconSubFolder() {
+            return this.$config.get('setIconsFolder');
+        },
+
         iconDirectory() {
             let iconDirectory = this.$config.get('setIconsDirectory');
             let iconFolder = this.$config.get('setIconsFolder');
@@ -228,7 +236,23 @@ export default {
             if (! this.hasMultipleSets) {
                 this.addSet(this.sets[0].sets[0].handle);
             }
-        }
+        },
+
+        groupIconName(name) {
+            if (! name) return 'folder-generic';
+
+            return this.iconSubFolder
+                ? this.iconSubFolder+'/'+name
+                : name;
+        },
+
+        setIconName(name) {
+            if (! name) return 'light/add';
+
+            return this.iconSubFolder
+                ? this.iconSubFolder+'/'+name
+                : name;
+        },
 
     }
 

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -27,7 +27,7 @@
             <div class="p-1 max-h-[21rem] overflow-auto">
                 <div v-for="(item, i) in items" :key="item.handle" class="cursor-pointer rounded" :class="{ 'bg-gray-200': selectionIndex === i }" @mouseover="selectionIndex = i">
                     <div v-if="item.type === 'group'" @click="selectGroup(item.handle)" class="flex items-center group px-2 py-1.5 rounded-md">
-                        <div class="h-9 w-9 rounded bg-white border border-gray-600 mr-2 p-2 text-gray-800" v-html="item.icon" />
+                        <svg-icon :name="item.icon" :directory="iconDirectory" class="h-9 w-9 rounded bg-white border border-gray-600 mr-2 p-2 text-gray-800" />
                         <div class="flex-1">
                             <div class="text-md font-medium text-gray-800 truncate w-52">{{ __(item.display || item.handle) }}</div>
                             <div v-if="item.instructions" class="text-2xs text-gray-700 truncate w-52">{{ __(item.instructions) }}</div>
@@ -35,7 +35,7 @@
                         <svg-icon name="micro/chevron-right-thin" class="text-gray-600 group-hover:text-gray-800" />
                     </div>
                     <div v-if="item.type === 'set'" @click="addSet(item.handle)" class="flex items-center group px-2 py-1.5 rounded-md">
-                        <div class="h-9 w-9 rounded bg-white border border-gray-600 mr-2 p-2 text-gray-800" v-html="item.icon" />
+                        <svg-icon :name="item.icon" :directory="iconDirectory" class="h-9 w-9 rounded bg-white border border-gray-600 mr-2 p-2 text-gray-800" />
                         <div class="flex-1">
                             <div class="text-md font-medium text-gray-800 truncate w-52">{{ __(item.display || item.handle) }}</div>
                             <div v-if="item.instructions" class="text-2xs text-gray-700 truncate w-52">{{ __(item.instructions) }}</div>
@@ -135,7 +135,18 @@ export default {
 
         noSearchResults() {
             return this.search && this.visibleSets.length === 0;
-        }
+        },
+
+        iconDirectory() {
+            let iconDirectory = this.$config.get('setIconsDirectory');
+            let iconFolder = this.$config.get('setIconsFolder');
+
+            if (iconFolder) {
+                iconDirectory = iconDirectory+'/'+iconFolder;
+            }
+
+            return iconDirectory;
+        },
 
     },
 

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -27,9 +27,7 @@
             <div class="p-1 max-h-[21rem] overflow-auto">
                 <div v-for="(item, i) in items" :key="item.handle" class="cursor-pointer rounded" :class="{ 'bg-gray-200': selectionIndex === i }" @mouseover="selectionIndex = i">
                     <div v-if="item.type === 'group'" @click="selectGroup(item.handle)" class="flex items-center group px-2 py-1.5 rounded-md">
-                        <div class="h-9 w-9 rounded bg-white border border-gray-600 mr-2 p-2">
-                            <svg-icon :name="item.icon ? `plump/${item.icon}` : 'folder-generic'" class="text-gray-800" />
-                        </div>
+                        <div class="h-9 w-9 rounded bg-white border border-gray-600 mr-2 p-2 text-gray-800" v-html="item.icon" />
                         <div class="flex-1">
                             <div class="text-md font-medium text-gray-800 truncate w-52">{{ __(item.display || item.handle) }}</div>
                             <div v-if="item.instructions" class="text-2xs text-gray-700 truncate w-52">{{ __(item.instructions) }}</div>
@@ -37,9 +35,7 @@
                         <svg-icon name="micro/chevron-right-thin" class="text-gray-600 group-hover:text-gray-800" />
                     </div>
                     <div v-if="item.type === 'set'" @click="addSet(item.handle)" class="flex items-center group px-2 py-1.5 rounded-md">
-                        <div class="h-9 w-9 rounded bg-white border border-gray-600 mr-2 p-2">
-                            <svg-icon :name="item.icon ? `plump/${item.icon}` : 'light/add'" class="text-gray-800" />
-                        </div>
+                        <div class="h-9 w-9 rounded bg-white border border-gray-600 mr-2 p-2 text-gray-800" v-html="item.icon" />
                         <div class="flex-1">
                             <div class="text-md font-medium text-gray-800 truncate w-52">{{ __(item.display || item.handle) }}</div>
                             <div v-if="item.instructions" class="text-2xs text-gray-700 truncate w-52">{{ __(item.instructions) }}</div>

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -716,7 +716,7 @@ class Bard extends Replicator
         return $value[0]['content'] ?? [];
     }
 
-    public static function setIcons($directory, $folder = null)
+    public static function setIcons($directory = null, $folder = null)
     {
         Statamic::provideToScript([
             'bard_set_icons_directory' => $directory,

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -15,7 +15,6 @@ use Statamic\GraphQL\Types\BardSetsType;
 use Statamic\GraphQL\Types\BardTextType;
 use Statamic\GraphQL\Types\ReplicatorSetType;
 use Statamic\Query\Scopes\Filters\Fields\Bard as BardFilter;
-use Statamic\Statamic;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
@@ -714,13 +713,5 @@ class Bard extends Replicator
     private function unwrapInlineValue($value)
     {
         return $value[0]['content'] ?? [];
-    }
-
-    public static function setIcons($directory = null, $folder = null)
-    {
-        Statamic::provideToScript([
-            'bard_set_icons_directory' => $directory,
-            'bard_set_icons_folder' => $folder,
-        ]);
     }
 }

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -232,6 +232,32 @@ class Bard extends Replicator
                     ],
                 ],
             ],
+            [
+                'display' => __('Set Icons'),
+                'fields' => [
+                    'set_icons_directory' => [
+                        'display' => __('Directory'),
+                        'instructions' => __('statamic::fieldtypes.icon.config.directory'),
+                        'type' => 'text',
+                        'placeholder' => 'vendor/statamic/cms/resources/svg/icons',
+                    ],
+                    'set_icons_folder' => [
+                        'display' => __('Folder'),
+                        'instructions' => __('statamic::fieldtypes.icon.config.folder'),
+                        'type' => 'text',
+                        'placeholder' => 'plump',
+                    ],
+                    'merge_with_default_set_icons' => [
+                        'display' => __('Merge With Defaults'),
+                        'instructions' => __('Merge with default set icons.'), // TODO: translate
+                        'type' => 'toggle',
+                        'default' => true,
+                        'if' => [
+                            'set_icons_directory' => 'not empty',
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -15,6 +15,7 @@ use Statamic\GraphQL\Types\BardSetsType;
 use Statamic\GraphQL\Types\BardTextType;
 use Statamic\GraphQL\Types\ReplicatorSetType;
 use Statamic\Query\Scopes\Filters\Fields\Bard as BardFilter;
+use Statamic\Statamic;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
@@ -229,32 +230,6 @@ class Bard extends Replicator
                         'instructions' => __('statamic::fieldtypes.bard.config.previews'),
                         'type' => 'toggle',
                         'default' => true,
-                    ],
-                ],
-            ],
-            [
-                'display' => __('Set Icons'),
-                'fields' => [
-                    'set_icons_directory' => [
-                        'display' => __('Directory'),
-                        'instructions' => __('statamic::fieldtypes.icon.config.directory'),
-                        'type' => 'text',
-                        'placeholder' => 'vendor/statamic/cms/resources/svg/icons',
-                    ],
-                    'set_icons_folder' => [
-                        'display' => __('Folder'),
-                        'instructions' => __('statamic::fieldtypes.icon.config.folder'),
-                        'type' => 'text',
-                        'placeholder' => 'plump',
-                    ],
-                    'merge_with_default_set_icons' => [
-                        'display' => __('Merge With Defaults'),
-                        'instructions' => __('Merge with default set icons.'), // TODO: translate
-                        'type' => 'toggle',
-                        'default' => true,
-                        'if' => [
-                            'set_icons_directory' => 'not empty',
-                        ],
                     ],
                 ],
             ],
@@ -739,5 +714,13 @@ class Bard extends Replicator
     private function unwrapInlineValue($value)
     {
         return $value[0]['content'] ?? [];
+    }
+
+    public static function setIcons($directory, $folder = null)
+    {
+        Statamic::provideToScript([
+            'bard_set_icons_directory' => $directory,
+            'bard_set_icons_folder' => $folder,
+        ]);
     }
 }

--- a/src/Fieldtypes/Icon.php
+++ b/src/Fieldtypes/Icon.php
@@ -39,11 +39,13 @@ class Icon extends Fieldtype
                         'display' => __('Directory'),
                         'instructions' => __('statamic::fieldtypes.icon.config.directory'),
                         'type' => 'text',
+                        'placeholder' => 'vendor/statamic/cms/resources/svg/icons',
                     ],
                     'folder' => [
                         'display' => __('Folder'),
                         'instructions' => __('statamic::fieldtypes.icon.config.folder'),
                         'type' => 'text',
+                        'placeholder' => static::DEFAULT_FOLDER,
                     ],
                     'default' => [
                         'display' => __('Default Value'),

--- a/src/Fieldtypes/Icon.php
+++ b/src/Fieldtypes/Icon.php
@@ -2,10 +2,12 @@
 
 namespace Statamic\Fieldtypes;
 
+use Illuminate\Filesystem\Filesystem;
 use Statamic\Facades\File;
 use Statamic\Facades\Folder;
 use Statamic\Facades\Path;
 use Statamic\Fields\Fieldtype;
+use Statamic\Support\Str;
 
 class Icon extends Fieldtype
 {
@@ -13,6 +15,8 @@ class Icon extends Fieldtype
 
     protected $categories = ['media'];
     protected $icon = 'icon_picker';
+
+    protected static $customSvgIcons = [];
 
     public function preload(): array
     {
@@ -86,5 +90,33 @@ class Icon extends Fieldtype
             $folder,
             $hasConfiguredDirectory,
         ];
+    }
+
+    /**
+     * Provide custom SVG icons to script.
+     *
+     * @param  string  $directory
+     * @param  string|null  $folder
+     */
+    public static function provideCustomSvgIconsToScript($directory, $folder = null)
+    {
+        $path = Str::removeRight(Path::tidy($directory.'/'.$folder), '/');
+
+        static::$customSvgIcons[$path] = collect(app(Filesystem::class)->files($path))
+            ->filter(fn ($file) => strtolower($file->getExtension()) === 'svg')
+            ->keyBy(fn ($file) => pathinfo($file->getBasename(), PATHINFO_FILENAME))
+            ->map
+            ->getContents()
+            ->all();
+    }
+
+    /**
+     * Get custom SVG icons for script.
+     *
+     * @return array
+     */
+    public static function getCustomSvgIcons()
+    {
+        return static::$customSvgIcons;
     }
 }

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -47,14 +47,14 @@ class Sets extends Fieldtype
                 'handle' => $groupHandle,
                 'display' => $group['display'] ?? null,
                 'instructions' => $group['instructions'] ?? null,
-                'icon' => $group['icon'] ?? null,
+                'icon' => $this->getIconHtml(Arr::get($group, 'icon')),
                 'sections' => collect($group['sets'] ?? [])->map(function ($set, $setHandle) use ($groupId) {
                     return [
                         '_id' => $setId = $groupId.'-section-'.$setHandle,
                         'handle' => $setHandle,
                         'display' => $set['display'] ?? null,
                         'instructions' => $set['instructions'] ?? null,
-                        'icon' => $set['icon'] ?? null,
+                        'icon' => $this->getIconHtml(Arr::get($set, 'icon')),
                         'fields' => collect($set['fields'])->map(function ($field, $i) use ($setId) {
                             return array_merge(FieldTransformer::toVue($field), ['_id' => $setId.'-'.$i]);
                         })->all(),

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -46,7 +46,7 @@ class Sets extends Fieldtype
                 'handle' => $groupHandle,
                 'display' => $group['display'] ?? null,
                 'instructions' => $group['instructions'] ?? null,
-                'icon' => $group['icon'] ?? null,
+                'icon' => $group['icon'] ?? 'regular/folder-generic',
                 'sections' => collect($group['sets'] ?? [])->map(function ($set, $setHandle) use ($groupId) {
                     return [
                         '_id' => $setId = $groupId.'-section-'.$setHandle,

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -137,9 +137,9 @@ class Sets extends Fieldtype
     }
 
     /**
-     * Allow the user to set custom location for SVG set icons.
+     * Allow the user to set custom icon directory and/or folder for SVG set icons.
      */
-    public static function iconConfig($directory = null, $folder = null)
+    public static function setIconsDirectory($directory = null, $folder = null)
     {
         // If they are specifying new base directory, ensure we do not assume sub-folder
         if ($directory) {

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -46,14 +46,14 @@ class Sets extends Fieldtype
                 'handle' => $groupHandle,
                 'display' => $group['display'] ?? null,
                 'instructions' => $group['instructions'] ?? null,
-                'icon' => $group['icon'] ?? 'regular/folder-generic',
+                'icon' => $group['icon'] ?? null,
                 'sections' => collect($group['sets'] ?? [])->map(function ($set, $setHandle) use ($groupId) {
                     return [
                         '_id' => $setId = $groupId.'-section-'.$setHandle,
                         'handle' => $setHandle,
                         'display' => $set['display'] ?? null,
                         'instructions' => $set['instructions'] ?? null,
-                        'icon' => $set['icon'] ?? 'regular/folder-generic',
+                        'icon' => $set['icon'] ?? null,
                         'fields' => collect($set['fields'])->map(function ($field, $i) use ($setId) {
                             return array_merge(FieldTransformer::toVue($field), ['_id' => $setId.'-'.$i]);
                         })->all(),

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -88,14 +88,12 @@ class Sets extends Fieldtype
         return collect($sets)->map(function ($group, $groupHandle) {
             return array_merge($group, [
                 'handle' => $groupHandle,
-                'icon' => $group['icon'] ?? 'regular/folder-generic',
                 'sets' => collect($group['sets'])
                     ->map(function ($config, $name) {
                         return array_merge($config, [
                             'handle' => $name,
                             'id' => $name,
                             'fields' => (new NestedFields)->preProcessConfig(array_get($config, 'fields', [])),
-                            'icon' => $config['icon'] ?? 'light/add',
                         ]);
                     })
                     ->values()

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -13,7 +13,7 @@ class Sets extends Fieldtype
 {
     protected $selectable = false;
 
-    protected static $iconsDirectory = 'vendor/statamic/cms/resources/svg/icons';
+    protected static $iconsDirectory = null;
     protected static $iconsFolder = 'plump';
 
     /**

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -54,7 +54,7 @@ class Sets extends Fieldtype
                         'handle' => $setHandle,
                         'display' => $set['display'] ?? null,
                         'instructions' => $set['instructions'] ?? null,
-                        'icon' => $this->getIconHtml(Arr::get($set, 'icon')),
+                        'icon' => $this->getIconHtml(Arr::get($set, 'icon'), 'regular/folder-generic'),
                         'fields' => collect($set['fields'])->map(function ($field, $i) use ($setId) {
                             return array_merge(FieldTransformer::toVue($field), ['_id' => $setId.'-'.$i]);
                         })->all(),

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -160,26 +160,32 @@ class Sets extends Fieldtype
     }
 
     /**
-     * Get icon HTML, because our <svg-icon> component with Vite reference custom user paths.
+     * Get icon HTML, because our <svg-icon> component cannot reference custom paths at runtime without a Vite re-build.
      *
      * @param  string|null  $configuredIcon
-     * @param  string  $fallbackVendorIcon
-     * @return string
+     * @param  string|null  $fallbackVendorIcon
+     * @return string|null
      */
-    protected function getIconHtml($configuredIcon, $fallbackVendorIcon)
+    protected function getIconHtml($configuredIcon, $fallbackVendorIcon = null)
     {
-        $fallbackPath = base_path(static::$iconsDirectory."/{$fallbackVendorIcon}.svg");
-
         $iconPath = collect([static::$iconsDirectory, static::$iconsFolder, $configuredIcon])
             ->filter()
             ->implode('/').'.svg';
 
-        $absoluteIconPath = Path::isAbsolute($iconPath) ? $iconPath : Path::makeFull($iconPath);
+        $absoluteIconPath = Path::isAbsolute($iconPath)
+            ? $iconPath
+            : Path::makeFull($iconPath);
 
-        ray($absoluteIconPath);
+        if ($configuredIcon && File::exists($absoluteIconPath)) {
+            return File::get($absoluteIconPath);
+        }
 
-        return $configuredIcon && File::exists($absoluteIconPath)
-            ? File::get($iconPath)
-            : File::get($fallbackPath);
+        $absoluteFallbackIconPath = base_path(static::$iconsDirectory."/{$fallbackVendorIcon}.svg");
+
+        if ($fallbackVendorIcon && File::exists($absoluteFallbackIconPath)) {
+            return File::get($absoluteFallbackIconPath);
+        }
+
+        return null;
     }
 }

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -147,7 +147,7 @@ class Sets extends Fieldtype
         // If they are specifying new base directory, ensure we do not assume sub-folder
         if ($directory) {
             static::$iconsDirectory = $directory;
-            static::$iconsFolder = null;
+            static::$iconsFolder = $folder;
         }
 
         // Of if they are specifying just a sub-folder, use that with original base directory

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -154,8 +154,8 @@ class Sets extends Fieldtype
 
         // Then provide to script for <icon-fieldtype> selector components in blueprint config
         Statamic::provideToScript([
-            'set_icons_directory' => static::$iconsDirectory,
-            'set_icons_folder' => static::$iconsFolder,
+            'setIconsDirectory' => static::$iconsDirectory,
+            'setIconsFolder' => static::$iconsFolder,
         ]);
     }
 

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -152,7 +152,7 @@ class Sets extends Fieldtype
             static::$iconsFolder = $folder;
         }
 
-        // Then provide to script for <icon-fieldtype> selectors in blueprint config
+        // Then provide to script for <icon-fieldtype> selector components in blueprint config
         Statamic::provideToScript([
             'set_icons_directory' => static::$iconsDirectory,
             'set_icons_folder' => static::$iconsFolder,

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -138,6 +138,9 @@ class Sets extends Fieldtype
 
     /**
      * Allow the user to set custom icon directory and/or folder for SVG set icons.
+     *
+     * @param  string|null  $directory
+     * @param  string|null  $folder
      */
     public static function setIconsDirectory($directory = null, $folder = null)
     {

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -9,6 +9,7 @@ use Statamic\Facades\CP\Toast;
 use Statamic\Facades\Preference;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
+use Statamic\Fieldtypes\Icon;
 use Statamic\Statamic;
 use Statamic\Support\Str;
 use voku\helper\ASCII;
@@ -67,6 +68,7 @@ class JavascriptComposer
             'livePreview' => config('statamic.live_preview'),
             'permissions' => $this->permissions($user),
             'hasLicenseBanner' => $licenses->invalid() || $licenses->requestFailed(),
+            'customSvgIcons' => Icon::getCustomSvgIcons(),
         ];
     }
 

--- a/src/Providers/CpServiceProvider.php
+++ b/src/Providers/CpServiceProvider.php
@@ -10,6 +10,7 @@ use Statamic\CP\Utilities\UtilityRepository;
 use Statamic\Extensions\Translation\Loader;
 use Statamic\Extensions\Translation\Translator;
 use Statamic\Facades\User;
+use Statamic\Fieldtypes\Sets;
 use Statamic\Http\View\Composers\CustomLogoComposer;
 use Statamic\Http\View\Composers\FieldComposer;
 use Statamic\Http\View\Composers\JavascriptComposer;
@@ -35,6 +36,8 @@ class CpServiceProvider extends ServiceProvider
         Blade::directive('cp_svg', function ($expression) {
             return "<?php echo Statamic::svg({$expression}) ?>";
         });
+
+        Sets::setIconsDirectory();
 
         $this->registerMiddlewareGroups();
     }

--- a/tests/Fieldtypes/SetsTest.php
+++ b/tests/Fieldtypes/SetsTest.php
@@ -77,14 +77,14 @@ class SetsTest extends TestCase
                 'handle' => 'bravo',
                 'display' => null,
                 'instructions' => null,
-                'icon' => null,
+                'icon' => 'regular/folder-generic',
                 'sections' => [
                     [
                         '_id' => 'group-bravo-section-two',
                         'handle' => 'two',
                         'display' => null,
                         'instructions' => null,
-                        'icon' => null,
+                        'icon' => 'regular/folder-generic',
                         'fields' => [
                             [
                                 '_id' => 'group-bravo-section-two-0',
@@ -127,7 +127,7 @@ class SetsTest extends TestCase
                 'handle' => 'main',
                 'display' => 'Main',
                 'instructions' => null,
-                'icon' => null,
+                'icon' => 'regular/folder-generic',
                 'sections' => [
                     [
                         '_id' => 'group-main-section-one',
@@ -238,10 +238,12 @@ class SetsTest extends TestCase
             ],
             [
                 'handle' => 'bravo',
+                'icon' => 'regular/folder-generic',
                 'sets' => [
                     [
                         'id' => 'two',
                         'handle' => 'two',
+                        'icon' => 'light/add',
                         'fields' => [
                             [
                                 'display' => 'Field Two',
@@ -289,6 +291,7 @@ class SetsTest extends TestCase
         $this->assertEquals([
             [
                 'handle' => 'main',
+                'icon' => 'regular/folder-generic',
                 'sets' => [
                     [
                         'id' => 'one',

--- a/tests/Fieldtypes/SetsTest.php
+++ b/tests/Fieldtypes/SetsTest.php
@@ -4,6 +4,8 @@ namespace Tests\Fieldtypes;
 
 use Statamic\Fields\ConfigField;
 use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Sets;
+use Statamic\Statamic;
 use Tests\TestCase;
 
 class SetsTest extends TestCase
@@ -392,5 +394,47 @@ class SetsTest extends TestCase
                 ],
             ],
         ], $field->process()->value());
+    }
+
+    /** @test */
+    public function it_provides_statamic_plump_icons_to_script_by_default()
+    {
+        $jsonVariables = Statamic::jsonVariables(request());
+
+        $this->assertEquals('vendor/statamic/cms/resources/svg/icons', $jsonVariables['setIconsDirectory']);
+        $this->assertEquals('plump', $jsonVariables['setIconsFolder']);
+    }
+
+    /** @test */
+    public function it_can_provide_custom_user_icons_subfolder()
+    {
+        Sets::setIconsDirectory(folder: 'light');
+
+        $jsonVariables = Statamic::jsonVariables(request());
+
+        $this->assertEquals('vendor/statamic/cms/resources/svg/icons', $jsonVariables['setIconsDirectory']);
+        $this->assertEquals('light', $jsonVariables['setIconsFolder']);
+    }
+
+    /** @test */
+    public function it_can_provide_custom_user_icons_directory()
+    {
+        Sets::setIconsDirectory($customDir = resource_path());
+
+        $jsonVariables = Statamic::jsonVariables(request());
+
+        $this->assertEquals($customDir, $jsonVariables['setIconsDirectory']);
+        $this->assertEquals(null, $jsonVariables['setIconsFolder']);
+    }
+
+    /** @test */
+    public function it_can_provide_custom_user_icons_directory_and_sub_folder()
+    {
+        Sets::setIconsDirectory($customDir = base_path(), $customSubFolder = 'resources');
+
+        $jsonVariables = Statamic::jsonVariables(request());
+
+        $this->assertEquals($customDir, $jsonVariables['setIconsDirectory']);
+        $this->assertEquals($customSubFolder, $jsonVariables['setIconsFolder']);
     }
 }

--- a/tests/Fieldtypes/SetsTest.php
+++ b/tests/Fieldtypes/SetsTest.php
@@ -79,14 +79,14 @@ class SetsTest extends TestCase
                 'handle' => 'bravo',
                 'display' => null,
                 'instructions' => null,
-                'icon' => 'regular/folder-generic',
+                'icon' => null,
                 'sections' => [
                     [
                         '_id' => 'group-bravo-section-two',
                         'handle' => 'two',
                         'display' => null,
                         'instructions' => null,
-                        'icon' => 'regular/folder-generic',
+                        'icon' => null,
                         'fields' => [
                             [
                                 '_id' => 'group-bravo-section-two-0',
@@ -129,7 +129,7 @@ class SetsTest extends TestCase
                 'handle' => 'main',
                 'display' => 'Main',
                 'instructions' => null,
-                'icon' => 'regular/folder-generic',
+                'icon' => null,
                 'sections' => [
                     [
                         '_id' => 'group-main-section-one',
@@ -240,12 +240,10 @@ class SetsTest extends TestCase
             ],
             [
                 'handle' => 'bravo',
-                'icon' => 'regular/folder-generic',
                 'sets' => [
                     [
                         'id' => 'two',
                         'handle' => 'two',
-                        'icon' => 'light/add',
                         'fields' => [
                             [
                                 'display' => 'Field Two',
@@ -293,7 +291,6 @@ class SetsTest extends TestCase
         $this->assertEquals([
             [
                 'handle' => 'main',
-                'icon' => 'regular/folder-generic',
                 'sets' => [
                     [
                         'id' => 'one',
@@ -401,7 +398,7 @@ class SetsTest extends TestCase
     {
         $jsonVariables = Statamic::jsonVariables(request());
 
-        $this->assertEquals('vendor/statamic/cms/resources/svg/icons', $jsonVariables['setIconsDirectory']);
+        $this->assertNull($jsonVariables['setIconsDirectory']);
         $this->assertEquals('plump', $jsonVariables['setIconsFolder']);
     }
 
@@ -412,7 +409,7 @@ class SetsTest extends TestCase
 
         $jsonVariables = Statamic::jsonVariables(request());
 
-        $this->assertEquals('vendor/statamic/cms/resources/svg/icons', $jsonVariables['setIconsDirectory']);
+        $this->assertNull($jsonVariables['setIconsDirectory']);
         $this->assertEquals('light', $jsonVariables['setIconsFolder']);
     }
 


### PR DESCRIPTION
This PR adds ability for user to customize bard/replicator set icons directory in a service provider.

## Usage

Choose a different icon set for bard/replicator set icons...

```php
\Statamic\Fieldtypes\Sets::setIconsDirectory(folder: 'light');
```

Choose a different base directory altogether...

```php
\Statamic\Fieldtypes\Sets::setIconsDirectory(directory: resource_path('custom-icons'));
```

## Todo

- [x] Add helper to set custom base directory and/or icon set sub-folder in service provider
- [x] Wire up to icon selector dropdowns in blueprint editor
- [x] Wire up to tabs and sections in blueprint editor
- [x] Wire up to the set picker used in bard/replicator fields on publish forms
- [x] Tests