### PR TITLE
[4.x] Fix `statamic.web` middleware not being merged

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -29,9 +29,8 @@ class AppServiceProvider extends ServiceProvider
         $this->app->booted(function () {
             Statamic::runBootedCallbacks();
             $this->loadRoutesFrom("{$this->root}/routes/routes.php");
+            $this->registerMiddlewareGroup();
         });
-
-        $this->registerMiddlewareGroup();
 
         $this->app[\Illuminate\Contracts\Http\Kernel::class]
             ->pushMiddleware(\Statamic\Http\Middleware\PoweredByHeader::class)
@@ -166,14 +165,13 @@ class AppServiceProvider extends ServiceProvider
 
     protected function registerMiddlewareGroup()
     {
-        $this->app->make(Router::class)->middlewareGroup('statamic.web', [
-            \Statamic\Http\Middleware\StacheLock::class,
-            \Statamic\Http\Middleware\HandleToken::class,
-            \Statamic\Http\Middleware\Localize::class,
-            \Statamic\Http\Middleware\AddViewPaths::class,
-            \Statamic\Http\Middleware\AuthGuard::class,
-            \Statamic\StaticCaching\Middleware\Cache::class,
-        ]);
+        $this->app->make(Router::class)
+            ->pushMiddlewareToGroup('statamic.web', \Statamic\Http\Middleware\StacheLock::class)
+            ->pushMiddlewareToGroup('statamic.web', \Statamic\Http\Middleware\HandleToken::class)
+            ->pushMiddlewareToGroup('statamic.web', \Statamic\Http\Middleware\Localize::class)
+            ->pushMiddlewareToGroup('statamic.web', \Statamic\Http\Middleware\AddViewPaths::class)
+            ->pushMiddlewareToGroup('statamic.web', \Statamic\Http\Middleware\AuthGuard::class)
+            ->pushMiddlewareToGroup('statamic.web', \Statamic\StaticCaching\Middleware\Cache::class);
     }
 
     protected function addAboutCommandInfo()

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -165,13 +165,16 @@ class AppServiceProvider extends ServiceProvider
 
     protected function registerMiddlewareGroup()
     {
-        $this->app->make(Router::class)
-            ->pushMiddlewareToGroup('statamic.web', \Statamic\Http\Middleware\StacheLock::class)
-            ->pushMiddlewareToGroup('statamic.web', \Statamic\Http\Middleware\HandleToken::class)
-            ->pushMiddlewareToGroup('statamic.web', \Statamic\Http\Middleware\Localize::class)
-            ->pushMiddlewareToGroup('statamic.web', \Statamic\Http\Middleware\AddViewPaths::class)
-            ->pushMiddlewareToGroup('statamic.web', \Statamic\Http\Middleware\AuthGuard::class)
-            ->pushMiddlewareToGroup('statamic.web', \Statamic\StaticCaching\Middleware\Cache::class);
+        $router = $this->app->make(Router::class);
+
+        collect([
+            \Statamic\Http\Middleware\StacheLock::class,
+            \Statamic\Http\Middleware\HandleToken::class,
+            \Statamic\Http\Middleware\Localize::class,
+            \Statamic\Http\Middleware\AddViewPaths::class,
+            \Statamic\Http\Middleware\AuthGuard::class,
+            \Statamic\StaticCaching\Middleware\Cache::class,
+        ])->each(fn ($middleware) => $router->pushMiddlewareToGroup('statamic.web', $middleware));
     }
 
     protected function addAboutCommandInfo()


### PR DESCRIPTION
This pull request attempts to fix an issue where Statamic's middlewares for the `statamic.web` group would not get used when the developer pushes their own array of middlewares. 

This PR ensures any custom middlewares provided for the `statamic.web` group in `app/Http/Kernel.php` are merged with Statamic's middlewares, rather than overriding them.

Fixes #8453.