### PR TITLE
[4.x] Fix missing title on relationship fields in multi-site

### DIFF
--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -72,7 +72,7 @@ abstract class Relationship extends Fieldtype
         return $this->getItemsForPreProcessIndex($data)->map(function ($item) {
             return [
                 'id' => method_exists($item, 'id') ? $item->id() : $item->handle(),
-                'title' => method_exists($item, 'title') ? $item->title() : $item->get('title'),
+                'title' => method_exists($item, 'title') ? $item->title() : $item->value('title'),
                 'edit_url' => $item->editUrl(),
                 'published' => $this->statusIcons ? $item->published() : null,
             ];


### PR DESCRIPTION
This pull request fixes an issue with the Relationship Fieldtype where it would sometimes show a missing title on listing tables, when on multi-site.

Fixes #6605.
Fixes #8821.