### PR TITLE
[4.x] Fix infinite loop on listing table of mounted collection

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -851,7 +851,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
             'handle' => $this->handle(),
         ];
 
-        if (! Statamic::isApiRoute()) {
+        if (! Statamic::isApiRoute() && ! Statamic::isCpRoute()) {
             $data['mount'] = $this->mount();
         }
 


### PR DESCRIPTION
This pull request fixes an issue with #8928 where the listing table of a mounted collection would fail to load due to an infinite loop.