### PR TITLE
[4.x] Use translations from fallback locale when primary locale is missing translations

### DIFF
--- a/resources/js/translations/translator.js
+++ b/resources/js/translations/translator.js
@@ -45,15 +45,10 @@ export const translateChoice = function (key, count, replacements) {
  */
 const getLine = function (key) {
     const translations = Statamic.$config.get('translations');
-    const fallbackTranslations = Statamic.$config.get('fallbackTranslations');
 
     return translations[`*.${key}`]
         || translations[key]
         || translations[`statamic::${key}`]
         || translations[`statamic::messages.${key}`]
-        || fallbackTranslations[`*.${key}`]
-        || fallbackTranslations[key]
-        || fallbackTranslations[`statamic::${key}`]
-        || fallbackTranslations[`statamic::messages.${key}`]
         || key;
 }

--- a/resources/js/translations/translator.js
+++ b/resources/js/translations/translator.js
@@ -45,10 +45,15 @@ export const translateChoice = function (key, count, replacements) {
  */
 const getLine = function (key) {
     const translations = Statamic.$config.get('translations');
+    const fallbackTranslations = Statamic.$config.get('fallbackTranslations');
 
     return translations[`*.${key}`]
         || translations[key]
         || translations[`statamic::${key}`]
         || translations[`statamic::messages.${key}`]
+        || fallbackTranslations[`*.${key}`]
+        || fallbackTranslations[key]
+        || fallbackTranslations[`statamic::${key}`]
+        || fallbackTranslations[`statamic::messages.${key}`]
         || key;
 }

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -39,7 +39,7 @@ class JavascriptComposer
             'flash' => Statamic::flash(),
             'toasts' => Toast::toArray(),
             'translationLocale' => app('translator')->locale(),
-            'translations' => app('translator')->toJson(),
+            'translations' => $this->translations(),
             'locale' => config('app.locale'),
             'asciiReplaceExtraSymbols' => $replaceSymbols = config('statamic.system.ascii_replace_extra_symbols'),
             'charmap' => ASCII::charsArray($replaceSymbols),
@@ -98,5 +98,13 @@ class JavascriptComposer
             'preferences' => Preference::all(),
             'permissions' => $user->permissions()->all(),
         ])->toArray();
+    }
+
+    protected function translations(): array
+    {
+        $translations = app('translator')->toJson();
+        $fallbackTranslations = tap(app('translator'))->setLocale(app('translator')->getFallback())->toJson();
+
+        return array_merge($fallbackTranslations, $translations);
     }
 }

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -40,7 +40,6 @@ class JavascriptComposer
             'toasts' => Toast::toArray(),
             'translationLocale' => app('translator')->locale(),
             'translations' => app('translator')->toJson(),
-            'fallbackTranslations' => tap(app('translator'))->setLocale(app('translator')->getFallback())->toJson(),
             'locale' => config('app.locale'),
             'asciiReplaceExtraSymbols' => $replaceSymbols = config('statamic.system.ascii_replace_extra_symbols'),
             'charmap' => ASCII::charsArray($replaceSymbols),

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -40,6 +40,7 @@ class JavascriptComposer
             'toasts' => Toast::toArray(),
             'translationLocale' => app('translator')->locale(),
             'translations' => app('translator')->toJson(),
+            'fallbackTranslations' => tap(app('translator'))->setLocale(app('translator')->getFallback())->toJson(),
             'locale' => config('app.locale'),
             'asciiReplaceExtraSymbols' => $replaceSymbols = config('statamic.system.ascii_replace_extra_symbols'),
             'charmap' => ASCII::charsArray($replaceSymbols),


### PR DESCRIPTION
This pull request ensures that when the site's primary locale is missing a translation then it'll fallback to using the site's fallback locale (configured in `config/app.php`).

Previously, when a translation was missing on the site's primary locale, the JavaScript translation method would display the translation key instead of a fallback which would be more useful.

Fixes #5610.
Closes #5277.