### PR TITLE
[4.x] Support arrays in wrap modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2812,6 +2812,12 @@ class CoreModifiers extends Modifier
             return $value;
         }
 
+        if (is_array($value)) {
+            return array_map(function ($value) use ($params) {
+                return $this->wrap($value, $params);
+            }, $value);
+        }
+
         $attributes = '';
         $tag = Arr::get($params, 0);
 

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2813,8 +2813,8 @@ class CoreModifiers extends Modifier
         }
 
         if (is_array($value)) {
-            return array_map(function ($value) use ($params) {
-                return $this->wrap($value, $params);
+            return array_map(function ($item) use ($params) {
+                return $this->wrap($item, $params);
             }, $value);
         }
 


### PR DESCRIPTION
This PR allows you to pass arrays to the `wrap` modifier. So you can do:


```antlers
{{ test = "one two" }
{{ test | wrap('span') }}
{{ test | explode(' ') | wrap('span') | join(' ') }}
```

Resulting in:

```html
<span>one two</span>
<span>one</span> <span>two</span>
```