### PR TITLE
[4.x] Add cmd+k support for Bard

### DIFF
--- a/resources/js/components/Popover.vue
+++ b/resources/js/components/Popover.vue
@@ -100,7 +100,7 @@ export default {
             if (this.disabled) return;
 
             this.isOpen = true;
-            this.escBinding = this.$keys.bind('esc', e => this.close());
+            this.escBinding = this.$keys.bindGlobal('esc', e => this.close());
             this.$nextTick(() => {
                 this.cleanupAutoUpdater = autoUpdate(this.$refs.trigger.firstChild, this.$refs.popover, this.computePosition);
 

--- a/resources/js/components/fieldtypes/bard/Link.js
+++ b/resources/js/components/fieldtypes/bard/Link.js
@@ -64,6 +64,12 @@ export const Link = Mark.create({
         ]
     },
 
+    addKeyboardShortcuts() {
+        return {
+            'Mod-k': () => this.options.vm.$emit('link-toggle'),
+        }
+    },
+
     addProseMirrorPlugins() {
         const vm = this.options.vm;
         return [

--- a/resources/js/components/fieldtypes/bard/LinkToolbarButton.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbarButton.vue
@@ -71,8 +71,17 @@ export default {
             this.close();
             this.editor.view.dom.focus();
         }
+    },
 
+    created() {
+        this.bard.$on('link-toggle', () => {
+            this.toggleLinkToolbar();
+            this.$refs.popover.toggle();
+        });
+    },
+
+    beforeDestroy() {
+        this.bard.$off('link-toggle');
     }
-
 }
 </script>


### PR DESCRIPTION
This PR replaces #8941. In order for the user to close the popup with Esc after pressing cmd+k in Bard, I had to bind the Esc key event globally. The event wouldn't fire when the input field is focused. This shouldn't cause any problems with the other cases that use popover, unless this behavior was explicitly there for UX reasons. 