### PR TITLE
[4.x] Remove debounce when renaming assets & folders

### DIFF
--- a/resources/js/components/assets/Browser/CreateFolder.vue
+++ b/resources/js/components/assets/Browser/CreateFolder.vue
@@ -17,6 +17,7 @@
                 :instructions="__('messages.asset_folders_directory_instructions')"
                 :focus="true"
                 :required="true"
+                :config="{ debounce: false }"
                 v-model="directory"
             />
 

--- a/resources/js/components/fieldtypes/TextFieldtype.vue
+++ b/resources/js/components/fieldtypes/TextFieldtype.vue
@@ -13,7 +13,7 @@
         :placeholder="__(config.placeholder)"
         :name="name"
         :id="fieldId"
-        @input="updateDebounced"
+        @input="inputUpdated"
         @focus="$emit('focus')"
         @blur="$emit('blur')"
     />
@@ -24,7 +24,17 @@ import Fieldtype from './Fieldtype.vue';
 
 export default {
 
-    mixins: [Fieldtype]
+    mixins: [Fieldtype],
+
+    methods: {
+        inputUpdated(value) {
+            if (! this.config.debounce) {
+                return this.update(value)
+            }
+
+            this.updateDebounced(value)
+        }
+    }
 
 }
 </script>

--- a/src/Actions/RenameAsset.php
+++ b/src/Actions/RenameAsset.php
@@ -51,6 +51,7 @@ class RenameAsset extends Action
                 'classes' => 'mousetrap',
                 'focus' => true,
                 'placeholder' => $this->items->containsOneItem() ? $this->items->first()->filename() : null,
+                'debounce' => false,
             ],
         ];
     }

--- a/src/Actions/RenameAssetFolder.php
+++ b/src/Actions/RenameAssetFolder.php
@@ -46,6 +46,7 @@ class RenameAssetFolder extends Action
                 'validate' => 'required|alpha_dash',
                 'classes' => 'mousetrap',
                 'focus' => true,
+                'debounce' => false,
             ],
         ];
     }


### PR DESCRIPTION
This pull request adds a config setting to the `Text` fieldtype, removing the debounce when renaming assets & asset folders.

Fixes #8708.