### PR TITLE
[4.x] Bind `AssetContainerContents` to the service provider

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -282,7 +282,7 @@ class AssetContainer implements Arrayable, ArrayAccess, AssetContainerContract, 
     public function contents()
     {
         return Blink::once('asset-listing-cache-'.$this->handle(), function () {
-            return new AssetContainerContents($this);
+            return app(AssetContainerContents::class)->container($this);
         });
     }
 

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -16,9 +16,11 @@ class AssetContainerContents
     protected $filteredFiles;
     protected $filteredDirectories;
 
-    public function __construct($container)
+    public function container($container)
     {
         $this->container = $container;
+
+        return $this;
     }
 
     /**

--- a/src/Providers/FilesystemServiceProvider.php
+++ b/src/Providers/FilesystemServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Statamic\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Statamic\Assets\AssetContainerContents;
 use Statamic\Filesystem\FilesystemAdapter;
 
 class FilesystemServiceProvider extends ServiceProvider
@@ -11,6 +12,10 @@ class FilesystemServiceProvider extends ServiceProvider
     {
         $this->app->bind(FilesystemAdapter::class, function () {
             return new FilesystemAdapter($this->app->make('files'), base_path());
+        });
+
+        $this->app->bind(AssetContainerContents::class, function () {
+            return new AssetContainerContents();
         });
 
         $paths = [

--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -192,7 +192,7 @@ class AssetFolderTest extends TestCase
         Storage::fake('local');
 
         $container = $this->mock(AssetContainer::class);
-        $container->shouldReceive('contents')->andReturn(new AssetContainerContents($container));
+        $container->shouldReceive('contents')->andReturn((new AssetContainerContents)->container($container));
         $container->shouldReceive('disk')->andReturn(new FlysystemAdapter($disk = Storage::disk('local')));
         $container->shouldReceive('foldersCacheKey')->andReturn('irrelevant for test');
         $container->shouldReceive('handle')->andReturn('local');
@@ -216,7 +216,7 @@ class AssetFolderTest extends TestCase
         Storage::fake('local');
 
         $container = $this->mock(AssetContainer::class);
-        $container->shouldReceive('contents')->andReturn(new AssetContainerContents($container));
+        $container->shouldReceive('contents')->andReturn((new AssetContainerContents)->container($container));
         $container->shouldReceive('disk')->andReturn(new FlysystemAdapter($disk = Storage::disk('local')));
         $container->shouldReceive('foldersCacheKey')->andReturn('irrelevant for test');
         $container->shouldReceive('handle')->andReturn('local');


### PR DESCRIPTION
Can we bind `AssetContainerContents` to the service provider so it can be extended by eloquent driver?

I would like to change it to use an eloquent AssetQueryBuilder rather than a stache/cache store, which is causing some issues with large amounts of assets (60k+).