### PR TITLE
[4.x] Fix error when getting alt on bard image when asset is missing

### DIFF
--- a/src/Fieldtypes/Bard/ImageNode.php
+++ b/src/Fieldtypes/Bard/ImageNode.php
@@ -62,11 +62,11 @@ class ImageNode extends Node
 
     protected function getUrl($id)
     {
-        return optional(Asset::find($id))->url();
+        return Asset::find($id)?->url();
     }
 
     protected function getAlt($id)
     {
-        return optional(Asset::find($id))->data()->get('alt');
+        return Asset::find($id)?->data()->get('alt');
     }
 }


### PR DESCRIPTION
Fix 'Call to a member function get() on null' where Bard asset doesn't exist.

If an asset used within a Bard image node does not exist (e.g. it has been deleted from the assets panel), currently a `Call to a member function get() on null` error will be thrown when Statamic attempts to fetch the alt text.

`Optional` only provides null safety for the first method call in the chain. Using the `?->` operator instead provides the desired effect.