### PR TITLE
[4.x] Update revision values on save

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -558,6 +558,7 @@ export default {
                 .then(() => {
                     // If revisions are enabled, just emit event.
                     if (this.revisionsEnabled) {
+                        this.values = this.resetValuesFromResponse(response.data.data.values);
                         this.$nextTick(() => this.$emit('saved', response));
                         return;
                     }

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -245,6 +245,9 @@ class EntriesController extends CpController
                 ->makeWorkingCopy()
                 ->user(User::current())
                 ->save();
+
+            // catch any changes through RevisionSaving event
+            $entry = $entry->fromWorkingCopy();
         } else {
             if (! $entry->revisionsEnabled() && User::current()->can('publish', $entry)) {
                 $entry->published($request->published);


### PR DESCRIPTION
When you update an entry in the CP (without revisions) any changes made through EntrySaving are updated in the UI immediately. This currently isn't the case for revisions so this PR adds immediate UI updates for revisions.

To test you need to have a RevisionSaving event that does something similar to:

```php
    public function handle(RevisionSaving $event)
    {
        $data = $event->revision->attribute('data');
        $data['title'] = uniqid();
        $event->revision->attribute('data', $data);
    }
```

