### PR TITLE
[4.x] Antlers identifier finder

### DIFF
--- a/src/View/Antlers/Antlers.php
+++ b/src/View/Antlers/Antlers.php
@@ -4,6 +4,7 @@ namespace Statamic\View\Antlers;
 
 use Closure;
 use Statamic\Contracts\View\Antlers\Parser;
+use Statamic\View\Antlers\Language\Parser\IdentifierFinder;
 
 class Antlers
 {
@@ -42,5 +43,10 @@ class Antlers
     public function parseLoop($content, $data, $supplement = true, $context = [])
     {
         return new AntlersLoop($this->parser(), $content, $data, $supplement, $context);
+    }
+
+    public function identifiers(string $content): array
+    {
+        return (new IdentifierFinder)->getIdentifiers($content);
     }
 }

--- a/src/View/Antlers/Language/Parser/IdentifierFinder.php
+++ b/src/View/Antlers/Language/Parser/IdentifierFinder.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Statamic\View\Antlers\Language\Parser;
+
+use Illuminate\Support\Str;
+use Statamic\View\Antlers\Language\Nodes\AntlersNode;
+use Statamic\View\Antlers\Language\Nodes\Paths\PathNode;
+use Statamic\View\Antlers\Language\Nodes\Paths\VariableReference;
+use Statamic\View\Antlers\Language\Nodes\VariableNode;
+
+class IdentifierFinder
+{
+    private DocumentParser $documentParser;
+
+    public function __construct()
+    {
+        $this->documentParser = new DocumentParser;
+    }
+
+    public function getIdentifiers(string $content): array
+    {
+        $this->documentParser->resetState();
+        $this->documentParser->parse($content);
+
+        // Get nodes will return a "flat" list of nodes.
+        // This will make things a bit easier on us.
+        $antlersNodes = collect($this->documentParser->getNodes())->filter(function ($node) {
+            return $node instanceof AntlersNode && ! $node->isComment && ! ($node->isClosingTag && ! $node->isSelfClosing);
+        })->values()->all();
+
+        $identifiers = [];
+
+        foreach ($antlersNodes as $node) {
+            $identifiers = array_merge($this->processNode($node, $identifiers));
+        }
+
+        return collect($identifiers)->filter(function ($identifier) {
+            // Quick and dirty check to see if we care about this identifier.
+            return ! Str::contains($identifier, ['.', ':', '[', ']', '(', ')', '{', '}']);
+        })->unique()->values()->all();
+    }
+
+    protected function processVarReference(AntlersNode $node, VariableReference $reference, array $identifiers): array
+    {
+        foreach ($reference->pathParts as $part) {
+            if ($part instanceof PathNode) {
+                if (! array_key_exists($part->name, $node->interpolationRegions)) {
+                    $identifiers[] = $part->name;
+                }
+            } elseif ($part instanceof VariableReference) {
+                $identifiers = array_merge($this->processVarReference($node, $part, $identifiers));
+            }
+        }
+
+        return $identifiers;
+    }
+
+    protected function processNode(AntlersNode $node, array $identifiers): array
+    {
+        if ($node->name != null) {
+            $identifiers[] = $node->name->name;
+
+            if ($node->name->methodPart && ! Str::contains($node->name->methodPart, ':')) {
+                $identifiers[] = $node->name->methodPart;
+            }
+
+            if ($node->pathReference != null) {
+                $identifiers = array_merge($this->processVarReference($node, $node->pathReference, $identifiers));
+            }
+
+            if (! empty($node->processedInterpolationRegions)) {
+                foreach ($node->processedInterpolationRegions as $region) {
+                    if (count($region) == 0 || ! $region[0] instanceof AntlersNode) {
+                        continue;
+                    }
+
+                    $identifiers = array_merge($this->processNode($region[0], $identifiers));
+                }
+            }
+
+            if ($node->hasParameters) {
+                foreach ($node->parameters as $parameter) {
+                    if ($parameter->isVariableReference) {
+                        $identifiers[] = $parameter->value;
+                    }
+                }
+            } else {
+                if (! empty($node->runtimeNodes)) {
+                    foreach ($node->runtimeNodes as $runtimeNode) {
+                        if (! $runtimeNode instanceof VariableNode) {
+                            continue;
+                        }
+
+                        if ($runtimeNode->variableReference == null) {
+                            $identifiers[] = $runtimeNode->name;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $identifiers;
+    }
+}

--- a/tests/Antlers/Parser/IdentifierFinderTest.php
+++ b/tests/Antlers/Parser/IdentifierFinderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Antlers\Parser;
+
+use Statamic\View\Antlers\Language\Parser\IdentifierFinder;
+use Tests\Antlers\ParserTestCase;
+
+class IdentifierFinderTest extends ParserTestCase
+{
+    /** @test */
+    public function it_finds_identifiers()
+    {
+        $template = <<<'EOT'
+{{ foo }}
+{{ bar:baz }}
+{{ collection:blog :limit="the_limit" alfa="bravo" charlie="{delta} {echo}" }}
+  {{ title }}
+{{ /collection:blog }}
+EOT;
+        $this->assertEquals([
+            'foo',
+            'bar',
+            'baz',
+            'collection',
+            'blog',
+            'delta',
+            'echo',
+            'the_limit',
+            'title',
+        ], (new IdentifierFinder)->getIdentifiers($template));
+    }
+}


### PR DESCRIPTION
This PR adds an identifier finder utility which allows you to extract any potential variable usage within a template.

For example, in this template:

```antlers
{{ collection:articles :limit="the_limit" title:is="{foo} {bar}" }}
  <a href="{{ url }}">{{ title }}</a>
{{ /collection:articles }}
```
```php
Antlers::identifiers($template);
// [collection, articles, the_limit, foo, bar, url, title]
```

A use case for this could be in the `nav` tag where we allow you to select specific fields for performance that you need in your template:

```antlers
{{ nav select="url|title" }}
  <a href="{{ url }}">{{ title }}</a>
{{ /nav }}
```

We could potentially leverage the `identifiers` to automatically select fields rather than you having to manually specify them.