### PR TITLE
[4.x] Don't require current password when changing another user's password

### DIFF
--- a/resources/js/components/users/ChangePassword.vue
+++ b/resources/js/components/users/ChangePassword.vue
@@ -11,7 +11,7 @@
         <div class="publish-fields p-4 pb-0 w-96">
             <form-group
                 handle="password"
-                :display="__('Current Password')"
+                :display="__('Your Password')"
                 v-model="currentPassword"
                 :errors="errors.current_password"
                 class="p-0 mb-6"

--- a/resources/js/components/users/ChangePassword.vue
+++ b/resources/js/components/users/ChangePassword.vue
@@ -10,6 +10,7 @@
         </div>
         <div class="publish-fields p-4 pb-0 w-96">
             <form-group
+                v-if="requiresCurrentPassword"
                 handle="password"
                 :display="__('Your Password')"
                 v-model="currentPassword"
@@ -49,6 +50,7 @@ export default {
 
     props: {
         saveUrl: String,
+        requiresCurrentPassword: Boolean,
     },
 
     data() {

--- a/resources/js/components/users/ChangePassword.vue
+++ b/resources/js/components/users/ChangePassword.vue
@@ -12,7 +12,7 @@
             <form-group
                 v-if="requiresCurrentPassword"
                 handle="password"
-                :display="__('Your Password')"
+                :display="__('Current Password')"
                 v-model="currentPassword"
                 :errors="errors.current_password"
                 class="p-0 mb-6"

--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -13,6 +13,7 @@
                     <change-password
                         v-if="canEditPassword"
                         :save-url="actions.password"
+                        :requires-current-password="requiresCurrentPassword"
                         class="mr-4"
                     />
 
@@ -75,7 +76,8 @@ export default {
         actions: Object,
         method: String,
         canEditPassword: Boolean,
-        canEditBlueprint: Boolean
+        canEditBlueprint: Boolean,
+        requiresCurrentPassword: Boolean,
     },
 
     data() {

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -14,6 +14,7 @@
         :initial-meta="{{ json_encode($meta) }}"
         :can-edit-password="{{ Statamic\Support\Str::bool($canEditPassword) }}"
         :can-edit-blueprint="{{ Statamic\Support\Str::bool($user->can('configure fields')) }}"
+        :requires-current-password="{{ Statamic\Support\Str::bool($requiresCurrentPassword) }}"
     ></user-publish-form>
 
 @endsection

--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -16,10 +16,15 @@ class PasswordController extends CpController
 
         $this->authorize('editPassword', $user);
 
-        $request->validate([
-            'current_password' => ['required', 'current_password'],
+        $rules = [
             'password' => ['required', 'confirmed', Password::default()],
-        ]);
+        ];
+
+        if ($request->user()->id === $user) {
+            $rules['current_password'] = ['required', 'current_password'];
+        }
+
+        $request->validate($rules);
 
         $user->password($request->password)->save();
 

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -233,6 +233,7 @@ class UsersController extends CpController
                 'editBlueprint' => cp_route('users.blueprint.edit'),
             ],
             'canEditPassword' => User::fromUser($request->user())->can('editPassword', $user),
+            'requiresCurrentPassword' => $request->user()->id === $user->id(),
         ];
 
         if ($request->wantsJson()) {


### PR DESCRIPTION
This pull request hides the "Current Password" field when changing another user's password. The field will still be shown when users reset their own passwords. 

Closes #7395.
Regression from #7287.