### PR TITLE
[4.x] Front-end form asset field php file validation

### DIFF
--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -177,7 +177,11 @@ class FormController extends Controller
                 return $field->fieldtype()->handle() === 'assets';
             })
             ->mapWithKeys(function ($field) {
-                return [$field->handle().'.*' => 'file'];
+                return [$field->handle().'.*' => ['file', function ($attribute, $value, $fail) {
+                    if (in_array(trim(strtolower($value->getClientOriginalExtension())), ['php', 'php3', 'php4', 'php5', 'phtml'])) {
+                        $fail(__('validation.uploaded'));
+                    }
+                }]];
             })
             ->all();
 


### PR DESCRIPTION
Prevents php files being uploaded through asset fields on front-end forms the same way as it works in the control panel.
