### PR TITLE
[4.x] Add global attribute support to bard's small mark

### DIFF
--- a/resources/js/components/fieldtypes/bard/Small.js
+++ b/resources/js/components/fieldtypes/bard/Small.js
@@ -1,8 +1,14 @@
-import { Mark } from '@tiptap/core';
+import { Mark, mergeAttributes } from '@tiptap/core';
 
 export const Small = Mark.create({
 
     name: 'small',
+
+    addOptions() {
+        return {
+            HTMLAttributes: {},
+        }
+    },
 
     parseHTML() {
         return [
@@ -12,8 +18,8 @@ export const Small = Mark.create({
         ]
     },
 
-    renderHTML() {
-        return ['small', 0]
+    renderHTML({ HTMLAttributes }) {
+        return ['small', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes), 0]
     },
 
     addCommands() {

--- a/src/Fieldtypes/Bard/Marks/Small.php
+++ b/src/Fieldtypes/Bard/Marks/Small.php
@@ -3,10 +3,18 @@
 namespace Statamic\Fieldtypes\Bard\Marks;
 
 use Tiptap\Core\Mark;
+use Tiptap\Utils\HTML;
 
 class Small extends Mark
 {
     public static $name = 'small';
+
+    public function addOptions()
+    {
+        return [
+            'HTMLAttributes' => [],
+        ];
+    }
 
     public function parseHTML()
     {
@@ -17,8 +25,12 @@ class Small extends Mark
         ];
     }
 
-    public function renderHTML($mark)
+    public function renderHTML($mark, $HTMLAttributes = [])
     {
-        return ['small', 0];
+        return [
+            'small',
+            HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes),
+            0,
+        ];
     }
 }


### PR DESCRIPTION
Tiptap allows you to apply attributes to nodes/marks globally, which all the default extensions support.

This PR adds the same support to bard's `small` mark.