### PR TITLE
[4.x] Fix impersonation redirect

### DIFF
--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -65,6 +65,6 @@ class Impersonate extends Action
             return $url;
         }
 
-        return $users->first()->can('access cp') ? cp_route('dashboard') : '/';
+        return $users->first()->can('access cp') ? cp_route('index') : '/';
     }
 }


### PR DESCRIPTION
Closes #8970

When you impersonate, it would redirect to the control panel dashboard.

If the user's start page isn't the dashboard it might be a bit confusing, especially if they've made the conscious decision to hide the dashboard.

This PR will redirect to the control panel index, which redirects to the appropriate start page.
