### PR TITLE
[4.x] Add 'Hide Display Label' option to fields

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -93,6 +93,7 @@ return [
     'fields_instructions_position_instructions' => 'Show instructions above or below the field.',
     'fields_listable_instructions' => 'Control the listing column visibility.',
     'fields_visibility_instructions' => 'Control field visibility on publish forms.',
+    'fields_hide_display_instructions' => 'Control whether the field\'s display label is shown',
     'fields_replicator_preview_instructions' => 'Control preview visibility in Replicator/Bard sets.',
     'fieldset_import_fieldset_instructions' => 'The fieldset to be imported.',
     'fieldset_import_prefix_instructions' => 'The prefix that should be applied to each field when they are imported. eg. hero_',

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -29,9 +29,7 @@ class FieldsController extends CpController
 
         $fieldtype = FieldtypeRepository::find($request->type);
 
-        $blueprint = $this
-            ->blueprint($fieldtype->configBlueprint())
-            ->ensureField('hide_display', ['type' => 'toggle', 'visibility' => 'hidden']);
+        $blueprint = $this->blueprint($fieldtype->configBlueprint());
 
         $fields = $blueprint
             ->fields()
@@ -146,6 +144,12 @@ class FieldsController extends CpController
                 ],
                 'default' => 'visible',
                 'type' => 'select',
+            ],
+            'hide_display' => [
+                'display' => __('Hide Display Label'),
+                'instructions' => __('statamic::messages.fields_hide_display_instructions'),
+                'type' => 'toggle',
+                'default' => false,
             ],
             'replicator_preview' => [
                 'display' => __('Preview'),


### PR DESCRIPTION
This pull request adds a new 'Hide Display Label' option to fields in the blueprint/fieldset builder. When enabled, the display label for a field will be hidden. 

The `hide_display` option already existed so just added a visible option for it in the builder. The only nuance of this setting is there will still be a "row" for the label if the field is required / is read only / is locked / etc as we use that space in those features. 

Closes statamic/ideas#555.
Partially addresses statamic/ideas#262.