### PR TITLE
[4.x] Fix super not saving on eloquent users

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -243,9 +243,7 @@ class User extends BaseUser
 
     public function saveToDatabase()
     {
-        $model = $this->model();
-        $model->super = $this->super ?? false;
-        $model->save();
+        $model = $this->model()->save();
 
         $this->saveRoles();
 
@@ -358,6 +356,10 @@ class User extends BaseUser
     {
         if ($key === 'timestamps') {
             return $this->model()->timestamps = $value;
+        }
+
+        if ($key === 'super') {
+            return $this->model()->super = $value;
         }
 
         return $this->$key = $value;

--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -243,7 +243,9 @@ class User extends BaseUser
 
     public function saveToDatabase()
     {
-        $this->model()->save();
+        $model = $this->model();
+        $model->super = $this->super ?? false;
+        $model->save();
 
         $this->saveRoles();
 

--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -243,7 +243,7 @@ class User extends BaseUser
 
     public function saveToDatabase()
     {
-        $model = $this->model()->save();
+        $this->model()->save();
 
         $this->saveRoles();
 

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -139,4 +139,24 @@ class EloquentUserTest extends TestCase
 
         $this->assertFalse($user->timestamps);
     }
+
+    /** @test */
+    public function it_gets_super_correctly_on_the_model()
+    {
+        $user = $this->makeUser();
+
+        $this->assertNull($user->super);
+
+        $user->super = true;
+        $user->save();
+
+        $this->assertTrue($user->super);
+        $this->assertTrue($user->model()->super);
+
+        $user->super = false;
+        $user->save();
+
+        $this->assertFalse($user->super);
+        $this->assertFalse($user->model()->super);
+    }
 }


### PR DESCRIPTION
As [reported here](https://github.com/statamic/cms/issues/8978), adding super to an existing eloquent user would not save/persist.

This PR fixes that by setting it explicitly on saveToDatabase() and adds test coverage to ensure it works going forward.

Closes https://github.com/statamic/cms/issues/8978