### PR TITLE
[4.x] Auto-populate Array Fieldtype Options

### DIFF
--- a/resources/js/components/fieldtypes/ArrayFieldtype.vue
+++ b/resources/js/components/fieldtypes/ArrayFieldtype.vue
@@ -117,18 +117,9 @@ export default {
     watch: {
         data: {
             deep: true,
-            handler: _.debounce(function (data) {
-                // data = data.map(element => {
-                //     if (element.key !== null && element.value === null) {
-                //         element.value = element.key;
-                //     }
-
-                //     return element;
-                // })
-
-                this.update(this.sortableToObject(data));
-            }, 150),
-        },
+            handler (data) {
+                this.updateDebounced(this.sortableToObject(data));
+            }
 
         value(value) {
             if (JSON.stringify(value) == JSON.stringify(this.sortableToObject(this.data))) return;

--- a/resources/js/components/fieldtypes/ArrayFieldtype.vue
+++ b/resources/js/components/fieldtypes/ArrayFieldtype.vue
@@ -120,6 +120,7 @@ export default {
             handler (data) {
                 this.updateDebounced(this.sortableToObject(data));
             }
+        },
 
         value(value) {
             if (JSON.stringify(value) == JSON.stringify(this.sortableToObject(this.data))) return;

--- a/resources/js/components/fieldtypes/ArrayFieldtype.vue
+++ b/resources/js/components/fieldtypes/ArrayFieldtype.vue
@@ -61,7 +61,7 @@
                             <tr class="sortable-row" v-for="(element, index) in data" :key="element._id">
                                 <td class="sortable-handle table-drag-handle" v-if="!isReadOnly"></td>
                                 <td>
-                                    <input type="text" class="input-text font-bold" v-model="element.key" :readonly="isReadOnly" />
+                                    <input type="text" class="input-text font-bold" v-model="element.key" :readonly="isReadOnly" @blur="keyUpdated(element)" />
                                 </td>
                                 <td>
                                     <input type="text" class="input-text" v-model="element.value" :readonly="isReadOnly" />
@@ -117,9 +117,17 @@ export default {
     watch: {
         data: {
             deep: true,
-            handler (data) {
-                this.updateDebounced(this.sortableToObject(data));
-            }
+            handler: _.debounce(function (data) {
+                // data = data.map(element => {
+                //     if (element.key !== null && element.value === null) {
+                //         element.value = element.key;
+                //     }
+
+                //     return element;
+                // })
+
+                this.update(this.sortableToObject(data));
+            }, 150),
         },
 
         value(value) {
@@ -210,7 +218,21 @@ export default {
 
         setKey(key) {
             this.selectedKey = key
-        }
+        },
+
+        keyUpdated(element) {
+            if (element.key === null || element.value !== null) {
+                return null;
+            }
+
+            let value = element.key.charAt(0).toUpperCase() + element.key.slice(1);
+
+            this.data.find((item, index) => {
+                if (item._id === element._id) {
+                    this.data[index].value = value;
+                }
+            })
+        },
     }
 
 }


### PR DESCRIPTION
This pull request introduces a small improvement to the Array Fieldtype. It'll automatically populate the options values in the Array Fieldtype after entering the option key. 

This is useful when you're adding the keys for options in a Select fieldtype and the labels/values will pretty much be the same as the key, just with a capitalised initial character.

![CleanShot 2023-11-13 at 11 57 20](https://github.com/statamic/cms/assets/19637309/b5913385-6a29-4288-8b51-722b2f1b86db)

Closes statamic/ideas#1075.