### PR TITLE
[4.x] Fix Asset browser firing 2 requests on initial Assets page load

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -451,6 +451,7 @@ export default {
         },
 
         container(container) {
+            this.initializing = true;
             this.preferencesPrefix = `assets.${container.id}`;
             this.mode = this.getPreference('mode') || 'table';
             this.setInitialPerPage();
@@ -462,7 +463,7 @@ export default {
         },
 
         parameters(after, before) {
-            if (JSON.stringify(before) === JSON.stringify(after)) return;
+            if (this.initializing || JSON.stringify(before) === JSON.stringify(after)) return;
             this.loadAssets();
         },
 


### PR DESCRIPTION
Hey everyone,

Our users noticed weird behavior in the asset browser.

Basically what happened is when they had a `per-page` preference enabled for assets, the assets browser would trigger 2 network requests on the initial load.

Paired with an average internet and a lot of assets resulted in the following:

1. Opening the asset browser by clicking on Assets in the navigation
2. Asset browser would trigger 2 requests with parameter (perPage=500)
3. Our user would open a folder
4. Then a second request, that has been queued would finish, and our user would be returned to the first page


Steps to replicate:

1. Open assets browser
2. Try to search for something
3. Scroll to the bottom of the search results and set the `per-page` preference to different than the default
4. Open assets browser again
5. You will see there are 2 requests triggered, one pending and one being processed
![image](https://github.com/statamic/cms/assets/31577031/2356675f-4622-497f-8e30-b3598ccd50cf)


This happens because of the `parameters` watcher inside the `resources/js/components/assets/Browser/Browser.vue`.
Container watcher calls the `this.setInitialPerPage();` and then, a line after it calls `this.loadAssets();`. The `this.setInitialPerPage();` triggers a watcher that also calls `this.loadAssets();` inside.

So, what I did is used the `initializing` and by resetting it in a container watcher, I'm able to decide on whether I should call `this.loadAssets();` inside the parameters watcher. The `loadAssets();` method resets the `initializing` parameter, after we call `setInitialPerPage()` .