### PR TITLE
[4.x] Update vite.config.js to allow deploying statamic with url-prefix

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, process.cwd(), '');
 
     return {
-        base: '/vendor/statamic/cp/build',
+        base: './',
         plugins: [
             laravel({
                 valetTls: env.VALET_TLS,


### PR DESCRIPTION
As [reported here](https://github.com/statamic/cms/issues/8773), it is currently not possible, to deploy a statamic cms application with a url-prefix (e.g. https://my-domain.example/my-application instead of https://my-application.example).

This PR fixes that by setting a relativ path in the vite config, that is used to bundle the frontend.

Closes #8773