### PR TITLE
[4.x] Hide export submissions button when there are no valid exporters

### DIFF
--- a/resources/views/forms/show.blade.php
+++ b/resources/views/forms/show.blade.php
@@ -30,7 +30,7 @@
                 @endcan
             </dropdown-list>
 
-            @if (($exporters = $form->exporters()) && $exporters->count())
+            @if (($exporters = $form->exporters()) && $exporters->isNotEmpty())
             <dropdown-list>
                 <button class="btn" slot="trigger">{{ __('Export Submissions') }}</button>
                 @foreach ($exporters as $exporter)

--- a/resources/views/forms/show.blade.php
+++ b/resources/views/forms/show.blade.php
@@ -30,7 +30,7 @@
                 @endcan
             </dropdown-list>
 
-            @if ($exporters = $form->exporters())
+            @if (($exporters = $form->exporters()) && $exporters->count())
             <dropdown-list>
                 <button class="btn" slot="trigger">{{ __('Export Submissions') }}</button>
                 @foreach ($exporters as $exporter)


### PR DESCRIPTION
If there are no valid form exporters the hide submissions button shouldn't display. For example if you have an empty array in `statamic.forms.exporters`

This PR adds a check in the template to ensure the exporters collection is not empty.