### PR TITLE
[4.x] Only namespace asset validation attributes when on a CP route

### DIFF
--- a/src/Fieldtypes/Assets/DimensionsRule.php
+++ b/src/Fieldtypes/Assets/DimensionsRule.php
@@ -4,6 +4,7 @@ namespace Statamic\Fieldtypes\Assets;
 
 use Illuminate\Contracts\Validation\Rule;
 use Statamic\Facades\Asset;
+use Statamic\Statamic;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class DimensionsRule implements Rule
@@ -63,7 +64,7 @@ class DimensionsRule implements Rule
      */
     public function message()
     {
-        return __('statamic::validation.dimensions');
+        return __((Statamic::isCpRoute() ? 'statamic::' : '').'validation.dimensions');
     }
 
     /**

--- a/src/Fieldtypes/Assets/ImageRule.php
+++ b/src/Fieldtypes/Assets/ImageRule.php
@@ -4,6 +4,7 @@ namespace Statamic\Fieldtypes\Assets;
 
 use Illuminate\Contracts\Validation\Rule;
 use Statamic\Facades\Asset;
+use Statamic\Statamic;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class ImageRule implements Rule
@@ -46,6 +47,6 @@ class ImageRule implements Rule
      */
     public function message()
     {
-        return __('statamic::validation.image');
+        return __((Statamic::isCpRoute() ? 'statamic::' : '').'validation.image');
     }
 }

--- a/src/Fieldtypes/Assets/MaxRule.php
+++ b/src/Fieldtypes/Assets/MaxRule.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Fieldtypes\Assets;
 
+use Statamic\Statamic;
+
 class MaxRule extends SizeBasedRule
 {
     /**
@@ -22,6 +24,6 @@ class MaxRule extends SizeBasedRule
      */
     public function message()
     {
-        return str_replace(':max', $this->parameters[0], __('statamic::validation.max.file'));
+        return str_replace(':max', $this->parameters[0], __((Statamic::isCpRoute() ? 'statamic::' : '').'validation.max.file'));
     }
 }

--- a/src/Fieldtypes/Assets/MimesRule.php
+++ b/src/Fieldtypes/Assets/MimesRule.php
@@ -4,6 +4,7 @@ namespace Statamic\Fieldtypes\Assets;
 
 use Illuminate\Contracts\Validation\Rule;
 use Statamic\Facades\Asset;
+use Statamic\Statamic;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class MimesRule implements Rule
@@ -48,6 +49,6 @@ class MimesRule implements Rule
      */
     public function message()
     {
-        return str_replace(':values', implode(', ', $this->parameters), __('statamic::validation.mimes'));
+        return str_replace(':values', implode(', ', $this->parameters), __((Statamic::isCpRoute() ? 'statamic::' : '').'validation.mimes'));
     }
 }

--- a/src/Fieldtypes/Assets/MimetypesRule.php
+++ b/src/Fieldtypes/Assets/MimetypesRule.php
@@ -4,6 +4,7 @@ namespace Statamic\Fieldtypes\Assets;
 
 use Illuminate\Contracts\Validation\Rule;
 use Statamic\Facades\Asset;
+use Statamic\Statamic;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class MimetypesRule implements Rule
@@ -43,6 +44,6 @@ class MimetypesRule implements Rule
      */
     public function message()
     {
-        return str_replace(':values', implode(', ', $this->parameters), __('statamic::validation.mimetypes'));
+        return str_replace(':values', implode(', ', $this->parameters), __((Statamic::isCpRoute() ? 'statamic::' : '').'validation.mimetypes'));
     }
 }

--- a/src/Fieldtypes/Assets/MinRule.php
+++ b/src/Fieldtypes/Assets/MinRule.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Fieldtypes\Assets;
 
+use Statamic\Statamic;
+
 class MinRule extends SizeBasedRule
 {
     /**
@@ -22,6 +24,6 @@ class MinRule extends SizeBasedRule
      */
     public function message()
     {
-        return str_replace(':min', $this->parameters[0], __('statamic::validation.min.file'));
+        return str_replace(':min', $this->parameters[0], __((Statamic::isCpRoute() ? 'statamic::' : '').'validation.min.file'));
     }
 }

--- a/tests/Fieldtypes/AssetsTest.php
+++ b/tests/Fieldtypes/AssetsTest.php
@@ -106,6 +106,8 @@ class AssetsTest extends TestCase
     /** @test */
     public function it_replaces_dimensions_rule()
     {
+        config()->set('statamic.cp.route', '/');
+
         $replaced = $this->fieldtype(['validate' => ['dimensions:width=180,height=180']])->fieldRules();
 
         $this->assertIsArray($replaced);
@@ -117,6 +119,8 @@ class AssetsTest extends TestCase
     /** @test */
     public function it_replaces_image_rule()
     {
+        config()->set('statamic.cp.route', '/');
+
         $replaced = $this->fieldtype(['validate' => ['image']])->fieldRules();
 
         $this->assertIsArray($replaced);
@@ -128,6 +132,8 @@ class AssetsTest extends TestCase
     /** @test */
     public function it_replaces_mimes_rule()
     {
+        config()->set('statamic.cp.route', '/');
+
         $replaced = $this->fieldtype(['validate' => ['mimes:jpg,png']])->fieldRules();
 
         $this->assertIsArray($replaced);
@@ -139,6 +145,8 @@ class AssetsTest extends TestCase
     /** @test */
     public function it_replaces_mimestypes_rule()
     {
+        config()->set('statamic.cp.route', '/');
+
         $replaced = $this->fieldtype(['validate' => ['mimetypes:image/jpg,image/png']])->fieldRules();
 
         $this->assertIsArray($replaced);
@@ -150,6 +158,8 @@ class AssetsTest extends TestCase
     /** @test */
     public function it_replaces_min_filesize_rule()
     {
+        config()->set('statamic.cp.route', '/');
+
         $replaced = $this->fieldtype(['validate' => ['min_filesize:100']])->fieldRules();
 
         $this->assertIsArray($replaced);
@@ -161,6 +171,8 @@ class AssetsTest extends TestCase
     /** @test */
     public function it_replaces_max_filesize_rule()
     {
+        config()->set('statamic.cp.route', '/');
+
         $replaced = $this->fieldtype(['validate' => ['max_filesize:100']])->fieldRules();
 
         $this->assertIsArray($replaced);
@@ -172,6 +184,8 @@ class AssetsTest extends TestCase
     /** @test */
     public function it_doesnt_replace_non_image_related_rule()
     {
+        config()->set('statamic.cp.route', '/');
+
         $replaced = $this->fieldtype(['validate' => ['file']])->fieldRules();
 
         $this->assertIsArray($replaced);


### PR DESCRIPTION
The custom asset validation rules are using statamic translations strings which makes sense inside the CP. But when outside the CP (eg a front end form) you may want to override them so they should look for the default lang validation strings.

Closes https://github.com/statamic/cms/issues/6254