### PR TITLE
[4.x] Add `children` tag

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -150,6 +150,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Tags\Assets::class,
         Tags\Cache::class,
         Tags\Can::class,
+        Tags\Children::class,
         Tags\Collection\Collection::class,
         Tags\Cookie::class,
         Tags\Dd::class,

--- a/src/Tags/Children.php
+++ b/src/Tags/Children.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Statamic\Tags;
+
+use Statamic\Facades\Entry;
+use Statamic\Facades\Site;
+use Statamic\Facades\URL;
+use Statamic\Support\Str;
+
+class Children extends Structure
+{
+    /**
+     * The {{ children }} tag.
+     *
+     * Get any children of the current url
+     *
+     * @return string
+     */
+    public function index()
+    {
+        if (! $this->params->get('from')) {
+            $this->params->put('from', Str::start(Str::after(URL::getCurrent(), Site::current()->url()), '/'));
+        }
+
+        return $this->structure($this->params->get('handle', 'collection::pages'));
+    }
+}

--- a/src/Tags/Children.php
+++ b/src/Tags/Children.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Tags;
 
-use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Support\Str;

--- a/src/Tags/Children.php
+++ b/src/Tags/Children.php
@@ -18,9 +18,8 @@ class Children extends Structure
      */
     public function index()
     {
-        if (! $this->params->get('from')) {
-            $this->params->put('from', Str::start(Str::after(URL::getCurrent(), Site::current()->url()), '/'));
-        }
+        $this->params->put('from', Str::start(Str::after(URL::getCurrent(), Site::current()->url()), '/'));
+        $this->params->put('max_depth', 1);
 
         return $this->structure($this->params->get('handle', 'collection::pages'));
     }

--- a/tests/Tags/ChildrenTest.php
+++ b/tests/Tags/ChildrenTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Tags;
 
 use Facades\Tests\Factories\EntryFactory;
+use Mockery;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Parse;
 use Statamic\Facades\Site;
+use Statamic\Tags\Children;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -80,4 +82,19 @@ class ChildrenTest extends TestCase
 
         $this->assertEquals('the french bar entry', $this->tag('{{ children }}{{ title }}{{ /children }}'));
     }
+
+    /** @test */
+    public function it_doesnt_affect_children_in_nav()
+    {
+        $this->setUpEntries();
+
+        $mock = Mockery::mock(Children::class);
+        $mock->shouldNotReceive('index');
+
+        $this->get('/foo');
+
+        $this->assertEquals('the bar entry', $this->tag('{{ nav }}{{ children }}{{ title }}{{ /children }}{{ /nav }}'));
+
+    }
+
 }

--- a/tests/Tags/ChildrenTest.php
+++ b/tests/Tags/ChildrenTest.php
@@ -96,5 +96,4 @@ class ChildrenTest extends TestCase
         $this->assertEquals('the bar entry', $this->tag('{{ nav }}{{ children }}{{ title }}{{ /children }}{{ /nav }}'));
 
     }
-
 }

--- a/tests/Tags/ChildrenTest.php
+++ b/tests/Tags/ChildrenTest.php
@@ -50,13 +50,13 @@ class ChildrenTest extends TestCase
 
         $collection->structure()->in('en')->tree([
             ['entry' => 'foo', 'url' => '/foo', 'children' => [
-                ['entry' => 'bar', 'url' => '/foo/bar',],
+                ['entry' => 'bar', 'url' => '/foo/bar'],
             ]],
         ])->save();
 
         $collection->structure()->in('fr')->tree([
             ['entry' => 'fr-foo', 'url' => '/fr-foo', 'children' => [
-                ['entry' => 'fr-bar', 'url' => '/fr-foo/fr-bar',],
+                ['entry' => 'fr-bar', 'url' => '/fr-foo/fr-bar'],
             ]],
         ])->save();
     }

--- a/tests/Tags/ChildrenTest.php
+++ b/tests/Tags/ChildrenTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Tags;
+
+use Facades\Tests\Factories\EntryFactory;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Parse;
+use Statamic\Facades\Site;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ChildrenTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Site::setConfig(['sites' => [
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR'],
+        ]]);
+    }
+
+    private function tag($tag, $data = [])
+    {
+        return (string) Parse::template($tag, $data);
+    }
+
+    private function setUpEntries()
+    {
+        $collection = tap(Collection::make('pages')->sites(['en', 'fr'])->routes('{slug}')->structureContents(['root' => false]))->save();
+
+        EntryFactory::collection('pages')->id('foo')->data([
+            'title' => 'the foo entry',
+        ])->create();
+
+        EntryFactory::collection('pages')->id('bar')->data([
+            'title' => 'the bar entry',
+        ])->create();
+
+        EntryFactory::collection('pages')->id('fr-foo')->origin('foo')->locale('fr')->data([
+            'title' => 'the french foo entry',
+        ])->create();
+
+        EntryFactory::collection('pages')->id('fr-bar')->origin('foo')->locale('fr')->data([
+            'title' => 'the french bar entry',
+        ])->create();
+
+        $collection->structure()->in('en')->tree([
+            ['entry' => 'foo', 'url' => '/foo', 'children' => [
+                ['entry' => 'bar', 'url' => '/foo/bar',],
+            ]],
+        ])->save();
+
+        $collection->structure()->in('fr')->tree([
+            ['entry' => 'fr-foo', 'url' => '/fr-foo', 'children' => [
+                ['entry' => 'fr-bar', 'url' => '/fr-foo/fr-bar',],
+            ]],
+        ])->save();
+    }
+
+    /** @test */
+    public function it_gets_children_data()
+    {
+        $this->setUpEntries();
+
+        $this->get('/foo');
+
+        $this->assertEquals('the bar entry', $this->tag('{{ children }}{{ title }}{{ /children }}'));
+    }
+
+    /** @test */
+    public function it_gets_children_data_when_in_another_site()
+    {
+        $this->setUpEntries();
+
+        $this->get('/fr/fr-foo');
+
+        $this->assertEquals('the french bar entry', $this->tag('{{ children }}{{ title }}{{ /children }}'));
+    }
+}

--- a/tests/Tags/ChildrenTest.php
+++ b/tests/Tags/ChildrenTest.php
@@ -91,6 +91,8 @@ class ChildrenTest extends TestCase
         $mock = Mockery::mock(Children::class);
         $mock->shouldNotReceive('index');
 
+        $this->app['statamic.tags']['children'] = $mock;
+
         $this->get('/foo');
 
         $this->assertEquals('the bar entry', $this->tag('{{ nav }}{{ children }}{{ title }}{{ /children }}{{ /nav }}'));


### PR DESCRIPTION
Sometimes you want to get and loop over the children of the current page, for example to show an inline sub-nav. You can do this with the right combination of params on the `{{ nav }}` tag but given there is a `{{ parent }}` tag, people might expect an equivalent `{{ children }}` tag.

Closes https://github.com/statamic/cms/issues/5567