### PR TITLE
[4.x] Adding a fieldset with the same name should throw an error

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -237,7 +237,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::post('edit', [FieldsController::class, 'edit'])->name('fields.edit');
         Route::post('update', [FieldsController::class, 'update'])->name('fields.update');
         Route::get('field-meta', [MetaController::class, 'show']);
-        Route::resource('fieldsets', FieldsetController::class);
+        Route::resource('fieldsets', FieldsetController::class)->except(['show']);
         Route::get('blueprints', [BlueprintController::class, 'index'])->name('blueprints.index');
         Route::get('fieldtypes', [FieldtypesController::class, 'index']);
     });

--- a/src/Http/Controllers/CP/Fields/FieldsetController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsetController.php
@@ -92,7 +92,13 @@ class FieldsetController extends CpController
         ]);
 
         if (Facades\Fieldset::find($request->handle)) {
-            return back()->withInput()->with('error', __('A fieldset with that name already exists.'));
+            $error = __('A fieldset with that name already exists.');
+
+            if ($request->wantsJson()) {
+                throw new \Exception($error);
+            }
+
+            return back()->withInput()->with('error', $error);
         }
 
         $fieldset = (new Fieldset)


### PR DESCRIPTION
As [reported here](https://github.com/statamic/cms/issues/6826) adding a fieldset with a name already used redirected to a page that doesn't exist.

This PR fixes it by:
1. Preventing calls to the controller show method
2. Throwing an ajax error which the fieldset create page expects

Closes #6826