### PR TITLE
[4.x] Check if a globalset exists before adding one with the same handle

### DIFF
--- a/src/Http/Controllers/CP/Globals/GlobalsController.php
+++ b/src/Http/Controllers/CP/Globals/GlobalsController.php
@@ -149,6 +149,16 @@ class GlobalsController extends CpController
 
         $handle = $data['handle'] ?? Str::snake($data['title']);
 
+        if (GlobalSet::find($handle)) {
+            $error = __('A Global Set with that handle already exists.');
+
+            if ($request->wantsJson()) {
+                throw new \Exception($error);
+            }
+
+            return back()->withInput()->with('error', $error);
+        }
+
         $global = GlobalSet::make($handle)->title($data['title']);
 
         $global->addLocalization($global->makeLocalization(Site::default()->handle()));

--- a/src/Http/Controllers/CP/Navigation/NavigationController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationController.php
@@ -150,6 +150,16 @@ class NavigationController extends CpController
             'handle' => 'required|alpha_dash',
         ]);
 
+        if (Nav::find($values['handle'])) {
+            $error = __('A navigation with that handle already exists.');
+
+            if ($request->wantsJson()) {
+                throw new \Exception($error);
+            }
+
+            return back()->withInput()->with('error', $error);
+        }
+
         $structure = Nav::make()
             ->title($values['title'])
             ->handle($values['handle']);

--- a/src/Http/Controllers/CP/Navigation/NavigationController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationController.php
@@ -150,16 +150,6 @@ class NavigationController extends CpController
             'handle' => 'required|alpha_dash',
         ]);
 
-        if (Nav::find($values['handle'])) {
-            $error = __('A navigation with that handle already exists.');
-
-            if ($request->wantsJson()) {
-                throw new \Exception($error);
-            }
-
-            return back()->withInput()->with('error', $error);
-        }
-
         $structure = Nav::make()
             ->title($values['title'])
             ->handle($values['handle']);


### PR DESCRIPTION
As [reported here](https://github.com/statamic/cms/issues/6826#issuecomment-1278088661), adding a globalset with the same handle overwrites the existing one. Thats not good.

This PR prevents that by checking if the handle already exists and throws an error if it does.