### PR TITLE
[4.x] Show error when there is a duplicate taxonomy blueprint name

### DIFF
--- a/resources/views/taxonomies/blueprints/create.blade.php
+++ b/resources/views/taxonomies/blueprints/create.blade.php
@@ -16,6 +16,9 @@
                 <div class="text-2xs text-gray-600 mt-2 flex items-center">
                     {{ __('statamic::messages.blueprints_title_instructions') }}
                 </div>
+                @if ($errors->has('title'))
+                    <div class="text-red-500 text-xs mt-2">{{ $errors->first('title') }}</div>
+                @endif
             </div>
         </div>
 


### PR DESCRIPTION
As [reported here](https://github.com/statamic/cms/issues/6826#issuecomment-1278088661), adding a taxonomy blueprint with the same handle does not show an error message.

This PR prevents adds the error message to the display