### PR TITLE
[4.x] Check if user roles and groups exist before creating them

### DIFF
--- a/src/Http/Controllers/CP/Users/RolesController.php
+++ b/src/Http/Controllers/CP/Users/RolesController.php
@@ -66,9 +66,21 @@ class RolesController extends CpController
             'permissions' => 'array',
         ]);
 
+        $handle = $request->handle ?: snake_case($request->title);
+
+        if (Role::find($handle)) {
+            $error = __('A Role with that handle already exists.');
+
+            if ($request->wantsJson()) {
+                return response()->json(['message' => $error], 422);
+            }
+
+            return back()->withInput()->with('error', $error);
+        }
+
         $role = Role::make()
             ->title($request->title)
-            ->handle($request->handle ?: snake_case($request->title));
+            ->handle($handle);
 
         if ($request->super && User::current()->isSuper()) {
             $role->permissions(['super']);

--- a/src/Http/Controllers/CP/Users/UserGroupsController.php
+++ b/src/Http/Controllers/CP/Users/UserGroupsController.php
@@ -167,10 +167,22 @@ class UserGroupsController extends CpController
 
         $values = $fields->process()->values()->except(['title', 'handle', 'roles']);
 
+        $handle = $request->handle ?: snake_case($request->title);
+
+        if (UserGroup::find($handle)) {
+            $error = __('A User Group with that handle already exists.');
+
+            if ($request->wantsJson()) {
+                return response()->json(['message' => $error], 422);
+            }
+
+            return back()->withInput()->with('error', $error);
+        }
+
         $group = UserGroup::make()
             ->title($request->title)
             ->data($values)
-            ->handle($request->handle ?: snake_case($request->title));
+            ->handle($handle);
 
         if (User::current()->can('assign roles')) {
             $group->roles($request->roles);


### PR DESCRIPTION
As [reported here](https://github.com/statamic/cms/issues/6826#issuecomment-1278088661), adding a user roles and groups with the same handle does not show an error message and overwrites the existing role/group.

This PR checks if they already exist and shows an error message if they do.