### PR TITLE
[4.x] Prevent concurrent requests to the Outpost

### DIFF
--- a/resources/views/forms/show.blade.php
+++ b/resources/views/forms/show.blade.php
@@ -30,7 +30,7 @@
                 @endcan
             </dropdown-list>
 
-            @if ($exporters = $form->exporters())
+            @if (($exporters = $form->exporters()) && $exporters->isNotEmpty())
             <dropdown-list>
                 <button class="btn" slot="trigger">{{ __('Export Submissions') }}</button>
                 @foreach ($exporters as $exporter)

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -45,7 +45,6 @@ class Outpost
         $lock = $this->cache()->lock(static::LOCK_KEY, 10);
 
         if ($this->hasCachedResponse()) {
-            $lock->release();
             return $this->getCachedResponse();
         }
 

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -51,12 +51,13 @@ class Outpost
 
         try {
             $lock->block(5);
-
             return $this->performAndCacheRequest();
         } catch (ConnectException $e) {
             return $this->cacheAndReturnErrorResponse($e);
         } catch (RequestException $e) {
             return $this->handleRequestException($e);
+        } catch(LockTimeoutException $e) {
+            return $this->cacheAndReturnErrorResponse($e);
         } finally {
             $lock->release();
         }

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -42,14 +42,14 @@ class Outpost
 
     private function request()
     {
-        if ($this->hasCachedResponse()) {
-            return $this->getCachedResponse();
-        }
-
         $lock = $this->cache()->lock(static::LOCK_KEY, 10);
 
         try {
             $lock->block(5);
+
+            if ($this->hasCachedResponse()) {
+                return $this->getCachedResponse();
+            }
 
             return $this->performAndCacheRequest();
         } catch (ConnectException $e) {

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -41,17 +41,11 @@ class Outpost
 
     private function request()
     {
-        if ($this->hasCachedResponse()) {
-            return $this->getCachedResponse();
-        }
-
         $lock = $this->cache()->lock(static::LOCK_KEY, 5);
 
         if ($lock->get()) {
-            // If we have a cached response from a previous lock, we can just return it.
             if ($this->hasCachedResponse()) {
                 $lock->release();
-
                 return $this->getCachedResponse();
             }
 

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -51,6 +51,7 @@ class Outpost
             // If we have a cached response from a previous lock, we can just return it.
             if ($this->hasCachedResponse()) {
                 $lock->release();
+
                 return $this->getCachedResponse();
             }
 

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -42,11 +42,11 @@ class Outpost
 
     private function request()
     {
-        $lock = $this->cache()->lock(static::LOCK_KEY, 10);
-
         if ($this->hasCachedResponse()) {
             return $this->getCachedResponse();
         }
+
+        $lock = $this->cache()->lock(static::LOCK_KEY, 10);
 
         try {
             $lock->block(5);

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -50,12 +50,13 @@ class Outpost
 
         try {
             $lock->block(5);
+
             return $this->performAndCacheRequest();
         } catch (ConnectException $e) {
             return $this->cacheAndReturnErrorResponse($e);
         } catch (RequestException $e) {
             return $this->handleRequestException($e);
-        } catch(LockTimeoutException $e) {
+        } catch (LockTimeoutException $e) {
             return $this->cacheAndReturnErrorResponse($e);
         } finally {
             $lock->release();

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -45,7 +45,7 @@ class Outpost
         $lock = $this->cache()->lock(static::LOCK_KEY, 10);
 
         try {
-            $lock->block(5);
+            $lock->block(static::REQUEST_TIMEOUT);
 
             if ($this->hasCachedResponse()) {
                 return $this->getCachedResponse();

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -69,8 +69,6 @@ class Outpost
 
     private function performAndCacheRequest()
     {
-        ray('performAndCacheRequest');
-
         return $this->cacheResponse(now()->addHour(), $this->performRequest());
     }
 


### PR DESCRIPTION
This pull request attempts to prevent concurrent requests being made to the Outpost by implementing Laravel's [atomic locking feature](https://laravel.com/docs/master/cache#lock-driver-prerequisites).

Fixes #4194.