### PR TITLE
[4.x] Fix missing cursor when editing inline code in Bard

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -465,7 +465,7 @@
     }
 
     p > code {
-        @apply font-mono bg-gray-400 rounded-sm text-xs relative;
+        @apply font-mono bg-gray-400 rounded-sm text-xs;
         padding: 2px 4px;
         top: -1px;
     }


### PR DESCRIPTION
Fixes missing cursor:

![2023-11-15 19 07 22](https://github.com/statamic/cms/assets/1102712/681876ba-dedc-4cad-9da4-225c35a8c565)
