### PR TITLE
[4.x] Prevent registering the Users Stache Store when users are stored in a database

### DIFF
--- a/config/stache.php
+++ b/config/stache.php
@@ -86,7 +86,7 @@ return [
 
         'users' => [
             'class' => Stores\UsersStore::class,
-            'directory' => config('statamic.users.repository') === 'file' ? base_path('users') : null,
+            'directory' => base_path('users'),
         ],
 
     ],

--- a/config/stache.php
+++ b/config/stache.php
@@ -86,7 +86,7 @@ return [
 
         'users' => [
             'class' => Stores\UsersStore::class,
-            'directory' => base_path('users'),
+            'directory' => config('statamic.users.repository') === 'file' ? base_path('users') : null,
         ],
 
     ],

--- a/src/Console/Commands/ImportUsers.php
+++ b/src/Console/Commands/ImportUsers.php
@@ -10,8 +10,10 @@ use Statamic\Auth\UserRepositoryManager;
 use Statamic\Console\RunsInPlease;
 use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Contracts\Auth\UserRepository as UserRepositoryContract;
+use Statamic\Facades\Stache;
 use Statamic\Facades\User;
 use Statamic\Stache\Repositories\UserRepository as FileRepository;
+use Statamic\Stache\Stores\UsersStore;
 
 class ImportUsers extends Command
 {
@@ -60,6 +62,9 @@ class ImportUsers extends Command
 
             return;
         }
+
+        $store = app(UsersStore::class)->directory(config('statamic.stache.stores.users.directory', base_path('users')));
+        Stache::registerStore($store);
 
         app()->bind(UserContract::class, FileUser::class);
         app()->bind(UserRepositoryContract::class, FileRepository::class);

--- a/src/Stache/ServiceProvider.php
+++ b/src/Stache/ServiceProvider.php
@@ -50,6 +50,7 @@ class ServiceProvider extends LaravelServiceProvider
         $published = config('statamic.stache.stores');
 
         $nativeStores = collect($config['stores'])
+            ->reject(fn ($config, $key) => $key === 'users' && config('statamic.users.repository') !== 'file')
             ->map(function ($config, $key) use ($published) {
                 return array_merge($config, $published[$key] ?? []);
             });


### PR DESCRIPTION
This pull request fixes an error that some users would run into after moving users into the database. 

The error (`Call to undefined method Statamic\Auth\Eloquent\User::initialPath()`) happened due to the [`->initialPath()`](https://github.com/statamic/cms/blob/4.x/src/Stache/Stores/UsersStore.php#L49) method on the `UserStore` being called and trying to create a user in the Stache with the `User` facade.

However, by that point, the `UserRepository` contract had been switched to the Eloquent implementation away from the Stache implementation. It's only the Stache implementation that has an `initialPath` method.

This PR fixes that issue by preventing the users Stache store from being registered if users are currently powered by the database (or any other non-file user repository). It also manually registers the users store in the `eloquent:import-users` command which is used to migrate flat-file users to the database.

Fixes #4498.