### PR TITLE
[4.x] Fix nocache tag when using the regex antlers parser

### DIFF
--- a/src/StaticCaching/NoCache/Tags.php
+++ b/src/StaticCaching/NoCache/Tags.php
@@ -23,13 +23,13 @@ class Tags extends \Statamic\Tags\Tags
     {
         if ($this->params->has('select')) {
             $fields = $this->params->explode('select');
-        } else {
+        } elseif (config('statamic.antlers.version') === 'runtime') {
             $fields = Antlers::identifiers($this->content);
         }
 
         return $this
             ->nocache
-            ->pushRegion($this->content, $this->context->only($fields)->all(), 'antlers.html')
+            ->pushRegion($this->content, $this->context->only($fields ?? null)->all(), 'antlers.html')
             ->placeholder();
     }
 }

--- a/src/View/Antlers/Antlers.php
+++ b/src/View/Antlers/Antlers.php
@@ -47,6 +47,10 @@ class Antlers
 
     public function identifiers(string $content): array
     {
+        if (config('statamic.antlers.version') !== 'runtime') {
+            throw new \Exception('Antlers identifiers can only be retrieved when using the runtime parser.');
+        }
+
         return (new IdentifierFinder)->getIdentifiers($content);
     }
 }


### PR DESCRIPTION
Fixes #9001

The nocache tag intelligently grabs the appropriate fields you'll need in the template in #8956.

However since it uses a runtime parser feature to do it, it throws an error when you're using the regex parser.

This PR fixes that by falling back to the old less-performant behavior when you're using the regex parser.
