### PR TITLE
[4.x] Pass autocomplete config param to CP text inputs

### DIFF
--- a/resources/js/components/fieldtypes/TextFieldtype.vue
+++ b/resources/js/components/fieldtypes/TextFieldtype.vue
@@ -4,6 +4,7 @@
         :value="value"
         :classes="config.classes"
         :focus="config.focus || name === 'title' || name === 'alt'"
+        :autocomplete="config.autocomplete"
         :autoselect="config.autoselect"
         :type="config.input_type"
         :isReadOnly="isReadOnly"

--- a/resources/js/components/inputs/Text.vue
+++ b/resources/js/components/inputs/Text.vue
@@ -18,6 +18,7 @@
                 :disabled="disabled"
                 :readonly="isReadOnly"
                 :placeholder="placeholder"
+                :autocomplete="autocomplete"
                 :autofocus="focus"
                 :min="min"
                 @input="$emit('input', $event.target.value)"
@@ -55,6 +56,7 @@ export default {
         prepend: { default: null },
         append: { default: null },
         focus: { type: Boolean },
+        autocomplete: { default: null },
         autoselect: { type: Boolean },
         min: { type: Number, default: undefined }
     },


### PR DESCRIPTION
The autocomplete config on text inputs wasnt being passed to text inputs in the CP. This PR now ensures the value is set.

Closes https://github.com/statamic/cms/issues/8988 