### PR TITLE
[4.x] Fix nocache tag when URL ends in `?`

### DIFF
--- a/src/StaticCaching/NoCache/Controller.php
+++ b/src/StaticCaching/NoCache/Controller.php
@@ -16,6 +16,10 @@ class Controller
             $url = explode('?', $url)[0];
         }
 
+        if (Str::endsWith($url, '?')) {
+            $url = Str::replaceLast('?', '', $url);
+        }
+
         if (Str::contains($url, '?')) {
             $url = Str::before($url, '?').'?'.Request::normalizeQueryString(Str::after($url, '?'));
         }


### PR DESCRIPTION
This pull request fixes an issue where the `{{ nocache }}` tag wouldn't return any regions when the page's URL ends in a `?`.

Fixes #8673.