### PR TITLE
[4.x] Assets Fieldtype: Download asset when no URL is available

### DIFF
--- a/resources/js/components/fieldtypes/assets/Asset.js
+++ b/resources/js/components/fieldtypes/assets/Asset.js
@@ -77,6 +77,10 @@ export default {
         },
 
         open() {
+            if (! this.asset.url && this.asset.downloadUrl) {
+                return this.download();
+            }
+
             window.open(this.asset.url, '_blank');
         },
 

--- a/resources/js/components/fieldtypes/assets/Asset.js
+++ b/resources/js/components/fieldtypes/assets/Asset.js
@@ -77,7 +77,7 @@ export default {
         },
 
         open() {
-            if (! this.asset.url && this.asset.downloadUrl) {
+            if (! this.asset.url) {
                 return this.download();
             }
 


### PR DESCRIPTION
This pull request makes a small improvement to the Assets Fieldtype....

When on a read-only asset field and clicking onto an asset, it would previously go to the asset's URL. However, if the asset container's filesystem doesn't have a URL set, the URL wouldn't work. Instead, it'll now open the download prompt. 

Fixes #8595.