### PR TITLE
[4.x] Prevent `{{ range times="0" }}` from outputting

### DIFF
--- a/src/Tags/Range.php
+++ b/src/Tags/Range.php
@@ -12,6 +12,10 @@ class Range extends Tags
         $to = $this->params->int(['to', 'times']);
         $vars = [];
 
+        if ($to === 0 && ! $this->params->has('from')) {
+            return [];
+        }
+
         foreach (range($from, $to) as $i) {
             $vars[] = [
                 'value' => $i,

--- a/tests/Tags/RangeTest.php
+++ b/tests/Tags/RangeTest.php
@@ -17,6 +17,7 @@ class RangeTest extends TestCase
     {
         $this->assertEquals('123', $this->tag('{{ range to="3" }}{{ value }}{{ /range }}'));
         $this->assertEquals('23', $this->tag('{{ range from="2" to="3" }}{{ value }}{{ /range }}'));
+        $this->assertEquals('543210', $this->tag('{{ range from="5" to="0" }}{{ value }}{{ /range }}'));
     }
 
     /** @test */

--- a/tests/Tags/RangeTest.php
+++ b/tests/Tags/RangeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Tags;
+
+use Statamic\Facades\Parse;
+use Tests\TestCase;
+
+class RangeTest extends TestCase
+{
+    private function tag($tag, $data = [])
+    {
+        return (string) Parse::template($tag, $data);
+    }
+
+    /** @test */
+    public function it_outputs_range()
+    {
+        $this->assertEquals('123', $this->tag('{{ range to="3" }}{{ value }}{{ /range }}'));
+        $this->assertEquals('23', $this->tag('{{ range from="2" to="3" }}{{ value }}{{ /range }}'));
+    }
+
+    /** @test */
+    public function it_outputs_nothing_if_from_is_not_set_and_times_is_zero()
+    {
+        $this->assertEquals('', $this->tag('{{ range to="0" }}{{ value }}{{ /range }}'));
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/statamic/cms/issues/9017