### PR TITLE
[4.x] Allow revision actions to be translated

### DIFF
--- a/resources/js/components/revision-history/Revision.vue
+++ b/resources/js/components/revision-history/Revision.vue
@@ -21,7 +21,7 @@
                 </div>
 
                 <span class="badge" v-if="revision.working" v-text="__('Working Copy')" />
-                <span class="badge" :class="revision.action" v-else v-text="revision.action" />
+                <span class="badge" :class="revision.action" v-else v-text="__(revision.action)" />
                 <span class="badge bg-orange" v-if="revision.attributes.current" v-text="__('Current')" />
 
                 <revision-preview


### PR DESCRIPTION
This PR wraps the revision action in the revision history in the translate method, allowing these strings to be translated.
Currently the only possible values are `revision`, `publish` or `unpublish`

Closes https://github.com/statamic/cms/issues/8737