### PR TITLE
[4.x] Fix error in `HasRequestedColumns` trait on Laravel Vapor

### DIFF
--- a/src/Http/Resources/CP/Concerns/HasRequestedColumns.php
+++ b/src/Http/Resources/CP/Concerns/HasRequestedColumns.php
@@ -36,6 +36,8 @@ trait HasRequestedColumns
             return [];
         }
 
-        return explode(',', $columns);
+        return is_array($columns)
+            ? $columns
+            : explode(',', $columns);
     }
 }


### PR DESCRIPTION
This pull request fixes an error that would only occur when using Statamic, on Laravel Vapor, with a AWS function URL.

After some digging and talking with Vapor support, I managed to figure out that AWS function URLs parse query parameters like `title,status,slug` as an array, instead of a string like they'd be parsed anywhere else.

This happens due to the way that AWS maps the requests internally. This isn't an issue for projects with custom domains or vanity domains where Vapor is able to workaround the issue.

Fixes #6868.