### PR TITLE
[4.x] Fix Outpost locking code for cache drivers without locking support

### DIFF
--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -211,6 +211,6 @@ class Outpost
             };
         }
 
-        return $this->cache()->lock(static::LOCK_KEY, 10);
+        return $this->cache()->lock($key, $seconds);
     }
 }

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -196,7 +196,7 @@ class Outpost
 
     private function acquireLock(string $key, int $seconds = 10)
     {
-        $cacheSupportsLocking = in_array(LockProvider::class, class_implements($this->cache()->getStore()));
+        $cacheSupportsLocking = $this->cache()->getStore() instanceof LockProvider;
 
         if (! $cacheSupportsLocking) {
             return new class

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -196,9 +196,9 @@ class Outpost
 
     private function acquireLock(string $key, int $seconds = 10)
     {
-        $cacheSupportsLock = in_array(LockProvider::class, class_implements($this->cache()->getStore()));
+        $cacheSupportsLocking = in_array(LockProvider::class, class_implements($this->cache()->getStore()));
 
-        if (! $cacheSupportsLock) {
+        if (! $cacheSupportsLocking) {
             return new class
             {
                 public function block(int $timeout): void


### PR DESCRIPTION
This pull request fixes a regression from #9000, where we implemented cache locking to prevent concurrent requests to the Outpost. 

Most of the popular cache drivers have support for caching locking. However, the APC driver doesn't support cache locking. This PR works around that issue by creating a mock class for the locking stuff. 

This mock class won't prevent concurrent requests to the Outpost. If you're experiencing this issue on a cache driver that *doesn't* support locks, we'd recommend using [one that does](https://laravel.com/docs/master/cache#atomic-locks) like `file`, `redis`, `database`.

Fixes #9026.