### PR TITLE
[4.x] Add `href` attribute to relationship item links

### DIFF
--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -14,7 +14,7 @@
                 v-text="item.title" />
 
 
-            <a v-if="!item.invalid && editable" @click="edit" v-text="item.title" class="truncate" v-tooltip="item.title" :href="item.edit_url" @click.prevent />
+            <a v-if="!item.invalid && editable" @click.prevent="edit" v-text="item.title" class="truncate" v-tooltip="item.title" :href="item.edit_url" />
 
             <div v-if="!item.invalid && !editable" v-text="item.title" />
 

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -14,7 +14,7 @@
                 v-text="item.title" />
 
 
-            <a v-if="!item.invalid && editable" @click="edit" v-text="item.title" class="truncate" v-tooltip="item.title" />
+            <a v-if="!item.invalid && editable" @click="edit" v-text="item.title" class="truncate" v-tooltip="item.title" :href="item.edit_url" @click.prevent />
 
             <div v-if="!item.invalid && !editable" v-text="item.title" />
 


### PR DESCRIPTION
Sometimes it's useful to open related items in a separate tab, rather than the stack overlay. This PR adds an `href` attribute to relationship item links, allowing you to open them in a new tab via the browser's right-click context menu.