### PR TITLE
[4.x] Glide: Output absolute URL when external image has invalid extension

### DIFF
--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -199,7 +199,7 @@ class Glide extends Tags
             return;
         }
 
-        $url = ($this->params->bool('absolute', $this->useAbsoluteUrls())) ? URL::makeAbsolute($url) : URL::makeRelative($url);
+        $url = ($this->params->bool('absolute', $this->useAbsoluteUrls($url))) ? URL::makeAbsolute($url) : URL::makeRelative($url);
 
         return $url;
     }
@@ -340,8 +340,12 @@ class Glide extends Tags
         return ImageValidator::isValidExtension(Path::extension($item));
     }
 
-    private function useAbsoluteUrls()
+    private function useAbsoluteUrls(string $url): bool
     {
+        if (! $this->isValidExtension($url) && Str::startsWith($url, ['http://', 'https://'])) {
+            return true;
+        }
+
         return Str::startsWith(GlideManager::url(), ['http://', 'https://']);
     }
 }

--- a/tests/Tags/GlideTest.php
+++ b/tests/Tags/GlideTest.php
@@ -51,7 +51,10 @@ class GlideTest extends TestCase
         $this->assertEquals('https://localhost/glide/paths/bar.jpg/689e9cd88cc1d852c9a4d3a1e27d68c2.jpg', $this->absoluteTestTag(true));
     }
 
-    /** @test */
+    /**
+     * @test
+     * https://github.com/statamic/cms/pull/9031
+     */
     public function it_outputs_an_absolute_url_when_the_url_does_not_have_a_valid_extension()
     {
         $parse = (string) Parse::template('{{ glide src="https://statamic.com/foo" }}');

--- a/tests/Tags/GlideTest.php
+++ b/tests/Tags/GlideTest.php
@@ -51,6 +51,14 @@ class GlideTest extends TestCase
         $this->assertEquals('https://localhost/glide/paths/bar.jpg/689e9cd88cc1d852c9a4d3a1e27d68c2.jpg', $this->absoluteTestTag(true));
     }
 
+    /** @test */
+    public function it_outputs_an_absolute_url_when_the_url_does_not_have_a_valid_extension()
+    {
+        $parse = (string) Parse::template('{{ glide src="https://statamic.com/foo" }}');
+
+        $this->assertSame('https://statamic.com/foo', $parse);
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
This pull request fixes an issue with the Glide tag, when using it with an external URL without a valid extension.

For example, with `{{ glide src="https://statamic.com/foo" }}`, the Glide tag would output `/foo`, which isn't very useful as a fallback.

Now, with this PR, `https://statamic.com/foo` will be outputted.

Fixes #5753.