### PR TITLE
[4.x] Create tree for navigation if one doesn't exist

### DIFF
--- a/src/Http/Controllers/CP/Navigation/NavigationController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationController.php
@@ -68,7 +68,11 @@ class NavigationController extends CpController
         $site = $request->site ?? Site::selected()->handle();
 
         if (! $nav->existsIn($site)) {
-            return redirect($nav->trees()->first()->showUrl());
+            if ($nav->trees()->isNotEmpty()) {
+                return redirect($nav->trees()->first()->showUrl());
+            }
+
+            $nav->makeTree($site)->save();
         }
 
         $this->authorize('view', $nav->in($site), __('You are not authorized to view navs.'));


### PR DESCRIPTION
This pull request fixes an issue where the Control Panel would error if you delete the tree file for a navigation. Now, when a tree file is missing, it'll be created.

Fixes #5244.