### PR TITLE
[4.x] Apply appropriate file extension when uploading

### DIFF
--- a/src/Assets/AssetUploader.php
+++ b/src/Assets/AssetUploader.php
@@ -26,7 +26,7 @@ class AssetUploader extends Uploader
 
     protected function uploadPath(UploadedFile $file)
     {
-        $ext = $this->getNewExtension() ?? $file->getClientOriginalExtension();
+        $ext = $this->getNewExtension() ?? $this->getFileExtension($file);
 
         if (config('statamic.assets.lowercase')) {
             $ext = strtolower($ext);
@@ -69,6 +69,17 @@ class AssetUploader extends Uploader
         }
 
         return $ext;
+    }
+
+    private function getFileExtension(UploadedFile $file)
+    {
+        $extension = $file->getClientOriginalExtension();
+        $guessed = $file->guessExtension();
+
+        // Only use the guessed extension if it's different than the original.
+        // This allows us to maintain the casing of the original extension
+        // if the the "lowercase filenames" config option is disabled.
+        return strtolower($extension) === strtolower($guessed) ? $extension : $guessed;
     }
 
     public static function getSafeFilename($string)

--- a/src/Assets/FileUploader.php
+++ b/src/Assets/FileUploader.php
@@ -22,7 +22,9 @@ class FileUploader extends Uploader
 
     protected function uploadPath(UploadedFile $file)
     {
-        return now()->timestamp.'/'.$file->getClientOriginalName();
+        $filename = pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME);
+
+        return now()->timestamp.'/'.$filename.'.'.$file->guessExtension();
     }
 
     protected function uploadPathPrefix()

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1706,7 +1706,6 @@ class AssetTest extends TestCase
             ['md'],  // not an image
             ['svg'], // doesn't work with imagick without extra server config
             ['pdf'], // doesn't work with imagick without extra server config
-            ['eps'], // doesn't work with imagick without extra server config
         ];
     }
 
@@ -1757,21 +1756,21 @@ class AssetTest extends TestCase
             'h' => '15',
         ]]);
 
-        // Normally eps files (for example) are not supported by gd or imagick. However, imagick does
+        // Normally pdf files (for example) are not supported by gd or imagick. However, imagick does
         // does actually support over 100 formats with extra configuration (eg. via ghostscript).
         // Thus, we allow the user to configure additional extensions in their assets config.
         config(['statamic.assets.image_manipulation.additional_extensions' => [
-            'eps',
+            'pdf',
         ]]);
 
         $this->container->sourcePreset('small');
 
-        $asset = (new Asset)->container($this->container)->path('path/to/asset.eps')->syncOriginal();
+        $asset = (new Asset)->container($this->container)->path('path/to/asset.pdf')->syncOriginal();
 
         Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
-        Storage::disk('test')->assertMissing('path/to/asset.eps');
+        Storage::disk('test')->assertMissing('path/to/asset.pdf');
 
-        $file = UploadedFile::fake()->image('asset.eps', 20, 30);
+        $file = UploadedFile::fake()->image('asset.pdf', 20, 30);
 
         // Ensure a glide server is instantiated and `makeImage()` is called...
         Facades\Glide::partialMock()
@@ -1793,8 +1792,8 @@ class AssetTest extends TestCase
         $this->assertEquals($asset, $return);
         $this->assertDirectoryExists($glideDir = storage_path('statamic/glide/tmp'));
         $this->assertEmpty(app('files')->allFiles($glideDir)); // no temp files
-        Storage::disk('test')->assertExists('path/to/asset.eps');
-        $this->assertEquals('path/to/asset.eps', $asset->path());
+        Storage::disk('test')->assertExists('path/to/asset.pdf');
+        $this->assertEquals('path/to/asset.pdf', $asset->path());
         Event::assertDispatched(AssetUploaded::class, function ($event) use ($asset) {
             return $event->asset = $asset;
         });
@@ -1802,7 +1801,7 @@ class AssetTest extends TestCase
         $meta = $asset->meta();
 
         // Normally we assert changes to the meta, but we cannot in this test because we can't guarantee
-        // the test suite has imagick with ghostscript installed (required for eps files, for example).
+        // the test suite has imagick with ghostscript installed (required for pdf files, for example).
         // $this->assertEquals(10, $meta['width']);
         // $this->assertEquals(15, $meta['height']);
     }


### PR DESCRIPTION
When uploading a file that has a mime type that doesn't match the file extension, the file extension will be changed so that it matches the mime type.

For example, this fixes an issue where someone could upload an `.html` file with a spoofed `image/jpg` mime type. This could allow parts of the system to believe it is a jpg, passing image validation, but continue to act as an html file in other parts.

Now, if you upload an `.html` file with a `image/jpg` mime type, it'll get saved as `.jpg`.

This PR also adjust some seemingly unrelated Glide tests so that we check against pdf instead of eps files. In faked uploaded files, eps files ended up getting renamed to ai files. (Actual uploaded files don't.) I changed the test to use pdf which is the same outcome, but doesn't end up with the renaming issue.
