### PR TITLE
[4.x] Fix missing `nestedListing` method on `Html` class

### DIFF
--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -201,7 +201,7 @@ class Html
     protected static function nestedListing($key, $type, $value)
     {
         if (is_int($key)) {
-            return static::listing($type, $value);
+            return '<li>'.static::listing($type, $value).'</li>';
         } else {
             return '<li>'.$key.static::listing($type, $value).'</li>';
         }

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -191,6 +191,23 @@ class Html
     }
 
     /**
+     * Create the HTML for a nested listing attribute.
+     *
+     * @param  mixed  $key
+     * @param  string  $type
+     * @param  mixed  $value
+     * @return string
+     */
+    protected static function nestedListing($key, $type, $value)
+    {
+        if (is_int($key)) {
+            return static::listing($type, $value);
+        } else {
+            return '<li>'.$key.static::listing($type, $value).'</li>';
+        }
+    }
+
+    /**
      * Obfuscate a string to prevent spam-bots from sniffing it.
      *
      * @param  string  $value

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -200,11 +200,13 @@ class Html
      */
     protected static function nestedListing($key, $type, $value)
     {
-        if (is_int($key)) {
-            return '<li>'.static::listing($type, $value).'</li>';
-        } else {
-            return '<li>'.$key.static::listing($type, $value).'</li>';
+        $html = '<li>';
+
+        if (! is_int($key)) {
+            $html .= $key;
         }
+
+        return $html.static::listing($type, $value).'</li>';
     }
 
     /**

--- a/tests/Support/HtmlTest.php
+++ b/tests/Support/HtmlTest.php
@@ -32,19 +32,19 @@ class HtmlTest extends TestCase
         $this->assertEquals('<ol class="example"><li>foo</li><li>bar</li><li>&amp;</li></ol>', $ol);
     }
 
-    /**
-     * @test
-     * https://github.com/statamic/cms/issues/5233
-     */
-    public function it_returns_list_with_nesting()
+    /** @test */
+    public function nested_listing_with_keyed_sub_array()
     {
-        $list = ['foo', 'bar', 'baz' => ['foo', 'bar', 'baz']];
+        $list = [
+            'foo',
+            'bar',
+            'baz' => ['alfa', 'bravo'],
+        ];
 
-        $attributes = ['class' => 'example'];
+        $ol = Html::ol($list);
 
-        $ol = Html::ol($list, $attributes);
+        $this->assertEquals('<ol><li>foo</li><li>bar</li><li>baz<ol><li>alfa</li><li>bravo</li></ol></li></ol>', $ol);
 
-        $this->assertEquals('<ol class="example"><li>foo</li><li>bar</li><li>baz<ol><li>foo</li><li>bar</li><li>baz</li></ol></li></ol>', $ol);
     }
 
     /**

--- a/tests/Support/HtmlTest.php
+++ b/tests/Support/HtmlTest.php
@@ -34,6 +34,21 @@ class HtmlTest extends TestCase
 
     /**
      * @test
+     * https://github.com/statamic/cms/issues/5233
+     */
+    public function it_returns_list_with_nesting()
+    {
+        $list = ['foo', 'bar', 'baz' => ['foo', 'bar', 'baz']];
+
+        $attributes = ['class' => 'example'];
+
+        $ol = Html::ol($list, $attributes);
+
+        $this->assertEquals('<ol class="example"><li>foo</li><li>bar</li><li>baz<ol><li>foo</li><li>bar</li><li>baz</li></ol></li></ol>', $ol);
+    }
+
+    /**
+     * @test
      */
     public function it_returns_empty_string_when_no_list_items_given(): void
     {

--- a/tests/Support/HtmlTest.php
+++ b/tests/Support/HtmlTest.php
@@ -44,7 +44,20 @@ class HtmlTest extends TestCase
         $ol = Html::ol($list);
 
         $this->assertEquals('<ol><li>foo</li><li>bar</li><li>baz<ol><li>alfa</li><li>bravo</li></ol></li></ol>', $ol);
+    }
 
+    /** @test */
+    public function nested_listing_with_unkeyed_sub_array()
+    {
+        $list = [
+            'foo',
+            ['alfa', 'bravo'],
+            'bar',
+        ];
+
+        $ol = Html::ol($list);
+
+        $this->assertEquals('<ol><li>foo</li><li><ol><li>alfa</li><li>bravo</li></ol></li><li>bar</li></ol>', $ol);
     }
 
     /**

--- a/tests/Support/HtmlTest.php
+++ b/tests/Support/HtmlTest.php
@@ -37,13 +37,13 @@ class HtmlTest extends TestCase
     {
         $list = [
             'foo',
-            'bar',
-            'baz' => ['alfa', 'bravo'],
+            'bar' => ['alfa', 'bravo'],
+            'baz',
         ];
 
         $ol = Html::ol($list);
 
-        $this->assertEquals('<ol><li>foo</li><li>bar</li><li>baz<ol><li>alfa</li><li>bravo</li></ol></li></ol>', $ol);
+        $this->assertEquals('<ol><li>foo</li><li>bar<ol><li>alfa</li><li>bravo</li></ol></li><li>baz</li></ol>', $ol);
     }
 
     /** @test */


### PR DESCRIPTION
This pull request copies the missing `nestedListing` method from [`laravelcollective/html`](https://github.com/LaravelCollective/html/blob/6.x/src/HtmlBuilder.php#L410) into our `Html` class.

Fixes #5233.