### PR TITLE
[4.x] Fix URI validation error when collection route uses entry IDs

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -10,6 +10,7 @@ use Statamic\Exceptions\BlueprintNotFoundException;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
+use Statamic\Facades\Stache;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
@@ -531,7 +532,12 @@ class EntriesController extends CpController
         }
 
         if (! $tree) {
-            return $entry->uri();
+            return app(\Statamic\Contracts\Routing\UrlBuilder::class)
+                ->content($entry)
+                ->merge([
+                    'id' => $entry->id() ?? Stache::generateId(),
+                ])
+                ->build($entry->route());
         }
 
         $parent = $parent ? $tree->find($parent) : null;

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -10,6 +10,7 @@ use Statamic\Exceptions\BlueprintNotFoundException;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
+use Statamic\Facades\Stache;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
@@ -363,6 +364,7 @@ class EntriesController extends CpController
         $values = $fields->process()->values()->except(['slug', 'blueprint', 'published']);
 
         $entry = Entry::make()
+            ->id(Stache::generateId())
             ->collection($collection)
             ->blueprint($request->_blueprint)
             ->locale($site->handle())

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -10,7 +10,6 @@ use Statamic\Exceptions\BlueprintNotFoundException;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
-use Statamic\Facades\Stache;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
@@ -364,7 +363,6 @@ class EntriesController extends CpController
         $values = $fields->process()->values()->except(['slug', 'blueprint', 'published']);
 
         $entry = Entry::make()
-            ->id(Stache::generateId())
             ->collection($collection)
             ->blueprint($request->_blueprint)
             ->locale($site->handle())


### PR DESCRIPTION
This pull request fixes an issue when creating a new entry, where the collection's route uses the entry ID, like this: `/members/{id}` or simply `/{id}`.

Previously, when creating an entry, no ID would exist so the URI would be simplified to `/members` so if you had an existing entry at `/members`, it would cause a validation error.

This PR attempts to fix this by always passing an ID into the `UrlBuilder` if the entry doesn't already have one set. 

Fixes #5500.