### PR TITLE
[4.x] Don't prompt user to select search index when there's only 1 configured

### DIFF
--- a/src/Search/Commands/Update.php
+++ b/src/Search/Commands/Update.php
@@ -37,6 +37,10 @@ class Update extends Command
             return $this->indexes();
         }
 
+        if ($this->indexes()->count() === 1) {
+            return $this->indexes();
+        }
+
         $selection = $this->choice(
             'Select an index to update',
             collect(['all'])->merge($this->indexes()->keys())->all(),


### PR DESCRIPTION
This pull request makes a small improvement to the `php please search:update` command. 

When you only have 1 search index configured in `config/statamic/search.php`, there's no point prompting the user to select  which index to update, if they only have one option to pick from. 

## Before

![CleanShot 2023-11-20 at 21 25 19](https://github.com/statamic/cms/assets/19637309/80a67806-2a32-4be8-a064-b3b47a6a3373)

## After

![CleanShot 2023-11-20 at 21 25 36](https://github.com/statamic/cms/assets/19637309/ad03285b-f3d4-4cad-b438-168fb183cefa)
