### PR TITLE
[4.x] Only allow uploading certain file extensions

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -198,4 +198,16 @@ return [
 
     'lowercase' => true,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Additional Uploadable Extensions
+    |--------------------------------------------------------------------------
+    |
+    | Statamic will only allow uploads of certain approved file extensions.
+    | If you need to allow more file extensions, you may add them here.
+    |
+    */
+
+    'additional_uploadable_extensions' => [],
+
 ];

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -11,6 +11,7 @@ use Statamic\Facades\AssetContainer;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Resources\CP\Assets\Asset as AssetResource;
+use Statamic\Validation\AllowedFile;
 
 class AssetsController extends CpController
 {
@@ -68,11 +69,7 @@ class AssetsController extends CpController
         $request->validate([
             'container' => 'required',
             'folder' => 'required',
-            'file' => ['file', function ($attribute, $value, $fail) {
-                if (in_array(trim(strtolower($value->getClientOriginalExtension())), ['php', 'php3', 'php4', 'php5', 'php7', 'php8', 'phtml', 'phar'])) {
-                    $fail(__('validation.uploaded'));
-                }
-            }],
+            'file' => ['file', new AllowedFile],
         ]);
 
         $container = AssetContainer::find($request->container);

--- a/src/Http/Controllers/CP/Fieldtypes/FilesFieldtypeController.php
+++ b/src/Http/Controllers/CP/Fieldtypes/FilesFieldtypeController.php
@@ -5,17 +5,14 @@ namespace Statamic\Http\Controllers\CP\Fieldtypes;
 use Illuminate\Http\Request;
 use Statamic\Assets\FileUploader as Uploader;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Validation\AllowedFile;
 
 class FilesFieldtypeController extends CpController
 {
     public function upload(Request $request)
     {
         $request->validate([
-            'file' => ['file', function ($attribute, $value, $fail) {
-                if (in_array(trim(strtolower($value->getClientOriginalExtension())), ['php', 'php3', 'php4', 'php5', 'php7', 'php8', 'phtml', 'phar'])) {
-                    $fail(__('validation.uploaded'));
-                }
-            }],
+            'file' => ['file', new AllowedFile],
         ]);
 
         $file = $request->file('file');

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -19,6 +19,7 @@ use Statamic\Forms\Exceptions\FileContentTypeRequiredException;
 use Statamic\Forms\SendEmails;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
+use Statamic\Validation\AllowedFile;
 
 class FormController extends Controller
 {
@@ -177,11 +178,7 @@ class FormController extends Controller
                 return $field->fieldtype()->handle() === 'assets';
             })
             ->mapWithKeys(function ($field) {
-                return [$field->handle().'.*' => ['file', function ($attribute, $value, $fail) {
-                    if (in_array(trim(strtolower($value->getClientOriginalExtension())), ['php', 'php3', 'php4', 'php5', 'php7', 'php8', 'phtml', 'phar'])) {
-                        $fail(__('validation.uploaded'));
-                    }
-                }]];
+                return [$field->handle().'.*' => ['file', new AllowedFile]];
             })
             ->all();
 

--- a/src/Validation/AllowedFile.php
+++ b/src/Validation/AllowedFile.php
@@ -44,6 +44,7 @@ class AllowedFile implements ValidationRule
         'm4a',
         'm4v',
         'mcc',
+        'md',
         'mid',
         'mov',
         'mp3',

--- a/src/Validation/AllowedFile.php
+++ b/src/Validation/AllowedFile.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Statamic\Validation;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Http\UploadedFile;
+
+class AllowedFile implements ValidationRule
+{
+    private array $extensions = [
+        '7z',
+        'aiff',
+        'asc',
+        'asf',
+        'avi',
+        'avif',
+        'bmp',
+        'cap',
+        'cin',
+        'csv',
+        'dfxp',
+        'doc',
+        'docx',
+        'dotm',
+        'dotx',
+        'fla',
+        'flv',
+        'gif',
+        'gz',
+        'gzip',
+        'heic',
+        'heif',
+        'hevc',
+        'itt',
+        'jp2',
+        'jpeg',
+        'jpg',
+        'jpx',
+        'js',
+        'json',
+        'lrc',
+        'm2t',
+        'm4a',
+        'm4v',
+        'mcc',
+        'mid',
+        'mov',
+        'mp3',
+        'mp4',
+        'mpc',
+        'mpeg',
+        'mpg',
+        'mpsub',
+        'ods',
+        'odt',
+        'ogg',
+        'ogv',
+        'pdf',
+        'png',
+        'potx',
+        'pps',
+        'ppsm',
+        'ppsx',
+        'ppt',
+        'pptm',
+        'pptx',
+        'ppz',
+        'pxd',
+        'qt',
+        'ram',
+        'rar',
+        'rm',
+        'rmi',
+        'rmvb',
+        'rt',
+        'rtf',
+        'sami',
+        'sbv',
+        'scc',
+        'sdc',
+        'sitd',
+        'smi',
+        'srt',
+        'stl',
+        'sub',
+        'svg',
+        'swf',
+        'sxc',
+        'sxw',
+        'tar',
+        'tds',
+        'tgz',
+        'tif',
+        'tiff',
+        'ttml',
+        'txt',
+        'vob',
+        'vsd',
+        'vtt',
+        'wav',
+        'webm',
+        'webp',
+        'wma',
+        'wmv',
+        'xls',
+        'xlsx',
+        'zip',
+    ];
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! $this->isAllowed($value)) {
+            $fail(__('validation.uploaded'));
+        }
+    }
+
+    private function isAllowed(UploadedFile $file): bool
+    {
+        $extensions = array_merge($this->extensions, config('statamic.assets.additional_uploadable_extensions', []));
+
+        return in_array(trim(strtolower($file->getClientOriginalExtension())), $extensions);
+    }
+}

--- a/src/Validation/AllowedFile.php
+++ b/src/Validation/AllowedFile.php
@@ -2,11 +2,10 @@
 
 namespace Statamic\Validation;
 
-use Closure;
-use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\InvokableRule;
 use Illuminate\Http\UploadedFile;
 
-class AllowedFile implements ValidationRule
+class AllowedFile implements InvokableRule
 {
     private array $extensions = [
         '7z',
@@ -109,7 +108,7 @@ class AllowedFile implements ValidationRule
         'zip',
     ];
 
-    public function validate(string $attribute, mixed $value, Closure $fail): void
+    public function __invoke($attribute, $value, $fail): void
     {
         if (! $this->isAllowed($value)) {
             $fail(__('validation.uploaded'));


### PR DESCRIPTION
For improved security, file uploads are restricted to a list of extensions.

The list covers most use cases, but if you have a need for more you may them to your config.
