### PR TITLE
[4.x] Select Fieldtype: Fallback to key when option label is missing

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -104,7 +104,7 @@ trait HasSelectOptions
             $value = $this->castFromBoolean($value);
         }
 
-        return $this->isOption($value)
+        return $this->isOption($value) && Arr::get($this->config('options'), $value)
             ? Arr::get($this->config('options'), $value, $value)
             : $actualValue;
     }


### PR DESCRIPTION
This pull request fixes an issue where nothing would be displayed for a Select Fieldtype option in a Listing Table if the selected option was missing a label. 

When a select option is missing a label, it'll display the option's key/value instead.

Fixes #6533.