### PR TITLE
[4.x] Ensure field handles are in snake case

### DIFF
--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -99,7 +99,7 @@ class FieldsController extends CpController
                 'type' => 'slug',
                 'from' => 'display',
                 'separator' => '_',
-                'validate' => 'required|not_in:'.implode(',', $reserved),
+                'validate' => 'required|regex:/^[a-zA-Z0-9_]+$/|not_in:'.implode(',', $reserved),
                 'show_regenerate' => true,
             ],
             'instructions' => [

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -99,7 +99,7 @@ class FieldsController extends CpController
                 'type' => 'slug',
                 'from' => 'display',
                 'separator' => '_',
-                'validate' => 'required|regex:/^[a-zA-Z_][a-zA-Z0-9_]*$/|not_in:'.implode(',', $reserved),
+                'validate' => 'required|regex:/^[a-zA-Z][a-zA-Z0-9_]*$/|not_in:'.implode(',', $reserved),
                 'show_regenerate' => true,
             ],
             'instructions' => [

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -99,7 +99,7 @@ class FieldsController extends CpController
                 'type' => 'slug',
                 'from' => 'display',
                 'separator' => '_',
-                'validate' => 'required|regex:/^[a-zA-Z0-9_]+$/|not_in:'.implode(',', $reserved),
+                'validate' => 'required|regex:/^[a-zA-Z_][a-zA-Z0-9_]*$/|not_in:'.implode(',', $reserved),
                 'show_regenerate' => true,
             ],
             'instructions' => [


### PR DESCRIPTION
This pull request ensures that field handles are formatted in snake case (eg. without any spaces, dashes, slashes, etc). 

Closes #6457.