### PR TITLE
[4.x] Prevent showing "Saved" toast message when listener cancels save

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -534,6 +534,9 @@ export default {
 
             this.$axios[this.method](this.actions.save, payload).then(response => {
                 this.saving = false;
+                if (! response.data.saved) {
+                    return this.$toast.error(__(`Couldn't save entry`));
+                }
                 this.title = response.data.data.title;
                 this.isWorkingCopy = true;
                 if (this.isBase) {

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -222,6 +222,9 @@ export default {
 
             this.$axios[this.method](this.actions.save, payload).then(response => {
                 this.saving = false;
+                if (!response.data.saved) {
+                    return this.$toast.error(`Couldn't save global set`)
+                }
                 if (!this.isCreating) this.$toast.success(__('Saved'));
                 this.$refs.container.saved();
                 this.runAfterSaveHook(response);

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -445,6 +445,9 @@ export default {
 
             this.$axios[this.method](this.actions.save, payload).then(response => {
                 this.saving = false;
+                if (! response.data.saved) {
+                    return this.$toast.error(__(`Couldn't save term`));
+                }
                 this.title = response.data.data.title;
                 this.permalink = response.data.data.permalink;
                 this.isWorkingCopy = true;

--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -111,6 +111,9 @@ export default {
 
             this.$axios[this.method](this.actions.save, this.visibleValues).then(response => {
                 this.title = response.data.title;
+                if (!response.data.saved) {
+                    return this.$toast.error(`Couldn't save user`)
+                }
                 if (!this.isCreating) this.$toast.success(__('Saved'));
                 this.$refs.container.saved();
                 this.$nextTick(() => this.$emit('saved', response));

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -253,7 +253,13 @@ class EntriesController extends CpController
                 $entry->published($request->published);
             }
 
-            $entry->updateLastModified(User::current())->save();
+            $save = $entry->updateLastModified(User::current())->save();
+
+            if (! $save) {
+                return response([
+                    'message' => __("Couldn't save entry"),
+                ], 401);
+            }
         }
 
         [$values] = $this->extractFromFields($entry, $blueprint);
@@ -398,7 +404,13 @@ class EntriesController extends CpController
                 'user' => User::current(),
             ]);
         } else {
-            $entry->updateLastModified(User::current())->save();
+            $save = $entry->updateLastModified(User::current())->save();
+
+            if (! $save) {
+                return response([
+                    'message' => __("Couldn't save entry"),
+                ], 401);
+            }
         }
 
         return new EntryResource($entry);

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -253,19 +253,14 @@ class EntriesController extends CpController
                 $entry->published($request->published);
             }
 
-            $save = $entry->updateLastModified(User::current())->save();
-
-            if (! $save) {
-                return response([
-                    'message' => __("Couldn't save entry"),
-                ], 401);
-            }
+            $saved = $entry->updateLastModified(User::current())->save();
         }
 
         [$values] = $this->extractFromFields($entry, $blueprint);
 
         return (new EntryResource($entry->fresh()))
             ->additional([
+                'saved' => $saved ?? false,
                 'data' => [
                     'values' => $values,
                 ],
@@ -404,16 +399,11 @@ class EntriesController extends CpController
                 'user' => User::current(),
             ]);
         } else {
-            $save = $entry->updateLastModified(User::current())->save();
-
-            if (! $save) {
-                return response([
-                    'message' => __("Couldn't save entry"),
-                ], 401);
-            }
+            $saved = $entry->updateLastModified(User::current())->save();
         }
 
-        return new EntryResource($entry);
+        return (new EntryResource($entry))
+            ->additional(['saved' => $saved ?? false]);
     }
 
     private function resolveSlug($request)

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -241,7 +241,7 @@ class EntriesController extends CpController
         $this->validateUniqueUri($entry, $tree ?? null, $parent ?? null);
 
         if ($entry->revisionsEnabled() && $entry->published()) {
-            $entry
+            $saved = $entry
                 ->makeWorkingCopy()
                 ->user(User::current())
                 ->save();
@@ -260,7 +260,7 @@ class EntriesController extends CpController
 
         return (new EntryResource($entry->fresh()))
             ->additional([
-                'saved' => $saved ?? false,
+                'saved' => $saved,
                 'data' => [
                     'values' => $values,
                 ],
@@ -394,7 +394,7 @@ class EntriesController extends CpController
         $this->validateUniqueUri($entry, $tree ?? null, $parent ?? null);
 
         if ($entry->revisionsEnabled()) {
-            $entry->store([
+            $saved = $entry->store([
                 'message' => $request->message,
                 'user' => User::current(),
             ]);
@@ -403,7 +403,7 @@ class EntriesController extends CpController
         }
 
         return (new EntryResource($entry))
-            ->additional(['saved' => $saved ?? false]);
+            ->additional(['saved' => $saved]);
     }
 
     private function resolveSlug($request)

--- a/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
+++ b/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
@@ -104,9 +104,11 @@ class GlobalVariablesController extends CpController
 
         $set->data($values);
 
-        $set->globalSet()->addLocalization($set)->save();
+        $save = $set->globalSet()->addLocalization($set)->save();
 
-        return response('', 204);
+        return response()->json([
+            'saved' => is_bool($save) ? $save : true,
+        ]);
     }
 
     protected function extractFromFields($set, $blueprint)

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -195,7 +195,13 @@ class TermsController extends CpController
                 $term->published($request->published);
             }
 
-            $term->updateLastModified(User::current())->save();
+            $save = $term->updateLastModified(User::current())->save();
+
+            if (! $save) {
+                return response([
+                    'message' => __("Couldn't save term"),
+                ], 401);
+            }
         }
 
         return new TermResource($term);
@@ -299,7 +305,13 @@ class TermsController extends CpController
                 'user' => User::current(),
             ]);
         } else {
-            $term->updateLastModified(User::current())->save();
+            $save = $term->updateLastModified(User::current())->save();
+
+            if (! $save) {
+                return response([
+                    'message' => __("Couldn't save term"),
+                ], 401);
+            }
         }
 
         return new TermResource($term);

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -195,16 +195,11 @@ class TermsController extends CpController
                 $term->published($request->published);
             }
 
-            $save = $term->updateLastModified(User::current())->save();
-
-            if (! $save) {
-                return response([
-                    'message' => __("Couldn't save term"),
-                ], 401);
-            }
+            $saved = $term->updateLastModified(User::current())->save();
         }
 
-        return new TermResource($term);
+        return (new TermResource($term))
+            ->additional(['saved' => $saved]);
     }
 
     public function create(Request $request, $taxonomy, $site)
@@ -305,16 +300,11 @@ class TermsController extends CpController
                 'user' => User::current(),
             ]);
         } else {
-            $save = $term->updateLastModified(User::current())->save();
-
-            if (! $save) {
-                return response([
-                    'message' => __("Couldn't save term"),
-                ], 401);
-            }
+            $saved = $term->updateLastModified(User::current())->save();
         }
 
-        return new TermResource($term);
+        return (new TermResource($term))
+            ->additional(['saved' => $saved]);
     }
 
     protected function extractFromFields($term, $blueprint)

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -277,9 +277,12 @@ class UsersController extends CpController
             $user->groups($request->groups);
         }
 
-        $user->save();
+        $save = $user->save();
 
-        return ['title' => $user->title()];
+        return [
+            'title' => $user->title(),
+            'saved' => is_bool($save) ? $save : true,
+        ];
     }
 
     public function destroy($user)

--- a/src/Revisions/Revisable.php
+++ b/src/Revisions/Revisable.php
@@ -116,7 +116,7 @@ trait Revisable
             ->updateLastModified($user = $options['user'] ?? false)
             ->save();
 
-        $this
+        return $this
             ->makeRevision()
             ->user($user)
             ->message($options['message'] ?? false)

--- a/src/Revisions/Revision.php
+++ b/src/Revisions/Revision.php
@@ -138,6 +138,8 @@ class Revision implements Arrayable, Contract
         Revisions::save($this);
 
         RevisionSaved::dispatch($this);
+
+        return true;
     }
 
     public function delete()


### PR DESCRIPTION
This pull request fixes an issue where a successful "Saved" toast message would be displayed after cancelling the save with the `EntrySaving` event.

This fix also applies to some of the other `Saving` events.

Fixes #6293.

## To Do

* [x] Entries
  * [x] `EntrySaving`
  * [x] `RevisionSaving`
* [x] `TermSaving`
* [x] `GlobalSetSaving`
* [x] `UserSaving`