### PR TITLE
[4.x] Ensure `{{ user:is }}` and `{{ user:isnt }}` work with roles fieldtype

### DIFF
--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Auth;
 
+use Illuminate\Support\Collection;
 use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Fields\Field;
@@ -505,7 +506,11 @@ class UserTags extends Tags
             return $this->parser ? null : false;
         }
 
-        $roles = Arr::wrap($this->params->explode(['role', 'roles']));
+        $roles = $this->params->get(['role', 'roles']);
+
+        if (! $roles instanceof Collection) {
+            $roles = Arr::wrap($this->params->explode(['role', 'roles']));
+        }
 
         foreach ($roles as $role) {
             if ($user->hasRole($role)) {
@@ -529,7 +534,11 @@ class UserTags extends Tags
             return $this->parser ? $this->parse() : true;
         }
 
-        $roles = Arr::wrap($this->params->explode(['roles', 'role']));
+        $roles = $this->params->get(['role', 'roles']);
+
+        if (! $roles instanceof Collection) {
+            $roles = Arr::wrap($this->params->explode(['roles', 'role']));
+        }
 
         $is = false;
 

--- a/tests/Tags/User/UserTagsTest.php
+++ b/tests/Tags/User/UserTagsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Tags\User;
 
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Statamic\Facades\Parse;
+use Statamic\Facades\Role;
 use Statamic\Facades\User;
 use Tests\FakesRoles;
 use Tests\FakesUserGroups;
@@ -16,9 +17,9 @@ class UserTagsTest extends TestCase
         FakesUserGroups,
         PreventSavingStacheItemsToDisk;
 
-    private function tag($tag)
+    private function tag($tag, $params = [])
     {
-        return Parse::template($tag, []);
+        return Parse::template($tag, $params);
     }
 
     /** @test */
@@ -68,6 +69,10 @@ class UserTagsTest extends TestCase
         // Test if user is assigned any of these roles
         $this->assertEquals('yes', $this->tag('{{ user:is role="webmaster|admin" }}yes{{ /user:is }}'));
         $this->assertEquals('', $this->tag('{{ user:isnt role="webmaster|admin" }}yes{{ /user:isnt }}'));
+
+        // test if it handles the value of a user_roles tag
+        $this->assertEquals('yes', $this->tag('{{ user:is :roles="roles" }}yes{{ /user:is }}', ['roles' => Role::all()]));
+        $this->assertEquals('', $this->tag('{{ user:isnt :roles="roles" }}yes{{ /user:isnt }}', ['roles' => Role::all()]));
     }
 
     /** @test */


### PR DESCRIPTION
When you use `{{ user:is }}` and `{{ user:isnt }}` in combination with a user_roles field type it fails as ->explode() gives you a json string, not the roles that have been passed.

This PR updates the tags to check if the param is a collection of roles, and if not continue with the existing behaviour.

Closes https://github.com/statamic/cms/issues/4346