### PR TITLE
[4.x] Fix deprecated: passing null to parameter of type string

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -156,7 +156,7 @@ abstract class Builder implements Contract
 
     public function prepareValueAndOperator($value, $operator, $useDefault = false)
     {
-        $loweredOperator = strtolower($operator);
+        $loweredOperator = strtolower((string) $operator);
 
         if ($useDefault) {
             return [$operator, '='];


### PR DESCRIPTION
Passing `null` to parameter of type `string` (parameter 1 in `strtolower()`) is deprecated since PHP 8.1.