### PR TITLE
[4.x] Fix entries tag not filtering by taxonomy when terms field is `max_items: 1`

### DIFF
--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -357,6 +357,10 @@ class Entries
                 return;
             }
 
+            if (! is_iterable($values)) {
+                $values = [$values];
+            }
+
             $values = collect($values)->map(function ($term) use ($taxonomy) {
                 if ($term instanceof Term) {
                     return $term->id();

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -504,7 +504,11 @@ class EntriesTest extends TestCase
         $this->assertEquals([1, 3, 4], $this->getEntryIds(['taxonomy' => 'tags::rad|tags::meh|categories::news']));
         $this->assertEquals([1], $this->getEntryIds(['taxonomy::all' => 'tags::rad|categories::news'])); // modifier still expected to be 3rd segment
         $this->assertEquals([1], $this->getEntryIds(['taxonomy' => 'tags::rad|tags::meh', 'taxonomy:categories' => 'news'])); // mix and match
-    }
+
+        // Ensure it works when passing terms (eg from a term fieldtype)
+        $this->assertEquals([1, 3, 4], $this->getEntryIds(['taxonomy:tags:in' => Term::query()->whereIn('slug', ['rad', 'meh'])->get()]));
+        $this->assertEquals([1, 3], $this->getEntryIds(['taxonomy:tags:in' => Term::find('tags::rad')]));
+     }
 
     /** @test */
     public function it_throws_an_exception_when_using_an_unknown_taxonomy_query_modifier()

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -508,7 +508,7 @@ class EntriesTest extends TestCase
         // Ensure it works when passing terms (eg from a term fieldtype)
         $this->assertEquals([1, 3, 4], $this->getEntryIds(['taxonomy:tags:in' => Term::query()->whereIn('slug', ['rad', 'meh'])->get()]));
         $this->assertEquals([1, 3], $this->getEntryIds(['taxonomy:tags:in' => Term::find('tags::rad')]));
-     }
+    }
 
     /** @test */
     public function it_throws_an_exception_when_using_an_unknown_taxonomy_query_modifier()


### PR DESCRIPTION
This PR allows you to pass terms fields to a collection tag without having to consider the length of your terms field.

`{{ collection:articles :taxonomy:topics:any="taxonomy_terms_field" }}`

Closes https://github.com/statamic/cms/issues/7697