### PR TITLE
[4.x] Add validation to limit characters in slugs

### DIFF
--- a/resources/js/plugins/slugify.js
+++ b/resources/js/plugins/slugify.js
@@ -18,9 +18,6 @@ export default {
             // Prevent `Block - Hero` turning into `block_-_hero`
             custom[" - "] = " ";
 
-            // Limit to 200 characters.
-            text = text.substr(0, 200);
-
             return getSlug(text, {
                 separator: glue || '-',
                 lang,

--- a/resources/js/plugins/slugify.js
+++ b/resources/js/plugins/slugify.js
@@ -18,6 +18,9 @@ export default {
             // Prevent `Block - Hero` turning into `block_-_hero`
             custom[" - "] = " ";
 
+            // Limit to 200 characters.
+            text = text.substr(0, 200);
+
             return getSlug(text, {
                 separator: glue || '-',
                 lang,

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -344,7 +344,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
         }
 
         if ($this->requiresSlugs() && ! $blueprint->hasField('slug')) {
-            $blueprint->ensureField('slug', ['type' => 'slug', 'localizable' => true], 'sidebar');
+            $blueprint->ensureField('slug', ['type' => 'slug', 'localizable' => true, 'validate' => 'max:200'], 'sidebar');
         }
 
         if ($this->dated() && ! $blueprint->hasField('date')) {

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -143,7 +143,7 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
     {
         $blueprint
             ->ensureFieldPrepended('title', ['type' => 'text', 'required' => true])
-            ->ensureField('slug', ['type' => 'slug', 'required' => true, 'validate' => 'max:255'], 'sidebar');
+            ->ensureField('slug', ['type' => 'slug', 'required' => true, 'validate' => 'max:200'], 'sidebar');
 
         return $blueprint;
     }

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -143,7 +143,7 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
     {
         $blueprint
             ->ensureFieldPrepended('title', ['type' => 'text', 'required' => true])
-            ->ensureField('slug', ['type' => 'slug', 'required' => true], 'sidebar');
+            ->ensureField('slug', ['type' => 'slug', 'required' => true, 'validate' => 'max:255'], 'sidebar');
 
         return $blueprint;
     }

--- a/tests/Feature/Collections/Blueprints/UpdateBlueprintTest.php
+++ b/tests/Feature/Collections/Blueprints/UpdateBlueprintTest.php
@@ -151,6 +151,7 @@ class UpdateBlueprintTest extends TestCase
                                     'field' => [
                                         'type' => 'slug',
                                         'localizable' => true,
+                                        'validate' => 'max:200',
                                     ],
                                 ],
                             ],
@@ -339,6 +340,7 @@ class UpdateBlueprintTest extends TestCase
                                     'field' => [
                                         'type' => 'slug',
                                         'localizable' => true,
+                                        'validate' => 'max:200',
                                     ],
                                 ],
                             ],
@@ -468,6 +470,7 @@ class UpdateBlueprintTest extends TestCase
                                     'field' => [
                                         'type' => 'slug',
                                         'localizable' => true,
+                                        'validate' => 'max:200',
                                     ],
                                 ],
                             ],

--- a/tests/Feature/Taxonomies/Blueprints/UpdateBlueprintTest.php
+++ b/tests/Feature/Taxonomies/Blueprints/UpdateBlueprintTest.php
@@ -153,6 +153,7 @@ class UpdateBlueprintTest extends TestCase
                                     'field' => [
                                         'type' => 'slug',
                                         'required' => true,
+                                        'validate' => 'max:200',
                                     ],
                                 ],
                             ],
@@ -340,6 +341,7 @@ class UpdateBlueprintTest extends TestCase
                                     'field' => [
                                         'type' => 'slug',
                                         'required' => true,
+                                        'validate' => 'max:200',
                                     ],
                                 ],
                             ],


### PR DESCRIPTION
This pull request adds `max:200` to the ensured slug fields on both entry & term blueprints.

Fixes #4426.