### PR TITLE
[4.x] Improve sanitization of Replicator set preview text

### DIFF
--- a/resources/js/bootstrap/globals.js
+++ b/resources/js/bootstrap/globals.js
@@ -1,6 +1,7 @@
 import { marked } from 'marked';
 import { translate, translateChoice } from '../translations/translator';
 import uid from 'uniqid';
+import PreviewHtml from '../components/fieldtypes/replicator/PreviewHtml';
 
 export function cp_url(url) {
     url = Statamic.$config.get('cpUrl') + '/' + url;
@@ -102,4 +103,8 @@ export function escapeHtml(string) {
         .replaceAll('>', '&gt;')
         .replaceAll('"', '&quot;')
         .replaceAll("'", '&#039;');
+}
+
+export function replicatorPreviewHtml(html) {
+    return new PreviewHtml(html);
 }

--- a/resources/js/components/fieldtypes/CodeFieldtype.vue
+++ b/resources/js/components/fieldtypes/CodeFieldtype.vue
@@ -105,7 +105,7 @@ export default {
             return 'theme-' + this.config.theme;
         },
         replicatorPreview() {
-            return this.value.code ? truncate(escapeHtml(this.value.code), 60) : '';
+            return this.value.code ? truncate(this.value.code, 60) : '';
         },
         readOnlyOption() {
             return this.isReadOnly ? 'nocursor' : false;

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -162,6 +162,7 @@ import Selector from '../../assets/Selector.vue';
 import Uploader from '../../assets/Uploader.vue';
 import Uploads from '../../assets/Uploads.vue';
 import { SortableList } from '../../sortable/Sortable';
+import PreviewHtml from '../replicator/PreviewHtml';
 
 export default {
 
@@ -328,11 +329,11 @@ export default {
         },
 
         replicatorPreview() {
-            return _.map(this.assets, (asset) => {
+            return new PreviewHtml(_.map(this.assets, (asset) => {
                 return (asset.isImage || asset.isSvg) ?
                     `<img src="${asset.thumbnail}" width="20" height="20" title="${asset.basename}" />`
                     : asset.basename;
-            }).join(', ');
+            }).join(', '));
         },
 
         showPicker() {

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -162,7 +162,6 @@ import Selector from '../../assets/Selector.vue';
 import Uploader from '../../assets/Uploader.vue';
 import Uploads from '../../assets/Uploads.vue';
 import { SortableList } from '../../sortable/Sortable';
-import PreviewHtml from '../replicator/PreviewHtml';
 
 export default {
 
@@ -329,7 +328,7 @@ export default {
         },
 
         replicatorPreview() {
-            return new PreviewHtml(_.map(this.assets, (asset) => {
+            return replicatorPreviewHtml(_.map(this.assets, (asset) => {
                 return (asset.isImage || asset.isSvg) ?
                     `<img src="${asset.thumbnail}" width="20" height="20" title="${asset.basename}" />`
                     : asset.basename;

--- a/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
+++ b/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
@@ -1,3 +1,5 @@
+import PreviewHtml from "./PreviewHtml";
+
 export default {
 
     computed: {
@@ -13,6 +15,8 @@ export default {
                     return value;
                 })
                 .map(value => {
+                    if (value instanceof PreviewHtml) return value.html;
+
                     if (typeof value === 'string') return escapeHtml(value);
 
                     if (Array.isArray(value) && typeof value[0] === 'string') {

--- a/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
+++ b/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
@@ -13,13 +13,13 @@ export default {
                     return value;
                 })
                 .map(value => {
-                    if (typeof value === 'string') return value;
+                    if (typeof value === 'string') return escapeHtml(value);
 
                     if (Array.isArray(value) && typeof value[0] === 'string') {
-                        return value.join(', ');
+                        return escapeHtml(value.join(', '));
                     }
 
-                    return JSON.stringify(value);
+                    return escapeHtml(JSON.stringify(value));
                 })
                 .join(' / ');
         }

--- a/resources/js/components/fieldtypes/replicator/PreviewHtml.js
+++ b/resources/js/components/fieldtypes/replicator/PreviewHtml.js
@@ -1,0 +1,5 @@
+export default class PreviewHtml {
+    constructor(html) {
+        this.html = html;
+    }
+}


### PR DESCRIPTION
This PR will escape the replicator preview text in a more central place so it happens automatically for all fieldtypes.

If you need html, you can wrap your html this function, like the assets fieldtype is doing here.

```diff
computed: {
  replicatorPreview() {
    const html = `<img src="thumbnail.jpg" />`;

-   return html;
+   return replicatorPreviewHtml(html);
  }
}
```
