### PR TITLE
[4.x] Fix checkbox selection in listing tables 'jumping' on Safari

### DIFF
--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -263,8 +263,8 @@ export default {
         },
 
         checkboxClicked(row, index, $event) {
-            this.$refs.table.focus();
             if ($event.shiftKey && this.lastItemClicked !== null) {
+                this.$refs.table.focus();
                 this.selectRange(
                     Math.min(this.lastItemClicked, index),
                     Math.max(this.lastItemClicked, index)


### PR DESCRIPTION
This PR fixes the table `jumping` bug that Rob was experiencing.

It seemed to be caused by the focus() being set on the table, which I assume was due to the need to support shift clicking (?). I moved it inside the shift logic and the jump went away.

Closes https://github.com/statamic/cms/issues/8536

~Leaving as a draft until Rob verifies that it works.~