### PR TITLE
[4.x] Use RedirectIfAuthorized middleware on password reset & activate pages

### DIFF
--- a/src/Http/Controllers/ActivateAccountController.php
+++ b/src/Http/Controllers/ActivateAccountController.php
@@ -4,9 +4,15 @@ namespace Statamic\Http\Controllers;
 
 use Illuminate\Support\Facades\Password;
 use Statamic\Auth\Passwords\PasswordReset;
+use Statamic\Http\Middleware\CP\RedirectIfAuthorized;
 
 class ActivateAccountController extends ResetPasswordController
 {
+    public function __construct()
+    {
+        $this->middleware(RedirectIfAuthorized::class);
+    }
+
     protected function resetFormAction()
     {
         return route('statamic.account.activate.action');

--- a/src/Http/Controllers/ResetPasswordController.php
+++ b/src/Http/Controllers/ResetPasswordController.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Password;
 use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Auth\ResetsPasswords;
 use Statamic\Contracts\Auth\User;
-use Statamic\Http\Middleware\RedirectIfAuthenticated;
+use Statamic\Http\Middleware\CP\RedirectIfAuthorized;
 
 class ResetPasswordController extends Controller
 {
@@ -16,7 +16,7 @@ class ResetPasswordController extends Controller
 
     public function __construct()
     {
-        $this->middleware(RedirectIfAuthenticated::class);
+        $this->middleware(RedirectIfAuthorized::class);
     }
 
     public function showResetForm(Request $request, $token = null)

--- a/src/Http/Middleware/CP/RedirectIfAuthorized.php
+++ b/src/Http/Middleware/CP/RedirectIfAuthorized.php
@@ -16,8 +16,8 @@ class RedirectIfAuthorized
      */
     public function handle($request, Closure $next, $guard = null)
     {
-        if (User::current()) {
-            return redirect(cp_route('index'));
+        if ($user = User::current()) {
+            return redirect($user->can('access cp') ? cp_route('index') : '/');
         }
 
         return $next($request);

--- a/src/Http/Middleware/CP/RedirectIfAuthorized.php
+++ b/src/Http/Middleware/CP/RedirectIfAuthorized.php
@@ -19,7 +19,7 @@ class RedirectIfAuthorized
     {
         if ($user = User::current()) {
             if ($user->can('access cp')) {
-                Toast::error(__('You can\'t do this while logged in'));
+                Toast::error(__("You can't do this while logged in"));
 
                 return redirect(cp_route('index'));
             }

--- a/src/Http/Middleware/CP/RedirectIfAuthorized.php
+++ b/src/Http/Middleware/CP/RedirectIfAuthorized.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Middleware\CP;
 
 use Closure;
+use Statamic\Facades\CP\Toast;
 use Statamic\Facades\User;
 
 class RedirectIfAuthorized
@@ -17,7 +18,13 @@ class RedirectIfAuthorized
     public function handle($request, Closure $next, $guard = null)
     {
         if ($user = User::current()) {
-            return redirect($user->can('access cp') ? cp_route('index') : '/');
+            if ($user->can('access cp')) {
+                Toast::error(__('You can\'t do this while logged in'));
+
+                return redirect(cp_route('index'));
+            }
+
+            return redirect('/');
         }
 
         return $next($request);

--- a/src/Http/Middleware/CP/RedirectIfAuthorized.php
+++ b/src/Http/Middleware/CP/RedirectIfAuthorized.php
@@ -3,7 +3,7 @@
 namespace Statamic\Http\Middleware\CP;
 
 use Closure;
-use Statamic\Facades\CP\Toast;
+use Illuminate\Support\Facades\Auth;
 use Statamic\Facades\User;
 
 class RedirectIfAuthorized
@@ -17,16 +17,14 @@ class RedirectIfAuthorized
      */
     public function handle($request, Closure $next, $guard = null)
     {
-        if ($user = User::current()) {
-            if ($user->can('access cp')) {
-                Toast::error(__("You can't do this while logged in"));
-
-                return redirect(cp_route('index'));
-            }
-
-            return redirect('/');
+        if (! Auth::guard($guard)->check()) {
+            return $next($request);
         }
 
-        return $next($request);
+        $user = User::current();
+
+        $url = $user->can('access cp') ? cp_route('index') : '/';
+
+        return redirect($url)->withError(__("You can't do this while logged in"));
     }
 }


### PR DESCRIPTION
This PR adds the `RedirectIfAuthorized` middleware to password reset & activate pages, so if a logged in user tries to visit those pages they will be redirected away.

I've also updated RedirectIfAuthorized to check if the user can access the cp or not, if they can they are taken to it, and if they cant they are just taken to the homepage.

I think this closes https://github.com/statamic/cms/issues/2521