### PR TITLE
[4.x] Fix redirect actions showing a toast error

### DIFF
--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -135,6 +135,7 @@ export default {
                 if (this.$axios.isCancel(e)) return;
                 this.loading = false;
                 this.initializing = false;
+                if (e.request && ! e.response) return;
                 this.$toast.error(e.response ? e.response.data.message : __('Something went wrong'), { duration: null });
             })
         },


### PR DESCRIPTION
[Redirect actions](https://statamic.dev/extending/actions#redirects) show a toast error when you go back to the CP. 

This PR handles the situation checks when an axios request was made and has no response, instead of showing the default toast we do nothing.

Closes https://github.com/statamic/cms/issues/3166