### PR TITLE
Allow focus on textarea fieldtypes

### DIFF
--- a/resources/js/components/fieldtypes/TextareaFieldtype.vue
+++ b/resources/js/components/fieldtypes/TextareaFieldtype.vue
@@ -1,5 +1,6 @@
 <template>
     <textarea-input
+        :focus="config.focus"
         :name="name"
         :isReadOnly="isReadOnly"
         :limit="config.character_limit || null"


### PR DESCRIPTION
In Peak I use a textarea instead of a text field for alt texts in the asset blueprint as I think these are more appropriate and inviting to write good alt texts. However, today I learned that the text fieldtype gets autofocus when it's called `title` or `alt`. 

I suspect you don't want this behaviour duplicated for textareas, but this PR does at the config option to textareas so we can use `focus: true` in their config.

If you'd be fine with the autofocus for textareas named `title` or `alt` I'd be happy to update this PR. The line would then have to be: `:focus="config.focus || name === 'title' || name === 'alt'"`.