### PR TITLE
[4.x] Scope filters can return null

### DIFF
--- a/src/Query/Scopes/Filters/Concerns/QueriesFilters.php
+++ b/src/Query/Scopes/Filters/Concerns/QueriesFilters.php
@@ -23,7 +23,7 @@ trait QueriesFilters
                     'values' => $values,
                 ];
             })
-            ->filter(fn($filter) => $filter->filterInstance != null)
+            ->filter(fn ($filter) => $filter->filterInstance != null)
             ->each(function ($filter) use ($query) {
                 $filter->filterInstance->apply($query, $filter->values);
             })

--- a/src/Query/Scopes/Filters/Concerns/QueriesFilters.php
+++ b/src/Query/Scopes/Filters/Concerns/QueriesFilters.php
@@ -23,6 +23,7 @@ trait QueriesFilters
                     'values' => $values,
                 ];
             })
+            ->filter(fn($filter) => $filter->filterInstance != null)
             ->each(function ($filter) use ($query) {
                 $filter->filterInstance->apply($query, $filter->values);
             })

--- a/src/Query/Scopes/ScopeRepository.php
+++ b/src/Query/Scopes/ScopeRepository.php
@@ -15,7 +15,7 @@ class ScopeRepository
     public function find($key, $context = [])
     {
         if ($scope = app('statamic.scopes')->get($key)) {
-            return app($scope)->context($context);
+            return app($scope)?->context($context);
         }
     }
 


### PR DESCRIPTION
We updated to Statamic 4. By having a great UI change anyways, we decided hide some default filters as we have many custom filters covering all our needed use cases. 

To hide default filters in the Service Provider.

```php
app()->bind(\Statamic\Query\Scopes\Filters\Fields::class, fn () => null);
app()->bind(\Statamic\Query\Scopes\Filters\UserRole::class, fn () => null);
app()->bind(\Statamic\Query\Scopes\Filters\UserGroup::class, fn () => null);
```

By doing so, a scope can return null. If a user has old presets containing those filters, an error occures.

This PR covers the case, that `app($scope)` might find a filter but returns null anyways. With this PR, Statamic can handle that case and should not include any breaking change. It is simply hardening the code base for funky cases like this. 

Small note:
Depending on the personal taste, line 26 could look like this as well:
```php
->reject(fn($filter) => $filter->filterInstance == null)
// OR
->reject(fn($filter) => is_null($filter->filterInstance))
```