### PR TITLE
[4.x] Fix utility permissions not showing when using route caching

### DIFF
--- a/src/Auth/CorePermissions.php
+++ b/src/Auth/CorePermissions.php
@@ -214,6 +214,8 @@ class CorePermissions
 
     protected function registerUtilities()
     {
+        Utility::boot();
+
         Utility::all()->each(function ($utility) {
             Permission::register("access {$utility->handle()} utility", function ($perm) use ($utility) {
                 return $perm

--- a/src/Auth/CorePermissions.php
+++ b/src/Auth/CorePermissions.php
@@ -214,9 +214,7 @@ class CorePermissions
 
     protected function registerUtilities()
     {
-        Utility::boot();
-
-        Utility::all()->each(function ($utility) {
+        Utility::boot()->all()->each(function ($utility) {
             Permission::register("access {$utility->handle()} utility", function ($perm) use ($utility) {
                 return $perm
                     ->label(__('statamic::permissions.access_utility', ['title' => $utility->title()]))

--- a/src/CP/Utilities/UtilityRepository.php
+++ b/src/CP/Utilities/UtilityRepository.php
@@ -76,8 +76,6 @@ class UtilityRepository
 
     public function routes()
     {
-        $this->boot();
-
         Route::namespace('\\')->prefix('utilities')->name('utilities.')->group(function () {
             $this->all()->each(function ($utility) {
                 if ($utility->action()) {

--- a/src/CP/Utilities/UtilityRepository.php
+++ b/src/CP/Utilities/UtilityRepository.php
@@ -18,6 +18,10 @@ class UtilityRepository
 
     public function boot()
     {
+        if ($this->utilities->isNotEmpty()) {
+            return;
+        }
+
         CoreUtilities::boot();
 
         foreach ($this->extensions as $callback) {

--- a/src/CP/Utilities/UtilityRepository.php
+++ b/src/CP/Utilities/UtilityRepository.php
@@ -66,12 +66,12 @@ class UtilityRepository
 
     public function find($handle)
     {
-        return $this->utilities->get($handle);
+        return $this->all()->get($handle);
     }
 
     public function findBySlug($slug)
     {
-        return $this->utilities->first(fn ($utility) => $utility->slug() === $slug);
+        return $this->all()->first(fn ($utility) => $utility->slug() === $slug);
     }
 
     public function routes()

--- a/src/CP/Utilities/UtilityRepository.php
+++ b/src/CP/Utilities/UtilityRepository.php
@@ -10,6 +10,7 @@ class UtilityRepository
 {
     protected $utilities;
     protected $extensions = [];
+    protected $booted = false;
 
     public function __construct()
     {
@@ -23,6 +24,8 @@ class UtilityRepository
         foreach ($this->extensions as $callback) {
             $callback($this);
         }
+
+        $this->booted = true;
     }
 
     public function extend($callback)
@@ -48,6 +51,10 @@ class UtilityRepository
 
     public function all()
     {
+        if (! $this->booted) {
+            $this->boot();
+        }
+
         return $this->utilities;
     }
 

--- a/src/CP/Utilities/UtilityRepository.php
+++ b/src/CP/Utilities/UtilityRepository.php
@@ -10,7 +10,6 @@ class UtilityRepository
 {
     protected $utilities;
     protected $extensions = [];
-    protected $booted = false;
 
     public function __construct()
     {
@@ -24,8 +23,6 @@ class UtilityRepository
         foreach ($this->extensions as $callback) {
             $callback($this);
         }
-
-        $this->booted = true;
     }
 
     public function extend($callback)
@@ -51,10 +48,6 @@ class UtilityRepository
 
     public function all()
     {
-        if (! $this->booted) {
-            $this->boot();
-        }
-
         return $this->utilities;
     }
 

--- a/src/CP/Utilities/UtilityRepository.php
+++ b/src/CP/Utilities/UtilityRepository.php
@@ -52,6 +52,8 @@ class UtilityRepository
 
     public function all()
     {
+        $this->boot();
+
         return $this->utilities;
     }
 

--- a/src/CP/Utilities/UtilityRepository.php
+++ b/src/CP/Utilities/UtilityRepository.php
@@ -23,6 +23,8 @@ class UtilityRepository
         foreach ($this->extensions as $callback) {
             $callback($this);
         }
+
+        return $this;
     }
 
     public function extend($callback)
@@ -70,10 +72,8 @@ class UtilityRepository
 
     public function routes()
     {
-        $this->boot();
-
         Route::namespace('\\')->prefix('utilities')->name('utilities.')->group(function () {
-            $this->all()->each(function ($utility) {
+            $this->boot()->all()->each(function ($utility) {
                 if ($utility->action()) {
                     Route::get($utility->slug(), $utility->action())
                         ->middleware("can:access {$utility->handle()} utility")

--- a/src/CP/Utilities/UtilityRepository.php
+++ b/src/CP/Utilities/UtilityRepository.php
@@ -18,10 +18,6 @@ class UtilityRepository
 
     public function boot()
     {
-        if ($this->utilities->isNotEmpty()) {
-            return;
-        }
-
         CoreUtilities::boot();
 
         foreach ($this->extensions as $callback) {
@@ -52,8 +48,6 @@ class UtilityRepository
 
     public function all()
     {
-        $this->boot();
-
         return $this->utilities;
     }
 
@@ -76,6 +70,8 @@ class UtilityRepository
 
     public function routes()
     {
+        $this->boot();
+
         Route::namespace('\\')->prefix('utilities')->name('utilities.')->group(function () {
             $this->all()->each(function ($utility) {
                 if ($utility->action()) {


### PR DESCRIPTION
This pull request attempts to fix an issue where the permissions for utilities are missing when you're using route caching.

From what I can tell, without route caching it looks like the utilities are booted **before** the permissions are booted but _with_ route caching, the permissions are booted before utilities are.

To workaround this, we've made the `boot` method in the `UtilitiesRepository` fluent so we can do `Utility::boot()->all()` to ensure utilities have always been booted before we use them.

Fixes #8691.