### PR TITLE
[4.x] Fix pagination in Relationship Fieldtype causing page to scroll to the top

### DIFF
--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -75,6 +75,7 @@
                             class="border-t shadow-lg"
                             :resource-meta="meta"
                             :inline="true"
+                            :scroll-to-top="false"
                             @page-selected="setPage" />
 
                         <div class="p-4 border-t flex items-center justify-between bg-gray-200">


### PR DESCRIPTION
This pull request fixes an issue when using the pagination in the Relationship Fieldtype, where it'd scroll the user to the top of the page.

Fixes #7278.