### PR TITLE
[4.x] Fix `redirect: @child` redirecting to `@child` when not a link fieldtype

### DIFF
--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -77,11 +77,7 @@ class DataResponse implements Responsable
             throw new NotFoundHttpException;
         }
 
-        if ($redirect === '@child') {
-            $redirect = (new ResolveRedirect)($redirect, $this->data);
-        }
-
-        return redirect($redirect);
+        return redirect((new ResolveRedirect)($redirect, $this->data));
     }
 
     protected function protect()

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -77,6 +77,9 @@ class DataResponse implements Responsable
             throw new NotFoundHttpException;
         }
 
+        // If there is a redirect value but no corresponding blueprint field, (e.g. someone
+        // manually set a redirect in the YAML), we'll need to resolve it manually since
+        // they might have set one of the magic values like @child or entry::some-id.
         $redirect = ResolveRedirect::resolve($redirect, $this->data);
 
         if ($redirect === 404) {

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -8,6 +8,7 @@ use Statamic\Auth\Protect\Protection;
 use Statamic\Events\ResponseCreated;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Site;
+use Statamic\Routing\ResolveRedirect;
 use Statamic\View\View;
 
 class DataResponse implements Responsable
@@ -74,6 +75,10 @@ class DataResponse implements Responsable
 
         if (! $redirect = $this->data->redirect) {
             throw new NotFoundHttpException;
+        }
+
+        if ($redirect === '@child') {
+            $redirect = (new ResolveRedirect)($redirect, $this->data);
         }
 
         return redirect($redirect);

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -77,7 +77,13 @@ class DataResponse implements Responsable
             throw new NotFoundHttpException;
         }
 
-        return redirect(ResolveRedirect::resolve($redirect, $this->data));
+        $redirect = ResolveRedirect::resolve($redirect, $this->data);
+
+        if ($redirect === 404) {
+            throw new NotFoundHttpException;
+        }
+
+        return redirect($redirect);
     }
 
     protected function protect()

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -2,13 +2,13 @@
 
 namespace Statamic\Http\Responses;
 
+use Facades\Statamic\Routing\ResolveRedirect;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Str;
 use Statamic\Auth\Protect\Protection;
 use Statamic\Events\ResponseCreated;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Site;
-use Statamic\Routing\ResolveRedirect;
 use Statamic\View\View;
 
 class DataResponse implements Responsable
@@ -77,7 +77,7 @@ class DataResponse implements Responsable
             throw new NotFoundHttpException;
         }
 
-        return redirect((new ResolveRedirect)($redirect, $this->data));
+        return redirect(ResolveRedirect::resolve($redirect, $this->data));
     }
 
     protected function protect()

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use Facades\Statamic\CP\LivePreview;
-use Facades\Statamic\Routing\ResolveRedirect;
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;


### PR DESCRIPTION
Not sure if this is the best approach, but this PR brings back the previous functionality when the redirect is to `@child`. This means if you add that to your .md file regardless of the field type (or if there isnt even one) the redirect still happens.

Closes https://github.com/statamic/cms/issues/8680