### PR TITLE
[4.x] If entry has an origin, get the mount from there

### DIFF
--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -79,6 +79,10 @@ class AugmentedEntry extends AbstractAugmented
 
     protected function mount()
     {
+        if ($origin = $this->origin()) {
+            return $origin->mount();
+        }
+
         return $this->data->value('mount') ?? Collection::findByMount($this->data);
     }
 

--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -79,11 +79,13 @@ class AugmentedEntry extends AbstractAugmented
 
     protected function mount()
     {
-        if ($origin = $this->data->origin()) {
+        $mount = $this->data->value('mount') ?? Collection::findByMount($this->data);
+
+        if (! $mount && ($origin = $this->data->origin())) {
             return Collection::findByMount($origin);
         }
 
-        return $this->data->value('mount') ?? Collection::findByMount($this->data);
+        return $mount;
     }
 
     public function authors()

--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -79,8 +79,8 @@ class AugmentedEntry extends AbstractAugmented
 
     protected function mount()
     {
-        if ($origin = $this->origin()) {
-            return $origin->mount();
+        if ($origin = $this->data->origin()) {
+            return Collection::findByMount($origin);
         }
 
         return $this->data->value('mount') ?? Collection::findByMount($this->data);


### PR DESCRIPTION
If an augmented entry has an origin, the mount should be found from the origin, not the entry itself.

Closes https://github.com/statamic/cms/issues/6906