### PR TITLE
[4.x] Bard: Fix adding sets with horizontal cursor

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.js
+++ b/resources/js/components/fieldtypes/bard/Set.js
@@ -1,6 +1,7 @@
 import { Node } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-2'
 import SetComponent from './Set.vue';
+import { TextSelection } from '@tiptap/pm/state';
 
 export const Set = Node.create({
 
@@ -54,7 +55,10 @@ export const Set = Node.create({
                 const { selection } = tr;
                 const node = this.type.create(attrs);
                 if (dispatch) {
-                    const transaction = tr.insert(selection.$cursor.pos - 1, node);
+                    const transaction = selection instanceof TextSelection
+                        ? tr.insert(selection.$cursor.pos - 1, node)
+                        : tr.insert(selection.$head.pos, node);
+
                     dispatch(transaction);
                 }
             },


### PR DESCRIPTION
This pull request fixes a bug with Bard where you couldn't add any sets when you have a "horizontal cursor".

Normally, the `selection` with a normal cursor would be an instance of `TextSelection`. However, when it's a "horizontal cursor", a `GapCursor` will instead be returned which doesn't have a `$cursor` to get the position from.

Fixes #7712.