### PR TITLE
[4.x] Fix missing config pass to mount manager

### DIFF
--- a/src/Imaging/Attributes.php
+++ b/src/Imaging/Attributes.php
@@ -17,7 +17,7 @@ class Attributes
         if ($source->getAdapter() instanceof LocalFilesystemAdapter) {
             $this->cacheDisk = $source;
         } else {
-            $manager = $this->mountManager($source->getDriver(), $this->cacheDisk()->getDriver());
+            $manager = $this->mountManager($source->getDriver(), $this->cacheDisk()->getDriver(), $source->getConfig());
 
             if ($manager->has($destination = "cache://{$path}")) {
                 $manager->delete($destination);
@@ -68,12 +68,12 @@ class Attributes
         return ['width' => 300, 'height' => 150];
     }
 
-    private function mountManager($source, $cache)
+    private function mountManager($source, $cache, $config)
     {
         return new MountManager([
             'source' => $source,
             'cache' => $cache,
-        ]);
+        ], $config);
     }
 
     private function cacheDisk()


### PR DESCRIPTION
Pass the config to the MountManager constructor, otherwise the config (from config/filesystems) will be empty and the copyAcrossFilesystem will call visibility method on AwsS3V3Adapter which is unsupported on R2 (and possibly other S3 providers other than AWS).

![284050261-3b550248-2dd9-49cb-8066-e87c5bcceb9d](https://github.com/statamic/cms/assets/829510/4723176c-4a61-49f6-8510-2cf79bd97b84)

Closes #7193 