### PR TITLE
[4.x] Revert "[4.x] Auto-populate Array Fieldtype Options (#8980)"

### DIFF
--- a/resources/js/components/fieldtypes/ArrayFieldtype.vue
+++ b/resources/js/components/fieldtypes/ArrayFieldtype.vue
@@ -61,7 +61,7 @@
                             <tr class="sortable-row" v-for="(element, index) in data" :key="element._id">
                                 <td class="sortable-handle table-drag-handle" v-if="!isReadOnly"></td>
                                 <td>
-                                    <input type="text" class="input-text font-bold" v-model="element.key" :readonly="isReadOnly" @blur="keyUpdated(element)" />
+                                    <input type="text" class="input-text font-bold" v-model="element.key" :readonly="isReadOnly" />
                                 </td>
                                 <td>
                                     <input type="text" class="input-text" v-model="element.value" :readonly="isReadOnly" />
@@ -210,21 +210,7 @@ export default {
 
         setKey(key) {
             this.selectedKey = key
-        },
-
-        keyUpdated(element) {
-            if (element.key === null || element.value !== null) {
-                return null;
-            }
-
-            let value = element.key.charAt(0).toUpperCase() + element.key.slice(1);
-
-            this.data.find((item, index) => {
-                if (item._id === element._id) {
-                    this.data[index].value = value;
-                }
-            })
-        },
+        }
     }
 
 }


### PR DESCRIPTION
This pull request reverts #8980, which automatically populated labels from option keys in the Array Fieldtype.

 