### PR TITLE
[4.x] Allow tag conditions to support querying on sub fields using dot notation

### DIFF
--- a/src/Tags/Concerns/QueriesConditions.php
+++ b/src/Tags/Concerns/QueriesConditions.php
@@ -45,6 +45,8 @@ trait QueriesConditions
     {
         $regexOperator = $value ? 'regexp' : 'not regexp';
 
+        $field = str_replace('.', '->', $field);
+
         switch ($condition) {
             case 'is':
             case 'equals':


### PR DESCRIPTION
This PR allows tag conditions to query on sub fields, eg date ranges. 

Technically this was already possible, just the syntax was ugly:
`:date_field->end:is_after="today"`

after this PR you can do 
`:date_field.end:is_after="today"`

Which looks a bit nicer I think.

Closes https://github.com/statamic/cms/issues/7099