### PR TITLE
[4.x] Add `collection` to augmented term values

### DIFF
--- a/src/Http/Resources/API/TermResource.php
+++ b/src/Http/Resources/API/TermResource.php
@@ -14,17 +14,17 @@ class TermResource extends JsonResource
      */
     public function toArray($request)
     {
-        $fields = $this->resource->selectedQueryColumns() ?? $this->resource->augmented()->keys();
+        $fields = collect($this->resource->selectedQueryColumns() ?? $this->resource->augmented()->keys());
 
-        // Don't want the 'entries' variable in API requests.
-        $fields = array_diff($fields, ['entries']);
+        // Don't want these variables in API requests.
+        $fields = $fields->reject(fn ($field) => in_array($field, ['entries', 'collection']));
 
         $with = $this->blueprint()
             ->fields()->all()
             ->filter->isRelationship()->keys()->all();
 
         return $this->resource
-            ->toAugmentedCollection($fields)
+            ->toAugmentedCollection($fields->all())
             ->withRelations($with)
             ->withShallowNesting()
             ->toArray();

--- a/src/Taxonomies/AugmentedTerm.php
+++ b/src/Taxonomies/AugmentedTerm.php
@@ -33,6 +33,7 @@ class AugmentedTerm extends AbstractAugmented
             'taxonomy',
             'edit_url',
             'locale',
+            'collection',
             'updated_at',
             'updated_by',
         ];

--- a/tests/Data/Taxonomies/AugmentedTermTest.php
+++ b/tests/Data/Taxonomies/AugmentedTermTest.php
@@ -95,14 +95,13 @@ class AugmentedTermTest extends AugmentedTestCase
     }
 
     /** @test */
-    public function collection_is_present_when_taxonomy_is_mounted()
+    public function collection_is_present_when_set()
     {
         $collection = tap(Collection::make('test'))->save();
         tap(Taxonomy::make('test'))->save();
 
         $term = Term::make()
             ->taxonomy('test')
-            ->collection($collection)
             ->blueprint('test')
             ->in('en')
             ->slug('term-slug')
@@ -110,9 +109,11 @@ class AugmentedTermTest extends AugmentedTestCase
 
         $augmented = new AugmentedTerm($term);
 
-        $value = $augmented->get('collection')->value();
+        $this->assertNull($augmented->get('collection')->value());
 
-        $this->assertInstanceOf(CollectionContract::class, $value);
+        $term->collection($collection);
+
+        $this->assertInstanceOf(CollectionContract::class, $value = $augmented->get('collection')->value());
         $this->assertEquals($collection->handle(), $value->handle());
     }
 }


### PR DESCRIPTION
When a taxonomy is mounted make the `collection` variable available to the front end view by adding the key to the augmented term.

Closes https://github.com/statamic/cms/issues/8472