### PR TITLE
[4.x] If collection is not available on a site, redirect back

### DIFF
--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -573,10 +573,8 @@ class CollectionsController extends CpController
 
     protected function ensureCollectionIsAvailableOnSite($collection, $site)
     {
-        if (Site::hasMultiple()) {
-            if (! $collection->sites()->contains($site->handle())) {
-                return redirect()->back()->with('error', __('Collection is not available on this site (:handle)', ['handle' => $site->handle]));
-            }
+        if (Site::hasMultiple() && ! $collection->sites()->contains($site->handle())) {
+            return redirect()->back()->with('error', __('Collection is not available on this site (:handle)', ['handle' => $site->handle]));
         }
     }
 }

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -55,6 +55,12 @@ class CollectionsController extends CpController
     {
         $this->authorize('view', $collection, __('You are not authorized to view this collection.'));
 
+        $site = $request->site ? Site::get($request->site) : Site::selected();
+
+        if ($response = $this->ensureCollectionIsAvailableOnSite($collection, $site)) {
+            return $response;
+        }
+
         $blueprints = $collection
             ->entryBlueprints()
             ->reject->hidden()
@@ -64,8 +70,6 @@ class CollectionsController extends CpController
                     'title' => $blueprint->title(),
                 ];
             })->values();
-
-        $site = $request->site ? Site::get($request->site) : Site::selected();
 
         $blueprint = $collection->entryBlueprint();
 
@@ -565,5 +569,14 @@ class CollectionsController extends CpController
             })
             ->values()
             ->all();
+    }
+
+    protected function ensureCollectionIsAvailableOnSite($collection, $site)
+    {
+        if (Site::hasMultiple()) {
+            if (! $collection->sites()->contains($site->handle())) {
+                return redirect()->back()->with('error', __('Collection is not available on this site (:handle)', ['handle' => $site->handle]));
+            }
+        }
     }
 }

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -574,7 +574,7 @@ class CollectionsController extends CpController
     protected function ensureCollectionIsAvailableOnSite($collection, $site)
     {
         if (Site::hasMultiple() && ! $collection->sites()->contains($site->handle())) {
-            return redirect()->back()->with('error', __('Collection is not available on this site (:handle)', ['handle' => $site->handle]));
+            return redirect()->back()->with('error', __('Collection is not available on site ":handle".', ['handle' => $site->handle]));
         }
     }
 }

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -581,7 +581,7 @@ class EntriesController extends CpController
     protected function ensureCollectionIsAvailableOnSite($collection, $site)
     {
         if (Site::hasMultiple() && ! $collection->sites()->contains($site->handle())) {
-            return redirect()->back()->with('error', __('Collection is not available on this site (:handle)', ['handle' => $site->handle]));
+            return redirect()->back()->with('error', __('Collection is not available on site ":handle".', ['handle' => $site->handle]));
         }
     }
 }

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -28,7 +28,7 @@ class EntriesController extends CpController
     {
         $this->authorize('view', $collection);
 
-        if ($response = $this->ensureCollectionIsAvailableOnSite($collection, $site)) {
+        if ($response = $this->ensureCollectionIsAvailableOnSite($collection, Site::current())) {
             return $response;
         }
 

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -8,7 +8,6 @@ use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\CP\Breadcrumbs;
 use Statamic\Exceptions\BlueprintNotFoundException;
 use Statamic\Facades\Asset;
-use Statamic\Facades\Cp\Toast;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
@@ -587,8 +586,7 @@ class EntriesController extends CpController
     {
         if (Site::hasMultiple()) {
             if (! $collection->sites()->contains($site->handle)) {
-                Toast::error(__('Collection is not available on this site (:handle)', ['handle' => $site->handle]));
-                return redirect()->back();
+                return redirect()->back()->with('error', __('Collection is not available on this site (:handle)', ['handle' => $site->handle]));
             }
         }
     }

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -580,10 +580,8 @@ class EntriesController extends CpController
 
     protected function ensureCollectionIsAvailableOnSite($collection, $site)
     {
-        if (Site::hasMultiple()) {
-            if (! $collection->sites()->contains($site->handle())) {
-                return redirect()->back()->with('error', __('Collection is not available on this site (:handle)', ['handle' => $site->handle]));
-            }
+        if (Site::hasMultiple() && ! $collection->sites()->contains($site->handle())) {
+            return redirect()->back()->with('error', __('Collection is not available on this site (:handle)', ['handle' => $site->handle]));
         }
     }
 }

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -28,10 +28,6 @@ class EntriesController extends CpController
     {
         $this->authorize('view', $collection);
 
-        if ($response = $this->ensureCollectionIsAvailableOnSite($collection, Site::current())) {
-            return $response;
-        }
-
         $query = $this->indexQuery($collection);
 
         $activeFilterBadges = $this->queryFilters($query, $request->filters, [
@@ -585,7 +581,7 @@ class EntriesController extends CpController
     protected function ensureCollectionIsAvailableOnSite($collection, $site)
     {
         if (Site::hasMultiple()) {
-            if (! $collection->sites()->contains($site->handle)) {
+            if (! $collection->sites()->contains($site->handle())) {
                 return redirect()->back()->with('error', __('Collection is not available on this site (:handle)', ['handle' => $site->handle]));
             }
         }


### PR DESCRIPTION
A possible solution to both https://github.com/statamic/cms/issues/6762 and https://github.com/statamic/cms/issues/3756

If the collection is not set up on a site then redirect back with a toast message telling the user that the collection isn't available.

Closes https://github.com/statamic/cms/issues/6762 
Closes https://github.com/statamic/cms/issues/3756