### PR TITLE
[4.x] Provide searchables()->lazy and insertLazily methods to search indexes

### DIFF
--- a/src/Search/Algolia/Index.php
+++ b/src/Search/Algolia/Index.php
@@ -61,7 +61,7 @@ class Index extends BaseIndex
             $index->setSettings($this->config['settings']);
         }
 
-        $this->insertMultiple($this->searchables()->all());
+        $this->insertLazily($this->searchables()->lazy());
 
         return $this;
     }

--- a/src/Search/Algolia/Index.php
+++ b/src/Search/Algolia/Index.php
@@ -61,7 +61,7 @@ class Index extends BaseIndex
             $index->setSettings($this->config['settings']);
         }
 
-        $this->insertLazily($this->searchables()->lazy());
+        $this->searchables()->lazy()->each(fn ($searchables) => $this->insertMultiple($searchables));
 
         return $this;
     }

--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -90,9 +90,7 @@ abstract class Index
 
     public function insertLazily(LazyCollection $providers)
     {
-        foreach ($providers as $documents) {
-            $this->insertMultiple($documents);
-        }
+        $providers->each(fn ($documents) => $this->insertMultiple($documents));
 
         return $this;
     }

--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Search;
 
-use Illuminate\Support\LazyCollection;
 use Statamic\Contracts\Search\Searchable;
 use Statamic\Support\Arr;
 
@@ -58,7 +57,7 @@ abstract class Index
     {
         $this->deleteIndex();
 
-        $this->insertLazily($this->searchables()->lazy());
+        $this->searchables()->lazy()->each(fn ($searchables) => $this->insertMultiple($searchables));
 
         return $this;
     }
@@ -84,13 +83,6 @@ abstract class Index
         });
 
         $this->insertDocuments($documents);
-
-        return $this;
-    }
-
-    public function insertLazily(LazyCollection $providers)
-    {
-        $providers->each(fn ($documents) => $this->insertMultiple($documents));
 
         return $this;
     }

--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Search;
 
+use Illuminate\Support\LazyCollection;
 use Statamic\Contracts\Search\Searchable;
 use Statamic\Support\Arr;
 
@@ -57,7 +58,7 @@ abstract class Index
     {
         $this->deleteIndex();
 
-        $this->insertMultiple($this->searchables()->all());
+        $this->insertLazily($this->searchables()->lazy());
 
         return $this;
     }
@@ -83,6 +84,15 @@ abstract class Index
         });
 
         $this->insertDocuments($documents);
+
+        return $this;
+    }
+
+    public function insertLazily(LazyCollection $providers)
+    {
+        foreach ($providers as $documents) {
+            $this->insertMultiple($documents);
+        }
 
         return $this;
     }

--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -4,6 +4,7 @@ namespace Statamic\Search;
 
 use Closure;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Search\Searchable;
 use Statamic\Search\Searchables\Providers;
@@ -41,6 +42,15 @@ class Searchables
     public function all(): Collection
     {
         return $this->providers->flatMap->provide();
+    }
+
+    public function lazy(): LazyCollection
+    {
+        return LazyCollection::make(function () {
+            foreach ($this->providers as $provider) {
+                yield $provider->provide();
+            }
+        });
     }
 
     public function contains($searchable)

--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -4,8 +4,8 @@ namespace Statamic\Search;
 
 use Closure;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 use Statamic\Contracts\Search\Searchable;
 use Statamic\Search\Searchables\Providers;
 use Statamic\Support\Arr;


### PR DESCRIPTION
Maybe not the right approach, but this PR works to reduce the memory usage of searchables()->all() by providing a searchables()->lazy() method returning a less memory heavy LazyCollection. It also updates Algolia and Comb to use this instead of searchables()->all().

It could be possible to take this a step further and have the provider return a lazy collection and then insert each document individually rather than multiple, but that would mean more http calls so maybe thats a trade off.

Should help with https://github.com/statamic/cms/issues/8854