### PR TITLE
[4.x] Extend Ray modifier for use of the color helper function

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1794,11 +1794,11 @@ class CoreModifiers extends Modifier
      *
      * @return void
      */
-    public function ray($value)
+    public function ray($value, $params)
     {
         throw_unless(function_exists('ray'), new \Exception('Ray is not installed. Run `composer require spatie/laravel-ray --dev`'));
 
-        ray($value);
+        ray($value)->color(Arr::get($params, 0, 'gray'));
 
         return $value;
     }


### PR DESCRIPTION
As proposed and approved in statamic/ideas#1083 this PR allows the usage of a color as parameter for the Ray modifier.

Example:
```antlers
{{ hello_world | ray('red');
```

<img width="790" alt="Screenshot 2023-11-27 at 16 48 58" src="https://github.com/statamic/cms/assets/1247666/22f10aa2-0a78-4c06-8201-3726edd23a2c">


Closes statamic/ideas#1083