### PR TITLE
[4.x] Make whole tree branches clickable in Entries Fieldtype in Tree Mode

### DIFF
--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -131,10 +131,12 @@
                                 :site="site"
                                 :preferences-prefix="`selector-field.${name}`"
                                 :editable="false"
+                                @branch-clicked="$refs[`tree-branch-${$event.id}`].click()"
                             >
                                 <template #branch-action="{ branch, index }">
                                     <div>
                                         <input
+                                            :ref="`tree-branch-${branch.id}`"
                                             type="checkbox"
                                             class="mt-3 ml-3"
                                             :value="branch.id"

--- a/resources/js/components/structures/Branch.vue
+++ b/resources/js/components/structures/Branch.vue
@@ -5,7 +5,7 @@
             <div class="page-move w-6" />
         </slot>
         <div class="flex items-center flex-1 p-2 ml-2 text-xs leading-normal">
-            <div class="flex items-center flex-1">
+            <div class="flex items-center flex-1" @click="$emit('branch-clicked', page)">
                 <div class="little-dot mr-2" :class="getStatusClass()" v-tooltip="getStatusTooltip()" />
                 <svg-icon name="home-page" class="mr-2 h-4 w-4 text-gray-800" v-if="isRoot" v-tooltip="__('This is the root page')" />
                 <a

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -47,6 +47,7 @@
                     @toggle-open="store.toggleOpen(page)"
                     @removed="pageRemoved"
                     @children-orphaned="childrenOrphaned"
+                    @branch-clicked="$emit('branch-clicked', page)"
                 >
                     <template #branch-action="props">
                         <slot name="branch-action" v-bind="{ ...props, vm }" />


### PR DESCRIPTION
This pull request makes a small improvement to the Entries Fieldtype in Tree Mode. 

Previously, you could only click on the checkbox to toggle if an entry was selected or not. Now, you can click anywhere on the "tree branch".

Closes #9043.