### PR TITLE
[4.x] Pass site parameter from Entry Publish Form to Tree Listing

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -337,7 +337,7 @@ export default {
         canEditBlueprint: Boolean,
         canManagePublishState: Boolean,
         createAnotherUrl: String,
-        listingUrl: String,
+        initialListingUrl: String,
         collectionHasRoutes: Boolean,
         previewTargets: Array,
         autosaveInterval: Number,
@@ -412,6 +412,10 @@ export default {
 
         published() {
             return this.values.published;
+        },
+
+        listingUrl() {
+            return `${this.initialListingUrl}?site=${this.site}`;
         },
 
         livePreviewUrl() {

--- a/resources/views/entries/create.blade.php
+++ b/resources/views/entries/create.blade.php
@@ -17,7 +17,7 @@
         :breadcrumbs="{{ $breadcrumbs->toJson() }}"
         site="{{ $locale }}"
         create-another-url="{{ cp_route('collections.entries.create', [$collection, $locale, 'blueprint' => $blueprint['handle'], 'parent' => $values['parent'] ?? null]) }}"
-        listing-url="{{ cp_route('collections.show', $collection) }}"
+        initial-listing-url="{{ cp_route('collections.show', $collection) }}"
         :can-manage-publish-state="{{ Statamic\Support\Str::bool($canManagePublishState) }}"
         :preview-targets="{{ json_encode($previewTargets) }}"
     ></base-entry-create-form>

--- a/resources/views/entries/edit.blade.php
+++ b/resources/views/entries/edit.blade.php
@@ -33,7 +33,7 @@
         :can-edit-blueprint="{{ $str::bool($user->can('configure fields')) }}"
         :can-manage-publish-state="{{ $str::bool($canManagePublishState) }}"
         create-another-url="{{ cp_route('collections.entries.create', [$collection, $locale]) }}"
-        listing-url="{{ cp_route('collections.show', $collection) }}"
+        initial-listing-url="{{ cp_route('collections.show', $collection) }}"
         :preview-targets="{{ json_encode($previewTargets) }}"
         :autosave-interval="{{ json_encode($autosaveInterval) }}"
     ></entry-publish-form>


### PR DESCRIPTION
This pull request fixes an issue where changing the selected site when editing an entry doesn't take affect to the site selected when the user is redirected back to a collection's tree listing.

Fixes #6600.