### PR TITLE
[4.x] Prevent existing term data being overwritten in terms fieldtype

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -184,7 +184,9 @@ class Terms extends Relationship
                 }
 
                 return explode('::', $id, 2)[1];
-            })->all();
+            })
+                ->unique()
+                ->all();
 
             if ($this->field->get('max_items') === 1) {
                 return $data[0] ?? null;
@@ -410,12 +412,16 @@ class Terms extends Relationship
             ? Site::get($parent->locale())->lang()
             : Site::default()->lang();
 
-        $term = Facades\Term::make()
-            ->slug(Str::slug($string, '-', $lang))
-            ->taxonomy(Facades\Taxonomy::findByHandle($taxonomy))
-            ->set('title', $string);
+        $slug = Str::slug($string, '-', $lang);
 
-        $term->save();
+        if (! $term = Facades\Term::find("{$taxonomy}::{$slug}")) {
+            $term = Facades\Term::make()
+                ->slug($slug)
+                ->taxonomy(Facades\Taxonomy::findByHandle($taxonomy))
+                ->set('title', $string);
+
+            $term->save();
+        }
 
         return $term->id();
     }


### PR DESCRIPTION
When using a term field type you can search for an existing value and press enter without selecting anything from the autocomplete. On save, this would cause a new term to be created using the same slug, which in turn overwrites the previous terms data.

This PR updates the term creation logic on the fieldtype to check if the term already exists. It also adds a unique constraint on process to prevent duplicates being added.

Closes https://github.com/statamic/cms/issues/7332