### PR TITLE
[4.x] Prevent terms fieldtype in typehead mode showing results until a search is entered

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -216,6 +216,10 @@ class Terms extends Relationship
 
     public function getIndexItems($request)
     {
+        if ($this->config('mode') == 'typeahead' && ! $request->search) {
+            return collect();
+        }
+
         $query = $this->getIndexQuery($request);
 
         if ($sort = $this->getSortColumn($request)) {


### PR DESCRIPTION
When using typeahead mode for the terms field type, prevent any results from showing until a search is made. This prevents a full query being carried out on all terms - if you are using typeahead it's usually due to you having lots of terms.

Closes https://github.com/statamic/cms/issues/5919