### PR TITLE
[4.x] Pass target field handle to custom conditions

### DIFF
--- a/resources/js/components/field-conditions/Validator.js
+++ b/resources/js/components/field-conditions/Validator.js
@@ -184,9 +184,9 @@ export default class {
         let target = condition.field
             ? this.getFieldValue(condition.field)
             : null;
-        let field = condition.field;
+        let targetHandle = condition.field;
 
-        return {functionName, params, target, field};
+        return {functionName, params, target, targetHandle};
     }
 
     prepareFunctionName(condition) {
@@ -259,7 +259,7 @@ export default class {
         let passes = customFunction({
             params: condition.params,
             target: condition.target,
-            field: condition.field,
+            targetHandle: condition.targetHandle,
             values: this.values,
             root: this.rootValues,
             store: this.store,

--- a/resources/js/components/field-conditions/Validator.js
+++ b/resources/js/components/field-conditions/Validator.js
@@ -184,8 +184,9 @@ export default class {
         let target = condition.field
             ? this.getFieldValue(condition.field)
             : null;
+        let field = condition.field;
 
-        return {functionName, params, target};
+        return {functionName, params, target, field};
     }
 
     prepareFunctionName(condition) {
@@ -258,6 +259,7 @@ export default class {
         let passes = customFunction({
             params: condition.params,
             target: condition.target,
+            field: condition.field,
             values: this.values,
             root: this.rootValues,
             store: this.store,


### PR DESCRIPTION
Currently if you add a custom condition with a target field handle, like this:

```yaml
if:
  my_target: 'custom foo:bar'
```

The field handle (my_target) isn't passed to the condition callback, only the target value is.

Having the field handle is useful if you want to run a condition based on meta data from the store, rather than the field's raw value. For example if you have a condition based a relationship field the target value will just be the ID, but you might want to check the collection handle that's stored in `store...meta.my_target.data[0]`.

This PR adds the field handle to the data that's passed to the callbacks.