### PR TITLE
[4.x] Fix user wizard styles

### DIFF
--- a/resources/js/components/users/Wizard.vue
+++ b/resources/js/components/users/Wizard.vue
@@ -176,9 +176,9 @@
     </div>
 </template>
 
-<style>
-.publish-fields .form-group .field-inner > label {
-    @apply text-base font-bold mb-1 !important;
+<style scoped>
+>>> .publish-fields .form-group .field-inner > label {
+    @apply text-base font-bold mb-1;
     & + .help-block { @apply -mt-1 !important; }
 }
 </style>


### PR DESCRIPTION
In #9003 I unintentionally made the label css leak onto other pages.
This fixes it by using scoped styles.
It also removes the important which wasn't necessary.
