### PR TITLE
[4.x] Fix select fieldtype fallback differently

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -104,8 +104,8 @@ trait HasSelectOptions
             $value = $this->castFromBoolean($value);
         }
 
-        return $this->isOption($value) && Arr::get($this->config('options'), $value)
-            ? Arr::get($this->config('options'), $value, $value)
+        return $this->isOption($value)
+            ? Arr::get($this->config('options'), $value) ?? $value
             : $actualValue;
     }
 


### PR DESCRIPTION
This is an alternate solution of #9038.
The issue was that `Arr::get` will return only return the fallback if the key is completely missing.
In the bug's case, the key (the value) was there but the value (the label) was null. 
This adjusts it to use a `??` so we always get the fallback and never null.

```php
$arr = [
  'alfa' => 'Alfa',
  'bravo' => null,
];

Arr::get($arr, 'alfa', 'fallback'); // "Alfa"
Arr::get($arr, 'bravo', 'fallback'); // null - We were expecting "fallback"
Arr::get($arr, 'charlie', 'fallback'); // "fallback"
```
