### PR TITLE
[4.x] Fix date replicator preview in more configurations

### DIFF
--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -161,6 +161,10 @@ export default {
         replicatorPreview() {
             if (! this.value.date) return;
 
+            if (this.isRange) {
+                return `${this.value.date.start} - ${this.value.date.end}`;
+            }
+
             return this.hasTime
                 ? `${this.value.date} ${this.value.time}`
                 : this.value.date;

--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -162,12 +162,16 @@ export default {
             if (! this.value.date) return;
 
             if (this.isRange) {
-                return `${this.value.date.start} - ${this.value.date.end}`;
+                return Vue.moment(this.value.date.start).format(this.displayFormat) + ' – ' + Vue.moment(this.value.date.end).format(this.displayFormat);
             }
 
-            return this.hasTime
-                ? `${this.value.date} ${this.value.time}`
-                : this.value.date;
+            let preview = Vue.moment(this.value.date).format(this.displayFormat);
+
+            if (this.hasTime) {
+                preview += ` ${this.value.time}`;
+            }
+
+            return preview;
         },
 
     },

--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -159,6 +159,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.value.date) return;
+
             return this.hasTime
                 ? `${this.value.date} ${this.value.time}`
                 : this.value.date;


### PR DESCRIPTION
Closes #9088

- When you have time enabled and no value, it would now as `null`. Now it outputs nothing as expected.
- Fix ranges being output as JSON. Now it outputs `start - end`.
- Fix configured date format not being used. Now it does.
