### PR TITLE
[4.x] Fix date field not populating with current date, revert prevention of ensuring fields if they already exist

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -338,22 +338,20 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
 
     public function ensureEntryBlueprintFields($blueprint)
     {
-        if (! $blueprint->hasField('title')) {
-            $blueprint->ensureFieldPrepended('title', [
-                'type' => ($auto = $this->autoGeneratesTitles()) ? 'hidden' : 'text',
-                'required' => ! $auto,
-            ]);
-        }
+        $blueprint->ensureFieldPrepended('title', [
+            'type' => ($auto = $this->autoGeneratesTitles()) ? 'hidden' : 'text',
+            'required' => ! $auto,
+        ]);
 
-        if ($this->requiresSlugs() && ! $blueprint->hasField('slug')) {
+        if ($this->requiresSlugs()) {
             $blueprint->ensureField('slug', ['type' => 'slug', 'localizable' => true, 'validate' => 'max:200'], 'sidebar');
         }
 
-        if ($this->dated() && ! $blueprint->hasField('date')) {
+        if ($this->dated()) {
             $blueprint->ensureField('date', ['type' => 'date', 'required' => true, 'default' => 'now'], 'sidebar');
         }
 
-        if ($this->hasStructure() && ! $this->orderable() && ! $blueprint->hasField('parent')) {
+        if ($this->hasStructure() && ! $this->orderable()) {
             $blueprint->ensureField('parent', [
                 'type' => 'entries',
                 'collections' => [$this->handle()],


### PR DESCRIPTION
This reverts #8926.
I noticed that when you create an entry, the `date` field is no longer pre-filled with the current date if you have a `date` field in your blueprint.
This is because we wouldn't merge `['default' => 'now']` into the config due to #8926.

I was ready to go ahead and re-fix #2743, but it looks like the issue isn't there anyway. You can make the slug field unlocalizable just fine.
