### PR TITLE
[4.x] When appending glide filename consider that the extension may have changed

### DIFF
--- a/src/Imaging/GlideManager.php
+++ b/src/Imaging/GlideManager.php
@@ -47,6 +47,10 @@ class GlideManager
 
                     $cachePath .= '/'.Str::beforeLast($filename, '.').'/'.Str::of($path)->after('/');
 
+                    if ($extension = ($params['fm'] ?? false)) {
+                        $cachePath = Str::beforeLast($cachePath, '.').'.'.$extension;
+                    }
+
                     return $cachePath;
                 });
         }


### PR DESCRIPTION
In https://github.com/statamic/cms/pull/8661/ I didn't consider the possibility of the file extension changing, so if you do something like 

        {{ glide src="/assets/content/lagoa.jpg" format="webp" width="200" dpr="2" }}

the file last part of the url is still .jpg, which is not good. This PR updates that to use the correct extension.