### PR TITLE
[4.x] Fix replicator preview for Date fieldtype when time is empty

### DIFF
--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -167,7 +167,7 @@ export default {
 
             let preview = Vue.moment(this.value.date).format(this.displayFormat);
 
-            if (this.hasTime) {
+            if (this.hasTime && this.value.time) {
                 preview += ` ${this.value.time}`;
             }
 


### PR DESCRIPTION
This pull request follows on from #9093, by fixing an issue with the Date fieldtype's replicator preview. When the time value was left empty, `null` would be returned in the replicator preview.

Related: https://github.com/statamic/cms/issues/9088#issuecomment-1835678901

## Before

![CleanShot 2023-12-01 at 10 30 59](https://github.com/statamic/cms/assets/19637309/e3c4c5a3-62cb-4ebe-bb6a-0d611bee75f9)

## Now

![CleanShot 2023-12-01 at 10 31 12](https://github.com/statamic/cms/assets/19637309/1ce975ed-31b6-476f-972f-9509d7f270fa)
