### PR TITLE
[4.x] Antlers: corrects a subtle bug with conditions resolving variables

### DIFF
--- a/src/View/Antlers/Language/Parser/AntlersNodeParser.php
+++ b/src/View/Antlers/Language/Parser/AntlersNodeParser.php
@@ -243,8 +243,16 @@ class AntlersNodeParser
 
         $node->isClosingTag = $this->canBeClosingTag($node);
 
+        $lexerContent = $node->getContent();
+
+        if ($node->name->name == 'if' || $node->name->name == 'unless' || $node->name->name == 'elseif') {
+            if (mb_strlen(trim($lexerContent)) > 0) {
+                $lexerContent = '('.$lexerContent.')';
+            }
+        }
+
         // Need to run node type analysis here before the runtime node step.
-        $runtimeNodes = $this->lexer->tokenize($node, $node->getContent());
+        $runtimeNodes = $this->lexer->tokenize($node, $lexerContent);
 
         $node->runtimeNodes = $runtimeNodes;
 

--- a/tests/Antlers/Parser/ConditionalNodesTest.php
+++ b/tests/Antlers/Parser/ConditionalNodesTest.php
@@ -149,7 +149,8 @@ EOT;
 
         /** @var AntlersNode $firstNode */
         $firstNode = $nodes[0];
-        $this->assertCount(7, $firstNode->runtimeNodes);
+        // The () are added automatically.
+        $this->assertCount(9, $firstNode->runtimeNodes);
 
         // Parse the text that would produce the 7 runtime nodes above.
         $runtimeNodes = $this->getParsedRuntimeNodes("{{ is_small_article || collection:handle == 'vacancies' }}");

--- a/tests/Antlers/Runtime/ConditionLogicTest.php
+++ b/tests/Antlers/Runtime/ConditionLogicTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Antlers\Runtime;
 
 use Facades\Tests\Factories\EntryFactory;
+use Statamic\Fields\Field;
 use Statamic\Fields\LabeledValue;
 use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Code;
 use Statamic\Fieldtypes\Select;
 use Statamic\Support\Arr;
 use Statamic\Tags\Tags;
@@ -13,9 +15,12 @@ use Statamic\View\Antlers\Language\Exceptions\AntlersException;
 use Statamic\View\Cascade;
 use Tests\Antlers\Fixtures\Addon\Tags\VarTest;
 use Tests\Antlers\ParserTestCase;
+use Tests\FakesViews;
 
 class ConditionLogicTest extends ParserTestCase
 {
+    use FakesViews;
+
     public function test_negation_following_or_is_evaluated()
     {
         $template = '{{ if !first && first_row_headers || !first_row_headers }}yes{{ else }}no{{ /if }}';
@@ -768,5 +773,42 @@ EOT;
 EOT;
 
         $this->assertSame('No', $this->renderString($template));
+    }
+
+    public function test_arrayable_strings_inside_conditions_used_with_modifiers()
+    {
+        $code = new Code();
+        $field = new Field('code_field', [
+            'type' => 'code',
+            'antlers' => false,
+        ]);
+
+        $code->setField($field);
+        $value = new Value('Oh hai, mark.', 'code_field', $code);
+
+        $template = <<<'EOT'
+{{ partial:test :code="code_field" }}
+EOT;
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('test', <<<'EOT'
+{{ if code | starts_with('<div>') }}
+Yes{{ else }}
+No{{ /if }}
+EOT
+
+        );
+
+        $this->assertSame('No', trim($this->renderString($template, ['code_field' => $value], true)));
+
+        $this->viewShouldReturnRaw('test', <<<'EOT'
+{{ if code | starts_with('Oh hai, mark.') }}
+Yes{{ else }}
+No{{ /if }}
+EOT
+
+        );
+
+        $this->assertSame('Yes', trim($this->renderString($template, ['code_field' => $value], true)));
     }
 }


### PR DESCRIPTION
This PR fixes #9096 by silently forcing all conditions to have the form

```antlers
{{ if (this == that) }}

{{ /if }}
```

this resolve an incredibly subtle issue where conditions would aggressively collapse values (in the original issue, the `ArrayableString` would be collapsed to its array too early). This behavior doesn't happen when using the modifiers normally (i.e., not in a condition).

This issue is easiest to reproduce with partials, but is not *caused* by conditions in partials. The linked issue contains a repository to reproduce the bug; updating the `default.antlers.html` to contain the following will also manifest the issue:

```antlers
{{ code = settings:code_field }}

{{ if code | starts_with('<div>') }}
<div>Yes, "code" starts with div</div>
{{ else }}
<div>No, it does not</div>
{{ /if }}
```