### PR TITLE
[4.x] Harden collection handle check in Taxonomy::findByUri to prevent partial matches

### DIFF
--- a/src/Stache/Repositories/TaxonomyRepository.php
+++ b/src/Stache/Repositories/TaxonomyRepository.php
@@ -67,7 +67,7 @@ class TaxonomyRepository implements RepositoryContract
                     return true;
                 }
 
-                return Str::startsWith($uri, '/'.$collection->handle());
+                return Str::startsWith($uri.'/', '/'.$collection->handle().'/');
             });
 
         if ($collection) {


### PR DESCRIPTION
The Taxonomy::findByUri fallback to checking by collection handle, however if you have a collection that partially matches the name of a taxonomy, the taxonomy then 404s.

eg if you have a taxonomy named `topics`, then a collection named `topic`, then `/topics` 404s.

This PR hardens the checks by adding trailing slashes.