### PR TITLE
[4.x] Handle glide exceptions gracefully

### DIFF
--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -168,6 +168,8 @@ class Glide extends Tags
 
             return $this->getGenerator()->generateByAsset(Asset::find($item), $params);
         } catch (\Exception $e) {
+            \Log::error($e->getMessage());
+
             return null;
         }
     }

--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -148,8 +148,6 @@ class Glide extends Tags
                 return $data;
             } catch (\Exception $e) {
                 \Log::error($e->getMessage());
-
-                return null;
             }
         })->filter()->all();
     }

--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -156,16 +156,20 @@ class Glide extends Tags
      */
     private function generateImage($item)
     {
-        $item = $this->normalizeItem($item);
-        $params = $this->getGlideParams($item);
+        try {
+            $item = $this->normalizeItem($item);
+            $params = $this->getGlideParams($item);
 
-        if (is_string($item) && Str::isUrl($item)) {
-            return Str::startsWith($item, ['http://', 'https://'])
-                ? $this->getGenerator()->generateByUrl($item, $params)
-                : $this->getGenerator()->generateByPath($item, $params);
+            if (is_string($item) && Str::isUrl($item)) {
+                return Str::startsWith($item, ['http://', 'https://'])
+                    ? $this->getGenerator()->generateByUrl($item, $params)
+                    : $this->getGenerator()->generateByPath($item, $params);
+            }
+
+            return $this->getGenerator()->generateByAsset(Asset::find($item), $params);
+        } catch (\Exception $e) {
+            return null;
         }
-
-        return $this->getGenerator()->generateByAsset(Asset::find($item), $params);
     }
 
     /**


### PR DESCRIPTION
We have a similar issue to https://github.com/statamic/cms/issues/2791 in that glide is throwing exceptions that are causing 500 errors on the page. Our errors are often due to a mismatch of image format (eg Image [image.jpeg] does not actually appear to be a valid image)

This PR prevents that by catching any glide errors and suppressing the output. Instead we log the errors, which feels more antlers-y ?

Closes https://github.com/statamic/cms/issues/2791