### PR TITLE
[4.x] Fix "Hide Display" setting not being persisted on reference field

### DIFF
--- a/resources/js/components/fieldtypes/FieldDisplayFieldtype.vue
+++ b/resources/js/components/fieldtypes/FieldDisplayFieldtype.vue
@@ -47,8 +47,17 @@ export default {
             return parent;
         },
 
+        nearestFieldSettings() {
+            let parent = this;
+            while (parent.$options._componentTag !== 'field-settings') {
+                parent = parent.$parent;
+                if (parent === this.$root) return null;
+            }
+            return parent;
+        },
+
         hidden() {
-            return this.$store.state.publish[this.storeName].values.hide_display;
+            return this.nearestFieldSettings.values.hide_display;
         }
 
     },
@@ -60,7 +69,7 @@ export default {
     methods: {
 
         toggleHidden() {
-            this.nearestPublishContainer.setFieldValue('hide_display', ! this.hidden);
+            this.nearestFieldSettings.updateField('hide_display', ! this.hidden)
         }
 
     }


### PR DESCRIPTION
This pull request fixes an issue where changes to the "Hide Display" setting in the blueprint builder weren't being persisted back to the blueprint's YAML file when editing a "reference field".

This was caused by `hide_display` being updated on the publish container without the `updateField` method on `FieldSettings` being called which is responsible for adding the edited field to its `editedFields` array, which is then subsequently used when figuring out which config values should be saved back to the YAML file.

Fixes #9107.