### PR TITLE
[4.x] Use date facade and carbon interface

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -499,7 +499,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
                     return null;
                 }
 
-                if ($date instanceof \Carbon\Carbon) {
+                if ($date instanceof \Carbon\CarbonInterface) {
                     return $date;
                 }
 

--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Middleware;
 
 use Carbon\Carbon;
 use Closure;
+use Illuminate\Support\Facades\Date;
 use Statamic\Facades\Site;
 use Statamic\Statamic;
 
@@ -32,7 +33,7 @@ class Localize
         $format = (new \ReflectionClass(Carbon::class))->getProperty('toStringFormat');
         $format->setAccessible(true);
         $originalToStringFormat = $format->getValue();
-        Carbon::setToStringFormat(Statamic::dateFormat());
+        Date::setToStringFormat(Statamic::dateFormat());
 
         $response = $next($request);
 
@@ -40,7 +41,7 @@ class Localize
         // not within the scope of the request to be the "defaults".
         setlocale(LC_TIME, $originalLocale);
         app()->setLocale($originalAppLocale);
-        Carbon::setToStringFormat($originalToStringFormat);
+        Date::setToStringFormat($originalToStringFormat);
 
         return $response;
     }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -3,7 +3,7 @@
 namespace Statamic\Modifiers;
 
 use ArrayAccess;
-use Carbon\Carbon;
+use Carbon\CarbonInterface as Carbon;
 use Countable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -7,6 +7,7 @@ use Carbon\CarbonInterface as Carbon;
 use Countable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Facades\Antlers;
@@ -3008,7 +3009,7 @@ class CoreModifiers extends Modifier
     private function carbon($value)
     {
         if (! $value instanceof Carbon) {
-            $value = (is_numeric($value)) ? Carbon::createFromTimestamp($value) : Carbon::parse($value);
+            $value = (is_numeric($value)) ? Date::createFromTimestamp($value) : Date::parse($value);
         }
 
         return $value;

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -2,10 +2,12 @@
 
 namespace Statamic\Providers;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\ServiceProvider;
 use Statamic\Facades;
 use Statamic\Facades\Addon;
@@ -26,6 +28,8 @@ class AppServiceProvider extends ServiceProvider
 
     public function boot()
     {
+        Date::use(CarbonImmutable::class);
+
         $this->app->booted(function () {
             Statamic::runBootedCallbacks();
             $this->loadRoutesFrom("{$this->root}/routes/routes.php");

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -2,12 +2,10 @@
 
 namespace Statamic\Providers;
 
-use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Date;
 use Illuminate\Support\ServiceProvider;
 use Statamic\Facades;
 use Statamic\Facades\Addon;
@@ -28,8 +26,6 @@ class AppServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        Date::use(CarbonImmutable::class);
-
         $this->app->booted(function () {
             Statamic::runBootedCallbacks();
             $this->loadRoutesFrom("{$this->root}/routes/routes.php");

--- a/tests/Feature/Fieldtypes/FilesTest.php
+++ b/tests/Feature/Fieldtypes/FilesTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature\Fieldtypes;
 
-use Carbon\Carbon;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Storage;
 use Statamic\Assets\AssetContainer;
 use Statamic\Facades\User;
@@ -45,7 +45,7 @@ class FilesTest extends TestCase
             ? UploadedFile::fake()->image('test.jpg', 50, 75)
             : UploadedFile::fake()->create('test.txt');
 
-        Carbon::setTestNow(Carbon::createFromTimestamp(1671484636));
+        Date::setTestNow(Date::createFromTimestamp(1671484636));
 
         $disk = Storage::fake('local');
 

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -7,6 +7,7 @@ use Facades\Statamic\Routing\ResolveRedirect;
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Event;
 use Statamic\Events\ResponseCreated;
 use Statamic\Facades\Blueprint;
@@ -664,7 +665,7 @@ class FrontendTest extends TestCase
     public function it_sets_the_carbon_to_string_format()
     {
         config(['statamic.system.date_format' => 'd/m/Y']);
-        Carbon::setTestNow('October 21st, 2022');
+        Date::setTestNow('October 21st, 2022');
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
         $this->viewShouldReturnRaw('some_template', '<p>{{ now }}</p>');
         $this->makeCollection()->save();
@@ -737,8 +738,8 @@ class FrontendTest extends TestCase
     private function assertDefaultCarbonFormat()
     {
         $this->assertEquals(
-            Carbon::now()->format(Carbon::DEFAULT_TO_STRING_FORMAT),
-            (string) Carbon::now(),
+            Date::now()->format(Carbon::DEFAULT_TO_STRING_FORMAT),
+            (string) Date::now(),
             'Carbon was not formatted using the default format.'
         );
     }


### PR DESCRIPTION
Inspired by #9101.

It could be very useful to add `Date::use(CarbonImmutable::class)` in your AppServiceProvider to make all dates immutable.

If we add that to our service provider and run the test suite, there were some errors and failures. This PR makes the necessary changes to get the tests passing again.
