### PR TITLE
[4.x] Show `search:results` where status: published, or where there is no status

### DIFF
--- a/src/Search/Tags.php
+++ b/src/Search/Tags.php
@@ -49,7 +49,7 @@ class Tags extends BaseTags
             return;
         }
 
-        return $query->where('status', 'published');
+        return $query->where(fn ($query) => $query->where('status', 'published')->orWhereNull('status'));
     }
 
     protected function querySite($query)

--- a/tests/Tags/SearchTest.php
+++ b/tests/Tags/SearchTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Tags;
 
 use Facades\Tests\Factories\EntryFactory;
+use Illuminate\Support\Facades\Storage;
+use Statamic\Facades\Asset;
+use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Parse;
 use Statamic\Facades\Search;
 use Statamic\Search\QueryBuilder;
@@ -58,6 +61,32 @@ class SearchTest extends TestCase
             '<entry a><entry b>',
             $this->tag(
                 '{{ search:results as="stuff" }}{{ if no_results }}No results{{ else }}{{ stuff }}<{{ title }}>{{ /stuff }}{{ /if }}{{ /search:results }}'
+            )
+        );
+    }
+
+    /** @test */
+    public function it_outputs_results_where_there_are_no_statuses()
+    {
+        Storage::fake('images');
+        AssetContainer::make('images')->disk('images')->save();
+
+        $entryA = EntryFactory::id('a')->collection('test')->data(['title' => 'entry a'])->create();
+        $entryB = EntryFactory::id('b')->collection('test')->data(['title' => 'entry b'])->create();
+        $assetA = tap(Asset::make()->container('images')->path('a.jpg')->data(['title' => 'asset a']))->save();
+
+        $builder = $this->mock(QueryBuilder::class);
+        $builder->shouldReceive('ensureExists', 'search', 'withData', 'limit', 'offset', 'where')->andReturnSelf();
+        $builder->shouldReceive('get')->andReturn(collect([$entryA, $entryB, $assetA]));
+
+        Search::shouldReceive('index')->with(null)->once()->andReturn($builder);
+
+        $this->get('/whatever?q=foo'); // just a way to get a query param into the request(). the url is irrelevant.
+
+        $this->assertEquals(
+            '<entry a><entry b><asset a>',
+            $this->tag(
+                '{{ search:results }}{{ if no_results }}No results{{ else }}<{{ title }}>{{ /if }}{{ /search:results }}'
             )
         );
     }


### PR DESCRIPTION
If you add something to your index that has no status, eg assets, users, or terms, it has no status column, so the search index tag does not return them by default.

This PR updates the search:results tag's query to filter where status: published OR where status is NULL.

Closes https://github.com/statamic/cms/issues/4682