### PR TITLE
[4.x] Fix for Can't add title to a fieldset and use fieldset prefixes at the same time

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -257,7 +257,7 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
                 $field = $allFields->get($importKey);
                 $tab = $field['tab'];
                 $fields = collect($tabs[$tab]['sections'][$targetSectionIndex]['fields'])->keyBy(function ($field) {
-                    return (isset($field['import'])) ? 'import:'.$field['import'] : $field['handle'];
+                    return (isset($field['import'])) ? 'import:'.($field['prefix'] ?? null).$field['import'] : $field['handle'];
                 });
                 $importedConfig = $importedField['field']->config();
                 $config = array_merge($config, $importedConfig);


### PR DESCRIPTION
This one took a bit of code diving, but when using an imported field which is in an ensuredField, the import prefix was being ignored when handles were being mapped at one point in the code.

This resolves that.

Closes https://github.com/statamic/cms/issues/4869