### PR TITLE
[4.x] Change nocache performance optimizations to be opt-in

### DIFF
--- a/src/StaticCaching/NoCache/Tags.php
+++ b/src/StaticCaching/NoCache/Tags.php
@@ -23,8 +23,11 @@ class Tags extends \Statamic\Tags\Tags
     {
         if ($this->params->has('select')) {
             $fields = $this->params->explode('select');
-        } elseif (config('statamic.antlers.version') === 'runtime') {
-            $fields = Antlers::identifiers($this->content);
+
+            if (in_array('@auto', $fields)) {
+                $identifiers = Antlers::identifiers($this->content);
+                $fields = array_merge(array_diff($fields, ['@auto']), $identifiers);
+            }
         }
 
         return $this

--- a/tests/StaticCaching/NocacheTagsTest.php
+++ b/tests/StaticCaching/NocacheTagsTest.php
@@ -106,10 +106,13 @@ EOT;
     /** @test */
     public function it_only_adds_appropriate_fields_of_context_to_session()
     {
-        // We will not add `baz` to the session because it is not used in the template.
-        // We will not add `nope` to the session because it is not in the context.
-        $expectedFields = ['foo', 'bar'];
-        $template = '{{ nocache }}{{ foo }}{{ bar }}{{ nope }}{{ /nocache }}';
+        $expectedFields = [
+            'foo', // By adding @auto it will be picked up from the template.
+            'baz', // Explicitly selected
+            // 'bar' // Not explicitly selected
+            // 'nope' // Not in the context
+        ];
+        $template = '{{ nocache select="@auto|baz" }}{{ foo }}{{ nope }}{{ /nocache }}';
         $context = [
             'foo' => 'alfa',
             'bar' => 'bravo',


### PR DESCRIPTION
In #8956 we made it so that the nocache tag will only add variables to the cached session if they are used in the template. This turns out to be too heavy handed.

If variables were being used indirectly, such as in a partial or a custom tag, they would be missing from the context.

This PR makes the optimizations opt-in. You will need to explicitly select the fields you need. Without any selections, the former unoptimized version containing all contextual variables will be used.

You can select explicit fields:

```antlers
{{ nocache select="this|that" }}
```

Or use the `@auto` placeholder to extract them from the template (this is similar to the `@shallow` placeholder in the nav tag):

```antlers
{{ nocache select="@auto" }}
```

Or combine them to extract the variables from the template and add additional ones:

```antlers
{{ nocache select="@auto|this|that" }}
```


Closes #9123
Closes #9110