### PR TITLE
[4.x] Fix tree view when configuring collection mount

### DIFF
--- a/resources/js/components/collections/EditForm.vue
+++ b/resources/js/components/collections/EditForm.vue
@@ -9,6 +9,7 @@
         :values="values"
         :meta="meta"
         :errors="errors"
+        :site="site"
         @updated="values = $event"
     >
         <div slot-scope="{ setFieldValue, setFieldMeta }">
@@ -85,6 +86,12 @@ export default {
             this.submit();
         });
     },
+
+    computed: {
+        site() {
+            return this.$config.get('selectedSite');
+        }
+    }
 
 }
 </script>


### PR DESCRIPTION
This pull request fixes an issue when selecting an entry to mount a collection onto. It would only happen when a site has 2 collections (eg. Pages & News) and the user is viewing the new "Tree View".

No site was being passed down the chain to the `PageTree` so the tree that was returned from the backend was empty and didn't contain any entries.

Fixes #9120.