### PR TITLE
[4.x] Fix styling of grid stacked mode header when deleting is not possible

### DIFF
--- a/resources/css/components/fieldtypes/replicator.css
+++ b/resources/css/components/fieldtypes/replicator.css
@@ -33,6 +33,10 @@
         @apply flex items-center;
     }
 
+    .replicator-set-header-inner {
+        min-height: 32px;
+    }
+
     &.invalid {
         .replicator-set-header-inner {
             @apply bg-red-100;


### PR DESCRIPTION
This PR adds min-height to the set inner header matching the height of an icon, so the height of the set header stays consistent even if no delete icon is present.

Closes https://github.com/statamic/cms/issues/9127