### PR TITLE
[4.x] Prevent events being added to an element that doesn't exist when in grid table mode

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -346,9 +346,12 @@ export default {
         this.$store.commit(`publish/${this.storeName}/setFieldSubmitsJson`, this.fieldPathPrefix || this.handle);
 
         this.$nextTick(() => {
-            document.querySelector(`label[for="${this.fieldId}"]`).addEventListener('click', () => {
-                this.editor.commands.focus();
-            });
+            let el = document.querySelector(`label[for="${this.fieldId}"]`);
+            if (el) {
+                el.addEventListener('click', () => {
+                    this.editor.commands.focus();
+                });
+            }
         });
     },
 

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -197,9 +197,12 @@ export default {
     mounted() {
         this.initToolbarButtons();
 
-        document.querySelector(`label[for="${this.fieldId}"]`).addEventListener('click', () => {
-            this.codemirror.focus();
-        });
+        let el = document.querySelector(`label[for="${this.fieldId}"]`);
+        if (el) {
+            el.addEventListener('click', () => {
+                this.codemirror.focus();
+            });
+        }
     },
 
     methods: {


### PR DESCRIPTION
In grid table mode the label element doesn't exist to add the click listener to, so double check it exists before adding the listener.

Closes https://github.com/statamic/cms/issues/8947