### PR TITLE
[4.x] "Configure asset containers" permission should override other asset permissions

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -384,15 +384,15 @@ export default {
         },
 
         canEdit() {
-            return this.can('edit '+ this.container.id +' assets')
+            return this.can('edit '+ this.container.id +' assets') || this.can('configure asset containers')
         },
 
         canUpload() {
-            return this.folder && this.container.allow_uploads && this.can('upload '+ this.container.id +' assets');
+            return this.folder && this.container.allow_uploads && (this.can('upload '+ this.container.id +' assets') || this.can('configure asset containers'));
         },
 
         canCreateFolders() {
-            return this.folder && this.container.create_folders && ! this.restrictFolderNavigation && this.can('upload '+ this.container.id +' assets');
+            return this.folder && this.container.create_folders && ! this.restrictFolderNavigation && (this.can('upload '+ this.container.id +' assets') || this.can('configure asset containers'));
         },
 
         parameters() {

--- a/src/Policies/AssetPolicy.php
+++ b/src/Policies/AssetPolicy.php
@@ -6,6 +6,15 @@ use Statamic\Facades\User;
 
 class AssetPolicy
 {
+    public function before($user)
+    {
+        $user = User::fromUser($user);
+
+        if ($user->hasPermission('configure asset containers')) {
+            return true;
+        }
+    }
+
     public function view($user, $asset)
     {
         return User::fromUser($user)->hasPermission("view {$asset->containerHandle()} assets");


### PR DESCRIPTION
This pull request fixes an issue where the "configure asset containers" permission doesn't override other asset permissions (like the ability to upload assets or create folders).

Fixes #7382.