### PR TITLE
[4.x] Fix test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
         if: steps.should-run-tests.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, :php-psr
           coverage: none
 
       - name: Install dependencies


### PR DESCRIPTION
Tests started failing in GitHub actions because of a change in the `setup-php` action.

This PR is the workaround mentioned in https://github.com/shivammathur/setup-php/issues/799#issuecomment-1843575027

Thanks @felipeelia @jhoff
