### PR TITLE
[4.x] Add chunk and lazy to query builder

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -7,6 +7,7 @@ use DateTimeInterface;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use Statamic\Contracts\Query\Builder as Contract;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
@@ -659,5 +660,74 @@ abstract class Builder implements Contract
         $this->with = array_merge($this->with, Arr::wrap($relations));
 
         return $this;
+    }
+
+    /**
+     * Chunk the results of the query.
+     *
+     * @param  int  $count
+     * @param  callable  $callback
+     * @return bool
+     */
+    public function chunk($count, callable $callback)
+    {
+        $page = 1;
+
+        do {
+            // We'll execute the query for the given page and get the results. If there are
+            // no results we can just break and return from here. When there are results
+            // we will call the callback with the current chunk of these results here.
+            $results = $this->forPage($page, $count)->get();
+
+            $countResults = $results->count();
+
+            if ($countResults == 0) {
+                break;
+            }
+
+            // On each chunk result set, we will pass them to the callback and then let the
+            // developer take care of everything within the callback, which allows us to
+            // keep the memory low for spinning through large result sets for working.
+            if ($callback($results, $page) === false) {
+                return false;
+            }
+
+            unset($results);
+
+            $page++;
+        } while ($countResults == $count);
+
+        return true;
+    }
+
+    /**
+     * Query lazily, by chunks of the given size.
+     *
+     * @param  int  $chunkSize
+     * @return \Illuminate\Support\LazyCollection
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function lazy($chunkSize = 1000)
+    {
+        if ($chunkSize < 1) {
+            throw new InvalidArgumentException('The chunk size should be at least 1');
+        }
+
+        return LazyCollection::make(function () use ($chunkSize) {
+            $page = 1;
+
+            while (true) {
+                $results = $this->forPage($page++, $chunkSize)->get();
+
+                foreach ($results as $result) {
+                    yield $result;
+                }
+
+                if ($results->count() < $chunkSize) {
+                    return;
+                }
+            }
+        });
     }
 }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -666,7 +666,6 @@ abstract class Builder implements Contract
      * Chunk the results of the query.
      *
      * @param  int  $count
-     * @param  callable  $callback
      * @return bool
      */
     public function chunk($count, callable $callback)

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -737,4 +737,26 @@ class EntryQueryBuilderTest extends TestCase
             return [$like => [$like, $expected]];
         });
     }
+
+    /** @test */
+    public function entries_are_found_using_chunk()
+    {
+        $this->createDummyCollectionAndEntries();
+
+        $count = 0;
+        Entry::query()->chunk(2, function ($entries) use (&$count) {
+            $this->assertCount($count++ == 0 ? 2 : 1, $entries);
+        });
+    }
+
+    /** @test */
+    public function entries_are_found_using_lazy()
+    {
+        $this->createDummyCollectionAndEntries();
+
+        $entries = Entry::query()->lazy();
+
+        $this->assertInstanceOf(\Illuminate\Support\LazyCollection::class, $entries);
+        $this->assertCount(3, $entries);
+    }
 }


### PR DESCRIPTION
Basically lifted from the Laravel builder, but we may as well support `chunk()` and `lazy()` in query builders, useful when you have lots of entries.