### PR TITLE
[4.x] Revert mount from augmented collection

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -860,15 +860,9 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
 
     public function augmentedArrayData()
     {
-        $data = [
+        return [
             'title' => $this->title(),
             'handle' => $this->handle(),
         ];
-
-        if (! Statamic::isApiRoute() && ! Statamic::isCpRoute()) {
-            $data['mount'] = $this->mount();
-        }
-
-        return $data;
     }
 }

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Data\Entries;
 
 use Facades\Statamic\Fields\BlueprintRepository;
-use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Event;
 use Statamic\Contracts\Data\Augmentable;
@@ -723,15 +722,13 @@ class CollectionTest extends TestCase
     /** @test */
     public function it_augments()
     {
-        $mountedEntry = EntryFactory::collection('pages')->id('blog')->slug('blog')->data(['title' => 'Blog'])->create();
-
-        $collection = (new Collection)->mount('blog')->handle('test');
+        $collection = (new Collection)->handle('test');
 
         $this->assertInstanceof(Augmentable::class, $collection);
-        $this->assertCount(3, $augmentedArray = $collection->toAugmentedArray());
-        $this->assertEquals('Test', $augmentedArray['title']);
-        $this->assertEquals('test', $augmentedArray['handle']);
-        $this->assertEquals($mountedEntry, $augmentedArray['mount']->value());
+        $this->assertEquals([
+            'title' => 'Test',
+            'handle' => 'test',
+        ], $collection->toAugmentedArray());
     }
 
     /** @test */


### PR DESCRIPTION
This reverts #8928. It introduces too many issues. We'll need to rethink it.

See #8937
Fixes #9012
Fixes #9119
