### PR TITLE
[4.x] Make the `container` field in the `assets` fieldtype required

### DIFF
--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -54,6 +54,7 @@ class Assets extends Fieldtype
                         'type' => 'asset_container',
                         'max_items' => 1,
                         'mode' => 'select',
+                        'required' => true,
                         'default' => AssetContainer::all()->count() == 1 ? AssetContainer::all()->first()->handle() : null,
                     ],
                     'folder' => [


### PR DESCRIPTION
The amount of times I forget to add a container to an assets field is staggering. While I realise this is definitely a me problem, this PR makes the field required to prevent future me from doing this again.