### PR TITLE
[4.x] Fix disabled save button when creating term inside term inside stack

### DIFF
--- a/resources/js/components/DirtyState.js
+++ b/resources/js/components/DirtyState.js
@@ -29,8 +29,7 @@ const vm = new Vue({
         },
 
         remove(name) {
-            const i = this.names.indexOf(name);
-            this.names.splice(i, 1);
+            this.names = this.names.filter(n => n !== name);
         },
 
         enableWarning() {


### PR DESCRIPTION
This pull request attempts to fix an issue where the "Save" button on a term's inline publish form would be disabled if you had created another term inside that publish form... 

If that description doesn't make any sense, watch the video in #8308 which will describe it nice and clear 😆 

When you saved the second term (in the demo, that's the province one), `isDirty` on the first term become `false` instead of `true`. After some digging, it seems like the `names` array was cleared when saving the second term, which it shouldn't have been (there's still dirty state on the root publish form & on the first term's publish form). 

This PR refactors how items are removed from the `names` array which seems to have fixed the issue in my testing.

Fixes #8308.