### PR TITLE
[4.x] Fix collapsed Bard set revealer data loss

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -32,7 +32,7 @@
                     </dropdown-list>
                 </div>
             </div>
-            <div class="replicator-set-body publish-fields @container" v-if="!collapsed && index !== undefined">
+            <div class="replicator-set-body publish-fields @container" v-show="!collapsed" v-if="index !== undefined">
                 <set-field
                     v-for="field in fields"
                     v-show="showField(field, fieldPath(field))"


### PR DESCRIPTION
In https://github.com/statamic/cms/pull/6902 the collapsed set `v-if` directives were changed to `v-show`. Somewhere down the line that change was lost for Bard sets (it's still correct for [replicator sets](https://github.com/statamic/cms/blob/4ef401a0ecb331acb0c0921663dda33a5fd39e83/resources/js/components/fieldtypes/replicator/Set.vue#L35)). As detailed in the original PR using `v-if` can cause data loss (which I've just run in to).

You can see this by creating a Bard field with a set that contains a field that's hidden by a revealer, and then setting the Bard field to collapse all sets by default. If you give the revealed field a value, save, reload, then save again (without expanding the set) the value is lost (check the markdown or reload the page again).

This PR restores the `v-show` from the original PR.