### PR TITLE
[4.x] Exclude taxonomy index pages from nav:breadcrumbs tag when view is missing

### DIFF
--- a/src/Tags/Nav.php
+++ b/src/Tags/Nav.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Tags;
 
+use Statamic\Contracts\Taxonomies\Taxonomy;
 use Statamic\Facades\Data;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
@@ -45,11 +46,13 @@ class Nav extends Structure
             $this->content = trim($this->content);
         }
 
-        $crumbs = $crumbs->values()->map(function ($crumb) {
-            $crumb->setSupplement('is_current', URL::getCurrent() === $crumb->urlWithoutRedirect());
+        $crumbs = $crumbs->values()
+            ->reject(fn ($crumb) => $crumb instanceof Taxonomy && ! view()->exists($crumb->template()))
+            ->map(function ($crumb) {
+                $crumb->setSupplement('is_current', URL::getCurrent() === $crumb->urlWithoutRedirect());
 
-            return $crumb;
-        });
+                return $crumb;
+            });
 
         if (! $this->parser) {
             return $crumbs;


### PR DESCRIPTION
This pull request excludes taxonomy index pages from being returned by the `{{ nav:breadcrumbs }}` tag when the index view is missing.

An attempt was made in #4147 to fix this but it implemented a new `view_exists` variable, instead of filtering the page out of the breadcrumbs like this PR does.

Fixes #3863.