### PR TITLE
[4.x] Asset field now supports mixed permissions

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -27,6 +27,7 @@
                 >
 
                     <button
+                        v-if="canBrowse"
                         :class="{'opacity-0': dragging }"
                         type="button"
                         class="btn btn-with-icon"
@@ -350,6 +351,10 @@ export default {
         showSetAlt() {
             return this.config.show_set_alt && ! this.isReadOnly;
         },
+
+        canBrowse() {
+            return this.can('view '+ this.container +' assets')
+        }
 
     },
 

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -353,7 +353,7 @@ export default {
         },
 
         canBrowse() {
-            return this.can('view '+ this.container +' assets')
+            return this.can('configure asset containers') || this.can('view '+ this.container +' assets')
         }
 
     },

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -336,6 +336,8 @@ export default {
         },
 
         showPicker() {
+            if (! this.canBrowse && ! this.canUpload) return false
+
             if (this.maxFilesReached && ! this.isFullWidth) return false
 
             if (this.maxFilesReached && (this.isInGridField || this.isInLinkField)) return false
@@ -356,7 +358,7 @@ export default {
         },
 
         canUpload() {
-            return this.config.allow_uploads && (this.can('configure asset containers') || this.can('upload  '+ this.container +' assets'))
+            return this.config.allow_uploads && (this.can('configure asset containers') || this.can('upload '+ this.container +' assets'))
         },
 
     },

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -4,7 +4,7 @@
         <uploader
             ref="uploader"
             :container="container"
-            :enabled="config.allow_uploads"
+            :enabled="canUpload"
             :path="folder"
             @updated="uploadsUpdated"
             @upload-complete="uploadComplete"

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -128,7 +128,6 @@
             </selector>
         </stack>
     </div>
-    </element-container>
 </template>
 
 

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -38,7 +38,7 @@
                         {{ __('Browse') }}
                     </button>
 
-                    <p class="asset-upload-control" v-if="config.allow_uploads">
+                    <p class="asset-upload-control" v-if="canUpload">
                         <button type="button" class="upload-text-button" @click.prevent="uploadFile">
                             {{ __('Upload file') }}
                         </button>
@@ -354,7 +354,11 @@ export default {
 
         canBrowse() {
             return this.can('configure asset containers') || this.can('view '+ this.container +' assets')
-        }
+        },
+
+        canUpload() {
+            return this.config.allow_uploads && (this.can('configure asset containers') || this.can('upload  '+ this.container +' assets'))
+        },
 
     },
 

--- a/resources/js/components/roles/PermissionTree.vue
+++ b/resources/js/components/roles/PermissionTree.vue
@@ -6,14 +6,12 @@
                 class="flex items-center justify-between py-2 pr-4 border-b group hover:bg-gray-100"
                 :style="{ paddingLeft: `${16*depth}px` }"
             >
-                <div class="flex" :class="{ 'text-gray-500': disabled, 'cursor-not-allowed': disabled }">
+                <div class="flex">
                     <div class="leading-normal">
                         <input type="checkbox"
                             v-model="permission.checked"
                             :value="permission.value"
-                            :disabled="disabled"
                             name="permissions[]"
-                            :class="{ 'cursor-not-allowed': disabled }"
                         />
                     </div>
                     <div class="pl-2">
@@ -27,7 +25,6 @@
                 v-if="permission.children.length"
                 :depth="depth+1"
                 :initial-permissions="permission.children"
-                :disabled="!permission.checked"
             />
         </div>
     </div>
@@ -39,7 +36,6 @@ export default {
 
     props: {
         initialPermissions: Array,
-        disabled: Boolean,
         depth: Number
     },
 
@@ -47,16 +43,6 @@ export default {
         return {
             permissions: this.initialPermissions
         }
-    },
-
-    watch: {
-
-        disabled(disabled) {
-            if (disabled) {
-                this.permissions.map(permission => permission.checked = false);
-            }
-        }
-
     }
 
 }


### PR DESCRIPTION
Our use case is that we'd like to allow certain roles to upload assets, but not view them.

Additionally, when they delete (assuming they have permission), we'd like the asset to be removed from the container.

Updates:

- [x] Allow permission to be given even if "parent" permission NOT enabled. The permission hierarchy is visual only so there really isn't a parent, it only looks like there is
- [x] Remove Asset Browse button if they don't have permission to view assets
- [ ] ~Add asset field config to enable asset deletion, only if they have permission. Otherwise the existing  "unlink" behaviour stays.~