### PR TITLE
[4.x] Support chunk on query builders in Antlers

### DIFF
--- a/src/Tags/Chunks.php
+++ b/src/Tags/Chunks.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Statamic\Tags;
+
+use Illuminate\Support\Collection;
+
+class Chunks extends Collection
+{
+}

--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -65,7 +65,7 @@ trait GetsQueryResults
 
     protected function chunkedResults($query, $chunkSize)
     {
-        $key = $this->params->get('as', 'chunk');
+        $key = $this->params->get('chunk_key', 'chunk');
 
         $results = collect();
 

--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -65,7 +65,7 @@ trait GetsQueryResults
 
     protected function chunkedResults($query, $chunkSize)
     {
-        $key = $this->params->get('chunk_key', 'chunk');
+        $key = $this->params->get('as', 'chunk');
 
         $results = collect();
 

--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -3,6 +3,7 @@
 namespace Statamic\Tags\Concerns;
 
 use Statamic\Facades\Blink;
+use Statamic\Tags\Chunks;
 
 trait GetsQueryResults
 {
@@ -65,11 +66,9 @@ trait GetsQueryResults
 
     protected function chunkedResults($query, $chunkSize)
     {
-        $key = $this->params->get('chunk_key', 'chunk');
+        $results = Chunks::make();
 
-        $results = collect();
-
-        $query->chunk($chunkSize, fn ($chunk) => $results->push(collect([$key => $chunk])));
+        $query->chunk($chunkSize, fn ($chunk) => $results->push($chunk));
 
         return $results;
     }

--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -22,6 +22,10 @@ trait GetsQueryResults
             $query->offset($offset);
         }
 
+        if ($chunk = $this->params->int('chunk')) {
+            return $this->chunkedResults($query, $chunk);
+        }
+
         return $query->get();
     }
 
@@ -57,5 +61,16 @@ trait GetsQueryResults
             ->all();
 
         $query->whereNotin('id', $offsetIds);
+    }
+
+    protected function chunkedResults($query, $chunkSize)
+    {
+        $key = $this->params->get('chunk_key', 'chunk');
+
+        $results = collect();
+
+        $query->chunk($chunkSize, fn ($chunk) => $results->push(collect([$key => $chunk])));
+
+        return $results;
     }
 }

--- a/src/Tags/Concerns/OutputsItems.php
+++ b/src/Tags/Concerns/OutputsItems.php
@@ -26,17 +26,16 @@ trait OutputsItems
 
     protected function chunkedOutput($items)
     {
-        $key = $this->params->get('as');
+        $key = $this->params->get('chunk_key', 'chunk');
 
-        if (! $key) {
-            return $items->map(fn ($chunk) => ['chunk' => $chunk]);
-        }
-
-        return [
-            $key => $items->map(fn ($chunk) => ['chunk' => $chunk, 'chunk_total' => $chunk->count()]),
-            'total_results' => $items->sum(fn ($chunk) => $chunk->count()),
+        $extra = [
+            'total_items' => $items->sum(fn ($chunk) => $chunk->count()),
             'total_chunks' => $items->count(),
         ];
+
+        return $items->map(fn ($chunk) => array_merge([
+            $key => $chunk,
+        ], $extra))->all();
     }
 
     protected function extraOutput($items)

--- a/src/Tags/Concerns/OutputsItems.php
+++ b/src/Tags/Concerns/OutputsItems.php
@@ -33,7 +33,7 @@ trait OutputsItems
         }
 
         return [
-            $key => $items->map(fn ($chunk) => ['chunk' => $chunk]),
+            $key => $items->map(fn ($chunk) => ['chunk' => $chunk, 'chunk_total' => $chunk->count()]),
             'total_results' => $items->sum(fn ($chunk) => $chunk->count()),
             'total_chunks' => $items->count(),
         ];

--- a/src/Tags/Concerns/OutputsItems.php
+++ b/src/Tags/Concerns/OutputsItems.php
@@ -33,7 +33,7 @@ trait OutputsItems
         }
 
         return [
-            $key => $items->map(fn ($chunk) => ['items' => $chunk]),
+            $key => $items->map(fn ($chunk) => ['chunk' => $chunk]),
             'total_results' => $items->sum(fn ($chunk) => $chunk->count()),
             'total_chunks' => $items->count(),
         ];

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -567,8 +567,8 @@ class EntriesTest extends TestCase
 
         $entries = $this->getEntries(['chunk' => 2]);
 
-        $this->assertEquals([1, 2], $entries->first()->get('chunk')->map->slug()->all());
-        $this->assertEquals([3], $entries->last()->get('chunk')->map->slug()->all());
+        $this->assertEquals([1, 2], $entries->first()->map->slug()->all());
+        $this->assertEquals([3], $entries->last()->map->slug()->all());
     }
 }
 

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -557,6 +557,19 @@ class EntriesTest extends TestCase
 
         $this->assertEquals([3], $this->getEntries(['taxonomy:tags:all' => $builder])->map->slug()->all());
     }
+
+    /** @test */
+    public function it_chunks_entries()
+    {
+        $this->makeEntry('1')->save();
+        $this->makeEntry('2')->save();
+        $this->makeEntry('3')->save();
+
+        $entries = $this->getEntries(['chunk' => 2]);
+
+        $this->assertEquals([1, 2], $entries->first()->get('chunk')->map->slug()->all());
+        $this->assertEquals([3], $entries->last()->get('chunk')->map->slug()->all());
+    }
 }
 
 class PostType extends Scope


### PR DESCRIPTION
This PR add support for `chunk` on query builder variables in antlers, so you can now do:

```antlers
        {{ assets_field chunk="2" }}
            {{ chunk }}
                {{ url }} - {{ alt }}
            {{ /chunk }}
        {{ /assets_field}}
```

Partially closes https://github.com/statamic/cms/issues/8195