### PR TITLE
[4.x] Fix fullscreen button overlap of stacked grid in replicator

### DIFF
--- a/resources/css/components/fieldtypes/grid.css
+++ b/resources/css/components/fieldtypes/grid.css
@@ -79,3 +79,8 @@
     z-index: 998; /*  to appear over the top of the rest of the stuff on the page. */
                 /*  too high and it'll be over the top of stacks, etc. */
 }
+
+/* when a stacked grid is inside a replicator the fullscreen button needs some more room */
+.replicator-set-body .grid-stacked {
+    @apply mt-6;
+}


### PR DESCRIPTION
Before:
![CleanShot 2023-12-08 at 08 13 24@2x](https://github.com/statamic/cms/assets/51899/7f969ca2-0022-4f38-8367-b1d17cec99c9)

After:
![CleanShot 2023-12-08 at 08 13 52@2x](https://github.com/statamic/cms/assets/51899/586c46d5-4705-4a6e-80c7-c4fa0d92d442)

Ideally the label would push down a bit too - but I couldn't get that working without also affecting the table mode of the grid field type.

Closes https://github.com/statamic/cms/issues/8748