### PR TITLE
[4.x] Fix updating localized search index through the CP

### DIFF
--- a/resources/views/utilities/search.blade.php
+++ b/resources/views/utilities/search.blade.php
@@ -71,7 +71,7 @@
                         <td class="text-right">
                             <form method="POST" action="{{ cp_route('utilities.search') }}">
                                 @csrf
-                                <input type="hidden" name="indexes[]" value="{{ $index->name() }}">
+                                <input type="hidden" name="indexes[]" value="{{ $index->name() }}::{{ $index->locale() }}">
                                 <button type="submit" class="btn btn-xs">{{ __('Update') }}</button>
                             </form>
                         </td>

--- a/src/Http/Controllers/CP/Utilities/UpdateSearchController.php
+++ b/src/Http/Controllers/CP/Utilities/UpdateSearchController.php
@@ -5,6 +5,7 @@ namespace Statamic\Http\Controllers\CP\Utilities;
 use Illuminate\Http\Request;
 use Statamic\Facades\Search;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Support\Str;
 
 class UpdateSearchController extends CpController
 {
@@ -15,7 +16,11 @@ class UpdateSearchController extends CpController
         ])['indexes']);
 
         $indexes->each(function ($index) {
-            Search::index($index)->update();
+            [$name, $locale] = explode('::', $index);
+            if ($locale) {
+                $name = Str::before($name, '_'.$locale);
+            }
+            Search::index($name, $locale ?: null)->update();
         });
 
         return back()->withSuccess(__('Update successful.'));

--- a/src/Search/IndexManager.php
+++ b/src/Search/IndexManager.php
@@ -9,7 +9,6 @@ use Statamic\Search\Algolia\Index as AlgoliaIndex;
 use Statamic\Search\Comb\Index as CombIndex;
 use Statamic\Search\Null\NullIndex;
 use Statamic\Support\Manager;
-use Statamic\Support\Str;
 
 class IndexManager extends Manager
 {
@@ -45,19 +44,6 @@ class IndexManager extends Manager
     public function driver($name = null, $locale = null)
     {
         $name = $name ?: $this->getDefaultDriver();
-
-        // on the cp search utilities page, the locale is appended to the name
-        if (! $locale) {
-            if (str_contains($name, '_') && ($locale = Str::after($name, '_'))) {
-                if (Site::all()->firstWhere('handle', $locale)) {
-                    $name = Str::before($name, '_');
-                }
-            }
-
-            if (! $locale) {
-                $locale = Site::current()->handle();
-            }
-        }
 
         $handle = $name.'_'.$locale;
 

--- a/src/Search/IndexManager.php
+++ b/src/Search/IndexManager.php
@@ -45,6 +45,8 @@ class IndexManager extends Manager
     {
         $name = $name ?: $this->getDefaultDriver();
 
+        $locale = $locale ?: Site::current()->handle();
+
         $handle = $name.'_'.$locale;
 
         if ($this->drivers[$handle] ?? null) {

--- a/src/Search/IndexManager.php
+++ b/src/Search/IndexManager.php
@@ -48,7 +48,7 @@ class IndexManager extends Manager
 
         // on the cp search utilities page, the locale is appended to the name
         if (! $locale) {
-            if ($locale = Str::after($name, '_')) {
+            if ($name && ($locale = Str::after($name, '_'))) {
                 if (Site::all()->firstWhere('handle', $locale)) {
                     $name = Str::before($name, '_');
                 }

--- a/src/Search/IndexManager.php
+++ b/src/Search/IndexManager.php
@@ -48,7 +48,7 @@ class IndexManager extends Manager
 
         // on the cp search utilities page, the locale is appended to the name
         if (! $locale) {
-            if ($name && ($locale = Str::after($name, '_'))) {
+            if (str_contains($name, '_') && ($locale = Str::after($name, '_'))) {
                 if (Site::all()->firstWhere('handle', $locale)) {
                     $name = Str::before($name, '_');
                 }

--- a/src/Search/IndexManager.php
+++ b/src/Search/IndexManager.php
@@ -9,6 +9,7 @@ use Statamic\Search\Algolia\Index as AlgoliaIndex;
 use Statamic\Search\Comb\Index as CombIndex;
 use Statamic\Search\Null\NullIndex;
 use Statamic\Support\Manager;
+use Statamic\Support\Str;
 
 class IndexManager extends Manager
 {
@@ -45,7 +46,18 @@ class IndexManager extends Manager
     {
         $name = $name ?: $this->getDefaultDriver();
 
-        $locale = $locale ?: Site::current()->handle();
+        // on the cp search utilities page, the locale is appended to the name
+        if (! $locale) {
+            if ($locale = Str::after($name, '_')) {
+                if (Site::all()->firstWhere('handle', $locale)) {
+                    $name = Str::before($name, '_');
+                }
+            }
+
+            if (! $locale) {
+                $locale = Site::current()->handle();
+            }
+        }
 
         $handle = $name.'_'.$locale;
 


### PR DESCRIPTION
As [reported here](https://github.com/statamic-rad-pack/meilisearch/issues/30) updating multi-site search indexes through the CP utilities is not working as it tries to find an index which already has a locale/site appended, then appends the current one to that.

This PR modifies the logic to check if the locale is already appended to the name, and if so, splits out the index name and the locale.