### PR TITLE
[4.x] Antlers: Corrects an issue where string interpolation checks would run Str::contains on objects

### DIFF
--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -1353,7 +1353,7 @@ class Environment
             }
         }
 
-        if (! empty($this->interpolationReplacements)) {
+        if (! empty($this->interpolationReplacements) && is_string($value)) {
             if (Str::contains($value, $this->interpolationKeys)) {
                 $value = strtr($value, $this->interpolationReplacements);
             }

--- a/tests/Antlers/Runtime/ConditionLogicTest.php
+++ b/tests/Antlers/Runtime/ConditionLogicTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Antlers\Runtime;
 
 use Facades\Tests\Factories\EntryFactory;
+use Statamic\Entries\Collection;
 use Statamic\Fields\Field;
 use Statamic\Fields\LabeledValue;
 use Statamic\Fields\Value;
@@ -16,10 +17,12 @@ use Statamic\View\Cascade;
 use Tests\Antlers\Fixtures\Addon\Tags\VarTest;
 use Tests\Antlers\ParserTestCase;
 use Tests\FakesViews;
+use Tests\PreventSavingStacheItemsToDisk;
 
 class ConditionLogicTest extends ParserTestCase
 {
     use FakesViews;
+    use PreventSavingStacheItemsToDisk;
 
     public function test_negation_following_or_is_evaluated()
     {
@@ -810,5 +813,27 @@ EOT
         );
 
         $this->assertSame('Yes', trim($this->renderString($template, ['code_field' => $value], true)));
+    }
+
+    public function test_conditions_with_objects_inside_interpolations_dont_trigger_string_errors()
+    {
+        $collection = Collection::make('blog')->routes('{slug}')->save();
+
+        $template = <<<'EOT'
+{{ if items | where('collection', {collection}) }}
+Yes
+{{ /if }}
+EOT;
+
+        $data = [
+            'items' => [
+                [
+                    'collection' => 'blog',
+                ],
+            ],
+            'collection' => $collection,
+        ];
+
+        $this->assertSame('Yes', trim($this->renderString($template, $data, true)));
     }
 }


### PR DESCRIPTION
This PR fixes #9161 by ensuring the Str::contains (when processing nested string interpolations) doesn't run on objects.