### PR TITLE
[4.x] Fix deleting collections with localized entries

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -727,7 +727,10 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
 
     public function delete()
     {
-        $this->queryEntries()->get()->each->delete();
+        $this->queryEntries()->get()->each(function ($entry) {
+            $entry->deleteDescendants();
+            $entry->delete();
+        });
 
         Facades\Collection::delete($this);
 

--- a/src/Routing/Routable.php
+++ b/src/Routing/Routable.php
@@ -4,7 +4,6 @@ namespace Statamic\Routing;
 
 use Closure;
 use Statamic\Contracts\Routing\UrlBuilder;
-use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Support\Str;
 

--- a/src/Routing/Routable.php
+++ b/src/Routing/Routable.php
@@ -4,6 +4,7 @@ namespace Statamic\Routing;
 
 use Closure;
 use Statamic\Contracts\Routing\UrlBuilder;
+use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Support\Str;
 
@@ -26,6 +27,10 @@ trait Routable
 
             if (! $slug) {
                 return null;
+            }
+
+            if (is_null($this->site())) {
+                dd($this->locale, Site::all());
             }
 
             $lang = method_exists($this, 'site') ? $this->site()->lang() : null;

--- a/src/Routing/Routable.php
+++ b/src/Routing/Routable.php
@@ -29,10 +29,6 @@ trait Routable
                 return null;
             }
 
-            if (is_null($this->site())) {
-                dd($this->locale, Site::all());
-            }
-
             $lang = method_exists($this, 'site') ? $this->site()->lang() : null;
 
             return Str::slug($slug, '-', $lang);


### PR DESCRIPTION
This pull request fixes an error which would occur when deleting a collection in a multi-site, where entries have localizations.

Fixes #3890.