### PR TITLE
[4.x] Add nocache regions and CSRF to `statamic:nocache.replaced` event

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -237,7 +237,7 @@ class FileCacher extends AbstractCacher
             window.livewireScriptConfig.csrf = data.csrf
         }
 
-        document.dispatchEvent(new CustomEvent('statamic:nocache.replaced'));
+        document.dispatchEvent(new CustomEvent('statamic:nocache.replaced', { detail: data }));
     });
 })();
 EOT;


### PR DESCRIPTION
We should make the nocache region and CSRF available through the event in case a developer needs to update a variable or something thats not handled by the default options provided.

The developer can then listen for this 

```js
document.addEventListener('statamic:nocache.replaced`, (event) => {
	// do something with event.detail.regions or event.detail.csrf
});
```

Closes https://github.com/statamic/cms/issues/9162