### PR TITLE
[4.x] Translate validation attributes when pulled from display

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -166,7 +166,7 @@ class Field implements Arrayable
     {
         $display = Lang::has($key = 'validation.attributes.'.$this->handle())
             ? Lang::get($key)
-            : $this->display();
+            : __($this->display());
 
         return array_merge(
             [$this->handle() => $display],


### PR DESCRIPTION
As [reported here](https://github.com/statamic/cms/issues/9168), validation attributes are not being translated, so you get the default locale display for the field in the error message.

This PR fixes that by translating the display.

Before:
![CleanShot 2023-12-10 at 19 32 17@2x](https://github.com/statamic/cms/assets/51899/a45df87d-07e0-49e4-b43f-87e2bc790f77)

After:
![CleanShot 2023-12-10 at 19 32 30@2x](https://github.com/statamic/cms/assets/51899/672840df-ff40-4470-8ede-7b40a3151c13)

Note the difference in the "Bericht" field.

Closes https://github.com/statamic/cms/issues/9168