### PR TITLE
[4.x] Prevent precognitive validation on asset fields

### DIFF
--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -68,6 +68,10 @@ class Validator
         }
 
         return $this->fields->preProcessValidatables()->all()->reduce(function ($carry, $field) {
+            if (request()->isPrecognitive() && $field->type() == 'assets') {
+                return $carry;
+            }
+
             return $carry->merge($field->setValidationContext($this->context)->rules());
         }, collect());
     }


### PR DESCRIPTION
In line with the file upload section here: https://laravel.com/docs/10.x/precognition#handling-file-uploads

I feel we should prevent asset fields from validating on precognitive requests, so this PR prevents any validation rules for assets running during those requests.

Closes https://github.com/statamic/cms/issues/9138