### PR TITLE
[4.x] Provide searchable entries and terms lazily

### DIFF
--- a/src/Search/ProvidesSearchables.php
+++ b/src/Search/ProvidesSearchables.php
@@ -3,6 +3,7 @@
 namespace Statamic\Search;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 
 interface ProvidesSearchables
 {
@@ -12,7 +13,7 @@ interface ProvidesSearchables
 
     public function setKeys(array $keys): self;
 
-    public function provide(): Collection;
+    public function provide(): Collection|LazyCollection;
 
     public function contains($searchable): bool;
 

--- a/src/Search/Searchables/Entries.php
+++ b/src/Search/Searchables/Entries.php
@@ -31,7 +31,7 @@ class Entries extends Provider
             $query->where('site', $site);
         }
 
-        return $query->lazy(10)->filter($this->filter())->values();
+        return $query->lazy(100)->filter($this->filter())->values();
     }
 
     public function contains($searchable): bool

--- a/src/Search/Searchables/Entries.php
+++ b/src/Search/Searchables/Entries.php
@@ -3,6 +3,7 @@
 namespace Statamic\Search\Searchables;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Facades\Entry;
 
@@ -18,7 +19,7 @@ class Entries extends Provider
         return 'entry';
     }
 
-    public function provide(): Collection
+    public function provide(): Collection|LazyCollection
     {
         $query = Entry::query();
 
@@ -30,7 +31,7 @@ class Entries extends Provider
             $query->where('site', $site);
         }
 
-        return $query->get()->filter($this->filter())->values();
+        return $query->lazy()->filter($this->filter())->values();
     }
 
     public function contains($searchable): bool

--- a/src/Search/Searchables/Entries.php
+++ b/src/Search/Searchables/Entries.php
@@ -31,7 +31,7 @@ class Entries extends Provider
             $query->where('site', $site);
         }
 
-        return $query->lazy()->filter($this->filter())->values();
+        return $query->lazy(10)->filter($this->filter())->values();
     }
 
     public function contains($searchable): bool

--- a/src/Search/Searchables/Terms.php
+++ b/src/Search/Searchables/Terms.php
@@ -32,7 +32,7 @@ class Terms extends Provider
             $query->where('site', $site);
         }
 
-        return $query->lazy()->filter($this->filter())->values();
+        return $query->lazy(10)->filter($this->filter())->values();
     }
 
     public function contains($searchable): bool

--- a/src/Search/Searchables/Terms.php
+++ b/src/Search/Searchables/Terms.php
@@ -3,6 +3,7 @@
 namespace Statamic\Search\Searchables;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 use Statamic\Contracts\Taxonomies\Term as TermContract;
 use Statamic\Facades\Term;
 use Statamic\Support\Str;
@@ -19,7 +20,7 @@ class Terms extends Provider
         return 'term';
     }
 
-    public function provide(): Collection
+    public function provide(): Collection|LazyCollection
     {
         $query = Term::query();
 
@@ -31,7 +32,7 @@ class Terms extends Provider
             $query->where('site', $site);
         }
 
-        return $query->get()->filter($this->filter())->values();
+        return $query->lazy()->filter($this->filter())->values();
     }
 
     public function contains($searchable): bool

--- a/src/Search/Searchables/Terms.php
+++ b/src/Search/Searchables/Terms.php
@@ -32,7 +32,7 @@ class Terms extends Provider
             $query->where('site', $site);
         }
 
-        return $query->lazy(10)->filter($this->filter())->values();
+        return $query->lazy(100)->filter($this->filter())->values();
     }
 
     public function contains($searchable): bool


### PR DESCRIPTION
Now that the [query builder supports lazy](https://github.com/statamic/cms/pull/9148), the searchable provider provide() method can make use of that to return documents in a more memory efficient manner.

The PR updates the interface to allow this method to return a LazyCollection and updates both entries and terms to do that. It seems this is not a breaking change, as other providers still return a standard collection and I encountered no errors.

I notice that assets and users are not using a query builder (they are just returning a filtered `all()`), so there is definitely scope to improve things further by updating those providers to do that.

This should close https://github.com/statamic/cms/issues/8854