### PR TITLE
[4.x] Fix template lookup with dots in view path

### DIFF
--- a/src/Http/Controllers/CP/API/TemplatesController.php
+++ b/src/Http/Controllers/CP/API/TemplatesController.php
@@ -17,7 +17,7 @@ class TemplatesController extends CpController
 
                 foreach ($iterator as $file) {
                     if ($file->isFile()) {
-                        $views->push(str_before(str_replace_first($path . '/', '', $file->getPathname()), '.'));
+                        $views->push(str_before(str_replace_first($path.'/', '', $file->getPathname()), '.'));
                     }
                 }
 

--- a/src/Http/Controllers/CP/API/TemplatesController.php
+++ b/src/Http/Controllers/CP/API/TemplatesController.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Http\Controllers\CP\API;
 
-use Illuminate\Support\Str;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Statamic\Http\Controllers\CP\CpController;
@@ -18,7 +17,7 @@ class TemplatesController extends CpController
 
                 foreach ($iterator as $file) {
                     if ($file->isFile()) {
-                        $views->push(str_replace_first($path.'/', '', Str::beforeLast($file->getPathname(), '.')));
+                        $views->push(str_before(str_replace_first($path . '/', '', $file->getPathname()), '.'));
                     }
                 }
 

--- a/src/Http/Controllers/CP/API/TemplatesController.php
+++ b/src/Http/Controllers/CP/API/TemplatesController.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Http\Controllers\CP\API;
 
+use Illuminate\Support\Str;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Statamic\Http\Controllers\CP\CpController;
@@ -17,7 +18,7 @@ class TemplatesController extends CpController
 
                 foreach ($iterator as $file) {
                     if ($file->isFile()) {
-                        $views->push(str_replace_first($path.'/', '', str_before($file->getPathname(), '.')));
+                        $views->push(str_replace_first($path.'/', '', Str::beforeLast($file->getPathname(), '.')));
                     }
                 }
 


### PR DESCRIPTION
Since [the last change](https://github.com/statamic/cms/commit/765d30bc10f146b5e137fe433a4d435b59e65b06) in `TemplateController.php` there is a problem with dots on the view path, because everything after the first dot will be stripped.

So, for example, if your site is located in `/Users/username/Sites/mysite.com` you’d get a list like this in the control panel when selecting a template:

- /Users/username/Sites/mysite
- /Users/username/Sites/mysite
- /Users/username/Sites/mysite
- ...

Fixes #9177.