### PR TITLE
[4.x] Ensure publish date field can only be in `single` mode

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -174,6 +174,7 @@ return [
     'date_fieldtype_start_date_invalid' => 'Not a valid start date.',
     'date_fieldtype_end_date_required' => 'End date is required.',
     'date_fieldtype_end_date_invalid' => 'Not a valid end date.',
+    'date_fieldtype_only_single_mode_allowed' => 'You can only use "Single" mode when the field handle is date.',
     'code_fieldtype_rulers' => 'This is invalid.',
     'options_require_keys' => 'All options must have keys.',
 

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -61,9 +61,17 @@ class FieldsController extends CpController
             ->fields()
             ->addValues($request->values);
 
-        $fields->validate([], [
+        $extraRules = [];
+        $customMessages = [
             'handle.not_in' => __('statamic::validation.reserved'),
-        ]);
+        ];
+
+        if ($request->type === 'date' && $request->values['handle'] === 'date') {
+            $extraRules['mode'] = 'in:single';
+            $customMessages['mode.in'] = __('statamic::validation.date_fieldtype_only_single_mode_allowed');
+        }
+
+        $fields->validate($extraRules, $customMessages);
 
         $values = array_merge($request->values, $fields->process()->values()->all());
 


### PR DESCRIPTION
This pull request implements validation to the blueprint builder to ensure Date Fields with the handle of `date` are always using `single` mode.

This is to avoid the publish date field being changed to the "Range" mode, where the publish form would error out because it's not supported.

Initially, I wanted to put the validation rule in the Date Fieldtype code somewhere but I wouldn't be able to check the field handle there so had to put it in the `FieldsController`. Happy to re-work this fix if there's a better place for this.

Fixes #3655.
Partially fixes #4818.