### PR TITLE
[4.x] Clarify which changes will stay in sync

### DIFF
--- a/resources/js/components/blueprints/LinkFields.vue
+++ b/resources/js/components/blueprints/LinkFields.vue
@@ -23,7 +23,7 @@
 
                     <div>
                         <p class="text-sm font-medium mb-2" v-text="__('Link a single field')" />
-                        <p class="text-2xs text-gray mb-2" v-text="__('Changes to this field will stay in sync.')" />
+                        <p class="text-2xs text-gray mb-2" v-text="__('Changes to this field in the fieldset will stay in sync.')" />
                         <v-select
                             name="field"
                             :placeholder="__('Fields')"


### PR DESCRIPTION
This pull request clarifies which changes will stay in sync on the "Link Fields" function in the blueprint/fieldset builder. 

Only changes made in the *fieldset* will be synced. Changes made to the field in the _blueprint_ won't sync their way back to the fieldset.

![CleanShot 2023-12-11 at 15 13 56](https://github.com/statamic/cms/assets/19637309/66c62f97-fb0f-40d1-87a1-d9932d9a821a)

Closes #3798.
