### PR TITLE
[4.x] Render layout on 403 Forbidden pages

### DIFF
--- a/src/Auth/Protect/Protectors/Authenticated.php
+++ b/src/Auth/Protect/Protectors/Authenticated.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Auth\Protect\Protectors;
 
+use Statamic\Exceptions\ForbiddenHttpException;
+
 class Authenticated extends Protector
 {
     public function protect()
@@ -15,7 +17,7 @@ class Authenticated extends Protector
         }
 
         if (! $this->getLoginUrl()) {
-            abort(403);
+            throw new ForbiddenHttpException();
         }
 
         abort(redirect($this->getLoginUrl()));

--- a/src/Auth/Protect/Protectors/Fallback.php
+++ b/src/Auth/Protect/Protectors/Fallback.php
@@ -2,10 +2,12 @@
 
 namespace Statamic\Auth\Protect\Protectors;
 
+use Statamic\Exceptions\ForbiddenHttpException;
+
 class Fallback extends Protector
 {
     public function protect()
     {
-        abort(403);
+        throw new ForbiddenHttpException();
     }
 }

--- a/src/Auth/Protect/Protectors/IpAddress.php
+++ b/src/Auth/Protect/Protectors/IpAddress.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Auth\Protect\Protectors;
 
+use Statamic\Exceptions\ForbiddenHttpException;
+
 class IpAddress extends Protector
 {
     public function protect()
@@ -9,7 +11,7 @@ class IpAddress extends Protector
         $ips = array_get($this->config, 'allowed', []);
 
         if (! in_array(request()->ip(), $ips)) {
-            abort(403);
+            throw new ForbiddenHttpException();
         }
     }
 }

--- a/src/Auth/Protect/Protectors/Password/PasswordProtector.php
+++ b/src/Auth/Protect/Protectors/Password/PasswordProtector.php
@@ -4,6 +4,7 @@ namespace Statamic\Auth\Protect\Protectors\Password;
 
 use Facades\Statamic\Auth\Protect\Protectors\Password\Token;
 use Statamic\Auth\Protect\Protectors\Protector;
+use Statamic\Exceptions\ForbiddenHttpException;
 
 class PasswordProtector extends Protector
 {
@@ -15,7 +16,7 @@ class PasswordProtector extends Protector
     public function protect()
     {
         if (empty(array_get($this->config, 'allowed', []))) {
-            abort(403);
+            throw new ForbiddenHttpException();
         }
 
         if (request()->isLivePreview()) {

--- a/src/Exceptions/Concerns/RendersHttpExceptions.php
+++ b/src/Exceptions/Concerns/RendersHttpExceptions.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Statamic\Exceptions\Concerns;
+
+use Statamic\Facades\Cascade;
+use Statamic\Statamic;
+use Statamic\View\View;
+
+trait RendersHttpExceptions
+{
+    public function render()
+    {
+        if (Statamic::isCpRoute()) {
+            return response()->view('statamic::errors.'.$this->getStatusCode(), [], $this->getStatusCode());
+        }
+
+        if (view()->exists('errors.'.$this->getStatusCode())) {
+            return response($this->contents(), $this->getStatusCode());
+        }
+    }
+
+    protected function contents()
+    {
+        Cascade::hydrated(function ($cascade) {
+            $cascade->set('response_code', $this->getStatusCode());
+        });
+
+        return app(View::class)
+            ->template('errors.'.$this->getStatusCode())
+            ->layout($this->layout())
+            ->render();
+    }
+
+    protected function layout()
+    {
+        $layouts = collect([
+            'errors.layout',
+            'layouts.layout',
+            'layout',
+            'statamic::blank',
+        ]);
+
+        return $layouts->filter()->first(function ($layout) {
+            return view()->exists($layout);
+        });
+    }
+}

--- a/src/Exceptions/ForbiddenHttpException.php
+++ b/src/Exceptions/ForbiddenHttpException.php
@@ -2,52 +2,15 @@
 
 namespace Statamic\Exceptions;
 
-use Statamic\Facades\Cascade;
-use Statamic\Statamic;
-use Statamic\View\View;
+use Statamic\Exceptions\Concerns\RendersHttpExceptions;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class ForbiddenHttpException extends HttpException
 {
+    use RendersHttpExceptions;
+
     public function __construct(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(403, $message, $previous, $headers, $code);
-    }
-
-    public function render()
-    {
-        if (Statamic::isCpRoute()) {
-            return response()->view('statamic::errors.403', [], 403);
-        }
-
-        if (view()->exists('errors.403')) {
-            return response($this->contents(), 403);
-        }
-    }
-
-    protected function contents()
-    {
-        Cascade::hydrated(function ($cascade) {
-            $cascade->set('response_code', 403);
-        });
-
-        return app(View::class)
-            ->template('errors.403')
-            ->layout($this->layout())
-            ->render();
-    }
-
-    protected function layout()
-    {
-        $layouts = collect([
-            'errors.layout',
-            'layouts.layout',
-            'layout',
-            'statamic::blank',
-        ]);
-
-        return $layouts->filter()->first(function ($layout) {
-            return view()->exists($layout);
-        });
     }
 }

--- a/src/Exceptions/ForbiddenHttpException.php
+++ b/src/Exceptions/ForbiddenHttpException.php
@@ -9,7 +9,7 @@ class ForbiddenHttpException extends HttpException
 {
     use RendersHttpExceptions;
 
-    public function __construct(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = '', ?\Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(403, $message, $previous, $headers, $code);
     }

--- a/src/Exceptions/ForbiddenHttpException.php
+++ b/src/Exceptions/ForbiddenHttpException.php
@@ -5,10 +5,15 @@ namespace Statamic\Exceptions;
 use Statamic\Facades\Cascade;
 use Statamic\Statamic;
 use Statamic\View\View;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException as SymfonyException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class ForbiddenHttpException extends SymfonyException
+class ForbiddenHttpException extends HttpException
 {
+    public function __construct(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
+    {
+        parent::__construct(403, $message, $previous, $headers, $code);
+    }
+
     public function render()
     {
         if (Statamic::isCpRoute()) {

--- a/src/Exceptions/ForbiddenHttpException.php
+++ b/src/Exceptions/ForbiddenHttpException.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Statamic\Exceptions;
+
+use Statamic\Facades\Cascade;
+use Statamic\Statamic;
+use Statamic\View\View;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException as SymfonyException;
+
+class ForbiddenHttpException extends SymfonyException
+{
+    public function render()
+    {
+        if (Statamic::isCpRoute()) {
+            return response()->view('statamic::errors.403', [], 403);
+        }
+
+        if (view()->exists('errors.403')) {
+            return response($this->contents(), 403);
+        }
+    }
+
+    protected function contents()
+    {
+        Cascade::hydrated(function ($cascade) {
+            $cascade->set('response_code', 403);
+        });
+
+        return app(View::class)
+            ->template('errors.403')
+            ->layout($this->layout())
+            ->render();
+    }
+
+    protected function layout()
+    {
+        $layouts = collect([
+            'errors.layout',
+            'layouts.layout',
+            'layout',
+            'statamic::blank',
+        ]);
+
+        return $layouts->filter()->first(function ($layout) {
+            return view()->exists($layout);
+        });
+    }
+}

--- a/src/Exceptions/NotFoundHttpException.php
+++ b/src/Exceptions/NotFoundHttpException.php
@@ -2,47 +2,10 @@
 
 namespace Statamic\Exceptions;
 
-use Statamic\Facades\Cascade;
-use Statamic\Statamic;
-use Statamic\View\View;
+use Statamic\Exceptions\Concerns\RendersHttpExceptions;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException as SymfonyException;
 
 class NotFoundHttpException extends SymfonyException
 {
-    public function render()
-    {
-        if (Statamic::isCpRoute()) {
-            return response()->view('statamic::errors.404', [], 404);
-        }
-
-        if (view()->exists('errors.404')) {
-            return response($this->contents(), 404);
-        }
-    }
-
-    protected function contents()
-    {
-        Cascade::hydrated(function ($cascade) {
-            $cascade->set('response_code', 404);
-        });
-
-        return app(View::class)
-            ->template('errors.404')
-            ->layout($this->layout())
-            ->render();
-    }
-
-    protected function layout()
-    {
-        $layouts = collect([
-            'errors.layout',
-            'layouts.layout',
-            'layout',
-            'statamic::blank',
-        ]);
-
-        return $layouts->filter()->first(function ($layout) {
-            return view()->exists($layout);
-        });
-    }
+    use RendersHttpExceptions;
 }


### PR DESCRIPTION
This pull request fixes an issue where the layout wouldn't be used when rendering the 403 Forbidden pages, only the template's content would be used.

Fixes #4014.