### PR TITLE
[4.x] Laravel Pint: Use the default for `nullable_type_declaration_for_default_null_value `

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -6,9 +6,6 @@
                 "method": "one"
             }
         },
-        "nullable_type_declaration_for_default_null_value": {
-            "use_nullable_type_declaration": false
-        },
         "psr_autoloading": true
     }
 }

--- a/src/Actions/DuplicateEntry.php
+++ b/src/Actions/DuplicateEntry.php
@@ -55,7 +55,7 @@ class DuplicateEntry extends Action
             ->each(fn ($original) => $this->duplicateEntry($original));
     }
 
-    private function duplicateEntry(Entry $original, string $origin = null)
+    private function duplicateEntry(Entry $original, ?string $origin = null)
     {
         $originalParent = $this->getEntryParentFromStructure($original);
         [$title, $slug] = $this->generateTitleAndSlug($original);

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -886,7 +886,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      *
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function download(string $name = null, array $headers = [])
+    public function download(?string $name = null, array $headers = [])
     {
         return $this->disk()->filesystem()->download($this->path(), $name, $headers);
     }

--- a/src/Assets/FileUploader.php
+++ b/src/Assets/FileUploader.php
@@ -15,7 +15,7 @@ class FileUploader extends Uploader
         $this->container = $container ? AssetContainer::find($container) : null;
     }
 
-    public static function container(string $container = null)
+    public static function container(?string $container = null)
     {
         return new static($container);
     }

--- a/src/Auth/Eloquent/RoleRepository.php
+++ b/src/Auth/Eloquent/RoleRepository.php
@@ -7,7 +7,7 @@ use Statamic\Contracts\Auth\Role as RoleContract;
 
 class RoleRepository extends BaseRepository
 {
-    public function make(string $handle = null): RoleContract
+    public function make(?string $handle = null): RoleContract
     {
         return (new Role)->handle($handle);
     }

--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -20,7 +20,7 @@ class User extends BaseUser
     protected $roles;
     protected $groups;
 
-    public function model(Model $model = null)
+    public function model(?Model $model = null)
     {
         if (is_null($model)) {
             return $this->model;

--- a/src/Auth/File/Role.php
+++ b/src/Auth/File/Role.php
@@ -24,7 +24,7 @@ class Role extends BaseRole
         $this->permissions = collect();
     }
 
-    public function title(string $title = null)
+    public function title(?string $title = null)
     {
         if (func_num_args() === 0) {
             return $this->title;
@@ -40,7 +40,7 @@ class Role extends BaseRole
         return $this->handle();
     }
 
-    public function handle(string $handle = null)
+    public function handle(?string $handle = null)
     {
         if (func_num_args() === 0) {
             return $this->handle;

--- a/src/Auth/File/RoleRepository.php
+++ b/src/Auth/File/RoleRepository.php
@@ -7,7 +7,7 @@ use Statamic\Contracts\Auth\Role as RoleContract;
 
 class RoleRepository extends BaseRepository
 {
-    public function make(string $handle = null): RoleContract
+    public function make(?string $handle = null): RoleContract
     {
         return (new Role)->handle($handle);
     }

--- a/src/Auth/Permission.php
+++ b/src/Auth/Permission.php
@@ -18,7 +18,7 @@ class Permission
     protected $description;
     protected $group;
 
-    public function value(string $value = null)
+    public function value(?string $value = null)
     {
         if (func_num_args() > 0) {
             $this->value = $value;
@@ -39,7 +39,7 @@ class Permission
         return $this->label;
     }
 
-    public function label(string $label = null)
+    public function label(?string $label = null)
     {
         if (func_num_args() > 0) {
             $this->label = $label;
@@ -52,17 +52,17 @@ class Permission
         return __($label, [$this->placeholder => $this->placeholderLabel]);
     }
 
-    public function placeholder(string $placeholder = null)
+    public function placeholder(?string $placeholder = null)
     {
         return $this->fluentlyGetOrSet('placeholder')->args(func_get_args());
     }
 
-    public function placeholderLabel(string $label = null)
+    public function placeholderLabel(?string $label = null)
     {
         return $this->fluentlyGetOrSet('placeholderLabel')->args(func_get_args());
     }
 
-    public function placeholderValue(string $placeholderValue = null)
+    public function placeholderValue(?string $placeholderValue = null)
     {
         return $this->fluentlyGetOrSet('placeholderValue')->args(func_get_args());
     }
@@ -103,7 +103,7 @@ class Permission
         })->values();
     }
 
-    public function children(array $children = null)
+    public function children(?array $children = null)
     {
         return $this
             ->fluentlyGetOrSet('children')
@@ -156,7 +156,7 @@ class Permission
         })->all();
     }
 
-    public function group(string $group = null)
+    public function group(?string $group = null)
     {
         return $this->fluentlyGetOrSet('group')->args(func_get_args());
     }

--- a/src/Auth/UserGroup.php
+++ b/src/Auth/UserGroup.php
@@ -29,7 +29,7 @@ abstract class UserGroup implements Arrayable, ArrayAccess, Augmentable, UserGro
         $this->data = collect();
     }
 
-    public function title(string $title = null)
+    public function title(?string $title = null)
     {
         if (func_num_args() === 0) {
             return $this->title;
@@ -45,7 +45,7 @@ abstract class UserGroup implements Arrayable, ArrayAccess, Augmentable, UserGro
         return $this->handle();
     }
 
-    public function handle(string $handle = null)
+    public function handle(?string $handle = null)
     {
         if (is_null($handle)) {
             return $this->handle;

--- a/src/CP/Utilities/Utility.php
+++ b/src/CP/Utilities/Utility.php
@@ -99,7 +99,7 @@ class Utility
         return cp_route('utilities.index').'/'.$this->slug();
     }
 
-    public function routes(Closure $routes = null)
+    public function routes(?Closure $routes = null)
     {
         return $this->fluentlyGetOrSet('routes')->args(func_get_args());
     }

--- a/src/Console/Processes/Composer.php
+++ b/src/Console/Processes/Composer.php
@@ -109,7 +109,7 @@ class Composer extends Process
      *
      * @param  mixed  $extraParams
      */
-    public function require(string $package, string $version = null, ...$extraParams)
+    public function require(string $package, ?string $version = null, ...$extraParams)
     {
         if ($version) {
             $parts[] = $version;
@@ -125,7 +125,7 @@ class Composer extends Process
     /**
      * Require a dev package.
      */
-    public function requireDev(string $package, string $version = null, ...$extraParams)
+    public function requireDev(string $package, ?string $version = null, ...$extraParams)
     {
         $this->require($package, $version, '--dev', ...$extraParams);
     }

--- a/src/Contracts/Assets/Asset.php
+++ b/src/Contracts/Assets/Asset.php
@@ -76,7 +76,7 @@ interface Asset
      *
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function download(string $name = null, array $headers = []);
+    public function download(?string $name = null, array $headers = []);
 
     /**
      * Get the asset file contents.

--- a/src/Contracts/Assets/AssetContainerRepository.php
+++ b/src/Contracts/Assets/AssetContainerRepository.php
@@ -12,5 +12,5 @@ interface AssetContainerRepository
 
     public function findByHandle(string $handle): ?AssetContainer;
 
-    public function make(string $handle = null): AssetContainer;
+    public function make(?string $handle = null): AssetContainer;
 }

--- a/src/Contracts/Auth/Role.php
+++ b/src/Contracts/Auth/Role.php
@@ -6,9 +6,9 @@ interface Role
 {
     public function id(): string;
 
-    public function title(string $title = null);
+    public function title(?string $title = null);
 
-    public function handle(string $handle = null);
+    public function handle(?string $handle = null);
 
     public function permissions($permissions = null);
 

--- a/src/Contracts/Auth/RoleRepository.php
+++ b/src/Contracts/Auth/RoleRepository.php
@@ -12,5 +12,5 @@ interface RoleRepository
 
     public function exists(string $id): bool;
 
-    public function make(string $handle = null): Role;
+    public function make(?string $handle = null): Role;
 }

--- a/src/Contracts/Auth/UserGroup.php
+++ b/src/Contracts/Auth/UserGroup.php
@@ -6,9 +6,9 @@ interface UserGroup
 {
     public function id(): string;
 
-    public function title(string $title = null);
+    public function title(?string $title = null);
 
-    public function handle(string $slug = null);
+    public function handle(?string $slug = null);
 
     public function users();
 

--- a/src/Contracts/Entries/CollectionRepository.php
+++ b/src/Contracts/Entries/CollectionRepository.php
@@ -14,7 +14,7 @@ interface CollectionRepository
 
     public function findByMount($mount): ?Collection;
 
-    public function make(string $handle = null): Collection;
+    public function make(?string $handle = null): Collection;
 
     public function handles(): IlluminateCollection;
 

--- a/src/Contracts/Structures/NavigationRepository.php
+++ b/src/Contracts/Structures/NavigationRepository.php
@@ -14,5 +14,5 @@ interface NavigationRepository
 
     public function save(Nav $nav);
 
-    public function make(string $handle = null): Nav;
+    public function make(?string $handle = null): Nav;
 }

--- a/src/Contracts/Taxonomies/TaxonomyRepository.php
+++ b/src/Contracts/Taxonomies/TaxonomyRepository.php
@@ -14,7 +14,7 @@ interface TaxonomyRepository
 
     public function findByUri(string $uri): ?Taxonomy;
 
-    public function make(string $handle = null): Taxonomy;
+    public function make(?string $handle = null): Taxonomy;
 
     public function handles(): Collection;
 

--- a/src/Contracts/Taxonomies/TermRepository.php
+++ b/src/Contracts/Taxonomies/TermRepository.php
@@ -14,7 +14,7 @@ interface TermRepository
 
     public function findByUri(string $uri);
 
-    public function make(string $slug = null);
+    public function make(?string $slug = null);
 
     public function query();
 

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -678,7 +678,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
             ->args(func_get_args());
     }
 
-    public function structureContents(array $contents = null)
+    public function structureContents(?array $contents = null)
     {
         return $this
             ->fluentlyGetOrSet('structureContents')

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -175,7 +175,7 @@ class FieldsetRepository
         $this->hints[$namespace] = $directory;
     }
 
-    protected function getFieldsetsByDirectory(string $directory, string $namespace = null): Collection
+    protected function getFieldsetsByDirectory(string $directory, ?string $namespace = null): Collection
     {
         return File::withAbsolutePaths()
             ->getFilesByTypeRecursively($directory, 'yaml')

--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -309,7 +309,7 @@ abstract class Fieldtype implements Arrayable
             : 'statamic::forms.fields.default';
     }
 
-    public function config(string $key = null, $fallback = null)
+    public function config(?string $key = null, $fallback = null)
     {
         if (! $this->field) {
             return $fallback;

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -182,7 +182,7 @@ class Date extends Fieldtype
         ];
     }
 
-    private function splitDateTimeForPreProcessRange(array $range = null)
+    private function splitDateTimeForPreProcessRange(?array $range = null)
     {
         return ['date' => $range, 'time' => null];
     }

--- a/src/GraphQL/Queries/Query.php
+++ b/src/GraphQL/Queries/Query.php
@@ -21,7 +21,7 @@ abstract class Query extends BaseQuery
         static::$auth = $closure;
     }
 
-    public function authorize($root, array $args, $ctx, ResolveInfo $resolveInfo = null, Closure $getSelectFields = null): bool
+    public function authorize($root, array $args, $ctx, ?ResolveInfo $resolveInfo = null, ?Closure $getSelectFields = null): bool
     {
         if (static::$auth) {
             return call_user_func_array(static::$auth, [$root, $args, $ctx, $resolveInfo, $getSelectFields]);

--- a/src/GraphQL/Types/ArrayType.php
+++ b/src/GraphQL/Types/ArrayType.php
@@ -21,7 +21,7 @@ class ArrayType extends ScalarType implements TypeConvertible
         return $value;
     }
 
-    public function parseLiteral(Node $valueNode, array $variables = null)
+    public function parseLiteral(Node $valueNode, ?array $variables = null)
     {
         return $valueNode->value;
     }

--- a/src/Imaging/GuzzleAdapter.php
+++ b/src/Imaging/GuzzleAdapter.php
@@ -40,7 +40,7 @@ class GuzzleAdapter implements FilesystemAdapter
      * @param  string  $base  The base URL.
      * @param  \GuzzleHttp\ClientInterface  $client  An optional Guzzle client.
      */
-    public function __construct($base, ClientInterface $client = null)
+    public function __construct($base, ?ClientInterface $client = null)
     {
         $this->base = rtrim($base, '/').'/';
         $this->client = $client ?: new Client();

--- a/src/Imaging/ResponseFactory.php
+++ b/src/Imaging/ResponseFactory.php
@@ -20,7 +20,7 @@ class ResponseFactory implements ResponseFactoryInterface
      *
      * @param  Request|null  $request  Request object to check "is not modified".
      */
-    public function __construct(Request $request = null)
+    public function __construct(?Request $request = null)
     {
         $this->request = $request;
     }

--- a/src/Preferences/Preference.php
+++ b/src/Preferences/Preference.php
@@ -8,7 +8,7 @@ class Preference
     protected $field;
     protected $tab = 'general';
 
-    public function handle(string $handle = null)
+    public function handle(?string $handle = null)
     {
         if (func_num_args() === 0) {
             return $this->handle;
@@ -19,7 +19,7 @@ class Preference
         return $this;
     }
 
-    public function field(array $field = null)
+    public function field(?array $field = null)
     {
         if (func_num_args() === 0) {
             return $this->field;
@@ -30,7 +30,7 @@ class Preference
         return $this;
     }
 
-    public function tab(string $tab = null)
+    public function tab(?string $tab = null)
     {
         if (func_num_args() === 0) {
             return $this->tab;

--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -21,7 +21,7 @@ abstract class Index
 
     abstract protected function deleteIndex();
 
-    public function __construct($name, array $config, string $locale = null)
+    public function __construct($name, array $config, ?string $locale = null)
     {
         $this->name = $locale ? $name.'_'.$locale : $name;
         $this->config = $config;

--- a/src/Search/Result.php
+++ b/src/Search/Result.php
@@ -61,7 +61,7 @@ class Result implements ContainsQueryableValues, Contract
         return $this->searchable->getSearchReference();
     }
 
-    public function setScore(int $score = null): self
+    public function setScore(?int $score = null): self
     {
         $this->score = $score;
 

--- a/src/Search/Searchables/Providers.php
+++ b/src/Search/Searchables/Providers.php
@@ -30,7 +30,7 @@ class Providers
         });
     }
 
-    public function make(string $key, Index $index = null, array $keys = null)
+    public function make(string $key, ?Index $index = null, ?array $keys = null)
     {
         if (! $provider = $this->providers()->get($key)) {
             throw new \Exception('Unknown searchable ['.$key.']');

--- a/src/Stache/Repositories/AssetContainerRepository.php
+++ b/src/Stache/Repositories/AssetContainerRepository.php
@@ -33,7 +33,7 @@ class AssetContainerRepository implements RepositoryContract
         return $this->store->getItem($handle);
     }
 
-    public function make(string $handle = null): AssetContainer
+    public function make(?string $handle = null): AssetContainer
     {
         return app(AssetContainer::class)->handle($handle);
     }

--- a/src/Stache/Repositories/CollectionRepository.php
+++ b/src/Stache/Repositories/CollectionRepository.php
@@ -51,7 +51,7 @@ class CollectionRepository implements RepositoryContract
         });
     }
 
-    public function make(string $handle = null): Collection
+    public function make(?string $handle = null): Collection
     {
         return app(Collection::class)->handle($handle);
     }

--- a/src/Stache/Repositories/EntryRepository.php
+++ b/src/Stache/Repositories/EntryRepository.php
@@ -43,7 +43,7 @@ class EntryRepository implements RepositoryContract
         return $this->query()->where('id', $id)->first();
     }
 
-    public function findByUri(string $uri, string $site = null): ?Entry
+    public function findByUri(string $uri, ?string $site = null): ?Entry
     {
         $site = $site ?? $this->stache->sites()->first();
 

--- a/src/Stache/Repositories/NavigationRepository.php
+++ b/src/Stache/Repositories/NavigationRepository.php
@@ -45,7 +45,7 @@ class NavigationRepository implements RepositoryContract
         $this->store->delete($nav);
     }
 
-    public function make(string $handle = null): Nav
+    public function make(?string $handle = null): Nav
     {
         return app(Nav::class)->handle($handle);
     }

--- a/src/Stache/Repositories/TaxonomyRepository.php
+++ b/src/Stache/Repositories/TaxonomyRepository.php
@@ -54,12 +54,12 @@ class TaxonomyRepository implements RepositoryContract
         $this->store->delete($taxonomy);
     }
 
-    public function make(string $handle = null): Taxonomy
+    public function make(?string $handle = null): Taxonomy
     {
         return app(Taxonomy::class)->handle($handle);
     }
 
-    public function findByUri(string $uri, string $site = null): ?Taxonomy
+    public function findByUri(string $uri, ?string $site = null): ?Taxonomy
     {
         $collection = Facades\Collection::all()
             ->first(function ($collection) use ($uri, $site) {

--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -45,7 +45,7 @@ class TermRepository implements RepositoryContract
         return $this->query()->where('id', $id)->first();
     }
 
-    public function findByUri(string $uri, string $site = null): ?Term
+    public function findByUri(string $uri, ?string $site = null): ?Term
     {
         $site = $site ?? $this->stache->sites()->first();
 
@@ -112,7 +112,7 @@ class TermRepository implements RepositoryContract
         return new TermQueryBuilder($this->store);
     }
 
-    public function make(string $slug = null): Term
+    public function make(?string $slug = null): Term
     {
         return app(Term::class)->slug($slug);
     }

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -36,7 +36,7 @@ final class Installer
      *
      * @param  mixed  $console
      */
-    public function __construct(string $package, $console = null, LicenseManager $licenseManager = null)
+    public function __construct(string $package, $console = null, ?LicenseManager $licenseManager = null)
     {
         $this->package = $package;
         $this->licenseManager = $licenseManager;
@@ -51,7 +51,7 @@ final class Installer
      * @param  mixed  $console
      * @return static
      */
-    public static function package(string $package, $console = null, LicenseManager $licenseManager = null)
+    public static function package(string $package, $console = null, ?LicenseManager $licenseManager = null)
     {
         return new self($package, $console, $licenseManager);
     }

--- a/src/StaticCaching/NoCache/BladeDirective.php
+++ b/src/StaticCaching/NoCache/BladeDirective.php
@@ -14,7 +14,7 @@ class BladeDirective
         $this->nocache = $nocache;
     }
 
-    public function handle($expression, array $params, array $data = null)
+    public function handle($expression, array $params, ?array $data = null)
     {
         if (func_num_args() == 2) {
             $data = $params;

--- a/tests/Antlers/Runtime/PhpEnabledTest.php
+++ b/tests/Antlers/Runtime/PhpEnabledTest.php
@@ -105,7 +105,7 @@ EOT;
                 return $value;
             }
 
-            public function config(string $key = null, $fallback = null)
+            public function config(?string $key = null, $fallback = null)
             {
                 return true;
             }
@@ -153,7 +153,7 @@ EOT;
                 return $value;
             }
 
-            public function config(string $key = null, $fallback = null)
+            public function config(?string $key = null, $fallback = null)
             {
                 return true;
             }

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -36,28 +36,28 @@ class EloquentUserTest extends TestCase
     {
         $roleA = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'a';
             }
         };
         $roleB = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'b';
             }
         };
         $roleC = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'c';
             }
         };
         $roleD = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'd';
             }

--- a/tests/Auth/PermissibleContractTests.php
+++ b/tests/Auth/PermissibleContractTests.php
@@ -19,28 +19,28 @@ trait PermissibleContractTests
     {
         $roleA = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'a';
             }
         };
         $roleB = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'b';
             }
         };
         $roleC = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'c';
             }
         };
         $roleD = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'd';
             }
@@ -80,28 +80,28 @@ trait PermissibleContractTests
     {
         $roleA = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'a';
             }
         };
         $roleB = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'b';
             }
         };
         $roleC = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'c';
             }
         };
         $roleD = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'd';
             }
@@ -126,14 +126,14 @@ trait PermissibleContractTests
     {
         $roleA = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'a';
             }
         };
         $roleB = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'b';
             }
@@ -229,7 +229,7 @@ trait PermissibleContractTests
     {
         $superRole = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'superrole';
             }
@@ -241,7 +241,7 @@ trait PermissibleContractTests
         };
         $nonSuperRole = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'nonsuperrole';
             }

--- a/tests/Auth/UserGroupTest.php
+++ b/tests/Auth/UserGroupTest.php
@@ -81,7 +81,7 @@ class UserGroupTest extends TestCase
 
         $role = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'test';
             }
@@ -98,7 +98,7 @@ class UserGroupTest extends TestCase
     {
         $role = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'test';
             }
@@ -115,7 +115,7 @@ class UserGroupTest extends TestCase
     {
         $role = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'test';
             }
@@ -135,21 +135,21 @@ class UserGroupTest extends TestCase
     {
         RoleAPI::shouldReceive('find')->with('one')->andReturn($roleOne = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'one';
             }
         });
         RoleAPI::shouldReceive('find')->with('two')->andReturn($roleTwo = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'two';
             }
         });
         RoleAPI::shouldReceive('find')->with('three')->andReturn($roleThree = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'three';
             }
@@ -170,7 +170,7 @@ class UserGroupTest extends TestCase
     {
         $role = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'test';
             }
@@ -189,7 +189,7 @@ class UserGroupTest extends TestCase
     {
         $role = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'test';
             }
@@ -209,14 +209,14 @@ class UserGroupTest extends TestCase
     {
         $roleA = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'a';
             }
         };
         $roleB = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'b';
             }
@@ -233,14 +233,14 @@ class UserGroupTest extends TestCase
     {
         $roleA = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'a';
             }
         };
         $roleB = new class extends Role
         {
-            public function handle(string $handle = null)
+            public function handle(?string $handle = null)
             {
                 return 'b';
             }

--- a/tests/Modifiers/AddQueryParamTest.php
+++ b/tests/Modifiers/AddQueryParamTest.php
@@ -26,7 +26,7 @@ class AddQueryParamTest extends TestCase
         $this->assertSame("{$this->baseUrl}#test", $this->modify("{$this->baseUrl}#test"));
     }
 
-    private function modify(string $url, array $queryParam = null)
+    private function modify(string $url, ?array $queryParam = null)
     {
         if (is_null($queryParam)) {
             return Modify::value($url)->addQueryParam()->fetch();

--- a/tests/Modifiers/RemoveQueryParamTest.php
+++ b/tests/Modifiers/RemoveQueryParamTest.php
@@ -33,7 +33,7 @@ class RemoveQueryParamTest extends TestCase
         $this->assertSame($this->baseUrl, $this->modify($this->baseUrl));
     }
 
-    private function modify(string $url, string $queryParamKey = null)
+    private function modify(string $url, ?string $queryParamKey = null)
     {
         if (is_null($queryParamKey)) {
             return Modify::value($url)->removeQueryParam()->fetch();

--- a/tests/Modifiers/SetQueryParamTest.php
+++ b/tests/Modifiers/SetQueryParamTest.php
@@ -63,7 +63,7 @@ class SetQueryParamTest extends TestCase
         $this->assertSame($this->baseUrl, $this->modify($this->baseUrl));
     }
 
-    private function modify(string $url, array $queryParam = null)
+    private function modify(string $url, ?array $queryParam = null)
     {
         if (is_null($queryParam)) {
             return Modify::value($url)->setQueryParam()->fetch();

--- a/tests/Routing/RouteBindingTest.php
+++ b/tests/Routing/RouteBindingTest.php
@@ -169,8 +169,8 @@ class RouteBindingTest extends TestCase
      */
     public function binds_route_parameters_in_frontend_routes(
         $uri,
-        Closure $enabledCallback = null,
-        Closure $disabledCallback = null,
+        ?Closure $enabledCallback = null,
+        ?Closure $disabledCallback = null,
     ) {
         $this->setupContent();
 
@@ -193,8 +193,8 @@ class RouteBindingTest extends TestCase
      */
     public function binds_route_parameters_in_frontend_routes_with_bindings_disabled(
         $uri,
-        Closure $enabledCallback = null,
-        Closure $disabledCallback = null,
+        ?Closure $enabledCallback = null,
+        ?Closure $disabledCallback = null,
     ) {
         $this->setupContent();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -177,7 +177,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     }
 
     // This method is unavailable on earlier versions of Laravel.
-    public function partialMock($abstract, \Closure $mock = null)
+    public function partialMock($abstract, ?\Closure $mock = null)
     {
         $mock = \Mockery::mock(...array_filter(func_get_args()))->makePartial();
         $this->app->instance($abstract, $mock);

--- a/tests/View/Antlers/ParserTests.php
+++ b/tests/View/Antlers/ParserTests.php
@@ -1144,7 +1144,7 @@ EOT;
                 return 'augmented '.$value;
             }
 
-            public function config(string $key = null, $fallback = null)
+            public function config(?string $key = null, $fallback = null)
             {
                 return true;
             }
@@ -1158,7 +1158,7 @@ EOT;
                 return 'augmented '.$value;
             }
 
-            public function config(string $key = null, $fallback = null)
+            public function config(?string $key = null, $fallback = null)
             {
                 return false;
             }


### PR DESCRIPTION
This PR follows on from #9126 last week where an update in Laravel Pint introduced a syntax change to method signatures throughout the codebase.

We initially thought this was a breaking change so we reverted the value for the updated setting (`nullable_type_declaration_for_default_null_value`) to the previous default.

However, after some additional testing, we [found it to not be breaking](https://github.com/laravel/pint/pull/236) so this PR removes our override of the setting and runs Laravel Pint.