### PR TITLE
[4.x] Delete collection tree files when deleting collections

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -732,6 +732,10 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
             $entry->delete();
         });
 
+        if ($this->hasStructure()) {
+            $this->structure()->trees()->each->delete();
+        }
+
         Facades\Collection::delete($this);
 
         CollectionDeleted::dispatch($this);

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -190,7 +190,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
                     if (optional($parent)->isRoot()) {
                         $parent = null;
                     }
-                    $this->page()->pages()->all()->each(function ($child) use ($tree, $parent) {
+                    $this->page()?->pages()->all()->each(function ($child) use ($tree, $parent) {
                         $tree->move($child->id(), optional($parent)->id());
                     });
                     $tree->remove($this);

--- a/src/Structures/StructureRepository.php
+++ b/src/Structures/StructureRepository.php
@@ -25,7 +25,7 @@ class StructureRepository implements RepositoryContract
     public function findByHandle($handle): ?Structure
     {
         if (Str::startsWith($handle, 'collection::')) {
-            return Collection::find(Str::after($handle, 'collection::'))->structure();
+            return Collection::find(Str::after($handle, 'collection::'))?->structure();
         }
 
         return Nav::find($handle);

--- a/tests/Feature/Collections/DeleteCollectionTest.php
+++ b/tests/Feature/Collections/DeleteCollectionTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Collections;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
+use Statamic\Facades\Structure;
 use Statamic\Facades\User;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -76,5 +77,57 @@ class DeleteCollectionTest extends TestCase
             ->assertOk();
 
         $this->assertCount(0, Collection::all());
+    }
+
+    /** @test */
+    public function it_deletes_tree_files()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'configure collections']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        $collection = tap(Collection::make('test')->structureContents(['root' => true]))->save();
+
+        Entry::make()->id('a')->slug('a')->collection('test')->data(['title' => 'A'])->save();
+        Entry::make()->id('b')->slug('b')->collection('test')->data(['title' => 'B'])->save();
+        Entry::make()->id('c')->slug('c')->collection('test')->data(['title' => 'C'])->save();
+
+        $collection->structure()->in('en')->tree([['entry' => 'a'], ['entry' => 'b'], ['entry' => 'c']]);
+
+        $this
+            ->actingAs($user)
+            ->delete(cp_route('collections.destroy', $collection->handle()))
+            ->assertOk();
+
+        $this->assertCount(0, Collection::all());
+        $this->assertNull(Structure::find('collection::test'));
+    }
+
+    /** @test */
+    public function it_deletes_tree_files_in_a_multisite()
+    {
+        Site::setConfig(['sites' => [
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr', 'locale' => 'fr_FR'],
+        ]]);
+
+        $this->setTestRoles(['test' => ['access cp', 'configure collections']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        $collection = tap(Collection::make('test')->sites(['en', 'fr'])->structureContents(['root' => true]))->save();
+
+        Entry::make()->id('a')->slug('a')->locale('en')->collection('test')->data(['title' => 'A'])->save();
+        Entry::make()->id('b')->slug('b')->locale('en')->collection('test')->data(['title' => 'B'])->save();
+        Entry::make()->id('c')->slug('c')->locale('fr')->collection('test')->data(['title' => 'C'])->save();
+
+        $collection->structure()->in('en')->tree([['entry' => 'a'], ['entry' => 'b']]);
+        $collection->structure()->in('fr')->tree([['entry' => 'c']]);
+
+        $this
+            ->actingAs($user)
+            ->delete(cp_route('collections.destroy', $collection->handle()))
+            ->assertOk();
+
+        $this->assertCount(0, Collection::all());
+        $this->assertNull(Structure::find('collection::test'));
     }
 }


### PR DESCRIPTION
This pull request deletes the tree files for collection structures when deleting a collection. Previously, deleting a collection would result in an empty tree file like this:

```
{  }
```

I've added the nullsafe operator in some places to gracefully ignore issues about collections/pages not existing. 

Fixes #3848.