### PR TITLE
[4.x] Fix Global Set without a blueprint breaking the Fieldsets page

### DIFF
--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -123,7 +123,7 @@ class Fieldset
             ...GlobalSet::all()->map->blueprint(),
             ...AssetContainer::all()->map->blueprint(),
             ...Blueprint::in('')->values(),
-        ])->filter(function (Blueprint $blueprint) {
+        ])->filter()->filter(function (Blueprint $blueprint) {
             return collect($blueprint->contents()['tabs'])
                 ->pluck('sections')
                 ->flatten(1)


### PR DESCRIPTION
This pull request fixes an issue where a Global Set without a blueprint would break the Fieldsets index page.

Fixes #9186.