### PR TITLE
[4.x] Fix Read Only icon when viewing revisions

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -16,7 +16,7 @@
             </dropdown-list>
 
             <div class="pt-px text-2xs text-gray-600 flex mr-4" v-if="readOnly">
-                <svg-icon name="lock" class="w-4 mr-1 -mt-1" /> {{ __('Read Only') }}
+                <svg-icon name="light/lock" class="w-4 mr-1 -mt-1" /> {{ __('Read Only') }}
             </div>
 
             <div class="hidden md:flex items-center">

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -8,7 +8,7 @@
                 <h1 class="flex-1" v-text="__(title)" />
 
                 <div class="pt-px text-2xs text-gray-600 ml-4 flex" v-if="! canEdit">
-                    <svg-icon name="lock" class="w-4 mr-1 -mt-1" /> {{ __('Read Only') }}
+                    <svg-icon name="light/lock" class="w-4 mr-1 -mt-1" /> {{ __('Read Only') }}
                 </div>
 
                 <dropdown-list v-if="canConfigure || canEditBlueprint" class="mr-2">

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -18,7 +18,7 @@
             </dropdown-list>
 
             <div class="pt-px text-2xs text-gray-600 flex mr-4" v-if="readOnly">
-                <svg-icon name="lock" class="w-4 mr-1 -mt-1" /> {{ __('Read Only') }}
+                <svg-icon name="light/lock" class="w-4 mr-1 -mt-1" /> {{ __('Read Only') }}
             </div>
 
             <div class="hidden md:flex items-center">


### PR DESCRIPTION
This pull request fixes an issue where the 'lock' icon wasn't being displayed correctly when viewing revisions.

![image](https://github.com/statamic/cms/assets/19637309/dafe1155-83ac-48b3-a96d-a86aad61c2e1)

Fixes #9184.