### PR TITLE
[4.x] Fix issue with meta being updated wrongly in Link Fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/grid/ManagesRowMeta.js
+++ b/resources/js/components/fieldtypes/grid/ManagesRowMeta.js
@@ -6,7 +6,7 @@ export default {
                 ...this.meta,
                 existing: {
                     ...this.meta.existing,
-                    [row]: value
+                    [row]: clone(value)
                 }
             });
         },


### PR DESCRIPTION
This pull request fixes an issue with Grid/Bard/Replicator fields when new items would be added, JavaScript would consider the `meta` value that's passed into each of the new rows as the same thing. This means that anytime that meta was updated on the new items, the other new items would have that updated meta. 

This was causing issues with the Link Fieldtype on a Grid/Replicator, when you add a new row and select an entry, the title would show fine, then when you do it again, the ID of the previous entry would be shown rather than the title because of the item data (in `meta.entry.data`) being overridden.

Fixes #8793.
Fixes #8764.