### PR TITLE
[4.x] Fix previewing revisions via Relationship Fieldtype

### DIFF
--- a/resources/js/components/revision-history/Preview.vue
+++ b/resources/js/components/revision-history/Preview.vue
@@ -15,7 +15,7 @@ export default {
             readOnly: true,
             method: 'patch',
             action: 'update',
-            itemUrl: `${document.location.pathname}/revisions/${this.revision.id}`,
+            itemUrl: `${this.revision.attributes.id}/revisions/${this.revision.id}`,
         }
     },
 


### PR DESCRIPTION
This pull request fixes an issue when attempting to preview revisions via a Relationship Fieldtype. 

When clicking a revision in the revision history, it would show an endless loading spinner because it was trying to use the ID of the base entry, rather than the ID of the entry the revision's attached to.

Fixes #3810.