### PR TITLE
[4.x] Fix error from static caching invalidator when deleting entries

### DIFF
--- a/src/StaticCaching/Invalidate.php
+++ b/src/StaticCaching/Invalidate.php
@@ -9,7 +9,7 @@ use Statamic\Events\BlueprintDeleted;
 use Statamic\Events\BlueprintSaved;
 use Statamic\Events\CollectionTreeDeleted;
 use Statamic\Events\CollectionTreeSaved;
-use Statamic\Events\EntryDeleted;
+use Statamic\Events\EntryDeleting;
 use Statamic\Events\EntrySaved;
 use Statamic\Events\FormDeleted;
 use Statamic\Events\FormSaved;
@@ -31,7 +31,7 @@ class Invalidate implements ShouldQueue
         AssetSaved::class => 'invalidateAsset',
         AssetDeleted::class => 'invalidateAsset',
         EntrySaved::class => 'invalidateEntry',
-        EntryDeleted::class => 'invalidateEntry',
+        EntryDeleting::class => 'invalidateEntry',
         TermSaved::class => 'invalidateTerm',
         TermDeleted::class => 'invalidateTerm',
         GlobalSetSaved::class => 'invalidateGlobalSet',


### PR DESCRIPTION
This pull request attempts to fix an issue from the Static Caching invalidator when deleting entries in a structured collection.

When you have a structured collection, the invalidation logic would attempt to get the entry's URL but in doing so it called a method on an entry which no longer existed.

This PR changes when invalidation happens for entries. Instead of it happening *after* the entry has been deleted (& removed from the tree), it'll happen *before* the entry is deleted and removed from the tree so the full entry URI is known and to prevent the error from happening.

Fixes #5836.