### PR TITLE
[4.x] Update the bug report template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -45,8 +45,8 @@ body:
       label: Antlers Parser
       description: If using 3.3+, which Antlers Parser are you using?
       options:
-        - regex (default)
-        - runtime (new)
+        - runtime (default)
+        - regex (old)
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -45,8 +45,8 @@ body:
       label: Antlers Parser
       description: If using 3.3+, which Antlers Parser are you using?
       options:
-        - runtime (default)
-        - regex (old)
+        - Runtime (default)
+        - Regex (legacy)
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
Swap the default for the antlers parser in the bug report template. The runtime parser has been the new default since a while.
