### PR TITLE
[4.x] Fix template selector issues on Windows

### DIFF
--- a/src/Fieldtypes/TemplateFolder.php
+++ b/src/Fieldtypes/TemplateFolder.php
@@ -24,7 +24,7 @@ class TemplateFolder extends Relationship
 
                 foreach ($iterator as $file) {
                     if ($file->isDir() && ! $iterator->isDot() && ! $iterator->isLink()) {
-                        $directories->push(str_replace_first($path.'/', '', $file->getPathname()));
+                        $directories->push(str_replace_first($path.DIRECTORY_SEPARATOR, '', $file->getPathname()));
                     }
                 }
 

--- a/src/Http/Controllers/CP/API/TemplatesController.php
+++ b/src/Http/Controllers/CP/API/TemplatesController.php
@@ -17,7 +17,7 @@ class TemplatesController extends CpController
 
                 foreach ($iterator as $file) {
                     if ($file->isFile()) {
-                        $views->push(str_before(str_replace_first($path.'/', '', $file->getPathname()), '.'));
+                        $views->push(str_before(str_replace_first($path.DIRECTORY_SEPARATOR, '', $file->getPathname()), '.'));
                     }
                 }
 


### PR DESCRIPTION
This pull request fixes an issue where the Template & Template Folder fieldtypes were outputting the absolute paths to templates.

I don't have access to a Windows PC to test but I believe this was happening due to paths on Windows being separated by `\`, not `/` like macOS and Linux.

An example given on Discord was: `C:\xampp\htdocs\statamic\brandnew\resources\views\default`

Fixes #9196.