### PR TITLE
[4.x] Prevent Bard augmentation error after enabling "Save HTML" option

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -242,7 +242,7 @@ class Bard extends Replicator
 
     protected function performAugmentation($value, $shallow)
     {
-        if ($this->shouldSaveHtml()) {
+        if ($this->shouldSaveHtml() && is_string($value)) {
             return is_null($value) ? $value : $this->resolveStatamicUrls($value);
         }
 


### PR DESCRIPTION
This pull request attempts to fix an issue when augmenting Bard fields after the "Save HTML" option is enabled on the field but it is yet to be re-saved (& be converted to HTML).

Fixes #6045.