### PR TITLE
[4.x] Prevent configuring multiple conditions for the same field

### DIFF
--- a/resources/js/components/field-conditions/Builder.vue
+++ b/resources/js/components/field-conditions/Builder.vue
@@ -134,7 +134,7 @@ export default {
 
         fieldOptions() {
             return this.normalizeInputOptions(
-                _.reject(this.suggestableFields, field => field === this.config.handle)
+                _.reject(this.suggestableFields, field => field === this.config.handle || this.conditions.map(condition => condition.field).includes(field))
             );
         },
 


### PR DESCRIPTION
This pull request prevents you configuring multiple conditions for the same field in the blueprint/fieldset builder.

Previously, the "Field" dropdown in the builder allowed you to select fields even if they already had conditions configured against them. Then, when you saved the field, only one of the multiple conditions would actually be saved.

This PR prevents you from doing that until we implement the ability to configure multiple conditions for the same field (see statamic/ideas#1101).

Fixes #6008.