### PR TITLE
[4.x] Fix stack hover offset on close

### DIFF
--- a/resources/js/components/stacks/Stack.vue
+++ b/resources/js/components/stacks/Stack.vue
@@ -122,6 +122,7 @@ export default {
                 return;
             }
             this.$events.$emit(`stacks.hit-area-clicked`, this.depth - 1);
+            this.$events.$emit(`stacks.${this.depth - 1}.hit-area-mouseout`);
         },
 
         mouseEnterHitArea() {

--- a/resources/js/components/stacks/Stack.vue
+++ b/resources/js/components/stacks/Stack.vue
@@ -118,16 +118,24 @@ export default {
     methods: {
 
         clickedHitArea() {
+            if (!this.visible) {
+                return;
+            }
             this.$events.$emit(`stacks.hit-area-clicked`, this.depth - 1);
         },
 
         mouseEnterHitArea() {
+            if (!this.visible) {
+                return;
+            }
             this.$events.$emit(`stacks.${this.depth - 1}.hit-area-mouseenter`);
         },
 
         mouseOutHitArea() {
+            if (!this.visible) {
+                return;
+            }
             this.$events.$emit(`stacks.${this.depth - 1}.hit-area-mouseout`);
-
         },
 
         runCloseCallback() {


### PR DESCRIPTION
There's currently a glitch with the background stack hover offset, best explained with a video:

https://github.com/statamic/cms/assets/126740/626e7dd9-7d15-4276-ad26-cd25f85fd8da

When the second stack is closed the first one moves (gap appears on the right) and then gets stuck there.

This happens because there's a 300ms delay between closing the stack and the component being destroyed. During that time the second stack's `mouseenter` event will still trigger, activating the first stack's hover state, but then it's destroyed so the hover state is never cleared.

The PR fixes it by checking that `visible` is true before firing any of the background hit area events. The same issue also occurs when you click on the hit area to go back, so to fix that I've added a `hit-area-mouseout` event during `hit-area-clicked`.

Not sure if this is the best fix, there might be a better one.