### PR TITLE
[4.x] Filter out any nulls from checkboxes in front end forms

### DIFF
--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -118,7 +118,7 @@ class FrontendFormRequest extends FormRequest
     {
         $fields->all()
             ->filter(fn ($field) => $field->fieldtype()->handle() === 'checkboxes')
-            ->each(fn ($field) => Arr::set($values, $field->handle(), collect(Arr::get($values, $field->handle(), []))->reject(fn ($value) => $value === null)->all()));
+            ->each(fn ($field) => Arr::set($values, $field->handle(), collect(Arr::get($values, $field->handle(), []))->reject(fn ($value) => $value === 'null')->all()));
 
         return $values;
     }

--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -118,7 +118,7 @@ class FrontendFormRequest extends FormRequest
     {
         $fields->all()
             ->filter(fn ($field) => $field->fieldtype()->handle() === 'checkboxes')
-            ->each(fn ($field) => Arr::set($values, $field->handle(), collect(Arr::get($values, $field->handle(), []))->reject(fn ($value) => $value === 'null')->all()));
+            ->each(fn ($field) => Arr::set($values, $field->handle(), collect(Arr::get($values, $field->handle(), []))->filter(fn ($value) => $value !== null)->values()));
 
         return $values;
     }

--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -100,7 +100,7 @@ class FrontendFormRequest extends FormRequest
 
         $this->assets = $this->normalizeAssetsValues($fields);
 
-        $values = array_merge($this->all(), $this->assets);
+        $values = array_merge($this->removeNullsFromCheckboxes($this->all()), $this->assets);
 
         return $this->cachedFields = $fields->addValues($values);
     }
@@ -112,6 +112,15 @@ class FrontendFormRequest extends FormRequest
             ->filter(fn ($field) => $field->fieldtype()->handle() === 'assets' && $this->hasFile($field->handle()))
             ->map(fn ($field) => Arr::wrap($this->file($field->handle())))
             ->all();
+    }
+
+    private function removeNullsFromCheckboxes($fields, $values)
+    {
+        $fields->all()
+            ->filter(fn ($field) => $field->fieldtype()->handle() === 'checkboxes')
+            ->each(fn ($field) => Arr::set($values, $field->handle(), collect(Arr::get($values, $field->handle(), []))->reject(fn ($value) => $value === null)->all()));
+
+        return $values;
     }
 
     public function validateResolved()

--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -100,7 +100,7 @@ class FrontendFormRequest extends FormRequest
 
         $this->assets = $this->normalizeAssetsValues($fields);
 
-        $values = array_merge($this->removeNullsFromCheckboxes($this->all()), $this->assets);
+        $values = array_merge($this->removeNullsFromCheckboxes($fields, $this->all()), $this->assets);
 
         return $this->cachedFields = $fields->addValues($values);
     }


### PR DESCRIPTION
Filter out any null values in checkboxes on front end form requests.

The hidden input cant be removed as it was [added to solve an issue on user profile forms](https://github.com/statamic/cms/pull/7180/files).

Closes https://github.com/statamic/cms/issues/9194