### PR TITLE
[4.x] Prevent dirt on saved entry

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -565,10 +565,9 @@ export default {
                 .then(() => {
                     // If revisions are enabled, just emit event.
                     if (this.revisionsEnabled) {
-                        clearTimeout(this.trackDirtyStateTimeout)
-                        this.trackDirtyState = false
+                        this.trackDirtyState = false;
                         this.values = this.resetValuesFromResponse(response.data.data.values);
-                        this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350)
+                        this.nextTick(() => this.trackDirtyState = true);
                         this.$nextTick(() => this.$emit('saved', response));
                         return;
                     }
@@ -589,10 +588,9 @@ export default {
                     // the hooks are resolved because if this form is being shown in a stack, we only
                     // want to close it once everything's done.
                     else {
-                        clearTimeout(this.trackDirtyStateTimeout)
-                        this.trackDirtyState = false
+                        this.trackDirtyState = false;
                         this.values = this.resetValuesFromResponse(response.data.data.values);
-                        this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350)
+                        this.nextTick(() => this.trackDirtyState = true);
                         this.initialPublished = response.data.data.published;
                         this.activeLocalization.published = response.data.data.published;
                         this.activeLocalization.status = response.data.data.status;

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -565,7 +565,10 @@ export default {
                 .then(() => {
                     // If revisions are enabled, just emit event.
                     if (this.revisionsEnabled) {
+                        clearTimeout(this.trackDirtyStateTimeout)
+                        this.trackDirtyState = false
                         this.values = this.resetValuesFromResponse(response.data.data.values);
+                        this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350)
                         this.$nextTick(() => this.$emit('saved', response));
                         return;
                     }
@@ -586,7 +589,10 @@ export default {
                     // the hooks are resolved because if this form is being shown in a stack, we only
                     // want to close it once everything's done.
                     else {
+                        clearTimeout(this.trackDirtyStateTimeout)
+                        this.trackDirtyState = false
                         this.values = this.resetValuesFromResponse(response.data.data.values);
+                        this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350)
                         this.initialPublished = response.data.data.published;
                         this.activeLocalization.published = response.data.data.published;
                         this.activeLocalization.status = response.data.data.status;


### PR DESCRIPTION
In version 4.35.0, PR #8961 was introduced to show changes from the `EntrySaving` event in the edit-form UI. 

However, the values from the response are in many edge-cases slightly different than the current values. This causes the form to become dirty when an entry is saved. This dirtiness is especially inconvenient when using revisions as it causes the publish button to become disabled. Issue #9068 is an example of this.

This PR disables dirty-tracking while resetting the values from the response.

I am new to the Statamic-codebase and do not know if a timeout is the best approach here. Setting the timeout to 300 did not work which is why I increased it to 350.

 