### PR TITLE
[4.x] Fix tag {{ children }} for every collection

### DIFF
--- a/src/Tags/Children.php
+++ b/src/Tags/Children.php
@@ -20,6 +20,8 @@ class Children extends Structure
         $this->params->put('from', Str::start(Str::after(URL::getCurrent(), Site::current()->url()), '/'));
         $this->params->put('max_depth', 1);
 
-        return $this->structure($this->params->get('handle', 'collection::pages'));
+        $currentCollection = 'collection::'.$this->context->value('collection')->handle;
+
+        return $this->structure($this->params->get('handle', $currentCollection));
     }
 }

--- a/src/Tags/Children.php
+++ b/src/Tags/Children.php
@@ -20,8 +20,8 @@ class Children extends Structure
         $this->params->put('from', Str::start(Str::after(URL::getCurrent(), Site::current()->url()), '/'));
         $this->params->put('max_depth', 1);
 
-        $currentCollection = 'collection::'.$this->context->value('collection')->handle;
+        $collection = $this->params->get('collection') ?? $this->context->value('collection')?->handle ?? 'pages';
 
-        return $this->structure($this->params->get('handle', $currentCollection));
+        return $this->structure("collection::{$collection}");
     }
 }

--- a/src/Tags/Children.php
+++ b/src/Tags/Children.php
@@ -20,7 +20,7 @@ class Children extends Structure
         $this->params->put('from', Str::start(Str::after(URL::getCurrent(), Site::current()->url()), '/'));
         $this->params->put('max_depth', 1);
 
-        $collection = $this->params->get('collection') ?? $this->context->value('collection')?->handle ?? 'pages';
+        $collection = $this->params->get('collection', $this->context->value('collection')?->handle());
 
         return $this->structure("collection::{$collection}");
     }

--- a/tests/Tags/ChildrenTest.php
+++ b/tests/Tags/ChildrenTest.php
@@ -14,6 +14,7 @@ use Tests\TestCase;
 class ChildrenTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
+
     private $collection;
 
     public function setUp(): void

--- a/tests/Tags/ChildrenTest.php
+++ b/tests/Tags/ChildrenTest.php
@@ -10,10 +10,17 @@ use Statamic\Facades\Site;
 use Statamic\Tags\Children;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
+use Statamic\Facades\Config;
+use Illuminate\Support\Arr;
+use Statamic\Tags\Context;
+
+
+
 
 class ChildrenTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
+    private $collection;
 
     public function setUp(): void
     {
@@ -32,7 +39,7 @@ class ChildrenTest extends TestCase
 
     private function setUpEntries()
     {
-        $collection = tap(Collection::make('pages')->sites(['en', 'fr'])->routes('{slug}')->structureContents(['root' => false]))->save();
+        $this->collection = tap(Collection::make('pages')->sites(['en', 'fr'])->routes('{slug}')->structureContents(['root' => false]))->save();
 
         EntryFactory::collection('pages')->id('foo')->data([
             'title' => 'the foo entry',
@@ -50,13 +57,13 @@ class ChildrenTest extends TestCase
             'title' => 'the french bar entry',
         ])->create();
 
-        $collection->structure()->in('en')->tree([
+        $this->collection->structure()->in('en')->tree([
             ['entry' => 'foo', 'url' => '/foo', 'children' => [
                 ['entry' => 'bar', 'url' => '/foo/bar'],
             ]],
         ])->save();
 
-        $collection->structure()->in('fr')->tree([
+        $this->collection->structure()->in('fr')->tree([
             ['entry' => 'fr-foo', 'url' => '/fr-foo', 'children' => [
                 ['entry' => 'fr-bar', 'url' => '/fr-foo/fr-bar'],
             ]],
@@ -67,10 +74,9 @@ class ChildrenTest extends TestCase
     public function it_gets_children_data()
     {
         $this->setUpEntries();
-
         $this->get('/foo');
 
-        $this->assertEquals('the bar entry', $this->tag('{{ children }}{{ title }}{{ /children }}'));
+        $this->assertEquals('the bar entry', $this->tag('{{ children }}{{ title }}{{ /children }}', ['collection' => $this->collection ]));
     }
 
     /** @test */
@@ -80,7 +86,7 @@ class ChildrenTest extends TestCase
 
         $this->get('/fr/fr-foo');
 
-        $this->assertEquals('the french bar entry', $this->tag('{{ children }}{{ title }}{{ /children }}'));
+        $this->assertEquals('the french bar entry', $this->tag('{{ children }}{{ title }}{{ /children }}', ['collection' => $this->collection ]));
     }
 
     /** @test */

--- a/tests/Tags/ChildrenTest.php
+++ b/tests/Tags/ChildrenTest.php
@@ -10,12 +10,6 @@ use Statamic\Facades\Site;
 use Statamic\Tags\Children;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
-use Statamic\Facades\Config;
-use Illuminate\Support\Arr;
-use Statamic\Tags\Context;
-
-
-
 
 class ChildrenTest extends TestCase
 {
@@ -102,6 +96,5 @@ class ChildrenTest extends TestCase
         $this->get('/foo');
 
         $this->assertEquals('the bar entry', $this->tag('{{ nav }}{{ children }}{{ title }}{{ /children }}{{ /nav }}'));
-
     }
 }

--- a/tests/Tags/ChildrenTest.php
+++ b/tests/Tags/ChildrenTest.php
@@ -76,7 +76,7 @@ class ChildrenTest extends TestCase
         $this->setUpEntries();
         $this->get('/foo');
 
-        $this->assertEquals('the bar entry', $this->tag('{{ children }}{{ title }}{{ /children }}', ['collection' => $this->collection ]));
+        $this->assertEquals('the bar entry', $this->tag('{{ children }}{{ title }}{{ /children }}', ['collection' => $this->collection]));
     }
 
     /** @test */
@@ -86,7 +86,7 @@ class ChildrenTest extends TestCase
 
         $this->get('/fr/fr-foo');
 
-        $this->assertEquals('the french bar entry', $this->tag('{{ children }}{{ title }}{{ /children }}', ['collection' => $this->collection ]));
+        $this->assertEquals('the french bar entry', $this->tag('{{ children }}{{ title }}{{ /children }}', ['collection' => $this->collection]));
     }
 
     /** @test */


### PR DESCRIPTION
With the tag {{ children }} use the current collection instead of using Pages.

You can test it by creating a collection with parent & child entry and in the template of the parent use {{ children }} to return all of his children.

Fix #9207