### PR TITLE
[4.x] Revert to original dirty state fix

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -565,9 +565,10 @@ export default {
                 .then(() => {
                     // If revisions are enabled, just emit event.
                     if (this.revisionsEnabled) {
-                        this.trackDirtyState = false;
+                        clearTimeout(this.trackDirtyStateTimeout)
+                        this.trackDirtyState = false
                         this.values = this.resetValuesFromResponse(response.data.data.values);
-                        this.nextTick(() => this.trackDirtyState = true);
+                        this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350)
                         this.$nextTick(() => this.$emit('saved', response));
                         return;
                     }
@@ -588,9 +589,10 @@ export default {
                     // the hooks are resolved because if this form is being shown in a stack, we only
                     // want to close it once everything's done.
                     else {
+                        clearTimeout(this.trackDirtyStateTimeout);
                         this.trackDirtyState = false;
                         this.values = this.resetValuesFromResponse(response.data.data.values);
-                        this.nextTick(() => this.trackDirtyState = true);
+                        this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350);
                         this.initialPublished = response.data.data.published;
                         this.activeLocalization.published = response.data.data.published;
                         this.activeLocalization.status = response.data.data.status;


### PR DESCRIPTION
This pull request reverts to the original dirty state fix in #9203. 

Before merging that PR, I had refactored it to use `$nextTick` but I typo-d it & when I fixed it, it didn't sort the issue for Bard fields.

`setTimeout` seems to be used elsewhere for dirty state stuff so I reckon we'll be fine to use it here too.