### PR TITLE
[4.x] (Re-)Allow nested JSON field handles

### DIFF
--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -107,7 +107,11 @@ class FieldsController extends CpController
                 'type' => 'slug',
                 'from' => 'display',
                 'separator' => '_',
-                'validate' => 'required|regex:/^[a-zA-Z][a-zA-Z0-9_]*$/|not_in:'.implode(',', $reserved),
+                'validate' => [
+                    'required',
+                    'regex:/^[a-zA-Z]([a-zA-Z0-9_]|->)*$/',
+                    'not_in:'.implode(',', $reserved),
+                ],
                 'show_regenerate' => true,
             ],
             'instructions' => [


### PR DESCRIPTION
This PR addresses a bit of a regression introduced in #9039, which I believe was tagged in v4.36. Prior to that, you could do something like this in a field handle, and it would Just Work™:
```yaml
handle: config->nested_field
```
Due to the regex added in #9039, that functionality broke. Tbh, I'm not event 100% sure this functionality is intentional from Statamic's perspective, but we have a project that depends somewhat heavily on it. This PR simply tweaks the regex a bit, to allow for `->` arrows within the handle.

See **[this warning on the regex validation rule from Laravel's docs](https://laravel.com/docs/10.x/validation#rule-regex)**, for context on the switch to an array (instead of the normal string/piped approach) for the handle's `validate` property. And here's **[a RegExr if you'd like to tinker](https://regexr.com/7p77f)**, and a screenshot:

![image](https://github.com/statamic/cms/assets/13950848/ad7bd479-547e-489b-979f-2758980f3d2c)

Let me know if there's anything else I can provide, here!