### PR TITLE
[4.x] Allow a cache invalidation handler class to be specified

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -83,6 +83,8 @@ return [
             //
         ],
 
+        'handler' => null,
+
     ],
 
     /*

--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -14,11 +14,13 @@ use Statamic\Support\Arr;
 class DefaultInvalidator implements Invalidator
 {
     protected $cacher;
+    protected $handler;
     protected $rules;
 
-    public function __construct(Cacher $cacher, $rules = [])
+    public function __construct(Cacher $cacher, $rules = [], $handler = null)
     {
         $this->cacher = $cacher;
+        $this->handler = $handler;
         $this->rules = $rules;
     }
 
@@ -26,6 +28,14 @@ class DefaultInvalidator implements Invalidator
     {
         if ($this->rules === 'all') {
             return $this->cacher->flush();
+        }
+
+        if ($this->handler && class_exists($this->handler)) {
+            $result = (new $this->handler)->handle($this->cacher, $item);
+
+            if (! $result) {
+                return;
+            }
         }
 
         if ($item instanceof Entry) {

--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -29,7 +29,8 @@ class ServiceProvider extends LaravelServiceProvider
         $this->app->bind(DefaultInvalidator::class, function ($app) {
             return new DefaultInvalidator(
                 $app[Cacher::class],
-                $app['config']['statamic.static_caching.invalidation.rules']
+                $app['config']['statamic.static_caching.invalidation.rules'],
+                $app['config']['statamic.static_caching.invalidation.handler'] ?? null
             );
         });
 


### PR DESCRIPTION
This PR adds a new config var `statamic.static_caching.invalidation.handler` where a class can be specified to programatically determine what urls should be invalidated. 

This is useful whenever you want to clear cache items that the saved item appears on, for example, if its a taxonomy term you may want to clear entries that it appears on, or if its a page builder 'event' entry you may want to clear 'pages' where that item appears.

The invalidator class itself is just a handle method that accepts 2 parameters, $cacher and $item. A simple example below:

```php
<?php

namespace App\Invalidators;

use Statamic\StaticCaching\Cacher;

class MyInvalidator
{
    public function handle(Cacher $cacher, $item)
    {
        $cacher->invalidateUrls([
            '/some-url'
        ]);

        return false;
    }
}
```

A more complete example, where you clear any page builder urls containing an events listing would be:

```php
<?php

namespace App\Invalidators;

use Statamic\Contracts\Entries\Entry;
use Statamic\Facades;
use Statamic\StaticCaching\Cacher;

class MyInvalidator
{
    public function handle(Cacher $cacher, $item)
    {
        $urls = [];
        
        if ($item instanceof Entry) {
            if ($item->collection() == 'events') {
                
                $pages = Facades\Entry::query()
                    ->where('collection', 'pages')
                    ->where('published', true)
                    ->get(['panels']);

                // loop over all pages
                foreach ($pages as $page) {

                    // loop over panels within pages
                    foreach ($page->panels as $panel) {

                        if ($panel['type'] == 'events_listing') {
                            $urls[] = $page->url();
                        }

                    }

                }
                
            }
        }
        
        if ($urls) {
            $cacher->invalidateUrls($urls);
        }

        return false;
    }
}
```

If the handle method returns false(y) then any rules specified in the invalidation config will not be run. If it returns true, they will continue to process as normal. If rules === all, then the invalidator class is never run as it is redundant.

I tried to add some tests to DefaultInvalidatorTest for this, but I couldn't work out a way to meaningfully test this is working. I would appreciate any help you can give with that.