### PR TITLE
[4.x] Add *-deleting events

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -21,6 +21,7 @@ use Statamic\Data\TracksQueriedColumns;
 use Statamic\Data\TracksQueriedRelations;
 use Statamic\Events\AssetContainerBlueprintFound;
 use Statamic\Events\AssetDeleted;
+use Statamic\Events\AssetDeleting;
 use Statamic\Events\AssetReplaced;
 use Statamic\Events\AssetReuploaded;
 use Statamic\Events\AssetSaved;
@@ -618,6 +619,10 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      */
     public function delete()
     {
+        if (AssetDeleting::dispatch($this) === false) {
+            return false;
+        }
+
         $this->disk()->delete($this->path());
         $this->disk()->delete($this->metaPath());
 

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -26,6 +26,7 @@ use Statamic\Data\TracksQueriedRelations;
 use Statamic\Events\UserCreated;
 use Statamic\Events\UserCreating;
 use Statamic\Events\UserDeleted;
+use Statamic\Events\UserDeleting;
 use Statamic\Events\UserSaved;
 use Statamic\Events\UserSaving;
 use Statamic\Facades;
@@ -197,6 +198,10 @@ abstract class User implements Arrayable, ArrayAccess, Augmentable, Authenticata
 
     public function delete()
     {
+        if (UserDeleting::dispatch($this) === false) {
+            return false;
+        }
+
         Facades\User::delete($this);
 
         UserDeleted::dispatch($this);

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -13,6 +13,7 @@ use Statamic\Data\HasAugmentedData;
 use Statamic\Events\CollectionCreated;
 use Statamic\Events\CollectionCreating;
 use Statamic\Events\CollectionDeleted;
+use Statamic\Events\CollectionDeleting;
 use Statamic\Events\CollectionSaved;
 use Statamic\Events\CollectionSaving;
 use Statamic\Events\EntryBlueprintFound;
@@ -727,6 +728,10 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
 
     public function delete()
     {
+        if (CollectionDeleting::dispatch($this) === false) {
+            return false;
+        }
+
         $this->queryEntries()->get()->each(function ($entry) {
             $entry->deleteDescendants();
             $entry->delete();

--- a/src/Events/AssetDeleting.php
+++ b/src/Events/AssetDeleting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class AssetDeleting extends Event
+{
+    public $asset;
+
+    public function __construct($asset)
+    {
+        $this->asset = $asset;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Events/BlueprintDeleting.php
+++ b/src/Events/BlueprintDeleting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class BlueprintDeleting extends Event
+{
+    public $blueprint;
+
+    public function __construct($blueprint)
+    {
+        $this->blueprint = $blueprint;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Events/CollectionDeleting.php
+++ b/src/Events/CollectionDeleting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class CollectionDeleting extends Event
+{
+    public $collection;
+
+    public function __construct($collection)
+    {
+        $this->collection = $collection;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Events/FieldsetDeleting.php
+++ b/src/Events/FieldsetDeleting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class FieldsetDeleting extends Event
+{
+    public $fieldset;
+
+    public function __construct($fieldset)
+    {
+        $this->fieldset = $fieldset;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Events/FormDeleting.php
+++ b/src/Events/FormDeleting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class FormDeleting extends Event
+{
+    public $form;
+
+    public function __construct($form)
+    {
+        $this->form = $form;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Events/GlobalSetDeleting.php
+++ b/src/Events/GlobalSetDeleting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class GlobalSetDeleting extends Event
+{
+    public $globals;
+
+    public function __construct($globals)
+    {
+        $this->globals = $globals;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Events/GlobalVariablesDeleting.php
+++ b/src/Events/GlobalVariablesDeleting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class GlobalVariablesDeleting extends Event
+{
+    public $variables;
+
+    public function __construct($variables)
+    {
+        $this->variables = $variables;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Events/NavDeleting.php
+++ b/src/Events/NavDeleting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class NavDeleting extends Event
+{
+    public $nav;
+
+    public function __construct($nav)
+    {
+        $this->nav = $nav;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Events/TaxonomyDeleting.php
+++ b/src/Events/TaxonomyDeleting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class TaxonomyDeleting extends Event
+{
+    public $taxonomy;
+
+    public function __construct($taxonomy)
+    {
+        $this->taxonomy = $taxonomy;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Events/TermDeleting.php
+++ b/src/Events/TermDeleting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class TermDeleting extends Event
+{
+    public $term;
+
+    public function __construct($term)
+    {
+        $this->term = $term;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Events/UserDeleting.php
+++ b/src/Events/UserDeleting.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class UserDeleting extends Event
+{
+    public $user;
+
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -16,6 +16,7 @@ use Statamic\Data\HasAugmentedData;
 use Statamic\Events\BlueprintCreated;
 use Statamic\Events\BlueprintCreating;
 use Statamic\Events\BlueprintDeleted;
+use Statamic\Events\BlueprintDeleting;
 use Statamic\Events\BlueprintSaved;
 use Statamic\Events\BlueprintSaving;
 use Statamic\Exceptions\DuplicateFieldException;
@@ -458,6 +459,10 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
 
     public function delete()
     {
+        if (BlueprintDeleting::dispatch($this) === false) {
+            return false;
+        }
+
         BlueprintRepository::delete($this);
 
         BlueprintDeleted::dispatch($this);

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -5,6 +5,7 @@ namespace Statamic\Fields;
 use Statamic\Events\FieldsetCreated;
 use Statamic\Events\FieldsetCreating;
 use Statamic\Events\FieldsetDeleted;
+use Statamic\Events\FieldsetDeleting;
 use Statamic\Events\FieldsetSaved;
 use Statamic\Events\FieldsetSaving;
 use Statamic\Facades;
@@ -235,6 +236,10 @@ class Fieldset
 
     public function delete()
     {
+        if (FieldsetDeleting::dispatch($this) === false) {
+            return false;
+        }
+
         FieldsetRepository::delete($this);
 
         FieldsetDeleted::dispatch($this);

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -12,6 +12,7 @@ use Statamic\Events\FormBlueprintFound;
 use Statamic\Events\FormCreated;
 use Statamic\Events\FormCreating;
 use Statamic\Events\FormDeleted;
+use Statamic\Events\FormDeleting;
 use Statamic\Events\FormSaved;
 use Statamic\Events\FormSaving;
 use Statamic\Facades\Blueprint;
@@ -220,6 +221,10 @@ class Form implements Arrayable, Augmentable, FormContract
      */
     public function delete()
     {
+        if (FormDeleting::dispatch($this) === false) {
+            return false;
+        }
+
         $this->submissions()->each->delete();
 
         File::delete($this->path());

--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -8,6 +8,7 @@ use Statamic\Data\ExistsAsFile;
 use Statamic\Events\GlobalSetCreated;
 use Statamic\Events\GlobalSetCreating;
 use Statamic\Events\GlobalSetDeleted;
+use Statamic\Events\GlobalSetDeleting;
 use Statamic\Events\GlobalSetSaved;
 use Statamic\Events\GlobalSetSaving;
 use Statamic\Facades;
@@ -128,6 +129,10 @@ class GlobalSet implements Contract
 
     public function delete()
     {
+        if (GlobalSetDeleting::dispatch($this) === false) {
+            return false;
+        }
+
         $this->localizations()->each->delete();
 
         Facades\GlobalSet::delete($this);

--- a/src/Globals/Variables.php
+++ b/src/Globals/Variables.php
@@ -19,6 +19,7 @@ use Statamic\Events\GlobalVariablesBlueprintFound;
 use Statamic\Events\GlobalVariablesCreated;
 use Statamic\Events\GlobalVariablesCreating;
 use Statamic\Events\GlobalVariablesDeleted;
+use Statamic\Events\GlobalVariablesDeleting;
 use Statamic\Events\GlobalVariablesSaved;
 use Statamic\Events\GlobalVariablesSaving;
 use Statamic\Facades;
@@ -156,6 +157,10 @@ class Variables implements Arrayable, ArrayAccess, Augmentable, Contract, Locali
 
     public function delete()
     {
+        if (GlobalVariablesDeleting::dispatch($this) === false) {
+            return false;
+        }
+
         Facades\GlobalVariables::delete($this);
 
         GlobalVariablesDeleted::dispatch($this);

--- a/src/Structures/Nav.php
+++ b/src/Structures/Nav.php
@@ -8,6 +8,7 @@ use Statamic\Contracts\Structures\NavTreeRepository;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Events\NavBlueprintFound;
 use Statamic\Events\NavDeleted;
+use Statamic\Events\NavDeleting;
 use Statamic\Events\NavSaved;
 use Statamic\Facades;
 use Statamic\Facades\Blink;
@@ -33,6 +34,10 @@ class Nav extends Structure implements Contract
 
     public function delete()
     {
+        if (NavDeleting::dispatch($this) === false) {
+            return false;
+        }
+
         Facades\Nav::delete($this);
 
         NavDeleted::dispatch($this);

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -14,6 +14,7 @@ use Statamic\Data\HasAugmentedData;
 use Statamic\Events\TaxonomyCreated;
 use Statamic\Events\TaxonomyCreating;
 use Statamic\Events\TaxonomyDeleted;
+use Statamic\Events\TaxonomyDeleting;
 use Statamic\Events\TaxonomySaved;
 use Statamic\Events\TaxonomySaving;
 use Statamic\Events\TermBlueprintFound;
@@ -235,6 +236,10 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
 
     public function delete()
     {
+        if (TaxonomyDeleting::dispatch($this) === false) {
+            return false;
+        }
+
         $this->queryTerms()->get()->each->delete();
 
         Facades\Taxonomy::delete($this);

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -9,6 +9,7 @@ use Statamic\Events\TermBlueprintFound;
 use Statamic\Events\TermCreated;
 use Statamic\Events\TermCreating;
 use Statamic\Events\TermDeleted;
+use Statamic\Events\TermDeleting;
 use Statamic\Events\TermSaved;
 use Statamic\Events\TermSaving;
 use Statamic\Facades;
@@ -242,6 +243,10 @@ class Term implements TermContract
 
     public function delete()
     {
+        if (TermDeleting::dispatch($this) === false) {
+            return false;
+        }
+
         Facades\Term::delete($this);
 
         TermDeleted::dispatch($this);

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -10,6 +10,8 @@ use Statamic\Contracts\Entries\Entry;
 use Statamic\Entries\Collection;
 use Statamic\Events\CollectionCreated;
 use Statamic\Events\CollectionCreating;
+use Statamic\Events\CollectionDeleted;
+use Statamic\Events\CollectionDeleting;
 use Statamic\Events\CollectionSaved;
 use Statamic\Events\CollectionSaving;
 use Statamic\Events\EntryBlueprintFound;
@@ -961,5 +963,38 @@ class CollectionTest extends TestCase
         $this->assertTrue($user->can('view', $collection1));
         $this->assertTrue($user->can('view', $collection2));
         $this->assertFalse($user->can('view', $collection3));
+    }
+
+    /** @test */
+    public function it_fires_a_deleting_event()
+    {
+        Event::fake();
+
+        $collection = Facades\Collection::make('test')->save();
+
+        $collection->delete();
+
+        Event::assertDispatched(CollectionDeleting::class, function ($event) use ($collection) {
+            return $event->collection === $collection;
+        });
+    }
+
+    /** @test */
+    public function it_does_not_delete_when_a_deleting_event_returns_false()
+    {
+        Facades\Collection::spy();
+        Event::fake([CollectionDeleted::class]);
+
+        Event::listen(CollectionDeleting::class, function () {
+            return false;
+        });
+
+        $collection = new Collection('test');
+
+        $return = $collection->delete();
+
+        $this->assertFalse($return);
+        Facades\Collection::shouldNotHaveReceived('delete');
+        Event::assertNotDispatched(CollectionDeleted::class);
     }
 }

--- a/tests/Data/Taxonomies/TaxonomyTest.php
+++ b/tests/Data/Taxonomies/TaxonomyTest.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Event;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Events\TaxonomyCreated;
 use Statamic\Events\TaxonomyCreating;
+use Statamic\Events\TaxonomyDeleted;
+use Statamic\Events\TaxonomyDeleting;
 use Statamic\Events\TaxonomySaved;
 use Statamic\Events\TaxonomySaving;
 use Statamic\Events\TermBlueprintFound;
@@ -468,5 +470,38 @@ class TaxonomyTest extends TestCase
             'through object' => [false],
             'through facade' => [true],
         ];
+    }
+
+    /** @test */
+    public function it_fires_a_deleting_event()
+    {
+        Event::fake();
+
+        $taxonomy = tap(Facades\Taxonomy::make('test'))->save();
+
+        $taxonomy->delete();
+
+        Event::assertDispatched(TaxonomyDeleting::class, function ($event) use ($taxonomy) {
+            return $event->taxonomy === $taxonomy;
+        });
+    }
+
+    /** @test */
+    public function it_does_not_delete_when_a_deleting_event_returns_false()
+    {
+        Facades\Taxonomy::spy();
+        Event::fake([TaxonomyDeleted::class]);
+
+        Event::listen(TaxonomyDeleting::class, function () {
+            return false;
+        });
+
+        $taxonomy = new Taxonomy('test');
+
+        $return = $taxonomy->delete();
+
+        $this->assertFalse($return);
+        Facades\Taxonomy::shouldNotHaveReceived('delete');
+        Event::assertNotDispatched(TaxonomyDeleted::class);
     }
 }

--- a/tests/Fields/FieldsetTest.php
+++ b/tests/Fields/FieldsetTest.php
@@ -5,6 +5,8 @@ namespace Tests\Fields;
 use Illuminate\Support\Facades\Event;
 use Statamic\Events\FieldsetCreated;
 use Statamic\Events\FieldsetCreating;
+use Statamic\Events\FieldsetDeleted;
+use Statamic\Events\FieldsetDeleting;
 use Statamic\Events\FieldsetSaved;
 use Statamic\Events\FieldsetSaving;
 use Statamic\Facades\Blueprint;
@@ -523,5 +525,37 @@ class FieldsetTest extends TestCase
         $this->assertEquals($fieldset, $return);
 
         Event::assertNotDispatched(FieldsetSaved::class);
+    }
+
+    /** @test */
+    public function it_fires_a_deleting_event()
+    {
+        Event::fake();
+
+        $fieldset = (new Fieldset)->setHandle('test');
+
+        $fieldset->delete();
+
+        Event::assertDispatched(FieldsetDeleting::class, function ($event) use ($fieldset) {
+            return $event->fieldset === $fieldset;
+        });
+    }
+
+    /** @test */
+    public function it_does_not_delete_when_a_deleting_event_returns_false()
+    {
+        FieldsetRepository::spy();
+        Event::fake([FieldsetDeleted::class]);
+
+        Event::listen(FieldsetDeleting::class, function () {
+            return false;
+        });
+
+        $fieldset = (new Fieldset)->setHandle('test');
+        $return = $fieldset->delete();
+
+        $this->assertFalse($return);
+        FieldsetRepository::shouldNotHaveReceived('delete');
+        Event::assertNotDispatched(FieldsetDeleted::class);
     }
 }

--- a/tests/Forms/FormTest.php
+++ b/tests/Forms/FormTest.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Event;
 use Statamic\Events\FormCreated;
 use Statamic\Events\FormCreating;
+use Statamic\Events\FormDeleted;
+use Statamic\Events\FormDeleting;
 use Statamic\Events\FormSaved;
 use Statamic\Events\FormSaving;
 use Statamic\Facades\Form;
@@ -190,5 +192,38 @@ class FormTest extends TestCase
         $route = route('statamic.forms.submit', $form->handle());
 
         $this->assertEquals($route, $form->actionUrl());
+    }
+
+    /** @test */
+    public function it_fires_a_deleting_event()
+    {
+        Event::fake();
+
+        $form = Form::make('contact_us');
+
+        $form->delete();
+
+        Event::assertDispatched(FormDeleting::class, function ($event) use ($form) {
+            return $event->form === $form;
+        });
+    }
+
+    /** @test */
+    public function it_does_not_delete_when_a_deleting_event_returns_false()
+    {
+        Form::spy();
+        Event::fake([FormDeleted::class]);
+
+        Event::listen(FormDeleting::class, function () {
+            return false;
+        });
+
+        $form = new \Statamic\Forms\Form('test');
+
+        $return = $form->delete();
+
+        $this->assertFalse($return);
+        Form::shouldNotHaveReceived('delete');
+        Event::assertNotDispatched(FormDeleted::class);
     }
 }


### PR DESCRIPTION
This PR follows on from https://github.com/statamic/cms/pull/8833 and adds the following deleting events:

AssetDeleting
BlueprintDeleting
CollectionDeleting
FieldsetDeleting
FormDeleting
GlobalSetDeleting
GlobalVariablesDeleting
NavDeleting
TaxonomyDeleting
TermDeleting
UserDeleting

