### PR TITLE
[4.x] Add passkey 🔑 support to CP logins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "symfony/yaml": "^4.1 || ^5.1 || ^6.0",
         "ueberdosis/tiptap-php": "^1.1",
         "voku/portable-ascii": "^1.6.1 || ^2.0",
+        "web-auth/webauthn-lib": "^4.7",
         "wilderborn/partyline": "^1.0"
     },
     "require-dev": {

--- a/config/stache.php
+++ b/config/stache.php
@@ -89,6 +89,11 @@ return [
             'directory' => base_path('users'),
         ],
 
+        'passkeys' => [
+            'class' => Stores\PasskeysStore::class,
+            'directory' => base_path('users/passkeys'),
+        ],
+
     ],
 
     /*

--- a/config/webauthn.php
+++ b/config/webauthn.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    'enabled' => env('STATAMIC_WEBAUTHN_ENABLED', true),
+
+    'rp_entity' => [
+        'name' => null, // defaults to app.name
+        'id' => null, // defaults to app.url
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Remember Me
+    |--------------------------------------------------------------------------
+    |
+    | Whether or not the "remember me" functionality should be used when
+    | authenticating using WebAuthn. When enabled, the user will remain
+    | logged in indefinitely, or until they manually log out.
+    |
+    */
+
+    'remember_me' => true,
+
+];

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@floating-ui/dom": "^1.2.5",
     "@shopify/draggable": "^1.0.0-beta.12",
+    "@simplewebauthn/browser": "^8.3.4",
     "@tiptap/core": "^2.0.2",
     "@tiptap/extension-blockquote": "^2.0.2",
     "@tiptap/extension-bold": "^2.0.2",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -100,6 +100,7 @@ import GlobalSearch from './components/GlobalSearch.vue';
 import GlobalSiteSelector from './components/GlobalSiteSelector.vue';
 import Login from './components/login/login';
 import LoginModal from './components/login/LoginModal.vue';
+import Passkeys from './components/login/passkeys';
 import BaseEntryCreateForm from './components/entries/BaseCreateForm.vue';
 import BaseTermCreateForm from './components/terms/BaseCreateForm.vue';
 import CreateTermButton from './components/terms/CreateTermButton.vue';
@@ -155,6 +156,7 @@ Statamic.app({
         GlobalSiteSelector,
         Login,
         LoginModal,
+        Passkeys,
         BaseEntryCreateForm,
         BaseTermCreateForm,
         CreateTermButton,

--- a/resources/js/components/login/login.js
+++ b/resources/js/components/login/login.js
@@ -34,13 +34,13 @@ export default {
 
             this.$axios.post(this.webAuthnRoutes.verify, startAuthResponse)
                 .then(response => {
-
-                    if (response && response.verified) {
-                        alert('it worked');
-                    } else {
-                        alert('it failed');
-                        console.log(response);
+                    if (response && response.data.redirect) {
+                        location.href = response.data.redirect;
+                        return;
                     }
+
+                    alert('it failed');
+                    console.log(response);
 
                 })
                 .catch (e => {

--- a/resources/js/components/login/login.js
+++ b/resources/js/components/login/login.js
@@ -1,3 +1,5 @@
+import { startAuthentication, browserSupportsWebAuthn } from '@simplewebauthn/browser';
+
 export default {
 
     props: {
@@ -6,6 +8,10 @@ export default {
         },
         hasError: {
             default: false
+        },
+        webAuthnRoutes: {
+            default: {},
+            type: Object,
         }
     },
 
@@ -13,6 +19,36 @@ export default {
         if (this.hasError) {
             this.$el.parentElement.parentElement.classList.add('animation-shake');
         }
+    },
+
+    computed: {
+        showWebAuthn() {
+            return browserSupportsWebAuthn();
+        },
+    },
+
+    methods: {
+        async webAuthn() {
+            const authOptionsResponse = await fetch(this.webAuthnRoutes.options);
+            const startAuthResponse = await startAuthentication(await authOptionsResponse.json());
+
+            const verificationResponse = await fetch(this.webAuthnRoutes.verify, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(startAuthResponse),
+            });
+
+            const verificationJSON = await verificationResp.json();
+
+            if (verificationJSON && verificationJSON.verified) {
+                alert('it worked');
+            } else {
+                alert('it failed');
+                console.log(verificationJSON);
+            }
+        },
     }
 
 };

--- a/resources/js/components/login/login.js
+++ b/resources/js/components/login/login.js
@@ -51,10 +51,18 @@ export default {
                     }
 
                     this.webAuthnError = response.data.message;
-                })
-                .catch (e => {
-                    this.webAuthnError = e.message;
-                });
+                }).catch(e => this.handleAxiosError(e));
+
+        },
+
+        handleAxiosError(e) {
+            if (e.response) {
+                const { message, errors } = e.response.data;
+                this.webAuthnError = message;
+                return;
+            }
+
+            this.webAuthnError = __('Something went wrong');
         },
     }
 

--- a/resources/js/components/login/login.js
+++ b/resources/js/components/login/login.js
@@ -25,6 +25,16 @@ export default {
         showWebAuthn() {
             return browserSupportsWebAuthn();
         },
+
+        showWebAuthnError() {
+            return this.webAuthnError !== false;
+        },
+    },
+
+    data() {
+        return {
+            webAuthnError: false,
+        }
     },
 
     methods: {
@@ -34,17 +44,16 @@ export default {
 
             this.$axios.post(this.webAuthnRoutes.verify, startAuthResponse)
                 .then(response => {
+                    console.log(response);
                     if (response && response.data.redirect) {
                         location.href = response.data.redirect;
                         return;
                     }
 
-                    alert('it failed');
-                    console.log(response);
-
+                    this.webAuthnError = response.data.message;
                 })
                 .catch (e => {
-                    console.error(e);
+                    this.webAuthnError = e.message;
                 });
         },
     }

--- a/resources/js/components/login/passkeys.js
+++ b/resources/js/components/login/passkeys.js
@@ -10,9 +10,19 @@ export default {
     },
 
     computed: {
+        showErrorModal() {
+            return this.error !== false;
+        },
+
         showWebAuthn() {
             return browserSupportsWebAuthn();
         },
+    },
+
+    data() {
+        return {
+            error: false,
+        }
     },
 
     methods: {
@@ -31,17 +41,15 @@ export default {
 
             this.$axios.post(this.webAuthnRoutes.verify, startRegistrationResponse)
                 .then(response => {
-
-                    if (response && response.data.redirect) {
-                        location.href = response.data.redirect;
+                    if (response && response.data.verified) {
+                        location.refresh();
                         return;
                     }
 
-                    alert('it failed');
-                    console.log(response);
+                    this.error = response.data.message;
                 })
                 .catch (e => {
-                    console.error(e);
+                    this.error = e.message;
                 });
         },
     }

--- a/resources/js/components/login/passkeys.js
+++ b/resources/js/components/login/passkeys.js
@@ -24,13 +24,15 @@ export default {
             this.$axios.post(this.webAuthnRoutes.verify, startRegistrationResponse)
                 .then(response => {
 
-                    if (response && response.verified) {
-                        alert('it worked');
-                    } else {
-                        alert('it failed');
-                        console.log(response);
+                    console.log(response.data);
+
+                    if (response && response.data.redirect) {
+                        location.href = response.data.redirect;
+                        return;
                     }
 
+                    alert('it failed');
+                    console.log(response);
                 })
                 .catch (e => {
                     console.error(e);

--- a/resources/js/components/login/passkeys.js
+++ b/resources/js/components/login/passkeys.js
@@ -11,20 +11,26 @@ export default {
 
     computed: {
         showWebAuthn() {
-            console.log('Supported: ' + browserSupportsWebAuthn());
             return browserSupportsWebAuthn();
         },
     },
 
     methods: {
+        deletePasskey(id, target) {
+            if (confirm(__('Are you sure?'))) {
+                this.$axios.delete(this.webAuthnRoutes.delete + id).then(response => {
+                    let row = target.closest('tr');
+                    row.parentNode.removeChild(row);
+                });
+            }
+        },
+
         async webAuthn() {
             const authOptionsResponse = await fetch(this.webAuthnRoutes.options);
             const startRegistrationResponse = await startRegistration(await authOptionsResponse.json());
 
             this.$axios.post(this.webAuthnRoutes.verify, startRegistrationResponse)
                 .then(response => {
-
-                    console.log(response.data);
 
                     if (response && response.data.redirect) {
                         location.href = response.data.redirect;

--- a/resources/js/components/login/passkeys.js
+++ b/resources/js/components/login/passkeys.js
@@ -47,10 +47,18 @@ export default {
                     }
 
                     this.error = response.data.message;
-                })
-                .catch (e => {
-                    this.error = e.message;
-                });
+                }).catch(e => this.handleAxiosError(e));
+
+        },
+
+        handleAxiosError(e) {
+            if (e.response) {
+                const { message, errors } = e.response.data;
+                this.error = message;
+                return;
+            }
+
+            this.error = __('Something went wrong');
         },
     }
 

--- a/resources/js/components/login/passkeys.js
+++ b/resources/js/components/login/passkeys.js
@@ -1,28 +1,17 @@
-import { startAuthentication, browserSupportsWebAuthn } from '@simplewebauthn/browser';
+import { startRegistration, browserSupportsWebAuthn } from '@simplewebauthn/browser';
 
 export default {
 
     props: {
-        showEmailLogin: {
-            default: false
-        },
-        hasError: {
-            default: false
-        },
         webAuthnRoutes: {
             default: {},
             type: Object,
         }
     },
 
-    mounted() {
-        if (this.hasError) {
-            this.$el.parentElement.parentElement.classList.add('animation-shake');
-        }
-    },
-
     computed: {
         showWebAuthn() {
+            console.log('Supported: ' + browserSupportsWebAuthn());
             return browserSupportsWebAuthn();
         },
     },
@@ -30,9 +19,9 @@ export default {
     methods: {
         async webAuthn() {
             const authOptionsResponse = await fetch(this.webAuthnRoutes.options);
-            const startAuthResponse = await startAuthentication(await authOptionsResponse.json());
+            const startRegistrationResponse = await startRegistration(await authOptionsResponse.json());
 
-            this.$axios.post(this.webAuthnRoutes.verify, startAuthResponse)
+            this.$axios.post(this.webAuthnRoutes.verify, startRegistrationResponse)
                 .then(response => {
 
                     if (response && response.verified) {

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -26,6 +26,12 @@
                             </a>
                         </div>
                     @endforeach
+
+                    @if ($webAuthnEnabled)
+                    <div class="provider mb-2" v-show="showWebAuthn">
+                        <button class="w-full btn-primary" @click="webAuthn()">{{ __('Log in with passkey') }}</button>
+                    </div>
+                    @endif
                 </div>
 
                 @if($emailLoginEnabled)
@@ -63,12 +69,6 @@
                     <button type="submit" class="btn-primary">{{ __('Log in') }}</button>
                 </div>
             </form>
-
-            @if ($webAuthnEnabled)
-            <div v-show="showWebAuthn">
-                <button class="btn-primary" @click="webAuthn()">{{ __('Login with passkey') }}</button>
-            </div>
-            @endif
 
         </div>
     </login>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -30,6 +30,7 @@
                     @if ($webAuthnEnabled)
                     <div class="provider mb-2" v-show="showWebAuthn">
                         <button class="w-full btn-primary" @click="webAuthn()">{{ __('Log in with passkey') }}</button>
+                        <div class="text-red-500 text-xs mt-2 text-center" v-if="showWebAuthnError" v-text="webAuthnError" />
                     </div>
                     @endif
                 </div>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -7,55 +7,70 @@
 @include('statamic::partials.outside-logo')
 
 <div class="card auth-card mx-auto">
-    <login inline-template :show-email-login="!{{ $str::bool($oauth) }}" :has-error="{{ $str::bool(count($errors) > 0) }}">
-    <div>
-        @if ($oauth)
-            <div class="login-oauth-providers">
-                @foreach ($providers as $provider)
-                    <div class="provider mb-2">
-                        <a href="{{ $provider->loginUrl() }}?redirect={{ parse_url(cp_route('index'))['path'] }}" class="w-full btn-primary">
-                            {{ __('Log in with :provider', ['provider' => $provider->label()]) }}
+    <login
+        inline-template
+        :show-email-login="!{{ $str::bool($oauth) }}"
+        :has-error="{{ $str::bool(count($errors) > 0) }}"
+        :web-authn-routes=@json([
+            'options' => route('statamic.cp.webauthn.verify-options'),
+            'verify' => route('statamic.cp.webauthn.verify'),
+        ])
+    >
+        <div>
+            @if ($oauth)
+                <div class="login-oauth-providers">
+                    @foreach ($providers as $provider)
+                        <div class="provider mb-2">
+                            <a href="{{ $provider->loginUrl() }}?redirect={{ parse_url(cp_route('index'))['path'] }}" class="w-full btn-primary">
+                                {{ __('Log in with :provider', ['provider' => $provider->label()]) }}
+                            </a>
+                        </div>
+                    @endforeach
+                </div>
+
+                @if($emailLoginEnabled)
+                    <div class="text-center text-sm text-gray-700 py-6">&mdash; {{ __('or') }} &mdash;</div>
+
+                    <div class="login-with-email" v-if="! showEmailLogin">
+                        <a class="btn w-full" @click.prevent="showEmailLogin = true">
+                            {{ __('Log in with email') }}
                         </a>
                     </div>
-                @endforeach
-            </div>
-
-            @if($emailLoginEnabled)
-                <div class="text-center text-sm text-gray-700 py-6">&mdash; {{ __('or') }} &mdash;</div>
-
-                <div class="login-with-email" v-if="! showEmailLogin">
-                    <a class="btn w-full" @click.prevent="showEmailLogin = true">
-                        {{ __('Log in with email') }}
-                    </a>
-                </div>
+                @endif
             @endif
-        @endif
 
-        <form method="POST" v-show="showEmailLogin" class="email-login select-none" @if ($oauth) v-cloak @endif>
-            {!! csrf_field() !!}
+            <form method="POST" v-show="showEmailLogin" class="email-login select-none" @if ($oauth) v-cloak @endif>
+                {!! csrf_field() !!}
 
-            <input type="hidden" name="referer" value="{{ $referer }}" />
+                <input type="hidden" name="referer" value="{{ $referer }}" />
 
-            <div class="mb-8">
-                <label class="mb-2" for="input-email">{{ __('Email') }}</label>
-                <input type="text" class="input-text input-text" name="email" value="{{ old('email') }}" autofocus id="input-email">
-                @if ($hasError('email'))<div class="text-red-500 text-xs mt-2">{{ $errors->first('email') }}</div>@endif
+                <div class="mb-8">
+                    <label class="mb-2" for="input-email">{{ __('Email') }}</label>
+                    <input type="text" class="input-text input-text" name="email" value="{{ old('email') }}" autofocus id="input-email">
+                    @if ($hasError('email'))<div class="text-red-500 text-xs mt-2">{{ $errors->first('email') }}</div>@endif
+                </div>
+
+                <div class="mb-8">
+                    <label class="mb-2" for="input-password">{{ __('Password') }}</label>
+                    <input type="password" class="input-text input-text" name="password" id="input-password">
+                    @if ($hasError('password'))<div class="text-red-500 text-xs mt-2">{{ $errors->first('password') }}</div>@endif
+                </div>
+                <div class="flex justify-between items-center">
+                    <label for="remember-me" class="flex items-center cursor-pointer">
+                        <input type="checkbox" name="remember" id="remember-me">
+                        <span class="ml-2">{{ __('Remember me') }}</span>
+                    </label>
+                    <button type="submit" class="btn-primary">{{ __('Log in') }}</button>
+                </div>
+            </form>
+
+            @if ($webAuthnEnabled)
+            <div v-show="showWebAuthn">
+                <button class="btn-primary" @click="webAuthn()">{{ __('Login with passkey') }}</button>
             </div>
+            @endif
 
-            <div class="mb-8">
-                <label class="mb-2" for="input-password">{{ __('Password') }}</label>
-                <input type="password" class="input-text input-text" name="password" id="input-password">
-                @if ($hasError('password'))<div class="text-red-500 text-xs mt-2">{{ $errors->first('password') }}</div>@endif
-            </div>
-            <div class="flex justify-between items-center">
-                <label for="remember-me" class="flex items-center cursor-pointer">
-                    <input type="checkbox" name="remember" id="remember-me">
-                    <span class="ml-2">{{ __('Remember me') }}</span>
-                </label>
-                <button type="submit" class="btn-primary">{{ __('Log in') }}</button>
-            </div>
-        </form>
-    </div>
+        </div>
     </login>
 </div>
 @if ($emailLoginEnabled)

--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -115,6 +115,9 @@
             <div class="divider"></div>
 
             <dropdown-item :text="__('Profile')" redirect="{{ route('statamic.cp.account') }}"></dropdown-item>
+            @if (config('statamic.webauthn.enabled'))
+            <dropdown-item :text="__('Passkeys')" redirect="{{ route('statamic.cp.webauthn.view') }}"></dropdown-item>
+            @endif
             @if (session()->get('statamic_impersonated_by'))
                 <dropdown-item :text="__('Stop Impersonating')" redirect="{{ cp_route('impersonation.stop') }}"></dropdown-item>
             @endif

--- a/resources/views/users/webauthn.blade.php
+++ b/resources/views/users/webauthn.blade.php
@@ -27,7 +27,7 @@
                                 <span class="font-bold">{{ $passkey->id() }}</span>
                                 <span class="badge uppercase font-bold text-gray-600">{{ $passkey->get('type') }}</span>
                             </td>
-                            <td>{{ $passkey->lastLogin()?->format(config('statamic.cp.date_format')).' '.$passkey->lastLogin()?->format('H:i') }}
+                            <td>{{ ($login = $passkey->lastLogin()) ? ($login->format(config('statamic.cp.date_format')).' '.$login->format('H:i')) : __('Never') }}
 
                             <td class="text-right text-red-500"><a class="btn-sm btn-danger" @click="(event) => deletePasskey('{{ $passkey->id() }}', event.target)">{{ __('Delete') }}</a></td>
                         </tr>
@@ -40,7 +40,24 @@
                 <a class="btn btn-primary mr-4" @click="webAuthn">{{ __('Create Passkey') }}</a>
             </div>
 
+            <modal name="passkey-create-error" v-if="showErrorModal">
+                <div class="confirmation-modal flex flex-col h-full">
+                    <div class="text-lg font-medium p-4 pb-0">
+                        {{ __('There was an error creating your passkey') }}
+                    </div>
+                    <div class="flex-1 px-4 py-6 text-gray">
+                        <p class="mb-4" v-text="error" />
+                    </div>
+                    <div class="p-4 bg-gray-200 border-t flex items-center justify-end text-sm">
+                        <button class="text-gray hover:text-gray-900"
+                            @click="error = false"
+                            v-text="__('Close')" />
+                    </div>
+                </div>
+            </modal>
+
         </div>
+
     </passkeys>
 
 @stop

--- a/resources/views/users/webauthn.blade.php
+++ b/resources/views/users/webauthn.blade.php
@@ -1,0 +1,49 @@
+@extends('statamic::layout')
+@section('title', __('Passkeys'))
+
+@section('content')
+
+    @include('statamic::partials.breadcrumb', [
+        'url' => cp_route('users.index'),
+        'title' => __('Users')
+    ])
+
+    <div class="flex mb-6">
+        <h1 class="flex-1">{{ __('Passkeys') }}</h1>
+    </div>
+
+    <passkeys
+        inline-template
+        :web-authn-routes=@json([
+            'options' => route('statamic.cp.webauthn.create-options'),
+            'verify' => route('statamic.cp.webauthn.create'),
+        ])
+    >
+    {{--
+    <h6 class="mt-8">Site</h6>
+    <div class="card p-0 mt-2">
+        <table class="data-table">
+            <tr>
+                <td class="w-64 font-bold">
+                    <span class="little-dot {{ $site->valid() ? 'bg-green-600' : 'bg-red-500' }} mr-2"></span>
+                    {{ $site->key() ?? __('No license key') }}
+                </td>
+                <td class="relative">
+                    {{ $site->domain()['url'] ?? '' }}
+                    @if ($site->hasMultipleDomains())
+                        <span class="text-2xs">({{ trans_choice('and :count more', $site->additionalDomainCount()) }})</span>
+                    @endif
+                </td>
+                <td class="text-right text-red-500">{{ $site->invalidReason() }}</td>
+            </tr>
+        </table>
+    </div>
+    --}}
+
+    <div class="mt-10 py-4 border-t flex items-center" v-show="showWebAuthn">
+        <a class="btn btn-primary mr-4" @click="webAuthn">{{ __('Create Passkey') }}</a>
+    </div>
+
+    </passkeys>
+
+@stop

--- a/resources/views/users/webauthn.blade.php
+++ b/resources/views/users/webauthn.blade.php
@@ -12,38 +12,35 @@
         <h1 class="flex-1">{{ __('Passkeys') }}</h1>
     </div>
 
-    <passkeys
-        inline-template
-        :web-authn-routes=@json([
-            'options' => route('statamic.cp.webauthn.create-options'),
-            'verify' => route('statamic.cp.webauthn.create'),
-        ])
-    >
-    {{--
-    <h6 class="mt-8">Site</h6>
-    <div class="card p-0 mt-2">
-        <table class="data-table">
-            <tr>
-                <td class="w-64 font-bold">
-                    <span class="little-dot {{ $site->valid() ? 'bg-green-600' : 'bg-red-500' }} mr-2"></span>
-                    {{ $site->key() ?? __('No license key') }}
-                </td>
-                <td class="relative">
-                    {{ $site->domain()['url'] ?? '' }}
-                    @if ($site->hasMultipleDomains())
-                        <span class="text-2xs">({{ trans_choice('and :count more', $site->additionalDomainCount()) }})</span>
-                    @endif
-                </td>
-                <td class="text-right text-red-500">{{ $site->invalidReason() }}</td>
-            </tr>
-        </table>
-    </div>
-    --}}
+    <passkeys inline-template :web-authn-routes=@json($routes)>
+        <div>
 
-    <div class="mt-10 py-4 border-t flex items-center" v-show="showWebAuthn">
-        <a class="btn btn-primary mr-4" @click="webAuthn">{{ __('Create Passkey') }}</a>
-    </div>
+            @if ($passkeys->isEmpty())
+            <p class="text-sm text-gray mt-2">{{ __('No passkeys created') }}</p>
+            @else
+            <div class="card p-0 mt-10">
+                <table class="data-table">
+                    @foreach ($passkeys as $passkey)
+                        <tr>
+                            <td class="w-128 mr-2">
+                                <span class="little-dot bg-green-600 mr-2"></span>
+                                <span class="font-bold">{{ $passkey->id() }}</span>
+                                <span class="badge uppercase font-bold text-gray-600">{{ $passkey->get('type') }}</span>
+                            </td>
+                            <td>{{ $passkey->lastLogin()?->format(config('statamic.cp.date_format')).' '.$passkey->lastLogin()?->format('H:i') }}
 
+                            <td class="text-right text-red-500"><a class="btn-sm btn-danger" @click="(event) => deletePasskey('{{ $passkey->id() }}', event.target)">{{ __('Delete') }}</a></td>
+                        </tr>
+                    @endforeach
+                </table>
+            </div>
+            @endif
+
+            <div class="mt-10 py-4 border-t flex items-center" v-show="showWebAuthn">
+                <a class="btn btn-primary mr-4" @click="webAuthn">{{ __('Create Passkey') }}</a>
+            </div>
+
+        </div>
     </passkeys>
 
 @stop

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -341,7 +341,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
     });
 
     Route::group(['prefix' => 'webauthn'], function () {
-        Route::get('/', [WebAuthnController::class, 'view'])->name('webauthn.list');
+        Route::get('/', [WebAuthnController::class, 'view'])->name('webauthn.view');
         Route::get('create', [WebAuthnController::class, 'createOptions'])->name('webauthn.create-options');
         Route::post('create', [WebAuthnController::class, 'create'])->name('webauthn.create');
     });

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -344,6 +344,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::get('/', [WebAuthnController::class, 'view'])->name('webauthn.view');
         Route::get('create', [WebAuthnController::class, 'createOptions'])->name('webauthn.create-options');
         Route::post('create', [WebAuthnController::class, 'create'])->name('webauthn.create');
+        Route::delete('delete/{id}', [WebAuthnController::class, 'delete'])->name('webauthn.delete');
     });
 
     Route::get('session-timeout', SessionTimeoutController::class)->name('session.timeout');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -24,6 +24,7 @@ use Statamic\Http\Controllers\CP\Auth\ImpersonationController;
 use Statamic\Http\Controllers\CP\Auth\LoginController;
 use Statamic\Http\Controllers\CP\Auth\ResetPasswordController;
 use Statamic\Http\Controllers\CP\Auth\UnauthorizedController;
+use Statamic\Http\Controllers\CP\Auth\WebAuthnController;
 use Statamic\Http\Controllers\CP\Collections\CollectionBlueprintsController;
 use Statamic\Http\Controllers\CP\Collections\CollectionsController;
 use Statamic\Http\Controllers\CP\Collections\CollectionTreeController;
@@ -114,6 +115,11 @@ Route::group(['prefix' => 'auth'], function () {
     Route::get('unauthorized', UnauthorizedController::class)->name('unauthorized');
 
     Route::get('stop-impersonating', [ImpersonationController::class, 'stop'])->name('impersonation.stop');
+
+    Route::group(['prefix' => 'webauthn'], function () {
+        Route::get('verify', [WebAuthnController::class, 'verifyOptions'])->name('webauthn.verify-options');
+        Route::post('verify', [WebAuthnController::class, 'verify'])->name('webauthn.verify');
+    });
 });
 
 Route::middleware('statamic.cp.authenticated')->group(function () {
@@ -332,6 +338,12 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
                 Route::delete('default', [DefaultNavController::class, 'destroy'])->name('default.destroy');
             });
         });
+    });
+
+    Route::group(['prefix' => 'webauthn'], function () {
+        Route::get('/', [WebAuthnController::class, 'view'])->name('webauthn.list');
+        Route::get('create', [WebAuthnController::class, 'createOptions'])->name('webauthn.create-options');
+        Route::post('create', [WebAuthnController::class, 'create'])->name('webauthn.create');
     });
 
     Route::get('session-timeout', SessionTimeoutController::class)->name('session.timeout');

--- a/src/Auth/File/Passkey.php
+++ b/src/Auth/File/Passkey.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Statamic\Auth\File;
+
+use Statamic\Contracts\Auth\Passkey as PasskeyContract;
+use Statamic\Data\ContainsData;
+use Statamic\Data\ExistsAsFile;
+use Statamic\Facades;
+use Statamic\Facades\Stache;
+use Statamic\Support\Traits\FluentlyGetsAndSets;
+use Webauthn\PublicKeyCredentialSource;
+
+class Passkey implements PasskeyContract
+{
+    use ContainsData, ExistsAsFile, FluentlyGetsAndSets;
+
+    protected $id;
+    protected $user;
+
+    public function __construct()
+    {
+        $this->data = collect();
+        $this->supplements = collect();
+    }
+
+    public function id($id = null)
+    {
+        return $this->fluentlyGetOrSet('id')->args(func_get_args());
+    }
+
+    public function user($user = null)
+    {
+        return $this
+            ->fluentlyGetOrSet('user')
+            ->setter(function ($user) {
+                return is_string($user) ? $user : $user->id();
+            })
+            ->getter(function ($id) {
+                return Facades\User::find($id);
+            })
+            ->args(func_get_args());
+    }
+
+    public function path()
+    {
+        return vsprintf('%s/%s.yaml', [
+            rtrim(Stache::store('passkeys')->directory(), '/'),
+            $this->id(),
+        ]);
+    }
+
+    public function fileData()
+    {
+        return $this->data()->merge([
+            'id' => (string) $this->id(),
+            'user' => $this->user()?->id(),
+        ])->all();
+    }
+
+    public function fresh()
+    {
+        return Facades\Passkey::find($this->id);
+    }
+
+    public function save()
+    {
+        Facades\Passkey::save($this);
+
+        return $this;
+    }
+
+    public function delete()
+    {
+        Facades\Passkey::delete($this);
+
+        return true;
+    }
+
+    public function toPublicKeyCredentialSource()
+    {
+        $data = $this->data()->all();
+
+        $data['trustPath'] = [
+            'type' => \Webauthn\TrustPath\EmptyTrustPath::class,
+        ];
+
+        return PublicKeyCredentialSource::createFromArray($data);
+    }
+}

--- a/src/Auth/File/Passkey.php
+++ b/src/Auth/File/Passkey.php
@@ -2,9 +2,12 @@
 
 namespace Statamic\Auth\File;
 
+use Carbon\Carbon;
 use Statamic\Contracts\Auth\Passkey as PasskeyContract;
 use Statamic\Data\ContainsData;
 use Statamic\Data\ExistsAsFile;
+use Statamic\Data\TracksQueriedColumns;
+use Statamic\Data\TracksQueriedRelations;
 use Statamic\Facades;
 use Statamic\Facades\Stache;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
@@ -12,7 +15,7 @@ use Webauthn\PublicKeyCredentialSource;
 
 class Passkey implements PasskeyContract
 {
-    use ContainsData, ExistsAsFile, FluentlyGetsAndSets;
+    use ContainsData, ExistsAsFile, FluentlyGetsAndSets, TracksQueriedColumns, TracksQueriedRelations;
 
     protected $id;
     protected $user;
@@ -74,6 +77,11 @@ class Passkey implements PasskeyContract
         Facades\Passkey::delete($this);
 
         return true;
+    }
+
+    public function lastLogin()
+    {
+        return ($login = $this->get('last_login')) ? Carbon::createFromTimestamp($login) : null;
     }
 
     public function toPublicKeyCredentialSource()

--- a/src/Auth/File/PasskeyQueryBuilder.php
+++ b/src/Auth/File/PasskeyQueryBuilder.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Statamic\Auth\File;
+
+use Exception;
+use Statamic\Auth\PasskeyCollection;
+use Statamic\Contracts\Assets\AssetContainer;
+use Statamic\Contracts\Auth\PasskeyQueryBuilder as Contract;
+use Statamic\Facades;
+use Statamic\Stache\Query\Builder as BaseQueryBuilder;
+
+class PasskeyQueryBuilder extends BaseQueryBuilder implements Contract
+{
+    protected function getFilteredKeys()
+    {
+        if (! empty($this->wheres)) {
+            return $this->getKeysWithWheres($this->wheres);
+        }
+
+        return collect($this->store->paths()->keys());
+    }
+
+    protected function getKeysWithWheres($wheres)
+    {
+        return collect($wheres)->reduce(function ($ids, $where) {
+            $keys = $where['type'] == 'Nested'
+                ? $this->getKeysWithWheres($where['query']->wheres)
+                : $this->getKeysWithWhere($where);
+
+            return $this->intersectKeysFromWhereClause($ids, $keys, $where);
+        });
+    }
+
+    protected function getKeysWithWhere($where)
+    {
+        $items = app('stache')
+            ->store('passkeys')
+            ->index($where['column'])->items();
+
+        $method = 'filterWhere'.$where['type'];
+
+        return $this->{$method}($items, $where)->keys();
+    }
+
+    protected function collect($items = [])
+    {
+        return new PasskeyCollection($items);
+    }
+
+    protected function getOrderKeyValuesByIndex()
+    {
+        return collect($this->orderBys)->mapWithKeys(function ($orderBy) {
+            $items = $this->store->index($orderBy->sort)->items()->all();
+
+            return [$orderBy->sort => $items];
+        });
+    }
+}

--- a/src/Auth/File/PasskeyQueryBuilder.php
+++ b/src/Auth/File/PasskeyQueryBuilder.php
@@ -2,11 +2,8 @@
 
 namespace Statamic\Auth\File;
 
-use Exception;
 use Statamic\Auth\PasskeyCollection;
-use Statamic\Contracts\Assets\AssetContainer;
 use Statamic\Contracts\Auth\PasskeyQueryBuilder as Contract;
-use Statamic\Facades;
 use Statamic\Stache\Query\Builder as BaseQueryBuilder;
 
 class PasskeyQueryBuilder extends BaseQueryBuilder implements Contract

--- a/src/Auth/File/PasskeyRepository.php
+++ b/src/Auth/File/PasskeyRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Statamic\Auth\File;
+
+use Illuminate\Support\Collection;
+use Statamic\Contracts\Auth\Passkey;
+use Statamic\Contracts\Auth\PasskeyRepository as RepositoryContract;
+use Statamic\Stache\Stache;
+
+class PasskeyRepository implements RepositoryContract
+{
+    protected $store;
+
+    public function __construct(Stache $stache)
+    {
+        $this->store = $stache->store('passkeys');
+    }
+
+    public function all(): Collection
+    {
+        $keys = $this->store->paths()->keys();
+
+        return $this->store->getItems($keys);
+    }
+
+    public function find($id): ?Passkey
+    {
+        return $this->store->getItem($id);
+    }
+
+    public function make(): Passkey
+    {
+        return app(Passkey::class);
+    }
+
+    public function save(Passkey $passkey)
+    {
+        $this->store->save($passkey);
+    }
+
+    public function delete(Passkey $passkey)
+    {
+        $this->store->delete($passkey);
+    }
+
+    public static function bindings(): array
+    {
+        return [
+            Passkey::class => \Statamic\Auth\File\Passkey::class,
+        ];
+    }
+}

--- a/src/Auth/File/PasskeyRepository.php
+++ b/src/Auth/File/PasskeyRepository.php
@@ -4,6 +4,7 @@ namespace Statamic\Auth\File;
 
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Auth\Passkey;
+use Statamic\Contracts\Auth\PasskeyQueryBuilder;
 use Statamic\Contracts\Auth\PasskeyRepository as RepositoryContract;
 use Statamic\Stache\Stache;
 
@@ -33,6 +34,11 @@ class PasskeyRepository implements RepositoryContract
         return app(Passkey::class);
     }
 
+    public function query()
+    {
+        return app(PasskeyQueryBuilder::class);
+    }
+
     public function save(Passkey $passkey)
     {
         $this->store->save($passkey);
@@ -47,6 +53,7 @@ class PasskeyRepository implements RepositoryContract
     {
         return [
             Passkey::class => \Statamic\Auth\File\Passkey::class,
+            PasskeyQueryBuilder::class => \Statamic\Auth\File\PasskeyQueryBuilder::class,
         ];
     }
 }

--- a/src/Auth/PasskeyCollection.php
+++ b/src/Auth/PasskeyCollection.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Statamic\Auth;
+
+use Statamic\Data\DataCollection;
+
+/**
+ * A collection of Passkeys.
+ */
+class PasskeyCollection extends DataCollection
+{
+}

--- a/src/Contracts/Auth/Passkey.php
+++ b/src/Contracts/Auth/Passkey.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Statamic\Contracts\Auth;
+
+interface Passkey
+{
+    public function id($id = null);
+
+    public function user($user = null);
+
+    public function save();
+
+    public function delete();
+}

--- a/src/Contracts/Auth/PasskeyQueryBuilder.php
+++ b/src/Contracts/Auth/PasskeyQueryBuilder.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Statamic\Contracts\Auth;
+
+use Statamic\Contracts\Query\Builder;
+
+interface PasskeyQueryBuilder extends Builder
+{
+}

--- a/src/Contracts/Auth/PasskeyRepository.php
+++ b/src/Contracts/Auth/PasskeyRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Statamic\Contracts\Auth;
+
+use Illuminate\Support\Collection;
+
+interface PasskeyRepository
+{
+    public function all(): Collection;
+
+    public function find(string $id): ?Passkey;
+
+    public function make(): Passkey;
+
+    public function save(Passkey $passkey);
+
+    public function delete(Passkey $passkey);
+}

--- a/src/Facades/Passkey.php
+++ b/src/Facades/Passkey.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Statamic\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Statamic\Contracts\Auth\PasskeyRepository;
+
+/**
+ * @method static \lluminate\Support\Collection all()
+ * @method static null|\Statamic\Contracts\Auth\Passkey find($id)
+ * @method static \Statamic\Contracts\Auth\Passkey make()
+ *
+ * @see \Statamic\Auth\File\PasskeyRepository
+ */
+class Passkey extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return PasskeyRepository::class;
+    }
+}

--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -34,6 +34,7 @@ class LoginController extends CpController
     {
         $data = [
             'title' => __('Log in'),
+            'webAuthnEnabled' => config('statamic.webauthn.enabled'),
             'oauth' => $enabled = OAuth::enabled(),
             'emailLoginEnabled' => $enabled ? config('statamic.oauth.email_login_enabled') : true,
             'providers' => $enabled ? OAuth::providers() : [],

--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -34,10 +34,10 @@ class LoginController extends CpController
     {
         $data = [
             'title' => __('Log in'),
-            'webAuthnEnabled' => config('statamic.webauthn.enabled'),
-            'oauth' => $enabled = OAuth::enabled(),
+            'webAuthnEnabled' => $webAuthnEnabled = config('statamic.webauthn.enabled'),
+            'oauth' => $enabled = OAuth::enabled() || $webAuthnEnabled,
             'emailLoginEnabled' => $enabled ? config('statamic.oauth.email_login_enabled') : true,
-            'providers' => $enabled ? OAuth::providers() : [],
+            'providers' => OAuth::enabled() ? OAuth::providers() : [],
             'referer' => $this->getReferrer($request),
             'hasError' => $this->hasError(),
         ];

--- a/src/Http/Controllers/CP/Auth/WebAuthnController.php
+++ b/src/Http/Controllers/CP/Auth/WebAuthnController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Statamic\Http\Controllers\CP\Auth;
+
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Statamic\Facades\User;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialLoader;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+class WebAuthnController
+{
+    public function createOptions()
+    {
+        if (! $user = User::current()) {
+            throw new Exception('You must be logged in');
+        }
+
+        $userEntity = PublicKeyCredentialUserEntity::create(
+            $user->email(),
+            $user->id(),
+            $user->name()
+        );
+
+        return PublicKeyCredentialCreationOptions::create(
+            $this->rpEntity(),
+            $userEntity,
+            random_bytes(16),
+        );
+    }
+
+    public function create(Request $request)
+    {
+        // https://webauthn-doc.spomky-labs.com/pure-php/authenticator-registration#creation-response
+
+        $publicKeyCredential = (new PublicKeyCredentialLoader())->load($request->getContent());
+
+        if (! $publicKeyCredential->response instanceof AuthenticatorAttestationResponse) {
+            throw new Exception('Invalid credentials'); // maybe redirect back with errors?
+        }
+
+        try {
+            $publicKeyCredentialSource = (new AuthenticatorAttestationResponseValidator)->check(
+                $publicKeyCredential->response,
+                $this->createOptions(),
+                config('statamic.webauthn.rrp_entity.id', config('app.url'))
+            );
+        } catch (Exception $e) {
+            throw new Exception('Invalid credentials'); // maybe redirect back with errors?
+        }
+
+        if (! $user = User::current()) {
+            throw new Exception('You must be logged in');
+        }
+
+        WebAuthnRepository::create([
+            'id' => $publicKeyCredentialSource->rawId, // should we store it all?
+            'user' => $user
+        ]);
+    }
+
+    public function verifyOptions()
+    {
+        return PublicKeyCredentialRequestOptions::create(
+            random_bytes(32),
+            userVerification: PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_REQUIRED
+        );
+    }
+
+    public function verify(Request $request)
+    {
+        // https://webauthn-doc.spomky-labs.com/pure-php/authenticate-your-users#response-verification
+
+        $publicKeyCredential = (new PublicKeyCredentialLoader())->load($request->getContent());
+
+        if (! $publicKeyCredential->response instanceof AuthenticatorAssertionResponse) {
+            throw new Exception('Invalid credentials'); // maybe redirect back with errors?
+        }
+
+        // get from passkey repository
+        $passkey = WebAuthnRepository::find($publicKeyCredential->rawId);
+
+        if (! $passkey) {
+            throw new Exception('Invalid credentials'); // maybe redirect back with errors?
+        }
+
+        try {
+            $publicKeyCredentialSource = (new AuthenticatorAssertionResponseValidator)->check(
+                $passkey,
+                $publicKeyCredential->response,
+                $this->verifyOptions(),
+                config('statamic.webauthn.rrp_entity.id', config('app.url'))
+            );
+        } catch (Exception $e) {
+            throw new Exception('Invalid credentials'); // maybe redirect back with errors?
+        }
+
+        Auth::login($passkey->user, config('statamic.webauthn.remember_me', true));
+
+        return redirect()->to($this->successRedirectUrl());
+    }
+
+    public function view()
+    {
+        throw new Exception('Show a list of the users existing passkeys, with revoke option and the ability to let them create a new one');
+    }
+
+    private function rpEntity(): PublicKeyCredentialRpEntity
+    {
+        return PublicKeyCredentialRpEntity::create(
+            name: config('statamic.webauthn.rrp_entity.name', config('app.name')),
+            id: config('statamic.webauthn.rrp_entity.id', config('app.url')),
+        );
+    }
+
+    private function successRedirectUrl()
+    {
+        $default = '/';
+
+        $previous = session('_previous.url');
+
+        if (! $query = array_get(parse_url($previous), 'query')) {
+            return $default;
+        }
+
+        parse_str($query, $query);
+
+        return array_get($query, 'redirect', $default);
+    }
+}

--- a/src/Http/Controllers/CP/Auth/WebAuthnController.php
+++ b/src/Http/Controllers/CP/Auth/WebAuthnController.php
@@ -4,7 +4,8 @@ namespace Statamic\Http\Controllers\CP\Auth;
 
 use Cose\Algorithm\Manager;
 use Cose\Algorithm\Signature\ECDSA\ES256;
-use Cose\Algorithm\Signature\RSA\RS256;use Exception;
+use Cose\Algorithm\Signature\RSA\RS256;
+use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -81,7 +82,7 @@ class WebAuthnController
         $passkey->save();
 
         return [
-            'verified' => true
+            'verified' => true,
         ];
     }
 

--- a/src/Http/Controllers/CP/Auth/WebAuthnController.php
+++ b/src/Http/Controllers/CP/Auth/WebAuthnController.php
@@ -2,19 +2,13 @@
 
 namespace Statamic\Http\Controllers\CP\Auth;
 
-use Exception;
+use Cose\Algorithm\Manager;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Algorithm\Signature\RSA\RS256;use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Statamic\Facades\User;
-use Webauthn\AuthenticatorAssertionResponse;
-use Webauthn\AuthenticatorAssertionResponseValidator;
-use Webauthn\AuthenticatorAttestationResponse;
-use Webauthn\AuthenticatorAttestationResponseValidator;
-use Webauthn\PublicKeyCredentialCreationOptions;
-use Webauthn\PublicKeyCredentialLoader;
-use Webauthn\PublicKeyCredentialRequestOptions;
-use Webauthn\PublicKeyCredentialRpEntity;
-use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn;
 
 class WebAuthnController
 {
@@ -24,34 +18,46 @@ class WebAuthnController
             throw new Exception('You must be logged in');
         }
 
-        $userEntity = PublicKeyCredentialUserEntity::create(
+        if (! $challenge = session()->pull('webauthn.challenge')) {
+            $challenge = random_bytes(16);
+            session()->put('webauthn.challenge', $challenge);
+        }
+
+        $userEntity = Webauthn\PublicKeyCredentialUserEntity::create(
             $user->email(),
             $user->id(),
             $user->name()
         );
 
-        return PublicKeyCredentialCreationOptions::create(
+        return Webauthn\PublicKeyCredentialCreationOptions::create(
             $this->rpEntity(),
             $userEntity,
-            random_bytes(16),
+            $challenge,
         );
     }
 
     public function create(Request $request)
     {
         // https://webauthn-doc.spomky-labs.com/pure-php/authenticator-registration#creation-response
+        $publicKeyCredential = $this->credentialLoader()->loadArray($request->all());
 
-        $publicKeyCredential = (new PublicKeyCredentialLoader())->load($request->getContent());
-
-        if (! $publicKeyCredential->response instanceof AuthenticatorAttestationResponse) {
+        if (! $publicKeyCredential->response instanceof Webauthn\AuthenticatorAttestationResponse) {
             throw new Exception('Invalid credentials'); // maybe redirect back with errors?
         }
 
         try {
-            $publicKeyCredentialSource = (new AuthenticatorAttestationResponseValidator)->check(
+            $responseValidator = Webauthn\AuthenticatorAttestationResponseValidator::create(
+                $this->attestationSupportManager(),
+                null,
+                null,
+                Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler::create()
+            );
+
+            $publicKeyCredentialSource = $responseValidator->check(
                 $publicKeyCredential->response,
                 $this->createOptions(),
-                config('statamic.webauthn.rrp_entity.id', config('app.url'))
+                $request->getHost(),
+                config('statamic.webauthn.rrp_entity.id', [])
             );
         } catch (Exception $e) {
             throw new Exception('Invalid credentials'); // maybe redirect back with errors?
@@ -69,9 +75,9 @@ class WebAuthnController
 
     public function verifyOptions()
     {
-        return PublicKeyCredentialRequestOptions::create(
+        return Webauthn\PublicKeyCredentialRequestOptions::create(
             random_bytes(32),
-            userVerification: PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_REQUIRED
+            userVerification: Webauthn\PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_REQUIRED
         );
     }
 
@@ -79,9 +85,9 @@ class WebAuthnController
     {
         // https://webauthn-doc.spomky-labs.com/pure-php/authenticate-your-users#response-verification
 
-        $publicKeyCredential = (new PublicKeyCredentialLoader())->load($request->getContent());
+        $publicKeyCredential = $this->credentialLoader()->load($request->getContent());
 
-        if (! $publicKeyCredential->response instanceof AuthenticatorAssertionResponse) {
+        if (! $publicKeyCredential->response instanceof Webauthn\AuthenticatorAssertionResponse) {
             throw new Exception('Invalid credentials'); // maybe redirect back with errors?
         }
 
@@ -93,11 +99,25 @@ class WebAuthnController
         }
 
         try {
-            $publicKeyCredentialSource = (new AuthenticatorAssertionResponseValidator)->check(
+            $algorithmManager = Manager::create()
+                ->add(
+                    ES256::create(),
+                    RS256::create()
+                )
+            ;
+
+            $responseValidator = Webauthn\AuthenticatorAssertionResponseValidator::create(
+                null,
+                null,
+                Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler::create(),
+                $algorithmManager
+            );
+
+            $publicKeyCredentialSource = $responseValidator->check(
                 $passkey,
                 $publicKeyCredential->response,
                 $this->verifyOptions(),
-                config('statamic.webauthn.rrp_entity.id', config('app.url'))
+                config('statamic.webauthn.rrp_entity.id', [])
             );
         } catch (Exception $e) {
             throw new Exception('Invalid credentials'); // maybe redirect back with errors?
@@ -110,14 +130,31 @@ class WebAuthnController
 
     public function view()
     {
-        throw new Exception('Show a list of the users existing passkeys, with revoke option and the ability to let them create a new one');
+        return view('statamic::users.webauthn', [
+            'passkeys' => [],
+        ]);
     }
 
-    private function rpEntity(): PublicKeyCredentialRpEntity
+    private function attestationSupportManager(): Webauthn\AttestationStatement\AttestationStatementSupportManager
     {
-        return PublicKeyCredentialRpEntity::create(
+        $attestationStatementSupportManager = Webauthn\AttestationStatement\AttestationStatementSupportManager::create();
+        $attestationStatementSupportManager->add(Webauthn\AttestationStatement\NoneAttestationStatementSupport::create());
+
+        return $attestationStatementSupportManager;
+    }
+
+    private function credentialLoader(): Webauthn\PublicKeyCredentialLoader
+    {
+        $attestationObjectLoader = Webauthn\AttestationStatement\AttestationObjectLoader::create($this->attestationSupportManager());
+
+        return Webauthn\PublicKeyCredentialLoader::create($attestationObjectLoader);
+    }
+
+    private function rpEntity(): Webauthn\PublicKeyCredentialRpEntity
+    {
+        return Webauthn\PublicKeyCredentialRpEntity::create(
             name: config('statamic.webauthn.rrp_entity.name', config('app.name')),
-            id: config('statamic.webauthn.rrp_entity.id', config('app.url')),
+            id: config('statamic.webauthn.rrp_entity.id', null),
         );
     }
 

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -21,7 +21,7 @@ class AppServiceProvider extends ServiceProvider
 
     protected $configFiles = [
         'antlers', 'api', 'assets', 'autosave', 'cp', 'editions', 'forms', 'git', 'graphql', 'live_preview', 'markdown', 'oauth', 'protect', 'revisions',
-        'routes', 'search', 'static_caching', 'sites', 'stache', 'system', 'users',
+        'routes', 'search', 'static_caching', 'sites', 'stache', 'system', 'users', 'webauthn',
     ];
 
     public function boot()

--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -11,6 +11,7 @@ use Statamic\Auth\Permissions;
 use Statamic\Auth\Protect\ProtectorManager;
 use Statamic\Auth\UserProvider;
 use Statamic\Auth\UserRepositoryManager;
+use Statamic\Contracts\Auth\PasskeyRepository;
 use Statamic\Contracts\Auth\RoleRepository;
 use Statamic\Contracts\Auth\UserGroupRepository;
 use Statamic\Contracts\Auth\UserRepository;
@@ -75,6 +76,10 @@ class AuthServiceProvider extends ServiceProvider
         $this->app->singleton(PermissionCache::class, function ($app) {
             return new PermissionCache;
         });
+
+        if (! $this->app->bound(PasskeyRepository::class)) {
+            \Statamic\Statamic::repository(PasskeyRepository::class, \Statamic\Auth\File\PasskeyRepository::class);
+        }
     }
 
     public function boot()

--- a/src/Stache/Indexes/Users/User.php
+++ b/src/Stache/Indexes/Users/User.php
@@ -3,7 +3,6 @@
 namespace Statamic\Stache\Indexes\Users;
 
 use Statamic\Stache\Indexes\Value;
-use Statamic\Support\Str;
 
 class User extends Value
 {

--- a/src/Stache/Indexes/Users/User.php
+++ b/src/Stache/Indexes/Users/User.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Statamic\Stache\Indexes\Users;
+
+use Statamic\Stache\Indexes\Value;
+use Statamic\Support\Str;
+
+class User extends Value
+{
+    public function getItemValue($item)
+    {
+        return $item->user()?->id();
+    }
+}

--- a/src/Stache/ServiceProvider.php
+++ b/src/Stache/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace Statamic\Stache;
 
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 use Statamic\Assets\QueryBuilder as AssetQueryBuilder;
+use Statamic\Auth\File\PasskeyQueryBuilder;
 use Statamic\Facades\File;
 use Statamic\Facades\Site;
 use Statamic\Stache\Query\EntryQueryBuilder;
@@ -30,6 +31,10 @@ class ServiceProvider extends LaravelServiceProvider
 
         $this->app->bind(AssetQueryBuilder::class, function () {
             return new AssetQueryBuilder($this->app->make(Stache::class)->store('assets'));
+        });
+
+        $this->app->bind(PasskeyQueryBuilder::class, function () {
+            return new PasskeyQueryBuilder($this->app->make(Stache::class)->store('passkeys'));
         });
     }
 

--- a/src/Stache/Stores/PasskeysStore.php
+++ b/src/Stache/Stores/PasskeysStore.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Statamic\Stache\Stores;
+
+use Statamic\Facades\Passkey;
+use Statamic\Facades\YAML;
+
+class PasskeysStore extends BasicStore
+{
+    public function key()
+    {
+        return 'passkeys';
+    }
+
+    public function makeItemFromFile($path, $contents)
+    {
+        $id = pathinfo($path, PATHINFO_FILENAME);
+        $data = YAML::file($path)->parse($contents);
+
+        return Passkey::make()
+            ->id($id)
+            ->user($data['user'])
+            ->data($data);
+    }
+}

--- a/src/Stache/Stores/PasskeysStore.php
+++ b/src/Stache/Stores/PasskeysStore.php
@@ -4,9 +4,14 @@ namespace Statamic\Stache\Stores;
 
 use Statamic\Facades\Passkey;
 use Statamic\Facades\YAML;
+use Statamic\Stache\Indexes;
 
 class PasskeysStore extends BasicStore
 {
+    protected $storeIndexes = [
+        'user' => Indexes\Users\User::class,
+    ];
+
     public function key()
     {
         return 'passkeys';


### PR DESCRIPTION
This PR adds WebAuthn/Passkey support to the CP login:

https://github.com/statamic/cms/assets/51899/97eca681-2d55-478c-8ed8-0dfd88aa796d

We make use of the following libraries for backend and front end support respectively:
https://github.com/web-auth/webauthn-lib
https://simplewebauthn.dev/docs/packages/browser/

I noticed CraftCMS have used the same libraries for their Passkey support.

The user flow is as follows:

- An already authenticated user goes to the Passkeys page (new option under user menu) where they can create or remove Passkeys.
- Once a passkey has been created (through the Browsers in-built UI) the user then has the option to login using that on the CP login page. It should 'just work'.

The changes behind the scenes are:

- There is a new webauthn config file, allow this functionality to be enabled
- There is a new passkeys stache store (inside a new passkeys folder in the users folder)
- There is a passkeys repository and query builder to allow querying of a user's passkeys

I still need to add support for eloquent stored passkeys, and the UI on the passkeys page in the CP could do with being improved by someone who has better design skills than me.

