### PR TITLE
[4.x] Fix issue with AuthServiceProvider and Laravel Octane

### DIFF
--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -48,8 +48,8 @@ class AuthServiceProvider extends ServiceProvider
             $repository = $app[UserRepositoryManager::class]->repository();
 
             foreach ($repository::bindings() as $abstract => $concrete) {
-                if (! $this->app->bound($abstract)) {
-                    $this->app->bind($abstract, $concrete);
+                if (! $app->bound($abstract)) {
+                    $app->bind($abstract, $concrete);
                 }
             }
 


### PR DESCRIPTION
While getting Statamic working with Octane in our production environments I've hit an issue with AuthServiceProvider using an old instance of the Container.

Octane appears to be working by creating single instances of ServiceProvider for a worker's lifetime but created cloned instances of the Container for each request. The binding callbacks are then re-ran for each request and given the new container instance (a clone of the original.) This even appears to happen for the first request. As such the `$this->app` will be an instance of an Container that is never used for any request but just for initial registration.

Best practice [from the docs](https://laravel.com/docs/10.x/octane#container-injection) suggests using `app()` or however from testing the `$app` parameter from the singleton callback appears to be the same instance.

I'll keep raising any other quirks I find but so far so good 👏