### PR TITLE
[4.x] Allow CP Nav to be created each request under Laravel Octane

### DIFF
--- a/src/Http/View/Composers/NavComposer.php
+++ b/src/Http/View/Composers/NavComposer.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\View\Composers;
 
 use Illuminate\View\View;
+use Statamic\Facades\Blink;
 use Statamic\Facades\CP\Nav;
 
 class NavComposer
@@ -12,10 +13,8 @@ class NavComposer
         'statamic::partials.nav-mobile',
     ];
 
-    protected static $nav;
-
     public function compose(View $view)
     {
-        $view->with('nav', self::$nav = self::$nav ?? Nav::build());
+        $view->with('nav', Blink::once('nav-composer::navigation', fn () => Nav::build()));
     }
 }


### PR DESCRIPTION
When running under Octane, most static properties should be considered static for the lifetime of the application, not just the request. With the CP NavComposer, it was stored in the class's static property, meaning switched between different sections of the CP only the first that was loaded "tree" is shown.

Switching this to use Blink allows Octane lifecycle methods to give us a fresh cache each request. I've used my best judgement for the key name, but obviously can be changed easily enough.

N.B. Just be to clear I know Statamic doesn't officially support Octane, but we're having good success with it so wanting to contribute some of the edge cases back to the project.