### PR TITLE
[4.x] Ensure unique slugs

### DIFF
--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -198,7 +198,7 @@ class CollectionEntriesStore extends ChildStore
         while (true) {
             $ext = '.'.$item->fileExtension();
             $filename = Str::beforeLast($basePath, $ext);
-            $suffix = $num ? ".$num" : '';
+            $suffix = $num ? "-$num" : '';
             $path = "{$filename}{$suffix}{$ext}";
 
             if (! $contents = File::get($path)) {

--- a/tests/Stache/Stores/EntriesStoreTest.php
+++ b/tests/Stache/Stores/EntriesStoreTest.php
@@ -213,13 +213,13 @@ class EntriesStoreTest extends TestCase
 
         $entry = Facades\Entry::make()->id('new-id')->slug('test')->collection('blog')->date('2017-07-04');
         $this->parent->store('blog')->save($entry);
-        $newPath = $this->directory.'/blog/2017-07-04.test.1.md';
+        $newPath = $this->directory.'/blog/2017-07-04.test-1.md';
         $this->assertStringEqualsFile($existingPath, $existingContents);
         $this->assertStringEqualsFile($newPath, $entry->fileContents());
 
         $anotherEntry = Facades\Entry::make()->id('another-new-id')->slug('test')->collection('blog')->date('2017-07-04');
         $this->parent->store('blog')->save($anotherEntry);
-        $anotherNewPath = $this->directory.'/blog/2017-07-04.test.2.md';
+        $anotherNewPath = $this->directory.'/blog/2017-07-04.test-2.md';
         $this->assertStringEqualsFile($existingPath, $existingContents);
         $this->assertStringEqualsFile($anotherNewPath, $anotherEntry->fileContents());
 
@@ -285,7 +285,7 @@ class EntriesStoreTest extends TestCase
     /** @test */
     public function it_keeps_the_suffix_even_if_the_suffixless_path_is_available()
     {
-        $existingPath = $this->directory.'/blog/2017-07-04.test.1.md';
+        $existingPath = $this->directory.'/blog/2017-07-04.test-1.md';
         $suffixlessPath = $this->directory.'/blog/2017-07-04.test.md';
 
         file_put_contents($existingPath, 'id: 123');


### PR DESCRIPTION
This PR provides a fix to ensure unique slugs when saving entries programmatically.

In a collection with required slugs, you will run into a validation error when trying to save an entry with a slug that already exists. However, this validation only happens when saving entries in the CP. 

If you save entries programmatically, duplicate entries will get a number appended to the filename.

```
jack-mcdade.md
jack-mcdade.1.md
jack-mcdade.2.md
```

While this ensures that we don't override existing entries, it doesn't solve the issue of duplicate slugs. Each entry now shares the same `jack-mcdade` slug. This can easily be fixed by making the delimiter slug-friendly by changing it from `.` to `-`.