### PR TITLE
[4.x] Clear permission cache

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -673,6 +673,7 @@ export default {
                 this.site = localization.handle;
                 this.localizing = false;
                 this.initialPublished = data.values.published;
+                this.readOnly = data.readOnly;
 
                 this.trackDirtyStateTimeout = setTimeout(() => this.trackDirtyState = true, 300); // after any fieldtypes do a debounced update
             })

--- a/src/Auth/File/Role.php
+++ b/src/Auth/File/Role.php
@@ -68,6 +68,8 @@ class Role extends BaseRole
 
         $this->permissions = collect($permissions);
 
+        app(PermissionCache::class)->clear();
+
         return $this;
     }
 
@@ -88,6 +90,8 @@ class Role extends BaseRole
         $this->permissions = $this->permissions
             ->diff(Arr::wrap($permission))
             ->values();
+
+        app(PermissionCache::class)->clear();
 
         return $this;
     }


### PR DESCRIPTION
The permission cache is already cleared when adding a permission with the `addPermission()` method. It should also be cleared when removing a permission with `removePermission()` or overriding existing permissions with the `permissions()` method.

My use case is this middleware, where I remove permissions based on the current site. Without this PR, the user will still have access to edit the entries, as the permissions are cached.

```php
class AuthorizeGounity
{
    public function handle(Request $request, Closure $next): Response
    {
        $site = Site::selected()->handle();

        if ($request->route()->getName() === 'statamic.cp.collections.entries.edit') {
            $id = array_last($request->segments());
            $site = Entry::find($id)->site()->handle();
        }

        if ($site === 'gounity') {
            Role::find('people')->removePermission([
                'edit people entries',
                'edit other authors people entries',
                'publish people entries',
                'publish other authors people entries'
            ]);
        }

        return $next($request);
    }
}
```

This PR also fetches `readOnly` when changing the site in an entry's sidebar. This ensures that the permissions that were set in the middleware are considered when switching sites, and not just on the initial page load.

PS: This case is really a hack around the limitations of multi-site permissions.