### PR TITLE
[4.x] Fix Link Fieldtype inside nested Bard

### DIFF
--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -119,7 +119,9 @@ export default {
             this.update(url);
         },
 
-        meta(meta) {
+        meta(meta, oldMeta) {
+            if (JSON.stringify(meta) === JSON.stringify(oldMeta)) return;
+
             this.metaChanging = true;
             this.urlValue = meta.initialUrl;
             this.option = meta.initialOption;


### PR DESCRIPTION
This pull request fixes #9238, where a Link Fieldtype would break when used in a Bard set, which is nested in a Replicator or Bard field.

For clarity, here's what the blueprint needs to look like to test:

- Bard / Replicator
  - Set
      - Bard
          - Set
              - Link

This bug was caused by our previous fix in #9189. In that fix, we started cloning the field meta to prevent the same meta being references for all link fields.

This fix subsequently caused the `meta` to technically be different, which caused the `meta` watcher to get called. We've fixed this by returning early if the contents of the "new" meta and "old" meta are the same. 

Fixes #9238.