### PR TITLE
[4.x] Corrects an issue with short interpolated variables

### DIFF
--- a/src/View/Antlers/Language/Nodes/AntlersNode.php
+++ b/src/View/Antlers/Language/Nodes/AntlersNode.php
@@ -474,7 +474,10 @@ class AntlersNode extends AbstractNode
     public function reduceParameterInterpolations(ParameterNode $param, NodeProcessor $processor, $mutateVar, $data)
     {
         if ($param->parent != null && ! empty($param->interpolations)) {
-            foreach ($param->interpolations as $interpolationVar) {
+            $parameterInterpolations = $param->interpolations;
+            rsort($parameterInterpolations);
+
+            foreach ($parameterInterpolations as $interpolationVar) {
                 if (array_key_exists($interpolationVar, $param->parent->processedInterpolationRegions)) {
                     $interpolationResult = $processor->cloneProcessor()
                         ->setData($data)

--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -914,6 +914,12 @@ class DocumentParser
             $varContent = $this->interpolatedCollisions[$content];
         }
 
+        // Forcefully rotate the initial int_ to int0 to reduce the chance of string processing collisions.
+        if ($varContent == 'int_') {
+            $varContent = 'int0';
+            $this->interpolationRegions['int_'] = -1;
+        }
+
         $newLen = mb_strlen($varContent);
         $origLen = mb_strlen($content);
 

--- a/tests/Antlers/Runtime/ParametersTest.php
+++ b/tests/Antlers/Runtime/ParametersTest.php
@@ -308,4 +308,30 @@ EOT;
 
         $this->assertSame('0:123', $this->renderString($template, [], true));
     }
+
+    public function test_short_tag_parameters_do_not_cause_collisions()
+    {
+        (new class extends Tags
+        {
+            protected static $handle = 'test';
+
+            public function index()
+            {
+                return $this->params->get('param').':'.$this->params->get('param_two');
+            }
+        })::register();
+
+        $template = <<<'EOT'
+{{ test param="{id}" param_two="{other:id}" }}
+EOT;
+
+        $result = $this->renderString($template, [
+            'id' => '123',
+            'other' => [
+                'id' => '456',
+            ],
+        ], true);
+
+        $this->assertSame('123:456', $result);
+    }
 }


### PR DESCRIPTION
This PR solves an edge-case that can cause unexpected results when using string interpolations inside tag parameters (an example repo with this edge-case can be found here: https://github.com/aerni/statamic-collection-filter-bug).

At a high level, this happens when we have really short interpolations like so:

```antlers
{{ collection:events id:not="{id}" another_parameter="{another:variable}" }}

{{ /collection:events }}
```

Due to how interpolation is handled inside parameters when attempting to resolve to a string, it is possible for an unexpected value to be returned that incorporates the `another:variable` value.

This PR fixes this in two ways:

1. For parameters, the most specific replacements are handled first, continuing on to the least specific
2. The internal interpolation-variable naming system has been adjusted so that an internal variable named `int_` will no longer be produced

For # 2, this is important as it will help to reduce accidental collisions since all interpolated variable regions (`{id}` - including the `{` and `}`) longer than 4 characters will be prefixed with `int_`. For these smaller regions, the internal collision avoidance will now start at `int0` and move into `int1`, `int2`, etc. instead of `int_`, `int1`, `int2`, etc. (this will also introduce a very slight performance improvement for tags that contain a lot of small interpolations like that, but that was not the main goal with this adjustment).

