### PR TITLE
[4.x] Fix hidden fields when re-ordering Replicator/Bard sets or Grid items

### DIFF
--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -207,7 +207,30 @@ export default {
         },
 
         sorted(rows) {
+            let oldRows = this.value;
             this.update(rows);
+
+            let originalHiddenFields = this.$store.state.publish[this.storeName].hiddenFields || {};
+            let updatedHiddenFields = {};
+
+            rows.forEach((set, newIndex) => {
+                let originalIndex = oldRows.findIndex((oldSet) => oldSet._id === set._id);
+
+                Object.entries(originalHiddenFields)
+                    .filter(([key, value]) => {
+                        return key.startsWith(`${this.fieldPathPrefix || this.handle}.${originalIndex}.`)
+                    })
+                    .forEach(([key, value]) => {
+                        updatedHiddenFields[key.replace(`${this.fieldPathPrefix || this.handle}.${originalIndex}.`, `${this.fieldPathPrefix || this.handle}.${newIndex}.`)] = value;
+                    });
+            });
+
+            Object.entries(updatedHiddenFields).forEach(([key, value]) => {
+                this.$store.commit(`publish/${this.storeName}/setHiddenField`, {
+                    dottedKey: key,
+                    ...value,
+                });
+            });
         },
 
         focus() {

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -193,7 +193,30 @@ export default {
         },
 
         sorted(value) {
+            let oldValue = this.value;
             this.update(value);
+
+            let originalHiddenFields = this.storeState.hiddenFields || {};
+            let updatedHiddenFields = {};
+
+            value.forEach((set, newIndex) => {
+                let originalIndex = oldValue.findIndex((oldSet) => oldSet._id === set._id);
+
+                Object.entries(originalHiddenFields)
+                    .filter(([key, value]) => {
+                        return key.startsWith(`${this.fieldPathPrefix || this.handle}.${originalIndex}.`)
+                    })
+                    .forEach(([key, value]) => {
+                        updatedHiddenFields[key.replace(`${this.fieldPathPrefix || this.handle}.${originalIndex}.`, `${this.fieldPathPrefix || this.handle}.${newIndex}.`)] = value;
+                    });
+            });
+
+            Object.entries(updatedHiddenFields).forEach(([key, value]) => {
+                this.$store.commit(`publish/${this.storeName}/setHiddenField`, {
+                    dottedKey: key,
+                    ...value,
+                });
+            });
         },
 
         addSet(handle, index) {


### PR DESCRIPTION
This pull request attempts to fix an issue where the `hiddenFields` state in the Vuex store wasn't updated when Replicator/Bard sets were re-ordered or when Grid items were re-ordered.

Now, when re-ordering takes place in these fieldtypes, they'll react and update the relevant hidden fields in Vuex.

I've tested this in a few situations and it *seems* to be working but there's very possibly still some edge cases where things don't work as expected.

Fixes #8677.