### PR TITLE
[4.x] Ensure error message is displayed when uploading large file

### DIFF
--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -176,7 +176,14 @@ export default {
             const id = upload.id;
 
             upload.instance.upload().then(response => {
-                const json = JSON.parse(response.data);
+                let json = null;
+
+                try {
+                    json = JSON.parse(response.data);
+                } catch (error) {
+                    // If it fails, it's probably because the response is HTML.
+                }
+
                 response.status === 200
                     ? this.handleUploadSuccess(id, json)
                     : this.handleUploadError(id, status, json);
@@ -190,7 +197,7 @@ export default {
 
         handleUploadError(id, status, response) {
             const upload = this.findUpload(id);
-            let msg = response.message;
+            let msg = response?.message;
             if (! msg) {
                 if (status === 413) {
                     msg = __('Upload failed. The file is larger than is allowed by your server.');


### PR DESCRIPTION
Sometimes, when you upload a file which is larger than PHP's file size limit, you'll get an error from Nginx (or Apache) which isn't a JSON response.

Because it's not a JSON response, `JSON.parse` errors out before we can display a useful error message to the user. This PR handles that situation.


