### PR TITLE
[4.x] Allow revision history date and time formats to be chosen

### DIFF
--- a/config/revisions.php
+++ b/config/revisions.php
@@ -27,4 +27,17 @@ return [
 
     'path' => storage_path('statamic/revisions'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Date format
+    |--------------------------------------------------------------------------
+    |
+    | This is the date and time format used to display months in the revision
+    | history panel. See: https://momentjs.com/docs/#/displaying/format
+    |
+    */
+
+    'history_date_format' => 'LL',
+    'history_time_format' => 'LT',
+
 ];

--- a/resources/js/components/revision-history/History.vue
+++ b/resources/js/components/revision-history/History.vue
@@ -25,7 +25,7 @@
                 v-for="group in revisions"
                 :key="group.day"
             >
-                <h6 class="revision-date" v-text="$moment.unix(group.day).isBefore($moment().startOf('day')) ? $moment.unix(group.day).format('LL') : __('Today')" />
+                <h6 class="revision-date" v-text="$moment.unix(group.day).isBefore($moment().startOf('day')) ? $moment.unix(group.day).format(Statamic.$config.get('revisionHistoryDateFormat') ?? 'LL') : __('Today')" />
                 <div class="revision-list">
                     <revision
                         v-for="revision in group.revisions"

--- a/resources/js/components/revision-history/Revision.vue
+++ b/resources/js/components/revision-history/Revision.vue
@@ -16,7 +16,7 @@
                 <div class="flex-1">
                     <div class="revision-author text-gray-700 text-2xs">
                         <template v-if="revision.user">{{ revision.user.name || revision.user.email }} &ndash;</template>
-                        {{ date.isBefore($moment().startOf('day')) ? date.format('LT') : date.fromNow() }}
+                        {{ date.isBefore($moment().startOf('day')) ? date.format(Statamic.$config.get('revisionHistoryTimeFormat') ?? 'LT') : date.fromNow() }}
                     </div>
                 </div>
 

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -69,6 +69,8 @@ class JavascriptComposer
             'permissions' => $this->permissions($user),
             'hasLicenseBanner' => $licenses->invalid() || $licenses->requestFailed(),
             'customSvgIcons' => Icon::getCustomSvgIcons(),
+            'revisionHistoryDateFormat' => config('statamic.revisions.history_date_format'),
+            'revisionHistoryTimeFormat' => config('statamic.revisions.history_time_format'),
         ];
     }
 


### PR DESCRIPTION
This PR presents a possible solution to the issue highlighted in https://github.com/statamic/cms/issues/2508, where the moment localised date (and likely time) formats are not what the end user would want to see.

This is resolved by allowing the date and time formats in the revision panel to be specified in new config variables.

Closes https://github.com/statamic/cms/issues/2508