### PR TITLE
[4.x] Prevent updating a term slug from creating two stache terms

### DIFF
--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -93,23 +93,9 @@ class TermRepository implements RepositoryContract
 
     public function save($term)
     {
-        $store = $this->store->store($term->taxonomyHandle());
-
-        if (($originalSlug = $term->getOriginal('slug')) && $originalSlug != $term->slug()) {
-            foreach ($term->localizations() as $item) {
-                $key = $item->locale().'::'.$originalSlug;
-                $store->forgetItem($key);
-                $store->resolveIndexes()->filter->isCached()->each->forgetItem($key);
-            }
-
-            // we need to call sync original here so the original values are saved to the stache
-            // otherwise the slug code above only works on the first slug change, not subsequent ones
-            // we clone it so as not to affect the original term passed to this function
-            $term = clone $term;
-            $term->syncOriginal();
-        }
-
-        $store->save($term);
+        $this->store
+            ->store($term->taxonomyHandle())
+            ->save($term);
     }
 
     public function delete($term)

--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -101,11 +101,13 @@ class TermRepository implements RepositoryContract
                 $store->forgetItem($key);
                 $store->resolveIndexes()->filter->isCached()->each->forgetItem($key);
             }
-        }
 
-        // we need to call sync original here so the original values are saved to the stache
-        // otherwise the slug code above only works on the first slug change, not subsequent ones
-        $term->syncOriginal();
+            // we need to call sync original here so the original values are saved to the stache
+            // otherwise the slug code above only works on the first slug change, not subsequent ones
+            // we clone it so as not to affect the original term passed to this function
+            $term = clone $term;
+            $term->syncOriginal();
+        }
 
         $store->save($term);
     }

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -197,6 +197,21 @@ class TaxonomyTermsStore extends ChildStore
         }
     }
 
+    public function delete($term)
+    {
+        $this->deleteItemFromDisk($term);
+
+        foreach ($term->localizations() as $item) {
+            $key = $this->getItemKey($item);
+
+            $this->forgetItem($key);
+
+            $this->forgetPath($key);
+
+            $this->resolveIndexes()->filter->isCached()->each->forgetItem($key);
+        }
+    }
+
     protected function getItemFromModifiedPath($path)
     {
         return parent::getItemFromModifiedPath($path)->localizations()->all();

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -185,7 +185,7 @@ class TaxonomyTermsStore extends ChildStore
         // Since we store terms by slug, if the slug changes it's technically
         // a completely new term, and we'll need to delete the existing one.
         if (($originalSlug = $term->getOriginal('slug')) && $originalSlug != $term->slug()) {
-            $existing = Term::find($term->taxonomyHandle().'::'.$term->getOriginal('slug'));
+            $existing = Term::find($term->taxonomyHandle().'::'.$originalSlug);
             $this->delete($existing->term());
         }
 


### PR DESCRIPTION
This PR adds some logic to the stache terms store to handle the issue that when a slug is updated it adds a second stache entry until stache:clear is called.

This issue only appears in terms as they are indexed by slug, rather than a unique id.

Closes https://github.com/statamic/cms/issues/5449