### PR TITLE
[4.x] Use the site locale when auto generated titles

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -8,6 +8,7 @@ use Facades\Statamic\Entries\InitiatorStack;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Traits\Localizable;
 use LogicException;
 use Statamic\Contracts\Auth\Protect\Protectable;
 use Statamic\Contracts\Data\Augmentable;
@@ -53,7 +54,7 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableValues, Contract, Localization, Protectable, ResolvesValuesContract, Responsable, SearchableContract
 {
-    use ContainsComputedData, ContainsData, ExistsAsFile, FluentlyGetsAndSets, HasAugmentedInstance, Publishable, Revisable, Searchable, TracksLastModified, TracksQueriedColumns, TracksQueriedRelations;
+    use ContainsComputedData, ContainsData, ExistsAsFile, FluentlyGetsAndSets, HasAugmentedInstance, Localizable, Publishable, Revisable, Searchable, TracksLastModified, TracksQueriedColumns, TracksQueriedRelations;
 
     use HasOrigin {
         value as originValue;
@@ -926,7 +927,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
 
         // Since the slug is generated from the title, we'll avoid augmenting
         // the slug which could result in an infinite loop in some cases.
-        $title = (string) Antlers::parse($format, $this->augmented()->except('slug')->all());
+        $title = $this->withLocale($this->site()->locale(), fn () => (string) Antlers::parse($format, $this->augmented()->except('slug')->all()));
 
         return trim($title);
     }


### PR DESCRIPTION
When using dates in auto generated titles with a user whose selected locale is different from the site locale they are editing, the antlers parser will use the user's locale rather than the site locale.

This PR ensures we are using the right locale to generate the dates.

Closes https://github.com/statamic/cms/issues/6966