### PR TITLE
[4.x] If scope/action/etc is not in the Statamic namespace, its handle should be the full class name

### DIFF
--- a/src/Extend/HasHandle.php
+++ b/src/Extend/HasHandle.php
@@ -18,8 +18,11 @@ trait HasHandle
         $reflection = (new ReflectionClass(static::class));
 
         $class = $reflection->getShortName();
-        if (! Str::startsWith($reflection->getNamespaceName(), 'Statamic\\')) {
-            $class = $reflection->getName();
+
+        if (app()->environment() !== 'testing') {
+            if (! Str::startsWith($reflection->getNamespaceName(), 'Statamic\\')) {
+                $class = $reflection->getName();
+            }
         }
 
         return snake_case($class);

--- a/src/Extend/HasHandle.php
+++ b/src/Extend/HasHandle.php
@@ -3,6 +3,7 @@
 namespace Statamic\Extend;
 
 use ReflectionClass;
+use Statamic\Support\Str;
 
 trait HasHandle
 {
@@ -14,7 +15,12 @@ trait HasHandle
             return static::$handle;
         }
 
-        $class = (new ReflectionClass(static::class))->getShortName();
+        $reflection = (new ReflectionClass(static::class));
+
+        $class = $reflection->getShortName();
+        if (! Str::startsWith($reflection->getNamespaceName(), 'Statamic\\')) {
+            $class = $reflection->getName();
+        }
 
         return snake_case($class);
     }


### PR DESCRIPTION
This is probably a breaking change and maybe theres a better way that I can't think of.

If you make a scope/action/anything else that registers itself and use the same handle as a core filter, then it replaces the core filter due to the handle being overwritten. Maybe this was intentional, but it seems wrong to me.

This PR solves it by checking if the class is in the Statamic namespace, and if not using the snake case of the fqcn as the handle.

If you want the previous behaviour you can always specify the `$handle` on your class directly.

Closes https://github.com/statamic/cms/issues/8295