### PR TITLE
[4.x] Always use the scope facade and allow removing of scopes

### DIFF
--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource as Resource;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Statamic\CP\Column;
+use Statamic\Facades\Scope;
 use Statamic\Fields\Fieldtype;
 
 abstract class Relationship extends Fieldtype
@@ -327,7 +328,7 @@ abstract class Relationship extends Fieldtype
     protected function applyIndexQueryScopes($query, $params)
     {
         collect(Arr::wrap($this->config('query_scopes')))
-            ->map(fn ($handle) => app('statamic.scopes')->get($handle))
+            ->map(fn ($handle) => Scope::find($handle))
             ->filter()
             ->each(fn ($class) => app($class)->apply($query, $params));
     }

--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -330,6 +330,6 @@ abstract class Relationship extends Fieldtype
         collect(Arr::wrap($this->config('query_scopes')))
             ->map(fn ($handle) => Scope::find($handle))
             ->filter()
-            ->each(fn ($class) => app($class)->apply($query, $params));
+            ->each(fn ($scope) => $scope->apply($query, $params));
     }
 }

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -118,6 +118,6 @@ class BrowserController extends CpController
         collect(Arr::wrap($params['queryScopes'] ?? null))
             ->map(fn ($handle) => Scope::find($handle))
             ->filter()
-            ->each(fn ($class) => app($class)->apply($query, $params));
+            ->each(fn ($scope) => $scope->apply($query, $params));
     }
 }

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
 use Statamic\Exceptions\AuthorizationException;
 use Statamic\Facades\Asset;
+use Statamic\Facades\Scope;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Resources\CP\Assets\FolderAssetsCollection;
@@ -115,7 +116,7 @@ class BrowserController extends CpController
     protected function applyQueryScopes($query, $params)
     {
         collect(Arr::wrap($params['queryScopes'] ?? null))
-            ->map(fn ($handle) => app('statamic.scopes')->get($handle))
+            ->map(fn ($handle) => Scope::find($handle))
             ->filter()
             ->each(fn ($class) => app($class)->apply($query, $params));
     }

--- a/src/Query/Scopes/ScopeRepository.php
+++ b/src/Query/Scopes/ScopeRepository.php
@@ -36,6 +36,5 @@ class ScopeRepository
     public function remove(string $handle)
     {
         $this->removed[] = $handle;
-
     }
 }

--- a/src/Query/Scopes/ScopeRepository.php
+++ b/src/Query/Scopes/ScopeRepository.php
@@ -36,5 +36,7 @@ class ScopeRepository
     public function remove(string $handle)
     {
         $this->removed[] = $handle;
+
+        return $this;
     }
 }

--- a/src/Query/Scopes/ScopeRepository.php
+++ b/src/Query/Scopes/ScopeRepository.php
@@ -17,11 +17,25 @@ class ScopeRepository
 
     public function find($key, $context = [])
     {
-        if ($scope = app('statamic.scopes')->get($key)) {
-            if (! in_array($scope->handle(), $this->removed)) {
-                return app($scope)?->context($context);
-            }
+        if (in_array($key, $this->removed)) {
+            return;
         }
+
+        if (! $scope = app('statamic.scopes')->get($key)) {
+            return;
+        }
+
+        $scope = app($scope);
+
+        if (! $scope) {
+            return;
+        }
+
+        if (! method_exists($scope, 'context')) {
+            return $scope;
+        }
+
+        return $scope->context($context);
     }
 
     public function filters($key, $context = [])

--- a/src/Query/Scopes/ScopeRepository.php
+++ b/src/Query/Scopes/ScopeRepository.php
@@ -4,10 +4,13 @@ namespace Statamic\Query\Scopes;
 
 class ScopeRepository
 {
+    private $removed = [];
+
     public function all()
     {
         return app('statamic.scopes')
             ->map(fn ($class) => app($class))
+            ->reject(fn ($class) => in_array($class->handle(), $this->removed))
             ->filter()
             ->values();
     }
@@ -15,7 +18,9 @@ class ScopeRepository
     public function find($key, $context = [])
     {
         if ($scope = app('statamic.scopes')->get($key)) {
-            return app($scope)?->context($context);
+            if (! in_array($scope->handle(), $this->removed)) {
+                return app($scope)?->context($context);
+            }
         }
     }
 
@@ -26,5 +31,11 @@ class ScopeRepository
             ->each->context($context)
             ->filter->visibleTo($key)
             ->values();
+    }
+
+    public function remove(string $handle)
+    {
+        $this->removed[] = $handle;
+
     }
 }

--- a/src/Tags/Concerns/QueriesScopes.php
+++ b/src/Tags/Concerns/QueriesScopes.php
@@ -14,8 +14,7 @@ trait QueriesScopes
                 return Scope::find($handle);
             })
             ->filter()
-            ->each(function ($class) use ($query) {
-                $scope = app($class);
+            ->each(function ($scope) use ($query) {
                 $scope->apply($query, $this->params);
             });
     }

--- a/src/Tags/Concerns/QueriesScopes.php
+++ b/src/Tags/Concerns/QueriesScopes.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Tags\Concerns;
 
+use Statamic\Facades\Scope;
 use Statamic\Support\Arr;
 
 trait QueriesScopes
@@ -10,7 +11,7 @@ trait QueriesScopes
     {
         $this->parseQueryScopes()
             ->map(function ($handle) {
-                return app('statamic.scopes')->get($handle);
+                return Scope::find($handle);
             })
             ->filter()
             ->each(function ($class) use ($query) {


### PR DESCRIPTION
Inspired by the conversation in https://github.com/statamic/cms/pull/9058

This PR ensures the Scope facade is always used (instead of calling app.scopes directly) and also provides a way of removing scopes (`Facades\Scope::remove($handle)`).