### PR TITLE
[4.x] Prevent users without "edit" permission editing navs 

### DIFF
--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -8,7 +8,7 @@
             <div class="flex items-center">
                 <h1 class="flex-1" v-text="__(title)" />
 
-                <dropdown-list v-if="$slots.twirldown" class="mr-2">
+                <dropdown-list v-if="editable" class="mr-2">
                     <slot name="twirldown" />
                 </dropdown-list>
 
@@ -22,7 +22,7 @@
                     @input="siteSelected"
                 />
 
-                <dropdown-list :disabled="! hasCollections">
+                <dropdown-list v-if="canEdit" :disabled="! hasCollections">
                     <template #trigger>
                         <button
                             class="btn"
@@ -38,6 +38,7 @@
                 </dropdown-list>
 
                 <button
+                    v-if="canEdit"
                     class="btn-primary ml-4"
                     :class="{ 'disabled': !changed }"
                     :disabled="!changed"
@@ -55,6 +56,7 @@
             :expects-root="expectsRoot"
             :site="site"
             :preferences-prefix="preferencesPrefix"
+            :editable="canEdit"
             @edit-page="editPage"
             @changed="changed = true; targetParent = null;"
             @saved="treeSaved"
@@ -101,7 +103,7 @@
                 <svg-icon v-if="isTextBranch(branch)" class="inline-block w-4 h-4 text-gray-500" name="light/file-text" v-tooltip="__('Text')" />
             </template>
 
-            <template #branch-options="{ branch, removeBranch, orphanChildren, vm, depth }">
+            <template v-if="canEdit" #branch-options="{ branch, removeBranch, orphanChildren, vm, depth }">
                 <dropdown-item
                     v-if="isEntryBranch(branch)"
                     :text="__('Edit Entry')"
@@ -138,6 +140,7 @@
             :publish-info="publishInfo[editingPage.page.id]"
             :blueprint="blueprint"
             :handle="handle"
+            :read-only="!canEdit"
             @publish-info-updated="updatePublishInfo"
             @localized-fields-updated="updateLocalizedFields"
             @closed="closePageEditor"
@@ -150,6 +153,7 @@
             :site="site"
             :blueprint="blueprint"
             :handle="handle"
+            :read-only="!canEdit"
             @publish-info-updated="updatePendingCreatedPagePublishInfo"
             @localized-fields-updated="updatePendingCreatedPageLocalizedFields"
             @closed="closePageCreator"
@@ -197,7 +201,8 @@ export default {
         expectsRoot: { type: Boolean, required: true },
         site: { type: String, required: true },
         sites: { type: Array, required: true },
-        blueprint: { type: Object, required: true }
+        blueprint: { type: Object, required: true },
+        canEdit: { type: Boolean, required: true }
     },
 
     data() {

--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -8,7 +8,7 @@
             <div class="flex items-center">
                 <h1 class="flex-1" v-text="__(title)" />
 
-                <dropdown-list class="mr-2">
+                <dropdown-list v-if="$slots.twirldown" class="mr-2">
                     <slot name="twirldown" />
                 </dropdown-list>
 

--- a/resources/js/components/structures/Branch.vue
+++ b/resources/js/components/structures/Branch.vue
@@ -1,7 +1,7 @@
 <template>
 
     <div class="flex">
-        <slot name="branch-action" :branch="page">
+        <slot name="branch-action" :branch="page" v-if="editable">
             <div class="page-move w-6" />
         </slot>
         <div class="flex items-center flex-1 p-2 ml-2 text-xs leading-normal">

--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -37,11 +37,11 @@
                             <loading-graphic text="" />
                         </div>
 
-
                         <publish-sections
                             :sections="adjustedBlueprint.tabs[0].sections"
                             :syncable="type == 'entry'"
                             :syncable-fields="syncableFields"
+                            :read-only="readOnly"
                             @updated="setFieldValue"
                             @meta-updated="setFieldMeta"
                             @synced="syncField"
@@ -54,8 +54,8 @@
 
             </div>
 
-            <div v-if="!loading" class="bg-gray-200 p-4 border-t flex items-center justify-between flex-row-reverse">
-                <div>
+            <div v-if="!loading && (!readOnly || type === 'entry')" class="bg-gray-200 p-4 border-t flex items-center justify-between flex-row-reverse">
+                <div v-if="!readOnly">
                     <button @click="confirmClose(close)" class="btn mr-2">{{ __('Cancel') }}</button>
                     <button @click="submit" class="btn-primary">{{ __('Submit') }}</button>
                 </div>
@@ -65,7 +65,6 @@
                         {{ __('Edit Entry') }}
                     </a>
                 </div>
-
             </div>
 
         </div>
@@ -84,7 +83,8 @@ export default {
         blueprint: Object,
         handle: String,
         editEntryUrl: String,
-        creating: Boolean
+        creating: Boolean,
+        readOnly: Boolean,
     },
 
     data() {

--- a/resources/views/navigation/show.blade.php
+++ b/resources/views/navigation/show.blade.php
@@ -3,6 +3,7 @@
 @section('title', Statamic::crumb($nav->title(), 'Navigation'))
 
 @section('content')
+
     <navigation-view
         title="{{ $nav->title() }}"
         handle="{{ $nav->handle() }}"
@@ -16,16 +17,16 @@
         :max-depth="{{ $nav->maxDepth() ?? 'Infinity' }}"
         :expects-root="{{ $str::bool($expectsRoot) }}"
         :blueprint="{{ json_encode($blueprint) }}"
+        :can-edit="{{ Statamic\Support\Str::bool($user->can('edit', $nav)) }}"
     >
-        @if(Auth::user()->can('edit', $nav) || Auth::user()->can('configure fields'))
-            <template #twirldown>
-                @can('edit', $nav)
-                    <dropdown-item :text="__('Edit Navigation')" redirect="{{ $nav->editUrl() }}"></dropdown-item>
-                @endcan
-                @can('configure fields')
-                    <dropdown-item :text="__('Edit Blueprint')" redirect="{{ cp_route('navigation.blueprint.edit', $nav->handle()) }}"></dropdown-item>
-                @endcan
-            </template>
-        @endif
+        <template #twirldown>
+            @can('edit', $nav)
+                <dropdown-item :text="__('Edit Navigation')" redirect="{{ $nav->editUrl() }}"></dropdown-item>
+            @endcan
+            @can('configure fields')
+                <dropdown-item :text="__('Edit Blueprint')" redirect="{{ cp_route('navigation.blueprint.edit', $nav->handle()) }}"></dropdown-item>
+            @endcan
+        </template>
     </navigation-view>
+
 @endsection

--- a/resources/views/navigation/show.blade.php
+++ b/resources/views/navigation/show.blade.php
@@ -3,7 +3,6 @@
 @section('title', Statamic::crumb($nav->title(), 'Navigation'))
 
 @section('content')
-
     <navigation-view
         title="{{ $nav->title() }}"
         handle="{{ $nav->handle() }}"
@@ -18,14 +17,15 @@
         :expects-root="{{ $str::bool($expectsRoot) }}"
         :blueprint="{{ json_encode($blueprint) }}"
     >
-        <template #twirldown>
-            @can('edit', $nav)
-                <dropdown-item :text="__('Edit Navigation')" redirect="{{ $nav->editUrl() }}"></dropdown-item>
-            @endcan
-            @can('configure fields')
-                <dropdown-item :text="__('Edit Blueprint')" redirect="{{ cp_route('navigation.blueprint.edit', $nav->handle()) }}"></dropdown-item>
-            @endcan
-        </template>
+        @if(Auth::user()->can('edit', $nav) || Auth::user()->can('configure fields'))
+            <template #twirldown>
+                @can('edit', $nav)
+                    <dropdown-item :text="__('Edit Navigation')" redirect="{{ $nav->editUrl() }}"></dropdown-item>
+                @endcan
+                @can('configure fields')
+                    <dropdown-item :text="__('Edit Blueprint')" redirect="{{ cp_route('navigation.blueprint.edit', $nav->handle()) }}"></dropdown-item>
+                @endcan
+            </template>
+        @endif
     </navigation-view>
-
 @endsection


### PR DESCRIPTION
This pull request fixes an issue where users with the "view ... nav" permission could see & click on things that are only intended to be shown if you have the "edit ... nav" permission.

Fixes #8184.