### PR TITLE
[4.x] Localize revision dates

### DIFF
--- a/resources/js/components/revision-history/History.vue
+++ b/resources/js/components/revision-history/History.vue
@@ -27,7 +27,7 @@
             >
                 <h6 class="revision-date" v-text="
                     $moment.unix(group.day).isBefore($moment().startOf('day'))
-                        ? $moment.unix(group.day).toDate().toLocaleDateString($config.get('locale'), { month: 'long', day: 'numeric', year: 'numeric' })
+                        ? $moment.unix(group.day).toDate().toLocaleDateString($config.get('locale').replace('_', '-'), { month: 'long', day: 'numeric', year: 'numeric' })
                         : __('Today')" />
                 <div class="revision-list">
                     <revision

--- a/resources/js/components/revision-history/History.vue
+++ b/resources/js/components/revision-history/History.vue
@@ -25,7 +25,10 @@
                 v-for="group in revisions"
                 :key="group.day"
             >
-                <h6 class="revision-date" v-text="$moment.unix(group.day).isBefore($moment().startOf('day')) ? $moment.unix(group.day).format('LL') : __('Today')" />
+                <h6 class="revision-date" v-text="
+                    $moment.unix(group.day).isBefore($moment().startOf('day'))
+                        ? $moment.unix(group.day).toDate().toLocaleDateString($config.get('locale'), { month: 'long', day: 'numeric', year: 'numeric' })
+                        : __('Today')" />
                 <div class="revision-list">
                     <revision
                         v-for="revision in group.revisions"

--- a/resources/js/components/revision-history/Revision.vue
+++ b/resources/js/components/revision-history/Revision.vue
@@ -16,7 +16,7 @@
                 <div class="flex-1">
                     <div class="revision-author text-gray-700 text-2xs">
                         <template v-if="revision.user">{{ revision.user.name || revision.user.email }} &ndash;</template>
-                        {{ date.isBefore($moment().startOf('day')) ? date.format('LT') : date.fromNow() }}
+                        {{ date.toDate().toLocaleTimeString($config.get('locale'), { hour: 'numeric', minute: '2-digit' }) }}
                     </div>
                 </div>
 

--- a/resources/js/components/revision-history/Revision.vue
+++ b/resources/js/components/revision-history/Revision.vue
@@ -16,7 +16,7 @@
                 <div class="flex-1">
                     <div class="revision-author text-gray-700 text-2xs">
                         <template v-if="revision.user">{{ revision.user.name || revision.user.email }} &ndash;</template>
-                        {{ date.toDate().toLocaleTimeString($config.get('locale'), { hour: 'numeric', minute: '2-digit' }) }}
+                        {{ date.toDate().toLocaleTimeString($config.get('locale').replace('_', '-'), { hour: 'numeric', minute: '2-digit' }) }}
                     </div>
                 </div>
 


### PR DESCRIPTION
This will localize revision dates using native JS instead of Moment.
It scraps the relative time, which isn't really important.
Closes #2508