### PR TITLE
[4.x] Fix "Update All" in search utility

### DIFF
--- a/resources/views/utilities/search.blade.php
+++ b/resources/views/utilities/search.blade.php
@@ -14,7 +14,7 @@
             <form method="POST" action="{{ cp_route('utilities.search', 'all') }}">
                 @csrf
                 @foreach (\Statamic\Facades\Search::indexes() as $index)
-                    <input type="hidden" name="indexes[]" value="{{ $index->name() }}">
+                    <input type="hidden" name="indexes[]" value="{{ $index->name() }}::{{ $index->locale() }}">
                 @endforeach
                 <button class="btn-primary">{{ __('Update All') }}</button>
             </form>


### PR DESCRIPTION
This pull request fixes an issue where the "Update All" button in the Search utility was erroring out.

The error was happening due to the locale not being appended to the indexes here:

https://github.com/statamic/cms/blob/549a8baea9646a2932fc3dca3ab58bd6d63f5ca0/resources/views/utilities/search.blade.php#L17

While it was for the singular "Update" button in the indexes loop:

https://github.com/statamic/cms/blob/549a8baea9646a2932fc3dca3ab58bd6d63f5ca0/resources/views/utilities/search.blade.php#L74

Fixes #9267.