### PR TITLE
[4.x] Removes problematic JSON directive

### DIFF
--- a/resources/views/partials/scripts.blade.php
+++ b/resources/views/partials/scripts.blade.php
@@ -15,9 +15,9 @@
 @endforeach
 
 <script>
-var StatamicConfig = @json(array_merge(Statamic::jsonVariables(request()), [
+var StatamicConfig = {!! json_encode(array_merge(Statamic::jsonVariables(request()), [
     'wrapperClass' => $__env->getSection('wrapper_class', 'max-w-xl')
-]))
+])) !!}
 </script>
 
 {{-- Deferred to allow Vite modules to load first --}}


### PR DESCRIPTION
This PR refactors away the `@json` directive that creates Statamic's `StatamicConfig` control panel object. The current implementation currently works fine on accident:

```blade
<script>
var StatamicConfig = @json(array_merge(Statamic::jsonVariables(request()), [
    'wrapperClass' => $__env->getSection('wrapper_class', 'max-w-xl')
]))
</script>
```

If we were to add another item to merge in the future (or simply add a trailing comma):

```blade
<script>
var StatamicConfig = @json(array_merge(Statamic::jsonVariables(request()), [
    'wrapperClass' => $__env->getSection('wrapper_class', 'max-w-xl'),
]))
</script>
```

the view will compile to invalid PHP code. The current version works "on accident" because the following values are used by the Blade compiler, and can take advantage of the emitted commas for the `json_encode` call:

**value**

```
array_merge(Statamic::jsonVariables(request())
```

**flags**

```

[
    'wrapperClass' => $__env->getSection('wrapper_class'
```

**depth**

```
'max-w-xl')
])
```

The remaining `@json` directives within the control panel are fine since they use simple variables.