### PR TITLE
[4.x] After updating, ensure values are updated in other publish containers for the same entry

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -573,6 +573,17 @@ export default {
                         return;
                     }
 
+                    // When saving an entry in a stack & that same entry is being edited in another publish
+                    // form, we need to update its values too.
+                    if (! this.isBase) {
+                        Object.entries(this.$store.state.publish)
+                            .filter(([key, value]) => key !== this.publishContainer)
+                            .filter(([key, value]) => value.values.id === this.values.id)
+                            .forEach(([key, value]) => {
+                                this.$store.commit(`publish/${key}/setValues`, response.data.data.values)
+                            })
+                    }
+
                     let nextAction = this.quickSave || this.isAutosave ? 'continue_editing' : this.afterSaveOption;
 
                     // If the user has opted to create another entry, redirect them to create page.


### PR DESCRIPTION
This pull request attempts to fix #3026, where you be editing Entry A, then edit Entry B in a stack, then open Entry A in another stack.

Then, when you made any changes to Entry A in the stack, those changes wouldn't make their way back to the "base" publish container for that entry.

This PR *does* fix that issue, it does mean that any changes made in the "base" publish form for Entry A will be overwritten when the same entry is saved in the stack. Maybe we should track which fields are changed, then reset the values apart from for those fields?

Fixes #3026.