### PR TITLE
[4.x] Throw 404 exception on Taxonomy Term Entries endpoint when term doesn't exist

### DIFF
--- a/src/Http/Controllers/API/TaxonomyTermEntriesController.php
+++ b/src/Http/Controllers/API/TaxonomyTermEntriesController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\API;
 
 use Facades\Statamic\API\FilterAuthorizer;
 use Facades\Statamic\API\ResourceAuthorizer;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Term;
 use Statamic\Http\Resources\API\EntryResource;
@@ -31,6 +32,8 @@ class TaxonomyTermEntriesController extends ApiController
         $this->abortIfDisabled();
 
         $term = Term::find($taxonomy.'::'.$term);
+
+        throw_unless($term, new NotFoundHttpException);
 
         $query = $term->queryEntries();
 


### PR DESCRIPTION
This pull request addresses an issue with the Taxonomy Term Entries API endpoint, where you'd receive a 500 Server Error when fetching entries for a term that doesn't exist.

The API endpoint only accepts passing slugs of terms, not titles which was why the endpoint was erroring in #4219.

This PR fixes that by throwing a 404 exception when the specified term doesn't exist.

Fixes #4219.