### PR TITLE
[4.x] Fix usage of children tag with multisite and specified url

### DIFF
--- a/src/Tags/Children.php
+++ b/src/Tags/Children.php
@@ -17,7 +17,7 @@ class Children extends Structure
      */
     public function index()
     {
-        $this->params->put('from', Str::start(Str::after(URL::getCurrent(), Site::current()->url()), '/'));
+        $this->params->put('from', Str::start(Str::after(URL::makeAbsolute(URL::getCurrent()), Site::current()->absoluteUrl()), '/'));
         $this->params->put('max_depth', 1);
 
         $collection = $this->params->get('collection', $this->context->value('collection')?->handle());


### PR DESCRIPTION
This pull request fix an issue where if you specify the site url in your multi-site you get the wrong data from the children tag on other sites.

Fixed by using the absolute url.

Fix #9279 

