### PR TITLE
[4.x] Prevent errors from invalid form submission data

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -302,7 +302,7 @@ class Form implements Arrayable, Augmentable, FormContract
                 $data = YAML::parse(File::get($file));
             } catch (ParseException $e) {
                 $data = [];
-                Log::warning('Could not parse form submission data.', ['submission' => $file]);
+                Log::warning('Could not parse form submission file: '.$file);
             }
 
             return $this->makeSubmission()

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -3,6 +3,7 @@
 namespace Statamic\Forms;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Facades\Log;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Contracts\Forms\Form as FormContract;
@@ -25,6 +26,7 @@ use Statamic\Forms\Exporters\Exporter;
 use Statamic\Statamic;
 use Statamic\Support\Arr;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
+use Statamic\Yaml\ParseException;
 
 class Form implements Arrayable, Augmentable, FormContract
 {
@@ -296,9 +298,16 @@ class Form implements Arrayable, Augmentable, FormContract
         $path = config('statamic.forms.submissions').'/'.$this->handle();
 
         return collect(Folder::getFilesByType($path, 'yaml'))->map(function ($file) {
+            try {
+                $data = YAML::parse(File::get($file));
+            } catch (ParseException $e) {
+                $data = [];
+                Log::warning("Could not parse form submission data.", ['submission' => $file]);
+            }
+
             return $this->makeSubmission()
                 ->id(pathinfo($file)['filename'])
-                ->data(YAML::parse(File::get($file)));
+                ->data($data);
         });
     }
 

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -302,7 +302,7 @@ class Form implements Arrayable, Augmentable, FormContract
                 $data = YAML::parse(File::get($file));
             } catch (ParseException $e) {
                 $data = [];
-                Log::warning("Could not parse form submission data.", ['submission' => $file]);
+                Log::warning('Could not parse form submission data.', ['submission' => $file]);
             }
 
             return $this->makeSubmission()


### PR DESCRIPTION
This pull request prevents the Control Panel from erroring out due to invalid form submission data.

Instead of an error being thrown, Statamic will load the problematic form submission without any data & append a line to your log file so you can tell there's an issue. 

Fixes #6860.
Fixes #6969.
Fixes #7775.