### PR TITLE
[4.x] Clear selections when navigating pagination

### DIFF
--- a/resources/js/components/data-list/HasPagination.js
+++ b/resources/js/components/data-list/HasPagination.js
@@ -45,10 +45,12 @@ export default {
 
         selectPage(page) {
             this.page = page;
+            this.$events.$emit('clear-selections');
         },
 
         resetPage() {
             this.page = 1;
+            this.$events.$emit('clear-selections');
         },
 
     }


### PR DESCRIPTION
This pull request fixes an issue on Listing Tables where any selections would be persisted even after navigating to another page (pagination).

This change doesn't seem to affect selections in the Relationship Fieldtype. You can continue to select items across multiple pages on there. 

Fixes #6767.