### PR TITLE
[4.x] Fix `metaPath` for root assets

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -290,7 +290,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
     {
         $path = dirname($this->path()).'/.meta/'.$this->basename().'.yaml';
 
-        return ltrim($path, '/');
+        return (string) Str::of($path)->replaceFirst('./', '')->ltrim('/');
     }
 
     protected function metaExists()


### PR DESCRIPTION
This pull request fixes an issue on the `Asset` class where the `metaPath` was returning an incorrect path for assets in the root in the asset container.

Previously, a `metaPath` would return `./.meta/default2023.jpg.yaml` for a root asset. Now, it returns: `.meta/default2023.jpg.yaml`.

This will fix an issue where the `->metaExists()` method would always return `false` for root assets. 

Fixes #6870.