### PR TITLE
[4.x] Prevent caching CP responses

### DIFF
--- a/src/Http/Middleware/CP/AddHeaders.php
+++ b/src/Http/Middleware/CP/AddHeaders.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Statamic\Http\Middleware\CP;
+
+use Closure;
+use Illuminate\Http\Response;
+
+class AddHeaders
+{
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        if ($response instanceof Response) {
+            $response->header('Cache-Control', 'no-store');
+        }
+
+        return $response;
+    }
+}

--- a/src/Providers/CpServiceProvider.php
+++ b/src/Providers/CpServiceProvider.php
@@ -84,6 +84,7 @@ class CpServiceProvider extends ServiceProvider
             \Statamic\Http\Middleware\CP\Authorize::class,
             \Statamic\Http\Middleware\CP\Localize::class,
             \Statamic\Http\Middleware\CP\SelectedSite::class,
+            \Statamic\Http\Middleware\CP\AddHeaders::class,
             \Statamic\Http\Middleware\CP\BootPermissions::class,
             \Statamic\Http\Middleware\CP\BootPreferences::class,
             \Statamic\Http\Middleware\CP\BootUtilities::class,


### PR DESCRIPTION
Closes #4814

This disables caching of control panel responses, which can become problematic when using the back/forward browser buttons.

For example:
1. Open the edit entry form.
2. Click the twirldown and choose "Edit blueprint".
3. Make a change to a field, like replacing a markdown field with a textarea.
4. Click the browser's back button.

Before this PR, the entry edit form would have been cached, and you'd see the form with the unchanged field.

After this PR, the form would not be cached, and it would be reloaded, so you'd see the form in the new (expected) state.

