### PR TITLE
[4.x] Shallow augment Control Panel user object

### DIFF
--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -96,7 +96,7 @@ class JavascriptComposer
             return [];
         }
 
-        return $user->toAugmentedCollection()->merge([
+        return $user->toShallowAugmentedCollection()->merge([
             'preferences' => Preference::all(),
             'permissions' => $user->permissions()->all(),
         ])->toArray();


### PR DESCRIPTION
While working on a separate item, I discovered it was possible to brick the Control Panel if you update the user blueprint and add a reference to another entry that also references the currently signed in user (easily done via. the `updated_by` field).

I've created a simple repository that can replicate this here: https://github.com/JohnathonKoster/statamic-control-panel-config-bug

The root cause of the issue is the `json_encode` call encountering recursive references, ultimately leading to an error and no output. When this manifests, the source of the rendered page will contain the following for the `StatamicConfig` object:

```html
<script>
   var StatamicConfig =
   </script>
```

The user will also see a page similar to the following:

<img width="683" alt="image" src="https://github.com/statamic/cms/assets/5232890/42593741-5a7b-4e34-bddb-4655b124a115">

along with the associated JavaScript errors related to `StatamicConfig` being undefined.

## Potential Breaking Change

There is the potential that this introduces a breaking change to any site that has custom Vue components relying on the `StatamicConfig` object containing additional user data. I have an alterative approach to account for this, but figured I'd attempt the simpler solution first.