### PR TITLE
[4.x] Fix creating entries with `JsonResource::withoutWrapping()`

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -407,8 +407,10 @@ class EntriesController extends CpController
             $saved = $entry->updateLastModified(User::current())->save();
         }
 
-        return (new EntryResource($entry))
-            ->additional(['saved' => $saved]);
+        return [
+            'data' => (new EntryResource($entry))->resolve()['data'],
+            'saved' => $saved,
+        ];
     }
 
     private function resolveSlug($request)


### PR DESCRIPTION
This pull request fixes an issue creating entries when using `JsonResource::withoutWrapping()` in a service provider.

I've tried to fix this in a similar way to some of the previous withoutWrapping fixes, see #7072.

Fixes #9283.