### PR TITLE
[4.x] Use correct set_time_limit no limit value

### DIFF
--- a/config/system.php
+++ b/config/system.php
@@ -108,7 +108,7 @@ return [
     */
 
     'php_memory_limit' => '-1',
-    'php_max_execution_time' => '-1',
+    'php_max_execution_time' => '0',
     'ajax_timeout' => '600000',
     'pcre_backtrack_limit' => '-1',
 


### PR DESCRIPTION
The config value for `statamic.system.php_max_execution_time` is currently set to `-1` by default. This value is then passed to `set_time_limit` to "crank things up" to eleven. The problem is though that the "no limit" value for setting the maximum execution time is `0` and not `-1` (see https://www.php.net/manual/en/function.set-time-limit.php). Apparently PHP-FPM just swallows this invalid value, but Frankenphp throws an error about receiving an incorrect value here.

The config value is only used on `set_time_limit` calls (https://github.com/search?q=repo%3Astatamic%2Fcms%20php_max_execution_time&type=code), so the default can safely be set to its correct value.