### PR TITLE
[4.x] Fix asset meta file not being deleted with asset

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -225,6 +225,10 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
             return $this->metaValue($key);
         }
 
+        if (! $this->exists()) {
+            return $this->generateMeta();
+        }
+
         if (! config('statamic.assets.cache_meta')) {
             return $this->generateMeta();
         }

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -721,6 +721,23 @@ class AssetTest extends TestCase
     }
 
     /** @test */
+    public function it_does_not_write_to_meta_file_when_asset_does_not_exist()
+    {
+        Storage::fake('test');
+
+        $container = Facades\AssetContainer::make('test')->disk('test');
+        $asset = (new Asset)->container($container)->path('foo/test.txt');
+
+        // No meta file should exist yet...
+        $this->assertFalse(Storage::disk('test')->exists('foo/.meta/test.txt.yaml'));
+
+        // Calling `meta` should return an empty meta array, but not write a meta file...
+        $meta = $asset->meta();
+        $this->assertEquals(['data' => []], $meta);
+        $this->assertFalse(Storage::disk('test')->exists('foo/.meta/test.txt.yaml'));
+    }
+
+    /** @test */
     public function it_gets_meta_path()
     {
         $asset = (new Asset)->container($this->container)->path('test.txt');

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -562,6 +562,7 @@ class AssetTest extends TestCase
     public function it_gets_the_extension_guessed_extension_and_mime_type()
     {
         Storage::fake('test');
+        Storage::disk('test')->put('foo.mp4a', '');
         Storage::disk('test')->put('.meta/foo.mp4a.yaml', YAML::dump(['mime_type' => 'audio/mp4']));
 
         $container = Facades\AssetContainer::make('test')->disk('test');
@@ -1415,6 +1416,7 @@ class AssetTest extends TestCase
     public function it_gets_no_ratio_when_height_is_zero()
     {
         Storage::fake('test');
+        Storage::disk('test')->put('image.jpg', '');
         Storage::disk('test')->put('.meta/image.jpg.yaml', YAML::dump(['width' => '30', 'height' => '0']));
 
         $container = Facades\AssetContainer::make('test')->disk('test');
@@ -2180,6 +2182,7 @@ class AssetTest extends TestCase
     /** @test */
     public function it_syncs_original_state_with_no_data_but_with_data_in_meta()
     {
+        Storage::disk('test')->put('path/to/test.txt', '');
         Storage::disk('test')->put('path/to/.meta/test.txt.yaml', "data:\n  foo: bar");
         $asset = (new Asset)->container($this->container)->path('path/to/test.txt');
 
@@ -2208,6 +2211,7 @@ class AssetTest extends TestCase
     /** @test */
     public function it_syncs_original_state_with_data()
     {
+        Storage::disk('test')->put('path/to/test.txt', '');
         $yaml = <<<'YAML'
 data:
   alfa: bravo
@@ -2249,6 +2253,7 @@ YAML;
     /** @test */
     public function it_resolves_pending_original_meta_values_when_hydrating()
     {
+        Storage::disk('test')->put('path/to/test.txt', '');
         $yaml = <<<'YAML'
 data:
   alfa: bravo


### PR DESCRIPTION
This pull request fixes an issue where an asset's `.meta` file would not be deleted when the asset itself was deleted.

Although the meta file was actually deleted, it was shortly after being re-created by the `UpdateAssetReferences` listener which calls the `getOriginal()` method on the `Asset`, which ended up calling `meta()` and because of a meta file not being found for the asset, it created one.

This PR attempts to fix that issue by checking if the asset itself actually exists before writing the meta file to disk. If one doesn't exist, it'll now just return an empty meta array.

Fixes #7042.