### PR TITLE
[4.x] Fix spacing around fullscreen button on Stacked Grid

### DIFF
--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -28,6 +28,7 @@
                 :can-delete-rows="canDeleteRows"
                 :can-add-rows="canAddRows"
                 :allow-fullscreen="config.fullscreen"
+                :hide-display="config.hide_display"
                 @updated="updated"
                 @meta-updated="updateRowMeta"
                 @removed="removed"

--- a/resources/js/components/fieldtypes/grid/Stacked.vue
+++ b/resources/js/components/fieldtypes/grid/Stacked.vue
@@ -18,7 +18,14 @@
         @dragend="$emit('blur')"
         @input="(rows) => $emit('sorted', rows)"
     >
-        <div class="grid-stacked" slot-scope="{}">
+        <div
+            class="grid-stacked"
+            :class="{
+                'mt-12': !grid.fullScreenMode && hideDisplay,
+                'mt-6': !grid.fullScreenMode && !hideDisplay,
+            }"
+            slot-scope="{}"
+        >
             <stacked-row
                 v-for="(row, index) in rows"
                 :key="`row-${row._id}`"
@@ -54,7 +61,7 @@ export default {
     components: {
         StackedRow,
         SortableList
-    }
+    },
 
 }
 </script>

--- a/resources/js/components/fieldtypes/grid/View.vue
+++ b/resources/js/components/fieldtypes/grid/View.vue
@@ -1,7 +1,7 @@
 <script>
 export default {
 
-    props: ['fields', 'rows', 'meta', 'name', 'canDeleteRows', 'canAddRows', 'allowFullscreen'],
+    props: ['fields', 'rows', 'meta', 'name', 'canDeleteRows', 'canAddRows', 'allowFullscreen', 'hideDisplay'],
 
     inject: ['grid'],
 


### PR DESCRIPTION
This pull request fixes spacing around the fullscreen button on Stacked Grid fields. This PR improves spacing both with & without the field's display being hidden.

### `hide_display: true`

![CleanShot 2024-01-11 at 15 14 34](https://github.com/statamic/cms/assets/19637309/e46331ef-1dc7-4a8d-99e1-c3a289501fa9)

### `hide_display: false`

![CleanShot 2024-01-11 at 15 14 57](https://github.com/statamic/cms/assets/19637309/60a16986-cf77-4156-ad53-11d0aefd5425)

Fixes #8748.
Replaces #9158.