### PR TITLE
[4.x] Entries Fieldtype: Fix missing checkbox on Tree Mode

### DIFF
--- a/resources/js/components/structures/Branch.vue
+++ b/resources/js/components/structures/Branch.vue
@@ -1,8 +1,8 @@
 <template>
 
     <div class="flex">
-        <slot name="branch-action" :branch="page" v-if="editable">
-            <div class="page-move w-6" />
+        <slot name="branch-action" :branch="page">
+            <div v-if="editable" class="page-move w-6" />
         </slot>
         <div class="flex items-center flex-1 p-2 ml-2 text-xs leading-normal">
             <div class="flex items-center flex-1" @click="$emit('branch-clicked', page)">


### PR DESCRIPTION
This pull request fixes an issue where you wouldn't be able to select entries while using Tree mode in the Entries Fieldtype. It was due to a `v-if` in the wrong place - introduced by #9265.

There's no issue since I just ran into it while testing something else.