### PR TITLE
[4.x] Ensure file array is correctly formatted

### DIFF
--- a/src/Stache/Stores/ContainerAssetsStore.php
+++ b/src/Stache/Stores/ContainerAssetsStore.php
@@ -81,7 +81,7 @@ class ContainerAssetsStore extends ChildStore
     private function getFiles()
     {
         return $this->container()->listContents()->reject(function ($file) {
-            return !isset($file['type'])
+            return ! isset($file['type'])
                 || $file['type'] !== 'file'
                 || $file['path'] === ''
                 || $file['dirname'] === '.meta'

--- a/src/Stache/Stores/ContainerAssetsStore.php
+++ b/src/Stache/Stores/ContainerAssetsStore.php
@@ -81,7 +81,8 @@ class ContainerAssetsStore extends ChildStore
     private function getFiles()
     {
         return $this->container()->listContents()->reject(function ($file) {
-            return $file['type'] !== 'file'
+            return !isset($file['type'])
+                || $file['type'] !== 'file'
                 || $file['path'] === ''
                 || $file['dirname'] === '.meta'
                 || Str::contains($file['path'], '/.meta/')


### PR DESCRIPTION
On a fresh install, I have this exception `Undefined array key "type"` when going to the */cp/utilities/cache* page.
I have enable the avatar field in the users blueprint.

The content of the `$files` is this:

```php
array:1 [▶
  "path" => "avatar"
]
```

Given that we do not use a DTO, we should ensure that the array structure is correct.

<img width="1111" alt="Screenshot 2024-01-12 - 16-28-35@2x" src="https://github.com/statamic/cms/assets/408237/92226525-50d2-4d39-be91-00724f6bf9eb">
