### PR TITLE
[4.x] Fix too many redirects

### DIFF
--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -574,7 +574,7 @@ class CollectionsController extends CpController
     protected function ensureCollectionIsAvailableOnSite($collection, $site)
     {
         if (Site::hasMultiple() && ! $collection->sites()->contains($site->handle())) {
-            return redirect()->back()->with('error', __('Collection is not available on site ":handle".', ['handle' => $site->handle]));
+            return redirect(cp_route('collections.index'))->with('error', __('Collection is not available on site ":handle".', ['handle' => $site->handle]));
         }
     }
 }


### PR DESCRIPTION
This PR resolves an issue with too many redirects when switching the selected site to a site that a collection is not configured for. In the example below, the `articles` collection is only configured for the `default` site. The redirect issue happens when switching to the `german` site. 

### Before Fix

https://github.com/statamic/cms/assets/23167701/4f330134-61e3-478c-9088-52f3dd62805e


### After Fix

https://github.com/statamic/cms/assets/23167701/bbd00905-feb6-4981-8b7f-4737ca2848da

