### PR TITLE
[4.x] Fix additional blueprints in multi-part namespaces

### DIFF
--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -63,10 +63,11 @@ class BlueprintRepository
     public function findNamespacedBlueprintPath($handle)
     {
         [$namespace, $handle] = explode('::', $handle);
+        $namespaceDir = str_replace('.', '/', $namespace);
         $handle = str_replace('/', '.', $handle);
         $path = str_replace('.', '/', $handle);
 
-        $overridePath = "{$this->directory}/vendor/{$namespace}/{$path}.yaml";
+        $overridePath = "{$this->directory}/vendor/{$namespaceDir}/{$path}.yaml";
 
         if (File::exists($overridePath)) {
             return $overridePath;
@@ -207,7 +208,7 @@ class BlueprintRepository
             if (isset($this->additionalNamespaces[$namespace])) {
                 $directory = $this->additionalNamespaces[$namespace];
 
-                $overridePath = "{$this->directory}/vendor/{$namespace}";
+                $overridePath = "{$this->directory}/vendor/{$namespaceDir}";
 
                 if (File::exists($overridePath)) {
                     $directory = $overridePath;

--- a/src/Http/Controllers/CP/Fields/BlueprintController.php
+++ b/src/Http/Controllers/CP/Fields/BlueprintController.php
@@ -22,7 +22,7 @@ class BlueprintController extends CpController
         $additional = Blueprint::getAdditionalNamespaces()
             ->map(function ($path, $key) {
                 return [
-                    'title' => Str::humanize($key),
+                    'title' => str_replace('.', ' ', Str::humanize($key)),
                     'blueprints' => Blueprint::in($key)
                         ->map(function ($blueprint) {
                             return [


### PR DESCRIPTION
This PR fixes a bug and makes a tweak to the new blueprint namespaces feature when using multi-part namespaces (`something.otherthing`).

The `findNamespacedBlueprintPath` and `filesIn` methods are currently using the namespace key to check the override paths rather than the namespace directory.

And the `humanize` helper doesn't replace the dots when generating titles for the listing view:

![Screenshot 2024-01-15 at 10 54 21](https://github.com/statamic/cms/assets/126740/4c961c6b-4f8a-44bf-8e7f-74cdfe353692)
