### PR TITLE
[4.x] Updating an add-on blueprint shouldnt remove it from the vendor folder

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -696,13 +696,6 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
 
     public function writeFile($path = null)
     {
-        $path = $path ?? $this->buildPath();
-        $initial = $this->path();
-
-        if ($initial && $path !== $initial) {
-            File::delete($initial);
-        }
-
-        File::put($path, $this->fileContents());
+        File::put($path ?? $this->buildPath(), $this->fileContents());
     }
 }

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -22,6 +22,7 @@ use Statamic\Events\BlueprintSaving;
 use Statamic\Exceptions\DuplicateFieldException;
 use Statamic\Facades;
 use Statamic\Facades\Blink;
+use Statamic\Facades\File;
 use Statamic\Facades\Path;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -108,6 +108,10 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
 
     public function initialPath()
     {
+        if ($this->isNamespaced()) {
+            return $this->path();
+        }
+
         return $this->initialPath;
     }
 

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -108,10 +108,6 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
 
     public function initialPath()
     {
-        if ($this->isNamespaced()) {
-            return $this->path();
-        }
-
         return $this->initialPath;
     }
 
@@ -695,5 +691,17 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
     public function toQueryableValue()
     {
         return $this->handle();
+    }
+
+    public function writeFile($path = null)
+    {
+        $path = $path ?? $this->buildPath();
+        $initial = $this->path();
+
+        if ($initial && $path !== $initial) {
+            File::delete($initial);
+        }
+
+        File::put($path, $this->fileContents());
     }
 }


### PR DESCRIPTION
It seems the line that we changed was needed, otherwise when you save a blueprint it deletes the original blueprint in the vendor folder (the root vendor folder not the blueprint/vendor folder).

Maybe theres a better way to do it, but this does solve it.