### PR TITLE
[4.x] Hide collections when selected site isn't one of the collection's configured sites

### DIFF
--- a/src/CP/Navigation/CoreNav.php
+++ b/src/CP/Navigation/CoreNav.php
@@ -16,6 +16,7 @@ use Statamic\Facades\Form as FormAPI;
 use Statamic\Facades\GlobalSet as GlobalSetAPI;
 use Statamic\Facades\Nav as NavAPI;
 use Statamic\Facades\Role as RoleAPI;
+use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
 use Statamic\Facades\Taxonomy as TaxonomyAPI;
 use Statamic\Facades\UserGroup as UserGroupAPI;
@@ -65,11 +66,13 @@ class CoreNav
             ->icon('/content-writing')
             ->can('index', Collection::class)
             ->children(function () {
-                return CollectionAPI::all()->sortBy->title()->map(function ($collection) {
-                    return Nav::item($collection->title())
-                        ->url($collection->showUrl())
-                        ->can('view', $collection);
-                });
+                return CollectionAPI::all()->sortBy->title()
+                    ->filter(fn ($collection) => $collection->sites()->contains(Site::selected()->handle()))
+                    ->map(function ($collection) {
+                        return Nav::item($collection->title())
+                            ->url($collection->showUrl())
+                            ->can('view', $collection);
+                    });
             });
 
         Nav::content('Navigation')

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -24,7 +24,8 @@ class CollectionsController extends CpController
         $this->authorize('index', CollectionContract::class, __('You are not authorized to view collections.'));
 
         $collections = Collection::all()->filter(function ($collection) {
-            return User::current()->can('view', $collection);
+            return User::current()->can('view', $collection)
+                && $collection->sites()->contains(Site::selected()->handle());
         })->map(function ($collection) {
             return [
                 'id' => $collection->handle(),


### PR DESCRIPTION
This pull request filters collections out of the CP Nav and Collections Index list when the currently selected site isn't part of the collection's list of configured sites.