### PR TITLE
[4.x] No events triggered at form if indicated in form-tag

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -40,7 +40,7 @@ class Form implements Arrayable, Augmentable, FormContract
     protected $email;
     protected $metrics;
     protected $afterSaveCallbacks = [];
-    protected $withEvents = true;
+    public $withEvents = true;
 
     /**
      * Get or set the handle.
@@ -331,8 +331,13 @@ class Form implements Arrayable, Augmentable, FormContract
      */
     public function makeSubmission()
     {
-        $submission = app(Submission::class);
 
+        $submission = app(Submission::class);
+        if(isset($_POST['_no_events'])){
+            if($_POST['_no_events'] == "no"){
+                $this->withEvents = false;
+                }
+          }
         $submission->form($this);
 
         return $submission;

--- a/src/Forms/SendEmail.php
+++ b/src/Forms/SendEmail.php
@@ -28,7 +28,10 @@ class SendEmail implements ShouldQueue
 
     public function handle()
     {
+        if($this->submission->withEvents == true){
+
         Mail::mailer($this->config['mailer'] ?? null)
             ->send(new Email($this->submission, $this->config, $this->site));
+        }
     }
 }

--- a/src/Forms/SendEmails.php
+++ b/src/Forms/SendEmails.php
@@ -23,7 +23,12 @@ class SendEmails
 
     public function handle()
     {
+
+        if($this->submission->withEvents == true){
+
         $this->jobs()->each(fn ($job) => Bus::dispatch($job));
+        }
+
     }
 
     private function jobs()

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -33,7 +33,7 @@ class Submission implements Augmentable, SubmissionContract
     public $form;
 
     protected $afterSaveCallbacks = [];
-    protected $withEvents = true;
+    public $withEvents = true;
 
     protected ?string $redirect = null;
 
@@ -145,8 +145,13 @@ class Submission implements Augmentable, SubmissionContract
     {
         $isNew = is_null($this->form()->submission($this->id()));
 
-        $withEvents = $this->withEvents;
-        $this->withEvents = true;
+        if(isset($_POST['_no_events'])){
+            if($_POST['_no_events'] == "no"){
+            $this->withEvents = false;
+            }
+          }
+      $withEvents = $this->withEvents;
+
 
         $afterSaveCallbacks = $this->afterSaveCallbacks;
         $this->afterSaveCallbacks = [];

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -21,7 +21,7 @@ class Tags extends BaseTags
         Concerns\OutputsItems,
         Concerns\RendersForms;
 
-    const HANDLE_PARAM = ['handle', 'is', 'in', 'form', 'formset'];
+    const HANDLE_PARAM = ['handle', 'is', 'in', 'form', 'formset', 'no_events'];
 
     protected static $handle = 'form';
 
@@ -69,6 +69,10 @@ class Tags extends BaseTags
 
         $data['honeypot'] = $form->honeypot();
 
+
+
+
+
         if ($jsDriver) {
             $data['js_driver'] = $jsDriver->handle();
             $data['show_field'] = $jsDriver->copyShowFieldToFormData($data['fields']);
@@ -88,6 +92,8 @@ class Tags extends BaseTags
         $action = $this->params->get('action', $form->actionUrl());
         $method = $this->params->get('method', 'POST');
 
+
+
         $attrs = [];
 
         if ($jsDriver) {
@@ -95,7 +101,7 @@ class Tags extends BaseTags
         }
 
         $params = [];
-
+        $params['no_events'] = $this->params->get('no_events');
         if ($redirect = $this->getRedirectUrl()) {
             $params['redirect'] = $this->parseRedirect($redirect);
         }
@@ -114,6 +120,7 @@ class Tags extends BaseTags
         $html = $this->formOpen($action, $method, $knownParams, $attrs);
 
         $html .= $this->formMetaFields($params);
+
 
         $html .= $this->parse($data);
 
@@ -192,6 +199,16 @@ class Tags extends BaseTags
     protected function getSortOrder()
     {
         return $this->params->get('sort', 'date');
+    }
+
+     /**
+     * Get the sort order for a collection.
+     *
+     * @return string
+     */
+    protected function getNoEvents()
+    {
+        return $this->params->get('no_events');
     }
 
     /**
@@ -364,6 +381,7 @@ class Tags extends BaseTags
 
         return $form;
     }
+
 
     public function eventUrl($url, $relative = true)
     {


### PR DESCRIPTION
So, I was facing the following the problem: I have a form defined that is used in the front-end, but sometimes an administrator needs to add a record as well. To keep everything in one place (all the submissions), you don't want to split in two forms and have it merged after then. I published the form in the back-end as well, but of course you want to prevent e-mails being send out somites if it is submitted via the back-end.

I therefore added a param to the form tag and if used with the introduced param (no_events) set to no, it will not send out events and emails, but still record the submission. It is maybe a little bit ugly, but it works as there is no other way to prevent an e-mail sent out in some cases based on where the form is shown (without changing the form itself).

While typing this, I also realized I fixed something weird I think. In case you manage to hit the function savequietly on forms / submissions, the withEvents-variable is set to false, but afterwards the function save is triggered again and that would set the withEvents back to true I saw while debugging.

Please let me know if this okay (not really used to doing this). If not wanted in this way, please feel free to close it.

Is this a feature/addition big enough to open an issue in the docs-repo?


