### PR TITLE
[4.x] Fix custom asset edit URLs not being used in asset browser

### DIFF
--- a/resources/js/components/assets/AssetManager.vue
+++ b/resources/js/components/assets/AssetManager.vue
@@ -92,25 +92,19 @@ export default {
         /**
          * Push a new state onto the browser's history
          */
-        pushState() {
-            let url = cp_url('assets/browse/' + this.container.id);
-
-            if (this.path !== '/') {
-                url += '/' + this.path;
-            }
-
+        pushState(asset) {
             window.history.pushState({
-                container: this.container, path: this.path
-            }, '', url);
+                container: this.container, path: asset.path
+            }, '', asset.edit_url);
         },
 
         /**
-         * When a user has navigated to another folder or container
+         * When a user has navigated to another folder or container.
          */
-        navigate(container, path) {
+        navigate(container, asset) {
             this.container = container;
-            this.path = path;
-            this.pushState();
+            this.path = asset.path;
+            this.pushState(asset);
 
             // Clear out any selections. It would be confusing to navigate to a different
             // folder and/or container, perform an action, and discover you performed

--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -273,6 +273,7 @@
             :id="editedAssetId"
             :read-only="! canEdit"
             @closed="closeAssetEditor"
+            @navigated="$emit('navigated', container, $event)"
             @saved="assetSaved"
         />
 
@@ -477,14 +478,6 @@ export default {
 
         loading(loading) {
             this.$progress.loading('asset-browser', loading);
-        },
-
-        editedAssetId(editedAssetId) {
-            let path = editedAssetId
-                ? [this.path, this.editedAssetBasename].filter(value => value != '/').join('/') + '/edit'
-                : this.path;
-
-            this.$emit('navigated', this.container, path);
         },
 
         searchQuery() {

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -320,6 +320,8 @@ export default {
                     .flatten(true)
                     .value();
 
+                this.$emit('navigated', this.asset);
+
                 this.loading = false;
             });
         },

--- a/src/Http/Resources/CP/Assets/Asset.php
+++ b/src/Http/Resources/CP/Assets/Asset.php
@@ -16,6 +16,7 @@ class Asset extends JsonResource
             'filename' => $this->filename(),
             'basename' => $this->basename(),
             'url' => $this->url(),
+            'edit_url' => $this->editUrl(),
             'reference' => $this->reference(),
             'permalink' => $this->absoluteUrl(),
             'extension' => $this->extension(),


### PR DESCRIPTION
This pull request fixes an issue for sites where the `Asset@editUrl` method has been overridden. 

Until now, the asset browser on the frontend built the URL itself based on the various components of the URL. However, if the `editUrl` is being overridden (for example, to replace the path with some kind of internal ID), that wouldn't be respected.

Fixes #2906.