### PR TITLE
[4.x] Support fieldsets in subdirectories

### DIFF
--- a/resources/js/components/fieldsets/CreateForm.vue
+++ b/resources/js/components/fieldsets/CreateForm.vue
@@ -12,12 +12,18 @@
                 <div class="text-2xs text-gray-600 mt-2 flex items-center">
                     {{ __('messages.fieldsets_title_instructions') }}
                 </div>
+                <div v-if="errors.title">
+                    <small class="help-block text-red-500 mt-2 mb-0" v-for="(error, i) in errors.title" :key="i" v-text="error" />
+                </div>
             </div>
             <div class="mb-4">
                 <label class="font-bold text-base mb-1" for="name">{{ __('Handle') }}</label>
                 <input type="text" v-model="handle" class="input-text" tabindex="2">
                 <div class="text-2xs text-gray-600 mt-2 flex items-center">
                     {{ __('messages.fieldsets_handle_instructions') }}
+                </div>
+                <div v-if="errors.handle">
+                    <small class="help-block text-red-500 mt-2 mb-0" v-for="(error, i) in errors.handle" :key="i" v-text="error" />
                 </div>
             </div>
         </div>
@@ -43,7 +49,8 @@ export default {
     data() {
         return {
             title: null,
-            handle: null
+            handle: null,
+            errors: [],
         }
     },
 
@@ -64,6 +71,7 @@ export default {
             this.$axios.post(this.route, {title: this.title, handle: this.handle}).then(response => {
                 window.location = response.data.redirect;
             }).catch(error => {
+                this.errors = error.response.data.errors;
                 this.$toast.error(error.response.data.message);
             });
         }

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -167,7 +167,7 @@ class FieldsetRepository
             throw new \Exception('Namespaced fieldsets cannot be deleted');
         }
 
-        File::delete("{$this->directory}/{$fieldset->handle()}.yaml");
+        File::delete($fieldset->path());
     }
 
     public function addNamespace(string $namespace, string $directory): void

--- a/src/Http/Controllers/CP/Fields/FieldsetController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsetController.php
@@ -37,7 +37,8 @@ class FieldsetController extends CpController
                         'title' => $fieldset->title(),
                     ],
                 ];
-            });
+            })
+            ->sortBy(fn ($value, $key) => $key === __('My Fieldsets') ? '0' : $key);
 
         if ($request->wantsJson()) {
             return $fieldsets;
@@ -153,6 +154,14 @@ class FieldsetController extends CpController
 
     private function groupKey(Fieldset $fieldset): string
     {
-        return $fieldset->isNamespaced() ? Str::of($fieldset->namespace())->replace('_', ' ')->title() : __('My Fieldsets');
+        if ($fieldset->isNamespaced()) {
+            return Str::of($fieldset->namespace())->replace('_', ' ')->title();
+        }
+
+        if (str_contains($fieldset->handle(), '.')) {
+            return Str::of($fieldset->handle())->beforeLast('.')->title();
+        }
+
+        return __('My Fieldsets');
     }
 }

--- a/src/Http/Controllers/CP/Fields/FieldsetController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsetController.php
@@ -115,8 +115,8 @@ class FieldsetController extends CpController
     public function store(Request $request)
     {
         $request->validate([
-            'title' => 'required',
-            'handle' => 'required|alpha_dash',
+            'title' => ['required'],
+            'handle' => ['required', 'regex:/^[a-zA-Z0-9._-]+$/'],
         ]);
 
         if (Facades\Fieldset::find($request->handle)) {

--- a/tests/Feature/Fieldsets/StoreFieldsetTest.php
+++ b/tests/Feature/Fieldsets/StoreFieldsetTest.php
@@ -64,6 +64,28 @@ class StoreFieldsetTest extends TestCase
     }
 
     /** @test */
+    public function fieldset_gets_created_in_subdirectory()
+    {
+        $user = tap(Facades\User::make()->makeSuper())->save();
+        $this->assertCount(0, Facades\Fieldset::all());
+
+        $this
+            ->actingAs($user)
+            ->submit(['handle' => 'components.test'])
+            ->assertOk()
+            ->assertJson(['redirect' => cp_route('fieldsets.edit', 'components.test')])
+            ->assertSessionHas('success');
+
+        $this->assertCount(1, Facades\Fieldset::all());
+        $fieldset = Facades\Fieldset::find('components.test');
+        $this->assertEquals([
+            'title' => 'Test',
+            'fields' => [],
+        ], $fieldset->contents());
+        $this->assertEquals('components.test', $fieldset->handle());
+    }
+
+    /** @test */
     public function title_is_required()
     {
         $user = tap(Facades\User::make()->makeSuper())->save();


### PR DESCRIPTION
This pull request adds support for creating & managing fieldsets located in subdirectories. This was already *kinda* possible but there was a few rough edges, which this PR sorts out. 

One of the rough edges was the fact you couldn't previously create a fieldset in a subdirectory in the Control Panel, you had to go in and manually create the file. 

This PR fixes that so you can create fieldsets in subdirectories, using this syntax: `components.team_members`

Another change I've made is that fieldsets in subdirectories will be split out into separate groups on the Fieldsets Index page, like we do for namespaced fieldsets.

Here's an example of what that looks like (the "My Fieldsets" group will always be displayed first): 

![CleanShot 2024-01-17 at 11 38 34](https://github.com/statamic/cms/assets/19637309/89a3c851-6281-4b32-9b0a-49db6d9a358a)

One last thing I had to fix was deleting fieldsets. Previously, the `FieldsetRepository@delete` method was manually constructing the file path and it wasn't replacing `.` with `/`. I've adjusted this to use the fieldset's `path` instead which takes this into account.

---

Closes #3178.
Closes statamic/ideas#915.