### PR TITLE
[4.x] Prevent Bard causing dirty state issues

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -367,13 +367,17 @@ export default {
         json(json) {
             if (!this.mounted) return;
 
+            let jsonValue = JSON.stringify(json);
+
+            if (jsonValue === this.value) return;
+
             // Prosemirror's JSON will include spaces between tags.
             // For example (this is not the actual json)...
             // "<p>One <b>two</b> three</p>" becomes ['OneSPACE', '<b>two</b>', 'SPACEthree']
             // But, Laravel's TrimStrings middleware would remove them.
             // Those spaces need to be there, otherwise it would be rendered as <p>One<b>two</b>three</p>
             // To combat this, we submit the JSON string instead of an object.
-            this.updateDebounced(JSON.stringify(json));
+            this.updateDebounced(jsonValue);
         },
 
         value(value, oldValue) {


### PR DESCRIPTION
After doing some digging into #9294, I managed to track down Bard as the culprit of the dirty state issues. 

After an entry is saved, the [publish form values get updated](https://github.com/statamic/cms/blob/4.x/resources/js/components/entries/PublishForm.vue#L570). This consequently triggers Bard's `value` to be updated, which causes Bard to think it's `json` has changed and it needs to emit the updated value upwards.

However... in comparing the string-ified JSON with the actual `value` being passed into Bard, they were exactly the same. Yet, because it was emitted up the chain, it triggered the dirty state. 

This only *seems* to be an issue when you have a few different sets open because it needs to take over 360ms (the timeout on `PublishForm@runAfterSaveHook`) to parse the JSON, stringify it again and do whatever else it needs to do, before the `setTimeout` re-enables the dirty state tracking.   

I've put this fix directly into the `BardFieldtype`. However, let me know if you'd prefer this to be fixed in the `Fieldtype` mixin instead.

Fixes #9294.