### PR TITLE
Update entry order and uri by ids

### DIFF
--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -81,18 +81,44 @@ class CollectionsStore extends BasicStore
 
     public function updateEntryUris($collection, $ids = null)
     {
-        Stache::store('entries')
+        $index = Stache::store('entries')
             ->store($collection->handle())
-            ->index('uri')
-            ->update();
+            ->index('uri');
+
+            if (empty($ids)) {
+                $index->update();
+                
+                return;
+            }
+        
+            foreach($ids as $id) {
+                if (!$entry = Entry::find($id)) {
+                    continue;
+                }
+
+                $index->updateItem($entry);
+            }
     }
 
     public function updateEntryOrder($collection, $ids = null)
     {
         Stache::store('entries')
             ->store($collection->handle())
-            ->index('order')
-            ->update();
+            ->index('order');
+
+        if (empty($ids)) {
+            $index->update();
+            
+            return;
+        }
+    
+        foreach($ids as $id) {
+            if (!$entry = Entry::find($id)) {
+                continue;
+            }
+
+            $index->updateItem($entry);
+        }
     }
 
     public function handleFileChanges()

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -102,7 +102,7 @@ class CollectionsStore extends BasicStore
 
     public function updateEntryOrder($collection, $ids = null)
     {
-        Stache::store('entries')
+        $index = Stache::store('entries')
             ->store($collection->handle())
             ->index('order');
 


### PR DESCRIPTION
Part of #9236 

Right now when saving changes in the collection tree the uri index and order index will be updated completely, even though the specific ids are passed as a parameter. 

This causes performance issues when having a lot of entries. 

This PR fixes that and updates only the affected parts.

