### PR TITLE
[4.x] Update entry order and uri by ids

### DIFF
--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -86,19 +86,16 @@ class CollectionsStore extends BasicStore
             ->store($collection->handle())
             ->index('uri');
 
-        if (empty($ids)) {
-            $index->update();
+        $ids = collect($ids ?? []);
 
-            return;
+        if ($ids->isEmpty()) {
+            return $index->update();
         }
 
-        foreach ($ids as $id) {
-            if (! $entry = Entry::find($id)) {
-                continue;
-            }
-
-            $index->updateItem($entry);
-        }
+        $ids
+            ->map(fn ($id) => Entry::find($id))
+            ->filter()
+            ->each(fn ($entry) => $index->updateItem($entry));
     }
 
     public function updateEntryOrder($collection, $ids = null)
@@ -107,19 +104,16 @@ class CollectionsStore extends BasicStore
             ->store($collection->handle())
             ->index('order');
 
-        if (empty($ids)) {
-            $index->update();
+        $ids = collect($ids ?? []);
 
-            return;
+        if ($ids->isEmpty()) {
+            return $index->update();
         }
 
-        foreach ($ids as $id) {
-            if (! $entry = Entry::find($id)) {
-                continue;
-            }
-
-            $index->updateItem($entry);
-        }
+        $ids
+            ->map(fn ($id) => Entry::find($id))
+            ->filter()
+            ->each(fn ($entry) => $index->updateItem($entry));
     }
 
     public function handleFileChanges()

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -86,16 +86,7 @@ class CollectionsStore extends BasicStore
             ->store($collection->handle())
             ->index('uri');
 
-        $ids = collect($ids ?? []);
-
-        if ($ids->isEmpty()) {
-            return $index->update();
-        }
-
-        $ids
-            ->map(fn ($id) => Entry::find($id))
-            ->filter()
-            ->each(fn ($entry) => $index->updateItem($entry));
+        $this->updateEntriesWithinIndex($index, $ids);
     }
 
     public function updateEntryOrder($collection, $ids = null)
@@ -104,6 +95,11 @@ class CollectionsStore extends BasicStore
             ->store($collection->handle())
             ->index('order');
 
+        $this->updateEntriesWithinIndex($index, $ids);
+    }
+
+    private function updateEntriesWithinIndex($index, $ids)
+    {
         $ids = collect($ids ?? []);
 
         if ($ids->isEmpty()) {

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -3,6 +3,7 @@
 namespace Statamic\Stache\Stores;
 
 use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
 use Statamic\Facades\Path;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -81,18 +81,44 @@ class CollectionsStore extends BasicStore
 
     public function updateEntryUris($collection, $ids = null)
     {
-        Stache::store('entries')
+        $index = Stache::store('entries')
             ->store($collection->handle())
-            ->index('uri')
-            ->update();
+            ->index('uri');
+
+            if (empty($ids)) {
+                $index->update();
+
+                return;
+            }
+
+            foreach($ids as $id) {
+                if (!$entry = Entry::find($id)) {
+                    continue;
+                }
+
+                $index->updateItem($entry);
+            }
     }
 
     public function updateEntryOrder($collection, $ids = null)
     {
-        Stache::store('entries')
+        $index = Stache::store('entries')
             ->store($collection->handle())
-            ->index('order')
-            ->update();
+            ->index('order');
+
+        if (empty($ids)) {
+            $index->update();
+
+            return;
+        }
+
+        foreach($ids as $id) {
+            if (!$entry = Entry::find($id)) {
+                continue;
+            }
+
+            $index->updateItem($entry);
+        }
     }
 
     public function handleFileChanges()

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -100,13 +100,11 @@ class CollectionsStore extends BasicStore
 
     private function updateEntriesWithinIndex($index, $ids)
     {
-        $ids = collect($ids ?? []);
-
-        if ($ids->isEmpty()) {
+        if (empty($ids)) {
             return $index->update();
         }
 
-        $ids
+        collect($ids)
             ->map(fn ($id) => Entry::find($id))
             ->filter()
             ->each(fn ($entry) => $index->updateItem($entry));

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -113,7 +113,7 @@ class CollectionsStore extends BasicStore
         }
 
         foreach ($ids as $id) {
-            if (!$ entry = Entry::find($id)) {
+            if (! $entry = Entry::find($id)) {
                 continue;
             }
 

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -85,19 +85,19 @@ class CollectionsStore extends BasicStore
             ->store($collection->handle())
             ->index('uri');
 
-            if (empty($ids)) {
-                $index->update();
+        if (empty($ids)) {
+            $index->update();
 
-                return;
+            return;
+        }
+
+        foreach ($ids as $id) {
+            if (! $entry = Entry::find($id)) {
+                continue;
             }
 
-            foreach($ids as $id) {
-                if (!$entry = Entry::find($id)) {
-                    continue;
-                }
-
-                $index->updateItem($entry);
-            }
+            $index->updateItem($entry);
+        }
     }
 
     public function updateEntryOrder($collection, $ids = null)
@@ -112,8 +112,8 @@ class CollectionsStore extends BasicStore
             return;
         }
 
-        foreach($ids as $id) {
-            if (!$entry = Entry::find($id)) {
+        foreach ($ids as $id) {
+            if (!$ entry = Entry::find($id)) {
                 continue;
             }
 


### PR DESCRIPTION
Part of https://github.com/statamic/cms/issues/9236

Right now when saving changes in the collection tree the uri index and order index will be rebuild completely, even though the specific ids are passed as a parameter.

This causes performance issues when having a lot of entries.

This PR fixes that and updates only the affected parts.