### PR TITLE
[4.x] Prevent handling field previews when previews are disabled

### DIFF
--- a/resources/js/components/fieldtypes/ArrayFieldtype.vue
+++ b/resources/js/components/fieldtypes/ArrayFieldtype.vue
@@ -170,6 +170,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return _.reduce(this.value, (carry, value, key) => {
                 let str = `${key}: ${value}`;
                 if (carry) str = carry + ', ' + str;

--- a/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
@@ -28,6 +28,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             var option = _.findWhere(this.config.options, {value: this.value});
             return (option) ? option.label : this.value;
         },

--- a/resources/js/components/fieldtypes/CheckboxesFieldtype.vue
+++ b/resources/js/components/fieldtypes/CheckboxesFieldtype.vue
@@ -34,6 +34,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return this.values.map(value => {
                 const option = _.findWhere(this.options, { value });
                 return option ? option.label : value;

--- a/resources/js/components/fieldtypes/CodeFieldtype.vue
+++ b/resources/js/components/fieldtypes/CodeFieldtype.vue
@@ -105,6 +105,8 @@ export default {
             return 'theme-' + this.config.theme;
         },
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return this.value.code ? truncate(this.value.code, 60) : '';
         },
         readOnlyOption() {

--- a/resources/js/components/fieldtypes/ColorFieldtype.vue
+++ b/resources/js/components/fieldtypes/ColorFieldtype.vue
@@ -92,6 +92,8 @@ export default {
     computed: {
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return this.value
                 ? `<span class="little-dot" style="background-color:${this.value}"></span>`
                 : null;

--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -159,6 +159,7 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
             if (! this.value.date) return;
 
             if (this.isRange) {

--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -60,6 +60,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return this.value;
         },
 

--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -21,6 +21,10 @@ export default {
             type: Boolean,
             default: false
         },
+        showFieldPreviews: {
+            type: Boolean,
+            default: false
+        },
         namePrefix: String,
         fieldPathPrefix: String,
     },
@@ -71,6 +75,8 @@ export default {
         replicatorPreview: {
             immediate: true,
             handler(text) {
+                if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
                 this.$emit('replicator-preview-updated', text);
             }
         }

--- a/resources/js/components/fieldtypes/GroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/GroupFieldtype.vue
@@ -106,6 +106,8 @@ export default {
             return this.config.fields;
         },
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return Object.values(this.value).join(', ');
         }
     },

--- a/resources/js/components/fieldtypes/RadioFieldtype.vue
+++ b/resources/js/components/fieldtypes/RadioFieldtype.vue
@@ -32,6 +32,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             var option = _.findWhere(this.config.options, {value: this.value});
             return (option) ? option.label : this.value;
         },

--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -110,6 +110,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return this.selectedOptions.map(option => option.label).join(', ');
         },
 

--- a/resources/js/components/fieldtypes/TableFieldtype.vue
+++ b/resources/js/components/fieldtypes/TableFieldtype.vue
@@ -163,6 +163,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             // Join all values with commas. Exclude any empties.
             return _(this.data)
                 .map(row => row.value.cells.filter(cell => !!cell).join(', '))

--- a/resources/js/components/fieldtypes/ToggleFieldtype.vue
+++ b/resources/js/components/fieldtypes/ToggleFieldtype.vue
@@ -16,6 +16,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return (this.value ? '✓' : '✗') + ' ' + __(this.config.display);
         }
 

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -336,6 +336,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return replicatorPreviewHtml(_.map(this.assets, (asset) => {
                 return (asset.isImage || asset.isSvg) ?
                     `<img src="${asset.thumbnail}" width="20" height="20" title="${asset.basename}" />`

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -286,6 +286,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             const stack = JSON.parse(this.value);
             let text = '';
             while (stack.length) {

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -44,6 +44,7 @@
                     :set-index="index"
                     :field-path="fieldPath(field)"
                     :read-only="isReadOnly"
+                    :show-field-previews="showFieldPreviews"
                     @updated="updated(field.handle, $event)"
                     @meta-updated="metaUpdated(field.handle, $event)"
                     @focus="focused"

--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -136,6 +136,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return `${__(this.config.display)}: ${__n(':count row|:count rows', this.value.length)}`;
         }
 

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -692,6 +692,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return marked(this.data || '', { renderer: new PlainTextRenderer })
                 .replace(/<\/?[^>]+(>|$)/g, "");
         }

--- a/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
+++ b/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
@@ -134,6 +134,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return this.value.map(id => {
                 const item = _.findWhere(this.meta.data, { id });
                 return item ? item.title : id;

--- a/resources/js/components/fieldtypes/replicator/Field.vue
+++ b/resources/js/components/fieldtypes/replicator/Field.vue
@@ -23,6 +23,7 @@
             :field-path-prefix="fieldPath"
             :has-error="hasError || hasNestedError"
             :read-only="isReadOnly"
+            :show-field-previews="showFieldPreviews"
             @input="$emit('updated', $event)"
             @meta-updated="$emit('meta-updated', $event)"
             @focus="$emit('focus')"
@@ -69,6 +70,7 @@ export default {
             type: String
         },
         readOnly: Boolean,
+        showFieldPreviews: Boolean,
     },
 
     inject: ['storeName'],

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -172,6 +172,8 @@ export default {
         },
 
         replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
             return `${__(this.config.display)}: ${__n(':count set|:count sets', this.value.length)}`;
         }
     },

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -44,6 +44,7 @@
                     :set-index="index"
                     :field-path="fieldPath(field)"
                     :read-only="isReadOnly"
+                    :show-field-previews="showFieldPreviews"
                     @updated="updated(field.handle, $event)"
                     @meta-updated="metaUpdated(field.handle, $event)"
                     @focus="$emit('focus')"


### PR DESCRIPTION
This pull request adds some checks to prevent unnecessary field previews from being computed & emitted to parent components when field previews are disabled. 

Without these changes, any time a field's value changes, it would compute & emit the field preview, even if it's a root field or the parent Bard/Replicator has field previews disabled. 

This should *hopefully* help somewhat with performance with the Bard & Replicator fieldtypes. 🤞 

In the [first commit](https://github.com/statamic/cms/pull/9353/commits/380c2ce5de8835ac3324849f109f74ce6d026d3e), I made it so the `replicator-preview-updated` event doesn't get emitted when field previews are disabled. 

Then, in my [second commit](https://github.com/statamic/cms/pull/9353/commits/b078329d0674ea3da5515bd062f9ca86230e21ad), I added the same check to the `replicatorPreview` method on the individual fieldtypes because even the fact we're generating them in the first place is going to have some kind of performance impact, especially for fields with larger values (like Bards & Replicators). 

Maybe we don't need the checks in both places, maybe we do. Happy to change it.

Closes #9248.
Potentially helps with https://github.com/statamic/cms/issues/9351.