### PR TITLE
[4.x] Fix error from Relationship Index Fieldtype after toggling column

### DIFF
--- a/resources/js/components/fieldtypes/relationship/RelationshipIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/relationship/RelationshipIndexFieldtype.vue
@@ -33,11 +33,11 @@ export default {
 
     computed: {
         items() {
-            return this.showingAll ? this.value : this.value.slice(0, 2);
+            return this.showingAll ? this.value : this.value?.slice(0, 2);
         },
 
         hasMore() {
-            return this.value.length > 2;
+            return this.value?.length > 2;
         },
     },
 


### PR DESCRIPTION
This pull request fixes an issue I spotted with the Relationship Index Fieldtype component, where it'd error causing items to not be shown after toggling a relationship column to show.

### Steps to reproduce

1. Add an Entries fieldtype to collection blueprint
2. Go into an entry and link some other entries
3. On the Listing Table, open the "Column Picker" and toggle the Entries field. 
4. A column *will* show for the Entries field but no items will be displayed until you refresh the page. 