### PR TITLE
[4.x] Fix whereTime affecting the date as well as time

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -484,7 +484,7 @@ abstract class Builder implements Contract
             $value = Carbon::parse($value);
         }
 
-        $value = $value->format('H:i'); // we only care about the time part
+        $value = $value->format('H:i:s'); // we only care about the time part
 
         $this->wheres[] = [
             'type' => 'Time',

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -480,6 +480,12 @@ abstract class Builder implements Contract
             throw new InvalidArgumentException('Illegal operator for date comparison');
         }
 
+        if (! ($value instanceof DateTimeInterface)) {
+            $value = Carbon::parse($value);
+        }
+
+        $value = $value->format('H:i'); // we only care about the time part
+
         $this->wheres[] = [
             'type' => 'Time',
             'column' => $column,

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Data\Entries;
 
 use Facades\Tests\Factories\EntryFactory;
+use Illuminate\Support\Carbon;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -174,6 +175,15 @@ class EntryQueryBuilderTest extends TestCase
 
         $this->assertCount(2, $entries);
         $this->assertEquals(['Post 1', 'Post 4'], $entries->map->title->all());
+
+        // if we send full dates it should only consider the time part
+        $entries = Entry::query()->whereTime('test_date', '2021-11-13 09:00')->get();
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Post 2'], $entries->map->title->all());
+
+        $entries = Entry::query()->whereTime('test_date', Carbon::createFromFormat('Y-m-d H:i', '2021-11-13 09:00'))->get();
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Post 2'], $entries->map->title->all());
     }
 
     private function createWhereDateTestEntries()


### PR DESCRIPTION
For a bit of context, check out: https://github.com/mitydigital/statamic-scheduled-cache-invalidator/pull/3#issuecomment-1899900451

The add-on was passing a full date string to whereTime... eg whereTime('2023-01-01 09:00'), which I hadn't accounted for. This meant it worked like whereDateTime() setting the whole date to that time, which unfortunately doesn't exist. I feel like Carbon should have been handling this possibility in their setTimeFromTimeString method, but they weren't.

The result was that it would get the date matches for that date only, ignoring any others that have a matching time but a different date, which isnt how whereTime is meant to work.

Anyway, its an edge case, and it was quite a nice bug as it made queries simpler, but its not the same behaviour as eloquent, so you would get different results between the two query builders.

The fix was to do a similar value modification in whereTime to what we do in whereDate, so we only use the time part of the date string.