### PR TITLE
[4.x] make placeholders translatable

### DIFF
--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -28,7 +28,7 @@
                             type="text"
                             ref="urlInput"
                             class="input h-auto text-sm"
-                            placeholder="URL"
+                            :placeholder="__('URL')"
                             @keydown.enter.prevent="commit"
                         />
     
@@ -39,7 +39,7 @@
                             type="text"
                             ref="mailtoInput"
                             class="input h-auto text-sm"
-                            placeholder="Email Address"
+                            :placeholder="__('Email Address')"
                             @keydown.enter.prevent="commit"
                         />
     


### PR DESCRIPTION
Makes some placeholders translatable in Bard fieldtype.