### PR TITLE
[4.x] Strip out `.html` from `parent_uri`

### DIFF
--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -195,7 +195,7 @@ class Page implements Arrayable, ArrayAccess, Augmentable, Entry, JsonSerializab
         }
 
         $parentUri = $this->parent && ! $this->parent->isRoot() ? $this->parent->uri() : '';
-        $parentUri = Str::replace(['.html', '.htm', '.xml', '.xhtml'], '', $parentUri);
+        $parentUri = Str::replace('.html', '', $parentUri);
 
         return $uris[$this->reference] = app(UrlBuilder::class)
             ->content($this)

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -22,6 +22,7 @@ use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\GraphQL\ResolvesValues;
+use Statamic\Support\Str;
 
 class Page implements Arrayable, ArrayAccess, Augmentable, Entry, JsonSerializable, Protectable, ResolvesValuesContract, Responsable
 {
@@ -193,10 +194,13 @@ class Page implements Arrayable, ArrayAccess, Augmentable, Entry, JsonSerializab
             return $uris[$this->reference] = $this->entry()->uri();
         }
 
+        $parentUri = $this->parent && ! $this->parent->isRoot() ? $this->parent->uri() : '';
+        $parentUri = Str::replace(['.html', '.htm', '.xml', '.xhtml'], '', $parentUri);
+
         return $uris[$this->reference] = app(UrlBuilder::class)
             ->content($this)
             ->merge([
-                'parent_uri' => $this->parent && ! $this->parent->isRoot() ? $this->parent->uri() : '',
+                'parent_uri' => $parentUri,
                 'slug' => $this->isRoot() ? '' : $this->slug(),
                 'depth' => $this->depth,
                 'is_root' => $this->isRoot(),

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -195,7 +195,7 @@ class Page implements Arrayable, ArrayAccess, Augmentable, Entry, JsonSerializab
         }
 
         $parentUri = $this->parent && ! $this->parent->isRoot() ? $this->parent->uri() : '';
-        $parentUri = Str::replace('.html', '', $parentUri);
+        $parentUri = Str::replace(['.html', '.htm'], '', $parentUri);
 
         return $uris[$this->reference] = app(UrlBuilder::class)
             ->content($this)

--- a/tests/Data/Structures/PageTest.php
+++ b/tests/Data/Structures/PageTest.php
@@ -185,8 +185,12 @@ class PageTest extends TestCase
         $this->assertFalse($page->hasCustomUrl());
     }
 
-    /** @test */
-    public function it_builds_a_uri_and_strips_out_file_extensions_from_parent_uri()
+    /**
+     * @test
+     *
+     * @dataProvider stripExtensionFromParentUriProvider
+     */
+    public function it_builds_a_uri_and_strips_out_file_extensions_from_parent_uri($ext)
     {
         $entry = new class extends Entry
         {
@@ -205,7 +209,7 @@ class PageTest extends TestCase
 
         $parent = Mockery::mock(Page::class);
         $parent->shouldReceive('id')->andReturn('the-parent-entry');
-        $parent->shouldReceive('uri')->andReturn('/the-parent-entry.html');
+        $parent->shouldReceive('uri')->andReturn('/the-parent-entry.'.$ext);
         $parent->shouldReceive('isRoot')->andReturnFalse();
 
         $tree = $this->newTree()->setStructure(
@@ -214,12 +218,20 @@ class PageTest extends TestCase
 
         $page = (new Page)
             ->setTree($tree)
-            ->setRoute('/{parent_uri}/{slug}.html')
+            ->setRoute('/{parent_uri}/{slug}.'.$ext)
             ->setParent($parent)
             ->setEntry($entry);
 
-        $this->assertEquals('/the-parent-entry/entry-slug.html', $page->uri());
+        $this->assertEquals('/the-parent-entry/entry-slug.'.$ext, $page->uri());
         $this->assertFalse($page->hasCustomUrl());
+    }
+
+    public function stripExtensionFromParentUriProvider()
+    {
+        return [
+            'html' => ['html'],
+            'htm' => ['htm'],
+        ];
     }
 
     /** @test */


### PR DESCRIPTION
This pull request fixes an issue when using `.html` (or a few other file extensions) in collection routes.

For example: if you had a collection route like this...

```yaml
route: /{parent_uri}/{slug}.html
```

The URL for an entry could be `/parent.html/child.html` instead of `/parent/child.html` which is expected.

Fixes #7324.