### PR TITLE
[4.x] Always show slug rengerate button if enabled

### DIFF
--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -12,7 +12,7 @@
                 v-model="slug"
                 classes="font-mono text-xs"
                 :isReadOnly="isReadOnly"
-                :append="config.show_regenerate && value"
+                :append="config.show_regenerate"
                 :name="slug"
                 :id="fieldId"
                 @focus="$emit('focus')"


### PR DESCRIPTION
Previously, you'd need to have a value for it to show.

If you cleared out the slug field, the button would disappear.
Or, if you add a slug field to a form that didn't previously have slugs, like an user, then the button wouldn't be there until you typed something.
