### PR TITLE
[4.x] Bard: Only configure placeholder extension when placeholder is provided

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -706,6 +706,7 @@ export default {
 
         getExtensions() {
             let modeExts = this.inputIsInline ? [DocumentInline] : [DocumentBlock, HardBreak];
+
             if (this.config.inline === 'break') {
                 modeExts.push(HardBreak.extend({
                     addKeyboardShortcuts() {
@@ -716,8 +717,12 @@ export default {
                     },
                 }));
             }
-           
-            // Allow passthrough of Ctrl/Cmd + Enter to submit the form 
+
+            if (this.config.placeholder) {
+                modeExts.push(Placeholder.configure({ placeholder: __(this.config.placeholder) }));
+            }
+
+            // Allow passthrough of Ctrl/Cmd + Enter to submit the form
             const DisableCtrlEnter = Extension.create({
                 addKeyboardShortcuts() {
                     return {
@@ -735,7 +740,6 @@ export default {
                 Gapcursor,
                 History,
                 Paragraph,
-                Placeholder.configure({ placeholder: __(this.config.placeholder) }),
                 Set.configure({ bard: this }),
                 Text
             ];


### PR DESCRIPTION
This pull request makes a small change to Bard so the TipTap Placeholder extension is only loaded when a placeholder has been configured for the Bard field.

Currently, the Placeholder extension seems to be breaking other extensions (see #9235) so moving this to only be enabled when a placeholder is configured should at least provide a workaround until the extension is properly fixed in TipTap Core.

Related: #9235