### PR TITLE
[4.x] Hide actions on form index/show pages when user is missing relevant permissions

### DIFF
--- a/resources/js/components/forms/Listing.vue
+++ b/resources/js/components/forms/Listing.vue
@@ -13,9 +13,9 @@
                     <a :href="form.show_url">{{ form.title }}</a>
                 </template>
                 <template slot="actions" slot-scope="{ row: form, index }">
-                    <dropdown-list>
-                        <dropdown-item :text="__('Edit')" :redirect="form.edit_url" />
-                        <dropdown-item :text="__('Edit Blueprint')" :redirect="form.blueprint_url" />
+                    <dropdown-list v-if="form.can_edit || form.can_edit_blueprints || form.actions.length">
+                        <dropdown-item v-if="form.can_edit" :text="__('Edit')" :redirect="form.edit_url" />
+                        <dropdown-item v-if="form.can_edit_blueprints" :text="__('Edit Blueprint')" :redirect="form.blueprint_url" />
                         <div class="divider" v-if="form.actions.length" />
                         <data-list-inline-actions
                             :item="form.id"

--- a/resources/views/forms/show.blade.php
+++ b/resources/views/forms/show.blade.php
@@ -14,21 +14,23 @@
                 {{ $form->title() }}
             </h1>
 
-            <dropdown-list class="mr-2">
-                @can('edit', $form)
-                    <dropdown-item :text="__('Edit Form')" redirect="{{ $form->editUrl() }}"></dropdown-item>
-                @endcan
-                @can('delete', $form)
-                    <dropdown-item :text="__('Delete Form')" class="warning" @click="$refs.deleter.confirm()">
-                        <resource-deleter
-                            ref="deleter"
-                            resource-title="{{ $form->title() }}"
-                            route="{{ $form->deleteUrl() }}"
-                            redirect="{{ cp_route('forms.index') }}"
-                        ></resource-deleter>
-                    </dropdown-item>
-                @endcan
-            </dropdown-list>
+            @if(\Statamic\Facades\User::current()->can('edit', $form) || \Statamic\Facades\User::current()->can('delete', $form))
+                <dropdown-list class="mr-2">
+                    @can('edit', $form)
+                        <dropdown-item :text="__('Edit Form')" redirect="{{ $form->editUrl() }}"></dropdown-item>
+                    @endcan
+                    @can('delete', $form)
+                        <dropdown-item :text="__('Delete Form')" class="warning" @click="$refs.deleter.confirm()">
+                            <resource-deleter
+                                ref="deleter"
+                                resource-title="{{ $form->title() }}"
+                                route="{{ $form->deleteUrl() }}"
+                                redirect="{{ cp_route('forms.index') }}"
+                            ></resource-deleter>
+                        </dropdown-item>
+                    @endcan
+                </dropdown-list>
+            @endif
 
             @if (($exporters = $form->exporters()) && $exporters->isNotEmpty())
             <dropdown-list>

--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -35,6 +35,8 @@ class FormsController extends CpController
                     'show_url' => $form->showUrl(),
                     'edit_url' => $form->editUrl(),
                     'blueprint_url' => cp_route('forms.blueprint.edit', $form->handle()),
+                    'can_edit' => User::current()->can('edit', $form),
+                    'can_edit_blueprint' => User::current()->can('configure form fields', $form),
                     'actions' => Action::for($form),
                 ];
             })


### PR DESCRIPTION
This pull request fixes a small issue on Forms pages where users could see dropdown options or empty dropdowns when they don't have the relevant form permissions.

No issue exists for this issue - just noticed it the other day on a personal project.