### PR TITLE
[4.x] Avoid saving icons to field configs

### DIFF
--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -38,7 +38,7 @@ class FieldTransformer
 
         if (Arr::get($field, 'duplicate', true) === true) {
             unset($field['duplicate']);
-    }
+        }
 
         if (Arr::has($field, 'icon')) {
             unset($field['icon']);

--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -38,6 +38,10 @@ class FieldTransformer
 
         if (Arr::get($field, 'duplicate', true) === true) {
             unset($field['duplicate']);
+    }
+
+        if (Arr::has($field, 'icon')) {
+            unset($field['icon']);
         }
 
         return array_filter([


### PR DESCRIPTION
This pull request prevents the `icon` setting from being saved to field configs.

I couldn't replicate this with the first-party fieldtypes I tried but I've seen it happen with third-party addons (example: [the Review fieldtype](transformstudios/review)), where the `icon` was being saved to the field YAML.

It doesn't break anything *but* is a little weird to see a big long SVG string saved in your blueprint's YAML.

