### PR TITLE
[4.x] Avoid caching URLs with a token

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -116,7 +116,7 @@ class Cache
             return false;
         }
 
-        if ($request->isLivePreview()) {
+        if ($request->statamicToken()) {
             return false;
         }
 
@@ -141,7 +141,7 @@ class Cache
             return false;
         }
 
-        if ($request->isLivePreview()) {
+        if ($request->statamicToken()) {
             return false;
         }
 


### PR DESCRIPTION
Replaces #8964

Having token-based functionality on a page more than likely implies there's a dynamic aspect to the page.
We'll avoid statically caching the page if there's a valid token.
