### PR TITLE
[4.x] Catch errors when sending user activation email

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -224,6 +224,7 @@ return [
     'updater_require_version_command' => 'To require a specific version, run the following command',
     'updater_update_to_latest_command' => 'To update to the latest version, run the following command',
     'updates_available' => 'Updates are available!',
+    'user_activation_email_not_sent_error' => 'The activation email couldn\'t be sent. Please check your email configuration and try again.',
     'user_groups_handle_instructions' => 'Used to reference this user group on the frontend. It\'s non-trivial to change later.',
     'user_groups_intro' => 'User groups allow you to organize users and apply permission-based roles in aggregate.',
     'user_groups_role_instructions' => 'Assign roles to give users in this group all of their corresponding permissions.',

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -190,7 +190,7 @@ class UsersController extends CpController
             try {
                 $user->generateTokenAndSendActivateAccountNotification();
             } catch (TransportException $e) {
-                Toast::error(__("The activation email couldn't be sent. Please check your email configuration and try again."));
+                Toast::error(__('statamic::messages.user_activation_email_not_sent_error'));
             }
 
             $url = null;

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\CP\Toast;
 use Statamic\Facades\Scope;
 use Statamic\Facades\Search;
 use Statamic\Facades\User;
@@ -16,6 +17,7 @@ use Statamic\Http\Resources\CP\Users\Users;
 use Statamic\Notifications\ActivateAccount;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 use Statamic\Search\Result;
+use Symfony\Component\Mailer\Exception\TransportException;
 
 class UsersController extends CpController
 {
@@ -184,7 +186,13 @@ class UsersController extends CpController
         if ($request->invitation['send']) {
             ActivateAccount::subject($request->invitation['subject']);
             ActivateAccount::body($request->invitation['message']);
-            $user->generateTokenAndSendActivateAccountNotification();
+
+            try {
+                $user->generateTokenAndSendActivateAccountNotification();
+            } catch (TransportException $e) {
+                Toast::error(__("The activation email couldn't be sent. Please check your email configuration and try again."));
+            }
+
             $url = null;
         } else {
             $url = PasswordReset::url($user->generateActivateAccountToken(), PasswordReset::BROKER_ACTIVATIONS);


### PR DESCRIPTION
This pull request implements handling to catch any errors thrown by mailers when sending the user activation email as part of the create user wizard.

Previously, when a mailer threw an exception while sending the activation email and you tried to re-submit you'd hit a validation error due to the email already being used, since the user was created the last time the wizard was submitted.

With the handling added in this PR, the wizard will complete but the user will see a toast message on the next page telling them the email didn't get sent. 

**Note:** The toast will only display if you're using the `sync` queue driver. If you're using a "proper" queue driver, we assume you already know how to handle failed jobs.

![CleanShot 2024-01-23 at 20 43 33](https://github.com/statamic/cms/assets/19637309/d4adf5c5-5ded-4700-9945-ef9983c3e509)

Fixes #9309.