### PR TITLE
[4.x] Only use site language for form submission validation messages if submitted from front-end

### DIFF
--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -116,8 +116,11 @@ class FrontendFormRequest extends FormRequest
 
     public function validateResolved()
     {
-        $site = Site::findByUrl(URL::previous()) ?? Site::default();
+        // If this was submitted from a front-end form, we want to use the appropriate language
+        // for the translation messages. If there's no previous url, it was likely submitted
+        // directly in a headless format. In that case, we'll just use the default lang.
+        $site = ($previousUrl = session()->previousUrl()) ? Site::findByUrl($previousUrl) : null;
 
-        return $this->withLocale($site->lang(), fn () => parent::validateResolved());
+        return $this->withLocale($site?->lang(), fn () => parent::validateResolved());
     }
 }


### PR DESCRIPTION
When submitting a form on the front-end, validation messages will be in the appropriate site's language.

However, some people are using this same URL to create form submissions in a headless fashion, without using a `form:create` tag on the front-end.
Additionally, they are setting the app locale manually in a middleware.

This PR will make it so that the validation language is only used if submitted from the frontend. Otherwise it'll just fall back to the default locale (not the language of the default site like it does now).

It's worth noting that `URL::previous()` will fall back to the the home page when there's no referrer header, where as `session()->previousUrl()` will fall back to `null`, which is what we need here.
