### PR TITLE
[4.x] Fix importing fieldsets in custom blueprint namespaces

### DIFF
--- a/src/Http/View/Composers/FieldComposer.php
+++ b/src/Http/View/Composers/FieldComposer.php
@@ -12,6 +12,7 @@ use Statamic\Support\Str;
 class FieldComposer
 {
     const VIEWS = [
+        'statamic::blueprints.edit',
         'statamic::*.blueprints.edit',
         'statamic::fieldsets.edit',
     ];


### PR DESCRIPTION
This pull request fixes an issue when attempting to import a fieldset in the Blueprint Builder for a custom namespaced blueprint.

The error was happening due to `fieldsets` not being found in the `StatamicConfig` object due to the blueprint view being `resources/views/blueprints/edit.blade.php` instead of `resources/views/..../blueprints/edit.blade.php`

Fixes statamic-rad-pack/runway#410.