### PR TITLE
[4.x] Revert overzealous file extension renaming feature

### DIFF
--- a/src/Assets/AssetUploader.php
+++ b/src/Assets/AssetUploader.php
@@ -26,7 +26,7 @@ class AssetUploader extends Uploader
 
     protected function uploadPath(UploadedFile $file)
     {
-        $ext = $this->getNewExtension() ?? $this->getFileExtension($file);
+        $ext = $this->getNewExtension() ?? $file->getClientOriginalExtension();
 
         if (config('statamic.assets.lowercase')) {
             $ext = strtolower($ext);
@@ -69,17 +69,6 @@ class AssetUploader extends Uploader
         }
 
         return $ext;
-    }
-
-    private function getFileExtension(UploadedFile $file)
-    {
-        $extension = $file->getClientOriginalExtension();
-        $guessed = $file->guessExtension();
-
-        // Only use the guessed extension if it's different than the original.
-        // This allows us to maintain the casing of the original extension
-        // if the the "lowercase filenames" config option is disabled.
-        return strtolower($extension) === strtolower($guessed) ? $extension : $guessed;
     }
 
     public static function getSafeFilename($string)

--- a/src/Assets/FileUploader.php
+++ b/src/Assets/FileUploader.php
@@ -22,9 +22,7 @@ class FileUploader extends Uploader
 
     protected function uploadPath(UploadedFile $file)
     {
-        $filename = pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME);
-
-        return now()->timestamp.'/'.$filename.'.'.$file->guessExtension();
+        return now()->timestamp.'/'.$file->getClientOriginalName();
     }
 
     protected function uploadPathPrefix()


### PR DESCRIPTION
This PR reverts #9033 which seems to cause more problems than it resolved.
The problem that PR was solving also seems to be solved by #9037 which will remain in the codebase.

Resolves #9182
Resolves #9314
