### PR TITLE
[4.x] Make copy reset password link action opt-in

### DIFF
--- a/src/Actions/CopyPasswordResetLink.php
+++ b/src/Actions/CopyPasswordResetLink.php
@@ -16,7 +16,7 @@ class CopyPasswordResetLink extends Action
 
     public function visibleTo($item)
     {
-        return $item instanceof UserContract;
+        return config('statamic.users.allow_copy_reset_password_link', false) && $item instanceof UserContract;
     }
 
     public function visibleToBulk($items)


### PR DESCRIPTION
This PR makes the "Copy Reset Password Link" action opt-in due to a security concern.

You may add `'allow_copy_reset_password_link' => true` to `config/statamic/users.php` to enable it.

The ability to send the reset link via email remains - it's just the ability to copy it that is changing.
