### PR TITLE
[4.x] Revert uniform image validation

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -4,7 +4,6 @@ namespace Statamic\Assets;
 
 use ArrayAccess;
 use Facades\Statamic\Assets\Attributes;
-use Facades\Statamic\Imaging\ImageValidator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
@@ -486,7 +485,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      */
     public function isImage()
     {
-        return ImageValidator::isValidExtension($this->extension());
+        return $this->extensionIsOneOf(['jpg', 'jpeg', 'png', 'gif', 'webp']);
     }
 
     /**


### PR DESCRIPTION
This reverts #9284 (which hasn't been released) as it now doesn't seem to have had any effect.
