### PR TITLE
[4.x] Fix pagination with the `nocache` tag

### DIFF
--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\StaticCaching\NoCache;
 
+use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\Cascade;
 use Statamic\Facades\Data;
@@ -113,6 +115,8 @@ class Session
         $this->regions = $this->regions->merge($session['regions'] ?? []);
         $this->cascade = $this->restoreCascade();
 
+        $this->resolvePageAndPathForPagination();
+
         return $this;
     }
 
@@ -122,6 +126,15 @@ class Session
             ->withContent(Data::findByRequestUrl($this->url))
             ->hydrate()
             ->toArray();
+    }
+
+    private function resolvePageAndPathForPagination(): void
+    {
+        AbstractPaginator::currentPathResolver(fn () => Str::before($this->url, '?'));
+
+        AbstractPaginator::currentPageResolver(function () {
+            return Str::of($this->url)->after('page=')->before('&')->__toString();
+        });
     }
 
     private function cacheRegion(Region $region)

--- a/src/Tags/Concerns/OutputsItems.php
+++ b/src/Tags/Concerns/OutputsItems.php
@@ -60,7 +60,7 @@ trait OutputsItems
             'current_page' => $paginator->currentPage(),
             'prev_page' => $paginator->previousPageUrl(),
             'next_page' => $paginator->nextPageUrl(),
-            'auto_links' => $paginator->render('pagination::default'),
+            'auto_links' => $paginator->render('pagination::default')->__toString(),
             'links' => $paginator->renderArray(),
         ];
     }

--- a/src/Tags/Concerns/OutputsItems.php
+++ b/src/Tags/Concerns/OutputsItems.php
@@ -60,7 +60,7 @@ trait OutputsItems
             'current_page' => $paginator->currentPage(),
             'prev_page' => $paginator->previousPageUrl(),
             'next_page' => $paginator->nextPageUrl(),
-            'auto_links' => $paginator->render('pagination::default')->__toString(),
+            'auto_links' => (string) $paginator->render('pagination::default'),
             'links' => $paginator->renderArray(),
         ];
     }


### PR DESCRIPTION
This pull request aims to fix issues with pagination when using the `{{ nocache }}` tag.

* [x] Fixes an issue where the current path & page sometimes aren't resolved correctly.
    * In my testing, the previous/next page URLs were `/!/nocache?page=2` due to the "current URL" not being the URL of the original page.
* [x] #8052

Fixes https://github.com/statamic/cms/issues/8052.