### PR TITLE
[4.x] Support data in Eloquent based user groups

### DIFF
--- a/src/Auth/Eloquent/UserGroup.php
+++ b/src/Auth/Eloquent/UserGroup.php
@@ -15,6 +15,7 @@ class UserGroup extends FileUserGroup
             ->title($model->title)
             ->handle($model->handle)
             ->roles($model->roles ?? [])
+            ->data($model->data ?? [])
             ->model($model);
     }
 
@@ -25,6 +26,7 @@ class UserGroup extends FileUserGroup
                 'title' => $this->title,
                 'handle' => $this->handle,
                 'roles' => $this->roles->keys(),
+                'data' => $this->data->all(),
             ]);
     }
 

--- a/src/Auth/Eloquent/UserGroupModel.php
+++ b/src/Auth/Eloquent/UserGroupModel.php
@@ -12,6 +12,7 @@ class UserGroupModel extends Eloquent
 
     protected $casts = [
         'roles' => 'json',
+        'data' => 'json',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];

--- a/src/Console/Commands/ImportGroups.php
+++ b/src/Console/Commands/ImportGroups.php
@@ -69,7 +69,8 @@ class ImportGroups extends Command
             $eloquentGroup = UserGroup::make()
                 ->handle($group->handle())
                 ->title($group->title())
-                ->roles($group->roles());
+                ->roles($group->roles())
+                ->data($group->data()->except(['title', 'roles']));
 
             $eloquentGroup->save();
         });

--- a/src/Console/Commands/stubs/auth/statamic_groups_table.php.stub
+++ b/src/Console/Commands/stubs/auth/statamic_groups_table.php.stub
@@ -17,6 +17,7 @@ class StatamicGroupsTable extends Migration
             $table->id();
             $table->string('handle')->unique();
             $table->string('title');
+            $table->json('data')->nullable();
             $table->json('roles')->nullable();
             $table->timestamps();
         });

--- a/src/Http/Controllers/CP/Users/UserGroupsController.php
+++ b/src/Http/Controllers/CP/Users/UserGroupsController.php
@@ -74,7 +74,11 @@ class UserGroupsController extends CpController
 
         $fields = $blueprint
             ->fields()
-            ->addValues($group->data()->merge(['handle' => $group->handle()])->all())
+            ->addValues($group->data()->merge([
+                'title' => $group->title(),
+                'handle' => $group->handle(),
+                'roles' => $group->roles()->map->handle()->values()->all(),
+            ])->all())
             ->preProcess();
 
         $viewData = [

--- a/tests/Auth/Eloquent/EloquentUserGroupTest.php
+++ b/tests/Auth/Eloquent/EloquentUserGroupTest.php
@@ -5,9 +5,11 @@ namespace Tests\Auth\Eloquent;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Statamic\Auth\Eloquent\User as EloquentUser;
 use Statamic\Auth\Eloquent\UserGroup as EloquentGroup;
 use Statamic\Auth\Eloquent\UserGroupModel;
+use Statamic\Facades\UserGroup;
 use Tests\TestCase;
 
 class EloquentUserGroupTest extends TestCase
@@ -62,13 +64,11 @@ class EloquentUserGroupTest extends TestCase
 
     public function makeGroup()
     {
-        return (new EloquentGroup)
-            ->model(UserGroupModel::create([
-                'handle' => $this->faker->word,
-                'title' => $this->faker->words(2, true),
-                'roles' => [],
-            ])
-            );
+        return EloquentGroup::fromModel(UserGroupModel::create([
+            'handle' => $this->faker->word,
+            'title' => $this->faker->words(2, true),
+            'roles' => [],
+        ]));
     }
 
     public function makeUser()
@@ -114,5 +114,23 @@ class EloquentUserGroupTest extends TestCase
         $user->removeFromGroup($group);
 
         $this->assertCount(0, $user->groups());
+    }
+
+    /** @test */
+    public function it_sets_and_gets_data()
+    {
+        $group = $this->makeGroup();
+
+        $this->assertInstanceOf(Collection::class, $data = $group->data());
+        $this->assertEquals([], $data->all());
+
+        $group->data(['alfa' => 'bravo']);
+        $group->set('charlie', 'delta');
+        $this->assertEquals(['alfa' => 'bravo', 'charlie' => 'delta'], $group->data()->all());
+
+        $group->save();
+
+        $group = UserGroup::all()->first();
+        $this->assertEquals(['alfa' => 'bravo', 'charlie' => 'delta'], $group->data()->all());
     }
 }


### PR DESCRIPTION
Turns out that #5686 didn't support user group data. Probably because it was authored before the feature was introduced.
