### PR TITLE
[4.x] Enable background re-caching of static cache

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -125,4 +125,16 @@ return [
 
     'warm_queue' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Background Re-cache Token
+    |--------------------------------------------------------------------------
+    |
+    | If you want Statamic to re-cache URLs in the background, without removing
+    | them, add a unique string here that should not be easy to guess
+    |
+    */
+
+    'background_recache_token' => env('STATAMIC_BACKGROUND_RECACHE_TOKEN', null),
+
 ];

--- a/src/Jobs/StaticRecacheJob.php
+++ b/src/Jobs/StaticRecacheJob.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Statamic\Jobs;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Statamic\StaticCaching\Cacher;
+
+class StaticRecacheJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public Request $request;
+
+    public $tries = 1;
+
+    public function __construct($url, $domain)
+    {
+        $domain ??= app(Cacher::class)->getBaseUrl();
+
+        $url = $domain.$url;
+
+        $param = '__recache='.config('statamic.static_caching.background_recache_token');
+
+        $url .= (str_contains($url, '?') ? '&' : '?').$param;
+
+        $this->request = new Request('PUT', $url);
+    }
+
+    public function handle(Client $client)
+    {
+        $client->send($this->request);
+    }
+}

--- a/src/Jobs/StaticRecacheJob.php
+++ b/src/Jobs/StaticRecacheJob.php
@@ -28,7 +28,7 @@ class StaticRecacheJob implements ShouldQueue
 
         $url .= (str_contains($url, '?') ? '&' : '?').$param;
 
-        $this->request = new Request('PUT', $url);
+        $this->request = new Request('GET', $url);
     }
 
     public function handle(Client $client)

--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -138,6 +138,13 @@ abstract class AbstractCacher implements Cacher
     {
         $url = $request->getUri();
 
+        if ($recache = $request->input('__recache')) {
+            $url = str_replace('__recache='.$recache, '', $url);
+            if (substr($url, -1, 1) == '?') {
+                $url = substr($url, 0, -1);
+            }
+        }
+
         if ($this->config('ignore_query_strings')) {
             $url = explode('?', $url)[0];
         }

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -60,7 +60,7 @@ class FileCacher extends AbstractCacher
 
         $content = $this->normalizeContent($content);
 
-        $path = $this->getFilePath($request->getUri());
+        $path = $this->getFilePath($url);
 
         if (! $this->writer->write($path, $content, $this->config('lock_hold_length'))) {
             return;

--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -47,71 +47,133 @@ class DefaultInvalidator implements Invalidator
 
     protected function invalidateFormUrls($form)
     {
-        $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "forms.{$form->handle()}.urls")
-        );
+        $this->cacher->invalidateUrls($this->getFormUrls($form));
     }
 
     protected function invalidateAssetUrls($asset)
     {
-        $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "assets.{$asset->container()->handle()}.urls")
-        );
+        $this->cacher->invalidateUrls($this->getAssetUrls($asset));
     }
 
     protected function invalidateEntryUrls($entry)
     {
-        $entry->descendants()->merge([$entry])->each(function ($entry) {
-            if (! $entry->isRedirect() && $url = $entry->absoluteUrl()) {
-                $this->cacher->invalidateUrl(...$this->splitUrlAndDomain($url));
-            }
-        });
-
-        $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "collections.{$entry->collectionHandle()}.urls")
-        );
+        $this->cacher->invalidateUrls($this->getEntryUrls($entry));
     }
 
     protected function invalidateTermUrls($term)
     {
-        if ($url = $term->absoluteUrl()) {
-            $this->cacher->invalidateUrl(...$this->splitUrlAndDomain($url));
-
-            $term->taxonomy()->collections()->each(function ($collection) use ($term) {
-                if ($url = $term->collection($collection)->absoluteUrl()) {
-                    $this->cacher->invalidateUrl(...$this->splitUrlAndDomain($url));
-                }
-            });
-        }
-
-        $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "taxonomies.{$term->taxonomyHandle()}.urls")
-        );
+        $this->cacher->invalidateUrls($this->getTermUrls($term));
     }
 
     protected function invalidateNavUrls($nav)
     {
-        $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "navigation.{$nav->handle()}.urls")
-        );
+        $this->cacher->invalidateUrls($this->getNavUrls($nav));
     }
 
     protected function invalidateGlobalUrls($set)
     {
-        $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "globals.{$set->handle()}.urls")
-        );
+        $this->cacher->invalidateUrls($this->getGlobalUrls($set));
     }
 
     protected function invalidateCollectionUrls($collection)
     {
-        if ($url = $collection->absoluteUrl()) {
-            $this->cacher->invalidateUrl(...$this->splitUrlAndDomain($url));
+        $this->cacher->invalidateUrls($this->getCollectionUrls($collection));
+    }
+
+    public function invalidateAndRecache($item)
+    {
+        $urls = [];
+
+        if ($this->rules === 'all') {
+            $this->recacheUrls($this->cacher->getUrls());
+
+            return;
         }
 
-        $this->cacher->invalidateUrls(
-            Arr::get($this->rules, "collections.{$collection->handle()}.urls")
-        );
+        if ($item instanceof Entry) {
+            $urls = $this->getEntryUrls($item);
+        } elseif ($item instanceof Term) {
+            $urls = $this->getTermUrls($item);
+        } elseif ($item instanceof Nav) {
+            $urls = $this->getNavUrls($item);
+        } elseif ($item instanceof GlobalSet) {
+            $this->getGlobalUrls($item);
+        } elseif ($item instanceof Collection) {
+            $urls = $this->getCollectionUrls($item);
+        } elseif ($item instanceof Asset) {
+            $urls = $this->getAssetUrls($item);
+        } elseif ($item instanceof Form) {
+            $urls = $this->getFormUrls($item);
+        }
+
+        $this->recacheUrls($urls);
+    }
+
+    public function recacheUrls($urls)
+    {
+        collect($urls)->each(fn ($url) => is_array($url) ? $this->recacheUrl(...$url) : $this->recacheUrl($url));
+    }
+
+    public function recacheUrl($path, $domain = null)
+    {
+        StaticRecacheJob::dispatch($path, $domain);
+    }
+
+    private function getFormUrls($form)
+    {
+        return Arr::get($this->rules, "forms.{$form->handle()}.urls");
+    }
+
+    protected function getAssetUrls($asset)
+    {
+        return Arr::get($this->rules, "assets.{$asset->container()->handle()}.urls");
+    }
+
+    protected function getEntryUrls($entry)
+    {
+        $urls = $entry->descendants()->merge([$entry])->map(function ($entry) {
+            if (! $entry->isRedirect() && $url = $entry->absoluteUrl()) {
+                return $this->splitUrlAndDomain($url);
+            }
+        })->filter();
+
+        return $urls->merge(Arr::get($this->rules, "collections.{$entry->collectionHandle()}.urls"))->all();
+    }
+
+    protected function getTermUrls($term)
+    {
+        $urls = collect();
+        if ($url = $term->absoluteUrl()) {
+            $urls = $urls->push($this->splitUrlAndDomain($url));
+
+            $urls = $urls->merge($term->taxonomy()->collections()->each(function ($collection) use ($term) {
+                if ($url = $term->collection($collection)->absoluteUrl()) {
+                    return $this->splitUrlAndDomain($url);
+                }
+            })->filter();
+        }
+
+        return $urls->merge(Arr::get($this->rules, "taxonomies.{$term->taxonomyHandle()}.urls"))->all();
+    }
+
+    protected function getNavUrls($nav)
+    {
+        return Arr::get($this->rules, "navigation.{$nav->handle()}.urls");
+    }
+
+    protected function getGlobalUrls($set)
+    {
+        return Arr::get($this->rules, "globals.{$set->handle()}.urls");
+    }
+
+    protected function getCollectionUrls($collection)
+    {
+        $urls = [];
+        if ($url = $collection->absoluteUrl()) {
+            $urls[] = $this->splitUrlAndDomain($url);
+        }
+
+        return array_merge($urls, Arr::get($this->rules, "collections.{$collection->handle()}.urls"));
     }
 
     private function splitUrlAndDomain(string $url)

--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -82,6 +82,10 @@ class DefaultInvalidator implements Invalidator
 
     public function invalidateAndRecache($item)
     {
+        if (! config('statamic.static_caching.background_recache_token')) {
+            return $this->invalidate($item);
+        }
+
         $urls = [];
 
         if ($this->rules === 'all') {

--- a/src/StaticCaching/Invalidate.php
+++ b/src/StaticCaching/Invalidate.php
@@ -28,23 +28,23 @@ class Invalidate implements ShouldQueue
     protected $invalidator;
 
     protected $events = [
-        AssetSaved::class => 'invalidateAsset',
+        AssetSaved::class => 'invalidateAndRecacheAsset',
         AssetDeleted::class => 'invalidateAsset',
-        EntrySaved::class => 'invalidateEntry',
+        EntrySaved::class => 'invalidateAndRecacheEntry',
         EntryDeleting::class => 'invalidateEntry',
-        TermSaved::class => 'invalidateTerm',
+        TermSaved::class => 'invalidateAndRecacheTerm',
         TermDeleted::class => 'invalidateTerm',
-        GlobalSetSaved::class => 'invalidateGlobalSet',
+        GlobalSetSaved::class => 'invalidateAndRecacheGlobalSet',
         GlobalSetDeleted::class => 'invalidateGlobalSet',
-        NavSaved::class => 'invalidateNav',
+        NavSaved::class => 'invalidateAndRecacheNav',
         NavDeleted::class => 'invalidateNav',
-        FormSaved::class => 'invalidateForm',
+        FormSaved::class => 'invalidateAndRecacheForm',
         FormDeleted::class => 'invalidateForm',
-        CollectionTreeSaved::class => 'invalidateCollectionByTree',
+        CollectionTreeSaved::class => 'invalidateAndRecacheCollectionByTree',
         CollectionTreeDeleted::class => 'invalidateCollectionByTree',
-        NavTreeSaved::class => 'invalidateNavByTree',
+        NavTreeSaved::class => 'invalidateAndRecacheNavByTree',
         NavTreeDeleted::class => 'invalidateNavByTree',
-        BlueprintSaved::class => 'invalidateByBlueprint',
+        BlueprintSaved::class => 'invalidateAndRecacheByBlueprint',
         BlueprintDeleted::class => 'invalidateByBlueprint',
     ];
 
@@ -65,9 +65,19 @@ class Invalidate implements ShouldQueue
         $this->invalidator->invalidate($event->asset);
     }
 
+    public function invalidateAndRecacheAsset($event)
+    {
+        $this->invalidator->invalidateAndRecache($event->asset);
+    }
+
     public function invalidateEntry($event)
     {
         $this->invalidator->invalidate($event->entry);
+    }
+
+    public function invalidateAndRecacheEntry($event)
+    {
+        $this->invalidator->invalidateAndRecache($event->entry);
     }
 
     public function invalidateTerm($event)
@@ -75,9 +85,19 @@ class Invalidate implements ShouldQueue
         $this->invalidator->invalidate($event->term);
     }
 
+    public function invalidateAndRecacheTerm($event)
+    {
+        $this->invalidator->invalidateAndRecache($event->term);
+    }
+
     public function invalidateGlobalSet($event)
     {
         $this->invalidator->invalidate($event->globals);
+    }
+
+    public function invalidateAndRecacheGlobalSet($event)
+    {
+        $this->invalidator->invalidateAndRecache($event->globals);
     }
 
     public function invalidateNav($event)
@@ -85,9 +105,19 @@ class Invalidate implements ShouldQueue
         $this->invalidator->invalidate($event->nav);
     }
 
+    public function invalidateAndRecacheNav($event)
+    {
+        $this->invalidator->invalidateAndRecache($event->nav);
+    }
+
     public function invalidateForm($event)
     {
         $this->invalidator->invalidate($event->form);
+    }
+
+    public function invalidateAndRecacheForm($event)
+    {
+        $this->invalidator->invalidateAndRecache($event->form);
     }
 
     public function invalidateCollectionByTree($event)
@@ -95,9 +125,19 @@ class Invalidate implements ShouldQueue
         $this->invalidator->invalidate($event->tree->collection());
     }
 
+    public function invalidateAndRecacheCollectionByTree($event)
+    {
+        $this->invalidator->invalidateAndRecache($event->tree->collection());
+    }
+
     public function invalidateNavByTree($event)
     {
         $this->invalidator->invalidate($event->tree->structure());
+    }
+
+    public function invalidateAndRecacheNavByTree($event)
+    {
+        $this->invalidator->invalidateAndRecache($event->tree->structure());
     }
 
     public function invalidateByBlueprint($event)
@@ -105,6 +145,15 @@ class Invalidate implements ShouldQueue
         if ($event->blueprint->namespace() === 'forms') {
             if ($form = Form::find($event->blueprint->handle())) {
                 $this->invalidator->invalidate($form);
+            }
+        }
+    }
+
+    public function invalidateAndRecacheByBlueprint($event)
+    {
+        if ($event->blueprint->namespace() === 'forms') {
+            if ($form = Form::find($event->blueprint->handle())) {
+                $this->invalidator->invalidateAndRecache($form);
             }
         }
     }

--- a/src/StaticCaching/Invalidator.php
+++ b/src/StaticCaching/Invalidator.php
@@ -5,4 +5,6 @@ namespace Statamic\StaticCaching;
 interface Invalidator
 {
     public function invalidate($item);
+
+    public function invalidateAndRecache($item);
 }

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -120,6 +120,10 @@ class Cache
             return false;
         }
 
+        if ($this->hasValidRecacheToken($request)) {
+            return false;
+        }
+
         return true;
     }
 
@@ -129,14 +133,7 @@ class Cache
         // POST requests to preview the changes. We don't want those to trigger any caching,
         // or else pending changes will be shown immediately, even without hitting save.
         if ($request->method() !== 'GET') {
-            if ($request->method() != 'PUT') {
-                return false;
-            }
-
-            // if we are not a recache attempt
-            if (! ($token = $request->input('__recache')) && ($token === config('statamic.static_caching.background_recache_token', ''))) {
-                return false;
-            }
+            return false;
         }
 
         // Draft and private pages should not be cached.
@@ -153,6 +150,15 @@ class Cache
         }
 
         return true;
+    }
+
+    private function hasValidRecacheToken($request)
+    {
+        if (! $token = $request->input('__recache')) {
+            return false;
+        }
+
+        return $token === config('statamic.static_caching.background_recache_token');
     }
 
     private function createLock($request)

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -134,7 +134,7 @@ class Cache
             }
 
             // if we are not a recache attempt
-            if (! ($request->headers->has('X-Statamic-Recache') && $request->input('__recache'))) {
+            if (! ($token = $request->input('__recache')) && ($token === config('statamic.static_caching.background_recache_token', ''))) {
                 return false;
             }
         }

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -129,7 +129,14 @@ class Cache
         // POST requests to preview the changes. We don't want those to trigger any caching,
         // or else pending changes will be shown immediately, even without hitting save.
         if ($request->method() !== 'GET') {
-            return false;
+            if ($request->method() != 'PUT') {
+                return false;
+            }
+
+            // if we are not a recache attempt
+            if (! ($request->headers->has('X-Statamic-Recache') && $request->input('__recache'))) {
+                return false;
+            }
         }
 
         // Draft and private pages should not be cached.


### PR DESCRIPTION
This PR enables background re-caching of the static cache through a new `static_caching.background_recache_token` variable (or STATAMIC_BACKGROUND_RECACHE_TOKEN value). 

When a value is provided the static cache will re-cache the page without invalidating the previous cache, so at every point a static file will exist and end users will not find encounter slow loading pages.

Invalidation continues to occur as it currently does when content is deleted, or when this token is not provided.

Tests to follow...