### PR TITLE
[4.x] Fix translations in `nocache` tag

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use Statamic\Http\Middleware\AuthGuard;
 use Statamic\Http\Middleware\CP\AuthGuard as CPAuthGuard;
 use Statamic\Statamic;
 use Statamic\StaticCaching\NoCache\Controller as NoCacheController;
+use Statamic\StaticCaching\NoCache\NoCacheLocalize;
 
 Route::name('statamic.')->group(function () {
     Route::group(['prefix' => config('statamic.routes.action')], function () {
@@ -45,6 +46,7 @@ Route::name('statamic.')->group(function () {
 
     Route::prefix(config('statamic.routes.action'))
         ->post('nocache', NoCacheController::class)
+        ->middleware(NoCacheLocalize::class)
         ->withoutMiddleware('App\Http\Middleware\VerifyCsrfToken');
 
     if (OAuth::enabled()) {

--- a/src/StaticCaching/NoCache/Controller.php
+++ b/src/StaticCaching/NoCache/Controller.php
@@ -2,13 +2,10 @@
 
 namespace Statamic\StaticCaching\NoCache;
 
-use Closure;
 use Illuminate\Http\Request;
-use Statamic\Http\Middleware\Localize;
+use Illuminate\Routing\Controller as BaseController;
 use Statamic\StaticCaching\Replacers\NoCacheReplacer;
 use Statamic\Support\Str;
-use Illuminate\Routing\Controller as BaseController;
-use Statamic\Facades\Site;
 
 class Controller extends BaseController
 {

--- a/src/StaticCaching/NoCache/Controller.php
+++ b/src/StaticCaching/NoCache/Controller.php
@@ -3,17 +3,11 @@
 namespace Statamic\StaticCaching\NoCache;
 
 use Illuminate\Http\Request;
-use Illuminate\Routing\Controller as BaseController;
 use Statamic\StaticCaching\Replacers\NoCacheReplacer;
 use Statamic\Support\Str;
 
-class Controller extends BaseController
+class Controller
 {
-    public function __construct()
-    {
-        $this->middleware(NoCacheLocalize::class);
-    }
-
     public function __invoke(Request $request, Session $session)
     {
         $url = $request->input('url');

--- a/src/StaticCaching/NoCache/Controller.php
+++ b/src/StaticCaching/NoCache/Controller.php
@@ -2,12 +2,21 @@
 
 namespace Statamic\StaticCaching\NoCache;
 
+use Closure;
 use Illuminate\Http\Request;
+use Statamic\Http\Middleware\Localize;
 use Statamic\StaticCaching\Replacers\NoCacheReplacer;
 use Statamic\Support\Str;
+use Illuminate\Routing\Controller as BaseController;
+use Statamic\Facades\Site;
 
-class Controller
+class Controller extends BaseController
 {
+    public function __construct()
+    {
+        $this->middleware(NoCacheLocalize::class);
+    }
+
     public function __invoke(Request $request, Session $session)
     {
         $url = $request->input('url');

--- a/src/StaticCaching/NoCache/NoCacheLocalize.php
+++ b/src/StaticCaching/NoCache/NoCacheLocalize.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Statamic\StaticCaching\NoCache;
+
+use Closure;
+use Statamic\Facades\Site;
+use Statamic\Http\Middleware\Localize;
+
+class NoCacheLocalize extends Localize
+{
+    public function handle($request, Closure $next)
+    {
+        Site::resolveCurrentUrlUsing(fn () => $request->get('url'));
+
+        return parent::handle($request, $next);
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue with translations when using the `{{ nocache }}` tag.

Fixes #7893.