### PR TITLE
[4.x] Allow a custom static caching url store to be specified

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -36,6 +36,7 @@ return [
         'full' => [
             'driver' => 'file',
             'path' => public_path('static'),
+            'cache_path' => null,
             'lock_hold_length' => 0,
         ],
 

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -4,6 +4,7 @@ namespace Statamic\StaticCaching\Cachers;
 
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\File as LaravelFile;
 use Illuminate\Support\Facades\Log;
 use Statamic\Events\UrlInvalidated;
 use Statamic\Facades\File;
@@ -101,6 +102,10 @@ class FileCacher extends AbstractCacher
     {
         foreach ($this->getCachePaths() as $path) {
             $this->writer->flush($path);
+        }
+
+        if ($path = config('statamic.static_caching.strategies.full.cache_path')) {
+            LaravelFile::deleteDirectory($path);
         }
 
         $this->flushUrls();

--- a/src/StaticCaching/StaticCacheManager.php
+++ b/src/StaticCaching/StaticCacheManager.php
@@ -4,6 +4,7 @@ namespace Statamic\StaticCaching;
 
 use Illuminate\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
+use Statamic\Extensions\FileStore;
 use Statamic\Facades\Site;
 use Statamic\StaticCaching\Cachers\ApplicationCacher;
 use Statamic\StaticCaching\Cachers\FileCacher;
@@ -30,7 +31,15 @@ class StaticCacheManager extends Manager
 
     public function createFileDriver(array $config)
     {
-        return new FileCacher(new Writer, $this->app[Repository::class], $config);
+        $customCacheStore = null;
+
+        if ($path = config('statamic.static_caching.strategies.full.cache_path')) {
+            $customCacheStore = app('cache')->repository(
+                (new FileStore($this->app['files'], $path))
+            );
+        }
+
+        return new FileCacher(new Writer, $customCacheStore ?? $this->app[Repository::class], $config);
     }
 
     public function createApplicationDriver(array $config)


### PR DESCRIPTION
Static caching stores a cache of mapping of URLs to filenames in the Laravel cache, which is retrieved during invalidation. 

However, if you have cleared your Laravel cache (eg artisan cache:clear), this mapping is lost, so no URLs are invalidated. 

This PR provides a work around this behaviour by allowing a `cache_path` to be specified for the URL store, which is then used for storing the mapping, and it updates the `static:clear` command to remove this cache folder. 

As it is an `on-the-fly` cache store, it wont be cleared by the Laravel cache clear command.

I've defaulted the value to null for backwards compatibility, but given updating to Statamic will clear the cache and trigger the error, maybe it should default to the new behaviour?

Closes https://github.com/statamic/cms/issues/7333