### PR TITLE
[4.x] Push listing page state to URL query params

### DIFF
--- a/resources/js/bootstrap/globals.js
+++ b/resources/js/bootstrap/globals.js
@@ -87,6 +87,15 @@ export function utf8btoa(stringToEncode) {
     return btoa(utf8String);
 }
 
+export function utf8atob(stringToDecode) {
+    // Decode from base64 to UTF-8 byte representation
+    const utf8String = atob(stringToDecode);
+
+    // Convert the UTF-8 byte representation back to a regular string
+    return decodeURIComponent(utf8String.split('')
+        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));
+}
+
 export function uniqid() {
     return uid();
 }

--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -202,7 +202,7 @@ export default {
         },
 
         popState(event) {
-            if (!this.pushQuery) {
+            if (!this.pushQuery || !event.state) {
                 return;
             }
             this.popping = true;

--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -231,10 +231,10 @@ export default {
                 return;
             }
             const parameters = this.parameters;
-            const keys = Object.keys(parameters);
-            const except = Object.keys(this.additionalParameters);
+            const keys = Object.keys(this.queryParameters);
+            // This ensures no additionalParameters are added to the URL
             const searchParams = new URLSearchParams(Object.fromEntries(keys
-                .filter(key => !except.includes(key))
+                .filter(key => parameters.hasOwnProperty(key))
                 .map(key => [key, parameters[key]])));
             window.history.pushState({ parameters }, '', '?' + searchParams.toString());
         },

--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -86,8 +86,7 @@ export default {
                 return this.visibleColumns.map(column => column.field).join(',');
             },
             set(value) {
-                const handles = value.split(',');
-                this.visibleColumns = this.columns.filter(column => handles.includes(column.field));
+                this.visibleColumns = value.split(',').map(field => this.columns.find(column => column.field === field));
             },
         },
 

--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -232,7 +232,11 @@ export default {
             }
             const searchParams = new URLSearchParams(window.location.search);
             const parameters = Object.fromEntries(searchParams.entries());
+            this.popping = true;
             this.parameters = parameters;
+            this.$nextTick(() => {
+                this.popping = false;
+            });
         },
 
     }

--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -34,9 +34,9 @@ export default {
             visibleColumns: this.initialColumns.filter(column => column.visible),
             sortColumn: this.initialSortColumn,
             sortDirection: this.initialSortDirection,
-            popping: false,
-            pushQuery: false,
             meta: null,
+            pushQuery: false,
+            popping: false,
         }
     },
 

--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -112,12 +112,16 @@ export default {
     },
 
     mounted() {
-        window.history.replaceState({ parameters: this.parameters }, '');
-        window.addEventListener('popstate', this.popState);
+        if (this.pushQuery) {
+            window.history.replaceState({ parameters: this.parameters }, '');
+            window.addEventListener('popstate', this.popState);
+        }
     },
 
     beforeDestroy() {
-        window.removeEventListener('popstate', this.popState);
+        if (this.pushQuery) {
+            window.removeEventListener('popstate', this.popState);
+        }
     },
 
     watch: {

--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -105,6 +105,12 @@ export default {
 
     },
 
+    created() {
+        this.autoApplyFilters(this.filters);
+        this.autoApplyState();
+        this.request();
+    },
+
     mounted() {
         window.history.replaceState({ parameters: this.parameters }, '');
         window.addEventListener('popstate', this.popState);
@@ -112,12 +118,6 @@ export default {
 
     beforeDestroy() {
         window.removeEventListener('popstate', this.popState);
-    },
-
-    created() {
-        this.autoApplyFilters(this.filters);
-        this.autoApplyState();
-        this.request();
     },
 
     watch: {

--- a/resources/js/components/Listing.vue
+++ b/resources/js/components/Listing.vue
@@ -37,7 +37,13 @@ export default {
             meta: null,
             pushQuery: false,
             popping: false,
-            queryParameters: {
+        }
+    },
+
+    computed: {
+
+        parameterMap()  {
+            return {
                 sort: 'sortColumn',
                 order: 'sortDirection',
                 page: 'page',
@@ -45,15 +51,12 @@ export default {
                 search: 'searchQuery',
                 filters: 'activeFilterParameters',
                 columns: 'visibleColumnParameters',
-            },
-        }
-    },
-
-    computed: {
+            };
+        },
 
         parameters:  {
             get() {
-                const parameters = Object.fromEntries(Object.entries(this.queryParameters)
+                const parameters = Object.fromEntries(Object.entries(this.parameterMap)
                     .map(([key, prop]) => {
                         return [key, this[prop]];
                     })
@@ -66,7 +69,7 @@ export default {
                 };
             },
             set(value) {
-                Object.entries(this.queryParameters)
+                Object.entries(this.parameterMap)
                     .forEach(([key, prop]) => {
                         if (value.hasOwnProperty(key)) {
                             this[prop] = value[key];
@@ -231,7 +234,7 @@ export default {
                 return;
             }
             const parameters = this.parameters;
-            const keys = Object.keys(this.queryParameters);
+            const keys = Object.keys(this.parameterMap);
             // This ensures no additionalParameters are added to the URL
             const searchParams = new URLSearchParams(Object.fromEntries(keys
                 .filter(key => parameters.hasOwnProperty(key))

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -139,6 +139,7 @@ export default {
             requestUrl: cp_url(`collections/${this.collection}/entries`),
             currentSite: this.site,
             initialSite: this.site,
+            pushQuery: true,
         }
     },
 

--- a/resources/js/components/terms/Listing.vue
+++ b/resources/js/components/terms/Listing.vue
@@ -127,6 +127,7 @@ export default {
             listingKey: 'terms',
             preferencesPrefix: `taxonomies.${this.taxonomy}`,
             requestUrl: cp_url(`taxonomies/${this.taxonomy}/terms`),
+            pushQuery: true,
         }
     },
 

--- a/resources/js/components/users/Listing.vue
+++ b/resources/js/components/users/Listing.vue
@@ -141,6 +141,7 @@ export default {
         return {
             preferencesPrefix: 'users',
             requestUrl: cp_url('users'),
+            pushQuery: true,
         }
     },
 


### PR DESCRIPTION
This PR pushes the listing components `parameters` to the URL, so that you can bookmark, refresh and navigate back/forwards while maintaining the selected sort, filters, search, columns, page etc.

This is an opt-in feature of the listing mixin, since it might not make sense for all types of listing, especially when you have more than one on the same page (eg. Dashboard). To enable it set `pushQuery` to `true`.

I have enabled it for the main entry, term and user listings.

The `additionalParameters` are not pushed to the URL, since the listing mixin wont know what they are or how to handle them.

I asked ChatGPT for the `utf8atob` function, it seems to work fine but I have no idea if it's perfect.

Closes https://github.com/statamic/ideas/issues/93