### PR TITLE
[4.x] Prevent serialization errors with`@nocache` directive when using Blade view components

### DIFF
--- a/src/StaticCaching/NoCache/Region.php
+++ b/src/StaticCaching/NoCache/Region.php
@@ -29,8 +29,14 @@ abstract class Region
     protected function filterContext(array $context)
     {
         $context = collect($context)
-            ->reject(fn ($value, $key) => $value instanceof InvokableComponentVariable)
             ->reject(fn ($value, $key) => in_array($key, ['__env', 'app', 'errors', 'resolve', 'resolveComponentsUsing', 'forgetComponentsResolver', 'forgetFactory', 'flushCache', 'constructor']))
+            ->map(function ($value, $key) {
+                if ($value instanceof InvokableComponentVariable) {
+                    return $value->resolveDisplayableValue();
+                }
+
+                return $value;
+            })
             ->toArray();
 
         return $this->arrayRecursiveDiff($context, $this->session->cascade());

--- a/src/StaticCaching/NoCache/Region.php
+++ b/src/StaticCaching/NoCache/Region.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\StaticCaching\NoCache;
 
+use Illuminate\View\InvokableComponentVariable;
 use Statamic\Support\Arr;
 
 abstract class Region
@@ -27,9 +28,10 @@ abstract class Region
 
     protected function filterContext(array $context)
     {
-        foreach (['__env', 'app', 'errors', 'resolve', 'resolveComponentsUsing', 'forgetComponentsResolver', 'forgetFactory', 'flushCache', 'constructor'] as $var) {
-            unset($context[$var]);
-        }
+        $context = collect($context)
+            ->reject(fn ($value, $key) => $value instanceof InvokableComponentVariable)
+            ->reject(fn ($value, $key) => in_array($key, ['__env', 'app', 'errors', 'resolve', 'resolveComponentsUsing', 'forgetComponentsResolver', 'forgetFactory', 'flushCache', 'constructor']))
+            ->toArray();
 
         return $this->arrayRecursiveDiff($context, $this->session->cascade());
     }


### PR DESCRIPTION
This pull request fixes a serialization error with the `@nocache` directive when using a Blade view component with a custom method.

This PR will evaluate any custom methods in Blade view components.

Fixes #8203.
Related: #6935