### PR TITLE
[4.x] Bug: Values class not forwarding calls to proxied collection methods

### DIFF
--- a/src/Fields/Values.php
+++ b/src/Fields/Values.php
@@ -108,11 +108,6 @@ class Values implements Arrayable, ArrayAccess, IteratorAggregate, JsonSerializa
         return $this->getProxiedInstance()->toArray();
     }
 
-    public function all()
-    {
-        return $this->getProxiedInstance()->all();
-    }
-
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {

--- a/src/Fields/Values.php
+++ b/src/Fields/Values.php
@@ -91,8 +91,9 @@ class Values implements Arrayable, ArrayAccess, IteratorAggregate, JsonSerializa
 
     public function __call($method, $args)
     {
-        if ($this->getProxiedInstance()->has($method)) {
-            $value = $this->getNormalizedValueFromProxiedCollection($method);
+        if (method_exists($this->getProxiedInstance(), $method)) {
+            return $this->getProxiedInstance()->$method(...$args);
+        }
 
             if (Compare::isQueryBuilder($value)) {
                 return $value;

--- a/src/Fields/Values.php
+++ b/src/Fields/Values.php
@@ -111,7 +111,7 @@ class Values implements Arrayable, ArrayAccess, IteratorAggregate, JsonSerializa
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
-        return $this->all();
+        return $this->getProxiedInstance()->all();
     }
 
     public function resolveGqlValue($field)

--- a/src/Fields/Values.php
+++ b/src/Fields/Values.php
@@ -95,9 +95,9 @@ class Values implements Arrayable, ArrayAccess, IteratorAggregate, JsonSerializa
             return $this->getProxiedInstance()->$method(...$args);
         }
 
-            if (Compare::isQueryBuilder($value)) {
-                return $value;
-            }
+        $value = $this->getNormalizedValueFromProxiedCollection($method);
+        if (Compare::isQueryBuilder($value)) {
+            return $value;
         }
 
         throw new BadMethodCallException(sprintf('Method %s::%s does not exist.', static::class, $method));

--- a/src/Fields/Values.php
+++ b/src/Fields/Values.php
@@ -100,7 +100,7 @@ class Values implements Arrayable, ArrayAccess, IteratorAggregate, JsonSerializa
             return $value;
         }
 
-        throw new BadMethodCallException(sprintf('Method %s::%s does not exist.', static::class, $method));
+        throw new BadMethodCallException(sprintf('Method %s::%s does not exist on proxied instance, and is not a query builder.', static::class, $method));
     }
 
     public function toArray()

--- a/tests/Fields/ValuesTest.php
+++ b/tests/Fields/ValuesTest.php
@@ -67,6 +67,18 @@ class ValuesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_pass_collection_method_calls_to_proxied_instance()
+    {
+        $values = new Values([
+            'body' => 'Potato',
+            'part' => new Value('Head', null, $this->fieldtype),
+        ]);
+
+        $this->assertEquals('Potato Head (augmented)', $values->implode(' '));
+        $this->assertEquals('Mr. Potato Head (augmented)', $values->prepend('Mr.', 'prefix')->implode(' '));
+    }
+
+    /** @test */
     public function its_arrayable()
     {
         $mockOne = Mockery::mock(Collection::class)->shouldReceive('toArray')->andReturn(['title' => 'first'])->getMock();
@@ -196,7 +208,7 @@ class ValuesTest extends TestCase
     public function it_throws_exception_if_trying_to_get_query_for_field_that_isnt_a_query()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Method Statamic\Fields\Values::not_a_query does not exist.');
+        $this->expectExceptionMessage('Method Statamic\Fields\Values::not_a_query does not exist on proxied instance, and is not a query builder.');
 
         $values = new Values(['not_a_query' => 'test']);
 
@@ -207,7 +219,7 @@ class ValuesTest extends TestCase
     public function it_throws_exception_if_trying_to_get_query_for_missing_field()
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Method Statamic\Fields\Values::missing does not exist.');
+        $this->expectExceptionMessage('Method Statamic\Fields\Values::missing does not exist on proxied instance, and is not a query builder.');
 
         $values = new Values(['not_a_query' => 'test']);
 


### PR DESCRIPTION
This PR makes a few changes to how the magic `__call` method works, within `Fields\Values.php`.  Currently, it performs a single check and throws an exception if this condition is not met:

```php
$this->getProxiedInstance()->has($method)
```

We get the collection back as the proxied instance, but the `has` method checks for the existence of a particular _key_ in the data—not an available _method_ on the class itself.

With this PR, we're adding in an initial check to see if the passed `$method` exists on the Collection, via the `getProxiedInstance()`. If it _does_ exist, call it with the additional `$args` and return the value. Otherwise, continue to the same query builder check we had originally. If neither of these apply, throw an exception w/ a slightly more descriptive message.

Also added to the `ValuesTest`, with an example that illustrates our particular use-case for some custom front-end output.

---

**_Disclaimer:_** the way this method was defined lead me to believe it's missing the functionality outlined above, _**but by all means, check my work/logic here, and don't hesitate to trash this PR if it's not inline with the intended use of that class or method.**_