### PR TITLE
[4.x] Rename route binding parameters to prevent overlapping

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -246,8 +246,8 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
 
     Route::get('updater', [UpdaterController::class, 'index'])->name('updater');
     Route::get('updater/count', [UpdaterController::class, 'count']);
-    Route::get('updater/{product}', [UpdateProductController::class, 'show'])->name('updater.product');
-    Route::get('updater/{product}/changelog', [UpdateProductController::class, 'changelog']);
+    Route::get('updater/{marketplaceProductSlug}', [UpdateProductController::class, 'show'])->name('updater.product');
+    Route::get('updater/{marketplaceProductSlug}/changelog', [UpdateProductController::class, 'changelog']);
 
     Route::group(['prefix' => 'duplicates'], function () {
         Route::get('/', [DuplicatesController::class, 'index'])->name('duplicates');

--- a/src/Http/Controllers/CP/Updater/UpdateProductController.php
+++ b/src/Http/Controllers/CP/Updater/UpdateProductController.php
@@ -12,16 +12,16 @@ class UpdateProductController extends CpController
      *
      * @param  string  $slug
      */
-    public function show($slug)
+    public function show($marketplaceProductSlug)
     {
         $this->authorize('view updates');
 
-        if (! $product = Marketplace::product($slug)) {
+        if (! $product = Marketplace::product($marketplaceProductSlug)) {
             return $this->pageNotFound();
         }
 
         return view('statamic::updater.show', [
-            'slug' => $slug,
+            'slug' => $marketplaceProductSlug,
             'package' => $product->package(),
             'name' => $product->name(),
         ]);
@@ -32,11 +32,11 @@ class UpdateProductController extends CpController
      *
      * @param  string  $slug
      */
-    public function changelog($slug)
+    public function changelog($marketplaceProductSlug)
     {
         $this->authorize('view updates');
 
-        if (! $product = Marketplace::product($slug)) {
+        if (! $product = Marketplace::product($marketplaceProductSlug)) {
             return $this->pageNotFound();
         }
 


### PR DESCRIPTION
This pull request changes the name of the route binding parameter that gets passed to the Product Updater controller to prevent issues with `{product}` overlapping with any custom app logic.

Fixes #8897.