### PR TITLE
[4.x] Fix user wizard error when user blueprint has bard field

### DIFF
--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -132,7 +132,7 @@ class UsersController extends CpController
         $viewData = [
             'values' => (object) $fields->values()->only($additional)->all(),
             'meta' => (object) $fields->meta()->only($additional)->all(),
-            'fields' => collect($fields->toPublishArray())->filter(fn ($field) => $additional->contains($field['handle']))->values()->all(),
+            'fields' => collect($blueprint->fields()->toPublishArray())->filter(fn ($field) => $additional->contains($field['handle']))->values()->all(),
             'blueprint' => $blueprint->toPublishArray(),
             'expiry' => $expiry,
             'separateNameFields' => $blueprint->hasField('first_name'),


### PR DESCRIPTION
Fixes a user wizard error when the user blueprint has a bard field, which was accidentally introduced by https://github.com/statamic/cms/pull/9003, and reported by @edalzell.

The issue is that the PR introduced a `toPublishArray()` call on a set of `preProcess()`'d fields (in order to provide the new additional fields to the user wizard). The additional `fields` passed to the user wizard don't need to be `preProcessed()` though, since we pass `values` separately, so this fix uses a fresh `Fields` instance off the blueprint.

There's no tests for this fix, because it's a bit of a bandaid fix for a slightly deeper issue. Bard fields `preProcess()` empty values to a string JSON value of `'[]'`, which then errors you try to `toPublishArray()`. We're unsure what the actual fix should be. We've been preprocessing bard fields to JSON since 3.0-beta, but what was the reason for that?