### PR TITLE
[4.x] Hide listing filters when reordering entries

### DIFF
--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -16,7 +16,7 @@
         >
             <div slot-scope="{ hasSelections }">
                 <div class="card overflow-hidden p-0 relative">
-                    <div class="flex flex-wrap items-center justify-between px-2 pb-2 text-sm border-b">
+                    <div v-if="!reordering" class="flex flex-wrap items-center justify-between px-2 pb-2 text-sm border-b">
 
                         <data-list-filter-presets
                             ref="presets"


### PR DESCRIPTION
This pull request fixes an issue on the Entries Listing Table where it was possible to use filter views & search entries when reordering entries. 

This function was [previously disabled](https://github.com/statamic/cms/blob/3.4/resources/js/components/entries/Listing.vue#L21) when reordering, however, it must have been missed with the Listing Table refactoring that was done for v4.

Closes #9331.