### PR TITLE
[4.x] Don't set termTemplate and template if they are the defaults

### DIFF
--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -133,8 +133,8 @@ class TaxonomiesController extends CpController
             'collections' => $taxonomy->collections()->map->handle()->all(),
             'sites' => $taxonomy->sites()->all(),
             'preview_targets' => $taxonomy->basePreviewTargets(),
-            'term_template' => $taxonomy->termTemplate(),
-            'template' => $taxonomy->template(),
+            'term_template' => $taxonomy->termTemplate,
+            'template' => $taxonomy->template,
             'layout' => $taxonomy->layout(),
         ];
 

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -383,13 +383,6 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
 
                 return $termTemplate;
             })
-            ->setter(function ($termTemplate) {
-                if (! $termTemplate) {
-                    return;
-                }
-
-                return $termTemplate;
-            })
             ->args(func_get_args());
     }
 
@@ -406,13 +399,6 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
 
                 if ($collection = $this->collection()) {
                     $template = $collection->handle().'.'.$template;
-                }
-
-                return $template;
-            })
-            ->setter(function ($template) {
-                if (! $template) {
-                    return;
                 }
 
                 return $template;

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -383,6 +383,13 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
 
                 return $termTemplate;
             })
+            ->setter(function ($termTemplate) {
+                if (! $termTemplate) {
+                    return;
+                }
+
+                return $termTemplate;
+            })
             ->args(func_get_args());
     }
 
@@ -399,6 +406,13 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
 
                 if ($collection = $this->collection()) {
                     $template = $collection->handle().'.'.$template;
+                }
+
+                return $template;
+            })
+            ->setter(function ($template) {
+                if (! $template) {
+                    return;
                 }
 
                 return $template;


### PR DESCRIPTION
https://github.com/statamic/cms/pull/8372 introducted termTemplate and template on Taxonomies, but it unfortunately also always saves the default values through the CP, which means the magic collection views never get called.

This PR reverts that behaviour, and doesnt save these values unless they are explicitly set.

Closes https://github.com/statamic/cms/issues/9418