### PR TITLE
[4.x] Fix issue with Set Previews in Bard

### DIFF
--- a/resources/js/components/fieldtypes/ListFieldtype.vue
+++ b/resources/js/components/fieldtypes/ListFieldtype.vue
@@ -171,10 +171,6 @@ export default {
         deleteItem(index) {
             return this.data.splice(index, 1);
         },
-
-        getReplicatorPreviewText() {
-            return this.data.map(item => item.value).join(', ');
-        }
     }
 };
 </script>

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -487,14 +487,6 @@ export default {
             this.$refs.uploader.browse();
         },
 
-        getReplicatorPreviewText() {
-            return _.map(this.assets, (asset) => {
-                return asset.is_image ?
-                    `<img src="${asset.thumbnail}" width="20" height="20" title="${asset.basename}" />`
-                    : asset.basename;
-            }).join(', ');
-        },
-
         idChanged(oldId, newId) {
             const index = this.value.indexOf(oldId);
             this.update([...this.value.slice(0, index), newId, ...this.value.slice(index + 1)]);

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -179,9 +179,7 @@ export default {
         },
 
         previewUpdated(handle, value) {
-            let previews = clone(this.previews);
-            previews[handle] = value;
-            this.extension.options.bard.updateSetPreviews(this.node.attrs.id, previews);
+            this.extension.options.bard.updateSetPreviews(this.node.attrs.id, { ...this.previews, [handle]: value });
         },
 
         focused() {


### PR DESCRIPTION
This pull request fixes an issue with Set Previews in Bard where fields returning `PreviewHtml` objects would be converted into "normal" objects when the previews are [cloned here](https://github.com/statamic/cms/blob/6bd4976198b9e4cdb68c3c69686487a3c391c30a/resources/js/components/fieldtypes/bard/Set.vue#L182).

You can easily reproduce this with an Assets field & Forms field in a Bard set. When you change/remove the form, the preview for the Asset field in the set shows you the JSON rather than the expected preview output. 

I've copied the fix for this from how we do the same thing on Replicator sets. I've also removed the `getReplicatorPreviewText` methods from the Asset & List fieldtypes since they're no longer used.

Fixes #9174.