### PR TITLE
[4.x] Improve the workflow around enabling Statamic Pro

### DIFF
--- a/config/editions.php
+++ b/config/editions.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'pro' => false,
+    'pro' => env('STATAMIC_PRO_ENABLED', false),
 
     'addons' => [
         //

--- a/src/Console/Commands/ProEnable.php
+++ b/src/Console/Commands/ProEnable.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Statamic\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Statamic\Console\EnhancesCommands;
+use Statamic\Console\RunsInPlease;
+
+class ProEnable extends Command
+{
+    use ConfirmableTrait, EnhancesCommands, RunsInPlease;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'statamic:pro:enable
+        { --force : Force the operation to run when in production }';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Enable Statamic Pro in .env';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! $this->setProInEnvironmentFile()) {
+            return;
+        }
+
+        $this->laravel['config']['statamic.editions.pro'] = true;
+
+        $this->checkInfo('Statamic Pro successfully enabled.');
+    }
+
+    /**
+     * Set to pro in the environment file.
+     *
+     * @return bool
+     */
+    protected function setProInEnvironmentFile()
+    {
+        if (! $this->confirmToProceed()) {
+            return false;
+        }
+
+        if ($this->proEnvVarExists()) {
+            $this->ensureProInEnv();
+        } else {
+            $this->appendProToEnv();
+        }
+
+        return true;
+    }
+
+    /**
+     * Check whether the pro env var already exists.
+     *
+     * @return bool
+     */
+    protected function proEnvVarExists()
+    {
+        return preg_match('/^STATAMIC_PRO_ENABLED=/m', $this->envContents());
+    }
+
+    /**
+     * Ensure pro in .env file.
+     *
+     * @return void
+     */
+    protected function ensureProInEnv()
+    {
+        file_put_contents($this->envPath(), preg_replace(
+            '/^STATAMIC_PRO_ENABLED=.*$/m',
+            'STATAMIC_PRO_ENABLED=true',
+            $this->envContents()
+        ));
+    }
+
+    /**
+     * Append pro to end of .env file.
+     *
+     * @return void
+     */
+    protected function appendProToEnv()
+    {
+        file_put_contents($this->envPath(), $this->envContents()."\nSTATAMIC_PRO_ENABLED=true");
+    }
+
+    /**
+     * Get app .env path.
+     *
+     * @return string
+     */
+    protected function envPath()
+    {
+        return $this->laravel->environmentFilePath();
+    }
+
+    /**
+     * Get app .env contents.
+     *
+     * @return string
+     */
+    protected function envContents()
+    {
+        return file_get_contents($this->envPath());
+    }
+}

--- a/src/Console/Commands/ProEnable.php
+++ b/src/Console/Commands/ProEnable.php
@@ -39,7 +39,13 @@ class ProEnable extends Command
 
         $this->laravel['config']['statamic.editions.pro'] = true;
 
-        $this->checkInfo('Statamic Pro successfully enabled.');
+        $this->checkInfo('Statamic Pro successfully enabled in .env file!');
+
+        if ($this->configNotReferencingEnv()) {
+            $this->crossLine('Statamic editions config not currently referencing .env file.');
+            $this->comment(PHP_EOL.'For this setting to take effect, please modify your [config/statamic/editions.php] as follows:');
+            $this->line("'pro' => env('STATAMIC_PRO_ENABLED', false)");
+        }
     }
 
     /**
@@ -114,5 +120,19 @@ class ProEnable extends Command
     protected function envContents()
     {
         return file_get_contents($this->envPath());
+    }
+
+    /**
+     * Check whether the editions config is referencing the .env var.
+     *
+     * @return bool
+     */
+    protected function configNotReferencingEnv()
+    {
+        if (! file_exists($configPath = config_path('statamic/editions.php'))) {
+            return false;
+        }
+
+        return ! preg_match('/[\'"]pro[\'"]\s*=>\s*env\([\'"]STATAMIC_PRO_ENABLED[\'"]/m', file_get_contents($configPath));
     }
 }

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -46,6 +46,7 @@ class ConsoleServiceProvider extends ServiceProvider
         Commands\ImportGroups::class,
         Commands\ImportRoles::class,
         Commands\ImportUsers::class,
+        Commands\ProEnable::class,
     ];
 
     public function boot()


### PR DESCRIPTION
Adds `php please pro:enable` command, so that user doesn't have to find (or publish in Laravel 11) their editions config:

![CleanShot 2024-01-31 at 13 54 14](https://github.com/statamic/cms/assets/5187394/11f3b849-dc2f-4123-86ad-9820d0347ccc)

And if they still have old config with hardcoded boolean, we can instruct them:

![CleanShot 2024-01-31 at 13 55 42](https://github.com/statamic/cms/assets/5187394/a9b45446-a5b3-4a57-8333-b5689f77b1e0)

The logic is mostly taken from our existing `license:set` command, so this isn't a new pattern 👌