### PR TITLE
[4.x] Implied Statamic route views

### DIFF
--- a/src/Mixins/Router.php
+++ b/src/Mixins/Router.php
@@ -3,12 +3,17 @@
 namespace Statamic\Mixins;
 
 use Statamic\Http\Controllers\FrontendController;
+use Statamic\Support\Str;
 
 class Router
 {
     public function statamic()
     {
-        return function ($uri, $view, $data = []) {
+        return function ($uri, $view = null, $data = []) {
+            if (! $view) {
+                $view = Str::of($uri)->ltrim('/');
+            }
+
             return $this->get($uri, [FrontendController::class, 'route'])
                 ->defaults('view', $view)
                 ->defaults('data', $data);


### PR DESCRIPTION
When making simple routes like this:

```php
Route::statamic('my-page', 'my-page');
```

It's a little redundant when the view is the same as the URI. This PR makes the view optional and fall back to use the URI as the view.

```php
Route::statamic('my-page'); // Implies 'my-page'
Route::statamic('/my-page'); // Implies 'my-page'
Route::statamic('/foo/bar'); // Implies 'foo.bar'
```
