### PR TITLE
[5.x] Remove deprecated `revisions` method from Collection

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -615,17 +615,6 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
             ->args(func_get_args());
     }
 
-    /** @deprecated */
-    public function revisions($enabled = null)
-    {
-        return $this
-            ->fluentlyGetOrSet('revisions')
-            ->getter(function ($behavior) {
-                return $behavior ?? false;
-            })
-            ->args(func_get_args());
-    }
-
     public function revisionsEnabled($enabled = null)
     {
         return $this


### PR DESCRIPTION
This pull request removes the deprecated `revisions` method from the `Collection` class. The [`revisionsEnabled`](https://github.com/statamic/cms/blob/bffeeddb6a023fc8d6fff73a9eb35df861a636f9/src/Entries/Collection.php#L629) method should be used instead.

Closes #9433.