### PR TITLE
[4.x] Ensure template and termTemplate are accessed correctly in Taxonomy controller

### DIFF
--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -133,8 +133,8 @@ class TaxonomiesController extends CpController
             'collections' => $taxonomy->collections()->map->handle()->all(),
             'sites' => $taxonomy->sites()->all(),
             'preview_targets' => $taxonomy->basePreviewTargets(),
-            'term_template' => $taxonomy->termTemplate,
-            'template' => $taxonomy->template,
+            'term_template' => $taxonomy->hasCustomTermTemplate() ? $taxonomy->termTemplate() : null,
+            'template' => $taxonomy->hasCustomTemplate() ? $taxonomy->template() : null,
             'layout' => $taxonomy->layout(),
         ];
 

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -44,8 +44,8 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
     protected $revisions = false;
     protected $searchIndex;
     protected $previewTargets = [];
-    protected $template;
-    protected $termTemplate;
+    public $template;
+    public $termTemplate;
     protected $layout;
     protected $afterSaveCallbacks = [];
     protected $withEvents = true;

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -44,8 +44,8 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
     protected $revisions = false;
     protected $searchIndex;
     protected $previewTargets = [];
-    public $template;
-    public $termTemplate;
+    protected $template;
+    protected $termTemplate;
     protected $layout;
     protected $afterSaveCallbacks = [];
     protected $withEvents = true;
@@ -517,5 +517,15 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
                 'refresh' => $target['refresh'],
             ];
         })->filter()->values()->all();
+    }
+
+    public function hasCustomTemplate()
+    {
+        return $this->template !== null;
+    }
+
+    public function hasCustomTermTemplate()
+    {
+        return $this->termTemplate !== null;
     }
 }


### PR DESCRIPTION
Who knew this would keep coming back around.

This PR makes template and termTemplate public, as otherwise the fields in the TaxonomyController never have values.

Im sorry.