### PR TITLE
[4.x] Tidy up replicator field styles to match "normal" fields

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Field.vue
+++ b/resources/js/components/fieldtypes/replicator/Field.vue
@@ -9,7 +9,7 @@
         </label>
 
         <div
-            class="help-block"
+            class="help-block" :class="{ '-mt-2': showLabel }"
             v-if="instructions && field.instructions_position !== 'below'"
             v-html="instructions" />
 
@@ -37,7 +37,7 @@
             v-html="instructions" />
 
         <div v-if="hasError">
-            <small class="help-block text-red-500 mt-2" v-for="(error, i) in errors" :key="i" v-text="error" />
+            <small class="help-block text-red-500 mt-2 mb-0" v-for="(error, i) in errors" :key="i" v-text="error" />
         </div>
 
     </div>


### PR DESCRIPTION
This pull request makes a small tweak to the styles of fields inside replicators to match the styles of "normal" fields in publish forms.

Closes #9438.

## Before

![CleanShot 2024-02-01 at 17 09 05](https://github.com/statamic/cms/assets/19637309/31012e21-c615-4523-a1c1-fa848adefa06)

## After

![CleanShot 2024-02-01 at 17 08 45](https://github.com/statamic/cms/assets/19637309/d79d75d3-eedb-4b01-888b-eede149b9630)
