### PR TITLE
[4.x] Fix timeout when using nocache tag

### DIFF
--- a/src/StaticCaching/NoCache/Region.php
+++ b/src/StaticCaching/NoCache/Region.php
@@ -37,7 +37,7 @@ abstract class Region
 
                 return $value;
             })
-            ->toArray();
+            ->all();
 
         return $this->arrayRecursiveDiff($context, $this->session->cascade());
     }

--- a/src/StaticCaching/NoCache/Region.php
+++ b/src/StaticCaching/NoCache/Region.php
@@ -28,15 +28,16 @@ abstract class Region
 
     protected function filterContext(array $context)
     {
-        foreach (['__env', 'app', 'errors', 'resolve', 'resolveComponentsUsing', 'forgetComponentsResolver', 'forgetFactory', 'flushCache', 'constructor'] as $var) {
-            unset($context[$var]);
-        }
+        $context = collect($context)
+            ->reject(fn ($value, $key) => in_array($key, ['__env', 'app', 'errors', 'resolve', 'resolveComponentsUsing', 'forgetComponentsResolver', 'forgetFactory', 'flushCache', 'constructor']))
+            ->map(function ($value, $key) {
+                if ($value instanceof InvokableComponentVariable) {
+                    return $value->resolveDisplayableValue();
+                }
 
-        foreach ($context as $key => $value) {
-            if ($value instanceof InvokableComponentVariable) {
-                $context[$key] = $value->resolveDisplayableValue();
-            }
-        }
+                return $value;
+            })
+            ->toArray();
 
         return $this->arrayRecursiveDiff($context, $this->session->cascade());
     }

--- a/src/StaticCaching/NoCache/Region.php
+++ b/src/StaticCaching/NoCache/Region.php
@@ -28,16 +28,15 @@ abstract class Region
 
     protected function filterContext(array $context)
     {
-        $context = collect($context)
-            ->reject(fn ($value, $key) => in_array($key, ['__env', 'app', 'errors', 'resolve', 'resolveComponentsUsing', 'forgetComponentsResolver', 'forgetFactory', 'flushCache', 'constructor']))
-            ->map(function ($value, $key) {
-                if ($value instanceof InvokableComponentVariable) {
-                    return $value->resolveDisplayableValue();
-                }
+        foreach (['__env', 'app', 'errors', 'resolve', 'resolveComponentsUsing', 'forgetComponentsResolver', 'forgetFactory', 'flushCache', 'constructor'] as $var) {
+            unset($context[$var]);
+        }
 
-                return $value;
-            })
-            ->toArray();
+        foreach ($context as $key => $value) {
+            if ($value instanceof InvokableComponentVariable) {
+                $context[$key] = $value->resolveDisplayableValue();
+            }
+        }
 
         return $this->arrayRecursiveDiff($context, $this->session->cascade());
     }


### PR DESCRIPTION
This pull request fixes an issue where pages would timeout when the `{{ nocache }}` tag is being used on a page. This was caused by #9409.

It seems like the fact we were processing it through a `Collection` was causing the issue. When I tried refactoring to use a simple foreach loop, the timeout went away. 

Fixes #9437.