### PR TITLE
[4.x] Addons: Make it possible to opt-out of blueprint & fieldset auto-loading

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -175,6 +175,16 @@ abstract class AddonServiceProvider extends ServiceProvider
      */
     protected $translations = true;
 
+    /**
+     * @var bool
+     */
+    protected $loadBlueprints = true;
+
+    /**
+     * @var bool
+     */
+    protected $loadFieldsets = true;
+
     public function boot()
     {
         Statamic::booted(function () {
@@ -626,6 +636,10 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootBlueprints()
     {
+        if (! $this->loadBlueprints) {
+            return $this;
+        }
+
         if (! file_exists($path = "{$this->getAddon()->directory()}resources/blueprints")) {
             return $this;
         }
@@ -640,6 +654,10 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootFieldsets()
     {
+        if (! $this->loadFieldsets) {
+            return $this;
+        }
+
         if (! file_exists($path = "{$this->getAddon()->directory()}resources/fieldsets")) {
             return $this;
         }


### PR DESCRIPTION
This pull request adds two options to the `AddonServiceProvider`, allowing addon developers to opt-out of their blueprints/fieldsets being auto-loaded and appearing as editable in the Control Panel.

I've noticed this with Simple Commerce where because I have a `resources/blueprints` directory with blueprint stubs (they're copied into the user's app upon install). 

Related: https://github.com/statamic/cms/pull/9324