### PR TITLE
[4.x] Use more appropriate file permissions for full measure static caching

### DIFF
--- a/src/StaticCaching/Cachers/Writer.php
+++ b/src/StaticCaching/Cachers/Writer.php
@@ -17,7 +17,7 @@ class Writer
      */
     public function write($path, $content, $lockFor = 0)
     {
-        @mkdir(dirname($path), 0777, true);
+        @mkdir(dirname($path), 0755, true);
 
         // Create the file handle. We use the "c" mode which will avoid writing an
         // empty file if we abort when checking the lock status in the next step.
@@ -31,7 +31,7 @@ class Writer
         }
 
         fwrite($handle, $content);
-        chmod($path, 0777);
+        chmod($path, 0644);
 
         // Hold the file lock for a moment to prevent other processes from trying to write the same file.
         sleep($lockFor);


### PR DESCRIPTION
This reduces the permissions to match Flysystem's "public" permissions.

See https://github.com/thephpleague/flysystem/blob/b25a361508c407563b34fac6f64a8a17a8819675/src/UnixVisibility/PortableVisibilityConverter.php#L13-L15
