### PR TITLE
[4.x] Add sites to support details output

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Support\ServiceProvider;
 use Statamic\Facades;
 use Statamic\Facades\Addon;
 use Statamic\Facades\Preference;
+use Statamic\Facades\Site;
 use Statamic\Facades\Token;
 use Statamic\Sites\Sites;
 use Statamic\Statamic;
@@ -191,10 +192,26 @@ class AppServiceProvider extends ServiceProvider
             'Addons' => $addons->count(),
             'Stache Watcher' => config('statamic.stache.watcher') ? 'Enabled' : 'Disabled',
             'Static Caching' => config('statamic.static_caching.strategy') ?: 'Disabled',
+            'Sites' => fn () => $this->sitesAboutCommandInfo(),
         ]);
 
         foreach ($addons as $addon) {
             AboutCommand::add('Statamic Addons', $addon->package(), $addon->version());
         }
+    }
+
+    private function sitesAboutCommandInfo()
+    {
+        if (($sites = Site::all())->count() === 1) {
+            return 1;
+        }
+
+        // If there are 5 or fewer sites, list all their names.
+        // If there are more than 5, list the first 3 and append "and n more".
+        $summary = $sites->count() <= 5
+            ? $sites->map->name()->join(', ')
+            : $sites->take(3)->map->name()->join(', ').', and '.($sites->count() - 3).' more';
+
+        return $sites->count().' ('.$summary.')';
     }
 }


### PR DESCRIPTION
Sometimes its useful to know at a glance whether a project is using single or multisite, and how many.

This will output the names of the first few sites, which can be helpful to know _how_ people are using multisite.

![CleanShot 2024-02-05 at 16 08 03](https://github.com/statamic/cms/assets/105211/7e462f34-bdf1-4500-ab51-0c666bbe0f83)

