### PR TITLE
[4.x] Allow custom Echo client configuration

### DIFF
--- a/resources/js/components/Echo.js
+++ b/resources/js/components/Echo.js
@@ -18,7 +18,7 @@ class Echo {
     }
 
     start() {
-        const config = this.configCallback ? this.configCallback(this) : {
+        let config = {
             broadcaster: 'pusher',
             key: Statamic.$config.get('broadcasting.pusher.key'),
             cluster: Statamic.$config.get('broadcasting.pusher.cluster'),
@@ -26,6 +26,10 @@ class Echo {
             csrfToken: Statamic.$config.get('csrfToken'),
             authEndpoint: Statamic.$config.get('broadcasting.endpoint'),
         };
+
+        if (this.configCallback) {
+            config = this.configCallback(config);
+        }
 
         this.echo = new LaravelEcho(config);
 

--- a/resources/js/components/Echo.js
+++ b/resources/js/components/Echo.js
@@ -5,7 +5,12 @@ window.Pusher = Pusher;
 class Echo {
 
     constructor() {
+        this.configCallback = null;
         this.bootedCallbacks = [];
+    }
+
+    config(callback) {
+        this.configCallback = callback;
     }
 
     booted(callback) {
@@ -13,7 +18,7 @@ class Echo {
     }
 
     start() {
-        const config = {
+        const config = this.configCallback ? this.configCallback(this) : {
             broadcaster: 'pusher',
             key: Statamic.$config.get('broadcasting.pusher.key'),
             cluster: Statamic.$config.get('broadcasting.pusher.cluster'),

--- a/resources/js/components/Echo.js
+++ b/resources/js/components/Echo.js
@@ -5,12 +5,12 @@ window.Pusher = Pusher;
 class Echo {
 
     constructor() {
-        this.configCallback = null;
+        this.configCallbacks = [];
         this.bootedCallbacks = [];
     }
 
     config(callback) {
-        this.configCallback = callback;
+        this.configCallbacks.push(callback);
     }
 
     booted(callback) {
@@ -27,9 +27,7 @@ class Echo {
             authEndpoint: Statamic.$config.get('broadcasting.endpoint'),
         };
 
-        if (this.configCallback) {
-            config = this.configCallback(config);
-        }
+        this.configCallbacks.forEach(callback => config = callback(config));
 
         this.echo = new LaravelEcho(config);
 

--- a/src/Providers/BroadcastServiceProvider.php
+++ b/src/Providers/BroadcastServiceProvider.php
@@ -27,7 +27,6 @@ class BroadcastServiceProvider extends ServiceProvider
                 'scheme' => config('broadcasting.connections.pusher.options.scheme'),
                 'host' => config('broadcasting.connections.pusher.options.host'),
                 'port' => config('broadcasting.connections.pusher.options.port'),
-                'useTLS' => config('broadcasting.connections.pusher.options.useTLS'),
             ],
         ];
     }

--- a/src/Providers/BroadcastServiceProvider.php
+++ b/src/Providers/BroadcastServiceProvider.php
@@ -24,6 +24,10 @@ class BroadcastServiceProvider extends ServiceProvider
                 'key' => config('broadcasting.connections.pusher.key'),
                 'cluster' => config('broadcasting.connections.pusher.options.cluster'),
                 'encrypted' => config('broadcasting.connections.pusher.options.encrypted'),
+                'scheme' => config('broadcasting.connections.pusher.options.scheme'),
+                'host' => config('broadcasting.connections.pusher.options.host'),
+                'port' => config('broadcasting.connections.pusher.options.port'),
+                'useTLS' => config('broadcasting.connections.pusher.options.useTLS'),
             ],
         ];
     }


### PR DESCRIPTION
This PR allows you to use a custom broadcasting Echo client config within the CP.

It adds a new `Statamic.$echo.config()` method and passes some additional pusher options through to the JS side.

For example to use with [Soketi](https://docs.soketi.app/getting-started/client-configuration/laravel-echo) add this to `cp.js`:

```js
Statamic.booting(() => {
    
    Statamic.$echo.config(() => ({
        broadcaster: "pusher",
        key: Statamic.$config.get('broadcasting.pusher.key'),
        cluster: Statamic.$config.get('broadcasting.pusher.cluster'),
        wsHost: Statamic.$config.get('broadcasting.pusher.host'),
        wsPort: Statamic.$config.get('broadcasting.pusher.port'),
        wssPort: Statamic.$config.get('broadcasting.pusher.port'),
        forceTLS: false,
        encrypted: true,
        disableStats: true,
        enabledTransports: ["ws", "wss"],
    }));

});
```