### PR TITLE
[4.x] Make tags macroable

### DIFF
--- a/src/Tags/Tags.php
+++ b/src/Tags/Tags.php
@@ -130,8 +130,19 @@ abstract class Tags
      */
     public function __call($method, $args)
     {
-        if ($this->wildcardHandled || ! method_exists($this, $this->wildcardMethod) || ! static::hasMacro($method)) {
+        if ($this->wildcardHandled || ! method_exists($this, $this->wildcardMethod)) {
             throw new \BadMethodCallException("Call to undefined method {$method}.");
+        }
+
+        if (static::hasMacro($method))
+        {
+            $macro = static::$macros[$method];
+
+            if ($macro instanceof Closure) {
+                $macro = $macro->bindTo($this, static::class);
+            }
+
+            return $macro(...$args);
         }
 
         $this->wildcardHandled = true;

--- a/src/Tags/Tags.php
+++ b/src/Tags/Tags.php
@@ -134,8 +134,7 @@ abstract class Tags
             throw new \BadMethodCallException("Call to undefined method {$method}.");
         }
 
-        if (static::hasMacro($method))
-        {
+        if (static::hasMacro($method)) {
             $macro = static::$macros[$method];
 
             if ($macro instanceof Closure) {

--- a/src/Tags/Tags.php
+++ b/src/Tags/Tags.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Tags;
 
+use Illuminate\Support\Traits\Macroable;
 use Statamic\Extend\HasAliases;
 use Statamic\Extend\HasHandle;
 use Statamic\Extend\RegistersItself;
@@ -10,7 +11,7 @@ use Statamic\Support\Arr;
 
 abstract class Tags
 {
-    use HasAliases, HasHandle, RegistersItself;
+    use HasAliases, HasHandle, Macroable, RegistersItself;
 
     protected static $binding = 'tags';
 

--- a/src/Tags/Tags.php
+++ b/src/Tags/Tags.php
@@ -130,7 +130,7 @@ abstract class Tags
      */
     public function __call($method, $args)
     {
-        if ($this->wildcardHandled || ! method_exists($this, $this->wildcardMethod)) {
+        if ($this->wildcardHandled || ! method_exists($this, $this->wildcardMethod) || ! static::hasMacro($method)) {
             throw new \BadMethodCallException("Call to undefined method {$method}.");
         }
 

--- a/tests/Tags/LinkTest.php
+++ b/tests/Tags/LinkTest.php
@@ -5,6 +5,7 @@ namespace Tests\Tags;
 use Statamic\Facades\Data;
 use Statamic\Facades\Parse;
 use Statamic\Facades\Site;
+use Statamic\Tags\Link;
 use Tests\TestCase;
 
 class LinkTest extends TestCase
@@ -149,5 +150,15 @@ class LinkTest extends TestCase
         Data::shouldReceive('find')->with('123')->andReturnNull();
 
         $this->assertEquals('', $this->tag('{{ link:123 }}'));
+    }
+
+    /** @test */
+    public function it_outputs_statamic_website_using_macroable()
+    {
+        Link::macro('statamic', function () {
+            return 'https://www.statamic.com';
+        });
+
+        $this->assertEquals('https://www.statamic.com', $this->tag('{{ link:statamic }}'));
     }
 }


### PR DESCRIPTION
Instead of extending or overriding existing Statamic tags, make them macroable so we can extend them from multiple sources like addons and locally.

Simple example put in boot method of a serviceprovider:
```php
Link::macro('statamic', function () {
    return 'https://www.statamic.com';
});
```

In antlers:
```antlers
{{ link:statamic }}
```