### PR TITLE
[4.x] Fix unit translations

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -139,23 +139,23 @@ class Str
     public static function fileSizeForHumans($bytes, $decimals = 2)
     {
         if ($bytes >= 1073741824) {
-            return trans_choice('statamic::messages.units.GB', number_format($bytes / 1073741824, $decimals));
+            return trans('statamic::messages.units.GB', ['count' => number_format($bytes / 1073741824, $decimals)]);
         } elseif ($bytes >= 1048576) {
-            return trans_choice('statamic::messages.units.MB', number_format($bytes / 1048576, $decimals));
+            return trans('statamic::messages.units.MB', ['count' => number_format($bytes / 1048576, $decimals)]);
         } elseif ($bytes >= 1024) {
-            return trans_choice('statamic::messages.units.KB', number_format($bytes / 1024, $decimals));
+            return trans('statamic::messages.units.KB', ['count' => number_format($bytes / 1024, $decimals)]);
         }
 
-        return trans_choice('statamic::messages.units.B', $bytes);
+        return trans('statamic::messages.units.B', ['count' => $bytes]);
     }
 
     public static function timeForHumans($ms)
     {
         if ($ms < 1000) {
-            return trans_choice('statamic::messages.units.ms', $ms);
+            return trans('statamic::messages.units.ms', ['count' => $ms]);
         }
 
-        return trans_choice('statamic::messages.units.s', round($ms / 1000, 2));
+        return trans('statamic::messages.units.s', ['count' => round($ms / 1000, 2)]);
     }
 
     /**


### PR DESCRIPTION
Fixes #9471

The `trans_choice` helper expects the count argument to be an integer. The error was due to `number_format` resulting in an uncastable number sometimes when it got formatted with a comma.

The `trans_choice` helper doesn't need to be used anyway as it's not a different translation depending on the number. This PR changes it to `trans` as it should have been.

I've updated the three spots where `number_format` _wasn't_ used, for consistency, even though it wouldn't cause an error.
