### PR TITLE
[4.x] Fix updates badge

### DIFF
--- a/resources/views/nav/updates.blade.php
+++ b/resources/views/nav/updates.blade.php
@@ -1,6 +1,6 @@
 <li class="{{ $item->isActive() ? 'current' : '' }}">
     <a href="{{ $item->url() }}">
-        <i>{!! $item->icon() !!}</i><span>{{ __($item->name()) }}</span>
+        <i>{!! $item->icon() !!}</i><span v-pre>{{ __($item->name()) }}</span>
         <updates-badge class="ml-2"></updates-badge>
     </a>
 </li>

--- a/resources/views/partials/nav-main.blade.php
+++ b/resources/views/partials/nav-main.blade.php
@@ -2,7 +2,7 @@
 
 @section('nav-main')
     <nav class="nav-main" v-cloak>
-        <div class="nav-main-inner" v-pre>
+        <div class="nav-main-inner">
             @foreach ($nav as $section)
                 @if ($section['display'] !== 'Top Level')
                     <h6>{{ __($section['display']) }}</h6>
@@ -10,7 +10,7 @@
                 <ul class="nav-section-{{ Statamic\Support\Str::slug($section['display']) }}">
                     @foreach ($section['items'] as $item)
                         @unless ($item->view())
-                            <li class="{{ $item->isActive() ? 'current' : '' }}">
+                            <li class="{{ $item->isActive() ? 'current' : '' }}" v-pre>
                                 <a href="{{ $item->url() }}" {{ $item->attributes() }}>
                                     <i>{!! $item->icon() !!}</i><span>{{ __($item->name()) }}</span>
                                 </a>

--- a/resources/views/partials/nav-main.blade.php
+++ b/resources/views/partials/nav-main.blade.php
@@ -5,7 +5,7 @@
         <div class="nav-main-inner">
             @foreach ($nav as $section)
                 @if ($section['display'] !== 'Top Level')
-                    <h6>{{ __($section['display']) }}</h6>
+                    <h6 v-pre>{{ __($section['display']) }}</h6>
                 @endif
                 <ul class="nav-section-{{ Statamic\Support\Str::slug($section['display']) }}">
                     @foreach ($section['items'] as $item)

--- a/resources/views/partials/nav-mobile.blade.php
+++ b/resources/views/partials/nav-mobile.blade.php
@@ -1,7 +1,7 @@
 @php use function Statamic\trans as __; @endphp
 
 <nav class="nav-main nav-mobile" v-cloak>
-    <div class="nav-main-inner" v-pre>
+    <div class="nav-main-inner">
         @foreach ($nav as $section)
             @if ($section['display'] !== 'Top Level')
                 <h6>{{ __($section['display']) }}</h6>
@@ -9,7 +9,7 @@
             <ul>
                 @foreach ($section['items'] as $item)
                     @unless ($item->view())
-                        <li class="{{ $item->isActive() ? 'current' : '' }}">
+                        <li class="{{ $item->isActive() ? 'current' : '' }}" v-pre>
                             <a href="{{ $item->url() }}">
                                 <i>{!! $item->icon() !!}</i><span>{{ __($item->name()) }}</span>
                             </a>

--- a/resources/views/partials/nav-mobile.blade.php
+++ b/resources/views/partials/nav-mobile.blade.php
@@ -4,7 +4,7 @@
     <div class="nav-main-inner">
         @foreach ($nav as $section)
             @if ($section['display'] !== 'Top Level')
-                <h6>{{ __($section['display']) }}</h6>
+                <h6 v-pre>{{ __($section['display']) }}</h6>
             @endif
             <ul>
                 @foreach ($section['items'] as $item)


### PR DESCRIPTION
In #9256 a `v-pre` was added, but this caused the Vue component within the updates nav item to not be compiled.

This PR moves the `v-pre` onto each nav item.

Fixes #9474