### PR TITLE
[4.x] Add clear value button to popover date fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/date/RangePopover.vue
+++ b/resources/js/components/fieldtypes/date/RangePopover.vue
@@ -28,7 +28,7 @@
                         <div class="input-group-prepend flex items-center">
                             <svg-icon name="light/calendar" class="w-4 h-4" />
                         </div>
-                        <div class="input-text border border-gray-500 border-l-0" :class="{ 'read-only': isReadOnly }">
+                        <div class="input-text border border-gray-500 border-l-0 flex items-center pr-0" :class="{ 'read-only': isReadOnly }">
                             <input
                                 class="input-text-minimal p-0 bg-transparent leading-none"
                                 :readonly="isReadOnly"
@@ -37,6 +37,9 @@
                                 @focus="$emit('focus', $event.target)"
                                 @blur="$emit('blur')"
                             />
+                            <button @click="clear" type="button" title="Clear" aria-label="Clear" class="cursor-pointer px-2 hover:text-blue-500">
+                                <span>×</span>
+                            </button>
                         </div>
                     </div>
                 </template>
@@ -193,6 +196,10 @@ export default {
                 this.$refs.startPopover?.close()
                 this.$refs.endPopover?.close()
             });
+        },
+
+        clear() {
+            this.$emit('input', null)
         },
 
         resetPicker() {

--- a/resources/js/components/fieldtypes/date/SinglePopover.vue
+++ b/resources/js/components/fieldtypes/date/SinglePopover.vue
@@ -23,7 +23,7 @@
                     <div class="input-group-prepend flex items-center">
                         <svg-icon name="light/calendar" class="w-4 h-4" />
                     </div>
-                    <div class="input-text border border-gray-500 border-l-0" :class="{ 'read-only': isReadOnly }">
+                    <div class="input-text border border-gray-500 border-l-0 flex items-center pr-0" :class="{ 'read-only': isReadOnly }">
                         <input
                             class="input-text-minimal p-0 bg-transparent leading-none"
                             :readonly="isReadOnly"
@@ -32,6 +32,9 @@
                             @focus="$emit('focus', $event.target)"
                             @blur="$emit('blur')"
                         />
+                        <button @click="clear" type="button" title="Clear" aria-label="Clear" class="cursor-pointer px-2 hover:text-blue-500">
+                            <span>×</span>
+                        </button>
                     </div>
                 </div>
             </template>
@@ -91,6 +94,10 @@ export default {
         dateSelected(date) {
             this.$emit('input', date)
             this.$nextTick(() => this.$refs.popover?.close());
+        },
+
+        clear() {
+            this.$emit('input', null)
         },
 
         resetPicker() {


### PR DESCRIPTION
A couple of clients have been unsure how to clear a popover date fieldtype, as it's not super obvious that you have to delete the text or open the popover and deselect the date.

This PR adds clear buttons:

![Screenshot 2024-02-07 at 11 04 05](https://github.com/statamic/cms/assets/126740/af554e7d-069c-4a22-99b0-9c75dd1e6b6a)

I wasn't 100% sure on where to place them. I think putting them in the fields looks tidiest, and it matches the select fieldtype's clear button, but it does feel a bit odd in time and range modes. At the moment the fields they appear in are the same ones that already clear the value when you delete the text, so there is some logic to it.