### PR TITLE
[4.x] Fix update counter

### DIFF
--- a/resources/js/components/UpdatesBadge.vue
+++ b/resources/js/components/UpdatesBadge.vue
@@ -6,26 +6,49 @@
 
 <script>
     export default {
-        data() {
-            return {
-                count: 0,
-            };
-        },
 
-        mounted() {
-            this.getCount();
+        computed: {
+            count() {
+                return this.$store.state.updates.count;
+            }
         },
 
         created() {
-            this.$events.$on('recount-updates', this.getCount);
+            this.registerVuexModule();
+
+            this.getCount();
         },
 
         methods: {
+            registerVuexModule() {
+                if (this.$store.state.updates) return;
+
+                this.$store.registerModule('updates', {
+                    namespaced: true,
+                    state: {
+                        count: 0,
+                        requested: false,
+                    },
+                    mutations: {
+                        count(state, count) {
+                            state.count = count;
+                        },
+                        requested(state) {
+                            state.requested = true;
+                        },
+                    }
+                })
+            },
+
             getCount() {
-                this.$axios.get(cp_url('updater/count')).then(response => {
-                    this.count = !isNaN(response.data) ? response.data : 0;
-                });
-            }
+                if (this.$store.state.updates.requested) return;
+
+                this.$axios
+                    .get(cp_url('updater/count'))
+                    .then(response => this.$store.commit('updates/count', !isNaN(response.data) ? response.data : 0));
+
+                this.$store.commit('updates/requested');
+            },
         }
     }
 </script>

--- a/resources/js/components/UpdatesBadge.vue
+++ b/resources/js/components/UpdatesBadge.vue
@@ -30,12 +30,8 @@
                         requested: false,
                     },
                     mutations: {
-                        count(state, count) {
-                            state.count = count;
-                        },
-                        requested(state) {
-                            state.requested = true;
-                        },
+                        count: (state, count) => state.count = count,
+                        requested: (state) => state.requested = true,
                     }
                 })
             },

--- a/resources/js/components/UpdatesBadge.vue
+++ b/resources/js/components/UpdatesBadge.vue
@@ -21,10 +21,8 @@
         },
 
         methods: {
-            getCount(clearCache = true) {
-                let params = clearCache ? {'clearCache': clearCache} : {};
-
-                this.$axios.get(cp_url('updater/count'), params).then(response => {
+            getCount() {
+                this.$axios.get(cp_url('updater/count')).then(response => {
                     this.count = !isNaN(response.data) ? response.data : 0;
                 });
             }

--- a/src/Http/Controllers/CP/Updater/UpdaterController.php
+++ b/src/Http/Controllers/CP/Updater/UpdaterController.php
@@ -40,7 +40,7 @@ class UpdaterController extends CpController
     {
         $this->authorize('view updates');
 
-        return UpdatesOverview::count($request->input('clearCache', false));
+        return UpdatesOverview::count();
     }
 
     /**

--- a/src/Updater/UpdatesOverview.php
+++ b/src/Updater/UpdatesOverview.php
@@ -18,46 +18,42 @@ class UpdatesOverview
     /**
      * Get updates count.
      *
-     * @param  bool  $clearCache
      * @return int
      */
-    public function count($clearCache = false)
+    public function count()
     {
-        return $this->getCached('updates-overview.count', $clearCache);
+        return $this->getCached('updates-overview.count');
     }
 
     /**
      * Check if statamic update is available.
      *
-     * @param  bool  $clearCache
      * @return bool
      */
-    public function hasStatamicUpdate($clearCache = false)
+    public function hasStatamicUpdate()
     {
-        return $this->getCached('updates-overview.statamic', $clearCache);
+        return $this->getCached('updates-overview.statamic');
     }
 
     /**
      * List updatable addons.
      *
-     * @param  bool  $clearCache
      * @return array
      */
-    public function updatableAddons($clearCache = false)
+    public function updatableAddons()
     {
-        return $this->getCached('updates-overview.addons', $clearCache);
+        return $this->getCached('updates-overview.addons');
     }
 
     /**
      * Get value from cache.
      *
      * @param  string  $key
-     * @param  bool  $clearCache
      * @return mixed
      */
-    public function getCached($key, $clearCache = false)
+    public function getCached($key)
     {
-        if (! Cache::has($key) || $clearCache) {
+        if (! Cache::has($key)) {
             $this->checkAndCache();
         }
 


### PR DESCRIPTION
**Fix double AJAX calls**

The update counter badge was performing 2 ajax request for every cp page request.
The vue component is rendered twice: once in the desktop nav and once in the mobile nav.
This is fixed now by using a Vuex store to keep track of the count and request. Only one of them will trigger the request.


**Remove unnecessary caching boolean**

The update count is cached. We had a boolean being passed to the ajax route which attempted to force a re-cache when necessary. This has never actually been working, and is unnecessary anyway. This PR removes that unnecessary code.
