### PR TITLE
[4.x] Fix directory separator in Templates fieldtype on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v42
         with:
           files: |
             config
@@ -55,24 +55,29 @@ jobs:
             .github/workflows/tests.yml
             **.php
 
-      - name: Determine whether tests should run
-        id: should-run-tests
-        if: steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule'
+      - name: Determine whether tests should run (Ubuntu)
+        id: should-run-tests-ubuntu
+        if: matrix.os == 'ubuntu-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
         run: echo "result=true" >> $GITHUB_OUTPUT
 
+      - name: Determine whether tests should run (Windows)
+        id: should-run-tests-windows
+        if: matrix.os == 'windows-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
+        run: echo "result=true" >> $env:GITHUB_OUTPUT
+
       - name: Update apt sources
-        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
+        if: (steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true') && matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get check || sudo apt --fix-broken install -y
           sudo apt-get update
 
       - name: Install French Locale
-        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
+        if: (steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true') && matrix.os == 'ubuntu-latest'
         run: sudo apt-get install language-pack-fr
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
@@ -80,7 +85,7 @@ jobs:
 
       - name: Install dependencies
         uses: nick-invision/retry@v2
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -89,11 +94,11 @@ jobs:
             composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         run: composer show -D
 
       - name: Execute tests
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         run: vendor/bin/phpunit
 
   js-tests:
@@ -108,27 +113,32 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v42
         with:
           files: |
             **.{js,vue,ts}
             package.json
 
-      - name: Determine whether tests should run
-        id: should-run-tests
-        if: steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule'
+      - name: Determine whether tests should run (Ubuntu)
+        id: should-run-tests-ubuntu
+        if: matrix.os == 'ubuntu-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
         run: echo "result=true" >> $GITHUB_OUTPUT
 
+      - name: Determine whether tests should run (Windows)
+        id: should-run-tests-windows
+        if: matrix.os == 'windows-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
+        run: echo "result=true" >> $env:GITHUB_OUTPUT
+
       - name: Install required npm version
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         run: npm -g install npm@8.5.5
 
       - name: Install dependencies
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         run: npm ci
 
       - name: Execute tests
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         run: npm run test
 
   slack:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,29 +55,26 @@ jobs:
             .github/workflows/tests.yml
             **.php
 
-      - name: Determine whether tests should run (Ubuntu)
-        id: should-run-tests-ubuntu
-        if: matrix.os == 'ubuntu-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
-        run: echo "result=true" >> $GITHUB_OUTPUT
-
-      - name: Determine whether tests should run (Windows)
-        id: should-run-tests-windows
-        if: matrix.os == 'windows-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
-        run: echo "result=true" >> $env:GITHUB_OUTPUT
+      - name: Determine whether tests should run
+        id: should-run-tests
+        if: steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule'
+        run: |
+          echo "result=true" >> $GITHUB_OUTPUT
+          echo "result=true" >> $env:GITHUB_OUTPUT
 
       - name: Update apt sources
-        if: (steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true') && matrix.os == 'ubuntu-latest'
+        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get check || sudo apt --fix-broken install -y
           sudo apt-get update
 
       - name: Install French Locale
-        if: (steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true') && matrix.os == 'ubuntu-latest'
+        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
         run: sudo apt-get install language-pack-fr
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
@@ -85,7 +82,7 @@ jobs:
 
       - name: Install dependencies
         uses: nick-invision/retry@v2
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -94,11 +91,11 @@ jobs:
             composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         run: composer show -D
 
       - name: Execute tests
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         run: vendor/bin/phpunit
 
   js-tests:
@@ -113,32 +110,29 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v41
         with:
           files: |
             **.{js,vue,ts}
             package.json
 
-      - name: Determine whether tests should run (Ubuntu)
-        id: should-run-tests-ubuntu
-        if: matrix.os == 'ubuntu-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
-        run: echo "result=true" >> $GITHUB_OUTPUT
-
-      - name: Determine whether tests should run (Windows)
-        id: should-run-tests-windows
-        if: matrix.os == 'windows-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
-        run: echo "result=true" >> $env:GITHUB_OUTPUT
+      - name: Determine whether tests should run
+        id: should-run-tests
+        if: steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule'
+        run: |
+          echo "result=true" >> $GITHUB_OUTPUT
+          echo "result=true" >> $env:GITHUB_OUTPUT
 
       - name: Install required npm version
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         run: npm -g install npm@8.5.5
 
       - name: Install dependencies
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         run: npm ci
 
       - name: Execute tests
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         run: npm run test
 
   slack:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,26 +55,29 @@ jobs:
             .github/workflows/tests.yml
             **.php
 
-      - name: Determine whether tests should run
-        id: should-run-tests
-        if: steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule'
-        run: |
-          echo "result=true" >> $GITHUB_OUTPUT
-          echo "result=true" >> $env:GITHUB_OUTPUT
+      - name: Determine whether tests should run (Ubuntu)
+        id: should-run-tests-ubuntu
+        if: matrix.os == 'ubuntu-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
+        run: echo "result=true" >> $GITHUB_OUTPUT
+
+      - name: Determine whether tests should run (Windows)
+        id: should-run-tests-windows
+        if: matrix.os == 'windows-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
+        run: echo "result=true" >> $env:GITHUB_OUTPUT
 
       - name: Update apt sources
-        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
+        if: (steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true') && matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get check || sudo apt --fix-broken install -y
           sudo apt-get update
 
       - name: Install French Locale
-        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
+        if: (steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true') && matrix.os == 'ubuntu-latest'
         run: sudo apt-get install language-pack-fr
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
@@ -82,7 +85,7 @@ jobs:
 
       - name: Install dependencies
         uses: nick-invision/retry@v2
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -91,11 +94,11 @@ jobs:
             composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         run: composer show -D
 
       - name: Execute tests
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         run: vendor/bin/phpunit
 
   js-tests:
@@ -110,29 +113,32 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v42
         with:
           files: |
             **.{js,vue,ts}
             package.json
 
-      - name: Determine whether tests should run
-        id: should-run-tests
-        if: steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule'
-        run: |
-          echo "result=true" >> $GITHUB_OUTPUT
-          echo "result=true" >> $env:GITHUB_OUTPUT
+      - name: Determine whether tests should run (Ubuntu)
+        id: should-run-tests-ubuntu
+        if: matrix.os == 'ubuntu-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
+        run: echo "result=true" >> $GITHUB_OUTPUT
+
+      - name: Determine whether tests should run (Windows)
+        id: should-run-tests-windows
+        if: matrix.os == 'windows-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
+        run: echo "result=true" >> $env:GITHUB_OUTPUT
 
       - name: Install required npm version
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         run: npm -g install npm@8.5.5
 
       - name: Install dependencies
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         run: npm ci
 
       - name: Execute tests
-        if: steps.should-run-tests.outputs.result == 'true'
+        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
         run: npm run test
 
   slack:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v41
         with:
           files: |
             config
@@ -55,29 +55,24 @@ jobs:
             .github/workflows/tests.yml
             **.php
 
-      - name: Determine whether tests should run (Ubuntu)
-        id: should-run-tests-ubuntu
-        if: matrix.os == 'ubuntu-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
+      - name: Determine whether tests should run
+        id: should-run-tests
+        if: steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule'
         run: echo "result=true" >> $GITHUB_OUTPUT
 
-      - name: Determine whether tests should run (Windows)
-        id: should-run-tests-windows
-        if: matrix.os == 'windows-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
-        run: echo "result=true" >> $env:GITHUB_OUTPUT
-
       - name: Update apt sources
-        if: (steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true') && matrix.os == 'ubuntu-latest'
+        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get check || sudo apt --fix-broken install -y
           sudo apt-get update
 
       - name: Install French Locale
-        if: (steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true') && matrix.os == 'ubuntu-latest'
+        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
         run: sudo apt-get install language-pack-fr
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
@@ -85,7 +80,7 @@ jobs:
 
       - name: Install dependencies
         uses: nick-invision/retry@v2
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         with:
           timeout_minutes: 5
           max_attempts: 5
@@ -94,11 +89,11 @@ jobs:
             composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         run: composer show -D
 
       - name: Execute tests
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         run: vendor/bin/phpunit
 
   js-tests:
@@ -113,32 +108,27 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v41
         with:
           files: |
             **.{js,vue,ts}
             package.json
 
-      - name: Determine whether tests should run (Ubuntu)
-        id: should-run-tests-ubuntu
-        if: matrix.os == 'ubuntu-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
+      - name: Determine whether tests should run
+        id: should-run-tests
+        if: steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule'
         run: echo "result=true" >> $GITHUB_OUTPUT
 
-      - name: Determine whether tests should run (Windows)
-        id: should-run-tests-windows
-        if: matrix.os == 'windows-latest' && (steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule')
-        run: echo "result=true" >> $env:GITHUB_OUTPUT
-
       - name: Install required npm version
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         run: npm -g install npm@8.5.5
 
       - name: Install dependencies
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         run: npm ci
 
       - name: Execute tests
-        if: steps.should-run-tests-ubuntu.outputs.result == 'true' || steps.should-run-tests-windows.outputs.result == 'true'
+        if: steps.should-run-tests.outputs.result == 'true'
         run: npm run test
 
   slack:

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -300,8 +300,8 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
     });
 
     Route::group(['prefix' => 'api', 'as' => 'api.'], function () {
-        Route::resource('addons', AddonsApiController::class);
-        Route::resource('templates', TemplatesController::class);
+        Route::resource('addons', AddonsApiController::class)->only('index');
+        Route::resource('templates', TemplatesController::class)->only('index');
     });
 
     Route::group(['prefix' => 'preferences', 'as' => 'preferences.'], function () {

--- a/src/Http/Controllers/CP/API/TemplatesController.php
+++ b/src/Http/Controllers/CP/API/TemplatesController.php
@@ -5,6 +5,7 @@ namespace Statamic\Http\Controllers\CP\API;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Support\Str;
 
 class TemplatesController extends CpController
 {
@@ -17,7 +18,13 @@ class TemplatesController extends CpController
 
                 foreach ($iterator as $file) {
                     if ($file->isFile()) {
-                        $views->push(str_before(str_replace_first($path.DIRECTORY_SEPARATOR, '', $file->getPathname()), '.'));
+                        $viewPath = Str::of($file->getPathname())
+                            ->after($path.DIRECTORY_SEPARATOR)
+                            ->before('.')
+                            ->replace('\\', '/')
+                            ->toString();
+
+                        $views->push($viewPath);
                     }
                 }
 

--- a/src/Http/Controllers/CP/API/TemplatesController.php
+++ b/src/Http/Controllers/CP/API/TemplatesController.php
@@ -21,7 +21,7 @@ class TemplatesController extends CpController
                     }
                 }
 
-                return $views->filter()->values();
+                return $views->filter()->sort()->values();
             })
             ->values();
     }

--- a/tests/Fieldtypes/TemplatesTest.php
+++ b/tests/Fieldtypes/TemplatesTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use Statamic\Facades\User;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class TemplatesTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app['config']->set('view.paths', [
+            __DIR__.'/../__fixtures__/templates',
+        ]);
+    }
+
+    /** @test */
+    public function it_returns_a_list_of_templates()
+    {
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->get(cp_route('api.templates.index'))
+            ->assertJson([
+                'blog/index',
+                'conditions-literals',
+                'five_hundred_nested_ifs',
+                'nested-conditionals',
+            ]);
+    }
+}

--- a/tests/__fixtures__/templates/blog/index.antlers.html
+++ b/tests/__fixtures__/templates/blog/index.antlers.html
@@ -1,0 +1,1 @@
+<h1>Blog Listing</h1>


### PR DESCRIPTION
This pull request fixes an issue where the directory separator is wrong when using the Templates fieldtype on Windows.

I tried to fix this issue a few months ago in #9197 but seems like it's still an issue. I've added a test to ensure it's actually fixed since we don't use Windows for development.

Fixes #9458.