### PR TITLE
[4.x] Allow namespace to be passed in Blueprint::make()

### DIFF
--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -130,6 +130,15 @@ class BlueprintRepository
         $blueprint = new Blueprint;
 
         if ($handle) {
+            $handle = explode('::', $handle);
+
+            if (count($handle) > 1) {
+                $namespace = array_shift($handle);
+                $blueprint->setNamespace($namespace);
+            }
+
+            $handle = implode('::', $handle);
+
             $blueprint->setHandle($handle);
         }
 

--- a/tests/Fields/BlueprintRepositoryTest.php
+++ b/tests/Fields/BlueprintRepositoryTest.php
@@ -293,4 +293,13 @@ EOT;
         $this->assertInstanceOf(Collection::class, $all);
         $this->assertCount(0, $all);
     }
+
+    /** @test */
+    public function it_sets_the_namespace_when_passed_when_making()
+    {
+        $blueprint = $this->repo->make('test::handle');
+
+        $this->assertSame($blueprint->namespace(), 'test');
+        $this->assertSame($blueprint->handle(), 'handle');
+    }
 }


### PR DESCRIPTION
This PR contains a small DX improvement.

Currently you can Blueprint::find('namespace::handle') but you cant Blueprint::make('namespace::handle') which feels inconsistent.

This PR changes that to be possible.