### PR TITLE
[4.x] Fix error from Code Fieldtype when switching sites in global

### DIFF
--- a/resources/js/components/fieldtypes/CodeFieldtype.vue
+++ b/resources/js/components/fieldtypes/CodeFieldtype.vue
@@ -136,6 +136,8 @@ export default {
     watch: {
         value(value, oldValue) {
             if (value.code == this.codemirror.doc.getValue()) return;
+            if (! value.code) value.code = '';
+
             this.codemirror.doc.setValue(value.code);
         },
         readOnlyOption(val) {


### PR DESCRIPTION
This pull request fixes an issue with the Code Fieldtype where it would error out when switching between sites on the Globals Publish Form.

If the site you're switching into has no value, `value.code` would be null which causes issues in CoreMirror. This PR fixes that by instead passing in an empty string.

Fixes #9485.