### PR TITLE
[4.x] Make `BlueprintRepository` a singleton

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -134,7 +134,7 @@ class AppServiceProvider extends ServiceProvider
                 ->setRepository('user', \Statamic\Contracts\Auth\UserRepository::class);
         });
 
-        $this->app->bind(\Statamic\Fields\BlueprintRepository::class, function () {
+        $this->app->singleton(\Statamic\Fields\BlueprintRepository::class, function () {
             return (new \Statamic\Fields\BlueprintRepository)
                 ->setDirectory(resource_path('blueprints'))
                 ->setFallback('default', function () {


### PR DESCRIPTION
The `BlueprintRepository` isn't currently a singleton. This is causing a problem with the new blueprint namespaces feature as new repository objects are being created which don't have the additional namespaces registered.

This PR makes it a singleton

This matches the `FieldsetRepository` which is already a singleton.