### PR TITLE
[4.x] Fix `$authenticatedUser` error with third-party addon events

### DIFF
--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -3,13 +3,14 @@
 namespace Statamic\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
+use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Facades\User;
 
 abstract class Event
 {
     use Dispatchable;
 
-    public $authenticatedUser;
+    public ?UserContract $authenticatedUser = null;
 
     public static function dispatch()
     {

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -3,14 +3,13 @@
 namespace Statamic\Events;
 
 use Illuminate\Foundation\Events\Dispatchable;
-use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Facades\User;
 
 abstract class Event
 {
     use Dispatchable;
 
-    public ?UserContract $authenticatedUser;
+    public $authenticatedUser;
 
     public static function dispatch()
     {


### PR DESCRIPTION
This pull request sets the `$authenticatedUser` property to `null` on our base `Event` class to prevent `$authenticatedUser must not be accessed before initialization` errors.

This error mostly seems to be happening for addons with their own events, which extend our base `Event`. It also only happens when they're [dispatching events with Laravel's `event` method](https://github.com/riasvdv/statamic-redirect/blob/f6e1ce3e128a718526199dc610fa5df31d507171/src/Stache/Redirects/RedirectRepository.php#L81), rather than the `::dispatch` static method we normally use in Core.

Fixes https://github.com/riasvdv/statamic-redirect/issues/163.

Related Discord conversation: https://discord.com/channels/489818810157891584/1153390699161587823/1204384286052978689