### PR TITLE
[4.x] Add `includes` condition and modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -922,8 +922,16 @@ class CoreModifiers extends Modifier
     {
         $needle = $this->getFromContext($context, $params);
 
+        if ($needle instanceof Collection) {
+            $needle = $needle->values()->all();
+        }
+
         if (! is_array($needle)) {
             $needle = [$needle];
+        }
+
+        if ($haystack instanceof Collection) {
+            $haystack = $haystack->values()->all();
         }
 
         if (! is_array($haystack)) {

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -910,6 +910,29 @@ class CoreModifiers extends Modifier
         }
     }
 
+    /**
+     * Returns true if the array contains $needle, false otherwise
+     *
+     * @param  string|array  $haystack
+     * @param  array  $params
+     * @param  array  $context
+     * @return bool
+     */
+    public function includes($haystack, $params, $context)
+    {
+        $needle = $this->getFromContext($context, $params);
+
+        if (! is_array($needle)) {
+            $needle = [$needle];
+        }
+
+        if (! is_array($haystack)) {
+            return false;
+        }
+
+        return count(array_intersect($haystack, $needle)) > 0;
+    }
+
     private function renderAPStyleHeadline($value)
     {
         $exceptions = [

--- a/src/Tags/Concerns/QueriesConditions.php
+++ b/src/Tags/Concerns/QueriesConditions.php
@@ -122,6 +122,10 @@ trait QueriesConditions
                 return $this->queryIsBeforeCondition($query, $field, $value);
             case 'is_numberwang':
                 return $this->queryIsNumberwangCondition($query, $field, $regexOperator);
+            case 'includes':
+                return $this->queryIncludesCondition($query, $field, $value);
+            case 'doesnt_include':
+                return $this->queryDoesntIncludeCondition($query, $field, $value);
         }
     }
 
@@ -298,6 +302,24 @@ trait QueriesConditions
     protected function queryIsNumberwangCondition($query, $field, $regexOperator)
     {
         return $query->where($field, $regexOperator, "^(1|22|7|9|1002|2\.3|15|109876567|31)$");
+    }
+
+    protected function queryIncludesCondition($query, $field, $value)
+    {
+        if (is_string($value)) {
+            $value = $this->getPipedValues($value);
+        }
+
+        return $query->whereJsonContains($field, $value);
+    }
+
+    protected function queryDoesntIncludeCondition($query, $field, $value)
+    {
+        if (is_string($value)) {
+            $value = $this->getPipedValues($value);
+        }
+
+        return $query->whereJsonDoesntContain($field, $value);
     }
 
     /**

--- a/tests/Modifiers/IncludesTest.php
+++ b/tests/Modifiers/IncludesTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+/**
+ * @group array
+ */
+class IncludesTest extends TestCase
+{
+    /** @test */
+    public function it_returns_true_if_needle_found_in_array(): void
+    {
+        $haystack = ['a', 'b', 'c'];
+
+        $modified = $this->modify($haystack, ['b'], []);
+        $this->assertTrue($modified);
+    }
+
+    /** @test */
+    public function it_returns_false_if_needle_is_not_found_in_array(): void
+    {
+        $haystack = ['a', 'b', 'c'];
+
+        $modified = $this->modify($haystack, ['d'], []);
+        $this->assertFalse($modified);
+    }
+
+    /** @test */
+    public function it_returns_false_if_haystack_is_not_an_array(): void
+    {
+        $haystack = 'this is a string';
+
+        $modified = $this->modify($haystack, ['d'], []);
+        $this->assertFalse($modified);
+    }
+
+    /** @test */
+    public function it_returns_true_if_needle_is_an_array_and_is_found_in_array(): void
+    {
+        $haystack = ['a', 'b', 'c'];
+
+        $modified = $this->modify($haystack, ['array'], ['array' => ['a', 'b']]);
+        $this->assertTrue($modified);
+    }
+
+    /** @test */
+    public function it_returns_true_if_needle_is_an_array_and_some_are_not_found_in_array(): void
+    {
+        $haystack = ['a', 'b', 'c'];
+
+        $modified = $this->modify($haystack, ['array'], ['array' => ['d', 'b']]);
+        $this->assertTrue($modified);
+    }
+
+    private function modify($value, array $params, array $context)
+    {
+        return Modify::value($value)->context($context)->includes($params)->fetch();
+    }
+}

--- a/tests/Tags/Concerns/QueriesConditionsTest.php
+++ b/tests/Tags/Concerns/QueriesConditionsTest.php
@@ -585,6 +585,30 @@ class QueriesConditionsTest extends TestCase
     }
 
     /** @test */
+    public function it_filters_by_includes_condition()
+    {
+        $this->makeEntry('a')->set('ages', [22, 52, 72])->save();
+        $this->makeEntry('b')->set('ages', [57, 72])->save();
+        $this->makeEntry('c')->set('ages', [2, 31, 22])->save();
+
+        $this->assertCount(3, $this->getEntries());
+        $this->assertCount(2, $this->getEntries(['ages:includes' => 72]));
+        $this->assertCount(1, $this->getEntries(['ages:includes' => 31]));
+    }
+
+    /** @test */
+    public function it_filters_by_doesnt_include_condition()
+    {
+        $this->makeEntry('a')->set('ages', [22, 52, 72])->save();
+        $this->makeEntry('b')->set('ages', [57, 72])->save();
+        $this->makeEntry('c')->set('ages', [2, 31, 22])->save();
+
+        $this->assertCount(3, $this->getEntries());
+        $this->assertCount(1, $this->getEntries(['ages:doesnt_include' => 72]));
+        $this->assertCount(2, $this->getEntries(['ages:doesnt_include' => 31]));
+    }
+
+    /** @test */
     public function when_the_value_is_an_augmentable_object_it_will_use_the_corresponding_value()
     {
         // The value doesn't have to be an entry, it just has to be an augmentable.


### PR DESCRIPTION
This is a second go at this and is an alternative to / replaces https://github.com/statamic/cms/pull/8357

This PR adds an `includes` modifier and tag condition. The Modifier is intentionally a loose comparison, so if any of the values in needle are found it counts as a match. This is to mirror how `whereJsonContains()` on the eloquent side.

Potentially an `includes_all` modifier could be added for a strict comparison (or the naming of this could be changed to `includes_any`).





