### PR TITLE
[4.x] Localize entry & term fields in Taxonomy Term GraphQL queries

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -23,6 +23,7 @@ use Statamic\Query\StatusQueryBuilder;
 use Statamic\Search\Index;
 use Statamic\Search\Result;
 use Statamic\Support\Arr;
+use Statamic\Taxonomies\LocalizedTerm;
 
 class Entries extends Relationship
 {
@@ -321,7 +322,7 @@ class Entries extends Relationship
     public function augment($values)
     {
         $site = Site::current()->handle();
-        if (($parent = $this->field()->parent()) && $parent instanceof Localization) {
+        if (($parent = $this->field()->parent()) && ($parent instanceof Localization || $parent instanceof LocalizedTerm)) {
             $site = $parent->locale();
         }
 

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -22,6 +22,7 @@ use Statamic\Query\OrderedQueryBuilder;
 use Statamic\Query\Scopes\Filters\Fields\Terms as TermsFilter;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
+use Statamic\Taxonomies\LocalizedTerm;
 
 class Terms extends Relationship
 {
@@ -111,7 +112,7 @@ class Terms extends Relationship
         // entry, but could also be something else, like another taxonomy term.
         $parent = $this->field->parent();
 
-        $site = $parent && $parent instanceof Localization
+        $site = $parent && ($parent instanceof Localization || $parent instanceof LocalizedTerm)
             ? $parent->locale()
             : Site::current()->handle(); // Use the "current" site so this will get localized appropriately on the front-end.
 


### PR DESCRIPTION
This pull request fixes an issue where entry & term fields weren't being localized when querying taxonomy terms.

The *real* fix for this issue would be to add the `Localization` interface to the `LocalizedTerm` class. However, in doing that, we'd need to change the method signature of the `locale` method which would be a breaking change for anyone overriding that class. 

Fixes #9469.