### PR TITLE
[5.x] Implement `Localization` interface on `LocalizedTerm`

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -23,7 +23,6 @@ use Statamic\Query\StatusQueryBuilder;
 use Statamic\Search\Index;
 use Statamic\Search\Result;
 use Statamic\Support\Arr;
-use Statamic\Taxonomies\LocalizedTerm;
 
 class Entries extends Relationship
 {
@@ -322,7 +321,7 @@ class Entries extends Relationship
     public function augment($values)
     {
         $site = Site::current()->handle();
-        if (($parent = $this->field()->parent()) && ($parent instanceof Localization || $parent instanceof LocalizedTerm)) {
+        if (($parent = $this->field()->parent()) && $parent instanceof Localization) {
             $site = $parent->locale();
         }
 

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -22,7 +22,6 @@ use Statamic\Query\OrderedQueryBuilder;
 use Statamic\Query\Scopes\Filters\Fields\Terms as TermsFilter;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
-use Statamic\Taxonomies\LocalizedTerm;
 
 class Terms extends Relationship
 {
@@ -112,7 +111,7 @@ class Terms extends Relationship
         // entry, but could also be something else, like another taxonomy term.
         $parent = $this->field->parent();
 
-        $site = $parent && ($parent instanceof Localization || $parent instanceof LocalizedTerm)
+        $site = $parent && $parent instanceof Localization
             ? $parent->locale()
             : Site::current()->handle(); // Use the "current" site so this will get localized appropriately on the front-end.
 

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Carbon;
 use Statamic\Contracts\Auth\Protect\Protectable;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
-use Statamic\Contracts\Data\Localizable;
 use Statamic\Contracts\Data\Localization;
 use Statamic\Contracts\GraphQL\ResolvesValues as ResolvesValuesContract;
 use Statamic\Contracts\Query\ContainsQueryableValues;
@@ -35,7 +34,7 @@ use Statamic\Search\Searchable;
 use Statamic\Statamic;
 use Statamic\Support\Str;
 
-class LocalizedTerm implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableValues, Protectable, ResolvesValuesContract, Responsable, SearchableContract, Term, Localization
+class LocalizedTerm implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableValues, Localization, Protectable, ResolvesValuesContract, Responsable, SearchableContract, Term
 {
     use ContainsSupplementalData, HasAugmentedInstance, Publishable, ResolvesValues, Revisable, Routable, Searchable, TracksLastModified, TracksQueriedColumns, TracksQueriedRelations;
 

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Carbon;
 use Statamic\Contracts\Auth\Protect\Protectable;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
+use Statamic\Contracts\Data\Localizable;
+use Statamic\Contracts\Data\Localization;
 use Statamic\Contracts\GraphQL\ResolvesValues as ResolvesValuesContract;
 use Statamic\Contracts\Query\ContainsQueryableValues;
 use Statamic\Contracts\Search\Searchable as SearchableContract;
@@ -33,7 +35,7 @@ use Statamic\Search\Searchable;
 use Statamic\Statamic;
 use Statamic\Support\Str;
 
-class LocalizedTerm implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableValues, Protectable, ResolvesValuesContract, Responsable, SearchableContract, Term
+class LocalizedTerm implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableValues, Protectable, ResolvesValuesContract, Responsable, SearchableContract, Term, Localization
 {
     use ContainsSupplementalData, HasAugmentedInstance, Publishable, ResolvesValues, Revisable, Routable, Searchable, TracksLastModified, TracksQueriedColumns, TracksQueriedRelations;
 
@@ -269,8 +271,12 @@ class LocalizedTerm implements Arrayable, ArrayAccess, Augmentable, ContainsQuer
         return $this->isDefaultLocale();
     }
 
-    public function locale()
+    public function locale($locale = null)
     {
+        if (func_num_args() === 1) {
+            throw new \Exception('The locale cannot be set on a LocalizedTerm.');
+        }
+
         return $this->locale;
     }
 


### PR DESCRIPTION
In #9492, we implemented a temporary fix for entry & term fields not being localized when taxonomy terms were being queried in GraphQL. 

This PR reverts that temporary fix in favour of implementing the `Localization` interface on the `LocalizedTerm` class, which is what we do for entries. Since implementing this interface requires a change to the `locale` method signature, this is a breaking change. 

Related: https://github.com/statamic/cms/issues/9469