### PR TITLE
[4.x] Include honeypot in Alpine.js form data

### DIFF
--- a/src/Forms/JsDrivers/AbstractJsDriver.php
+++ b/src/Forms/JsDrivers/AbstractJsDriver.php
@@ -136,6 +136,7 @@ abstract class AbstractJsDriver implements JsDriver
             ->fields()
             ->preProcess()
             ->values()
+            ->when($this->form->honeypot(), fn ($fields, $honeypot) => $fields->merge([$honeypot => null]))
             ->map(function ($defaultProcessedValue, $handle) use ($oldValues) {
                 return $oldValues->has($handle)
                     ? $oldValues->get($handle)

--- a/tests/Tags/Form/FormCreateAlpineTest.php
+++ b/tests/Tags/Form/FormCreateAlpineTest.php
@@ -97,6 +97,7 @@ class FormCreateAlpineTest extends FormTestCase
             'fav_animals' => [],
             'fav_colour' => null,
             'fav_subject' => null,
+            'winnie' => null
         ]);
 
         $expected = '<form method="POST" action="http://localhost/!/forms/contact" x-data="'.$expectedXData.'">';
@@ -122,6 +123,7 @@ class FormCreateAlpineTest extends FormTestCase
             'fav_animals' => [],
             'fav_colour' => null,
             'fav_subject' => null,
+            'winnie' => null,
         ]);
 
         $expected = '<form method="POST" action="http://localhost/!/forms/contact" x-data="'.$expectedXData.'">';
@@ -142,6 +144,7 @@ class FormCreateAlpineTest extends FormTestCase
                 'fav_animals' => [],
                 'fav_colour' => null,
                 'fav_subject' => null,
+                'winnie' => null,
             ],
         ]);
 
@@ -170,6 +173,7 @@ class FormCreateAlpineTest extends FormTestCase
                 'fav_animals' => ['cat'],
                 'fav_colour' => null,
                 'fav_subject' => null,
+                'winnie' => null,
             ],
         ]);
 
@@ -194,7 +198,7 @@ class FormCreateAlpineTest extends FormTestCase
             ],
         ];
 
-        $expected = 'x-data="'.$this->jsonEncode(['favourite_animals' => []]).'"';
+        $expected = 'x-data="'.$this->jsonEncode(['favourite_animals' => [], 'winnie' => null]).'"';
 
         $this->assertFieldRendersHtml($expected, $config, [], ['js' => 'alpine']);
     }
@@ -211,7 +215,7 @@ class FormCreateAlpineTest extends FormTestCase
             ],
         ];
 
-        $expected = 'x-data="'.$this->jsonEncode(['selfies' => []]).'"';
+        $expected = 'x-data="'.$this->jsonEncode(['selfies' => [], 'winnie' => null]).'"';
 
         $this->assertFieldRendersHtml($expected, $config, [], ['js' => 'alpine']);
     }

--- a/tests/Tags/Form/FormCreateAlpineTest.php
+++ b/tests/Tags/Form/FormCreateAlpineTest.php
@@ -97,7 +97,7 @@ class FormCreateAlpineTest extends FormTestCase
             'fav_animals' => [],
             'fav_colour' => null,
             'fav_subject' => null,
-            'winnie' => null
+            'winnie' => null,
         ]);
 
         $expected = '<form method="POST" action="http://localhost/!/forms/contact" x-data="'.$expectedXData.'">';

--- a/tests/Tags/Form/FormCreateCustomDriverTest.php
+++ b/tests/Tags/Form/FormCreateCustomDriverTest.php
@@ -156,6 +156,7 @@ EOT
             'name' => null,
             'email' => null,
             'message' => null,
+            'winnie' => null,
         ];
 
         $this->assertEquals($expected, $initialData);
@@ -179,6 +180,7 @@ EOT
             'name' => 'San Holo',
             'email' => null,
             'message' => null,
+            'winnie' => null,
         ];
 
         $this->assertEquals($expected, $initialData);


### PR DESCRIPTION
This pull request adds the Honeypot field to the form data object (eg. `x-data` when using Alpine.js) to prevent forms being processed when the honeypot contains a value.

Although this PR adds the honeypot field to the form data (`x-data`), developers will still need to add an `x-model` to the honeypot fields in their templates.

```html
<input id="{{ honeypot }}" type="text" name="{{ honeypot }}" x-model="form.{{ honeypot }}" />
```

Fixes #9495.