### PR TITLE
[4.x] Clean up some event handlers

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -446,6 +446,11 @@ export default {
         this.$events.$on('editor-action-completed', this.actionCompleted);
     },
 
+    destroyed() {
+        this.$events.$off('editor-action-started', this.actionStarted);
+        this.$events.$off('editor-action-completed', this.actionCompleted);
+    },
+
     watch: {
 
         initialContainer() {

--- a/resources/js/components/data-list/Action.vue
+++ b/resources/js/components/data-list/Action.vue
@@ -92,6 +92,10 @@ export default {
         this.$events.$on('reset-action-modals', this.reset);
     },
 
+    destroyed() {
+        this.$events.$off('reset-action-modals', this.reset);
+    },
+
     methods: {
 
         select() {

--- a/resources/js/components/data-list/DataList.vue
+++ b/resources/js/components/data-list/DataList.vue
@@ -109,6 +109,10 @@ export default {
         this.$events.$on('clear-selections', this.clearSelections);
     },
 
+    destroyed() {
+        this.$events.$off('clear-selections', this.clearSelections);
+    },
+
     methods: {
 
         setInitialSortColumn() {


### PR DESCRIPTION
This PR gets rid of some event handlers when the Vue components are destroyed.

This might help towards #9351
