### PR TITLE
[4.x] Antlers: Allow number literals inside variable bindings

### DIFF
--- a/src/View/Antlers/Language/Parser/AntlersNodeParser.php
+++ b/src/View/Antlers/Language/Parser/AntlersNodeParser.php
@@ -15,6 +15,7 @@ use Statamic\View\Antlers\Language\Nodes\AntlersNode;
 use Statamic\View\Antlers\Language\Nodes\Parameters\ParameterNode;
 use Statamic\View\Antlers\Language\Nodes\RecursiveNode;
 use Statamic\View\Antlers\Language\Nodes\TagIdentifier;
+use Statamic\View\Antlers\Language\Runtime\Sandbox\TypeCoercion;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
 
 class AntlersNodeParser
@@ -569,6 +570,11 @@ class AntlersNodeParser
                 if (Str::startsWith($name, DocumentParser::Punctuation_Colon)) {
                     $parameterNode->isVariableReference = true;
                     $name = StringUtilities::substr($name, 1);
+
+                    if (is_numeric($content)) {
+                        $content = TypeCoercion::coerceType($content);
+                        $parameterNode->isVariableReference = false;
+                    }
                 }
 
                 $parameterNode->name = $name;

--- a/tests/Antlers/Runtime/ParametersTest.php
+++ b/tests/Antlers/Runtime/ParametersTest.php
@@ -334,4 +334,35 @@ EOT;
 
         $this->assertSame('123:456', $result);
     }
+
+    public function test_numeric_literals_inside_variable_bindings_stay_numbers()
+    {
+        (new class extends Tags
+        {
+            protected static $handle = 'test';
+
+            public function index()
+            {
+                return $this->parse(array_merge($this->params->all(), $this->context->all()));
+            }
+        })::register();
+
+        $this->assertSame(
+            '124',
+            $this->renderString('{{ test :my_value="123" }}{{ my_value + 1 }}{{ /test }}', [], true),
+            'Simple addition'
+        );
+
+        $this->assertSame(
+            '-122',
+            $this->renderString('{{ test :my_value="-123" }}{{ my_value + 1 }}{{ /test }}', [], true),
+            'Negative numbers'
+        );
+
+        $this->assertSame(
+            '123.5',
+            $this->renderString('{{ test :my_value="123.0" }}{{ my_value + 0.5 }}{{ /test }}', [], true),
+            'Floats'
+        );
+    }
 }


### PR DESCRIPTION
This PR removes an existing papercut by allowing number literals inside Antlers parameter variable bindings. Currently, it is difficult/non-obvious on how one should go about passing a numeric value to a tag, as normal parameters are converted to strings:

```antlers
{{ my_tag param="1234" }}
```

We can now simply use variable binding syntax to pass along the numeric literal:

```antlers
{{ my_tag :param="1234" }}
{{ my_tag :param="-1234" }}
{{ my_tag :param="1234.56" }}
```

The current behavior would treat the numeric literal as a variable name, which is invalid, and always end up returning `null`, so I don't see this is as a breaking change. This PR does not automatically cast numeric values in all other situations since that would be a breaking change:

The following will remain a string value:

```antlers
{{ my_tag param="1234" }}
```

The behavior of the following has not been changed, as it is possible for tags to start with numbers:

```antlers
{{ my_tag param="{404}" }}
```
