### PR TITLE
[4.x] Antlers: stops double-initial execution of tags within conditions

### DIFF
--- a/src/View/Antlers/Language/Runtime/ConditionProcessor.php
+++ b/src/View/Antlers/Language/Runtime/ConditionProcessor.php
@@ -77,19 +77,6 @@ class ConditionProcessor
                     $this->processor->registerInterpolations($branch->head);
                 }
 
-                if (! empty($branch->head->interpolationRegions)) {
-                    /**
-                     * @var string $varKey
-                     * @var AbstractNode[] $interpolationRegion
-                     */
-                    foreach ($branch->head->processedInterpolationRegions as $varKey => $interpolationRegion) {
-                        $interpolationResult = $this->processor->cloneProcessor()->setData($data)->render($interpolationRegion);
-
-                        $dataToUse[$varKey] = $interpolationResult;
-                        $interpolationReplacements[$varKey] = $interpolationResult;
-                    }
-                }
-
                 $environment->setInterpolationReplacements($interpolationReplacements);
                 $environment->setData($dataToUse);
 

--- a/src/View/Antlers/Language/Runtime/ConditionProcessor.php
+++ b/src/View/Antlers/Language/Runtime/ConditionProcessor.php
@@ -83,10 +83,6 @@ class ConditionProcessor
                      * @var AbstractNode[] $interpolationRegion
                      */
                     foreach ($branch->head->processedInterpolationRegions as $varKey => $interpolationRegion) {
-                        if ($interpolationRegion[0]->isTagNode) {
-                            continue;
-                        }
-
                         $interpolationResult = $this->processor->cloneProcessor()->setData($data)->render($interpolationRegion);
 
                         $dataToUse[$varKey] = $interpolationResult;
@@ -108,7 +104,6 @@ class ConditionProcessor
                 }
 
                 if ($result == true) {
-
                     $this->processor->setIsConditionProcessor($condValueToRestore);
 
                     return $branch;

--- a/src/View/Antlers/Language/Runtime/ConditionProcessor.php
+++ b/src/View/Antlers/Language/Runtime/ConditionProcessor.php
@@ -77,6 +77,23 @@ class ConditionProcessor
                     $this->processor->registerInterpolations($branch->head);
                 }
 
+                if (! empty($branch->head->interpolationRegions)) {
+                    /**
+                     * @var string $varKey
+                     * @var AbstractNode[] $interpolationRegion
+                     */
+                    foreach ($branch->head->processedInterpolationRegions as $varKey => $interpolationRegion) {
+                        if ($interpolationRegion[0]->isTagNode) {
+                            continue;
+                        }
+
+                        $interpolationResult = $this->processor->cloneProcessor()->setData($data)->render($interpolationRegion);
+
+                        $dataToUse[$varKey] = $interpolationResult;
+                        $interpolationReplacements[$varKey] = $interpolationResult;
+                    }
+                }
+
                 $environment->setInterpolationReplacements($interpolationReplacements);
                 $environment->setData($dataToUse);
 

--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -1567,7 +1567,11 @@ class Environment
             $varName = $this->nameOf($val);
 
             if ($val->isInterpolationReference) {
-                $interpolationValue = $this->adjustValue($this->nodeProcessor->reduceInterpolatedVariable($val), $val);
+                if (array_key_exists($varName->normalizedReference, $this->data)) {
+                    $interpolationValue = $this->adjustValue($this->data[$varName->normalizedReference], $val);
+                } else {
+                    $interpolationValue = $this->adjustValue($this->nodeProcessor->reduceInterpolatedVariable($val), $val);
+                }
 
                 // If the currently active node is an instance of ArithmeticNodeContract,
                 // we will ask the runtime type coercion to convert whatever value

--- a/tests/Antlers/Sandbox/ConditionalsTest.php
+++ b/tests/Antlers/Sandbox/ConditionalsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Antlers\Sandbox;
 
+use Statamic\Tags\Tags;
 use Tests\Antlers\ParserTestCase;
 
 class ConditionalsTest extends ParserTestCase
@@ -47,13 +48,22 @@ EOT;
         $this->assertSame('no', $this->renderString($template, $data));
     }
 
-    public function test_tags_are_not_evaluated_twice()
+    public function test_tags_are_not_initially_evaluated_twice()
     {
         $template = <<<'EOT'
 {{ if {switch between='yes|no'} == 'yes' }}yes{{ else }}no{{ /if }}{{ if {switch between='yes|no'} == 'yes' }}yes{{ else }}no{{ /if }}
 EOT;
 
         $this->assertSame('yesno', $this->renderString($template, [], true));
+    }
+
+    public function test_tags_are_evaluated_twice_if_called_twice()
+    {
+        $template = <<<'EOT'
+{{ if {switch between='yes|no'} == 'yes' && {switch between='yes|no'} == 'no' }}yes{{ else }}no{{ /if }}{{ if {switch between='yes|no'} == 'yes' && {switch between='yes|no'} == 'no' }}yes{{ else }}no{{ /if }}{{ if {switch between='yes|no'} == 'no' && {switch between='yes|no'} == 'yes' }}yes{{ else }}no{{ /if }}
+EOT;
+
+        $this->assertSame('yesyesno', $this->renderString($template, [], true));
     }
 
     public function test_value_adjustments_inside_of_conditionals()
@@ -64,6 +74,32 @@ EOT;
         $this->assertSame('yes', $this->renderString($template, ['c' => 'b'], false));
     }
 
+    public function test_many_tag_value_adjustments_inside_of_conditionals()
+    {
+        $template = <<<'EOT'
+{{ if 'one_{switch between='yes|no'}' == 'one_yes' && 'two_{switch between='yes|no'}' == 'two_no' }}yes{{ else }}no{{ /if }}
+EOT;
+
+        $this->assertSame('yes', $this->renderString($template, [], true));
+    }
+
+    public function test_value_adjustments_resolved_tag_values()
+    {
+        (new class extends Tags
+        {
+            protected static $handle = 'the_tag';
+
+            public function index()
+            {
+                return 'bob';
+            }
+        })::register();
+
+        $template = <<<'EOT'
+{{ if 'bob' == '{the_tag}' }}yes{{ else }}no{{ /if }}
+EOT;
+        $this->assertSame('yes', $this->renderString($template, [], true));
+    }
 
     public function test_sandbox_evaluates_simple_boolean_expressions()
     {

--- a/tests/Antlers/Sandbox/ConditionalsTest.php
+++ b/tests/Antlers/Sandbox/ConditionalsTest.php
@@ -47,6 +47,15 @@ EOT;
         $this->assertSame('no', $this->renderString($template, $data));
     }
 
+    public function test_tags_are_not_evaluated_twice()
+    {
+        $template = <<<'EOT'
+{{ if {switch between='yes|no'} == 'yes' }}yes{{ else }}no{{ /if }}{{ if {switch between='yes|no'} == 'yes' }}yes{{ else }}no{{ /if }}
+EOT;
+
+        $this->assertSame('yesno', $this->renderString($template, [], true));
+    }
+
     public function test_sandbox_evaluates_simple_boolean_expressions()
     {
         $result = $this->getBoolResult('true == false', []);

--- a/tests/Antlers/Sandbox/ConditionalsTest.php
+++ b/tests/Antlers/Sandbox/ConditionalsTest.php
@@ -56,6 +56,15 @@ EOT;
         $this->assertSame('yesno', $this->renderString($template, [], true));
     }
 
+    public function test_value_adjustments_inside_of_conditionals()
+    {
+        $template = <<<'EOT'
+{{ if 'bob' == 'bo{c}' }}yes{{ else }}no{{ /if }}
+EOT;
+        $this->assertSame('yes', $this->renderString($template, ['c' => 'b'], false));
+    }
+
+
     public function test_sandbox_evaluates_simple_boolean_expressions()
     {
         $result = $this->getBoolResult('true == false', []);


### PR DESCRIPTION
This PR resolves a bug when using tags inside conditions. Currently, it will evaluate a tag _twice_ on initial usage. This existing bug can be observed by using a template similar to the following:

```antlers
{{ if {switch between='yes|no'} == 'yes' }}yes{{ else }}no{{ /if }}
{{ if {switch between='yes|no'} == 'yes' }}yes{{ else }}no{{ /if }}
```

Currently, all evaluations would print `no` since the tag with execute once when building up the context before evaluating the condition, and would execute again when evaluating the condition itself. This PR improves this internal behavior to prevent double execution for the initial tag execution.

Existing (valid) behaviors have not been changed, and additional test coverage added to ensure they are working correctly.

Interpolations are still processed when evaluating conditions:

```antlers
{{ if 'some_value' == 'some_{variable_name}' }}yes{{ else }}no{{ /if }}
```

If tags are used multiple times in the condition, they are still executed each time they are used. Test coverage added to ensure we are not using the cached value of the initial evaluation:

```antlers
{{ if 'one_{switch between='yes|no'}' == 'one_yes' && 'two_{switch between='yes|no'}' == 'two_no' }}yes{{ else }}no{{ /if }}
```