### PR TITLE
[4.x] Prevent warming redirect URLs

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -189,6 +189,10 @@ class StaticWarm extends Command
                 return null;
             }
 
+            if ($entry->isRedirect()) {
+                return null;
+            }
+
             return $entry->absoluteUrl();
         })->filter();
 


### PR DESCRIPTION
This pull request prevents entries with redirects from being warmed by the `static:warm` command.

There's no existing issue for this but I noticed it this morning while deploying my personal site, that it was warming external URLs.