### PR TITLE
[4.x] Fix scrolling in Inline Publish Form on Safari on iOS

### DIFF
--- a/resources/js/components/inputs/relationship/InlinePublishForm.vue
+++ b/resources/js/components/inputs/relationship/InlinePublishForm.vue
@@ -5,7 +5,7 @@
         :before-close="shouldClose"
         @closed="close"
     >
-    <div class="h-full overflow-auto p-6 bg-gray-300">
+    <div class="h-full overflow-scroll overflow-x-auto p-6 bg-gray-300">
 
         <div v-if="loading" class="absolute inset-0 z-200 flex items-center justify-center text-center">
             <loading-graphic />


### PR DESCRIPTION
This pull request fixes an issue when scrolling the `InlinePublishForm` component on Safari on iOS. I copied the fix for this from my previous PR #9250, which fixed a similar issue but on the field settings stack.

Fixes #9501.