### PR TITLE
[4.x] Fix numbers not being cast in API filters

### DIFF
--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -101,6 +101,8 @@ class ApiController extends Controller
                     $value = true;
                 } elseif ($value === 'false') {
                     $value = false;
+                } elseif (is_numeric($value)) {
+                    $value = str_contains($value, '.') ? (float) $value : (int) $value;
                 }
 
                 if (Str::contains($filter, ':')) {


### PR DESCRIPTION
This fixes an issue where if you're trying to use numbers in filters, they'd be strings and your comparisons would end up incorrect.

For example:

`/api/somewhere?filter[integer_field:gt]=5`

This would end up with a query like `where('integer_field', '>', '5')`. You want `5` though, not `"5"`.

This PR casts numeric values to either an integer or float.
