### PR TITLE
[4.x] Make entries json serializable

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Traits\Localizable;
+use JsonSerializable;
 use LogicException;
 use Statamic\Contracts\Auth\Protect\Protectable;
 use Statamic\Contracts\Data\Augmentable;
@@ -52,7 +53,7 @@ use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableValues, Contract, Localization, Protectable, ResolvesValuesContract, Responsable, SearchableContract
+class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableValues, Contract, JsonSerializable, Localization, Protectable, ResolvesValuesContract, Responsable, SearchableContract
 {
     use ContainsComputedData, ContainsData, ExistsAsFile, FluentlyGetsAndSets, HasAugmentedInstance, Localizable, Publishable, Revisable, Searchable, TracksLastModified, TracksQueriedColumns, TracksQueriedRelations;
 
@@ -998,5 +999,10 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
     protected function getComputedCallbacks()
     {
         return Facades\Collection::getComputedCallbacks($this->collection);
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
     }
 }

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -2438,4 +2438,19 @@ class EntryTest extends TestCase
             ['7', '7'],
         ], $events->map(fn ($event) => [$event->entry->id(), $event->initiator->id()])->all());
     }
+
+    /** @test */
+    public function entry_is_json_serializable()
+    {
+        $entry = EntryFactory::collection('test')->create();
+        $entry->set('title', 'Serializable Title');
+
+        // Json serialize and deserialize
+        $json = json_encode($entry);
+        $array = json_decode($json, true);
+
+        $this->assertJson($json);
+        $this->assertArrayHasKey('title', $array);
+        $this->assertTrue(data_get($array, 'collection.handle') === 'test');
+    }
 }


### PR DESCRIPTION
To pass event data into webhooks as json, we need to be able to serialize the entries to json.
This update adds JsonSerializable to the entries for this purpose.

Without JsonSerializable, the EntrySaving event will return a empty object for the entry like below example.

```json
{
    "trigger_event":"Statamic\\Events\\EntrySaving",
    "event":{
        "entry":{}
    }
}
```