### PR TITLE
[5.x] Make Bard/Replicator/Grid sets sit at the bottom of the field configs

### DIFF
--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -40,6 +40,16 @@ class FieldTransformer
             unset($field['duplicate']);
         }
 
+        if (Arr::has($field, 'sets')) {
+            $sets = Arr::pull($field, 'sets');
+            $field['sets'] = $sets;
+        }
+
+        if (Arr::has($field, 'fields')) {
+            $fields = Arr::pull($field, 'fields');
+            $field['fields'] = $fields;
+        }
+
         return array_filter([
             'handle' => $submitted['handle'],
             'field' => $field,


### PR DESCRIPTION
This pull request makes a small DX improvement by ensuring that Bard/Replicator/Grid sets always sit at the bottom of field configs, rather than in the midst of the various other config options.

The Bard & Replicator fieldtypes use `sets` for their sets & the Grid fieldtype uses `fields` for its set of fields. 

Closes #9432.