### PR TITLE
[4.x] Prevent non-images being processed through source preset

### DIFF
--- a/src/Assets/AssetUploader.php
+++ b/src/Assets/AssetUploader.php
@@ -64,6 +64,10 @@ class AssetUploader extends Uploader
             return null;
         }
 
+        if (! $this->asset->isImage()) {
+            return null;
+        }
+
         if (! $ext = Arr::get(Image::userManipulationPresets(), "$preset.fm")) {
             return null;
         }


### PR DESCRIPTION
This pull request fixes an issue when using an asset container with a `source_preset` defined. All uploaded files would be renamed, even if they aren't images.

Fixes #9515.