### PR TITLE
[4.x] Fix issues when saving entries with `JsonResource::withoutWrapping()`

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -259,13 +259,13 @@ class EntriesController extends CpController
 
         [$values] = $this->extractFromFields($entry, $blueprint);
 
-        return (new EntryResource($entry->fresh()))
-            ->additional([
-                'saved' => $saved,
-                'data' => [
-                    'values' => $values,
-                ],
-            ]);
+        return [
+            'data' => [
+                ...(new EntryResource($entry->fresh()))->resolve()['data'],
+                'values' => $values,
+            ],
+            'saved' => $saved,
+        ];
     }
 
     public function create(Request $request, $collection, $site)

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -260,10 +260,9 @@ class EntriesController extends CpController
         [$values] = $this->extractFromFields($entry, $blueprint);
 
         return [
-            'data' => [
-                ...(new EntryResource($entry->fresh()))->resolve()['data'],
+            'data' => array_merge((new EntryResource($entry->fresh()))->resolve()['data'], [
                 'values' => $values,
-            ],
+            ]),
             'saved' => $saved,
         ];
     }


### PR DESCRIPTION
This pull request fixes an issue when updating entries when using `JsonResource::withoutWrapping()` to prevent wrapping of JSON resources.

Fixes #9518.