### PR TITLE
[4.x] Support YouTube Shorts in embed_code modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2909,6 +2909,10 @@ class CoreModifiers extends Modifier
             }
         }
 
+        if (Str::contains($url, 'youtube.com/shorts/')) {
+            $url = str_replace('shorts/', 'embed/', $url);
+        }
+
         if (Str::contains($url, 'youtube.com')) {
             $url = str_replace('youtube.com', 'youtube-nocookie.com', $url);
         }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2917,9 +2917,7 @@ class CoreModifiers extends Modifier
             $url = str_replace('youtube.com', 'youtube-nocookie.com', $url);
         }
 
-        /**
-         * This avoids SSL issues when using https://youtube-nocookie.com instead of https://www.youtube-nocookie.com
-         */
+        // This avoids SSL issues when using the non-www version
         if (Str::contains($url, '//youtube-nocookie.com')) {
             $url = str_replace('//youtube-nocookie.com', '//www.youtube-nocookie.com', $url);
         }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2917,6 +2917,13 @@ class CoreModifiers extends Modifier
             $url = str_replace('youtube.com', 'youtube-nocookie.com', $url);
         }
 
+        /**
+         * This avoids SSL issues when using https://youtube-nocookie.com instead of https://www.youtube-nocookie.com
+         */
+        if (Str::contains($url, '//youtube-nocookie.com')) {
+            $url = str_replace('//youtube-nocookie.com', '//www.youtube-nocookie.com', $url);
+        }
+
         return $url;
     }
 


### PR DESCRIPTION
This PR adds support for YouTube Shorts to the embed_url Antlers modifier.

Also it fixes an issue where youtube-nocookie.com embeds are not working without [www](http://www/). You can reproduce it when omitting www from a YouTube embed link (working: https://www.youtube.com/watch?v=7hYbrdC_-s8, not working: https://youtube.com/watch?v=7hYbrdC_-s8)