### PR TITLE
[4.x] Fix table drag handles disappearing

### DIFF
--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -242,6 +242,7 @@
 
 td.table-drag-handle {
 	@apply w-3 border-r h-full p-2;
+    min-width: 16px;
 	cursor: grab;
 	background: theme('colors.gray.200') url('../../svg/icons/light/drag-dots.svg') center center no-repeat;
     background-size: 7px 17px;


### PR DESCRIPTION
Sometimes when you click the "Reorder" button on a collection listing, the table row drag handles aren't visible.

This happens when you have enough columns that the horizontal overflow kicks in, and the drag handle table cell gets squished.

This PR gives it a min width to prevent squishing.
