### PR TITLE
[4.x] Also Use static_cache store for nocache

### DIFF
--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -49,7 +49,7 @@ class Session
 
     public function region(string $key): Region
     {
-        if ($this->regions->contains($key) && ($region = Cache::get('nocache::region.'.$key))) {
+        if ($this->regions->contains($key) && ($region = StaticCache::cacheStore()->get('nocache::region.'.$key))) {
             return $region;
         }
 

--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -4,7 +4,6 @@ namespace Statamic\StaticCaching\NoCache;
 
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Statamic\Facades\Cascade;
 use Statamic\Facades\Data;

--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Statamic\Facades\Cascade;
 use Statamic\Facades\Data;
+use Statamic\Facades\StaticCache;
 
 class Session
 {
@@ -102,7 +103,7 @@ class Session
             return;
         }
 
-        $store = $this->cacheStore();
+        $store = StaticCache::cacheStore();
 
         $store->forever('nocache::urls', collect($store->get('nocache::urls', []))->push($this->url)->unique()->all());
 
@@ -113,7 +114,7 @@ class Session
 
     public function restore()
     {
-        $session = $this->cacheStore()->get('nocache::session.'.md5($this->url));
+        $session = StaticCache::cacheStore()->get('nocache::session.'.md5($this->url));
 
         $this->regions = $this->regions->merge($session['regions'] ?? []);
         $this->cascade = $this->restoreCascade();
@@ -142,17 +143,6 @@ class Session
 
     private function cacheRegion(Region $region)
     {
-        $this->cacheStore()->forever('nocache::region.'.$region->key(), $region);
-    }
-
-    private function cacheStore()
-    {
-        try {
-            $store = Cache::store('static_cache');
-        } catch (InvalidArgumentException $e) {
-            $store = Cache::store();
-        }
-
-        return $store;
+        StaticCache::cacheStore()->forever('nocache::region.'.$region->key(), $region);
     }
 }

--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -6,7 +6,6 @@ use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
-use InvalidArgumentException;
 use Statamic\Facades\Cascade;
 use Statamic\Facades\Data;
 use Statamic\Facades\StaticCache;

--- a/tests/StaticCaching/ManagerTest.php
+++ b/tests/StaticCaching/ManagerTest.php
@@ -21,6 +21,7 @@ class ManagerTest extends TestCase
         $mock = Mockery::mock(Cacher::class)->shouldReceive('flush')->once()->getMock();
         StaticCache::extend('test', fn () => $mock);
 
+        Cache::shouldReceive('store')->andReturnSelf();
         Cache::shouldReceive('get')->with('nocache::urls', [])->once()->andReturn(['/one', '/two']);
         Cache::shouldReceive('get')->with('nocache::session.'.md5('/one'))->once()->andReturn(['regions' => ['r1', 'r2']]);
         Cache::shouldReceive('get')->with('nocache::session.'.md5('/two'))->once()->andReturn(['regions' => ['r3', 'r4']]);

--- a/tests/StaticCaching/NoCacheSessionTest.php
+++ b/tests/StaticCaching/NoCacheSessionTest.php
@@ -80,6 +80,8 @@ class NoCacheSessionTest extends TestCase
 
         // Testing that the cache key used is unique to the url.
         // The contents aren't really important.
+        Cache::shouldReceive('store')
+            ->andReturnSelf();
 
         Cache::shouldReceive('forever')
             ->with('nocache::session.'.md5('/'), Mockery::any())


### PR DESCRIPTION
Following on from https://github.com/statamic/cms/pull/9405 I've noticed that `php artisan cache:clear` clears the no cache store which goes hand in hand with the static cache URLS. This means you get missing no cache regions after a cache clear.

This PR ensures that the no cache stores use the same `static_cache` store as the static cache urls, which is cleared only when the static cache is cleared and not when the default cache is cleared. 