### PR TITLE
[4.x] Only search for descendants if multi-site mode is enabled

### DIFF
--- a/src/Actions/DuplicateEntry.php
+++ b/src/Actions/DuplicateEntry.php
@@ -21,7 +21,7 @@ class DuplicateEntry extends Action
 
     public function confirmationText()
     {
-        $hasDescendants = $this->items
+        $hasDescendants = collect(config('statamic.sites'))->count() > 1 && $this->items
             ->map(fn ($entry) => $entry->hasOrigin() ? $entry->root() : $entry)
             ->unique()
             ->contains(fn ($entry) => $entry->descendants()->count());

--- a/src/Actions/DuplicateEntry.php
+++ b/src/Actions/DuplicateEntry.php
@@ -5,6 +5,7 @@ namespace Statamic\Actions;
 use Illuminate\Support\Str;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\Entry as Entries;
+use Statamic\Facades\Site;
 use Statamic\Facades\User;
 
 class DuplicateEntry extends Action

--- a/src/Actions/DuplicateEntry.php
+++ b/src/Actions/DuplicateEntry.php
@@ -21,7 +21,7 @@ class DuplicateEntry extends Action
 
     public function confirmationText()
     {
-        $hasDescendants = collect(config('statamic.sites'))->count() > 1 && $this->items
+        $hasDescendants = Site::hasMultiple() && $this->items
             ->map(fn ($entry) => $entry->hasOrigin() ? $entry->root() : $entry)
             ->unique()
             ->contains(fn ($entry) => $entry->descendants()->count());


### PR DESCRIPTION
### Summary
This pull request introduces a change to only check for descendants if multiple sites are used. 
**This will increase the perfomance of the control panel on single sites.**

### More information
When initializing the Duplicate Entry action, it will search for entries where the `origin_id` equals the `id` of the entry of this action. If the Multi-Site feature of Statamic is not used, this will cause multiple unnecessary file (or database) requests on the index page of a collection in the control panel. 

