### PR TITLE
[4.x] Check if form request wantsJson

### DIFF
--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -98,7 +98,7 @@ class FormController extends Controller
      */
     private function formFailure($params, $errors, $form)
     {
-        if (request()->ajax()) {
+        if (request()->ajax() || request()->wantsJson()) {
             return response([
                 'errors' => (new MessageBag($errors))->all(),
                 'error' => collect($errors)->map(function ($errors, $field) {

--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -60,7 +60,7 @@ class FrontendFormRequest extends FormRequest
 
     protected function failedValidation(Validator $validator)
     {
-        if ($this->ajax()) {
+        if ($this->ajax() || $this->wantsJson()) {
             $errors = $validator->errors();
 
             $response = response([


### PR DESCRIPTION
I noticed that we arent checking if a form request wantsJson() in the failure message the way the success message is. 

This means using JS fetch() on the front end gets a redirect rather than JSON when you throw a validation exception in a FormSubmitted listener.

This PR fixes that to return the JSON response.
