### PR TITLE
[4.x] Exclude super when using a custom field

### DIFF
--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -271,7 +271,7 @@ class UsersController extends CpController
             ->withReplacements(['id' => $user->id()])
             ->validate();
 
-        $values = $fields->process()->values()->except(['email', 'groups', 'roles']);
+        $values = $fields->process()->values()->except(['email', 'groups', 'roles', 'super']);
 
         foreach ($values as $key => $value) {
             $user->set($key, $value);

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -126,7 +126,7 @@ class UsersController extends CpController
         $expiry = config("auth.passwords.{$broker}.expire") / 60;
 
         $additional = $fields->all()
-            ->reject(fn ($field) => in_array($field->handle(), ['roles', 'groups']))
+            ->reject(fn ($field) => in_array($field->handle(), ['roles', 'groups', 'super']))
             ->keys();
 
         $viewData = [


### PR DESCRIPTION
When you're editing a user while logged in as a super user, we add a toggle for you. We also check your permission on the server side when saving it back onto the user.

However if you explicitly added your own super field onto the blueprint, `$fields` would contain `super`, and the value gets applied without running through the check.

This PR excludes it from the values so it has to go through the explicit check.

It also removes it from the "User information" step of the create form. If you're a super user, it'll already be on the "Roles & Groups" step.
