### PR TITLE
[4.x] Corrects Stache problem on Windows

### DIFF
--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -131,9 +131,15 @@ abstract class Index
 
     public function cacheKey()
     {
+        $replacements = ['::', '->'];
+
+        if (windows_os()) {
+            $replacements[1] = '-]';
+        }
+
         return vsprintf('stache::indexes::%s::%s', [
             $this->store->key(),
-            str_replace(['.', '/'], ['::', '->'], $this->name),
+            str_replace(['.', '/'], $replacements, $this->name),
         ]);
     }
 


### PR DESCRIPTION
This PR fixes #9524 by adjusting how Stache index paths are created on Windows.

The breaking change happened here:

https://github.com/statamic/cms/pull/6131/files#diff-b0fa04a7e478fa6c45835c964c3230f6d455a170013366c3b6657e01519e2915R136

This PR adjusts the created path from `->` to `-]`, but only on Windows (to not impact any existing paths and cause unnecessary update challenges for non-Windows users). I'm not sure how to add a test for this, but the existing tests pass and the issues outlined in #6131 seem to be working fine for me on Windows.