### PR TITLE
[4.x] Customize Columns Modal Height Thrashing

### DIFF
--- a/resources/css/components/modal.css
+++ b/resources/css/components/modal.css
@@ -6,12 +6,6 @@
     @apply rounded-lg !important;
 }
 
-/* Prevent height thrashing for https://github.com/statamic/cms/issues/9473 */
-.vm--modal > div:first-child {
-    /* 1px difference to prevent subtle shimmer */
-    max-height: calc(100vh - 1px) !important;
-}
-
 .vm--overlay {
     background: hsla(210, 20%, 10%, .15) !important;
 }

--- a/resources/css/components/modal.css
+++ b/resources/css/components/modal.css
@@ -6,6 +6,12 @@
     @apply rounded-lg !important;
 }
 
+/* Prevent height thrashing for https://github.com/statamic/cms/issues/9473 */
+.vm--modal > div:first-child {
+    /* 1px difference to prevent subtle shimmer */
+    max-height: calc(100vh - 1px) !important;
+}
+
 .vm--overlay {
     background: hsla(210, 20%, 10%, .15) !important;
 }

--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -90,3 +90,7 @@
 [x-cloak] {
     display: none
 }
+
+.-max-h-screen-1 {
+    max-height: calc(100vh - 1px) !important;
+}

--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -91,6 +91,6 @@
     display: none
 }
 
-.-max-h-screen-1 {
+.-max-h-screen-px {
     max-height: calc(100vh - 1px) !important;
 }

--- a/resources/js/components/SessionExpiry.vue
+++ b/resources/js/components/SessionExpiry.vue
@@ -5,7 +5,7 @@
         <button v-if="isWarning" class="session-expiry-stripe" @click="extend" v-text="warningText" />
 
         <modal name="session-timeout-login" v-if="isShowingLogin" height="auto" width="500px" :adaptive="true">
-            <div class="-max-h-screen-1">
+            <div class="-max-h-screen-px">
             <div class="flex items-center p-6 bg-gray-200 border-b text-center">
                 {{ __('Resume Your Session') }}
             </div>

--- a/resources/js/components/SessionExpiry.vue
+++ b/resources/js/components/SessionExpiry.vue
@@ -5,40 +5,42 @@
         <button v-if="isWarning" class="session-expiry-stripe" @click="extend" v-text="warningText" />
 
         <modal name="session-timeout-login" v-if="isShowingLogin" height="auto" width="500px" :adaptive="true">
-            <div class="flex items-center p-6 bg-gray-200 border-b text-center">
-                {{ __('Resume Your Session') }}
-            </div>
-
-            <div v-if="isUsingOauth" class="p-6">
-                <a :href="oauthProvider.loginUrl" target="_blank" class="btn-primary">
-                    {{ __('Log in with :provider', {provider: oauthProvider.label}) }}
-                </a>
-                <div class="text-2xs text-gray mt-4">
-                    {{ __('messages.session_expiry_new_window') }}
+            <div>
+                <div class="flex items-center p-6 bg-gray-200 border-b text-center">
+                    {{ __('Resume Your Session') }}
                 </div>
-            </div>
-
-            <div v-if="!isUsingOauth" class="publish-fields">
-                <div class="form-group w-full">
-                    <label v-text="__('messages.session_expiry_enter_password')" />
-                    <small
-                        class="help-block text-red-500"
-                        v-if="errors.email"
-                        v-text="errors.email[0]" />
-                    <small
-                        class="help-block text-red-500"
-                        v-if="errors.password"
-                        v-text="errors.password[0]" />
-                    <div class="flex items-center">
-                        <input
-                            type="password"
-                            v-model="password"
-                            ref="password"
-                            class="input-text"
-                            tabindex="1"
-                            autofocus
-                            @keydown.enter.prevent="submit" />
-                        <button @click="submit" class="btn-primary ml-2" v-text="__('Log in')" />
+    
+                <div v-if="isUsingOauth" class="p-6">
+                    <a :href="oauthProvider.loginUrl" target="_blank" class="btn-primary">
+                        {{ __('Log in with :provider', {provider: oauthProvider.label}) }}
+                    </a>
+                    <div class="text-2xs text-gray mt-4">
+                        {{ __('messages.session_expiry_new_window') }}
+                    </div>
+                </div>
+    
+                <div v-if="!isUsingOauth" class="publish-fields">
+                    <div class="form-group w-full">
+                        <label v-text="__('messages.session_expiry_enter_password')" />
+                        <small
+                            class="help-block text-red-500"
+                            v-if="errors.email"
+                            v-text="errors.email[0]" />
+                        <small
+                            class="help-block text-red-500"
+                            v-if="errors.password"
+                            v-text="errors.password[0]" />
+                        <div class="flex items-center">
+                            <input
+                                type="password"
+                                v-model="password"
+                                ref="password"
+                                class="input-text"
+                                tabindex="1"
+                                autofocus
+                                @keydown.enter.prevent="submit" />
+                            <button @click="submit" class="btn-primary ml-2" v-text="__('Log in')" />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/js/components/SessionExpiry.vue
+++ b/resources/js/components/SessionExpiry.vue
@@ -5,44 +5,44 @@
         <button v-if="isWarning" class="session-expiry-stripe" @click="extend" v-text="warningText" />
 
         <modal name="session-timeout-login" v-if="isShowingLogin" height="auto" width="500px" :adaptive="true">
-            <div>
-                <div class="flex items-center p-6 bg-gray-200 border-b text-center">
-                    {{ __('Resume Your Session') }}
+            <div class="-max-h-screen-1">
+            <div class="flex items-center p-6 bg-gray-200 border-b text-center">
+                {{ __('Resume Your Session') }}
+            </div>
+
+            <div v-if="isUsingOauth" class="p-6">
+                <a :href="oauthProvider.loginUrl" target="_blank" class="btn-primary">
+                    {{ __('Log in with :provider', {provider: oauthProvider.label}) }}
+                </a>
+                <div class="text-2xs text-gray mt-4">
+                    {{ __('messages.session_expiry_new_window') }}
                 </div>
-    
-                <div v-if="isUsingOauth" class="p-6">
-                    <a :href="oauthProvider.loginUrl" target="_blank" class="btn-primary">
-                        {{ __('Log in with :provider', {provider: oauthProvider.label}) }}
-                    </a>
-                    <div class="text-2xs text-gray mt-4">
-                        {{ __('messages.session_expiry_new_window') }}
+            </div>
+
+            <div v-if="!isUsingOauth" class="publish-fields">
+                <div class="form-group w-full">
+                    <label v-text="__('messages.session_expiry_enter_password')" />
+                    <small
+                        class="help-block text-red-500"
+                        v-if="errors.email"
+                        v-text="errors.email[0]" />
+                    <small
+                        class="help-block text-red-500"
+                        v-if="errors.password"
+                        v-text="errors.password[0]" />
+                    <div class="flex items-center">
+                        <input
+                            type="password"
+                            v-model="password"
+                            ref="password"
+                            class="input-text"
+                            tabindex="1"
+                            autofocus
+                            @keydown.enter.prevent="submit" />
+                        <button @click="submit" class="btn-primary ml-2" v-text="__('Log in')" />
                     </div>
                 </div>
-    
-                <div v-if="!isUsingOauth" class="publish-fields">
-                    <div class="form-group w-full">
-                        <label v-text="__('messages.session_expiry_enter_password')" />
-                        <small
-                            class="help-block text-red-500"
-                            v-if="errors.email"
-                            v-text="errors.email[0]" />
-                        <small
-                            class="help-block text-red-500"
-                            v-if="errors.password"
-                            v-text="errors.password[0]" />
-                        <div class="flex items-center">
-                            <input
-                                type="password"
-                                v-model="password"
-                                ref="password"
-                                class="input-text"
-                                tabindex="1"
-                                autofocus
-                                @keydown.enter.prevent="submit" />
-                            <button @click="submit" class="btn-primary ml-2" v-text="__('Log in')" />
-                        </div>
-                    </div>
-                </div>
+            </div>
             </div>
         </modal>
 

--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -9,7 +9,7 @@
         </button>
 
         <modal v-if="open" name="column-picker" @closed="open = false" draggable=".modal-drag-handle" click-to-close>
-            <div class="flex flex-col h-full">
+            <div class="flex flex-col h-full -max-h-screen-1">
 
                 <header class="modal-drag-handle p-4 bg-gray-200 border-b flex items-center justify-between cursor-grab active:cursor-grabbing">
                     <h2>{{ __('Customize Columns') }}</h2>

--- a/resources/js/components/data-list/ColumnPicker.vue
+++ b/resources/js/components/data-list/ColumnPicker.vue
@@ -9,7 +9,7 @@
         </button>
 
         <modal v-if="open" name="column-picker" @closed="open = false" draggable=".modal-drag-handle" click-to-close>
-            <div class="flex flex-col h-full -max-h-screen-1">
+            <div class="flex flex-col h-full -max-h-screen-px">
 
                 <header class="modal-drag-handle p-4 bg-gray-200 border-b flex items-center justify-between cursor-grab active:cursor-grabbing">
                     <h2>{{ __('Customize Columns') }}</h2>

--- a/resources/js/components/modals/KeyboardShortcutsModal.vue
+++ b/resources/js/components/modals/KeyboardShortcutsModal.vue
@@ -1,6 +1,6 @@
 <template>
     <modal v-if="open" name="keyboard-shortcuts" width="380" height="auto" :adaptive="true" @closed="open = false" click-to-close>
-        <div class="-max-h-screen-1">
+        <div class="-max-h-screen-px">
         <h1 class="p-4 bg-gray-200 border-b text-center">
             {{ __('Keyboard Shortcuts') }}
         </h1>

--- a/resources/js/components/modals/KeyboardShortcutsModal.vue
+++ b/resources/js/components/modals/KeyboardShortcutsModal.vue
@@ -1,50 +1,52 @@
 <template>
     <modal v-if="open" name="keyboard-shortcuts" width="380" height="auto" :adaptive="true" @closed="open = false" click-to-close>
-        <h1 class="p-4 bg-gray-200 border-b text-center">
-            {{ __('Keyboard Shortcuts') }}
-        </h1>
-        <div class="p-6 relative">
-            <div class="shortcut-pair">
-                <span class="shortcut-combo">
-                    <span class="shortcut">shift</span><span class="shortcut-joiner">+</span><span class="shortcut">?</span>
-                </span>
-                <span class="shortcut-value">{{ __('Show Keyboard Shortcuts') }}</span>
-            </div>
-
-            <div class="shortcut-pair">
-                <span class="shortcut-combo">
-                    <span class="shortcut">/</span> <span class="shortcut-joiner">or</span>
-                    <span class="shortcut">ctrl</span><span class="shortcut-joiner">+</span><span class="shortcut">f</span>
-                </span>
-                <span class="shortcut-value">{{ __('Focus Search') }}</span>
-            </div>
-
-            <div class="shortcut-pair">
-                <span class="shortcut-combo">
-                    <span class="shortcut">⌘</span><span class="shortcut-joiner">+</span><span class="shortcut">return</span>
-                </span>
-                <span class="shortcut-value">{{ __('Save') }}</span>
-            </div>
-
-            <div class="shortcut-pair">
-                <span class="shortcut-combo">
-                    <span class="shortcut">⌘</span><span class="shortcut-joiner">+</span><span class="shortcut">s</span>
-                </span>
-                <span class="shortcut-value">{{ __('Quick Save') }}</span>
-            </div>
-
-            <div class="shortcut-pair">
-                <span class="shortcut-combo">
-                    <span class="shortcut">⌘</span><span class="shortcut-joiner">+</span><span class="shortcut">\</span>
-                </span>
-                <span class="shortcut-value">{{ __('Toggle Sidebar') }}</span>
-            </div>
-
-            <div class="shortcut-pair mb-0">
-                <span class="shortcut-combo">
-                    <span class="shortcut">esc</span>
-                </span>
-                <span class="shortcut-value">{{ __('Close Modal') }}</span>
+        <div class="overflow-y-auto">
+            <h1 class="p-4 bg-gray-200 border-b text-center">
+                {{ __('Keyboard Shortcuts') }}
+            </h1>
+            <div class="p-6 relative">
+                <div class="shortcut-pair">
+                    <span class="shortcut-combo">
+                        <span class="shortcut">shift</span><span class="shortcut-joiner">+</span><span class="shortcut">?</span>
+                    </span>
+                    <span class="shortcut-value">{{ __('Show Keyboard Shortcuts') }}</span>
+                </div>
+    
+                <div class="shortcut-pair">
+                    <span class="shortcut-combo">
+                        <span class="shortcut">/</span> <span class="shortcut-joiner">or</span>
+                        <span class="shortcut">ctrl</span><span class="shortcut-joiner">+</span><span class="shortcut">f</span>
+                    </span>
+                    <span class="shortcut-value">{{ __('Focus Search') }}</span>
+                </div>
+    
+                <div class="shortcut-pair">
+                    <span class="shortcut-combo">
+                        <span class="shortcut">⌘</span><span class="shortcut-joiner">+</span><span class="shortcut">return</span>
+                    </span>
+                    <span class="shortcut-value">{{ __('Save') }}</span>
+                </div>
+    
+                <div class="shortcut-pair">
+                    <span class="shortcut-combo">
+                        <span class="shortcut">⌘</span><span class="shortcut-joiner">+</span><span class="shortcut">s</span>
+                    </span>
+                    <span class="shortcut-value">{{ __('Quick Save') }}</span>
+                </div>
+    
+                <div class="shortcut-pair">
+                    <span class="shortcut-combo">
+                        <span class="shortcut">⌘</span><span class="shortcut-joiner">+</span><span class="shortcut">\</span>
+                    </span>
+                    <span class="shortcut-value">{{ __('Toggle Sidebar') }}</span>
+                </div>
+    
+                <div class="shortcut-pair mb-0">
+                    <span class="shortcut-combo">
+                        <span class="shortcut">esc</span>
+                    </span>
+                    <span class="shortcut-value">{{ __('Close Modal') }}</span>
+                </div>
             </div>
         </div>
     </modal>

--- a/resources/js/components/modals/KeyboardShortcutsModal.vue
+++ b/resources/js/components/modals/KeyboardShortcutsModal.vue
@@ -1,53 +1,53 @@
 <template>
     <modal v-if="open" name="keyboard-shortcuts" width="380" height="auto" :adaptive="true" @closed="open = false" click-to-close>
-        <div class="overflow-y-auto">
-            <h1 class="p-4 bg-gray-200 border-b text-center">
-                {{ __('Keyboard Shortcuts') }}
-            </h1>
-            <div class="p-6 relative">
-                <div class="shortcut-pair">
-                    <span class="shortcut-combo">
-                        <span class="shortcut">shift</span><span class="shortcut-joiner">+</span><span class="shortcut">?</span>
-                    </span>
-                    <span class="shortcut-value">{{ __('Show Keyboard Shortcuts') }}</span>
-                </div>
-    
-                <div class="shortcut-pair">
-                    <span class="shortcut-combo">
-                        <span class="shortcut">/</span> <span class="shortcut-joiner">or</span>
-                        <span class="shortcut">ctrl</span><span class="shortcut-joiner">+</span><span class="shortcut">f</span>
-                    </span>
-                    <span class="shortcut-value">{{ __('Focus Search') }}</span>
-                </div>
-    
-                <div class="shortcut-pair">
-                    <span class="shortcut-combo">
-                        <span class="shortcut">⌘</span><span class="shortcut-joiner">+</span><span class="shortcut">return</span>
-                    </span>
-                    <span class="shortcut-value">{{ __('Save') }}</span>
-                </div>
-    
-                <div class="shortcut-pair">
-                    <span class="shortcut-combo">
-                        <span class="shortcut">⌘</span><span class="shortcut-joiner">+</span><span class="shortcut">s</span>
-                    </span>
-                    <span class="shortcut-value">{{ __('Quick Save') }}</span>
-                </div>
-    
-                <div class="shortcut-pair">
-                    <span class="shortcut-combo">
-                        <span class="shortcut">⌘</span><span class="shortcut-joiner">+</span><span class="shortcut">\</span>
-                    </span>
-                    <span class="shortcut-value">{{ __('Toggle Sidebar') }}</span>
-                </div>
-    
-                <div class="shortcut-pair mb-0">
-                    <span class="shortcut-combo">
-                        <span class="shortcut">esc</span>
-                    </span>
-                    <span class="shortcut-value">{{ __('Close Modal') }}</span>
-                </div>
+        <div class="-max-h-screen-1">
+        <h1 class="p-4 bg-gray-200 border-b text-center">
+            {{ __('Keyboard Shortcuts') }}
+        </h1>
+        <div class="p-6 relative">
+            <div class="shortcut-pair">
+                <span class="shortcut-combo">
+                    <span class="shortcut">shift</span><span class="shortcut-joiner">+</span><span class="shortcut">?</span>
+                </span>
+                <span class="shortcut-value">{{ __('Show Keyboard Shortcuts') }}</span>
             </div>
+
+            <div class="shortcut-pair">
+                <span class="shortcut-combo">
+                    <span class="shortcut">/</span> <span class="shortcut-joiner">or</span>
+                    <span class="shortcut">ctrl</span><span class="shortcut-joiner">+</span><span class="shortcut">f</span>
+                </span>
+                <span class="shortcut-value">{{ __('Focus Search') }}</span>
+            </div>
+
+            <div class="shortcut-pair">
+                <span class="shortcut-combo">
+                    <span class="shortcut">⌘</span><span class="shortcut-joiner">+</span><span class="shortcut">return</span>
+                </span>
+                <span class="shortcut-value">{{ __('Save') }}</span>
+            </div>
+
+            <div class="shortcut-pair">
+                <span class="shortcut-combo">
+                    <span class="shortcut">⌘</span><span class="shortcut-joiner">+</span><span class="shortcut">s</span>
+                </span>
+                <span class="shortcut-value">{{ __('Quick Save') }}</span>
+            </div>
+
+            <div class="shortcut-pair">
+                <span class="shortcut-combo">
+                    <span class="shortcut">⌘</span><span class="shortcut-joiner">+</span><span class="shortcut">\</span>
+                </span>
+                <span class="shortcut-value">{{ __('Toggle Sidebar') }}</span>
+            </div>
+
+            <div class="shortcut-pair mb-0">
+                <span class="shortcut-combo">
+                    <span class="shortcut">esc</span>
+                </span>
+                <span class="shortcut-value">{{ __('Close Modal') }}</span>
+            </div>
+        </div>
         </div>
     </modal>
 </template>


### PR DESCRIPTION
This PR fixes #9473 by constraining the modal heights to 100% of the view height minus 1 pixel. This issue could also happen with the the Keyboard Shortcuts and Session Expiry modal windows if you *really* tried (I also added `overflow-y-auto` to the keyboards shortcut window so you could scroll and see content if you want a really short window).

The root cause seems to be inside `vue-js-modal`, where it gets confused when height is set to `auto` and the calculated height of the modal gets very close to the window's inner height on the problematic zoom levels. Constraining the height to `100vh` largely fixes the issue, but a noticeable shimmer would persist at the very bottom of the modal window. Adding the `- 1px` got rid of this shimmering.

The easiest way I found to reproduce this bug (in all browsers I tested in) was to get the Customize Columns lists to scroll and adjust the zoom level to 90% (110% also works, but weirdly not all of them would trigger this).

Note: it's not important *what* causes overflow inside the modal, as long as it causes the height to be re-calculated.


https://github.com/statamic/cms/assets/5232890/dd14c475-8a3a-42b2-9ca8-59f18bc4f8f3

