### PR TITLE
[4.x] Delete temporary uploaded file after response

### DIFF
--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -16,9 +16,7 @@ abstract class Uploader
 
         $this->write($source, $path = $this->uploadPath($file));
 
-        dispatch(function () {
-            app('files')->delete($source);
-        })->afterResponse();
+        dispatch(fn () => app('files')->delete($source))->afterResponse();
 
         return $path;
     }

--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -16,6 +16,12 @@ abstract class Uploader
 
         $this->write($source, $path = $this->uploadPath($file));
 
+        if (app()->runningInConsole()) {
+            app('files')->delete($source);
+
+            return $path;
+        }
+
         dispatch(fn () => app('files')->delete($source))->afterResponse();
 
         return $path;

--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -16,7 +16,9 @@ abstract class Uploader
 
         $this->write($source, $path = $this->uploadPath($file));
 
-        app('files')->delete($source);
+        dispatch(function () {
+            app('files')->delete($source);
+        })->afterResponse();
 
         return $path;
     }


### PR DESCRIPTION
A potential solution to https://github.com/statamic/cms/issues/9512 is to not delete the temporary upload file until after the response has been sent. 

This avoids restructuring a lot of the upload logic or potentially introducing breaking changes.

Fixes #9512