### PR TITLE
[4.x] Fix protection redirect URLs when they contain query parameters

### DIFF
--- a/src/Auth/Protect/Protection.php
+++ b/src/Auth/Protect/Protection.php
@@ -67,7 +67,7 @@ class Protection
 
     protected function url()
     {
-        return URL::tidy(request()->url());
+        return URL::tidy(request()->fullUrl());
     }
 
     protected function log($message)


### PR DESCRIPTION
This pull request fixes an issue with the Protection feature where the redirect URL wouldn't include the original query parameters.

Closes #9532.