### PR TITLE
[5.x] Fix failing Antlers tests

### DIFF
--- a/tests/Antlers/Runtime/TemplateTest.php
+++ b/tests/Antlers/Runtime/TemplateTest.php
@@ -435,7 +435,7 @@ EOT;
     /** @test */
     public function ternary_condition_inside_parameter()
     {
-        $this->app['statamic.tags']['test'] = \Tests\Fixtures\Addon\Tags\Test::class;
+        $this->app['statamic.tags']['test'] = \Tests\Fixtures\Addon\Tags\TestTags::class;
 
         $this->assertEquals('yes', $this->renderString(
             "{{ test variable='{{ good ? 'yes' : 'fail' }}' }}",
@@ -653,7 +653,7 @@ EOT;
     public function tags_with_curlies_in_params_gets_parsed()
     {
         // the variables are inside Test@index
-        $this->app['statamic.tags']['test'] = \Tests\Fixtures\Addon\Tags\Test::class;
+        $this->app['statamic.tags']['test'] = \Tests\Fixtures\Addon\Tags\TestTags::class;
 
         $template = "{{ test variable='{string}' }}";
 
@@ -736,7 +736,7 @@ EOT;
     /** @test */
     public function empty_values_are_not_overridden_by_previous_iteration_with_parsing()
     {
-        $this->app['statamic.tags']['test'] = \Tests\Antlers\Fixtures\Addon\Tags\Test::class;
+        $this->app['statamic.tags']['test'] = \Tests\Antlers\Fixtures\Addon\Tags\TestTags::class;
 
         // Variable name was changed from "loop" to "loopvar" compared to the original test to avoid a
         // headache since the base test class is going to be loading all of the core Statamic Tags.


### PR DESCRIPTION
This pull request fixes an issue with failing tests on `master`, due to a renamed class in #9529.

I'm not _entirely_ sure why it's only failing now, after [I merged in the latest commits](https://github.com/statamic/cms/commit/91c0834ace880da459c69c2186febada5cf3c89c#diff-9a1e4199f71e750b614f734d99704b91721cbe19146a9b22bdcb8fb0b5fd1869) from `master` and not after the PHPUnit 10 PR was merged. 