### PR TITLE
[4.x] Antlers: Resolve values from augmented values when there is more data to process

### DIFF
--- a/src/View/Antlers/Language/Runtime/PathDataManager.php
+++ b/src/View/Antlers/Language/Runtime/PathDataManager.php
@@ -476,6 +476,15 @@ class PathDataManager
         }
     }
 
+    private function collapseValues(bool $isFinal)
+    {
+        if (! $isFinal && $this->reducedVar instanceof Values) {
+            $this->lockData();
+            $this->reducedVar = self::reduce($this->reducedVar, true, $this->shouldDoValueIntercept);
+            $this->unlockData();
+        }
+    }
+
     private function collapseQueryBuilder($builder)
     {
         $this->reducedVar = $builder->get();
@@ -616,6 +625,8 @@ class PathDataManager
                             $this->unlockData();
                         }
 
+                        $this->collapseValues($pathItem->isFinal);
+
                         continue;
                     } else {
                         if ($this->cascade != null) {
@@ -659,6 +670,8 @@ class PathDataManager
                 }
 
                 $this->reduceVar($pathItem, $data);
+
+                $this->collapseValues($pathItem->isFinal);
 
                 if ($pathItem->isFinal && $this->reducedVar instanceof Builder && ! $wasBuilderGoingIntoLast) {
                     $this->encounteredBuilderOnFinalPart = true;

--- a/tests/Antlers/Runtime/ParametersTest.php
+++ b/tests/Antlers/Runtime/ParametersTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Antlers\Runtime;
 
 use Carbon\Carbon;
+use Statamic\Fields\Field;
+use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Group;
 use Statamic\Tags\Tags;
 use Tests\Antlers\Fixtures\Addon\Tags\EchoMethod;
 use Tests\Antlers\Fixtures\Addon\Tags\TestTags as Test;
@@ -364,5 +367,62 @@ EOT;
             $this->renderString('{{ test :my_value="123.0" }}{{ my_value + 0.5 }}{{ /test }}', [], true),
             'Floats'
         );
+    }
+
+    public function test_values_objects_are_resolved_when_processing_tag_params()
+    {
+        (new class extends Tags
+        {
+            protected static $handle = 'test';
+
+            public function index()
+            {
+                return $this->params->get('param');
+            }
+        })::register();
+
+        $theGroup = new Group();
+
+        $theField = new Field('the_group', [
+            'type' => 'group',
+            'fields' => [
+                ['handle' => 'one', 'field' => ['type' => 'text']],
+                ['handle' => 'two', 'field' => ['type' => 'text']],
+            ],
+        ]);
+
+        $theGroup->setField($theField);
+
+        $theValue = new Value([
+            'one' => 'One',
+            'two' => 'Two',
+        ], 'the_group', $theGroup);
+
+        $data = [
+            'thing' => [
+                [
+                    'the_group' => $theValue,
+                ],
+            ],
+        ];
+
+        $template = <<<'EOT'
+{{ thing scope="block" }}
+{{ test :param="block:the_group:two" }}
+{{ /thing }}
+EOT;
+
+        $this->assertSame('Two', trim($this->renderString($template, $data, true)));
+
+        // Test when the group is the first part of the path.
+        $data = [
+            'the_group' => $theValue,
+        ];
+
+        $template = <<<'EOT'
+{{ test :param="the_group:one" }}
+EOT;
+
+        $this->assertSame('One', trim($this->renderString($template, $data, true)));
     }
 }


### PR DESCRIPTION
This PR corrects an issue when a `Values` object is returned by an augmented field, and is part of nested value call:

```antlers
{{ something:the_thing_that_augments_to_values:another_thing }}
```

The current buggy behavior will just return the `Values` object as the final result, regardless of what appears to the right of it.

This was discovered from the comment here: https://github.com/statamic/cms/pull/9503#issuecomment-1953164331
This change here is what triggered the bug condition: https://github.com/statamic/cms/pull/9499/files#diff-5c8d3eca361eba1478f85d8aa0cbf091c90260e0225230356b99aea0d37eb445R115

To trigger this bug, an Augmentable object has to augment to a Values object directly. The other fieldtypes that utilize `Values` always use them inside a wrapper array (which causes them to get augmented by themselves when used as part of a variable).