### PR TITLE
[4.x] Remove any uploaded assets when submission silently fails or validation fails

### DIFF
--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -10,6 +10,7 @@ use Statamic\Contracts\Forms\Submission;
 use Statamic\Events\FormSubmitted;
 use Statamic\Events\SubmissionCreated;
 use Statamic\Exceptions\SilentFormFailureException;
+use Statamic\Facades\Asset;
 use Statamic\Facades\Form;
 use Statamic\Facades\Site;
 use Statamic\Forms\Exceptions\FileContentTypeRequiredException;
@@ -50,7 +51,9 @@ class FormController extends Controller
         try {
             throw_if(Arr::get($values, $form->honeypot()), new SilentFormFailureException);
 
-            $values = array_merge($values, $submission->uploadFiles($assets));
+            $uploadedAssets = $submission->uploadFiles($assets);
+
+            $values = array_merge($values, $uploadedAssets);
 
             $submission->data(
                 $fields->addValues($values)->process()->values()
@@ -60,8 +63,14 @@ class FormController extends Controller
             // If they want to add validation errors, they can throw an exception.
             throw_if(FormSubmitted::dispatch($submission) === false, new SilentFormFailureException);
         } catch (ValidationException $e) {
+            $this->removeUploadedAssets($uploadedAssets);
+
             return $this->formFailure($params, $e->errors(), $form->handle());
         } catch (SilentFormFailureException $e) {
+            if (isset($uploadedAssets)) {
+                $this->removeUploadedAssets($uploadedAssets);
+            }
+
             return $this->formSuccess($params, $submission, true);
         }
 
@@ -155,5 +164,22 @@ class FormController extends Controller
         }
 
         return $redirect;
+    }
+
+    /**
+     * Remove any uploaded assets
+     *
+     * Triggered by a validation exception or silent failure
+     *
+     */
+    private function removeUploadedAssets(array $assets)
+    {
+        collect($assets)
+            ->flatten()
+            ->each(function ($id) {
+                if ($asset = Asset::find($id)) {
+                    $asset->delete();
+                }
+            });
     }
 }

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -170,7 +170,6 @@ class FormController extends Controller
      * Remove any uploaded assets
      *
      * Triggered by a validation exception or silent failure
-     *
      */
     private function removeUploadedAssets(array $assets)
     {

--- a/tests/Tags/Form/FormCreateTest.php
+++ b/tests/Tags/Form/FormCreateTest.php
@@ -2,6 +2,11 @@
 
 namespace Tests\Tags\Form;
 
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\ValidationException;
+use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Form;
 use Statamic\Statamic;
 
@@ -821,5 +826,77 @@ EOT
 
         $this->assertEquals($form['honeypot'], 'winnie');
         $this->assertEquals($form['js_driver'], 'alpine');
+    }
+
+    /** @test */
+    public function it_removes_any_uploaded_assets_when_a_submission_silently_fails()
+    {
+        Storage::fake('avatars');
+        AssetContainer::make('avatars')->disk('avatars')->save();
+
+        Event::listen(function (\Statamic\Events\FormSubmitted $event) {
+            return false;
+        });
+
+        $this->createForm([
+            'tabs' => [
+                'main' => [
+                    'sections' => [
+                        [
+                            'display' => 'One',
+                            'instructions' => 'One Instructions',
+                            'fields' => [
+                                ['handle' => 'alpha', 'field' => ['type' => 'text']],
+                                ['handle' => 'bravo', 'field' => ['type' => 'assets', 'container' => 'avatars']],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], 'survey');
+
+        $this
+            ->post('/!/forms/survey', [
+                'alpha' => 'test',
+                'bravo' => UploadedFile::fake()->image('avatar.jpg'),
+            ]);
+
+        Storage::disk('avatars')->assertMissing('avatar.jpg');
+    }
+
+    /** @test */
+    public function it_removes_any_uploaded_assets_when_a_listener_throws_a_validation_exception()
+    {
+        Storage::fake('avatars');
+        AssetContainer::make('avatars')->disk('avatars')->save();
+
+        Event::listen(function (\Statamic\Events\FormSubmitted $event) {
+            throw ValidationException::withMessages(['custom' => 'This is a custom message']);
+        });
+
+        $this->createForm([
+            'tabs' => [
+                'main' => [
+                    'sections' => [
+                        [
+                            'display' => 'One',
+                            'instructions' => 'One Instructions',
+                            'fields' => [
+                                ['handle' => 'alpha', 'field' => ['type' => 'text']],
+                                ['handle' => 'bravo', 'field' => ['type' => 'assets', 'container' => 'avatars']],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], 'survey');
+
+        $this
+            ->post('/!/forms/survey', [
+                'alpha' => 'test',
+                'bravo' => UploadedFile::fake()->image('avatar.jpg'),
+            ]);
+
+        Storage::disk('avatars')->assertMissing('avatar.jpg');
     }
 }

--- a/tests/Tags/Form/FormCreateTest.php
+++ b/tests/Tags/Form/FormCreateTest.php
@@ -829,6 +829,38 @@ EOT
     }
 
     /** @test */
+    public function it_uploads_assets()
+    {
+        Storage::fake('avatars');
+        AssetContainer::make('avatars')->disk('avatars')->save();
+
+        $this->createForm([
+            'tabs' => [
+                'main' => [
+                    'sections' => [
+                        [
+                            'display' => 'One',
+                            'instructions' => 'One Instructions',
+                            'fields' => [
+                                ['handle' => 'alpha', 'field' => ['type' => 'text']],
+                                ['handle' => 'bravo', 'field' => ['type' => 'assets', 'container' => 'avatars']],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], 'survey');
+
+        $this
+            ->post('/!/forms/survey', [
+                'alpha' => 'test',
+                'bravo' => UploadedFile::fake()->image('avatar.jpg'),
+            ]);
+
+        Storage::disk('avatars')->assertExists('avatar.jpg');
+    }
+
+    /** @test */
     public function it_removes_any_uploaded_assets_when_a_submission_silently_fails()
     {
         Storage::fake('avatars');


### PR DESCRIPTION
Before this PR if you silently fail a form submission through a `FormSubmitted` listener, or throw a validation exception in a `FormSubmitted` listener, any assets uploaded persist in the file system.

This PR changes that so any uploaded assets are removed.