### PR TITLE
[4.x] Pass parent field and index down to imported fields

### DIFF
--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -260,7 +260,10 @@ class Fields
             $field->setConfig(array_merge($field->config(), $overrides));
         }
 
-        return $field->setParent($this->parent)->setHandle($config['handle']);
+        return $field
+            ->setParent($this->parent)
+            ->setParentField($this->parentField, $this->parentIndex)
+            ->setHandle($config['handle']);
     }
 
     private function getImportedFields(array $config): array
@@ -291,7 +294,11 @@ class Fields
             }
 
             return $fields;
-        })->each->setParent($this->parent)->all();
+        })->each(function ($field) {
+            $field
+                ->setParent($this->parent)
+                ->setParentField($this->parentField, $this->parentIndex);
+        })->all();
     }
 
     public function meta()

--- a/tests/Fields/FieldsTest.php
+++ b/tests/Fields/FieldsTest.php
@@ -1003,4 +1003,58 @@ class FieldsTest extends TestCase
         $this->assertEquals(1, $collection['one']->parentIndex());
         $this->assertEquals(1, $collection['two']->parentIndex());
     }
+
+    /**
+     * @test
+     */
+    public function it_sets_the_parentfield_and_parentindex_on_imported_fields()
+    {
+        $fieldset = (new Fieldset)->setHandle('partial')->setContents([
+            'fields' => [
+                ['handle' => 'bar', 'field' => ['type' => 'text']],
+            ],
+        ]);
+
+        FieldsetRepository::shouldReceive('find')->with('partial')->once()->andReturn($fieldset);
+
+        $parentField = new Field('foo', ['type' => 'replicator']);
+
+        $fields = new Fields(
+            [['import' => 'partial']],
+            null,
+            $parentField,
+            1,
+        );
+
+        $collection = $fields->all();
+        $this->assertEquals($parentField, $collection['bar']->parentField());
+        $this->assertEquals(1, $collection['bar']->parentIndex());
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_the_parentfield_and_parentindex_on_referenced_fields()
+    {
+        $fieldset = (new Fieldset)->setHandle('partial')->setContents([
+            'fields' => [
+                ['handle' => 'bar', 'field' => ['type' => 'text']],
+            ],
+        ]);
+
+        FieldsetRepository::shouldReceive('find')->with('partial')->once()->andReturn($fieldset);
+
+        $parentField = new Field('foo', ['type' => 'replicator']);
+
+        $fields = new Fields(
+            [['handle' => 'bar', 'field' => 'partial.bar']],
+            null,
+            $parentField,
+            1,
+        );
+
+        $collection = $fields->all();
+        $this->assertEquals($parentField, $collection['bar']->parentField());
+        $this->assertEquals(1, $collection['bar']->parentIndex());
+    }
 }


### PR DESCRIPTION
Something I overlooked in https://github.com/statamic/cms/pull/9080.

This PR ensures the new parent field and index are passed down to imported and referenced fields.