### PR TITLE
[4.x] Add accepted_if validation to Bard enable_input_rules

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -113,6 +113,7 @@ class Bard extends Replicator
                         'instructions' => __('statamic::fieldtypes.bard.config.enable_input_rules'),
                         'type' => 'toggle',
                         'default' => true,
+                        'validate' => 'accepted_if:smart_typography,true',
                     ],
                     'enable_paste_rules' => [
                         'display' => __('Enable Paste Rules'),


### PR DESCRIPTION
Closes #9554

This adds `accepted_if:smart_typography,true` to the `enable_input_rules` toggle for the Bard fieldtype.