### PR TITLE
[4.x] Add `accepted_if` validation rule

### DIFF
--- a/resources/js/components/field-validation/Rules.js
+++ b/resources/js/components/field-validation/Rules.js
@@ -11,6 +11,11 @@ export default [
         value: 'accepted'
     },
     {
+        label: 'Accepted If',
+        value: 'accepted_if:',
+        example: 'accepted_if:anotherfield,value,...'
+    },
+    {
         label: 'Active URL',
         value: 'active_url'
     },

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -113,6 +113,7 @@ class Bard extends Replicator
                         'instructions' => __('statamic::fieldtypes.bard.config.enable_input_rules'),
                         'type' => 'toggle',
                         'default' => true,
+                        'validate' => 'accepted_if:smart_typography,true',
                     ],
                     'enable_paste_rules' => [
                         'display' => __('Enable Paste Rules'),

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -113,7 +113,6 @@ class Bard extends Replicator
                         'instructions' => __('statamic::fieldtypes.bard.config.enable_input_rules'),
                         'type' => 'toggle',
                         'default' => true,
-                        'validate' => 'accepted_if:smart_typography,true',
                     ],
                     'enable_paste_rules' => [
                         'display' => __('Enable Paste Rules'),


### PR DESCRIPTION
Adds the `accepted_if` validation rule to the field validation options. It turns out this exists and it's quite handy!

You can use this with the toggle fieldtype. E.g: toggle needs to be accepted (true) based on the value of another field.