### PR TITLE
[4.x] Wire up global site picker groups

### DIFF
--- a/resources/css/vendors/vue-select.css
+++ b/resources/css/vendors/vue-select.css
@@ -156,7 +156,6 @@
 }
 
 .vs__dropdown-option--selected {
-	opacity: .25;
 	cursor: text;
 }
 

--- a/resources/js/components/GlobalSiteSelector.vue
+++ b/resources/js/components/GlobalSiteSelector.vue
@@ -34,16 +34,7 @@ export default {
 
     computed: {
         sites() {
-            let sites = Statamic.$config.get('sites');
-
-            // group by each key's group
-            let newsites = _.groupBy(sites, 'group');
-
-            let grouped = _.reduce(newsites, (acc, sites, name) => {
-                return acc.concat({ name, header: true }, ...sites);
-            }, []);
-
-            return grouped;
+            return Statamic.$config.get('groupedSites');
         },
 
         active() {

--- a/resources/js/components/GlobalSiteSelector.vue
+++ b/resources/js/components/GlobalSiteSelector.vue
@@ -16,8 +16,13 @@
                     <div class="whitespace-nowrap">{{ __(option.name) }}</div>
                 </div>
             </template>
-            <template #option="{ name, handle }">
-                <div :class="{ 'text-gray-500': handle === active }">{{ __(name) }}</div>
+            <template #option="{ name, handle, header}">
+                <div :class="{
+                    'text-blue': handle === active,
+                    'font-semibold text-gray-700 opacity-100': header === true,
+                }">
+                    <span v-if="!header" class="text-gray-500">&ndash;&nbsp;</span>{{ __(name) }}
+                </div>
             </template>
         </v-select>
     </div>
@@ -29,7 +34,16 @@ export default {
 
     computed: {
         sites() {
-            return Statamic.$config.get('sites');
+            let sites = Statamic.$config.get('sites');
+
+            // group by each key's group
+            let newsites = _.groupBy(sites, 'group');
+
+            let grouped = _.reduce(newsites, (acc, sites, name) => {
+                return acc.concat({ name, header: true }, ...sites);
+            }, []);
+
+            return grouped;
         },
 
         active() {

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -63,6 +63,7 @@ class JavascriptComposer
             'paginationSize' => config('statamic.cp.pagination_size'),
             'paginationSizeOptions' => config('statamic.cp.pagination_size_options'),
             'sites' => $this->sites(),
+            'groupedSites' => $this->groupedSites(),
             'selectedSite' => Site::selected()->handle(),
             'preloadableFieldtypes' => FieldtypeRepository::preloadable()->keys(),
             'livePreview' => config('statamic.live_preview'),
@@ -81,6 +82,15 @@ class JavascriptComposer
                 'lang' => $site->lang(),
                 'group' => $site->group(),
             ];
+        })->values();
+    }
+
+    protected function groupedSites()
+    {
+        return $this->sites()->groupBy('group')->flatMap(function ($sites, $group) {
+            return array_merge([
+                ['name' => $group, 'header' => true],
+            ], $sites->all());
         })->values();
     }
 

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -16,7 +16,7 @@ use voku\helper\ASCII;
 
 class JavascriptComposer
 {
-    const VIEWS = ['statamic::partials.scripts'];
+    public const VIEWS = ['statamic::partials.scripts'];
 
     public function compose(View $view)
     {
@@ -79,6 +79,7 @@ class JavascriptComposer
                 'name' => $site->name(),
                 'handle' => $site->handle(),
                 'lang' => $site->lang(),
+                'group' => $site->group(),
             ];
         })->values();
     }

--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -34,6 +34,11 @@ class Site implements Augmentable
         return $this->config['locale'];
     }
 
+    public function group()
+    {
+        return $this->config['group'] ?? __('Other');
+    }
+
     public function shortLocale()
     {
         return explode('-', str_replace('_', '-', $this->locale()))[0];
@@ -97,6 +102,7 @@ class Site implements Augmentable
         return [
             'handle' => $this->handle(),
             'name' => $this->name(),
+            'group' => $this->group(),
             'lang' => $this->lang(),
             'locale' => $this->locale(),
             'short_locale' => $this->shortLocale(),


### PR DESCRIPTION
I have a proof of concept working for the global site picker, but can't work out the best way to not duplicate a bunch of this logic in JS everywhere we need to use it. Could use an assist here.

- [x] Global Site Picker
- [ ] Entries Sidebar
- [ ] Terms Sidebar