### PR TITLE
[4.x] Fix locales tag inside replicator, bard, and grid

### DIFF
--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -158,7 +158,7 @@ class Locales extends Tags
             return $this->data;
         }
 
-        $id = $this->params->get('id', $this->context->value('id'));
+        $id = $this->params->get('id', $this->context->value('page.id'));
 
         $data = Data::find($id);
 

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -158,7 +158,9 @@ class Locales extends Tags
             return $this->data;
         }
 
-        $id = $this->params->get('id', $this->context->value('page.id'));
+        $contextId = $this->context->value('page.id') ?? $this->context->value('id');
+
+        $id = $this->params->get('id', $contextId);
 
         $data = Data::find($id);
 

--- a/src/Tags/Locales.php
+++ b/src/Tags/Locales.php
@@ -158,9 +158,7 @@ class Locales extends Tags
             return $this->data;
         }
 
-        $contextId = $this->context->value('page.id') ?? $this->context->value('id');
-
-        $id = $this->params->get('id', $contextId);
+        $id = $this->params->get('id') ?? $this->context->value('page.id') ?? $this->context->value('id');
 
         $data = Data::find($id);
 

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -449,4 +449,20 @@ HTML;
             $this->tag('{{ locales }}you should not see this{{ /locales }}', ['page' => ['id' => $value]])
         );
     }
+
+    /** @test */
+    public function it_falls_back_to_context_id_if_there_is_no_context_page()
+    {
+        (new EntryFactory)
+            ->collection('test')
+            ->locale('english')
+            ->id('1')
+            ->data(['title' => 'hello'])
+            ->create();
+
+        $this->assertEquals(
+            '<hello>',
+            $this->tag('{{ locales }}<{{ title }}>{{ /locales }}', ['id' => '1'])
+        );
+    }
 }

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -139,7 +139,7 @@ EOT;
 
 HTML;
 
-        $this->assertEquals($expected, $this->tag($this->template('{{ locales }}'), ['page' => ['id' => '1']]));
+        $this->assertEquals($expected, $this->tag($this->template('{{ locales }}'), ['id' => '1']));
     }
 
     /** @test */
@@ -161,7 +161,7 @@ HTML;
 
         $this->assertEquals(
             '<hello><hola>',
-            $this->tag('{{ locales }}<{{ title }}>{{ /locales }}', ['page' => ['id' => '1']])
+            $this->tag('{{ locales }}<{{ title }}>{{ /locales }}', ['id' => '1'])
         );
     }
 
@@ -234,7 +234,7 @@ HTML;
 
 HTML;
 
-        $this->assertEquals($expected, $this->tag($this->template('{{ locales all="true" }}'), ['page' => ['id' => '1']]));
+        $this->assertEquals($expected, $this->tag($this->template('{{ locales all="true" }}'), ['id' => '1']));
     }
 
     /** @test */
@@ -264,7 +264,7 @@ HTML;
 
         $this->assertEquals(
             '<hello><hola>',
-            $this->tag('{{ locales }}<{{ title }}>{{ /locales }}', ['page' => ['id' => '1']])
+            $this->tag('{{ locales }}<{{ title }}>{{ /locales }}', ['id' => '1'])
         );
     }
 
@@ -345,7 +345,7 @@ HTML;
 
 HTML;
 
-        $this->assertEquals($expected, $this->tag($this->template('{{ locales all="true" }}'), ['page' => ['id' => '1']]));
+        $this->assertEquals($expected, $this->tag($this->template('{{ locales all="true" }}'), ['id' => '1']));
     }
 
     /** @test */
@@ -374,7 +374,7 @@ HTML;
 
         $this->assertEquals(
             '<bonjour><hola>',
-            $this->tag('{{ locales self="false" }}<{{ title }}>{{ /locales }}', ['page' => ['id' => '1']])
+            $this->tag('{{ locales self="false" }}<{{ title }}>{{ /locales }}', ['id' => '1'])
         );
     }
 
@@ -397,7 +397,7 @@ HTML;
 
         $this->assertEquals(
             '<hola>',
-            $this->tag('{{ locales:espanol }}<{{ title }}>{{ /locales:espanol }}', ['page' => ['id' => '1']])
+            $this->tag('{{ locales:espanol }}<{{ title }}>{{ /locales:espanol }}', ['id' => '1'])
         );
     }
 
@@ -413,7 +413,7 @@ HTML;
 
         $this->assertEquals(
             '',
-            $this->tag('{{ locales:espanol }}<{{ title }}>{{ /locales:espanol }}', ['page' => ['id' => '1']])
+            $this->tag('{{ locales:espanol }}<{{ title }}>{{ /locales:espanol }}', ['id' => '1'])
         );
     }
 
@@ -429,7 +429,7 @@ HTML;
 
         $this->assertEquals(
             '',
-            $this->tag('{{ locales self="false" }}you should not see this{{ /locales }}', ['page' => ['id' => '1']])
+            $this->tag('{{ locales self="false" }}you should not see this{{ /locales }}', ['id' => '1'])
         );
     }
 
@@ -446,7 +446,7 @@ HTML;
 
         $this->assertEquals(
             '',
-            $this->tag('{{ locales }}you should not see this{{ /locales }}', ['page' => ['id' => $value]])
+            $this->tag('{{ locales }}you should not see this{{ /locales }}', ['id' => $value])
         );
     }
 

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -139,7 +139,7 @@ EOT;
 
 HTML;
 
-        $this->assertEquals($expected, $this->tag($this->template('{{ locales }}'), ['id' => '1']));
+        $this->assertEquals($expected, $this->tag($this->template('{{ locales }}'), ['page' => ['id' => '1']]));
     }
 
     /** @test */
@@ -161,7 +161,7 @@ HTML;
 
         $this->assertEquals(
             '<hello><hola>',
-            $this->tag('{{ locales }}<{{ title }}>{{ /locales }}', ['id' => '1'])
+            $this->tag('{{ locales }}<{{ title }}>{{ /locales }}', ['page' => ['id' => '1']])
         );
     }
 
@@ -234,7 +234,7 @@ HTML;
 
 HTML;
 
-        $this->assertEquals($expected, $this->tag($this->template('{{ locales all="true" }}'), ['id' => '1']));
+        $this->assertEquals($expected, $this->tag($this->template('{{ locales all="true" }}'), ['page' => ['id' => '1']]));
     }
 
     /** @test */
@@ -264,7 +264,7 @@ HTML;
 
         $this->assertEquals(
             '<hello><hola>',
-            $this->tag('{{ locales }}<{{ title }}>{{ /locales }}', ['id' => '1'])
+            $this->tag('{{ locales }}<{{ title }}>{{ /locales }}', ['page' => ['id' => '1']])
         );
     }
 
@@ -345,7 +345,7 @@ HTML;
 
 HTML;
 
-        $this->assertEquals($expected, $this->tag($this->template('{{ locales all="true" }}'), ['id' => '1']));
+        $this->assertEquals($expected, $this->tag($this->template('{{ locales all="true" }}'), ['page' => ['id' => '1']]));
     }
 
     /** @test */
@@ -374,7 +374,7 @@ HTML;
 
         $this->assertEquals(
             '<bonjour><hola>',
-            $this->tag('{{ locales self="false" }}<{{ title }}>{{ /locales }}', ['id' => '1'])
+            $this->tag('{{ locales self="false" }}<{{ title }}>{{ /locales }}', ['page' => ['id' => '1']])
         );
     }
 
@@ -397,7 +397,7 @@ HTML;
 
         $this->assertEquals(
             '<hola>',
-            $this->tag('{{ locales:espanol }}<{{ title }}>{{ /locales:espanol }}', ['id' => '1'])
+            $this->tag('{{ locales:espanol }}<{{ title }}>{{ /locales:espanol }}', ['page' => ['id' => '1']])
         );
     }
 
@@ -413,7 +413,7 @@ HTML;
 
         $this->assertEquals(
             '',
-            $this->tag('{{ locales:espanol }}<{{ title }}>{{ /locales:espanol }}', ['id' => '1'])
+            $this->tag('{{ locales:espanol }}<{{ title }}>{{ /locales:espanol }}', ['page' => ['id' => '1']])
         );
     }
 
@@ -429,7 +429,7 @@ HTML;
 
         $this->assertEquals(
             '',
-            $this->tag('{{ locales self="false" }}you should not see this{{ /locales }}', ['id' => '1'])
+            $this->tag('{{ locales self="false" }}you should not see this{{ /locales }}', ['page' => ['id' => '1']])
         );
     }
 
@@ -446,7 +446,7 @@ HTML;
 
         $this->assertEquals(
             '',
-            $this->tag('{{ locales }}you should not see this{{ /locales }}', ['id' => $value])
+            $this->tag('{{ locales }}you should not see this{{ /locales }}', ['page' => ['id' => $value]])
         );
     }
 }

--- a/tests/Tags/LocalesTagTest.php
+++ b/tests/Tags/LocalesTagTest.php
@@ -451,7 +451,7 @@ HTML;
     }
 
     /** @test */
-    public function it_falls_back_to_context_id_if_there_is_no_context_page()
+    public function it_prefers_page_id_over_id()
     {
         (new EntryFactory)
             ->collection('test')
@@ -462,7 +462,23 @@ HTML;
 
         $this->assertEquals(
             '<hello>',
-            $this->tag('{{ locales }}<{{ title }}>{{ /locales }}', ['id' => '1'])
+            $this->tag('{{ locales }}<{{ title }}>{{ /locales }}', ['page' => ['id' => '1']])
+        );
+    }
+
+    /** @test */
+    public function it_prefers_id_param_over_page_id()
+    {
+        (new EntryFactory)
+            ->collection('test')
+            ->locale('english')
+            ->id('1')
+            ->data(['title' => 'hello'])
+            ->create();
+
+        $this->assertEquals(
+            '<hello>',
+            $this->tag('{{ locales id="1" }}<{{ title }}>{{ /locales }}', ['page' => ['id' => '7']])
         );
     }
 }


### PR DESCRIPTION
This PR fixes the `locales` tag inside a replicator, bard, or grid loop. 

Since Statamic v3.4 the `{{ id }}` inside a loop reflects the [ID of the item rather than the entry](https://statamic.dev/upgrade-guide/3-3-to-3-4#replicator-bard-and-grid-ids).

You could work around this issue by manually passing the `id` to the `locales` tag. But this is super cumbersome.

```antlers
{{ locales id="{page:id}" }}
    {{ permalink }}
{{ /locales }}
```

So this PR gets the ID from the context's `page` instead.