### PR TITLE
[4.x] Allow to get site by key

### DIFF
--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -206,7 +206,7 @@ class Cascade
             'old' => Arr::sanitize(old(null, [])),
 
             'site' => $this->site,
-            'sites' => Facades\Site::all()->values(),
+            'sites' => Facades\Site::all(),
             'homepage' => $this->site->url(),
             'is_homepage' => $this->site->absoluteUrl() == $this->request->url(),
             'cp_url' => cp_route('index'),


### PR DESCRIPTION
I've come across this issue on almost every multi-site I've built. So this is an attempt to provide an easy fix without the need for some ugly Antlers or a new tag.

I need to output some data of a specific site on the frontend. There is already a `sites` variable in the cascade. However, it uses integers as the keys, so you can't get a specific site by its handle.

This is unfeasible and prone to errors as the order of the sites might change in the `config/sites.php` config:

```antlers
{{ sites:0:permalink }}
```

This technically works:

```antlers
{{ sites | where('handle', 'gounity') | first | get('permalink') }}
```

But getting the site by handle is much nicer:

```antlers
{{ sites:gounity:permalink }}
```

I've tried using the `locales` tag to do what I need as well. But it has its own quirks and doesn't work reliably in every scenario. It wasn't built to simply output the data of a given site.

This PR is technically a breaking change, as a user might have output a site by integer key in the template:

```antlers
{{ sites:0:permalink }}
```

So it's probably safest to merge this into Statamic 5.

I'm not entirely sure why you've called `->values()` on the sites in the first place. So please enlighten me, if there was a specific reason for this.