### PR TITLE
[4.x] Roles/Groups fields can be read-only when they've been included in the blueprint

### DIFF
--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -213,11 +213,11 @@ class UsersController extends CpController
         $blueprint = $user->blueprint();
 
         if (! User::current()->can('assign roles')) {
-            $blueprint->ensureField('roles', ['visibility' => 'read_only']);
+            $blueprint->ensureFieldHasConfig('roles', ['visibility' => 'read_only']);
         }
 
         if (! User::current()->can('assign user groups')) {
-            $blueprint->ensureField('groups', ['visibility' => 'read_only']);
+            $blueprint->ensureFieldHasConfig('groups', ['visibility' => 'read_only']);
         }
 
         if (User::current()->isSuper() && User::current()->id() !== $user->id()) {


### PR DESCRIPTION
This is a start to https://github.com/statamic/cms/issues/9564.

I have added `roles` and `groups` fields to my user blueprint, so we can control where they are in the user, visually.

When we added those, we discovered that if a user doesn't have the permissions to assign roles, they still could.

This fixes that specific use case, although there is a larger issue when those fields are in an imported fieldset.