### PR TITLE
[4.x] Fix pixel gap on relationship fieldtype items

### DIFF
--- a/resources/css/components/items.css
+++ b/resources/css/components/items.css
@@ -10,7 +10,7 @@
     }
 
     .item-inner {
-        @apply w-full flex items-center p-2;
+        @apply w-full flex items-center px-2;
     }
 
     &.invalid {


### PR DESCRIPTION
This fixes a pixel gap on the top/bottom of relationship fieldtype items that's been hanging around for a while.

Before: 
![CleanShot 2024-02-23 at 16 55 22](https://github.com/statamic/cms/assets/105211/cbea69b1-10a2-403f-be9e-5cb31c5fd002)

After:
![CleanShot 2024-02-23 at 16 55 43](https://github.com/statamic/cms/assets/105211/81a527fc-c792-4b44-bbac-4e63d24e8812)
