### PR TITLE
Add Hex To RGB modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -910,6 +910,13 @@ class CoreModifiers extends Modifier
         }
     }
 
+    public function hexToRgb($value)
+    {
+        $hex = ltrim($value, '#');
+        $rgb = sscanf($hex, "%02x%02x%02x");
+        return implode(', ', $rgb);
+    }
+
     private function renderAPStyleHeadline($value)
     {
         $exceptions = [


### PR DESCRIPTION
Adds a new modifier that takes a hex value and turns it into RGB, this can be useful when working with the colour field type.
