### PR TITLE
[4.x] Tweak SuggestsConditionalFields behaviour when dealing with a fields prefix.

### DIFF
--- a/resources/js/components/blueprints/SuggestsConditionalFields.js
+++ b/resources/js/components/blueprints/SuggestsConditionalFields.js
@@ -49,15 +49,7 @@ export default {
                             : [field]
                     );
                 }, [])
-                .map(handle => {
-                    if (prefix) {
-                        let prefixed = JSON.parse(JSON.stringify(handle)); // perform a deep clone (otherwise it changes the global version)
-                        prefixed.handle = prefix + prefixed.handle;
-                        return prefixed;
-                    }
-
-                    return handle;
-                });
+                .map(field => prefix ? { ...field, handle: prefix + field.handle } : field);
         }
 
     }

--- a/resources/js/components/blueprints/SuggestsConditionalFields.js
+++ b/resources/js/components/blueprints/SuggestsConditionalFields.js
@@ -49,7 +49,15 @@ export default {
                             : [field]
                     );
                 }, [])
-                .map(handle => prefix ? `${prefix}${handle}` : handle);
+                .map(handle => {
+                    if (prefix) {
+                        let prefixed = JSON.parse(JSON.stringify(handle)); // perform a deep clone (otherwise it changes the global version)
+                        prefixed.handle = prefix + prefixed.handle;
+                        return prefixed;
+                    }
+
+                    return handle;
+                });
         }
 
     }


### PR DESCRIPTION
When working within a Replicator that imports a Fieldset with a prefix, the `SuggestsConditionalFields` logic converts the field configuration to a string, and results in an error.

A working repo with Fieldsets configured, and full details, is available:
[https://github.com/martyf/statamic-conditional-suggestions](https://github.com/martyf/statamic-conditional-suggestions)

The JS error looks like:

```
TypeError: can't access property "display", M.config is undefined
    fieldOptions http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:172
    fieldOptions http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:172
    get http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    evaluate http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    createComputedGetter http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    _sfc_render$3Y http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:172
    _render http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    N http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    get http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    M http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    mountComponent http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    $mount http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    $mount http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:9
    init http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    G http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    K http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    fe http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    ve http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    fe http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    ve http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    createPatchFunction http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    _update http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    N http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    get http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    run http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    flushSchedulerQueue http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    1 http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    flushCallbacks http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    promise callback*timerFunc http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    nextTick$1 http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    queueWatcher http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    update http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    notify http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    set http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    set http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    callback http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:172
    invokeWithErrorHandling http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    I http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    invokeWithErrorHandling http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    $emit http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    change http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:208
    invokeWithErrorHandling http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    I http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
    _wrapper http://conditional-test.test/vendor/statamic/cp/build/assets/app-4e6d4633.js:5
app-4e6d4633.js:5:38036
```

This error comes because the existing logic concats the prefix with the field itself - but the issue is that the field is an object, resulting in the field being incorrectly returned as:
`fieldset_prefix_[Object object]`

This PR changes the behaviour of the `getFieldsFromImportedFieldset` method to take a clone of the field configuration (so to not override the global field object), and only apply the prefix to the object's handle, then return a prefixed version of the field.

This resolves the issue, and appears in the suggested fields list.

However, it is not actually what should be happening: but that might be a separate issue.

In the demo repo, there are two sets: when adding a new field to the first set, you would expect only the fields from *that* set are suggested - however the logic is showing all fields within the entire setup - which is not correct. How to resolve that may be a bit of a bigger one though and wasn't sure what would be a good approach to tackle this.