### PR TITLE
[5.x] Add `findOrFail` method to `EntryRepository` interface

### DIFF
--- a/src/Contracts/Entries/EntryRepository.php
+++ b/src/Contracts/Entries/EntryRepository.php
@@ -12,6 +12,8 @@ interface EntryRepository
 
     public function find($id);
 
+    public function findOrFail($id);
+
     public function findByUri(string $uri);
 
     public function make();


### PR DESCRIPTION
This pull request adds the `findOrFail` method to the `EntryRepository` interface.

The method was added into v4 in #9506, but without the method being added to the contract to avoid a breaking change. 