### PR TITLE
[4.x] Only run custom validation errors when not precognitive

### DIFF
--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -60,19 +60,17 @@ class FrontendFormRequest extends FormRequest
 
     protected function failedValidation(Validator $validator)
     {
-        if (! $this->isPrecognitive()) {
-            if ($this->ajax() || $this->wantsJson()) {
-                $errors = $validator->errors();
+        if (! $this->isPrecognitive() && ($this->ajax() || $this->wantsJson())) {
+            $errors = $validator->errors();
 
-                $response = response([
-                    'errors' => $errors->all(),
-                    'error' => collect($errors->messages())->map(function ($errors, $field) {
-                        return $errors[0];
-                    })->all(),
-                ], 400);
+            $response = response([
+                'errors' => $errors->all(),
+                'error' => collect($errors->messages())->map(function ($errors, $field) {
+                    return $errors[0];
+                })->all(),
+            ], 400);
 
-                throw (new ValidationException($validator, $response));
-            }
+            throw (new ValidationException($validator, $response));
         }
 
         return parent::failedValidation($validator);

--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -60,17 +60,19 @@ class FrontendFormRequest extends FormRequest
 
     protected function failedValidation(Validator $validator)
     {
-        if ($this->ajax() || $this->wantsJson()) {
-            $errors = $validator->errors();
+        if (! $this->isPrecognitive()) {
+            if ($this->ajax() || $this->wantsJson()) {
+                $errors = $validator->errors();
 
-            $response = response([
-                'errors' => $errors->all(),
-                'error' => collect($errors->messages())->map(function ($errors, $field) {
-                    return $errors[0];
-                })->all(),
-            ], 400);
+                $response = response([
+                    'errors' => $errors->all(),
+                    'error' => collect($errors->messages())->map(function ($errors, $field) {
+                        return $errors[0];
+                    })->all(),
+                ], 400);
 
-            throw (new ValidationException($validator, $response));
+                throw (new ValidationException($validator, $response));
+            }
         }
 
         return parent::failedValidation($validator);


### PR DESCRIPTION
Sorry back with another tweak on this - the failedValidation change causes precognition errors to not return as they are JSON. My mistake.

Fixes: https://github.com/statamic/cms/issues/9598