### PR TITLE
[4.x] Fix docblock of FluentTag param method

### DIFF
--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -149,7 +149,7 @@ class FluentTag implements \ArrayAccess, \IteratorAggregate
      * Allow calls to tag params.
      *
      * @param  string  $param
-     * @param  array  $value
+     * @param  mixed  $value
      * @return $this
      */
     public function param($param, $value = true)


### PR DESCRIPTION
[According to the documentation](https://statamic.dev/blade#using-explicit-parameter-setters) we can use e.g. a filter-param with FluentTag's like this:

```php
Statamic::tag('collection:pages')->param('title:contains', 'pizza');
```

At least my IDE complains about the current docblock awaiting an array type.
This "fixes" this by changing the docblock to mixed.