### PR TITLE
[4.x] Replicator: Only show fields from current set in field conditions dropdown

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -123,7 +123,22 @@ export default {
 
     computed: {
 
+        isInsideSetsFieldtype() {
+            let parent = this;
+
+            while (parent.$options.name !== 'sets-fieldtype') {
+                parent = parent.$parent;
+                if (parent === this.$root) return false;
+            }
+
+            return parent.$options.name === 'sets-fieldtype';
+        },
+
         suggestableConditionFields() {
+            if (this.isInsideSetsFieldtype) {
+                return this.section.fields
+            }
+
             return this.suggestableConditionFieldsProvider?.suggestableFields || [];
         },
 


### PR DESCRIPTION
This pull request fixes an issue where fields from other sets would show in the field conditions dropdown. This was an issue when configuring sets for both Replicator & Bard fields.

This PR fixes that by checking if any of the `BlueprintSection`'s parent components are the `sets-fieldtype`. If they are, then it only returns the fields from that section (or set).

It does seem a little weird to fix this in the `Section` component since it gets used for all the blueprint section/tab stuff, however I couldn't find a way to fix it directly in the Replicator code. 

Happy to re-work if there's a better solution for this.

Fixes #9603.