### PR TITLE
[4.x] Prevent localizing entries without "edit ... entries" permission

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -166,10 +166,11 @@
                                     <div
                                         v-for="option in localizations"
                                         :key="option.handle"
-                                        class="text-sm flex items-center -mx-4 px-4 py-2 cursor-pointer"
-                                        :class="option.active ? 'bg-blue-100' : 'hover:bg-gray-200'"
-                                        :disabled="!canSave"
-                                        v-tooltip="!canSave ? __(`You don't have permission to localize this entry.`) : null"
+                                        class="text-sm flex items-center -mx-4 px-4 py-2"
+                                        :class="[
+                                            option.active ? 'bg-blue-100' : 'hover:bg-gray-200',
+                                            !canSave && !option.exists ? 'cursor-not-allowed' : 'cursor-pointer',
+                                        ]"
                                         @click="localizationSelected(option)"
                                     >
                                         <div class="flex-1 flex items-center" :class="{ 'line-through': !option.exists }">
@@ -628,7 +629,11 @@ export default {
         },
 
         localizationSelected(localization) {
-            if (!this.canSave) return;
+            if (!this.canSave) {
+                if (localization.exists) this.editLocalization(localization);
+                return;
+            }
+
             if (localization.active) return;
 
             if (this.isDirty) {

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -168,6 +168,8 @@
                                         :key="option.handle"
                                         class="text-sm flex items-center -mx-4 px-4 py-2 cursor-pointer"
                                         :class="option.active ? 'bg-blue-100' : 'hover:bg-gray-200'"
+                                        :disabled="!canSave"
+                                        v-tooltip="!canSave ? __(`You don't have permission to localize this entry.`) : null"
                                         @click="localizationSelected(option)"
                                     >
                                         <div class="flex-1 flex items-center" :class="{ 'line-through': !option.exists }">
@@ -626,6 +628,7 @@ export default {
         },
 
         localizationSelected(localization) {
+            if (!this.canSave) return;
             if (localization.active) return;
 
             if (this.isDirty) {

--- a/src/Http/Controllers/CP/Collections/LocalizeEntryController.php
+++ b/src/Http/Controllers/CP/Collections/LocalizeEntryController.php
@@ -10,6 +10,8 @@ class LocalizeEntryController extends CpController
 {
     public function __invoke(Request $request, $collection, $entry)
     {
+        $this->authorize('edit', $entry);
+
         $request->validate(['site' => 'required']);
 
         $localized = $entry->makeLocalization($site = $request->site);

--- a/tests/Feature/Entries/LocalizeEntryTest.php
+++ b/tests/Feature/Entries/LocalizeEntryTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Entries;
 
 use Facades\Tests\Factories\EntryFactory;
 use Statamic\Facades\Collection;
-use Statamic\Facades\Role;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Tests\FakesRoles;

--- a/tests/Feature/Entries/LocalizeEntryTest.php
+++ b/tests/Feature/Entries/LocalizeEntryTest.php
@@ -67,8 +67,7 @@ class LocalizeEntryTest extends TestCase
     public function cant_localize_entry_without_edit_permissions()
     {
         $user = $this->user();
-        $this->setTestRoles(['view' => ['access cp', 'access en site', 'access fr site', 'view blog entries']]);
-        $user->assignRole('view')->removeRole('test')->save();
+        $this->setTestRoles(['test' => ['access cp', 'access en site', 'access fr site', 'view blog entries']]);
 
         $entry = EntryFactory::collection(tap(Collection::make('blog')->revisionsEnabled(false))->save())->slug('test')->create();
         $this->assertNull($entry->in('fr'));


### PR DESCRIPTION
This pull request attempts to prevent users from being able to localize entries in other sites without the relevant "edit ... entries" permission.

This PR prevents it on the front-end by showing a tooltip when the user doesn't have enough permissions and also adds authorization in the controller to prevent it on the backend.

Fixes #9602.