### PR TITLE
[4.x] Fix search dropdown being hidden on Taggable Fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/TagsFieldtype.vue
+++ b/resources/js/components/fieldtypes/TagsFieldtype.vue
@@ -10,6 +10,7 @@
         :searchable="true"
         :select-on-key-codes="[9, 13, 188]"
         :taggable="true"
+        :append-to-body="true"
         :value="value"
         @input="update"
         @search:focus="$emit('focus')"


### PR DESCRIPTION
This pull request fixes an issue where the "dropdown" in the Taggable Fieldtype was being hidden. This PR applies a fix suggested by @jacksleight on Discord.

Fixes #9594.