### PR TITLE
[4.x] Use protection scheme from data before using site-wide protection scheme

### DIFF
--- a/src/Auth/Protect/Protection.php
+++ b/src/Auth/Protect/Protection.php
@@ -30,12 +30,16 @@ class Protection
 
     public function scheme()
     {
-        if ($default = config('statamic.protect.default')) {
-            return $default;
+        if (
+            $this->data
+            && $this->data instanceof Protectable
+            && $scheme = $this->data->getProtectionScheme()
+        ) {
+            return $scheme;
         }
 
-        if ($this->data && $this->data instanceof Protectable) {
-            return $this->data->getProtectionScheme();
+        if ($default = config('statamic.protect.default')) {
+            return $default;
         }
 
         return null;

--- a/tests/Auth/Protect/ProtectionTest.php
+++ b/tests/Auth/Protect/ProtectionTest.php
@@ -49,6 +49,20 @@ class ProtectionTest extends TestCase
     }
 
     /** @test */
+    public function scheme_comes_from_data_even_when_sitewide_scheme_is_defined()
+    {
+        config(['statamic.protect.default' => 'logged_in']);
+        config(['statamic.protect.schemes.logged_in' => [
+            'driver' => 'auth',
+            'form_url' => '/login',
+        ]]);
+
+        $this->protection->setData($this->createEntryWithScheme('password'));
+
+        $this->assertEquals('password', $this->protection->scheme());
+    }
+
+    /** @test */
     public function if_the_data_isnt_protectable_it_doesnt_get_a_scheme()
     {
         $this->assertNull($this->protection->scheme());


### PR DESCRIPTION
This pull request tweaks the `Protection@scheme` method so it uses the protection scheme from the data (eg. entry, term) _before_ it uses the site-wide default protection scheme.

Right now, if a site-wide protection scheme is configured, Statamic will use that before it checks the data.

Fixes #9552.