### PR TITLE
[4.x] Filter away bad bard nodes during preprocessing

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -351,7 +351,7 @@ class Bard extends Replicator
     {
         // Filter out broken nodes
         if (is_array($value)) {
-            $value = collect($value)->filter(function($node) {
+            $value = collect($value)->filter(function ($node) {
                 return array_key_exists('type', $node);
             })->all();
         }

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -353,7 +353,7 @@ class Bard extends Replicator
         if (is_array($value)) {
             $value = collect($value)->filter(function ($node) {
                 return array_key_exists('type', $node);
-            })->all();
+            })->values()->all();
         }
 
         if (empty($value) || $value === '[]') {

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -349,6 +349,13 @@ class Bard extends Replicator
 
     public function preProcess($value)
     {
+        // Filter out broken nodes
+        if (is_array($value)) {
+            $value = collect($value)->filter(function($node) {
+                return array_key_exists('type', $node);
+            })->all();
+        }
+
         if (empty($value) || $value === '[]') {
             return '[]';
         }

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -1217,7 +1217,7 @@ EOT;
         $data = [
             [],
             ['type' => 'text', 'text' => 'This is inline text.'],
-            ['text' => 'I have no type']
+            ['text' => 'I have no type'],
         ];
 
         $expected = '[{"type":"paragraph","content":[{"type":"text","text":"This is inline text."}]}]';

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -1211,6 +1211,20 @@ EOT;
         $this->assertEquals('test.-1.words', $value['defaults']['one']['words']);
     }
 
+    /** @test */
+    public function it_filters_away_bad_nodes()
+    {
+        $data = [
+            [],
+            ['type' => 'text', 'text' => 'This is inline text.'],
+            ['text' => 'I have no type']
+        ];
+
+        $expected = '[{"type":"paragraph","content":[{"type":"text","text":"This is inline text."}]}]';
+
+        $this->assertEquals($expected, $this->bard(['input_mode' => 'block', 'sets' => null])->preProcess($data));
+    }
+
     private function bard($config = [])
     {
         return (new Bard)->setField(new Field('test', array_merge(['type' => 'bard', 'sets' => ['one' => []]], $config)));


### PR DESCRIPTION
Filter away bad nodes during preprocessing instead of hard failing with exceptions.
Nodes without types would not be rendered anyway.