### PR TITLE
[4.x] Fix Glide cache not clearing on image reupload if `append_original_filename` is enabled

### DIFF
--- a/src/Imaging/GlideManager.php
+++ b/src/Imaging/GlideManager.php
@@ -141,8 +141,12 @@ class GlideManager
         $pathPrefix = ImageGenerator::assetCachePathPrefix($asset);
         $manifestKey = ImageGenerator::assetCacheManifestKey($asset);
 
-        // Delete generated glide cache for asset.
-        $this->server()->deleteCache($pathPrefix.'/'.$asset->path());
+        // Delete generated glide cache for asset, making sure to use the default cache path callable.
+        $server = $this->server();
+        $customCallable = $server->getCachePathCallable();
+        $server->setCachePathCallable(null);
+        $server->deleteCache($pathPrefix.'/'.$asset->path());
+        $server->setCachePathCallable($customCallable);
 
         // Use manifest to clear each manipulation key from cache store.
         collect($this->cacheStore()->get($manifestKey, []))->each(function ($manipulationKey) {

--- a/src/Imaging/GlideManager.php
+++ b/src/Imaging/GlideManager.php
@@ -141,7 +141,7 @@ class GlideManager
         $pathPrefix = ImageGenerator::assetCachePathPrefix($asset);
         $manifestKey = ImageGenerator::assetCacheManifestKey($asset);
 
-        // Delete generated glide cache for asset
+        // Delete generated glide cache for asset.
         if (config('statamic.assets.image_manipulation.append_original_filename', false)) {
             // Make sure to use the default cache path when clearing the cache
             tap($this->server(), function ($server) use ($pathPrefix, $asset) {

--- a/src/Imaging/GlideManager.php
+++ b/src/Imaging/GlideManager.php
@@ -141,12 +141,18 @@ class GlideManager
         $pathPrefix = ImageGenerator::assetCachePathPrefix($asset);
         $manifestKey = ImageGenerator::assetCacheManifestKey($asset);
 
-        // Delete generated glide cache for asset, making sure to use the default cache path callable.
-        $server = $this->server();
-        $customCallable = $server->getCachePathCallable();
-        $server->setCachePathCallable(null);
-        $server->deleteCache($pathPrefix.'/'.$asset->path());
-        $server->setCachePathCallable($customCallable);
+        // Delete generated glide cache for asset
+        if (config('statamic.assets.image_manipulation.append_original_filename', false)) {
+            // Make sure to use the default cache path when clearing the cache
+            tap($this->server(), function ($server) use ($pathPrefix, $asset) {
+                $customCallable = $server->getCachePathCallable();
+                $server->setCachePathCallable(null);
+                $server->deleteCache($pathPrefix.'/'.$asset->path());
+                $server->setCachePathCallable($customCallable);
+            });
+        } else {
+            $this->server()->deleteCache($pathPrefix.'/'.$asset->path());
+        }
 
         // Use manifest to clear each manipulation key from cache store.
         collect($this->cacheStore()->get($manifestKey, []))->each(function ($manipulationKey) {


### PR DESCRIPTION
**Fixes** #9609

**Description**

- Make sure that reuploading an image will always clear the Glide cache, even if `append_original_filename` is enabled

**Required changes**

- Use the default Glide cache path callable during cache deletion

**Tests**

- No new tests for now
- First-time contributor here and having a bit of trouble finding my way through the test setup
- Might revisit that if I find the time