### PR TITLE
[4.x] OAuth improvements including support for SAML2 providers

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
-use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Support\Facades\Route;
 use Statamic\Auth\Protect\Protectors\Password\Controller as PasswordProtectController;
 use Statamic\Facades\OAuth;

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Support\Facades\Route;
 use Statamic\Auth\Protect\Protectors\Password\Controller as PasswordProtectController;
 use Statamic\Facades\OAuth;
@@ -51,7 +52,9 @@ Route::name('statamic.')->group(function () {
 
     if (OAuth::enabled()) {
         Route::get(config('statamic.oauth.routes.login'), [OAuthController::class, 'redirectToProvider'])->name('oauth.login');
-        Route::get(config('statamic.oauth.routes.callback'), [OAuthController::class, 'handleProviderCallback'])->name('oauth.callback');
+        Route::match(['get', 'post'], config('statamic.oauth.routes.callback'), [OAuthController::class, 'handleProviderCallback'])
+            ->withoutMiddleware('App\Http\Middleware\VerifyCsrfToken')
+            ->name('oauth.callback');
     }
 });
 

--- a/src/Auth/UserRepository.php
+++ b/src/Auth/UserRepository.php
@@ -8,7 +8,7 @@ use Statamic\Data\StoresComputedFieldCallbacks;
 use Statamic\Events\UserBlueprintFound;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Blueprint;
-use Statamic\OAuth\Provider;
+use Statamic\Facades\OAuth;
 use Statamic\Statamic;
 
 abstract class UserRepository implements RepositoryContract
@@ -86,7 +86,7 @@ abstract class UserRepository implements RepositoryContract
     public function findByOAuthId(string $provider, string $id): ?User
     {
         return $this->find(
-            (new Provider($provider))->getUserId($id)
+            OAuth::provider($provider)->getUserId($id)
         );
     }
 }

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -16,15 +16,15 @@ class OAuthController
 
     public function handleProviderCallback($provider)
     {
-        $provider = OAuth::provider($provider);
+        $OAuthProvider = OAuth::provider($provider);
 
         try {
-            $providerUser = $provider->getSocialiteUser();
+            $providerUser = $OAuthProvider->getSocialiteUser();
         } catch (InvalidStateException $e) {
-            return $this->redirectToProvider($provider->name());
+            return $this->redirectToProvider($provider);
         }
 
-        $user = $provider->findOrCreateUser($providerUser);
+        $user = $OAuthProvider->findOrCreateUser($providerUser);
 
         session()->put('oauth-provider', $provider);
 

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -16,15 +16,15 @@ class OAuthController
 
     public function handleProviderCallback($provider)
     {
-        $oauthProvider = OAuth::provider($provider);
+        $oauth = OAuth::provider($provider);
 
         try {
-            $providerUser = $oauthProvider->getSocialiteUser();
+            $providerUser = $oauth->getSocialiteUser();
         } catch (InvalidStateException $e) {
             return $this->redirectToProvider($provider);
         }
 
-        $user = $oauthProvider->findOrCreateUser($providerUser);
+        $user = $oauth->findOrCreateUser($providerUser);
 
         session()->put('oauth-provider', $provider);
 

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -16,15 +16,15 @@ class OAuthController
 
     public function handleProviderCallback($provider)
     {
-        $OAuthProvider = OAuth::provider($provider);
+        $oAuthProvider = OAuth::provider($provider);
 
         try {
-            $providerUser = $OAuthProvider->getSocialiteUser();
+            $providerUser = $oAuthProvider->getSocialiteUser();
         } catch (InvalidStateException $e) {
             return $this->redirectToProvider($provider);
         }
 
-        $user = $OAuthProvider->findOrCreateUser($providerUser);
+        $user = $oAuthProvider->findOrCreateUser($providerUser);
 
         session()->put('oauth-provider', $provider);
 

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -16,15 +16,15 @@ class OAuthController
 
     public function handleProviderCallback($provider)
     {
-        $oAuthProvider = OAuth::provider($provider);
+        $oauthProvider = OAuth::provider($provider);
 
         try {
-            $providerUser = $oAuthProvider->getSocialiteUser();
+            $providerUser = $oauthProvider->getSocialiteUser();
         } catch (InvalidStateException $e) {
             return $this->redirectToProvider($provider);
         }
 
-        $user = $oAuthProvider->findOrCreateUser($providerUser);
+        $user = $oauthProvider->findOrCreateUser($providerUser);
 
         session()->put('oauth-provider', $provider);
 

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
 use Statamic\Facades\OAuth;
-use Statamic\Support\Arr;
 
 class OAuthController
 {
@@ -17,20 +16,15 @@ class OAuthController
 
     public function handleProviderCallback($provider)
     {
+        $provider = OAuth::provider($provider);
+
         try {
-            $socialiteProvider = Socialite::driver($provider);
-            $providerConfig = OAuth::providers()->first(fn ($prov) => $provider === $prov->name())->config();
-
-            if (Arr::get($providerConfig, 'stateless', false)) {
-                $socialiteProvider->stateless();
-            }
-
-            $providerUser = $socialiteProvider->user();
+            $providerUser = $provider->getSocialiteUser();
         } catch (InvalidStateException $e) {
-            return $this->redirectToProvider($provider);
+            return $this->redirectToProvider($provider->name());
         }
 
-        $user = OAuth::provider($provider)->findOrCreateUser($providerUser);
+        $user = $provider->findOrCreateUser($providerUser);
 
         session()->put('oauth-provider', $provider);
 

--- a/src/OAuth/Manager.php
+++ b/src/OAuth/Manager.php
@@ -29,10 +29,10 @@ class Manager
                 // When the $value is NOT an integer, it means the provider has config settings.
                 // eg. ['github' => 'GitHub', 'facebook' => ['label' => 'Facebook', 'stateless' => true]]
                 if (! is_int($value)) {
-                  $provider = $value;
-                  $config = is_array($key)
-                    ? $key
-                    : ['label' => $key];
+                    $provider = $value;
+                    $config = is_array($key)
+                      ? $key
+                      : ['label' => $key];
                 }
 
                 $oAuthProvider = $this

--- a/src/OAuth/Manager.php
+++ b/src/OAuth/Manager.php
@@ -34,9 +34,7 @@ class Manager
                 // eg. ['github' => 'GitHub', 'facebook' => ['label' => 'Facebook', 'stateless' => true]]
                 if (! is_int($key)) {
                     $provider = $key;
-                    $config = is_array($value)
-                      ? $value
-                      : ['label' => $value];
+                    $config = is_array($value) ? $value : ['label' => $value];
                 }
 
                 $oAuthProvider = (new Provider($provider))

--- a/src/OAuth/Manager.php
+++ b/src/OAuth/Manager.php
@@ -26,17 +26,17 @@ class Manager
     public function providers()
     {
         return collect(config('statamic.oauth.providers'))
-            ->mapWithKeys(function ($key, $value) {
-                $provider = $key;
+            ->mapWithKeys(function ($value, $key) {
+                $provider = $value;
                 $config = null;
 
-                // When the $value is NOT an integer, it means the provider has config settings.
+                // When the $key is NOT an integer, it means the provider has config settings.
                 // eg. ['github' => 'GitHub', 'facebook' => ['label' => 'Facebook', 'stateless' => true]]
-                if (! is_int($value)) {
-                    $provider = $value;
-                    $config = is_array($key)
-                      ? $key
-                      : ['label' => $key];
+                if (! is_int($key)) {
+                    $provider = $key;
+                    $config = is_array($value)
+                      ? $value
+                      : ['label' => $value];
                 }
 
                 $oAuthProvider = (new Provider($provider))

--- a/src/OAuth/Manager.php
+++ b/src/OAuth/Manager.php
@@ -20,7 +20,7 @@ class Manager
             return static::$providers[$provider];
         }
 
-        return $this->providers()->get($provider);
+        return static::$providers[$provider] = $this->providers()->get($provider);
     }
 
     public function providers()

--- a/src/OAuth/Manager.php
+++ b/src/OAuth/Manager.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\OAuth;
 
-use Statamic\Support\Arr;
-
 class Manager
 {
     protected static $providers = [];
@@ -28,7 +26,7 @@ class Manager
         return collect(config('statamic.oauth.providers'))
             ->mapWithKeys(function ($value, $key) {
                 $provider = $value;
-                $config = null;
+                $config = [];
 
                 // When the $key is NOT an integer, it means the provider has config settings.
                 // eg. ['github' => 'GitHub', 'facebook' => ['label' => 'Facebook', 'stateless' => true]]
@@ -37,11 +35,7 @@ class Manager
                     $config = is_array($value) ? $value : ['label' => $value];
                 }
 
-                $oAuthProvider = (new Provider($provider))
-                    ->label(Arr::get($config, 'label'))
-                    ->config($config);
-
-                return [$provider => $oAuthProvider];
+                return [$provider => new Provider($provider, $config)];
             });
     }
 }

--- a/src/OAuth/Manager.php
+++ b/src/OAuth/Manager.php
@@ -16,7 +16,11 @@ class Manager
 
     public function provider($provider)
     {
-        return static::$providers[$provider] = static::$providers[$provider] ?? new Provider($provider);
+        if (isset(static::$providers[$provider])) {
+            return static::$providers[$provider];
+        }
+
+        return $this->providers()->get($provider);
     }
 
     public function providers()
@@ -35,8 +39,7 @@ class Manager
                       : ['label' => $key];
                 }
 
-                $oAuthProvider = $this
-                    ->provider($provider)
+                $oAuthProvider = (new Provider($provider))
                     ->label(Arr::get($config, 'label'))
                     ->config($config);
 

--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -24,11 +24,6 @@ class Provider
         $this->name = $name;
     }
 
-    public function name()
-    {
-        return $this->name;
-    }
-
     public function getSocialiteUser()
     {
         $driver = Socialite::driver($this->name);

--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -13,15 +13,16 @@ use Statamic\Support\Str;
 
 class Provider
 {
-    protected $name;
+    /** @deprecated */
     protected $label;
-    protected $config;
+
     protected $userCallback;
     protected $userDataCallback;
 
-    public function __construct(string $name)
-    {
-        $this->name = $name;
+    public function __construct(
+        protected string $name,
+        protected array $config = []
+    ) {
     }
 
     public function getSocialiteUser()
@@ -127,7 +128,7 @@ class Provider
     public function label($label = null)
     {
         if (func_num_args() === 0) {
-            return $this->label ?? Str::title($this->name);
+            return $this->label ?? $this->config['label'] ?? Str::title($this->name);
         }
 
         $this->label = $label;

--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -5,11 +5,11 @@ namespace Statamic\OAuth;
 use Closure;
 use Illuminate\Support\Arr;
 use Laravel\Socialite\Contracts\User as SocialiteUser;
+use Laravel\Socialite\Facades\Socialite;
 use Statamic\Contracts\Auth\User as StatamicUser;
 use Statamic\Facades\File;
 use Statamic\Facades\User;
 use Statamic\Support\Str;
-use Laravel\Socialite\Facades\Socialite;
 
 class Provider
 {

--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -136,15 +136,9 @@ class Provider
         return $this;
     }
 
-    public function config($config = null)
+    public function config()
     {
-        if (func_num_args() === 0) {
-            return $this->config ?? [];
-        }
-
-        $this->config = $config;
-
-        return $this;
+        return $this->config;
     }
 
     protected function getIds()

--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -13,6 +13,7 @@ class Provider
 {
     protected $name;
     protected $label;
+    protected $config;
     protected $userCallback;
     protected $userDataCallback;
 
@@ -117,6 +118,17 @@ class Provider
         }
 
         $this->label = $label;
+
+        return $this;
+    }
+
+    public function config($config = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->config ?? [];
+        }
+
+        $this->config = $config;
 
         return $this;
     }

--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -3,11 +3,13 @@
 namespace Statamic\OAuth;
 
 use Closure;
+use Illuminate\Support\Arr;
 use Laravel\Socialite\Contracts\User as SocialiteUser;
 use Statamic\Contracts\Auth\User as StatamicUser;
 use Statamic\Facades\File;
 use Statamic\Facades\User;
 use Statamic\Support\Str;
+use Laravel\Socialite\Facades\Socialite;
 
 class Provider
 {
@@ -25,6 +27,17 @@ class Provider
     public function name()
     {
         return $this->name;
+    }
+
+    public function getSocialiteUser()
+    {
+        $driver = Socialite::driver($this->name);
+
+        if (Arr::get($this->config, 'stateless', false)) {
+            $driver->stateless();
+        }
+
+        return $driver->user();
     }
 
     /**

--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -22,6 +22,11 @@ class Provider
         $this->name = $name;
     }
 
+    public function name()
+    {
+        return $this->name;
+    }
+
     /**
      * Get a Statamic user ID from an OAuth user ID.
      *

--- a/tests/OAuth/ProviderTest.php
+++ b/tests/OAuth/ProviderTest.php
@@ -32,6 +32,22 @@ class ProviderTest extends TestCase
     }
 
     /** @test */
+    public function it_gets_the_config()
+    {
+        $this->assertEquals([], (new Provider('test'))->config());
+
+        $this->assertEquals(['foo' => 'bar'], (new Provider('test', ['foo' => 'bar']))->config());
+    }
+
+    /** @test */
+    public function it_gets_the_label_through_the_config()
+    {
+        $this->assertEquals('Test', (new Provider('test'))->label());
+
+        $this->assertEquals('Foo Bar', (new Provider('test', ['label' => 'Foo Bar']))->label());
+    }
+
+    /** @test */
     public function it_gets_user_data()
     {
         $data = $this->provider()->userData($this->socialite());

--- a/tests/OAuth/ProviderTest.php
+++ b/tests/OAuth/ProviderTest.php
@@ -21,6 +21,10 @@ class ProviderTest extends TestCase
             'driver' => 'local',
             'root' => $this->tempDir = __DIR__.'/tmp',
         ]]);
+
+        config(['statamic.oauth.providers' => [
+            'test',
+        ]]);
     }
 
     public function tearDown(): void


### PR DESCRIPTION
This pull request fixes two issues preventing our Socialite/oAuth integration from working with SAML2 Socialite Providers, like Auth0/Okta.

Essentially, there were only two changes required to make our code work with SAML2:

* The `/oauth/{provider}/callback` route needs to accept `POST` requests, not just `GET` requests.
* When we're fetching the user via Socialite, we needed to call `->stateless()`, otherwise we'd get an error.
    * However, the `->stateless()` option only works for *some* providers and not all of them. There's also no way for us to know programatically if a specific provider supports it or not - you need to simply test it and see.
    * To workaround this, I've made it possible to specify `stateless` as a config option in the `providers` array in `config/statamic/oauth.php`... more details on that below

## Provider "Configs"

You can configure which providers Statamic should use for oAuth in the `providers` array in `config/statamic/oauth.php`. You can optionally configure labels for providers too.

```php
'providers' => [
    'github',
    'saml2' => 'Okta',
],
```

Like I mentioned, only some providers support the `->stateless()` method, so I've made it so you can pass an array of config options:

```php
'providers' => [
    'github',
    'saml2' => ['stateless' => true, 'label' => 'Okta'],
],
```

Most of the code changes in this PR are around making the config stuff work. Happy to re-work if you think there's a better way to do this.

---

Fixes #9535.