### PR TITLE
[4.x] Fixes Antlers Sections not being yieldable in Blade layouts

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -101,6 +101,13 @@ class View
             GlobalRuntimeState::$containsLayout = false;
             GlobalRuntimeState::$shareVariablesTemplateTrigger = '';
 
+            $factory = app('view');
+
+            // Put the sections back. The ->render() will have flushed the sections.
+            Cascade::sections()->each(function ($content, $section) use ($factory) {
+                $factory->startSection($section, (string) $content);
+            });
+
             $contents = view($this->layoutViewName(), array_merge($cascade, GlobalRuntimeState::$layoutVariables, [
                 'template_content' => $contents,
             ]));

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\View;
 
+use Illuminate\Support\HtmlString;
 use InvalidArgumentException;
 use Statamic\Facades\Cascade;
 use Statamic\Support\Arr;
@@ -105,7 +106,7 @@ class View
 
             // Put the sections back. The ->render() will have flushed the sections.
             Cascade::sections()->each(function ($content, $section) use ($factory) {
-                $factory->startSection($section, (string) $content);
+                $factory->startSection($section, new HtmlString((string) $content));
             });
 
             $contents = view($this->layoutViewName(), array_merge($cascade, GlobalRuntimeState::$layoutVariables, [


### PR DESCRIPTION
This PR corrects an issue with Antlers sections not being yieldable in Blade layouts. The render method here https://github.com/statamic/cms/blob/4.x/src/View/View.php#L100 flushes the sections. The changes here put them back before rendering the layout.

After this, the following will now work again:

layout.blade.php
```blade

@yield('the_section')
```

template.antlers.html
```antlers
{{ section:the_section }}
The section contents.
{{ /section:the_section }}
```