### PR TITLE
[4.x] Antlers: Corrects an issue with strict equality inside conditions

### DIFF
--- a/src/View/Antlers/Language/Runtime/ConditionProcessor.php
+++ b/src/View/Antlers/Language/Runtime/ConditionProcessor.php
@@ -83,7 +83,8 @@ class ConditionProcessor
                      * @var AbstractNode[] $interpolationRegion
                      */
                     foreach ($branch->head->processedInterpolationRegions as $varKey => $interpolationRegion) {
-                        $interpolationResult = $this->processor->cloneProcessor()->setData($data)->render($interpolationRegion);
+                        $interpolationResult = $this->processor->cloneProcessor()
+                            ->setIsInterpolationProcessor(true)->setData($data)->render($interpolationRegion);
 
                         $dataToUse[$varKey] = $interpolationResult;
                         $interpolationReplacements[$varKey] = $interpolationResult;

--- a/tests/Antlers/Sandbox/ConditionalsTest.php
+++ b/tests/Antlers/Sandbox/ConditionalsTest.php
@@ -199,4 +199,25 @@ EOT;
         $this->assertSame('No', $this->renderString('{{ if 0 }}Yes{{ else }}No{{ /if }}'));
         $this->assertSame('No', $this->renderString('{{ if 0.0 }}Yes{{ else }}No{{ /if }}'));
     }
+
+    public function test_interpolations_inside_conditions_are_evaluated_using_conditional_mode()
+    {
+        (new class extends Tags
+        {
+            protected static $handle = 'the_tag';
+
+            public function wildcard($method)
+            {
+                return true;
+            }
+        })::register();
+
+        $template = <<<'EOT'
+{{ if {the_tag:has:some:nested:stuff} === true }}
+Yes
+{{ /if }}
+EOT;
+
+        $this->assertSame('Yes', trim($this->renderString($template, [], true)));
+    }
 }


### PR DESCRIPTION
This PR fixes #9615 by ensuring that context variables for the condition processor are evaluated with the correct settings, to prevent collapsing values too early (as was the case when double executing tags).

The linked issue manifests because the bugged behavior will return `1`, causing the strict equality to fail.