### PR TITLE
[4.x] Roll back to initial simple isAjax() check on front end forms

### DIFF
--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -60,7 +60,8 @@ class FrontendFormRequest extends FormRequest
 
     protected function failedValidation(Validator $validator)
     {
-        if (! $this->isPrecognitive() && ($this->ajax() || $this->wantsJson())) {
+        if ($this->ajax()) {
+
             $errors = $validator->errors();
 
             $response = response([


### PR DESCRIPTION
 I've created an ongoing problem here, sorry about this.

The initial idea around https://github.com/statamic/cms/pull/9533 was to give the same response for XMLHttpRequest as for fetch() but maybe that was the wrong thing to do, lets just leave it as fetch() gets the 'normal' laravel error response format, rather than the amended response that Statamic is returning.

Lets just undo https://github.com/statamic/cms/pull/9599

Closes https://github.com/statamic/cms/issues/9627 
Closes https://github.com/statamic/cms/issues/9628