### PR TITLE
[4.x] Only retrieve from origin blink cache when its not null

### DIFF
--- a/src/Data/HasOrigin.php
+++ b/src/Data/HasOrigin.php
@@ -68,13 +68,9 @@ trait HasOrigin
                     return $found;
                 }
 
-                $found = $this->getOriginByString($origin);
-
-                if ($found) {
+                return tap($this->getOriginByString($origin), function ($found) {
                     Blink::put($this->getOriginBlinkKey(), $found);
-                }
-
-                return $found;
+                });
             })
             ->setter(function ($origin) {
                 Blink::forget($this->getOriginBlinkKey());

--- a/src/Data/HasOrigin.php
+++ b/src/Data/HasOrigin.php
@@ -60,9 +60,21 @@ trait HasOrigin
     {
         return $this->fluentlyGetOrSet('origin')
             ->getter(function ($origin) {
-                return $origin
-                    ? Blink::once($this->getOriginBlinkKey(), fn () => $this->getOriginByString($origin))
-                    : null;
+                if (! $origin) {
+                    return null;
+                }
+
+                if ($found = Blink::get($this->getOriginBlinkKey())) {
+                    return $found;
+                }
+
+                $found = $this->getOriginByString($origin);
+
+                if ($found) {
+                    Blink::put($this->getOriginBlinkKey(), $found);
+                }
+
+                return $found;
             })
             ->setter(function ($origin) {
                 Blink::forget($this->getOriginBlinkKey());


### PR DESCRIPTION
https://github.com/statamic/cms/issues/9631 (and similar other reports) seem to be being caused by the load order on multi-sites, specifically when an origin is loaded after a descendant (eg `de` loads before `en`).

As we syncOriginalState on load, and that now includes the origins, it blinks a null value, which persists.

This PR changes the origin approach from using Blink::once() to using a get/set approach, checking if the value is not null and early returning it. This should give most of the performance once() wanted, but also allow a re-query when the value is null.

Closes https://github.com/statamic/cms/issues/9631