### PR TITLE
[4.x] Only suggest fields in the same replicator set

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -124,7 +124,7 @@ export default {
     computed: {
 
         suggestableConditionFields() {
-            return this.suggestableConditionFieldsProvider?.suggestableFields || [];
+            return this.suggestableConditionFieldsProvider?.suggestableFields(this) || [];
         },
 
         iconBaseDirectory() {

--- a/resources/js/components/blueprints/SuggestsConditionalFields.js
+++ b/resources/js/components/blueprints/SuggestsConditionalFields.js
@@ -6,18 +6,10 @@ export default {
         }
     },
 
-    computed: {
+    methods: {
 
-        fieldsForConditionSuggestions() {
-            return this.tabs.reduce((fields, tab) => {
-                return fields.concat(tab.sections.reduce((fields, section) => {
-                    return fields.concat(section.fields);
-                }, []));
-            }, []);
-        },
-
-        suggestableConditionFields() {
-            let fields = this.fieldsForConditionSuggestions.reduce((fields, field) => {
+        suggestableConditionFields(section = null) {
+            let fields = this.fieldsForConditionSuggestions(section).reduce((fields, field) => {
                 return fields.concat(
                     field.type === 'import'
                         ? this.getFieldsFromImportedFieldset(field.fieldset, field.prefix)
@@ -28,15 +20,10 @@ export default {
             return _.unique(fields);
         },
 
-    },
-
-    methods: {
-
         makeConditionsProvider() {
-            const provide = {};
-            Object.defineProperties(provide, {
-                suggestableFields: { get: () => this.suggestableConditionFields },
-            });
+            const provide = {
+                suggestableFields: (vm) => this.suggestableConditionFields(vm),
+            };
             return provide;
         },
 
@@ -50,6 +37,14 @@ export default {
                     );
                 }, [])
                 .map(field => prefix ? { ...field, handle: prefix + field.handle } : field);
+        },
+
+        fieldsForConditionSuggestions(vm = null) {
+            return this.tabs.reduce((fields, tab) => {
+                return fields.concat(tab.sections.reduce((fields, section) => {
+                    return fields.concat(section.fields);
+                }, []));
+            }, []);
         }
 
     }

--- a/resources/js/components/blueprints/SuggestsConditionalFields.js
+++ b/resources/js/components/blueprints/SuggestsConditionalFields.js
@@ -6,10 +6,22 @@ export default {
         }
     },
 
+    computed: {
+
+        fieldsForConditionSuggestions() {
+            return this.tabs.reduce((fields, tab) => {
+                return fields.concat(tab.sections.reduce((fields, section) => {
+                    return fields.concat(section.fields);
+                }, []));
+            }, []);
+        }
+
+    },
+
     methods: {
 
         suggestableConditionFields(section = null) {
-            let fields = this.fieldsForConditionSuggestions(section).reduce((fields, field) => {
+            let fields = this.getSectionFieldsForConditionSuggestions(section).reduce((fields, field) => {
                 return fields.concat(
                     field.type === 'import'
                         ? this.getFieldsFromImportedFieldset(field.fieldset, field.prefix)
@@ -39,12 +51,8 @@ export default {
                 .map(field => prefix ? { ...field, handle: prefix + field.handle } : field);
         },
 
-        fieldsForConditionSuggestions(vm = null) {
-            return this.tabs.reduce((fields, tab) => {
-                return fields.concat(tab.sections.reduce((fields, section) => {
-                    return fields.concat(section.fields);
-                }, []));
-            }, []);
+        getSectionFieldsForConditionSuggestions(vm = null) {
+            return this.fieldsForConditionSuggestions;
         }
 
     }

--- a/resources/js/components/fieldsets/EditForm.vue
+++ b/resources/js/components/fieldsets/EditForm.vue
@@ -37,7 +37,7 @@
                 :fields="fieldset.fields"
                 :editing-field="editingField"
                 :exclude-fieldset="fieldset.handle"
-                :suggestable-condition-fields="suggestableConditionFields"
+                :suggestable-condition-fields="suggestableConditionFields(this)"
                 @field-created="fieldCreated"
                 @field-updated="fieldUpdated"
                 @field-linked="fieldLinked"

--- a/resources/js/components/fieldtypes/grid/FieldsFieldtype.vue
+++ b/resources/js/components/fieldtypes/grid/FieldsFieldtype.vue
@@ -4,7 +4,7 @@
         :fields="fields"
         :editing-field="editingField"
         :can-define-localizable="false"
-        :suggestable-condition-fields="suggestableConditionFields"
+        :suggestable-condition-fields="suggestableConditionFields(this)"
         @field-created="fieldCreated"
         @field-updated="fieldUpdated"
         @field-linked="fieldLinked"

--- a/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
@@ -43,6 +43,10 @@ export default {
 
         tabsUpdated(tabs) {
             this.update(tabs);
+        },
+
+        fieldsForConditionSuggestions(vm = null) {
+            return vm.section.fields;
         }
 
     }

--- a/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
@@ -45,7 +45,7 @@ export default {
             this.update(tabs);
         },
 
-        fieldsForConditionSuggestions(vm = null) {
+        getSectionFieldsForConditionSuggestions(vm = null) {
             return vm.section.fields;
         }
 


### PR DESCRIPTION
Closes #9603

This PR passes along the current section where the suggestable fields are going to be used. This allows us to override the logic depending on a section.

When configuring a replicator, a section is a set. Inside SetsFieldtype, we'll accept that set and just use the fields on it.

Everywhere else, it continues to use the existing logic:
- standard "get all fields from all tabs" logic for top level fields
- "get all fields in this fieldset" when editing a fieldset
- etc