### PR TITLE
[4.x] Fix prop type warning in validation builder

### DIFF
--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -78,7 +78,7 @@
                 <sortable-list
                     item-class="sortable-item"
                     handle-class="sortable-item"
-                    distance="5"
+                    :distance="5"
                     :mirror="false"
                     v-model="rules"
                 >


### PR DESCRIPTION
This ensures the type passed into the component is an integer as expected, rather than a string.
You'd get a Vue warning whenever editing a field in the blueprint builder, but only when running npm run dev though. Annoying for us.

```
Settings.vue:276 [Vue warn]: Invalid prop: type check failed for prop "distance". Expected Number with value 5, got String with value "5".
```
