### PR TITLE
[4.x] Bard & Replicators: Show set group in UI

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -180,7 +180,8 @@ export default {
             showAddSetButton: false,
             provide: {
                 bard: this.makeBardProvide(),
-                storeName: this.storeName
+                storeName: this.storeName,
+                bardSets: this.config.sets
             }
         }
     },

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -9,7 +9,13 @@
             <div class="replicator-set-header" :class="{'collapsed': collapsed, 'invalid': isInvalid }">
                 <div class="item-move sortable-handle" data-drag-handle />
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
-                    <label v-text="display || config.handle" class="text-xs whitespace-nowrap mr-2"/>
+                    <label class="text-xs whitespace-nowrap mr-2">
+                        <template v-if="bardSets.length > 1">
+                            {{ setGroup.display }}
+                            <svg-icon name="micro/chevron-right" class="w-4" />
+                        </template>
+                        {{ display || config.handle }}
+                    </label>
                     <div class="flex items-center" v-if="config.instructions && !collapsed">
                         <svg-icon name="micro/circle-help" class="text-gray-700 hover:text-gray-800 h-3 w-3 text-xs" v-tooltip="{ content: $options.filters.markdown(__(config.instructions)), html:true }" />
                     </div>
@@ -80,7 +86,7 @@ export default {
 
     mixins: [ValidatesFieldConditions, ManagesPreviewText],
 
-    inject: ['bard'],
+    inject: ['bard', 'bardSets'],
 
     computed: {
 
@@ -114,6 +120,12 @@ export default {
 
         setConfigs() {
             return this.bard.setConfigs;
+        },
+
+        setGroup() {
+            return this.bardSets.find((group) => {
+                return group.sets.filter((set) => set.handle === this.config.handle).length > 0;
+            });
         },
 
         isReadOnly() {

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -136,7 +136,8 @@ export default {
             previews: this.meta.previews,
             fullScreenMode: false,
             provide: {
-                storeName: this.storeName
+                storeName: this.storeName,
+                replicatorSets: this.config.sets
             }
         }
     },

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -7,7 +7,11 @@
             <div class="replicator-set-header" :class="{ 'p-2': isReadOnly, 'collapsed': collapsed, 'invalid': isInvalid }">
                 <div class="item-move sortable-handle" :class="sortableHandleClass" v-if="!isReadOnly"></div>
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
-                    <label v-text="display || config.handle" class="text-xs whitespace-nowrap mr-2 cursor-pointer"/>
+                    <label class="text-xs whitespace-nowrap mr-2 cursor-pointer">
+                        {{ setGroup.display }}
+                        <svg-icon name="micro/chevron-right" class="w-4" />
+                        {{ display || config.handle }}
+                    </label>
                     <div class="flex items-center" v-if="config.instructions && !collapsed">
                         <svg-icon name="micro/circle-help" class="text-gray-700 hover:text-gray-800 h-3 w-3 text-xs" v-tooltip="{ content: $options.filters.markdown(__(config.instructions)), html:true }" />
                     </div>
@@ -78,6 +82,8 @@ export default {
 
     mixins: [ValidatesFieldConditions, ManagesPreviewText],
 
+    inject: ['replicatorSets'],
+
     props: {
         config: {
             type: Object,
@@ -146,6 +152,12 @@ export default {
 
         instructions() {
             return this.config.instructions ? markdown(__(this.config.instructions)) : null;
+        },
+
+        setGroup() {
+            return this.replicatorSets.find((group) => {
+                return group.sets.filter((set) => set.handle === this.config.handle).length > 0;
+            });
         },
 
         hasMultipleFields() {

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -8,8 +8,10 @@
                 <div class="item-move sortable-handle" :class="sortableHandleClass" v-if="!isReadOnly"></div>
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
                     <label class="text-xs whitespace-nowrap mr-2 cursor-pointer">
-                        {{ setGroup.display }}
-                        <svg-icon name="micro/chevron-right" class="w-4" />
+                        <template v-if="replicatorSets.length > 1">
+                            {{ setGroup.display }}
+                            <svg-icon name="micro/chevron-right" class="w-4" />
+                        </template>
                         {{ display || config.handle }}
                     </label>
                     <div class="flex items-center" v-if="config.instructions && !collapsed">


### PR DESCRIPTION
This pull request displays the name of the set group, next to the name of the set.

![CleanShot 2024-03-05 at 21 57 53](https://github.com/statamic/cms/assets/19637309/b644cc03-8c18-4d18-acab-ff851f043da4)

The styles around the chevron look a bit off to me but I didn't have much luck in making it look better. Might need a bit of tweaking before being merged?

Closes statamic/ideas#1132.