### PR TITLE
[4.x] Users Listing: Allow for configuring default sort field & direction

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -158,11 +158,26 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here you can configure if impersonation is available, and what URL to
-    | redirect to after impersonation begins
+    | redirect to after impersonation begins.
     |
     */
+
     'impersonate' => [
         'enabled' => env('STATAMIC_IMPERSONATE_ENABLED', true),
         'redirect' => env('STATAMIC_IMPERSONATE_REDIRECT', null),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Sorting
+    |--------------------------------------------------------------------------
+    |
+    | Here you can configure the default sort field and direction for the
+    | Users listing table in the Control Panel.
+    |
+    */
+
+    'sort_field' => 'email',
+    'sort_direction' => 'asc',
+
 ];

--- a/config/users.php
+++ b/config/users.php
@@ -172,8 +172,7 @@ return [
     | Default Sorting
     |--------------------------------------------------------------------------
     |
-    | Here you can configure the default sort field and direction for the
-    | Users listing table in the Control Panel.
+    | Here you may configure the default sort behavior for user listings.
     |
     */
 

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -24,8 +24,8 @@
 
     <user-listing
         listing-key="users"
-        initial-sort-column="email"
-        initial-sort-direction="asc"
+        initial-sort-column="{{ config('statamic.users.sort_field', 'email') }}"
+        initial-sort-direction="{{ config('statamic.users.sort_direction', 'asc') }}"
         :filters="{{ $filters->toJson() }}"
         action-url="{{ cp_route('users.actions.run') }}"
     ></user-listing>

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -68,9 +68,19 @@ class UsersController extends CpController
             'blueprints' => ['user'],
         ]);
 
-        $users = $query
-            ->orderBy(request('sort', 'email'), request('order', 'asc'))
-            ->paginate(request('perPage'));
+        $sortField = request('sort');
+        $sortDirection = request('order', 'asc');
+
+        if (! $sortField && ! request('search')) {
+            $sortField = config('statamic.user.sort_field', 'email');
+            $sortDirection = config('statamic.user.sort_direction', 'asc');
+        }
+
+        if ($sortField) {
+            $query->orderBy($sortField, $sortDirection);
+        }
+
+        $users = $query->paginate(request('perPage'));
 
         if ($users->getCollection()->first() instanceof Result) {
             $users->setCollection($users->getCollection()->map->getSearchable());

--- a/src/Tags/Users.php
+++ b/src/Tags/Users.php
@@ -43,6 +43,6 @@ class Users extends Tags
 
     protected function defaultOrderBy()
     {
-        return config('statamic.users.sort_field', 'email') . ':' . config('statamic.users.sort_direction', 'asc');
+        return config('statamic.users.sort_field', 'email').':'.config('statamic.users.sort_direction', 'asc');
     }
 }

--- a/src/Tags/Users.php
+++ b/src/Tags/Users.php
@@ -40,4 +40,9 @@ class Users extends Tags
 
         return $query;
     }
+
+    protected function defaultOrderBy()
+    {
+        return config('statamic.users.sort_field', 'email') . ':' . config('statamic.users.sort_direction', 'asc');
+    }
 }


### PR DESCRIPTION
This pull request introduces two new config options to Statamic's `users` config file, allowing developers to configure the default sort field & direction for the Users Listing Table.

At the moment, users are returned in ascending order by their `email`. However, it's possible that developers may wish users to be ordered by other fields like `last_login_at` instead.