### PR TITLE
[4.x] Fix Collection::computed docblock

### DIFF
--- a/src/Facades/Collection.php
+++ b/src/Facades/Collection.php
@@ -15,7 +15,7 @@ use Statamic\Contracts\Entries\CollectionRepository;
  * @method static bool handleExists(string $handle)
  * @method static \Illuminate\Support\Collection whereStructured()
  * @method static \Illuminate\Support\Collection getComputedCallbacks(string $collection)
- * @method static void computed(string $collection, string $field, \Closure $callback)
+ * @method static void computed(string|array $scopes, string $field, \Closure $callback)
  *
  * @see \Illuminate\Support\Collection
  * @see \Statamic\Entries\Collection


### PR DESCRIPTION
If using named parameters, the Collection Facade has a wrong docblock. It's `$scopes`, not `$collection`. It also accepts arrays.