### PR TITLE
[5.x] Cache mounted collections

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -450,6 +450,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
         Facades\Collection::save($this);
 
         Blink::forget('collection-handles');
+        Blink::forget('mounted-collections');
         Blink::flushStartingWith("collection-{$this->id()}");
 
         if ($isNew) {
@@ -734,6 +735,8 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
         Facades\Collection::delete($this);
 
         CollectionDeleted::dispatch($this);
+
+        Blink::forget('mounted-collections');
 
         return true;
     }

--- a/src/Stache/Repositories/CollectionRepository.php
+++ b/src/Stache/Repositories/CollectionRepository.php
@@ -46,16 +46,11 @@ class CollectionRepository implements RepositoryContract
             return null;
         }
 
-        return $this->mountedCollections()->get($mount->id());
-    }
-
-    private function mountedCollections(): IlluminateCollection
-    {
         return Blink::once('mounted-collections', fn () => $this
             ->all()
             ->keyBy(fn ($collection) => $collection->mount()?->id())
             ->filter()
-        );
+        )->get($mount->id());
     }
 
     public function make(?string $handle = null): Collection

--- a/src/Stache/Repositories/CollectionRepository.php
+++ b/src/Stache/Repositories/CollectionRepository.php
@@ -35,6 +35,15 @@ class CollectionRepository implements RepositoryContract
         return $this->findByHandle($id);
     }
 
+    protected function mountedCollections(): IlluminateCollection
+    {
+        return Blink::once('mounted-collections', function () {
+            return $this->all()->keyBy(function ($collection) {
+                return $collection->mount()?->id();
+            })->filter();
+        });
+    }
+
     public function findByHandle($handle): ?Collection
     {
         return $this->store->getItem($handle);
@@ -46,9 +55,7 @@ class CollectionRepository implements RepositoryContract
             return null;
         }
 
-        return $this->all()->first(function ($collection) use ($mount) {
-            return optional($collection->mount())->id() === $mount->id();
-        });
+        return $this->mountedCollections()->get($mount->id());
     }
 
     public function make(?string $handle = null): Collection

--- a/src/Stache/Repositories/CollectionRepository.php
+++ b/src/Stache/Repositories/CollectionRepository.php
@@ -35,15 +35,6 @@ class CollectionRepository implements RepositoryContract
         return $this->findByHandle($id);
     }
 
-    protected function mountedCollections(): IlluminateCollection
-    {
-        return Blink::once('mounted-collections', function () {
-            return $this->all()->keyBy(function ($collection) {
-                return $collection->mount()?->id();
-            })->filter();
-        });
-    }
-
     public function findByHandle($handle): ?Collection
     {
         return $this->store->getItem($handle);
@@ -56,6 +47,15 @@ class CollectionRepository implements RepositoryContract
         }
 
         return $this->mountedCollections()->get($mount->id());
+    }
+
+    private function mountedCollections(): IlluminateCollection
+    {
+        return Blink::once('mounted-collections', function () {
+            return $this->all()->keyBy(function ($collection) {
+                return $collection->mount()?->id();
+            })->filter();
+        });
     }
 
     public function make(?string $handle = null): Collection

--- a/src/Stache/Repositories/CollectionRepository.php
+++ b/src/Stache/Repositories/CollectionRepository.php
@@ -51,11 +51,11 @@ class CollectionRepository implements RepositoryContract
 
     private function mountedCollections(): IlluminateCollection
     {
-        return Blink::once('mounted-collections', function () {
-            return $this->all()->keyBy(function ($collection) {
-                return $collection->mount()?->id();
-            })->filter();
-        });
+        return Blink::once('mounted-collections', fn () => $this
+            ->all()
+            ->keyBy(fn ($collection) => $collection->mount()?->id())
+            ->filter()
+        );
     }
 
     public function make(?string $handle = null): Collection

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -477,6 +477,7 @@ class CollectionTest extends TestCase
         Facades\Collection::shouldReceive('save')->with($collection)->once();
         Facades\Collection::shouldReceive('handleExists')->with('test')->once();
         Facades\Blink::shouldReceive('forget')->with('collection-handles')->once();
+        Facades\Blink::shouldReceive('forget')->with('mounted-collections')->once();
         Facades\Blink::shouldReceive('flushStartingWith')->with('collection-test')->once();
 
         $return = $collection->save();


### PR DESCRIPTION
This PR refactors the `findByMount` method to use a cached mapping of mount ids and collection instances.