### PR TITLE
[4.x] Fix bug in deleting users in the CP controller

### DIFF
--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -303,10 +303,6 @@ class UsersController extends CpController
     {
         throw_unless($user = User::find($user), new NotFoundHttpException);
 
-        if (! $user = User::find($user)) {
-            return $this->pageNotFound();
-        }
-
         $this->authorize('delete', $user);
 
         $user->delete();


### PR DESCRIPTION
Fix a bug in the destroy method of the UsersController, it was trying to get $user twice so the second call was throwing a stache error as its no longer a string.