### PR TITLE
[4.x] Upgrade `maennchen/zipstream-php` to `^3.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "league/commonmark": "^2.2",
         "league/csv": "^9.0",
         "league/glide": "^1.1 || ^2.0",
-        "maennchen/zipstream-php": "^2.2",
+        "maennchen/zipstream-php": "^3.1",
         "michelf/php-smartypants": "^1.8.1",
         "nesbot/carbon": "^2.62.1",
         "pixelfear/composer-dist-plugin": "^0.1.4",


### PR DESCRIPTION
Upgrade **maennchen/zipstream-php** package to enable compatibility with Statamic CMS and other up-to-date packages, avoiding conflicts:

Especially for example the project is using the latest spatie/laravel-medialibrary package which required to use
```
"maennchen/zipstream-php": "^3.1",
```

In that case we couldn't use **"^2.2"** for Statamic CMS.