### PR TITLE
[4.x] Add preventEntryCreation option to collections

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -63,6 +63,7 @@ return [
     'collections_mount_instructions' => 'Choose an entry on which this collection should be mounted. Learn more in the [documentation](https://statamic.dev/collections-and-entries#mounting).',
     'collections_orderable_instructions' => 'Enable manual ordering via drag & drop.',
     'collections_past_date_behavior_instructions' => 'How past dated entries should behave.',
+    'collections_prevent_entry_creation_instructions' => 'Should it be possible to add new entries to this collection?',
     'collections_preview_targets_instructions' => 'The URLs to be viewable within Live Preview. Learn more in the [documentation](https://statamic.dev/live-preview#preview-targets).',
     'collections_route_instructions' => 'The route controls entries URL pattern. Learn more in the [documentation](https://statamic.dev/collections#routing).',
     'collections_sort_direction_instructions' => 'The default sort direction.',

--- a/resources/views/collections/empty.blade.php
+++ b/resources/views/collections/empty.blade.php
@@ -24,6 +24,7 @@
                 <p>{{ __('statamic::messages.collection_next_steps_configure_description') }}</p>
             </div>
         </a>
+        @if (! $collection->preventEntryCreation())
         <?php $multipleBlueprints = $collection->entryBlueprints()->count() > 1 ?>
         @if ($multipleBlueprints)<div
         @else<a href="{{ cp_route('collections.entries.create', [$collection->handle(), $site]) }}"
@@ -44,6 +45,7 @@
                 @endif
             </div>
         @if ($multipleBlueprints)</div>@else</a>@endif
+        @endif
         <a href="{{ cp_route('collections.blueprints.index', $collection->handle()) }}" class="w-full lg:w-1/2 p-4 flex items-start hover:bg-gray-200 rounded-md group">
             <div class="h-8 w-8 mr-4 text-gray-800">
                 @cp_svg('icons/light/blueprint')

--- a/resources/views/collections/show.blade.php
+++ b/resources/views/collections/show.blade.php
@@ -8,7 +8,7 @@
         title="{{ $collection->title() }}"
         handle="{{ $collection->handle() }}"
         breadcrumb-url="{{ cp_route('collections.index') }}"
-        :can-create="@can('create', ['Statamic\Contracts\Entries\Entry', $collection]) true @else false @endcan"
+        :can-create="@can('create', ['Statamic\Contracts\Entries\Entry', $collection]) @if ($collection->preventEntryCreation()) false @else true @endif @else false @endcan"
         :create-urls='@json($createUrls)'
         create-label="{{ $collection->createLabel() }}"
         :blueprints='@json($blueprints)'

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -53,6 +53,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
     protected $positions;
     protected $defaultPublishState = true;
     protected $originBehavior = 'select';
+    protected $preventEntryCreation = false;
     protected $futureDateBehavior = 'public';
     protected $pastDateBehavior = 'public';
     protected $structure;
@@ -508,6 +509,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
             'past_date_behavior' => $this->pastDateBehavior(),
             'future_date_behavior' => $this->futureDateBehavior(),
             'default_publish_state' => $this->defaultPublishState,
+            'prevent_entry_creation' => $this->preventEntryCreation,
             'sites' => $this->sites,
             'propagate' => $this->propagate(),
             'template' => $this->template,
@@ -611,6 +613,16 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
             ->fluentlyGetOrSet('pastDateBehavior')
             ->getter(function ($behavior) {
                 return $behavior ?? 'public';
+            })
+            ->args(func_get_args());
+    }
+
+    public function preventEntryCreation($preventEntryCreation = null)
+    {
+        return $this
+            ->fluentlyGetOrSet('preventEntryCreation')
+            ->getter(function ($prevent) {
+                return $prevent ?? false;
             })
             ->args(func_get_args());
     }

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -509,7 +509,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
             'past_date_behavior' => $this->pastDateBehavior(),
             'future_date_behavior' => $this->futureDateBehavior(),
             'default_publish_state' => $this->defaultPublishState,
-            'prevent_entry_creation' => $this->preventEntryCreation,
+            'prevent_entry_creation' => $this->preventEntryCreation ?: null,
             'sites' => $this->sites,
             'propagate' => $this->propagate(),
             'template' => $this->template,

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -332,6 +332,10 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
     {
         $isNew = is_null(Facades\Entry::find($this->id()));
 
+        if ($isNew && $this->collection()->preventEntryCreation()) {
+            return false;
+        }
+
         $withEvents = $this->withEvents;
         $this->withEvents = true;
 

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -153,6 +153,7 @@ class CollectionsController extends CpController
             'taxonomies' => $collection->taxonomies()->map->handle()->all(),
             'revisions' => $collection->revisionsEnabled(),
             'default_publish_state' => $collection->defaultPublishState(),
+            'prevent_entry_creation' => $collection->preventEntryCreation(),
             'template' => $collection->template(),
             'layout' => $collection->layout(),
             'sites' => $collection->sites()->all(),
@@ -232,6 +233,7 @@ class CollectionsController extends CpController
             ->template($values['template'])
             ->layout($values['layout'])
             ->defaultPublishState($values['default_publish_state'])
+            ->preventEntryCreation($values['prevent_entry_creation'])
             ->sortDirection($values['sort_direction'])
             ->mount($values['mount'] ?? null)
             ->revisionsEnabled($values['revisions'] ?? false)
@@ -428,6 +430,11 @@ class CollectionsController extends CpController
                     'default_publish_state' => [
                         'display' => __('Publish by Default'),
                         'instructions' => __('statamic::messages.collections_default_publish_state_instructions'),
+                        'type' => 'toggle',
+                    ],
+                    'prevent_entry_creation' => [
+                        'display' => __('Prevent new entries from being created'),
+                        'instructions' => __('statamic::messages.collections_prevent_entry_creation_instructions'),
                         'type' => 'toggle',
                     ],
                     'template' => [

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -275,6 +275,10 @@ class EntriesController extends CpController
             return $response;
         }
 
+        if ($collection->preventEntryCreation()) {
+            throw new \Exception(__('Entries cannot be created on this collection.'));
+        }
+
         $blueprint = $collection->entryBlueprint($request->blueprint);
 
         if (! $blueprint) {

--- a/src/Http/Controllers/CP/Navigation/NavigationTreeController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationTreeController.php
@@ -61,6 +61,7 @@ class NavigationTreeController extends CpController
     private function updateData(array $data, Blueprint $blueprint)
     {
         collect($data)->each(function ($branch, $id) use ($blueprint) {
+            dd($branch);
             $data = $blueprint->fields()
                 ->addValues($branch['values'] ?? [])
                 ->process()
@@ -72,6 +73,8 @@ class NavigationTreeController extends CpController
                 $this->generatedIds[$id] = $newId;
                 $id = $newId;
             }
+
+            dd($data);
 
             $this->data[$id] = Arr::removeNullValues([
                 'id' => $id,

--- a/src/Http/Controllers/CP/Navigation/NavigationTreeController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationTreeController.php
@@ -61,7 +61,6 @@ class NavigationTreeController extends CpController
     private function updateData(array $data, Blueprint $blueprint)
     {
         collect($data)->each(function ($branch, $id) use ($blueprint) {
-            dd($branch);
             $data = $blueprint->fields()
                 ->addValues($branch['values'] ?? [])
                 ->process()
@@ -73,8 +72,6 @@ class NavigationTreeController extends CpController
                 $this->generatedIds[$id] = $newId;
                 $id = $newId;
             }
-
-            dd($data);
 
             $this->data[$id] = Arr::removeNullValues([
                 'id' => $id,

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -51,6 +51,7 @@ class CollectionsStore extends BasicStore
             ->searchIndex(array_get($data, 'search_index'))
             ->revisionsEnabled(array_get($data, 'revisions', false))
             ->defaultPublishState($this->getDefaultPublishState($data))
+            ->preventEntryCreation(array_get($data, 'prevent_entry_creation', false))
             ->originBehavior(array_get($data, 'origin_behavior', 'select'))
             ->structureContents(array_get($data, 'structure'))
             ->sortField(array_get($data, 'sort_by'))

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -1575,6 +1575,22 @@ class EntryTest extends TestCase
     }
 
     /** @test */
+    public function if_collection_prevents_entry_creation_it_does_not_save()
+    {
+        Facades\Entry::spy();
+        Event::fake([EntryCreated::class]);
+
+        $collection = tap(Collection::make('test')->preventEntryCreation(true))->save();
+        $entry = (new Entry)->collection($collection);
+
+        $return = $entry->save();
+
+        $this->assertFalse($return);
+        Facades\Entry::shouldNotHaveReceived('save');
+        Event::assertNotDispatched(EntryCreated::class);
+    }
+
+    /** @test */
     public function it_adds_propagated_entry_to_structure()
     {
         Event::fake();


### PR DESCRIPTION
This PR adds a new `preventEntryCreation()` option to the Collection content model, allowing for collections where new entries cannot be added.

This can be useful if your content is of a fixed quantity (eg a country list) or if it is being created by an API, eg in the Shopify add on "Products" come via a Shopify web hook. With this option enabled on the Products collection, we could ensure that no new products are added through the UI which can cause data issues. 

I've ensured they cant be added through the UI or by the API, so in the Shopify add-on case we would need to programatically disable this setting before saving a new product, then re-enable it after save.