### PR TITLE
[5.x] Clone the date in `modifyDate` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1543,7 +1543,7 @@ class CoreModifiers extends Modifier
      */
     public function modifyDate($value, $params)
     {
-        return $this->carbon($value)->modify(Arr::get($params, 0));
+        return $this->carbon($value)->copy()->modify(Arr::get($params, 0));
     }
 
     /**


### PR DESCRIPTION
This pull request calls `->clone()` on the Carbon instance in the `modifyDate` modifier before it does any date modifying, so the original date instance doesn't change.

This change was initially PR'd by @jaygeorge in #9101. This PR just copies the over to the `master` branch, for v5. 

Related: #9100