### PR TITLE
[4.x] Fix queue worker state issue around assets

### DIFF
--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -294,7 +294,11 @@ class AssetContainerContents
             $this->add($dir);
         }
 
-        $this->all()->put($path, $metadata);
+        $files = $this->all()->put($path, $metadata);
+
+        if (Statamic::isWorker()) {
+            Cache::put($this->key(), $files, $this->ttl());
+        }
 
         $this->filteredFiles = null;
         $this->filteredDirectories = null;


### PR DESCRIPTION
This PR resolves an issue where the `AssetContainerContents` are not updated when creating an asset in a job. 

I tried to submit a failing test but gave up after half a day and three different approaches. I just can't get a test going that reproduces the issue. So I went ahead and created a sample repo with a detailed explanation: https://github.com/aerni/statamic-assets-cache-bug

The fix appears to be quite simple.

I found a couple of related PRs: 
- https://github.com/statamic/cms/pull/6726
- https://github.com/statamic/cms/pull/7467