### PR TITLE
[5.x] Orders Staches indexes; uses index order to optimize some sorts

### DIFF
--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -31,7 +31,7 @@ class Site implements Augmentable
 
     public function locale()
     {
-        return $this->config['locale'];
+        return $this->config['locale'] ?? null;
     }
 
     public function shortLocale()

--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -3,6 +3,7 @@
 namespace Statamic\Stache\Indexes;
 
 use Illuminate\Support\Facades\Cache;
+use Statamic\Facades\Compare;
 use Statamic\Facades\Stache;
 use Statamic\Statamic;
 
@@ -104,8 +105,20 @@ abstract class Index
         return Cache::has($this->cacheKey());
     }
 
+    protected function orderIndex()
+    {
+        // Order all indexes in ascending order. If we want
+        // a descending sort later, we can reverse the
+        // keys after doing our index comparisons.
+        uasort($this->items, function ($a, $b) {
+            return Compare::values($a, $b);
+        });
+    }
+
     public function cache()
     {
+        $this->orderIndex();
+
         Cache::forever($this->cacheKey(), $this->items);
     }
 

--- a/src/Stache/Query/EntryQueryBuilder.php
+++ b/src/Stache/Query/EntryQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Stache\Query;
 
+use Illuminate\Support\Str;
 use Statamic\Contracts\Entries\QueryBuilder;
 use Statamic\Entries\EntryCollection;
 use Statamic\Facades;
@@ -11,6 +12,13 @@ class EntryQueryBuilder extends Builder implements QueryBuilder
     use QueriesTaxonomizedEntries;
 
     protected $collections;
+
+    protected function prepareKeysForOptimizedSort($keys)
+    {
+        return $keys->map(function ($value) {
+            return Str::after($value, '::');
+        })->combine($keys);
+    }
 
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {

--- a/src/Stache/Query/TermQueryBuilder.php
+++ b/src/Stache/Query/TermQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Stache\Query;
 
+use Illuminate\Support\Str;
 use Statamic\Facades;
 use Statamic\Facades\Collection;
 use Statamic\Taxonomies\TermCollection;
@@ -10,6 +11,13 @@ class TermQueryBuilder extends Builder
 {
     protected $taxonomies;
     protected $collections;
+
+    protected function prepareKeysForOptimizedSort($keys)
+    {
+        return $keys->map(function ($value) {
+            return Str::after($value, '::');
+        })->combine($keys);
+    }
 
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {

--- a/tests/Auth/UserGroupTest.php
+++ b/tests/Auth/UserGroupTest.php
@@ -68,7 +68,7 @@ class UserGroupTest extends TestCase
 
         $userB->addToGroup($group)->save();
         $this->assertCount(2, $group->users());
-        $this->assertSame([$userA, $userB], $group->users()->all());
+        $this->assertSame([$userB, $userA], $group->users()->all());
         $this->assertTrue($group->hasUser($userA));
         $this->assertTrue($group->hasUser($userB));
     }

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -511,7 +511,7 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertCount(2, $entries);
         $this->assertEquals(['Post 1', 'Post 5'], $entries->map->title->all());
 
-        $entries = Entry::query()->where('content->value', '<>', 1)->get();
+        $entries = Entry::query()->where('content->value', '<>', 1)->orderBy('title')->get();
 
         $this->assertCount(5, $entries);
         $this->assertEquals(['Post 2', 'Post 3', 'Post 4', 'Post 6', 'Post 7'], $entries->map->title->all());
@@ -719,17 +719,17 @@ class EntryQueryBuilderTest extends TestCase
                 ->create();
         });
 
-        $this->assertEquals($expected, Entry::query()->where('title', 'like', $like)->get()->map->title->all());
+        $this->assertEquals($expected, Entry::query()->where('title', 'like', $like)->orderBy('title')->get()->map->title->all());
     }
 
     public static function likeProvider()
     {
         return collect([
             'foo' => ['foo'],
-            'foo%' => ['foo', 'food', 'foo bar', 'foo_bar', 'foodbar'],
+            'foo%' => ['foo', 'foo bar', 'foo_bar', 'food', 'foodbar'],
             '%world' => ['hello world', 'waterworld'],
             '%world%' => ['hello world', 'waterworld', 'world of warcraft'],
-            '_oo' => ['foo', 'boo'],
+            '_oo' => ['boo', 'foo'],
             'o_' => ['on'],
             'foo_bar' => ['foo bar', 'foo_bar', 'foodbar'],
             'foo__bar' => [],

--- a/tests/Data/Taxonomies/TermQueryBuilderTest.php
+++ b/tests/Data/Taxonomies/TermQueryBuilderTest.php
@@ -21,8 +21,8 @@ class TermQueryBuilderTest extends TestCase
     public function it_gets_terms()
     {
         Site::setConfig(['sites' => [
-            'en' => ['url' => '/'],
-            'fr' => ['url' => '/fr/'],
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR'],
         ]]);
 
         Taxonomy::make('tags')->sites(['en', 'fr'])->save();
@@ -83,7 +83,7 @@ class TermQueryBuilderTest extends TestCase
         Term::make('d')->taxonomy('tags')->data(['test' => 'foo'])->save();
         Term::make('e')->taxonomy('tags')->data(['test' => 'raz'])->save();
 
-        $terms = Term::query()->whereIn('test', ['foo', 'bar'])->orWhereIn('test', ['foo', 'raz'])->get();
+        $terms = Term::query()->whereIn('test', ['foo', 'bar'])->orWhereIn('test', ['foo', 'raz'])->orderBy('slug')->get();
 
         $this->assertEquals(['a', 'b', 'd', 'e'], $terms->map->slug()->values()->all());
     }

--- a/tests/Data/Users/UserQueryBuilderTest.php
+++ b/tests/Data/Users/UserQueryBuilderTest.php
@@ -34,10 +34,10 @@ class UserQueryBuilderTest extends TestCase
         User::make()->email('aragorn@precious.com')->data(['name' => 'Aragorn'])->save();
         User::make()->email('bombadil@precious.com')->data(['name' => 'Tommy'])->save();
 
-        $users = User::query()->whereIn('name', ['Gandalf', 'Frodo'])->orWhereIn('name', ['Gandalf', 'Aragorn', 'Tommy'])->get();
+        $users = User::query()->whereIn('name', ['Gandalf', 'Frodo'])->orWhereIn('name', ['Gandalf', 'Aragorn', 'Tommy'])->orderBy('name')->get();
 
         $this->assertCount(4, $users);
-        $this->assertEquals(['Gandalf', 'Frodo', 'Aragorn', 'Tommy'], $users->map->name->all());
+        $this->assertEquals(['Aragorn', 'Frodo', 'Gandalf', 'Tommy'], $users->map->name->all());
     }
 
     /** @test **/
@@ -53,7 +53,7 @@ class UserQueryBuilderTest extends TestCase
         $users = User::query()->whereNotIn('name', ['Gandalf', 'Frodo'])->orWhereNotIn('name', ['Gandalf', 'Sauron'])->get();
 
         $this->assertCount(3, $users);
-        $this->assertEquals(['Smeagol', 'Aragorn', 'Tommy'], $users->map->name->all());
+        $this->assertEquals(['Aragorn', 'Smeagol', 'Tommy'], $users->map->name->all());
     }
 
     /** @test **/
@@ -119,17 +119,19 @@ class UserQueryBuilderTest extends TestCase
 
         $users = User::query()
             ->where('content->value', 1)
+            ->orderBy('name')
             ->get();
 
         $this->assertCount(2, $users);
-        $this->assertEquals(['Gandalf', 'Aragorn'], $users->map->name->all());
+        $this->assertEquals(['Aragorn', 'Gandalf'], $users->map->name->all());
 
         $users = User::query()
             ->where('content->value', '<>', 1)
+            ->orderBy('name', 'desc')
             ->get();
 
         $this->assertCount(6, $users);
-        $this->assertEquals(['Smeagol', 'Frodo', 'Tommy', 'Sauron', 'Arwen', 'Bilbo'], $users->map->name->all());
+        $this->assertEquals(['Tommy', 'Smeagol', 'Sauron', 'Frodo', 'Bilbo', 'Arwen'], $users->map->name->all());
     }
 
     /** @test **/
@@ -225,7 +227,7 @@ class UserQueryBuilderTest extends TestCase
         $userTwo->addToGroup($groupOne)->save();
         $userThree->addToGroup($groupTwo)->save();
 
-        $users = User::query()->whereGroup('one')->get();
+        $users = User::query()->whereGroup('one')->orderBy('name')->get();
 
         $this->assertCount(2, $users);
         $this->assertEquals(['Gandalf', 'Smeagol'], $users->map->name->all());
@@ -302,7 +304,7 @@ class UserQueryBuilderTest extends TestCase
         $userTwo->assignRole($roleOne)->save();
         $userThree->assignRole($roleTwo)->save();
 
-        $users = User::query()->whereRole('one')->get();
+        $users = User::query()->whereRole('one')->orderBy('name')->get();
 
         $this->assertCount(2, $users);
         $this->assertEquals(['Gandalf', 'Smeagol'], $users->map->name->all());

--- a/tests/Feature/GraphQL/TermsTest.php
+++ b/tests/Feature/GraphQL/TermsTest.php
@@ -100,8 +100,8 @@ GQL;
                 ['id' => 'tags::bravo', 'title' => 'Tag Bravo'],
                 ['id' => 'categories::alpha', 'title' => 'Category Alpha'],
                 ['id' => 'categories::bravo', 'title' => 'Category Bravo'],
-                ['id' => 'sizes::small', 'title' => 'Size Small'],
                 ['id' => 'sizes::large', 'title' => 'Size Large'],
+                ['id' => 'sizes::small', 'title' => 'Size Small'],
             ]]]]);
     }
 
@@ -272,8 +272,8 @@ GQL;
             ->assertExactJson(['data' => ['terms' => ['data' => [
                 ['id' => 'categories::alpha', 'title' => 'Category Alpha'],
                 ['id' => 'categories::bravo', 'title' => 'Category Bravo'],
-                ['id' => 'sizes::small', 'title' => 'Size Small'],
                 ['id' => 'sizes::large', 'title' => 'Size Large'],
+                ['id' => 'sizes::small', 'title' => 'Size Small'],
             ]]]]);
     }
 
@@ -327,8 +327,8 @@ GQL;
             ->assertExactJson(['data' => ['terms' => ['data' => [
                 ['id' => 'tags::alpha', 'foo' => 'FOO!'],
                 ['id' => 'tags::bravo', 'bar' => 'BAR!'],
-                ['id' => 'sizes::small', 'shorthand' => 'sm'],
                 ['id' => 'sizes::large', 'shorthand' => 'lg'],
+                ['id' => 'sizes::small', 'shorthand' => 'sm'],
             ]]]]);
     }
 

--- a/tests/Feature/GraphQL/UsersTest.php
+++ b/tests/Feature/GraphQL/UsersTest.php
@@ -220,7 +220,7 @@ GQL;
             contains: "rad",
             ends_with: "!"
         }
-    }) {
+    }, sort: "id") {
         data {
             id
             bio

--- a/tests/Feature/Taxonomies/TermEntriesTest.php
+++ b/tests/Feature/Taxonomies/TermEntriesTest.php
@@ -139,9 +139,9 @@ class TermEntriesTest extends TestCase
         $this->assertEquals(['rouge-shirt'], Term::find('colors::red')->in('fr')->entries()->map->slug()->all());
 
         $this->assertEquals(2, Term::find('colors::black')->in('en')->entriesCount());
-        $this->assertEquals(['panther', 'black-shirt'], Term::find('colors::black')->in('en')->entries()->map->slug()->all());
+        $this->assertEquals(['black-shirt', 'panther'], Term::find('colors::black')->in('en')->entries()->map->slug()->sort()->values()->all());
         $this->assertEquals(2, Term::find('colors::black')->in('fr')->entriesCount());
-        $this->assertEquals(['panthere', 'noir-shirt'], Term::find('colors::black')->in('fr')->entries()->map->slug()->all());
+        $this->assertEquals(['noir-shirt', 'panthere'], Term::find('colors::black')->in('fr')->entries()->map->slug()->sort()->values()->all());
 
         $this->assertEquals(1, Term::find('colors::yellow')->in('en')->entriesCount());
         $this->assertEquals(['cheetah'], Term::find('colors::yellow')->in('en')->entries()->map->slug()->all());
@@ -151,13 +151,13 @@ class TermEntriesTest extends TestCase
         // and for the base Term class, it should not filter by locale
 
         $this->assertEquals(2, Term::find('colors::red')->term()->entriesCount());
-        $this->assertEquals(['red-shirt', 'rouge-shirt'], Term::find('colors::red')->term()->entries()->map->slug()->all());
+        $this->assertEquals(['red-shirt', 'rouge-shirt'], Term::find('colors::red')->term()->entries()->map->slug()->sort()->values()->all());
 
         $this->assertEquals(4, Term::find('colors::black')->term()->entriesCount());
-        $this->assertEquals(['panther', 'panthere', 'black-shirt', 'noir-shirt'], Term::find('colors::black')->term()->entries()->map->slug()->all());
+        $this->assertEquals(['black-shirt', 'noir-shirt', 'panther', 'panthere'], Term::find('colors::black')->term()->entries()->map->slug()->sort()->values()->all());
 
         $this->assertEquals(2, Term::find('colors::yellow')->term()->entriesCount());
-        $this->assertEquals(['cheetah', 'guepard'], Term::find('colors::yellow')->term()->entries()->map->slug()->all());
+        $this->assertEquals(['cheetah', 'guepard'], Term::find('colors::yellow')->term()->entries()->map->slug()->sort()->values()->all());
     }
 
     /** @test */
@@ -233,16 +233,16 @@ class TermEntriesTest extends TestCase
         $this->assertEquals([], Term::find('colors::red')->collection($animals)->term()->entries()->map->slug()->all());
 
         $this->assertEquals(2, Term::find('colors::black')->collection($animals)->term()->entriesCount());
-        $this->assertEquals(['panther', 'panthere'], Term::find('colors::black')->collection($animals)->term()->entries()->map->slug()->all());
+        $this->assertEquals(['panther', 'panthere'], Term::find('colors::black')->collection($animals)->term()->entries()->map->slug()->sort()->values()->all());
 
         $this->assertEquals(2, Term::find('colors::yellow')->collection($animals)->term()->entriesCount());
-        $this->assertEquals(['cheetah', 'guepard'], Term::find('colors::yellow')->collection($animals)->term()->entries()->map->slug()->all());
+        $this->assertEquals(['cheetah', 'guepard'], Term::find('colors::yellow')->collection($animals)->term()->entries()->map->slug()->sort()->values()->all());
 
         $this->assertEquals(2, Term::find('colors::red')->collection($clothes)->term()->entriesCount());
-        $this->assertEquals(['red-shirt', 'rouge-shirt'], Term::find('colors::red')->collection($clothes)->term()->entries()->map->slug()->all());
+        $this->assertEquals(['red-shirt', 'rouge-shirt'], Term::find('colors::red')->collection($clothes)->term()->entries()->map->slug()->sort()->values()->all());
 
         $this->assertEquals(2, Term::find('colors::black')->collection($clothes)->term()->entriesCount());
-        $this->assertEquals(['black-shirt', 'noir-shirt'], Term::find('colors::black')->collection($clothes)->term()->entries()->map->slug()->all());
+        $this->assertEquals(['black-shirt', 'noir-shirt'], Term::find('colors::black')->collection($clothes)->term()->entries()->map->slug()->sort()->values()->all());
 
         $this->assertEquals(0, Term::find('colors::yellow')->collection($clothes)->term()->entriesCount());
         $this->assertEquals([], Term::find('colors::yellow')->collection($clothes)->term()->entries()->map->slug()->all());


### PR DESCRIPTION
This PR imposes an order on all Stache indexes. When ordering keys for query results, the base Builder will determine if it can leverage a Stache index to perform the sort, resulting in a substantial performance improvement (most notably in the Control Panel when sorting on indexed columns). This optimization only applies to sorting on a single column at the moment.

Challenges:

- [ ] Sorting while updating indexing is very intensive (Comparator/Strings bottlenecking)
- [ ] Maintaining two separate indexes (one for the actual values, and a "hidden" one to contain the values to maintain sort) seems like overkill