### PR TITLE
[5.x] Adjust sorting and comparison implementations

### DIFF
--- a/src/Data/DataCollection.php
+++ b/src/Data/DataCollection.php
@@ -41,21 +41,28 @@ class DataCollection extends IlluminateCollection
         }
 
         $sorts = explode('|', $sort);
+        $preparedSorts = [];
+
+        foreach ($sorts as $sort) {
+            $bits = explode(':', $sort);
+            $sortBy = $bits[0];
+            $sortDir = $bits[1] ?? null;
+
+            $preparedSorts[$sortBy] = $sortDir === 'desc';
+        }
 
         $arr = $this->all();
 
-        uasort($arr, function ($a, $b) use ($sorts) {
-            foreach ($sorts as $sort) {
-                $bits = explode(':', $sort);
-                $sort_by = $bits[0];
-                $sort_dir = array_get($bits, 1);
+        $comparator = Compare::getFacadeRoot();
 
-                [$one, $two] = $this->getSortableValues($sort_by, $a, $b);
+        uasort($arr, function ($a, $b) use ($comparator, $preparedSorts) {
+            foreach ($preparedSorts as $sortBy => $sortDir) {
+                [$one, $two] = $this->getSortableValues($sortBy, $a, $b);
 
-                $result = Compare::values($one, $two);
+                $result = $comparator->values($one, $two);
 
                 if ($result !== 0) {
-                    return ($sort_dir === 'desc') ? $result * -1 : $result;
+                    return ($sortDir === true) ? $result * -1 : $result;
                 }
             }
 

--- a/src/Support/Comparator.php
+++ b/src/Support/Comparator.php
@@ -8,10 +8,16 @@ use Statamic\Facades\Site;
 class Comparator
 {
     protected $locale;
+    protected static $hasCheckedCollator = false;
+    protected static $canUseCollator = false;
 
     public function __construct()
     {
         $this->locale = Site::current()->locale();
+
+        if (! self::$hasCheckedCollator) {
+            self::$canUseCollator = class_exists(Collator::class);
+        }
     }
 
     public function locale($locale)
@@ -85,10 +91,10 @@ class Comparator
      */
     public function strings(string $one, string $two): int
     {
-        $one = Str::lower($one);
-        $two = Str::lower($two);
+        $one = mb_strtolower($one);
+        $two = mb_strtolower($two);
 
-        if (! class_exists(Collator::class)) {
+        if (! self::$canUseCollator) {
             return strcmp($one, $two);
         }
 

--- a/src/Support/Comparator.php
+++ b/src/Support/Comparator.php
@@ -8,14 +8,13 @@ use Statamic\Facades\Site;
 class Comparator
 {
     protected $locale;
-    protected static $hasCheckedCollator = false;
-    protected static $canUseCollator = false;
+    private static bool $canUseCollator;
 
     public function __construct()
     {
         $this->locale = Site::current()->locale();
 
-        if (! self::$hasCheckedCollator) {
+        if (! isset(self::$canUseCollator)) {
             self::$canUseCollator = class_exists(Collator::class);
         }
     }


### PR DESCRIPTION
This PR makes adjustments to the sorting and comparison implementation. For the multisort implementation itself, it prepares the sort column and direction outside of the `uasort` callback to reduce the number of `explode` calls. Additionally, it resolves the `Compare` instance once from the service container and reuses it.

For the Comparator, it moves the `class_exists(Collator::class)` call out of the `strings` method. The `Str::lower` calls were also refactored to just `mb_strtolower`.

These combined changes reduced control panel load times by ~ 1.5-2 seconds for 20K+ entries.