### PR TITLE
[5.x] Add ability to specify which Stache stores to warm

### DIFF
--- a/src/Console/Commands/StacheWarm.php
+++ b/src/Console/Commands/StacheWarm.php
@@ -11,7 +11,7 @@ class StacheWarm extends Command
 {
     use RunsInPlease;
 
-    protected $signature = 'statamic:stache:warm';
+    protected $signature = 'statamic:stache:warm {store?}';
     protected $description = 'Build the "Stache" cache';
 
     public function handle()
@@ -20,7 +20,11 @@ class StacheWarm extends Command
 
         $this->line('Please wait. This may take a while if you have a lot of content.');
 
-        Stache::warm();
+        if ($stores = $this->argument('store')) {
+            $stores = collect(explode(',', $stores))->map(fn ($store) => trim($store))->all();
+        }
+
+        Stache::warm($stores ?? []);
 
         $this->info('You have poured oil over the Stache and polished it until it shines. It is warm and ready');
     }

--- a/src/Facades/Stache.php
+++ b/src/Facades/Stache.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string generateId()
  * @method static self clear()
  * @method static void refresh()
- * @method static void warm()
+ * @method static void warm($stores = [])
  * @method static self instance()
  * @method static mixed fileCount()
  * @method static mixed|null fileSize()

--- a/src/Stache/Stache.php
+++ b/src/Stache/Stache.php
@@ -98,7 +98,7 @@ class Stache
         return $this->clear()->warm();
     }
 
-    public function warm()
+    public function warm($stores = [])
     {
         Partyline::comment('Warming Stache...');
 
@@ -106,7 +106,13 @@ class Stache
 
         $this->startTimer();
 
-        $this->stores()->each->warm();
+        $this->stores()->where(function ($store, $key) use ($stores) {
+            if (count($stores) == 0) {
+                return true;
+            }
+
+            return in_array($key, $stores);
+        })->each->warm();
 
         $this->stopTimer();
 


### PR DESCRIPTION
This PR adds the ability to specify which Stache store to warm. It can be used like so:

Warm all stores:

```bash
php please stache: warm
```

Warm a single store:

```bash
php please stache:warm global-variables
```

Warm a set of stores:

```bash
php please stache:warm globals,global-variables
```