### PR TITLE
[4.x] Ensure submission values take precedence over globals data

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -208,7 +208,7 @@ class Email extends Mailable
         return collect($config)->map(function ($value) {
             $value = Parse::env($value); // deprecated
 
-            return (string) Antlers::parse($value, array_merge($this->submissionData, $this->getGlobalsData()));
+            return (string) Antlers::parse($value, array_merge($this->getGlobalsData(), $this->submissionData));
         });
     }
 }


### PR DESCRIPTION
This pull request makes it so submission values take precedence over global set values when using Antlers variables in form email configurations.

In the case of #9696, since global sets called `global` don't need name-spacing and the global set had an `email` field, it conflicted with the `email` field present in the form submission.

Fixes #9696.
Related: https://github.com/statamic/cms/pull/8892 and eacf874.