### PR TITLE
[4.x] Fix "Create Entry" button on collection widget in multisite

### DIFF
--- a/resources/views/widgets/collection.blade.php
+++ b/resources/views/widgets/collection.blade.php
@@ -1,3 +1,5 @@
+@php use Statamic\Facades\Site; @endphp
+
 <div class="card p-0 overflow-hidden h-full">
     <div class="flex justify-between items-center p-4">
         <h2>
@@ -11,7 +13,7 @@
         @can('create', ['Statamic\Contracts\Entries\Entry', $collection])
         <create-entry-button
             button-class="btn-primary"
-            url="{{ $collection->createEntryUrl() }}"
+            url="{{ $collection->createEntryUrl(Site::selected()) }}"
             :blueprints="{{ $blueprints->toJson() }}"
             text="{{ $button }}"></create-entry-button>
         @endcan


### PR DESCRIPTION
This pull request fixes an issue where the "Create Entry" button on the collection widget in a multi-site install would always result in the entry being created in the "default" site, rather than the currently selected site.

Fixes #9678.