### PR TITLE
[5.x] Upgrade to Zipstream 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "league/commonmark": "^2.2",
         "league/csv": "^9.0",
         "league/glide": "^2.0",
-        "maennchen/zipstream-php": "^2.2",
+        "maennchen/zipstream-php": "^3.1",
         "michelf/php-smartypants": "^1.8.1",
         "nesbot/carbon": "^2.62.1",
         "pixelfear/composer-dist-plugin": "^0.1.4",

--- a/src/Actions/Concerns/MakesZips.php
+++ b/src/Actions/Concerns/MakesZips.php
@@ -3,18 +3,19 @@
 namespace Statamic\Actions\Concerns;
 
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use ZipStream\Option\Archive;
 use ZipStream\ZipStream;
 
 trait MakesZips
 {
     protected function makeZip($name, $files)
     {
-        $options = new Archive;
-        $options->setZeroHeader(true);
-        $options->setSendHttpHeaders(true);
+        $zip = new ZipStream(
+            outputName: $name,
+            defaultEnableZeroHeader: true,
+            sendHttpHeaders: true,
+        );
 
-        return tap(new ZipStream($name, $options), function ($zip) use ($files) {
+        return tap($zip, function ($zip) use ($files) {
             $files->each(fn ($stream, $path) => $zip->addFileFromStream($path, $stream));
         });
     }


### PR DESCRIPTION
This pull request upgrades the `maennchen/zipstream-php` package to v3, making the necessary code changes. 

Closes #9680.
Replaces #9679.