### PR TITLE
[5.x] Ensure structured collections are ordered by `order` by default

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -150,7 +150,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
             ->getter(function ($sortField) {
                 if ($sortField) {
                     return $sortField;
-                } elseif ($this->orderable()) {
+                } elseif ($this->orderable() || $this->hasStructure()) {
                     return 'order';
                 } elseif ($this->dated()) {
                     return 'date';

--- a/tests/Data/Entries/CollectionTest.php
+++ b/tests/Data/Entries/CollectionTest.php
@@ -434,10 +434,10 @@ class CollectionTest extends TestCase
         $this->assertNull($datedAndOrdered->customSortDirection());
 
         $alpha->structureContents(['max_depth' => 99]);
-        $this->assertEquals('title', $alpha->sortField());
+        $this->assertEquals('order', $alpha->sortField());
         $this->assertEquals('asc', $alpha->sortDirection());
         $dated->structureContents(['max_depth' => 99]);
-        $this->assertEquals('date', $dated->sortField());
+        $this->assertEquals('order', $dated->sortField());
         $this->assertEquals('desc', $dated->sortDirection());
 
         // Custom sort field and direction should override any other logic.


### PR DESCRIPTION
This pull request tweaks the logic in the `Collection@sortField` method so that by default, "structured collections" are ordered using the `order` field, instead of the `title` field.

We already default "orderable collections" (so, ordered collections where max depth = 1) to `order`, so that makes it true of "structured collections" too.

Closes #9429.
Related: #8810