### PR TITLE
[4.x] Fix broken navigation tree

### DIFF
--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -43,7 +43,7 @@
                     :is-open="page.open"
                     :has-children="page.children.length > 0"
                     :show-slugs="showSlugs"
-                    :show-blueprint="blueprints.length > 1"
+                    :show-blueprint="blueprints && blueprints.length > 1"
                     :editable="editable"
                     @edit="$emit('edit-page', page, vm, store, $event)"
                     @toggle-open="store.toggleOpen(page)"

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -43,7 +43,7 @@
                     :is-open="page.open"
                     :has-children="page.children.length > 0"
                     :show-slugs="showSlugs"
-                    :show-blueprint="blueprints && blueprints.length > 1"
+                    :show-blueprint="blueprints?.length > 1"
                     :editable="editable"
                     @edit="$emit('edit-page', page, vm, store, $event)"
                     @toggle-open="store.toggleOpen(page)"


### PR DESCRIPTION
This pull request fixes an issue where the navigation tree wouldn't load when attempting to edit a navigation, due to the `blueprints` prop not being passed in.

I've just ran into this myself after updating my site to the latest version.

Fixes #9708.
Caused by #9413.