### PR TITLE
[5.x] Use stable versions of Laravel 11 and Testbench 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,16 +78,6 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
-      - name: Install Laravel 11
-        uses: nick-invision/retry@v2
-        if: steps.should-run-tests.outputs.result == 'true' && matrix.laravel == '11.*'
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: |
-            composer config minimum-stability dev
-            composer config prefer-stable true
-
       - name: Install dependencies
         uses: nick-invision/retry@v2
         if: steps.should-run-tests.outputs.result == 'true'

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "google/cloud-translate": "^1.6",
         "laravel/pint": "^1.0",
         "mockery/mockery": "^1.3.3",
-        "orchestra/testbench": "^8.0 || ^9.x",
+        "orchestra/testbench": "^8.0 || ^9.0",
         "phpunit/phpunit": "^9.0 || ^10.0"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "google/cloud-translate": "^1.6",
         "laravel/pint": "^1.0",
         "mockery/mockery": "^1.3.3",
-        "orchestra/testbench": "^8.0 || ^9.x-dev",
+        "orchestra/testbench": "^8.0 || ^9.x",
         "phpunit/phpunit": "^9.0 || ^10.0"
     },
     "config": {


### PR DESCRIPTION
Waiting on https://github.com/orchestral/testbench to release 9.0

- [x] Laravel 11
- [x] Testbench 9 