### PR TITLE
[5.x] PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "laravel/pint": "^1.0",
         "mockery/mockery": "^1.3.3",
         "orchestra/testbench": "^8.0 || ^9.x-dev",
-        "phpunit/phpunit": "^9.0 || ^10.0"
+        "phpunit/phpunit": "^10.0"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
#9529 added support for PHPUnit 10, but kept 9 because we still needed it for older versions of Laravel.

Now that we've dropped Laravel 10, we can drop PHPUnit 9.
