### PR TITLE
[4.x] Fix CP OAuth login when using independent authentication guard

### DIFF
--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -28,7 +28,7 @@ class OAuthController
 
         session()->put('oauth-provider', $provider);
 
-        Auth::login($user, config('statamic.oauth.remember_me', true));
+        Auth::guard(config('statamic.users.guards.cp'))->login($user, config('statamic.oauth.remember_me', true));
 
         return redirect()->to($this->successRedirectUrl());
     }


### PR DESCRIPTION
Currently it is not possible to use the OAuth login when using an [independent authentication guard](https://statamic.dev/tips/using-an-independent-authentication-guard). 

The [OAuthController](https://github.com/statamic/cms/blob/4.x/src/Http/Controllers/OAuthController.php) always uses the default Laravel authentification guard defined in `auth.defaults.guard`, no matter what is defined in `statamic.users.guards.cp`.

This is because there is no guard defined in the OAuthController:

https://github.com/statamic/cms/blob/d08d2cde9e45ee6c3b7c962c14113d01af8053fe/src/Http/Controllers/OAuthController.php#L31

This pull request adds the guard defined in `auth.defaults.guard`.