### PR TITLE
[4.x] Fix "A field with a handle of X already exists" error when editing fieldsets

### DIFF
--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -68,7 +68,7 @@ class FieldsController extends CpController
             'handle' => [
                 function ($attribute, $value, $fail) use ($request) {
                     $existingFieldWithHandle = collect($request->fields ?? [])
-                        ->when($request->id, fn ($collection) => $collection->reject(fn ($field) => $field['_id'] === $request->id))
+                        ->when($request->has('id'), fn ($collection) => $collection->reject(fn ($field) => $field['_id'] === $request->id))
                         ->flatMap(function (array $field) {
                             if ($field['type'] === 'import') {
                                 return Fieldset::find($field['fieldset'])->fields()->all()->map->handle()->toArray();


### PR DESCRIPTION
This pull request fixes an issue when editing fieldsets where you'd run into this error message when applying changes to a field: "A field with the handle of ... already exists".

This validation message should only be displayed when there's already a field in the blueprint/fieldset with the same handle as the field you're applying.

For some reason, the code inside the `->when()` closure sometimes wasn't being called, meaning it wouldn't ignore the current field when looking at all fields for those with the same handle.

Fixes #9716.
Caused by #9337.