### PR TITLE
[4.x] Ensure pagination is always displayed at the bottom of collection widget

### DIFF
--- a/resources/js/components/entries/Widget.vue
+++ b/resources/js/components/entries/Widget.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="h-full">
         <div v-if="initializing" class="loading">
             <loading-graphic />
         </div>
@@ -11,6 +11,7 @@
             :sort="false"
             :sort-column="sortColumn"
             :sort-direction="sortDirection"
+            class="h-full flex flex-col justify-between"
         >
             <div slot-scope="{ }">
                 <data-list-table :loading="loading">

--- a/resources/views/widgets/collection.blade.php
+++ b/resources/views/widgets/collection.blade.php
@@ -1,6 +1,6 @@
 @php use Statamic\Facades\Site; @endphp
 
-<div class="card p-0 overflow-hidden h-full">
+<div class="card p-0 overflow-hidden h-full flex flex-col">
     <div class="flex justify-between items-center p-4">
         <h2>
             <a class="flex items-center" href="{{ $collection->showUrl() }}">


### PR DESCRIPTION
This pull request fixes an issue where the pagination wasn't always displaying at the bottom of the collection widget if there was another widget in the same row that was longer.

![CleanShot 2024-03-13 at 13 10 39](https://github.com/statamic/cms/assets/19637309/2d1659dd-4ff1-4f3b-b004-ff08c1097215)

Thanks to @robdekort for helping me with the fix.

Fixes #9439.