### PR TITLE
[4.x] Add @tags blade directive

### DIFF
--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -176,7 +176,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerBladeDirectives()
     {
         Blade::directive('tags', function ($expression) {
-            return "<?php extract(\Statamic\View\Blade\BladeTagsDirective::handle($expression)) ?>";
+            return "<?php extract(\Statamic\View\Blade\TagsDirective::handle($expression)) ?>";
         });
     }
 

--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -176,25 +176,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerBladeDirectives()
     {
         Blade::directive('tags', function ($expression) {
-            return "<?php
-                foreach (Arr::wrap($expression) as \$__key => \$__value) {
-                    if (is_array(\$__value) && in_array('tag', \$__value)) {
-                        \$__tag = \$__value['tag'];
-                        \$__params = \$__value['params'] ?? [];
-                    } else if (is_array(\$__value) && count(\$__value) == 1) {
-                        \$__tag = array_keys(\$__value)[0];
-                        \$__params = array_values(\$__value)[0];
-                    } else if (is_string(\$__value)) {
-                        \$__tag = \$__value;
-                        \$__params = [];
-                    } else {
-                        continue;
-                    }
-                    \$__varName = is_string(\$__key) ? \$__key : camel_case(str_replace(':', '_', \$__tag));
-                    \${\$__varName} = Statamic::tag(\$__tag)->params(\$__params)->fetch();
-                }
-                unset(\$__tag, \$__params, \$__varName, \$__key, \$__value);
-            ?>";
+            return "<?php extract(\Statamic\View\Blade\BladeTagsDirective::handle($expression)) ?>";
         });
     }
 

--- a/src/View/Blade/BladeTagsDirective.php
+++ b/src/View/Blade/BladeTagsDirective.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Statamic\View\Blade;
+
+use Illuminate\Support\Arr;
+use Statamic\Statamic;
+
+class BladeTagsDirective
+{
+    public static function handle($tags): array
+    {
+        $variables = [];
+
+        foreach (Arr::wrap($tags) as $key => $value) {
+            if (is_array($value) && count($value) > 0) {
+                $tag = array_keys($value)[0];
+                $params = array_values($value)[0];
+            } else if (is_string($value)) {
+                $tag = $value;
+                $params = [];
+            } else {
+                continue;
+            }
+
+            $varName = is_string($key) ? $key : camel_case(str_replace(':', '_', $tag));
+            $variables[$varName] = Statamic::tag($tag)->params($params)->fetch();
+        }
+
+        return $variables;
+    }
+}

--- a/src/View/Blade/TagsDirective.php
+++ b/src/View/Blade/TagsDirective.php
@@ -2,16 +2,14 @@
 
 namespace Statamic\View\Blade;
 
-use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Statamic\Statamic;
 
 class TagsDirective
 {
     public static function handle($tags): array
     {
-        $variables = [];
-
-        foreach (Arr::wrap($tags) as $key => $value) {
+        return Collection::wrap($tags)->mapWithKeys(function ($value, $key) {
             if (is_array($value) && count($value) > 0) {
                 $tag = array_keys($value)[0];
                 $params = array_values($value)[0];
@@ -20,10 +18,9 @@ class TagsDirective
                 $params = [];
             }
 
-            $varName = is_string($key) ? $key : camel_case(str_replace(':', '_', $tag));
-            $variables[$varName] = Statamic::tag($tag)->params($params)->fetch();
-        }
+            $var = is_string($key) ? $key : camel_case(str_replace(':', '_', $tag));
 
-        return $variables;
+            return [$var => Statamic::tag($tag)->params($params)->fetch()];
+        })->all();
     }
 }

--- a/src/View/Blade/TagsDirective.php
+++ b/src/View/Blade/TagsDirective.php
@@ -5,7 +5,7 @@ namespace Statamic\View\Blade;
 use Illuminate\Support\Arr;
 use Statamic\Statamic;
 
-class BladeTagsDirective
+class TagsDirective
 {
     public static function handle($tags): array
     {
@@ -15,11 +15,9 @@ class BladeTagsDirective
             if (is_array($value) && count($value) > 0) {
                 $tag = array_keys($value)[0];
                 $params = array_values($value)[0];
-            } else if (is_string($value)) {
+            } elseif (is_string($value)) {
                 $tag = $value;
                 $params = [];
-            } else {
-                continue;
             }
 
             $varName = is_string($key) ? $key : camel_case(str_replace(':', '_', $tag));

--- a/tests/View/Blade/TagsDirectiveTest.php
+++ b/tests/View/Blade/TagsDirectiveTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\View\Blade;
+
+use Statamic\Tags\Tags;
+use Statamic\View\Blade\TagsDirective;
+use Tests\TestCase;
+
+class TagsDirectiveTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        TheTag::register();
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider singleTagProvider
+     */
+    public function it_gets_single_tag($tag, $expected)
+    {
+        $variables = TagsDirective::handle($tag);
+
+        $this->assertEquals($expected, $variables);
+    }
+
+    public static function singleTagProvider()
+    {
+        return [
+            '1 part' => ['the_tag', ['theTag' => 'the index, foo: ']],
+            '2 parts' => ['the_tag:another_one', ['theTagAnotherOne' => 'another, baz: ']],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider singleTagWithAliasProvider
+     */
+    public function it_aliases_using_array($alias, $tag, $expected)
+    {
+        $variables = TagsDirective::handle([$alias => $tag]);
+
+        $this->assertEquals($expected, $variables);
+    }
+
+    public static function singleTagWithAliasProvider()
+    {
+        return [
+            '1 part' => ['myTag', 'the_tag', ['myTag' => 'the index, foo: ']],
+            '2 parts' => ['secondTag', 'the_tag:another_one', ['secondTag' => 'another, baz: ']],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider withParametersProvider
+     */
+    public function it_aliases_with_parameters($alias, $tag, $params, $expected)
+    {
+        $variables = TagsDirective::handle([
+            $alias => [$tag => $params],
+        ]);
+
+        $this->assertEquals($expected, $variables);
+    }
+
+    public static function withParametersProvider()
+    {
+        return [
+            '1 part' => ['myTag', 'the_tag', ['foo' => 'bar'],  ['myTag' => 'the index, foo: bar']],
+            '2 parts' => ['secondTag', 'the_tag:another_one', ['baz' => 'qux'], ['secondTag' => 'another, baz: qux']],
+        ];
+    }
+
+    /** @test */
+    public function it_supports_multiple_tags()
+    {
+        $variables = TagsDirective::handle([
+            'myTag' => ['the_tag' => ['foo' => 'bar']],
+            'anotherTag' => ['the_tag:another_one' => ['baz' => 'qux']],
+        ]);
+
+        $this->assertEquals([
+            'myTag' => 'the index, foo: bar',
+            'anotherTag' => 'another, baz: qux',
+        ], $variables);
+    }
+}
+
+class TheTag extends Tags
+{
+    public function index()
+    {
+        return 'the index, foo: '.$this->params->get('foo');
+    }
+
+    public function anotherOne()
+    {
+        return 'another, baz: '.$this->params->get('baz');
+    }
+}


### PR DESCRIPTION
When working on Statamic projects that use Blade, we often run into needing to use `Statamic::tag` a lot. With a small directive like this we can simplify our usage of that a good bit.

This directive can be used in the following way:

```blade
@tags(['collection:products', 'taxonomy:types'])
```

This will give you camelCased variables called `$collectionProducts` and `$taxonomyTypes` that can then be used in your blade file.

Some other ways to use this:


```blade
@tags('collection:products')
```
```blade
@tags([
    'products' => [
        'tag' => 'collection:products',
    ],
    'types' => [
        'tag' => 'taxonomy:types',
        'params' => ['color:is' => 'red'],
    ],
])
```
```blade
@tags([
    'products' => 'collection:products',
    'types' => ['taxonomy:types' => ['color:is' => 'red']],
])
```

I wasn't able to figure out a good way to set up tests for this unfortunately.