### PR TITLE
[4.x] Fix stacked grid margin-top styling

### DIFF
--- a/resources/js/components/fieldtypes/grid/Stacked.vue
+++ b/resources/js/components/fieldtypes/grid/Stacked.vue
@@ -21,8 +21,9 @@
         <div
             class="grid-stacked"
             :class="{
-                'mt-12': !grid.fullScreenMode && hideDisplay,
-                'mt-6': !grid.fullScreenMode && !hideDisplay,
+                'mt-0': !allowFullscreen && hideDisplay,
+                'mt-4': !hideDisplay,
+                'mt-10': allowFullscreen,
             }"
             slot-scope="{}"
         >

--- a/resources/js/components/publish/Field.vue
+++ b/resources/js/components/publish/Field.vue
@@ -15,7 +15,7 @@
                     v-text="__(labelText)"
                     v-tooltip="{content: config.handle, delay: 500, autoHide: false}"
                 />
-                <i class="required rtl:ml-1 ltr:mr-1" v-if="config.required">*</i>
+                <i class="required rtl:ml-1 ltr:mr-1" v-if="showLabelText && config.required">*</i>
                 <avatar v-if="isLocked" :user="lockingUser" class="w-4 rounded-full -mt-px rtl:mr-2 ltr:ml-2 rtl:ml-2 ltr:mr-2" v-tooltip="lockingUser.name" />
                 <span v-if="isReadOnly && !isTab && !isSection" class="text-gray-500 font-normal text-2xs rtl:ml-1 ltr:mr-1">
                     {{ isLocked ? __('Locked') : __('Read Only') }}


### PR DESCRIPTION
This PR builds on @duncanmcclean's https://github.com/statamic/cms/pull/9307 PR to fix more edge case styling issues around stacked grid rows...

- [x] Fix edge case margin-top styling issues around stacked grid rows.
  - With different combinations of `fullscreen` and `hide_display` configured on `stacked` grids
- [x] Also, if you take 🔪 decide to hide display label, hide the `required: true` asterisk `*` as well, since it's part of label, semantically speaking.
  - If you want to see the label, don't hide the label!

## Examples

Here are some screenshots showing what it looks like after my proposed changes...

### When showing both the display label & fullscreen button:

![CleanShot 2024-03-14 at 12 22 04](https://github.com/statamic/cms/assets/5187394/99784fe5-bc59-4cb2-a05b-3c21776e5ade)

### When hiding both the display label & fullscreen button:

_Note: this is the edge case I need fixed for https://github.com/statamic/cms/pull/9632_

![CleanShot 2024-03-14 at 12 22 34](https://github.com/statamic/cms/assets/5187394/fa946928-6b7c-409d-a8b1-64730053c3ed)
 
 ### When showing only the display label (with fullscreen button hidden):
  
![CleanShot 2024-03-14 at 12 24 29](https://github.com/statamic/cms/assets/5187394/5dea81d9-a67f-4b95-946a-2b3764184752)

### When showing only the fullscreen button (with display label hidden):

![CleanShot 2024-03-14 at 12 24 56](https://github.com/statamic/cms/assets/5187394/ba0d7e8d-4c16-4a85-8425-1124acae5047)