### PR TITLE
[5.x] Revert isApiRoute static property cache

### DIFF
--- a/src/Listeners/ClearState.php
+++ b/src/Listeners/ClearState.php
@@ -3,14 +3,12 @@
 namespace Statamic\Listeners;
 
 use Statamic\Facades\URL;
-use Statamic\Statamic;
 use Statamic\View\State\StateManager;
 
 class ClearState
 {
     public function handle()
     {
-        Statamic::clearApiRouteCache();
         StateManager::resetState();
         URL::clearExternalUrlCache();
     }

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -36,7 +36,6 @@ class Statamic
     protected static $jsonVariables = [];
     protected static $bootedCallbacks = [];
     protected static $afterInstalledCallbacks = [];
-    private static $isApiRouteCache;
 
     public static function version()
     {
@@ -213,22 +212,13 @@ class Statamic
         return $route;
     }
 
-    public static function clearApiRouteCache()
-    {
-        self::$isApiRouteCache = null;
-    }
-
     public static function isApiRoute()
     {
-        if (self::$isApiRouteCache !== null) {
-            return self::$isApiRouteCache;
-        }
-
         if (! config('statamic.api.enabled') || ! static::pro()) {
-            return self::$isApiRouteCache = false;
+            return false;
         }
 
-        return self::$isApiRouteCache = starts_with(request()->path(), config('statamic.api.route'));
+        return starts_with(request()->path(), config('statamic.api.route'));
     }
 
     public static function apiRoute($route, $params = [])


### PR DESCRIPTION
Reverts #9638, at least temporarily. Putting it in a static property is too heavy handed. It turns out it doesn't always get cleared, e.g. in some tests. The first time you call isApiRoute it'll get saved to the static property then it'll persist across all tests.
