### PR TITLE
[4.x] Improve locale preference selector

### DIFF
--- a/src/Preferences/CorePreferences.php
+++ b/src/Preferences/CorePreferences.php
@@ -77,7 +77,7 @@ class CorePreferences
             'tr' => 'Turkish',
             'zh_CN' => 'Chinese (China)',
             'zh_TW' => 'Chinese (Taiwan)',
-        ])->when(extension_loaded('intl'), fn ($locales) => $locales->mapWithKeys(function ($label, $locale) use ($current) {
+        ])->when(extension_loaded('intl'), fn ($locales) => $locales->map(function ($label, $locale) use ($current) {
             $label = Locale::getDisplayName($locale, $current);
             $native = Locale::getDisplayName($locale, $locale);
 
@@ -85,7 +85,7 @@ class CorePreferences
                 $label .= '<span class="ltr:ml-4 rtl:mr-4 text-gray-600">'.$native.'</span>';
             }
 
-            return [$locale => $label];
+            return $label;
         }))->all();
     }
 }

--- a/src/Preferences/CorePreferences.php
+++ b/src/Preferences/CorePreferences.php
@@ -14,6 +14,7 @@ class CorePreferences
             'instructions' => __('statamic::messages.preference_locale_instructions'),
             'clearable' => true,
             'options' => [
+                'cs' => 'Czech',
                 'da' => 'Danish',
                 'de' => 'German',
                 'de_CH' => 'German (Switzerland)',
@@ -24,6 +25,7 @@ class CorePreferences
                 'hu' => 'Hungarian',
                 'id' => 'Indonesian',
                 'it' => 'Italian',
+                'ja' => 'Japanese',
                 'ms' => 'Malay',
                 'nb' => 'Norwegian',
                 'nl' => 'Dutch',

--- a/src/Preferences/CorePreferences.php
+++ b/src/Preferences/CorePreferences.php
@@ -77,15 +77,20 @@ class CorePreferences
             'tr' => 'Turkish',
             'zh_CN' => 'Chinese (China)',
             'zh_TW' => 'Chinese (Taiwan)',
-        ])->when(extension_loaded('intl'), fn ($locales) => $locales->map(function ($label, $locale) use ($current) {
-            $label = Locale::getDisplayName($locale, $current);
-            $native = Locale::getDisplayName($locale, $locale);
+        ])->when(extension_loaded('intl'), fn ($locales) => $locales
+            ->map(fn ($label, $locale) => [
+                'label' => Locale::getDisplayName($locale, $current),
+                'native' => Locale::getDisplayName($locale, $locale),
+            ])
+            ->sortBy('native', SORT_NATURAL | SORT_FLAG_CASE)
+            ->map(function ($item, $locale) use ($current) {
+                ['label' => $label, 'native' => $native] = $item;
 
-            if ($locale !== $current && $label !== $native) {
-                $label .= '<span class="ltr:ml-4 rtl:mr-4 text-gray-600">'.$native.'</span>';
-            }
+                if ($locale !== $current && $label !== $native) {
+                    $label .= '<span class="ltr:ml-4 rtl:mr-4 text-gray-600">'.$native.'</span>';
+                }
 
-            return $label;
-        }))->all();
+                return $label;
+            }))->all();
     }
 }

--- a/src/Preferences/CorePreferences.php
+++ b/src/Preferences/CorePreferences.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Preferences;
 
+use Locale;
 use Statamic\Facades\Preference;
+use Statamic\Statamic;
 
 class CorePreferences
 {
@@ -13,32 +15,8 @@ class CorePreferences
             'display' => __('Locale'),
             'instructions' => __('statamic::messages.preference_locale_instructions'),
             'clearable' => true,
-            'options' => [
-                'cs' => 'Czech',
-                'da' => 'Danish',
-                'de' => 'German',
-                'de_CH' => 'German (Switzerland)',
-                'en' => 'English',
-                'es' => 'Spanish',
-                'fa' => 'Persian',
-                'fr' => 'French',
-                'hu' => 'Hungarian',
-                'id' => 'Indonesian',
-                'it' => 'Italian',
-                'ja' => 'Japanese',
-                'ms' => 'Malay',
-                'nb' => 'Norwegian',
-                'nl' => 'Dutch',
-                'pl' => 'Polish',
-                'pt' => 'Portuguese',
-                'pt_BR' => 'Portuguese (Brazil)',
-                'ru' => 'Russian',
-                'sl' => 'Slovenian',
-                'sv' => 'Swedish',
-                'tr' => 'Turkish',
-                'zh_CN' => 'Chinese (China)',
-                'zh_TW' => 'Chinese (Taiwan)',
-            ],
+            'label_html' => true,
+            'options' => $this->localeOptions(),
         ]);
 
         Preference::register('start_page', [
@@ -68,5 +46,46 @@ class CorePreferences
                 ],
             ],
         ]);
+    }
+
+    private function localeOptions(): array
+    {
+        $current = Statamic::cpLocale();
+
+        return collect([
+            'cs' => 'Czech',
+            'da' => 'Danish',
+            'de' => 'German',
+            'de_CH' => 'German (Switzerland)',
+            'en' => 'English',
+            'es' => 'Spanish',
+            'fa' => 'Persian',
+            'fr' => 'French',
+            'hu' => 'Hungarian',
+            'id' => 'Indonesian',
+            'it' => 'Italian',
+            'ja' => 'Japanese',
+            'ms' => 'Malay',
+            'nb' => 'Norwegian',
+            'nl' => 'Dutch',
+            'pl' => 'Polish',
+            'pt' => 'Portuguese',
+            'pt_BR' => 'Portuguese (Brazil)',
+            'ru' => 'Russian',
+            'sl' => 'Slovenian',
+            'sv' => 'Swedish',
+            'tr' => 'Turkish',
+            'zh_CN' => 'Chinese (China)',
+            'zh_TW' => 'Chinese (Taiwan)',
+        ])->when(extension_loaded('intl'), fn ($locales) => $locales->mapWithKeys(function ($label, $locale) use ($current) {
+            $label = Locale::getDisplayName($locale, $current);
+            $native = Locale::getDisplayName($locale, $locale);
+
+            if ($locale !== $current && $label !== $native) {
+                $label .= '<span class="ltr:ml-4 rtl:mr-4 text-gray-600">'.$native.'</span>';
+            }
+
+            return [$locale => $label];
+        }))->all();
     }
 }


### PR DESCRIPTION
When the `Intl` extension is enabled, the dropdown options will be displayed in the appropriate languages. For example, the language name will also be displayed in the native language as hints:

![CleanShot 2024-03-15 at 10 49 00](https://github.com/statamic/cms/assets/105211/db0ca45b-abea-4b77-96f1-41c240a2f51f)

If you have the CP currently set to another language, the labels will be in your language:

![CleanShot 2024-03-15 at 10 51 20](https://github.com/statamic/cms/assets/105211/6c459432-2a21-4253-b1a9-5221fe6008a3)

It also works with non-latin alphabets and RTL languages:

![CleanShot 2024-03-15 at 10 53 51](https://github.com/statamic/cms/assets/105211/43bd3924-a3ba-4594-b577-a9d82aa3fbd1)

When the `Intl` extension is _not_ installed, you get the plain English options like would before this PR:

![CleanShot 2024-03-15 at 10 54 40](https://github.com/statamic/cms/assets/105211/0d2907c7-8346-4062-aa35-a34a0e0f2da5)

Additionally, we have Czech and Japanese translations but they were missing from this dropdown, so they've been added.
