### PR TITLE
[4.x] Replace Mix paths with Vite paths in `starter-kit.yaml` stub

### DIFF
--- a/src/Console/Commands/stubs/starter-kits/starter-kit.yaml.stub
+++ b/src/Console/Commands/stubs/starter-kits/starter-kit.yaml.stub
@@ -5,8 +5,7 @@
 #   - resources/blueprints
 #   - resources/css/site.css
 #   - resources/views
-#   - public/assets
-#   - public/css
+#   - public/build
 #   - package.json
 #   - tailwind.config.js
-#   - webpack.mix.js
+#   - vite.config.js


### PR DESCRIPTION
We switched from Laravel Mix to Vite in `statamic/statamic` a while back. 

However, I noticed that the `starter-kit.yaml` stub still had Laravel Mix paths in it, so I've replaced them with Vite paths, so there's one less thing that needs tweaked when exporting your starter kit.