### PR TITLE
[4.x] Throw exception from `whereCollection`/`whereTaxonomy` methods when collection/taxonomies don't exist

### DIFF
--- a/src/Stache/Repositories/EntryRepository.php
+++ b/src/Stache/Repositories/EntryRepository.php
@@ -6,7 +6,9 @@ use Statamic\Contracts\Entries\Entry;
 use Statamic\Contracts\Entries\EntryRepository as RepositoryContract;
 use Statamic\Contracts\Entries\QueryBuilder;
 use Statamic\Entries\EntryCollection;
+use Statamic\Exceptions\CollectionNotFoundException;
 use Statamic\Exceptions\EntryNotFoundException;
+use Statamic\Facades\Collection;
 use Statamic\Stache\Query\EntryQueryBuilder;
 use Statamic\Stache\Stache;
 use Statamic\Support\Arr;
@@ -31,11 +33,19 @@ class EntryRepository implements RepositoryContract
 
     public function whereCollection(string $handle): EntryCollection
     {
+        if (! Collection::find($handle)) {
+            throw new CollectionNotFoundException($handle);
+        }
+
         return $this->query()->where('collection', $handle)->get();
     }
 
     public function whereInCollection(array $handles): EntryCollection
     {
+        collect($handles)
+            ->reject(fn ($collection) => Collection::find($collection))
+            ->each(fn ($collection) => throw new CollectionNotFoundException($collection));
+
         return $this->query()->whereIn('collection', $handles)->get();
     }
 

--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -4,6 +4,7 @@ namespace Statamic\Stache\Repositories;
 
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Contracts\Taxonomies\TermRepository as RepositoryContract;
+use Statamic\Exceptions\TaxonomyNotFoundException;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Taxonomy;
 use Statamic\Stache\Query\TermQueryBuilder;
@@ -32,11 +33,19 @@ class TermRepository implements RepositoryContract
 
     public function whereTaxonomy(string $handle): TermCollection
     {
+        if (! Taxonomy::find($handle)) {
+            throw new TaxonomyNotFoundException($handle);
+        }
+
         return $this->query()->where('taxonomy', $handle)->get();
     }
 
     public function whereInTaxonomy(array $handles): TermCollection
     {
+        collect($handles)
+            ->reject(fn ($taxonomy) => Taxonomy::find($taxonomy))
+            ->each(fn ($taxonomy) => throw new TaxonomyNotFoundException($taxonomy));
+
         return $this->query()->whereIn('taxonomy', $handles)->get();
     }
 


### PR DESCRIPTION
This pull request makes a very small developer experience to the `Entry::whereCollection` and `Term::whereTaxonomy` methods where an exception will be thrown if the collection / taxonomy passed into the method does not exist. 

This PR does the same for the `whereInCollection`/`whereInTaxonomy` equivalents, where it'll loop through all the handles passed in and check if they exist. 

Closes statamic/ideas#1058.