### PR TITLE
[5.x] Adjust broadcasting enabled check for Laravel 11

### DIFF
--- a/src/Providers/BroadcastServiceProvider.php
+++ b/src/Providers/BroadcastServiceProvider.php
@@ -34,7 +34,7 @@ class BroadcastServiceProvider extends ServiceProvider
     protected function enabled()
     {
         return in_array(
-            \App\Providers\BroadcastServiceProvider::class,
+            \Illuminate\Broadcasting\BroadcastServiceProvider::class,
             array_keys($this->app->getLoadedProviders())
         );
     }


### PR DESCRIPTION
This pull request changes how we determine if Laravel's [broadcasting](https://laravel.com/docs/master/broadcasting#main-content) feature is enabled in order to be compatible with projects using the new Laravel 11 application structure.

Previously, we were checking if the `App\Providers\BroadcastServiceProvider` was uncommented in the user's `config/app.php` file.

However, with Laravel 11's new application structure, developers don't need to uncomment the service provider, instead they run `install:broadcasting` to install the relevant pieces.

After some testing, I've discovered that in both Laravel 10 and 11, with and without the new structure, that Laravel's own `BroadcastServiceProvider` is *also* being loaded, so we can check for that being loaded instead.