### PR TITLE
[4.x] Allow slashes in comb search queries

### DIFF
--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -379,7 +379,7 @@ class Comb
      */
     private function preformat($raw_query)
     {
-        return trim(mb_ereg_replace("[^\w\d\-\.:+\s@&’'‘]", '', $raw_query));
+        return trim(mb_ereg_replace("[^\w\d\-\.:+\s\\\/@&’'‘]", '', $raw_query));
     }
 
     /**

--- a/tests/Search/CombTest.php
+++ b/tests/Search/CombTest.php
@@ -222,6 +222,32 @@ EOT;
         $this->assertSame(1, $result['info']['total_results']);
     }
 
+    /**
+     * @test
+     **/
+    public function it_can_search_for_slashes()
+    {
+        $comb = new Comb([
+            ['content' => 'Cont\ent'],
+            ['content' => 'Cont/ent'],
+        ]);
+
+        $result = $comb->lookUp('\\');
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertSame(1, $result['info']['total_results']);
+
+        $result = $comb->lookUp('/');
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertSame(1, $result['info']['total_results']);
+
+        $result = $comb->lookUp('Cont\\e');
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertSame(1, $result['info']['total_results']);
+    }
+
     public static function searchesProvider()
     {
         return [


### PR DESCRIPTION
This PR adds slashes to the allowable characters in a Comb search query.

Closes https://github.com/statamic/cms/issues/9674
Closes https://github.com/statamic/cms/issues/4743