### PR TITLE
[4.x] Enable configuration of static cache file and directory permissions

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -37,6 +37,10 @@ return [
             'driver' => 'file',
             'path' => public_path('static'),
             'lock_hold_length' => 0,
+            'permissions' => [
+                'directory' => 0755,
+                'file' => 0644,
+            ],
         ],
 
     ],
@@ -124,20 +128,4 @@ return [
     */
 
     'warm_queue' => null,
-
-    /*
-    |--------------------------------------------------------------------------
-    | Permissions
-    |--------------------------------------------------------------------------
-    |
-    | If you are using full static caching you can specify the permissions
-    | applied to directories and files created
-    |
-    */
-
-    'permissions' => [
-        'directory' => 0755,
-        'file' => 0644,
-    ],
-
 ];

--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -125,4 +125,19 @@ return [
 
     'warm_queue' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Permissions
+    |--------------------------------------------------------------------------
+    |
+    | If you are using full static caching you can specify the permissions
+    | applied to directories and files created
+    |
+    */
+
+    'permissions' => [
+        'directory' => 0755,
+        'file' => 0644,
+    ],
+
 ];

--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -128,4 +128,5 @@ return [
     */
 
     'warm_queue' => null,
+
 ];

--- a/src/StaticCaching/Cachers/Writer.php
+++ b/src/StaticCaching/Cachers/Writer.php
@@ -7,6 +7,16 @@ use Statamic\Facades\Folder;
 
 class Writer
 {
+    private $permissions = [
+        'file' => 0644,
+        'directory' => 0755,
+    ];
+
+    public function __construct($permissions = [])
+    {
+        $this->permissions = array_merge($this->permissions, $permissions);
+    }
+
     /**
      * Write the cache file to disk.
      *
@@ -17,7 +27,7 @@ class Writer
      */
     public function write($path, $content, $lockFor = 0)
     {
-        @mkdir(dirname($path), config('statamic.static_caching.permissions.directory', 0755), true);
+        @mkdir(dirname($path), $this->permissions['directory'], true);
 
         // Create the file handle. We use the "c" mode which will avoid writing an
         // empty file if we abort when checking the lock status in the next step.
@@ -31,7 +41,7 @@ class Writer
         }
 
         fwrite($handle, $content);
-        chmod($path, config('statamic.static_caching.permissions.file', 0644));
+        chmod($path, $this->permissions['file']);
 
         // Hold the file lock for a moment to prevent other processes from trying to write the same file.
         sleep($lockFor);

--- a/src/StaticCaching/Cachers/Writer.php
+++ b/src/StaticCaching/Cachers/Writer.php
@@ -17,7 +17,7 @@ class Writer
      */
     public function write($path, $content, $lockFor = 0)
     {
-        @mkdir(dirname($path), 0777, true);
+        @mkdir(dirname($path), config('statamic.static_caching.permissions.directory', 0755), true);
 
         // Create the file handle. We use the "c" mode which will avoid writing an
         // empty file if we abort when checking the lock status in the next step.
@@ -31,7 +31,7 @@ class Writer
         }
 
         fwrite($handle, $content);
-        chmod($path, 0777);
+        chmod($path, config('statamic.static_caching.permissions.file', 0644));
 
         // Hold the file lock for a moment to prevent other processes from trying to write the same file.
         sleep($lockFor);

--- a/src/StaticCaching/Cachers/Writer.php
+++ b/src/StaticCaching/Cachers/Writer.php
@@ -14,7 +14,6 @@ class Writer
 
     /**
      * @param  array  $permissions  An array of file and directory umask permissions
-     * @return self
      */
     public function __construct(array $permissions = [])
     {

--- a/src/StaticCaching/Cachers/Writer.php
+++ b/src/StaticCaching/Cachers/Writer.php
@@ -7,12 +7,16 @@ use Statamic\Facades\Folder;
 
 class Writer
 {
-    private $permissions = [
+    private array $permissions = [
         'file' => 0644,
         'directory' => 0755,
     ];
 
-    public function __construct($permissions = [])
+    /**
+     * @param  array  $permissions  An array of file and directory umask permissions
+     * @return self
+     */
+    public function __construct(array $permissions = [])
     {
         $this->permissions = array_merge($this->permissions, $permissions);
     }

--- a/src/StaticCaching/StaticCacheManager.php
+++ b/src/StaticCaching/StaticCacheManager.php
@@ -31,7 +31,7 @@ class StaticCacheManager extends Manager
 
     public function createFileDriver(array $config)
     {
-        return new FileCacher(new Writer, $this->cacheStore(), $config);
+        return new FileCacher(new Writer($config['permissions'] ?? []), $this->cacheStore(), $config);
     }
 
     public function createApplicationDriver(array $config)


### PR DESCRIPTION
This PR provides new configuration keys for the permissions with which to write static caching files and directories.

This also reduces the default permissions inline with what you'd expect based on Flysystem. See https://github.com/thephpleague/flysystem/blob/b25a361508c407563b34fac6f64a8a17a8819675/src/UnixVisibility/PortableVisibilityConverter.php#L13-L15

Closes https://github.com/statamic/cms/issues/9480