### PR TITLE
[5.x] Reduce failure rate of Arr::shuffle() tests

### DIFF
--- a/tests/Support/Concerns/TestsIlluminateArr.php
+++ b/tests/Support/Concerns/TestsIlluminateArr.php
@@ -831,24 +831,29 @@ trait TestsIlluminateArr
         $this->assertEquals([1 => 'hAz'], Arr::set($array, 1, 'hAz'));
     }
 
-    public function testShuffle()
+    public function testShuffleProducesDifferentShuffles()
     {
-        $input = ['a', 'b', 'c', 'd', 'e', 'f'];
+        $input = range('a', 'z');
 
-        $this->assertNotEquals(
-            $input,
-            Arr::shuffle($input)
+        $this->assertFalse(
+            Arr::shuffle($input) === Arr::shuffle($input) && Arr::shuffle($input) === Arr::shuffle($input),
+            "The shuffles produced the same output each time, which shouldn't happen."
         );
+    }
 
-        $this->assertNotEquals(
-            Arr::shuffle($input),
-            Arr::shuffle($input)
+    public function testShuffleActuallyShuffles()
+    {
+        $input = range('a', 'z');
+
+        $this->assertFalse(
+            Arr::shuffle($input) === $input && Arr::shuffle($input) === $input,
+            "The shuffles were unshuffled each time, which shouldn't happen."
         );
     }
 
     public function testShuffleKeepsSameValues()
     {
-        $input = ['a', 'b', 'c', 'd', 'e', 'f'];
+        $input = range('a', 'z');
         $shuffled = Arr::shuffle($input);
         sort($shuffled);
 


### PR DESCRIPTION
We have a copy of Laravel's Arr tests to ensure that our Arr class works properly.
This PR updates the `Arr::shuffle()` tests to reduce failure rates. See https://github.com/laravel/framework/pull/49769 
