### PR TITLE
[5.x] Laravel Reverb support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "fuse.js": "^3.4.6",
         "highlight.js": "^11.7.0",
         "imask": "^6.6.0-alpha.0",
-        "laravel-echo": "^1.6.1",
+        "laravel-echo": "^1.16.0",
         "lowlight": "^2.8.1",
         "marked": "^4.0.10",
         "marked-plaintext": "0.0.2",
@@ -7640,9 +7640,9 @@
       }
     },
     "node_modules/laravel-echo": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/laravel-echo/-/laravel-echo-1.15.0.tgz",
-      "integrity": "sha512-q5YaEw2NFu9xra6sYUfh/FX2YotN5iY1nMeKz90J3W3Vpa+5WjK3/DYeEzkTfBZz8Oq1Dv9vWNE4IUvt7kxYIg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/laravel-echo/-/laravel-echo-1.16.0.tgz",
+      "integrity": "sha512-BJGUa4tcKvYmTkzTmcBGMHiO2tq+k7Do5wPmLbRswWfzKwyfZEUR+J5iwBTPEfLLwNPZlA9Kjo6R/NV6pmyIpg==",
       "engines": {
         "node": ">=10"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "fuse.js": "^3.4.6",
     "highlight.js": "^11.7.0",
     "imask": "^6.6.0-alpha.0",
-    "laravel-echo": "^1.6.1",
+    "laravel-echo": "^1.16.0",
     "lowlight": "^2.8.1",
     "marked": "^4.0.10",
     "marked-plaintext": "0.0.2",

--- a/resources/js/components/Echo.js
+++ b/resources/js/components/Echo.js
@@ -19,10 +19,7 @@ class Echo {
 
     start() {
         let config = {
-            broadcaster: 'pusher',
-            key: Statamic.$config.get('broadcasting.pusher.key'),
-            cluster: Statamic.$config.get('broadcasting.pusher.cluster'),
-            encrypted: Statamic.$config.get('broadcasting.pusher.encrypted'),
+            ...Statamic.$config.get('broadcasting.options'),
             csrfToken: Statamic.$config.get('csrfToken'),
             authEndpoint: Statamic.$config.get('broadcasting.endpoint'),
         };

--- a/src/Providers/BroadcastServiceProvider.php
+++ b/src/Providers/BroadcastServiceProvider.php
@@ -17,17 +17,34 @@ class BroadcastServiceProvider extends ServiceProvider
 
     protected function variables()
     {
-        return [
-            'enabled' => true,
-            'endpoint' => $this->authEndpoint(),
-            'pusher' => [
+        $options = [];
+
+        if (config('broadcasting.default') === 'pusher') {
+            $options = [
+                'broadcaster' => 'pusher',
                 'key' => config('broadcasting.connections.pusher.key'),
                 'cluster' => config('broadcasting.connections.pusher.options.cluster'),
                 'encrypted' => config('broadcasting.connections.pusher.options.encrypted'),
-                'scheme' => config('broadcasting.connections.pusher.options.scheme'),
-                'host' => config('broadcasting.connections.pusher.options.host'),
-                'port' => config('broadcasting.connections.pusher.options.port'),
-            ],
+            ];
+        }
+
+        if (config('broadcasting.default') === 'reverb') {
+            $options = [
+                'broadcaster' => 'reverb',
+                'key' => config('broadcasting.connections.reverb.key'),
+                'wsHost' => config('broadcasting.connections.reverb.options.host'),
+                'wsPort' => config('broadcasting.connections.reverb.options.port', 80),
+                'wssPort' => config('broadcasting.connections.reverb.options.port', 443),
+                'forceTLS' => config('broadcasting.connections.reverb.options.useTLS'),
+                'enabledTransports' => ['ws', 'wss'],
+            ];
+        }
+
+        return [
+            'enabled' => true,
+            'endpoint' => $this->authEndpoint(),
+            'connection' => config('broadcasting.default'),
+            'options' => $options,
         ];
     }
 


### PR DESCRIPTION
This pull request introduces support for [Laravel Reverb](https://laravel.com/docs/11.x/reverb), a self-hosted WebSockets server provided by a first-party Laravel package.

Previously, Statamic only supported using Pusher as a broadcasting driver so our Echo implementation was hardcoded to use Pusher (although, you could override it in JavaScript if you wanted). 

In adding support for Laravel Reverb, we've moved the generation of the Echo config into our `BroadcastServiceProvider` so we can easily return different config options depending on the `BROADCAST_CONNECTION` configured in your `.env`.