### PR TITLE
[4.x] Fix field locking user avatar size

### DIFF
--- a/resources/js/components/publish/Field.vue
+++ b/resources/js/components/publish/Field.vue
@@ -16,7 +16,7 @@
                     v-tooltip="{content: config.handle, delay: 500, autoHide: false}"
                 />
                 <i class="required rtl:ml-1 ltr:mr-1" v-if="showLabelText && config.required">*</i>
-                <avatar v-if="isLocked" :user="lockingUser" class="w-4 rounded-full -mt-px rtl:mr-2 ltr:ml-2 rtl:ml-2 ltr:mr-2" v-tooltip="lockingUser.name" />
+                <avatar v-if="isLocked" :user="lockingUser" class="w-6 h-6 rounded-full -mt-px rtl:mr-2 ltr:ml-2 rtl:ml-2 ltr:mr-2" v-tooltip="lockingUser.name" />
                 <span v-if="isReadOnly && !isTab && !isSection" class="text-gray-500 font-normal text-2xs rtl:ml-1 ltr:mr-1">
                     {{ isLocked ? __('Locked') : __('Read Only') }}
                 </span>


### PR DESCRIPTION
This pull request fixes an issue where the "locking user" avatar isn't being displayed correctly. This PR tweaks the classes so they are the same as the avatars displayed at the top of the entry publish form.

![image](https://github.com/statamic/cms/assets/19637309/5d902cd7-455f-4d34-97b5-12088dbcb2dc)

Fixes statamic/collaboration#84.