### PR TITLE
[4.x] Enable pro fix and improvements

### DIFF
--- a/src/Console/Commands/ProEnable.php
+++ b/src/Console/Commands/ProEnable.php
@@ -46,10 +46,13 @@ class ProEnable extends Command
             $this->checkInfo('Statamic editions config successfully updated to reference .env var!');
         }
 
-        if (! $this->configReferencingEnv()) {
-            $this->crossLine('Statamic editions config not currently referencing .env var.');
+        if ($this->option('update-config') && ! $this->configReferencingEnv()) {
+            $this->crossLine('Could not reliably update editions config to reference .env var!');
             $this->comment(PHP_EOL.'For this setting to take effect, please modify your [config/statamic/editions.php] as follows:');
             $this->line("'pro' => env('STATAMIC_PRO_ENABLED', false)");
+        } elseif (! $this->configReferencingEnv()) {
+            $this->crossLine('Statamic editions config not currently referencing .env var!');
+            $this->comment('Please re-run this command with the `--update-config` option.');
         }
     }
 

--- a/src/Console/Commands/ProEnable.php
+++ b/src/Console/Commands/ProEnable.php
@@ -38,21 +38,21 @@ class ProEnable extends Command
             return;
         }
 
-        $this->laravel['config']['statamic.editions.pro'] = true;
-
         $this->checkInfo('Statamic Pro successfully enabled in .env file!');
 
         if ($this->option('update-config') && $this->updateConfig()) {
             $this->checkInfo('Statamic editions config successfully updated to reference .env var!');
         }
 
-        if ($this->option('update-config') && ! $this->configReferencingEnv()) {
+        if ($this->option('update-config') && ! $this->isConfigReferencingEnv()) {
             $this->crossLine('Could not reliably update editions config to reference .env var!');
             $this->comment(PHP_EOL.'For this setting to take effect, please modify your [config/statamic/editions.php] as follows:');
             $this->line("'pro' => env('STATAMIC_PRO_ENABLED', false)");
-        } elseif (! $this->configReferencingEnv()) {
+        } elseif (! $this->isConfigReferencingEnv()) {
             $this->crossLine('Statamic editions config not currently referencing .env var!');
             $this->comment('Please re-run this command with the `--update-config` option.');
+        } else {
+            $this->laravel['config']['statamic.editions.pro'] = true;
         }
     }
 
@@ -141,7 +141,7 @@ class ProEnable extends Command
             return false;
         }
 
-        if ($this->configReferencingEnv()) {
+        if ($this->isConfigReferencingEnv()) {
             return false;
         }
 
@@ -165,10 +165,10 @@ class ProEnable extends Command
      *
      * @return bool
      */
-    protected function configReferencingEnv()
+    protected function isConfigReferencingEnv()
     {
         if (! file_exists($configPath = config_path('statamic/editions.php'))) {
-            return false;
+            return true;
         }
 
         return (bool) preg_match('/[\'"]pro[\'"]\s*=>\s*env\([\'"]STATAMIC_PRO_ENABLED[\'"]/m', file_get_contents($configPath));

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -5,6 +5,7 @@ namespace Statamic;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Vite;
 use Laravel\Nova\Nova;
@@ -48,17 +49,7 @@ class Statamic
 
     public static function enablePro()
     {
-        $path = config_path('statamic/editions.php');
-
-        $contents = File::get($path);
-
-        if (! Str::contains($contents, "'pro' => false,")) {
-            throw new \Exception('Could not reliably update the config file.');
-        }
-
-        $contents = str_replace("'pro' => false,", "'pro' => true,", $contents);
-
-        File::put($path, $contents);
+        Artisan::call('statamic:pro:enable', ['--update-config' => true]);
     }
 
     public static function availableScripts(Request $request)

--- a/tests/Console/Commands/ProEnableTest.php
+++ b/tests/Console/Commands/ProEnableTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tests\Console\Commands;
+
+use Illuminate\Filesystem\Filesystem;
+use Statamic\Statamic;
+use Tests\TestCase;
+
+class ProEnableTest extends TestCase
+{
+    private $files;
+    private $envPath;
+    private $editionsPath;
+    private $defaultEnvContents;
+    private $defaultEditionsContents;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = app(Filesystem::class);
+
+        $this->envPath = base_path('.env');
+        $this->editionsPath = config_path('statamic/editions.php');
+
+        $this->defaultEnvContents = <<<'ENV'
+APP_NAME=Statamic
+STATAMIC_PRO_ENABLED=false
+STATAMIC_LICENSE_KEY=
+ENV;
+
+        $this->defaultEditionsContents = $this->files->get(__DIR__.'/../../../config/editions.php');
+
+        $this->files->put($this->envPath, $this->defaultEnvContents);
+        $this->files->put($this->editionsPath, $this->defaultEditionsContents);
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('statamic.editions.pro', false);
+    }
+
+    public function tearDown(): void
+    {
+        $this->files->delete($this->envPath);
+        $this->files->delete($this->editionsPath);
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_can_enable_pro_by_updating_existing_var_in_env()
+    {
+        $this->assertFalse(Statamic::pro());
+        $this->assertEquals($this->defaultEditionsContents, $this->files->get($this->editionsPath));
+        $this->assertEquals($this->defaultEnvContents, $this->files->get($this->envPath));
+
+        $this->artisan('statamic:pro:enable');
+
+        $this->assertTrue(Statamic::pro());
+        $this->assertEquals($this->defaultEditionsContents, $this->files->get($this->editionsPath));
+        $this->assertEquals(<<<'ENV'
+APP_NAME=Statamic
+STATAMIC_PRO_ENABLED=true
+STATAMIC_LICENSE_KEY=
+ENV, $this->files->get($this->envPath));
+    }
+
+    /** @test */
+    public function it_can_enable_pro_by_appending_to_env()
+    {
+        $this->files->put($this->envPath, $this->defaultEnvContents = <<<'ENV'
+APP_NAME=Statamic
+STATAMIC_LICENSE_KEY=
+ENV);
+
+        $this->assertFalse(Statamic::pro());
+        $this->assertEquals($this->defaultEditionsContents, $this->files->get($this->editionsPath));
+
+        $this->artisan('statamic:pro:enable');
+
+        $this->assertTrue(Statamic::pro());
+        $this->assertEquals($this->defaultEditionsContents, $this->files->get($this->editionsPath));
+        $this->assertEquals(<<<'ENV'
+APP_NAME=Statamic
+STATAMIC_LICENSE_KEY=
+STATAMIC_PRO_ENABLED=true
+ENV, $this->files->get($this->envPath));
+    }
+
+    /** @test */
+    public function if_config_is_not_referencing_env_var_it_should_prompt_user_to_run_with_update_config_option()
+    {
+        $this->files->put($this->editionsPath, $this->defaultEditionsContents = <<<'EDITIONS'
+<?php
+
+return [
+
+    'pro' => env('WRONG!!!', false),
+
+    'addons' => [
+        //
+    ],
+
+];
+EDITIONS);
+
+        $this->assertFalse(Statamic::pro());
+        $this->assertEquals($this->defaultEnvContents, $this->files->get($this->envPath));
+
+        $this
+            ->artisan('statamic:pro:enable')
+            ->expectsOutput('Please re-run this command with the `--update-config` option.');
+
+        // Though it should still update .env
+        $this->assertEquals(<<<'ENV'
+APP_NAME=Statamic
+STATAMIC_PRO_ENABLED=true
+STATAMIC_LICENSE_KEY=
+ENV, $this->files->get($this->envPath));
+
+        // Pro should not be enabled in the in-memory config, because config is not properly referencing .env var yet
+        $this->assertFalse(Statamic::pro());
+    }
+
+    public static function hardcodedBooleans()
+    {
+        return [
+            'true' => ['true'],
+            'false' => ['false'],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider hardcodedBooleans
+     */
+    public function it_can_update_editions_config_to_reference_env_var($boolean)
+    {
+        $this->files->put($this->editionsPath, <<<"EDITIONS"
+<?php
+
+return [
+
+    'pro' => $boolean,
+
+    'addons' => [
+        //
+    ],
+
+];
+
+EDITIONS);
+
+        $this->assertFalse(Statamic::pro());
+        $this->assertEquals($this->defaultEnvContents, $this->files->get($this->envPath));
+
+        $this->artisan('statamic:pro:enable', ['--update-config' => true]);
+
+        $this->assertTrue(Statamic::pro());
+        $this->assertEquals($this->defaultEditionsContents, $this->files->get($this->editionsPath));
+        $this->assertEquals(<<<'ENV'
+APP_NAME=Statamic
+STATAMIC_PRO_ENABLED=true
+STATAMIC_LICENSE_KEY=
+ENV, $this->files->get($this->envPath));
+    }
+
+    /** @test */
+    public function if_it_has_trouble_updating_editions_config_it_should_instruct_user()
+    {
+        $this->files->put($this->editionsPath, <<<'EDITIONS'
+<?php
+
+return [
+
+    'pro' => 'wabbajack', // It should fail trying to update this!
+
+    'addons' => [
+        //
+    ],
+
+];
+EDITIONS);
+
+        $this->assertFalse(Statamic::pro());
+        $this->assertEquals($this->defaultEnvContents, $this->files->get($this->envPath));
+
+        $this
+            ->artisan('statamic:pro:enable', ['--update-config' => true])
+            ->expectsOutput(PHP_EOL.'For this setting to take effect, please modify your [config/statamic/editions.php] as follows:')
+            ->expectsOutput("'pro' => env('STATAMIC_PRO_ENABLED', false)");
+
+        // Though it should still update .env
+        $this->assertEquals(<<<'ENV'
+APP_NAME=Statamic
+STATAMIC_PRO_ENABLED=true
+STATAMIC_LICENSE_KEY=
+ENV, $this->files->get($this->envPath));
+
+        // Pro should not be enabled in the in-memory config, because config is not properly referencing .env var yet
+        $this->assertFalse(Statamic::pro());
+    }
+}

--- a/tests/Console/Commands/ProEnableTest.php
+++ b/tests/Console/Commands/ProEnableTest.php
@@ -32,6 +32,8 @@ ENV;
         $this->defaultEditionsContents = $this->files->get(__DIR__.'/../../../config/editions.php');
 
         $this->files->put($this->envPath, $this->defaultEnvContents);
+
+        $this->files->makeDirectory(dirname($this->editionsPath), 0777, true, true);
         $this->files->put($this->editionsPath, $this->defaultEditionsContents);
     }
 


### PR DESCRIPTION
When working on the `php please multisite` command for https://github.com/statamic/cms/pull/9632, I realized that `Statamic::enablePro()` updates the editions config, but https://github.com/statamic/cms/pull/9435 introduced smarter logic to enable Statamic Pro using an .env var.

## What's changed?

If you have the newer editions config style with proper reference to the .env var, nothing has changed:

![CleanShot 2024-03-19 at 22 32 22](https://github.com/statamic/cms/assets/5187394/0062d461-68ff-4ec8-bbbc-b74f2ee5ad77)

If it detects that your editions config is not properly referencing the .env var, it'll suggest the `--update-config` option:

![image](https://github.com/statamic/cms/assets/5187394/9d2f91de-a5a5-41f9-94d1-fa03e4a72e99)

When running with `--update-config`, it'll update both your .env var and your editions config:

![CleanShot 2024-03-19 at 22 27 00](https://github.com/statamic/cms/assets/5187394/5fab386f-232e-4d67-86e3-176bb24d1207)

And if it fails to update your editions config, you'll be given instructions on how to manually update this yourself:

![CleanShot 2024-03-19 at 22 29 53](https://github.com/statamic/cms/assets/5187394/a72be6b3-1501-4343-aaa1-ec063ac28738)

_Note: I don't think the `--update-config` should be default behaviour, because the only reason you'd run with `--update-config` is for older apps where you want to migrate your editions config if it happens to still have a hardcoded boolean. As you can see above though, it's still user-friendly despite being opt-in._

## Why these changes?

1. Better UX for the `pro:enable` command.
2. With this new `--update-config` option, the `Statamic::enablePro()` command can now programatically enable pro without any user intervention, but simply deferring to the command.
    - Technically, `Statamic::enablePro()` is completely broken on newer installs, because it doesn't touch the .env. This PR fixes all that 👍