### PR TITLE
[4.x] Fix markdown and code fieldtype read-only modes

### DIFF
--- a/resources/js/components/fieldtypes/CodeFieldtype.vue
+++ b/resources/js/components/fieldtypes/CodeFieldtype.vue
@@ -5,7 +5,7 @@
     <div class="code-fieldtype-container" :class="[themeClass, {'code-fullscreen': fullScreenMode }]">
         <div class="code-fieldtype-toolbar">
             <div>
-                <select-input v-if="config.mode_selectable" :options="modes" v-model="mode" class="text-xs leading-none" />
+                <select-input v-if="config.mode_selectable" :options="modes" v-model="mode" :is-read-only="isReadOnly" class="text-xs leading-none" />
                 <div v-else v-text="modeLabel" class="text-xs font-mono text-gray-700"></div>
             </div>
             <button @click="fullScreenMode = !fullScreenMode" class="btn-icon h-8 leading-none flex items-center justify-center text-gray-800" v-tooltip="__('Toggle Fullscreen Mode')">

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -190,7 +190,11 @@ export default {
 
         mode(mode) {
             if (mode === 'preview') this.updateMarkdownPreview();
-        }
+        },
+
+        readOnly(readOnly) {
+            this.codemirror.setOption('readOnly', readOnly ? 'nocursor' : false);
+        },
 
     },
 


### PR DESCRIPTION
This pull request fixes an issue with the Markdown fieldtype where you could edit the content even when the field was locked.

This was happening due to the `readOnly` state on the CoreMirror instance only being set when the fieldtype is being mounted. Changes to the `readOnly` prop weren't updating the CoreMirror state.

This PR also fixes an issue where the "Mode" dropdown was usable even when the Code Fieldtype was read-only.

Fixes statamic/collaboration#76.