### PR TITLE
[4.x] Add ability to install starter kit from specific branch

### DIFF
--- a/tests/Fakes/Composer/FakeComposer.php
+++ b/tests/Fakes/Composer/FakeComposer.php
@@ -3,6 +3,7 @@
 namespace Tests\Fakes\Composer;
 
 use Illuminate\Filesystem\Filesystem;
+use Statamic\Facades\Blink;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
@@ -17,6 +18,8 @@ class FakeComposer
 
     public function require($package, $version = null, ...$extraParams)
     {
+        [$package, $branch] = $this->parseRawPackageArg($package);
+
         if (collect($extraParams)->contains('--dry-run')) {
             return;
         }
@@ -27,6 +30,8 @@ class FakeComposer
 
     public function requireDev($package, $version = null, ...$extraParams)
     {
+        [$package, $branch] = $this->parseRawPackageArg($package);
+
         if (collect($extraParams)->contains('--dry-run')) {
             return;
         }
@@ -129,6 +134,17 @@ class FakeComposer
         if ($this->files->exists($path = base_path("vendor/{$package}"))) {
             $this->files->deleteDirectory($path);
         }
+    }
+
+    protected function parseRawPackageArg(string $package): array
+    {
+        $parts = explode(':', $package);
+
+        if (count($parts) === 1) {
+            $parts[] = null;
+        }
+
+        return $parts;
     }
 
     public function __call($method, $args)

--- a/tests/Fakes/Composer/FakeComposer.php
+++ b/tests/Fakes/Composer/FakeComposer.php
@@ -20,6 +20,9 @@ class FakeComposer
     {
         [$package, $branch] = $this->parseRawPackageArg($package);
 
+        Blink::put('composer-require-package', $package);
+        Blink::put('composer-require-branch', $branch);
+
         if (collect($extraParams)->contains('--dry-run')) {
             return;
         }
@@ -31,6 +34,9 @@ class FakeComposer
     public function requireDev($package, $version = null, ...$extraParams)
     {
         [$package, $branch] = $this->parseRawPackageArg($package);
+
+        Blink::put('composer-require-dev-package', $package);
+        Blink::put('composer-require-dev-branch', $branch);
 
         if (collect($extraParams)->contains('--dry-run')) {
             return;

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -659,6 +659,29 @@ EOT;
         $this->assertFileDoesNotExist(base_path('vendor/statamic/cool-runnings'));
     }
 
+    /** @test */
+    public function it_parses_branch_from_package_param_when_installing()
+    {
+        $this->assertFileDoesNotExist($this->kitVendorPath());
+        $this->assertComposerJsonDoesntHave('repositories');
+        $this->assertFileDoesNotExist(base_path('copied.md'));
+
+        $this->installCoolRunnings([
+            'package' => 'statamic/cool-runnings:dev-custom-branch',
+        ]);
+
+        // Ensure `Composer::requireDev()` gets called with `package:branch`
+        $this->assertEquals(Blink::get('composer-require-dev-package'), 'statamic/cool-runnings');
+        $this->assertEquals(Blink::get('composer-require-dev-branch'), 'dev-custom-branch');
+
+        // But ensure the rest of the installer handles parsed `package` without branch messing things up
+        $this->assertFalse(Blink::has('starter-kit-repository-added'));
+        $this->assertFileDoesNotExist($this->kitVendorPath());
+        $this->assertFileDoesNotExist(base_path('composer.json.bak'));
+        $this->assertComposerJsonDoesntHave('repositories');
+        $this->assertFileExists(base_path('copied.md'));
+    }
+
     private function kitRepoPath($path = null)
     {
         return collect([base_path('repo/cool-runnings'), $path])->filter()->implode('/');


### PR DESCRIPTION
## The problem

In a support request, a user was trying to install from specific branch by manually adding the repo to `require-dev` in their composer.json file:

```json
"require-dev": {
    "<namespace>/<starter-kit-name>": "dev-develop"
},
```

But when Statamic runs `composer require --dev`, the composer require command stomps whatever is in their composer.json file, so it would just require the main/master branch.

## The solution

This PR adds the ability to require a branch on the cli just as you would with `composer require package:branch`...

![CleanShot 2024-03-20 at 11 40 45](https://github.com/statamic/cms/assets/5187394/ef827360-9683-4ae4-9a3c-7621e3303057)