### PR TITLE
[4.x] Allow custom 403 views to use error layout

### DIFF
--- a/src/Exceptions/UnauthorizedHttpException.php
+++ b/src/Exceptions/UnauthorizedHttpException.php
@@ -2,8 +2,10 @@
 
 namespace Statamic\Exceptions;
 
+use Statamic\Exceptions\Concerns\RendersHttpExceptions;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class UnauthorizedHttpException extends HttpException
 {
+    use RendersHttpExceptions;
 }


### PR DESCRIPTION
I wanted to customize a 403 error page and found that it wasn't pulling in the layout, this fixes that.