### PR TITLE
[4.x] Avoid using a pipeline if there are no Hooks registered

### DIFF
--- a/src/Support/Traits/Hookable.php
+++ b/src/Support/Traits/Hookable.php
@@ -29,6 +29,10 @@ trait Hookable
             debugbar()->addMessage($message, 'hooks');
         }
 
+        if ($closures->isEmpty()) {
+            return $payload;
+        }
+
         return (new Pipeline)
             ->send($payload)
             ->through($closures->all())


### PR DESCRIPTION
This should make the performance overhead even lower for things like #9625.
