### PR TITLE
[4.x] Fix return type of AssetContainer:all()

### DIFF
--- a/src/Facades/AssetContainer.php
+++ b/src/Facades/AssetContainer.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 use Statamic\Contracts\Assets\AssetContainerRepository;
 
 /**
- * @method static \lluminate\Support\Collection all()
+ * @method static \Illuminate\Support\Collection all()
  * @method static null|\Statamic\Contracts\Assets\AssetContainer find($id)
  * @method static null|\Statamic\Contracts\Assets\AssetContainer findByHandle(string $handle)
  * @method static \Statamic\Contracts\Assets\AssetContainer make(string $handle = null)


### PR DESCRIPTION
- Fix typo in return type of `AssetContainer` facade docblock
- Stumbled upon this through a phpstan error in a project