### PR TITLE
[5.x] Update deprecated contract usages in custom validation rules

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -157,7 +157,7 @@ return [
     'handle' => 'Must contain only lowercase letters and numbers with underscores as separators.',
     'slug' => 'Must contain only letters and numbers with dashes or underscores as separators.',
     'code_fieldtype_rulers' => 'This is invalid.',
-    'composer_package' => 'Please enter a valid composer package name (eg. hasselhoff/kung-fury).',
+    'composer_package' => 'Must be a valid composer package name (eg. hasselhoff/kung-fury).',
     'date_fieldtype_date_required' => 'Date is required.',
     'date_fieldtype_end_date_invalid' => 'Not a valid end date.',
     'date_fieldtype_end_date_required' => 'End date is required.',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -155,6 +155,7 @@ return [
     */
 
     'code_fieldtype_rulers' => 'This is invalid.',
+    'composer_package' => 'Please enter a valid composer package name (eg. hasselhoff/kung-fury).',
     'date_fieldtype_date_required' => 'Date is required.',
     'date_fieldtype_end_date_invalid' => 'Not a valid end date.',
     'date_fieldtype_end_date_required' => 'End date is required.',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -164,6 +164,7 @@ return [
     'date_fieldtype_time_required' => 'Time is required.',
     'duplicate_field_handle' => 'A field with a handle of :handle already exists.',
     'duplicate_uri' => 'Duplicate URI :value',
+    'email_available' => 'A user with this email already exists.',
     'one_site_without_origin' => 'At least one site must not have an origin.',
     'options_require_keys' => 'All options must have keys.',
     'origin_cannot_be_disabled' => 'Cannot select a disabled origin.',

--- a/src/Rules/ComposerPackage.php
+++ b/src/Rules/ComposerPackage.php
@@ -2,29 +2,18 @@
 
 namespace Statamic\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class ComposerPackage implements Rule
+class ComposerPackage implements ValidationRule
 {
     /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
+     * Run the validation rule.
      */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return preg_match("/^[^\/\s]+\/[^\/\s]+$/", $value);
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return 'Please enter a valid composer package name (eg. hasselhoff/kung-fury).';
+        if (! preg_match("/^[^\/\s]+\/[^\/\s]+$/", $value)) {
+            $fail('statamic::validation.composer_package')->translate();
+        }
     }
 }

--- a/src/Rules/ComposerPackage.php
+++ b/src/Rules/ComposerPackage.php
@@ -7,9 +7,6 @@ use Illuminate\Contracts\Validation\ValidationRule;
 
 class ComposerPackage implements ValidationRule
 {
-    /**
-     * Run the validation rule.
-     */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (! preg_match("/^[^\/\s]+\/[^\/\s]+$/", $value)) {

--- a/src/Rules/EmailAvailable.php
+++ b/src/Rules/EmailAvailable.php
@@ -2,30 +2,19 @@
 
 namespace Statamic\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Statamic\Facades\User;
 
-class EmailAvailable implements Rule
+class EmailAvailable implements ValidationRule
 {
     /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
+     * Run the validation rule.
      */
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return User::query()->where('email', trim($value))->count() === 0;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return 'A user with this email already exists.';
+        if (User::query()->where('email', trim($value))->count() !== 0) {
+            $fail('statamic::validation.email_available')->translate();
+        }
     }
 }

--- a/src/Rules/EmailAvailable.php
+++ b/src/Rules/EmailAvailable.php
@@ -8,9 +8,6 @@ use Statamic\Facades\User;
 
 class EmailAvailable implements ValidationRule
 {
-    /**
-     * Run the validation rule.
-     */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (User::query()->where('email', trim($value))->count() !== 0) {

--- a/tests/Console/Commands/MakeAddonTest.php
+++ b/tests/Console/Commands/MakeAddonTest.php
@@ -56,10 +56,10 @@ class MakeAddonTest extends TestCase
     public function it_cannot_make_addon_with_invalid_composer_package_name()
     {
         $this->artisan('statamic:make:addon', ['addon' => 'deaths-tar-vulnerability'])
-            ->expectsOutput('Please enter a valid composer package name (eg. hasselhoff/kung-fury).');
+            ->expectsOutput(trans('statamic::validation.composer_package'));
 
         $this->artisan('statamic:make:addon', ['addon' => 'some/path/deaths-tar-vulnerability'])
-            ->expectsOutput('Please enter a valid composer package name (eg. hasselhoff/kung-fury).');
+            ->expectsOutput(trans('statamic::validation.composer_package'));
 
         $this->assertFileDoesNotExist(base_path('addons/erso/deaths-tar-vulnerability'));
     }

--- a/tests/Rules/ComposerPackageTest.php
+++ b/tests/Rules/ComposerPackageTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Rules;
+
+use Statamic\Rules\ComposerPackage;
+use Tests\TestCase;
+
+class ComposerPackageTest extends TestCase
+{
+    use ValidatesCustomRule;
+
+    protected static $customRule = ComposerPackage::class;
+
+    /** @test */
+    public function it_validates_handles()
+    {
+        $this->assertPasses('the-hasselhoff/kung-fury');
+        $this->assertPasses('blastoff12345/chocolate-ship67890');
+
+        $this->assertFails('not a package');
+        $this->assertFails('not-a-package');
+        $this->assertFails(' vendor/not-a-package');
+        $this->assertFails('vendor/not-a-package ');
+        $this->assertFails('vendor /not-a-package');
+        $this->assertFails('vendor/ not-a-package');
+    }
+
+    /** @test */
+    public function it_outputs_helpful_validation_error()
+    {
+        $this->assertValidationErrorOutput('Please enter a valid composer package name (eg. hasselhoff/kung-fury).', 'not-a-package');
+    }
+}

--- a/tests/Rules/ComposerPackageTest.php
+++ b/tests/Rules/ComposerPackageTest.php
@@ -28,6 +28,6 @@ class ComposerPackageTest extends TestCase
     /** @test */
     public function it_outputs_helpful_validation_error()
     {
-        $this->assertValidationErrorOutput('Please enter a valid composer package name (eg. hasselhoff/kung-fury).', 'not-a-package');
+        $this->assertValidationErrorOutput(trans('statamic::validation.composer_package'), 'not-a-package');
     }
 }

--- a/tests/Rules/EmailAvailableTest.php
+++ b/tests/Rules/EmailAvailableTest.php
@@ -39,6 +39,6 @@ class EmailAvailableTest extends TestCase
     /** @test */
     public function it_outputs_helpful_validation_error()
     {
-        $this->assertValidationErrorOutput('A user with this email already exists.', 'frodo@lotr.com');
+        $this->assertValidationErrorOutput(trans('statamic::validation.email_available'), 'frodo@lotr.com');
     }
 }

--- a/tests/Rules/EmailAvailableTest.php
+++ b/tests/Rules/EmailAvailableTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Rules;
+
+use Statamic\Facades\User;
+use Statamic\Rules\EmailAvailable;
+use Tests\TestCase;
+
+class EmailAvailableTest extends TestCase
+{
+    use ValidatesCustomRule;
+
+    protected static $customRule = EmailAvailable::class;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        User::make()->email('frodo@lotr.com')->save();
+    }
+
+    public function tearDown(): void
+    {
+        User::all()->each->delete();
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_validates_handles()
+    {
+        $this->assertPasses('gandalf@lotr.com');
+        $this->assertPasses('aragorn@lotr.com');
+        $this->assertPasses('samwise@lotr.com');
+
+        $this->assertFails('frodo@lotr.com');
+    }
+
+    /** @test */
+    public function it_outputs_helpful_validation_error()
+    {
+        $this->assertValidationErrorOutput('A user with this email already exists.', 'frodo@lotr.com');
+    }
+}

--- a/tests/Rules/ValidatesCustomRule.php
+++ b/tests/Rules/ValidatesCustomRule.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Rules;
+
+use Illuminate\Support\Facades\Validator;
+
+trait ValidatesCustomRule
+{
+    public function validator($string)
+    {
+        return Validator::make(
+            ['input' => $string],
+            ['input' => [new static::$customRule]]
+        );
+    }
+
+    public function assertPasses($string)
+    {
+        return $this->assertTrue($this->validator($string)->passes());
+    }
+
+    public function assertFails($string)
+    {
+        return $this->assertFalse($this->validator($string)->passes());
+    }
+
+    public function assertValidationErrorOutput($expectedErrorMessage, $badInput)
+    {
+        $this->assertEquals($expectedErrorMessage, $this->validator($badInput)->errors()->first());
+    }
+}


### PR DESCRIPTION
Was working on https://github.com/statamic/cms/pull/9778 and noticed that we are using a deprecated Laravel `Rule` contract. This PR adds test coverage and updates those implementations.

- [x] Update `EmailAvailable` rule
- [x] Update `ComposerPackage` rule
- [x] Add test coverage