### PR TITLE
[4.x] Add option to prepend parameters to Glide urls

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -126,6 +126,18 @@ return [
 
         'append_original_filename' => false,
 
+        /*
+        |--------------------------------------------------------------------------
+        | Prepend used Parameters
+        |--------------------------------------------------------------------------
+        |
+        | Prepend the used parameters to Glide generated URLs.
+        | This helps identifying which parameters were used, for
+        | example on external S3 urls.
+        |
+        */
+
+        'prepend_used_parameters' => false,
     ],
 
     /*

--- a/src/Imaging/GlideManager.php
+++ b/src/Imaging/GlideManager.php
@@ -47,23 +47,24 @@ class GlideManager
                     $filename = Str::afterLast($cachePath, '/');
                     $cachePath = Str::beforeLast($cachePath, '/');
 
-                    if( config('statamic.assets.image_manipulation.prepend_used_parameters', false)) {
+                    if (config('statamic.assets.image_manipulation.prepend_used_parameters', false)) {
                         $flatParams = Arr::join(Arr::map(Arr::dot($params), function (string $value, string $key) {
-                            return $key . $value;
+                            return $key.$value;
                         }), '-');
 
-                        if( !empty($flatParams)) {
-                            $filename = Str::slug($flatParams) . '-' . $filename;
+                        if (! empty($flatParams)) {
+                            $filename = Str::slug($flatParams).'-'.$filename;
                         }
                     }
 
-                    if( config('statamic.assets.image_manipulation.append_original_filename', false)) {
+                    if (config('statamic.assets.image_manipulation.append_original_filename', false)) {
                         $cachePath .= '/'.Str::beforeLast($filename, '.').'/'.Str::of($path)->after('/');
 
                         if ($extension = ($params['fm'] ?? false)) {
                             $cachePath = Str::beforeLast($cachePath, '.').'.'.$extension;
                         }
                     }
+
                     return $cachePath;
                 });
         }

--- a/src/Imaging/GlideUrlBuilder.php
+++ b/src/Imaging/GlideUrlBuilder.php
@@ -92,7 +92,7 @@ class GlideUrlBuilder extends ImageUrlBuilder
 
         if (config('statamic.assets.image_manipulation.prepend_used_parameters', false)) {
             $flatParams = Arr::join(Arr::map(Arr::dot($params), function (string $value, string $key) {
-                return $key . $value;
+                return $key.$value;
             }), '-');
             $parts[] = Str::slug($flatParams);
         }

--- a/tests/Imaging/GlideUrlBuilderTest.php
+++ b/tests/Imaging/GlideUrlBuilderTest.php
@@ -97,6 +97,39 @@ class GlideUrlBuilderTest extends TestCase
         );
     }
 
+    public function testConfigAddsParams()
+    {
+        Config::set('statamic.assets.image_manipulation.prepend_used_parameters', true);
+
+        $asset = new Asset;
+        $asset->container((new AssetContainer)->handle('main'));
+        $asset->path('img/foo.jpg');
+
+        $encoded = base64_encode('main/img/foo.jpg');
+
+        $this->assertEquals(
+            "/img/asset/$encoded/w100-h50?w=100&h=50",
+            $this->builder->build($asset, ['w' => '100', 'h' => '50'])
+        );
+    }
+
+    public function testConfigAddsFilenameAndParams()
+    {
+        Config::set('statamic.assets.image_manipulation.append_original_filename', true);
+        Config::set('statamic.assets.image_manipulation.prepend_used_parameters', true);
+
+        $asset = new Asset;
+        $asset->container((new AssetContainer)->handle('main'));
+        $asset->path('img/foo.jpg');
+
+        $encoded = base64_encode('main/img/foo.jpg');
+
+        $this->assertEquals(
+            "/img/asset/$encoded/w100-h50-foo.jpg?w=100&h=50",
+            $this->builder->build($asset, ['w' => '100', 'h' => '50'])
+        );
+    }
+
     public function testMarkWithAsset()
     {
         $asset = new Asset;


### PR DESCRIPTION
Add option to prepend parameters to Glide urls.

In addition to the 'append_original_filename', this option 'prepend_used_parameters' will prepend the used Glide parameters to the url. It will be appended before the hash, so the original filename at the end won't change (important for SEO).

On custom glide caches (S3 buckets) you can then see what kind of parameters have been used. This can be used by developers or QA to easily spot mistakes in the used Glide parameters.

If these parameters were given: format=webp, width=600, dpr=2, then this would be added to the url: `fmwebp-w600-dpr2`

Example:

```
<picture>
    <source type="image/webp" media="(min-width: 1024px)" srcset="
        {{ glide :src="asset" format="webp" width="600" dpr="1" }}{{ url }}{{ /glide }},
        {{ glide :src="asset" format="webp" width="600" dpr="2" }}{{ url }}{{ /glide }} 2x,
        {{ glide :src="asset" format="webp" width="600" dpr="3" }}{{ url }}{{ /glide }} 3x
    ">
    <source type="image/webp" media="(min-width: 768px)" srcset="
        {{ glide :src="asset" format="webp" width="1000" }}{{ url }}{{ /glide }},
        {{ glide :src="asset" format="webp" width="1500" }}{{ url }}{{ /glide }} 2x,
        {{ glide :src="asset" format="webp" width="2000" }}{{ url }}{{ /glide }} 3x
    ">
    <img src="{{ glide :src="asset" format="jpg" width="1000" }}{{ url }}{{ /glide }}">
</picture>
```

If we now set the 'prepend_used_parameters' to true, we can check if the urls have proper parameters.

Output:

```
<picture>
  <source type="image/webp" media="(min-width: 1024px)" srcset="
    https://***amazonaws.com/***/image.png/fmwebp-w600-dpr1-aaaz8ca37e84b301d3fdf219e04ac1e0/image.webp,
    https://***amazonaws.com/***/image.png/fmwebp-w600-dpr2-bbbz8ca37e84b301d3fdf219e04ac1e0/image.webp 2x,
    https://***amazonaws.com/***/image.png/fmwebp-w600-dpr3-cccz8ca37e84b301d3fdf219e04ac1e0/image.webp 3x
    ">
  <source type="image/webp" media="(min-width: 768px)" srcset="
    https://***amazonaws.com/***/image.png/fmwebp-w1000-dddz8ca37e84b301d3fdf219e04ac1e0/image.webp,
    https://***amazonaws.com/***/image.png/fmwebp-w1500-eeez8ca37e84b301d3fdf219e04ac1e0/image.webp 2x,
    https://***amazonaws.com/***/image.png/fmwebp-w2000-fffz8ca37e84b301d3fdf219e04ac1e0/image.webp 3x
    ">
  <img src="https://***amazonaws.com/***/image.png/fmjpg-w1000-gggz8ca37e84b301d3fdf219e04ac1e0/image.jpg">
</picture>
```

