### PR TITLE
[4.x] Fix Bard IME input in Safari

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -368,12 +368,13 @@ export default {
 
     watch: {
 
-        json(json) {
+        json(json, oldJson) {
             if (!this.mounted) return;
 
             let jsonValue = JSON.stringify(json);
-
-            if (jsonValue === this.value) return;
+            let oldJonValue = JSON.stringify(oldJson);
+                        
+            if (jsonValue === oldJonValue) return;
 
             // Prosemirror's JSON will include spaces between tags.
             // For example (this is not the actual json)...

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -372,9 +372,9 @@ export default {
             if (!this.mounted) return;
 
             let jsonValue = JSON.stringify(json);
-            let oldJonValue = JSON.stringify(oldJson);
+            let oldJsonValue = JSON.stringify(oldJson);
                         
-            if (jsonValue === oldJonValue) return;
+            if (jsonValue === oldJsonValue) return;
 
             // Prosemirror's JSON will include spaces between tags.
             // For example (this is not the actual json)...


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/9769

For whatever reason when you exit IME mode in Safari by hitting enter two extra update events are fired. The first of these reverts the new value back to the previous one and the second re-applies the new value. As the watcher is checking `this.value` when these two events are fired at the same time a race condition occurs and the revert update wins, resulting in the newly input text disappearing. At least that's what I think is happening.

Other browsers do not fire these two additional update events which is why they work fine.

This PR fixes it by comparing against the old value passed to the watcher rather than checking `this.value`, avoiding the race condition. It would be nicer if you could just detect and ignore these extra update events, but I'm not sure if that's even possible and if it was I think it would have to be a fix in Taptap. It would be even nicer if Safari wasn't so weird.
