### PR TITLE
[4.x] When updating asset references, check the type of the data instead of `max_files`

### DIFF
--- a/src/Assets/AssetReferenceUpdater.php
+++ b/src/Assets/AssetReferenceUpdater.php
@@ -56,7 +56,12 @@ class AssetReferenceUpdater extends DataReferenceUpdater
                     && $this->getConfiguredAssetsFieldContainer($field) === $this->container;
             })
             ->each(function ($field) use ($dottedPrefix) {
-                $field->get('max_files') === 1
+                $data = $this->item->data()->all();
+                $dottedKey = $dottedPrefix.$field->handle();
+
+                $value = Arr::get($data, $dottedKey);
+
+                is_string($value)
                     ? $this->updateStringValue($field, $dottedPrefix)
                     : $this->updateArrayValue($field, $dottedPrefix);
             });


### PR DESCRIPTION
This pull request attempts to prevent an issue where renaming / moving assets would cause the references to that asset in content to not be updated.

From my testing, a [`foreach() argument must be of type array|object, string given`](https://app.honeybadger.io/fault/121776/10ded7b7dfcf88d7f8b475ef0815cac1) error would occur when a blueprint had an Assets field but the paths to the assets in the content was formatted differently.

For example:

* If you have `max_files: 1` set on your Assets field, then later remove it, when you rename/move an asset, you'd experience the error because the `AssetReferenceUpdater` expects data to be stored as an array, however some data is still stored as strings.
* The reverse of this is also true. If you don't have `max_files` set at all, then set `max_files: 1`, when you rename/move assets, you'd experience the error since `AssetReferenceUpdater` expects the data to be an array but it's a string.

Closes #9701.
Related to #7555 and #8114.