### PR TITLE
[4.x] Fix serializing entries when `slug` property is a closure

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -1016,4 +1016,14 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
     {
         return Facades\Collection::getComputedCallbacks($this->collection);
     }
+
+    public function __sleep()
+    {
+        if ($this->slug instanceof Closure) {
+            $slug = $this->slug;
+            $this->slug = $slug($this);
+        }
+
+        return array_keys(get_object_vars($this));
+    }
 }

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -147,6 +147,18 @@ class EntryTest extends TestCase
     }
 
     /** @test */
+    public function it_resolves_the_slug_when_serializing()
+    {
+        $entry = new Entry;
+        $entry->slug(fn () => 'the-slug');
+
+        // This would throw an exception if the slug remained an unresolved closure.
+        $serialized = serialize($entry);
+
+        $this->assertEquals('the-slug', unserialize($serialized)->slug());
+    }
+
+    /** @test */
     public function it_sets_gets_and_removes_data_values()
     {
         $collection = tap(Collection::make('test'))->save();


### PR DESCRIPTION
This pull request fixes an issue when serializing entries where routing is disabled for the collection, causing the `$entry->slug` property to be a closure, rather than a string.

This PR fixes that by evaluating the slug closure before the entry gets serialized. 

Fixes #9787.