### PR TITLE
[4.x] Prevent overwriting filter views 

### DIFF
--- a/resources/js/components/data-list/FilterPresets.vue
+++ b/resources/js/components/data-list/FilterPresets.vue
@@ -44,7 +44,7 @@
             :title="__('Rename View')"
             :buttonText="__('Rename')"
             @cancel="showRenameModal = false"
-            @confirm="savePreset()"
+            @confirm="savePreset(savingPresetSlug)"
         >
             <text-input :focus="true" v-model="savingPresetName" @keydown.enter="savePreset()" />
         </confirmation-modal>
@@ -162,9 +162,24 @@ export default {
 
             this.$preferences.set(`${this.preferencesKey}.${presetHandle}`, this.presetPreferencesPayload)
                 .then(response => {
+                    if (this.showRenameModal) {
+                        this.$preferences.remove(`${this.preferencesKey}.${this.activePreset}`)
+                            .then(response => {
+                                this.$toast.success(__('View renamed'));
+                                this.$emit('deleted', this.activePreset);
+                                this.showRenameModal = false;
+                                this.refreshPresets();
+                            })
+                            .catch(error => {
+                                this.$toast.error(__('Unable to rename view'));
+                                this.showRenameModal = false;
+                            });
+
+                        return;
+                    }
+
                     this.$toast.success(__('View saved'));
                     this.showCreateModal = false;
-                    this.showRenameModal = false;
                     this.setPreset(presetHandle);
                 })
                 .catch(error => {

--- a/resources/js/components/data-list/FilterPresets.vue
+++ b/resources/js/components/data-list/FilterPresets.vue
@@ -39,7 +39,7 @@
             <text-input :focus="true" v-model="savingPresetName" @keydown.enter="savePreset(savingPresetSlug)" />
 
             <div v-if="Object.keys(presets).includes(savingPresetSlug)">
-                <small class="help-block text-red-500 mt-2 mb-0">A view already exists with this name. Creating this view will overwrite the existing view with this name.</small>
+                <small class="help-block text-red-500 mt-2 mb-0" v-text="__('messages.filters_view_already_exists')"></small>
             </div>
         </confirmation-modal>
 
@@ -53,7 +53,7 @@
             <text-input :focus="true" v-model="savingPresetName" @keydown.enter="savePreset()" />
 
             <div v-if="Object.keys(presets).filter(preset => preset !== activePreset).includes(savingPresetSlug)">
-                <small class="help-block text-red-500 mt-2 mb-0">A view already exists with this name. Creating this view will overwrite the existing view with this name.</small>
+                <small class="help-block text-red-500 mt-2 mb-0" v-text="__('messages.filters_view_already_exists')"></small>
             </div>
         </confirmation-modal>
 

--- a/resources/js/components/data-list/FilterPresets.vue
+++ b/resources/js/components/data-list/FilterPresets.vue
@@ -38,7 +38,7 @@
         >
             <text-input :focus="true" v-model="savingPresetName" @keydown.enter="savePreset(savingPresetSlug)" />
 
-            <div v-if="Object.keys(presets).includes(savingPresetSlug)">
+            <div v-if="presets && Object.keys(presets).includes(savingPresetSlug)">
                 <small class="help-block text-red-500 mt-2 mb-0" v-text="__('messages.filters_view_already_exists')"></small>
             </div>
         </confirmation-modal>

--- a/resources/js/components/data-list/FilterPresets.vue
+++ b/resources/js/components/data-list/FilterPresets.vue
@@ -37,6 +37,10 @@
             @confirm="savePreset(savingPresetSlug)"
         >
             <text-input :focus="true" v-model="savingPresetName" @keydown.enter="savePreset(savingPresetSlug)" />
+
+            <div v-if="Object.keys(presets).includes(savingPresetSlug)">
+                <small class="help-block text-red-500 mt-2 mb-0">A view already exists with this name. Creating this view will overwrite the existing view with this name.</small>
+            </div>
         </confirmation-modal>
 
         <confirmation-modal
@@ -47,6 +51,10 @@
             @confirm="savePreset(savingPresetSlug)"
         >
             <text-input :focus="true" v-model="savingPresetName" @keydown.enter="savePreset()" />
+
+            <div v-if="Object.keys(presets).filter(preset => preset !== activePreset).includes(savingPresetSlug)">
+                <small class="help-block text-red-500 mt-2 mb-0">A view already exists with this name. Creating this view will overwrite the existing view with this name.</small>
+            </div>
         </confirmation-modal>
 
         <confirmation-modal

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -100,6 +100,7 @@ return [
     'fieldset_link_fields_prefix_instructions' => 'Every field in the linked fieldset will be prefixed with this. Useful if you want to import the same fields multiple times.',
     'fieldsets_handle_instructions' => 'Used to reference this fieldset elsewhere. It\'s non-trivial to change later.',
     'fieldsets_title_instructions' => 'Usually describes what fields will be inside, like Image Block or Meta Data',
+    'filters_view_already_exists' => 'A view already exists with this name. Creating this view will overwrite the existing view with this name.',
     'focal_point_instructions' => 'Setting a focal point allows dynamic photo cropping with a subject that stays in frame.',
     'focal_point_previews_are_examples' => 'Crop previews are for example only',
     'forgot_password_enter_email' => 'Enter your email address so we can send a reset password link.',


### PR DESCRIPTION
This pull request fixes an issue when renaming filter views, where the handle of the view wasn't updated when the view was renamed.

This meant it was possible to accidentally overwrite an existing view (for example: if you rename a view, then create a new view using the old view's name, it would overwrite the renamed view).

This PR fixes that issue by updating the handle of the view whenever a view is renamed (technically, it actually creates a new view and deletes the old one). 

This PR also adds a new warning message that'll show when creating/renaming a view with the same handle of an existing view:

![CleanShot 2024-03-26 at 22 40 05](https://github.com/statamic/cms/assets/19637309/99b7b572-33f5-4d1f-ba4a-161064316846)

Fixes #9703.