### PR TITLE
[4.x] Use the configured Git binary in commands

### DIFF
--- a/config/git.php
+++ b/config/git.php
@@ -132,8 +132,8 @@ return [
     */
 
     'commands' => [
-        'git add {{ paths }}',
-        'git -c "user.name={{ name }}" -c "user.email={{ email }}" commit -m "{{ message }}"',
+        config('statamic.git.binary') . ' add {{ paths }}',
+        config('statamic.git.binary') . ' -c "user.name={{ name }}" -c "user.email={{ email }}" commit -m "{{ message }}"',
     ],
 
     /*

--- a/config/git.php
+++ b/config/git.php
@@ -132,8 +132,8 @@ return [
     */
 
     'commands' => [
-        config('statamic.git.binary') . ' add {{ paths }}',
-        config('statamic.git.binary') . ' -c "user.name={{ name }}" -c "user.email={{ email }}" commit -m "{{ message }}"',
+        config('statamic.git.binary').' add {{ paths }}',
+        config('statamic.git.binary').' -c "user.name={{ name }}" -c "user.email={{ email }}" commit -m "{{ message }}"',
     ],
 
     /*


### PR DESCRIPTION
This pull request tweaks the Git commands in our default `git.php` config file, so the configured `binary` is used for Git commands.

Currently, the path to a custom Git binary has to be provided for in both the `binary` option and these two commands.

Closes #9767.