### PR TITLE
[4.x] Fix Revealer state issues when closing live preview

### DIFF
--- a/resources/js/components/live-preview/LivePreview.vue
+++ b/resources/js/components/live-preview/LivePreview.vue
@@ -1,7 +1,7 @@
 <template>
 
     <div>
-        <v-portal :to="livePreviewFieldsPortal" :disabled="!previewing">
+        <v-portal :to="livePreviewFieldsPortal" :disabled="!portalEnabled">
             <provider :variables="provides">
                 <slot name="default" />
             </provider>
@@ -101,6 +101,7 @@ export default {
 
     data() {
         return {
+            portalEnabled: false,
             panesVisible: false,
             headerVisible: false,
             editorWidth: null,
@@ -185,7 +186,13 @@ export default {
 
     watch: {
 
-        previewing(enabled) {
+        previewing(enabled, wasEnabled) {
+            if (wasEnabled && !enabled) {
+                this.$nextTick(() => this.portalEnabled = false);
+            } else {
+                this.portalEnabled = enabled;
+            }
+
             if (!enabled) return;
 
             this.update();


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/9697

## The problem:

A regression was introduced in https://github.com/statamic/cms/pull/7899, which added the following to our `RevealerFieldtype.vue`...

```js
beforeDestroy() {
    this.$store.commit(`publish/${this.storeName}/unsetRevealerField`, this.fieldPath);
},
```

Though this fix was/is necessary for when re-ordering bard/replicator sets (for example) with nested revealers, to ensure proper tracking of revealers in our VueX store, it caused an unintended side-effect when closing live preview...

![CleanShot 2024-03-27 at 11 30 16](https://github.com/statamic/cms/assets/5187394/f829d654-4077-4223-9fd0-b1b6c5323ebe)

^ When the live preview is closed, the destroy hooks on the fields in the live preview portal were happening AFTER the normal non-live-preview form gets re-mounted to the DOM. The reason this is an issue is because the mounted hooks are responsible for tracking revealer state, which is important for preventing data loss on revealer fields. You can see how this state was getting wiped here...

https://github.com/statamic/cms/assets/5187394/83a120f0-0385-4e09-954c-0940568cb1f1

## The solution:

This PR uses a strategic `$nextTick` to ensure the destroyed and mounted hooks fire in the correct order...

![CleanShot 2024-03-27 at 11 27 11](https://github.com/statamic/cms/assets/5187394/401e9380-fdf0-46a0-9711-de7143390805)

Which restores revealer state after closing the live preview...

https://github.com/statamic/cms/assets/5187394/9963564e-6ad2-40e8-9584-b468fe1228ca

_**Note**: You may ask why we don't just remove the `beforeDestroy()` behaviour on the `RevealerFieldtype`, but as mentioned above, it is still necessary in order to fix the bugs addressed in https://github.com/statamic/cms/pull/7899._