### PR TITLE
[4.x] Fix new lines not working in user activation email

### DIFF
--- a/src/Notifications/ActivateAccount.php
+++ b/src/Notifications/ActivateAccount.php
@@ -3,7 +3,9 @@
 namespace Statamic\Notifications;
 
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Arr;
 use Statamic\Auth\Passwords\PasswordReset as PasswordResetManager;
+use Statamic\Support\Str;
 
 class ActivateAccount extends PasswordReset
 {
@@ -49,7 +51,11 @@ class ActivateAccount extends PasswordReset
         return (new MailMessage)
             ->subject(static::$subject ?? __('statamic::messages.activate_account_notification_subject'))
             ->greeting(static::$greeting)
-            ->line(static::$body ?? __('statamic::messages.activate_account_notification_body'))
+            ->when(true, function ($mailMessage) {
+                collect(explode("\n", static::$body ?? __('statamic::messages.activate_account_notification_body')))
+                    ->filter()
+                    ->each(fn ($line) => $mailMessage->line($line));
+            })
             ->action(__('Activate Account'), PasswordResetManager::url($this->token, PasswordResetManager::BROKER_ACTIVATIONS));
     }
 

--- a/src/Notifications/ActivateAccount.php
+++ b/src/Notifications/ActivateAccount.php
@@ -3,9 +3,7 @@
 namespace Statamic\Notifications;
 
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Support\Arr;
 use Statamic\Auth\Passwords\PasswordReset as PasswordResetManager;
-use Statamic\Support\Str;
 
 class ActivateAccount extends PasswordReset
 {


### PR DESCRIPTION
This pull request fixes an issue when customizing the body of the user activation email, where any new lines wouldn't show on separate lines in the email.

<img width="576" alt="image" src="https://github.com/statamic/cms/assets/19637309/f9adc711-5e95-48c6-a292-157db7da4bbf">

<img width="605" alt="image" src="https://github.com/statamic/cms/assets/19637309/94bb252e-eb37-4852-bdea-1c3b51f18d8a">
