### PR TITLE
[4.x] Enforce max depth when validating entry parent

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -169,6 +169,7 @@ return [
     'origin_cannot_be_disabled' => 'Cannot select a disabled origin.',
     'parent_cannot_be_itself' => 'Cannot be its own parent.',
     'parent_causes_root_children' => 'This would cause the root page to have children.',
+    'parent_exceeds_max_depth' => 'This would exceed the maximum depth.',
     'reserved' => 'This is a reserved word.',
     'reserved_field_handle' => 'Field with a handle of :handle is a reserved word.',
     'unique_entry_value' => 'This value has already been taken.',

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -514,6 +514,11 @@ class EntriesController extends CpController
         // If the entry being edited is not the root, then we don't have anything to worry about.
         // If the parent is the root, that's fine, and is handled during the tree update later.
         if (! $parent || ! $entry->page()->isRoot()) {
+            // If a parent is selected, validate that it doesn't exceed the max depth of the structure.
+            if ($parent && $entry->page()->depth() > $entry->collection()->structure()->maxDepth()) {
+                throw ValidationException::withMessages(['parent' => "Page exceeds max depth of {$entry->collection()->structure()->maxDepth()}."]);
+            }
+
             return;
         }
 

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -516,7 +516,7 @@ class EntriesController extends CpController
         if (! $parent || ! $entry->page()->isRoot()) {
             // If a parent is selected, validate that it doesn't exceed the max depth of the structure.
             if ($parent && $entry->page()->depth() > $entry->collection()->structure()->maxDepth()) {
-                throw ValidationException::withMessages(['parent' => "Page exceeds max depth of {$entry->collection()->structure()->maxDepth()}."]);
+                throw ValidationException::withMessages(['parent' => __('statamic::validation.parent_exceeds_max_depth')]);
             }
 
             return;

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -515,7 +515,7 @@ class EntriesController extends CpController
         // If the parent is the root, that's fine, and is handled during the tree update later.
         if (! $parent || ! $entry->page()->isRoot()) {
             // If a parent is selected, validate that it doesn't exceed the max depth of the structure.
-            if ($parent && $entry->page()->depth() > $entry->collection()->structure()->maxDepth()) {
+            if ($parent && Entry::find($parent)->page()->depth() >= $entry->collection()->structure()->maxDepth()) {
                 throw ValidationException::withMessages(['parent' => __('statamic::validation.parent_exceeds_max_depth')]);
             }
 


### PR DESCRIPTION
This pull request ensures that the max depth of the parent is taken into consideration when validating an entry's parent.

Fixes #9388.