### PR TITLE
[5.x] Bump Laravel requirement to support `DB::connectUsing()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "composer/composer": "^2.2.22",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "james-heinrich/getid3": "^1.9.21",
-        "laravel/framework": "^10.33 || ^11.0",
+        "laravel/framework": "^10.40 || ^11.0",
         "laravel/helpers": "^1.1",
         "league/commonmark": "^2.2",
         "league/csv": "^9.0",


### PR DESCRIPTION
In PR #9695 I used `DB::connectUsing()` which was added in Laravel 10.40. This PR bumps the requirement to that.
