### PR TITLE
[4.x] Add delete user action to edit user page

### DIFF
--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -8,6 +8,14 @@
                 <h1 class="flex-1" v-text="title" />
                     <dropdown-list class="rtl:ml-4 ltr:mr-4" v-if="canEditBlueprint">
                         <dropdown-item :text="__('Edit Blueprint')" :redirect="actions.editBlueprint" />
+                        <dropdown-item v-if="canDelete" :text="__('Delete User')" class="warning" @click="$refs.deleter.confirm()">
+                            <resource-deleter
+                                ref="deleter"
+                                :resource-title="values.name"
+                                :route="actions.delete"
+                                :redirect="deleteRedirect"
+                            ></resource-deleter>
+                        </dropdown-item>
                     </dropdown-list>
 
                     <change-password
@@ -78,6 +86,8 @@ export default {
         canEditPassword: Boolean,
         canEditBlueprint: Boolean,
         requiresCurrentPassword: Boolean,
+        canDelete: Boolean,
+        deleteRedirect: String,
     },
 
     data() {

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -17,6 +17,8 @@
         :can-edit-password="{{ Statamic\Support\Str::bool($canEditPassword) }}"
         :can-edit-blueprint="{{ Statamic\Support\Str::bool($user->can('configure fields')) }}"
         :requires-current-password="{{ Statamic\Support\Str::bool($requiresCurrentPassword) }}"
+        :can-delete="{{ Statamic\Support\Str::bool($canDelete) }}"
+        delete-redirect="{{ $deleteRedirect }}"
     ></user-publish-form>
 
 @endsection

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -255,9 +255,12 @@ class UsersController extends CpController
                 'save' => $user->updateUrl(),
                 'password' => cp_route('users.password.update', $user->id()),
                 'editBlueprint' => cp_route('users.blueprint.edit'),
+                'delete' => cp_route('users.destroy', $user->id()),
             ],
             'canEditPassword' => User::fromUser($request->user())->can('editPassword', $user),
             'requiresCurrentPassword' => $request->user()->id === $user->id(),
+            'canDelete' => User::fromUser($request->user())->can('delete', $user) && $request->user()->id !== $user->id(),
+            'deleteRedirect' => cp_route('users.index'),
         ];
 
         if ($request->wantsJson()) {


### PR DESCRIPTION
Closes:
- https://github.com/statamic/ideas/issues/527

This PR adds an option to delete the user when on the edit user page - along with a confirmation:

![image](https://github.com/statamic/cms/assets/3847288/32387218-20f8-4312-8f23-7a032bc52c71)

---

Let me know if there is a way I can clean up the implementation.  I didn't particularly like having to pass both the delete action and the delete redirect parameters but that is the only way I could think of.