### PR TITLE
[5.x] Drop `laravel/helpers` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "james-heinrich/getid3": "^1.9.21",
         "laravel/framework": "^10.40 || ^11.0",
-        "laravel/helpers": "^1.1",
         "league/commonmark": "^2.2",
         "league/csv": "^9.0",
         "league/glide": "^2.0",

--- a/resources/views/forms/widget.blade.php
+++ b/resources/views/forms/widget.blade.php
@@ -1,4 +1,5 @@
 @php use function Statamic\trans as __; @endphp
+@php use Statamic\Support\Arr; @endphp
 
 <div class="card p-0 overflow-hidden">
     <div class="flex justify-between items-center p-4">
@@ -19,7 +20,7 @@
                 @foreach($submissions as $submission)
                     <tr>
                         @foreach($fields as $key => $field)
-                        <td><a href="{{ cp_route('forms.submissions.show', [$form->handle(), $submission['id']]) }}">{{ array_get($submission, $field) }}</a></td>
+                        <td><a href="{{ cp_route('forms.submissions.show', [$form->handle(), $submission['id']]) }}">{{ Arr::get($submission, $field) }}</a></td>
                         @endforeach
                         <td class="rtl:text-left ltr:text-right">
                             {{ ($submission['date']->diffInDays() <= 14) ? $submission['date']->diffForHumans() : $submission['date']->format($format) }}

--- a/src/Assets/AssetContainerManager.php
+++ b/src/Assets/AssetContainerManager.php
@@ -6,6 +6,7 @@ use Illuminate\Filesystem\FilesystemManager;
 use Statamic\Facades\Parse;
 use Statamic\Facades\Path;
 use Statamic\Facades\URL;
+use Statamic\Support\Arr;
 
 class AssetContainerManager
 {
@@ -69,7 +70,7 @@ class AssetContainerManager
     {
         $config = $this->parseEnv($config);
 
-        $config['root'] = array_get($config, 'path');
+        $config['root'] = Arr::get($config, 'path');
 
         return $this->filesystem->createS3Driver($config);
     }

--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -48,11 +48,11 @@ class AssetRepository implements Contract
         $siteUrl = rtrim(Site::current()->absoluteUrl(), '/');
         $containerUrl = $container->url();
 
-        if (starts_with($containerUrl, '/')) {
+        if (Str::startsWith($containerUrl, '/')) {
             $containerUrl = $siteUrl.$containerUrl;
         }
 
-        if (starts_with($containerUrl, $siteUrl)) {
+        if (Str::startsWith($containerUrl, $siteUrl)) {
             $url = $siteUrl.$url;
         }
 
@@ -77,8 +77,8 @@ class AssetRepository implements Contract
         return AssetContainer::all()->sortByDesc(function ($container) {
             return strlen($container->url());
         })->first(function ($container, $id) use ($url) {
-            return starts_with($url, $container->url())
-                || starts_with(URL::makeAbsolute($url), $container->url());
+            return Str::startsWith($url, $container->url())
+                || Str::startsWith(URL::makeAbsolute($url), $container->url());
         });
     }
 

--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -56,7 +56,7 @@ class AssetRepository implements Contract
             $url = $siteUrl.$url;
         }
 
-        $path = str_after($url, $containerUrl);
+        $path = Str::after($url, $containerUrl);
 
         return $container->asset($path);
     }

--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -45,7 +45,7 @@ class User extends BaseUser
                 'groups' => $this->groups()->map->handle()->values()->all(),
             ]);
 
-            return collect(array_except($data, ['id', 'email']));
+            return collect(Arr::except($data, ['id', 'email']));
         }
 
         foreach ($data as $key => $value) {

--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -117,7 +117,7 @@ class User extends BaseUser
 
     public function assignRole($role)
     {
-        $roles = collect(array_wrap($role))->map(function ($role) {
+        $roles = collect(Arr::wrap($role))->map(function ($role) {
             return is_string($role) ? Role::find($role) : $role;
         })->filter();
 
@@ -132,7 +132,7 @@ class User extends BaseUser
 
     public function removeRole($role)
     {
-        $roles = collect(array_wrap($role))->map(function ($role) {
+        $roles = collect(Arr::wrap($role))->map(function ($role) {
             return is_string($role) ? Role::find($role) : $role;
         })->filter();
 
@@ -183,7 +183,7 @@ class User extends BaseUser
 
     public function addToGroup($group)
     {
-        $groups = collect(array_wrap($group))->map(function ($group) {
+        $groups = collect(Arr::wrap($group))->map(function ($group) {
             return is_string($group) ? UserGroup::find($group) : $group;
         })->filter();
 
@@ -198,7 +198,7 @@ class User extends BaseUser
 
     public function removeFromGroup($group)
     {
-        $groups = collect(array_wrap($group))->map(function ($group) {
+        $groups = collect(Arr::wrap($group))->map(function ($group) {
             return is_string($group) ? UserGroup::find($group) : $group;
         })->filter();
 

--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -47,11 +47,11 @@ class User extends BaseUser
 
         $this->traitData($data);
 
-        if (array_has($data, 'password')) {
+        if (Arr::has($data, 'password')) {
             $this->remove('password')->password($data['password']);
         }
 
-        if (array_has($data, 'password_hash')) {
+        if (Arr::has($data, 'password_hash')) {
             $this->remove('password_hash')->passwordHash($data['password_hash']);
         }
 

--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -16,6 +16,7 @@ use Statamic\Facades\File;
 use Statamic\Facades\Stache;
 use Statamic\Facades\YAML;
 use Statamic\Preferences\HasPreferencesInProperty;
+use Statamic\Support\Arr;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 /**
@@ -314,7 +315,7 @@ class User extends BaseUser
     {
         $yaml = YAML::file($this->metaPath())->parse();
 
-        return array_get($yaml, $key, $default);
+        return Arr::get($yaml, $key, $default);
     }
 
     /**

--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -168,7 +168,7 @@ class User extends BaseUser
 
     public function assignRole($role)
     {
-        $roles = collect(array_wrap($role))->map(function ($role) {
+        $roles = collect(Arr::wrap($role))->map(function ($role) {
             return is_string($role) ? $role : $role->handle();
         })->all();
 
@@ -179,7 +179,7 @@ class User extends BaseUser
 
     public function removeRole($role)
     {
-        $toBeRemoved = collect(array_wrap($role))->map(function ($role) {
+        $toBeRemoved = collect(Arr::wrap($role))->map(function ($role) {
             return is_string($role) ? $role : $role->handle();
         });
 
@@ -202,7 +202,7 @@ class User extends BaseUser
 
     public function addToGroup($group)
     {
-        $groups = collect(array_wrap($group))->map(function ($group) {
+        $groups = collect(Arr::wrap($group))->map(function ($group) {
             return is_string($group) ? $group : $group->handle();
         })->all();
 
@@ -213,7 +213,7 @@ class User extends BaseUser
 
     public function removeFromGroup($group)
     {
-        $toBeRemoved = collect(array_wrap($group))->map(function ($group) {
+        $toBeRemoved = collect(Arr::wrap($group))->map(function ($group) {
             return is_string($group) ? $group : $group->handle();
         });
 

--- a/src/Auth/File/UserGroupRepository.php
+++ b/src/Auth/File/UserGroupRepository.php
@@ -8,6 +8,7 @@ use Statamic\Contracts\Auth\UserGroup as UserGroupContract;
 use Statamic\Facades;
 use Statamic\Facades\File;
 use Statamic\Facades\YAML;
+use Statamic\Support\Arr;
 
 class UserGroupRepository extends BaseRepository
 {
@@ -30,7 +31,7 @@ class UserGroupRepository extends BaseRepository
         return $this->groups = $this->raw()->map(function ($data, $handle) {
             $group = Facades\UserGroup::make()
                 ->handle($handle)
-                ->title(array_get($data, 'title'))
+                ->title(Arr::get($data, 'title'))
                 ->data($data);
 
             foreach ($data['roles'] ?? [] as $role) {

--- a/src/Auth/Protect/Protectors/Authenticated.php
+++ b/src/Auth/Protect/Protectors/Authenticated.php
@@ -3,6 +3,7 @@
 namespace Statamic\Auth\Protect\Protectors;
 
 use Statamic\Exceptions\ForbiddenHttpException;
+use Statamic\Support\Arr;
 
 class Authenticated extends Protector
 {
@@ -25,7 +26,7 @@ class Authenticated extends Protector
 
     protected function getLoginUrl()
     {
-        if (! $url = array_get($this->config, 'login_url')) {
+        if (! $url = Arr::get($this->config, 'login_url')) {
             return null;
         }
 
@@ -35,7 +36,7 @@ class Authenticated extends Protector
 
         $url = parse_url($url);
 
-        if ($query = array_get($url, 'query')) {
+        if ($query = Arr::get($url, 'query')) {
             $query .= '&';
         }
 
@@ -49,6 +50,6 @@ class Authenticated extends Protector
 
     protected function shouldAppendRedirect()
     {
-        return array_get($this->config, 'append_redirect', false);
+        return Arr::get($this->config, 'append_redirect', false);
     }
 }

--- a/src/Auth/Protect/Protectors/IpAddress.php
+++ b/src/Auth/Protect/Protectors/IpAddress.php
@@ -3,12 +3,13 @@
 namespace Statamic\Auth\Protect\Protectors;
 
 use Statamic\Exceptions\ForbiddenHttpException;
+use Statamic\Support\Arr;
 
 class IpAddress extends Protector
 {
     public function protect()
     {
-        $ips = array_get($this->config, 'allowed', []);
+        $ips = Arr::get($this->config, 'allowed', []);
 
         if (! in_array(request()->ip(), $ips)) {
             throw new ForbiddenHttpException();

--- a/src/Auth/Protect/Protectors/Password/Guard.php
+++ b/src/Auth/Protect/Protectors/Password/Guard.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Auth\Protect\Protectors\Password;
 
+use Statamic\Support\Arr;
+
 class Guard
 {
     protected $config;
@@ -13,7 +15,7 @@ class Guard
 
     public function check($password)
     {
-        $allowed = array_get($this->config, 'allowed', []);
+        $allowed = Arr::get($this->config, 'allowed', []);
 
         return in_array($password, $allowed);
     }

--- a/src/Auth/Protect/Protectors/Password/PasswordProtector.php
+++ b/src/Auth/Protect/Protectors/Password/PasswordProtector.php
@@ -5,6 +5,7 @@ namespace Statamic\Auth\Protect\Protectors\Password;
 use Facades\Statamic\Auth\Protect\Protectors\Password\Token;
 use Statamic\Auth\Protect\Protectors\Protector;
 use Statamic\Exceptions\ForbiddenHttpException;
+use Statamic\Support\Arr;
 
 class PasswordProtector extends Protector
 {
@@ -15,7 +16,7 @@ class PasswordProtector extends Protector
      */
     public function protect()
     {
-        if (empty(array_get($this->config, 'allowed', []))) {
+        if (empty(Arr::get($this->config, 'allowed', []))) {
             throw new ForbiddenHttpException();
         }
 

--- a/src/Auth/RoleRepository.php
+++ b/src/Auth/RoleRepository.php
@@ -31,9 +31,9 @@ abstract class RoleRepository implements RepositoryContract
         return $this->roles = $this->raw()->map(function ($role, $handle) {
             return Facades\Role::make()
                 ->handle($handle)
-                ->title(array_get($role, 'title'))
-                ->addPermission(array_get($role, 'permissions', []))
-                ->preferences(array_get($role, 'preferences', []));
+                ->title(Arr::get($role, 'title'))
+                ->addPermission(Arr::get($role, 'permissions', []))
+                ->preferences(Arr::get($role, 'preferences', []));
         });
     }
 

--- a/src/Console/Commands/GeneratorCommand.php
+++ b/src/Console/Commands/GeneratorCommand.php
@@ -126,7 +126,7 @@ abstract class GeneratorCommand extends IlluminateGeneratorCommand
     {
         // If explicitly setting addon path from an external command like `make:addon`,
         // use explicit path and allow external command to handle path output.
-        if (starts_with($addon, '/') && $this->files->exists($addon)) {
+        if (Str::startsWith($addon, '/') && $this->files->exists($addon)) {
             return $addon;
         }
 

--- a/src/Console/Commands/GeneratorCommand.php
+++ b/src/Console/Commands/GeneratorCommand.php
@@ -273,7 +273,7 @@ abstract class GeneratorCommand extends IlluminateGeneratorCommand
      */
     public function __get($attribute)
     {
-        $words = explode('_', snake_case($attribute));
+        $words = explode('_', Str::snake($attribute));
 
         // If trying to access `type` attribute, allow dynamic string manipulation like `typeLowerPlural`.
         if ($words[0] === 'type') {

--- a/src/Console/Commands/GeneratorCommand.php
+++ b/src/Console/Commands/GeneratorCommand.php
@@ -59,7 +59,7 @@ abstract class GeneratorCommand extends IlluminateGeneratorCommand
      */
     protected function getNameInput()
     {
-        return studly_case(parent::getNameInput());
+        return Str::studly(parent::getNameInput());
     }
 
     /**

--- a/src/Console/Commands/MakeAddon.php
+++ b/src/Console/Commands/MakeAddon.php
@@ -269,7 +269,7 @@ class MakeAddon extends GeneratorCommand
     {
         $prefix = $this->runningInPlease ? '' : 'statamic:';
 
-        $name = studly_case($this->nameSlug);
+        $name = Str::studly($this->nameSlug);
 
         // Prevent conflicts when also creating a scope, since they're in the same directory.
         if ($type === 'filter') {
@@ -323,7 +323,7 @@ class MakeAddon extends GeneratorCommand
      */
     protected function addonNamespace()
     {
-        return studly_case($this->vendorSlug).'\\'.studly_case($this->nameSlug);
+        return Str::studly($this->vendorSlug).'\\'.Str::studly($this->nameSlug);
     }
 
     /**

--- a/src/Console/Commands/MakeAddon.php
+++ b/src/Console/Commands/MakeAddon.php
@@ -103,8 +103,8 @@ class MakeAddon extends GeneratorCommand
     {
         $parts = explode('/', $this->package);
 
-        $this->vendorSlug = str_slug(Str::snake($parts[0]));
-        $this->nameSlug = str_slug(Str::snake($parts[1]));
+        $this->vendorSlug = Str::slug(Str::snake($parts[0]));
+        $this->nameSlug = Str::slug(Str::snake($parts[1]));
         $this->package = "{$this->vendorSlug}/{$this->nameSlug}";
     }
 

--- a/src/Console/Commands/MakeAddon.php
+++ b/src/Console/Commands/MakeAddon.php
@@ -333,7 +333,7 @@ class MakeAddon extends GeneratorCommand
      */
     protected function addonTitle()
     {
-        return str_replace('-', ' ', title_case($this->nameSlug));
+        return str_replace('-', ' ', Str::title($this->nameSlug));
     }
 
     /**

--- a/src/Console/Commands/MakeAddon.php
+++ b/src/Console/Commands/MakeAddon.php
@@ -8,6 +8,7 @@ use Statamic\Console\Processes\Exceptions\ProcessException;
 use Statamic\Console\RunsInPlease;
 use Statamic\Console\ValidatesInput;
 use Statamic\Rules\ComposerPackage;
+use Statamic\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -102,8 +103,8 @@ class MakeAddon extends GeneratorCommand
     {
         $parts = explode('/', $this->package);
 
-        $this->vendorSlug = str_slug(snake_case($parts[0]));
-        $this->nameSlug = str_slug(snake_case($parts[1]));
+        $this->vendorSlug = str_slug(Str::snake($parts[0]));
+        $this->nameSlug = str_slug(Str::snake($parts[1]));
         $this->package = "{$this->vendorSlug}/{$this->nameSlug}";
     }
 

--- a/src/Console/Commands/MakeFieldtype.php
+++ b/src/Console/Commands/MakeFieldtype.php
@@ -5,6 +5,7 @@ namespace Statamic\Console\Commands;
 use Archetype\Facades\PHPFile;
 use PhpParser\BuilderFactory;
 use Statamic\Console\RunsInPlease;
+use Statamic\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
 
 class MakeFieldtype extends GeneratorCommand
@@ -97,7 +98,7 @@ class MakeFieldtype extends GeneratorCommand
         $component = $this->files->get($this->getStub('fieldtype.vue.stub'));
 
         $component = str_replace('DummyName', $name, $component);
-        $component = str_replace('dummy_name', snake_case($name), $component);
+        $component = str_replace('dummy_name', Str::snake($name), $component);
 
         return $component;
     }

--- a/src/Console/Commands/MakeTag.php
+++ b/src/Console/Commands/MakeTag.php
@@ -5,6 +5,7 @@ namespace Statamic\Console\Commands;
 use Archetype\Facades\PHPFile;
 use PhpParser\BuilderFactory;
 use Statamic\Console\RunsInPlease;
+use Statamic\Support\Str;
 
 class MakeTag extends GeneratorCommand
 {
@@ -82,7 +83,7 @@ class MakeTag extends GeneratorCommand
     {
         $class = parent::buildClass($name);
 
-        $class = str_replace('dummy_tag', snake_case($this->getNameInput()), $class);
+        $class = str_replace('dummy_tag', Str::snake($this->getNameInput()), $class);
 
         return $class;
     }

--- a/src/Console/Commands/MakeWidget.php
+++ b/src/Console/Commands/MakeWidget.php
@@ -71,7 +71,7 @@ class MakeWidget extends GeneratorCommand
             'name' => $this->getNameInput(),
         ];
 
-        $filename = str_slug(Str::snake($this->getNameInput()));
+        $filename = Str::slug(Str::snake($this->getNameInput()));
 
         $this->createFromStub(
             'widget.blade.php.stub',
@@ -108,7 +108,7 @@ class MakeWidget extends GeneratorCommand
     {
         $class = parent::buildClass($name);
 
-        $name = str_slug(Str::snake($this->getNameInput()));
+        $name = Str::slug(Str::snake($this->getNameInput()));
         $viewPath = 'widgets.'.$name;
 
         if ($this->argument('addon')) {

--- a/src/Console/Commands/MakeWidget.php
+++ b/src/Console/Commands/MakeWidget.php
@@ -5,6 +5,7 @@ namespace Statamic\Console\Commands;
 use Archetype\Facades\PHPFile;
 use PhpParser\BuilderFactory;
 use Statamic\Console\RunsInPlease;
+use Statamic\Support\Str;
 
 class MakeWidget extends GeneratorCommand
 {
@@ -70,7 +71,7 @@ class MakeWidget extends GeneratorCommand
             'name' => $this->getNameInput(),
         ];
 
-        $filename = str_slug(snake_case($this->getNameInput()));
+        $filename = str_slug(Str::snake($this->getNameInput()));
 
         $this->createFromStub(
             'widget.blade.php.stub',
@@ -107,7 +108,7 @@ class MakeWidget extends GeneratorCommand
     {
         $class = parent::buildClass($name);
 
-        $name = str_slug(snake_case($this->getNameInput()));
+        $name = str_slug(Str::snake($this->getNameInput()));
         $viewPath = 'widgets.'.$name;
 
         if ($this->argument('addon')) {

--- a/src/Console/Commands/ProEnable.php
+++ b/src/Console/Commands/ProEnable.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Statamic\Console\EnhancesCommands;
 use Statamic\Console\RunsInPlease;
+use Statamic\Support\Str;
 
 class ProEnable extends Command
 {
@@ -147,9 +148,9 @@ class ProEnable extends Command
 
         $contents = file_get_contents($configPath);
 
-        if (str_contains($contents, "'pro' => false,")) {
+        if (Str::contains($contents, "'pro' => false,")) {
             $contents = str_replace("'pro' => false,", "'pro' => env('STATAMIC_PRO_ENABLED', false),", $contents);
-        } elseif (str_contains($contents, "'pro' => true,")) {
+        } elseif (Str::contains($contents, "'pro' => true,")) {
             $contents = str_replace("'pro' => true,", "'pro' => env('STATAMIC_PRO_ENABLED', false),", $contents);
         } else {
             return false;

--- a/src/Console/Processes/Process.php
+++ b/src/Console/Processes/Process.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Log;
 use Statamic\Console\Processes\Exceptions\ProcessException;
 use Statamic\Facades\Path;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process as SymfonyProcess;
 
@@ -57,7 +58,7 @@ class Process
      */
     public function __construct($basePath = null)
     {
-        $this->basePath = str_finish($basePath ?? base_path(), '/');
+        $this->basePath = Str::finish($basePath ?? base_path(), '/');
 
         $this->env = $this->constructEnv();
     }
@@ -449,7 +450,7 @@ class Process
     {
         $that = clone $this;
 
-        $that->basePath = str_finish(Path::resolve($this->basePath.'/../'), '/');
+        $that->basePath = Str::finish(Path::resolve($this->basePath.'/../'), '/');
 
         return $that;
     }

--- a/src/Extend/HasHandle.php
+++ b/src/Extend/HasHandle.php
@@ -3,6 +3,7 @@
 namespace Statamic\Extend;
 
 use ReflectionClass;
+use Statamic\Support\Str;
 
 trait HasHandle
 {
@@ -16,6 +17,6 @@ trait HasHandle
 
         $class = (new ReflectionClass(static::class))->getShortName();
 
-        return snake_case($class);
+        return Str::snake($class);
     }
 }

--- a/src/Extensions/Translation/Translator.php
+++ b/src/Extensions/Translation/Translator.php
@@ -4,6 +4,7 @@ namespace Statamic\Extensions\Translation;
 
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
 use Illuminate\Translation\Translator as BaseTranslator;
 use Statamic\Statamic;
 
@@ -45,7 +46,7 @@ class Translator extends BaseTranslator
         $translations->put('*', $this->loader->load($this->locale, '*', '*'));
 
         // The Javascript side is expecting one flattened object.
-        return array_dot($translations);
+        return Arr::dot($translations);
     }
 
     protected function getTranslations($path, $namespace)

--- a/src/Extensions/Translation/Translator.php
+++ b/src/Extensions/Translation/Translator.php
@@ -7,6 +7,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Translation\Translator as BaseTranslator;
 use Statamic\Statamic;
+use Statamic\Support\Str;
 
 class Translator extends BaseTranslator
 {
@@ -20,7 +21,7 @@ class Translator extends BaseTranslator
 
     public function parseKey($key)
     {
-        if (Statamic::isCpRoute() && starts_with($key, 'validation.')) {
+        if (Statamic::isCpRoute() && Str::startsWith($key, 'validation.')) {
             $key = 'statamic::'.$key;
         }
 

--- a/src/Facades/Endpoint/Path.php
+++ b/src/Facades/Endpoint/Path.php
@@ -3,6 +3,7 @@
 namespace Statamic\Facades\Endpoint;
 
 use Statamic\Facades\Pattern;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
 /**
@@ -209,7 +210,7 @@ class Path
     {
         $path = Str::before($path, '?');
 
-        return array_get(pathinfo($path), 'extension');
+        return Arr::get(pathinfo($path), 'extension');
     }
 
     /**

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -399,7 +399,7 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
 
     public function title()
     {
-        return array_get($this->contents, 'title', Str::humanize(Str::of($this->handle)->after('::')->afterLast('.')));
+        return Arr::get($this->contents, 'title', Str::humanize(Str::of($this->handle)->after('::')->afterLast('.')));
     }
 
     public function isNamespaced(): bool

--- a/src/Fields/ClassRuleParser.php
+++ b/src/Fields/ClassRuleParser.php
@@ -10,7 +10,7 @@ class ClassRuleParser
     {
         $rule = Str::substr($rule, 4);
 
-        if (! str_contains($rule, '(')) {
+        if (! Str::contains($rule, '(')) {
             return [$rule, []];
         }
 
@@ -29,7 +29,7 @@ class ClassRuleParser
                 }
 
                 if (is_numeric($arg)) {
-                    return [$key => str_contains($arg, '.') ? (float) $arg : (int) $arg];
+                    return [$key => Str::contains($arg, '.') ? (float) $arg : (int) $arg];
                 } elseif (Str::startsWith($arg, '"') && Str::endsWith($arg, '"')) {
                     return [$key => (string) Str::of($arg)->trim('"')->replace('\\"', '"')];
                 } elseif (Str::startsWith($arg, "'") && Str::endsWith($arg, "'")) {

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -97,7 +97,7 @@ class Field implements Arrayable
 
     public function type()
     {
-        return array_get($this->config, 'type', 'text');
+        return Arr::get($this->config, 'type', 'text');
     }
 
     public function fieldtype()
@@ -107,12 +107,12 @@ class Field implements Arrayable
 
     public function display()
     {
-        return array_get($this->config, 'display', __(Str::slugToTitle($this->handle)));
+        return Arr::get($this->config, 'display', __(Str::slugToTitle($this->handle)));
     }
 
     public function instructions()
     {
-        return array_get($this->config, 'instructions');
+        return Arr::get($this->config, 'instructions');
     }
 
     public function visibility()
@@ -395,7 +395,7 @@ class Field implements Arrayable
 
     public function get(string $key, $fallback = null)
     {
-        return array_get($this->config, $key, $fallback);
+        return Arr::get($this->config, $key, $fallback);
     }
 
     private function preProcessedConfig()

--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -103,7 +103,7 @@ class FieldTransformer
 
     private static function referenceTabField(array $submitted)
     {
-        $config = Arr::removeNullValues(array_only($submitted['config'], $submitted['config_overrides']));
+        $config = Arr::removeNullValues(Arr::only($submitted['config'], $submitted['config_overrides']));
 
         return array_filter([
             'handle' => $submitted['handle'],

--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -125,11 +125,11 @@ class FieldTransformer
 
     private static function referenceFieldToVue($field): array
     {
-        $fieldsetField = array_get(static::fieldsetFields(), $field['field'], []);
+        $fieldsetField = Arr::get(static::fieldsetFields(), $field['field'], []);
 
         $mergedConfig = array_merge(
-            $fieldsetFieldConfig = array_get($fieldsetField, 'config', []),
-            $config = array_get($field, 'config', [])
+            $fieldsetFieldConfig = Arr::get($fieldsetField, 'config', []),
+            $config = Arr::get($field, 'config', [])
         );
 
         $mergedConfig['width'] = $mergedConfig['width'] ?? 100;

--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -256,7 +256,7 @@ class Fields
             throw new \Exception("Field {$config['field']} not found.");
         }
 
-        if ($overrides = array_get($config, 'config')) {
+        if ($overrides = Arr::get($config, 'config')) {
             $field->setConfig(array_merge($field->config(), $overrides));
         }
 
@@ -283,7 +283,7 @@ class Fields
                 });
             }
 
-            if ($prefix = array_get($config, 'prefix')) {
+            if ($prefix = Arr::get($config, 'prefix')) {
                 $fields = $fields->mapWithKeys(function ($field) use ($prefix) {
                     $field = clone $field;
                     $handle = $prefix.$field->handle();

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -15,6 +15,7 @@ use Statamic\Facades\Fieldset as FieldsetRepository;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Path;
 use Statamic\Facades\Taxonomy;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
 class Fieldset
@@ -58,7 +59,7 @@ class Fieldset
 
     public function setContents(array $contents)
     {
-        $fields = array_get($contents, 'fields', []);
+        $fields = Arr::get($contents, 'fields', []);
 
         // Support legacy syntax
         if (! empty($fields) && array_keys($fields)[0] !== 0) {
@@ -86,7 +87,7 @@ class Fieldset
 
     public function fields(): Fields
     {
-        $fields = array_get($this->contents, 'fields', []);
+        $fields = Arr::get($this->contents, 'fields', []);
 
         return new Fields($fields);
     }

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -195,7 +195,7 @@ class FieldsetRepository
             ->reject(fn ($path) => Str::startsWith($path, $directory.'/vendor/'))
             ->map(function ($file) use ($directory, $namespace) {
                 $basename = Str::after($file, str_finish($directory, '/'));
-                $handle = str_before($basename, '.yaml');
+                $handle = Str::before($basename, '.yaml');
                 $handle = str_replace('/', '.', $handle);
 
                 if ($namespace) {

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -7,6 +7,7 @@ use Statamic\Exceptions\FieldsetNotFoundException;
 use Statamic\Facades\File;
 use Statamic\Facades\Path;
 use Statamic\Facades\YAML;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
 class FieldsetRepository
@@ -29,7 +30,7 @@ class FieldsetRepository
 
     public function find(string $handle): ?Fieldset
     {
-        if ($cached = array_get($this->fieldsets, $handle)) {
+        if ($cached = Arr::get($this->fieldsets, $handle)) {
             return $cached;
         }
 

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -194,7 +194,7 @@ class FieldsetRepository
             ->getFilesByTypeRecursively($directory, 'yaml')
             ->reject(fn ($path) => Str::startsWith($path, $directory.'/vendor/'))
             ->map(function ($file) use ($directory, $namespace) {
-                $basename = str_after($file, str_finish($directory, '/'));
+                $basename = Str::after($file, str_finish($directory, '/'));
                 $handle = str_before($basename, '.yaml');
                 $handle = str_replace('/', '.', $handle);
 

--- a/src/Fields/FieldsetRepository.php
+++ b/src/Fields/FieldsetRepository.php
@@ -194,7 +194,7 @@ class FieldsetRepository
             ->getFilesByTypeRecursively($directory, 'yaml')
             ->reject(fn ($path) => Str::startsWith($path, $directory.'/vendor/'))
             ->map(function ($file) use ($directory, $namespace) {
-                $basename = Str::after($file, str_finish($directory, '/'));
+                $basename = Str::after($file, Str::finish($directory, '/'));
                 $handle = Str::before($basename, '.yaml');
                 $handle = str_replace('/', '.', $handle);
 

--- a/src/Fields/Tab.php
+++ b/src/Fields/Tab.php
@@ -85,11 +85,11 @@ class Tab
 
     public function display()
     {
-        return array_get($this->contents, 'display', __(Str::humanize($this->handle)));
+        return Arr::get($this->contents, 'display', __(Str::humanize($this->handle)));
     }
 
     public function instructions()
     {
-        return array_get($this->contents, 'instructions');
+        return Arr::get($this->contents, 'instructions');
     }
 }

--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -81,7 +81,7 @@ class Validator
         foreach ($overrides as $field => $fieldRules) {
             $fieldRules = self::explodeRules($fieldRules);
 
-            if (array_has($original, $field)) {
+            if (Arr::has($original, $field)) {
                 $original[$field] = array_merge($original[$field], $fieldRules);
             } else {
                 $original[$field] = $fieldRules;

--- a/src/Fieldtypes/AssetFolder.php
+++ b/src/Fieldtypes/AssetFolder.php
@@ -3,6 +3,7 @@
 namespace Statamic\Fieldtypes;
 
 use Statamic\Facades\AssetContainer;
+use Statamic\Support\Str;
 
 class AssetFolder extends Relationship
 {
@@ -26,7 +27,7 @@ class AssetFolder extends Relationship
             })
             ->prepend(['id' => '/', 'title' => '/'])
             ->when($request->search, function ($folders, $search) {
-                return $folders->filter(fn ($folder) => str_contains($folder['title'], $search));
+                return $folders->filter(fn ($folder) => Str::contains($folder['title'], $search));
             })
             ->values();
     }

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -336,7 +336,7 @@ class Bard extends Replicator
     {
         $row['attrs']['values'] = parent::processRow($row['attrs']['values'], $index);
 
-        if (array_get($row, 'attrs.enabled', true) === true) {
+        if (Arr::get($row, 'attrs.enabled', true) === true) {
             unset($row['attrs']['enabled']);
         }
 

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -182,7 +182,7 @@ class Replicator extends Fieldtype
     protected function performAugmentation($values, $shallow)
     {
         return collect($values)->reject(function ($set, $key) {
-            return array_get($set, 'enabled', true) === false;
+            return Arr::get($set, 'enabled', true) === false;
         })->map(function ($set, $index) use ($shallow) {
             if (! Arr::get($this->flattenedSetsConfig(), "{$set['type']}.fields")) {
                 return $set;

--- a/src/Fieldtypes/RowId.php
+++ b/src/Fieldtypes/RowId.php
@@ -2,11 +2,13 @@
 
 namespace Statamic\Fieldtypes;
 
+use Statamic\Support\Str;
+
 class RowId
 {
     public function generate()
     {
-        return str_random(8);
+        return Str::random(8);
     }
 
     public function handle(): string

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -93,7 +93,7 @@ class Sets extends Fieldtype
                         return array_merge($config, [
                             'handle' => $name,
                             'id' => $name,
-                            'fields' => (new NestedFields)->preProcessConfig(array_get($config, 'fields', [])),
+                            'fields' => (new NestedFields)->preProcessConfig(Arr::get($config, 'fields', [])),
                         ]);
                     })
                     ->values()

--- a/src/Fieldtypes/TemplateFolder.php
+++ b/src/Fieldtypes/TemplateFolder.php
@@ -4,6 +4,7 @@ namespace Statamic\Fieldtypes;
 
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use Statamic\Support\Str;
 
 class TemplateFolder extends Relationship
 {
@@ -24,7 +25,7 @@ class TemplateFolder extends Relationship
 
                 foreach ($iterator as $file) {
                     if ($file->isDir() && ! $iterator->isDot() && ! $iterator->isLink()) {
-                        $directories->push(str_replace_first($path.DIRECTORY_SEPARATOR, '', $file->getPathname()));
+                        $directories->push(Str::replaceFirst($path.DIRECTORY_SEPARATOR, '', $file->getPathname()));
                     }
                 }
 

--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -151,7 +151,7 @@ class Email extends Mailable
         $augmented = $this->submission->toAugmentedArray();
         $fields = $this->getRenderableFieldData(Arr::except($augmented, ['id', 'date', 'form']));
 
-        if (array_has($this->config, 'attachments')) {
+        if (Arr::has($this->config, 'attachments')) {
             $fields = $fields->reject(fn ($field) => in_array($field['fieldtype'], ['assets', 'files']));
         }
 

--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -62,21 +62,21 @@ class Email extends Mailable
 
     protected function addAddresses()
     {
-        $this->to($this->addresses(array_get($this->config, 'to')));
+        $this->to($this->addresses(Arr::get($this->config, 'to')));
 
-        if ($from = array_get($this->config, 'from')) {
+        if ($from = Arr::get($this->config, 'from')) {
             $this->from($this->addresses($from));
         }
 
-        if ($replyTo = array_get($this->config, 'reply_to')) {
+        if ($replyTo = Arr::get($this->config, 'reply_to')) {
             $this->replyTo($this->addresses($replyTo));
         }
 
-        if ($cc = array_get($this->config, 'cc')) {
+        if ($cc = Arr::get($this->config, 'cc')) {
             $this->cc($this->addresses($cc));
         }
 
-        if ($bcc = array_get($this->config, 'bcc')) {
+        if ($bcc = Arr::get($this->config, 'bcc')) {
             $this->bcc($this->addresses($bcc));
         }
 
@@ -85,8 +85,8 @@ class Email extends Mailable
 
     protected function addViews()
     {
-        $html = array_get($this->config, 'html');
-        $text = array_get($this->config, 'text');
+        $html = Arr::get($this->config, 'html');
+        $text = Arr::get($this->config, 'text');
 
         if (! $text && ! $html) {
             return $this->view('statamic::forms.automagic-email');
@@ -97,7 +97,7 @@ class Email extends Mailable
         }
 
         if ($html) {
-            $method = array_get($this->config, 'markdown') ? 'markdown' : 'view';
+            $method = Arr::get($this->config, 'markdown') ? 'markdown' : 'view';
             $this->$method($html);
         }
 
@@ -106,7 +106,7 @@ class Email extends Mailable
 
     protected function addAttachments()
     {
-        if (! array_get($this->config, 'attachments')) {
+        if (! Arr::get($this->config, 'attachments')) {
             return $this;
         }
 
@@ -124,7 +124,7 @@ class Email extends Mailable
     {
         $value = $field['value'];
 
-        $value = array_get($field, 'config.max_files') === 1
+        $value = Arr::get($field, 'config.max_files') === 1
             ? collect([$value])->filter()
             : $value->get();
 
@@ -137,7 +137,7 @@ class Email extends Mailable
     {
         $value = $field['value'];
 
-        $value = array_get($field, 'config.max_files') === 1
+        $value = Arr::get($field, 'config.max_files') === 1
             ? collect([$value])->filter()
             : $value;
 

--- a/src/Forms/Metrics/AbstractMetric.php
+++ b/src/Forms/Metrics/AbstractMetric.php
@@ -4,6 +4,7 @@ namespace Statamic\Forms\Metrics;
 
 use Statamic\Contracts\Forms\Form;
 use Statamic\Contracts\Forms\Metric;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
 abstract class AbstractMetric implements Metric
@@ -48,7 +49,7 @@ abstract class AbstractMetric implements Metric
      */
     public function get($key, $default = null)
     {
-        return array_get($this->config(), $key, $default);
+        return Arr::get($this->config(), $key, $default);
     }
 
     /**

--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -102,7 +102,7 @@ class ApiController extends Controller
                 } elseif ($value === 'false') {
                     $value = false;
                 } elseif (is_numeric($value)) {
-                    $value = str_contains($value, '.') ? (float) $value : (int) $value;
+                    $value = Str::contains($value, '.') ? (float) $value : (int) $value;
                 }
 
                 if (Str::contains($filter, ':')) {

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -16,6 +16,7 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Rules\Handle;
 use Statamic\Statamic;
 use Statamic\Structures\CollectionStructure;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
 class CollectionsController extends CpController
@@ -237,15 +238,15 @@ class CollectionsController extends CpController
             ->mount($values['mount'] ?? null)
             ->revisionsEnabled($values['revisions'] ?? false)
             ->taxonomies($values['taxonomies'] ?? [])
-            ->futureDateBehavior(array_get($values, 'future_date_behavior'))
-            ->pastDateBehavior(array_get($values, 'past_date_behavior'))
-            ->mount(array_get($values, 'mount'))
-            ->propagate(array_get($values, 'propagate'))
+            ->futureDateBehavior(Arr::get($values, 'future_date_behavior'))
+            ->pastDateBehavior(Arr::get($values, 'past_date_behavior'))
+            ->mount(Arr::get($values, 'mount'))
+            ->propagate(Arr::get($values, 'propagate'))
             ->titleFormats($values['title_formats'])
             ->requiresSlugs($values['require_slugs'])
             ->previewTargets($values['preview_targets']);
 
-        if ($sites = array_get($values, 'sites')) {
+        if ($sites = Arr::get($values, 'sites')) {
             $collection
                 ->sites($sites)
                 ->originBehavior($values['origin_behavior']);

--- a/src/Http/Controllers/CP/Collections/EntryPreviewController.php
+++ b/src/Http/Controllers/CP/Collections/EntryPreviewController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Facades\Entry;
 use Statamic\Http\Controllers\CP\PreviewController;
+use Statamic\Support\Arr;
 
 class EntryPreviewController extends PreviewController
 {
@@ -18,7 +19,7 @@ class EntryPreviewController extends PreviewController
             ->addValues($preview = $request->preview)
             ->process();
 
-        $values = array_except($fields->values()->all(), ['slug']);
+        $values = Arr::except($fields->values()->all(), ['slug']);
 
         $entry = Entry::make()
             ->slug($preview['slug'] ?? 'slug')

--- a/src/Http/Controllers/CP/CpController.php
+++ b/src/Http/Controllers/CP/CpController.php
@@ -10,6 +10,7 @@ use Statamic\Facades\Folder;
 use Statamic\Facades\YAML;
 use Statamic\Http\Controllers\Controller;
 use Statamic\Statamic;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
 /**
@@ -58,7 +59,7 @@ class CpController extends Controller
             // Get the name if one exists in a meta file
             if (File::disk('themes')->exists($folder.'/meta.yaml')) {
                 $meta = YAML::parse(File::disk('themes')->get($folder.'/meta.yaml'));
-                $name = array_get($meta, 'name', $folder);
+                $name = Arr::get($meta, 'name', $folder);
             }
 
             $themes[] = compact('folder', 'name');

--- a/src/Http/Controllers/CP/DashboardController.php
+++ b/src/Http/Controllers/CP/DashboardController.php
@@ -5,6 +5,7 @@ namespace Statamic\Http\Controllers\CP;
 use Statamic\Facades\Preference;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
+use Statamic\Support\Arr;
 use Statamic\Widgets\Loader;
 
 class DashboardController extends CpController
@@ -51,7 +52,7 @@ class DashboardController extends CpController
             })
             ->map(function ($config) use ($loader) {
                 return [
-                    'widget' => $widget = $loader->load(array_get($config, 'type'), $config),
+                    'widget' => $widget = $loader->load(Arr::get($config, 'type'), $config),
                     'classes' => $widget->config('classes'),
                     'width' => $widget->config('width', 100),
                     'html' => (string) $widget->html(),

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -33,7 +33,7 @@ trait ManagesBlueprints
     private function setBlueprintContents(Request $request, Blueprint $blueprint)
     {
         $tabs = collect($request->tabs)->mapWithKeys(function ($tab) {
-            return [array_pull($tab, 'handle') => [
+            return [Arr::pull($tab, 'handle') => [
                 'display' => $tab['display'],
                 'sections' => $this->tabSections($tab['sections']),
             ]];

--- a/src/Http/Controllers/CP/PreviewController.php
+++ b/src/Http/Controllers/CP/PreviewController.php
@@ -5,6 +5,7 @@ namespace Statamic\Http\Controllers\CP;
 use Facades\Statamic\CP\LivePreview;
 use Illuminate\Http\Request;
 use Statamic\Facades\URL;
+use Statamic\Support\Arr;
 
 class PreviewController extends CpController
 {
@@ -22,7 +23,7 @@ class PreviewController extends CpController
             ->addValues($request->input('preview', []))
             ->process();
 
-        foreach (array_except($fields->values()->all(), ['slug']) as $key => $value) {
+        foreach (Arr::except($fields->values()->all(), ['slug']) as $key => $value) {
             $data->setSupplement($key, $value);
         }
 

--- a/src/Http/Controllers/CP/PreviewController.php
+++ b/src/Http/Controllers/CP/PreviewController.php
@@ -6,6 +6,7 @@ use Facades\Statamic\CP\LivePreview;
 use Illuminate\Http\Request;
 use Statamic\Facades\URL;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class PreviewController extends CpController
 {
@@ -47,7 +48,7 @@ class PreviewController extends CpController
         return vsprintf('%s%slive-preview=%s&token=%s', [
             $url,
             strpos($url, '?') === false ? '?' : '&',
-            str_random(), // random string to prevent caching
+            Str::random(), // random string to prevent caching
             $token,
         ]);
     }

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -17,6 +17,7 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Rules\Handle;
 use Statamic\Stache\Repositories\TermRepository as StacheTermRepository;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class TaxonomiesController extends CpController
 {
@@ -104,7 +105,7 @@ class TaxonomiesController extends CpController
             'handle' => ['nullable', new Handle],
         ]);
 
-        $handle = $request->handle ?? snake_case($request->title);
+        $handle = $request->handle ?? Str::snake($request->title);
 
         if (Taxonomy::findByHandle($handle)) {
             throw new \Exception('Taxonomy already exists');

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -16,6 +16,7 @@ use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Rules\Handle;
 use Statamic\Stache\Repositories\TermRepository as StacheTermRepository;
+use Statamic\Support\Arr;
 
 class TaxonomiesController extends CpController
 {
@@ -171,7 +172,7 @@ class TaxonomiesController extends CpController
             ->template($values['template'] ?? null)
             ->layout($values['layout'] ?? null);
 
-        if ($sites = array_get($values, 'sites')) {
+        if ($sites = Arr::get($values, 'sites')) {
             $taxonomy->sites($sites);
         }
 

--- a/src/Http/Controllers/CP/Taxonomies/TermPreviewController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermPreviewController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Statamic\Contracts\Taxonomies\Term as TermContract;
 use Statamic\Facades\Term;
 use Statamic\Http\Controllers\CP\PreviewController;
+use Statamic\Support\Arr;
 
 class TermPreviewController extends PreviewController
 {
@@ -18,7 +19,7 @@ class TermPreviewController extends PreviewController
             ->addValues($preview = $request->preview)
             ->process();
 
-        $values = array_except($fields->values()->all(), ['slug']);
+        $values = Arr::except($fields->values()->all(), ['slug']);
 
         $term = Term::make()
             ->slug($preview['slug'] ?? 'slug')

--- a/src/Http/Controllers/CP/Users/RolesController.php
+++ b/src/Http/Controllers/CP/Users/RolesController.php
@@ -10,6 +10,7 @@ use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Middleware\RequireStatamicPro;
 use Statamic\Rules\Handle;
+use Statamic\Support\Str;
 
 class RolesController extends CpController
 {
@@ -67,7 +68,7 @@ class RolesController extends CpController
             'permissions' => 'array',
         ]);
 
-        $handle = $request->handle ?: snake_case($request->title);
+        $handle = $request->handle ?: Str::snake($request->title);
 
         if (Role::find($handle)) {
             $error = __('A Role with that handle already exists.');
@@ -128,7 +129,7 @@ class RolesController extends CpController
 
         $role
             ->title($request->title)
-            ->handle($request->handle ?: snake_case($request->title));
+            ->handle($request->handle ?: Str::snake($request->title));
 
         if ($request->super && User::current()->isSuper()) {
             $role->permissions(['super']);

--- a/src/Http/Controllers/CP/Users/UserGroupsController.php
+++ b/src/Http/Controllers/CP/Users/UserGroupsController.php
@@ -8,6 +8,7 @@ use Statamic\Facades\User;
 use Statamic\Facades\UserGroup;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Middleware\RequireStatamicPro;
+use Statamic\Support\Str;
 
 class UserGroupsController extends CpController
 {
@@ -171,7 +172,7 @@ class UserGroupsController extends CpController
 
         $values = $fields->process()->values()->except(['title', 'handle', 'roles']);
 
-        $handle = $request->handle ?: snake_case($request->title);
+        $handle = $request->handle ?: Str::snake($request->title);
 
         if (UserGroup::find($handle)) {
             $error = __('A User Group with that handle already exists.');

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
 use Statamic\Facades\OAuth;
+use Statamic\Support\Arr;
 
 class OAuthController
 {
@@ -39,12 +40,12 @@ class OAuthController
 
         $previous = session('_previous.url');
 
-        if (! $query = array_get(parse_url($previous), 'query')) {
+        if (! $query = Arr::get(parse_url($previous), 'query')) {
             return $default;
         }
 
         parse_str($query, $query);
 
-        return array_get($query, 'redirect', $default);
+        return Arr::get($query, 'redirect', $default);
     }
 }

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -34,7 +34,7 @@ class JavascriptComposer
         return [
             'csrfToken' => csrf_token(),
             'cpUrl' => cp_route('index'),
-            'cpRoot' => str_start(config('statamic.cp.route'), '/'),
+            'cpRoot' => Str::start(config('statamic.cp.route'), '/'),
             'urlPath' => Str::after(request()->getRequestUri(), config('statamic.cp.route').'/'),
             'resourceUrl' => Statamic::cpAssetUrl(),
             'flash' => Statamic::flash(),

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1787,7 +1787,7 @@ class CoreModifiers extends Modifier
             $value = $value->all();
         }
 
-        return array_random($value);
+        return Arr::random($value);
     }
 
     /**

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1395,7 +1395,7 @@ class CoreModifiers extends Modifier
     public function link($value, $params)
     {
         $attributes = $this->buildAttributesFromParameters($params);
-        $title = array_pull($attributes, 'title', null);
+        $title = Arr::pull($attributes, 'title', null);
 
         return Html::link($value, $title, $attributes);
     }

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -417,15 +417,15 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootRoutes()
     {
-        if ($web = array_get($this->routes, 'web')) {
+        if ($web = Arr::get($this->routes, 'web')) {
             $this->registerWebRoutes($web);
         }
 
-        if ($cp = array_get($this->routes, 'cp')) {
+        if ($cp = Arr::get($this->routes, 'cp')) {
             $this->registerCpRoutes($cp);
         }
 
-        if ($actions = array_get($this->routes, 'actions')) {
+        if ($actions = Arr::get($this->routes, 'actions')) {
             $this->registerActionRoutes($actions);
         }
 

--- a/src/Query/StatusQueryBuilder.php
+++ b/src/Query/StatusQueryBuilder.php
@@ -4,6 +4,7 @@ namespace Statamic\Query;
 
 use Illuminate\Support\Traits\ForwardsCalls;
 use Statamic\Contracts\Query\Builder;
+use Statamic\Support\Arr;
 
 class StatusQueryBuilder implements Builder
 {
@@ -48,7 +49,7 @@ class StatusQueryBuilder implements Builder
 
     public function __call($method, $parameters)
     {
-        if (in_array($method, self::METHODS) && in_array(array_first($parameters), ['status', 'published'])) {
+        if (in_array($method, self::METHODS) && in_array(Arr::first($parameters), ['status', 'published'])) {
             $this->queryFallbackStatus = false;
         }
 

--- a/src/Routing/UrlBuilder.php
+++ b/src/Routing/UrlBuilder.php
@@ -82,8 +82,8 @@ class UrlBuilder implements UrlBuilderContract
 
     private function slugify($value)
     {
-        $slashPlaceholder = strtolower(str_random());
-        $dotPlaceholder = strtolower(str_random());
+        $slashPlaceholder = strtolower(Str::random());
+        $dotPlaceholder = strtolower(Str::random());
 
         $value = str_replace('/', $slashPlaceholder, $value);
         $value = str_replace('.', $dotPlaceholder, $value);

--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -934,10 +934,10 @@ class Comb
         $output = [];
 
         if (! is_array($words)) {
-            $output = str_singular($words);
+            $output = Str::singular($words);
         } else {
             foreach ($words as $word) {
-                array_push($output, str_singular($word));
+                array_push($output, Str::singular($word));
             }
         }
 

--- a/src/Search/Comb/Index.php
+++ b/src/Search/Comb/Index.php
@@ -10,6 +10,7 @@ use Statamic\Search\Documents;
 use Statamic\Search\Index as BaseIndex;
 use Statamic\Search\IndexNotFoundException;
 use Statamic\Search\Result;
+use Statamic\Support\Arr;
 
 class Index extends BaseIndex
 {
@@ -37,7 +38,7 @@ class Index extends BaseIndex
             $data['search_score'] = $result['score'];
             $data['search_snippets'] = $result['snippets'];
 
-            return array_except($data, '_category');
+            return Arr::except($data, '_category');
         });
     }
 

--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -4,6 +4,7 @@ namespace Statamic\Search;
 
 use Statamic\Contracts\Search\Searchable;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 abstract class Index
 {
@@ -35,7 +36,7 @@ abstract class Index
 
     public function title()
     {
-        return $this->config['title'] ?? title_case($this->name);
+        return $this->config['title'] ?? Str::title($this->name);
     }
 
     public function config()

--- a/src/Search/IndexManager.php
+++ b/src/Search/IndexManager.php
@@ -9,6 +9,7 @@ use Statamic\Search\Algolia\Index as AlgoliaIndex;
 use Statamic\Search\Comb\Index as CombIndex;
 use Statamic\Search\Null\NullIndex;
 use Statamic\Support\Manager;
+use Statamic\Support\Str;
 
 class IndexManager extends Manager
 {
@@ -87,7 +88,7 @@ class IndexManager extends Manager
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callLocalizedCustomCreator($config, $name, $locale);
         } else {
-            $driverMethod = 'create'.camel_case($config['driver']).'Driver';
+            $driverMethod = 'create'.Str::camel($config['driver']).'Driver';
 
             if (method_exists($this, $driverMethod)) {
                 return $this->{$driverMethod}($config, $name, $locale);

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -4,6 +4,7 @@ namespace Statamic\Sites;
 
 use Closure;
 use Statamic\Facades\User;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
 class Sites
@@ -94,7 +95,7 @@ class Sites
         if (is_null($value)) {
             $this->config = $key;
         } else {
-            array_set($this->config, $key, $value);
+            Arr::set($this->config, $key, $value);
         }
 
         $this->sites = $this->toSites($this->config['sites']);

--- a/src/Stache/Stores/AssetContainersStore.php
+++ b/src/Stache/Stores/AssetContainersStore.php
@@ -4,6 +4,7 @@ namespace Statamic\Stache\Stores;
 
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\YAML;
+use Statamic\Support\Arr;
 
 class AssetContainersStore extends BasicStore
 {
@@ -18,17 +19,17 @@ class AssetContainersStore extends BasicStore
         $data = YAML::file($path)->parse($contents);
 
         return AssetContainer::make($handle)
-            ->disk(array_get($data, 'disk'))
-            ->title(array_get($data, 'title'))
-            ->allowDownloading(array_get($data, 'allow_downloading'))
-            ->allowMoving(array_get($data, 'allow_moving'))
-            ->allowRenaming(array_get($data, 'allow_renaming'))
-            ->allowUploads(array_get($data, 'allow_uploads'))
-            ->createFolders(array_get($data, 'create_folders'))
-            ->sourcePreset(array_get($data, 'source_preset'))
-            ->warmPresets(array_get($data, 'warm_presets'))
-            ->searchIndex(array_get($data, 'search_index'))
-            ->sortField(array_get($data, 'sort_by'))
-            ->sortDirection(array_get($data, 'sort_dir'));
+            ->disk(Arr::get($data, 'disk'))
+            ->title(Arr::get($data, 'title'))
+            ->allowDownloading(Arr::get($data, 'allow_downloading'))
+            ->allowMoving(Arr::get($data, 'allow_moving'))
+            ->allowRenaming(Arr::get($data, 'allow_renaming'))
+            ->allowUploads(Arr::get($data, 'allow_uploads'))
+            ->createFolders(Arr::get($data, 'create_folders'))
+            ->sourcePreset(Arr::get($data, 'source_preset'))
+            ->warmPresets(Arr::get($data, 'warm_presets'))
+            ->searchIndex(Arr::get($data, 'search_index'))
+            ->sortField(Arr::get($data, 'sort_by'))
+            ->sortDirection(Arr::get($data, 'sort_dir'));
     }
 }

--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -28,7 +28,7 @@ class CollectionEntriesStore extends ChildStore
 
     public function getItemFilter(SplFileInfo $file)
     {
-        $dir = str_finish($this->directory(), '/');
+        $dir = Str::finish($this->directory(), '/');
         $relative = Path::tidy($file->getPathname());
 
         if (substr($relative, 0, strlen($dir)) == $dir) {

--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -13,6 +13,7 @@ use Statamic\Facades\Path;
 use Statamic\Facades\Site;
 use Statamic\Facades\YAML;
 use Statamic\Stache\Indexes;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -54,7 +55,7 @@ class CollectionEntriesStore extends ChildStore
 
         $data = YAML::file($path)->parse($contents);
 
-        if (! $id = array_pull($data, 'id')) {
+        if (! $id = Arr::pull($data, 'id')) {
             $idGenerated = true;
             $id = app('stache')->generateId();
         }
@@ -66,7 +67,7 @@ class CollectionEntriesStore extends ChildStore
             ->id($id)
             ->collection($collection);
 
-        if ($origin = array_pull($data, 'origin')) {
+        if ($origin = Arr::pull($data, 'origin')) {
             $entry->origin($origin);
         }
 
@@ -74,7 +75,7 @@ class CollectionEntriesStore extends ChildStore
             ->blueprint($data['blueprint'] ?? null)
             ->locale($site)
             ->initialPath($path)
-            ->published(array_pull($data, 'published', true))
+            ->published(Arr::pull($data, 'published', true))
             ->data($data);
 
         $slug = (new GetSlugFromPath)($path);

--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -114,7 +114,7 @@ class CollectionEntriesStore extends ChildStore
 
         // Support entries within subdirectories at any level.
         if (Str::contains($collection, '/')) {
-            $collection = str_before($collection, '/');
+            $collection = Str::before($collection, '/');
         }
 
         return [$collection, $site];

--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -106,7 +106,7 @@ class CollectionEntriesStore extends ChildStore
     {
         $site = Site::default()->handle();
         $collection = pathinfo($path, PATHINFO_DIRNAME);
-        $collection = str_after($collection, $this->parent->directory());
+        $collection = Str::after($collection, $this->parent->directory());
 
         if (Site::hasMultiple()) {
             [$collection, $site] = explode('/', $collection);

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -26,7 +26,7 @@ class CollectionsStore extends BasicStore
 
     public function getItemFilter(SplFileInfo $file)
     {
-        $dir = str_finish($this->directory, '/');
+        $dir = Str::finish($this->directory, '/');
         $relative = Str::after(Path::tidy($file->getPathname()), $dir);
 
         return $file->getExtension() === 'yaml' && substr_count($relative, '/') === 0;

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -8,6 +8,7 @@ use Statamic\Facades\Path;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
 use Statamic\Facades\YAML;
+use Statamic\Support\Arr;
 use Symfony\Component\Finder\SplFileInfo;
 
 class CollectionsStore extends BasicStore
@@ -35,32 +36,32 @@ class CollectionsStore extends BasicStore
         $handle = pathinfo($path, PATHINFO_FILENAME);
         $data = YAML::file($path)->parse($contents);
 
-        $sites = array_get($data, 'sites', Site::hasMultiple() ? [] : [Site::default()->handle()]);
+        $sites = Arr::get($data, 'sites', Site::hasMultiple() ? [] : [Site::default()->handle()]);
 
         $collection = Collection::make($handle)
-            ->title(array_get($data, 'title'))
-            ->routes(array_get($data, 'route'))
-            ->requiresSlugs(array_get($data, 'slugs', true))
-            ->titleFormats(array_get($data, 'title_format'))
-            ->mount(array_get($data, 'mount'))
-            ->dated(array_get($data, 'date', false))
+            ->title(Arr::get($data, 'title'))
+            ->routes(Arr::get($data, 'route'))
+            ->requiresSlugs(Arr::get($data, 'slugs', true))
+            ->titleFormats(Arr::get($data, 'title_format'))
+            ->mount(Arr::get($data, 'mount'))
+            ->dated(Arr::get($data, 'date', false))
             ->sites($sites)
-            ->template(array_get($data, 'template'))
-            ->layout(array_get($data, 'layout'))
-            ->cascade(array_get($data, 'inject', []))
-            ->searchIndex(array_get($data, 'search_index'))
-            ->revisionsEnabled(array_get($data, 'revisions', false))
+            ->template(Arr::get($data, 'template'))
+            ->layout(Arr::get($data, 'layout'))
+            ->cascade(Arr::get($data, 'inject', []))
+            ->searchIndex(Arr::get($data, 'search_index'))
+            ->revisionsEnabled(Arr::get($data, 'revisions', false))
             ->defaultPublishState($this->getDefaultPublishState($data))
-            ->originBehavior(array_get($data, 'origin_behavior', 'select'))
-            ->structureContents(array_get($data, 'structure'))
-            ->sortField(array_get($data, 'sort_by'))
-            ->sortDirection(array_get($data, 'sort_dir'))
-            ->taxonomies(array_get($data, 'taxonomies'))
-            ->propagate(array_get($data, 'propagate'))
-            ->previewTargets($this->normalizePreviewTargets(array_get($data, 'preview_targets', [])))
-            ->autosaveInterval(array_get($data, 'autosave'));
+            ->originBehavior(Arr::get($data, 'origin_behavior', 'select'))
+            ->structureContents(Arr::get($data, 'structure'))
+            ->sortField(Arr::get($data, 'sort_by'))
+            ->sortDirection(Arr::get($data, 'sort_dir'))
+            ->taxonomies(Arr::get($data, 'taxonomies'))
+            ->propagate(Arr::get($data, 'propagate'))
+            ->previewTargets($this->normalizePreviewTargets(Arr::get($data, 'preview_targets', [])))
+            ->autosaveInterval(Arr::get($data, 'autosave'));
 
-        if ($dateBehavior = array_get($data, 'date_behavior')) {
+        if ($dateBehavior = Arr::get($data, 'date_behavior')) {
             $collection
                 ->futureDateBehavior($dateBehavior['future'] ?? null)
                 ->pastDateBehavior($dateBehavior['past'] ?? null);
@@ -71,7 +72,7 @@ class CollectionsStore extends BasicStore
 
     protected function getDefaultPublishState($data)
     {
-        $value = array_get($data, 'default_status', 'published');
+        $value = Arr::get($data, 'default_status', 'published');
 
         if (! in_array($value, ['published', 'draft'])) {
             throw new \Exception('Invalid collection default_status value. Must be "published" or "draft".');

--- a/src/Stache/Stores/CollectionsStore.php
+++ b/src/Stache/Stores/CollectionsStore.php
@@ -9,6 +9,7 @@ use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
 use Statamic\Facades\YAML;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 use Symfony\Component\Finder\SplFileInfo;
 
 class CollectionsStore extends BasicStore
@@ -26,7 +27,7 @@ class CollectionsStore extends BasicStore
     public function getItemFilter(SplFileInfo $file)
     {
         $dir = str_finish($this->directory, '/');
-        $relative = str_after(Path::tidy($file->getPathname()), $dir);
+        $relative = Str::after(Path::tidy($file->getPathname()), $dir);
 
         return $file->getExtension() === 'yaml' && substr_count($relative, '/') === 0;
     }

--- a/src/Stache/Stores/GlobalVariablesStore.php
+++ b/src/Stache/Stores/GlobalVariablesStore.php
@@ -35,7 +35,7 @@ class GlobalVariablesStore extends BasicStore
     public function makeItemFromFile($path, $contents)
     {
         $relative = Str::after($path, $this->directory);
-        $handle = str_before($relative, '.yaml');
+        $handle = Str::before($relative, '.yaml');
 
         $data = YAML::file($path)->parse($contents);
 

--- a/src/Stache/Stores/GlobalVariablesStore.php
+++ b/src/Stache/Stores/GlobalVariablesStore.php
@@ -7,6 +7,7 @@ use Statamic\Facades\Path;
 use Statamic\Facades\Site;
 use Statamic\Facades\YAML;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 use Symfony\Component\Finder\SplFileInfo;
 
 class GlobalVariablesStore extends BasicStore
@@ -22,7 +23,7 @@ class GlobalVariablesStore extends BasicStore
             return false;
         }
 
-        $filename = str_after(Path::tidy($file->getPathName()), $this->directory);
+        $filename = Str::after(Path::tidy($file->getPathName()), $this->directory);
 
         if (! Site::hasMultiple()) {
             return substr_count($filename, '/') === 0;
@@ -33,7 +34,7 @@ class GlobalVariablesStore extends BasicStore
 
     public function makeItemFromFile($path, $contents)
     {
-        $relative = str_after($path, $this->directory);
+        $relative = Str::after($path, $this->directory);
         $handle = str_before($relative, '.yaml');
 
         $data = YAML::file($path)->parse($contents);

--- a/src/Stache/Stores/GlobalsStore.php
+++ b/src/Stache/Stores/GlobalsStore.php
@@ -38,7 +38,7 @@ class GlobalsStore extends BasicStore
     public function makeItemFromFile($path, $contents)
     {
         $relative = Str::after($path, $this->directory);
-        $handle = str_before($relative, '.yaml');
+        $handle = Str::before($relative, '.yaml');
 
         $data = YAML::file($path)->parse();
 

--- a/src/Stache/Stores/GlobalsStore.php
+++ b/src/Stache/Stores/GlobalsStore.php
@@ -7,6 +7,7 @@ use Statamic\Facades\Path;
 use Statamic\Facades\Stache;
 use Statamic\Facades\YAML;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 use Symfony\Component\Finder\SplFileInfo;
 
 class GlobalsStore extends BasicStore
@@ -29,14 +30,14 @@ class GlobalsStore extends BasicStore
     {
         // The global sets themselves should only exist in the root
         // (ie. no slashes in the filename)
-        $filename = str_after(Path::tidy($file->getPathName()), $this->directory);
+        $filename = Str::after(Path::tidy($file->getPathName()), $this->directory);
 
         return substr_count($filename, '/') === 0 && $file->getExtension() === 'yaml';
     }
 
     public function makeItemFromFile($path, $contents)
     {
-        $relative = str_after($path, $this->directory);
+        $relative = Str::after($path, $this->directory);
         $handle = str_before($relative, '.yaml');
 
         $data = YAML::file($path)->parse();

--- a/src/Stache/Stores/NavigationStore.php
+++ b/src/Stache/Stores/NavigationStore.php
@@ -27,7 +27,7 @@ class NavigationStore extends BasicStore
     public function makeItemFromFile($path, $contents)
     {
         $relative = Str::after($path, $this->directory);
-        $handle = str_before($relative, '.yaml');
+        $handle = Str::before($relative, '.yaml');
 
         $data = YAML::file($path)->parse($contents);
 

--- a/src/Stache/Stores/NavigationStore.php
+++ b/src/Stache/Stores/NavigationStore.php
@@ -5,6 +5,7 @@ namespace Statamic\Stache\Stores;
 use Statamic\Facades;
 use Statamic\Facades\Path;
 use Statamic\Facades\YAML;
+use Statamic\Support\Str;
 use Symfony\Component\Finder\SplFileInfo;
 
 class NavigationStore extends BasicStore
@@ -18,14 +19,14 @@ class NavigationStore extends BasicStore
     {
         // The structures themselves should only exist in the root
         // (ie. no slashes in the filename)
-        $filename = str_after(Path::tidy($file->getPathName()), $this->directory);
+        $filename = Str::after(Path::tidy($file->getPathName()), $this->directory);
 
         return substr_count($filename, '/') === 0 && $file->getExtension() === 'yaml';
     }
 
     public function makeItemFromFile($path, $contents)
     {
-        $relative = str_after($path, $this->directory);
+        $relative = Str::after($path, $this->directory);
         $handle = str_before($relative, '.yaml');
 
         $data = YAML::file($path)->parse($contents);

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -12,6 +12,7 @@ use Statamic\Stache\Indexes;
 use Statamic\Stache\Indexes\Index;
 use Statamic\Statamic;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 abstract class Store
 {
@@ -34,7 +35,7 @@ abstract class Store
             return $this->directory;
         }
 
-        $this->directory = str_finish(Path::tidy($directory), '/');
+        $this->directory = Str::finish(Path::tidy($directory), '/');
 
         return $this;
     }

--- a/src/Stache/Stores/TaxonomiesStore.php
+++ b/src/Stache/Stores/TaxonomiesStore.php
@@ -6,6 +6,7 @@ use Statamic\Facades\Path;
 use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
 use Statamic\Facades\YAML;
+use Statamic\Support\Arr;
 use Symfony\Component\Finder\SplFileInfo;
 
 class TaxonomiesStore extends BasicStore
@@ -36,24 +37,24 @@ class TaxonomiesStore extends BasicStore
         $handle = pathinfo($path, PATHINFO_FILENAME);
         $data = YAML::file($path)->parse($contents);
 
-        $sites = array_get($data, 'sites', Site::hasMultiple() ? [] : [Site::default()->handle()]);
+        $sites = Arr::get($data, 'sites', Site::hasMultiple() ? [] : [Site::default()->handle()]);
 
         return Taxonomy::make($handle)
-            ->title(array_get($data, 'title'))
-            ->cascade(array_get($data, 'inject', []))
-            ->revisionsEnabled(array_get($data, 'revisions', false))
-            ->searchIndex(array_get($data, 'search_index'))
+            ->title(Arr::get($data, 'title'))
+            ->cascade(Arr::get($data, 'inject', []))
+            ->revisionsEnabled(Arr::get($data, 'revisions', false))
+            ->searchIndex(Arr::get($data, 'search_index'))
             ->defaultPublishState($this->getDefaultPublishState($data))
             ->sites($sites)
-            ->previewTargets($this->normalizePreviewTargets(array_get($data, 'preview_targets', [])))
-            ->termTemplate(array_get($data, 'term_template', null))
-            ->template(array_get($data, 'template', null))
-            ->layout(array_get($data, 'layout', null));
+            ->previewTargets($this->normalizePreviewTargets(Arr::get($data, 'preview_targets', [])))
+            ->termTemplate(Arr::get($data, 'term_template', null))
+            ->template(Arr::get($data, 'template', null))
+            ->layout(Arr::get($data, 'layout', null));
     }
 
     protected function getDefaultPublishState($data)
     {
-        $value = array_get($data, 'default_status', 'published');
+        $value = Arr::get($data, 'default_status', 'published');
 
         if (! in_array($value, ['published', 'draft'])) {
             throw new \Exception('Invalid taxonomy default_status value. Must be "published" or "draft".');

--- a/src/Stache/Stores/TaxonomiesStore.php
+++ b/src/Stache/Stores/TaxonomiesStore.php
@@ -7,6 +7,7 @@ use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
 use Statamic\Facades\YAML;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 use Symfony\Component\Finder\SplFileInfo;
 
 class TaxonomiesStore extends BasicStore
@@ -27,7 +28,7 @@ class TaxonomiesStore extends BasicStore
 
     public function getItemFilter(SplFileInfo $file)
     {
-        $filename = str_after(Path::tidy($file->getPathName()), $this->directory);
+        $filename = Str::after(Path::tidy($file->getPathName()), $this->directory);
 
         return $file->getExtension() === 'yaml' && substr_count($filename, '/') === 0;
     }

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -28,7 +28,7 @@ class TaxonomyTermsStore extends ChildStore
 
     public function getItemFilter(SplFileInfo $file)
     {
-        $dir = str_finish($this->directory(), '/');
+        $dir = Str::finish($this->directory(), '/');
         $relative = $file->getPathname();
 
         if (substr($relative, 0, strlen($dir)) == $dir) {

--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -45,7 +45,7 @@ class TaxonomyTermsStore extends ChildStore
     public function makeItemFromFile($path, $contents)
     {
         $taxonomy = pathinfo($path, PATHINFO_DIRNAME);
-        $taxonomy = str_after($taxonomy, $this->parent->directory());
+        $taxonomy = Str::after($taxonomy, $this->parent->directory());
 
         $data = YAML::file($path)->parse($contents);
 

--- a/src/Stache/Stores/UsersStore.php
+++ b/src/Stache/Stores/UsersStore.php
@@ -40,7 +40,7 @@ class UsersStore extends BasicStore
     {
         $data = YAML::file($path)->parse($contents);
 
-        if (! $id = array_pull($data, 'id')) {
+        if (! $id = Arr::pull($data, 'id')) {
             $idGenerated = true;
             $id = app('stache')->generateId();
         }
@@ -49,7 +49,7 @@ class UsersStore extends BasicStore
             ->id($id)
             ->initialPath($path)
             ->email(pathinfo($path, PATHINFO_FILENAME))
-            ->preferences(array_pull($data, 'preferences', []))
+            ->preferences(Arr::pull($data, 'preferences', []))
             ->data($data);
 
         if (Arr::get($data, 'password') || isset($idGenerated)) {

--- a/src/Stache/Stores/UsersStore.php
+++ b/src/Stache/Stores/UsersStore.php
@@ -8,6 +8,7 @@ use Statamic\Facades\UserGroup;
 use Statamic\Facades\YAML;
 use Statamic\Stache\Indexes\Users\Group;
 use Statamic\Stache\Indexes\Users\Role;
+use Statamic\Support\Arr;
 
 class UsersStore extends BasicStore
 {
@@ -51,7 +52,7 @@ class UsersStore extends BasicStore
             ->preferences(array_pull($data, 'preferences', []))
             ->data($data);
 
-        if (array_get($data, 'password') || isset($idGenerated)) {
+        if (Arr::get($data, 'password') || isset($idGenerated)) {
             $user->writeFile();
         }
 

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -209,7 +209,7 @@ class Statamic
             return false;
         }
 
-        return starts_with(request()->path(), config('statamic.api.route'));
+        return Str::startsWith(request()->path(), config('statamic.api.route'));
     }
 
     public static function apiRoute($route, $params = [])

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -441,7 +441,7 @@ class Statamic
             // In case a file without any version will be passed,
             // a random version number will be created.
             if (! Str::contains($path, '?v=')) {
-                $version = str_random();
+                $version = Str::random();
 
                 // Add the file extension if not provided.
                 $path = Str::finish($path, ".{$extension}");

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -444,10 +444,10 @@ class Statamic
                 $version = str_random();
 
                 // Add the file extension if not provided.
-                $path = str_finish($path, ".{$extension}");
+                $path = Str::finish($path, ".{$extension}");
 
                 // Add the version to the path.
-                $path = str_finish($path, "?v={$version}");
+                $path = Str::finish($path, "?v={$version}");
             }
 
             return $path;

--- a/src/StaticCaching/NoCache/StringRegion.php
+++ b/src/StaticCaching/NoCache/StringRegion.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\StaticCaching\NoCache;
 
+use Statamic\Support\Str;
+
 class StringRegion extends Region
 {
     protected $content;
@@ -13,7 +15,7 @@ class StringRegion extends Region
         $this->content = $content;
         $this->context = $this->filterContext($context);
         $this->extension = $extension;
-        $this->key = sha1($content.str_random());
+        $this->key = sha1($content.Str::random());
     }
 
     public function key(): string

--- a/src/StaticCaching/NoCache/ViewRegion.php
+++ b/src/StaticCaching/NoCache/ViewRegion.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\StaticCaching\NoCache;
 
+use Statamic\Support\Str;
+
 class ViewRegion extends Region
 {
     protected $view;
@@ -11,7 +13,7 @@ class ViewRegion extends Region
         $this->session = $session;
         $this->view = $view;
         $this->context = $this->filterContext($context);
-        $this->key = str_random(32);
+        $this->key = Str::random(32);
     }
 
     public function key(): string

--- a/src/StaticCaching/Replacers/CsrfTokenReplacer.php
+++ b/src/StaticCaching/Replacers/CsrfTokenReplacer.php
@@ -5,6 +5,7 @@ namespace Statamic\StaticCaching\Replacers;
 use Illuminate\Http\Response;
 use Statamic\Facades\StaticCache;
 use Statamic\StaticCaching\Replacer;
+use Statamic\Support\Str;
 
 class CsrfTokenReplacer implements Replacer
 {
@@ -20,7 +21,7 @@ class CsrfTokenReplacer implements Replacer
             return;
         }
 
-        if (! str_contains($content, $token)) {
+        if (! Str::contains($content, $token)) {
             return;
         }
 

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -201,7 +201,7 @@ abstract class Tree implements Contract, Localization
     protected function removeEmptyChildren($array)
     {
         return collect($array)->map(function ($item) {
-            $item['children'] = $this->removeEmptyChildren(array_get($item, 'children', []));
+            $item['children'] = $this->removeEmptyChildren(Arr::get($item, 'children', []));
 
             if (empty($item['children'])) {
                 unset($item['children']);

--- a/src/Support/FileCollection.php
+++ b/src/Support/FileCollection.php
@@ -123,7 +123,7 @@ class FileCollection extends Collection
             foreach ($sorts as $sort) {
                 $bits = explode(':', $sort);
                 $sort_by = $bits[0];
-                $sort_dir = array_get($bits, 1);
+                $sort_dir = Arr::get($bits, 1);
 
                 [$one, $two] = $this->getSortableValues($sort_by, $a, $b);
 
@@ -200,8 +200,8 @@ class FileCollection extends Collection
             $data[] = [
                 'file' => URL::format($path), // Todo: This will only work when using the local file adapter
                 'filename' => $pathinfo['filename'],
-                'extension' => array_get($pathinfo, 'extension'),
-                'basename' => array_get($pathinfo, 'basename'),
+                'extension' => Arr::get($pathinfo, 'extension'),
+                'basename' => Arr::get($pathinfo, 'basename'),
                 'size' => File::sizeHuman($path),
                 'size_bytes' => $size,
                 'size_kilobytes' => $kb,

--- a/src/Support/Manager.php
+++ b/src/Support/Manager.php
@@ -43,7 +43,7 @@ abstract class Manager
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($config, $name);
         } else {
-            $driverMethod = 'create'.camel_case($config['driver']).'Driver';
+            $driverMethod = 'create'.Str::camel($config['driver']).'Driver';
 
             if (method_exists($this, $driverMethod)) {
                 return $this->{$driverMethod}($config, $name);

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -92,7 +92,7 @@ class Str
         $string = $language ? static::ascii($string, $language) : $string;
 
         // Statamic is a-OK with underscores in slugs.
-        $string = str_replace('_', $placeholder = strtolower(str_random(16)), $string);
+        $string = str_replace('_', $placeholder = strtolower(Str::random(16)), $string);
 
         $slug = IlluminateStr::slug($string, $separator, $language, $dictionary);
 

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -4,6 +4,7 @@ namespace Statamic\Tags\Concerns;
 
 use Closure;
 use Illuminate\Support\MessageBag;
+use Statamic\Support\Str;
 
 trait RendersForms
 {
@@ -126,7 +127,7 @@ trait RendersForms
     {
         $errors = session('errors') ? session('errors')->getBag($errorBag) : new MessageBag;
 
-        $missing = str_random();
+        $missing = Str::random();
         $old = old($field->handle(), $missing);
         $default = $field->value() ?? $field->defaultValue();
         $value = $old === $missing ? $default : $old;

--- a/src/Tags/Markdown.php
+++ b/src/Tags/Markdown.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Tags;
 
+use Statamic\Support\Arr;
 use Statamic\Support\Html;
 
 class Markdown extends Tags
@@ -30,7 +31,7 @@ class Markdown extends Tags
         // Count the number of whitespace characters at the beginning of the
         // first line to prevent over-trimming.
         preg_match($regex, $lines[$firstLine], $matches, PREG_OFFSET_CAPTURE);
-        $maxTrim = array_get($matches, '0.1');
+        $maxTrim = Arr::get($matches, '0.1');
 
         $md = $lines->map(function ($line) use ($maxTrim) {
             // Trim the appropriate amount of whitespace at the start of

--- a/src/Tags/ParentTags.php
+++ b/src/Tags/ParentTags.php
@@ -55,7 +55,7 @@ class ParentTags extends Tags
     {
         $parent = $this->getParent();
 
-        return array_get($parent, 'url');
+        return Arr::get($parent, 'url');
     }
 
     /**

--- a/src/Tags/Tags.php
+++ b/src/Tags/Tags.php
@@ -91,8 +91,8 @@ abstract class Tags
         $this->setContent($properties['content']);
         $this->setContext($properties['context']);
         $this->setParameters($properties['params']);
-        $this->tag = array_get($properties, 'tag');
-        $this->method = array_get($properties, 'tag_method');
+        $this->tag = Arr::get($properties, 'tag');
+        $this->method = Arr::get($properties, 'tag_method');
 
         $this->runHooks('init');
     }

--- a/src/View/Antlers/Language/Runtime/Sandbox/LanguageOperatorManager.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/LanguageOperatorManager.php
@@ -204,13 +204,13 @@ class LanguageOperatorManager
             }
 
             if (is_array($data)) {
-                return array_get($data, $node->name);
+                return Arr::get($data, $node->name);
             }
 
             return data_get($data, $node->name);
         } elseif ($node instanceof StringValueNode) {
             if (is_array($data)) {
-                return array_get($data, $node->value);
+                return Arr::get($data, $node->value);
             }
 
             return data_get($data, $node->value);
@@ -226,7 +226,7 @@ class LanguageOperatorManager
 
         if (is_string($node)) {
             if (is_array($data)) {
-                return array_get($data, $node);
+                return Arr::get($data, $node);
             }
 
             return data_get($data, $node);

--- a/src/View/Blade/TagsDirective.php
+++ b/src/View/Blade/TagsDirective.php
@@ -4,6 +4,7 @@ namespace Statamic\View\Blade;
 
 use Illuminate\Support\Collection;
 use Statamic\Statamic;
+use Statamic\Support\Str;
 
 class TagsDirective
 {
@@ -18,7 +19,7 @@ class TagsDirective
                 $params = [];
             }
 
-            $var = is_string($key) ? $key : camel_case(str_replace(':', '_', $tag));
+            $var = is_string($key) ? $key : Str::camel(str_replace(':', '_', $tag));
 
             return [$var => Statamic::tag($tag)->params($params)->fetch()];
         })->all();

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -71,7 +71,7 @@ class Cascade
 
     public function set($key, $value)
     {
-        array_set($this->data, $key, $value);
+        Arr::set($this->data, $key, $value);
     }
 
     public function data($data)

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -66,7 +66,7 @@ class Cascade
 
     public function get($key)
     {
-        return array_get($this->data, $key);
+        return Arr::get($this->data, $key);
     }
 
     public function set($key, $value)

--- a/src/Yaml/Yaml.php
+++ b/src/Yaml/Yaml.php
@@ -6,6 +6,7 @@ use Exception;
 use ReflectionProperty;
 use Statamic\Facades\File;
 use Statamic\Facades\Pattern;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Yaml\ParseException as StatamicParseException;
 use Symfony\Component\Yaml\Yaml as SymfonyYaml;
@@ -53,7 +54,7 @@ class Yaml
         if (Pattern::startsWith($str, '---')) {
             $split = preg_split("/\n---/", $str, 2, PREG_SPLIT_NO_EMPTY);
             $str = $split[0];
-            if (empty($content = ltrim(array_get($split, 1, '')))) {
+            if (empty($content = ltrim(Arr::get($split, 1, '')))) {
                 $content = null;
             }
         }

--- a/tests/Antlers/Fixtures/Addon/Tags/TestTags.php
+++ b/tests/Antlers/Fixtures/Addon/Tags/TestTags.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Antlers\Fixtures\Addon\Tags;
 
+use Statamic\Support\Arr;
 use Statamic\Tags\Tags;
 
 class TestTags extends Tags
@@ -26,7 +27,7 @@ class TestTags extends Tags
     {
         $var = $this->params->get('var');
 
-        $val = array_get($this->context, $var);
+        $val = Arr::get($this->context, $var);
 
         return $this->parse([$var => $val]);
     }

--- a/tests/Auth/Eloquent/EloquentRoleTest.php
+++ b/tests/Auth/Eloquent/EloquentRoleTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Carbon;
 use Statamic\Auth\Eloquent\Role as EloquentRole;
 use Statamic\Auth\Eloquent\RoleModel;
 use Statamic\Auth\Eloquent\User as EloquentUser;
+use Statamic\Support\Str;
 use Tests\TestCase;
 
 class EloquentRoleTest extends TestCase
@@ -79,7 +80,7 @@ class EloquentRoleTest extends TestCase
                 'name' => $this->faker->name,
                 'email' => $this->faker->unique()->safeEmail,
                 // 'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
-                'remember_token' => str_random(10),
+                'remember_token' => Str::random(10),
             ])
             );
     }

--- a/tests/Auth/Eloquent/EloquentUserGroupTest.php
+++ b/tests/Auth/Eloquent/EloquentUserGroupTest.php
@@ -10,6 +10,7 @@ use Statamic\Auth\Eloquent\User as EloquentUser;
 use Statamic\Auth\Eloquent\UserGroup as EloquentGroup;
 use Statamic\Auth\Eloquent\UserGroupModel;
 use Statamic\Facades\UserGroup;
+use Statamic\Support\Str;
 use Tests\TestCase;
 
 class EloquentUserGroupTest extends TestCase
@@ -78,7 +79,7 @@ class EloquentUserGroupTest extends TestCase
                 'name' => $this->faker->name,
                 'email' => $this->faker->unique()->safeEmail,
                 // 'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
-                'remember_token' => str_random(10),
+                'remember_token' => Str::random(10),
             ])
             );
     }

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -12,6 +12,7 @@ use Statamic\Auth\File\UserGroup;
 use Statamic\Contracts\Auth\Role as RoleContract;
 use Statamic\Contracts\Auth\UserGroup as UserGroupContract;
 use Statamic\Facades;
+use Statamic\Support\Str;
 use Tests\Auth\PermissibleContractTests;
 use Tests\Auth\UserContractTests;
 use Tests\Preferences\HasPreferencesTests;

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -238,7 +238,7 @@ class EloquentUserTest extends TestCase
                 'name' => $this->faker->name(),
                 'email' => $this->faker->unique()->safeEmail(),
                 // 'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
-                'remember_token' => str_random(10),
+                'remember_token' => Str::random(10),
             ])
             );
     }

--- a/tests/Fakes/FakeFieldsetRepository.php
+++ b/tests/Fakes/FakeFieldsetRepository.php
@@ -3,6 +3,7 @@
 namespace Tests\Fakes;
 
 use Statamic\Fields\Fieldset;
+use Statamic\Support\Arr;
 
 class FakeFieldsetRepository
 {
@@ -10,7 +11,7 @@ class FakeFieldsetRepository
 
     public function find(string $handle): ?Fieldset
     {
-        if ($fieldset = array_get($this->fieldsets, $handle)) {
+        if ($fieldset = Arr::get($this->fieldsets, $handle)) {
             // Return a clone so that modifications to the object will only be updated when saving.
             return clone $fieldset;
         }

--- a/tests/Fixtures/Addon/Tags/TestTags.php
+++ b/tests/Fixtures/Addon/Tags/TestTags.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Fixtures\Addon\Tags;
 
+use Statamic\Support\Arr;
 use Statamic\Tags\Tags;
 
 class TestTags extends Tags
@@ -22,7 +23,7 @@ class TestTags extends Tags
     {
         $var = $this->params->get('var');
 
-        $val = array_get($this->context, $var);
+        $val = Arr::get($this->context, $var);
 
         return $this->parse([$var => $val]);
     }

--- a/tests/Http/Middleware/AddViewPathsTest.php
+++ b/tests/Http/Middleware/AddViewPathsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Http\Middleware;
 use Illuminate\Http\Request;
 use Statamic\Facades\Site;
 use Statamic\Http\Middleware\AddViewPaths;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response;
@@ -71,14 +72,14 @@ class AddViewPathsTest extends TestCase
         $handled = false;
 
         (new AddViewPaths())->handle($request, function () use ($expectedPaths, &$handled) {
-            $this->assertEquals($expectedPaths, array_get(view()->getFinder()->getHints(), 'foo'));
+            $this->assertEquals($expectedPaths, Arr::get(view()->getFinder()->getHints(), 'foo'));
             $handled = true;
 
             return new Response;
         });
 
         $this->assertTrue($handled);
-        $this->assertEquals($originalHints, array_get(view()->getFinder()->getHints(), 'foo'));
+        $this->assertEquals($originalHints, Arr::get(view()->getFinder()->getHints(), 'foo'));
     }
 
     private function setCurrentSiteBasedOnUrl($requestUrl)

--- a/tests/Imaging/GlideImageManipulatorTest.php
+++ b/tests/Imaging/GlideImageManipulatorTest.php
@@ -6,6 +6,7 @@ use Mockery;
 use Statamic\Assets\Asset;
 use Statamic\Contracts\Imaging\UrlBuilder;
 use Statamic\Imaging\GlideImageManipulator;
+use Statamic\Support\Arr;
 use Tests\TestCase;
 
 class GlideImageManipulatorTest extends TestCase
@@ -137,7 +138,7 @@ class GlideImageManipulatorTest extends TestCase
         $this->man->fit('crop_focal');
 
         $this->assertArrayHasKey('fit', $this->man->getParams());
-        $this->assertEquals('crop-60-40', array_get($this->man->getParams(), 'fit'));
+        $this->assertEquals('crop-60-40', Arr::get($this->man->getParams(), 'fit'));
     }
 
     /** @test */
@@ -149,6 +150,6 @@ class GlideImageManipulatorTest extends TestCase
         $this->man->fit('crop_focal');
 
         $this->assertArrayHasKey('fit', $this->man->getParams());
-        $this->assertEquals('crop', array_get($this->man->getParams(), 'fit'));
+        $this->assertEquals('crop', Arr::get($this->man->getParams(), 'fit'));
     }
 }

--- a/tests/Modifiers/WhereTest.php
+++ b/tests/Modifiers/WhereTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Modifiers;
 
 use Statamic\Modifiers\Modify;
+use Statamic\Support\Arr;
 use Tests\TestCase;
 
 /**
@@ -20,7 +21,7 @@ class WhereTest extends TestCase
         ];
         $expected = ['Dominion', 'Netrunner'];
         $modified = $this->modify($games, ['feeling', 'love']);
-        $this->assertEquals($expected, array_pluck($modified, 'title'));
+        $this->assertEquals($expected, Arr::pluck($modified, 'title'));
     }
 
     /** @test */
@@ -36,7 +37,7 @@ class WhereTest extends TestCase
         ];
         $expected = ['Dominion', 'Netrunner'];
         $modified = $this->modify($games, ['feeling:love']);
-        $this->assertEquals($expected, array_pluck($modified, 'title'));
+        $this->assertEquals($expected, Arr::pluck($modified, 'title'));
     }
 
     private function modify($value, array $params)

--- a/tests/Policies/PolicyTestCase.php
+++ b/tests/Policies/PolicyTestCase.php
@@ -4,6 +4,7 @@ namespace Tests\Policies;
 
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
+use Statamic\Support\Str;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -21,7 +22,7 @@ class PolicyTestCase extends TestCase
 
     protected function userWithPermissions(array $permissions)
     {
-        $role = str_random();
+        $role = Str::random();
 
         $this->setTestRole($role, $permissions);
 

--- a/tests/PreventSavingStacheItemsToDisk.php
+++ b/tests/PreventSavingStacheItemsToDisk.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Statamic\Facades\Path;
 use Statamic\Facades\Stache;
+use Statamic\Support\Str;
 
 trait PreventSavingStacheItemsToDisk
 {
@@ -15,7 +16,7 @@ trait PreventSavingStacheItemsToDisk
 
         Stache::stores()->each(function ($store) {
             $dir = Path::tidy(__DIR__.'/__fixtures__');
-            $relative = str_after(str_after($store->directory(), $dir), '/');
+            $relative = Str::after(Str::after($store->directory(), $dir), '/');
             $store->directory($this->fakeStacheDirectory.'/'.$relative);
         });
     }


### PR DESCRIPTION
This pull request drops the `laravel/helpers` dependency, which provided global functions for array & string helper which were removed from the Laravel framework a few years ago.

All of the helper functions in the `helpers` package forward calls to Laravel's `Arr`/`Str` so this PR is pretty much a big find & replace. 😄 

Closes #9721.