### PR TITLE
[4.x] Fix OAuth login when using independent auth guards

### DIFF
--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -2,19 +2,30 @@
 
 namespace Statamic\Http\Controllers;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
 use Statamic\Facades\OAuth;
+use Statamic\Support\Str;
 
 class OAuthController
 {
-    public function redirectToProvider($provider)
+    public function redirectToProvider(Request $request, string $provider)
     {
+        $referer = $request->headers->get('referer');
+        $guard = config('statamic.users.guards.web', 'web');
+
+        if (Str::startsWith(parse_url($referer)['path'], Str::ensureLeft(config('statamic.cp.route'), '/'))) {
+            $guard = config('statamic.users.guards.cp', 'web');
+        }
+
+        $request->session()->put('statamic.oauth.guard', $guard);
+
         return Socialite::driver($provider)->redirect();
     }
 
-    public function handleProviderCallback($provider)
+    public function handleProviderCallback(Request $request, string $provider)
     {
         $oauth = OAuth::provider($provider);
 
@@ -28,7 +39,8 @@ class OAuthController
 
         session()->put('oauth-provider', $provider);
 
-        Auth::login($user, config('statamic.oauth.remember_me', true));
+        Auth::guard($request->session()->get('statamic.oauth.guard'))
+            ->login($user, config('statamic.oauth.remember_me', true));
 
         return redirect()->to($this->successRedirectUrl());
     }


### PR DESCRIPTION
This pull request fixes an issue with Statamic's OAuth login feature when you have different authentication guards configured for the frontend and the Control Panel.

Before this PR, our `OAuthController` would attempt to login the user but it'd use the default `web` guard, which may not necessarily be the one you have configured for Statamic users. If this happened, it'd redirect you but you wouldn't actually be logged in.

This PR fixes that by checking *where* the user came from (eg. the frontend or the CP), then uses that to determine which user guard should be used to login the user. 

---

Fixes #9773.
Replaces #9717.
