### PR TITLE
[4.x] Ensure redirects work for localized entries

### DIFF
--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -69,7 +69,7 @@ class DataResponse implements Responsable
 
     protected function getRedirect()
     {
-        if (! $raw = $this->data->get('redirect')) {
+        if (! $raw = $this->data->value('redirect')) {
             return;
         }
 

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -69,7 +69,7 @@ class DataResponse implements Responsable
 
     protected function getRedirect()
     {
-        if (! $raw = $this->data->value('redirect')) {
+        if (! $raw = (method_exists($this->data, 'value') ? $this->data->value('redirect') : $this->data->get('redirect'))) {
             return;
         }
 

--- a/tests/FakesContent.php
+++ b/tests/FakesContent.php
@@ -9,7 +9,7 @@ trait FakesContent
 {
     protected function createPage($slug, $attributes = [])
     {
-        $this->makeCollection()->save();
+        $this->makeCollection()?->save();
 
         return tap($this->makePage($slug, $attributes))->save();
     }
@@ -25,6 +25,10 @@ trait FakesContent
 
     protected function makeCollection()
     {
+        if (Collection::find('pages')) {
+            return;
+        }
+
         return Collection::make('pages')
             ->routes('{slug}')
             ->template('default');

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -13,6 +13,7 @@ use Statamic\Events\ResponseCreated;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Cascade;
 use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Tags\Tags;
@@ -957,6 +958,45 @@ class FrontendTest extends TestCase
         ]))->save();
 
         $response = $this->get('/about');
+
+        $response->assertRedirect('/test');
+        $response->assertStatus(301);
+    }
+
+    /**
+     * @test
+     */
+    public function redirect_is_followed_when_value_is_inherited_from_origin()
+    {
+        Site::setConfig(['sites' => [
+            'en' => ['url' => '/', 'locale' => 'en'],
+            'fr' => ['url' => "/fr/", 'locale' => 'fr'],
+        ]]);
+
+        $blueprint = Blueprint::makeFromFields([
+            'redirect' => [
+                'type' => 'group',
+                'fields' => [
+                    ['handle' => 'url', 'field' => ['type' => 'link']],
+                    ['handle' => 'status', 'field' => ['type' => 'radio', 'options' => [301, 302]]],
+                ],
+            ]]);
+        Blueprint::shouldReceive('in')->with('collections/pages')->andReturn(collect([$blueprint]));
+
+        Collection::make('pages')->sites(['en', 'fr'])->routes(['en' => '{slug}', 'fr' => '{slug}'])->save();
+
+        $entry = tap($this->createPage('about', [
+            'with' => [
+                'title' => 'About',
+                'redirect' => [
+                    'url' => '/test',
+                    'status' => 301,
+                ],
+            ],
+        ]))->save();
+        tap($entry->makeLocalization('fr'))->save();
+
+        $response = $this->get('/fr/about');
 
         $response->assertRedirect('/test');
         $response->assertStatus(301);

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -970,7 +970,7 @@ class FrontendTest extends TestCase
     {
         Site::setConfig(['sites' => [
             'en' => ['url' => '/', 'locale' => 'en'],
-            'fr' => ['url' => "/fr/", 'locale' => 'fr'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr'],
         ]]);
 
         $blueprint = Blueprint::makeFromFields([


### PR DESCRIPTION
This pull request fixes an issue when using the [collection redirects feature](https://statamic.dev/collections#redirects), where localized entries of a redirect entry would return a 200 response, instead of a 301/302 redirect.

Fixes #9813.