### PR TITLE
[4.x] Track Laravel version in the Outpost

### DIFF
--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -91,6 +91,7 @@ class Outpost
             'statamic_version' => Statamic::version(),
             'statamic_pro' => Statamic::pro(),
             'php_version' => PHP_VERSION,
+            'laravel_version' => app()->version(),
             'packages' => $this->packagePayload(),
         ];
     }

--- a/tests/Licensing/OutpostTest.php
+++ b/tests/Licensing/OutpostTest.php
@@ -45,6 +45,7 @@ class OutpostTest extends TestCase
             'statamic_version' => '3.0.0-testing',
             'statamic_pro' => true,
             'php_version' => PHP_VERSION,
+            'laravel_version' => app()->version(),
             'packages' => [
                 'foo/bar' => ['version' => '1.2.3', 'edition' => null],
                 'baz/qux' => ['version' => '4.5.6', 'edition' => 'example'],


### PR DESCRIPTION
We will now track the installed Laravel version to provide a better experience on statamic.com.
