### PR TITLE
[4.x] Fix filter preset issues

### DIFF
--- a/resources/js/components/data-list/FilterPresets.vue
+++ b/resources/js/components/data-list/FilterPresets.vue
@@ -50,7 +50,7 @@
             @cancel="showRenameModal = false"
             @confirm="savePreset(savingPresetSlug)"
         >
-            <text-input :focus="true" v-model="savingPresetName" @keydown.enter="savePreset()" />
+            <text-input :focus="true" v-model="savingPresetName" @keydown.enter="savePreset(savingPresetSlug)" />
 
             <div v-if="Object.keys(presets).filter(preset => preset !== activePreset).includes(savingPresetSlug)">
                 <small class="help-block text-red-500 mt-2 mb-0" v-text="__('messages.filters_view_already_exists')"></small>

--- a/resources/js/components/data-list/FilterPresets.vue
+++ b/resources/js/components/data-list/FilterPresets.vue
@@ -188,12 +188,14 @@ export default {
 
                     this.$toast.success(__('View saved'));
                     this.showCreateModal = false;
+                    this.savingPresetName = null;
                     this.setPreset(presetHandle);
                 })
                 .catch(error => {
                     this.$toast.error(__('Unable to save view'));
                     this.showCreateModal = false;
                     this.showRenameModal = false;
+                    this.savingPresetName = null;
                 });
         },
 


### PR DESCRIPTION
This pull request fixes two issues with filter presets, on the back of my changes in #9792:

* Fixed an issue when updating existing filter presets, where after saving, all presets would have the same display name.
* Fixed an issue when renaming views where the view would disappear if you saved the rename by pressing enter, rather than clicking the "Rename" button.

Fixes #9824.