### PR TITLE
[4.x] Fix icons in preference save options

### DIFF
--- a/src/Http/Controllers/CP/Preferences/ManagesPreferences.php
+++ b/src/Http/Controllers/CP/Preferences/ManagesPreferences.php
@@ -65,21 +65,21 @@ trait ManagesPreferences
         $options->put('default', [
             'label' => __('Default'),
             'url' => cp_route('preferences.default.update'),
-            'icon' => 'earth',
+            'icon' => 'light/earth',
         ]);
 
         Role::all()->each(function ($role) use (&$options) {
             $options->put($role->handle(), [
                 'label' => $role->title(),
                 'url' => cp_route('preferences.role.update', $role->handle()),
-                'icon' => 'shield-key',
+                'icon' => 'light/shield-key',
             ]);
         });
 
         $options->put('user', [
             'label' => __('My Preferences'),
             'url' => cp_route('preferences.user.update'),
-            'icon' => 'user',
+            'icon' => 'light/user',
         ]);
 
         $options->forget($this->ignoreSaveAsOption());


### PR DESCRIPTION
This pull request fixes an issue on the preference/nav pages, where the icons in the "Save" dropdown wouldn't be shown properly. They'd just fallback to a default icon.

![CleanShot 2024-04-05 at 10 35 33](https://github.com/statamic/cms/assets/19637309/eea1fb8c-0a18-4dad-aff2-9754f5ca62b7)

Fixes #9825.