### PR TITLE
[4.x] Prevent "Permanently added the ECDSA host key for IP address" from being logged as a Git error

### DIFF
--- a/src/Console/Processes/Git.php
+++ b/src/Console/Processes/Git.php
@@ -85,7 +85,12 @@ class Git extends Process
      */
     protected function prepareErrorOutput($type, $buffer)
     {
-        if (Str::contains($buffer, 'remote: Resolving deltas')) {
+        $ignore = [
+            'remote: Resolving deltas',
+            'Permanently added the ECDSA host key for IP address',
+        ];
+
+        if (Str::contains($buffer, $ignore)) {
             return;
         }
 

--- a/tests/Git/GitProcessTest.php
+++ b/tests/Git/GitProcessTest.php
@@ -147,6 +147,14 @@ EOT;
         $this->simulateLoggableErrorOutput('remote: Resolving deltas: 0% (0/6)\nremote: Resolving deltas: 16% (1/6)\nremote: Resolving deltas: 33% (2/6)\nremote: Resolving deltas: 50% (3/6)\nremote: Resolving deltas: 66% (4/6)\nremote: Resolving deltas: 83% (5/6)\nremote: Resolving deltas: 100% (6/6)\nremote: Resolving deltas: 100% (6/6), completed with 5 local objects.');
     }
 
+    /** @test */
+    public function it_doesnt_log_added_host_key_to_known_hosts_as_error_output()
+    {
+        Log::shouldReceive('error')->never();
+
+        $this->simulateLoggableErrorOutput("Permanently added the ECDSA host key for IP address '127.0.0.1' to the list of known hosts.");
+    }
+
     private function showLastCommit($path)
     {
         return Process::create($path)->run('git show');


### PR DESCRIPTION
This pull request fixes an issue with the Git integration where `Permanently added the ECDSA host key for IP address [...] to the list of known hosts` was being falsely logged as a Git error, even though it's just a warning.

Fixes #9817.