### PR TITLE
[4.x] Fix js tests GitHub action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,10 +124,6 @@ jobs:
           echo "result=true" >> $GITHUB_OUTPUT
           echo "result=true" >> $env:GITHUB_OUTPUT
 
-      - name: Install required npm version
-        if: steps.should-run-tests.outputs.result == 'true'
-        run: npm -g install npm@8.5.5
-
       - name: Install dependencies
         if: steps.should-run-tests.outputs.result == 'true'
         run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,6 +124,14 @@ jobs:
           echo "result=true" >> $GITHUB_OUTPUT
           echo "result=true" >> $env:GITHUB_OUTPUT
 
+      - name: Use Node.js 16.13.0
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.13.0
+
+      - name: Install required npm version
+        run: npm -g install npm@8.5.5
+
       - name: Install dependencies
         if: steps.should-run-tests.outputs.result == 'true'
         run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,19 +136,19 @@ jobs:
         if: steps.should-run-tests.outputs.result == 'true'
         run: npm run test
 
-  slack:
-    name: Slack Notification
-    runs-on: ubuntu-20.04
-    needs: [php-tests, js-tests]
-    if: always() && github.event_name == 'schedule'
-    steps:
-      - uses: technote-space/workflow-conclusion-action@v1
-      - name: Send Slack notification
-        uses: 8398a7/action-slack@v2
-        if: env.WORKFLOW_CONCLUSION == 'failure'
-        with:
-          status: failure
-          author_name: ${{ github.actor }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#  slack:
+#    name: Slack Notification
+#    runs-on: ubuntu-20.04
+#    needs: [php-tests, js-tests]
+#    if: always() && github.event_name == 'schedule'
+#    steps:
+#      - uses: technote-space/workflow-conclusion-action@v1
+#      - name: Send Slack notification
+#        uses: 8398a7/action-slack@v2
+#        if: env.WORKFLOW_CONCLUSION == 'failure'
+#        with:
+#          status: failure
+#          author_name: ${{ github.actor }}
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,96 +7,96 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-#  php-tests:
-#    runs-on: ${{ matrix.os }}
-#    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-#
-#    strategy:
-#      matrix:
-#        php: [8.0, 8.1, 8.2, 8.3]
-#        laravel: [9.*, 10.*]
-#        stability: [prefer-lowest, prefer-stable]
-#        os: [ubuntu-latest]
-#        include:
-#          - os: windows-latest
-#            php: 8.1
-#            laravel: 9.*
-#            stability: prefer-stable
-#          - os: windows-latest
-#            php: 8.1
-#            laravel: 10.*
-#            stability: prefer-stable
-#        exclude:
-#          - php: 8.0
-#            laravel: 10.*
-#          - php: 8.3
-#            laravel: 9.*
-#
-#    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
-#
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v1
-#
-#      - name: Get changed files
-#        id: changed-files
-#        uses: tj-actions/changed-files@v42
-#        with:
-#          files: |
-#            config
-#            resources/lang
-#            resources/users
-#            resources/views
-#            routes
-#            src
-#            tests
-#            composer.json
-#            phpunit.xml.dist
-#            .github/workflows/tests.yml
-#            **.php
-#
-#      - name: Determine whether tests should run
-#        id: should-run-tests
-#        if: steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule'
-#        run: |
-#          echo "result=true" >> $GITHUB_OUTPUT
-#          echo "result=true" >> $env:GITHUB_OUTPUT
-#
-#      - name: Update apt sources
-#        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
-#        run: |
-#          sudo apt-get check || sudo apt --fix-broken install -y
-#          sudo apt-get update
-#
-#      - name: Install French Locale
-#        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
-#        run: sudo apt-get install language-pack-fr
-#
-#      - name: Setup PHP
-#        uses: shivammathur/setup-php@v2
-#        if: steps.should-run-tests.outputs.result == 'true'
-#        with:
-#          php-version: ${{ matrix.php }}
-#          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-#          coverage: none
-#
-#      - name: Install dependencies
-#        uses: nick-invision/retry@v2
-#        if: steps.should-run-tests.outputs.result == 'true'
-#        with:
-#          timeout_minutes: 5
-#          max_attempts: 5
-#          command: |
-#            composer require "illuminate/contracts:${{ matrix.laravel }}" --dev --no-interaction --no-update
-#            composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-#
-#      - name: List Installed Dependencies
-#        if: steps.should-run-tests.outputs.result == 'true'
-#        run: composer show -D
-#
-#      - name: Execute tests
-#        if: steps.should-run-tests.outputs.result == 'true'
-#        run: vendor/bin/phpunit
+  php-tests:
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+
+    strategy:
+      matrix:
+        php: [8.0, 8.1, 8.2, 8.3]
+        laravel: [9.*, 10.*]
+        stability: [prefer-lowest, prefer-stable]
+        os: [ubuntu-latest]
+        include:
+          - os: windows-latest
+            php: 8.1
+            laravel: 9.*
+            stability: prefer-stable
+          - os: windows-latest
+            php: 8.1
+            laravel: 10.*
+            stability: prefer-stable
+        exclude:
+          - php: 8.0
+            laravel: 10.*
+          - php: 8.3
+            laravel: 9.*
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v42
+        with:
+          files: |
+            config
+            resources/lang
+            resources/users
+            resources/views
+            routes
+            src
+            tests
+            composer.json
+            phpunit.xml.dist
+            .github/workflows/tests.yml
+            **.php
+
+      - name: Determine whether tests should run
+        id: should-run-tests
+        if: steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule'
+        run: |
+          echo "result=true" >> $GITHUB_OUTPUT
+          echo "result=true" >> $env:GITHUB_OUTPUT
+
+      - name: Update apt sources
+        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get check || sudo apt --fix-broken install -y
+          sudo apt-get update
+
+      - name: Install French Locale
+        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install language-pack-fr
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        if: steps.should-run-tests.outputs.result == 'true'
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          coverage: none
+
+      - name: Install dependencies
+        uses: nick-invision/retry@v2
+        if: steps.should-run-tests.outputs.result == 'true'
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: |
+            composer require "illuminate/contracts:${{ matrix.laravel }}" --dev --no-interaction --no-update
+            composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+
+      - name: List Installed Dependencies
+        if: steps.should-run-tests.outputs.result == 'true'
+        run: composer show -D
+
+      - name: Execute tests
+        if: steps.should-run-tests.outputs.result == 'true'
+        run: vendor/bin/phpunit
 
   js-tests:
     runs-on: ubuntu-20.04
@@ -136,19 +136,19 @@ jobs:
         if: steps.should-run-tests.outputs.result == 'true'
         run: npm run test
 
-#  slack:
-#    name: Slack Notification
-#    runs-on: ubuntu-20.04
-#    needs: [php-tests, js-tests]
-#    if: always() && github.event_name == 'schedule'
-#    steps:
-#      - uses: technote-space/workflow-conclusion-action@v1
-#      - name: Send Slack notification
-#        uses: 8398a7/action-slack@v2
-#        if: env.WORKFLOW_CONCLUSION == 'failure'
-#        with:
-#          status: failure
-#          author_name: ${{ github.actor }}
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  slack:
+    name: Slack Notification
+    runs-on: ubuntu-20.04
+    needs: [php-tests, js-tests]
+    if: always() && github.event_name == 'schedule'
+    steps:
+      - uses: technote-space/workflow-conclusion-action@v1
+      - name: Send Slack notification
+        uses: 8398a7/action-slack@v2
+        if: env.WORKFLOW_CONCLUSION == 'failure'
+        with:
+          status: failure
+          author_name: ${{ github.actor }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,96 +7,96 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  php-tests:
-    runs-on: ${{ matrix.os }}
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-
-    strategy:
-      matrix:
-        php: [8.0, 8.1, 8.2, 8.3]
-        laravel: [9.*, 10.*]
-        stability: [prefer-lowest, prefer-stable]
-        os: [ubuntu-latest]
-        include:
-          - os: windows-latest
-            php: 8.1
-            laravel: 9.*
-            stability: prefer-stable
-          - os: windows-latest
-            php: 8.1
-            laravel: 10.*
-            stability: prefer-stable
-        exclude:
-          - php: 8.0
-            laravel: 10.*
-          - php: 8.3
-            laravel: 9.*
-
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v1
-
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v42
-        with:
-          files: |
-            config
-            resources/lang
-            resources/users
-            resources/views
-            routes
-            src
-            tests
-            composer.json
-            phpunit.xml.dist
-            .github/workflows/tests.yml
-            **.php
-
-      - name: Determine whether tests should run
-        id: should-run-tests
-        if: steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule'
-        run: |
-          echo "result=true" >> $GITHUB_OUTPUT
-          echo "result=true" >> $env:GITHUB_OUTPUT
-
-      - name: Update apt sources
-        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get check || sudo apt --fix-broken install -y
-          sudo apt-get update
-
-      - name: Install French Locale
-        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install language-pack-fr
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        if: steps.should-run-tests.outputs.result == 'true'
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: none
-
-      - name: Install dependencies
-        uses: nick-invision/retry@v2
-        if: steps.should-run-tests.outputs.result == 'true'
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: |
-            composer require "illuminate/contracts:${{ matrix.laravel }}" --dev --no-interaction --no-update
-            composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-
-      - name: List Installed Dependencies
-        if: steps.should-run-tests.outputs.result == 'true'
-        run: composer show -D
-
-      - name: Execute tests
-        if: steps.should-run-tests.outputs.result == 'true'
-        run: vendor/bin/phpunit
+#  php-tests:
+#    runs-on: ${{ matrix.os }}
+#    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+#
+#    strategy:
+#      matrix:
+#        php: [8.0, 8.1, 8.2, 8.3]
+#        laravel: [9.*, 10.*]
+#        stability: [prefer-lowest, prefer-stable]
+#        os: [ubuntu-latest]
+#        include:
+#          - os: windows-latest
+#            php: 8.1
+#            laravel: 9.*
+#            stability: prefer-stable
+#          - os: windows-latest
+#            php: 8.1
+#            laravel: 10.*
+#            stability: prefer-stable
+#        exclude:
+#          - php: 8.0
+#            laravel: 10.*
+#          - php: 8.3
+#            laravel: 9.*
+#
+#    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+#
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v1
+#
+#      - name: Get changed files
+#        id: changed-files
+#        uses: tj-actions/changed-files@v42
+#        with:
+#          files: |
+#            config
+#            resources/lang
+#            resources/users
+#            resources/views
+#            routes
+#            src
+#            tests
+#            composer.json
+#            phpunit.xml.dist
+#            .github/workflows/tests.yml
+#            **.php
+#
+#      - name: Determine whether tests should run
+#        id: should-run-tests
+#        if: steps.changed-files.outputs.any_modified == 'true' || github.event_name == 'schedule'
+#        run: |
+#          echo "result=true" >> $GITHUB_OUTPUT
+#          echo "result=true" >> $env:GITHUB_OUTPUT
+#
+#      - name: Update apt sources
+#        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
+#        run: |
+#          sudo apt-get check || sudo apt --fix-broken install -y
+#          sudo apt-get update
+#
+#      - name: Install French Locale
+#        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
+#        run: sudo apt-get install language-pack-fr
+#
+#      - name: Setup PHP
+#        uses: shivammathur/setup-php@v2
+#        if: steps.should-run-tests.outputs.result == 'true'
+#        with:
+#          php-version: ${{ matrix.php }}
+#          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+#          coverage: none
+#
+#      - name: Install dependencies
+#        uses: nick-invision/retry@v2
+#        if: steps.should-run-tests.outputs.result == 'true'
+#        with:
+#          timeout_minutes: 5
+#          max_attempts: 5
+#          command: |
+#            composer require "illuminate/contracts:${{ matrix.laravel }}" --dev --no-interaction --no-update
+#            composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+#
+#      - name: List Installed Dependencies
+#        if: steps.should-run-tests.outputs.result == 'true'
+#        run: composer show -D
+#
+#      - name: Execute tests
+#        if: steps.should-run-tests.outputs.result == 'true'
+#        run: vendor/bin/phpunit
 
   js-tests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,6 +130,7 @@ jobs:
           node-version: 16.13.0
 
       - name: Install required npm version
+        if: steps.should-run-tests.outputs.result == 'true'
         run: npm -g install npm@8.5.5
 
       - name: Install dependencies


### PR DESCRIPTION
The failures must have something to do with GitHub deprecating Node versions.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

This PR is just kicking the can down the road. Explicitly requiring Node 16 fixes the errors. We'll need to figure this out properly eventually.