### PR TITLE
[5.x] Make properties protected so class can be extended

### DIFF
--- a/src/Data/HasOrigin.php
+++ b/src/Data/HasOrigin.php
@@ -10,7 +10,7 @@ trait HasOrigin
      * @var string
      */
     protected $origin;
-    private $cachedKeys;
+    protected $cachedKeys;
 
     public function keys()
     {

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -78,8 +78,8 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
     protected $withEvents = true;
     protected $template;
     protected $layout;
-    private $computedCallbackCache;
-    private $siteCache;
+    protected $computedCallbackCache;
+    protected $siteCache;
 
     public function __construct()
     {


### PR DESCRIPTION
I'm working on a PR to eloquent to mop up all the changes needed for 5.x (https://github.com/statamic/eloquent-driver/pull/264)

The test suite is currently failing with errors:

`ErrorException: serialize(): "cachedKeys" returned as member variable from __sleep() but does not exist`

and

`ErrorException: serialize(): "siteCache" returned as member variable from __sleep() but does not exist`

Can we make these properties `protected` instead of `private`?