### PR TITLE
[4.x] Improve array fieldtype validation for dynamically keyed fields

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -154,6 +154,7 @@ return [
     |
     */
 
+    'arr_fieldtype' => 'This is invalid.',
     'code_fieldtype_rulers' => 'This is invalid.',
     'date_fieldtype_date_required' => 'Date is required.',
     'date_fieldtype_end_date_invalid' => 'Not a valid end date.',

--- a/src/Fieldtypes/Arr.php
+++ b/src/Fieldtypes/Arr.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fieldtypes;
 
+use Closure;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 use Statamic\GraphQL\Types\ArrayType;
@@ -80,5 +81,24 @@ class Arr extends Fieldtype
     public function toGqlType()
     {
         return GraphQL::type(ArrayType::NAME);
+    }
+
+    public function rules(): array
+    {
+        if ($this->isKeyed()) {
+            return [];
+        }
+
+        return [function ($handle, $value, Closure $fail) {
+            $values = collect($value);
+
+            if ($values->has('null')) {
+                $fail('statamic::validation.arr_fieldtype')->translate();
+            }
+
+            if ($values->count() !== $values->reject(fn ($v) => is_null($v))->count()) {
+                $fail('statamic::validation.arr_fieldtype')->translate();
+            }
+        }];
     }
 }


### PR DESCRIPTION
I noticed this little oddity when working on https://github.com/statamic/cms/pull/9632, since we use array fieldtype in new sites configuration UI.

Before this PR, if you try to save a publish form with an array fieldtype that is set to `dynamic` mode, if you leave an empty key or value, you get weird data saved to your yaml:

```yaml
dynamically_keyed_array:
  foo: Bar
  'null': null
```

If you use `keyed` or `single` modes, key and value are both required for each submitted row. This PR adds validation to ensure you properly fill out each row.

![CleanShot 2024-04-05 at 16 25 05](https://github.com/statamic/cms/assets/5187394/9affbb0d-a0ac-484f-8936-09e017798c31)