### PR TITLE
[4.x] Fix overlapping set group & set name in Safari

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -10,10 +10,10 @@
                 <div class="item-move sortable-handle" data-drag-handle />
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
                     <label class="text-xs whitespace-nowrap rtl:ml-2 ltr:mr-2">
-                        <div v-if="setGroup" class="inline-block">
+                        <span v-if="setGroup">
                             {{ setGroup.display }}
                             <svg-icon name="micro/chevron-right" class="w-4" />
-                        </div>
+                        </span>
                         {{ display || config.handle }}
                     </label>
                     <div class="flex items-center" v-if="config.instructions && !collapsed">

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -10,10 +10,10 @@
                 <div class="item-move sortable-handle" data-drag-handle />
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
                     <label class="text-xs whitespace-nowrap rtl:ml-2 ltr:mr-2">
-                        <template v-if="setGroup">
+                        <div v-if="setGroup" class="inline-block">
                             {{ setGroup.display }}
                             <svg-icon name="micro/chevron-right" class="w-4" />
-                        </template>
+                        </div>
                         {{ display || config.handle }}
                     </label>
                     <div class="flex items-center" v-if="config.instructions && !collapsed">

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -8,10 +8,10 @@
                 <div class="item-move sortable-handle" :class="sortableHandleClass" v-if="!isReadOnly"></div>
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
                     <label class="text-xs whitespace-nowrap rtl:ml-2 ltr:mr-2 cursor-pointer">
-                        <template v-if="setGroup">
+                        <div v-if="setGroup" class="inline-block">
                             {{ setGroup.display }}
                             <svg-icon name="micro/chevron-right" class="w-4" />
-                        </template>
+                        </div>
                         {{ display || config.handle }}
                     </label>
                     <div class="flex items-center" v-if="config.instructions && !collapsed">

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -8,10 +8,10 @@
                 <div class="item-move sortable-handle" :class="sortableHandleClass" v-if="!isReadOnly"></div>
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
                     <label class="text-xs whitespace-nowrap rtl:ml-2 ltr:mr-2 cursor-pointer">
-                        <div v-if="setGroup" class="inline-block">
+                        <span v-if="setGroup">
                             {{ setGroup.display }}
                             <svg-icon name="micro/chevron-right" class="w-4" />
-                        </div>
+                        </span>
                         {{ display || config.handle }}
                     </label>
                     <div class="flex items-center" v-if="config.instructions && !collapsed">


### PR DESCRIPTION
This pull request fixes an issue where the set group name & the set name would overlap in Safari 17.4 (17.3 would work fine). After a little bit of testing, it seems the fix is as simple as swapping `<template>` for `<span>`. Don't ask me why.

Fixes #9713.
Caused by #9670.