### PR TITLE
[4.x] Ability to disable SVG sanitization on upload

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -222,4 +222,17 @@ return [
 
     'additional_uploadable_extensions' => [],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Disable SVG Sanitization
+    |--------------------------------------------------------------------------
+    |
+    | Statamic will automatically sanitize uploaded SVG files to avoid potential
+    | security issues. If you trust your users and need to disable this behaviour,
+    | you may do so here.
+    |
+    */
+
+    'disable_svg_sanitization' => false,
+
 ];

--- a/config/assets.php
+++ b/config/assets.php
@@ -224,15 +224,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Disable SVG Sanitization
+    | SVG Sanitization
     |--------------------------------------------------------------------------
     |
-    | Statamic will automatically sanitize uploaded SVG files to avoid potential
-    | security issues. If you trust your users and need to disable this behaviour,
-    | you may do so here.
+    | Statamic will automatically sanitize user-uploaded SVG files to avoid potential
+    | security issues. If you trust your users, you may disable thuis behavior.
     |
     */
 
-    'disable_svg_sanitization' => false,
+    'svg_sanitization' => true,
 
 ];

--- a/config/assets.php
+++ b/config/assets.php
@@ -227,11 +227,12 @@ return [
     | SVG Sanitization
     |--------------------------------------------------------------------------
     |
-    | Statamic will automatically sanitize user-uploaded SVG files to avoid potential
-    | security issues. If you trust your users, you may disable thuis behavior.
+    | Statamic will automatically sanitize SVG files when uploaded to avoid
+    | potential security issues. However, if you have a valid reason for
+    | disabling this, and you trust your users, you may do so here.
     |
     */
 
-    'svg_sanitization' => true,
+    'svg_sanitization_on_upload' => true,
 
 ];

--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -58,7 +58,7 @@ abstract class Uploader
     {
         $stream = fopen($sourcePath, 'r');
 
-        if (! config('statamic.assets.disable_svg_sanitization', false) && Str::endsWith($destinationPath, '.svg')) {
+        if (config('statamic.assets.svg_sanitization', true) && Str::endsWith($destinationPath, '.svg')) {
             $sanitizer = new DOMSanitizer(DOMSanitizer::SVG);
             $stream = $sanitizer->sanitize($svg = stream_get_contents($stream), [
                 'remove-xml-tags' => ! Str::startsWith($svg, '<?xml'),

--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -58,7 +58,7 @@ abstract class Uploader
     {
         $stream = fopen($sourcePath, 'r');
 
-        if (config('statamic.assets.svg_sanitization', true) && Str::endsWith($destinationPath, '.svg')) {
+        if (config('statamic.assets.svg_sanitization_on_upload', true) && Str::endsWith($destinationPath, '.svg')) {
             $sanitizer = new DOMSanitizer(DOMSanitizer::SVG);
             $stream = $sanitizer->sanitize($svg = stream_get_contents($stream), [
                 'remove-xml-tags' => ! Str::startsWith($svg, '<?xml'),

--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -58,7 +58,7 @@ abstract class Uploader
     {
         $stream = fopen($sourcePath, 'r');
 
-        if (Str::endsWith($destinationPath, '.svg')) {
+        if (! config('statamic.assets.disable_svg_sanitization', false) && Str::endsWith($destinationPath, '.svg')) {
             $sanitizer = new DOMSanitizer(DOMSanitizer::SVG);
             $stream = $sanitizer->sanitize($svg = stream_get_contents($stream), [
                 'remove-xml-tags' => ! Str::startsWith($svg, '<?xml'),

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1821,7 +1821,7 @@ class AssetTest extends TestCase
     {
         Event::fake();
 
-        config()->set('statamic.assets.disable_svg_sanitization', true);
+        config()->set('statamic.assets.svg_sanitization', false);
 
         $asset = (new Asset)->container($this->container)->path('path/to/asset.svg')->syncOriginal();
 

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1821,7 +1821,7 @@ class AssetTest extends TestCase
     {
         Event::fake();
 
-        config()->set('statamic.assets.svg_sanitization', false);
+        config()->set('statamic.assets.svg_sanitization_on_upload', false);
 
         $asset = (new Asset)->container($this->container)->path('path/to/asset.svg')->syncOriginal();
 

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1816,6 +1816,30 @@ class AssetTest extends TestCase
         $this->assertStringNotContainsString('</script>', $asset->contents());
     }
 
+    /** @test */
+    public function it_does_not_sanitizes_svgs_on_upload_when_behaviour_is_disabled()
+    {
+        Event::fake();
+
+        config()->set('statamic.assets.disable_svg_sanitization', true);
+
+        $asset = (new Asset)->container($this->container)->path('path/to/asset.svg')->syncOriginal();
+
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
+        Storage::disk('test')->assertMissing('path/to/asset.svg');
+
+        $return = $asset->upload(UploadedFile::fake()->createWithContent('asset.svg', '<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" width="500" height="500"><script type="text/javascript">alert(`Bad stuff could go in here.`);</script></svg>'));
+
+        $this->assertEquals($asset, $return);
+        Storage::disk('test')->assertExists('path/to/asset.svg');
+        $this->assertEquals('path/to/asset.svg', $asset->path());
+
+        // Ensure the inline scripts were stripped out.
+        $this->assertStringContainsString('<script', $asset->contents());
+        $this->assertStringContainsString('Bad stuff could go in here.', $asset->contents());
+        $this->assertStringContainsString('</script>', $asset->contents());
+    }
+
     public static function nonGlideableFileExtensionsProvider()
     {
         return [


### PR DESCRIPTION
This pull request makes it possible to disable the sanitization of SVG files when uploading to Statamic, which was introduced in #9365.

Most of the time, you'll want to keep SVG sanitization disabled. However, if you need to upload SVGs with dynamic portions **and** you trust your users (including those on the frontend if you're using form uploads), then this PR would allow for that:

```php
// config/statamic/assets.php

'svg_sanitization_on_upload' => false,
```

Ref support ticket: 5342
