### PR TITLE
[4.x] Add Edit Blueprint link to form page dropdown

### DIFF
--- a/resources/js/components/forms/Listing.vue
+++ b/resources/js/components/forms/Listing.vue
@@ -13,9 +13,9 @@
                     <a :href="form.show_url">{{ form.title }}</a>
                 </template>
                 <template slot="actions" slot-scope="{ row: form, index }">
-                    <dropdown-list v-if="form.can_edit || form.can_edit_blueprints || form.actions.length">
+                    <dropdown-list v-if="form.can_edit || form.can_edit_blueprint || form.actions.length">
                         <dropdown-item v-if="form.can_edit" :text="__('Edit')" :redirect="form.edit_url" />
-                        <dropdown-item v-if="form.can_edit_blueprints" :text="__('Edit Blueprint')" :redirect="form.blueprint_url" />
+                        <dropdown-item v-if="form.can_edit_blueprint" :text="__('Edit Blueprint')" :redirect="form.blueprint_url" />
                         <div class="divider" v-if="form.actions.length" />
                         <data-list-inline-actions
                             :item="form.id"

--- a/resources/views/forms/show.blade.php
+++ b/resources/views/forms/show.blade.php
@@ -21,6 +21,9 @@
                     @can('edit', $form)
                         <dropdown-item :text="__('Edit Form')" redirect="{{ $form->editUrl() }}"></dropdown-item>
                     @endcan
+                    @can('configure form fields')
+                        <dropdown-item :text="__('Edit Blueprint')" redirect="{{ cp_route('forms.blueprint.edit', $form->handle()) }}"></dropdown-item>
+                    @endcan
                     @can('delete', $form)
                         <dropdown-item :text="__('Delete Form')" class="warning" @click="$refs.deleter.confirm()">
                             <resource-deleter


### PR DESCRIPTION
This PR adds an Edit Blueprint link to the form show page's action dropdown:

![Screenshot 2024-04-08 at 14 26 25](https://github.com/statamic/cms/assets/126740/63feb01a-7481-4b9a-a2f8-75b96c558aee)

Saves going via the config page.