### PR TITLE
[4.x] Prevent recursive editing via relationship fieldtype

### DIFF
--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -13,7 +13,6 @@
                 v-tooltip.top="__('An item with this ID could not be found')"
                 v-text="__(item.title)" />
 
-
             <a v-if="!item.invalid && editable" @click.prevent="edit" v-text="__(item.title)" class="truncate" v-tooltip="item.title" :href="item.edit_url" />
 
             <div v-if="!item.invalid && !editable" v-text="__(item.title)" />
@@ -77,6 +76,13 @@ export default {
         edit() {
             if (! this.editable) return;
             if (this.item.invalid) return;
+
+            if (Object.entries(this.$store.state.publish).find(([key, value]) => value.values.id === this.item.id)) {
+                this.$toast.error(__("You're already editing this item."));
+
+                return;
+            }
+
             this.isEditing = true;
         },
 


### PR DESCRIPTION
This pull request fixes an issue where it was possible to recursively edit entries / terms (entry a -> entry b -> entry a), which would cause issues with data not being consistent between publish forms.

This PR fixes it by simply preventing recursive editing from being possible with the Relationship Fieldtype.

Closes #3026.
Replaces #9272.