### PR TITLE
[4.x] Fix max depth validation on "Parent" field when collection has no max depth set

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -514,8 +514,10 @@ class EntriesController extends CpController
         // If the entry being edited is not the root, then we don't have anything to worry about.
         // If the parent is the root, that's fine, and is handled during the tree update later.
         if (! $parent || ! $entry->page()->isRoot()) {
+            $maxDepth = $entry->collection()->structure()->maxDepth();
+
             // If a parent is selected, validate that it doesn't exceed the max depth of the structure.
-            if ($parent && Entry::find($parent)->page()->depth() >= $entry->collection()->structure()->maxDepth()) {
+            if ($parent && $maxDepth && Entry::find($parent)->page()->depth() >= $maxDepth) {
                 throw ValidationException::withMessages(['parent' => __('statamic::validation.parent_exceeds_max_depth')]);
             }
 

--- a/tests/Feature/Entries/UpdateEntryTest.php
+++ b/tests/Feature/Entries/UpdateEntryTest.php
@@ -12,6 +12,7 @@ use Statamic\Facades\Entry;
 use Statamic\Facades\Role;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
+use Statamic\Structures\CollectionStructure;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -365,6 +366,70 @@ class UpdateEntryTest extends TestCase
     public function user_without_permission_to_manage_publish_state_cannot_change_publish_status()
     {
         $this->markTestIncomplete();
+    }
+
+    /** @test */
+    public function validates_max_depth()
+    {
+        [$user, $collection] = $this->seedUserAndCollection();
+
+        $structure = (new CollectionStructure)->maxDepth(2)->expectsRoot(true);
+        $collection->structure($structure)->save();
+
+        EntryFactory::collection('test')->id('home')->slug('home')->data(['title' => 'Home', 'foo' => 'bar'])->create();
+        EntryFactory::collection('test')->id('about')->slug('about')->data(['title' => 'About', 'foo' => 'baz'])->create();
+        EntryFactory::collection('test')->id('team')->slug('team')->data(['title' => 'Team'])->create();
+
+        $entry = EntryFactory::collection($collection)
+            ->id('existing-entry')
+            ->slug('existing-entry')
+            ->data(['title' => 'Existing Entry', 'foo' => 'bar'])
+            ->create();
+
+        $collection->structure()->in('en')->tree([
+            ['entry' => 'home'],
+            ['entry' => 'about', 'children' => [
+                ['entry' => 'team'],
+            ]],
+            ['entry' => 'existing-entry'],
+        ])->save();
+
+        $this
+            ->actingAs($user)
+            ->update($entry, ['title' => 'Existing Entry', 'slug' => 'existing-entry', 'parent' => ['team']]) // This would make it 3 levels deep, so it should fail.
+            ->assertUnprocessable();
+    }
+
+    /** @test */
+    public function does_not_validate_max_depth_when_collection_max_depth_is_null()
+    {
+        [$user, $collection] = $this->seedUserAndCollection();
+
+        $structure = (new CollectionStructure)->expectsRoot(true);
+        $collection->structure($structure)->save();
+
+        EntryFactory::collection('test')->id('home')->slug('home')->data(['title' => 'Home', 'foo' => 'bar'])->create();
+        EntryFactory::collection('test')->id('about')->slug('about')->data(['title' => 'About', 'foo' => 'baz'])->create();
+        EntryFactory::collection('test')->id('team')->slug('team')->data(['title' => 'Team'])->create();
+
+        $entry = EntryFactory::collection($collection)
+            ->id('existing-entry')
+            ->slug('existing-entry')
+            ->data(['title' => 'Existing Entry', 'foo' => 'bar'])
+            ->create();
+
+        $collection->structure()->in('en')->tree([
+            ['entry' => 'home'],
+            ['entry' => 'about', 'children' => [
+                ['entry' => 'team'],
+            ]],
+            ['entry' => 'existing-entry'],
+        ])->save();
+
+        $this
+            ->actingAs($user)
+            ->update($entry, ['title' => 'Existing Entry', 'slug' => 'existing-entry', 'parent' => ['team']]) // Since we have no max depth set, this should be fine.
+            ->assertOk();
     }
 
     private function seedUserAndCollection()


### PR DESCRIPTION
This pull request fixes an issue with the recently introduced Max Depth validation on "Parent" fields, where you'd get the max depth validation message even if the collection has no max depth set.

I've added an additional check around the max depth validation to ensure the collection actually has a max depth set. This PR also adds some validation to prevent this from happening again.

Fixes #9847.