### PR TITLE
[4.x] Update URIs for mounted collection entries only if slug on mounted entry changed

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -777,7 +777,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
                     return null;
                 }
 
-                return Blink::once("collection-{$this->id()}-mount-{$mount}", function () use ($mount) {
+                return Blink::store('collection-mounts')->once("{$this->id()}-{$mount}", function () use ($mount) {
                     return Entry::find($mount);
                 });
             })

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -330,7 +330,8 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
 
     public function save()
     {
-        $isNew = is_null(Facades\Entry::find($this->id()));
+        $oldEntry = Facades\Entry::find($this->id());
+        $isNew = is_null($oldEntry);
 
         $withEvents = $this->withEvents;
         $this->withEvents = true;
@@ -375,7 +376,9 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
 
         $this->taxonomize();
 
-        optional(Collection::findByMount($this))->updateEntryUris();
+        if(!$isNew && $oldEntry->slug() !== $this->slug()) {
+            optional(Collection::findByMount($this))->updateEntryUris();
+        }
 
         foreach ($afterSaveCallbacks as $callback) {
             $callback($this);

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -376,7 +376,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
 
         $this->taxonomize();
 
-        if(!$isNew && $oldEntry->slug() !== $this->slug()) {
+        if (! $isNew && $oldEntry->slug() !== $this->slug()) {
             optional(Collection::findByMount($this))->updateEntryUris();
         }
 

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -330,8 +330,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
 
     public function save()
     {
-        $oldEntry = Facades\Entry::find($this->id());
-        $isNew = is_null($oldEntry);
+        $isNew = is_null(Facades\Entry::find($this->id()));
 
         $withEvents = $this->withEvents;
         $this->withEvents = true;
@@ -376,9 +375,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
 
         $this->taxonomize();
 
-        if(!$isNew && $oldEntry->slug() !== $this->slug()) {
-            optional(Collection::findByMount($this))->updateEntryUris();
-        }
+        optional(Collection::findByMount($this))->updateEntryUris();
 
         foreach ($afterSaveCallbacks as $callback) {
             $callback($this);

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -365,6 +365,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
             Blink::store('structure-uris')->forget($this->id());
             Blink::store('structure-entries')->forget($this->id());
             Blink::forget($this->getOriginBlinkKey());
+            Blink::store('collection-mounts')->flush();
         }
 
         $this->ancestors()->each(fn ($entry) => Blink::forget('entry-descendants-'.$entry->id()));

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -376,7 +376,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
 
         $this->taxonomize();
 
-        if (! $isNew && $oldEntry->slug() !== $this->slug()) {
+        if(!$isNew && $oldEntry->slug() !== $this->slug()) {
             optional(Collection::findByMount($this))->updateEntryUris();
         }
 

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -375,7 +375,9 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
 
         $this->taxonomize();
 
-        optional(Collection::findByMount($this))->updateEntryUris();
+        if ($this->isDirty('slug')) {
+            optional(Collection::findByMount($this))->updateEntryUris();
+        }
 
         foreach ($afterSaveCallbacks as $callback) {
             $callback($this);

--- a/tests/Feature/Entries/MountingTest.php
+++ b/tests/Feature/Entries/MountingTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Entries;
 
 use Facades\Tests\Factories\EntryFactory;
+use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -15,6 +16,9 @@ class MountingTest extends TestCase
     /** @test */
     public function updating_a_mounted_page_will_update_the_uris_for_each_entry_in_that_collection()
     {
+        config(['cache.default' => 'file']); // Doesn't work when they're arrays since the object is stored in memory.
+        Cache::clear();
+
         Collection::make('pages')->routes('pages/{slug}')->save();
 
         EntryFactory::collection('pages')->slug('another-page')->create();
@@ -38,6 +42,9 @@ class MountingTest extends TestCase
     /** @test */
     public function updating_a_mounted_page_will_not_update_the_uris_when_slug_is_clean()
     {
+        config(['cache.default' => 'file']); // Doesn't work when they're arrays since the object is stored in memory.
+        Cache::clear();
+
         Collection::make('pages')->routes('pages/{slug}')->save();
 
         EntryFactory::collection('pages')->slug('another-page')->create();


### PR DESCRIPTION
When saving the mounted entry for a collection the URIs for the entries in that collection get only updated if the slug of the mounted entry has changed.

Fixes: https://github.com/statamic/cms/issues/9848