### PR TITLE
[5.x] Revert requirement of prefixing attributes with `:attr`

### DIFF
--- a/src/Tags/Concerns/RendersAttributes.php
+++ b/src/Tags/Concerns/RendersAttributes.php
@@ -37,17 +37,21 @@ trait RendersAttributes
     /**
      * Render HTML attributes from tag params.
      *
-     * Parameters that are not prefixed with attr: will be automatically removed.
+     * Parameters that are not approved will be filtered out.
      *
      * @return string
      */
     protected function renderAttributesFromParams()
     {
-        $params = $this->params->filter(function ($value, $attribute) {
-            return preg_match('/^attr:/', $attribute);
-        })->all();
+        $params = $this->params->filter(fn ($v, $attr) => $this->isAllowedParamAttr($attr))->all();
 
         return $this->renderAttributes($params);
+    }
+
+    private function isAllowedParamAttr($attribute): bool
+    {
+        return Str::startsWith($attribute, ['attr:', 'aria-', 'data-'])
+            || in_array($attribute, ['class', 'autocomplete']);
     }
 
     /**

--- a/src/Tags/Concerns/RendersAttributes.php
+++ b/src/Tags/Concerns/RendersAttributes.php
@@ -37,21 +37,14 @@ trait RendersAttributes
     /**
      * Render HTML attributes from tag params.
      *
-     * Parameters that are not approved will be filtered out.
-     *
+     * @param  array  $except  Parameters that should be excluded. Typically used for tag parameters that control behavior.
      * @return string
      */
-    protected function renderAttributesFromParams()
+    protected function renderAttributesFromParams(array $except = [])
     {
-        $params = $this->params->filter(fn ($v, $attr) => $this->isAllowedParamAttr($attr))->all();
+        $params = $this->params->reject(fn ($v, $attr) => in_array($attr, $except))->all();
 
         return $this->renderAttributes($params);
-    }
-
-    private function isAllowedParamAttr($attribute): bool
-    {
-        return Str::startsWith($attribute, ['attr:', 'aria-', 'data-'])
-            || in_array($attribute, ['class', 'autocomplete']);
     }
 
     /**
@@ -59,11 +52,11 @@ trait RendersAttributes
      *
      * @return string
      */
-    protected function renderAttributesFromParamsWith(array $attrs)
+    protected function renderAttributesFromParamsWith(array $attrs, array $except = [])
     {
         return collect([
             $this->renderAttributes($attrs),
-            $this->renderAttributesFromParams(),
+            $this->renderAttributesFromParams($except),
         ])->filter()->implode(' ');
     }
 }

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -70,7 +70,10 @@ trait RendersForms
             $attrs['enctype'] = 'multipart/form-data';
         }
 
-        $attrs = $this->renderAttributesFromParamsWith($attrs, except: $knownTagParams);
+        $attrs = $this->renderAttributesFromParamsWith(
+            $attrs,
+            except: array_merge(['method', 'action'], $knownTagParams)
+        );
 
         $html = collect(['<form', $attrs])->filter()->implode(' ').'>';
 

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -70,7 +70,7 @@ trait RendersForms
             $attrs['enctype'] = 'multipart/form-data';
         }
 
-        $attrs = $this->renderAttributesFromParamsWith($attrs);
+        $attrs = $this->renderAttributesFromParamsWith($attrs, except: $knownTagParams);
 
         $html = collect(['<form', $attrs])->filter()->implode(' ').'>';
 

--- a/src/Tags/Svg.php
+++ b/src/Tags/Svg.php
@@ -48,7 +48,7 @@ class Svg extends Tags
             $svg = $this->params->get('src');
         }
 
-        $attributes = $this->renderAttributesFromParams();
+        $attributes = $this->renderAttributesFromParams(except: ['src', 'title', 'desc', 'sanitize']);
 
         if ($this->params->get('title') || $this->params->get('desc')) {
             $svg = $this->setTitleAndDesc($svg);

--- a/tests/Fieldtypes/IconTest.php
+++ b/tests/Fieldtypes/IconTest.php
@@ -21,7 +21,7 @@ class IconTest extends TestCase
     /** @test */
     public function it_accepts_svg_strings()
     {
-        $result = (string) Antlers::parse('{{ svg :src="test" attr:class="w-4 h-4" sanitize="false" }}', ['test' => new Value('add', $this->fieldtype())]);
+        $result = (string) Antlers::parse('{{ svg :src="test" class="w-4 h-4" sanitize="false" }}', ['test' => new Value('add', $this->fieldtype())]);
 
         $this->assertStringContainsString('<svg class="w-4 h-4"', $result);
     }

--- a/tests/Tags/Concerns/RendersAttributesTest.php
+++ b/tests/Tags/Concerns/RendersAttributesTest.php
@@ -24,12 +24,12 @@ class RendersAttributesTest extends TestCase
         $this->assertEquals('', $this->tag->renderAttributes([]));
 
         $output = $this->tag->renderAttributes([
-            'attr:class' => 'm-0 mb-2',
-            'attr::name' => 'first_name',
-            'attr:disabled' => 'true',
-            'attr:autocomplete' => true,
-            'attr:focusable' => false,
-            'attr:dont_render_nulls' => null,
+            'class' => 'm-0 mb-2',
+            ':name' => 'first_name',
+            'disabled' => 'true',
+            'autocomplete' => true,
+            'focusable' => false,
+            'dont_render_nulls' => null,
         ]);
 
         $this->assertEquals('class="m-0 mb-2" :name="first_name" disabled="true" autocomplete="true" focusable="false"', $output);
@@ -54,6 +54,28 @@ class RendersAttributesTest extends TestCase
             ->renderAttributesFromParams();
 
         $this->assertEquals('class="m-0 mb-2" name="Han" src="avatar.jpg" focusable="false" disabled="true" autocomplete="true"', $output);
+    }
+
+    /** @test */
+    public function it_renders_certain_attributes_from_params_without_needing_attr_prefix()
+    {
+        $this->assertEquals('', $this->tag->renderAttributesFromParams());
+
+        $output = $this->tag
+            ->setContext(['first_name' => 'Han'])
+            ->setParameters([
+                'class' => 'm-0 mb-2',
+                'autocomplete' => true,
+                'aria-alfa' => 'bravo',
+                'aria-charlie' => 'delta',
+                'aria-echo' => null,
+                'data-alfa' => 'bravo',
+                'data-charlie' => 'delta',
+                'data-echo' => null,
+            ])
+            ->renderAttributesFromParams();
+
+        $this->assertEquals('class="m-0 mb-2" autocomplete="true" aria-alfa="bravo" aria-charlie="delta" data-alfa="bravo" data-charlie="delta"', $output);
     }
 }
 

--- a/tests/Tags/Concerns/RendersAttributesTest.php
+++ b/tests/Tags/Concerns/RendersAttributesTest.php
@@ -43,13 +43,13 @@ class RendersAttributesTest extends TestCase
         $output = $this->tag
             ->setContext(['first_name' => 'Han'])
             ->setParameters([
-                'attr:class' => 'm-0 mb-2',
-                ':attr:name' => 'first_name',
+                'class' => 'm-0 mb-2',
+                ':name' => 'first_name',
                 'attr:src' => 'avatar.jpg',
-                'attr:focusable' => false,
-                'attr:dont_render_nulls' => null,
-                'attr:disabled' => 'true',
-                'attr:autocomplete' => true,
+                'focusable' => false,
+                'dont_render_nulls' => null,
+                'disabled' => 'true',
+                'autocomplete' => true,
             ])
             ->renderAttributesFromParams();
 
@@ -57,7 +57,31 @@ class RendersAttributesTest extends TestCase
     }
 
     /** @test */
-    public function it_renders_certain_attributes_from_params_without_needing_attr_prefix()
+    public function it_wont_render_attributes_for_known_params_unless_attr_prepended()
+    {
+        $output = $this->tag
+            ->setParameters([
+                'class' => 'm-0 mb-2',
+                'src' => 'avatar.jpg',
+                'name' => 'Han',
+            ])
+            ->renderAttributesFromParams(except: ['src', 'name']);
+
+        $this->assertEquals('class="m-0 mb-2"', $output);
+
+        $output = $this->tag
+            ->setParameters([
+                'class' => 'm-0 mb-2',
+                'attr:src' => 'avatar.jpg',
+                'name' => 'Han',
+            ])
+            ->renderAttributesFromParams(['src', 'name']);
+
+        $this->assertEquals('class="m-0 mb-2" src="avatar.jpg"', $output);
+    }
+
+    /** @test */
+    public function it_will_render_falsy_attributes()
     {
         $this->assertEquals('', $this->tag->renderAttributesFromParams());
 
@@ -65,17 +89,17 @@ class RendersAttributesTest extends TestCase
             ->setContext(['first_name' => 'Han'])
             ->setParameters([
                 'class' => 'm-0 mb-2',
+                ':name' => 'first_name',
+                'attr:src' => 'avatar.jpg',
+                'focusable' => false,
+                'dont_render_nulls' => null,
+                'disabled' => 'true',
                 'autocomplete' => true,
-                'aria-alfa' => 'bravo',
-                'aria-charlie' => 'delta',
-                'aria-echo' => null,
-                'data-alfa' => 'bravo',
-                'data-charlie' => 'delta',
-                'data-echo' => null,
+                'aria-hidden' => true,
             ])
             ->renderAttributesFromParams();
 
-        $this->assertEquals('class="m-0 mb-2" autocomplete="true" aria-alfa="bravo" aria-charlie="delta" data-alfa="bravo" data-charlie="delta"', $output);
+        $this->assertEquals('class="m-0 mb-2" name="Han" src="avatar.jpg" focusable="false" disabled="true" autocomplete="true" aria-hidden="true"', $output);
     }
 }
 

--- a/tests/Tags/Concerns/RendersFormsTest.php
+++ b/tests/Tags/Concerns/RendersFormsTest.php
@@ -47,7 +47,7 @@ class RendersFormsTest extends TestCase
     {
         $output = $this->tag
             ->setParameters([
-                'attr:class' => 'mb-2',
+                'class' => 'mb-2',
                 'attr:id' => 'form',
                 'method' => 'this should not render',
                 'action' => 'this should not render',

--- a/tests/Tags/Form/FormCreateTest.php
+++ b/tests/Tags/Form/FormCreateTest.php
@@ -36,7 +36,7 @@ class FormCreateTest extends FormTestCase
     /** @test */
     public function it_renders_form_with_params()
     {
-        $output = $this->tag('{{ form:contact redirect="/submitted" error_redirect="/errors" attr:class="form" attr:id="form" }}{{ /form:contact }}');
+        $output = $this->tag('{{ form:contact redirect="/submitted" error_redirect="/errors" class="form" id="form" }}{{ /form:contact }}');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/forms/contact" class="form" id="form">', $output);
         $this->assertStringContainsString('<input type="hidden" name="_redirect" value="/submitted" />', $output);

--- a/tests/Tags/SvgTagTest.php
+++ b/tests/Tags/SvgTagTest.php
@@ -30,7 +30,7 @@ class SvgTagTest extends TestCase
     /** @test */
     public function it_renders_svg_with_additional_params()
     {
-        $this->assertStringStartsWith('<svg class="mb-2" xmlns="', $this->tag('{{ svg src="users" sanitize="false" attr:class="mb-2" }}'));
+        $this->assertStringStartsWith('<svg class="mb-2" xmlns="', $this->tag('{{ svg src="users" sanitize="false" class="mb-2" }}'));
     }
 
     /** @test */

--- a/tests/Tags/User/ForgotPasswordFormTest.php
+++ b/tests/Tags/User/ForgotPasswordFormTest.php
@@ -31,7 +31,7 @@ class ForgotPasswordFormTest extends TestCase
     /** @test */
     public function it_renders_form_with_params()
     {
-        $output = $this->tag('{{ user:forgot_password_form redirect="/submitted" error_redirect="/errors" reset_url="/resetting" attr:class="form" attr:id="form" }}{{ /user:forgot_password_form }}');
+        $output = $this->tag('{{ user:forgot_password_form redirect="/submitted" error_redirect="/errors" reset_url="/resetting" class="form" id="form" }}{{ /user:forgot_password_form }}');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/password/email" class="form" id="form">', $output);
         $this->assertStringContainsString('<input type="hidden" name="_redirect" value="/submitted" />', $output);

--- a/tests/Tags/User/LoginFormTest.php
+++ b/tests/Tags/User/LoginFormTest.php
@@ -30,7 +30,7 @@ class LoginFormTest extends TestCase
     /** @test */
     public function it_renders_form_with_params()
     {
-        $output = $this->tag('{{ user:login_form redirect="/submitted" error_redirect="/errors" attr:class="form" attr:id="form" }}{{ /user:login_form }}');
+        $output = $this->tag('{{ user:login_form redirect="/submitted" error_redirect="/errors" class="form" id="form" }}{{ /user:login_form }}');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/login" class="form" id="form">', $output);
         $this->assertStringContainsString('<input type="hidden" name="_redirect" value="/submitted" />', $output);

--- a/tests/Tags/User/PasswordFormTest.php
+++ b/tests/Tags/User/PasswordFormTest.php
@@ -34,7 +34,7 @@ class PasswordFormTest extends TestCase
     {
         $this->actingAs(User::make()->password('mypassword')->save());
 
-        $output = $this->tag('{{ user:password_form redirect="/submitted" error_redirect="/errors" attr:class="form" attr:id="form" }}{{ /user:password_form }}');
+        $output = $this->tag('{{ user:password_form redirect="/submitted" error_redirect="/errors" class="form" id="form" }}{{ /user:password_form }}');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/password" class="form" id="form">', $output);
         $this->assertStringContainsString('<input type="hidden" name="_redirect" value="/submitted" />', $output);

--- a/tests/Tags/User/ProfileFormTest.php
+++ b/tests/Tags/User/ProfileFormTest.php
@@ -35,7 +35,7 @@ class ProfileFormTest extends TestCase
     {
         $this->actingAs(User::make()->save());
 
-        $output = $this->tag('{{ user:profile_form redirect="/submitted" error_redirect="/errors" attr:class="form" attr:id="form" }}{{ /user:profile_form }}');
+        $output = $this->tag('{{ user:profile_form redirect="/submitted" error_redirect="/errors" class="form" id="form" }}{{ /user:profile_form }}');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/profile" class="form" id="form">', $output);
         $this->assertStringContainsString('<input type="hidden" name="_redirect" value="/submitted" />', $output);

--- a/tests/Tags/User/RegisterFormTest.php
+++ b/tests/Tags/User/RegisterFormTest.php
@@ -36,7 +36,7 @@ class RegisterFormTest extends TestCase
     /** @test */
     public function it_renders_form_with_params()
     {
-        $output = $this->tag('{{ user:register_form redirect="/submitted" error_redirect="/errors" attr:class="form" attr:id="form" }}{{ /user:register_form }}');
+        $output = $this->tag('{{ user:register_form redirect="/submitted" error_redirect="/errors" class="form" id="form" }}{{ /user:register_form }}');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/register" class="form" id="form">', $output);
         $this->assertStringContainsString('<input type="hidden" name="_redirect" value="/submitted" />', $output);


### PR DESCRIPTION
This PR essentially reverts #9576.

Now, the only thing you'll need to change is that if you have a parameter that starts with `@`. Since #8887, prefixing a parameter with `@` will prevent parsing. You can get around this by prefixing with `attr:`, or using Vue/Alpine's alternate syntaxes:

```diff
{{ form:create
    in="contact"
-   @click="submitForm"
+   attr:@click="submitForm"
+   (or x-bind:click="submitForm")
}}
```

However! We're planning to change the syntax of #8887 so you won't even need to do that.