### PR TITLE
[5.x] Change @ to backslash to prevent parsing Antlers within tag parameters

### DIFF
--- a/src/View/Antlers/Language/Parser/AntlersNodeParser.php
+++ b/src/View/Antlers/Language/Parser/AntlersNodeParser.php
@@ -545,7 +545,7 @@ class AntlersNodeParser
 
             if ($hasFoundName == false && $current == DocumentParser::Punctuation_Equals) {
                 if (! empty($currentChars)) {
-                    if (! (ctype_alpha($currentChars[0]) || ctype_digit($currentChars[0]) || $currentChars[0] == DocumentParser::Punctuation_Colon || $currentChars[0] == DocumentParser::AtChar)) {
+                    if (! (ctype_alpha($currentChars[0]) || ctype_digit($currentChars[0]) || $currentChars[0] == DocumentParser::Punctuation_Colon || $currentChars[0] == DocumentParser::AtChar || $currentChars[0] == DocumentParser::String_EscapeCharacter)) {
                         $currentChars = [];
 
                         continue;
@@ -672,7 +672,7 @@ class AntlersNodeParser
                     }
                 }
 
-                if (Str::startsWith($name, DocumentParser::AtChar)) {
+                if (Str::startsWith($name, DocumentParser::String_EscapeCharacter)) {
                     $parameterNode->containsEscapedContent = true;
                     $name = mb_substr($name, 1);
                 }

--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -1057,7 +1057,7 @@ class DocumentParser
                 }
             }
 
-            if ($this->cur == self::AtChar && ($this->prev != null && ctype_space($this->prev))) {
+            if ($this->cur == self::String_EscapeCharacter && ($this->prev != null && ctype_space($this->prev))) {
                 if ($this->next != null && (ctype_alpha($this->next) || $this->next == self::Punctuation_Underscore || $this->next == self::AtChar)) {
                     // It is possible that we might be starting some escaped content.
                     // We will need more information to determine this, but let's

--- a/tests/Antlers/Parser/NodeParametersTest.php
+++ b/tests/Antlers/Parser/NodeParametersTest.php
@@ -252,7 +252,7 @@ EOT;
         $this->assertSame('FINAL_LITERAL</figure>', $nodes[2]->content);
 
         $template = <<<'EOT'
- <div class="list-of-classes">     {{ partial src="svg/" values="{{ article_icon_color:key }} {{ article_icon_size:key }}" }}FINAL_LITERAL </div> 
+ <div class="list-of-classes">     {{ partial src="svg/" values="{{ article_icon_color:key }} {{ article_icon_size:key }}" }}FINAL_LITERAL </div>
 EOT;
 
         $nodes = $this->parseNodes($template);
@@ -263,7 +263,7 @@ EOT;
         $this->assertInstanceOf(LiteralNode::class, $nodes[2]);
 
         $this->assertSame(' <div class="list-of-classes">     ', $nodes[0]->content);
-        $this->assertSame('FINAL_LITERAL </div> ', $nodes[2]->content);
+        $this->assertSame('FINAL_LITERAL </div>', $nodes[2]->content);
     }
 
     public function test_shorthand_variable_syntax()
@@ -332,7 +332,7 @@ EOT;
     public function test_curly_braces_inside_a_parameter_can_be_ignored_entirely()
     {
         $template = <<<'EOT'
-{{ form @x-data="{ open: false }" @attr:x-bind="..." @x-init="() => { open = true }" x-show="open" }}
+{{ form \x-data="{ open: false }" \attr:x-bind="..." \x-init="() => { open = true }" x-show="open" }}
 EOT;
 
         $nodes = $this->parseNodes($template);
@@ -348,17 +348,17 @@ EOT;
 
         $pXData = $antlersNode->parameters[0];
         $this->assertSame('x-data', $pXData->name);
-        $this->assertSame('@x-data', $pXData->originalName);
+        $this->assertSame('\x-data', $pXData->originalName);
         $this->assertSame('{ open: false }', $pXData->value);
 
         $pXBind = $antlersNode->parameters[1];
         $this->assertSame('attr:x-bind', $pXBind->name);
-        $this->assertSame('@attr:x-bind', $pXBind->originalName);
+        $this->assertSame('\attr:x-bind', $pXBind->originalName);
         $this->assertSame('...', $pXBind->value);
 
         $pXInit = $antlersNode->parameters[2];
         $this->assertSame('x-init', $pXInit->name);
-        $this->assertSame('@x-init', $pXInit->originalName);
+        $this->assertSame('\x-init', $pXInit->originalName);
         $this->assertSame('() => { open = true }', $pXInit->value);
 
         $pXShow = $antlersNode->parameters[3];


### PR DESCRIPTION
This PR is an extension of #8887 except that it uses `\` instead of `@` to prevent parsing.

(It's actually what John originally pitched)

The `@` made upgrading to v5 more complicated than it needed to, because of how people would use Vue/Alpine event listeners like `@click`.
