### PR TITLE
[5.x] Ensure expectation count isnt negative if Version is not called

### DIFF
--- a/src/Extend/AddonTestCase.php
+++ b/src/Extend/AddonTestCase.php
@@ -20,7 +20,7 @@ abstract class AddonTestCase extends OrchestraTestCase
         $this->withoutMix();
         $this->withoutVite();
 
-        Version::shouldReceive('get'->zeroOrMoreTimes()->andReturn(Composer::create(__DIR__.'/../')->installedVersion(Statamic::PACKAGE));
+        Version::shouldReceive('get')->zeroOrMoreTimes()->andReturn(Composer::create(__DIR__.'/../')->installedVersion(Statamic::PACKAGE));
         $this->addToAssertionCount(-1);
 
         \Statamic\Facades\CP\Nav::shouldReceive('build')->zeroOrMoreTimes()->andReturn(collect());

--- a/src/Extend/AddonTestCase.php
+++ b/src/Extend/AddonTestCase.php
@@ -20,7 +20,7 @@ abstract class AddonTestCase extends OrchestraTestCase
         $this->withoutMix();
         $this->withoutVite();
 
-        Version::shouldReceive('get')->andReturn(Composer::create(__DIR__.'/../')->installedVersion(Statamic::PACKAGE));
+        Version::shouldReceive('get'->zeroOrMoreTimes()->andReturn(Composer::create(__DIR__.'/../')->installedVersion(Statamic::PACKAGE));
         $this->addToAssertionCount(-1);
 
         \Statamic\Facades\CP\Nav::shouldReceive('build')->zeroOrMoreTimes()->andReturn(collect());


### PR DESCRIPTION
Since eloquent driver was updated to use AddonTestCase its being showing warning about skipping tests, which I've worked out is due to a negative assertion count.

It seems to be due to it not triggering a call to version, so the simple fix is to allow this to be called zero or more time.