### PR TITLE
[4.x] Add tailwind safelist with horizontal margins

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,12 @@ module.exports = {
         './resources/**/*.{html,js,vue,blade.php}',
         './tests/**/*.{html,vue,blade.php}'
     ],
+    safelist: [
+        {
+            pattern: /m[l|r]-\d+/,
+            variants: ['md', 'lg', 'xl']
+        },
+    ],
     theme: {
         colors: {
             transparent: 'transparent',


### PR DESCRIPTION
Since adding support for RTL, horizontal margin classes aren't used without a text direction prefix, which means classes like `mr-3` get purged out of the css.

Adding this safelist brings back those classes for addons. 
