### PR TITLE
[4.x] Adjust Slack action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,12 +145,12 @@ jobs:
     name: Slack Notification
     runs-on: ubuntu-20.04
     needs: [php-tests, js-tests]
-    if: always() && github.event_name == 'schedule'
+    if: always()
     steps:
       - uses: technote-space/workflow-conclusion-action@v1
       - name: Send Slack notification
         uses: 8398a7/action-slack@v2
-        if: env.WORKFLOW_CONCLUSION == 'failure'
+        if: env.WORKFLOW_CONCLUSION == 'failure' && github.event_name == 'schedule'
         with:
           status: failure
           author_name: ${{ github.actor }}


### PR DESCRIPTION
Since #9782, the entire Slack workflow job gets marked as skipped, and as a result the PR checks UI gets a little cluttered because it lists all the checks:

![CleanShot 2024-04-11 at 11 31 57](https://github.com/statamic/cms/assets/105211/0c7b91e7-444b-4240-9e35-10d463897c4e)

This PR moves the condition _into_ one of the steps of the job. ~Hopefully~ It does! it displays the job as successful so the UI goes back to the condensed version.

![CleanShot 2024-04-11 at 11 39 27](https://github.com/statamic/cms/assets/105211/61ef4655-13bf-4348-91e9-2c5fcff93821)

Super nitpicky thing but seeing the list of checks made me think something wasn't ready for merging.