### PR TITLE
[4.x] Fix tables in Bard not saving updates

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -655,7 +655,7 @@ export default {
                     }, 1);
                 },
                 onUpdate: () => {
-                    this.json = this.editor.getJSON().content;
+                    this.json = clone(this.editor.getJSON().content);
                     this.html = this.editor.getHTML();
                 },
                 onCreate: ({ editor }) => {


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/9860

This was caused by the change in https://github.com/statamic/cms/pull/9788.

Tiptap isn't (always?) creating new objects when `onUpdate` fires or `getJSON` is called, so after the first update `oldJson` is exactly the same object as `json`, so the comparison passes and no further updates are fired.

This wasn't a problem before https://github.com/statamic/cms/pull/9788 because it was comparing against `this.value` which was already stringified in the previous update.