### PR TITLE
[4.x] Support using closures for Statamic route data

### DIFF
--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -41,7 +41,7 @@ class FrontendController extends Controller
         $params = $request->route()->parameters();
         $view = Arr::pull($params, 'view');
         $data = Arr::pull($params, 'data');
-        $data = array_merge($params, $data);
+        $data = array_merge($params, is_callable($data) ? $data() : $data);
 
         $view = app(View::class)
             ->template($view)

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -31,6 +31,10 @@ class RoutesTest extends TestCase
         $app->booted(function () {
             Route::statamic('/basic-route-with-data', 'test', ['hello' => 'world']);
 
+            Route::statamic('/basic-route-with-data-from-closure', 'test', function () {
+                return ['hello' => 'world'];
+            });
+
             Route::statamic('/basic-route-without-data', 'test');
 
             Route::statamic('/route/with/placeholders/{foo}/{bar}/{baz}', 'test');
@@ -100,6 +104,17 @@ class RoutesTest extends TestCase
         $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
 
         $this->get('/basic-route-with-data')
+            ->assertOk()
+            ->assertSee('Hello world');
+    }
+
+    /** @test */
+    public function it_renders_a_view_with_data_from_a_closure()
+    {
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        $this->get('/basic-route-with-data-from-closure')
             ->assertOk()
             ->assertSee('Hello world');
     }


### PR DESCRIPTION
I love how these Statamic routes are so concise compared to using custom controllers. This PR adds the ability to use a closure for the data argument. So besides this

```php
Route::statamic('uri', 'view', ['foo' => 'bar']);
```

you can now also do this

```php
Route::statamic('uri', 'view', function () {
    $bar = gatherDataExpensively();

    return ['foo' => $bar];
});
```