### PR TITLE
[5.x] Addon Testing Changes

### DIFF
--- a/src/Console/Commands/stubs/addon/TestCase.php.stub
+++ b/src/Console/Commands/stubs/addon/TestCase.php.stub
@@ -3,7 +3,7 @@
 namespace {{ namespace }}\Tests;
 
 use {{ namespace }}\ServiceProvider;
-use Statamic\Extend\AddonTestCase;
+use Statamic\Testing\AddonTestCase;
 
 abstract class TestCase extends AddonTestCase
 {

--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -10,7 +10,7 @@ use Statamic\Console\Processes\Composer;
 use Statamic\Extend\Manifest;
 use Statamic\Providers\StatamicServiceProvider;
 use Statamic\Statamic;
-use Statamic\Testing\Concerns\PreventSavingStacheItemsToDisk;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 
 abstract class AddonTestCase extends OrchestraTestCase
 {
@@ -25,7 +25,7 @@ abstract class AddonTestCase extends OrchestraTestCase
 
         $uses = array_flip(class_uses_recursive(static::class));
 
-        if (isset($uses[PreventSavingStacheItemsToDisk::class])) {
+        if (isset($uses[PreventsSavingStacheItemsToDisk::class])) {
             $reflection = new ReflectionClass($this);
             $this->fakeStacheDirectory = Str::before(dirname($reflection->getFileName()), '/tests').'/tests/__fixtures__/dev-null';
 

--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Statamic\Extend;
+namespace Statamic\Testing;
 
 use Facades\Statamic\Version;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use ReflectionClass;
 use Statamic\Console\Processes\Composer;
+use Statamic\Extend\Manifest;
 use Statamic\Providers\StatamicServiceProvider;
 use Statamic\Statamic;
 

--- a/src/Testing/Concerns/PreventSavingStacheItemsToDisk.php
+++ b/src/Testing/Concerns/PreventSavingStacheItemsToDisk.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Statamic\Testing\Concerns;
+
+use Statamic\Facades\Path;
+use Statamic\Facades\Stache;
+use Statamic\Support\Str;
+
+trait PreventSavingStacheItemsToDisk
+{
+    protected function preventSavingStacheItemsToDisk(): void
+    {
+        $this->fakeStacheDirectory = Path::tidy($this->fakeStacheDirectory);
+
+        Stache::stores()->each(function ($store) {
+            $dir = Path::tidy(Str::before($this->fakeStacheDirectory, '/dev-null'));
+            $relative = Str::after(Str::after($store->directory(), $dir), '/');
+            $store->directory($this->fakeStacheDirectory.'/'.$relative);
+        });
+    }
+
+    protected function deleteFakeStacheDirectory(): void
+    {
+        app('files')->deleteDirectory($this->fakeStacheDirectory);
+
+        mkdir($this->fakeStacheDirectory);
+        touch($this->fakeStacheDirectory.'/.gitkeep');
+    }
+}

--- a/src/Testing/Concerns/PreventsSavingStacheItemsToDisk.php
+++ b/src/Testing/Concerns/PreventsSavingStacheItemsToDisk.php
@@ -6,7 +6,7 @@ use Statamic\Facades\Path;
 use Statamic\Facades\Stache;
 use Statamic\Support\Str;
 
-trait PreventSavingStacheItemsToDisk
+trait PreventsSavingStacheItemsToDisk
 {
     protected function preventSavingStacheItemsToDisk(): void
     {

--- a/tests/PreventSavingStacheItemsToDisk.php
+++ b/tests/PreventSavingStacheItemsToDisk.php
@@ -2,9 +2,9 @@
 
 namespace Tests;
 
-use Statamic\Testing\Concerns\PreventSavingStacheItemsToDisk as BasePreventSavingStacheItemsToDisk;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk as BasePreventsSavingStacheItemsToDisk;
 
 trait PreventSavingStacheItemsToDisk
 {
-    use BasePreventSavingStacheItemsToDisk;
+    use BasePreventsSavingStacheItemsToDisk;
 }

--- a/tests/PreventSavingStacheItemsToDisk.php
+++ b/tests/PreventSavingStacheItemsToDisk.php
@@ -2,30 +2,9 @@
 
 namespace Tests;
 
-use Statamic\Facades\Path;
-use Statamic\Facades\Stache;
-use Statamic\Support\Str;
+use Statamic\Testing\Concerns\PreventSavingStacheItemsToDisk as BasePreventSavingStacheItemsToDisk;
 
 trait PreventSavingStacheItemsToDisk
 {
-    protected $fakeStacheDirectory = __DIR__.'/__fixtures__/dev-null';
-
-    protected function preventSavingStacheItemsToDisk()
-    {
-        $this->fakeStacheDirectory = Path::tidy($this->fakeStacheDirectory);
-
-        Stache::stores()->each(function ($store) {
-            $dir = Path::tidy(__DIR__.'/__fixtures__');
-            $relative = Str::after(Str::after($store->directory(), $dir), '/');
-            $store->directory($this->fakeStacheDirectory.'/'.$relative);
-        });
-    }
-
-    protected function deleteFakeStacheDirectory()
-    {
-        app('files')->deleteDirectory($this->fakeStacheDirectory);
-
-        mkdir($this->fakeStacheDirectory);
-        touch($this->fakeStacheDirectory.'/.gitkeep');
-    }
+    use BasePreventSavingStacheItemsToDisk;
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,7 +26,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
         $uses = array_flip(class_uses_recursive(static::class));
 
-        if (isset($uses[PreventSavingStacheItemsToDisk::class])) {
+        if (isset($uses[PreventsSavingStacheItemsToDisk::class])) {
             $this->preventSavingStacheItemsToDisk();
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,7 +26,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
         $uses = array_flip(class_uses_recursive(static::class));
 
-        if (isset($uses[PreventsSavingStacheItemsToDisk::class])) {
+        if (isset($uses[PreventSavingStacheItemsToDisk::class])) {
             $this->preventSavingStacheItemsToDisk();
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
     protected $shouldFakeVersion = true;
     protected $shouldPreventNavBeingBuilt = true;
+    protected $fakeStacheDirectory = __DIR__.'/__fixtures__/dev-null';
 
     protected function setUp(): void
     {


### PR DESCRIPTION
This pull request makes a couple of changes around addon testing:

* Moves the `AddonTestCase` introduced in #9573 into the `Statamic\Testing` namespace
* Makes the `PreventSavingStacheItemsToDisk` trait available for addons
    * This trait prevents Stache items from being kept around on the disk after the test suite has finished running. 
    * I had to make some changes to the trait in order for the paths to be correct. Otherwise, the Stache files would live in `vendor/statamic/cms/src/Testing/Concerns/__fixtures__`.