### PR TITLE
[4.x] Add `date` to reserved fields for form blueprints

### DIFF
--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -8,6 +8,7 @@ use Statamic\Facades\Blueprint;
 use Statamic\Facades\Fieldset;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Middleware\CP\CanManageBlueprints;
+use Statamic\Support\Str;
 
 class FieldsController extends CpController
 {
@@ -85,9 +86,16 @@ class FieldsController extends CpController
                 },
             ],
         ];
+
         $customMessages = [
             'handle.not_in' => __('statamic::validation.reserved'),
         ];
+
+        $referer = $request->headers->get('referer');
+
+        if (Str::contains($referer, 'forms/') && Str::contains($referer, '/blueprint') && $request->values['handle'] === 'date') {
+            $extraRules['handle'][] = 'not_in:date';
+        }
 
         if ($request->type === 'date' && $request->values['handle'] === 'date') {
             $extraRules['mode'] = 'in:single';


### PR DESCRIPTION
This pull request adds `date` to the list of reserved field handles for Form blueprints. 

We don't pass any information about the _type_ of blueprint to the `FieldsController@update` method, so I'm just using the referrer URL to determine whether it's a form blueprint or not. 

Closes #9866.