### PR TITLE
[5.x] Fix issues with `PreventsSavingStacheItemsToDisk` trait

### DIFF
--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -8,6 +8,7 @@ use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use ReflectionClass;
 use Statamic\Console\Processes\Composer;
 use Statamic\Extend\Manifest;
+use Statamic\Facades\Path;
 use Statamic\Providers\StatamicServiceProvider;
 use Statamic\Statamic;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
@@ -97,5 +98,19 @@ abstract class AddonTestCase extends OrchestraTestCase
         ];
 
         $app['config']->set('statamic.users.repository', 'file');
+
+        $app['config']->set('statamic.stache.watcher', false);
+        $app['config']->set('statamic.stache.stores.taxonomies.directory', $directory.'/../tests/__fixtures__/content/taxonomies');
+        $app['config']->set('statamic.stache.stores.terms.directory', $directory.'/../tests/__fixtures__/content/taxonomies');
+        $app['config']->set('statamic.stache.stores.collections.directory', $directory.'/../tests/__fixtures__/content/collections');
+        $app['config']->set('statamic.stache.stores.entries.directory', $directory.'/../tests/__fixtures__/content/collections');
+        $app['config']->set('statamic.stache.stores.navigation.directory', $directory.'/../tests/__fixtures__/content/navigation');
+        $app['config']->set('statamic.stache.stores.globals.directory', $directory.'/../tests/__fixtures__/content/globals');
+        $app['config']->set('statamic.stache.stores.global-variables.directory', $directory.'/../tests/__fixtures__/content/globals');
+        $app['config']->set('statamic.stache.stores.asset-containers.directory', $directory.'/../tests/__fixtures__/content/assets');
+        $app['config']->set('statamic.stache.stores.nav-trees.directory', $directory.'/../tests/__fixtures__/content/structures/navigation');
+        $app['config']->set('statamic.stache.stores.collection-trees.directory', $directory.'/../tests/__fixtures__/content/structures/collections');
+        $app['config']->set('statamic.stache.stores.form-submissions.directory', $directory.'/../tests/__fixtures__/content/submissions');
+        $app['config']->set('statamic.stache.stores.users.directory', $directory.'/../tests/__fixtures__/users');
     }
 }

--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -8,7 +8,6 @@ use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use ReflectionClass;
 use Statamic\Console\Processes\Composer;
 use Statamic\Extend\Manifest;
-use Statamic\Facades\Path;
 use Statamic\Providers\StatamicServiceProvider;
 use Statamic\Statamic;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;

--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -43,7 +43,7 @@ abstract class AddonTestCase extends OrchestraTestCase
     {
         $uses = array_flip(class_uses_recursive(static::class));
 
-        if (isset($uses[PreventSavingStacheItemsToDisk::class])) {
+        if (isset($uses[PreventsSavingStacheItemsToDisk::class])) {
             $this->deleteFakeStacheDirectory();
         }
 

--- a/src/Testing/Concerns/PreventsSavingStacheItemsToDisk.php
+++ b/src/Testing/Concerns/PreventsSavingStacheItemsToDisk.php
@@ -13,8 +13,11 @@ trait PreventsSavingStacheItemsToDisk
         $this->fakeStacheDirectory = Path::tidy($this->fakeStacheDirectory);
 
         Stache::stores()->each(function ($store) {
-            $dir = Path::tidy(Str::before($this->fakeStacheDirectory, '/dev-null'));
-            $relative = Str::after(Str::after($store->directory(), $dir), '/');
+            $fixturesPath = Str::before($this->fakeStacheDirectory, '/dev-null');
+            $storeDirectory = '/'.Path::makeRelative($store->directory());
+
+            $relative = Str::after(Str::after($storeDirectory, $fixturesPath), '/');
+
             $store->directory($this->fakeStacheDirectory.'/'.$relative);
         });
     }


### PR DESCRIPTION
This pull request fixes some issues I introduced in my previous PR, #9871:

* After testing with the Eloquent Driver, I realised that it was creating the temporary files in paths like this: `tests/__fixtures__/dev-null/Users/duncan/Code/Statamic/eloquent-driver/vendor/orchestra/testbench-core/laravel/content/collections` instead of simply `tests/__fixtures__/content/collections`
    * This was only happening for addons, so I refactored the path replacement logic in the trait and configured the default Stache directories in the `AddonTestCase`
* After running the tests, the `tearDown` method is _supposed_ to delete the temporary Stache files. However, after I renamed the `PreventsSavingStacheItemsToDisk` trait in [c0d5f1f](https://github.com/statamic/cms/pull/9871/commits/c0d5f1f9ef4ab0fccacaa8447efe4befd57978a6), it stopped doing that.