### PR TITLE
[5.x] Fix event listeners not being triggered with Laravel 11

### DIFF
--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -39,7 +39,7 @@ class EventServiceProvider extends ServiceProvider
         \Statamic\Listeners\UpdateTermReferences::class,
     ];
 
-    public function boot()
+    public function register()
     {
         $this->booting(function () {
             foreach ($this->listen as $event => $listeners) {
@@ -52,7 +52,10 @@ class EventServiceProvider extends ServiceProvider
                 Event::subscribe($subscriber);
             }
         });
+    }
 
+    public function boot()
+    {
         Event::macro('forgetListener', function ($event, $handler) {
             $this->listeners[$event] = Arr::where($this->listeners[$event], function ($eventHandler) use ($handler) {
                 return $eventHandler != $handler;

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -47,4 +47,14 @@ class EventServiceProvider extends ServiceProvider
             });
         });
     }
+
+    /**
+     * Determine if events and listeners should be automatically discovered.
+     *
+     * @return bool
+     */
+    public function shouldDiscoverEvents()
+    {
+        return true;
+    }
 }

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Providers;
 
-use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Event;
 use Statamic\Support\Arr;
 
@@ -41,20 +41,22 @@ class EventServiceProvider extends ServiceProvider
 
     public function boot()
     {
+        $this->booting(function () {
+            foreach ($this->listen as $event => $listeners) {
+                foreach (array_unique($listeners, SORT_REGULAR) as $listener) {
+                    Event::listen($event, $listener);
+                }
+            }
+
+            foreach ($this->subscribe as $subscriber) {
+                Event::subscribe($subscriber);
+            }
+        });
+
         Event::macro('forgetListener', function ($event, $handler) {
             $this->listeners[$event] = Arr::where($this->listeners[$event], function ($eventHandler) use ($handler) {
                 return $eventHandler != $handler;
             });
         });
-    }
-
-    /**
-     * Determine if events and listeners should be automatically discovered.
-     *
-     * @return bool
-     */
-    public function shouldDiscoverEvents()
-    {
-        return true;
     }
 }


### PR DESCRIPTION
This pull request fixes an issue with Laravel 11 where event listeners weren't being triggered when they should have been.

Fixes #9862.