### PR TITLE
[5.x] Fix issues with Please commands on Laravel 11

### DIFF
--- a/src/Console/Please/Application.php
+++ b/src/Console/Please/Application.php
@@ -61,7 +61,7 @@ class Application extends ConsoleApplication
     /**
      * Resolve deferred commands.
      */
-    protected function resolveDeferredCommands()
+    public function resolveDeferredCommands()
     {
         foreach ($this->deferredCommands as $command) {
             $this->add($command);

--- a/src/Console/Please/Kernel.php
+++ b/src/Console/Please/Kernel.php
@@ -32,6 +32,13 @@ class Kernel extends ConsoleKernel
         return $this->artisan;
     }
 
+    public function call($command, array $parameters = [], $outputBuffer = null)
+    {
+        $this->getArtisan()->resolveDeferredCommands();
+
+        return parent::call($command, $parameters, $outputBuffer);
+    }
+
     protected function shouldDiscoverCommands()
     {
         return get_class($this) === __CLASS__;

--- a/src/Console/Please/Kernel.php
+++ b/src/Console/Please/Kernel.php
@@ -4,7 +4,6 @@ namespace Statamic\Console\Please;
 
 use App\Console\Kernel as ConsoleKernel;
 use Statamic\Console\Please\Application as Please;
-use Statamic\Statamic;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class Kernel extends ConsoleKernel


### PR DESCRIPTION
This pull request fixes two issues with Please commands on Laravel 11:

* It fixes an issue where an app's commands in `app/Console/Commands` with the `RunsInPlease` alias weren't available with Please. Updating `getArtisan` to be inline with Laravel's method fixes that.
* It fixes an issue where Artisan commands couldn't be called using `Artisan::call()`. We "defer" regular non-please commands within please so they don't show up in the listing. We fix this by resolving them when using Artisan::call().

Closes #9875.
Closes #9861.