### PR TITLE
[4.x] Fixes for asset/term reference updater strictness

### DIFF
--- a/src/Assets/AssetReferenceUpdater.php
+++ b/src/Assets/AssetReferenceUpdater.php
@@ -56,7 +56,7 @@ class AssetReferenceUpdater extends DataReferenceUpdater
                     && $this->getConfiguredAssetsFieldContainer($field) === $this->container;
             })
             ->each(function ($field) use ($dottedPrefix) {
-                $field->get('max_files') === 1
+                $this->hasStringValue($field, $dottedPrefix)
                     ? $this->updateStringValue($field, $dottedPrefix)
                     : $this->updateArrayValue($field, $dottedPrefix);
             });
@@ -100,7 +100,7 @@ class AssetReferenceUpdater extends DataReferenceUpdater
                     && $field->get('container') === $this->container;
             })
             ->each(function ($field) use ($dottedPrefix) {
-                $field->get('save_html') === true
+                $this->hasStringValue($field, $dottedPrefix)
                     ? $this->updateStatamicUrlsInStringValue($field, $dottedPrefix)
                     : $this->updateStatamicUrlsInArrayValue($field, $dottedPrefix);
             });

--- a/src/Data/DataReferenceUpdater.php
+++ b/src/Data/DataReferenceUpdater.php
@@ -209,6 +209,22 @@ abstract class DataReferenceUpdater
     }
 
     /**
+     * Determine if field has string value.
+     *
+     * @param  \Statamic\Fields\Field  $field
+     * @param  null|string  $dottedPrefix
+     * @return bool
+     */
+    protected function hasStringValue($field, $dottedPrefix)
+    {
+        $data = $this->item->data()->all();
+
+        $dottedKey = $dottedPrefix.$field->handle();
+
+        return is_string(Arr::get($data, $dottedKey));
+    }
+
+    /**
      * Update string value on item.
      *
      * @param  \Statamic\Fields\Field  $field

--- a/src/Taxonomies/TermReferenceUpdater.php
+++ b/src/Taxonomies/TermReferenceUpdater.php
@@ -60,7 +60,7 @@ class TermReferenceUpdater extends DataReferenceUpdater
                     && in_array($this->taxonomy, Arr::wrap($field->get('taxonomies')));
             })
             ->each(function ($field) use ($dottedPrefix) {
-                $field->get('max_items') === 1
+                $this->hasStringValue($field, $dottedPrefix)
                     ? $this->updateStringValue($field, $dottedPrefix)
                     : $this->updateArrayValue($field, $dottedPrefix);
             });
@@ -85,7 +85,7 @@ class TermReferenceUpdater extends DataReferenceUpdater
                     && count(Arr::wrap($field->get('taxonomies'))) === 0;
             })
             ->each(function ($field) use ($dottedPrefix) {
-                $field->get('max_items') === 1
+                $this->hasStringValue($field, $dottedPrefix)
                     ? $this->updateStringValue($field, $dottedPrefix)
                     : $this->updateArrayValue($field, $dottedPrefix);
             });

--- a/tests/Listeners/UpdateAssetReferencesTest.php
+++ b/tests/Listeners/UpdateAssetReferencesTest.php
@@ -260,6 +260,45 @@ class UpdateAssetReferencesTest extends TestCase
     }
 
     /** @test */
+    public function it_updates_assets_fields_regardless_of_max_files_setting()
+    {
+        $collection = tap(Facades\Collection::make('articles'))->save();
+
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                [
+                    'handle' => 'avatar',
+                    'field' => [
+                        'type' => 'assets',
+                        'container' => 'test_container',
+                        'max_files' => 1,
+                    ],
+                ],
+                [
+                    'handle' => 'products',
+                    'field' => [
+                        'type' => 'assets',
+                        'container' => 'test_container',
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry = tap(Facades\Entry::make()->collection($collection)->data([
+            'avatar' => ['hoff.jpg'], // assuming it was previously `max_files` > 1
+            'products' => 'surfboard.jpg', // assuming it was previously `max_files` == 1
+        ]))->save();
+
+        $this->assertEquals(['hoff.jpg'], $entry->get('avatar'));
+        $this->assertEquals('surfboard.jpg', $entry->get('products'));
+
+        $this->assetHoff->path('hoff-new.jpg')->save();
+
+        $this->assertEquals(['hoff-new.jpg'], $entry->fresh()->get('avatar'));
+        $this->assertEquals('surfboard.jpg', $entry->fresh()->get('products'));
+    }
+
+    /** @test */
     public function it_nullifies_references_when_deleting_an_asset()
     {
         $collection = tap(Facades\Collection::make('articles'))->save();
@@ -1028,6 +1067,159 @@ EOT;
 EOT;
 
         $this->assertEquals($expected, $entry->fresh()->get('bardo'));
+    }
+
+    /** @test */
+    public function it_updates_asset_references_in_bard_field_regardless_of_save_html_setting()
+    {
+        $collection = tap(Facades\Collection::make('articles'))->save();
+
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                [
+                    'handle' => 'pretend_array_value',
+                    'field' => [
+                        'type' => 'bard',
+                        'container' => 'test_container',
+                    ],
+                ],
+                [
+                    'handle' => 'pretend_html_value',
+                    'field' => [
+                        'type' => 'bard',
+                        'container' => 'test_container',
+                        'save_html' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $html = <<<'EOT'
+<p>Some text.</p>
+<img src="statamic://asset::test_container::hoff.jpg">
+<img src="statamic://asset::test_container::hoff.jpg" alt="test">
+</p>More text.</p>
+<p><a href="statamic://asset::test_container::hoff.jpg">Link</a></p>
+<img src="statamic://asset::test_container::norris.jpg">
+<p><a href="statamic://asset::test_container::norris.jpg">Link</a></p>
+<img src="statamic://asset::test_container::surfboard.jpg">
+<p><a href="statamic://asset::test_container::surfboard.jpg">Link</a></p>
+EOT;
+
+        $entry = tap(Facades\Entry::make()->collection($collection)->data([
+            'pretend_array_value' => $html,
+            'pretend_html_value' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'image',
+                            'attrs' => [
+                                'src' => 'asset::test_container::surfboard.jpg',
+                                'alt' => 'surfboard',
+                            ],
+                        ],
+                        [
+                            'type' => 'link',
+                            'attrs' => [
+                                'href' => 'statamic://asset::test_container::surfboard.jpg',
+                            ],
+                        ],
+                        [
+                            'type' => 'paragraph',
+                            'content' => 'unrelated',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'image',
+                            'attrs' => [
+                                'src' => 'asset::test_container::hoff.jpg',
+                                'alt' => 'hoff',
+                            ],
+                        ],
+                        [
+                            'type' => 'link',
+                            'attrs' => [
+                                'href' => 'statamic://asset::test_container::hoff.jpg',
+                            ],
+                        ],
+                        [
+                            'type' => 'paragraph',
+                            'content' => 'unrelated',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'image',
+                            'attrs' => [
+                                'src' => 'asset::test_container::norris.jpg',
+                                'alt' => 'norris',
+                            ],
+                        ],
+                        [
+                            'type' => 'link',
+                            'attrs' => [
+                                'href' => 'statamic://asset::test_container::norris.jpg',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => 'unrelated',
+                ],
+            ],
+        ]))->save();
+
+        $this->assertEquals($html, $entry->fresh()->get('pretend_array_value'));
+
+        $this->assertEquals('asset::test_container::surfboard.jpg', Arr::get($entry->fresh()->data(), 'pretend_html_value.0.content.0.attrs.src'));
+        $this->assertEquals('surfboard', Arr::get($entry->fresh()->data(), 'pretend_html_value.0.content.0.attrs.alt'));
+        $this->assertEquals('statamic://asset::test_container::surfboard.jpg', Arr::get($entry->fresh()->data(), 'pretend_html_value.0.content.1.attrs.href'));
+
+        $this->assertEquals('asset::test_container::hoff.jpg', Arr::get($entry->fresh()->data(), 'pretend_html_value.1.content.0.attrs.src'));
+        $this->assertEquals('hoff', Arr::get($entry->fresh()->data(), 'pretend_html_value.1.content.0.attrs.alt'));
+        $this->assertEquals('statamic://asset::test_container::hoff.jpg', Arr::get($entry->fresh()->data(), 'pretend_html_value.1.content.1.attrs.href'));
+
+        $this->assertEquals('asset::test_container::norris.jpg', Arr::get($entry->fresh()->data(), 'pretend_html_value.2.content.0.attrs.src'));
+        $this->assertEquals('norris', Arr::get($entry->fresh()->data(), 'pretend_html_value.2.content.0.attrs.alt'));
+        $this->assertEquals('statamic://asset::test_container::norris.jpg', Arr::get($entry->fresh()->data(), 'pretend_html_value.2.content.1.attrs.href'));
+
+        $this->assetHoff->path('content/hoff-new.jpg')->save();
+        $this->assetNorris->delete();
+
+        $expectedHtml = <<<'EOT'
+<p>Some text.</p>
+<img src="statamic://asset::test_container::content/hoff-new.jpg">
+<img src="statamic://asset::test_container::content/hoff-new.jpg" alt="test">
+</p>More text.</p>
+<p><a href="statamic://asset::test_container::content/hoff-new.jpg">Link</a></p>
+<img src="">
+<p><a href="">Link</a></p>
+<img src="statamic://asset::test_container::surfboard.jpg">
+<p><a href="statamic://asset::test_container::surfboard.jpg">Link</a></p>
+EOT;
+
+        $this->assertEquals($expectedHtml, $entry->fresh()->get('pretend_array_value'));
+
+        $this->assertEquals('asset::test_container::surfboard.jpg', Arr::get($entry->fresh()->data(), 'pretend_html_value.0.content.0.attrs.src'));
+        $this->assertEquals('surfboard', Arr::get($entry->fresh()->data(), 'pretend_html_value.0.content.0.attrs.alt'));
+        $this->assertEquals('statamic://asset::test_container::surfboard.jpg', Arr::get($entry->fresh()->data(), 'pretend_html_value.0.content.1.attrs.href'));
+
+        $this->assertEquals('asset::test_container::content/hoff-new.jpg', Arr::get($entry->fresh()->data(), 'pretend_html_value.1.content.0.attrs.src'));
+        $this->assertEquals('hoff', Arr::get($entry->fresh()->data(), 'pretend_html_value.1.content.0.attrs.alt'));
+        $this->assertEquals('statamic://asset::test_container::content/hoff-new.jpg', Arr::get($entry->fresh()->data(), 'pretend_html_value.1.content.1.attrs.href'));
+
+        $this->assertEquals('', Arr::get($entry->fresh()->data(), 'pretend_html_value.2.content.0.attrs.src'));
+        $this->assertEquals('norris', Arr::get($entry->fresh()->data(), 'pretend_html_value.2.content.0.attrs.alt'));
+        $this->assertEquals('', Arr::get($entry->fresh()->data(), 'pretend_html_value.2.content.1.attrs.href'));
     }
 
     /** @test */


### PR DESCRIPTION
This PR takes over from where #7555 and #9790 left off, but addresses more edge cases.

- [x] Asset reference updater
    - [x] Ensure we handle string/array values regardless of `max_files` configuration
    - [x] Ensure we handle string/array values regardless of `save_html` configuration
    - [x] Add test coverage for the above
- [x] Term reference updater
    - [x] Ensure we handle string/array values regardless of `max_items` configuration
    - [x] Ensure we handle string/array values for scoped terms regardless of `max_items` configuration
    - [x] Add test coverage for the above
    
Closes and fixes #7555
Closes #9790
Fixes #9701
Fixes #7547
References #7555
References #8114