### PR TITLE
[4.x] Fix Bard scrolling editor/page on link insert

### DIFF
--- a/resources/js/components/fieldtypes/bard/LinkToolbarButton.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbarButton.vue
@@ -52,7 +52,7 @@ export default {
             if (this.showingToolbar) {
                 this.linkAttrs = this.editor.getAttributes('link');
             } else {
-                this.editor.view.dom.focus();
+                this.editor.commands.focus();
             }
         },
 
@@ -66,10 +66,9 @@ export default {
         },
 
         setLink(attributes) {
-            this.editor.commands.setLink(attributes);
+            this.editor.chain().focus().setLink(attributes).run();
             this.linkAttrs = null;
             this.close();
-            this.editor.view.dom.focus();
         }
     },
 


### PR DESCRIPTION
There's currently in a glitch in Bard when you insert a link into a long run of text the scroll position moves up. The video below shows it, but I've also seen it scroll all the way to the top of the page (seems to be random, probably just depends on the browser/load etc.).

https://github.com/statamic/cms/assets/126740/ba5c30e2-e50d-491a-9ba7-dd31a68aa7ef

This PR fixes it by chaining Tiptap's focus command rather than manually focusing the dom.