### PR TITLE
[5.x] Fix duplicated field config header

### DIFF
--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -12,11 +12,6 @@
             </header>
         </template>
 
-        <header class="bg-gray-200 border-b py-3 rtl:pr-3 ltr:pl-3 flex items-center justify-between relative" v-if="fullScreenMode">
-            <h2 v-text="__(config.display)" />
-            <button class="btn-close absolute top-2 rtl:left-5 ltr:right-5" @click="fullScreenMode = false" :aria-label="__('Exit Fullscreen Mode')">&times;</button>
-        </header>
-
         <section :class="{'p-4': fullScreenMode}">
 
             <small v-if="hasExcessRows" class="help-block text-red-500">


### PR DESCRIPTION
When entering fullscreen mode in the grid field type configuration editor, two headers are unexpectedly added.