### PR TITLE
[4.x] Fix regression on bard/replicator group set previews

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -10,7 +10,7 @@
                 <div class="item-move sortable-handle" data-drag-handle />
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
                     <label class="text-xs whitespace-nowrap rtl:ml-2 ltr:mr-2">
-                        <span v-if="setGroup">
+                        <span v-if="isSetGroupVisible">
                             {{ setGroup.display }}
                             <svg-icon name="micro/chevron-right" class="w-4" />
                         </span>
@@ -128,6 +128,10 @@ export default {
             return this.bardSets.find((group) => {
                 return group.sets.filter((set) => set.handle === this.config.handle).length > 0;
             });
+        },
+
+        isSetGroupVisible() {
+            return this.bardSets.length > 1 && this.setGroup?.display;
         },
 
         isReadOnly() {

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -8,7 +8,7 @@
                 <div class="item-move sortable-handle" :class="sortableHandleClass" v-if="!isReadOnly"></div>
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
                     <label class="text-xs whitespace-nowrap rtl:ml-2 ltr:mr-2 cursor-pointer">
-                        <span v-if="hasVisibleSetGroup">
+                        <span v-if="isSetGroupVisible">
                             {{ setGroup.display }}
                             <svg-icon name="micro/chevron-right" class="w-4" />
                         </span>
@@ -168,9 +168,8 @@ export default {
             return this.fields.length > 1;
         },
 
-        hasVisibleSetGroup() {
-            return this.replicatorSets.length > 1
-                && this.setGroup?.display;
+        isSetGroupVisible() {
+            return this.replicatorSets.length > 1 && this.setGroup?.display;
         },
 
         isHidden() {

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -8,7 +8,7 @@
                 <div class="item-move sortable-handle" :class="sortableHandleClass" v-if="!isReadOnly"></div>
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
                     <label class="text-xs whitespace-nowrap rtl:ml-2 ltr:mr-2 cursor-pointer">
-                        <span v-if="setGroup">
+                        <span v-if="hasMultipleSetGroups">
                             {{ setGroup.display }}
                             <svg-icon name="micro/chevron-right" class="w-4" />
                         </span>
@@ -166,6 +166,10 @@ export default {
 
         hasMultipleFields() {
             return this.fields.length > 1;
+        },
+
+        hasMultipleSetGroups() {
+            return this.replicatorSets.length > 1;
         },
 
         isHidden() {

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -8,7 +8,7 @@
                 <div class="item-move sortable-handle" :class="sortableHandleClass" v-if="!isReadOnly"></div>
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
                     <label class="text-xs whitespace-nowrap rtl:ml-2 ltr:mr-2 cursor-pointer">
-                        <span v-if="hasMultipleSetGroups">
+                        <span v-if="hasVisibleSetGroup">
                             {{ setGroup.display }}
                             <svg-icon name="micro/chevron-right" class="w-4" />
                         </span>
@@ -168,8 +168,9 @@ export default {
             return this.fields.length > 1;
         },
 
-        hasMultipleSetGroups() {
-            return this.replicatorSets.length > 1;
+        hasVisibleSetGroup() {
+            return this.replicatorSets.length > 1
+                && this.setGroup?.display;
         },
 
         isHidden() {


### PR DESCRIPTION
Closes #9900 by checking the count of available set groups, instead of the existence of an associated set group. I've also added a secondary check, to ensure that the set group has a `display` property defined. That's actually how I stumbled onto this regression in the first place, as it kicks out a label that looks like this (if the `display` is missing):

![image](https://github.com/statamic/cms/assets/13950848/87aa68ac-6c89-4277-a684-0df38bae5e6b)

So this PR requires **both** conditions are met, for the set group label & chevron to be visible:

1. More than one set group option must be available, and
2. The associated set group, if present, must have a `display` defined

Feel free to amend that (or any) part of this PR, and let me know if there's anything else I can do to help this along!