### PR TITLE
[5.x] Make the SVG tag fail gracefully when `src` value is empty

### DIFF
--- a/src/Tags/Svg.php
+++ b/src/Tags/Svg.php
@@ -48,6 +48,10 @@ class Svg extends Tags
             $svg = $this->params->get('src');
         }
 
+        if (empty($svg)) {
+            return '';
+        }
+
         $attributes = $this->renderAttributesFromParams(except: ['src', 'title', 'desc', 'sanitize']);
 
         if ($this->params->get('title') || $this->params->get('desc')) {

--- a/tests/Tags/SvgTagTest.php
+++ b/tests/Tags/SvgTagTest.php
@@ -15,9 +15,9 @@ class SvgTagTest extends TestCase
         File::copy(__DIR__.'/../../resources/svg/icons/light/users.svg', resource_path('users.svg'));
     }
 
-    private function tag($tag)
+    private function tag($tag, $variables = [])
     {
-        return Parse::template($tag, []);
+        return Parse::template($tag, $variables);
     }
 
     /** @test */
@@ -78,5 +78,15 @@ SVG);
         File::put(resource_path('xmltag.svg'), $svg);
 
         $this->assertEquals($svg, $this->tag('{{ svg src="xmltag" }}'));
+    }
+
+    /** @test */
+    public function fails_gracefully_when_src_is_empty()
+    {
+        $output = $this->tag('{{ svg :src="icon" }}', [
+            'icon' => null,
+        ]);
+
+        $this->assertEmpty((string) $output);
     }
 }


### PR DESCRIPTION
This pull request makes it so the `{{ svg }}` tag fails gracefully when the provided `src` value is empty. This matches how the SVG tag handled empty `src` values in v4.

The example given in #9902, was that of an `icon` field without any value:

```antlers
{{ svg src="{{ foo }}" }}
```

Fixes #9902.