### PR TITLE
[4.x] Add title fallback for roles & groups

### DIFF
--- a/src/Auth/File/Role.php
+++ b/src/Auth/File/Role.php
@@ -28,7 +28,7 @@ class Role extends BaseRole
     {
         if (func_num_args() === 0) {
             return $this->title ?? ucfirst($this->handle);
-        };
+        }
 
         $this->title = $title;
 

--- a/src/Auth/File/Role.php
+++ b/src/Auth/File/Role.php
@@ -27,8 +27,8 @@ class Role extends BaseRole
     public function title(?string $title = null)
     {
         if (func_num_args() === 0) {
-            return $this->title;
-        }
+            return $this->title ?? ucfirst($this->handle);
+        };
 
         $this->title = $title;
 

--- a/src/Auth/UserGroup.php
+++ b/src/Auth/UserGroup.php
@@ -32,7 +32,7 @@ abstract class UserGroup implements Arrayable, ArrayAccess, Augmentable, UserGro
     public function title(?string $title = null)
     {
         if (func_num_args() === 0) {
-            return $this->title;
+            return $this->title ?? ucfirst($this->handle);
         }
 
         $this->title = $title;


### PR DESCRIPTION
This pull request adds a fallback to titles of roles & groups, to ensure the Control Panel doesn't break when they're created without titles (eg. created programatically).

The same behaviour already exists for collections, globals, etc, where we use the handle as the title if no title is specifically provided.

Fixes #9903.