### PR TITLE
[4.x] Fix Grid styles messing up row-controls of nested fields

### DIFF
--- a/resources/css/components/fieldtypes/grid.css
+++ b/resources/css/components/fieldtypes/grid.css
@@ -64,7 +64,7 @@
     }
 }
 
-.grid-table tbody .row-controls {
+.grid-table tbody .grid-row-controls {
     @apply rtl:pr-0 ltr:pl-0 text-center;
     width: 1%;
     padding-top: 21px; /*  pseudo-center for text/select fields */

--- a/resources/js/components/fieldtypes/grid/Row.vue
+++ b/resources/js/components/fieldtypes/grid/Row.vue
@@ -20,7 +20,7 @@
             @blur="$emit('blur')"
         />
 
-        <td class="row-controls" v-if="!grid.isReadOnly && (canAddRows || canDelete)">
+        <td class="grid-row-controls row-controls" v-if="!grid.isReadOnly && (canAddRows || canDelete)">
             <dropdown-list>
                 <dropdown-item :text="__('Duplicate Row')" @click="$emit('duplicate', index)" v-if="canAddRows" />
                 <dropdown-item v-if="canDelete" :text="__('Delete Row')" class="warning" @click="$emit('removed', index)" />

--- a/resources/js/components/fieldtypes/grid/Table.vue
+++ b/resources/js/components/fieldtypes/grid/Table.vue
@@ -9,7 +9,7 @@
                     :key="field.handle"
                     :field="field"
                 />
-                <th class="row-controls">
+                <th class="grid-row-controls row-controls">
                     <button v-if="allowFullscreen" @click="grid.toggleFullScreen" class="flex items-center w-full h-full justify-center text-gray-500 hover:text-gray-700">
                         <svg-icon name="expand-bold" class="h-3.5 w-3.5" v-show="! grid.fullScreenMode" />
                         <svg-icon name="shrink-all" class="h-3.5 w-3.5" v-show="grid.fullScreenMode" />


### PR DESCRIPTION
This pull request fixes an issue where the `row-controls` styles from the Grid fieldtype were messing up the styles of `row-controls` elements in fields in the Grid, for example the List fieldtype.

![CleanShot 2024-04-16 at 15 23 44](https://github.com/statamic/cms/assets/19637309/c2f02f5c-d542-4478-976c-594eca9931f2)

Fixes #9873.