### PR TITLE
[5.x] Remove manual Glide filenames

### DIFF
--- a/src/Contracts/Imaging/UrlBuilder.php
+++ b/src/Contracts/Imaging/UrlBuilder.php
@@ -9,8 +9,7 @@ interface UrlBuilder
      *
      * @param  \Statamic\Contracts\Assets\Asset|string  $item
      * @param  array  $params
-     * @param  string|null  $filename
      * @return string
      */
-    public function build($item, $params, $filename = null);
+    public function build($item, $params);
 }

--- a/src/Imaging/GlideImageManipulator.php
+++ b/src/Imaging/GlideImageManipulator.php
@@ -32,13 +32,6 @@ class GlideImageManipulator implements ImageManipulator
     protected $item_type;
 
     /**
-     * A custom filename.
-     *
-     * @var string|null
-     */
-    protected $filename;
-
-    /**
      * Methods available in Glide's API.
      *
      * @var array
@@ -106,20 +99,7 @@ class GlideImageManipulator implements ImageManipulator
      */
     public function build()
     {
-        return $this->builder->build($this->item, $this->params, $this->filename);
-    }
-
-    /**
-     * Set a custom filename.
-     *
-     * @param  string  $filename
-     * @return $this
-     */
-    public function filename($filename)
-    {
-        $this->filename = $filename;
-
-        return $this;
+        return $this->builder->build($this->item, $this->params);
     }
 
     /**

--- a/src/Imaging/GlideUrlBuilder.php
+++ b/src/Imaging/GlideUrlBuilder.php
@@ -30,26 +30,20 @@ class GlideUrlBuilder extends ImageUrlBuilder
      *
      * @throws \Exception
      */
-    public function build($item, $params, $filename = null)
+    public function build($item, $params)
     {
         $this->item = $item;
+
+        $filename = null;
 
         switch ($this->itemType()) {
             case 'url':
                 $path = 'http/'.base64_encode($item);
-
-                if (! $filename) {
-                    $filename = Str::afterLast($item, '/');
-                }
-
+                $filename = Str::afterLast($item, '/');
                 break;
             case 'asset':
                 $path = 'asset/'.base64_encode($this->item->containerId().'/'.$this->item->path());
-
-                if (! $filename) {
-                    $filename = Str::afterLast($this->item->path(), '/');
-                }
-
+                $filename = Str::afterLast($this->item->path(), '/');
                 break;
             case 'id':
                 $path = 'asset/'.base64_encode(str_replace('::', '/', $this->item));

--- a/src/Imaging/GlideUrlBuilder.php
+++ b/src/Imaging/GlideUrlBuilder.php
@@ -34,8 +34,6 @@ class GlideUrlBuilder extends ImageUrlBuilder
     {
         $this->item = $item;
 
-        $filename = null;
-
         switch ($this->itemType()) {
             case 'url':
                 $path = 'http/'.base64_encode($item);
@@ -57,7 +55,7 @@ class GlideUrlBuilder extends ImageUrlBuilder
 
         $builder = UrlBuilderFactory::create($this->options['route'], $this->options['key']);
 
-        if ($filename) {
+        if (isset($filename)) {
             $path .= Str::ensureLeft(URL::encode($filename), '/');
         }
 

--- a/src/Imaging/StaticUrlBuilder.php
+++ b/src/Imaging/StaticUrlBuilder.php
@@ -44,10 +44,9 @@ class StaticUrlBuilder extends ImageUrlBuilder
      *
      * @param  \Statamic\Contracts\Assets\Asset|string  $item
      * @param  array  $params
-     * @param  string|null  $filename
      * @return string
      */
-    public function build($item, $params, $filename = null)
+    public function build($item, $params)
     {
         $this->item = $item;
         $this->params = $params;

--- a/tests/Imaging/GlideUrlBuilderTest.php
+++ b/tests/Imaging/GlideUrlBuilderTest.php
@@ -72,14 +72,6 @@ class GlideUrlBuilderTest extends TestCase
         );
     }
 
-    public function testFilename()
-    {
-        $this->assertEquals(
-            '/img/foo.jpg/custom.png?w=100',
-            $this->builder->build('/foo.jpg', ['w' => '100'], 'custom.png')
-        );
-    }
-
     public function testConfigAddsFilename()
     {
         $asset = new Asset;


### PR DESCRIPTION
Since #9616 appends filenames automatically, there's no need to specify filenames manually anymore.

This was an undocumented relic of a feature that let you add a "fake" or "vanity" filename to the end of Glide URLs to be able to improve SEO. Now that's happening automatically rendering this feature irrelevant. This feature was broken in certain situations anyway, like if you tried to add `filename=""` to a glide tag where you are passing the path.

This is technically a breaking change since method signatures are changing. Also, you will need to remove `filename=""` from any `glide` tags otherwise nothing will be output.
