### PR TITLE
[4.x] Prevent computed fields from being sortable in listing tables

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -227,6 +227,10 @@ class Field implements Arrayable
 
     public function isSortable()
     {
+        if ($this->get('visibility') === 'computed') {
+            return false;
+        }
+
         if (is_null($this->get('sortable'))) {
             return true;
         }


### PR DESCRIPTION
This pull request prevents computed fields from being shown as "sortable" in listing tables. 

Since computed fields are by their very nature, computed, we don't store them which means we can't order by them in the query builder. However, the fact it looks like you *could* order by them caused some confusion in #9908.

Closes #9908.