### PR TITLE
[5.x] Ability to set custom Glide hash

### DIFF
--- a/src/Imaging/GlideManager.php
+++ b/src/Imaging/GlideManager.php
@@ -177,26 +177,17 @@ class GlideManager
             unset($params['s'], $params['p']);
             ksort($params);
 
-            $hash = $hashCallable($sourcePath, $params);
-            $cachePath = $this->cachePathPrefix.'/'.$sourcePath.'/'.$hash;
+            $ext = $params['fm'] ?? pathinfo($path, PATHINFO_EXTENSION);
+            $ext = $ext === 'pjpg' ? 'jpg' : $ext;
+            $ext = $ext ? ".$ext" : '';
 
-            if ($this->cacheWithFileExtensions) {
-                $ext = (isset($params['fm']) ? $params['fm'] : pathinfo($path)['extension']);
-                $ext = ($ext === 'pjpg') ? 'jpg' : $ext;
-                $cachePath .= '.'.$ext;
-            }
-
-            // then we append our original filename to the end
-            $filename = Str::afterLast($cachePath, '/');
-            $cachePath = Str::beforeLast($cachePath, '/');
-
-            $cachePath .= '/'.Str::beforeLast($filename, '.').'/'.pathinfo($path, PATHINFO_BASENAME);
-
-            if ($extension = ($params['fm'] ?? false)) {
-                $cachePath = Str::beforeLast($cachePath, '.').'.'.$extension;
-            }
-
-            return $cachePath;
+            return vsprintf('%s/%s/%s/%s%s', [
+                $this->cachePathPrefix,
+                $sourcePath,
+                $hashCallable($sourcePath, $params),
+                pathinfo($path, PATHINFO_FILENAME),
+                $ext,
+            ]);
         };
     }
 

--- a/src/Imaging/GlideManager.php
+++ b/src/Imaging/GlideManager.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Imaging;
 
+use Closure;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use League\Glide\ServerFactory;
@@ -12,6 +13,8 @@ use Statamic\Support\Str;
 
 class GlideManager
 {
+    private Closure $customHashCallable;
+
     /**
      * Create glide server.
      *
@@ -199,8 +202,13 @@ class GlideManager
 
     private function getHashCallable()
     {
-        return function (string $source, array $params) {
+        return $this->customHashCallable ?? function (string $source, array $params) {
             return md5($source.'?'.http_build_query($params));
         };
+    }
+
+    public function generateHashUsing(Closure $callback)
+    {
+        $this->customHashCallable = $callback;
     }
 }

--- a/src/Imaging/GlideManager.php
+++ b/src/Imaging/GlideManager.php
@@ -161,7 +161,9 @@ class GlideManager
 
     private function getCachePathCallable()
     {
-        return function ($path, $params) {
+        $hashCallable = $this->getHashCallable();
+
+        return function ($path, $params) use ($hashCallable) {
             $sourcePath = $this->getSourcePath($path);
 
             if ($this->sourcePathPrefix) {
@@ -172,7 +174,7 @@ class GlideManager
             unset($params['s'], $params['p']);
             ksort($params);
 
-            $hash = md5($sourcePath.'?'.http_build_query($params));
+            $hash = $hashCallable($sourcePath, $params);
             $cachePath = $this->cachePathPrefix.'/'.$sourcePath.'/'.$hash;
 
             if ($this->cacheWithFileExtensions) {
@@ -192,6 +194,13 @@ class GlideManager
             }
 
             return $cachePath;
+        };
+    }
+
+    private function getHashCallable()
+    {
+        return function (string $source, array $params) {
+            return md5($source.'?'.http_build_query($params));
         };
     }
 }


### PR DESCRIPTION
Alternate solution to #9781.

This PR lets you customer the unique hash in Glide-generated files.

By default, the hash is just literally just a md5 hash of the manipulation parameters.

You may want to customize it to make it more human readable for debugging or QA purposes as explained in #9781 or just because you prefer it aesthetically.

You can do this in your AppServiceProvider:

```php
public function register()
{
    $this->app->booting(function () {
        Glide::generateHashUsing(function (string $source, array $params) {
            return collect($params)
                ->sortKeys()
                ->map(fn ($value, $param) => "$param-$value")
                ->join('-');
        });
    });
}
```

When generating a glide image like this:
```antlers
{{ glide:myimage width="100" height="50" fit="crop" quality="50" }}
```
normally it would be generated to a path like this:
```
containers/assets/path/to/image.jpg/0638baede3a7fc1a91f605e095ab74cc/image.jpg
```
but with the custom closure it would get generated to this:
```
containers/assets/path/to/image.jpg/fit-crop-h-50-q-50-w-100/image.jpg
```

---

This PR also just does some minor cleanup and refactoring of the cachePath method.