### PR TITLE
[5.x] Make `tearDown` method protected on `AddonTestCase`

### DIFF
--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -39,7 +39,7 @@ abstract class AddonTestCase extends OrchestraTestCase
         $this->addToAssertionCount(-1); // Dont want to assert this
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $uses = array_flip(class_uses_recursive(static::class));
 


### PR DESCRIPTION
This pull request makes the `tearDown` method on our new `AddonTestCase` class protected instead of public.

In my testing, `tearDown` being public was causing issues for addons with Pest test suites. The `setUp` method is already protected.

