### PR TITLE
[5.x] Fix please version

### DIFF
--- a/src/Console/Please/Kernel.php
+++ b/src/Console/Please/Kernel.php
@@ -4,6 +4,7 @@ namespace Statamic\Console\Please;
 
 use App\Console\Kernel as ConsoleKernel;
 use Statamic\Console\Please\Application as Please;
+use Statamic\Statamic;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class Kernel extends ConsoleKernel
@@ -17,7 +18,7 @@ class Kernel extends ConsoleKernel
     {
         if (is_null($this->artisan)) {
             $this->artisan = tap(
-                (new Please($this->app, $this->events, $this->app->version()))
+                (new Please($this->app, $this->events, Statamic::version()))
                     ->resolveCommands($this->commands)
                     ->setContainerCommandLoader()
             )->setName('Statamic');


### PR DESCRIPTION
In #9877, we unintentionally made the version displayed when running `please` show the Laravel version instead of the Statamic version.
