### PR TITLE
[5.x] Fix statamic-prefixed commands not working when running Artisan::call() within please

### DIFF
--- a/src/Console/Please/Kernel.php
+++ b/src/Console/Please/Kernel.php
@@ -5,6 +5,7 @@ namespace Statamic\Console\Please;
 use App\Console\Kernel as ConsoleKernel;
 use Statamic\Console\Please\Application as Please;
 use Statamic\Statamic;
+use Statamic\Support\Str;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class Kernel extends ConsoleKernel
@@ -35,6 +36,10 @@ class Kernel extends ConsoleKernel
     public function call($command, array $parameters = [], $outputBuffer = null)
     {
         $this->getArtisan()->resolveDeferredCommands();
+
+        if (Str::startsWith($command, 'statamic:')) {
+            $command = Str::after($command, 'statamic:');
+        }
 
         return parent::call($command, $parameters, $outputBuffer);
     }

--- a/tests/Console/PleaseTest.php
+++ b/tests/Console/PleaseTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Console;
 
 use Statamic\Console\Please\Kernel;
+use Statamic\Facades\StaticCache;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Tests\TestCase;
 
@@ -18,8 +19,14 @@ class PleaseTest extends TestCase
     /** @test */
     public function it_can_run_an_artisan_command_with_statamic_prefix()
     {
+        StaticCache::shouldReceive('flush')->once();
         $this->artisan('statamic:static:clear');
+    }
 
+    /** @test */
+    public function statamic_prefixed_commands_will_throw_exception_when_running_in_artisan_without_prefix()
+    {
+        StaticCache::shouldReceive('flush')->never();
         $this->expectException(CommandNotFoundException::class);
         $this->artisan('static:clear');
     }
@@ -27,9 +34,14 @@ class PleaseTest extends TestCase
     /** @test */
     public function it_can_run_a_please_command_without_statamic_prefix()
     {
+        StaticCache::shouldReceive('flush')->once();
         $this->please('static:clear');
+    }
 
-        $this->expectException(CommandNotFoundException::class);
+    /** @test */
+    public function it_can_run_a_please_command_with_statamic_prefix()
+    {
+        StaticCache::shouldReceive('flush')->once();
         $this->please('statamic:static:clear');
     }
 


### PR DESCRIPTION
This fixes when `Artisan::call('statamic:something')` is used in a command run via `please`. If you used `artisan`, it would've worked fine.

Closes #9861
