### PR TITLE
Fix `DimensionsRule` for Livewire

### DIFF
--- a/src/Fieldtypes/Assets/DimensionsRule.php
+++ b/src/Fieldtypes/Assets/DimensionsRule.php
@@ -31,7 +31,7 @@ class DimensionsRule implements Rule
                     return true;
                 }
 
-                $size = getimagesize($id);
+                $size = getimagesize($id->getPathname());
             } else {
                 if (! $asset = Asset::find($id)) {
                     return false;

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -34,6 +34,7 @@ use Statamic\Facades\YAML;
 use Statamic\Fields\Blueprint;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Assets\DimensionsRule;
 use Statamic\Support\Arr;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -1481,6 +1482,15 @@ class AssetTest extends TestCase
         $this->assertEquals(30, $asset->width());
         $this->assertEquals(60, $asset->height());
         $this->assertEquals(0.5, $asset->ratio());
+    }
+
+    /** @test */
+    public function it_passes_the_dimensions_validation()
+    {
+        $file = UploadedFile::fake()->image('image.jpg', 30, 60);
+        $validDimensions = (new DimensionsRule(['max_width=10']))->passes('Image', [$file]);
+
+        $this->assertFalse($validDimensions);
     }
 
     /** @test */


### PR DESCRIPTION
I came across an issue in my Livewire Forms addon when validating Livewire's `TemporaryUploadedFile` with Statamic's `DimensionsRule`. The fix is pretty simple and doesn't cause any issues. I've added a simple test to display that things still work as expected.

**The issue:**

![CleanShot 2024-04-18 at 15 27 46@2x](https://github.com/statamic/cms/assets/23167701/10fdc009-93ac-4e17-afb7-5a848bd96b1b)
