### PR TITLE
[5.x] Fix slowdown caused by status PR

### DIFF
--- a/src/Stache/Query/EntryQueryBuilder.php
+++ b/src/Stache/Query/EntryQueryBuilder.php
@@ -59,7 +59,9 @@ class EntryQueryBuilder extends Builder implements QueryBuilder
 
     protected function getFilteredKeys()
     {
-        $this->collections = $collections = $this->initCollections();
+        $collections = empty($this->collections)
+            ? Facades\Collection::handles()
+            : $this->collections;
 
         $this->addTaxonomyWheres();
 
@@ -68,7 +70,12 @@ class EntryQueryBuilder extends Builder implements QueryBuilder
             : $this->getKeysFromCollectionsWithWheres($collections, $this->wheres);
     }
 
-    private function initCollections(): array
+    private function addCollectionWheres(): void
+    {
+        $this->collections = $this->getCollectionWheres();
+    }
+
+    private function getCollectionWheres(): array
     {
         // If the collections property isn't empty, it means the user has explicitly
         // queried for them. In that case, we'll use them and skip the auto-detection.
@@ -173,6 +180,8 @@ class EntryQueryBuilder extends Builder implements QueryBuilder
 
     public function whereStatus(string $status)
     {
+        $this->addCollectionWheres();
+
         if (! in_array($status, self::STATUSES)) {
             throw new \Exception("Invalid status [$status]");
         }


### PR DESCRIPTION
We noticed that #9317 actually made things a bit slower.

When you query by collections, we would a status clause for each query you specified.

However if you don't query for a collection, we would add a status query for _all_ collections. An example of that is if you query entries by only ID. These add up the more collections you have.

This PR improves on that by if you don't query a collection and you query by ids, we automatically query the collections for you. This results on those status nested wheres only being added for appropriate collections.
