### PR TITLE
[5.x] Drop legacy `rebing/graphql-laravel` code

### DIFF
--- a/src/GraphQL/ServiceProvider.php
+++ b/src/GraphQL/ServiceProvider.php
@@ -49,9 +49,7 @@ class ServiceProvider extends LaravelProvider
 
     private function disableGraphqlRoutes()
     {
-        $key = $this->isLegacyRebingGraphql() ? 'graphql.routes' : 'graphql.route';
-
-        config([$key => false]);
+        config(['graphql.route' => false]);
     }
 
     private function addMiddleware()
@@ -72,10 +70,5 @@ class ServiceProvider extends LaravelProvider
     private function setDefaultSchema()
     {
         config(['graphql.schemas.default' => DefaultSchema::class]);
-    }
-
-    protected function isLegacyRebingGraphql()
-    {
-        return class_exists('\Rebing\GraphQL\Support\ResolveInfoFieldsAndArguments');
     }
 }

--- a/src/Http/Controllers/CP/GraphQLController.php
+++ b/src/Http/Controllers/CP/GraphQLController.php
@@ -20,17 +20,8 @@ class GraphQLController extends CpController
     {
         $this->authorize('view graphql');
 
-        $configKey = $this->isLegacyRebingGraphql()
-            ? 'graphql.prefix'
-            : 'graphql.route.prefix';
-
         return view('statamic::graphql.graphiql', [
-            'url' => '/'.config($configKey),
+            'url' => '/'.config('graphql.route.prefix'),
         ]);
-    }
-
-    protected function isLegacyRebingGraphql()
-    {
-        return class_exists('\Rebing\GraphQL\Support\ResolveInfoFieldsAndArguments');
     }
 }


### PR DESCRIPTION
This pull request drops some code added during the Laravel 9 compatibility PR (#5188) to allow applications to continue using older versions of the `rebing/graphql-laravel` package. 

This code can be dropped now since the version of the package we're using for Laravel 11 compatibility [only supports Laravel 10 and 11](https://github.com/rebing/graphql-laravel/blob/master/composer.json#L39-L40), nothing before that.