### PR TITLE
[4.x] Prevent calling `notifications` method on `User` model

### DIFF
--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Data;
 
+use Statamic\Contracts\Auth\User;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Fields\Value;
 use Statamic\Statamic;
@@ -56,7 +57,7 @@ abstract class AbstractAugmented implements Augmented
                 : new Value($value, $method, null, $this->data);
         }
 
-        if (method_exists($this->data, $method) && collect($this->keys())->contains(Str::snake($handle))) {
+        if ($this->methodExistsOnData($method, $handle)) {
             return $this->wrapValue($this->data->$method(), $handle);
         }
 
@@ -78,6 +79,15 @@ abstract class AbstractAugmented implements Augmented
     private function methodExistsOnThisClass($method)
     {
         return method_exists($this, $method) && ! in_array($method, ['select', 'except']);
+    }
+
+    private function methodExistsOnData(string $method, string $handle): bool
+    {
+        if ($this->data instanceof User && $handle === 'notifications') {
+            return false;
+        }
+
+        return method_exists($this->data, $method) && collect($this->keys())->contains(Str::snake($handle));
     }
 
     protected function getFromData($handle)


### PR DESCRIPTION
This pull request fixes an issue when storing users in a database, where if you have a column called `notifications`, an error would be thrown during augmentation.

This was happening due to the Eloquent `User` model having a `notifications` method which returns a `morphMany` relationship, which our augmentation stuff doesn't know how to work with.

This PR fixes that by preventing the method on the `User` being called and falls back to checking the raw data on the user instead.

Fixes #9932.