### PR TITLE
[5.x] Blink augmentation of terms and entries fieldtypes

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -350,7 +350,7 @@ class Entries extends Relationship
         $query = $this->queryBuilder($values);
 
         if ($single) {
-            return tap($query->first(), fn ($entry) => Blink::put($key, $entry));
+            return Blink::once($key, fn () => $query->first());
         } else {
             return $query;
         }

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -349,11 +349,7 @@ class Entries extends Relationship
 
         $query = $this->queryBuilder($values);
 
-        if ($single) {
-            return Blink::once($key, fn () => $query->first());
-        } else {
-            return $query;
-        }
+        return $single ? Blink::once($key, fn () => $query->first()) : $query;
     }
 
     public function shallowAugment($values)

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -7,6 +7,7 @@ use Statamic\Contracts\Data\Localization;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\CP\Column;
 use Statamic\Exceptions\CollectionNotFoundException;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\GraphQL;
@@ -340,9 +341,19 @@ class Entries extends Relationship
 
     public function augment($values)
     {
+        $single = $this->config('max_items') === 1;
+
+        if ($single && Blink::has($key = 'entries-augment-'.$values)) {
+            return Blink::get($key);
+        }
+
         $query = $this->queryBuilder($values);
 
-        return $this->config('max_items') === 1 ? $query->first() : $query;
+        if ($single) {
+            return tap($query->first(), fn ($entry) => Blink::put($key, $entry));
+        } else {
+            return $query;
+        }
     }
 
     public function shallowAugment($values)

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -343,7 +343,7 @@ class Entries extends Relationship
     {
         $single = $this->config('max_items') === 1;
 
-        if ($single && Blink::has($key = 'entries-augment-'.$values)) {
+        if ($single && Blink::has($key = 'entries-augment-'.json_encode($values))) {
             return Blink::get($key);
         }
 

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -117,7 +117,7 @@ class Terms extends Relationship
         $query = $this->queryBuilder($values);
 
         if ($single) {
-            return tap($query->first(), fn ($term) => Blink::put($key, $term));
+            return Blink::once($key, fn () => $query->first());
         } else {
             return $query;
         }

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -116,11 +116,7 @@ class Terms extends Relationship
 
         $query = $this->queryBuilder($values);
 
-        if ($single) {
-            return Blink::once($key, fn () => $query->first());
-        } else {
-            return $query;
-        }
+        return $single ? Blink::once($key, fn () => $query->first()) : $query;
     }
 
     private function queryBuilder($values)

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -110,7 +110,7 @@ class Terms extends Relationship
     {
         $single = $this->config('max_items') === 1;
 
-        if ($single && Blink::has($key = 'terms-augment-'.$values)) {
+        if ($single && Blink::has($key = 'terms-augment-'.json_encode($values))) {
             return Blink::get($key);
         }
 


### PR DESCRIPTION
This PR will use blink to prevent unnecessary re-querying on entries and terms fieldtypes when using max_items 1.

On one particular test site, a blog post template a handful of typical taxonomy related bits on the page loaded in about 1.3s. This PR gets it down to about 750ms.
