### PR TITLE
[4.x] Prevent passing HTML to the Video fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/VideoFieldtype.vue
+++ b/resources/js/components/fieldtypes/VideoFieldtype.vue
@@ -15,7 +15,9 @@
             </div>
         </div>
 
-        <div class="video-preview-wrapper" v-if="isEmbeddable || isVideo">
+        <p v-if="isInvalid" class="text-red-500 mt-4">{{ __('Please provide a valid URL.') }}</p>
+
+        <div class="video-preview-wrapper" v-if="!isInvalid && (isEmbeddable || isVideo)">
             <div class="embed-video" v-if="isEmbeddable && canShowIframe">
                 <iframe :src="embedUrl" frameborder="0" allow="fullscreen"></iframe>
             </div>
@@ -87,6 +89,12 @@ export default {
 
         isEmbeddable() {
             return this.isUrl && this.data.includes('youtube') || this.data.includes('vimeo') || this.data.includes('youtu.be');
+        },
+
+        isInvalid() {
+            let htmlRegex = new RegExp(/<([A-Z][A-Z0-9]*)\b[^>]*>.*?<\/\1>|<([A-Z][A-Z0-9]*)\b[^\/]*\/>/i)
+
+            return htmlRegex.test(this.data);
         },
 
         isUrl() {

--- a/resources/js/components/fieldtypes/VideoFieldtype.vue
+++ b/resources/js/components/fieldtypes/VideoFieldtype.vue
@@ -15,7 +15,7 @@
             </div>
         </div>
 
-        <p v-if="isInvalid" class="text-red-500 mt-4">{{ __('Please provide a valid URL.') }}</p>
+        <p v-if="isInvalid" class="text-red-500 mt-4">{{ __('statamic::validation.url') }}</p>
 
         <div class="video-preview-wrapper" v-if="!isInvalid && (isEmbeddable || isVideo)">
             <div class="embed-video" v-if="isEmbeddable && canShowIframe">

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -142,7 +142,7 @@ return [
     'unique' => 'This value has already been taken.',
     'uploaded' => 'Failed to upload.',
     'uppercase' => 'Must be uppercase.',
-    'url' => 'Format is invalid.',
+    'url' => 'Must be a valid URL.',
     'uuid' => 'Must be a valid UUID.',
 
     /*


### PR DESCRIPTION
This pull request attempts to fix an issue where it was possible to add HTML into the "URL" input causing a Control Panel 404 page to be shown.

When an invalid URL is passed, an error/warning message will be displayed where the video preview would usually sit:

![CleanShot 2024-04-22 at 15 19 31](https://github.com/statamic/cms/assets/19637309/3399b6e4-3ae2-4c5c-a351-5e5c6e9b13e7)

Related: #9943

Also updates the `url` validation translation to match Laravel (but using inline grammar).