### PR TITLE
[4.x] Fix "Target class [blade.compiler] does not exist" issue

### DIFF
--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -43,7 +43,6 @@ class ViewServiceProvider extends ServiceProvider
 
         $this->registerRuntimeAntlers();
         $this->registerRegexAntlers();
-        $this->registerBladeDirectives();
 
         $this->app->bind(ParserContract::class, function ($app) {
             return config('statamic.antlers.version', 'regex') === 'regex'
@@ -183,6 +182,8 @@ class ViewServiceProvider extends ServiceProvider
     public function boot()
     {
         ViewFactory::addNamespace('compiled__views', storage_path('framework/views'));
+
+        $this->registerBladeDirectives();
 
         Blade::precompiler(function ($content) {
             return AntlersBladePrecompiler::compile($content);


### PR DESCRIPTION
This pull request fixes an issue where you could run into "Target class [blade.compiler] does not exist", which is caused by the `registerBladeDirectives` method in our `ViewServiceProvider` being called in the `register` method instead of the `boot` method.

Fixes #9940.
Related: #9732