### PR TITLE
[4.x] Require composer/semver instead of composer/composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "ext-json": "*",
         "ajthinking/archetype": "^1.0.3",
-        "composer/composer": "^1.10.22 || ^2.2.22",
+        "composer/semver": "^3.4",
         "facade/ignition-contracts": "^1.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "james-heinrich/getid3": "^1.9.21",

--- a/src/Console/Composer/Lock.php
+++ b/src/Console/Composer/Lock.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Console\Composer;
 
-use Composer\Package\Version\VersionParser;
+use Composer\Semver\VersionParser;
 use Illuminate\Filesystem\Filesystem;
 use Statamic\Exceptions\ComposerLockFileNotFoundException;
 use Statamic\Exceptions\ComposerLockPackageNotFoundException;

--- a/src/Extend/Addon.php
+++ b/src/Extend/Addon.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Extend;
 
-use Composer\Package\Version\VersionParser;
+use Composer\Semver\VersionParser;
 use Facades\Statamic\Licensing\LicenseManager;
 use ReflectionClass;
 use Statamic\Facades\File;

--- a/src/UpdateScripts/UpdateScript.php
+++ b/src/UpdateScripts/UpdateScript.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\UpdateScripts;
 
-use Composer\Package\Version\VersionParser;
+use Composer\Semver\VersionParser;
 use Illuminate\Filesystem\Filesystem;
 use Statamic\Console\Composer\Lock;
 use Statamic\Console\NullConsole;


### PR DESCRIPTION
Requiring the entire composer package isn't necessary. We only need their semver classes.

Ref: #9945
