### PR TITLE
[4.x] Fix dated collection listing when time is enabled

### DIFF
--- a/src/Http/Resources/CP/Entries/ListedEntry.php
+++ b/src/Http/Resources/CP/Entries/ListedEntry.php
@@ -36,7 +36,7 @@ class ListedEntry extends JsonResource
             'status' => $entry->status(),
             'private' => $entry->private(),
             'date' => $this->when($collection->dated(), function () {
-                return $this->resource->date()->inPreferredFormat();
+                return $this->resource->blueprint()->field('date')->fieldtype()->preProcessIndex($this->resource->date());
             }),
 
             $this->merge($this->values(['slug' => $entry->slug()])),


### PR DESCRIPTION
When you have a dated collection with time enabled the time does not appear in the listing column.

This PR fixes it by using date field's `preProcessIndex` method rather than `inPreferredFormat`.