### PR TITLE
[4.x] Fix `DataReferenceUpdater` when field data from array is null

### DIFF
--- a/src/Data/DataReferenceUpdater.php
+++ b/src/Data/DataReferenceUpdater.php
@@ -263,7 +263,13 @@ abstract class DataReferenceUpdater
 
         $dottedKey = $dottedPrefix.$field->handle();
 
-        $fieldData = collect(Arr::dot(Arr::get($data, $dottedKey, [])));
+        $fieldData = Arr::get($data, $dottedKey, []);
+
+        if (! $fieldData) {
+            return;
+        }
+
+        $fieldData = collect(Arr::dot($fieldData));
 
         if (! $fieldData->contains($this->originalValue())) {
             return;

--- a/tests/Listeners/UpdateAssetReferencesTest.php
+++ b/tests/Listeners/UpdateAssetReferencesTest.php
@@ -299,6 +299,34 @@ class UpdateAssetReferencesTest extends TestCase
     }
 
     /** @test */
+    public function it_updates_multi_assets_fields_even_when_existing_field_value_is_null()
+    {
+        $collection = tap(Facades\Collection::make('articles'))->save();
+
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                [
+                    'handle' => 'pics',
+                    'field' => [
+                        'type' => 'assets',
+                        'container' => 'test_container',
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry = tap(Facades\Entry::make()->collection($collection)->data([
+            'pics' => null,
+        ]))->save();
+
+        $this->assertNull($entry->get('pics'));
+
+        $this->assetNorris->path('content/norris.jpg')->save();
+
+        $this->assertNull($entry->fresh()->get('pics'));
+    }
+
+    /** @test */
     public function it_nullifies_references_when_deleting_an_asset()
     {
         $collection = tap(Facades\Collection::make('articles'))->save();


### PR DESCRIPTION
This pull request fixes an issue in the `DataReferenceUpdater` (& therefore the asset reference updater), where if `Arr::get()` returned `null`, `Arr::dot()` would error while trying to get a "dotted item" from the array. 

Closes #9930.