### PR TITLE
[5.x] Revert caching entry to property on Page instances

### DIFF
--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -42,7 +42,6 @@ class Page implements Arrayable, ArrayAccess, Augmentable, Entry, JsonSerializab
     private $absoluteUrl;
     private $absoluteUrlWithoutRedirect;
     private $blueprint;
-    private $entry;
     private $routeData;
     private $status;
     private $structure;
@@ -131,19 +130,15 @@ class Page implements Arrayable, ArrayAccess, Augmentable, Entry, JsonSerializab
 
     public function entry(): ?Entry
     {
-        if ($this->entry !== null) {
-            return $this->entry;
-        }
-
         if (! $this->reference) {
             return null;
         }
 
         if ($cached = Blink::store('structure-entries')->get($this->reference)) {
-            return $this->entry = $cached;
+            return $cached;
         }
 
-        return $this->entry = $this->tree->entry($this->reference);
+        return $this->tree->entry($this->reference);
     }
 
     public function reference()


### PR DESCRIPTION
This reverts #9659. It seemed to be the reason for the slowdown of SSG generation in #9888.

This was a micro optimization for extreme numbers. There doesn't seem to be much of a difference without it for most sites.

Closes #9888.
