### PR TITLE
[4.x] Use 'configure' permission for configuring navs

### DIFF
--- a/src/Http/Controllers/CP/Navigation/NavigationController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationController.php
@@ -39,7 +39,7 @@ class NavigationController extends CpController
     {
         $nav = Nav::find($nav);
 
-        $this->authorize('edit', $nav, __('You are not authorized to configure navs.'));
+        $this->authorize('configure', $nav, __('You are not authorized to configure navs.'));
 
         $values = [
             'title' => $nav->title(),

--- a/src/Policies/NavPolicy.php
+++ b/src/Policies/NavPolicy.php
@@ -41,6 +41,11 @@ class NavPolicy
         // handled by before()
     }
 
+    public function configure($user)
+    {
+        // handled by before()
+    }
+
     public function view($user, $nav)
     {
         $user = User::fromUser($user);

--- a/tests/Feature/Navigation/EditNavigationTest.php
+++ b/tests/Feature/Navigation/EditNavigationTest.php
@@ -32,7 +32,7 @@ class EditNavigationTest extends TestCase
     }
 
     /** @test */
-    public function it_denies_access_if_user_doesnt_have_edit_permission()
+    public function it_denies_access_if_user_doesnt_have_configure_permission()
     {
         $nav = $this->createNav('foo');
         Nav::shouldReceive('all')->andReturn(collect([$nav]));

--- a/tests/Feature/Navigation/EditNavigationTest.php
+++ b/tests/Feature/Navigation/EditNavigationTest.php
@@ -15,13 +15,13 @@ class EditNavigationTest extends TestCase
     use PreventSavingStacheItemsToDisk;
 
     /** @test */
-    public function it_shows_the_edit_form_if_user_has_edit_permission()
+    public function it_shows_the_edit_form_if_user_has_configure_permission()
     {
         $nav = $this->createNav('foo');
         Nav::shouldReceive('all')->andReturn(collect([$nav]));
         Nav::shouldReceive('find')->andReturn($nav);
 
-        $this->setTestRoles(['test' => ['access cp', 'edit foo nav']]);
+        $this->setTestRoles(['test' => ['access cp', 'configure navs']]);
         $user = Facades\User::make()->assignRole('test')->save();
 
         $response = $this


### PR DESCRIPTION
Currently every user that is allowed to edit a nav (meaning adding new entries etc.) is also allowed to _configure_ a nav (meaning changing the name, max depths etc.). This PR changes this behaviour to only allow the latter with the added `configure` policy, which resolves to the `configure navs` permission.

I don't know if that would be considered a breaking change. It _feels_ like this should be a fix, as the behaviour for e. g. collections works like that, however, I can see that it actually changes something that might be used in a certain way for some people. If you consider it breaking, maybe it might be better to add this to 5.x.