### PR TITLE
[5.x] Add tokens to eloquent cli install

### DIFF
--- a/src/Console/Commands/InstallEloquentDriver.php
+++ b/src/Console/Commands/InstallEloquentDriver.php
@@ -102,6 +102,7 @@ class InstallEloquentDriver extends Command
             'revisions' => 'Revisions',
             'taxonomies' => 'Taxonomies',
             'terms' => 'Terms',
+            'tokens' => 'Tokens',
         ])->reject(function ($value, $key) {
             switch ($key) {
                 case 'asset_containers':
@@ -149,6 +150,9 @@ class InstallEloquentDriver extends Command
 
                 case 'terms':
                     return config('statamic.eloquent-driver.terms.driver') === 'eloquent';
+
+                case 'tokens':
+                    return config('statamic.eloquent-driver.tokens.driver') === 'eloquent';
             }
         });
     }
@@ -533,6 +537,21 @@ class InstallEloquentDriver extends Command
 
             $this->components->info('Imported existing terms');
         }
+    }
+
+    protected function migrateTokens(): void
+    {
+        spin(
+            callback: function () {
+                $this->runArtisanCommand('vendor:publish --tag=statamic-eloquent-token-migrations');
+                $this->runArtisanCommand('migrate');
+
+                $this->switchToEloquentDriver('tokens');
+            },
+            message: 'Migrating tokens...'
+        );
+
+        $this->components->info('Configured tokens');
     }
 
     private function switchToEloquentDriver(string $repository): void


### PR DESCRIPTION
https://github.com/statamic/eloquent-driver/pull/277 adds the ability to have an eloquent token repository so it makes sense that this command would also support migrating to it.

Duncan made this nice and easy with how he set up the original command 🔥 

Requires https://github.com/statamic/eloquent-driver/pull/277