### PR TITLE
[5.x] Token repository contract

### DIFF
--- a/src/Contracts/Tokens/TokenRepository.php
+++ b/src/Contracts/Tokens/TokenRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Statamic\Contracts\Tokens;
+
+interface TokenRepository
+{
+    public function make(?string $token, string $handler, array $data = []): Token;
+
+    public function find(string $token): ?Token;
+
+    public function save(Token $token): bool;
+
+    public function delete(Token $token): bool;
+
+    public function collectGarbage(): void;
+}

--- a/src/Facades/Token.php
+++ b/src/Facades/Token.php
@@ -5,6 +5,13 @@ namespace Statamic\Facades;
 use Illuminate\Support\Facades\Facade;
 use Statamic\Tokens\TokenRepository;
 
+/**
+ * @method static \Statamic\Contracts\Tokens\Token make(?string $token, string $handler, array $data = [])
+ * @method static \Statamic\Contracts\Tokens\Token find(string $token)
+ * @method static bool save(\Statamic\Contracts\Tokens\Token $token)
+ * @method static bool delete(\Statamic\Contracts\Tokens\Token $token)
+ * @method static void collectGarbage()
+ */
 class Token extends Facade
 {
     protected static function getFacadeAccessor()

--- a/src/Facades/Token.php
+++ b/src/Facades/Token.php
@@ -3,7 +3,7 @@
 namespace Statamic\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use Statamic\Tokens\TokenRepository;
+use Statamic\Contracts\Tokens\TokenRepository;
 
 /**
  * @method static \Statamic\Contracts\Tokens\Token make(?string $token, string $handler, array $data = [])
@@ -11,6 +11,8 @@ use Statamic\Tokens\TokenRepository;
  * @method static bool save(\Statamic\Contracts\Tokens\Token $token)
  * @method static bool delete(\Statamic\Contracts\Tokens\Token $token)
  * @method static void collectGarbage()
+ *
+ * @see \Statamic\Tokens\TokenRepository
  */
 class Token extends Facade
 {

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -121,6 +121,7 @@ class AppServiceProvider extends ServiceProvider
             \Statamic\Contracts\Assets\AssetRepository::class => \Statamic\Assets\AssetRepository::class,
             \Statamic\Contracts\Forms\FormRepository::class => \Statamic\Forms\FormRepository::class,
             \Statamic\Contracts\Forms\SubmissionRepository::class => \Statamic\Stache\Repositories\SubmissionRepository::class,
+            \Statamic\Contracts\Tokens\TokenRepository::class => \Statamic\Tokens\TokenRepository::class,
         ])->each(function ($concrete, $abstract) {
             if (! $this->app->bound($abstract)) {
                 Statamic::repository($abstract, $concrete);

--- a/src/Tokens/TokenRepository.php
+++ b/src/Tokens/TokenRepository.php
@@ -3,17 +3,19 @@
 namespace Statamic\Tokens;
 
 use Illuminate\Support\Carbon;
+use Statamic\Contracts\Tokens\Token as TokenContract;
+use Statamic\Contracts\Tokens\TokenRepository as Contract;
 use Statamic\Facades\File;
 use Statamic\Facades\YAML;
 
-class TokenRepository
+class TokenRepository implements Contract
 {
-    public function make(?string $token, string $handler, array $data = []): Token
+    public function make(?string $token, string $handler, array $data = []): TokenContract
     {
         return new Token($token, $handler, $data);
     }
 
-    public function find(string $token)
+    public function find(string $token): ?TokenContract
     {
         $path = storage_path('statamic/tokens/'.$token.'.yaml');
 
@@ -24,21 +26,21 @@ class TokenRepository
         return $this->makeFromPath($path);
     }
 
-    public function save(Token $token)
+    public function save(TokenContract $token): bool
     {
         File::put(storage_path('statamic/tokens/'.$token->token().'.yaml'), $token->fileContents());
 
         return true;
     }
 
-    public function delete(Token $token)
+    public function delete(TokenContract $token): bool
     {
         File::delete(storage_path('statamic/tokens/'.$token->token().'.yaml'));
 
         return true;
     }
 
-    public function collectGarbage()
+    public function collectGarbage(): void
     {
         File::getFilesByType(storage_path('statamic/tokens'), 'yaml')
             ->map(fn ($path) => $this->makeFromPath($path))

--- a/src/Tokens/TokenRepository.php
+++ b/src/Tokens/TokenRepository.php
@@ -12,7 +12,7 @@ class TokenRepository implements Contract
 {
     public function make(?string $token, string $handler, array $data = []): TokenContract
     {
-        return new Token($token, $handler, $data);
+        return app()->makeWith(TokenContract::class, compact('token', 'handler', 'data'));
     }
 
     public function find(string $token): ?TokenContract
@@ -57,5 +57,12 @@ class TokenRepository implements Contract
         return $this
             ->make($token, $yaml['handler'], $yaml['data'] ?? [])
             ->expireAt(Carbon::createFromTimestamp($yaml['expires_at']));
+    }
+
+    public static function bindings(): array
+    {
+        return [
+            TokenContract::class => Token::class,
+        ];
     }
 }


### PR DESCRIPTION
This PR adds a contract for TokenRepository so it can be more easily overridden like other classes.

This is a breaking change if you were overriding the TokenRepository class yourself already.

References: statamic/eloquent-driver#277
