### PR TITLE
[4.x] Fix Starter Kit installation on Windows

### DIFF
--- a/src/Console/Processes/Composer.php
+++ b/src/Console/Processes/Composer.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Cache;
 use Statamic\Console\Composer\Lock;
 use Statamic\Jobs\RunComposer;
 use Statamic\Support\Str;
+use Statamic\View\Antlers\Language\Utilities\StringUtilities;
 
 class Composer extends Process
 {
@@ -312,7 +313,43 @@ class Composer extends Process
      */
     private function composerBinary(): string
     {
-        return $this->run(DIRECTORY_SEPARATOR === '\\' ? 'where composer' : 'which composer');
+        $isWindows = DIRECTORY_SEPARATOR === '\\';
+
+        $output = $this->run($isWindows ? 'where composer' : 'which composer');
+
+        if ($isWindows) {
+            return $this->locateComposerPharOnWindows($output);
+        }
+
+        return $this->output;
+    }
+
+    private function locateComposerPharOnWindows($output)
+    {
+        $output = StringUtilities::normalizeLineEndings($output);
+
+        if (! Str::contains($output, "\n")) {
+            $candidates = [trim($output)];
+        } else {
+            $candidates = explode("\n", $output);
+        }
+
+        foreach ($candidates as $candidate) {
+            // Do we have a bat file? The phar is likely beside it.
+            if (Str::endsWith($candidate, '.bat')) {
+                // Remove that 🦇 extension.
+                $candidate = mb_substr($candidate, 0, mb_strlen($candidate) - 4);
+            }
+
+            $pharPath = $candidate.'.phar';
+
+            if (file_exists($pharPath)) {
+                // Use "composer.phar" if we have it.
+                return $pharPath;
+            }
+        }
+
+        return $output;
     }
 
     /**

--- a/src/Console/Processes/Composer.php
+++ b/src/Console/Processes/Composer.php
@@ -324,7 +324,7 @@ class Composer extends Process
         return $output;
     }
 
-    private function locateComposerPharOnWindows($output)
+    private function locateComposerPharOnWindows($output): string
     {
         $output = StringUtilities::normalizeLineEndings($output);
 

--- a/src/Console/Processes/Composer.php
+++ b/src/Console/Processes/Composer.php
@@ -321,7 +321,7 @@ class Composer extends Process
             return $this->locateComposerPharOnWindows($output);
         }
 
-        return $this->output;
+        return $output;
     }
 
     private function locateComposerPharOnWindows($output)


### PR DESCRIPTION
This PR fixes https://github.com/statamic/cms/issues/9967

If we run a command that doesn't actually install the Stater Kit, we will end up with the `Starter kit config [starter-kit.yaml] does not exist.` error when installing using `php please starter-kit:install` directly, and is one of the ways to trigger the `There was a problem installing...` error when using the Statamic CLI.

The `where composer` command can return multiple results, which this PR handles. Additionally, since we are eventually passing this all to PHP, we need to look for the `composer.phar` file, as the results will often point to either a `composer.bat` file, or a `composer` file which often internally invokes PHP with the `composer.phar` file.