### PR TITLE
[4.x] Add missing Vite content tag

### DIFF
--- a/src/Tags/Vite.php
+++ b/src/Tags/Vite.php
@@ -52,6 +52,24 @@ class Vite extends Tags
             ->asset($src);
     }
 
+    /**
+     * The {{ vite:content }} tag.
+     *
+     * @return string
+     */
+    public function content()
+    {
+        if (! $src = $this->params->get('src')) {
+            throw new \Exception('Please provide a source file.');
+        }
+
+        $directory = $this->params->get('directory', 'build');
+
+        return $this->vite()
+            ->useBuildDirectory($directory)
+            ->content($src);
+    }
+
     private function vite()
     {
         return clone app(LaravelVite::class);


### PR DESCRIPTION
Related to #9972.

To inline Vite asset content you can use a new Antlers tag `{{ vite:content src="path/to/vite/asset" }}`

For exemple:

```twig
<script>{{ vite:content src="resources/js/manifest.js" }}</script>
<style>{{ vite:content src="resources/css/critical.css" }}</style>
```