### PR TITLE
[4.x] Add localizable toggle to edit field stack

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -93,6 +93,7 @@ return [
     'fields_instructions_position_instructions' => 'Show instructions above or below the field.',
     'fields_listable_instructions' => 'Control the listing column visibility.',
     'fields_visibility_instructions' => 'Control field visibility on publish forms.',
+    'fields_localizable_instructions' => 'If this field should be localizable.',
     'fields_replicator_preview_instructions' => 'Control preview visibility in Replicator/Bard sets.',
     'fieldset_import_fieldset_instructions' => 'The fieldset to be imported.',
     'fieldset_import_prefix_instructions' => 'The prefix that should be applied to each field when they are imported. eg. hero_',

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -190,6 +190,13 @@ class FieldsController extends CpController
                 'default' => 'visible',
                 'type' => 'select',
             ],
+            'localizable' => [
+                'display' => __('Localizable'),
+                'instructions' => __('statamic::messages.fields_localizable_instructions'),
+                'type' => 'toggle',
+                'validate' => 'boolean',
+                'default' => false,
+            ],
             'replicator_preview' => [
                 'display' => __('Preview'),
                 'instructions' => __('statamic::messages.fields_replicator_preview_instructions'),


### PR DESCRIPTION
This adds the `localizable` toggle to the edit field stack. Currently it's only available on the fieldset builder overview as a globe icon. Often users can't find out how to set `localizable` to `true`. This should help.