### PR TITLE
[4.x] Add `firstOrfail`, `firstOr`, `sole` and `exists` methods to base query builder

### DIFF
--- a/src/Exceptions/ItemNotFoundException.php
+++ b/src/Exceptions/ItemNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Statamic\Exceptions;
+
+class ItemNotFoundException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct('Item not found');
+    }
+}

--- a/src/Exceptions/MultipleRecordsFoundException.php
+++ b/src/Exceptions/MultipleRecordsFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Statamic\Exceptions;
+
+use Illuminate\Database\MultipleRecordsFoundException as LaravelMultipleRecordsFoundException;
+
+class MultipleRecordsFoundException extends LaravelMultipleRecordsFoundException
+{
+}

--- a/src/Exceptions/RecordsNotFoundException.php
+++ b/src/Exceptions/RecordsNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Statamic\Exceptions;
+
+use Illuminate\Database\RecordsNotFoundException as LaravelRecordsNotFoundException;
+
+class RecordsNotFoundException extends LaravelRecordsNotFoundException
+{
+}

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -580,6 +580,11 @@ abstract class Builder implements Contract
         return $result->first();
     }
 
+    public function exists()
+    {
+        return $this->count() >= 1;
+    }
+
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -11,6 +11,8 @@ use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use Statamic\Contracts\Query\Builder as Contract;
 use Statamic\Exceptions\ItemNotFoundException;
+use Statamic\Exceptions\MultipleRecordsFoundException;
+use Statamic\Exceptions\RecordsNotFoundException;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
 use Statamic\Facades\Pattern;
 
@@ -559,6 +561,23 @@ abstract class Builder implements Contract
         }
 
         return $callback();
+    }
+
+    public function sole($columns = ['*'])
+    {
+        $result = $this->get($columns);
+
+        $count = $result->count();
+
+        if ($count === 0) {
+            throw new RecordsNotFoundException();
+        }
+
+        if ($count > 1) {
+            throw new MultipleRecordsFoundException($count);
+        }
+
+        return $result->first();
     }
 
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use Statamic\Contracts\Query\Builder as Contract;
+use Statamic\Exceptions\ItemNotFoundException;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
 use Statamic\Facades\Pattern;
 
@@ -531,9 +532,33 @@ abstract class Builder implements Contract
         return $this->where('id', $id)->get($columns)->first();
     }
 
-    public function first()
+    public function first($columns = ['*'])
     {
-        return $this->get()->first();
+        return $this->get($columns)->first();
+    }
+
+    public function firstOrFail($columns = ['*'])
+    {
+        if (! is_null($item = $this->first($columns))) {
+            return $item;
+        }
+
+        throw new ItemNotFoundException();
+    }
+
+    public function firstOr($columns = ['*'], ?Closure $callback = null)
+    {
+        if ($columns instanceof Closure) {
+            $callback = $columns;
+
+            $columns = ['*'];
+        }
+
+        if (! is_null($model = $this->first($columns))) {
+            return $model;
+        }
+
+        return $callback();
     }
 
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use Statamic\Contracts\Query\Builder;
+use Statamic\Exceptions\ItemNotFoundException;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
 use Statamic\Facades\Blink;
 use Statamic\Support\Arr;
@@ -66,9 +67,33 @@ abstract class EloquentQueryBuilder implements Builder
         return $items;
     }
 
-    public function first()
+    public function first($columns = ['*'])
     {
-        return $this->get()->first();
+        return $this->get($columns)->first();
+    }
+
+    public function firstOrFail($columns = ['*'])
+    {
+        if (! is_null($item = $this->first($columns))) {
+            return $item;
+        }
+
+        throw new ItemNotFoundException();
+    }
+
+    public function firstOr($columns = ['*'], ?Closure $callback = null)
+    {
+        if ($columns instanceof Closure) {
+            $callback = $columns;
+
+            $columns = ['*'];
+        }
+
+        if (! is_null($model = $this->first($columns))) {
+            return $model;
+        }
+
+        return $callback();
     }
 
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -115,6 +115,11 @@ abstract class EloquentQueryBuilder implements Builder
         return $result->first();
     }
 
+    public function exists()
+    {
+        return $this->builder->count() >= 1;
+    }
+
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
         $paginator = $this->builder->paginate($perPage, $this->selectableColumns($columns), $pageName, $page);

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -10,6 +10,8 @@ use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use Statamic\Contracts\Query\Builder;
 use Statamic\Exceptions\ItemNotFoundException;
+use Statamic\Exceptions\MultipleRecordsFoundException;
+use Statamic\Exceptions\RecordsNotFoundException;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
 use Statamic\Facades\Blink;
 use Statamic\Support\Arr;
@@ -94,6 +96,23 @@ abstract class EloquentQueryBuilder implements Builder
         }
 
         return $callback();
+    }
+
+    public function sole($columns = ['*'])
+    {
+        $result = $this->get($columns);
+
+        $count = $result->count();
+
+        if ($count === 0) {
+            throw new RecordsNotFoundException();
+        }
+
+        if ($count > 1) {
+            throw new MultipleRecordsFoundException($count);
+        }
+
+        return $result->first();
     }
 
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)


### PR DESCRIPTION
This pull request adds various useful methods to Statamic's base query builder:

* `firstOrFail`
    * Gets the first result if one exists, otherwise, it throws an exception. 
* `firstOr`
    * Gets the first result if one exists, otherwise, it executes the provided callback.
* `sole`
    * Gets the first & only item if one exists. It'll throw an exception if no results can be found *or* if more than 1 result is found.
* `exists`
    * Returns `true` if the query returns one or more results. 

On the back of #9815, I was thinking a few of Laravel's first/find methods could be added to our "base" query builder since they're useful for everything, not just entries & terms.