### PR TITLE
[5.x] Fix please command `--help` listing

### DIFF
--- a/src/Console/Please/Application.php
+++ b/src/Console/Please/Application.php
@@ -3,8 +3,8 @@
 namespace Statamic\Console\Please;
 
 use Illuminate\Console\Application as ConsoleApplication;
-use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 
 class Application extends ConsoleApplication


### PR DESCRIPTION
Fix error/regression when trying to list please command options/arguments via `--help`

Before:

![CleanShot 2024-04-30 at 11 01 54](https://github.com/statamic/cms/assets/5187394/144e7cc1-5f97-42ba-b25e-73ae44dbdeca)

After:

![CleanShot 2024-04-30 at 11 17 43](https://github.com/statamic/cms/assets/5187394/88d1a2f7-063e-4e07-8cff-6a7b27ba37f3)