### PR TITLE
[4.x] Fix `starter-kit:install` with custom branch when branch has slash

### DIFF
--- a/src/Console/Commands/StarterKitInstall.php
+++ b/src/Console/Commands/StarterKitInstall.php
@@ -41,7 +41,9 @@ class StarterKitInstall extends Command
      */
     public function handle()
     {
-        if ($this->validationFails($package = $this->getPackage(), new ComposerPackage)) {
+        [$package, $branch] = $this->getPackageAndBranch();
+
+        if ($this->validationFails($package, new ComposerPackage)) {
             return;
         }
 
@@ -56,6 +58,7 @@ class StarterKitInstall extends Command
         }
 
         $installer = StarterKitInstaller::package($package, $this, $licenseManager)
+            ->branch($branch)
             ->fromLocalRepo($this->option('local'))
             ->withConfig($this->option('with-config'))
             ->withoutDependencies($this->option('without-dependencies'))
@@ -85,13 +88,21 @@ class StarterKitInstall extends Command
     }
 
     /**
-     * Get composer package.
+     * Get composer package (and optional branch).
      *
      * @return string
      */
-    protected function getPackage()
+    protected function getPackageAndBranch()
     {
-        return $this->argument('package') ?: $this->ask('Package');
+        $package = $this->argument('package') ?: $this->ask('Package');
+
+        $parts = explode(':', $package);
+
+        if (count($parts) === 1) {
+            $parts[] = null;
+        }
+
+        return $parts;
     }
 
     /**

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -39,7 +39,7 @@ final class Installer
      */
     public function __construct(string $package, $console = null, ?LicenseManager $licenseManager = null)
     {
-        [$this->package, $this->branch] = $this->parseRawPackageArg($package);
+        $this->package = $package;
 
         $this->licenseManager = $licenseManager;
 
@@ -60,17 +60,16 @@ final class Installer
     }
 
     /**
-     * Parse out package and branch from raw package arg.
+     * Install from specific branch.
+     *
+     * @param  string|null  $branch
+     * @return $this
      */
-    protected function parseRawPackageArg(string $package): array
+    public function branch($branch = null)
     {
-        $parts = explode(':', $package);
+        $this->branch = $branch;
 
-        if (count($parts) === 1) {
-            $parts[] = null;
-        }
-
-        return $parts;
+        return $this;
     }
 
     /**

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -682,6 +682,29 @@ EOT;
         $this->assertFileExists(base_path('copied.md'));
     }
 
+    /** @test */
+    public function it_installs_branch_with_slash_without_failing_package_validation()
+    {
+        $this->assertFileDoesNotExist($this->kitVendorPath());
+        $this->assertComposerJsonDoesntHave('repositories');
+        $this->assertFileDoesNotExist(base_path('copied.md'));
+
+        $this->installCoolRunnings([
+            'package' => 'statamic/cool-runnings:dev-feature/custom-branch',
+        ]);
+
+        // Ensure `Composer::requireDev()` gets called with `package:branch`
+        $this->assertEquals(Blink::get('composer-require-dev-package'), 'statamic/cool-runnings');
+        $this->assertEquals(Blink::get('composer-require-dev-branch'), 'dev-feature/custom-branch');
+
+        // But ensure the rest of the installer handles parsed `package` without branch messing things up
+        $this->assertFalse(Blink::has('starter-kit-repository-added'));
+        $this->assertFileDoesNotExist($this->kitVendorPath());
+        $this->assertFileDoesNotExist(base_path('composer.json.bak'));
+        $this->assertComposerJsonDoesntHave('repositories');
+        $this->assertFileExists(base_path('copied.md'));
+    }
+
     private function kitRepoPath($path = null)
     {
         return collect([base_path('repo/cool-runnings'), $path])->filter()->implode('/');


### PR DESCRIPTION
When [installing a starter kit from custom branch](https://github.com/statamic/cms/pull/9766)... if branch has a slash, it was failing composer package validation...

![CleanShot 2024-04-30 at 12 01 23](https://github.com/statamic/cms/assets/5187394/c7162079-2009-425d-8687-38920714d9ec)

This PR fixes that...

![CleanShot 2024-04-30 at 12 05 04](https://github.com/statamic/cms/assets/5187394/6b22afc2-cb4f-4025-89d3-09bcc7c74697)

References https://github.com/statamic/cms/pull/9766