### PR TITLE
[5.x] Single relationship query builders

### DIFF
--- a/src/Data/HasAugmentedInstance.php
+++ b/src/Data/HasAugmentedInstance.php
@@ -103,7 +103,12 @@ trait HasAugmentedInstance
     {
         $value = $this->augmentedValue($method);
 
-        $value = $value instanceof Value ? $value->value() : $value;
+        if ($value instanceof Value) {
+            if ($value->isRelationship()) {
+                $value->field()->setConfig(array_merge($value->field()->config(), ['max_items' => null]));
+            }
+            $value = $value->value();
+        }
 
         if (Compare::isQueryBuilder($value)) {
             return $value;


### PR DESCRIPTION
This PR is really intended to be an idea rather than a final implementation, the solution is a bit of a hack and a better approach is probably needed, but it would be really nice if this was possible.

At the moment if you're working in PHP and have an entry with either single or multi entries fields you can do this to fetch the published related entries:

```php
$publishedChildren = $parent->children;
$publishedChild = $parent->child;
```

If you want related entries of any status you can do this with multi entries fields:

```php
$anyChildren = $parent->children()->whereAnyStatus()->get();
```

But if you want a single related entry of any status there's not really a simple way to do it (I don't think). You can't do this with single entry fields, it throws a `child` method does not exist error:

```php
$anyChild = $parent->child()->whereAnyStatus()->first();
```

When working with Eloquent models you can do `$model->singleThing()` with a belongs to relationship and it'll give you a query builder, it'd be great if Statamic could do the same.

This PR makes the above work by tricking any relationship fieldtypes into returning a query builder even if it's a single entry field. This only happens during `__call` so shouldn't affect anything else.