### PR TITLE
[5.x] Prevent falsey values from returning blueprint defaults

### DIFF
--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -76,8 +76,8 @@ class Value implements IteratorAggregate, JsonSerializable
             return $raw;
         }
 
-        if (! $raw && ($default = $this->fieldtype->field()?->defaultValue())) {
-            $raw = $default;
+        if ($raw === null) {
+            $raw = $this->fieldtype->field()?->defaultValue() ?? null;
         }
 
         $value = $this->shallow

--- a/tests/Fields/ValueTest.php
+++ b/tests/Fields/ValueTest.php
@@ -178,6 +178,42 @@ class ValueTest extends TestCase
             $this->assertEquals('foo!', $value->value());
         });
     }
+
+    /** @test */
+    public function it_does_not_use_the_default_when_returning_falsey_values()
+    {
+        $fieldtype = new class extends Fieldtype
+        {
+            public function augment($value)
+            {
+                return $value;
+            }
+        };
+
+        $fieldtype->setField(new Field('the_handle', ['default' => true]));
+
+        tap(new Value(false, null, $fieldtype), function ($value) {
+            $this->assertSame(false, $value->value());
+        });
+    }
+
+    /** @test */
+    public function falsey_values_can_be_used_as_the_default()
+    {
+        $fieldtype = new class extends Fieldtype
+        {
+            public function augment($value)
+            {
+                return $value;
+            }
+        };
+
+        $fieldtype->setField(new Field('the_handle', ['default' => false]));
+
+        tap(new Value(null, null, $fieldtype), function ($value) {
+            $this->assertSame(false, $value->value());
+        });
+    }
 }
 
 class DummyAugmentable implements \Statamic\Contracts\Data\Augmentable


### PR DESCRIPTION
This PR fixes #9988 by ensuring field default values are not returned when the field's value is falsey.

Additionally, this PR corrects an issue where a falsey default value could not be used.