### PR TITLE
[4.x] Remove clear button of readonly date field

### DIFF
--- a/resources/js/components/fieldtypes/date/RangePopover.vue
+++ b/resources/js/components/fieldtypes/date/RangePopover.vue
@@ -37,7 +37,7 @@
                                 @focus="$emit('focus', $event.target)"
                                 @blur="$emit('blur')"
                             />
-                            <button @click="clear" type="button" title="Clear" aria-label="Clear" class="cursor-pointer px-2 hover:text-blue-500">
+                            <button v-if="!isReadOnly" @click="clear" type="button" title="Clear" aria-label="Clear" class="cursor-pointer px-2 hover:text-blue-500">
                                 <span>×</span>
                             </button>
                         </div>

--- a/resources/js/components/fieldtypes/date/SinglePopover.vue
+++ b/resources/js/components/fieldtypes/date/SinglePopover.vue
@@ -32,7 +32,7 @@
                             @focus="$emit('focus', $event.target)"
                             @blur="$emit('blur')"
                         />
-                        <button @click="clear" type="button" title="Clear" aria-label="Clear" class="cursor-pointer px-2 hover:text-blue-500">
+                        <button v-if="!isReadOnly" @click="clear" type="button" title="Clear" aria-label="Clear" class="cursor-pointer px-2 hover:text-blue-500">
                             <span>×</span>
                         </button>
                     </div>


### PR DESCRIPTION
## Change:
Removed the "x" button from the date field / date range field when it is readonly.

## Reasoning:
Removing this button eliminates the option to empty the date field. This resolves the issue where, if the date field is required but left empty, the page cannot be saved.

## Example:

Before, we could click on the cross to clear this field, thus making it impossible to save the entry if the date field is required :
<img width="338" alt="image" src="https://github.com/statamic/cms/assets/29105077/fc1722a0-52c6-4cd3-8162-5398f7618009">


### Before this fix:
<img width="325" alt="image" src="https://github.com/statamic/cms/assets/29105077/36ca9dcf-ba7f-48f3-a389-e7fbee99a85b">

### After (removed the x button):
<img width="314" alt="image" src="https://github.com/statamic/cms/assets/29105077/c8928da5-4b1d-4bd2-a1ed-d506b110ab14">
