### PR TITLE
[5.x] Prevent excessive nocache cache growth

### DIFF
--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -20,6 +20,8 @@ class Session
 
     protected $url;
 
+    private $regionCount = 0;
+
     public function __construct($url)
     {
         $this->url = $url;
@@ -53,6 +55,13 @@ class Session
         }
 
         throw new RegionNotFound($key);
+    }
+
+    public function getRegionId(): string
+    {
+        $this->regionCount += 1;
+
+        return md5($this->url.$this->regionCount);
     }
 
     public function pushRegion($contents, $context, $extension): StringRegion

--- a/src/StaticCaching/NoCache/StringRegion.php
+++ b/src/StaticCaching/NoCache/StringRegion.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\StaticCaching\NoCache;
 
-use Statamic\Support\Str;
-
 class StringRegion extends Region
 {
     protected $content;
@@ -15,7 +13,7 @@ class StringRegion extends Region
         $this->content = $content;
         $this->context = $this->filterContext($context);
         $this->extension = $extension;
-        $this->key = sha1($content.Str::random());
+        $this->key = sha1($content).$session->getRegionId();
     }
 
     public function key(): string

--- a/src/StaticCaching/NoCache/ViewRegion.php
+++ b/src/StaticCaching/NoCache/ViewRegion.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\StaticCaching\NoCache;
 
-use Statamic\Support\Str;
-
 class ViewRegion extends Region
 {
     protected $view;
@@ -13,7 +11,7 @@ class ViewRegion extends Region
         $this->session = $session;
         $this->view = $view;
         $this->context = $this->filterContext($context);
-        $this->key = Str::random(32);
+        $this->key = sha1($view).$session->getRegionId();
     }
 
     public function key(): string


### PR DESCRIPTION
This PR removes the randomness within nocache region keys, and instead relies on the session's URL and an incrementing value to determine the nocache region key. This allows the nocache regions to be unique within each session, but also not get regenerated on each request.

An easy way to test this behavior is to run `php please ssg:generate` on a decently sized site that contains `{{ nocache }}{{ /nocache }}` somewhere. Subsequent SSG runs should not cause the `storage/statamic/static-urls-cache` folder size to double on each run.