### PR TITLE
[4.x] Fix ButtonGroup from overflowing

### DIFF
--- a/resources/css/components/fieldtypes/button-group.css
+++ b/resources/css/components/fieldtypes/button-group.css
@@ -1,6 +1,30 @@
-/* Inside a Grid field
+/* Vertical alignment of btn groups when overflowing
   ========================================================================== */
 
-.grid-table td.button_group-fieldtype {
-    width: 1%;
+.btn-group:not(.btn-vertical) {
+    @apply flex-wrap;
+}
+.btn-group.btn-vertical {
+    @apply flex-col items-stretch justify-start p-0 h-auto;
+
+    button {
+        @apply border-b border-t-0 rounded-none border-l border-r ;
+        height: 2.375rem; /*  38px */
+    }
+
+    :is(.btn-group button:not(:last-child):not(.active)) {
+        @apply border-r border-l;
+    }
+
+    button.active+button {
+        @apply border-l border-r;
+    }
+
+    button:first-child {
+        @apply rounded-t rounded-b-none border-t;
+    }
+
+    button:last-child {
+        @apply rounded-t-none rounded-b border-b;
+    }
 }

--- a/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
@@ -53,7 +53,7 @@ export default {
     methods: {
 
         setupResizeObserver() {
-            this.resizeObserver = new ResizeObserver(entries => {
+            this.resizeObserver = new ResizeObserver(() => {
                 this.handleWrappingOfNode(this.$refs.buttonGroup);
             });
             this.resizeObserver.observe(this.$refs.buttonGroup);

--- a/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="button-group-fieldtype-wrapper" :class="{'inline-mode': config.inline}">
-        <div class="btn-group">
+        <div class="btn-group" ref="buttonGroup">
             <button class="btn px-4"
                 v-for="(option, $index) in options"
                 :key="$index"
@@ -18,9 +18,24 @@
 
 <script>
 import HasInputOptions from './HasInputOptions.js'
+import ResizeObserver from 'resize-observer-polyfill';
 
 export default {
     mixins: [Fieldtype, HasInputOptions],
+
+    data() {
+        return {
+            resizeObserver: null,
+        }
+    },
+
+    mounted() {
+        this.setupResizeObserver();
+    },
+
+    beforeDestroy() {
+        this.resizeObserver.disconnect();
+    },
 
     computed: {
         options() {
@@ -36,6 +51,25 @@ export default {
     },
 
     methods: {
+
+        setupResizeObserver() {
+            this.resizeObserver = new ResizeObserver(entries => {
+                this.handleWrappingOfNode(this.$refs.buttonGroup);
+            });
+            this.resizeObserver.observe(this.$refs.buttonGroup);
+        },
+
+        handleWrappingOfNode(node) {
+            const lastEl = node.lastChild;
+
+            if (!lastEl) return;
+
+            node.classList.remove('btn-vertical');
+
+            if(lastEl.offsetTop > node.clientTop) {
+                node.classList.add('btn-vertical');
+            }
+        },
 
         focus() {
             this.$refs.button[0].focus();


### PR DESCRIPTION
## Change:
This PR introduce a ResizeObserver for the ButtonGroup to handle the Overflowing cases.

Fix: #9044 
Fix: #9830 (Indirectly by removing the `width: 1%` of the `button-group.css` file - which was interfering with this)

## Some observations:
- I did not test the performance of such a change as I'm not sure what to look for ? If someone willing to do it and knowing how could have a look ? 
- I was not sure about the use of the `button-group.css` file. If needed, I can naturally put all css in the `resources/css/elements/buttons.css` file.
## Example:

### Example 1
When the button group can correctly be displayed as a flex row element, then the button still works the same:
<img width="488" alt="image" src="https://github.com/statamic/cms/assets/29105077/18cdc13e-d5d3-4114-93a9-7edebdd9e0f8">

### Example 2
When the button group does not have enough place to be displayed correctly without overflowing, then it will be display as a vertical button group:
<img width="270" alt="image" src="https://github.com/statamic/cms/assets/29105077/e26c2612-34b5-4a0d-aeee-b49921b51782">

### Example 3
This also works in other field types, like the replicator, grid, etc...:
*Without overflowing:*
<img width="677" alt="image" src="https://github.com/statamic/cms/assets/29105077/9fb9e931-0b10-4686-a501-aed499c9d26a">
*With overflowing:*
<img width="528" alt="image" src="https://github.com/statamic/cms/assets/29105077/36cfde21-8a71-406c-bd51-40eae9108b6e">

Or using the #9044 as an example:
Without overflowing:
<img width="597" alt="image" src="https://github.com/statamic/cms/assets/29105077/2b50066b-271d-4746-9a73-7bf0b7a5398e">

With overflowing:
<img width="569" alt="image" src="https://github.com/statamic/cms/assets/29105077/fa51b8d6-3487-4db2-aaa6-fec72c01668c">

