### PR TITLE
[5.x] Ensures values are resolved when checking Antlers parsing settings

### DIFF
--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -116,6 +116,8 @@ class Value implements IteratorAggregate, JsonSerializable
 
     public function shouldParseAntlers()
     {
+        $this->resolve();
+
         return $this->fieldtype && $this->fieldtype->config('antlers');
     }
 
@@ -147,6 +149,8 @@ class Value implements IteratorAggregate, JsonSerializable
 
     public function field()
     {
+        $this->resolve();
+
         return $this->fieldtype->field();
     }
 


### PR DESCRIPTION
This PR fixes #10001 by adding the missing calls to `resolve` within `Fields\Value`.

Without this, `shouldParseAntlers()` would check if `$this->fieldtype` was set, which might not always be the case with the lazy/deferred logic.