### PR TITLE
Collections are added as OR instead on AND in fetching entries from term query

### DIFF
--- a/src/Http/Controllers/API/TaxonomyTermEntriesController.php
+++ b/src/Http/Controllers/API/TaxonomyTermEntriesController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\API;
 
 use Facades\Statamic\API\FilterAuthorizer;
 use Facades\Statamic\API\ResourceAuthorizer;
+use Statamic\Eloquent\Entries\EntryQueryBuilder as Builder;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Term;
@@ -31,7 +32,7 @@ class TaxonomyTermEntriesController extends ApiController
     {
         $this->abortIfDisabled();
 
-        $term = Term::find($taxonomy.'::'.$term);
+        $term = Term::find($taxonomy . '::' . $term);
 
         throw_unless($term, new NotFoundHttpException);
 
@@ -39,9 +40,11 @@ class TaxonomyTermEntriesController extends ApiController
 
         $this->allowedCollections = $this->allowedCollections();
 
-        foreach ($this->allowedCollections as $collection) {
-            $query->where('collection', $collection);
-        }
+        $query->where(function (Builder $query) {
+            foreach ($this->allowedCollections as $collection) {
+                $query->orWhere('collection', $collection);
+            }
+        });
 
         $with = $this->getRelationshipFieldsFromCollections($taxonomy);
 


### PR DESCRIPTION
This fixes an issue with the REST API endpoint for fetching entries connected to a term. 

In the original code, the function checked the allowed, whitelisted collections and added that as a where per collection. When multiple collections where whitelisted in the api config. The query resulted in chained AND collection query like `collection = ? AND collection = ? AND collection = ?`. The result is not fetching any entries at all and caused the json data array to be empty.  