### PR TITLE
[4.x] Fix docblock on `Parse` facade - `template` returns `AntlersString`

### DIFF
--- a/src/Facades/Parse.php
+++ b/src/Facades/Parse.php
@@ -3,9 +3,10 @@
 namespace Statamic\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Statamic\View\Antlers\AntlersString;
 
 /**
- * @method static string template($str, $variables = [], $context = [], $php = false)
+ * @method static AntlersString template($str, $variables = [], $context = [], $php = false)
  * @method static string templateLoop($content, $data, $supplement = true, $context = [], $php = false)
  * @method static array YAML($str)
  * @method static mixed env($val)


### PR DESCRIPTION
This pull request makes a minor tweak to the `Parse` facade by updating the return type of the `template` method. It now returns an `AntlersString` instance rather than a string.