### PR TITLE
[4.x] Fix fullscreen button in Group Fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/GroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/GroupFieldtype.vue
@@ -67,7 +67,7 @@
 
 <style>
     .group-fieldtype-button-wrapper {
-        @apply flex justify-end absolute top-5 sm:top-7 rtl:left-0 ltr:right-0 @md:right-4 @lg:right-6;
+        @apply flex rtl:left-6 ltr:right-6 absolute top-5 sm:top-7;
     }
 
     .replicator-set .group-fieldtype-button-wrapper {


### PR DESCRIPTION
This pull request fixes an issue with the Group Fieldtype, where the fullscreen button wasn't being correctly positioned.... now it is:

## Left to right

![CleanShot 2024-05-07 at 16 03 25](https://github.com/statamic/cms/assets/19637309/62dd3e4d-76f4-4a5b-8b56-bda7b150742b)

## Right to left

![CleanShot 2024-05-07 at 16 03 45](https://github.com/statamic/cms/assets/19637309/70d50cb8-99e4-4371-b05f-594d78cb18fe)

---

Fixes #10007.