### PR TITLE
[4.x] Check the reference as part of recursive editing check  

### DIFF
--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -77,16 +77,7 @@ export default {
             if (! this.editable) return;
             if (this.item.invalid) return;
 
-            let isAlreadyEditing = Object.entries(this.$store.state.publish)
-                .filter(([key, value]) => {
-                    return this.item.reference
-                        ? value.reference === this.item.reference
-                        : true;
-                })
-                .filter(([key, value]) => value.values.id === this.item.id)
-                .length > 0;
-
-            if (isAlreadyEditing) {
+            if (this.item.reference && Object.entries(this.$store.state.publish).find(([key, value]) => value.reference === this.item.reference)) {
                 this.$toast.error(__("You're already editing this item."));
                 return;
             }

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -77,9 +77,17 @@ export default {
             if (! this.editable) return;
             if (this.item.invalid) return;
 
-            if (Object.entries(this.$store.state.publish).find(([key, value]) => value.values.id === this.item.id)) {
-                this.$toast.error(__("You're already editing this item."));
+            let isAlreadyEditing = Object.entries(this.$store.state.publish)
+                .filter(([key, value]) => {
+                    return this.item.blueprint
+                        ? value.blueprint.handle === this.item.blueprint
+                        : true;
+                })
+                .filter(([key, value]) => value.values.id === this.item.id)
+                .length > 0;
 
+            if (isAlreadyEditing) {
+                this.$toast.error(__("You're already editing this item."));
                 return;
             }
 

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -79,8 +79,8 @@ export default {
 
             let isAlreadyEditing = Object.entries(this.$store.state.publish)
                 .filter(([key, value]) => {
-                    return this.item.blueprint
-                        ? value.blueprint.handle === this.item.blueprint
+                    return this.item.reference
+                        ? value.reference === this.item.reference
                         : true;
                 })
                 .filter(([key, value]) => value.values.id === this.item.id)

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -82,6 +82,7 @@ export default {
                 localizedFields: _.clone(this.localizedFields),
                 site: this.site,
                 isRoot: this.isRoot,
+                reference: this.reference,
             };
 
             // If the store already exists, just reinitialize the state.
@@ -107,6 +108,7 @@ export default {
                     isRoot: initial.isRoot,
                     preloadedAssets: [],
                     autosaveInterval: null,
+                    reference: initial.reference,
                 },
                 mutations: {
                     setFieldValue(state, payload) {

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -343,6 +343,7 @@ class Terms extends Relationship
 
         return [
             'id' => $id,
+            'reference' => $term->reference(),
             'title' => $term->value('title'),
             'published' => $term->published(),
             'private' => $term->private(),

--- a/src/Http/Resources/CP/Entries/Entry.php
+++ b/src/Http/Resources/CP/Entries/Entry.php
@@ -10,6 +10,7 @@ class Entry extends JsonResource
     {
         $data = [
             'id' => $this->resource->id(),
+            'reference' => $this->resource->reference(),
             'title' => $this->resource->value('title'),
             'permalink' => $this->resource->absoluteUrl(),
             'published' => $this->resource->published(),
@@ -20,7 +21,6 @@ class Entry extends JsonResource
                 'title' => $this->resource->collection()->title(),
                 'handle' => $this->resource->collection()->handle(),
             ],
-            'blueprint' => $this->resource->blueprint()->handle(),
         ];
 
         return ['data' => $data];

--- a/src/Http/Resources/CP/Entries/Entry.php
+++ b/src/Http/Resources/CP/Entries/Entry.php
@@ -20,6 +20,7 @@ class Entry extends JsonResource
                 'title' => $this->resource->collection()->title(),
                 'handle' => $this->resource->collection()->handle(),
             ],
+            'blueprint' => $this->resource->blueprint()->handle(),
         ];
 
         return ['data' => $data];

--- a/src/Http/Resources/CP/Taxonomies/Term.php
+++ b/src/Http/Resources/CP/Taxonomies/Term.php
@@ -10,10 +10,10 @@ class Term extends JsonResource
     {
         $data = [
             'id' => $this->resource->id(),
+            'reference' => $this->resource->reference(),
             'title' => $this->resource->value('title'),
             'permalink' => $this->resource->absoluteUrl(),
             'edit_url' => $this->resource->editUrl(),
-            'blueprint' => $this->resource->blueprint()->handle(),
         ];
 
         return ['data' => $data];

--- a/src/Http/Resources/CP/Taxonomies/Term.php
+++ b/src/Http/Resources/CP/Taxonomies/Term.php
@@ -13,6 +13,7 @@ class Term extends JsonResource
             'title' => $this->resource->value('title'),
             'permalink' => $this->resource->absoluteUrl(),
             'edit_url' => $this->resource->editUrl(),
+            'blueprint' => $this->resource->blueprint()->handle(),
         ];
 
         return ['data' => $data];

--- a/src/Http/Resources/CP/Taxonomies/Term.php
+++ b/src/Http/Resources/CP/Taxonomies/Term.php
@@ -10,7 +10,6 @@ class Term extends JsonResource
     {
         $data = [
             'id' => $this->resource->id(),
-            'reference' => $this->resource->reference(),
             'title' => $this->resource->value('title'),
             'permalink' => $this->resource->absoluteUrl(),
             'edit_url' => $this->resource->editUrl(),


### PR DESCRIPTION
This pull request fixes an issue with the recursive editing check added in #9841, where it'd sometimes prevent editing unintentionally when it shouldn't be.

This issue can be seen in two scenarios:

* Eloquent Driver
    * Entries & terms are both using incrementing IDs.
    * When you're editing entry `1`, then try to edit term `1` inline, it'd error out because the IDs are the same, even though they're different "things".
* Runway
    * Two resources, with a Has Many or Belongs To fieldtype configured.
    * In this example, we have a `Product` model and a `Manufacturer` model.
    * When you're editing Product `1`, then try to edit manufacturer `1` inline, it'd error out because the IDs are the same, even though they're different models.

To fix this, we're now passing the item's "reference" to the publish container and checking it against the related item in the `RelationshipItem` component.

Fixes #10005.