### PR TITLE
[4.x] Include `alt` field in shallowly augmented assets

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -1063,7 +1063,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
 
     public function shallowAugmentedArrayKeys()
     {
-        return ['id', 'url', 'permalink', 'api_url'];
+        return ['id', 'url', 'permalink', 'api_url', 'alt'];
     }
 
     protected function defaultAugmentedRelations()

--- a/tests/Fieldtypes/AssetsTest.php
+++ b/tests/Fieldtypes/AssetsTest.php
@@ -69,6 +69,20 @@ class AssetsTest extends TestCase
     /** @test */
     public function it_shallow_augments_to_a_collection_of_assets()
     {
+        AssetContainer::find('test')
+            ->queryAssets()
+            ->where('path', 'foo/one.txt')
+            ->first()
+            ->set('alt', 'Alt text for one')
+            ->save();
+
+        AssetContainer::find('test')
+            ->queryAssets()
+            ->where('path', 'bar/two.txt')
+            ->first()
+            ->set('alt', 'Alt text for two')
+            ->save();
+
         $augmented = $this->fieldtype()->shallowAugment(['foo/one.txt', 'bar/two.txt', 'unknown.txt']);
 
         $this->assertInstanceOf(Collection::class, $augmented);
@@ -79,12 +93,14 @@ class AssetsTest extends TestCase
                 'url' => '/assets/foo/one.txt',
                 'permalink' => 'http://localhost/assets/foo/one.txt',
                 'api_url' => 'http://localhost/api/assets/test/foo/one.txt',
+                'alt' => 'Alt text for one',
             ],
             [
                 'id' => 'test::bar/two.txt',
                 'url' => '/assets/bar/two.txt',
                 'permalink' => 'http://localhost/assets/bar/two.txt',
                 'api_url' => 'http://localhost/api/assets/test/bar/two.txt',
+                'alt' => 'Alt text for two',
             ],
         ], $augmented->toArray());
     }
@@ -92,6 +108,13 @@ class AssetsTest extends TestCase
     /** @test */
     public function it_shallow_augments_to_a_single_asset_when_max_files_is_one()
     {
+        AssetContainer::find('test')
+            ->queryAssets()
+            ->where('path', 'foo/one.txt')
+            ->first()
+            ->set('alt', 'Alt text for one')
+            ->save();
+
         $augmented = $this->fieldtype(['max_files' => 1])->shallowAugment(['foo/one.txt']);
 
         $this->assertInstanceOf(AugmentedCollection::class, $augmented);
@@ -100,6 +123,7 @@ class AssetsTest extends TestCase
             'url' => '/assets/foo/one.txt',
             'permalink' => 'http://localhost/assets/foo/one.txt',
             'api_url' => 'http://localhost/api/assets/test/foo/one.txt',
+            'alt' => 'Alt text for one',
         ], $augmented->toArray());
     }
 


### PR DESCRIPTION
This pull request adds the `alt` field to the array of keys included when "shallowly augmenting" assets.

Without `alt` being part of shallowly augmented assets, it means developers need to do an additional API request for every asset they need to get alt text for.

Fixes #10011.