### PR TITLE
[4.x] Ensure blueprint tabs & sections always have handles

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -195,6 +195,10 @@ export default {
         },
 
         editConfirmed() {
+            if (! this.editingSection.handle) {
+                this.editingSection.handle = this.$slugify(this.editingSection.display, '_');
+            }
+
             this.$emit('updated', {...this.section, ...this.editingSection});
             this.editingSection = false;
         },

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -134,6 +134,10 @@ export default {
         },
 
         editConfirmed() {
+            if (! this.handle) {
+                this.handle = this.$slugify(this.display, '_');
+            }
+
             this.$emit('updated', {
                 ...this.tab,
                 handle: this.handle,
@@ -141,6 +145,7 @@ export default {
                 instructions: this.instructions,
                 icon: this.icon,
             });
+
             this.editing = false;
         },
 


### PR DESCRIPTION
This pull request fixes an issue where it was possible to set the handle for a blueprint tab/section to an empty string, which would lead to a broken publish form.

This PR fixes that by ensuring tabs & sections always have handles, by generating one when editing the tab/section if one hasn't been set in the edit modal.

Fixes #9983.