### PR TITLE
[4.x] Fix French "total characters" translation

### DIFF
--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -7,7 +7,7 @@
     ":count set|:count sets": ":count jeu|:count jeux",
     ":count word|:count words": ":count mot|:count mots",
     ":count\/:max selected": ":count sélectionnés \/:max",
-    ":count\/:total characters": "count caractères \/:total",
+    ":count\/:total characters": "count caractères :count\/:total",
     ":file uploaded": ":file téléchargé",
     ":start-:end of :total": ":start-:end sur :total",
     ":title Field": "Champ :title",


### PR DESCRIPTION
This pull request fixes the French translation for the "total characters" string used at the bottom right of Bard fields, it was previously only showing the character limit and not the total count like the English translation.

![CleanShot 2024-05-07 at 21 16 59](https://github.com/statamic/cms/assets/19637309/3b1cc56e-50f1-4e2b-894d-3f13ea624a3a)

Fixes #9980.