### PR TITLE
[4.x] Add `Vary: X-Requested-With` header to CP responses

### DIFF
--- a/src/Http/Middleware/CP/AddVaryHeaderToResponse.php
+++ b/src/Http/Middleware/CP/AddVaryHeaderToResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Statamic\Http\Middleware\CP;
+
+use Closure;
+
+class AddVaryHeaderToResponse
+{
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        $response->headers->set('Vary', 'X-Requested-With');
+
+        return $response;
+    }
+}

--- a/src/Providers/CpServiceProvider.php
+++ b/src/Providers/CpServiceProvider.php
@@ -11,6 +11,7 @@ use Statamic\Extensions\Translation\Loader;
 use Statamic\Extensions\Translation\Translator;
 use Statamic\Facades\User;
 use Statamic\Fieldtypes\Sets;
+use Statamic\Http\Middleware\CP\AddVaryHeaderToResponse;
 use Statamic\Http\View\Composers\CustomLogoComposer;
 use Statamic\Http\View\Composers\FieldComposer;
 use Statamic\Http\View\Composers\JavascriptComposer;
@@ -92,6 +93,7 @@ class CpServiceProvider extends ServiceProvider
             \Statamic\Http\Middleware\CP\BootPreferences::class,
             \Statamic\Http\Middleware\CP\BootUtilities::class,
             \Statamic\Http\Middleware\CP\CountUsers::class,
+            \Statamic\Http\Middleware\CP\AddVaryHeaderToResponse::class,
             \Statamic\Http\Middleware\DeleteTemporaryFileUploads::class,
         ]);
     }

--- a/src/Providers/CpServiceProvider.php
+++ b/src/Providers/CpServiceProvider.php
@@ -11,7 +11,6 @@ use Statamic\Extensions\Translation\Loader;
 use Statamic\Extensions\Translation\Translator;
 use Statamic\Facades\User;
 use Statamic\Fieldtypes\Sets;
-use Statamic\Http\Middleware\CP\AddVaryHeaderToResponse;
 use Statamic\Http\View\Composers\CustomLogoComposer;
 use Statamic\Http\View\Composers\FieldComposer;
 use Statamic\Http\View\Composers\JavascriptComposer;


### PR DESCRIPTION
This pull request adds a `Vary: X-Requested-With` header to Control Panel responses.

This fixes an issue with the Users listing page on Chrome. If you go onto the users listing table, do any kind of filtering, click on a user, then use the browser back button, you'll see a JSON response instead of the listing page.

This was only happening on the Users listing because it's the Blade view & JSON responses share the same URL, where our other listing pages have separate URLs.

From what I can tell, I believe this issue is only affecting Chrome(ium). The `Vary` header seems to tell the browser which headers cause a different response to be returned - the `X-Requested-With` header is different between the two types of requests so it fixes the issue.

Fixes #9937.