### PR TITLE
[5.x] Use `Statamic.$slug` helper instead of `$slugify`

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -196,7 +196,7 @@ export default {
 
         editConfirmed() {
             if (! this.editingSection.handle) {
-                this.editingSection.handle = this.$slugify(this.editingSection.display, '_');
+                this.editingSection.handle = Statamic.$slug.separatedBy('_').create(this.editingSection.display)
             }
 
             this.$emit('updated', {...this.section, ...this.editingSection});

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -196,7 +196,7 @@ export default {
 
         editConfirmed() {
             if (! this.editingSection.handle) {
-                this.editingSection.handle = Statamic.$slug.separatedBy('_').create(this.editingSection.display)
+                this.editingSection.handle = snake_case(this.editingSection.display)
             }
 
             this.$emit('updated', {...this.section, ...this.editingSection});

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -135,7 +135,7 @@ export default {
 
         editConfirmed() {
             if (! this.handle) {
-                this.handle = this.$slugify(this.display, '_');
+                this.handle = Statamic.$slug.separatedBy('_').create(this.display)
             }
 
             this.$emit('updated', {

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -135,7 +135,7 @@ export default {
 
         editConfirmed() {
             if (! this.handle) {
-                this.handle = Statamic.$slug.separatedBy('_').create(this.display)
+                this.handle = snake_case(this.display)
             }
 
             this.$emit('updated', {


### PR DESCRIPTION
In #10014, I used the `this.$slugify` helper to generate handles for tabs & sets based on their display names. 

In v5, `this.$slugify` has been deprecated in favour of `Statamic.$slug`. This PR updates that code in v5 to use the `Statamic.$slug` helper.