### PR TITLE
[5.x] Allow opting out of svg tag sanitization

### DIFF
--- a/src/Tags/Svg.php
+++ b/src/Tags/Svg.php
@@ -13,6 +13,8 @@ class Svg extends Tags
 {
     use Concerns\RendersAttributes;
 
+    private static $shouldSanitize = true;
+
     public function wildcard($src)
     {
         $this->params['src'] = $src;
@@ -95,7 +97,7 @@ class Svg extends Tags
 
     private function sanitize($svg)
     {
-        if ($this->params->bool('sanitize', true) === false) {
+        if ($this->params->bool('sanitize', static::$shouldSanitize) === false) {
             return $svg;
         }
 
@@ -125,5 +127,15 @@ class Svg extends Tags
         $disallowed = array_diff($sanitizer->getDisallowedTags(), $tags);
         $sanitizer->setAllowedTags($allowed);
         $sanitizer->setDisallowedTags($disallowed);
+    }
+
+    public static function disableSanitization()
+    {
+        static::$shouldSanitize = false;
+    }
+
+    public static function enableSanitization()
+    {
+        static::$shouldSanitize = true;
     }
 }


### PR DESCRIPTION
We made SVG tag sanitization enabled by default and let you opt out per tag.
This PR adds a method you can throw into a service provider to disable it. This may make upgrading simpler for some users.
You can still choose to sanitize per tag by adding `sanitize="true"` like you did in v4.
