### PR TITLE
[4.x] Fix button group wrapping on non-fieldtype buttons

### DIFF
--- a/resources/css/components/fieldtypes/button-group.css
+++ b/resources/css/components/fieldtypes/button-group.css
@@ -1,9 +1,10 @@
 /* Vertical alignment of btn groups when overflowing
   ========================================================================== */
 
-.btn-group:not(.btn-vertical) {
+.button-group-fieldtype-wrapper .btn-group:not(.btn-vertical) {
     @apply flex-wrap;
 }
+
 .btn-group.btn-vertical {
     @apply flex-col items-stretch justify-start p-0 h-auto;
 


### PR DESCRIPTION
This PR fix an issue caused by the #10000.

Button groups that were not part of a button-group fieldtype where wrapped for no reasons.

## Examples
Example on the Page Listing before this fix:
<img width="364" alt="image" src="https://github.com/statamic/cms/assets/29105077/b45729df-9f43-467c-bf94-7c2668d364dc">

## Fix
Fixed by targeting more specificaly the `.button-group-fieldtype-wrapper` :
(Still with some flex shrinking issues, but from before this PR - that would be for another time)
<img width="292" alt="image" src="https://github.com/statamic/cms/assets/29105077/af937094-c9e6-497a-90bb-5b83dcb3d8c2"> 