### PR TITLE
[4.x] Fix EloquentQueryBuilder orderby bug

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -511,7 +511,7 @@ abstract class EloquentQueryBuilder implements Builder
      */
     protected function enforceOrderBy()
     {
-        if (empty($this->builder->query->orders) && empty($this->builder->query->unionOrders)) {
+        if (empty($this->builder->getQuery()->orders) && empty($this->builder->getQuery()->unionOrders)) {
             $this->orderBy($this->builder->getModel()->getQualifiedKeyName(), 'asc');
         }
     }


### PR DESCRIPTION
This pull request attempts to fix an issue with the `EloquentQueryBuilder@enforceOrderBy` where it was erroring out. The `query` property is [protected on Laravel's Eloquent `Builder` class](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Eloquent/Builder.php#L44), so this PR updates the code to use the `getQuery` method.

```
Exception: Property [query] does not exist on the Eloquent builder instance.

/home/runner/work/eloquent-driver/eloquent-driver/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:1943
/home/runner/work/eloquent-driver/eloquent-driver/vendor/statamic/cms/src/Query/EloquentQueryBuilder.php:514
/home/runner/work/eloquent-driver/eloquent-driver/vendor/statamic/cms/src/Query/EloquentQueryBuilder.php:488
/home/runner/work/eloquent-driver/eloquent-driver/vendor/statamic/cms/src/Search/Searchables/Entries.php:34
/home/runner/work/eloquent-driver/eloquent-driver/vendor/statamic/cms/src/Search/Searchables.php:51
```

Caused by #9956.