### PR TITLE
[4.x] Add `notifications` method to `AugmentedUser`

### DIFF
--- a/src/Auth/AugmentedUser.php
+++ b/src/Auth/AugmentedUser.php
@@ -107,4 +107,9 @@ class AugmentedUser extends AbstractAugmented
     {
         return $this->data->preferredLocale();
     }
+
+    public function notifications()
+    {
+        return $this->data->get('notifications');
+    }
 }


### PR DESCRIPTION
This pull request adds a `notifications` method to the `AugmentedUser` class to prevent it falling back to the `notifications` method on the `User` when Laravel's `Notifiable` trait is present.

Fixes #9932.
Replaces #9936 & #10022.