### PR TITLE
[5.x] Fix `is_external_url` modifier with Link fields

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -26,6 +26,7 @@ use Statamic\Fields\Value;
 use Statamic\Fields\Values;
 use Statamic\Fieldtypes\Bard;
 use Statamic\Fieldtypes\Bard\Augmentor;
+use Statamic\Fieldtypes\Link\ArrayableLink;
 use Statamic\Support\Arr;
 use Statamic\Support\Dumper;
 use Statamic\Support\Html;
@@ -1263,6 +1264,10 @@ class CoreModifiers extends Modifier
      */
     public function isExternalUrl($value)
     {
+        if ($value instanceof ArrayableLink) {
+            $value = $value->value();
+        }
+
         return Str::isUrl($value) && URL::isExternal($value);
     }
 


### PR DESCRIPTION
This pull request fixes an issue with the `is_external_url` modifier where it'd error out when passed a Link field.

The error is actually coming from inside the [`URL::isExternal`](https://github.com/statamic/cms/blob/5.x/src/Facades/Endpoint/URL.php#L224) method, with the caching changes introduced in #9646. The method is expecting a string be passed to it instead of an `ArrayableLink` object like is the case w/ Link fields.

This worked fine in v4 because `ArrayableLink` casts to a string but with the recent caching changes, it's trying to get items in an array using `ArrayableLink` as a key which doesn't work. I though converting the value to a string before it ends up in `isExternal` might be the best way to fix it.

Fixes #10026.