### PR TITLE
[5.x] Fix translation command compatibility

### DIFF
--- a/src/Translator/Commands/Generate.php
+++ b/src/Translator/Commands/Generate.php
@@ -49,7 +49,7 @@ class Generate extends Command
             ->addOption('key', null, InputOption::VALUE_REQUIRED, 'Google Translate API Key');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->input = $input;
         $this->output = $output;

--- a/src/Translator/Commands/Review.php
+++ b/src/Translator/Commands/Review.php
@@ -32,7 +32,7 @@ class Review extends Command
             ->addArgument('file', InputArgument::OPTIONAL);
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->input = $input;
         $this->output = $output;

--- a/src/Translator/Commands/Stats.php
+++ b/src/Translator/Commands/Stats.php
@@ -34,7 +34,7 @@ class Stats extends Command
             ->addOption('type', null, InputOption::VALUE_OPTIONAL, 'Either "string" or "key"');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $counts = collect();
 

--- a/src/Translator/Commands/Translate.php
+++ b/src/Translator/Commands/Translate.php
@@ -38,7 +38,7 @@ class Translate extends Command
             ->addOption('key', null, InputOption::VALUE_REQUIRED, 'Google Translate API Key');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->input = $input;
         $this->output = $output;


### PR DESCRIPTION
This PR adds the return type to the translation commands to keep compatibility with Laravel

Closes https://github.com/statamic/cms/issues/10033