### PR TITLE
[5.x] Translatable blueprint titles in collection & taxonomy controllers

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -404,6 +404,11 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
         return Arr::get($this->contents, 'title', Str::humanize(Str::of($this->handle)->after('::')->afterLast('.')));
     }
 
+    public function translatedTitle()
+    {
+        return __($this->title());
+    }
+
     public function isNamespaced(): bool
     {
         return Facades\Blueprint::getAdditionalNamespaces()->has($this->namespace);

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -404,11 +404,6 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
         return Arr::get($this->contents, 'title', Str::humanize(Str::of($this->handle)->after('::')->afterLast('.')));
     }
 
-    public function translatedTitle()
-    {
-        return __($this->title());
-    }
-
     public function isNamespaced(): bool
     {
         return Facades\Blueprint::getAdditionalNamespaces()->has($this->namespace);

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -72,7 +72,7 @@ class CollectionsController extends CpController
             ->map(function ($blueprint) {
                 return [
                     'handle' => $blueprint->handle(),
-                    'title' => $blueprint->title(),
+                    'title' => __($blueprint->title()),
                 ];
             })->values();
 
@@ -421,7 +421,7 @@ class CollectionsController extends CpController
                         'type' => 'html',
                         'html' => ''.
                             '<div class="text-xs">'.
-                            '   <span class="rtl:ml-4 ltr:mr-4">'.$collection->entryBlueprints()->map->title()->join(', ').'</span>'.
+                            '   <span class="rtl:ml-4 ltr:mr-4">'.$collection->entryBlueprints()->map->translatedTitle()->join(', ').'</span>'.
                             '   <a href="'.cp_route('collections.blueprints.index', $collection).'" class="text-blue">'.__('Edit').'</a>'.
                             '</div>',
                     ],

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -421,7 +421,7 @@ class CollectionsController extends CpController
                         'type' => 'html',
                         'html' => ''.
                             '<div class="text-xs">'.
-                            '   <span class="rtl:ml-4 ltr:mr-4">'.$collection->entryBlueprints()->map->translatedTitle()->join(', ').'</span>'.
+                            '   <span class="rtl:ml-4 ltr:mr-4">'.$collection->entryBlueprints()->map(fn ($bp) => __($bp->title()))->join(', ').'</span>'.
                             '   <a href="'.cp_route('collections.blueprints.index', $collection).'" class="text-blue">'.__('Edit').'</a>'.
                             '</div>',
                     ],

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -59,7 +59,7 @@ class TaxonomiesController extends CpController
             ->map(function ($blueprint) {
                 return [
                     'handle' => $blueprint->handle(),
-                    'title' => $blueprint->title(),
+                    'title' => __($blueprint->title()),
                 ];
             })->values();
 
@@ -254,7 +254,7 @@ class TaxonomiesController extends CpController
                         'type' => 'html',
                         'html' => ''.
                             '<div class="text-xs">'.
-                            '   <span class="rtl:ml-4 ltr:mr-4">'.$taxonomy->termBlueprints()->map->translatedTitle()->join(', ').'</span>'.
+                            '   <span class="rtl:ml-4 ltr:mr-4">'.$taxonomy->termBlueprints()->map(fn ($bp) => __($bp->title()))->join(', ').'</span>'.
                             '   <a href="'.cp_route('taxonomies.blueprints.index', $taxonomy).'" class="text-blue">'.__('Edit').'</a>'.
                             '</div>',
                     ],

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -254,7 +254,7 @@ class TaxonomiesController extends CpController
                         'type' => 'html',
                         'html' => ''.
                             '<div class="text-xs">'.
-                            '   <span class="rtl:ml-4 ltr:mr-4">'.$taxonomy->termBlueprints()->map->title()->join(', ').'</span>'.
+                            '   <span class="rtl:ml-4 ltr:mr-4">'.$taxonomy->termBlueprints()->map->translatedTitle()->join(', ').'</span>'.
                             '   <a href="'.cp_route('taxonomies.blueprints.index', $taxonomy).'" class="text-blue">'.__('Edit').'</a>'.
                             '</div>',
                     ],


### PR DESCRIPTION
If a key from a dictionary has been utilized for the blueprint title, it should be translated in the collection and taxonomy controller pages.