### PR TITLE
[5.x] Entries Tree View: Make it possible to "open in new tab"

### DIFF
--- a/resources/js/components/structures/Branch.vue
+++ b/resources/js/components/structures/Branch.vue
@@ -11,6 +11,7 @@
                 <a
                     @click="$emit('edit', $event)"
                     :class="{ 'text-sm font-medium': isTopLevel }"
+                    :href="page.edit_url"
                     v-text="title" />
 
                 <span v-if="showSlugs" class="rtl:mr-2 ltr:ml-2 font-mono text-gray-700 text-2xs pt-px">

--- a/resources/js/components/structures/Branch.vue
+++ b/resources/js/components/structures/Branch.vue
@@ -9,7 +9,7 @@
                 <div class="little-dot rtl:ml-2 ltr:mr-2" :class="getStatusClass()" v-tooltip="getStatusTooltip()" />
                 <svg-icon name="home-page" class="rtl:ml-2 ltr:mr-2 h-4 w-4 text-gray-800" v-if="isRoot" v-tooltip="__('This is the root page')" />
                 <a
-                    @click="$emit('edit', $event)"
+                    @click.prevent="$emit('edit', $event)"
                     :class="{ 'text-sm font-medium': isTopLevel }"
                     :href="page.edit_url"
                     v-text="title" />


### PR DESCRIPTION
Currently, when you right click on an entry in a page tree, the "open in new tab" option doesn't show up, which is a little annoying when you want to open up multiple entries at once since clicking on them opens the edit form up in the same tab.

This PR adds the `href` attribute to the tree branch links, which will cause the "open in new tab" option to show.