### PR TITLE
[5.x] Improve sites update script output when custom `env()` calls are detected

### DIFF
--- a/src/Console/NullConsole.php
+++ b/src/Console/NullConsole.php
@@ -5,6 +5,7 @@ namespace Statamic\Console;
 class NullConsole
 {
     protected $errors = [];
+    protected $warnings = [];
 
     /**
      * Store error output.
@@ -27,6 +28,29 @@ class NullConsole
     public function getErrors()
     {
         return collect($this->errors);
+    }
+
+    /**
+     * Store warning output.
+     *
+     * @param  string  $warning
+     * @return $this
+     */
+    public function warn($warning)
+    {
+        $this->warnings[] = $warning;
+
+        return $this;
+    }
+
+    /**
+     * Get warning output.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getWarnings()
+    {
+        return collect($this->warnings);
     }
 
     /**

--- a/src/UpdateScripts/MigrateSitesConfigToYaml.php
+++ b/src/UpdateScripts/MigrateSitesConfigToYaml.php
@@ -92,6 +92,12 @@ class MigrateSitesConfigToYaml extends UpdateScript
         // Convert `env('APP_URL')` references
         $config = preg_replace('/env\([\'"]APP_URL[\'"]\)/', '\'{{ config:app:url }}\'', $config);
 
+        // Warn if any other `env()` calls are detected, so that user can handle them manually
+        if (preg_match_all('/env\([\'"]([^\'"]+)[\'"]/', $config, $matches)) {
+            $this->console->warn('The following .env vars were referenced in your sites.php config: '.collect($matches[1])->implode(', '));
+            $this->console->line('If you wish for these values to remain dynamic, please refactor to use `{{ config:... }}`.');
+        }
+
         return $config;
     }
 

--- a/tests/UpdateScripts/Concerns/RunsUpdateScripts.php
+++ b/tests/UpdateScripts/Concerns/RunsUpdateScripts.php
@@ -15,6 +15,8 @@ trait RunsUpdateScripts
         $script = new $fqcn($package);
 
         $script->update();
+
+        return $script;
     }
 
     protected function assertUpdateScriptRegistered($class)


### PR DESCRIPTION
If your sites.php config was referencing `APP_NAME` or `APP_URL`, we automatically convert these to `{{ config:app:name }}` and `{{ config:app:url }}` in our upgrade script 👍 

However, if you referenced other custom env vars, it would just resolve / hardcode them. This PR adds some transparency in the messaging after the end of a successful composer install, so that you can handle these yourself...

![CleanShot 2024-05-10 at 15 56 32](https://github.com/statamic/cms/assets/5187394/e7ab6ef7-37b9-421a-87d7-897bbe8031fd)

Closes #10043