### PR TITLE
[5.x] Update `ajthinking/archetype` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "proprietary",
     "require": {
         "ext-json": "*",
-        "ajthinking/archetype": "^1.0.3",
+        "ajthinking/archetype": "^2.0",
         "composer/semver": "^3.4",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "james-heinrich/getid3": "^1.9.21",


### PR DESCRIPTION
This pull request updates the `ajthinking/archetype` dependency to `^5.0`. This adds support for v5 of `nikic/php-parser`, which PHPUnit seems to require.

Fixes #10028.
Related: https://github.com/ajthinking/archetype/pull/85