### PR TITLE
[5.x] Prevent errors when viewing nav after collection has been deleted

### DIFF
--- a/src/Structures/Nav.php
+++ b/src/Structures/Nav.php
@@ -71,7 +71,7 @@ class Nav extends Structure implements Contract
             ->getter(function ($collections) {
                 return collect($collections)->map(function ($collection) {
                     return Collection::findByHandle($collection);
-                });
+                })->filter();
             })
             ->args(func_get_args());
     }


### PR DESCRIPTION
This pull request fixes an issue where you'd get an error viewing a navigation when one of the associated collections have been deleted.

This PR fixes it in [the same way](https://github.com/statamic/cms/blob/08cb2b70986e0f9d811a2fabc0d05f0b08a02b3a/src/Entries/Collection.php#L835) we handle viewing collections where the associated taxonomies have been deleted. 

Closes statamic/ideas#1164