### PR TITLE
[5.x] Ensure `container` option isn't removed from Asset fields

### DIFF
--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -46,7 +46,7 @@ class FieldTransformer
                     return true;
                 }
 
-                if ($submitted['fieldtype'] === 'assets' && $key === 'container') {
+                if (isset($submitted['fieldtype']) && $submitted['fieldtype'] === 'assets' && $key === 'container') {
                     return false;
                 }
 

--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -33,7 +33,7 @@ class FieldTransformer
             ->map->defaultValue()->filter();
 
         $field = collect($submitted['config'])
-            ->reject(function ($value, $key) use ($defaultConfig) {
+            ->reject(function ($value, $key) use ($submitted, $defaultConfig) {
                 if (in_array($key, ['isNew', 'icon', 'duplicate'])) {
                     return true;
                 }
@@ -44,6 +44,10 @@ class FieldTransformer
 
                 if ($key === 'localizable' && $value === false && ! Site::multiEnabled()) {
                     return true;
+                }
+
+                if ($submitted['fieldtype'] === 'assets' && $key === 'container') {
+                    return false;
                 }
 
                 return $defaultConfig->has($key) && $defaultConfig->get($key) === $value;

--- a/tests/Fields/FieldTransformerTest.php
+++ b/tests/Fields/FieldTransformerTest.php
@@ -4,10 +4,13 @@ namespace Tests\Fields;
 
 use Statamic\Facades\AssetContainer;
 use Statamic\Fields\FieldTransformer;
+use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class FieldTransformerTest extends TestCase
 {
+    use PreventSavingStacheItemsToDisk;
+
     protected function configToVue($config)
     {
         return FieldTransformer::toVue(['handle' => 'test', 'field' => $config])['config'];

--- a/tests/Fields/FieldTransformerTest.php
+++ b/tests/Fields/FieldTransformerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Fields;
 
+use Statamic\Facades\AssetContainer;
 use Statamic\Fields\FieldTransformer;
 use Tests\TestCase;
 
@@ -89,6 +90,29 @@ class FieldTransformerTest extends TestCase
             'character_limit' => 100,
             'listable' => true,
             'foo' => 'bar',
+        ], $fromVue['field']);
+    }
+
+    /** @test */
+    public function it_doesnt_remove_container_config_option_from_assets_field()
+    {
+        AssetContainer::make('assets')->save();
+
+        $fromVue = FieldTransformer::fromVue([
+            'fieldtype' => 'assets',
+            'handle' => 'test',
+            'type' => 'inline',
+            'config' => [
+                'mode' => 'list',  // The default.
+                'icon' => 'assets', // The default.
+                'foo' => 'bar', // Manually added by user.
+                'container' => 'assets', // The default, but it shouldn't get removed.
+            ],
+        ]);
+
+        $this->assertEquals([
+            'foo' => 'bar',
+            'container' => 'assets',
         ], $fromVue['field']);
     }
 


### PR DESCRIPTION
In #9685, we made it so default values for fieldtype configs are stripped out of the `config` array, slimming down blueprint & fieldset YAML files.

However, this change has caused an unintentional side affect.....

* When your site only has one asset container, the default value on Asset fields will be that of that asset container. 
    * This means that no `container` is saved into the blueprint/fieldset's YAML file.
* In the future, if you decide to create an additional asset container, because there's no default container to rely on (there's only a default when a single asset container is configured) and no explicit `container` is set on the fields, you'll see a lot of `An asset container has not been configured` errors

This can be easily fixed by ensuring the `container` config option is always saved, so when an additional asset container is created, existing Asset fields use the initial asset container since that's what's been set.

Fixes #10050.