### PR TITLE
[5.x] Fix incorrect revision edit URLs

### DIFF
--- a/resources/js/components/revision-history/Preview.vue
+++ b/resources/js/components/revision-history/Preview.vue
@@ -15,7 +15,7 @@ export default {
             readOnly: true,
             method: 'patch',
             action: 'update',
-            itemUrl: `${this.revision.attributes.id}/revisions/${this.revision.id}`,
+            itemUrl: this.revision.attributes.item_url,
         }
     },
 

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -162,6 +162,10 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
             Route::resource('revisions', EntryRevisionsController::class, [
                 'as' => 'collections.entries',
                 'only' => ['index', 'store', 'show'],
+            ])->names([
+                'index' => 'collections.entries.revisions.index',
+                'store' => 'collections.entries.revisions.store',
+                'show' => 'collections.entries.revisions.show',
             ]);
 
             Route::post('restore-revision', RestoreEntryRevisionController::class)->name('collections.entries.restore-revision');

--- a/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
+++ b/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
@@ -16,7 +16,14 @@ class EntryRevisionsController extends CpController
             ->revisions()
             ->reverse()
             ->prepend($this->workingCopy($entry))
-            ->filter();
+            ->filter()
+            ->each(function ($revision) use ($collection, $entry) {
+                $revision->attribute('item_url', cp_route('collections.entries.revisions.show', [
+                    'collection' => $collection,
+                    'entry' => $entry->id(),
+                    'revision' => $revision->id(),
+                ]));
+            });
 
         // The first non manually created revision would be considered the "current"
         // version. It's what corresponds to what's in the content directory.


### PR DESCRIPTION
This pull request fixes an issue where the revision edit URLs were invalid when you were tried to view the revision publish form for an entry in a different collection than the current entry.

Fixes #10034.