### PR TITLE
[5.x] Prevent certain blueprint config keys getting stripped out

### DIFF
--- a/src/Fields/ConfigField.php
+++ b/src/Fields/ConfigField.php
@@ -12,4 +12,9 @@ class ConfigField extends Field
 
         return $this->newInstance()->setValue($value);
     }
+
+    public function mustRemainInConfig(): bool
+    {
+        return $this->get('force_in_config') === true;
+    }
 }

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -551,6 +551,6 @@ class Field implements Arrayable
             ],
         ])->map(fn ($field, $handle) => compact('handle', 'field'))->values()->all();
 
-        return new Fields($fields);
+        return new ConfigFields($fields);
     }
 }

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -477,6 +477,10 @@ class Field implements Arrayable
                 'instructions' => __('statamic::messages.fields_display_instructions'),
                 'type' => 'field_display',
             ],
+            'hide_display' => [
+                'type' => 'toggle',
+                'visibility' => 'hidden',
+            ],
             'handle' => [
                 'display' => __('Handle'),
                 'instructions' => __('statamic::messages.fields_handle_instructions'),

--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -33,7 +33,7 @@ class FieldTransformer
 
         $field = collect($submitted['config'])
             ->reject(function ($value, $key) use ($fields) {
-                if (in_array($key, ['isNew', 'icon', 'duplicate'])) {
+                if (in_array($key, ['isNew', 'icon'])) {
                     return true;
                 }
 

--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -49,6 +49,10 @@ class FieldTransformer
                     return false;
                 }
 
+                if ($field->mustRemainInConfig()) {
+                    return false;
+                }
+
                 return $field->defaultValue() === $value;
             })
             ->map(function ($value, $key) {

--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -91,7 +91,6 @@ class FieldTransformer
 
                 return $value;
             })
-            ->filter()
             ->sortBy(function ($value, $key) {
                 // Push sets & fields to the end of the config.
                 if ($key === 'sets' || $key === 'fields') {
@@ -104,7 +103,7 @@ class FieldTransformer
 
         return array_filter([
             'handle' => $submitted['handle'],
-            'field' => $field,
+            'field' => Arr::removeNullValues($field),
         ]);
     }
 

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -56,6 +56,7 @@ class Assets extends Fieldtype
                         'mode' => 'select',
                         'required' => true,
                         'default' => AssetContainer::all()->count() == 1 ? AssetContainer::all()->first()->handle() : null,
+                        'force_in_config' => true,
                     ],
                     'folder' => [
                         'display' => __('Folder'),

--- a/src/Forms/Fieldtype.php
+++ b/src/Forms/Fieldtype.php
@@ -31,6 +31,7 @@ class Fieldtype extends Relationship
                 'display' => __('Max Items'),
                 'default' => 1,
                 'instructions' => __('statamic::fieldtypes.form.config.max_items'),
+                'force_in_config' => true,
             ],
             'mode' => [
                 'display' => __('UI Mode'),

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -32,9 +32,7 @@ class FieldsController extends CpController
 
         $fieldtype = FieldtypeRepository::find($request->type);
 
-        $blueprint = $this
-            ->blueprint($fieldtype->configBlueprint())
-            ->ensureField('hide_display', ['type' => 'toggle', 'visibility' => 'hidden']);
+        $blueprint = $this->blueprint($fieldtype->configBlueprint());
 
         $fields = $blueprint
             ->fields()


### PR DESCRIPTION
In #9685 we stripped out redundant blueprint configs where they matched the defaults.

This looks to be a bit heavy handed in some situations.

This PR allows certain keys to be forced into the config even when they match the defaults.

- [x] Fixes #10040
- [x] Fixes #10056
- [x] Fixes #10050

Replaces #10054
