### PR TITLE
Add failing test for issue caused by PR #9585

### DIFF
--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -11,6 +11,7 @@ use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Query\QueryableValue;
 use Statamic\CP\Column;
 use Statamic\CP\Columns;
+use Statamic\Entries\Entry;
 use Statamic\Events\BlueprintCreated;
 use Statamic\Events\BlueprintCreating;
 use Statamic\Events\BlueprintDeleted;
@@ -781,6 +782,29 @@ class BlueprintTest extends TestCase
             ],
         ]], $blueprint->contents());
         $this->assertEquals(['type' => 'textarea'], $blueprint->fields()->get('new')->config());
+    }
+
+    /** @test */
+    public function it_can_add_fields_multiple_times()
+    {
+        $blueprint = (new Blueprint)
+            ->setNamespace('collections/collection_one')
+            ->setHandle('blueprint_one');
+
+        $entry = (new Entry)
+            ->collection('collection_one')
+            ->blueprint($blueprint);
+
+        $blueprint->setParent($entry);
+
+        $blueprint->ensureFieldsInTab(['field_one' => ['type' => 'text']], 'tab_one');
+
+        $this->assertTrue($blueprint->hasField('field_one'));
+
+        $blueprint->ensureField('field_two', ['type' => 'textarea']);
+
+        $this->assertTrue($blueprint->hasField('field_two'));
+
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds a failing test to illustrate the issue that PR https://github.com/statamic/cms/pull/9585 causes. That PR makes it impossible to manipulate a blueprint multiple times during the same request. This is an issue when you are relying on manipulating the blueprint at different stages in an `EntryBlueprintFound` listener.

Jason mentioned: "I don't see any noticeable difference in load times, but this PR is only a handful of lines now so I don't think it hurts.". So, maybe it's not a big deal to revert the PR altogether?

Else, we might need to find a way to opt-out of the fields cache. Or maybe this is simply a bug that can be fixed while retaining the caching.