### PR TITLE
[5.x] Allow Bard's default buttons to be configured

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -22,6 +22,20 @@ class Bard extends Replicator
 {
     use Concerns\ResolvesStatamicUrls, Hookable;
 
+    public static $defaultButtons = [
+        'h2',
+        'h3',
+        'bold',
+        'italic',
+        'unorderedlist',
+        'orderedlist',
+        'removeformat',
+        'quote',
+        'anchor',
+        'image',
+        'table',
+    ];
+
     protected $categories = ['text', 'structured'];
     protected $defaultValue = [];
     protected $rules = [];
@@ -38,19 +52,7 @@ class Bard extends Replicator
                         'instructions' => __('statamic::fieldtypes.bard.config.buttons'),
                         'type' => 'bard_buttons_setting',
                         'full_width_setting' => true,
-                        'default' => [
-                            'h2',
-                            'h3',
-                            'bold',
-                            'italic',
-                            'unorderedlist',
-                            'orderedlist',
-                            'removeformat',
-                            'quote',
-                            'anchor',
-                            'image',
-                            'table',
-                        ],
+                        'default' => static::$defaultButtons,
                     ],
                     'smart_typography' => [
                         'display' => __('Smart Typography'),

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -22,7 +22,7 @@ class Bard extends Replicator
 {
     use Concerns\ResolvesStatamicUrls, Hookable;
 
-    public static $defaultButtons = [
+    private static $defaultButtons = [
         'h2',
         'h3',
         'bold',
@@ -743,5 +743,10 @@ class Bard extends Replicator
     public function runAugmentHooks($value)
     {
         return $this->runHooks('augment', $value);
+    }
+
+    public static function setDefaultButtons(array $buttons): void
+    {
+        static::$defaultButtons = $buttons;
     }
 }


### PR DESCRIPTION
We find anytime we are using Bard fields the default buttons are not what we would want selected, for example we always remove image and table, and rarely use block quote. So you end up deselecting them on every site.

It would be useful to be able to select the defaults so we don't have to do this. It's a 30 second time saver, but it's just one less thing to think about.

I considered using a config for this but theres no existing bard config so it felt like overkill for one setting. Instead I've defined the default buttons as a static property on the bard field type, so you can overwrite them as follows:

```php
// only allow h2 and h3
\Statamic\Fieldtypes\Bard::setDefaultButtons(['h2', 'h3']);
```
