### PR TITLE
[4.x] Add validation replacements to replicator and grid field types

### DIFF
--- a/src/Fieldtypes/AddValidationReplacements.php
+++ b/src/Fieldtypes/AddValidationReplacements.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Statamic\Fieldtypes;
+
+use Statamic\Entries\Entry;
+use Statamic\Fields\Field;
+use Statamic\Fields\Validator;
+
+trait AddValidationReplacements
+{
+    protected function addEntryValidationReplacements(Field $field, Validator $rules): Validator
+    {
+        $fieldParent = $field->parent();
+
+        if (! $fieldParent instanceof Entry) {
+            return $rules;
+        }
+
+        return $rules->withReplacements([
+            'id' => $fieldParent->id(),
+            'collection' => $fieldParent->collection()->handle(),
+            'site' => $fieldParent->locale(),
+        ]);
+    }
+}

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -14,6 +14,8 @@ use Statamic\Support\Str;
 
 class Grid extends Fieldtype
 {
+    use AddValidationReplacements;
+
     protected $categories = ['structured'];
     protected $defaultable = false;
     protected $defaultValue = [];
@@ -159,7 +161,10 @@ class Grid extends Fieldtype
             ->validator()
             ->withContext([
                 'prefix' => $this->field->validationContext('prefix').$this->rowRuleFieldPrefix($index).'.',
-            ])
+            ]);
+
+        $rules = $this
+            ->addEntryValidationReplacements($this->field, $rules)
             ->rules();
 
         return collect($rules)->mapWithKeys(function ($rules, $handle) use ($index) {

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -15,6 +15,8 @@ use Statamic\Support\Str;
 
 class Replicator extends Fieldtype
 {
+    use AddValidationReplacements;
+
     protected $categories = ['structured'];
     protected $defaultValue = [];
     protected $rules = ['array'];
@@ -138,7 +140,10 @@ class Replicator extends Fieldtype
             ->validator()
             ->withContext([
                 'prefix' => $this->field->validationContext('prefix').$this->setRuleFieldPrefix($index).'.',
-            ])
+            ]);
+
+        $rules = $this
+            ->addEntryValidationReplacements($this->field, $rules)
             ->rules();
 
         return collect($rules)->mapWithKeys(function ($rules, $handle) use ($index) {


### PR DESCRIPTION
Currently it’s not possible to use the validation replacements (for example, `validation_rule_handle:{id}`) in fields that are part of replicator or grid fields, because the validator instance that is used for the »top-level« fields isn’t the same that’s used for the fields inside the replicator/grid (at least I think that’s the reason).

This PR changes that and adds the replacements for replicator and grid fields, if the parent is an Entry.

Closes https://github.com/statamic/cms/issues/10065