### PR TITLE
[5.x] Fix `nocache` and OAuth routes for Laravel 11 apps

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -49,12 +49,12 @@ Route::name('statamic.')->group(function () {
     Route::prefix(config('statamic.routes.action'))
         ->post('nocache', NoCacheController::class)
         ->middleware(NoCacheLocalize::class)
-        ->withoutMiddleware('App\Http\Middleware\VerifyCsrfToken');
+        ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken']);
 
     if (OAuth::enabled()) {
         Route::get(config('statamic.oauth.routes.login'), [OAuthController::class, 'redirectToProvider'])->name('oauth.login');
         Route::match(['get', 'post'], config('statamic.oauth.routes.callback'), [OAuthController::class, 'handleProviderCallback'])
-            ->withoutMiddleware('App\Http\Middleware\VerifyCsrfToken')
+            ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken'])
             ->name('oauth.callback');
     }
 });


### PR DESCRIPTION
This  pull request fixes an issue with the `{{ nocache }}` tag and OAuth routes, for applications using the new Laravel 11 application skeleton.

Laravel applications previously included a `VerifyCsrfToken` middleware. However, with Laravel 11 and the slimmer application skeleton, the middleware is no longer included in the app's files and falls back to one in the Laravel framework.

Fixes #10068.