### PR TITLE
[5.x] Handle entries in Link field with `is_external_url` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Data\Augmentable;
+use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Compare;
@@ -1266,6 +1267,10 @@ class CoreModifiers extends Modifier
     {
         if ($value instanceof ArrayableLink) {
             $value = $value->value();
+        }
+
+        if ($value instanceof Entry) {
+            $value = $value->absoluteUrl();
         }
 
         return Str::isUrl($value) && URL::isExternal($value);

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1267,7 +1267,7 @@ class CoreModifiers extends Modifier
         if ($value instanceof ArrayableLink) {
             $value = $value->url();
         }
-        
+
         return Str::isUrl($value) && URL::isExternal($value);
     }
 

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1266,7 +1266,7 @@ class CoreModifiers extends Modifier
     public function isExternalUrl($value)
     {
         if ($value instanceof ArrayableLink) {
-            $value = $value->value();
+            $value = $value->url();
         }
 
         if ($value instanceof Entry) {

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Data\Augmentable;
-use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Compare;
@@ -1268,11 +1267,7 @@ class CoreModifiers extends Modifier
         if ($value instanceof ArrayableLink) {
             $value = $value->url();
         }
-
-        if ($value instanceof Entry) {
-            $value = $value->absoluteUrl();
-        }
-
+        
         return Str::isUrl($value) && URL::isExternal($value);
     }
 


### PR DESCRIPTION
This pull request fixes another issue with `is_external_url` - this time when an Entry is selected in a Link field, rather than a URL.

https://github.com/statamic/cms/issues/10026 was raised previously and fixed in https://github.com/statamic/cms/pull/10027

Fixes #10072.