### PR TITLE
[5.x] Ability to opt out of async slug behavior, and opt out in field settings

### DIFF
--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -5,6 +5,7 @@
         :from="source"
         :separator="separator"
         :language="language"
+        :async="config.async"
         @slugifying="syncing = true"
         @slugified="syncing = false"
         v-model="slug"

--- a/resources/js/components/slugs/Slugify.vue
+++ b/resources/js/components/slugs/Slugify.vue
@@ -17,12 +17,19 @@ export default {
         enabled: {
             type: Boolean,
             default: true
+        },
+        async: {
+            type: Boolean,
+            default: true
         }
     },
 
     data() {
+        let slugifier = this.$slug.in(this.language).separatedBy(this.separator);
+        if (this.async) slugifier.async();
+
         return {
-            slugifier: this.$slug.async().in(this.language).separatedBy(this.separator),
+            slugifier,
             slug: null,
             shouldSlugify: this.enabled && !this.to
         }
@@ -74,6 +81,14 @@ export default {
         },
 
         slugify() {
+            if (! this.async) {
+                return new Promise((resolve, reject) => {
+                    const slug = this.slugifier.create(this.from);
+                    this.slug = slug;
+                    resolve(slug);
+                });
+            }
+
             return new Promise((resolve, reject) => {
                 this.$emit('slugifying');
                 this.slugifier.create(this.from).then(slug => {

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -486,6 +486,7 @@ class Field implements Arrayable
                 'instructions' => __('statamic::messages.fields_handle_instructions'),
                 'type' => 'slug',
                 'from' => 'display',
+                'async' => false,
                 'separator' => '_',
                 'validate' => [
                     'required',


### PR DESCRIPTION
The async behavior is more correct as it uses the server-side slug logic, but it's slower because it makes server requests. 

This PR adds the ability to opt out of it when using the `<slugify>` component by adding an `async="false"` prop, or the `slug` fieldtype by adding an `async: false` option.

While I wasn't able to reproduce the completely incorrect slug behavior as described in #9959, I'm guessing that people were able to somehow trigger an issue in the additional debouncing within the Slug JS class itself. Since the async is opted out of in field settings now, it'll be back to how it performed in v4. The only delay is now the standard debouncing when you type into the title field.

It's possible the issue will reappear in other places that still use the async slugging, like the entry publish form. We'll address it then. 

Closes #9959
