### PR TITLE
[5.x] Dutch translations

### DIFF
--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -721,7 +721,7 @@
     "Records": "Records",
     "Redirect": "Redirect",
     "Refresh": "Verversen",
-    "Regards": "vriendelijke groeten",
+    "Regards": "Vriendelijke groeten",
     "Regenerate": "Hergenereer",
     "Regenerate from: :field": "Hergenereer vanuit :field",
     "Registration successful.": "Registratie succesvol",


### PR DESCRIPTION
Hi!

This is a very small change, but it fixes something that took a little bit of finding out 😅 This PR capitalizes the Dutch translation of "Regards". The default Laravel email signs off with "Regards,", and in the Dutch version it became "vriendelijke groeten,".