### PR TITLE
[5.x] Fix augmentation issues for URL nav items

### DIFF
--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -66,7 +66,7 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Entr
             return $this->augmentationReferenceKey = 'Page::'.$entry->getBulkAugmentationReferenceKey();
         }
 
-        return $this->augmentationReferenceKey = 'Page::';
+        return $this->augmentationReferenceKey = 'Page::'.$this->id();
     }
 
     public function setUrl($url)


### PR DESCRIPTION
This pull request fixes an issue with URL nav items not being augmented properly. 

I managed to track down the issue to some changes made in https://github.com/statamic/cms/pull/9636. As part of those changes, a `getBulkAugmentationReferenceKey` method has been added. It seems like the returned key is unique for entry nav items but wasn't for URL-based nav items.

This PR appends the nav item ID to the returned reference key which seems to fix the issues.

Fixes #10055.
Fixes #10080.