### PR TITLE
[5.x] Bring back support for archetype v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "proprietary",
     "require": {
         "ext-json": "*",
-        "ajthinking/archetype": "^2.0",
+        "ajthinking/archetype": "^1.0.3 || ^2.0",
         "composer/semver": "^3.4",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "james-heinrich/getid3": "^1.9.21",


### PR DESCRIPTION
Some packages still require the old version of `nikic/php-parser` which `ajthinking/archetype` requires. This prevents Statamic 5.1.0 being installable.
I don't think there's a problem with requiring v1.
