### PR TITLE
[5.x] Fix querying publish dates on undated collections

### DIFF
--- a/src/Stache/Query/QueriesEntryStatus.php
+++ b/src/Stache/Query/QueriesEntryStatus.php
@@ -22,6 +22,7 @@ trait QueriesEntryStatus
 
         return $this->where(fn ($query) => $this
             ->getCollectionsForStatusQuery()
+            ->filter(fn ($collection) => $collection->dated())
             ->each(fn ($collection) => $query->orWhere(fn ($q) => $this->addCollectionStatusLogicToQuery($q, $status, $collection))));
     }
 

--- a/src/Stache/Query/QueriesEntryStatus.php
+++ b/src/Stache/Query/QueriesEntryStatus.php
@@ -22,13 +22,20 @@ trait QueriesEntryStatus
 
         return $this->where(fn ($query) => $this
             ->getCollectionsForStatusQuery()
-            ->filter(fn ($collection) => $collection->dated())
             ->each(fn ($collection) => $query->orWhere(fn ($q) => $this->addCollectionStatusLogicToQuery($q, $status, $collection))));
     }
 
     private function addCollectionStatusLogicToQuery($query, $status, $collection): void
     {
         $this->addCollectionWhereToStatusQuery($query, $collection->handle());
+
+        if (! $collection->dated()) {
+            if ($status !== 'published') {
+                $query->where('date', 'invalid'); // intentionally trigger no results.
+            }
+
+            return;
+        }
 
         if ($collection->futureDateBehavior() === 'public' && $collection->pastDateBehavior() === 'public') {
             if ($status === 'scheduled' || $status === 'expired') {


### PR DESCRIPTION
I could be wrong here, but from what I'm seeing whereStatus is querying publish dates for collections that aren't dated. This doesn't seem to cause issues in stache queries, but is in eloquent ones ([as reported here](https://github.com/statamic/eloquent-driver/issues/288#issuecomment-2113100222))

It seems we should just filter out any collections that aren't dated?