### PR TITLE
[5.x] Sync entry form values after revision publish

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -747,6 +747,7 @@ export default {
             this.isWorkingCopy = isWorkingCopy;
             this.confirmingPublish = false;
             this.title = response.data.data.title;
+            this.values = this.resetValuesFromResponse(response.data.data.values);
             this.activeLocalization.title = response.data.data.title;
             this.activeLocalization.published = response.data.data.published;
             this.activeLocalization.status = response.data.data.status;

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -22,7 +22,8 @@ use Statamic\Support\Str;
 
 class EntriesController extends CpController
 {
-    use QueriesFilters;
+    use ExtractsFromEntryFields,
+        QueriesFilters;
 
     public function index(FilteredRequest $request, $collection)
     {
@@ -429,46 +430,6 @@ class EntriesController extends CpController
 
             return null;
         };
-    }
-
-    protected function extractFromFields($entry, $blueprint)
-    {
-        // The values should only be data merged with the origin data.
-        // We don't want injected collection values, which $entry->values() would have given us.
-        $values = collect();
-        $target = $entry;
-        while ($target) {
-            $values = $target->data()->merge($target->computedData())->merge($values);
-            $target = $target->origin();
-        }
-        $values = $values->all();
-
-        if ($entry->hasStructure()) {
-            $values['parent'] = array_filter([optional($entry->parent())->id()]);
-
-            if ($entry->revisionsEnabled() && $entry->has('parent')) {
-                $values['parent'] = [$entry->get('parent')];
-            }
-        }
-
-        if ($entry->collection()->dated()) {
-            $datetime = substr($entry->date()->toDateTimeString(), 0, 19);
-            $datetime = ($entry->hasTime()) ? $datetime : substr($datetime, 0, 10);
-            $values['date'] = $datetime;
-        }
-
-        $fields = $blueprint
-            ->fields()
-            ->addValues($values)
-            ->preProcess();
-
-        $values = $fields->values()->merge([
-            'title' => $entry->value('title'),
-            'slug' => $entry->slug(),
-            'published' => $entry->published(),
-        ]);
-
-        return [$values->all(), $fields->meta()];
     }
 
     protected function extractAssetsFromValues($values)

--- a/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
+++ b/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Statamic\Http\Controllers\CP\Collections;
+
+trait ExtractsFromEntryFields
+{
+    protected function extractFromFields($entry, $blueprint)
+    {
+        // The values should only be data merged with the origin data.
+        // We don't want injected collection values, which $entry->values() would have given us.
+        $values = collect();
+        $target = $entry;
+        while ($target) {
+            $values = $target->data()->merge($target->computedData())->merge($values);
+            $target = $target->origin();
+        }
+        $values = $values->all();
+
+        if ($entry->hasStructure()) {
+            $values['parent'] = array_filter([optional($entry->parent())->id()]);
+
+            if ($entry->revisionsEnabled() && $entry->has('parent')) {
+                $values['parent'] = [$entry->get('parent')];
+            }
+        }
+
+        if ($entry->collection()->dated()) {
+            $datetime = substr($entry->date()->toDateTimeString(), 0, 19);
+            $datetime = ($entry->hasTime()) ? $datetime : substr($datetime, 0, 10);
+            $values['date'] = $datetime;
+        }
+
+        $fields = $blueprint
+            ->fields()
+            ->addValues($values)
+            ->preProcess();
+
+        $values = $fields->values()->merge([
+            'title' => $entry->value('title'),
+            'slug' => $entry->slug(),
+            'published' => $entry->published(),
+        ]);
+
+        return [$values->all(), $fields->meta()];
+    }
+}

--- a/src/Http/Controllers/CP/Collections/PublishedEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/PublishedEntriesController.php
@@ -9,6 +9,8 @@ use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
 
 class PublishedEntriesController extends CpController
 {
+    use ExtractsFromEntryFields;
+
     public function store(Request $request, $collection, $entry)
     {
         $this->authorize('publish', $entry);
@@ -47,45 +49,5 @@ class PublishedEntriesController extends CpController
                 'values' => $values,
             ]),
         ];
-    }
-
-    protected function extractFromFields($entry, $blueprint)
-    {
-        // The values should only be data merged with the origin data.
-        // We don't want injected collection values, which $entry->values() would have given us.
-        $values = collect();
-        $target = $entry;
-        while ($target) {
-            $values = $target->data()->merge($target->computedData())->merge($values);
-            $target = $target->origin();
-        }
-        $values = $values->all();
-
-        if ($entry->hasStructure()) {
-            $values['parent'] = array_filter([optional($entry->parent())->id()]);
-
-            if ($entry->revisionsEnabled() && $entry->has('parent')) {
-                $values['parent'] = [$entry->get('parent')];
-            }
-        }
-
-        if ($entry->collection()->dated()) {
-            $datetime = substr($entry->date()->toDateTimeString(), 0, 19);
-            $datetime = ($entry->hasTime()) ? $datetime : substr($datetime, 0, 10);
-            $values['date'] = $datetime;
-        }
-
-        $fields = $blueprint
-            ->fields()
-            ->addValues($values)
-            ->preProcess();
-
-        $values = $fields->values()->merge([
-            'title' => $entry->value('title'),
-            'slug' => $entry->slug(),
-            'published' => $entry->published(),
-        ]);
-
-        return [$values->all(), $fields->meta()];
     }
 }


### PR DESCRIPTION
https://github.com/statamic/cms/pull/6842 made it so that the entry publish form values are synced on save. This PR adds the same functionality when you publish/unpublish a revision. This is useful when you have listeners that update entry values on publish/unpublish.

At the moment I've had to duplicate the `extractFromFields` method as this is in a different controller. I had to the same thing in the https://github.com/statamic/cms/pull/6375 for the actions controller. It makes sense to move this method somewhere that all the controllers can use, I'm just not sure where would be best?
