### PR TITLE
[5.x] Don't call ->in() twice while hydrating globals

### DIFF
--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -138,11 +138,11 @@ class Cascade
     protected function hydrateGlobals()
     {
         foreach (GlobalSet::all() as $global) {
-            if (! $global->existsIn($this->site->handle())) {
+            $global = $global?->in($this->site->handle());
+
+            if (! $global) {
                 continue;
             }
-
-            $global = $global->in($this->site->handle());
 
             $this->set($global->handle(), $global);
         }

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -138,13 +138,9 @@ class Cascade
     protected function hydrateGlobals()
     {
         foreach (GlobalSet::all() as $global) {
-            $global = $global?->in($this->site->handle());
-
-            if (! $global) {
-                continue;
+            if ($global = $global->in($this->site->handle())) {
+                $this->set($global->handle(), $global);
             }
-
-            $this->set($global->handle(), $global);
         }
 
         if ($mainGlobal = $this->get('global')) {


### PR DESCRIPTION
The `existsIn()` method calls `->in()` inside. The `in()` method is resource consuming when someone has a lot of sites.

This reduce the loading time of this function up to 50%.
