### PR TITLE
[5.x] Fix querying by status on non-dated collections

### DIFF
--- a/src/Stache/Query/QueriesEntryStatus.php
+++ b/src/Stache/Query/QueriesEntryStatus.php
@@ -29,10 +29,12 @@ trait QueriesEntryStatus
     {
         $this->addCollectionWhereToStatusQuery($query, $collection->handle());
 
-        if ($collection->futureDateBehavior() === 'public' && $collection->pastDateBehavior() === 'public') {
+        if (! $collection->dated() || ($collection->futureDateBehavior() === 'public' && $collection->pastDateBehavior() === 'public')) {
             if ($status === 'scheduled' || $status === 'expired') {
                 $query->where('date', 'invalid'); // intentionally trigger no results.
             }
+
+            return;
         }
 
         if ($collection->futureDateBehavior() === 'private') {

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -830,6 +830,12 @@ class EntryQueryBuilderTest extends TestCase
         EntryFactory::collection('calendar')->id('calendar-past')->published(true)->date(now()->subDay())->create();
         EntryFactory::collection('calendar')->id('calendar-past-draft')->published(false)->date(now()->subDay())->create();
 
+        // Undated, but with customized date behavior. Nonsensical situation, but it can happen.
+        // See https://github.com/statamic/eloquent-driver/issues/288
+        Collection::make('undated')->dated(false)->futureDateBehavior('private')->pastDateBehavior('private')->save();
+        EntryFactory::collection('undated')->id('undated')->published(true)->create();
+        EntryFactory::collection('undated')->id('undated-draft')->published(false)->create();
+
         $this->assertEquals($expected, Entry::query()->whereStatus($status)->get()->map->id->all());
     }
 
@@ -844,6 +850,7 @@ class EntryQueryBuilderTest extends TestCase
                 'event-past-draft',
                 'calendar-future-draft',
                 'calendar-past-draft',
+                'undated-draft',
             ]],
             'published' => ['published', [
                 'page',
@@ -851,6 +858,7 @@ class EntryQueryBuilderTest extends TestCase
                 'event-future',
                 'calendar-future',
                 'calendar-past',
+                'undated',
             ]],
             'scheduled' => ['scheduled', [
                 'blog-future',


### PR DESCRIPTION
This fixes an issue where if you have a collection that is _not_ dated but you have defined `date_behavior` for whatever reason, querying by status would not work correctly. Those entries would get filtered out.

Closes statamic/eloquent-driver#288
