### PR TITLE
[5.x] Fix entry model not being updated when importing entries

### DIFF
--- a/src/Console/Commands/InstallEloquentDriver.php
+++ b/src/Console/Commands/InstallEloquentDriver.php
@@ -289,7 +289,7 @@ class InstallEloquentDriver extends Command
                     File::put(
                         config_path('statamic/eloquent-driver.php'),
                         Str::of(File::get(config_path('statamic/eloquent-driver.php')))
-                            ->replace("'model'  => \Statamic\Eloquent\Entries\EntryModel::class", "'model'  => \Statamic\Eloquent\Entries\UuidEntryModel::class")
+                            ->replace("'model' => \Statamic\Eloquent\Entries\EntryModel::class", "'model' => \Statamic\Eloquent\Entries\UuidEntryModel::class")
                             ->__toString()
                     );
 


### PR DESCRIPTION
This pull request fixes an issue with the `install:eloquent-driver` command where the Eloquent model for entries wasn't being swapped to the special `UuidEntryModel`, used when importing existing entries.

We're updating the `eloquent-driver.php` file using simple string replacement, which didn't work here due to whitespace changes.