### PR TITLE
[5.x] Respect the current site when returning a View

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -5,6 +5,7 @@ namespace Statamic\View;
 use Illuminate\Support\HtmlString;
 use InvalidArgumentException;
 use Statamic\Facades\Cascade;
+use Statamic\Facades\Site;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\View\Antlers\Engine;
@@ -189,6 +190,7 @@ class View
     {
         return $this->cascade = $this->cascade ?? Cascade::instance()
             ->withContent($this->cascadeContent)
+            ->withSite(Site::current())
             ->hydrate()
             ->toArray();
     }


### PR DESCRIPTION
This PR fixes an issue where the current site wasn't resolved correctly when returning a view from an action route. Consider the following scenario:

## Example

I'm returning a `View` in a controller from an action route. 

```php
return (new View)
    ->layout($layout)
    ->template($template)
    ->cascadeContent($data);
```

When the `cascade()` is hydrated in the `View` class, it will resolve the `Cascade::instance()`from the container, where it was bound with `Site::current()`.

https://github.com/statamic/cms/blob/5cb5da6c34a5c6ea670266f53c8ceb9abeea4e74/src/View/View.php#L188-L194

https://github.com/statamic/cms/blob/5cb5da6c34a5c6ea670266f53c8ceb9abeea4e74/src/Providers/ViewServiceProvider.php#L39-L41

At the time when the `Cascade` is bound in the container, the current site will be resolved from the current URL. Because we are on an action route, the resolved site will always be the default site.

https://github.com/statamic/cms/blob/5cb5da6c34a5c6ea670266f53c8ceb9abeea4e74/src/Sites/Sites.php#L72-L77

This leads to the `View` always being hydrated with data from the default site.

In my scenario, I rely on localized content being returned from the action route. To solve this, I figured that I could set the current site before returning the view:

```php
Site::setCurrent($site);

return (new View)
    ->layout($layout)
    ->template($template)
    ->cascadeContent($data);
```

However, this won't work, as the `Cascade` was already bound with the site resolved from the current request before `Site::setCurrent($site)` is called.

To resolve this issue, we can explicitly set the current site using the `withSite()` method before the `Cascade` is hydrated in the `cascade()` method of the `View` class.