### PR TITLE
[5.x] Prevent configuring multiple conditions for the same field

### DIFF
--- a/resources/js/components/field-conditions/Builder.vue
+++ b/resources/js/components/field-conditions/Builder.vue
@@ -31,6 +31,7 @@
                 :index="index"
                 :config="config"
                 :condition="condition"
+                :conditions="conditions"
                 :key="condition._id"
                 :suggestable-fields="suggestableFields"
                 @updated="updated(index, $event)"

--- a/resources/js/components/field-conditions/Condition.vue
+++ b/resources/js/components/field-conditions/Condition.vue
@@ -123,7 +123,11 @@ export default {
             const conditions = this.conditions.map(condition => condition.field);
 
             return _(this.suggestableFields)
-                .reject(field => field.handle === this.config.handle || this.condition.field === field.handle || conditions.includes(field.handle))
+                .reject(field => {
+                    return field.handle === this.config.handle // Exclude the field you're adding a condition to.
+                        || this.condition.field === field.handle // Exclude the field being used in the current condition.
+                        || conditions.includes(field.handle); // Exclude fields already used in other conditions.
+                })
                 .map(field => {
                     let display = field.config.display;
 

--- a/resources/js/components/field-conditions/Condition.vue
+++ b/resources/js/components/field-conditions/Condition.vue
@@ -82,6 +82,10 @@ export default {
             type: Object,
             required: true
         },
+        conditions: {
+            type: Array,
+            required: true
+        },
         index: {
             type: Number,
             required: true
@@ -117,7 +121,7 @@ export default {
 
         fieldOptions() {
             return _(this.suggestableFields)
-                .reject(field => field.handle === this.config.handle || this.condition.field === field.handle)
+                .filter(field => this.conditions.filter(condition => condition.field === field.handle).length === 0)
                 .map(field => {
                     let display = field.config.display;
 

--- a/resources/js/components/field-conditions/Condition.vue
+++ b/resources/js/components/field-conditions/Condition.vue
@@ -120,8 +120,10 @@ export default {
         },
 
         fieldOptions() {
+            const conditions = this.conditions.map(condition => condition.field);
+
             return _(this.suggestableFields)
-                .filter(field => this.conditions.filter(condition => condition.field === field.handle).length === 0)
+                .reject(field => field.handle === this.config.handle || this.condition.field === field.handle || conditions.includes(field.handle))
                 .map(field => {
                     let display = field.config.display;
 


### PR DESCRIPTION
This pull request prevents you configuring multiple conditions for the same field in the blueprint/fieldset builder.

Previously, the "Field" dropdown in the builder allowed you to select fields even if they already had conditions configured against them. Then, when you saved the field, only one of the multiple conditions would actually be saved.

This PR prevents you from doing that until we implement the ability to configure multiple conditions for the same field (see https://github.com/statamic/ideas/issues/1101).

I originally fixed this in #9199. However, after my refactoring of the field conditions builder in #9379 that fix seems to have been lost.