### PR TITLE
[5.x] Corrects issue returning some collections from tags

### DIFF
--- a/src/View/Antlers/Language/Runtime/Sandbox/RuntimeValues.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/RuntimeValues.php
@@ -15,7 +15,7 @@ class RuntimeValues
     {
         GlobalRuntimeState::$requiresRuntimeIsolation = true;
         try {
-            if ($augmentable instanceof Collection && $augmentable->count() && $augmentable[0] instanceof Augmentable) {
+            if ($augmentable instanceof Collection && $augmentable->count() && $augmentable->first() instanceof Augmentable) {
                 $value = BulkAugmentor::make($augmentable)->toArray();
             } else {
                 $value = $augmentable->toDeferredAugmentedArray();

--- a/src/View/Antlers/Language/Runtime/Sandbox/RuntimeValues.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/RuntimeValues.php
@@ -15,7 +15,7 @@ class RuntimeValues
     {
         GlobalRuntimeState::$requiresRuntimeIsolation = true;
         try {
-            if ($augmentable instanceof Collection && $augmentable->count() && $augmentable->first() instanceof Augmentable) {
+            if ($augmentable instanceof Collection && $augmentable->first() instanceof Augmentable) {
                 $value = BulkAugmentor::make($augmentable)->toArray();
             } else {
                 $value = $augmentable->toDeferredAugmentedArray();

--- a/tests/Antlers/Runtime/TagsTest.php
+++ b/tests/Antlers/Runtime/TagsTest.php
@@ -31,4 +31,19 @@ class TagsTest extends ParserTestCase
 
         $this->assertSame('Test: test valuetest value - ', $result);
     }
+
+    public function test_collections_returned_from_tags()
+    {
+        (new class extends Tags
+        {
+            public static $handle = 'test_tag';
+
+            public function index()
+            {
+                return collect(['a' => 'b']);
+            }
+        })::register();
+
+        $this->assertSame('b', $this->renderString('{{ test_tag }}{{ a }}{{ /test_tag }}', [], true));
+    }
 }


### PR DESCRIPTION
This PR fixes #10111 by adjusting some internal bulk augmentation behavior. The fix involves checking the `first()` item of a collection rather than assuming an element always exists at `0`.