### PR TITLE
[5.x] Pluralize user activation email message

### DIFF
--- a/resources/js/components/users/Wizard.vue
+++ b/resources/js/components/users/Wizard.vue
@@ -221,7 +221,7 @@ export default {
             invitation: {
                 send: this.canSendInvitation,
                 subject: __('messages.user_wizard_invitation_subject', { site: window.location.hostname }),
-                message: __('messages.user_wizard_invitation_body', { site: window.location.hostname, expiry: this.activationExpiry }),
+                message: __n('messages.user_wizard_invitation_body', this.activationExpiry, { site: window.location.hostname, expiry: this.activationExpiry }),
             },
             userExists: false,
             completed: false,

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -241,7 +241,7 @@ return [
     'user_wizard_account_created' => 'The user account has been created.',
     'user_wizard_email_instructions' => 'The email address also serves as a username and must be unique.',
     'user_wizard_intro' => 'Users can be assigned to roles that customize their permissions, access, and abilities throughout the Control Panel.',
-    'user_wizard_invitation_body' => 'Activate your new Statamic account on :site to begin managing this website. For your security, the link below expires after :expiry hour. After that, please contact the site administrator for a new password.',
+    'user_wizard_invitation_body' => 'Activate your new Statamic account on :site to begin managing this website. For your security, the link below expires after :expiry hour. After that, please contact the site administrator for a new password.|Activate your new Statamic account on :site to begin managing this website. For your security, the link below expires after :expiry hours. After that, please contact the site administrator for a new password.',
     'user_wizard_invitation_intro' => 'Send a welcome email with account activation details to the new user.',
     'user_wizard_invitation_share' => 'Copy these credentials and share them with <code>:email</code> via your preferred method.',
     'user_wizard_invitation_share_before' => 'After creating a user, details will be provided to share with <code>:email</code> via your preferred method.',


### PR DESCRIPTION
Pluralize based on expiry hours. Closes #10116

It's a bit redundant but I don't see a better way.
