### PR TITLE
[5.x] Taggable fieldtype tweaks

### DIFF
--- a/resources/js/components/fieldtypes/TagsFieldtype.vue
+++ b/resources/js/components/fieldtypes/TagsFieldtype.vue
@@ -3,7 +3,7 @@
         ref="input"
         :name="name"
         :clearable="config.clearable"
-        :close-on-select="false"
+        :close-on-select="true"
         :options="config.options"
         :disabled="config.disabled || isReadOnly"
         :multiple="true"

--- a/resources/js/components/fieldtypes/TagsFieldtype.vue
+++ b/resources/js/components/fieldtypes/TagsFieldtype.vue
@@ -13,6 +13,7 @@
         :taggable="true"
         :append-to-body="true"
         :value="value"
+        :dropdown-should-open="({ open }) => open && config.options.length > 0"
         @input="update"
         @search:focus="$emit('focus')"
         @search:blur="$emit('blur')">


### PR DESCRIPTION
While reviewing #9933 I noticed a couple of little things that would be nice to address.

First, setting to close on select. This mimics how the relationship fieldtype works when in taggable mode.
The issue is that when you enter a tag, the dropdown doesn't close, so you can't see the values until you manually close it by hitting escape or clicking away.

Before:
![CleanShot 2024-05-20 at 16 47 16](https://github.com/statamic/cms/assets/105211/c07e0bff-0cb8-49b8-8b1e-91f01df207ef)

After:
![CleanShot 2024-05-20 at 16 51 04](https://github.com/statamic/cms/assets/105211/97187cc7-90b6-45cc-b930-6b324a737ebd)

The other thing is that the dropdown is visible even if there are no options. It's not really useful. You can see this in the previous gif. Now you'll only see the dropdown if there are options.

No options:
![CleanShot 2024-05-20 at 16 52 32](https://github.com/statamic/cms/assets/105211/dd4865dd-153e-49b7-af2e-009ef1bbad2a)

With options: (Free text entry is still allowed - you're not restricted to just the options)
![CleanShot 2024-05-20 at 16 53 05](https://github.com/statamic/cms/assets/105211/62168b05-269e-4d3f-bade-f4df574f4a57)
