### PR TITLE
[5.x] Fix to add dark mode to Widget pagination background

### DIFF
--- a/resources/js/components/entries/Widget.vue
+++ b/resources/js/components/entries/Widget.vue
@@ -24,7 +24,7 @@
                 </data-list-table>
                 <data-list-pagination
                     v-if="meta.last_page != 1"
-                    class="py-2 border-t bg-gray-200 rounded-b-lg text-sm"
+                    class="py-2 border-t bg-gray-200 rounded-b-lg text-sm dark:bg-dark-650 dark:border-gray-900"
                     :resource-meta="meta"
                     @page-selected="selectPage"
                     :scroll-to-top="false"


### PR DESCRIPTION
When a Widget, such as "collection", requires pagination, the footer panel was still light, and had no dark styles.

This PR adds styles - not 100% sure if the right background colour was picked, but I think it is close.

Before:
<img width="546" alt="image" src="https://github.com/statamic/cms/assets/1491079/a66b253c-e0c3-43f9-b2ef-87f39f5a8719">

After:
<img width="548" alt="image" src="https://github.com/statamic/cms/assets/1491079/48418684-843c-41cd-afc0-5cece7814380">
