### PR TITLE
[5.x] Add support for a dark mode custom logo

### DIFF
--- a/config/cp.php
+++ b/config/cp.php
@@ -122,6 +122,8 @@ return [
 
     'custom_logo_url' => env('STATAMIC_CUSTOM_LOGO_URL', null),
 
+    'custom_dark_logo_url' => env('STATAMIC_CUSTOM_DARK_LOGO_URL', null),
+
     'custom_favicon_url' => env('STATAMIC_CUSTOM_FAVICON_URL', null),
 
     'custom_css_url' => env('STATAMIC_CUSTOM_CSS_URL', null),

--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -8,7 +8,8 @@
         <a href="{{ route('statamic.cp.index') }}" class="flex items-end">
             <div v-tooltip="version" class="hidden md:block shrink-0">
                 @if ($customLogo)
-                    <img src="{{ $customLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo">
+                    <img src="{{ $customLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo dark:hidden">
+                    <img src="{{ $customDarkLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo hidden dark:block">
                 @else
                     @cp_svg('statamic-wordmark', 'w-24 logo')
                     @if (Statamic::pro())<span class="font-bold text-4xs align-top uppercase">{{ __('Pro') }}</span>@endif

--- a/resources/views/partials/outside-logo.blade.php
+++ b/resources/views/partials/outside-logo.blade.php
@@ -1,6 +1,7 @@
 <div class="logo pt-20">
     @if ($customLogo)
-        <img src="{{ $customLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo">
+        <img src="{{ $customLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo dark:hidden">
+        <img src="{{ $customDarkLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo hidden dark:block">
     @else
         @cp_svg('statamic-wordmark')
     @endif

--- a/src/Http/View/Composers/CustomLogoComposer.php
+++ b/src/Http/View/Composers/CustomLogoComposer.php
@@ -15,16 +15,20 @@ class CustomLogoComposer
 
     public function compose(View $view)
     {
-        $view->with('customLogo', $this->customLogo($view));
+        $view->with('customLogo', $this->customLogo($view, false));
+        $view->with('customDarkLogo', $this->customLogo($view, true));
     }
 
-    protected function customLogo($view)
+    protected function customLogo($view, bool $darkMode = false)
     {
         if (! Statamic::pro()) {
             return false;
         }
 
         $config = config('statamic.cp.custom_logo_url');
+        if ($darkMode && config('statamic.cp.custom_dark_logo_url')) {
+            $config = config('statamic.cp.custom_dark_logo_url');
+        }
 
         switch ($view->name()) {
             case 'statamic::partials.outside-logo':


### PR DESCRIPTION
Dark mode looks awesome! But not all custom logos work on a dark background, such as:
<img width="317" alt="image" src="https://github.com/statamic/cms/assets/1491079/33f342ca-5980-492c-886a-01d5c4924112">

This PR adds support for a second (optional) custom logo URL:
<img width="299" alt="image" src="https://github.com/statamic/cms/assets/1491079/f41564d0-f45e-4800-a702-c2736b568b0b">

This can be added using the new `STATAMIC_CUSTOM_DARK_LOGO_URL` env.

If it is not included, it will use the `STATAMIC_CUSTOM_LOGO_URL` logo behaviour. In other words, it only uses the dark version of the logo if one has been provided.

This applies to the global header (outside the CP) and the nav bar logo.