### PR TITLE
[5.x] Prevent opening set picker when `max_sets` has been exceeded

### DIFF
--- a/resources/js/components/fieldtypes/replicator/AddSetButton.vue
+++ b/resources/js/components/fieldtypes/replicator/AddSetButton.vue
@@ -1,7 +1,7 @@
 <template>
 
     <div class="replicator-set-picker">
-        <set-picker :sets="groups" @added="addSet">
+        <set-picker :enabled="enabled" :sets="groups" @added="addSet">
             <template #trigger>
                 <div class="replicator-set-picker-button-wrapper">
                     <button v-if="enabled" class="btn-round flex items-center justify-center" :class="{ 'h-5 w-5': ! last }" @click="addSetButtonClicked">

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -81,15 +81,12 @@
                 >
                     <template v-slot:picker>
                         <add-set-button
-                            v-if="canAddSet"
                             class="between"
                             :groups="groupConfigs"
                             :sets="setConfigs"
                             :index="index"
                             :enabled="canAddSet"
                             @added="addSet" />
-
-                        <div v-else class="my-3 replicator-set-picker between"></div>
                     </template>
                 </replicator-set>
             </div>

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -81,12 +81,15 @@
                 >
                     <template v-slot:picker>
                         <add-set-button
+                            v-if="canAddSet"
                             class="between"
                             :groups="groupConfigs"
                             :sets="setConfigs"
                             :index="index"
                             :enabled="canAddSet"
                             @added="addSet" />
+
+                        <div v-else class="my-3 replicator-set-picker between"></div>
                     </template>
                 </replicator-set>
             </div>

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -4,7 +4,7 @@
         ref="popover"
         class="set-picker select-none"
         placement="bottom-start"
-        :disabled="!hasMultipleSets"
+        :disabled="!enabled || !hasMultipleSets"
         @opened="opened"
         @closed="closed"
         @click="triggerWasClicked"
@@ -55,7 +55,8 @@
 export default {
 
     props: {
-        sets: Array
+        sets: Array,
+        enabled: { type: Boolean, default: true },
     },
 
     data() {


### PR DESCRIPTION
This pull request fixes an issue where it was possible to click on the `add-set-button` and open the set picker, even when the `max_sets` option had been exceeded.

The top instance of `add-set-button` was missing a `v-if` that the bottom one had. Then, to maintain the same spacing, I've added an empty div with the relevant classes.

Fixes #10105.