### PR TITLE
[5.x] Reference git binary as a variable, rather than config setting

### DIFF
--- a/config/git.php
+++ b/config/git.php
@@ -116,7 +116,7 @@ return [
     |
     */
 
-    'binary' => env('STATAMIC_GIT_BINARY', 'git'),
+    'binary' => $binary = env('STATAMIC_GIT_BINARY', 'git'),
 
     /*
     |--------------------------------------------------------------------------
@@ -132,8 +132,8 @@ return [
     */
 
     'commands' => [
-        config('statamic.git.binary').' add {{ paths }}',
-        config('statamic.git.binary').' -c "user.name={{ name }}" -c "user.email={{ email }}" commit -m "{{ message }}"',
+        $binary.' add {{ paths }}',
+        $binary.' -c "user.name={{ name }}" -c "user.email={{ email }}" commit -m "{{ message }}"',
     ],
 
     /*


### PR DESCRIPTION
This pull request attempts to fix #10102, where the `binary` wasn't being correctly pulled through to the commands in the Git config.

I'm not quite sure how I didn't notice this originally but it seems like referencing config settings in the *same* config file doesn't work so this PR references the binary as a variable instead, which in my testing seems to work.

Once this has been merged, I can copy the change over to `statamic/statamic`.

Fixes #10102.
Related: #9793.