### PR TITLE
[5.x] Update GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/pint-fix.yml
+++ b/.github/workflows/pint-fix.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.PINT }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@1.0.0
+        uses: aglipanci/laravel-pint-action@v2
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Fix styling

--- a/.github/workflows/pint-lint.yml
+++ b/.github/workflows/pint-lint.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check PHP code style issues
-        uses: aglipanci/laravel-pint-action@1.0.0
+        uses: aglipanci/laravel-pint-action@v2
         with:
           testMode: true
           verboseMode: true

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -15,7 +15,7 @@ jobs:
   uneditable:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             const repo = context.repo.repo;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Use Node.js 16.13.0
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16.13.0
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 60

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,11 +34,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             config
@@ -79,7 +79,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         if: steps.should-run-tests.outputs.result == 'true'
         with:
           timeout_minutes: 5
@@ -104,11 +104,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             **.{js,vue,ts}
@@ -123,7 +123,7 @@ jobs:
           echo "result=true" >> $env:GITHUB_OUTPUT
 
       - name: Use Node.js 16.13.0
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16.13.0
 
@@ -145,12 +145,13 @@ jobs:
     needs: [php-tests, js-tests]
     if: always()
     steps:
-      - uses: technote-space/workflow-conclusion-action@v1
+      - uses: technote-space/workflow-conclusion-action@v3
       - name: Send Slack notification
-        uses: 8398a7/action-slack@v2
+        uses: 8398a7/action-slack@v3
         if: env.WORKFLOW_CONCLUSION == 'failure' && github.event_name == 'schedule'
         with:
           status: failure
+          fields: repo,message,commit,author,action,eventName,ref,workflow
           author_name: ${{ github.actor }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
This PR updates the versions of the GitHub Actions workflows.
Some changes are unproblematic in my opinion, but some need some more considerations or are not testable by me.

### Laravel Pint

If you want to run a specific pint version, you can configure that using the following configuration.

```yaml
        - name: "Laravel Pint Action"
          uses: aglipanci/laravel-pint-action@v2
          with:
            pintVersion: 1.15.3
```

v1 runs using the latest version of pint as far as I know.

### Slack Notifications

The last of the changes, were on failure of tests and js-tests when the tests were scheduled are not testable by me, if it not works, these changes should probably be reverted.

- technote-space/workflow-conclusion-action
- 8398a7/action-slack (v3 requires explicitly listing the fields)