### PR TITLE
[5.x] Fix `routeData` trying to be called on `null`

### DIFF
--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -45,7 +45,7 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Entr
     private $absoluteUrl;
     private $absoluteUrlWithoutRedirect;
     private $blueprint;
-    private $routeData;
+    private ?array $routeData = null;
     private $status;
     private $structure;
 
@@ -215,7 +215,7 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Entr
         }
 
         if (! $this->structure() instanceof CollectionStructure) {
-            return $uris[$this->reference] = $this->entry()->uri();
+            return $uris[$this->reference] = $this->entry()?->uri();
         }
 
         $parentUri = $this->parent && ! $this->parent->isRoot() ? $this->parent->uri() : '';
@@ -395,7 +395,7 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Entr
     public function in($site)
     {
         if ($this->reference && $this->referenceExists()) {
-            if (! $entry = $this->entry()->in($site)) {
+            if (! $entry = $this->entry()?->in($site)) {
                 return null;
             }
 
@@ -408,7 +408,7 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Entr
     public function site()
     {
         if ($this->reference && $this->referenceExists()) {
-            return $this->entry()->site();
+            return $this->entry()?->site();
         }
 
         return Site::current(); // TODO: Get it from the tree instead.
@@ -432,13 +432,13 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Entr
         return $this->structure = $this->tree->structure();
     }
 
-    public function routeData()
+    public function routeData(): array
     {
-        if ($this->routeData !== null) {
-            return $this->routeData;
+        if ($this->routeData === null && $this->entry()) {
+            $this->routeData = $this->entry()->routeData();
         }
 
-        return $this->routeData = $this->entry()->routeData();
+        return $this->routeData ?? [];
     }
 
     public function published()


### PR DESCRIPTION
Fixes #10025

Since the entry() method might return `null` calling `routeData()` would fail, because there was no `null`-check. This commit adds a null-check and also makes sure, that routeData always returns an array, which is required by the UrlBuilder.

Unfortunately I cannot really find a good way to reproduce this error, but a production site of mine throws a lot of these errors as well, so it might be a good idea to see why clearing/warming the Stache is fixing this. Anyway, I think this PR at least fixes the critical 500 error for now and adds a missing null-check, but it is more like a workaround-fix.