### PR TITLE
[5.x] Save dark mode theme preference to local storage

### DIFF
--- a/resources/js/components/DarkModeToggle.vue
+++ b/resources/js/components/DarkModeToggle.vue
@@ -66,7 +66,16 @@ export default {
     methods: {
         prefer(mode) {
             this.preference = mode;
-            this.$preferences.set('theme', mode === 'auto' ? null : mode);
+
+            // Saving to user preference allows it to persist across browsers, whereas saving to local
+            // storage allows it to work before the user is authenticated, e.g. on the login screen.
+            if (mode === 'auto') {
+                this.$preferences.remove('theme');
+                localStorage.removeItem('statamic.theme');
+            } else {
+                this.$preferences.set('theme', mode);
+                localStorage.setItem('statamic.theme', mode);
+            }
         }
     }
 }

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -17,7 +17,8 @@
 
 <script>
     (function () {
-        let theme = '{{ $user?->preferredTheme() ?? "auto" }}';
+        let theme = {!! ($userTheme = $user?->preferredTheme()) ? "'".$userTheme."'" : "null" !!};
+        if (! theme) theme = localStorage.getItem('statamic.theme') ?? 'auto';
         if (theme === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches) theme = 'dark';
         if (theme === 'dark') document.documentElement.classList.add('dark');
     })();


### PR DESCRIPTION
At the moment your theme preference gets saved to your user account.
However if you log out, your preference won't be applied on the login page.

By also saving to local storage, your preference will be maintained when logged out, at least on that browser.
