### PR TITLE
[5.x] Fix actions on form submissions

### DIFF
--- a/src/Http/Controllers/CP/Forms/ExtractsFromSubmissionFields.php
+++ b/src/Http/Controllers/CP/Forms/ExtractsFromSubmissionFields.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Statamic\Http\Controllers\CP\Forms;
+
+trait ExtractsFromSubmissionFields
+{
+    protected function extractFromFields($submission, $blueprint)
+    {
+        $values = $submission->data();
+
+        $fields = $blueprint
+            ->fields()
+            ->addValues($values->all())
+            ->preProcess();
+
+        return [$fields->values()->all(), $fields->meta()->all()];
+    }
+}

--- a/src/Http/Controllers/CP/Forms/SubmissionActionController.php
+++ b/src/Http/Controllers/CP/Forms/SubmissionActionController.php
@@ -2,10 +2,13 @@
 
 namespace Statamic\Http\Controllers\CP\Forms;
 
+use Statamic\Facades\Action;
 use Statamic\Http\Controllers\CP\ActionController;
 
 class SubmissionActionController extends ActionController
 {
+    use ExtractsFromSubmissionFields;
+
     protected function getSelectedItems($items, $context)
     {
         $form = $this->request->route('form');
@@ -13,5 +16,18 @@ class SubmissionActionController extends ActionController
         return $items->map(function ($item) use ($form) {
             return $form->submission($item);
         });
+    }
+
+    protected function getItemData($submission, $context): array
+    {
+        $blueprint = $submission->blueprint();
+
+        [$values] = $this->extractFromFields($submission, $blueprint);
+
+        return [
+            'id' => $submission->id(),
+            'values' => array_merge($values, ['id' => $submission->id()]),
+            'itemActions' => Action::for($submission, $context),
+        ];
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where running actions on form submissions would result in an error, due to the `getItemData` method being missing from the `SubmissionActionController`.

Fixes #10141.