### PR TITLE
[5.x] Remove unnecessary `overflow-scroll` on submission listing

### DIFF
--- a/resources/js/components/forms/SubmissionListing.vue
+++ b/resources/js/components/forms/SubmissionListing.vue
@@ -15,7 +15,7 @@
             @visible-columns-updated="visibleColumns = $event"
         >
             <div slot-scope="{ hasSelections }">
-                <div class="card overflow-scroll p-0 relative">
+                <div class="card p-0 relative">
                     <div class="flex flex-wrap items-center justify-between px-2 pb-2 text-sm border-b dark:border-dark-900">
                         <data-list-filter-presets
                             ref="presets"


### PR DESCRIPTION
Looks like I didn't need to add `overflow-scroll` here in #10036, it works fine without it. I only added it because I saw it was being used on another of our listing tables.

This PR removes `overflow-scroll` since it causes a scrollbar to always be shown on the form submissions listing table.