### PR TITLE
[5.x] Fix styling issues with Assets Grid & Assets Fieldtype

### DIFF
--- a/resources/css/components/assets.css
+++ b/resources/css/components/assets.css
@@ -93,7 +93,7 @@
    ========================================================================== */
 
 .asset-tile {
-    @apply bg-white dark:bg-dark-500 relative min-w-0 flex items-center flex-col justify-between cursor-pointer border rounded border-dark-200;
+    @apply bg-white dark:bg-dark-500 relative min-w-0 flex items-center flex-col justify-between cursor-pointer border rounded dark:border-dark-200;
 
     .asset-thumb {
         @apply flex justify-center items-center w-full h-full rounded;

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -67,7 +67,7 @@
                         :animate="false"
                         append-to="body"
                     >
-                        <div class="asset-grid-listing border rounded overflow-hidden rounded-t-none" ref="assets">
+                        <div class="asset-grid-listing border dark:border-dark-900 rounded overflow-hidden rounded-t-none" ref="assets">
                             <asset-tile
                                 v-for="asset in assets"
                                 :key="asset.id"


### PR DESCRIPTION
This pull request fixes a couple of dark mode styling issues with the Assets Grid & the Assets Fieldtype in Grid mode:

![CleanShot 2024-05-21 at 19 32 12](https://github.com/statamic/cms/assets/19637309/fc264c95-a9b6-4850-b0c9-cbd87c3614ef)

![CleanShot 2024-05-21 at 19 32 24](https://github.com/statamic/cms/assets/19637309/63fc4961-df81-44f6-a519-541fa8d6c62f)

![CleanShot 2024-05-21 at 19 32 39](https://github.com/statamic/cms/assets/19637309/0e7ef118-a8ca-4a87-8a81-19a23dceb8f0)

![CleanShot 2024-05-21 at 19 32 49](https://github.com/statamic/cms/assets/19637309/31aeb924-5059-40b3-8e49-32741a9de261)

Fixes #10126