### PR TITLE
[5.x] Abstract a super-btn component 

### DIFF
--- a/resources/css/components/cards.css
+++ b/resources/css/components/cards.css
@@ -10,3 +10,11 @@
 @screen md {
     .card { @apply p-4; }
 }
+
+.card-lg {
+    @apply rounded-lg;
+}
+
+.card-lg header {
+    @apply py-6 px-8 border-b dark:bg-dark-650 rounded-t-lg dark:border-dark-800;
+}

--- a/resources/css/elements/buttons.css
+++ b/resources/css/elements/buttons.css
@@ -290,3 +290,16 @@ td .btn-icon {
         @apply bg-gray-500 dark:bg-dark-750;
     }
 }
+
+.super-btn {
+    @apply p-4 flex items-start hover:bg-gray-200 border border-transparent rounded-md space-x-4;
+    @apply dark:hover:bg-dark-575 dark:hover:border-dark-400;
+
+    svg {
+        @apply h-8 w-8 text-gray-800 dark:text-dark-175;
+    }
+
+    h3 {
+        @apply mb-2 text-blue dark:text-blue-600;
+    }
+}

--- a/resources/views/widgets/getting-started.blade.php
+++ b/resources/views/widgets/getting-started.blade.php
@@ -1,55 +1,45 @@
 @php use function Statamic\trans as __; @endphp
 
-<div class="card p-0 content">
-    <div class="py-6 px-8 border-b dark:border-dark-900">
+<div class="card card-lg p-0 content">
+    <header>
         <h1>{{ __('statamic::messages.getting_started_widget_header') }}</h1>
         <p>{{ __('statamic::messages.getting_started_widget_intro') }}</p>
-    </div>
+    </header>
     <div class="flex flex-wrap p-4">
-        <a href="https://statamic.dev" class="w-full lg:w-1/2 p-4 flex items-start hover:bg-gray-200 dark:hover:bg-dark-575 border border-transparent dark:hover:border-dark-400 rounded-md group">
-            <div class="h-8 w-8 rtl:ml-4 ltr:mr-4 text-gray-800 dark:text-dark-175">
-                @cp_svg('icons/light/book-pages')
-            </div>
+        <a href="https://statamic.dev" class="w-full lg:w-1/2 super-btn">
+            @cp_svg('icons/light/book-pages')
             <div class="flex-1">
-                <h3 class="mb-2 text-blue dark:text-blue-600">{{ __('Read the Documentation') }}</h3>
+                <h3>{{ __('Read the Documentation') }}</h3>
                 <p>{{ __('statamic::messages.getting_started_widget_docs') }}</p>
             </div>
         </a>
         @if (!Statamic::pro())
-        <a href="https://statamic.dev/licensing" class="w-full lg:w-1/2 p-4 flex items-start hover:bg-gray-200 dark:hover:bg-dark-575 border border-transparent dark:hover:border-dark-400 rounded-md group">
-            <div class="h-8 w-8 rtl:ml-4 ltr:mr-4 text-gray-800 dark:text-dark-175">
-                @cp_svg('icons/light/pro-ribbon')
-            </div>
+        <a href="https://statamic.dev/licensing" class="w-full lg:w-1/2 super-btn">
+            @cp_svg('icons/light/pro-ribbon')
             <div class="flex-1">
-                <h3 class="mb-2 text-blue dark:text-blue-600">{{ __('Enable Pro Mode') }}</h3>
+                <h3>{{ __('Enable Pro Mode') }}</h3>
                 <p>{{ __('statamic::messages.getting_started_widget_pro') }}</p>
             </div>
         </a>
         @endif
-        <a href="{{ cp_route('collections.create') }}" class="w-full lg:w-1/2 p-4 flex items-start hover:bg-gray-200 dark:hover:bg-dark-575 border border-transparent dark:hover:border-dark-400 rounded-md group">
-            <div class="h-8 w-8 rtl:ml-4 ltr:mr-4 text-gray-800 dark:text-dark-175">
-                @cp_svg('icons/light/content-writing')
-            </div>
+        <a href="{{ cp_route('collections.create') }}" class="w-full lg:w-1/2 super-btn">
+            @cp_svg('icons/light/content-writing')
             <div class="flex-1">
-                <h3 class="mb-2 text-blue dark:text-blue-600">{{ __('Create a Collection') }}</h3>
+                <h3>{{ __('Create a Collection') }}</h3>
                 <p>{{ __('statamic::messages.getting_started_widget_collections') }}</p>
             </div>
         </a>
-        <a href="{{ cp_route('blueprints.index') }}" class="w-full lg:w-1/2 p-4 flex items-start hover:bg-gray-200 dark:hover:bg-dark-575 border border-transparent dark:hover:border-dark-400 rounded-md group">
-            <div class="h-8 w-8 rtl:ml-4 ltr:mr-4 text-gray-800 dark:text-dark-175">
-                @cp_svg('icons/light/blueprints')
-            </div>
+        <a href="{{ cp_route('blueprints.index') }}" class="w-full lg:w-1/2 super-btn">
+            @cp_svg('icons/light/blueprints')
             <div class="flex-1">
-                <h3 class="mb-2 text-blue dark:text-blue-600">{{ __('Create a Blueprint') }}</h3>
+                <h3>{{ __('Create a Blueprint') }}</h3>
                 <p>{{ __('statamic::messages.getting_started_widget_blueprints') }}</p>
             </div>
         </a>
-        <a href="{{ cp_route('navigation.create') }}" class="w-full lg:w-1/2 p-4 flex items-start hover:bg-gray-200 dark:hover:bg-dark-575 border border-transparent dark:hover:border-dark-400 rounded-md group">
-            <div class="h-8 w-8 rtl:ml-4 ltr:mr-4 text-gray-800 dark:text-dark-175">
-                @cp_svg('icons/light/hierarchy-files')
-            </div>
+        <a href="{{ cp_route('navigation.create') }}" class="w-full lg:w-1/2 super-btn">
+            @cp_svg('icons/light/hierarchy-files')
             <div class="flex-1">
-                <h3 class="mb-2 text-blue dark:text-blue-600">{{ __('Create a Navigation') }}</h3>
+                <h3>{{ __('Create a Navigation') }}</h3>
                 <p>{{ __('statamic::messages.getting_started_widget_navigation') }}</p>
             </div>
         </a>

--- a/resources/views/widgets/getting-started.blade.php
+++ b/resources/views/widgets/getting-started.blade.php
@@ -5,8 +5,8 @@
         <h1>{{ __('statamic::messages.getting_started_widget_header') }}</h1>
         <p>{{ __('statamic::messages.getting_started_widget_intro') }}</p>
     </header>
-    <div class="flex flex-wrap p-4">
-        <a href="https://statamic.dev" class="w-full lg:w-1/2 super-btn">
+    <div class="grid lg:grid-cols-2 p-4">
+        <a href="https://statamic.dev" class="super-btn">
             @cp_svg('icons/light/book-pages')
             <div class="flex-1">
                 <h3>{{ __('Read the Documentation') }}</h3>
@@ -14,7 +14,7 @@
             </div>
         </a>
         @if (!Statamic::pro())
-        <a href="https://statamic.dev/licensing" class="w-full lg:w-1/2 super-btn">
+        <a href="https://statamic.dev/licensing" class="super-btn">
             @cp_svg('icons/light/pro-ribbon')
             <div class="flex-1">
                 <h3>{{ __('Enable Pro Mode') }}</h3>
@@ -22,21 +22,21 @@
             </div>
         </a>
         @endif
-        <a href="{{ cp_route('collections.create') }}" class="w-full lg:w-1/2 super-btn">
+        <a href="{{ cp_route('collections.create') }}" class="super-btn">
             @cp_svg('icons/light/content-writing')
             <div class="flex-1">
                 <h3>{{ __('Create a Collection') }}</h3>
                 <p>{{ __('statamic::messages.getting_started_widget_collections') }}</p>
             </div>
         </a>
-        <a href="{{ cp_route('blueprints.index') }}" class="w-full lg:w-1/2 super-btn">
+        <a href="{{ cp_route('blueprints.index') }}" class="super-btn">
             @cp_svg('icons/light/blueprints')
             <div class="flex-1">
                 <h3>{{ __('Create a Blueprint') }}</h3>
                 <p>{{ __('statamic::messages.getting_started_widget_blueprints') }}</p>
             </div>
         </a>
-        <a href="{{ cp_route('navigation.create') }}" class="w-full lg:w-1/2 super-btn">
+        <a href="{{ cp_route('navigation.create') }}" class="super-btn">
             @cp_svg('icons/light/hierarchy-files')
             <div class="flex-1">
                 <h3>{{ __('Create a Navigation') }}</h3>


### PR DESCRIPTION
So it can be re-used without needing to manually apply Tailwind dark mode classes everywhere.