### PR TITLE
[5.x] Run GitHub Actions workflows only once

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,10 @@ name: Run Tests
 
 on:
   push:
+    branches:
+      - master
+      - '*.x'
+      - '3.4'
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - '*.x'
-      - '3.4'
   pull_request:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
When creating a PR from a branch within the same repo (i.e. not a fork), the current tests workflows gets triggered twice - for both push and pull_request:

<img width="1060" alt="Screenshot 2024-05-22 at 09 55 28" src="https://github.com/statamic/cms/assets/15707543/b66bb1a3-293e-4728-913b-fea25bddceaf">

This PR adds constraints so that the workflow only runs once.
(Push Event will only be triggered on the `master`, `*.x` and `3.4` branch, See supported versions according to https://statamic.dev/release-schedule-support-policy#support-policy)

I already created a similar PR for the Laravel Framework, with my main reasons being that it is annoying to see always two test runs, double the run time and for environmental reasons of course:
https://github.com/laravel/framework/pull/44053

Branch names can use patterns for Pull Requests:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
