### PR TITLE
[5.x] Allow different timezone from app timezone for displaying date+time in CP and Antlers

### DIFF
--- a/config/system.php
+++ b/config/system.php
@@ -83,7 +83,7 @@ return [
     | time values in the control panel and in Antlers. That allows you to keep
     | the app timezone in UTC while having, for example, the `Europe/Berlin`
     | timezone for the control panel.
-    | 
+    |
     | That means, if you publish an entry at 2024-05-22 10:15 with the
     | client timezone being set to `Europe/Berlin` and the app timezone being
     | set to `UTC`, the entry date will be 2024-05-22 08:15 internally, but

--- a/config/system.php
+++ b/config/system.php
@@ -76,6 +76,25 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Client Timezone
+    |--------------------------------------------------------------------------
+    |
+    | If specified, this timezone is used as the timezone for visible date and
+    | time values in the control panel and in Antlers. That allows you to keep
+    | the app timezone in UTC while having, for example, the `Europe/Berlin`
+    | timezone for the control panel.
+    | 
+    | That means, if you publish an entry at 2024-05-22 10:15 with the
+    | client timezone being set to `Europe/Berlin` and the app timezone being
+    | set to `UTC`, the entry date will be 2024-05-22 08:15 internally, but
+    | displayed as 2024-05-22 10:15 in the control panel and in antlers.
+    |
+    */
+
+    'client_timezone' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Character Set
     |--------------------------------------------------------------------------
     |

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -57,12 +57,13 @@ abstract class AbstractAugmented implements Augmented
             $value->setAugmentable($deferred->augmentable());
 
             if ($deferred->raw() instanceof Carbon) {
-                $cpTimezone = config('statamic.system.client_timezone');
+                $clientTimezone = config('statamic.system.client_timezone');
                 $appTimezone = config('app.timezone');
-                if ($cpTimezone && $cpTimezone !== $appTimezone) {
-                    $deferred->raw()->setTimezone($cpTimezone);
+                if ($clientTimezone && $clientTimezone !== $appTimezone) {
+                    $deferred->raw()->setTimezone($clientTimezone);
                 }
             }
+
             return $deferred->raw();
         };
 

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Data;
 
+use Carbon\Carbon;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Fields\Value;
 use Statamic\Statamic;
@@ -55,6 +56,13 @@ abstract class AbstractAugmented implements Augmented
             $value->setFieldtype($deferred->fieldtype());
             $value->setAugmentable($deferred->augmentable());
 
+            if ($deferred->raw() instanceof Carbon) {
+                $cpTimezone = config('statamic.cp.timezone');
+                $appTimezone = config('app.timezone');
+                if ($cpTimezone && $cpTimezone !== $appTimezone) {
+                    $deferred->raw()->setTimezone($cpTimezone);
+                }
+            }
             return $deferred->raw();
         };
 

--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -57,7 +57,7 @@ abstract class AbstractAugmented implements Augmented
             $value->setAugmentable($deferred->augmentable());
 
             if ($deferred->raw() instanceof Carbon) {
-                $cpTimezone = config('statamic.cp.timezone');
+                $cpTimezone = config('statamic.system.client_timezone');
                 $appTimezone = config('app.timezone');
                 if ($cpTimezone && $cpTimezone !== $appTimezone) {
                     $deferred->raw()->setTimezone($cpTimezone);

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -232,15 +232,15 @@ class Date extends Fieldtype
 
     private function convertTimezoneForSave(Carbon $date): Carbon
     {
-        $cpTimezone = config('statamic.system.client_timezone');
+        $clientTimezone = config('statamic.system.client_timezone');
         $appTimezone = config('app.timezone');
-        if (! $cpTimezone || $cpTimezone === $appTimezone) {
+        if (! $clientTimezone || $clientTimezone === $appTimezone) {
             return $date;
         }
 
         // Date has the app timezone set, so we need to shift that to the CP timezone first without modifying the time.
         return $date
-            ->shiftTimezone($cpTimezone)
+            ->shiftTimezone($clientTimezone)
             ->setTimezone($appTimezone);
     }
 
@@ -367,9 +367,9 @@ class Date extends Fieldtype
             $carbon = Carbon::parse($value);
         }
 
-        $cpTimezone = config('statamic.system.client_timezone');
-        if ($convertTz && $cpTimezone && $cpTimezone !== config('app.timezone')) {
-            $carbon->setTimezone($cpTimezone);
+        $clientTimezone = config('statamic.system.client_timezone');
+        if ($convertTz && $clientTimezone && $clientTimezone !== config('app.timezone')) {
+            $carbon->setTimezone($clientTimezone);
         }
 
         return $carbon;

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -232,7 +232,7 @@ class Date extends Fieldtype
 
     private function convertTimezoneForSave(Carbon $date): Carbon
     {
-        $cpTimezone = config('statamic.cp.timezone');
+        $cpTimezone = config('statamic.system.client_timezone');
         $appTimezone = config('app.timezone');
         if (! $cpTimezone || $cpTimezone === $appTimezone) {
             return $date;
@@ -367,7 +367,7 @@ class Date extends Fieldtype
             $carbon = Carbon::parse($value);
         }
 
-        $cpTimezone = config('statamic.cp.timezone');
+        $cpTimezone = config('statamic.system.client_timezone');
         if ($convertTz && $cpTimezone && $cpTimezone !== config('app.timezone')) {
             $carbon->setTimezone($cpTimezone);
         }


### PR DESCRIPTION
Laravel encourages to not change the default `UTC` timezone in the config (https://laravel.com/docs/11.x/eloquent-mutators#date-casting-and-timezones), to prevent issues when comparing dates etc.

That said, I thought about how we could have both: the UTC timezone for all stored date/time values, but the values in the CP being displayed like in another timezone, for example `Europe/Berlin`, so if an editor in Germany tries to publish an entry immediately which has date+time enabled, it gets published right away and not when the UTC time is at the current point (so in one or two hours, depending on Daylight saving time)

I guess I did not find all places where that check and conversion should happen, so if you know of other places, please let me know :)

In general it should not change anything for existing and new installs, except the config value is set.