### PR TITLE
[5.x] Add dark mode to new User Wizard

### DIFF
--- a/resources/css/components/fieldtypes/assets.css
+++ b/resources/css/components/fieldtypes/assets.css
@@ -26,7 +26,7 @@
 }
 
 .assets-fieldtype .drag-drop-text {
-    @apply rtl:mr-1 ltr:ml-1 text-gray-700;
+    @apply rtl:mr-1 ltr:ml-1 text-gray-700 dark:text-dark-175;
 }
 
 .assets-fieldtype .asset-upload-control {

--- a/resources/css/components/wizard.css
+++ b/resources/css/components/wizard.css
@@ -25,12 +25,12 @@
     }
 
     .ball {
-        @apply h-10 w-10 bg-gray-300 dark:bg-dark-800 text-gray text-base rounded-full text-center z-10 mx-auto relative;
+        @apply h-10 w-10 bg-gray-300 dark:bg-dark-800 text-gray dark:text-dark-150 text-base rounded-full text-center z-10 mx-auto relative;
         line-height: 40px;
     }
 
     .label {
-        @apply text-xs mt-1 text-gray;
+        @apply text-xs mt-1 text-gray dark:text-dark-175;
     }
 
     .complete {

--- a/resources/css/components/wizard.css
+++ b/resources/css/components/wizard.css
@@ -21,11 +21,11 @@
 
     .step.complete:before,
     .step.complete:after {
-        @apply bg-blue;
+        @apply bg-blue !important;
     }
 
     .ball {
-        @apply h-10 w-10 bg-gray-300 text-gray text-base rounded-full text-center z-10 mx-auto relative;
+        @apply h-10 w-10 bg-gray-300 dark:bg-dark-800 text-gray text-base rounded-full text-center z-10 mx-auto relative;
         line-height: 40px;
     }
 
@@ -39,6 +39,15 @@
         }
         .label {
             @apply text-blue;
+        }
+    }
+}
+
+.dark {
+    .wizard-steps {
+        .step:not(:first-child):before,
+        .step:not(:first-child):after {
+            @apply bg-dark-800;
         }
     }
 }

--- a/resources/js/components/users/Wizard.vue
+++ b/resources/js/components/users/Wizard.vue
@@ -13,7 +13,7 @@
         <div v-if="!completed && onUserInfoStep">
             <div class="max-w-md mx-auto px-4 py-16 text-center">
                 <h1 class="mb-6">{{ __('Create User') }}</h1>
-                <p class="text-gray" v-text="__('messages.user_wizard_intro')" />
+                <p class="text-gray dark:text-dark-150" v-text="__('messages.user_wizard_intro')" />
             </div>
 
             <publish-container
@@ -41,7 +41,7 @@
         <div v-if="!completed && onPermissionStep" class="max-w-md mx-auto px-4 pb-4">
             <div class="py-16 text-center">
                 <h1 class="mb-6">{{ __('Roles & Groups') }}</h1>
-                <p class="text-gray" v-text="__('messages.user_wizard_roles_groups_intro')" />
+                <p class="text-gray dark:text-dark-150" v-text="__('messages.user_wizard_roles_groups_intro')" />
             </div>
 
             <!-- Super Admin -->
@@ -50,9 +50,9 @@
                     <toggle-input v-model="user.super" id="super" />
                     <label class="font-bold rtl:mr-2 ltr:ml-2" for="super">{{ __('Super Admin') }}</label>
                 </div>
-                <div class="text-2xs text-gray-600 mt-2 flex items-center">
-                    <svg-icon name="info-circle" class="h-4 w-4 rtl:ml-1 ltr:mr-1 flex items-center mb-px"></svg-icon>
-                    {{ __('messages.user_wizard_super_admin_instructions') }}
+                <div class="text-2xs text-gray-600 dark:text-dark-150 mt-2 flex items-center space-x-1">
+                    <svg-icon name="info-circle" class="h-4 w-4 flex items-center mb-px"></svg-icon>
+                    <span>{{ __('messages.user_wizard_super_admin_instructions') }}</span>
                 </div>
             </div>
 
@@ -97,7 +97,7 @@
         <div v-if="!completed && onInvitationStep">
             <div class="max-w-md mx-auto px-4 py-16 text-center">
                 <h1 class="mb-6">{{ __('Invitation') }}</h1>
-                <p class="text-gray" v-text="__('messages.user_wizard_invitation_intro')" />
+                <p class="text-gray dark:text-dark-150" v-text="__('messages.user_wizard_invitation_intro')" />
             </div>
 
             <!-- Send Email? -->

--- a/resources/js/components/users/Wizard.vue
+++ b/resources/js/components/users/Wizard.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="max-w-xl mx-auto rounded shadow bg-white">
+    <div class="max-w-xl mx-auto card">
         <div v-if="steps.length > 1" class="max-w-lg mx-auto pt-16 relative">
             <div class="wizard-steps">
                 <a class="step" :class="{'complete': currentStep >= index}" v-for="(step, index) in steps" @click="goToStep(index)">
@@ -106,18 +106,18 @@
                 <label class="font-bold rtl:mr-2 ltr:ml-2" for="send_email_invitation">{{ __('Send Email Invitation') }}</label>
             </div>
 
-            <div class="max-w-lg mx-auto bg-gray-100 py-10 mb-20 border rounded-lg " v-if="invitation.send">
+            <div class="max-w-lg mx-auto bg-gray-100 dark:bg-dark-650 py-10 mb-20 border dark:border-dark-900 rounded-lg " v-if="invitation.send">
                 <!-- Subject Line -->
                 <div class="max-w-md mx-auto px-4 pb-10">
                     <label class="font-bold text-base mb-1" for="invitation_subject">{{ __('Email Subject') }}</label>
-                    <input type="text" v-model="invitation.subject" class="input-text bg-white" id="invitation_subject">
+                    <input type="text" v-model="invitation.subject" class="input-text bg-white dark:bg-dark-700" id="invitation_subject">
                 </div>
 
                 <!-- Email Content -->
                 <div class="max-w-md mx-auto px-4">
                     <label class="font-bold text-base mb-1" for="invitation_message">{{ __('Email Content') }}</label>
                     <textarea
-                        class="input-text min-h-40 p-4 bg-white"
+                        class="input-text min-h-40 p-4 bg-white dark:bg-dark-700"
                         id="invitation_message"
                         v-model="invitation.message"
                         v-elastic
@@ -152,7 +152,7 @@
             </div>
         </div>
 
-        <div class="border-t p-4">
+        <div class="border-t dark:border-dark-900 p-4">
             <div class="max-w-md mx-auto flex items-center justify-center">
                 <button tabindex="3" class="btn mx-4 w-32" @click="previous" v-if="! completed && ! onFirstStep">
                     <span v-html="direction === 'ltr' ? '&larr;' : '&rarr;'"></span> {{ __('Previous')}}


### PR DESCRIPTION
The new User Wizard had poor Dark Mode support:
<img width="969" alt="image" src="https://github.com/statamic/cms/assets/1491079/01842263-bc0d-49fc-b717-5694ca913b02">

This PR adds dark mode support:
<img width="953" alt="image" src="https://github.com/statamic/cms/assets/1491079/c2de0b2f-5f97-45e6-8e49-2f908ee386a3">

The one odd part in `resources/css/components/wizard.css` is that the `dark:` prefix for the `:before` and `:after` elements did not get picked up correctly - so added it as a new section which is wrapped with `.dark`. Not sure if I missed something but couldn't get that to work.