### PR TITLE
[5.x] Add dark mode support for list items

### DIFF
--- a/resources/css/components/updater.css
+++ b/resources/css/components/updater.css
@@ -80,6 +80,7 @@
 			top: 7px;
 		    left: 4px ; [dir="rtl"] & { left: auto ; right: 4px ; }
 
+            .dark & { @apply bg-gray-300; }
 		}
 
 		.label {
@@ -90,14 +91,4 @@
 			line-height: 1;
 		}
 	}
-}
-
-.dark {
-    .update-release {
-        ul {
-            li:before {
-                @apply bg-gray-300;
-            }
-        }
-    }
 }

--- a/resources/css/components/updater.css
+++ b/resources/css/components/updater.css
@@ -78,7 +78,7 @@
 			width: 6px;
 			content: "";
 			top: 7px;
-		 left: 4px ; [dir="rtl"] & { left: auto ; right: 4px ; }
+		    left: 4px ; [dir="rtl"] & { left: auto ; right: 4px ; }
 
 		}
 
@@ -90,4 +90,14 @@
 			line-height: 1;
 		}
 	}
+}
+
+.dark {
+    .update-release {
+        ul {
+            li:before {
+                @apply bg-gray-300;
+            }
+        }
+    }
 }

--- a/resources/css/components/updater.css
+++ b/resources/css/components/updater.css
@@ -78,7 +78,7 @@
 			width: 6px;
 			content: "";
 			top: 7px;
-		left: 4px ; [dir="rtl"] & { left: auto ; right: 4px ; }
+		 left: 4px ; [dir="rtl"] & { left: auto ; right: 4px ; }
 
             .dark & { @apply bg-gray-300; }
 		}

--- a/resources/css/components/updater.css
+++ b/resources/css/components/updater.css
@@ -78,7 +78,7 @@
 			width: 6px;
 			content: "";
 			top: 7px;
-			left: 4px ; [dir="rtl"] & { left: auto ; right: 4px ; }
+		left: 4px ; [dir="rtl"] & { left: auto ; right: 4px ; }
 
             .dark & { @apply bg-gray-300; }
 		}

--- a/resources/css/components/updater.css
+++ b/resources/css/components/updater.css
@@ -78,7 +78,7 @@
 			width: 6px;
 			content: "";
 			top: 7px;
-		    left: 4px ; [dir="rtl"] & { left: auto ; right: 4px ; }
+			left: 4px ; [dir="rtl"] & { left: auto ; right: 4px ; }
 
             .dark & { @apply bg-gray-300; }
 		}


### PR DESCRIPTION
The list items in the Update Release list items (`resources/css/components/updater.css`) do not support dark mode for their list item mark:
<img width="217" alt="image" src="https://github.com/statamic/cms/assets/1491079/e19d666b-a85f-44a3-88a2-598254493ec7">

This PR addresses this:
<img width="220" alt="image" src="https://github.com/statamic/cms/assets/1491079/1a6c3764-319b-4915-842a-214b11393dc8">

Just like https://github.com/statamic/cms/pull/10171, using `dark:` with a pseudo-element was not working, so the same approach is done here.