### PR TITLE
[5.x] Allow extra `x-data` to be passed to alpine forms

### DIFF
--- a/src/Forms/JsDrivers/AbstractJsDriver.php
+++ b/src/Forms/JsDrivers/AbstractJsDriver.php
@@ -4,21 +4,24 @@ namespace Statamic\Forms\JsDrivers;
 
 use Statamic\Forms\Form;
 use Statamic\Support\Str;
+use Statamic\Tags\Parameters;
 
 abstract class AbstractJsDriver implements JsDriver
 {
     protected $form;
     protected $options;
+    protected $params;
 
     /**
      * Instantiate JS driver.
      *
      * @param  array  $options
      */
-    public function __construct(Form $form, $options = [])
+    public function __construct(Form $form, $options = [], ?Parameters $params)
     {
         $this->form = $form;
         $this->options = $options;
+        $this->params = $params;
 
         if (method_exists($this, 'parseOptions')) {
             $this->parseOptions($options);

--- a/src/Forms/JsDrivers/AbstractJsDriver.php
+++ b/src/Forms/JsDrivers/AbstractJsDriver.php
@@ -17,7 +17,7 @@ abstract class AbstractJsDriver implements JsDriver
      *
      * @param  array  $options
      */
-    public function __construct(Form $form, $options = [], ?Parameters $params)
+    public function __construct(Form $form, $options = [], ?Parameters $params = null)
     {
         $this->form = $form;
         $this->options = $options;

--- a/src/Forms/JsDrivers/Alpine.php
+++ b/src/Forms/JsDrivers/Alpine.php
@@ -25,8 +25,14 @@ class Alpine extends AbstractJsDriver
      */
     public function addToFormAttributes()
     {
+        $extraData = $this->params->pull('x-data', []);
+
+        if (is_string($extraData)) {
+            $extraData = json_decode($extraData);
+        }
+
         return [
-            'x-data' => $this->renderAlpineXData($this->getInitialFormData(), $this->scope),
+            'x-data' => $this->renderAlpineXData(collect($this->getInitialFormData())->merge($extraData)->all(), $this->scope),
         ];
     }
 

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -300,7 +300,7 @@ class Tags extends BaseTags
             throw new \Exception("Cannot find JS driver class for [{$handle}]!");
         }
 
-        $instance = new $class($form, $options);
+        $instance = new $class($form, $options, $this->params);
 
         if (! $instance instanceof JsDriver) {
             throw new \Exception("JS driver must implement [Statamic\Forms\JsDrivers\JsDriver] interface!");

--- a/tests/Tags/Form/FormCreateAlpineTest.php
+++ b/tests/Tags/Form/FormCreateAlpineTest.php
@@ -430,6 +430,29 @@ EOT
         $this->assertFieldRendersHtml('<input type="text" name="custom" value="" x-model="my_form.custom">', $config, [], ['js' => 'alpine:my_form']);
     }
 
+    /** @test */
+    public function it_merges_any_x_data_passed_to_the_tag()
+    {
+        $output = $this->tag('{{ form:contact js="alpine:my_form" \x-data=\'{"extra":"yes"}\' }}{{ /form:contact }}');
+
+        $expectedXData = $this->jsonEncode([
+            'my_form' => [
+                'name' => null,
+                'email' => null,
+                'message' => null,
+                'fav_animals' => [],
+                'fav_colour' => null,
+                'fav_subject' => null,
+                'winnie' => null,
+                'extra' => 'yes',
+            ],
+        ]);
+
+        $expected = '<form method="POST" action="http://localhost/!/forms/contact" x-data="'.$expectedXData.'">';
+
+        $this->assertStringContainsString($expected, $output);
+    }
+
     private function jsonEncode($data)
     {
         return Statamic::modify($data)->toJson()->entities();

--- a/tests/Tags/Form/FormCreateAlpineTest.php
+++ b/tests/Tags/Form/FormCreateAlpineTest.php
@@ -451,6 +451,27 @@ EOT
         $expected = '<form method="POST" action="http://localhost/!/forms/contact" x-data="'.$expectedXData.'">';
 
         $this->assertStringContainsString($expected, $output);
+
+        $params = ['xdata' => ['extra' => 'no']];
+
+        $output = $this->tag('{{ form:contact js="alpine:my_form" :x-data="xdata" }}{{ /form:contact }}', $params);
+
+        $expectedXData = $this->jsonEncode([
+            'my_form' => [
+                'name' => null,
+                'email' => null,
+                'message' => null,
+                'fav_animals' => [],
+                'fav_colour' => null,
+                'fav_subject' => null,
+                'winnie' => null,
+                'extra' => 'no',
+            ],
+        ]);
+
+        $expected = '<form method="POST" action="http://localhost/!/forms/contact" x-data="'.$expectedXData.'">';
+
+        $this->assertStringContainsString($expected, $output);
     }
 
     private function jsonEncode($data)

--- a/tests/Tags/Form/FormTestCase.php
+++ b/tests/Tags/Form/FormTestCase.php
@@ -67,9 +67,9 @@ abstract class FormTestCase extends TestCase
         ], $headers));
     }
 
-    protected function tag($tag)
+    protected function tag($tag, $params = [])
     {
-        return Parse::template($tag, []);
+        return Parse::template($tag, $params);
     }
 
     protected function createForm($blueprintContents = null, $handle = null)


### PR DESCRIPTION
We use the Alpine form driver and precognition forms on most of our sites. For some forms you need to pass extra x-data beyond what is available in the blueprint fields, for example something from the page context, logged in user etc etc.

It would be useful to be able to add to the x-data Statamic generates, so this PR enables you to do that:

```antlers
{{ form:test js="alpine:form" \x-data='{"something_extra": "value"}' }}
```

or

```antlers
{{ form:test js="alpine:form" :x-data="some_variable" }}
```

I've intentionally made it that passed x-data takes precedence over the x-data Statamic generates, so values can be overwritten if necessary.