### PR TITLE
[5.x] Add js tag

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -166,6 +166,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Tags\Installed::class,
         Tags\Is::class,
         Tags\Iterate::class,
+        Tags\Js::class,
         Tags\Link::class,
         Tags\Locales::class,
         Tags\Markdown::class,

--- a/src/Tags/Js.php
+++ b/src/Tags/Js.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\Tags;
 
-use Statamic\Tags\Tags;
-
 class Js extends Tags
 {
     /** @var \Statamic\Tags\Parameters */
@@ -37,7 +35,7 @@ class Js extends Tags
     public function render($name, $from)
     {
         return ($this->params->get('script', true) ? '<script>' : '')
-            . ($this->params->get('const', true) ? 'const' : 'let') . ' ' . $name . ' = ' . json_encode($from) . ';'
-            . ($this->params->get('script', true) ? '</script>' : '');
+            .($this->params->get('const', true) ? 'const' : 'let').' '.$name.' = '.json_encode($from).';'
+            .($this->params->get('script', true) ? '</script>' : '');
     }
 }

--- a/src/Tags/Js.php
+++ b/src/Tags/Js.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Statamic\Tags;
+
+use Statamic\Tags\Tags;
+
+class Js extends Tags
+{
+    /** @var \Statamic\Tags\Parameters */
+    public $params;
+
+    /** @var \Statamic\Tags\Context */
+    public $context;
+
+    public function index()
+    {
+        $name = $this->params->get('name');
+        $from = $this->params->get('from');
+        if (! $name || ! $from) {
+            return;
+        }
+
+        return $this->render($name, $from);
+    }
+
+    public function wildcard($from)
+    {
+        $name = $this->method;
+        $from = $this->context->get($name);
+        if (! $name || ! $from) {
+            return;
+        }
+
+        return $this->render($name, $from);
+    }
+
+    public function render($name, $from)
+    {
+        return ($this->params->get('script', true) ? '<script>' : '')
+            . ($this->params->get('const', true) ? 'const' : 'let') . ' ' . $name . ' = ' . json_encode($from) . ';'
+            . ($this->params->get('script', true) ? '</script>' : '');
+    }
+}

--- a/tests/Tags/JsTest.php
+++ b/tests/Tags/JsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Tags;
+
+use Statamic\Facades\Parse;
+use Tests\TestCase;
+
+class JsTest extends TestCase
+{
+    private function tag($tag, $data = [])
+    {
+        return (string) Parse::template($tag, $data);
+    }
+
+    /** @test */
+    public function it_outputs_javascript()
+    {
+        $data = [
+            'us_states' => [
+                'AL' => 'Alabama',
+                'AK' => 'Alaska',
+            ],
+        ];
+
+        $this->assertEquals(
+            '<script>const us_states = {"AL":"Alabama","AK":"Alaska"};</script>',
+            $this->tag('{{ js:us_states }}', $data),
+        );
+        $this->assertEquals(
+            '<script>const states = {"AL":"Alabama","AK":"Alaska"};</script>',
+            $this->tag('{{ js name="states" :from="us_states" }}', $data),
+        );
+        $this->assertEquals(
+            'let us_states = {"AL":"Alabama","AK":"Alaska"};',
+            $this->tag('{{ js:us_states script="false" const="false" }}', $data),
+        );
+    }
+}


### PR DESCRIPTION
A few times I have found the need to directly pass a variable for use in JS.  Granted this could be done with the current `{{ variable | to_json }}` modifier, but I wanted an easier way.

This PR adds a `{{ js }}` tag for this convenience.

### Example Data:
```php
$us_states = [
    'AL' => 'Alabama',
    'AK' => 'Alaska',
];
```

### Example Template:
```antlers
{{ js:us_states }}

{{ js name="states" :from="us_states" }}

<script>
{{ js:us_states script="false" const="false" }}
</script>
```

### Example Output:
```html
<script>const us_states = {"AL":"Alabama","AK":"Alaska"};</script>

<script>const states = {"AL":"Alabama","AK":"Alaska"};</script>

<script>
let us_states = {"AL":"Alabama","AK":"Alaska"};
</script>
```