### PR TITLE
[5.x] Fix link fieldtype state

### DIFF
--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -111,12 +111,16 @@ export default {
                     setTimeout(() => this.$refs.assets.openSelector(), 0);
                 }
             }
+
+            this.updateMeta({...this.meta, initialOption: option});
         },
 
         urlValue(url) {
             if (this.metaChanging) return;
 
             this.update(url);
+
+            this.updateMeta({...this.meta, initialUrl: url});
         },
 
         meta(meta, oldMeta) {
@@ -159,11 +163,13 @@ export default {
         entriesSelected(entries) {
             this.selectedEntries = entries;
             this.update(this.entryValue);
+            this.updateMeta({...this.meta, initialSelectedEntries: entries});
         },
 
         assetsSelected(assets) {
             this.selectedAssets = assets;
             this.update(this.assetValue);
+            this.updateMeta({...this.meta, initialSelectedAssets: assets});
         }
 
     }

--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -119,7 +119,6 @@ export default {
             if (this.metaChanging) return;
 
             this.update(url);
-
             this.updateMeta({...this.meta, initialUrl: url});
         },
 


### PR DESCRIPTION
Fixes #9526

When the link fieldtype is created, it initializes its state from the metadata. (e.g. the dropdown option).

Fresh link fields have nulls in the meta data (the "None" option in the dropdown, for example).

When you switch into live preview, or a bard field gets saved, the components get recreated. Since it gets reinitialized from the meta, it'll reset various things and that's why you see the dropdown revert to "None".

This PR maintains the meta data appropriately.

The meta data is called `initialThis`, `initialThat`, etc and updating those is a _little_ weird, but I don't want to get into renaming those right now.
