### PR TITLE
[5.x] Add select modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1755,6 +1755,41 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Gets certain values from a collection of items.
+     *
+     * @param  array|Collection  $value
+     * @param  array  $params
+     * @return array|Collection
+     */
+    public function only($value, $params)
+    {
+        $keys = Arr::wrap($params);
+
+        if ($wasArray = is_array($value)) {
+            $value = collect($value);
+        }
+
+        if (Compare::isQueryBuilder($value)) {
+            $value = $value->get();
+        }
+
+        $items = $value->map(function ($item) use ($keys) {
+            return collect($keys)->mapWithKeys(function ($key) use ($item) {
+                $value = null;
+                if (is_array($item) || $item instanceof ArrayAccess) {
+                    $value = Arr::get($item, $key);
+                } else {
+                    $value = method_exists($item, 'value') ? $item->value($key) : $item->get($key);
+                }
+
+                return [$key => $value];
+            })->all();
+        });
+
+        return $wasArray ? $items->all() : $items;
+    }
+
+    /**
      * Get the plural form of an English word with access to $context.
      *
      * @param  string  $value

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1755,13 +1755,13 @@ class CoreModifiers extends Modifier
     }
 
     /**
-     * Gets certain values from a collection of items.
+     * Selects certain values from each item in a collection.
      *
      * @param  array|Collection  $value
      * @param  array  $params
      * @return array|Collection
      */
-    public function only($value, $params)
+    public function select($value, $params)
     {
         $keys = Arr::wrap($params);
 

--- a/tests/Modifiers/OnlyTest.php
+++ b/tests/Modifiers/OnlyTest.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Mockery;
+use Statamic\Contracts\Query\Builder;
+use Statamic\Entries\EntryCollection;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class OnlyTest extends TestCase
+{
+    /** @test */
+    public function it_gets_only_certain_values_from_array_of_items()
+    {
+        $items = $this->items();
+
+        $modified = $this->modify($items, ['title', 'type']);
+        $this->assertIsArray($modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'type' => 'food'],
+                ['title' => 'Coffee', 'type' => 'drink'],
+            ],
+            $modified,
+        );
+
+        $modified = $this->modify($items, ['title', 'stock']);
+        $this->assertIsArray($modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'stock' => 1],
+                ['title' => 'Coffee', 'stock' => 2],
+            ],
+            $modified,
+        );
+    }
+
+    /** @test */
+    public function it_gets_only_certain_values_from_collections_of_items()
+    {
+        $items = Collection::make($this->items());
+
+        $modified = $this->modify($items, ['title', 'type']);
+        $this->assertInstanceOf(Collection::class, $modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'type' => 'food'],
+                ['title' => 'Coffee', 'type' => 'drink'],
+            ],
+            $modified->all(),
+        );
+
+        $modified = $this->modify($items, ['title', 'stock']);
+        $this->assertInstanceOf(Collection::class, $modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'stock' => 1],
+                ['title' => 'Coffee', 'stock' => 2],
+            ],
+            $modified->all(),
+        );
+    }
+
+    /** @test */
+    public function it_gets_only_certain_values_from_query_builder()
+    {
+        $builder = Mockery::mock(Builder::class);
+        $builder->shouldReceive('get')->andReturn(Collection::make($this->items()));
+
+        $modified = $this->modify($builder, ['title', 'type']);
+        $this->assertInstanceOf(Collection::class, $modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'type' => 'food'],
+                ['title' => 'Coffee', 'type' => 'drink'],
+            ],
+            $modified->all(),
+        );
+
+        $modified = $this->modify($builder, ['title', 'stock']);
+        $this->assertInstanceOf(Collection::class, $modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'stock' => 1],
+                ['title' => 'Coffee', 'stock' => 2],
+            ],
+            $modified->all(),
+        );
+    }
+
+    /** @test */
+    public function it_gets_only_certain_values_from_array_of_items_with_origins()
+    {
+        $items = $this->itemsWithOrigins();
+
+        $modified = $this->modify($items, ['title', 'type']);
+        $this->assertIsArray($modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'type' => 'food'],
+                ['title' => 'Pan', 'type' => 'food'],
+                ['title' => 'Coffee', 'type' => 'drink'],
+                ['title' => 'Cafe', 'type' => 'drink'],
+            ],
+            $modified,
+        );
+
+        $modified = $this->modify($items, ['title', 'stock']);
+        $this->assertIsArray($modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'stock' => 1],
+                ['title' => 'Pan', 'stock' => 1],
+                ['title' => 'Coffee', 'stock' => 2],
+                ['title' => 'Cafe', 'stock' => 2],
+            ],
+            $modified,
+        );
+    }
+
+    /** @test */
+    public function it_gets_only_certain_values_from_collections_of_items_with_origins()
+    {
+        $items = EntryCollection::make($this->itemsWithOrigins());
+
+        $modified = $this->modify($items, ['title', 'type']);
+        $this->assertInstanceOf(EntryCollection::class, $modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'type' => 'food'],
+                ['title' => 'Pan', 'type' => 'food'],
+                ['title' => 'Coffee', 'type' => 'drink'],
+                ['title' => 'Cafe', 'type' => 'drink'],
+            ],
+            $modified->all(),
+        );
+
+        $modified = $this->modify($items, ['title', 'stock']);
+        $this->assertInstanceOf(EntryCollection::class, $modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'stock' => 1],
+                ['title' => 'Pan', 'stock' => 1],
+                ['title' => 'Coffee', 'stock' => 2],
+                ['title' => 'Cafe', 'stock' => 2],
+            ],
+            $modified->all(),
+        );
+    }
+
+    /** @test */
+    public function it_gets_only_certain_values_from_array_of_items_of_type_array()
+    {
+        $items = $this->itemsOfTypeArray();
+
+        $modified = $this->modify($items, ['title', 'type']);
+        $this->assertIsArray($modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'type' => 'food'],
+                ['title' => 'Coffee', 'type' => 'drink'],
+            ],
+            $modified,
+        );
+
+        $modified = $this->modify($items, ['title', 'stock']);
+        $this->assertIsArray($modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'stock' => 1],
+                ['title' => 'Coffee', 'stock' => 2],
+            ],
+            $modified,
+        );
+    }
+
+    /** @test */
+    public function it_gets_only_certain_values_from_collections_of_items_of_type_array()
+    {
+        $items = EntryCollection::make($this->itemsOfTypeArray());
+
+        $modified = $this->modify($items, ['title', 'type']);
+        $this->assertInstanceOf(EntryCollection::class, $modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'type' => 'food'],
+                ['title' => 'Coffee', 'type' => 'drink'],
+            ],
+            $modified->all(),
+        );
+
+        $modified = $this->modify($items, ['title', 'stock']);
+        $this->assertInstanceOf(EntryCollection::class, $modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'stock' => 1],
+                ['title' => 'Coffee', 'stock' => 2],
+            ],
+            $modified->all(),
+        );
+    }
+
+    /** @test */
+    public function it_gets_only_certain_values_from_array_of_items_of_type_arrayaccess()
+    {
+        $items = $this->itemsOfTypeArrayAccess();
+
+        $modified = $this->modify($items, ['title', 'type']);
+        $this->assertIsArray($modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'type' => 'food'],
+                ['title' => 'Coffee', 'type' => 'drink'],
+            ],
+            $modified,
+        );
+
+        $modified = $this->modify($items, ['title', 'stock']);
+        $this->assertIsArray($modified);
+        $this->assertEquals(
+            [
+                ['title' => 'Bread', 'stock' => 1],
+                ['title' => 'Coffee', 'stock' => 2],
+            ],
+            $modified,
+        );
+    }
+
+    private function items()
+    {
+        return [
+            new Item(['title' => 'Bread', 'type' => 'food', 'stock' => 1]),
+            new Item(['title' => 'Coffee', 'type' => 'drink', 'stock' => 2]),
+        ];
+    }
+
+    private function itemsWithOrigins()
+    {
+        return [
+            $breadEn = new ItemWithOrigin(['title' => 'Bread', 'type' => 'food', 'stock' => 1]),
+            $breadEs = new ItemWithOrigin(['title' => 'Pan'], $breadEn),
+            $coffeeEn = new ItemWithOrigin(['title' => 'Coffee', 'type' => 'drink', 'stock' => 2]),
+            $coffeeEs = new ItemWithOrigin(['title' => 'Cafe'], $coffeeEn),
+        ];
+    }
+
+    private function itemsOfTypeArray()
+    {
+        return [
+            ['title' => 'Bread', 'type' => 'food', 'stock' => 1],
+            ['title' => 'Coffee', 'type' => 'drink', 'stock' => 2],
+        ];
+    }
+
+    private function itemsOfTypeArrayAccess()
+    {
+        return [
+            new ArrayAccessType(['title' => 'Bread', 'type' => 'food', 'stock' => 1]),
+            new ArrayAccessType(['title' => 'Coffee', 'type' => 'drink', 'stock' => 2]),
+        ];
+    }
+
+    private function modify($value, ...$keys)
+    {
+        return Modify::value($value)->only(Arr::flatten($keys))->fetch();
+    }
+}

--- a/tests/Modifiers/SelectTest.php
+++ b/tests/Modifiers/SelectTest.php
@@ -10,10 +10,10 @@ use Statamic\Entries\EntryCollection;
 use Statamic\Modifiers\Modify;
 use Tests\TestCase;
 
-class OnlyTest extends TestCase
+class SelectTest extends TestCase
 {
     /** @test */
-    public function it_gets_only_certain_values_from_array_of_items()
+    public function it_selects_certain_values_from_array_of_items()
     {
         $items = $this->items();
 
@@ -39,7 +39,7 @@ class OnlyTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_only_certain_values_from_collections_of_items()
+    public function it_selects_certain_values_from_collections_of_items()
     {
         $items = Collection::make($this->items());
 
@@ -65,7 +65,7 @@ class OnlyTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_only_certain_values_from_query_builder()
+    public function it_selects_certain_values_from_query_builder()
     {
         $builder = Mockery::mock(Builder::class);
         $builder->shouldReceive('get')->andReturn(Collection::make($this->items()));
@@ -92,7 +92,7 @@ class OnlyTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_only_certain_values_from_array_of_items_with_origins()
+    public function it_selects_certain_values_from_array_of_items_with_origins()
     {
         $items = $this->itemsWithOrigins();
 
@@ -122,7 +122,7 @@ class OnlyTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_only_certain_values_from_collections_of_items_with_origins()
+    public function it_selects_certain_values_from_collections_of_items_with_origins()
     {
         $items = EntryCollection::make($this->itemsWithOrigins());
 
@@ -152,7 +152,7 @@ class OnlyTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_only_certain_values_from_array_of_items_of_type_array()
+    public function it_selects_certain_values_from_array_of_items_of_type_array()
     {
         $items = $this->itemsOfTypeArray();
 
@@ -178,7 +178,7 @@ class OnlyTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_only_certain_values_from_collections_of_items_of_type_array()
+    public function it_selects_certain_values_from_collections_of_items_of_type_array()
     {
         $items = EntryCollection::make($this->itemsOfTypeArray());
 
@@ -204,7 +204,7 @@ class OnlyTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_only_certain_values_from_array_of_items_of_type_arrayaccess()
+    public function it_selects_certain_values_from_array_of_items_of_type_arrayaccess()
     {
         $items = $this->itemsOfTypeArrayAccess();
 
@@ -265,6 +265,6 @@ class OnlyTest extends TestCase
 
     private function modify($value, ...$keys)
     {
-        return Modify::value($value)->only(Arr::flatten($keys))->fetch();
+        return Modify::value($value)->select(Arr::flatten($keys))->fetch();
     }
 }


### PR DESCRIPTION
Sometimes it is useful to do more than just pluck a single set of values from an array/collection of items.

Similar to [Laravel's](https://laravel.com/docs/11.x/helpers#method-array-only) `Arr::only` this PR adds an `only` modifier to handle those cases where you need more than one key.

### Example Data:
```php
$items = [
    ['title' => 'Bread', 'slug' => 'bread', 'price' => '2'],
    ['title' => 'LEGO Coffee', 'slug' => 'lego-coffee', 'price' => '37'],
];
```

### Example Template:
```antlers
{{ items | only('title', 'slug') | to_json }}
```

### Example Output:
```json
[{"title":"Bread","slug":"bread"},{"title":"LEGO Coffee","slug":"lego-coffee"}]
```