### PR TITLE
[5.x] Add keys and values modifiers

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -785,6 +785,26 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Get the keys of an array.
+     * 
+     * @return array
+     */
+    public function keys($value, $params)
+    {
+        return array_keys($value);
+    }
+
+    /**
+     * Get the values of an array.
+     * 
+     * @return array
+     */
+    public function values($value, $params)
+    {
+        return array_values($value);
+    }
+
+    /**
      * Get a Gravatar image URL from an email.
      *
      * @return string

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -786,7 +786,7 @@ class CoreModifiers extends Modifier
 
     /**
      * Get the keys of an array.
-     * 
+     *
      * @return array
      */
     public function keys($value, $params)
@@ -796,7 +796,7 @@ class CoreModifiers extends Modifier
 
     /**
      * Get the values of an array.
-     * 
+     *
      * @return array
      */
     public function values($value, $params)

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -787,21 +787,21 @@ class CoreModifiers extends Modifier
     /**
      * Get the keys of an array.
      *
-     * @return array
+     * @return array|Collection
      */
-    public function keys($value, $params)
+    public function keys($value)
     {
-        return array_keys($value);
+        return is_array($value) ? array_keys($value) : $value->keys();
     }
 
     /**
      * Get the values of an array.
      *
-     * @return array
+     * @return array|Collection
      */
-    public function values($value, $params)
+    public function values($value)
     {
-        return array_values($value);
+        return is_array($value) ? array_values($value) : $value->values();
     }
 
     /**

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -785,26 +785,6 @@ class CoreModifiers extends Modifier
     }
 
     /**
-     * Get the keys of an array.
-     *
-     * @return array|Collection
-     */
-    public function keys($value)
-    {
-        return is_array($value) ? array_keys($value) : $value->keys();
-    }
-
-    /**
-     * Get the values of an array.
-     *
-     * @return array|Collection
-     */
-    public function values($value)
-    {
-        return is_array($value) ? array_values($value) : $value->values();
-    }
-
-    /**
      * Get a Gravatar image URL from an email.
      *
      * @return string
@@ -1346,6 +1326,16 @@ class CoreModifiers extends Modifier
         $rekeyed = collect($value)->keyBy(fn ($item) => $item[$params[0]]);
 
         return is_array($value) ? $rekeyed->all() : $rekeyed;
+    }
+
+    /**
+     * Get the keys of an array.
+     *
+     * @return array|Collection
+     */
+    public function keys($value)
+    {
+        return is_array($value) ? array_keys($value) : $value->keys();
     }
 
     /**
@@ -2786,6 +2776,16 @@ class CoreModifiers extends Modifier
         ][$key] : -1;
 
         return parse_url($value, $component);
+    }
+
+    /**
+     * Get the values of an array.
+     *
+     * @return array|Collection
+     */
+    public function values($value)
+    {
+        return is_array($value) ? array_values($value) : $value->values();
     }
 
     /**

--- a/tests/Modifiers/KeysTest.php
+++ b/tests/Modifiers/KeysTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Modifiers;
 
+use Illuminate\Support\Collection;
 use Statamic\Modifiers\Modify;
 use Tests\TestCase;
 
@@ -15,15 +16,24 @@ class KeysTest extends TestCase
             'nuggets' => 'Denver',
         ];
 
-        $expected = [
-            'chicken',
-            'nuggets',
-        ];
         $modified = $this->modify($input);
-        $this->assertEquals($expected, $modified);
+        $this->assertEquals(['chicken', 'nuggets'], $modified);
     }
 
-    private function modify(array $value)
+    /** @test */
+    public function it_gets_the_keys_of_a_collection(): void
+    {
+        $input = collect([
+            'chicken' => 'nuggets',
+            'nuggets' => 'Denver',
+        ]);
+
+        $modified = $this->modify($input);
+        $this->assertInstanceOf(Collection::class, $modified);
+        $this->assertEquals(['chicken', 'nuggets'], $modified->all());
+    }
+
+    private function modify($value)
     {
         return Modify::value($value)->keys()->fetch();
     }

--- a/tests/Modifiers/KeysTest.php
+++ b/tests/Modifiers/KeysTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class KeysTest extends TestCase
+{
+    /** @test */
+    public function it_gets_the_keys_of_an_array(): void
+    {
+        $input = [
+            'chicken' => 'nuggets',
+            'nuggets' => 'Denver',
+        ];
+
+        $expected = [
+            'chicken',
+            'nuggets',
+        ];
+        $modified = $this->modify($input);
+        $this->assertEquals($expected, $modified);
+    }
+
+    private function modify(array $value)
+    {
+        return Modify::value($value)->keys()->fetch();
+    }
+}

--- a/tests/Modifiers/ValuesTest.php
+++ b/tests/Modifiers/ValuesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Modifiers;
 
+use Illuminate\Support\Collection;
 use Statamic\Modifiers\Modify;
 use Tests\TestCase;
 
@@ -15,15 +16,24 @@ class ValuesTest extends TestCase
             'nuggets' => 'Denver',
         ];
 
-        $expected = [
-            'nuggets',
-            'Denver',
-        ];
         $modified = $this->modify($input);
-        $this->assertEquals($expected, $modified);
+        $this->assertEquals(['nuggets', 'Denver'], $modified);
     }
 
-    private function modify(array $value)
+    /** @test */
+    public function it_gets_the_values_of_a_collection(): void
+    {
+        $input = collect([
+            'chicken' => 'nuggets',
+            'nuggets' => 'Denver',
+        ]);
+
+        $modified = $this->modify($input);
+        $this->assertInstanceOf(Collection::class, $modified);
+        $this->assertEquals(['nuggets', 'Denver'], $modified->all());
+    }
+
+    private function modify($value)
     {
         return Modify::value($value)->values()->fetch();
     }

--- a/tests/Modifiers/ValuesTest.php
+++ b/tests/Modifiers/ValuesTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class ValuesTest extends TestCase
+{
+    /** @test */
+    public function it_gets_the_values_of_an_array(): void
+    {
+        $input = [
+            'chicken' => 'nuggets',
+            'nuggets' => 'Denver',
+        ];
+
+        $expected = [
+            'nuggets',
+            'Denver',
+        ];
+        $modified = $this->modify($input);
+        $this->assertEquals($expected, $modified);
+    }
+
+    private function modify(array $value)
+    {
+        return Modify::value($value)->values()->fetch();
+    }
+}


### PR DESCRIPTION
This PR adds two modifiers `keys` and `values` to complement the already robust array of array modifiers (ie. flip, flatten, sort, etc.)

### Example Data:
```php
$data = [
    'key1' => 'Value 1',
    'key2' => 'Value 2',
];
```

### Example Template:
```antlers
{{ data | keys | to_json }}

{{ data | values | to_json }}
```

### Example Output:
```
['key1', 'key2']

['Value 1', 'Value 2']
```