### PR TITLE
[5.x] remove border and shadow in closed nav

### DIFF
--- a/resources/css/components/nav-main.css
+++ b/resources/css/components/nav-main.css
@@ -74,6 +74,10 @@
         .showing-license-banner & {
             height: calc(100% - 105px);
         }
+
+        .nav-closed & {
+            @apply border-0 shadow-none;
+        }
     }
 }
 


### PR DESCRIPTION
In the closed nav, there is still one border visible in the window. While it's not necessarily a problem, it could potentially confuse some users like me! :d