### PR TITLE
[5.x] Fix error when serializing eloquent query builders

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -516,8 +516,21 @@ abstract class EloquentQueryBuilder implements Builder
         }
     }
 
-    public function __sleep()
+    public function __serialize(): array
     {
-        return array_keys(Arr::except(get_object_vars($this), ['builder']));
+        $this->builder->getQuery()->connection = null;
+        $this->builder->getQuery()->grammar = null;
+
+        return get_object_vars($this);
+    }
+
+    public function __unserialize($data): void
+    {
+        foreach ($data as $key => $value) {
+            $this->$key = $value;
+        }
+
+        $this->builder->getQuery()->connection = $this->builder->getModel()->getConnection();
+        $this->builder->getQuery()->grammar = $this->builder->getQuery()->connection->getQueryGrammar();
     }
 }

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -515,4 +515,9 @@ abstract class EloquentQueryBuilder implements Builder
             $this->orderBy($this->builder->getModel()->getQualifiedKeyName(), 'asc');
         }
     }
+
+    public function __sleep()
+    {
+        return array_keys(Arr::except(get_object_vars($this), ['builder']));
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue with the `{{ nocache }}` tag and Statamic's `EloquentQueryBuilder`, where passing eloquent query builder instances to partials would cause an error to be thrown:

```
Serialization of 'PDO' is not allowed
```

This error was happening due to the `PDO` object, which is nested in Eloquent's query builder not being serializable. This PR fixes that by removing the `connection` and `grammar` properties from the query before serializing, then sets them again when unserializing. 

Fixes statamic/eloquent-driver#291.