### PR TITLE
[5.x] Add `merge` method to Eloquent User class

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -294,6 +294,13 @@ class User extends BaseUser
         return $this;
     }
 
+    public function merge($data)
+    {
+        $this->data($this->data()->merge($data));
+
+        return $this;
+    }
+
     public function getRememberToken()
     {
         return $this->model()->getRememberToken();


### PR DESCRIPTION
This pull request adds a `merge` method to the Eloquent `User` class. 

The `merge` method already exists on the file `User` class, via the `ContainsData` trait, this PR just adds it to the Eloquent `User` class for consistency.

Fixes https://github.com/duncanmcclean/simple-commerce/issues/1078.