### PR TITLE
[5.x] Fix order of filter presets after renaming view

### DIFF
--- a/resources/js/components/data-list/FilterPresets.vue
+++ b/resources/js/components/data-list/FilterPresets.vue
@@ -168,24 +168,34 @@ export default {
                 return;
             }
 
-            this.$preferences.set(`${this.preferencesKey}.${presetHandle}`, this.presetPreferencesPayload)
-                .then(response => {
-                    if (this.showRenameModal) {
-                        this.$preferences.remove(`${this.preferencesKey}.${this.activePreset}`)
-                            .then(response => {
-                                this.$toast.success(__('View renamed'));
-                                this.$emit('deleted', this.activePreset);
-                                this.showRenameModal = false;
-                                this.refreshPresets();
-                            })
-                            .catch(error => {
-                                this.$toast.error(__('Unable to rename view'));
-                                this.showRenameModal = false;
-                            });
+            if (this.showRenameModal) {
+                let preference = this.$preferences.get(`${this.preferencesKey}`);
 
-                        return;
+                preference = Object.fromEntries(Object.entries(preference).map(([key, value]) => {
+                    if (key === this.activePreset) {
+                        return [this.savingPresetSlug, this.presetPreferencesPayload];
                     }
 
+                    return [key, value];
+                }));
+
+                this.$preferences.set(`${this.preferencesKey}`, preference)
+                    .then(response => {
+                        this.$toast.success(__('View renamed'));
+                        this.$emit('deleted', this.activePreset);
+                        this.showRenameModal = false;
+                        this.refreshPresets();
+                    })
+                    .catch(error => {
+                        this.$toast.error(__('Unable to rename view'));
+                        this.showRenameModal = false;
+                    });
+
+                return;
+            }
+
+            this.$preferences.set(`${this.preferencesKey}.${presetHandle}`, this.presetPreferencesPayload)
+                .then(response => {
                     this.$toast.success(__('View saved'));
                     this.showCreateModal = false;
                     this.savingPresetName = null;


### PR DESCRIPTION
This pull request fixes an issue where the position of a view in the list wasn't maintained after renaming a view.

This was happening since we were technically adding a view with the new name, then deleting the view with the old name. This PR fixes that by literally replacing the key & value of the existing item in the preferences object.

Fixes #10176.