### PR TITLE
[5.x] Filter out global set variables associated to deleted sites

### DIFF
--- a/src/Globals/GlobalSet.php
+++ b/src/Globals/GlobalSet.php
@@ -231,7 +231,9 @@ class GlobalSet implements Contract
 
     private function freshLocalizations()
     {
-        return GlobalVariables::whereSet($this->handle())->keyBy->locale();
+        return GlobalVariables::whereSet($this->handle())
+            ->filter(fn ($localization) => $localization->site())
+            ->keyBy->locale();
     }
 
     public function editUrl()


### PR DESCRIPTION
This pull request filters out Global Set Variables associated to non-existent sites. 

Fixes #10180.