### PR TITLE
[5.x] Add `to_qs` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2554,7 +2554,7 @@ class CoreModifiers extends Modifier
      *
      * @return string
      */
-    public function toQuery($value)
+    public function toQs($value)
     {
         return Arr::query($value);
     }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2550,6 +2550,16 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Converts the data to a query string.
+     *
+     * @return string
+     */
+    public function toQuery($value)
+    {
+        return Arr::query($value);
+    }
+
+    /**
      * Converts each tab in the string to some number of spaces, as defined by
      * $param[0]. By default, each tab is converted to 4 consecutive spaces.
      *

--- a/tests/Modifiers/ToQsTest.php
+++ b/tests/Modifiers/ToQsTest.php
@@ -6,7 +6,7 @@ use Statamic\Modifiers\Modify;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
-class ToQueryTest extends TestCase
+class ToQsTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
@@ -32,6 +32,6 @@ class ToQueryTest extends TestCase
 
     private function modify($value, $options = [])
     {
-        return Modify::value($value)->toQuery($options)->fetch();
+        return Modify::value($value)->toQs($options)->fetch();
     }
 }

--- a/tests/Modifiers/ToQueryTest.php
+++ b/tests/Modifiers/ToQueryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modifiers;
+
+use Statamic\Modifiers\Modify;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ToQueryTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    /**
+     * @test
+     */
+    public function it_converts_to_query_string(): void
+    {
+        $input = [
+            'mode' => 'plaid',
+            'area' => [51, 52],
+            'hat' => null,
+            'transportation' => [
+                'bike' => true,
+                'delorian' => false,
+            ],
+        ];
+        $modified = $this->modify(value($input));
+
+        $expected = 'mode=plaid&area%5B0%5D=51&area%5B1%5D=52&transportation%5Bbike%5D=1&transportation%5Bdelorian%5D=0';
+        $this->assertEquals($expected, $modified);
+    }
+
+    private function modify($value, $options = [])
+    {
+        return Modify::value($value)->toQuery($options)->fetch();
+    }
+}


### PR DESCRIPTION
This PR adds a simple `to_qs` modifier that passes the incoming array or array-like value to Laravel's `Arr::query()` helper method.

# Example Data:
```php
$params = [
    'mode' => 'plaid',
    'area' => [51, 52],
    'hat' => null,
    'transportation' => [
        'bike' => true,
        'delorian' => false,
    ],
];
```

# Example Template:
```antlers
<a href="/search?{{ params | to_qs }}">Search Now</a>
```

# Example Output:
```html
<a href="/search?mode=plaid&area%5B0%5D=51&area%5B1%5D=52&transportation%5Bbike%5D=1&transportation%5Bdelorian%5D=0">Search Now</a>
```

(I don't like the encoded characters any more than you do - but that is the output)

---

Edit: Changed the modifier to `to_qs` per the discussion below.