### PR TITLE
[5.x] Handle `null` in `bardText` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -265,6 +265,11 @@ class CoreModifiers extends Modifier
         if ($value instanceof Value) {
             $value = $value->raw();
         }
+
+        if (is_null($value)) {
+            return '';
+        }
+
         if (Arr::isAssoc($value)) {
             $value = [$value];
         }

--- a/tests/Modifiers/BardTextTest.php
+++ b/tests/Modifiers/BardTextTest.php
@@ -84,9 +84,7 @@ class BardTextTest extends TestCase
     /** @test */
     public function it_handles_null()
     {
-        $expected = '';
-
-        $this->assertEquals($expected, $this->modify(null));
+        $this->assertEquals('', $this->modify(null));
     }
 
     public function modify($arr, ...$args)

--- a/tests/Modifiers/BardTextTest.php
+++ b/tests/Modifiers/BardTextTest.php
@@ -81,6 +81,14 @@ class BardTextTest extends TestCase
         $this->assertEquals($expected, $this->modify($data));
     }
 
+    /** @test */
+    public function it_handles_null()
+    {
+        $expected = '';
+
+        $this->assertEquals($expected, $this->modify(null));
+    }
+
     public function modify($arr, ...$args)
     {
         return Modify::value($arr)->bard_text($args)->fetch();


### PR DESCRIPTION
Ran into a case where `null` was being passed into the `bardText` modifier and an error was being thrown.