### PR TITLE
[5.x] Allows Antlers & Blade stacks to be used interchangeably

### DIFF
--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -23,6 +23,7 @@ use Statamic\View\Blade\AntlersBladePrecompiler;
 use Statamic\View\Cascade;
 use Statamic\View\Debugbar\AntlersProfiler\PerformanceCollector;
 use Statamic\View\Debugbar\AntlersProfiler\PerformanceTracer;
+use Statamic\View\Interop\Stacks;
 use Statamic\View\Store;
 
 class ViewServiceProvider extends ServiceProvider
@@ -49,6 +50,7 @@ class ViewServiceProvider extends ServiceProvider
 
     private function registerAntlers()
     {
+        Stacks::register();
         GlobalRuntimeState::$environmentId = StringUtilities::uuidv4();
 
         // Set the debug mode before anything else starts.

--- a/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
+++ b/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
@@ -192,6 +192,7 @@ class GlobalRuntimeState
     public static $prefixState = [];
 
     public static $containsLayout = false;
+    public static $renderingLayout = false;
     public static $shareVariablesTemplateTrigger = '';
     public static $layoutVariables = [];
 

--- a/src/View/Antlers/Language/Runtime/StackReplacementManager.php
+++ b/src/View/Antlers/Language/Runtime/StackReplacementManager.php
@@ -4,6 +4,7 @@ namespace Statamic\View\Antlers\Language\Runtime;
 
 use Statamic\View\Antlers\Language\Nodes\AntlersNode;
 use Statamic\View\Antlers\Language\Nodes\Position;
+use Statamic\View\Interop\Stacks;
 
 class StackReplacementManager
 {
@@ -13,16 +14,48 @@ class StackReplacementManager
 
     protected static $cachedStacks = [];
 
+    protected static $stackNames = [];
+
     public static function clearStackState()
     {
         self::$stackContents = [];
         self::$arrayStacks = [];
         self::$stacks = [];
+        self::$stackNames = [];
+    }
+
+    public static function getStacks()
+    {
+        $stacks = [];
+
+        if (! array_key_exists(GlobalRuntimeState::$environmentId, self::$stackContents)) {
+            return $stacks;
+        }
+
+        $currentStacks = self::$stackContents[GlobalRuntimeState::$environmentId];
+
+        foreach (self::$stackNames as $replacement => $realName) {
+            if (! array_key_exists($replacement, $currentStacks)) {
+                continue;
+            }
+
+            $stacks[$realName] = [];
+
+            foreach ($currentStacks[$replacement] as $replacement) {
+                $stacks[$realName][] = $replacement;
+            }
+        }
+
+        return $stacks;
     }
 
     protected static function getStackReplacement($name)
     {
-        return '__stackReplacement::_'.md5($name);
+        $replacement = '__stackReplacement::_'.md5($name);
+
+        self::$stackNames[$replacement] = $name;
+
+        return $replacement;
     }
 
     public static function registerStack($name)
@@ -71,6 +104,8 @@ class StackReplacementManager
             $content = trim($content);
         }
 
+        Stacks::prependToBladeStack($stackName, $content);
+
         if (GlobalRuntimeState::$isCacheEnabled) {
             self::$cachedStacks[] = $stackName;
         }
@@ -93,6 +128,8 @@ class StackReplacementManager
         if ($trimContentWhitespace) {
             $content = trim($content);
         }
+
+        Stacks::pushToBladeStack($stackName, $content);
 
         if (GlobalRuntimeState::$isCacheEnabled) {
             self::$cachedStacks[] = $stackName;

--- a/src/View/Interop/Stacks.php
+++ b/src/View/Interop/Stacks.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Statamic\View\Interop;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\View\Factory;
+use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
+use Statamic\View\Antlers\Language\Runtime\StackReplacementManager;
+
+class Stacks
+{
+    public static function register(): void
+    {
+        Blade::directive('endpush', function () {
+            return <<<'PHP'
+<?php $___interop_pushed = $__env->stopPush(); Statamic\View\Interop\Stacks::endBladePush($___interop_pushed); ?>
+PHP;
+        });
+
+        Blade::directive('endpushOnce', function () {
+            return <<<'PHP'
+<?php $___interop_pushed = $__env->stopPush(); Statamic\View\Interop\Stacks::endBladePush($___interop_pushed); endif; ?>
+PHP;
+        });
+
+        Blade::directive('endprepend', function () {
+            return <<<'PHP'
+<?php $___interop_prepend = $__env->stopPrepend(); Statamic\View\Interop\Stacks::endBladePrepend($___interop_prepend); ?>
+PHP;
+        });
+
+        Blade::directive('endprependOnce', function () {
+            return <<<'PHP'
+<?php $___interop_prepend = $__env->stopPrepend(); Statamic\View\Interop\Stacks::endBladePrepend($___interop_prepend); endif; ?>
+PHP;
+        });
+    }
+
+    /**
+     * @return Factory
+     */
+    protected static function getBladeEnv()
+    {
+        return view()->shared('__env');
+    }
+
+    protected static function getBladeValue($property, $stack)
+    {
+        if (GlobalRuntimeState::$renderingLayout) {
+            return null;
+        }
+
+        // Retrieve value from the Blade environment.
+        $values = (fn () => $this->$property)->call(self::getBladeEnv());
+
+        if (! array_key_exists($stack, $values) || empty($values[$stack])) {
+            return null;
+        }
+
+        // Get the last item from the Blade environment.
+        $stackItems = $values[$stack];
+
+        return $stackItems[array_key_last($stackItems)];
+    }
+
+    public static function endBladePush($stack): void
+    {
+        if ($content = self::getBladeValue('pushes', $stack)) {
+            StackReplacementManager::pushStack($stack, $content, false);
+        }
+    }
+
+    public static function endBladePrepend($stack): void
+    {
+        if ($content = self::getBladeValue('prepends', $stack)) {
+            StackReplacementManager::prependStack($stack, $content, false);
+        }
+    }
+
+    public static function pushToBladeStack($stack, $content)
+    {
+        self::getBladeEnv()->startPush($stack, $content);
+    }
+
+    public static function prependToBladeStack($stack, $content)
+    {
+        self::getBladeEnv()->startPrepend($stack, $content);
+    }
+
+    public static function restoreStacks()
+    {
+        $env = self::getBladeEnv();
+
+        // Restore Blade stack contents.
+        foreach (StackReplacementManager::getStacks() as $stack => $contents) {
+            foreach ($contents as $content) {
+                $env->startPush($stack, $content);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR closes #9880 by allowing Antlers and Blade stacks to be used together. This is accomplished by modifying the output of stack-related Blade directives to push/prepend content to Antlers stacks, and pushing/prepending content to Blade stacks from Antlers templates.

This repository contains some example files that may be used to help review this PR: https://github.com/JohnathonKoster/statamic-antlers-blade-stacks