### PR TITLE
[5.x] Use multibyte methods for obfuscate

### DIFF
--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -222,10 +222,6 @@ class Html
         foreach (mb_str_split($value) as $letter) {
             $ordValue = mb_ord($letter);
 
-            if ($ordValue > 128) {
-                return $letter;
-            }
-
             // To properly obfuscate the value, we will randomly convert each letter to
             // its entity or hexadecimal representation, keeping a bot from sniffing
             // the randomly obfuscated letters out of the string on the responses.

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -219,8 +219,10 @@ class Html
     {
         $safe = '';
 
-        foreach (str_split($value) as $letter) {
-            if (ord($letter) > 128) {
+        foreach (mb_str_split($value) as $letter) {
+            $ordValue = mb_ord($letter);
+
+            if ($ordValue > 128) {
                 return $letter;
             }
 
@@ -229,10 +231,10 @@ class Html
             // the randomly obfuscated letters out of the string on the responses.
             switch (rand(1, 3)) {
                 case 1:
-                    $safe .= '&#'.ord($letter).';';
+                    $safe .= '&#'.$ordValue.';';
                     break;
                 case 2:
-                    $safe .= '&#x'.dechex(ord($letter)).';';
+                    $safe .= '&#x'.dechex($ordValue).';';
                     break;
                 case 3:
                     $safe .= $letter;

--- a/tests/Modifiers/ObfuscateTest.php
+++ b/tests/Modifiers/ObfuscateTest.php
@@ -14,6 +14,16 @@ class ObfuscateTest extends TestCase
         $this->assertTrue(in_array($modified, ['&#65;', '&#x41;', 'A']));
     }
 
+    /** @test */
+    public function it_obfuscates_a_multibyte_string(): void
+    {
+        $modified = $this->modify('é');
+        $this->assertTrue(in_array($modified, ['&#233;', '&#xE9;', 'é']));
+
+        $modified = $this->modify('ß');
+        $this->assertTrue(in_array($modified, ['&#223;', '&#xDF;', 'ß']));
+    }
+
     private function modify($value)
     {
         return Modify::value($value)->obfuscate()->fetch();

--- a/tests/Modifiers/ObfuscateTest.php
+++ b/tests/Modifiers/ObfuscateTest.php
@@ -14,14 +14,35 @@ class ObfuscateTest extends TestCase
         $this->assertTrue(in_array($modified, ['&#65;', '&#x41;', 'A']));
     }
 
-    /** @test */
-    public function it_obfuscates_a_multibyte_string(): void
+    /**
+     * @test
+     *
+     * @dataProvider seedProvider
+     */
+    public function it_obfuscates_strings($seed, $value, $expected)
     {
-        $modified = $this->modify('é');
-        $this->assertTrue(in_array($modified, ['&#233;', '&#xE9;', 'é']));
+        mt_srand($seed); // make rand predictable for testing.
 
-        $modified = $this->modify('ß');
-        $this->assertTrue(in_array($modified, ['&#223;', '&#xDF;', 'ß']));
+        $this->assertEquals($expected, $this->modify($value));
+
+        srand(); // reset to not affect other tests.
+    }
+
+    public static function seedProvider()
+    {
+        return [
+            'A, case 1' => [1, 'A', '&#x41;'],
+            'A, case 2' => [2, 'A', '&#65;'],
+            'A, case 3' => [5, 'A', 'A'],
+
+            'é, case 1' => [1, 'é', '&#xe9;'],
+            'é, case 2' => [2, 'é', '&#233;'],
+            'é, case 3' => [5, 'é', 'é'],
+
+            '🐘, case 1' => [1, '🐘', '&#x1f418;'],
+            '🐘, case 2' => [2, '🐘', '&#128024;'],
+            '🐘, case 3' => [5, '🐘', '🐘'],
+        ];
     }
 
     private function modify($value)

--- a/tests/Modifiers/ObfuscateTest.php
+++ b/tests/Modifiers/ObfuscateTest.php
@@ -7,13 +7,6 @@ use Tests\TestCase;
 
 class ObfuscateTest extends TestCase
 {
-    /** @test */
-    public function it_obfuscates_a_string(): void
-    {
-        $modified = $this->modify('A');
-        $this->assertTrue(in_array($modified, ['&#65;', '&#x41;', 'A']));
-    }
-
     /**
      * @test
      *


### PR DESCRIPTION
I encountered a bug with using livewire (v3) with Statamic v5 that told me "Malformed UTF-8 characters, possibly incorrectly encoded". After some digging I found out that the obfuscate modifier caused the trouble. I also found out that since PHP 8.2 the `utf8_encode()` is deprecated and should be replaced with a multibyte encoding method. All of this led me to trying `mb_str_split()` and `mb_ord()` for the obfuscate modifier. I reckon the error was caused by a multibyte character in my content and with the multibyte method equivalents I was able to fix it. 

Unfortunately I can't really expand on that problem any further, but I think it should be safely replaceable, since the methods just widen the range of values above 128. 