### PR TITLE
[5.x] Update DataResponse::handleDraft() to respect data inheritance

### DIFF
--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -102,7 +102,7 @@ class DataResponse implements Responsable
     {
         if (!method_exists($this->data,'value') || !($raw = $this->data->value('redirect'))) {
             if (!($raw = $this->data->get('redirect'))) {
-                return;
+                return $this;
             }
         }
 

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -100,8 +100,10 @@ class DataResponse implements Responsable
 
     protected function handleDraft()
     {
-        if (! method_exists($this->data, 'published')) {
-            return $this;
+        if (!method_exists($this->data,'value') || !($raw = $this->data->value('redirect'))) {
+            if (!($raw = $this->data->get('redirect'))) {
+                return;
+            }
         }
 
         if ($this->data->published()) {


### PR DESCRIPTION
Hello there,

I have identified an issue with the localization of the redirect field. Currently, the redirect field is filled on the origin site and is inherited by the child localizations. However, the child localizations do not redirect as expected because `$this->data->get('redirect')` does not inherit the value from the origin.

🔍 
This behavior seems unintended, so I propose the following changes to ensure the redirect field is properly inherited by child localizations.

Thank you for your attention to this matter!

Best regards,
Tin