### PR TITLE
[5.x] Fix JavaScript length error from Add Set button label

### DIFF
--- a/resources/js/components/fieldtypes/replicator/AddSetButton.vue
+++ b/resources/js/components/fieldtypes/replicator/AddSetButton.vue
@@ -9,7 +9,7 @@
                         class="btn-round flex items-center justify-center"
                         :class="{
                             'h-5 w-5': ! last,
-                            'mr-2': label.length > 0,
+                            'mr-2': label?.length > 0,
                         }"
                         @click="addSetButtonClicked"
                     >


### PR DESCRIPTION
This pull request fixes a JavaScript error that'd be thrown on Replicator fields, where no "Add Set Label" has been configured.

The `label` was undefined, so calling `.length` on it was causing an error. I wasn't able to reproduce the save issue reported in the issue but this fix prevents the JS error for me.

Fixes #10210.