### PR TITLE
[5.x] Fix "Add Set" button between sets on replicator

### DIFF
--- a/resources/js/components/fieldtypes/replicator/AddSetButton.vue
+++ b/resources/js/components/fieldtypes/replicator/AddSetButton.vue
@@ -42,7 +42,7 @@ export default {
         index: Number,
         last: Boolean,
         enabled: { type: Boolean, default: true },
-        label: String,
+        label: { type: String, default: '' },
     },
 
     methods: {


### PR DESCRIPTION
This fixes a bug with the "Add Set" button when between sets and no label is set.
See:  https://github.com/statamic/cms/pull/9806#issuecomment-2137502818

Solution is to add a default of an empty string to the label parameter.