### PR TITLE
[5.x] Allow long set names to wrap. Closes #9838

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -9,7 +9,7 @@
             <div class="replicator-set-header" :class="{'collapsed': collapsed, 'invalid': isInvalid }">
                 <div class="item-move sortable-handle" data-drag-handle />
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
-                    <label class="text-xs whitespace-nowrap rtl:ml-2 ltr:mr-2">
+                    <label class="text-xs rtl:ml-2 ltr:mr-2">
                         <span v-if="isSetGroupVisible">
                             {{ setGroup.display }}
                             <svg-icon name="micro/chevron-right" class="w-4" />

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -7,7 +7,7 @@
             <div class="replicator-set-header" :class="{ 'p-2': isReadOnly, 'collapsed': collapsed, 'invalid': isInvalid }">
                 <div class="item-move sortable-handle" :class="sortableHandleClass" v-if="!isReadOnly"></div>
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
-                    <label class="text-xs whitespace-nowrap rtl:ml-2 ltr:mr-2 cursor-pointer">
+                    <label class="text-xs rtl:ml-2 ltr:mr-2 cursor-pointer">
                         <span v-if="isSetGroupVisible">
                             {{ setGroup.display }}
                             <svg-icon name="micro/chevron-right" class="w-4" />


### PR DESCRIPTION
Wrapping is better than overflowing, and truncating is often a subpar user experience.