### PR TITLE
[5.x] Prevent user registration form from saving `password_confirmation`

### DIFF
--- a/src/Http/Requests/UserRegisterRequest.php
+++ b/src/Http/Requests/UserRegisterRequest.php
@@ -52,7 +52,7 @@ class UserRegisterRequest extends FormRequest
     {
         return $this->blueprintFields->process()->values()
             ->only(array_keys($this->submittedValues))
-            ->except(['email', 'groups', 'roles', 'super']);
+            ->except(['email', 'groups', 'roles', 'super', 'password_confirmation']);
     }
 
     public function validator()


### PR DESCRIPTION
Someone [reported on discord](https://discord.com/channels/489818810157891584/489818810157891586/1245129915880312923) that the changes to the RegisterController / UserRegisterRequest have meant that the password_confirmation is being saved - in eloquent this causes issues as the column doesn't exist, and when file based this adds it to the yaml which it definitely shouldn't.

This PR updates the except in the form request to exclude it from being saved.


