### PR TITLE
[5.x] fix(Terms): `getCreatables()` throws an error if no user is authenticated.

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -313,7 +313,7 @@ class Terms extends Relationship
 
             throw_if(! $taxonomy, new TaxonomyNotFoundException($taxonomyHandle));
 
-            if (! $user->can('create', [TermContract::class, $taxonomy])) {
+            if (! $user?->can('create', [TermContract::class, $taxonomy])) {
                 return null;
             }
 


### PR DESCRIPTION
## What

This simple, one-character PR changes `src/Fieldtypes/Terms` so that it won't throw an error if no user is authenticated when `getCreatables()` is called.

## Why

I originally raised this issue in duncanmcclean/simple-commerce#1076. In brief, the shop / products page for my store failed to work for unauthenticated users after adding a taxonomy field to the blueprint for product variations.

This issue stems from a `Statamic\Fields\Field` class being created and the `meta()` method being invoked on it.

### Whether this is a misuse of the framework, or a bug therein, I leave for you to decide.

Personally, I don't see the harm in allowing `getCreatables()` to work when no user is authenticated, but let me know if I'm wrong.

I have an image here of the stack trace I encountered:

![image](https://github.com/statamic/cms/assets/6729162/abb59e13-fa59-4750-bf7a-9880301d0867)

Let me know if there's anything else you need from me :smile: 
