### PR TITLE
[5.x] Ensure `prose`-based strong tag is readable in dark mode

### DIFF
--- a/resources/css/dark.css
+++ b/resources/css/dark.css
@@ -1,7 +1,7 @@
 .prose {
     @apply dark:text-dark-150;
 
-    :where(h2), :where(h3) {
+    :where(h2), :where(h3), :where(strong) {
         &:not(:where([class~=not-prose] *)) {
             @apply dark:text-dark-100;
         }


### PR DESCRIPTION
Include `strong` in the dark mode `.prose` class so that it is readable when dark mode is active

Closes #10234
