### PR TITLE
[5.x] Decrease the failure rate of RandomTest

### DIFF
--- a/tests/Modifiers/RandomTest.php
+++ b/tests/Modifiers/RandomTest.php
@@ -24,10 +24,12 @@ class RandomTest extends TestCase
 
     public static function inputsProvider()
     {
+        $range = range(1, 5000);
+
         return [
-            'array' => [range('a', 'z')],
-            'collection' => [collect(range('a', 'z'))],
-            'query builder' => [Mockery::mock(Builder::class)->shouldReceive('get')->andReturn(collect(range('a', 'z')))->getMock()],
+            'array' => [$range],
+            'collection' => [collect($range)],
+            'query builder' => [Mockery::mock(Builder::class)->shouldReceive('get')->andReturn(collect($range))->getMock()],
         ];
     }
 


### PR DESCRIPTION
This pesky test fails every now and then and has finally got under my skin enough to fix it.

![CleanShot 2024-05-30 at 16 27 57](https://github.com/statamic/cms/assets/105211/51ded824-64ee-474b-9dcb-9f3359bcd7a2)

We copied the test from the `shuffle` test - where this made more sense. The `shuffle` modifier gives you back a 26-item array. That's a huge number of combinations.

But in the `random` modifier, it's pulling _one_ item out of the 26. The odds of you picking the same single number out of 26 is much higher.

This PR bumps 26 possibilities to 5000. If we see a failure now, buy a lottery ticket.
