### PR TITLE
[5.x] Restore nav/structure select behavior

### DIFF
--- a/src/Data/BulkAugmentor.php
+++ b/src/Data/BulkAugmentor.php
@@ -10,7 +10,6 @@ class BulkAugmentor
     private $isTree = false;
     private $originalValues = [];
     private $augmentedValues = [];
-
     private $keyResolver;
 
     private function getAugmentationReference($item)

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -121,7 +121,7 @@ class Structure extends Tags
 
     public function toArray($tree, $parent = null, $depth = 1)
     {
-        $pages = BulkAugmentor::tree($tree)->map(function ($item, $data, $index) use ($depth, $tree, $parent) {
+        $pages = BulkAugmentor::tree($tree, fn ($item) => $this->getQuerySelectKeys($item))->map(function ($item, $data, $index) use ($depth, $tree, $parent) {
             $page = $item['page'];
             $children = empty($item['children']) ? [] : $this->toArray($item['children'], $page, $depth + 1);
 

--- a/tests/Tags/StructureTagTest.php
+++ b/tests/Tags/StructureTagTest.php
@@ -382,6 +382,23 @@ EOT;
         $this->assertEquals('[1=parent][1-1=parent][1-1-1=parent][1-1-1-1=current][2]', $result);
     }
 
+    /** @test */
+    public function it_limits_fields_using_select()
+    {
+        $this->createCollectionAndNav();
+
+        $template = '{{ nav:test select="title" }}<title:{{ title }}><nav_title:{{ nav_title }}>{{ *recursive children* }}{{ /nav:test }}';
+
+        $result = (string) Antlers::parse($template);
+
+        // The nav_title should always be empty since we did not select it.
+        $expected = <<<'EXP'
+<title:One><nav_title:><title:One One><nav_title:><title:URL and title><nav_title:><title:Two><nav_title:><title:Three><nav_title:><title:Three One><nav_title:><title:Three Two><nav_title:><title:Title only><nav_title:><title:URL only><nav_title:>
+EXP;
+
+        $this->assertSame($expected, $result);
+    }
+
     private function makeNav($tree)
     {
         $nav = Nav::make('test');


### PR DESCRIPTION
This PR restores the functionality of the nav tag's `select` parameter. The `BulkAugmentor` did not know how to resolve those; this PR adds the ability to specify a custom callback that will be used to retrieve augmentation keys. When present, the bulk augmentor will utilize this. If the callback returns `null`, it will default to its original behavior.

The nav tag uses its `getQuerySelectKeys` method as its callback to avoid copying that logic into the `BulkAugmentor`