### PR TITLE
Make `select` field values in entry tables localizable

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -105,7 +105,7 @@ trait HasSelectOptions
         }
 
         return $this->isOption($value)
-            ? Arr::get($this->config('options'), $value) ?? $value
+            ? __(Arr::get($this->config('options'), $value) ?? $value)
             : $actualValue;
     }
 


### PR DESCRIPTION
This turns this:
<img width="1271" alt="Screenshot 2024-05-31 at 13 27 30" src="https://github.com/statamic/cms/assets/69107412/f0c2ba0e-f799-49fe-9adf-38bbf14f8a40">

Into this:
<img width="1279" alt="Screenshot 2024-05-31 at 13 27 38" src="https://github.com/statamic/cms/assets/69107412/c1ba04b8-1d10-42de-8441-c349750e748f">
