### PR TITLE
[5.x] Fix relative modifier test

### DIFF
--- a/tests/Modifiers/RelativeTest.php
+++ b/tests/Modifiers/RelativeTest.php
@@ -11,7 +11,9 @@ class RelativeTest extends TestCase
     /** @test */
     public function it_converts_a_date_to_relative()
     {
-        $date = new Carbon('today -1 month');
+        Carbon::setTestNow('2024-06-30');
+
+        $date = new Carbon('2024-05-30');
 
         $this->assertEquals('1 month ago', $this->modify($date));
     }
@@ -19,7 +21,9 @@ class RelativeTest extends TestCase
     /** @test */
     public function it_converts_a_date_to_relative_without_modifiers()
     {
-        $date = new Carbon('today -1 month');
+        Carbon::setTestNow('2024-06-30');
+
+        $date = new Carbon('2024-05-30');
 
         $this->assertEquals('1 month', $this->modify($date, true));
         $this->assertEquals('1 month', $this->modify($date, 'true'));


### PR DESCRIPTION
When it is the 31st of the month and the previous month has 30 days, the test fails.

![image](https://github.com/statamic/cms/assets/105211/5aa02c14-8f1d-4833-91c9-8eceba7ae87c)

This PR addresses that by using fixed dates rather than relying on real life "now".
