### PR TITLE
[5.x] Address slow Windows GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
         if: steps.should-run-tests.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
-#          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo
+          extensions: fileinfo
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,19 +16,19 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.3]
-        laravel: [11.*]
-        stability: [prefer-stable]
+        php: [8.1, 8.2, 8.3]
+        laravel: [10.*, 11.*]
+        stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
-#        include:
-#          - os: windows-latest
-#            php: 8.3
-#            laravel: 10.*
-#            stability: prefer-stable
-#          - os: windows-latest
-#            php: 8.3
-#            laravel: 11.*
-#            stability: prefer-stable
+        include:
+          - os: windows-latest
+            php: 8.3
+            laravel: 10.*
+            stability: prefer-stable
+          - os: windows-latest
+            php: 8.3
+            laravel: 11.*
+            stability: prefer-stable
         exclude:
           - php: 8.1
             laravel: 11.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
         if: steps.should-run-tests.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
-          extensions: fileinfo
+          extensions: fileinfo, pdo, sqlite3
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
         if: steps.should-run-tests.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
-          extensions: fileinfo, pdo, sqlite3
+          extensions: fileinfo, pdo, sqlite
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         php: [8.1, 8.2, 8.3]
         laravel: [10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
-        os: [ubuntu-latest]
+        os: []
         include:
           - os: windows-latest
             php: 8.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
         if: steps.should-run-tests.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
-          extensions: fileinfo, pdo, sqlite
+          extensions: fileinfo, pdo, sqlite, gd
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,19 +16,19 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3]
-        laravel: [10.*, 11.*]
-        stability: [prefer-lowest, prefer-stable]
-        os: []
-        include:
-          - os: windows-latest
-            php: 8.3
-            laravel: 10.*
-            stability: prefer-stable
-          - os: windows-latest
-            php: 8.3
-            laravel: 11.*
-            stability: prefer-stable
+        php: [8.3]
+        laravel: [11.*]
+        stability: [prefer-stable]
+        os: [windows-latest]
+#        include:
+#          - os: windows-latest
+#            php: 8.3
+#            laravel: 10.*
+#            stability: prefer-stable
+#          - os: windows-latest
+#            php: 8.3
+#            laravel: 11.*
+#            stability: prefer-stable
         exclude:
           - php: 8.1
             laravel: 11.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         php: [8.3]
         laravel: [11.*]
         stability: [prefer-stable]
-        os: [windows-latest]
+        os: [ubuntu-latest]
 #        include:
 #          - os: windows-latest
 #            php: 8.3
@@ -78,7 +78,7 @@ jobs:
         if: steps.should-run-tests.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo
+#          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
         if: steps.should-run-tests.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
         if: steps.should-run-tests.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
-          extensions: fileinfo, pdo, sqlite, gd
+          extensions: fileinfo, exif, gd, pdo, sqlite, pdo_sqlite
           coverage: none
 
       - name: Install dependencies


### PR DESCRIPTION
Windows workflows are very slow.

Turns out the "setup php" step installing certain extensions was the bottleneck. e.g. it tries for ages to install `imagick` and failed anyway. I've removed any non-essential extensions.