### PR TITLE
[5.x] Only run parent code in `Revisable` trait when item is an entry

### DIFF
--- a/src/Revisions/Revisable.php
+++ b/src/Revisions/Revisable.php
@@ -3,6 +3,7 @@
 namespace Statamic\Revisions;
 
 use Illuminate\Support\Carbon;
+use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\Revision as Revisions;
 use Statamic\Statamic;
 
@@ -71,16 +72,18 @@ trait Revisable
     {
         $item = $this->fromWorkingCopy();
 
-        $parent = $item->get('parent');
+        if ($item instanceof Entry) {
+            $parent = $item->get('parent');
 
-        $item->remove('parent');
+            $item->remove('parent');
+        }
 
         $item
             ->published(true)
             ->updateLastModified($user = $options['user'] ?? false)
             ->save();
 
-        if ($item->collection()->hasStructure() && $parent) {
+        if ($item instanceof Entry && $item->collection()->hasStructure() && $parent) {
             $tree = $item->collection()->structure()->in($item->locale());
 
             if (optional($tree->find($parent))->isRoot()) {


### PR DESCRIPTION
This pull request moves the handling of parent entries in the `Revisable` trait inside of if statements, since the revisions feature shouldn't be tied to just entries.

