### PR TITLE
[5.x] Fix broken docs URLs; rename docs URL redirect to permalink

### DIFF
--- a/resources/views/assets/index.blade.php
+++ b/resources/views/assets/index.blade.php
@@ -16,7 +16,7 @@
 
     @include('statamic::partials.docs-callout', [
         'topic' => __('Assets'),
-        'url' => 'assets'
+        'url' => Statamic::docsUrl('assets')
     ])
 
 @endsection

--- a/resources/views/collections/empty.blade.php
+++ b/resources/views/collections/empty.blade.php
@@ -78,6 +78,6 @@
 
     @include('statamic::partials.docs-callout', [
         'topic' => __('Collections'),
-        'url' => 'collection'
+        'url' => Statamic::docsUrl('collections')
     ])
 @stop

--- a/resources/views/collections/index.blade.php
+++ b/resources/views/collections/index.blade.php
@@ -36,7 +36,7 @@
 
     @include('statamic::partials.docs-callout', [
         'topic' => __('Collections'),
-        'url' => Statamic::docsUrl('collections-and-entries')
+        'url' => Statamic::docsUrl('collections')
     ])
 
 @endsection


### PR DESCRIPTION
There were two templates not referencing the docs URL correctly:

* `resources/views/assets/index.blade.php`
* `resources/views/collections/empty.blade.php`

These show up like this (using Collections as an example):

![image](https://github.com/statamic/cms/assets/503/e4ab00c4-53d5-459a-bd0d-4600f9790645)

For example:

```php
@include('statamic::partials.docs-callout', [
    'topic' => __('Assets'),
    'url' => 'assets'
])
```

Instead of:

```php
@include('statamic::partials.docs-callout', [
    'topic' => __('Assets'),
    'url' => Statamic::docsUrl('assets')
])
```

In addition, `resources/views/collections/index.blade.php` was set up correctly, but pointing to https://statamic.dev/collections-and-entries which just redirects to https://statamic.dev/collections. This changes that so it's uniform with the `empty.blade.php` changes.