### PR TITLE
[5.x] Allow overriding `statusIcons` property in relationship fieldtype

### DIFF
--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -75,7 +75,7 @@ abstract class Relationship extends Fieldtype
                 'id' => method_exists($item, 'id') ? $item->id() : $item->handle(),
                 'title' => method_exists($item, 'title') ? $item->title() : $item->value('title'),
                 'edit_url' => $item->editUrl(),
-                'published' => $this->statusIcons ? $item->published() : null,
+                'published' => $this->statusIcons() ? $item->published() : null,
             ];
         });
     }
@@ -130,7 +130,7 @@ abstract class Relationship extends Fieldtype
             'canEdit' => $this->canEdit(),
             'canCreate' => $this->canCreate(),
             'canSearch' => $this->canSearch(),
-            'statusIcons' => $this->statusIcons,
+            'statusIcons' => $this->statusIcons(),
             'creatables' => $this->getCreatables(),
             'formComponent' => $this->getFormComponent(),
             'formComponentProps' => $this->getFormComponentProps(),
@@ -161,6 +161,11 @@ abstract class Relationship extends Fieldtype
     protected function canSearch()
     {
         return $this->canSearch;
+    }
+
+    protected function statusIcons()
+    {
+        return $this->statusIcons;
     }
 
     protected function getItemComponent()


### PR DESCRIPTION
This pull request adds a new method to allow overriding the `statusIcons` property in Relationship Fieldtypes.

For context: in Runway, I'm adding the concept of "publish states". This will be an opt-in feature, so the status icons are only needed when it's enabled.