### PR TITLE
[5.x] Fix failed slug validation when slug contains underscores

### DIFF
--- a/src/Rules/Slug.php
+++ b/src/Rules/Slug.php
@@ -9,7 +9,7 @@ class Slug implements ValidationRule
 {
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! preg_match('/^[a-zA-Z0-9]+(?:-{0,1}[a-zA-Z0-9])*$/', $value)) {
+        if (! preg_match('/^[a-zA-Z0-9]+(?:[-_]{0,1}[a-zA-Z0-9])*$/', $value)) {
             $fail('statamic::validation.slug')->translate();
         }
     }

--- a/tests/Rules/SlugTest.php
+++ b/tests/Rules/SlugTest.php
@@ -17,19 +17,26 @@ class SlugTest extends TestCase
         $this->assertPasses('foo');
         $this->assertPasses('foo-bar');
         $this->assertPasses('foo-bar-baz');
+        $this->assertPasses('foo_bar_baz');
         $this->assertPasses('foo-bar-baz-qux');
         $this->assertPasses('1-foo-bar234-baz-qux-5');
+        $this->assertPasses('1_foo_bar234_baz_qux_5');
+        $this->assertPasses('1-foo_bar234-baz_qux-5');
 
-        $this->assertFails('foo_bar');
         $this->assertFails('-foo');
         $this->assertFails('foo-');
         $this->assertFails('-foo-bar');
+        $this->assertFails('_foo-bar');
         $this->assertFails('foo-bar-');
+        $this->assertFails('foo-bar_');
         $this->assertFails('foo--bar');
+        $this->assertFails('foo__bar');
         $this->assertFails('foo---bar');
+        $this->assertFails('foo___bar');
         $this->assertFails('*foo');
         $this->assertFails('foo#');
         $this->assertFails('foo-!bar');
+        $this->assertFails('foo_!bar');
         $this->assertFails('foo-_-bar');
     }
 


### PR DESCRIPTION
Fixes #10262