### PR TITLE
[5.x] Fix tiny top left border radius on collection widget

### DIFF
--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -418,3 +418,18 @@ table.control {
         @apply rounded bg-gray-100 dark:bg-dark-700 border dark:border-dark-900 px-1 inline-block text-2xs line-clamp-1 mb-1;
     }
 }
+
+/* Widgets
+  ========================================================================== */
+
+.widget .data-table {
+    tbody {
+        tr {
+            &:first-child {
+                td:first-child, th:first-child {
+                    @apply rtl:rounded-tr-none ltr:rounded-tl-none;
+                }
+            }
+        }
+    }
+}

--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -418,18 +418,3 @@ table.control {
         @apply rounded bg-gray-100 dark:bg-dark-700 border dark:border-dark-900 px-1 inline-block text-2xs line-clamp-1 mb-1;
     }
 }
-
-/* Widgets
-  ========================================================================== */
-
-.widget .data-table {
-    tbody {
-        tr {
-            &:first-child {
-                td:first-child, th:first-child {
-                    @apply rtl:rounded-tr-none ltr:rounded-tl-none;
-                }
-            }
-        }
-    }
-}

--- a/resources/js/components/data-list/Table.vue
+++ b/resources/js/components/data-list/Table.vue
@@ -14,7 +14,7 @@
                         'cursor-not-allowed': !sortable,
                         'rtl:text-left ltr:text-right rtl:pl-8 ltr:pr-8': column.numeric,
                     }"
-                    class="group"
+                    class="group rounded-none"
                     @click.prevent="changeSortColumn(column.field)"
                 >
                     <span v-text="__(column.label)" />


### PR DESCRIPTION
This pull request fixes a small UI issue in the collection widget, where hovering on the first item in the table shows a tiny border left radius.

Right now, I've only removed the border radius when it's used in the context of a data table inside a widget. However, if this border radius shouldn't exist anywhere, let me know and I can update this PR. 😄 

Fixes #10260.

## Before

<img width="917" alt="image" src="https://github.com/statamic/cms/assets/19637309/9282b6c6-4376-4b3b-98ca-bdb17c6d7d5d">

## After

<img width="917" alt="image" src="https://github.com/statamic/cms/assets/19637309/1278e413-19d6-4436-9cbe-edf133497d8b">
