### PR TITLE
[5.x] Allow displaying status badges in collection widget

### DIFF
--- a/resources/js/components/entries/Widget.vue
+++ b/resources/js/components/entries/Widget.vue
@@ -17,9 +17,12 @@
                 <data-list-table :loading="loading">
                     <template slot="cell-title" slot-scope="{ row: entry }">
                         <div class="flex items-center">
-                            <div class="little-dot rtl:ml-2 ltr:mr-2" :class="[entry.published ? 'bg-green-600' : 'bg-gray-400']" />
+                            <span class="little-dot rtl:ml-2 ltr:mr-2" v-tooltip="getStatusLabel(entry)" :class="getStatusClass(entry)" v-if="! columnShowing('status')" />
                             <a :href="entry.edit_url">{{ entry.title }}</a>
                         </div>
+                    </template>
+                    <template slot="cell-status" slot-scope="{ row: entry }">
+                        <div class="status-index-field select-none" v-tooltip="getStatusTooltip(entry)" :class="`status-${entry.status}`" v-text="getStatusLabel(entry)" />
                     </template>
                 </data-list-table>
                 <data-list-pagination
@@ -58,6 +61,49 @@ export default {
             requestUrl: cp_url(`collections/${this.collection}/entries`),
         }
     },
+
+    methods: {
+        getStatusClass(entry) {
+            // TODO: Replace with `entry.status` (will need to pass down)
+            if (entry.published && entry.private) {
+                return 'bg-transparent border border-gray-600';
+            } else if (entry.published) {
+                return 'bg-green-600';
+            } else {
+                return 'bg-gray-400';
+            }
+        },
+
+        getStatusLabel(entry) {
+            if (entry.status === 'published') {
+                return __('Published');
+            } else if (entry.status === 'scheduled') {
+                return __('Scheduled');
+            } else if (entry.status === 'expired') {
+                return __('Expired');
+            } else if (entry.status === 'draft') {
+                return __('Draft');
+            }
+        },
+
+        getStatusTooltip(entry) {
+            if (entry.status === 'published') {
+                return entry.collection.dated
+                    ? __('messages.status_published_with_date', {date: entry.date})
+                    : null; // The label is sufficient.
+            } else if (entry.status === 'scheduled') {
+                return __('messages.status_scheduled_with_date', {date: entry.date})
+            } else if (entry.status === 'expired') {
+                return __('messages.status_expired_with_date', {date: entry.date})
+            } else if (entry.status === 'draft') {
+                return null; // The label is sufficient.
+            }
+        },
+
+        columnShowing(column) {
+            return this.cols.find(c => c.field === column);
+        },
+    }
 
 }
 </script>

--- a/src/Widgets/Collection.php
+++ b/src/Widgets/Collection.php
@@ -3,6 +3,7 @@
 namespace Statamic\Widgets;
 
 use Statamic\Contracts\Entries\Entry as EntryContract;
+use Statamic\CP\Column;
 use Statamic\Facades\Collection as CollectionAPI;
 use Statamic\Facades\Scope;
 use Statamic\Facades\User;
@@ -33,6 +34,11 @@ class Collection extends Widget
         $blueprint = $collection->entryBlueprint();
         $columns = $blueprint
             ->columns()
+            ->put('status', Column::make('status')
+                ->listable(true)
+                ->visible(true)
+                ->defaultVisibility(true)
+                ->sortable(false))
             ->only($this->config('fields', []))
             ->map(fn ($column) => $column->sortable(false)->visible(true))
             ->values();


### PR DESCRIPTION
This pull request fixes an issue in the collection widget, where it wasn't possible to configure the `status` field to display as a column in the collection widget.

Fixes #10256.