### PR TITLE
[5.x] Prevent text in <code> blocks from extending outside parent <pre> container

### DIFF
--- a/resources/css/core/typography.css
+++ b/resources/css/core/typography.css
@@ -77,6 +77,7 @@ a:not([class^="btn"]) {
 
     pre {
         background-color: #f9f2f4;
+        white-space: pre-wrap;
         @apply p-2;
 
         code {

--- a/resources/css/core/typography.css
+++ b/resources/css/core/typography.css
@@ -77,7 +77,7 @@ a:not([class^="btn"]) {
 
     pre {
         background-color: #f9f2f4;
-        white-space: normal;
+        word-wrap: normal;
         overflow: auto;
         @apply p-2;
 

--- a/resources/css/core/typography.css
+++ b/resources/css/core/typography.css
@@ -77,7 +77,8 @@ a:not([class^="btn"]) {
 
     pre {
         background-color: #f9f2f4;
-        white-space: pre-wrap;
+        white-space: normal;
+        overflow: auto;
         @apply p-2;
 
         code {

--- a/resources/css/core/typography.css
+++ b/resources/css/core/typography.css
@@ -77,7 +77,6 @@ a:not([class^="btn"]) {
 
     pre {
         background-color: #f9f2f4;
-        word-wrap: normal;
         overflow: auto;
         @apply p-2;
 


### PR DESCRIPTION
This fixes the CP's addon page description `<code>` block to match the CSS used in the [public addon page](https://statamic.com/addons/stillat/entry-relationships) (i.e., scrollbar for the `<code>` block.)

**Before:**

![css-old](https://github.com/statamic/cms/assets/503/448e68ac-1103-4812-9e69-445c424d0e50)

**After:**

![css-new](https://github.com/statamic/cms/assets/503/38c13f8c-7cbe-417c-a923-44623862383e)
