### PR TITLE
[5.x] Prevent the Link Fieldtype's Asset option from erroring when `container` is empty

### DIFF
--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -172,7 +172,7 @@ class Link extends Fieldtype
 
     private function showAssetOption()
     {
-        return $this->config('container') !== null;
+        return ! empty($this->config('container'));
     }
 
     public function toGqlType()


### PR DESCRIPTION
This pull request fixes an issue where the Link Fieldtype would consider the "Asset" link option to be active, even when the `container` config value is an empty array.

This PR fixes it by using the `empty` function instead of *just* checking that it's not null.

Fixes #10268.