### PR TITLE
[5.x] Prevent adding content to Blade stacks twice

### DIFF
--- a/src/View/Antlers/Language/Runtime/StackReplacementManager.php
+++ b/src/View/Antlers/Language/Runtime/StackReplacementManager.php
@@ -88,7 +88,7 @@ class StackReplacementManager
         return $name.$contentHash;
     }
 
-    public static function prependStack($stackName, $content, $trimContentWhitespace = false)
+    public static function prependStack($stackName, $content, $trimContentWhitespace = false, $isBlade = false)
     {
         $name = self::getStackReplacement($stackName);
 
@@ -104,7 +104,9 @@ class StackReplacementManager
             $content = trim($content);
         }
 
-        Stacks::prependToBladeStack($stackName, $content);
+        if (! $isBlade) {
+            Stacks::prependToBladeStack($stackName, $content);
+        }
 
         if (GlobalRuntimeState::$isCacheEnabled) {
             self::$cachedStacks[] = $stackName;
@@ -113,7 +115,7 @@ class StackReplacementManager
         array_unshift(self::$stackContents[GlobalRuntimeState::$environmentId][$name], $content);
     }
 
-    public static function pushStack($stackName, $content, $trimContentWhitespace = true)
+    public static function pushStack($stackName, $content, $trimContentWhitespace = true, $isBlade = false)
     {
         $name = self::getStackReplacement($stackName);
 
@@ -129,7 +131,9 @@ class StackReplacementManager
             $content = trim($content);
         }
 
-        Stacks::pushToBladeStack($stackName, $content);
+        if (! $isBlade) {
+            Stacks::pushToBladeStack($stackName, $content);
+        }
 
         if (GlobalRuntimeState::$isCacheEnabled) {
             self::$cachedStacks[] = $stackName;

--- a/src/View/Interop/Stacks.php
+++ b/src/View/Interop/Stacks.php
@@ -66,14 +66,14 @@ PHP;
     public static function endBladePush($stack): void
     {
         if ($content = self::getBladeValue('pushes', $stack)) {
-            StackReplacementManager::pushStack($stack, $content, false);
+            StackReplacementManager::pushStack($stack, $content, false, true);
         }
     }
 
     public static function endBladePrepend($stack): void
     {
         if ($content = self::getBladeValue('prepends', $stack)) {
-            StackReplacementManager::prependStack($stack, $content, false);
+            StackReplacementManager::prependStack($stack, $content, false, true);
         }
     }
 


### PR DESCRIPTION
This PR prevents prepending/pushing stack contents twice to a Blade stack. This seems to be the root cause of #10258, but would need help to validate this. This issue can be reproduced by utilizing a Blade template *and* a Blade layout together.

The changes in this PR address this by not invoking the interop logic to push to Blade if the request is coming from Blade itself. I've added another example page to https://github.com/JohnathonKoster/statamic-antlers-blade-stacks with this setup configured (simply navigate to `/blade-route` to observe the before/after behaviors).