### PR TITLE
[5.x] Drop default values from fieldtypes

### DIFF
--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -19,7 +19,6 @@ use Statamic\Support\Str;
 class Assets extends Fieldtype
 {
     protected $categories = ['media', 'relationship'];
-    protected $defaultValue = [];
     protected $selectableInForms = true;
 
     protected function configFieldItems(): array

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -38,7 +38,6 @@ class Bard extends Replicator
     ];
 
     protected $categories = ['text', 'structured'];
-    protected $defaultValue = [];
     protected $rules = [];
 
     protected function configFieldItems(): array

--- a/src/Fieldtypes/Files.php
+++ b/src/Fieldtypes/Files.php
@@ -6,7 +6,6 @@ use Statamic\Fields\Fieldtype;
 
 class Files extends Fieldtype
 {
-    protected $defaultValue = [];
     protected $selectable = false;
     protected $selectableInForms = true;
     protected $categories = ['media'];

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -16,7 +16,6 @@ class Grid extends Fieldtype
 {
     protected $categories = ['structured'];
     protected $defaultable = false;
-    protected $defaultValue = [];
 
     protected function configFieldItems(): array
     {

--- a/src/Fieldtypes/Group.php
+++ b/src/Fieldtypes/Group.php
@@ -13,7 +13,6 @@ class Group extends Fieldtype
 {
     protected $categories = ['structured'];
     protected $defaultable = false;
-    protected $defaultValue = [];
 
     protected function configFieldItems(): array
     {

--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -23,7 +23,6 @@ abstract class Relationship extends Fieldtype
     protected $canSearch = false;
     protected $statusIcons = false;
     protected $taggable = false;
-    protected $defaultValue = [];
     protected $formComponentProps = [
         '_' => '_', // forces an object in js
     ];

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -16,7 +16,6 @@ use Statamic\Support\Str;
 class Replicator extends Fieldtype
 {
     protected $categories = ['structured'];
-    protected $defaultValue = [];
     protected $rules = ['array'];
 
     protected function configFieldItems(): array

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -528,7 +528,7 @@ class FieldtypeTest extends TestCase
         $this->assertEquals(false, $fieldtype->config('delta'));
         $this->assertEquals(true, $fieldtype->config('echo'));
         $this->assertEquals(false, $fieldtype->config('foxtrot'));
-        $this->assertEquals([], $fieldtype->config('golf'));
+        $this->assertNull($fieldtype->config('golf'));
         $this->assertEquals(['hotel!'], $fieldtype->config('hotel'));
         $this->assertNull($fieldtype->config('unknown'));
         $this->assertEquals('fallback', $fieldtype->config('unknown', 'fallback'));

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -518,7 +518,7 @@ class FieldtypeTest extends TestCase
             'echo' => true, // Default set
             'foxtrot' => false, // Default set
             // Files fields (has default of empty array)
-            'golf' => [], // No default set
+            'golf' => null, // No default set
             'hotel' => ['hotel!'], // Default set
         ], $fieldtype->config());
         $this->assertEquals('bar', $fieldtype->config('foo'));

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -500,6 +500,12 @@ class FieldtypeTest extends TestCase
     /** @test */
     public function it_gets_a_config_value()
     {
+        (new class extends Fieldtype
+        {
+            protected static $handle = 'fieldtype_with_array_default';
+            protected $defaultValue = [];
+        })::register();
+
         $field = new Field('test', [
             'foo' => 'bar', // doesn't exist as a config field
             'alfa' => 'overridden', // doesn't have a default
@@ -517,8 +523,8 @@ class FieldtypeTest extends TestCase
             'delta' => false, // No default set
             'echo' => true, // Default set
             'foxtrot' => false, // Default set
-            // Files fields (has default of empty array)
-            'golf' => null, // No default set
+            // Test fields (has default of empty array)
+            'golf' => [], // No default set
             'hotel' => ['hotel!'], // Default set
         ], $fieldtype->config());
         $this->assertEquals('bar', $fieldtype->config('foo'));
@@ -528,7 +534,7 @@ class FieldtypeTest extends TestCase
         $this->assertEquals(false, $fieldtype->config('delta'));
         $this->assertEquals(true, $fieldtype->config('echo'));
         $this->assertEquals(false, $fieldtype->config('foxtrot'));
-        $this->assertNull($fieldtype->config('golf'));
+        $this->assertEquals([], $fieldtype->config('golf'));
         $this->assertEquals(['hotel!'], $fieldtype->config('hotel'));
         $this->assertNull($fieldtype->config('unknown'));
         $this->assertEquals('fallback', $fieldtype->config('unknown', 'fallback'));
@@ -595,10 +601,10 @@ class TestFieldtypeWithConfigFields extends Fieldtype
             'default' => false,
         ],
         'golf' => [
-            'type' => 'files',
+            'type' => 'fieldtype_with_array_default',
         ],
         'hotel' => [
-            'type' => 'files',
+            'type' => 'fieldtype_with_array_default',
             'default' => ['hotel!'],
         ],
     ];


### PR DESCRIPTION
In Statamic 5, we introduced some changes to how field configs work. Instead of saving all of a field's config options in a blueprint or fieldset's YAML file, we only saved the config options that *differ* from the option's default. This change is intended to help tidy up blueprints & fieldsets.

As a side affect of this change, it meant that when fieldtypes went to get their config values, they'd only be able to access those config options which are explicitly set in the field config (eg. the config values which differ from their defaults).

We fixed this in #10139, where the `Fieldtype::config()` method now merges in the default values from the fieldtype's config options.

However, as a result of this fix, it means that the `$defaultValue` property set on some of our fieldtypes would be the value it'd fallback to.

For some of our fieldtypes (including the `Relationship` one), the default value was set to an empty array. However, our fieldtypes were expecting to get `null` when no value was provided.

This PR fixes that by removing the `$defaultValue = []` property from some of our fieldtypes, to ensure the default value for them is `null`.

Fixes https://github.com/statamic/cms/issues/10268.
Replaces https://github.com/statamic/cms/pull/10270.