### PR TITLE
[5.x] Add cache for nested imported fieldsets

### DIFF
--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -149,7 +149,11 @@ class Fields
 
     public function toPublishArray()
     {
-        return $this->fields->values()->map->toPublishArray()->all();
+        $blink = md5(json_encode($this->fields));
+
+        return Blink::once($blink, function () {
+            return $this->fields->values()->map->toPublishArray()->all();
+        });
     }
 
     public function addValues(array $values)

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -3,6 +3,7 @@
 namespace Statamic\Fieldtypes;
 
 use Facades\Statamic\Fieldtypes\RowId;
+use Statamic\Facades\Blink;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fields;
 use Statamic\Fields\Fieldtype;
@@ -118,12 +119,17 @@ class Replicator extends Fieldtype
 
     public function fields($set, $index = -1)
     {
-        return new Fields(
-            Arr::get($this->flattenedSetsConfig(), "$set.fields"),
-            $this->field()->parent(),
-            $this->field(),
-            $index
-        );
+        $config = Arr::get($this->flattenedSetsConfig(), "$set.fields");
+        $hash = md5($index.json_encode($config));
+
+        return Blink::once($hash, function () use ($config, $index) {
+            return new Fields(
+                $config,
+                $this->field()->parent(),
+                $this->field(),
+                $index
+            );
+        });
     }
 
     public function extraRules(): array
@@ -207,15 +213,21 @@ class Replicator extends Fieldtype
             return [$set['_id'] => $this->fields($set['type'], $index)->addValues($set)->meta()->put('_', '_')];
         })->toArray();
 
-        $defaults = collect($this->flattenedSetsConfig())->map(function ($set, $handle) {
-            return $this->fields($handle)->all()->map(function ($field) {
-                return $field->fieldtype()->preProcess($field->defaultValue());
-            })->all();
-        })->all();
+        $blink = md5(json_encode($this->flattenedSetsConfig()));
 
-        $new = collect($this->flattenedSetsConfig())->map(function ($set, $handle) use ($defaults) {
-            return $this->fields($handle)->addValues($defaults[$handle])->meta()->put('_', '_');
-        })->toArray();
+        $defaults = Blink::once($blink.'-defaults', function () {
+            return collect($this->flattenedSetsConfig())->map(function ($set, $handle) {
+                return $this->fields($handle)->all()->map(function ($field) {
+                    return $field->fieldtype()->preProcess($field->defaultValue());
+                })->all();
+            })->all();
+        });
+
+        $new = Blink::once($blink.'-new', function () use ($defaults) {
+            return collect($this->flattenedSetsConfig())->map(function ($set, $handle) use ($defaults) {
+                return $this->fields($handle)->addValues($defaults[$handle])->meta()->put('_', '_');
+            })->toArray();
+        });
 
         $previews = collect($existing)->map(function ($fields) {
             return collect($fields)->map(function () {
@@ -234,21 +246,25 @@ class Replicator extends Fieldtype
 
     public function flattenedSetsConfig()
     {
-        $sets = collect($this->config('sets'));
+        $blink = md5($this->field?->handle().json_encode($this->field?->config()));
 
-        // If the first set doesn't have a nested "set" key, it would be the legacy format.
-        // We'll put it in a "main" group so it's compatible with the new format.
-        // This also happens in the "sets" fieldtype.
-        if (! Arr::has($sets->first(), 'sets')) {
-            $sets = collect([
-                'main' => [
-                    'sets' => $sets->all(),
-                ],
-            ]);
-        }
+        return Blink::once($blink, function () {
+            $sets = collect($this->config('sets'));
 
-        return $sets->flatMap(function ($section) {
-            return $section['sets'];
+            // If the first set doesn't have a nested "set" key, it would be the legacy format.
+            // We'll put it in a "main" group so it's compatible with the new format.
+            // This also happens in the "sets" fieldtype.
+            if (! Arr::has($sets->first(), 'sets')) {
+                $sets = collect([
+                    'main' => [
+                        'sets' => $sets->all(),
+                    ],
+                ]);
+            }
+
+            return $sets->flatMap(function ($section) {
+                return $section['sets'];
+            });
         });
     }
 


### PR DESCRIPTION
This re-implements #8397 and potentially fixes issue #8395

This adds Blink caches to avoid redundant method calls when importing same fields in a nested replicator context.

