### PR TITLE
[5.x] Statically cache 404s

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -138,6 +138,8 @@ return [
     | all errors. For example, the first time a 404 is encountered it will
     | be generated and cached, and then served for all subsequent 404s.
     |
+    | This is only supported for half measure.
+    |
     */
 
     'share_errors' => false,

--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -131,16 +131,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Errors
+    | Shared Error Pages
     |--------------------------------------------------------------------------
     |
-    | Here you may define the URLs that should be used for error pages. This
-    | will make all instances of a response code refer to the same page.
+    | You may choose to share the same statically generated error page across
+    | all errors. For example, the first time a 404 is encountered it will
+    | be generated and cached, and then served for all subsequent 404s.
     |
     */
 
-    'errors' => [
-        // 404 => '/404',
-    ],
+    'share_errors' => false,
 
 ];

--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -129,4 +129,18 @@ return [
 
     'warm_queue' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Errors
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define the URLs that should be used for error pages. This
+    | will make all instances of a response code refer to the same page.
+    |
+    */
+
+    'errors' => [
+        // 404 => '/404',
+    ],
+
 ];

--- a/src/Exceptions/Concerns/RendersHttpExceptions.php
+++ b/src/Exceptions/Concerns/RendersHttpExceptions.php
@@ -71,7 +71,7 @@ trait RendersHttpExceptions
             return null;
         }
 
-        $request = Request::createFrom(request())->fakeStaticCache404();
+        $request = Request::createFrom(request())->fakeStaticCacheStatus(404);
 
         $cacher = app(Cacher::class);
 

--- a/src/Exceptions/Concerns/RendersHttpExceptions.php
+++ b/src/Exceptions/Concerns/RendersHttpExceptions.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Response;
 use Statamic\Facades\Cascade;
 use Statamic\Statamic;
 use Statamic\StaticCaching\Cacher;
+use Statamic\StaticCaching\Cachers\ApplicationCacher;
 use Statamic\View\View;
 
 trait RendersHttpExceptions
@@ -69,9 +70,13 @@ trait RendersHttpExceptions
             return null;
         }
 
-        $request = Request::createFrom(request())->fakeStaticCacheStatus($status);
-
         $cacher = app(Cacher::class);
+
+        if (! $cacher instanceof ApplicationCacher) {
+            return null;
+        }
+
+        $request = Request::createFrom(request())->fakeStaticCacheStatus($status);
 
         return $cacher->hasCachedPage($request)
             ? $cacher->getCachedPage($request)->toResponse($request)

--- a/src/Exceptions/Concerns/RendersHttpExceptions.php
+++ b/src/Exceptions/Concerns/RendersHttpExceptions.php
@@ -65,7 +65,7 @@ trait RendersHttpExceptions
     {
         $status = $this->getStatusCode();
 
-        if (! config('statamic.static_caching.errors.'.$status)) {
+        if (! config('statamic.static_caching.share_errors')) {
             return null;
         }
 

--- a/src/Exceptions/Concerns/RendersHttpExceptions.php
+++ b/src/Exceptions/Concerns/RendersHttpExceptions.php
@@ -75,8 +75,8 @@ trait RendersHttpExceptions
 
         $cacher = app(Cacher::class);
 
-        if ($cacher->hasCachedPage($request)) {
-            return $cacher->getCachedPage($request)->toResponse($request);
-        }
+        return $cacher->hasCachedPage($request)
+            ? $cacher->getCachedPage($request)->toResponse($request)
+            : null;
     }
 }

--- a/src/Exceptions/Concerns/RendersHttpExceptions.php
+++ b/src/Exceptions/Concerns/RendersHttpExceptions.php
@@ -21,7 +21,7 @@ trait RendersHttpExceptions
             return response()->json(['message' => $this->getApiMessage()], $this->getStatusCode());
         }
 
-        if ($cached = $this->getCached404()) {
+        if ($cached = $this->getCachedError()) {
             return $cached;
         }
 
@@ -61,17 +61,15 @@ trait RendersHttpExceptions
         return $this->getMessage();
     }
 
-    private function getCached404(): ?Response
+    private function getCachedError(): ?Response
     {
-        if ($this->getStatusCode() !== 404) {
+        $status = $this->getStatusCode();
+
+        if (! config('statamic.static_caching.errors.'.$status)) {
             return null;
         }
 
-        if (! config('statamic.static_caching.errors.404')) {
-            return null;
-        }
-
-        $request = Request::createFrom(request())->fakeStaticCacheStatus(404);
+        $request = Request::createFrom(request())->fakeStaticCacheStatus($status);
 
         $cacher = app(Cacher::class);
 

--- a/src/Exceptions/Concerns/RendersHttpExceptions.php
+++ b/src/Exceptions/Concerns/RendersHttpExceptions.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Exceptions\Concerns;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Statamic\Facades\Cascade;
 use Statamic\Statamic;
@@ -66,15 +67,16 @@ trait RendersHttpExceptions
             return null;
         }
 
-        $cacher = app(Cacher::class);
-
-        $request = request();
-        //        $request->setUrl('404');
-
-        if (! $cacher->hasCachedPage($request)) {
+        if (! config('statamic.static_caching.errors.404')) {
             return null;
         }
 
-        return $cacher->getCachedPage($request)->toResponse($request);
+        $request = Request::createFrom(request())->fakeStaticCache404();
+
+        $cacher = app(Cacher::class);
+
+        if ($cacher->hasCachedPage($request)) {
+            return $cacher->getCachedPage($request)->toResponse($request);
+        }
     }
 }

--- a/src/StaticCaching/Cachers/ApplicationCacher.php
+++ b/src/StaticCaching/Cachers/ApplicationCacher.php
@@ -80,7 +80,7 @@ class ApplicationCacher extends AbstractCacher
     {
         $cachedPage = $this->cached ?? $this->getFromCache($request);
 
-        return new Page($cachedPage['content'], $cachedPage['headers'], $cachedPage['status']);
+        return new Page($cachedPage['content'], $cachedPage['headers'], $cachedPage['status'] ?? 200);
     }
 
     private function getFromCache(Request $request)

--- a/src/StaticCaching/Cachers/ApplicationCacher.php
+++ b/src/StaticCaching/Cachers/ApplicationCacher.php
@@ -52,6 +52,7 @@ class ApplicationCacher extends AbstractCacher
             $cacheValue = [
                 'content' => $value,
                 'headers' => $headers,
+                'status' => $event->response->getStatusCode(),
             ];
 
             $this->getDefaultExpiration()
@@ -79,7 +80,7 @@ class ApplicationCacher extends AbstractCacher
     {
         $cachedPage = $this->cached ?? $this->getFromCache($request);
 
-        return new Page($cachedPage['content'], $cachedPage['headers']);
+        return new Page($cachedPage['content'], $cachedPage['headers'], $cachedPage['status']);
     }
 
     private function getFromCache(Request $request)

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -85,7 +85,7 @@ class Cache
             return;
         }
 
-        $request = Request::createFrom($request)->fakeStaticCache404();
+        $request = Request::createFrom($request)->fakeStaticCacheStatus(404);
 
         if ($this->cacher->hasCachedPage($request)) {
             $this->cacher->cachePage($request, $response);

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -87,7 +87,7 @@ class Cache
 
         $request = Request::createFrom($request)->fakeStaticCacheStatus(404);
 
-        if ($this->cacher->hasCachedPage($request)) {
+        if (! $this->cacher->hasCachedPage($request)) {
             $this->cacher->cachePage($request, $response);
         }
     }

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -63,7 +63,7 @@ class Cache
         if ($this->shouldBeCached($request, $response)) {
             $lock->acquire(true);
 
-            $this->copy404($request, $response);
+            $this->copyError($request, $response);
 
             $this->makeReplacementsAndCacheResponse($request, $response);
 
@@ -75,17 +75,15 @@ class Cache
         return $response;
     }
 
-    private function copy404($request, $response)
+    private function copyError($request, $response)
     {
-        if ($response->getStatusCode() !== 404) {
+        $status = $response->getStatusCode();
+
+        if (! config('statamic.static_caching.errors.'.$status)) {
             return;
         }
 
-        if (! config('statamic.static_caching.errors.404')) {
-            return;
-        }
-
-        $request = Request::createFrom($request)->fakeStaticCacheStatus(404);
+        $request = Request::createFrom($request)->fakeStaticCacheStatus($status);
 
         if (! $this->cacher->hasCachedPage($request)) {
             $this->cacher->cachePage($request, $response);

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -79,7 +79,7 @@ class Cache
     {
         $status = $response->getStatusCode();
 
-        if (! config('statamic.static_caching.errors.'.$status)) {
+        if (! config('statamic.static_caching.share_errors')) {
             return;
         }
 

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -139,7 +139,7 @@ class Cache
             return false;
         }
 
-        if ($response->getStatusCode() !== 200 || $response->getContent() == '') {
+        if (! in_array($response->getStatusCode(), [200, 404]) || $response->getContent() == '') {
             return false;
         }
 

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Log;
 use Statamic\Facades\File;
 use Statamic\Statamic;
 use Statamic\StaticCaching\Cacher;
+use Statamic\StaticCaching\Cachers\ApplicationCacher;
 use Statamic\StaticCaching\Cachers\NullCacher;
 use Statamic\StaticCaching\NoCache\RegionNotFound;
 use Statamic\StaticCaching\NoCache\Session;
@@ -156,7 +157,9 @@ class Cache
             return false;
         }
 
-        if (! in_array($response->getStatusCode(), [200, 404]) || $response->getContent() == '') {
+        $statuses = $this->cacher instanceof ApplicationCacher ? [200, 404] : [200];
+
+        if (! in_array($response->getStatusCode(), $statuses) || $response->getContent() == '') {
             return false;
         }
 

--- a/src/StaticCaching/Page.php
+++ b/src/StaticCaching/Page.php
@@ -7,12 +7,15 @@ use Illuminate\Http\Response;
 
 class Page implements Responsable
 {
-    public function __construct(public string $content, public array $headers = [])
-    {
+    public function __construct(
+        public string $content,
+        public array $headers = [],
+        public int $status = 200
+    ) {
     }
 
     public function toResponse($request): Response
     {
-        return new Response($this->content, 200, $this->headers);
+        return new Response($this->content, $this->status, $this->headers);
     }
 }

--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -81,7 +81,7 @@ class ServiceProvider extends LaravelServiceProvider
         });
 
         Request::macro('fakeStaticCacheStatus', function (int $status) {
-            $url = str(config('statamic.static_caching.errors.'.$status))->start('/')->toString();
+            $url = '/__shared-errors/'.$status;
             $this->pathInfo = $url;
             $this->requestUri = $url;
 

--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -80,8 +80,8 @@ class ServiceProvider extends LaravelServiceProvider
             return '<?php echo app("Statamic\StaticCaching\NoCache\BladeDirective")->handle('.$exp.', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>';
         });
 
-        Request::macro('fakeStaticCache404', function () {
-            $url = str(config('statamic.static_caching.errors.404'))->start('/')->toString();
+        Request::macro('fakeStaticCacheStatus', function (int $status) {
+            $url = str(config('statamic.static_caching.errors.'.$status))->start('/')->toString();
             $this->pathInfo = $url;
             $this->requestUri = $url;
 

--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\StaticCaching;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
@@ -77,6 +78,14 @@ class ServiceProvider extends LaravelServiceProvider
 
         Blade::directive('nocache', function ($exp) {
             return '<?php echo app("Statamic\StaticCaching\NoCache\BladeDirective")->handle('.$exp.', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>';
+        });
+
+        Request::macro('fakeStaticCache404', function () {
+            $url = str(config('statamic.static_caching.errors.404'))->start('/')->toString();
+            $this->pathInfo = $url;
+            $this->requestUri = $url;
+
+            return $this;
         });
     }
 }

--- a/tests/StaticCaching/ApplicationCacherTest.php
+++ b/tests/StaticCaching/ApplicationCacherTest.php
@@ -42,6 +42,7 @@ class ApplicationCacherTest extends TestCase
         $cachedPage = $cacher->getCachedPage($request);
         $this->assertEquals('html content', $cachedPage->content);
         $this->assertEquals('application/html', $cachedPage->headers['Content-Type']);
+        $this->assertEquals(200, $cachedPage->status);
     }
 
     /** @test */


### PR DESCRIPTION
At the moment when you enable static caching and hit a 404-ing page, it does not get cached. If that 404-ing page is heavy, you could visit it repeatedly and increase the load on the server.

This PR has two parts. Both are only supported when using half measure, for now.

### Allow caching 404s
This PR allows 404s to be statically cached when using half measure. This is automatic and doesn't require a setting. This likely didn't already exist because it's not possible when using full measure. We handle this by a simple check for whether half measure is being used.

### Sharing errors
Additionally, this PR allows those 404s to be shared. For instance, the first time you encounter a 404, it will be rendered and cached. Then if you visit another 404ing page, it will serve the previously cached version regardless of the URL.

Each URL will have their own cache, but the rendering will be avoided. Subsequent 404s will just get copied from the result of the first one.

Since we can't know in the middleware if a cold page will be a 404 or not, we will manually retrieve it from the static cache just before Statamic would normally render the 404's view.