### PR TITLE
[5.x] Prevent additional augmented search result data from being lost

### DIFF
--- a/src/Search/Result.php
+++ b/src/Search/Result.php
@@ -106,6 +106,11 @@ class Result implements ContainsQueryableValues, Contract
         ])->merge($this->index->extraAugmentedResultData($this));
     }
 
+    public function toDeferredAugmentedArray($keys = null)
+    {
+        return $this->toAugmentedCollection($keys);
+    }
+
     public function newAugmentedInstance(): Augmented
     {
         if ($this->searchable instanceof Augmentable) {

--- a/src/View/Antlers/Language/Runtime/Sandbox/RuntimeValues.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/RuntimeValues.php
@@ -12,7 +12,7 @@ use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
 
 class RuntimeValues
 {
-    protected static function shouldBulkAugment($augmentable)
+    private static function shouldBulkAugment($augmentable)
     {
         if ($augmentable instanceof Collection) {
             $first = $augmentable->first();

--- a/src/View/Antlers/Language/Runtime/Sandbox/RuntimeValues.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/RuntimeValues.php
@@ -5,17 +5,29 @@ namespace Statamic\View\Antlers\Language\Runtime\Sandbox;
 use Exception;
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Data\Augmentable;
+use Statamic\Contracts\Data\BulkAugmentable;
 use Statamic\Data\BulkAugmentor;
 use Statamic\Fields\Value;
 use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
 
 class RuntimeValues
 {
+    protected static function shouldBulkAugment($augmentable)
+    {
+        if ($augmentable instanceof Collection) {
+            $first = $augmentable->first();
+
+            return $first instanceof Augmentable && $first instanceof BulkAugmentable;
+        }
+
+        return false;
+    }
+
     public static function resolveWithRuntimeIsolation($augmentable)
     {
         GlobalRuntimeState::$requiresRuntimeIsolation = true;
         try {
-            if ($augmentable instanceof Collection && $augmentable->first() instanceof Augmentable) {
+            if (self::shouldBulkAugment($augmentable)) {
                 $value = BulkAugmentor::make($augmentable)->toArray();
             } else {
                 $value = $augmentable->toDeferredAugmentedArray();


### PR DESCRIPTION
This PR fixes #10251 by only running the bulk augmentation process in Antlers when a collection contains `BulkAugmentable` instances. Additionally, the `Result` class's `toDeferredAugmentedArray` will now return the results of `toAugmentedCollection` to ensure the extra search data is added.

Notes for review: I had originally looked into simply adjusting the what the `Result` augments to, but decided against that since it could be quite the unexpected change for anyone doing stuff the results of `newAugmentedInstance` on `Result` objects. If curious, that was implemented here: https://github.com/statamic/cms/compare/5.x...JohnathonKoster:cms:search-result-augmentation and makes it Just Work ™️ with the bulk augmentation stuff. However, with _this_ PR, I think having it check for `instanceof BulkAugmentable` is a good idea for anything else that may have been missed.