### PR TITLE
[5.x] Fix issue when using Livewire with full measure static caching

### DIFF
--- a/src/StaticCaching/Replacers/NoCacheReplacer.php
+++ b/src/StaticCaching/Replacers/NoCacheReplacer.php
@@ -85,7 +85,7 @@ class NoCacheReplacer implements Replacer
                 Str::position($contents, '</head>')
             ])->filter()->min();
 
-            $js = "<script type=\"text/javascript\">{$cacher->getNocacheJs()}</>";
+            $js = "<script type=\"text/javascript\">{$cacher->getNocacheJs()}</script>";
 
             $contents = Str::substrReplace($contents, $js, $insertBefore, 0);
         }

--- a/src/StaticCaching/Replacers/NoCacheReplacer.php
+++ b/src/StaticCaching/Replacers/NoCacheReplacer.php
@@ -81,8 +81,9 @@ class NoCacheReplacer implements Replacer
         if ($cacher->shouldOutputJs()) {
             $firstLink = Str::position($contents, '<link');
             $firstScript = Str::position($contents, '<script');
-            $insertBefore = min($firstLink, $firstScript);
-            $js = "<script type=\"text/javascript\">{$cacher->getNocacheJs()}</script>";
+            $endOfHead = Str::position($contents, '</head>');
+            $insertBefore = min($firstLink, $firstScript, $endOfHead);
+            $js = "<script type=\"text/javascript\">{$cacher->getNocacheJs()}</>";
 
             $contents = Str::substrReplace($contents, $js, $insertBefore, 0);
         }

--- a/src/StaticCaching/Replacers/NoCacheReplacer.php
+++ b/src/StaticCaching/Replacers/NoCacheReplacer.php
@@ -82,7 +82,7 @@ class NoCacheReplacer implements Replacer
             $insertBefore = collect([
                 Str::position($contents, '<link'),
                 Str::position($contents, '<script'),
-                Str::position($contents, '</head>')
+                Str::position($contents, '</head>'),
             ])->filter()->min();
 
             $js = "<script type=\"text/javascript\">{$cacher->getNocacheJs()}</script>";

--- a/src/StaticCaching/Replacers/NoCacheReplacer.php
+++ b/src/StaticCaching/Replacers/NoCacheReplacer.php
@@ -79,10 +79,12 @@ class NoCacheReplacer implements Replacer
         $contents = $response->getContent();
 
         if ($cacher->shouldOutputJs()) {
-            $firstLink = Str::position($contents, '<link');
-            $firstScript = Str::position($contents, '<script');
-            $endOfHead = Str::position($contents, '</head>');
-            $insertBefore = min($firstLink, $firstScript, $endOfHead);
+            $insertBefore = collect([
+                Str::position($contents, '<link'),
+                Str::position($contents, '<script'),
+                Str::position($contents, '</head>')
+            ])->filter()->min();
+
             $js = "<script type=\"text/javascript\">{$cacher->getNocacheJs()}</>";
 
             $contents = Str::substrReplace($contents, $js, $insertBefore, 0);

--- a/tests/StaticCaching/FullMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/FullMeasureStaticCachingTest.php
@@ -57,7 +57,7 @@ class FullMeasureStaticCachingTest extends TestCase
         })::register();
 
         $this->withFakeViews();
-        $this->viewShouldReturnRaw('layout', '<html><body>{{ template_content }}</body></html>');
+        $this->viewShouldReturnRaw('layout', '<html><head></head><body>{{ template_content }}</body></html>');
         $this->viewShouldReturnRaw('default', '{{ example_count }} {{ nocache }}{{ example_count }}{{ /nocache }}');
 
         $this->createPage('about');
@@ -74,14 +74,14 @@ class FullMeasureStaticCachingTest extends TestCase
         $region = app(Session::class)->regions()->first();
 
         // Initial response should be dynamic and not contain javascript.
-        $this->assertEquals('<html><body>1 2</body></html>', $response->getContent());
+        $this->assertEquals('<html><head></head><body>1 2</body></html>', $response->getContent());
 
         // The cached response should have the nocache placeholder, and the javascript.
         $this->assertTrue(file_exists($this->dir.'/about_.html'));
-        $this->assertEquals(vsprintf('<html><body>1 <span class="nocache" data-nocache="%s">%s</span>%s</body></html>', [
+        $this->assertEquals(vsprintf('<html><head>%s</head><body>1 <span class="nocache" data-nocache="%s">%s</span></body></html>', [
+            '<script type="text/javascript">js here</script>',
             $region->key(),
             '<svg>Loading...</svg>',
-            '<script type="text/javascript">js here</script>',
         ]), file_get_contents($this->dir.'/about_.html'));
     }
 
@@ -134,7 +134,7 @@ class FullMeasureStaticCachingTest extends TestCase
     public function it_should_add_the_javascript_if_there_is_a_csrf_token()
     {
         $this->withFakeViews();
-        $this->viewShouldReturnRaw('layout', '<html><body>{{ template_content }}</body></html>');
+        $this->viewShouldReturnRaw('layout', '<html><head></head><body>{{ template_content }}</body></html>');
         $this->viewShouldReturnRaw('default', '{{ csrf_token }}');
 
         $this->createPage('about');
@@ -148,11 +148,11 @@ class FullMeasureStaticCachingTest extends TestCase
             ->assertOk();
 
         // Initial response should be dynamic and not contain javascript.
-        $this->assertEquals('<html><body>'.csrf_token().'</body></html>', $response->getContent());
+        $this->assertEquals('<html><head></head><body>'.csrf_token().'</body></html>', $response->getContent());
 
         // The cached response should have the token placeholder, and the javascript.
         $this->assertTrue(file_exists($this->dir.'/about_.html'));
-        $this->assertEquals(vsprintf('<html><body>STATAMIC_CSRF_TOKEN%s</body></html>', [
+        $this->assertEquals(vsprintf('<html><head>%s</head><body>STATAMIC_CSRF_TOKEN</body></html>', [
             '<script type="text/javascript">js here</script>',
         ]), file_get_contents($this->dir.'/about_.html'));
     }


### PR DESCRIPTION
I've worked on a couple of PR's for Jonas' Livewire addon to enhance support for Statamic's static caching. See https://github.com/jonassiewertsen/statamic-livewire/pull/61 and https://github.com/jonassiewertsen/statamic-livewire/pull/64. 

The newly added `AssetsReplacer` adds support for Livewire's [`@assets` Blade directive](https://livewire.laravel.com/docs/javascript#loading-assets), that allows you to push assets into the `<head>`. 

I've previously PR'd support for Livewire and Statamic's full measure static caching in https://github.com/statamic/cms/pull/8762. This script works as expected in general scenarios. However, I've encountered an edge case, where the CSRF token isn't replaced in time before a request to Livewire is made. 

This can happen, when a script, added to the `<head>` with the `@assets` directive, is making requests to Livewire, e.g. with `this.$wire`. The issue is that at the time of this request, the CSRF token hasn't been replaced yet, as the nocache script is only executed at the end of the `</body>`. So `this.$wire` is making a Livewire request using the `STATAMIC_CSRF_TOKEN` placeholder as the CSRF token.

This PR resolves this issue by moving the nocache JS to the head before any `<link>` or `<script>` so that the CSRF token placeholder is replaced before any other script is executed.