### PR TITLE
[5.x] Filter out `visibility: hidden` fields from form emails

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -171,14 +171,17 @@ class Email extends Mailable
 
     protected function getRenderableFieldData($values)
     {
-        return collect($values)->map(function ($value, $handle) {
-            $field = $value->field();
-            $display = $field->display();
-            $fieldtype = $field->type();
-            $config = $field->config();
+        return collect($values)
+            ->reject(fn ($field) => $field->field()->visibility() === 'hidden')
+            ->map(function ($value, $handle) {
+                $field = $value->field();
+                $display = $field->display();
+                $fieldtype = $field->type();
+                $config = $field->config();
 
-            return compact('display', 'handle', 'fieldtype', 'config', 'value');
-        })->values();
+                return compact('display', 'handle', 'fieldtype', 'config', 'value');
+            })
+            ->values();
     }
 
     private function getGlobalsData()


### PR DESCRIPTION
This pull request filters out fields with `visibility: hidden` from being output in form emails, in the `{{ fields }}` array.

Fixes #10305.