### PR TITLE
[5.x] Fix nested field path prefixes

### DIFF
--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -264,6 +264,8 @@ class Fields
             $field->setConfig(array_merge($field->config(), $overrides));
         }
 
+        $field = clone $field;
+
         return $field
             ->setParent($this->parent)
             ->setParentField($this->parentField, $this->parentIndex)
@@ -300,8 +302,10 @@ class Fields
             }
 
             return $fields;
-        })->each(function ($field) {
-            $field
+        })->map(function ($field) {
+            $field = clone $field;
+
+            return $field
                 ->setParent($this->parent)
                 ->setParentField($this->parentField, $this->parentIndex);
         })->all();

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -120,7 +120,7 @@ class Replicator extends Fieldtype
     public function fields($set, $index = -1)
     {
         $config = Arr::get($this->flattenedSetsConfig(), "$set.fields");
-        $hash = md5($index.json_encode($config));
+        $hash = md5($this->field->fieldPathPrefix().$index.json_encode($config));
 
         return Blink::once($hash, function () use ($config, $index) {
             return new Fields(


### PR DESCRIPTION
https://github.com/statamic/cms/pull/10280 introduced blink caching of the Fields objects in the replicator fields method. This took set indexes into account but not parent paths, which causes the wrong cached objects to be used when you have nested replicators.

This PR fixes that.

I also found an issue with the way field objects loaded from the repository are re-used. They have their parent index set when fetched, but since the same object is being returned it just updates that each time, resulting in one object with the last index set, rather than one object per index. I'm not sure if this is a result of the new blink caching or some other field caching that was introduced with v5, but cloning the object before setting the index fixes it.