### PR TITLE
[5.x] Hide "Restore Revision" button when user is missing relevant permissions

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -259,6 +259,7 @@
                 :index-url="actions.revisions"
                 :restore-url="actions.restore"
                 :reference="initialReference"
+                :can-restore-revisions="!readOnly"
                 @closed="close"
             />
         </stack>

--- a/resources/js/components/revision-history/History.vue
+++ b/resources/js/components/revision-history/History.vue
@@ -36,6 +36,7 @@
                         :revision="revision"
                         :restore-url="restoreUrl"
                         :reference="reference"
+                        :can-restore-revisions="canRestoreRevisions"
                         @working-copy-selected="close"
                     />
                 </div>
@@ -60,6 +61,7 @@ export default {
         indexUrl: String,
         restoreUrl: String,
         reference: String,
+        canRestoreRevisions: Boolean,
     },
 
     data() {

--- a/resources/js/components/revision-history/Revision.vue
+++ b/resources/js/components/revision-history/Revision.vue
@@ -33,6 +33,7 @@
                 >
                     <template slot="action-buttons-right">
                         <restore-revision
+                            v-if="canRestoreRevisions"
                             :revision="revision"
                             :url="restoreUrl"
                             :reference="reference"
@@ -60,6 +61,7 @@ export default {
         revision: Object,
         restoreUrl: String,
         reference: String,
+        canRestoreRevisions: Boolean,
     },
 
     data() {

--- a/src/Http/Controllers/CP/Collections/RestoreEntryRevisionController.php
+++ b/src/Http/Controllers/CP/Collections/RestoreEntryRevisionController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
+use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Revisions\WorkingCopy;
 
@@ -10,6 +11,10 @@ class RestoreEntryRevisionController extends CpController
 {
     public function __invoke(Request $request, $collection, $entry)
     {
+        if (User::current()->cant('edit', $entry)) {
+            abort(403);
+        }
+
         if (! $target = $entry->revision($request->revision)) {
             dd('no such revision', $request->revision);
             // todo: handle invalid revision reference


### PR DESCRIPTION
This pull request fixes an issue where the "Restore Revision" button would be shown in a revision preview stack, even when the user is missing the relevant permissions.

Fixes #10279.