### PR TITLE
[5.x] Allow defining a store in the cache tag

### DIFF
--- a/src/Tags/Cache.php
+++ b/src/Tags/Cache.php
@@ -17,7 +17,7 @@ class Cache extends Tags implements CachesOutput
             return [];
         }
 
-        $store = LaraCache::store();
+        $store = LaraCache::store($this->params->get('store'));
 
         if (count($tags = $this->params->explode('tags', []))) {
             $store = $store->tags($tags);

--- a/tests/Tags/CacheTagTest.php
+++ b/tests/Tags/CacheTagTest.php
@@ -35,6 +35,20 @@ class CacheTagTest extends TestCase
     }
 
     /** @test */
+    public function it_can_use_a_custom_cache_store()
+    {
+        config()->set('cache.stores.statamic', ['driver' => 'array']);
+
+        $template = '{{ cache store="statamic" }}expensive{{ /cache }}';
+
+        Event::fake();
+
+        $this->assertEquals('expensive', $this->tag($template));
+
+        $this->assertMissed();
+    }
+
+    /** @test */
     public function it_skips_the_cache_if_cache_tags_are_not_enabled()
     {
         Config::set('statamic.system.cache_tags_enabled', false);


### PR DESCRIPTION
Similar to #10303, we'd like to define which cache store our cache tags are using, as we need them to use an unprefixed store in a multi-tenant application.