### PR TITLE
[5.x] Hide "Rename" and "Delete" options for default filter presets

### DIFF
--- a/resources/js/components/Preference.js
+++ b/resources/js/components/Preference.js
@@ -43,6 +43,18 @@ class Preference {
 
         return promise;
     }
+
+    defaults() {
+        return this.instance.$store.state.statamic.config.defaultPreferences;
+    }
+
+    getDefault(key, fallback) {
+        return data_get(this.defaults(), key, fallback);
+    }
+
+    hasDefault(key) {
+        return this.getDefault(key) !== null;
+    }
 }
 
 Object.defineProperties(Vue.prototype, {

--- a/resources/js/components/Preference.js
+++ b/resources/js/components/Preference.js
@@ -45,7 +45,7 @@ class Preference {
     }
 
     defaults() {
-        return this.instance.$store.state.statamic.config.defaultPreferences;
+        return Statamic.$config.get('defaultPreferences');
     }
 
     getDefault(key, fallback) {

--- a/resources/js/components/data-list/FilterPresets.vue
+++ b/resources/js/components/data-list/FilterPresets.vue
@@ -14,9 +14,9 @@
                             </button>
                         </template>
                         <dropdown-item :text="__('Duplicate')" @click="createPreset" />
-                        <dropdown-item :text="__('Rename')" @click="renamePreset" />
+                        <dropdown-item v-if="canRenamePreset(handle)" :text="__('Rename')" @click="renamePreset" />
                         <div class="divider" />
-                        <dropdown-item :text="__('Delete')" class="warning" @click="deletePreset" />
+                        <dropdown-item v-if="canDeletePreset(handle)" :text="__('Delete')" class="warning" @click="deletePreset" />
                     </dropdown-list>
                 </button>
                 <button class="pill-tab rtl:ml-1 ltr:mr-1" v-else @click="viewPreset(handle)">
@@ -140,6 +140,14 @@ export default {
             } else {
                 this.viewAll();
             }
+        },
+
+        canRenamePreset(handle) {
+            return !this.$preferences.hasDefault(`${this.preferencesKey}.${handle}`);
+        },
+
+        canDeletePreset(handle) {
+            return !this.$preferences.hasDefault(`${this.preferencesKey}.${handle}`);
         },
 
         viewAll() {

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -61,6 +61,7 @@ class JavascriptComposer
             'googleDocsViewer' => config('statamic.assets.google_docs_viewer'),
             'focalPointEditorEnabled' => config('statamic.assets.focal_point_editor'),
             'user' => $this->user($user),
+            'defaultPreferences' => Preference::default()->all(),
             'paginationSize' => config('statamic.cp.pagination_size'),
             'paginationSizeOptions' => config('statamic.cp.pagination_size_options'),
             'multisiteEnabled' => Site::multiEnabled(),


### PR DESCRIPTION
This pull request hides the "Rename" and "Delete" options for default filter presets, since renaming & deleting doesn't *really* work for them.

Fixes #10278.