### PR TITLE
[5.x] Prevent entries being selected when collapsing/expending entries in Tree View

### DIFF
--- a/resources/js/components/structures/Branch.vue
+++ b/resources/js/components/structures/Branch.vue
@@ -22,7 +22,7 @@
                     v-if="hasChildren"
                     class="p-2 text-gray-600 dark:text-dark-175 hover:text-gray-700 dark:hover:text-dark-150 transition duration-100 outline-none flex"
                     :class="{ '-rotate-90': !isOpen }"
-                    @click="$emit('toggle-open')"
+                    @click.stop="$emit('toggle-open')"
                 >
                     <svg-icon name="micro/chevron-down-xs" class="h-1.5" />
                 </button>


### PR DESCRIPTION
This pull request fixes an issue in the Entries Fieldtype when using Tree View, where collapsing/expending "tree branches" would cause that entry to be selected.

This pull request adds `.stop` to the toggle's click event to prevent it from propagating to the parent click handler which handles the item selecting.

Fixes #10321.