### PR TITLE
[5.x] Fix linking to addon fields

### DIFF
--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -131,8 +131,7 @@ class FieldTransformer
 
     private static function referenceFieldToVue($field): array
     {
-        // have to use the Laravel Arr helper so that linking to an addon fieldset's field works
-        $fieldsetField = \Illuminate\Support\Arr::get(static::fieldsetFields(), $field['field'], []);
+        $fieldsetField = static::fieldsetFields()[$field['field']] ?? [];
 
         $mergedConfig = array_merge(
             $fieldsetFieldConfig = Arr::get($fieldsetField, 'config', []),

--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -131,7 +131,8 @@ class FieldTransformer
 
     private static function referenceFieldToVue($field): array
     {
-        $fieldsetField = Arr::get(static::fieldsetFields(), $field['field'], []);
+        // have to use the Laravel Arr helper so that linking to an addon fieldset's field works
+        $fieldsetField = \Illuminate\Support\Arr::get(static::fieldsetFields(), $field['field'], []);
 
         $mergedConfig = array_merge(
             $fieldsetFieldConfig = Arr::get($fieldsetField, 'config', []),

--- a/tests/Fields/FieldTransformerTest.php
+++ b/tests/Fields/FieldTransformerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Fields;
 
 use Statamic\Facades\AssetContainer;
+use Statamic\Fields\Fieldset;
 use Statamic\Fields\FieldTransformer;
 use Statamic\Fields\Fieldtype;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -365,5 +366,26 @@ class FieldTransformerTest extends TestCase
             'replicator_preview' => false,
             'duplicate' => false,
         ], $fromVue['field']);
+    }
+
+    /** @test */
+    public function it_supports_addon_linked_fields()
+    {
+        $fieldset = tap(new Fieldset)
+            ->setHandle('addon::some_fieldset')
+            ->setContents(['fields' => [
+                [
+                    'handle' => 'field1',
+                    'field' => ['type' => 'text'],
+                ],
+            ]]);
+
+        \Statamic\Facades\Fieldset::shouldReceive('all')->andReturn(collect([
+            'addon::some' => $fieldset,
+        ]));
+
+        $this->configToVue('addon::some_fieldset.field1');
+
+        $this->assertTrue(true);
     }
 }

--- a/tests/Fields/FieldTransformerTest.php
+++ b/tests/Fields/FieldTransformerTest.php
@@ -376,7 +376,7 @@ class FieldTransformerTest extends TestCase
             ->setContents(['fields' => [
                 [
                     'handle' => 'field1',
-                    'field' => ['type' => 'text'],
+                    'field' => ['type' => 'text', 'foo' => 'bar'],
                 ],
             ]]);
 
@@ -384,8 +384,11 @@ class FieldTransformerTest extends TestCase
             'addon::some' => $fieldset,
         ]));
 
-        $this->configToVue('addon::some_fieldset.field1');
-
-        $this->assertTrue(true);
+        $this->assertEquals([
+            'type' => 'text',
+            'foo' => 'bar',
+            'width' => 100,
+            'localizable' => false,
+        ], $this->configToVue('addon::some_fieldset.field1'));
     }
 }


### PR DESCRIPTION
In our site builder, we have field sets that link to other fieldset fields:
```yaml
  -
    handle: image_asset
    field: 'simple::image_asset.image_asset'
```

When you try to load a blueprint containing this, you get an error :

```
ErrorException: Undefined array key "type"

/Users/erin/Development/cms/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php:256
/Users/erin/Development/cms/src/Fields/FieldTransformer.php:152
/Users/erin/Development/cms/src/Fields/FieldTransformer.php:128
```

This is because Statamic's `Arr` helper class is used and it converts `:`'s to `'.'` so you get `simple..image_asset.image_asset` as the key, which isn't found.