### PR TITLE
[5.x] Provide Site attribute helper

### DIFF
--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -4,6 +4,7 @@ namespace Statamic\Sites;
 
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Data\HasAugmentedData;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Support\TextDirection;
 use Statamic\View\Antlers\Language\Runtime\RuntimeParser;
@@ -67,6 +68,11 @@ class Site implements Augmentable
     public function attributes()
     {
         return $this->config['attributes'] ?? [];
+    }
+
+    public function attribute($key, $default = null)
+    {
+        return Arr::get($this->attributes(), $key, $default);
     }
 
     public function absoluteUrl()

--- a/tests/Sites/SiteTest.php
+++ b/tests/Sites/SiteTest.php
@@ -304,4 +304,30 @@ class SiteTest extends TestCase
 
         $this->assertEquals('rtl', $site->direction());
     }
+
+    /** @test */
+    public function it_gets_attributes()
+    {
+        $this->assertEquals([], (new Site('test', []))->attributes());
+
+        $site = new Site('test', ['attributes' => [
+            'alfa' => 'bravo',
+            'charlie' => [
+                'delta' => 'echo',
+            ],
+        ]]);
+
+        $this->assertEquals([
+            'alfa' => 'bravo',
+            'charlie' => [
+                'delta' => 'echo',
+            ],
+        ], $site->attributes());
+
+        $this->assertEquals('bravo', $site->attribute('alfa'));
+        $this->assertEquals(['delta' => 'echo'], $site->attribute('charlie'));
+        $this->assertEquals('echo', $site->attribute('charlie.delta'));
+        $this->assertNull($site->attribute('unknown'));
+        $this->assertNull($site->attribute('charlie.unknown'));
+    }
 }


### PR DESCRIPTION
When using Antlers, accessing Site attributes is straightforward. For example, you can use:
`{{ site:attributes:company_name }}`

In Blade, the equivalent is often done like this?
`{{ $site->attributes()['company_name'] }}`

However, if the attribute isn't set, this will throw an "Undefined array key" exception. Using `Arr::get` to handle this is an option, but it adds a lot of overhead.

This pull request introduces a simple attribute helper:
`{{ $site->attribute('company_name') }}`

As a bonus, this helper "supports" dot notation and allows you to provide a fallback value.