### PR TITLE
[5.x] Fix broken revision links on unpublished entries

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
+++ b/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
@@ -7,6 +7,7 @@ use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
+use Statamic\Revisions\WorkingCopy;
 
 class EntryRevisionsController extends CpController
 {
@@ -18,12 +19,13 @@ class EntryRevisionsController extends CpController
             ->prepend($this->workingCopy($entry))
             ->filter()
             ->each(function ($revision) use ($collection, $entry) {
-                $url = $revision->id() ? cp_route('collections.entries.revisions.show', [
-                    'collection' => $collection,
-                    'entry' => $entry->id(),
-                    'revision' => $revision->id(),
-                ]) : '';
-                $revision->attribute('item_url', $url);
+                if (! $revision instanceof WorkingCopy) {
+                    $revision->attribute('item_url', cp_route('collections.entries.revisions.show', [
+                        'collection' => $collection,
+                        'entry' => $entry->id(),
+                        'revision' => $revision->id(),
+                    ]));
+                }
             });
 
         // The first non manually created revision would be considered the "current"

--- a/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
+++ b/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
@@ -7,7 +7,6 @@ use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
-use Statamic\Revisions\WorkingCopy;
 
 class EntryRevisionsController extends CpController
 {
@@ -16,17 +15,13 @@ class EntryRevisionsController extends CpController
         $revisions = $entry
             ->revisions()
             ->reverse()
+            ->each(fn ($revision) => $revision->attribute('item_url', cp_route('collections.entries.revisions.show', [
+                'collection' => $collection,
+                'entry' => $entry->id(),
+                'revision' => $revision->id(),
+            ])))
             ->prepend($this->workingCopy($entry))
-            ->filter()
-            ->each(function ($revision) use ($collection, $entry) {
-                if (! $revision instanceof WorkingCopy) {
-                    $revision->attribute('item_url', cp_route('collections.entries.revisions.show', [
-                        'collection' => $collection,
-                        'entry' => $entry->id(),
-                        'revision' => $revision->id(),
-                    ]));
-                }
-            });
+            ->filter();
 
         // The first non manually created revision would be considered the "current"
         // version. It's what corresponds to what's in the content directory.

--- a/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
+++ b/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
@@ -18,11 +18,12 @@ class EntryRevisionsController extends CpController
             ->prepend($this->workingCopy($entry))
             ->filter()
             ->each(function ($revision) use ($collection, $entry) {
-                $revision->attribute('item_url', cp_route('collections.entries.revisions.show', [
+                $url = $revision->id() ? cp_route('collections.entries.revisions.show', [
                     'collection' => $collection,
                     'entry' => $entry->id(),
                     'revision' => $revision->id(),
-                ]));
+                ]) : '';
+                $revision->attribute('item_url', $url);
             });
 
         // The first non manually created revision would be considered the "current"

--- a/tests/Feature/Entries/EntryRevisionsTest.php
+++ b/tests/Feature/Entries/EntryRevisionsTest.php
@@ -83,7 +83,7 @@ class EntryRevisionsTest extends TestCase
             ->assertJsonPath('0.revisions.0.action', 'revision')
             ->assertJsonPath('0.revisions.0.message', 'Revision one')
             ->assertJsonPath('0.revisions.0.attributes.data.title', 'Original title')
-            ->assertJsonPath('0.revisions.0.attributes.item_url', "http://localhost/cp/collections/blog/entries/1/revisions/".Carbon::parse('2017-02-01')->timestamp)
+            ->assertJsonPath('0.revisions.0.attributes.item_url', 'http://localhost/cp/collections/blog/entries/1/revisions/'.Carbon::parse('2017-02-01')->timestamp)
 
             ->assertJsonPath('1.revisions.0.action', 'revision')
             ->assertJsonPath('1.revisions.0.message', false)
@@ -93,7 +93,7 @@ class EntryRevisionsTest extends TestCase
             ->assertJsonPath('1.revisions.1.action', 'revision')
             ->assertJsonPath('1.revisions.1.message', 'Revision two')
             ->assertJsonPath('1.revisions.1.attributes.data.title', 'Original title')
-            ->assertJsonPath('1.revisions.1.attributes.item_url', "http://localhost/cp/collections/blog/entries/1/revisions/".Carbon::parse('2017-02-03')->timestamp);
+            ->assertJsonPath('1.revisions.1.attributes.item_url', 'http://localhost/cp/collections/blog/entries/1/revisions/'.Carbon::parse('2017-02-03')->timestamp);
     }
 
     /** @test */

--- a/tests/Feature/Entries/EntryRevisionsTest.php
+++ b/tests/Feature/Entries/EntryRevisionsTest.php
@@ -156,10 +156,6 @@ class EntryRevisionsTest extends TestCase
         $this->assertEquals('user-1', $revision->user()->id());
         $this->assertEquals('Test!', $revision->message());
         $this->assertEquals('unpublish', $revision->action());
-        $this->get(cp_route('collections.entries.revisions.index', [
-            'collection' => 'blog',
-            'entry' => '1',
-        ]))->assertOk();
     }
 
     /** @test */

--- a/tests/Feature/Entries/EntryRevisionsTest.php
+++ b/tests/Feature/Entries/EntryRevisionsTest.php
@@ -156,6 +156,10 @@ class EntryRevisionsTest extends TestCase
         $this->assertEquals('user-1', $revision->user()->id());
         $this->assertEquals('Test!', $revision->message());
         $this->assertEquals('unpublish', $revision->action());
+        $this->get(cp_route('collections.entries.revisions.index', [
+            'collection' => 'blog',
+            'entry' => '1',
+        ]))->assertOk();
     }
 
     /** @test */


### PR DESCRIPTION
Fixes: https://github.com/statamic/cms/issues/10331

When clicking on the 'View History' button of an **unpublished entry** in the CP, the revision history panel loads indefinitely.
The called route `cp/collections/{collection}/entries/{entry}/revisions` fails with error 500.
```
Illuminate\Routing\Exceptions\UrlGenerationException
Missing required parameter for [Route: statamic.cp.collections.entries.revisions.show] [URI: cp/collections/{collection}/entries/{entry}/revisions/{revision}] [Missing parameter: revision].
```

Apparently the working copy of the entry included in the entry's list of revisions has no id, as it is not associated with another revision. But this id is necessary to create a link in the list of revisions.

Using an empty link fixes this problem, as the working copy only exists locally and no revision shall be showed on click anyway.

Note: I was not able to find any tests of the `EntryRevisionsController` so I adapted a test related to this use-case. Feel free to shift it to the correct location.

See also: https://github.com/statamic/cms/pull/10057