### PR TITLE
[5.x] Prevent logging "remote: Processed 1 references in total" Git errors

### DIFF
--- a/src/Console/Processes/Git.php
+++ b/src/Console/Processes/Git.php
@@ -88,6 +88,7 @@ class Git extends Process
         $ignore = [
             'remote: Resolving deltas',
             'Permanently added the ECDSA host key for IP address',
+            'remote: Processed',
         ];
 
         if (Str::contains($buffer, $ignore)) {

--- a/tests/Git/GitProcessTest.php
+++ b/tests/Git/GitProcessTest.php
@@ -155,6 +155,14 @@ EOT;
         $this->simulateLoggableErrorOutput("Permanently added the ECDSA host key for IP address '127.0.0.1' to the list of known hosts.");
     }
 
+    /** @test */
+    public function it_doesnt_log_processed_references_as_error_output()
+    {
+        Log::shouldReceive('error')->never();
+
+        $this->simulateLoggableErrorOutput('remote: Processed 1 references in total');
+    }
+
     private function showLastCommit($path)
     {
         return Process::create($path)->run('git show');


### PR DESCRIPTION
This pull request prevents the `remote: Processed 1 references in total` Git error from being logged by the Git integration. 

Fixes #10329.