### PR TITLE
[5.x] Fix "Reupload Asset" action

### DIFF
--- a/resources/js/components/fieldtypes/FilesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FilesFieldtype.vue
@@ -17,7 +17,7 @@
                     <span>{{ __('Drop File to Upload') }}</span>
                 </div>
 
-                <div class="assets-fieldtype-picker py-4" :class="{ 'is-expanded': value.length }">
+                <div class="assets-fieldtype-picker py-4" :class="{ 'is-expanded': value?.length }">
                     <p class="asset-upload-control text-xs text-gray-600 rtl:mr-0 ltr:ml-0">
                         <button type="button" class="upload-text-button" @click.prevent="uploadFile">
                             {{ __('Upload file') }}
@@ -31,7 +31,7 @@
                     :uploads="uploads"
                 />
 
-                <div v-if="value.length" class="asset-table-listing">
+                <div v-if="value?.length" class="asset-table-listing">
                     <table class="table-fixed">
                         <tbody>
                             <tr


### PR DESCRIPTION
This pull request fixes an issue with the "Reupload Asset" action, where the Files fieldtype wasn't being displayed due to console errors.

There's no open issue for this but I've seen it crop up a few times on Discord.

## Before

![CleanShot 2024-06-19 at 13 39 51](https://github.com/statamic/cms/assets/19637309/d5f28920-e825-4ad5-a938-8137757ebc21)

## After

![CleanShot 2024-06-19 at 13 38 06](https://github.com/statamic/cms/assets/19637309/395d2396-fead-48b1-80bf-ac395252117a)
