### PR TITLE
[5.x] Static cache response statuses

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -15,6 +15,7 @@ use Statamic\StaticCaching\Cachers\NullCacher;
 use Statamic\StaticCaching\NoCache\RegionNotFound;
 use Statamic\StaticCaching\NoCache\Session;
 use Statamic\StaticCaching\Replacer;
+use Statamic\StaticCaching\ResponseStatus;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\NoLock;
 use Symfony\Component\Lock\Store\FlockStore;
@@ -98,6 +99,8 @@ class Cache
             $response = $cachedPage->toResponse($request);
 
             $this->makeReplacements($response);
+
+            $response->setStaticCacheResponseStatus(ResponseStatus::Hit);
 
             return $response;
         }

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -100,7 +100,7 @@ class Cache
 
             $this->makeReplacements($response);
 
-            $response->setStaticCacheResponseStatus(ResponseStatus::Hit);
+            $response->setStaticCacheResponseStatus(ResponseStatus::HIT);
 
             return $response;
         }

--- a/src/StaticCaching/ResponseStatus.php
+++ b/src/StaticCaching/ResponseStatus.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\StaticCaching;
 
-enum ResponseStatus: string
+enum ResponseStatus
 {
-    case Hit = 'hit';
-    case Miss = 'miss';
+    case HIT;
+    case MISS;
 }

--- a/src/StaticCaching/ResponseStatus.php
+++ b/src/StaticCaching/ResponseStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Statamic\StaticCaching;
+
+enum ResponseStatus: string
+{
+    case Hit = 'hit';
+    case Miss = 'miss';
+}

--- a/src/StaticCaching/ResponseStatus.php
+++ b/src/StaticCaching/ResponseStatus.php
@@ -6,4 +6,5 @@ enum ResponseStatus
 {
     case HIT;
     case MISS;
+    case UNDEFINED;
 }

--- a/src/StaticCaching/ResponseStatusTracker.php
+++ b/src/StaticCaching/ResponseStatusTracker.php
@@ -8,7 +8,7 @@ class ResponseStatusTracker
 {
     private array $responses = [];
 
-    public function set(Response $response, ResponseStatus $status)
+    public function set(Response $response, ResponseStatus $status): void
     {
         $this->responses[spl_object_id($response)] = $status;
     }
@@ -22,12 +22,8 @@ class ResponseStatusTracker
     {
         $tracker = $this;
 
-        Response::macro('setStaticCacheResponseStatus', function ($status) use ($tracker) {
-            $tracker->set($this, $status);
-        });
+        Response::macro('setStaticCacheResponseStatus', fn ($status) => $tracker->set($this, $status));
 
-        Response::macro('wasStaticallyCached', function () use ($tracker) {
-            return $tracker->get($this) === ResponseStatus::HIT;
-        });
+        Response::macro('wasStaticallyCached', fn () => $tracker->get($this) === ResponseStatus::HIT);
     }
 }

--- a/src/StaticCaching/ResponseStatusTracker.php
+++ b/src/StaticCaching/ResponseStatusTracker.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Statamic\StaticCaching;
+
+use Illuminate\Http\Response;
+
+class ResponseStatusTracker
+{
+    private array $responses = [];
+
+    public function set(Response $response, ResponseStatus $status)
+    {
+        $this->responses[spl_object_id($response)] = $status;
+    }
+
+    public function get(Response $response): ?ResponseStatus
+    {
+        return $this->responses[spl_object_id($response)] ?? null;
+    }
+
+    public function registerMacros(): void
+    {
+        $tracker = $this;
+
+        Response::macro('setStaticCacheResponseStatus', function ($status) use ($tracker) {
+            $tracker->set($this, $status);
+        });
+
+        Response::macro('wasStaticallyCached', function () use ($tracker) {
+            return $tracker->get($this) === ResponseStatus::Hit;
+        });
+    }
+}

--- a/src/StaticCaching/ResponseStatusTracker.php
+++ b/src/StaticCaching/ResponseStatusTracker.php
@@ -27,7 +27,7 @@ class ResponseStatusTracker
         });
 
         Response::macro('wasStaticallyCached', function () use ($tracker) {
-            return $tracker->get($this) === ResponseStatus::Hit;
+            return $tracker->get($this) === ResponseStatus::HIT;
         });
     }
 }

--- a/src/StaticCaching/ResponseStatusTracker.php
+++ b/src/StaticCaching/ResponseStatusTracker.php
@@ -13,9 +13,9 @@ class ResponseStatusTracker
         $this->responses[spl_object_id($response)] = $status;
     }
 
-    public function get(Response $response): ?ResponseStatus
+    public function get(Response $response): ResponseStatus
     {
-        return $this->responses[spl_object_id($response)] ?? null;
+        return $this->responses[spl_object_id($response)] ?? ResponseStatus::UNDEFINED;
     }
 
     public function registerMacros(): void
@@ -24,6 +24,8 @@ class ResponseStatusTracker
 
         Response::macro('setStaticCacheResponseStatus', fn ($status) => $tracker->set($this, $status));
 
-        Response::macro('wasStaticallyCached', fn () => $tracker->get($this) === ResponseStatus::HIT);
+        Response::macro('staticCacheResponseStatus', fn () => $tracker->get($this));
+
+        Response::macro('wasStaticallyCached', fn () => $this->staticCacheResponseStatus() === ResponseStatus::HIT);
     }
 }

--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -62,6 +62,8 @@ class ServiceProvider extends LaravelServiceProvider
                 $urls
             );
         });
+
+        $this->app->singleton(ResponseStatusTracker::class, fn () => new ResponseStatusTracker);
     }
 
     public function boot()
@@ -87,5 +89,7 @@ class ServiceProvider extends LaravelServiceProvider
 
             return $this;
         });
+
+        $this->app[ResponseStatusTracker::class]->registerMacros();
     }
 }


### PR DESCRIPTION
This PR allows developers to figure out if a given response was statically cached or not.

For example, in a custom middleware...

```php
public function handle($request, $next)
{
    $response = $next($request);

    if ($response->wasStaticallyCached()) {
      // the request was previously cached and has just been retrieved.
    } else {
      // the request was not previously cached and has just been rendered from scratch
    }

    return $response;
}
```

The `ResponseStatusTracker` class exists purely because we can't put arbitrary properties on classes in PHP anymore. If we could, we'd just pop a `$staticCacheResponseCode` property on the `Request` via a macro. Alas.

The `ResponseStatus` enum will let us have different statuses for static cache types, similar to how Cloudflare does it. e.g. `hit` for when serving from cache, `miss` when served fresh, etc. This PR only introduces `hit` for now.

We considered simply adding `X-Statamic-Static-Cache: hit` headers to the response and let developers read those - but we don't want to expose that people are using Statamic. Some people don't like that.