### PR TITLE
[5.x] Ensure `install:broadcasting` is run when installing into Laravel 11 application

### DIFF
--- a/src/Console/Commands/InstallCollaboration.php
+++ b/src/Console/Commands/InstallCollaboration.php
@@ -56,7 +56,7 @@ class InstallCollaboration extends Command
 
     protected function enableBroadcasting(): void
     {
-        if (in_array(\Illuminate\Broadcasting\BroadcastServiceProvider::class, array_keys(app()->getLoadedProviders()))) {
+        if (File::exists(config_path('broadcasting.php'))) {
             $this->components->warn('Broadcasting is already enabled.');
 
             return;

--- a/src/Console/Commands/InstallCollaboration.php
+++ b/src/Console/Commands/InstallCollaboration.php
@@ -56,15 +56,15 @@ class InstallCollaboration extends Command
 
     protected function enableBroadcasting(): void
     {
-        if (File::exists(config_path('broadcasting.php'))) {
-            $this->components->warn('Broadcasting is already enabled.');
-
-            return;
-        }
-
         if (version_compare(app()->version(), '11', '<')) {
             $this->enableBroadcastServiceProvider();
             $this->components->info('Broadcasting enabled successfully.');
+
+            return;
+        }
+        
+        if (File::exists(config_path('broadcasting.php'))) {
+            $this->components->warn('Broadcasting is already enabled.');
 
             return;
         }

--- a/src/Console/Commands/InstallCollaboration.php
+++ b/src/Console/Commands/InstallCollaboration.php
@@ -62,7 +62,7 @@ class InstallCollaboration extends Command
 
             return;
         }
-        
+
         if (File::exists(config_path('broadcasting.php'))) {
             $this->components->warn('Broadcasting is already enabled.');
 


### PR DESCRIPTION
This pull request fixes an issue in our `php please install:collaboration` command, where Laravel's `install:broadcasting` command wasn't being run, causing things like its config and routing files to not be published.

It seems like this was caused by the `BroadcastServiceProvider` always being part of the app's loaded service providers, even if Laravel's `install:broadcasting` command hasn't been run.

This PR fixes it by simply checking for the existence of the `broadcasting.php` config file, which is created as part of the `install:broadcasting` command.

Fixes statamic/collaboration#101.