### PR TITLE
[5.x] Fix password resetter not defined errors

### DIFF
--- a/src/Http/Controllers/ActivateAccountController.php
+++ b/src/Http/Controllers/ActivateAccountController.php
@@ -27,6 +27,10 @@ class ActivateAccountController extends ResetPasswordController
     {
         $broker = config('statamic.users.passwords.'.PasswordReset::BROKER_ACTIVATIONS);
 
+        if (is_array($broker)) {
+            $broker = $broker['activations'];
+        }
+
         return Password::broker($broker);
     }
 }

--- a/src/Http/Controllers/ForgotPasswordController.php
+++ b/src/Http/Controllers/ForgotPasswordController.php
@@ -39,7 +39,7 @@ class ForgotPasswordController extends Controller
         $broker = config('statamic.users.passwords.'.PasswordReset::BROKER_RESETS);
 
         if (is_array($broker)) {
-            $broker = $broker['web'];
+            $broker = $broker['resets'];
         }
 
         return Password::broker($broker);

--- a/src/Http/Controllers/ResetPasswordController.php
+++ b/src/Http/Controllers/ResetPasswordController.php
@@ -62,7 +62,7 @@ class ResetPasswordController extends Controller
         $broker = config('statamic.users.passwords.'.PasswordReset::BROKER_RESETS);
 
         if (is_array($broker)) {
-            $broker = $broker['web'];
+            $broker = $broker['resets'];
         }
 
         return Password::broker($broker);


### PR DESCRIPTION
This is an attempted fix for #10338.

It changes the array keys that the controllers for password activations and resets use, in order to match the array keys in the user.php config file.

Details of the issue are in https://github.com/statamic/cms/issues/10338

I'm a non coder, and not very experienced in contributing via Github, so please excuse any f***-ups.
