### PR TITLE
[5.x] Fix nocache tags on shared error pages

### DIFF
--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -82,10 +82,12 @@ class ServiceProvider extends LaravelServiceProvider
             return '<?php echo app("Statamic\StaticCaching\NoCache\BladeDirective")->handle('.$exp.', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>';
         });
 
-        Request::macro('fakeStaticCacheStatus', function (int $status) {
+        $session = $this->app[Session::class];
+        Request::macro('fakeStaticCacheStatus', function (int $status) use ($session) {
             $url = '/__shared-errors/'.$status;
             $this->pathInfo = $url;
             $this->requestUri = $url;
+            $session->setUrl($url);
 
             return $this;
         });

--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -82,12 +82,11 @@ class ServiceProvider extends LaravelServiceProvider
             return '<?php echo app("Statamic\StaticCaching\NoCache\BladeDirective")->handle('.$exp.', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>';
         });
 
-        $session = $this->app[Session::class];
-        Request::macro('fakeStaticCacheStatus', function (int $status) use ($session) {
+        Request::macro('fakeStaticCacheStatus', function (int $status) {
             $url = '/__shared-errors/'.$status;
             $this->pathInfo = $url;
             $this->requestUri = $url;
-            $session->setUrl($url);
+            app(Session::class)->setUrl($url);
 
             return $this;
         });


### PR DESCRIPTION
The shared error pages introduced in https://github.com/statamic/cms/pull/10294 currently throw a "Region not found" error when you use a nocache tag and hit a second URL. This is because there's only one cached page under a fake URL, but nocache is saving/fetching the region based on the actual URL.

This PR fixes it by setting the no cache session's URL to the fake one when calling `fakeStaticCacheStatus`.