### PR TITLE
[5.x] Make Asset::clearCaches protected

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -678,7 +678,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
     /**
      * Clear meta and filesystem listing caches.
      */
-    private function clearCaches()
+    protected function clearCaches()
     {
         $this->meta = null;
         Cache::forget($this->metaCacheKey());


### PR DESCRIPTION
This PR changes the visibility of Asset::clearCaches from private to protected, to allow it to be overridden by the eloquent driver. [See the conversation here](https://github.com/statamic/eloquent-driver/issues/307).