### PR TITLE
[5.x] Fix broken Ignition classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "rebing/graphql-laravel": "^9.5",
         "rhukster/dom-sanitizer": "^1.0.6",
         "spatie/blink": "^1.3",
-        "spatie/ignition": "^1.12",
+        "spatie/ignition": "^1.15",
         "statamic/stringy": "^3.1.2",
         "symfony/lock": "^6.4",
         "symfony/var-exporter": "^6.0",

--- a/src/Exceptions/AssetContainerNotFoundException.php
+++ b/src/Exceptions/AssetContainerNotFoundException.php
@@ -3,10 +3,10 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Facades\AssetContainer;
 use Statamic\Statamic;
 

--- a/src/Exceptions/BlueprintNotFoundException.php
+++ b/src/Exceptions/BlueprintNotFoundException.php
@@ -3,10 +3,10 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Facades\Blueprint;
 use Statamic\Statamic;
 

--- a/src/Exceptions/CollectionNotFoundException.php
+++ b/src/Exceptions/CollectionNotFoundException.php
@@ -3,10 +3,10 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Facades\Collection;
 use Statamic\Statamic;
 

--- a/src/Exceptions/ComposerJsonMissingPreUpdateCmdException.php
+++ b/src/Exceptions/ComposerJsonMissingPreUpdateCmdException.php
@@ -3,8 +3,8 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Ignition\Solutions\EnableComposerUpdateScripts;
 
 class ComposerJsonMissingPreUpdateCmdException extends Exception implements ProvidesSolution

--- a/src/Exceptions/DuplicateFieldException.php
+++ b/src/Exceptions/DuplicateFieldException.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Exceptions;
 
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class DuplicateFieldException extends \Exception implements ProvidesSolution

--- a/src/Exceptions/FieldsetNotFoundException.php
+++ b/src/Exceptions/FieldsetNotFoundException.php
@@ -3,10 +3,10 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Facades\Fieldset;
 use Statamic\Statamic;
 

--- a/src/Exceptions/FieldsetRecursionException.php
+++ b/src/Exceptions/FieldsetRecursionException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 
 class FieldsetRecursionException extends Exception implements ProvidesSolution
 {

--- a/src/Exceptions/FieldtypeNotFoundException.php
+++ b/src/Exceptions/FieldtypeNotFoundException.php
@@ -4,10 +4,10 @@ namespace Statamic\Exceptions;
 
 use Exception;
 use Facades\Statamic\Fields\FieldtypeRepository;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Statamic;
 
 class FieldtypeNotFoundException extends Exception implements ProvidesSolution

--- a/src/Exceptions/NavigationNotFoundException.php
+++ b/src/Exceptions/NavigationNotFoundException.php
@@ -3,10 +3,10 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Facades\Nav;
 use Statamic\Statamic;
 

--- a/src/Exceptions/NotBootedException.php
+++ b/src/Exceptions/NotBootedException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class NotBootedException extends Exception implements ProvidesSolution

--- a/src/Exceptions/SiteNotFoundException.php
+++ b/src/Exceptions/SiteNotFoundException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class SiteNotFoundException extends Exception implements ProvidesSolution

--- a/src/Exceptions/StatamicProRequiredException.php
+++ b/src/Exceptions/StatamicProRequiredException.php
@@ -3,8 +3,8 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Ignition\Solutions\EnableStatamicPro;
 
 class StatamicProRequiredException extends Exception implements ProvidesSolution

--- a/src/Exceptions/TaxonomyNotFoundException.php
+++ b/src/Exceptions/TaxonomyNotFoundException.php
@@ -3,10 +3,10 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Facades\Taxonomy;
 use Statamic\Statamic;
 

--- a/src/Exceptions/TermsFieldtypeBothOptionsUsedException.php
+++ b/src/Exceptions/TermsFieldtypeBothOptionsUsedException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class TermsFieldtypeBothOptionsUsedException extends Exception implements ProvidesSolution

--- a/src/Exceptions/TermsFieldtypeTaxonomyOptionUsed.php
+++ b/src/Exceptions/TermsFieldtypeTaxonomyOptionUsed.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class TermsFieldtypeTaxonomyOptionUsed extends Exception implements ProvidesSolution

--- a/src/Fieldtypes/Assets/UndefinedContainerException.php
+++ b/src/Fieldtypes/Assets/UndefinedContainerException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Fieldtypes\Assets;
 
 use LogicException;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class UndefinedContainerException extends LogicException implements ProvidesSolution

--- a/src/Fieldtypes/MultipleValuesEncounteredException.php
+++ b/src/Fieldtypes/MultipleValuesEncounteredException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Fieldtypes;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 
 class MultipleValuesEncounteredException extends Exception implements ProvidesSolution
 {

--- a/src/Forms/Exceptions/BlueprintUndefinedException.php
+++ b/src/Forms/Exceptions/BlueprintUndefinedException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Forms\Exceptions;
 
 use LogicException;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Forms\Form;
 use Statamic\Statamic;
 

--- a/src/Forms/Exceptions/FileContentTypeRequiredException.php
+++ b/src/Forms/Exceptions/FileContentTypeRequiredException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Forms\Exceptions;
 
 use LogicException;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class FileContentTypeRequiredException extends LogicException implements ProvidesSolution

--- a/src/Ignition/SolutionProviders/OAuthDisabled.php
+++ b/src/Ignition/SolutionProviders/OAuthDisabled.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Ignition\SolutionProviders;
 
-use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
+use Spatie\ErrorSolutions\Contracts\HasSolutionsForThrowable;
 use Statamic\Ignition\Solutions\EnableOAuth;
 use Throwable;
 

--- a/src/Ignition/SolutionProviders/UsingOldClass.php
+++ b/src/Ignition/SolutionProviders/UsingOldClass.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Ignition\SolutionProviders;
 
-use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
+use Spatie\ErrorSolutions\Contracts\HasSolutionsForThrowable;
 use Statamic\Ignition\Solutions\UpdateClassReference;
 use Statamic\Statamic;
 use Statamic\Support\Arr;

--- a/src/Ignition/Solutions/EnableComposerUpdateScripts.php
+++ b/src/Ignition/Solutions/EnableComposerUpdateScripts.php
@@ -4,7 +4,7 @@ namespace Statamic\Ignition\Solutions;
 
 use Exception;
 use Facades\Statamic\UpdateScripts\Manager as UpdateScriptManager;
-use Spatie\Ignition\Contracts\RunnableSolution;
+use Spatie\ErrorSolutions\Contracts\RunnableSolution;
 use Statamic\Console\Composer\Json as ComposerJson;
 use Statamic\Console\NullConsole;
 use Statamic\Statamic;

--- a/src/Ignition/Solutions/EnableOAuth.php
+++ b/src/Ignition/Solutions/EnableOAuth.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Ignition\Solutions;
 
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class EnableOAuth implements Solution

--- a/src/Ignition/Solutions/EnableStatamicPro.php
+++ b/src/Ignition/Solutions/EnableStatamicPro.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Ignition\Solutions;
 
-use Spatie\Ignition\Contracts\RunnableSolution;
+use Spatie\ErrorSolutions\Contracts\RunnableSolution;
 use Statamic\Statamic;
 
 class EnableStatamicPro implements RunnableSolution

--- a/src/Ignition/Solutions/UpdateClassReference.php
+++ b/src/Ignition/Solutions/UpdateClassReference.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Ignition\Solutions;
 
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 
 class UpdateClassReference implements Solution
 {

--- a/src/Modifiers/ModifierNotFoundException.php
+++ b/src/Modifiers/ModifierNotFoundException.php
@@ -3,10 +3,10 @@
 namespace Statamic\Modifiers;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Statamic;
 
 class ModifierNotFoundException extends Exception implements ProvidesSolution

--- a/src/Providers/IgnitionServiceProvider.php
+++ b/src/Providers/IgnitionServiceProvider.php
@@ -4,7 +4,7 @@ namespace Statamic\Providers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\ServiceProvider;
-use Spatie\Ignition\Contracts\SolutionProviderRepository;
+use Spatie\ErrorSolutions\Contracts\SolutionProviderRepository;
 use Statamic\Ignition\SolutionProviders\OAuthDisabled;
 use Statamic\Ignition\SolutionProviders\UsingOldClass;
 

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -6,7 +6,7 @@ use Facade\Ignition\Exceptions\ViewException;
 use Facade\Ignition\Exceptions\ViewExceptionWithSolution;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use ReflectionProperty;
-use Spatie\Ignition\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Statamic\Contracts\View\Antlers\Parser;
 use Statamic\Fields\Value;
 use Statamic\Modifiers\ModifierNotFoundException;

--- a/src/Widgets/WidgetNotFoundException.php
+++ b/src/Widgets/WidgetNotFoundException.php
@@ -3,10 +3,10 @@
 namespace Statamic\Widgets;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Statamic;
 
 class WidgetNotFoundException extends Exception implements ProvidesSolution

--- a/src/Yaml/ParseException.php
+++ b/src/Yaml/ParseException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Yaml;
 
 use ErrorException;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class ParseException extends ErrorException implements ProvidesSolution


### PR DESCRIPTION
If you delete the main asset container and try to visit your user profile, you'll get something like this:

![error](https://github.com/statamic/cms/assets/503/525fc55e-959b-424b-8573-4976066b49bc)

It looks like they recently refactored some stuff and moved it into `Spatie\ErrorSolutions`. This fixes everything again:

![Screenshot 2024-06-20 at 17 18 17](https://github.com/statamic/cms/assets/503/85e26573-a630-4918-8dc2-56d2b9147931)

(`spatie/error-solutions` is installed by `spatie/ignition` automatically.)

The most recent 5.10.0 release seems to have this issue.