### PR TITLE
[5.x] Resolving PHP Deprecated errors

### DIFF
--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -177,7 +177,7 @@ class Git
      */
     protected function statusWithFileCounts($status)
     {
-        $lines = collect(explode("\n", $status))->filter();
+        $lines = collect(explode("\n", $status ?? ''))->filter();
 
         $totalCount = $lines->count();
 

--- a/src/Support/Html.php
+++ b/src/Support/Html.php
@@ -92,7 +92,7 @@ class Html
      */
     public static function entities($value)
     {
-        return htmlentities($value, ENT_QUOTES, Config::get('statamic.system.charset', 'UTF-8'), false);
+        return htmlentities($value ?? '', ENT_QUOTES, Config::get('statamic.system.charset', 'UTF-8'), false);
     }
 
     /**
@@ -348,7 +348,7 @@ class Html
             return Arr::sanitize($value, $antlers);
         }
 
-        $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', $doubleEncode);
+        $value = htmlspecialchars($value ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', $doubleEncode);
 
         if ($antlers) {
             $value = str_replace(['{', '}'], ['&lbrace;', '&rbrace;'], $value);


### PR DESCRIPTION
While implementing an company-wide errorlog that tracks errors on all our websites, including Statamic-based ones, it throws errors we cannot fix. Therefore I have added some ternary operators to mute those errors. I am not a PHP prodigy, so if you have a better idea of fixing it, be my guest 🤙🏻 

Also I found many functions have PHPDoc description of input and return types, but isn't it better to have it also inside the function's body?

Thanks for clarification!
