### PR TITLE
[5.x] Display custom logo as plain text

### DIFF
--- a/config/cp.php
+++ b/config/cp.php
@@ -124,6 +124,8 @@ return [
 
     'custom_dark_logo_url' => env('STATAMIC_CUSTOM_DARK_LOGO_URL', null),
 
+    'custom_logo_text' => env('STATAMIC_CUSTOM_LOGO_TEXT', null),
+
     'custom_favicon_url' => env('STATAMIC_CUSTOM_FAVICON_URL', null),
 
     'custom_css_url' => env('STATAMIC_CUSTOM_CSS_URL', null),

--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -10,6 +10,8 @@
                 @if ($customLogo)
                     <img src="{{ $customLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo dark:hidden">
                     <img src="{{ $customDarkLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo hidden dark:block">
+                @elseif ($customLogoText)
+                    <span class="font-medium">{{ $customLogoText }}</span>
                 @else
                     @cp_svg('statamic-wordmark', 'w-24 logo')
                     @if (Statamic::pro())<span class="font-bold text-4xs align-top uppercase">{{ __('Pro') }}</span>@endif

--- a/resources/views/partials/outside-logo.blade.php
+++ b/resources/views/partials/outside-logo.blade.php
@@ -2,6 +2,8 @@
     @if ($customLogo)
         <img src="{{ $customLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo dark:hidden">
         <img src="{{ $customDarkLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo hidden dark:block">
+    @elseif ($customLogoText)
+        <div class="max-w-xs mx-auto mb-8 text-lg font-medium text-center opacity-50">{{ $customLogoText }}</div>
     @else
         @cp_svg('statamic-wordmark')
     @endif

--- a/src/Http/View/Composers/CustomLogoComposer.php
+++ b/src/Http/View/Composers/CustomLogoComposer.php
@@ -15,19 +15,23 @@ class CustomLogoComposer
 
     public function compose(View $view)
     {
-        $view->with('customLogo', $this->customLogo($view, false));
-        $view->with('customDarkLogo', $this->customLogo($view, true));
+        $view->with('customLogo', $this->customLogo($view));
+        $view->with('customDarkLogo', $this->customLogo($view, dark: true));
+        $view->with('customLogoText', $this->customLogo($view, text: true));
     }
 
-    protected function customLogo($view, bool $darkMode = false)
+    protected function customLogo($view, bool $dark = false, bool $text = false)
     {
         if (! Statamic::pro()) {
             return false;
         }
 
         $config = config('statamic.cp.custom_logo_url');
-        if ($darkMode && config('statamic.cp.custom_dark_logo_url')) {
+        if ($dark && config('statamic.cp.custom_dark_logo_url')) {
             $config = config('statamic.cp.custom_dark_logo_url');
+        }
+        if ($text && config('statamic.cp.custom_logo_text')) {
+            $config = config('statamic.cp.custom_logo_text');
         }
 
         switch ($view->name()) {


### PR DESCRIPTION
**Description**

Add an option to display the site's name in plain text in the control panel, as suggested in [feature idea #1185](https://github.com/statamic/ideas/issues/1185).

**Advantages of doing that**

- Consumes less bandwidth than a logo file
- Light/dark mode comes along for free
- Less setup for new projects: just paste in the name

**Details**

- When defined, logo image urls take precedence over logo text
- The logo text goes into a new `statamic.cp.custom_logo_text` config key
- Can also be set from a new `STATAMIC_CUSTOM_LOGO_TEXT` environment variable
- I guess this can be backported to 4.x without problems
- As far as I can tell, there's currently no tests for the custom logo behavior, so I haven't added any
- Manually tested, though :)

**Screenshots**

<img width="350" alt="Screenshot 2024-06-21 at 13 09 51" src="https://github.com/statamic/cms/assets/22225348/b80f127d-1cd3-4fba-9291-ff04599084a2">
 
<img width="350" alt="Screenshot 2024-06-21 at 13 10 11" src="https://github.com/statamic/cms/assets/22225348/ddef3e6a-3577-4f0b-9d9c-4d1efe5bec0e">
 
<img width="350" alt="Screenshot 2024-06-21 at 13 08 09" src="https://github.com/statamic/cms/assets/22225348/69e827b0-7ab4-4270-8431-495b0236ab9b">
 
<img width="350" alt="Screenshot 2024-06-21 at 13 08 28" src="https://github.com/statamic/cms/assets/22225348/467ab71b-7610-4aca-a217-c1708d7359e3">

Closes statamic/ideas#1185