### PR TITLE
[5.x] Custom file cache store adjustments

### DIFF
--- a/src/Extensions/FileStore.php
+++ b/src/Extensions/FileStore.php
@@ -8,6 +8,8 @@ use Statamic\Support\Str;
 
 class FileStore extends LaravelFileStore implements Store
 {
+    private ?string $dir = null;
+
     public function path($key)
     {
         if (! Str::startsWith($key, 'stache::')) {
@@ -16,6 +18,17 @@ class FileStore extends LaravelFileStore implements Store
 
         $key = Str::after($key, 'stache::');
 
-        return $this->directory.'/stache/'.str_replace('::', '/', $key);
+        return $this->dir().str_replace('::', '/', $key);
+    }
+
+    private function dir()
+    {
+        if ($this->dir) {
+            return $this->dir;
+        }
+
+        return $this->dir = Str::endsWith($this->directory, '/stache')
+            ? $this->directory.'/'
+            : $this->directory.'/stache/';
     }
 }

--- a/src/Providers/CacheServiceProvider.php
+++ b/src/Providers/CacheServiceProvider.php
@@ -37,6 +37,7 @@ class CacheServiceProvider extends ServiceProvider
     private function extendFileStore()
     {
         $this->app->booting(function () {
+            /** @deprecated */
             Cache::extend('statamic', function () {
                 return Cache::repository(new FileStore(
                     $this->app['files'],
@@ -45,10 +46,13 @@ class CacheServiceProvider extends ServiceProvider
                 ), $this->app['config']['cache.stores.file']);
             });
 
-            if (config('cache.default') === 'file') {
-                config(['cache.stores.statamic' => ['driver' => 'statamic']]);
-                config(['cache.default' => 'statamic']);
-            }
+            Cache::extend('file', function ($app, $config) {
+                return Cache::repository(
+                    (new FileStore($app['files'], $config['path'], $config['permission'] ?? null))
+                        ->setLockDirectory($config['lock_path'] ?? null),
+                    $config
+                );
+            });
         });
     }
 

--- a/tests/Extensions/FileStoreTest.php
+++ b/tests/Extensions/FileStoreTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Extensions;
+
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Support\Facades\Cache;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Extensions\FileStore;
+use Tests\TestCase;
+
+class FileStoreTest extends TestCase
+{
+    #[Test]
+    #[DefineEnvironment('cache')]
+    public function it_overrides_file_driven_stores()
+    {
+        $alfa = Cache::store('alfa')->getStore();
+        $this->assertInstanceOf(FileStore::class, $alfa);
+        $this->assertEquals(storage_path('framework/cache/alfa'), $alfa->getDirectory());
+
+        $bravo = Cache::store('bravo')->getStore();
+        $this->assertInstanceOf(FileStore::class, $bravo);
+        $this->assertEquals(storage_path('framework/cache/bravo'), $bravo->getDirectory());
+
+        // Non-file stores shouldn't be modified.
+        $charlie = Cache::store('charlie')->getStore();
+        $this->assertInstanceOf(ArrayStore::class, $charlie);
+    }
+
+    public function cache($app)
+    {
+        $app['config']->set('cache.stores.alfa', [
+            'driver' => 'file',
+            'path' => storage_path('framework/cache/alfa'),
+        ]);
+
+        $app['config']->set('cache.stores.bravo', [
+            'driver' => 'file',
+            'path' => storage_path('framework/cache/bravo'),
+        ]);
+
+        $app['config']->set('cache.stores.charlie', [
+            'driver' => 'array',
+        ]);
+    }
+}


### PR DESCRIPTION
We have a customized file driver for the cache that will organize any Stache related keys into a simplified file structure for ease of debugging.

This would only affect your default cache store.

This PR changes it so that _any_ store using the file driver will be changed to use our custom version. This is useful along with #10303.

We are newing up the FileStore [identically to how Laravel does it](https://github.com/laravel/framework/blob/7100359775330c7485cf5e65d78aa279cd483c72/src/Illuminate/Cache/CacheManager.php#L149-L153) now which would also fix custom `lock_path` not working.

Additionally, this PR avoids a nested `stache` directory if you point your cache store to a directory already named `stache`.

The cache driver named `statamic` is now deprecated in favor of just using `file`.
