### PR TITLE
[5.x] Fix HTML fieldtype

### DIFF
--- a/src/Fieldtypes/Html.php
+++ b/src/Fieldtypes/Html.php
@@ -20,6 +20,7 @@ class Html extends Fieldtype
                         'instructions' => __('statamic::fieldtypes.html.config.html_instruct'),
                         'type' => 'code',
                         'mode' => 'htmlmixed',
+                        'mode_selectable' => false,
                     ],
                 ],
             ],


### PR DESCRIPTION
The HTML fieldtype is currently broken:

![Screenshot 2024-06-25 at 11 59 42](https://github.com/statamic/cms/assets/126740/f868856e-6730-4c7d-a289-0188e6760dde)

This PR fixes it.