### PR TITLE
[5.x] Clarify Statamic repository differences in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 <p align="center"><img src="https://statamic.com/assets/branding/Statamic-Logo+Wordmark-Rad.svg" width="400" alt="Statamic Logo" /></p>
 
+# Statamic CMS for Laravel
+
 ## About Statamic
 
 Statamic is the flat-first, Laravel + Git powered CMS designed for building beautiful, easy to manage websites.
 
-> **Note:** This repository contains the code for the core CMS package. To start your own website project with Statamic, visit the [Statamic application repository][app-repo].
+> [!NOTE]
+> This repository contains the code for the core CMS package, for installation into an existing Laravel codebase. 
+> 
+> To start your own website project from scratch with Statamic, visit the [Statamic application repository][app-repo].
 
 ## Learning Statamic
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 <p align="center"><img src="https://statamic.com/assets/branding/Statamic-Logo+Wordmark-Rad.svg" width="400" alt="Statamic Logo" /></p>
 
-# Statamic CMS for Laravel
-
 ## About Statamic
 
 Statamic is the flat-first, Laravel + Git powered CMS designed for building beautiful, easy to manage websites.
 
 > [!NOTE]
-> This repository contains the code for the core CMS package, for installation into an existing Laravel codebase. 
+> This repository contains the code for the core Statamic Composer package, to be installed into an existing Laravel application. 
 > 
-> To start your own website project from scratch with Statamic, visit the [Statamic application repository][app-repo].
+> The [application repository][app-repo] is where you can find a Laravel application preconfigured with Statamic, which is used when creating a new project via the Statamic CLI tool.
 
 ## Learning Statamic
 


### PR DESCRIPTION
Providing a clearer title and explanatory note at the top of the readme, to help new users understand the differences between the two Statamic repositories.

Also moving the note to using the Github markdown styled alerts.
