### PR TITLE
[5.x] Support strings in `bard_text` & `bard_html` modifiers

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -300,6 +300,11 @@ class CoreModifiers extends Modifier
         if ($value instanceof Value) {
             $value = $value->raw();
         }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
         if (Arr::isAssoc($value)) {
             $value = [$value];
         }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -271,7 +271,7 @@ class CoreModifiers extends Modifier
         }
 
         if (is_string($value)) {
-            return $value;
+            return strip_tags($value);
         }
 
         if (Arr::isAssoc($value)) {

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -270,6 +270,10 @@ class CoreModifiers extends Modifier
             return '';
         }
 
+        if (is_string($value)) {
+            return $value;
+        }
+
         if (Arr::isAssoc($value)) {
             $value = [$value];
         }

--- a/tests/Modifiers/BardHtmlTest.php
+++ b/tests/Modifiers/BardHtmlTest.php
@@ -82,6 +82,16 @@ class BardHtmlTest extends TestCase
         $this->assertEquals($expected, $this->modify($data));
     }
 
+    #[Test]
+    public function it_returns_string()
+    {
+        $data = '<p>This is a paragraph.</p>';
+
+        $expected = '<p>This is a paragraph.</p>';
+
+        $this->assertEquals($expected, $this->modify($data));
+    }
+
     public function modify($arr, ...$args)
     {
         return Modify::value($arr)->bard_html($args)->fetch();

--- a/tests/Modifiers/BardTextTest.php
+++ b/tests/Modifiers/BardTextTest.php
@@ -85,7 +85,7 @@ class BardTextTest extends TestCase
     #[Test]
     public function it_extracts_bard_text_from_string()
     {
-        $data = 'This is a paragraph.';
+        $data = 'This <b>is a</b> paragraph.';
 
         $expected = 'This is a paragraph.';
 

--- a/tests/Modifiers/BardTextTest.php
+++ b/tests/Modifiers/BardTextTest.php
@@ -83,6 +83,16 @@ class BardTextTest extends TestCase
     }
 
     #[Test]
+    public function it_extracts_bard_text_from_string()
+    {
+        $data = 'This is a paragraph.';
+
+        $expected = 'This is a paragraph.';
+
+        $this->assertEquals($expected, $this->modify($data));
+    }
+
+    #[Test]
     public function it_handles_null()
     {
         $this->assertEquals('', $this->modify(null));


### PR DESCRIPTION
When dealing with legacy Bard content (like I'm talking almost a decade old!!) that was stored as HTML and never re-saved, the `bard_text` & `bard_html` modifiers throw an error.

- [x] need to `strip_tags` in returned string (update test too)
- [x] same code in `bard_html` perhaps