### PR TITLE
[5.x] Database static cache driver

### DIFF
--- a/src/StaticCaching/Cachers/DatabaseCacher.php
+++ b/src/StaticCaching/Cachers/DatabaseCacher.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Statamic\StaticCaching\Cachers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Events\ResponsePrepared;
+use Illuminate\Support\Facades\Event;
+use Statamic\Events\UrlInvalidated;
+use Statamic\Facades\StaticCache;
+use Statamic\StaticCaching\Page;
+use Statamic\Support\Str;
+
+class DatabaseCacher extends AbstractCacher
+{
+    private ?Page $cached = null;
+
+    public function __construct($config)
+    {
+        parent::__construct(StaticCache::cacheStore(), $config);
+    }
+
+    public function cachePage(Request $request, $content)
+    {
+        $url = $this->getUrl($request);
+
+        if ($this->isExcluded($url)) {
+            return;
+        }
+
+        Event::listen(ResponsePrepared::class, function (ResponsePrepared $event) use ($url, $content) {
+            $headers = collect($event->response->headers->all())
+                ->reject(fn ($value, $key) => in_array($key, ['date', 'x-powered-by', 'cache-control', 'expires', 'set-cookie']))
+                ->all();
+
+            PageModel::create([
+                'url' => $url,
+                'content' => $this->normalizeContent($content),
+                'headers' => $headers,
+                'status' => $event->response->getStatusCode(),
+            ]);
+        });
+    }
+
+    public function hasCachedPage(Request $request)
+    {
+        return (bool) $this->cached = $this->getPage($request);
+    }
+
+    public function getCachedPage(Request $request)
+    {
+        return $this->cached ?? $this->getPage($request);
+    }
+
+    private function getPage(Request $request): ?Page
+    {
+        $url = $this->getUrl($request);
+
+        if (! $model = PageModel::where('url', $url)->first()) {
+            return null;
+        }
+
+        return new Page($model->content, $model->headers, $model->status);
+    }
+
+    public function flush()
+    {
+        PageModel::truncate();
+    }
+
+    public function invalidateUrls($urls)
+    {
+        collect($urls)->each(function ($url) {
+            if (Str::contains($url, '*')) {
+                $this->invalidateWildcardUrl($url);
+            } else {
+                $this->invalidateUrl(...$this->getPathAndDomain($url));
+            }
+        });
+    }
+
+    public function invalidateUrl($url, $domain = null)
+    {
+        PageModel::where('url', $domain.$url)->delete();
+
+        UrlInvalidated::dispatch($url, $domain);
+    }
+}

--- a/src/StaticCaching/Cachers/PageModel.php
+++ b/src/StaticCaching/Cachers/PageModel.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class PageModel extends Model
 {
+    public $timestamps = false;
+
     protected $table = 'static_cache';
 
     protected $guarded = [];

--- a/src/StaticCaching/Cachers/PageModel.php
+++ b/src/StaticCaching/Cachers/PageModel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Statamic\StaticCaching\Cachers;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PageModel extends Model
+{
+    protected $table = 'static_cache';
+
+    protected $guarded = [];
+
+    protected function casts()
+    {
+        return [
+            'headers' => 'array',
+        ];
+    }
+}

--- a/src/StaticCaching/StaticCacheManager.php
+++ b/src/StaticCaching/StaticCacheManager.php
@@ -6,6 +6,7 @@ use Illuminate\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\Site;
 use Statamic\StaticCaching\Cachers\ApplicationCacher;
+use Statamic\StaticCaching\Cachers\DatabaseCacher;
 use Statamic\StaticCaching\Cachers\FileCacher;
 use Statamic\StaticCaching\Cachers\NullCacher;
 use Statamic\StaticCaching\Cachers\Writer;
@@ -36,6 +37,11 @@ class StaticCacheManager extends Manager
     public function createApplicationDriver(array $config)
     {
         return new ApplicationCacher($this->app[Repository::class], $config);
+    }
+
+    public function createDatabaseDriver(array $config)
+    {
+        return new DatabaseCacher($config);
     }
 
     public function cacheStore()


### PR DESCRIPTION
This PR allows the static cache to reside in a database.

It's still considered "half measure" as it requires PHP to be booted every request.

A migration is needed:

```php
Schema::create('static_cache', function (Blueprint $table) {
    $table->string('url');
    $table->index('url');
    $table->text('content');
    $table->integer('status');
    $table->json('headers');
});
```

Then change the driver in the config:

```diff
'strategies' => [
    'half' => [
-       'driver' => 'application',
+       'driver' => 'database',
        'expiry' => null,
    ],
]
```