### PR TITLE
[5.x] Allow for undefined file type in ContainerAssetsStore

### DIFF
--- a/src/Stache/Stores/ContainerAssetsStore.php
+++ b/src/Stache/Stores/ContainerAssetsStore.php
@@ -81,7 +81,8 @@ class ContainerAssetsStore extends ChildStore
     private function getFiles()
     {
         return $this->container()->listContents()->reject(function ($file) {
-            return $file['type'] ?? '' !== 'file'
+            return !isset($file['type'])
+                || $file['type'] !== 'file'
                 || $file['path'] === ''
                 || $file['dirname'] === '.meta'
                 || Str::contains($file['path'], '/.meta/')

--- a/src/Stache/Stores/ContainerAssetsStore.php
+++ b/src/Stache/Stores/ContainerAssetsStore.php
@@ -81,7 +81,7 @@ class ContainerAssetsStore extends ChildStore
     private function getFiles()
     {
         return $this->container()->listContents()->reject(function ($file) {
-            return $file['type'] !== 'file'
+            return $file['type'] ?? '' !== 'file'
                 || $file['path'] === ''
                 || $file['dirname'] === '.meta'
                 || Str::contains($file['path'], '/.meta/')

--- a/src/Stache/Stores/ContainerAssetsStore.php
+++ b/src/Stache/Stores/ContainerAssetsStore.php
@@ -81,7 +81,7 @@ class ContainerAssetsStore extends ChildStore
     private function getFiles()
     {
         return $this->container()->listContents()->reject(function ($file) {
-            return !isset($file['type'])
+            return ! isset($file['type'])
                 || $file['type'] !== 'file'
                 || $file['path'] === ''
                 || $file['dirname'] === '.meta'


### PR DESCRIPTION
This PR addresses a bug where S3 zero-byte "folders" do not send a "type" element. Debugging steps are shown below.

1. I set up S3 as my asset container
2. I created a folder via the Statamic UI
![Screenshot 2024-06-29 at 2 15 33 PM](https://github.com/statamic/cms/assets/1924752/0af8679d-589b-4470-ba6e-3f40794175d2)

3. I run stache:clear (or try to access the cache utilities page in the cp):
```
php please stache:clear

   ErrorException

  Undefined array key "type"

  at vendor/statamic/cms/src/Stache/Stores/ContainerAssetsStore.php:84
     80
     81    private function getFiles()
     82    {
     83        return $this->container()->listContents()->reject(function ($file) {
->   84            return $file['type'] !== 'file'
     85                || $file['path'] === ''
     86                || $file['dirname'] === '.meta'
     87                || Str::contains($file['path'], '/.meta/')
     88                || in_array($file['basename'], ['.gitignore', '.gitkeep', '.DS_Store']);

      +2 vendor frames

  3   [internal]:0
      Illuminate\Support\Collection::Illuminate\Support\Traits\{closure}(["logos"], "logos")
      +29 vendor frames

  33  please:18
      Illuminate\Foundation\Application::handleCommand(Object(Symfony\Component\Console\Input\ArgvInput))
```

4. I update getFiles() in `ContainerAssetsStore.php`
```
    private function getFiles()
    {
        return $this->container()->listContents()->reject(function ($file) {

            if (!isset($file['type'])) {
                dump($file);
            }

            return $file['type'] !== 'file'
                || $file['path'] === ''
                || $file['dirname'] === '.meta'
                || Str::contains($file['path'], '/.meta/')
                || in_array($file['basename'], ['.gitignore', '.gitkeep', '.DS_Store']);
        });
    }
```

5. I note that the directory only has `path`
```
array:1 [
  "path" => "logos"
] // vendor/statamic/cms/src/Stache/Stores/ContainerAssetsStore.php:86
```