### PR TITLE
[5.x] Refactor frontend formFailure to handle precognitive and fetch exceptions

### DIFF
--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -65,7 +65,7 @@ class FormController extends Controller
         } catch (ValidationException $e) {
             $this->removeUploadedAssets($uploadedAssets);
 
-            return $this->formFailure($params, $e, $form->handle());
+            return $this->formFailure($params, $e->errors(), $form->handle());
         } catch (SilentFormFailureException $e) {
             if (isset($uploadedAssets)) {
                 $this->removeUploadedAssets($uploadedAssets);
@@ -101,19 +101,17 @@ class FormController extends Controller
      * The steps for a failed form submission.
      *
      * @param  array  $params
-     * @param  ValidationException  $errors
+     * @param  array  $errors
      * @param  string  $form
      * @return Response|RedirectResponse
      */
-    private function formFailure($params, $exception, $form)
+    private function formFailure($params, $errors, $form)
     {
         $request = request();
 
         if ($request->isPrecognitive() || $request->wantsJson()) {
-            return $exception;
+            throw ValidationException::withMessages($errors);
         }
-
-        $errors = $exception->errors();
 
         if ($request->ajax()) {
             return response([

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -109,10 +109,6 @@ class FormController extends Controller
     {
         $request = request();
 
-        if ($request->isPrecognitive() || $request->wantsJson()) {
-            throw ValidationException::withMessages($errors);
-        }
-
         if ($request->ajax()) {
             return response([
                 'errors' => (new MessageBag($errors))->all(),
@@ -120,6 +116,10 @@ class FormController extends Controller
                     return $errors[0];
                 })->all(),
             ], 400);
+        }
+
+        if ($request->isPrecognitive() || $request->wantsJson()) {
+            throw ValidationException::withMessages($errors);
         }
 
         $redirect = Arr::get($params, '_error_redirect');

--- a/tests/Tags/Form/FormCreateTest.php
+++ b/tests/Tags/Form/FormCreateTest.php
@@ -957,5 +957,4 @@ EOT
         $this->assertArrayHasKey('errors', $json);
         $this->assertSame($json['errors'], ['some' => ['error']]);
     }
-
 }


### PR DESCRIPTION
As [discussed here](https://github.com/statamic/cms/discussions/10375#discussioncomment-9923796), throwing a ValidationException during a precognitive/fetch request returns a different errors response format to 'normal' errors, due to how formFailure was handling it.

This PR updates the logic to return the standard ValidationException response when the request wants it.