### PR TITLE
[5.x] Support operators in where modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2871,13 +2871,18 @@ class CoreModifiers extends Modifier
     public function where($value, $params)
     {
         $key = Arr::get($params, 0);
-        $val = Arr::get($params, 1);
+        $opr = Arr::get($params, 1);
+        $val = Arr::get($params, 2);
 
-        if (! $val && Str::contains($key, ':')) {
-            [$key, $val] = explode(':', $key);
+        if (! $opr && Str::contains($key, ':')) {
+            [$key, $opr] = explode(':', $key);
+        }
+        if (! $val) {
+            $val = $opr;
+            $opr = '==';
         }
 
-        $collection = collect($value)->where($key, $val);
+        $collection = collect($value)->where($key, $opr, $val);
 
         return $collection->values()->all();
     }

--- a/tests/Modifiers/WhereTest.php
+++ b/tests/Modifiers/WhereTest.php
@@ -40,6 +40,19 @@ class WhereTest extends TestCase
         $this->assertEquals($expected, Arr::pluck($modified, 'title'));
     }
 
+    #[Test]
+    public function it_filters_data_using_operator(): void
+    {
+        $games = [
+            ['feeling' => 'love', 'title' => 'Dominion'],
+            ['feeling' => 'love', 'title' => 'Netrunner'],
+            ['feeling' => 'hate', 'title' => 'Chutes and Ladders'],
+        ];
+        $expected = ['Chutes and Ladders'];
+        $modified = $this->modify($games, ['feeling', '!=', 'love']);
+        $this->assertEquals($expected, Arr::pluck($modified, 'title'));
+    }
+
     private function modify($value, array $params)
     {
         return Modify::value($value)->where($params)->fetch();


### PR DESCRIPTION
This PR adds the ability to pass operators to the where modifier, so that you can do checks like "where not" and "where greater than":

```antlers
{{ products | where('status', '!=', 'hidden') }}
```

Any operators supported by the [collection where method](https://laravel.com/docs/11.x/collections#method-where) can be used.