### PR TITLE
[5.x] Fix unauthorized page logout redirect

### DIFF
--- a/resources/views/auth/unauthorized.blade.php
+++ b/resources/views/auth/unauthorized.blade.php
@@ -10,7 +10,7 @@
     <div class="outside-shadow absolute inset-0"></div>
     <div class="card auth-card">
         <div class="mb-6">{{ __('Unauthorized') }}</div>
-        <a class="btn-primary" href="{{ cp_route('logout') }}?redirect={{ cp_route('login') }}">{{ __('Log out') }}</a>
+        <a class="btn-primary" href="{{ cp_route('logout') }}?redirect={{ $redirect }}">{{ __('Log out') }}</a>
     </div>
 </div>
 

--- a/src/Http/Controllers/CP/Auth/UnauthorizedController.php
+++ b/src/Http/Controllers/CP/Auth/UnauthorizedController.php
@@ -6,6 +6,10 @@ class UnauthorizedController
 {
     public function __invoke()
     {
-        return view('statamic::auth.unauthorized');
+        $redirect = config('statamic.cp.auth.enabled', true)
+            ? cp_route('login')
+            : config('statamic.cp.auth.redirect_to');
+
+        return view('statamic::auth.unauthorized', compact($redirect));
     }
 }


### PR DESCRIPTION
Following the release of v5.12.0, developers can now disable the CP authentication pages. However, if a user is unauthorized to access the control panel, an unexpected exception is thrown.

This is due to the `unauthorized `view attempting to use the login route as the redirect after logging out, however, that route will no longer be registered if CP authentication is disabled.

Therefore, to solve this, I've added a check in the `UnauthorizedController` to check whether the CP authentication pages are enabled. If they are, we will redirect to the login page after logout, otherwise, we will redirect back to URL specified in the config.