### PR TITLE
[5.x] Fix dirty state after entry action or revison publish

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -768,7 +768,10 @@ export default {
             this.isWorkingCopy = isWorkingCopy;
             this.confirmingPublish = false;
             this.title = response.data.data.title;
+            clearTimeout(this.trackDirtyStateTimeout);
+            this.trackDirtyState = false;
             this.values = this.resetValuesFromResponse(response.data.data.values);
+            this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350);
             this.activeLocalization.title = response.data.data.title;
             this.activeLocalization.published = response.data.data.published;
             this.activeLocalization.status = response.data.data.status;
@@ -816,7 +819,10 @@ export default {
             if (response.data) {
                 this.title = response.data.title;
                 if (!this.revisionsEnabled) this.permalink = response.data.permalink;
+                clearTimeout(this.trackDirtyStateTimeout);
+                this.trackDirtyState = false;
                 this.values = this.resetValuesFromResponse(response.data.values);
+                this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350);
                 this.initialPublished = response.data.published;
                 this.activeLocalization.published = response.data.published;
                 this.activeLocalization.status = response.data.status;


### PR DESCRIPTION
In https://github.com/statamic/cms/pull/6375 and https://github.com/statamic/cms/pull/10095 I added updating the publish store with values from the server after actions or revison publish, but they did not disable the dirty state tracking during that update, which can result in the store having an invalid dirty state if something changed on the server.

This PR fixes it.