### PR TITLE
[5.x] Preserve <?xml tags when sanitizing PHP short open tags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: fileinfo, exif, gd, pdo, sqlite, pdo_sqlite
+          ini-values: short_open_tag=on
           coverage: none
 
       - name: Install dependencies

--- a/src/View/Antlers/Language/Utilities/StringUtilities.php
+++ b/src/View/Antlers/Language/Utilities/StringUtilities.php
@@ -3,6 +3,7 @@
 namespace Statamic\View\Antlers\Language\Utilities;
 
 use Exception;
+use Illuminate\Support\Str;
 use Statamic\View\Antlers\Language\Parser\DocumentParser;
 
 class StringUtilities
@@ -81,10 +82,11 @@ class StringUtilities
         $text = str_replace('<?php', '&lt;?php', $text);
 
         // Also replace short tags if they're enabled.
-        // If they're disabled (which is the common default), you can use <?xml tags right in your template. How nice!
-        // If they're enabled, we want to make sure it doesn't run PHP. You'll need to use {{ xml_header }}.
         if (ini_get('short_open_tag')) {
+            $xmlPlaceholder = '__XML_PLACEHOLDER'.Str::uuid();
+            $text = str_replace('<?xml', $xmlPlaceholder, $text);
             $text = str_replace('<?', '&lt;?', $text);
+            $text = str_replace($xmlPlaceholder, '<?xml', $text);
         }
 
         return $text;


### PR DESCRIPTION
This PR removes a small papercut where you cannot use  the `<?xml ... ?>`  tag when the PHP option `short_open_tag` is enabled. This PR uses a temporary placeholder to preserve them while sanitizing.
