### PR TITLE
[5.x] Add negative bottom margin to Textarea's character counter

### DIFF
--- a/resources/js/components/inputs/Textarea.vue
+++ b/resources/js/components/inputs/Textarea.vue
@@ -13,7 +13,7 @@
             @focus="$emit('focus')"
             @blur="$emit('blur')"
         />
-        <div class="rtl:text-left ltr:text-right text-xs" :class="limitIndicatorColor" v-if="limit">
+        <div class="rtl:text-left ltr:text-right text-xs -mb-3 @sm:-mb-5 @lg:-mb-5" :class="limitIndicatorColor" v-if="limit">
             <span v-text="currentLength"></span>/<span v-text="limit"></span>
         </div>
     </div>


### PR DESCRIPTION
Because this element is aligned to the right, it creates a larger-than-normal gap between this field and the next one below it. This change will pull the next field up by the proper amount so it looks the same whether it's there or not.