### PR TITLE
[5.x] Remove container tabs from Asset Manager

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -21,17 +21,6 @@
                     <span>{{ __('Drop File to Upload') }}</span>
                 </div>
 
-                <div class="publish-tabs tabs rounded-none rounded-t mb-3 shadow-none" v-if="showContainerTabs">
-                    <button class="tab-button" v-for="item in containers" :key="item.id"
-                        v-text="__(item.title)"
-                        :class="{
-                            active: item.id === container.id,
-                            'border-b border-gray-300': item.id !== container.id
-                        }"
-                        @click="selectContainer(item.id)"
-                    />
-                </div>
-
                 <data-list
                     v-if="!initializing"
                     :rows="assets"
@@ -321,7 +310,6 @@ export default {
         // Either the ID, or the whole container object.
         initialContainer: {},
         selectedPath: String,        // The path to display, determined by a parent component.
-        restrictContainerNavigation: Boolean,  // Whether to restrict to a single container and prevent navigation.
         restrictFolderNavigation: Boolean,  // Whether to restrict to a single folder and prevent navigation.
         selectedAssets: Array,
         maxFiles: Number,
@@ -374,10 +362,6 @@ export default {
 
         actionContext() {
             return {container: this.selectedContainer};
-        },
-
-        showContainerTabs() {
-            return !this.restrictContainerNavigation && Object.keys(this.containers).length > 1
         },
 
         showAssetEditor() {
@@ -547,14 +531,6 @@ export default {
         selectFolder(path) {
             // Trigger re-loading of assets in the selected folder.
             this.path = path;
-            this.page = 1;
-
-            this.$emit('navigated', this.container, this.path);
-        },
-
-        selectContainer(id) {
-            this.container = this.containers[id];
-            this.path = '/';
             this.page = 1;
 
             this.$emit('navigated', this.container, this.path);

--- a/resources/js/components/assets/Selector.vue
+++ b/resources/js/components/assets/Selector.vue
@@ -8,7 +8,6 @@
                     :initial-per-page="$config.get('paginationSize')"
                     :selected-path="folder"
                     :selected-assets="browserSelections"
-                    :restrict-container-navigation="restrictContainerNavigation"
                     :restrict-folder-navigation="restrictFolderNavigation"
                     :max-files="maxFiles"
                     :query-scopes="queryScopes"
@@ -59,12 +58,6 @@ export default {
         selected: Array,
         maxFiles: Number,
         queryScopes: Array,
-        restrictContainerNavigation: {
-            type: Boolean,
-            default() {
-                return false;
-            }
-        },
         restrictFolderNavigation: {
             type: Boolean,
             default() {

--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -48,7 +48,7 @@
 <script>
 import HasInputOptions from '../fieldtypes/HasInputOptions.js'
 
-const onEachSide = 3;
+const onEachSide = 2;
 
 export default {
 

--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -48,7 +48,7 @@
 <script>
 import HasInputOptions from '../fieldtypes/HasInputOptions.js'
 
-const onEachSide = 2;
+const onEachSide = 3;
 
 export default {
 

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -118,7 +118,6 @@
             <selector
                 :container="container"
                 :folder="folder"
-                :restrict-container-navigation="true"
                 :restrict-folder-navigation="restrictNavigation"
                 :selected="selectedAssets"
                 :view-mode="selectorViewMode"

--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -47,7 +47,6 @@
                 <selector
                     :container="extension.options.bard.config.container"
                     :folder="extension.options.bard.config.folder || '/'"
-                    :restrict-container-navigation="true"
                     :restrict-folder-navigation="extension.options.bard.config.restrict_assets"
                     :selected="selections"
                     :view-mode="'grid'"

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -168,7 +168,6 @@
             <asset-selector
                 :container="config.container"
                 :folder="config.folder || '/'"
-                :restrict-container-navigation="true"
                 :restrict-folder-navigation="config.restrict_assets"
                 :selected="[]"
                 :view-mode="'grid'"

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -89,7 +89,6 @@
                   :container="container"
                   :folder="folder"
                   :selected="selectedAssets"
-                  :restrict-container-navigation="restrictAssetNavigation"
                   :restrict-folder-navigation="restrictAssetNavigation"
                   @selected="assetsSelected"
                   @closed="closeAssetSelector"

--- a/src/Http/Controllers/CP/Assets/RedirectsToFirstAssetContainer.php
+++ b/src/Http/Controllers/CP/Assets/RedirectsToFirstAssetContainer.php
@@ -2,13 +2,25 @@
 
 namespace Statamic\Http\Controllers\CP\Assets;
 
+use Illuminate\Support\Facades\URL;
+use Statamic\CP\Navigation\NavItem;
 use Statamic\Facades\AssetContainer;
+use Statamic\Facades\CP\Nav;
 use Statamic\Facades\User;
 
 trait RedirectsToFirstAssetContainer
 {
     public function redirectToFirstContainer()
     {
+        $firstContainerInNav = Nav::build()->pluck('items')->flatten()
+            ->filter(fn (NavItem $navItem) => $navItem->url() === cp_route('assets.index'))
+            ->map(fn (NavItem $navItem) => $navItem->children()?->first())
+            ->first();
+
+        if ($firstContainerInNav) {
+            abort(redirect($firstContainerInNav->url()));
+        }
+
         $containers = AssetContainer::all()->sortBy->title()->filter(function ($container) {
             return User::current()->can('view', $container);
         });

--- a/src/Http/Controllers/CP/Assets/RedirectsToFirstAssetContainer.php
+++ b/src/Http/Controllers/CP/Assets/RedirectsToFirstAssetContainer.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Http\Controllers\CP\Assets;
 
-use Illuminate\Support\Facades\URL;
 use Statamic\CP\Navigation\NavItem;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\CP\Nav;


### PR DESCRIPTION
This pull request removes container tabs from the Asset Manager, in favour of navigating between asset containers using the Control Panel navigation.

The asset container tabs were inherited from v2 and we don't really use tabs for navigating between "things" elsewhere, so we thought just removing them would be the easiest option.

By removing the tabs altogether, it means developers can re-order & hide asset containers by using the CP Nav customizer. This saves us needing to build a special way to re-order asset containers, as suggested in #10177.

In addition to removing the tabs, I've also tweaked the "redirect to first container" logic so it takes into the account any re-ordering of asset containers that has taken place in the CP nav customzer. 

Closes #10177.
Closes #10285.
Closes statamic/ideas#42.
Closes statamic/ideas#829.
Closes statamic/ideas#924.