### PR TITLE
[5.x] Fix toggle fields in data list filters

### DIFF
--- a/resources/js/components/data-list/Filter.vue
+++ b/resources/js/components/data-list/Filter.vue
@@ -63,7 +63,7 @@ export default {
             let filteredValues = clone(values);
 
             Object.keys(values).forEach(key => {
-                if (_.isEmpty(values[key])) delete filteredValues[key];
+                if (values[key] === null || values[key] === undefined) delete filteredValues[key];
             });
 
             this.$emit('changed', filteredValues);


### PR DESCRIPTION
This pull request fixes an issue when using Toggle fields in data list filters, where changing the value between true/false wouldn't trigger the data table to be refreshed.

It looks like this was happening due to Underscore's `_.isEmpty` function considering `true`/`false` to be empty, causing the toggle field's value to be filtered out before updating the filter's values.

I've replaced the check with a simple "is null or undefined" check which seems to fix the issue.

Fixes #10194.