### PR TITLE
[5.x] Fix updater widget icon in dark mode

### DIFF
--- a/resources/views/widgets/updater.blade.php
+++ b/resources/views/widgets/updater.blade.php
@@ -1,7 +1,7 @@
 @php use function Statamic\trans as __; @endphp
 
 <div class="card p-0 h-full">
-    <header class="flex justify-between items-center p-4 border-b">
+    <header class="flex justify-between items-center p-4 border-b dark:bg-dark-650 dark:border-b dark:border-dark-900">
         <h2 class="flex items-center">
             <div class="h-6 w-6 rtl:ml-2 ltr:mr-2 text-gray-800 dark:text-dark-200">
                 @cp_svg('icons/light/loading-bar')

--- a/resources/views/widgets/updater.blade.php
+++ b/resources/views/widgets/updater.blade.php
@@ -3,7 +3,7 @@
 <div class="card p-0 h-full">
     <header class="flex justify-between items-center p-4 border-b">
         <h2 class="flex items-center">
-            <div class="h-6 w-6 rtl:ml-2 ltr:mr-2 text-gray-800">
+            <div class="h-6 w-6 rtl:ml-2 ltr:mr-2 text-gray-800 dark:text-dark-200">
                 @cp_svg('icons/light/loading-bar')
             </div>
             <span>{{ __('Updates') }}</span>


### PR DESCRIPTION
Before:
![01](https://github.com/statamic/cms/assets/173099535/e64fdbec-a977-42e5-b845-54d4fe2a954d)

After:
![02](https://github.com/statamic/cms/assets/173099535/10d11196-979d-49b2-b37e-d7dacfa3abbc)
