### PR TITLE
[5.x] Pass the Guzzle config to the StaticWarmJob

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -74,12 +74,7 @@ class StaticWarm extends Command
 
     private function warm(): void
     {
-        $client = new Client([
-            'verify' => $this->shouldVerifySsl(),
-            'auth' => $this->option('user') && $this->option('password')
-                ? [$this->option('user'), $this->option('password')]
-                : null,
-        ]);
+        $client = new Client($this->clientConfig());
 
         $this->output->newLine();
         $this->line('Compiling URLs...');
@@ -93,7 +88,7 @@ class StaticWarm extends Command
             $this->line(sprintf('Adding %s requests onto %squeue...', count($requests), $queue ? $queue.' ' : ''));
 
             foreach ($requests as $request) {
-                StaticWarmJob::dispatch($request)->onQueue($queue);
+                StaticWarmJob::dispatch($request, $this->clientConfig())->onQueue($queue);
             }
         } else {
             $this->line('Visiting '.count($requests).' URLs...');
@@ -115,6 +110,16 @@ class StaticWarm extends Command
         $strategy = config('statamic.static_caching.strategy');
 
         return config("statamic.static_caching.strategies.$strategy.warm_concurrency", 25);
+    }
+
+    private function clientConfig(): array
+    {
+        return [
+            'verify' => $this->shouldVerifySsl(),
+            'auth' => $this->option('user') && $this->option('password')
+                ? [$this->option('user'), $this->option('password')]
+                : null,
+        ];
     }
 
     public function outputSuccessLine(Response $response, $index): void

--- a/src/Console/Commands/StaticWarmJob.php
+++ b/src/Console/Commands/StaticWarmJob.php
@@ -13,17 +13,14 @@ class StaticWarmJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
-    public Request $request;
-
     public $tries = 1;
 
-    public function __construct(Request $request)
+    public function __construct(public Request $request, public array $clientConfig)
     {
-        $this->request = $request;
     }
 
-    public function handle(Client $client)
+    public function handle()
     {
-        $client->send($this->request);
+        (new Client($this->clientConfig))->send($this->request);
     }
 }

--- a/tests/Console/Commands/StaticWarmJobTest.php
+++ b/tests/Console/Commands/StaticWarmJobTest.php
@@ -22,11 +22,9 @@ class StaticWarmJobTest extends TestCase
 
         $handlerStack = HandlerStack::create($mock);
 
-        $client = new Client(['handler' => $handlerStack]);
+        $job = new StaticWarmJob(new Request('GET', '/about'), ['handler' => $handlerStack]);
 
-        $job = new StaticWarmJob(new Request('GET', '/about'));
-
-        $job->handle($client);
+        $job->handle();
 
         $this->assertEquals('/about', $mock->getLastRequest()->getUri()->getPath());
     }

--- a/tests/Console/Commands/StaticWarmJobTest.php
+++ b/tests/Console/Commands/StaticWarmJobTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Console\Commands;
 
-use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;


### PR DESCRIPTION
This pull request fixes an issue with the `static:warm` command, where you couldn't queue warming **and** provide HTTP Auth credentials.

The HTTP Auth credentials were only being used in the `StaticWarm` command itself when newing up the Guzzle client. Those details weren't being passed to the `StaticWarmJob`, which is responsible for newing up it's own Guzzle client.

No issue, came out of a support ticket.