### PR TITLE
[5.x] Merge additional params after SVG sanitization

### DIFF
--- a/src/Tags/Svg.php
+++ b/src/Tags/Svg.php
@@ -60,9 +60,13 @@ class Svg extends Tags
 
         $svg = $this->sanitize($svg);
 
-        $svg = $this->mergeAdditionalParams($svg);
+        $attributes = $this->renderAttributesFromParams(except: ['src', 'title', 'desc', 'sanitize', 'allow_tags', 'allow_attrs']);
 
-        return $svg;
+        return str_replace(
+            '<svg',
+            collect(['<svg', $attributes])->filter()->implode(' '),
+            $svg
+        );
     }
 
     private function setTitleAndDesc($svg)
@@ -104,17 +108,6 @@ class Svg extends Tags
         return $sanitizer->sanitize($svg, [
             'remove-xml-tags' => ! Str::startsWith($svg, '<?xml'),
         ]);
-    }
-
-    private function mergeAdditionalParams($svg)
-    {
-        $attributes = $this->renderAttributesFromParams(except: ['src', 'title', 'desc', 'sanitize', 'allow_tags', 'allow_attrs']);
-
-        return str_replace(
-            '<svg',
-            collect(['<svg', $attributes])->filter()->implode(' '),
-            $svg
-        );
     }
 
     private function setAllowedAttrs(DOMSanitizer $sanitizer)

--- a/src/Tags/Svg.php
+++ b/src/Tags/Svg.php
@@ -54,19 +54,15 @@ class Svg extends Tags
             return '';
         }
 
-        $attributes = $this->renderAttributesFromParams(except: ['src', 'title', 'desc', 'sanitize']);
-
         if ($this->params->get('title') || $this->params->get('desc')) {
             $svg = $this->setTitleAndDesc($svg);
         }
 
-        $svg = str_replace(
-            '<svg',
-            collect(['<svg', $attributes])->filter()->implode(' '),
-            $svg
-        );
+        $svg = $this->sanitize($svg);
 
-        return $this->sanitize($svg);
+        $svg = $this->mergeAdditionalParams($svg);
+
+        return $svg;
     }
 
     private function setTitleAndDesc($svg)
@@ -108,6 +104,17 @@ class Svg extends Tags
         return $sanitizer->sanitize($svg, [
             'remove-xml-tags' => ! Str::startsWith($svg, '<?xml'),
         ]);
+    }
+
+    private function mergeAdditionalParams($svg)
+    {
+        $attributes = $this->renderAttributesFromParams(except: ['src', 'title', 'desc', 'sanitize', 'allow_tags', 'allow_attrs']);
+
+        return str_replace(
+            '<svg',
+            collect(['<svg', $attributes])->filter()->implode(' '),
+            $svg
+        );
     }
 
     private function setAllowedAttrs(DOMSanitizer $sanitizer)

--- a/tests/Tags/SvgTagTest.php
+++ b/tests/Tags/SvgTagTest.php
@@ -84,6 +84,12 @@ SVG);
     }
 
     #[Test]
+    public function sanitizing_doesnt_remove_additional_params()
+    {
+        $this->assertStringStartsWith('<svg x-ref="svg" xmlns="', $this->tag('{{ svg src="users" x-ref="svg" }}'));
+    }
+
+    #[Test]
     public function sanitization_can_be_disabled()
     {
         $rawSvg = StaticStringy::collapseWhitespace(<<<'SVG'


### PR DESCRIPTION
This PR makes sure that the SVG tag adds additional parameters after sanitization. This solves the problem of parameters being unintentionally removed by the sanitizer.

Until 5.0 this was possible without any issues:
```
Antlers:
{{ svg src="logo" x-ref="logo" }}

Result:
<svg x-ref="logo" xmlns="...
```

But since 5.0 this has changed, as sanitizing is active by default:
```
Antlers:
{{ svg src="logo" x-ref="logo" }}

Result:
<svg xmlns="...
```

We can set `sanitize="false"` of course. But in my opinion, it would be nicer to have the best of both worlds. First sanitizing potentially dangerous code, then merge additional parameters.

This relates to #9948 and potentially to #10161 as well.