### PR TITLE
[5.x] Use `ShouldBeUnique` on  `StaticWarmJob`

### DIFF
--- a/src/Console/Commands/StaticWarmJob.php
+++ b/src/Console/Commands/StaticWarmJob.php
@@ -14,21 +14,16 @@ class StaticWarmJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
+    public $uniqueId;
     public $tries = 1;
-    private $id;
 
     public function __construct(public Request $request, public array $clientConfig)
     {
-        $this->id = $request->getUri()->getHost().$request->getUri()->getPath();
+        $this->uniqueId = (string) $request->getUri();
     }
 
     public function handle()
     {
         (new Client($this->clientConfig))->send($this->request);
-    }
-
-    public function uniqueId(): string
-    {
-        return $this->id;
     }
 }

--- a/src/Console/Commands/StaticWarmJob.php
+++ b/src/Console/Commands/StaticWarmJob.php
@@ -19,7 +19,7 @@ class StaticWarmJob implements ShouldBeUnique, ShouldQueue
 
     public function __construct(public Request $request, public array $clientConfig)
     {
-        $this->id = $request->getUri()->getPath();
+        $this->id = $request->getUri()->getHost() . $request->getUri()->getPath();
     }
 
     public function handle()

--- a/src/Console/Commands/StaticWarmJob.php
+++ b/src/Console/Commands/StaticWarmJob.php
@@ -5,8 +5,8 @@ namespace Statamic\Console\Commands;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 

--- a/src/Console/Commands/StaticWarmJob.php
+++ b/src/Console/Commands/StaticWarmJob.php
@@ -6,21 +6,30 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 
-class StaticWarmJob implements ShouldQueue
+class StaticWarmJob implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
     public $tries = 1;
+    
+    private $id;
 
     public function __construct(public Request $request, public array $clientConfig)
     {
+        $this->id = $request->getUri()->getPath();
     }
 
     public function handle()
     {
         (new Client($this->clientConfig))->send($this->request);
+    }
+
+    public function uniqueId(): string
+    {
+        return $this->id;
     }
 }

--- a/src/Console/Commands/StaticWarmJob.php
+++ b/src/Console/Commands/StaticWarmJob.php
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 
-class StaticWarmJob implements ShouldQueue, ShouldBeUnique
+class StaticWarmJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 

--- a/src/Console/Commands/StaticWarmJob.php
+++ b/src/Console/Commands/StaticWarmJob.php
@@ -15,7 +15,6 @@ class StaticWarmJob implements ShouldQueue, ShouldBeUnique
     use Dispatchable, InteractsWithQueue, Queueable;
 
     public $tries = 1;
-    
     private $id;
 
     public function __construct(public Request $request, public array $clientConfig)

--- a/src/Console/Commands/StaticWarmJob.php
+++ b/src/Console/Commands/StaticWarmJob.php
@@ -19,7 +19,7 @@ class StaticWarmJob implements ShouldBeUnique, ShouldQueue
 
     public function __construct(public Request $request, public array $clientConfig)
     {
-        $this->id = $request->getUri()->getHost() . $request->getUri()->getPath();
+        $this->id = $request->getUri()->getHost().$request->getUri()->getPath();
     }
 
     public function handle()


### PR DESCRIPTION
This PR implements `ShouldBeUnique` on the `StaticWarmJob` and makes sure each job gets a unique ID based on the path of the URL it's supposed to warm. 

I'm fairly positive I'm doing stuff wrong here, but I wanted to give it a shot anyways :-).

Closes #10404
