### PR TITLE
[5.x] Prevent updating time fieldtype value if it hasn't changed

### DIFF
--- a/resources/js/components/fieldtypes/TimeFieldtype.vue
+++ b/resources/js/components/fieldtypes/TimeFieldtype.vue
@@ -115,7 +115,8 @@ export default {
             parts = parts.map(part => part.padStart(2, '0'));
 
             let newValue = parts.join(':');
-            this.update(newValue);
+
+            if (this.value !== newValue) this.update(newValue);
             this.inputValue = newValue;
         },
 


### PR DESCRIPTION
This pull request fixes an issue with the Time Fieldtype, where its value would end up being saved in the localized entry's data, even when the field wasn't marked as "Localizable" in the blueprint.

This was happening due to the fact the fieldtype was updating the field's value in the publish container, which subsequently added the time field to the `localizedFields` array, which is the array that contains the fields that should end up getting saved to the entry's data.

To fix this, I've wrapped the "update the value" code in a conditional to check whether the value has actually be changed or not.

No issue, related to support ticket 5742.