### PR TITLE
[5.x] Warm structure trees during static warm

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -195,6 +195,9 @@ class StaticWarm extends Command
     {
         $this->line('[ ] Entries...');
 
+        // "Warm" the structure trees
+        Facades\Collection::whereStructured()->each(fn ($collection) => $collection->structure()->trees()->each->tree());
+
         $entries = Facades\Entry::all()->map(function (Entry $entry) {
             if (! $entry->published() || $entry->private()) {
                 return null;


### PR DESCRIPTION
There's an issue where if you run `static:warm` immediately after a cache clear, entries from a structured collection will 404.

This is because mid-query for entries, the `uri` indexes get built (as expected) but for structured entries their uris come from their structures. As part of that, the trees are validated, which also queries the same entries, which don't have uri yet. The uris get indexed as nulls, and therefore will 404 when they are searched for later.

Or, something close to that. 😅

This PR is really a workaround, but seems to resolve it.

If you were to run `stache:warm` before `static:warm`, or if you visited any pages before running `static:warm`, you wouldn't have this issue.
