### PR TITLE
[5.x] Change method visibility in `AbstractAugmented` class

### DIFF
--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -115,7 +115,7 @@ abstract class AbstractAugmented implements Augmented
         return $value;
     }
 
-    private function wrapDeferredValue($handle)
+    protected function wrapDeferredValue($handle)
     {
         return new Value(
             fn () => $this->getFromData($handle),
@@ -125,7 +125,7 @@ abstract class AbstractAugmented implements Augmented
         );
     }
 
-    private function wrapAugmentedMethodInvokable(string $method, string $handle)
+    protected function wrapAugmentedMethodInvokable(string $method, string $handle)
     {
         return new Value(
             fn () => $this->$method(),
@@ -135,7 +135,7 @@ abstract class AbstractAugmented implements Augmented
         );
     }
 
-    private function wrapDataMethodInvokable(string $method, string $handle)
+    protected function wrapDataMethodInvokable(string $method, string $handle)
     {
         return new Value(
             fn () => $this->data->$method(),


### PR DESCRIPTION
PR https://github.com/statamic/cms/pull/9636 introduced a refactor to the `AbstractAugmented` class that broke a custom augmented class of mine. I need to be able to customize the returned `Value` object. This used to be possible by overriding the `wrapValue` method. However, the PR added some new methods that are currently `private` and can't be overridden.

This PR changes the visibility of those methods to `protected`. I talked to @JohnathonKoster about it and got green lights for this change.