### PR TITLE
[5.x] Prevent incompatible pagination parameter combinations

### DIFF
--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -9,7 +9,9 @@ trait GetsQueryResults
 {
     protected function results($query)
     {
-        $this->setPaginationParameterPrecedence();
+        $this
+            ->setPaginationParameterPrecedence()
+            ->preventIncompatiblePaginationParameters();
 
         if ($paginate = $this->params->int('paginate')) {
             return $this->paginatedResults($query, $paginate);
@@ -35,6 +37,25 @@ trait GetsQueryResults
         if ($this->params->get('paginate') === true) {
             $this->params->put('paginate', $this->params->get('limit'));
         }
+
+        return $this;
+    }
+
+    protected function preventIncompatiblePaginationParameters()
+    {
+        if ($this->params->int('paginate') && $this->params->int('limit')) {
+            throw new \Exception('Cannot use [paginate] integer in combination with [limit] param!');
+        }
+
+        if ($this->params->int('paginate') && $this->params->int('offset')) {
+            throw new \Exception('Cannot use [paginate] integer in combination with [offset] param!');
+        }
+
+        if ($this->params->int('paginate') && $this->params->int('chunk')) {
+            throw new \Exception('Cannot use [paginate] integer in combination with [chunk] param!');
+        }
+
+        return $this;
     }
 
     protected function paginatedResults($query, $perPage)

--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -44,12 +44,12 @@ trait GetsQueryResults
 
     protected function preventIncompatiblePaginationParameters()
     {
-        if ($this->params->int('paginate') && $this->params->int('limit')) {
+        if ($this->params->int('paginate') && $this->params->has('limit')) {
             throw new \Exception('Cannot use [paginate] integer in combination with [limit] param.');
         }
 
-        if ($this->params->int('paginate') && $this->params->int('chunk')) {
-            throw new \Exception('Cannot use [paginate] integer in combination with [chunk] param.');
+        if ($this->params->has('paginate') && $this->params->has('chunk')) {
+            throw new \Exception('Cannot use [paginate] in combination with [chunk] param.');
         }
 
         return $this;

--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -47,10 +47,6 @@ trait GetsQueryResults
             throw new \Exception('Cannot use [paginate] integer in combination with [limit] param!');
         }
 
-        if ($this->params->int('paginate') && $this->params->int('offset')) {
-            throw new \Exception('Cannot use [paginate] integer in combination with [offset] param!');
-        }
-
         if ($this->params->int('paginate') && $this->params->int('chunk')) {
             throw new \Exception('Cannot use [paginate] integer in combination with [chunk] param!');
         }

--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -10,7 +10,7 @@ trait GetsQueryResults
     protected function results($query)
     {
         $this
-            ->setPaginationParameterPrecedence()
+            ->allowLegacyStylePaginationLimiting()
             ->preventIncompatiblePaginationParameters();
 
         if ($paginate = $this->params->int('paginate')) {
@@ -32,7 +32,7 @@ trait GetsQueryResults
         return $query->get();
     }
 
-    protected function setPaginationParameterPrecedence()
+    protected function allowLegacyStylePaginationLimiting()
     {
         if ($this->params->get('paginate') === true) {
             $this->params->put('paginate', $this->params->get('limit'));

--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -45,11 +45,11 @@ trait GetsQueryResults
     protected function preventIncompatiblePaginationParameters()
     {
         if ($this->params->int('paginate') && $this->params->int('limit')) {
-            throw new \Exception('Cannot use [paginate] integer in combination with [limit] param!');
+            throw new \Exception('Cannot use [paginate] integer in combination with [limit] param.');
         }
 
         if ($this->params->int('paginate') && $this->params->int('chunk')) {
-            throw new \Exception('Cannot use [paginate] integer in combination with [chunk] param!');
+            throw new \Exception('Cannot use [paginate] integer in combination with [chunk] param.');
         }
 
         return $this;

--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -36,6 +36,7 @@ trait GetsQueryResults
     {
         if ($this->params->get('paginate') === true) {
             $this->params->put('paginate', $this->params->get('limit'));
+            $this->params->forget('limit');
         }
 
         return $this;

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -152,7 +152,22 @@ class EntriesTest extends TestCase
         $this->makeEntry('e')->save();
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Cannot use [paginate] integer in combination with [chunk] param.');
+        $this->expectExceptionMessage('Cannot use [paginate] in combination with [chunk] param.');
+
+        $this->assertCount(3, $this->getEntries(['paginate' => true, 'chunk' => 2]));
+    }
+
+    #[Test]
+    public function it_should_throw_exception_if_trying_to_paginate_with_integer_and_chunk_at_same_time()
+    {
+        $this->makeEntry('a')->save();
+        $this->makeEntry('b')->save();
+        $this->makeEntry('c')->save();
+        $this->makeEntry('d')->save();
+        $this->makeEntry('e')->save();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Cannot use [paginate] in combination with [chunk] param.');
 
         $this->assertCount(3, $this->getEntries(['paginate' => 3, 'chunk' => 2]));
     }

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -95,8 +95,7 @@ class EntriesTest extends TestCase
 
         $this->assertCount(5, $this->getEntries());
         $this->assertCount(3, $this->getEntries(['paginate' => 3])); // recommended v3 style
-        $this->assertCount(4, $this->getEntries(['paginate' => true, 'limit' => 4])); // v2 style
-        $this->assertCount(3, $this->getEntries(['paginate' => 3, 'limit' => 4])); // precedence test
+        $this->assertCount(4, $this->getEntries(['paginate' => true, 'limit' => 4])); // v2 style pagination limiting
         $this->assertCount(5, $this->getEntries(['paginate' => true])); // ignore if no perPage set
 
         $this->assertEquals(['a', 'b', 'c'], $this->getEntryIds(['paginate' => 3]));
@@ -126,6 +125,36 @@ class EntriesTest extends TestCase
         });
 
         $this->assertEquals(['f', 'g'], $this->getEntryIds(['paginate' => 3, 'offset' => 2]));
+    }
+
+    #[Test]
+    public function it_should_throw_exception_if_trying_to_paginate_and_limit_at_same_time()
+    {
+        $this->makeEntry('a')->save();
+        $this->makeEntry('b')->save();
+        $this->makeEntry('c')->save();
+        $this->makeEntry('d')->save();
+        $this->makeEntry('e')->save();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Cannot use [paginate] integer in combination with [limit] param.');
+
+        $this->assertCount(3, $this->getEntries(['paginate' => 3, 'limit' => 4]));
+    }
+
+    #[Test]
+    public function it_should_throw_exception_if_trying_to_paginate_and_chunk_at_same_time()
+    {
+        $this->makeEntry('a')->save();
+        $this->makeEntry('b')->save();
+        $this->makeEntry('c')->save();
+        $this->makeEntry('d')->save();
+        $this->makeEntry('e')->save();
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Cannot use [paginate] integer in combination with [chunk] param.');
+
+        $this->assertCount(3, $this->getEntries(['paginate' => 3, 'chunk' => 2]));
     }
 
     #[Test]


### PR DESCRIPTION
Throw an error, [as per Jason's suggestion here](https://github.com/statamic/cms/discussions/10407#discussioncomment-9990452) when trying to use `paginate` collection tag parameter with incompatible params like `limit` and `chunk`...

```antlers
{{ collection:articles paginate="10" limit="50" }}
{{ collection:articles paginate="10" chunk="50" }}
```

This is obviously [kinda confusing](https://github.com/statamic/cms/discussions/10407#discussion-6909445) because `limit` and `chunk` are completely and silently ignored in the above scenarios.

Introducing exceptions may seem like a breaking change, but technically these params were never meant to work together like this; It would only be breaking if people are relying on this already non-functional combo of tag params.