### PR TITLE
[5.x] Fix augmentable not resolved in transient values

### DIFF
--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -168,6 +168,8 @@ class Value implements IteratorAggregate, JsonSerializable
 
     public function augmentable()
     {
+        $this->resolve();
+
         return $this->augmentable;
     }
 


### PR DESCRIPTION
PR https://github.com/statamic/cms/pull/9636 introduced the concept of transient values that are only resolved once they are needed. This PR fixes an issue that would make it impossible to get the `augmentable` from the Value, as it is never resolved.

Consider this simple tag:

```php
class Resolver extends Tags
{
    public function index()
    {
        dd($this->context->get('id'));
    }
}
```

This is the dump: 

![CleanShot 2024-07-09 at 10 00 27@2x](https://github.com/statamic/cms/assets/23167701/29ecc2f6-4b9f-4099-b64a-75e3799de0ba)

Getting the augmentable would return `null`:

```php
class Resolver extends Tags
{
    public function index()
    {
        dd($this->context->get('id')->augmentable());
    }
}
```

So we need to resolve the value in the `augmentable()` method first to be able to get the augmentable entry:

![CleanShot 2024-07-09 at 10 02 46@2x](https://github.com/statamic/cms/assets/23167701/60640902-e511-4e2b-8380-a53ed351face)