### PR TITLE
Adds character replacements to ensure valid file names on Windows sys…

### DIFF
--- a/src/Assets/AssetUploader.php
+++ b/src/Assets/AssetUploader.php
@@ -80,6 +80,15 @@ class AssetUploader extends Uploader
         $replacements = [
             ' ' => '-',
             '#' => '-',
+            ':' => '-',
+            '<' => '-',
+            '>' => '-',
+            '""' => '-',
+            '/' => '-',
+            '\\' => '-',
+            '|' => '-',
+            '?' => '-',
+            '*' => '-'
         ];
 
         $str = Stringy::create(urldecode($string))->toAscii();


### PR DESCRIPTION
Addresses :  #10421


It's possible for assets to be uploaded with, what Windows considers, invalid characters in pathname.

This becomes a problem when hosting a live/dev site on a Linux system and the developer machine is Windows.
The client is uploading lots of files containing these characters and this prevents a Windows developer from pulling the latest content onto a local machine:


```
error: invalid path 'public/assets/.meta/example-filename:-more-words-here.docx.yaml'
error: invalid path 'public/assets/.meta/project-report:-stuff-and-things:-things-and-stuff.pdf.yaml'
error: invalid path 'public/assets/example-filename:-more-words-here.docx'
error: invalid path 'public/assets/project-report:-stuff-and-things:-things-and-stuff.pdf.yaml'
```

 
 (*opened issue #10421 as suggested by PR description placeholder text. Hope this is all copacetic with/for the workflow. )
 