### PR TITLE
[5.x] Use `Create Revision` instead of `Publish` in publish form if no publish permission 

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -224,7 +224,7 @@
                         class="rtl:mr-4 ltr:ml-4 btn-primary flex items-center"
                         :disabled="!canPublish"
                         @click="confirmingPublish = true">
-                        <span v-text="__('Publish')" />
+                        <span v-text="publishButtonText" />
                         <svg-icon name="micro/chevron-down-xs" class="rtl:mr-2 ltr:ml-2 w-2" />
                     </button>
                 </template>
@@ -248,7 +248,7 @@
                 class="rtl:mr-2 ltr:ml-2 btn btn-lg justify-center btn-primary flex items-center w-1/2"
                 :disabled="!canPublish"
                 @click="confirmingPublish = true">
-                <span v-text="__('Publish')" />
+                <span v-text="publishButtonText" />
                 <svg-icon name="micro/chevron-down-xs" class="rtl:mr-2 ltr:ml-2 w-2" />
             </button>
         </div>

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -470,12 +470,13 @@ export default {
                     return __('Save & Publish');
             }
         },
+
         publishButtonText() {
             if (this.canManagePublishState) {
-                return __('Publish');
+                return `${__('Publish')}…`
             }
 
-            return __('Create Revision');
+            return `${__('Create Revision')}…`
         },
 
         isUnpublishing() {

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -46,12 +46,12 @@
                 </save-button-options>
 
                 <button
-                    v-if="revisionsEnabled && !isCreating && canManagePublishState"
+                    v-if="revisionsEnabled && !isCreating"
                     class="rtl:mr-4 ltr:ml-4 btn-primary flex items-center"
                     :disabled="!canPublish"
-                    @click="confirmingPublish = true">
-                    <span>{{ __('Publish') }}…</span>
-                </button>
+                    @click="confirmingPublish = true"
+                    v-text="publishButtonText"
+                />
             </div>
 
             <slot name="action-buttons-right" />
@@ -469,6 +469,13 @@ export default {
                 default:
                     return __('Save & Publish');
             }
+        },
+        publishButtonText() {
+            if (this.canManagePublishState) {
+                return __('Publish');
+            }
+
+            return __('Create Revision');
         },
 
         isUnpublishing() {

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -46,7 +46,7 @@
                 </save-button-options>
 
                 <button
-                    v-if="revisionsEnabled && !isCreating"
+                    v-if="revisionsEnabled && !isCreating && canManagePublishState"
                     class="rtl:mr-4 ltr:ml-4 btn-primary flex items-center"
                     :disabled="!canPublish"
                     @click="confirmingPublish = true">


### PR DESCRIPTION
Right now if you have the ability to create/edit an entry but NOT the `Manage Publish State` permission, the "publish" button says "Publish" instead of "Create Revision".

No behaviour is changed, only the name.