### PR TITLE
[5.x] Only output terms in the current locale

### DIFF
--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -370,7 +370,7 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
 
         return (new \Statamic\Http\Responses\DataResponse($this))
             ->with([
-                'terms' => $termQuery = $this->queryTerms(),
+                'terms' => $termQuery = $this->queryTerms()->where('site', Site::current()),
                 $this->handle() => $termQuery,
             ])
             ->toResponse($request);


### PR DESCRIPTION
I've noticed that when [listing the terms](https://statamic.dev/taxonomies#listings-and-indexes) on a taxonomy route, all the localizations of a term would be output. It should only output the terms of the current locale, though. This is consistent with the behavior when [listing term entries](https://statamic.dev/taxonomies#listing-term-entries) on a term route, which also only shows the entries in the current locale.

### Before

![CleanShot 2024-07-10 at 18 27 20@2x](https://github.com/statamic/cms/assets/23167701/ffbef1c6-c726-453c-b25d-38aca7a19f94)

![CleanShot 2024-07-10 at 18 28 34@2x](https://github.com/statamic/cms/assets/23167701/049416c6-2cc9-440a-a749-a1c1c84abb57)

### After
![CleanShot 2024-07-10 at 18 27 47@2x](https://github.com/statamic/cms/assets/23167701/c690df5c-9c76-42a0-ac14-e166f9406199)

![CleanShot 2024-07-10 at 18 28 12@2x](https://github.com/statamic/cms/assets/23167701/bce2f85a-d0b4-498c-a9dd-074718964018)
