### PR TITLE
[5.x] Provide search index name callback

### DIFF
--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Search;
 
+use Closure;
 use Statamic\Contracts\Search\Searchable;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
@@ -11,6 +12,7 @@ abstract class Index
     protected $name;
     protected $locale;
     protected $config;
+    protected static ?Closure $nameCallback = null;
 
     abstract public function search($query);
 
@@ -31,7 +33,16 @@ abstract class Index
 
     public function name()
     {
+        if (static::$nameCallback) {
+            return call_user_func(static::$nameCallback, $this->name);
+        }
+
         return $this->name;
+    }
+
+    public static function resolveNaminglUsing(Closure $callback)
+    {
+        static::$nameCallback = $callback;
     }
 
     public function title()


### PR DESCRIPTION
Currently Statamic always generates search index names like this `$locale ? $name.'_'.$locale : $name`.

When using different environments (staging, production) and a cloud search provider (e.g. Algolia) index names tpyically collide. Staging updates overwrite those from production and vice versa.

At least in the lower pricing plans Algolia has a limit of 1 app per account and per app isolation is also often a configuration overhead. So an environment prefix for the search index name would be handy?

Afaik there a two approaches to get this solved in user land:

1. Within a dirty env access within `search.php` 
```php 
'indexes' => [
    env('APP_ENV') . '_pages' => [
        'driver' => 'algolia',
        'searchables' => ['collection:pages'],
        'fields' => ['title'],
        'sites' => 'all',
    ],
]
```

2. By overriding the default index within a ServiceProvider's boot method:
```php
Search::extend(
    driver: 'algolia',
    callback: fn (Application $app, array $config, string $name, string $locale): EnvironmentIndex => new EnvironmentIndex(
        client: SearchClient::create(
            appId: $config['credentials']['id'],
            apiKey: $config['credentials']['secret']
        ),
        name: $name,
        config: $config,
        locale: $locale
    )
);

//

namespace App\Statamic\Search\Algolia;

use Algolia\AlgoliaSearch\SearchClient;
use Statamic\Search\Algolia\Index as BaseIndex;

class EnvironmentIndex extends BaseIndex
{
    public function __construct(SearchClient $client, string $name, array $config, string $locale)
    {
        parent::__construct(
            client: $client,
            name: app()->environment() . '_' . $name,
            config: $config,
            locale: $locale
        );
    }
}
```

With this PR it would possible to override the generating of index names by setting a callback ServiceProvider's boot method e.g. like this:
```php 
use Statamic\Search\Algolia\Index as AlgoliaIndex;

AlgoliaIndex::resolveNaminglUsing(fn (string $name): string => app()->environment() . '_' . $name);
```

No breaking chances, default name generation is preserved.

Any chance that this is getting merged? :)
Thanks!