### PR TITLE
[5.x] Revision Query builder

### DIFF
--- a/config/stache.php
+++ b/config/stache.php
@@ -105,6 +105,10 @@ return [
             'directory' => storage_path('forms'),
         ],
 
+        'revisions' => [
+            'class' => Stores\RevisionsStore::class,
+        ],
+
     ],
 
     /*

--- a/src/Contracts/Revisions/RevisionQueryBuilder.php
+++ b/src/Contracts/Revisions/RevisionQueryBuilder.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Statamic\Contracts\Revisions;
+
+interface RevisionQueryBuilder
+{
+}

--- a/src/Revisions/Revision.php
+++ b/src/Revisions/Revision.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Support\Arrayable;
 use Statamic\Contracts\Auth\User;
 use Statamic\Contracts\Revisions\Revision as Contract;
 use Statamic\Data\ExistsAsFile;
+use Statamic\Data\TracksQueriedColumns;
+use Statamic\Data\TracksQueriedRelations;
 use Statamic\Events\RevisionDeleted;
 use Statamic\Events\RevisionSaved;
 use Statamic\Events\RevisionSaving;
@@ -15,7 +17,7 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class Revision implements Arrayable, Contract
 {
-    use ExistsAsFile, FluentlyGetsAndSets;
+    use ExistsAsFile, FluentlyGetsAndSets, TracksQueriedColumns, TracksQueriedRelations;
 
     protected $id;
     protected $key;

--- a/src/Revisions/RevisionRepository.php
+++ b/src/Revisions/RevisionRepository.php
@@ -2,10 +2,12 @@
 
 namespace Statamic\Revisions;
 
+use Illuminate\Support\Carbon;
 use Statamic\Contracts\Revisions\Revision as RevisionContract;
 use Statamic\Contracts\Revisions\RevisionQueryBuilder;
 use Statamic\Contracts\Revisions\RevisionRepository as Contract;
 use Statamic\Facades\File;
+use Statamic\Facades\YAML;
 use Statamic\Stache\Stache;
 
 class RevisionRepository implements Contract
@@ -65,6 +67,26 @@ class RevisionRepository implements Contract
     public function query()
     {
         return app(RevisionQueryBuilder::class);
+    }
+
+    // @deprecated - use makeRevisionFromArray
+    protected function makeRevisionFromFile($key, $path)
+    {
+        $yaml = YAML::parse(File::get($path));
+
+        return $this->makeRevisionFromArray($key, $yaml);
+    }
+
+    public function makeRevisionFromArray($key, $data = [])
+    {
+        return (new Revision)
+            ->key($key)
+            ->action($data['action'] ?? false)
+            ->id($date = $data['date'])
+            ->date(Carbon::createFromTimestamp($date))
+            ->user($data['user'] ?? false)
+            ->message($data['message'] ?? false)
+            ->attributes($data['attributes']);
     }
 
     public static function bindings(): array

--- a/src/Revisions/ServiceProvider.php
+++ b/src/Revisions/ServiceProvider.php
@@ -4,11 +4,18 @@ namespace Statamic\Revisions;
 
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 use Statamic\Contracts\Revisions\RevisionRepository as RevisionRepositoryContract;
+use Statamic\Stache\Query\RevisionQueryBuilder;
+use Statamic\Stache\Stache;
+use Statamic\Statamic;
 
 class ServiceProvider extends LaravelServiceProvider
 {
     public function register()
     {
-        $this->app->bind(RevisionRepositoryContract::class, RevisionRepository::class);
+        Statamic::repository(RevisionRepositoryContract::class, RevisionRepository::class);
+
+        $this->app->bind(RevisionQueryBuilder::class, function () {
+            return new RevisionQueryBuilder($this->app->make(Stache::class)->store('revisions'));
+        });
     }
 }

--- a/src/Stache/Query/RevisionQueryBuilder.php
+++ b/src/Stache/Query/RevisionQueryBuilder.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Statamic\Stache\Query;
+
+use Illuminate\Support\Collection;
+use Statamic\Contracts\Revisions\RevisionQueryBuilder as QueryBuilderContract;
+
+class RevisionQueryBuilder extends Builder implements QueryBuilderContract
+{
+    protected function collect($items = [])
+    {
+        return Collection::make($items);
+    }
+
+    protected function getFilteredKeys()
+    {
+        if (! empty($this->wheres)) {
+            return $this->getKeysWithWheres($this->wheres);
+        }
+
+        return collect($this->store->paths()->keys());
+    }
+
+    protected function getKeysWithWheres($wheres)
+    {
+        return collect($wheres)->reduce(function ($ids, $where) {
+            $keys = $where['type'] == 'Nested'
+                ? $this->getKeysWithWheres($where['query']->wheres)
+                : $this->getKeysWithWhere($where);
+
+            return $this->intersectKeysFromWhereClause($ids, $keys, $where);
+        });
+    }
+
+    protected function getKeysWithWhere($where)
+    {
+        $items = app('stache')
+            ->store('revisions')
+            ->index($where['column'])->items();
+
+        $method = 'filterWhere'.$where['type'];
+
+        return $this->{$method}($items, $where)->keys();
+    }
+
+    protected function getOrderKeyValuesByIndex()
+    {
+        return collect($this->orderBys)->mapWithKeys(function ($orderBy) {
+            $items = $this->store->index($orderBy->sort)->items()->all();
+
+            return [$orderBy->sort => $items];
+        });
+    }
+}

--- a/src/Stache/Stores/RevisionsStore.php
+++ b/src/Stache/Stores/RevisionsStore.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Statamic\Stache\Stores;
+
+use Illuminate\Support\Carbon;
+use Statamic\Facades\File;
+use Statamic\Facades\Path;
+use Statamic\Facades\YAML;
+use Statamic\Revisions\Revision;
+use Statamic\Revisions\WorkingCopy;
+use Statamic\Support\Str;
+use Symfony\Component\Finder\SplFileInfo;
+
+class RevisionsStore extends BasicStore
+{
+    public function getItemFilter(SplFileInfo $file)
+    {
+        $path = Path::tidy($file->getPathname());
+
+        if (Str::endsWith($path, 'working.yaml')) {
+            return false;
+        }
+
+        return $file->getExtension() === 'yaml';
+    }
+
+    public function key()
+    {
+        return 'revisions';
+    }
+
+    public function makeItemFromFile($path, $contents)
+    {
+        $yaml = YAML::parse(File::get($path));
+
+        $key = (string) Str::of($path)->beforeLast('/')->after($this->directory());
+
+        return (new Revision)
+            ->key($key)
+            ->action($yaml['action'] ?? false)
+            ->id($date = $yaml['date'])
+            ->date(Carbon::createFromTimestamp($date))
+            ->user($yaml['user'] ?? false)
+            ->message($yaml['message'] ?? false)
+            ->attributes($yaml['attributes']);
+    }
+
+    public function save($item)
+    {
+        if ($item instanceof WorkingCopy) {
+            $this->writeItemToDisk($item);
+
+            return;
+        }
+
+        return parent::save($item);
+    }
+
+    public function delete($item)
+    {
+        if ($item instanceof WorkingCopy) {
+            $this->deleteItemFromDisk($item);
+
+            return;
+        }
+
+        return parent::delete($item);
+    }
+}

--- a/src/Stache/Stores/RevisionsStore.php
+++ b/src/Stache/Stores/RevisionsStore.php
@@ -2,11 +2,10 @@
 
 namespace Statamic\Stache\Stores;
 
-use Illuminate\Support\Carbon;
 use Statamic\Facades\File;
 use Statamic\Facades\Path;
+use Statamic\Facades\Revision;
 use Statamic\Facades\YAML;
-use Statamic\Revisions\Revision;
 use Statamic\Revisions\WorkingCopy;
 use Statamic\Support\Str;
 use Symfony\Component\Finder\SplFileInfo;
@@ -32,17 +31,9 @@ class RevisionsStore extends BasicStore
     public function makeItemFromFile($path, $contents)
     {
         $yaml = YAML::parse(File::get($path));
-
         $key = (string) Str::of($path)->beforeLast('/')->after($this->directory());
 
-        return (new Revision)
-            ->key($key)
-            ->action($yaml['action'] ?? false)
-            ->id($date = $yaml['date'])
-            ->date(Carbon::createFromTimestamp($date))
-            ->user($yaml['user'] ?? false)
-            ->message($yaml['message'] ?? false)
-            ->attributes($yaml['attributes']);
+        return Revision::makeRevisionFromArray($key, $yaml);
     }
 
     public function save($item)

--- a/tests/Revisions/RepositoryTest.php
+++ b/tests/Revisions/RepositoryTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Revisions\Revision;
 use Statamic\Revisions\RevisionRepository;
+use Statamic\Contracts\Revisions\RevisionQueryBuilder;
 use Tests\TestCase;
 
 class RepositoryTest extends TestCase
@@ -27,5 +28,36 @@ class RepositoryTest extends TestCase
         $this->assertInstanceOf(Collection::class, $revisions);
         $this->assertCount(2, $revisions);
         $this->assertContainsOnlyInstancesOf(Revision::class, $revisions);
+    }
+
+    #[Test]
+    public function it_returns_a_query_builder()
+    {
+        $builder = $this->repo->query();
+
+        $this->assertInstanceOf(RevisionQueryBuilder::class, $builder);
+    }
+
+    #[Test]
+    public function it_gets_and_filters_items_using_query_builder()
+    {
+        $builder = $this->repo->query();
+
+        $revisions = $builder->get();
+
+        $this->assertInstanceOf(Collection::class, $revisions);
+        $this->assertCount(3, $revisions);
+        $this->assertContainsOnlyInstancesOf(Revision::class, $revisions);
+
+        $revisions = $builder->where('key','123')->get();
+
+        $this->assertInstanceOf(Collection::class, $revisions);
+        $this->assertCount(2, $revisions);
+        $this->assertContainsOnlyInstancesOf(Revision::class, $revisions);
+
+        $revisions = $builder->where('key','1234')->get();
+
+        $this->assertInstanceOf(Collection::class, $revisions);
+        $this->assertCount(0, $revisions);
     }
 }

--- a/tests/Revisions/RepositoryTest.php
+++ b/tests/Revisions/RepositoryTest.php
@@ -16,7 +16,7 @@ class RepositoryTest extends TestCase
     {
         parent::setUp();
         config(['statamic.revisions.path' => __DIR__.'/__fixtures__']);
-        $this->repo = (new RevisionRepository);
+        $this->repo = (new RevisionRepository($this->app->make('stache')));
     }
 
     #[Test]

--- a/tests/Revisions/RepositoryTest.php
+++ b/tests/Revisions/RepositoryTest.php
@@ -4,9 +4,9 @@ namespace Tests\Revisions;
 
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Contracts\Revisions\RevisionQueryBuilder;
 use Statamic\Revisions\Revision;
 use Statamic\Revisions\RevisionRepository;
-use Statamic\Contracts\Revisions\RevisionQueryBuilder;
 use Tests\TestCase;
 
 class RepositoryTest extends TestCase
@@ -49,13 +49,13 @@ class RepositoryTest extends TestCase
         $this->assertCount(3, $revisions);
         $this->assertContainsOnlyInstancesOf(Revision::class, $revisions);
 
-        $revisions = $builder->where('key','123')->get();
+        $revisions = $builder->where('key', '123')->get();
 
         $this->assertInstanceOf(Collection::class, $revisions);
         $this->assertCount(2, $revisions);
         $this->assertContainsOnlyInstancesOf(Revision::class, $revisions);
 
-        $revisions = $builder->where('key','1234')->get();
+        $revisions = $builder->where('key', '1234')->get();
 
         $this->assertInstanceOf(Collection::class, $revisions);
         $this->assertCount(0, $revisions);

--- a/tests/Revisions/__fixtures__/456/1553546521.yaml
+++ b/tests/Revisions/__fixtures__/456/1553546521.yaml
@@ -1,0 +1,2 @@
+date: 1553546521
+attributes: {}

--- a/tests/Revisions/__fixtures__/456/working.yaml
+++ b/tests/Revisions/__fixtures__/456/working.yaml
@@ -1,0 +1,1 @@
+attributes: {}


### PR DESCRIPTION
This PR changes revisions to work from a stache store and adds a query builder to allow revisions to be queried using the supported methods.

I've tried to implement this in a non breaking way so some of the choices are based around that.

@edalzell wanted this for some filters he's working on.

