### PR TITLE
[5.x] Fix files fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/FilesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FilesFieldtype.vue
@@ -17,7 +17,7 @@
                     <span>{{ __('Drop File to Upload') }}</span>
                 </div>
 
-                <div class="assets-fieldtype-picker py-4" :class="{ 'is-expanded': value?.length }">
+                <div class="assets-fieldtype-picker py-4" :class="{ 'is-expanded': value.length }">
                     <p class="asset-upload-control text-xs text-gray-600 rtl:mr-0 ltr:ml-0">
                         <button type="button" class="upload-text-button" @click.prevent="uploadFile">
                             {{ __('Upload file') }}
@@ -31,7 +31,7 @@
                     :uploads="uploads"
                 />
 
-                <div v-if="value?.length" class="asset-table-listing">
+                <div v-if="value.length" class="asset-table-listing">
                     <table class="table-fixed">
                         <tbody>
                             <tr

--- a/src/Fieldtypes/Files.php
+++ b/src/Fieldtypes/Files.php
@@ -29,6 +29,11 @@ class Files extends Fieldtype
         ];
     }
 
+    public function preProcess($data)
+    {
+        return $data ?? [];
+    }
+
     public function process($values)
     {
         return $this->config('max_files') === 1 ? collect($values)->first() : $values;


### PR DESCRIPTION
This pull request fixes an issue with the Files Fieldtype (which powers the "Re-upload asset" action). 

In #10272, we dropped the default values from various fieldtypes, including the Files fieldtype, since the default values weren't really needed.

This caused an issue with the Files fieldtype which we attempted to fix in #10333, however, that PR only fixed the *rendering* of the fieldtype. You'd get another error related to the `value` not being set after uploading a file.

This PR fixes it by reverting the fix from #10333, and instead returning an empty array in the fieldtype's `preProcess` method so that `value` is never null.

Fixes #10440.