### PR TITLE
[5.x] Fix cursor on Select fieldtype when `max_items` has been reached

### DIFF
--- a/resources/css/vendors/vue-select.css
+++ b/resources/css/vendors/vue-select.css
@@ -21,7 +21,7 @@
 .vs--disabled .vs__dropdown-toggle,
 .vs--disabled .vs__open-indicator,
 .vs--disabled .vs__search,
-.vs--disabled .vs__selected {
+.vs--disabled:not(.max-items-reached) .vs__selected {
 	cursor: not-allowed !important;
 }
 

--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -57,7 +57,7 @@
                         @input="update"
                     >
                     <div class="vs__selected-options-outside flex flex-wrap">
-                        <span v-for="option in selectedOptions" :key="option.value" class="vs__selected mt-2 sortable-item"">
+                        <span v-for="option in selectedOptions" :key="option.value" class="vs__selected mt-2 sortable-item">
                             <div v-if="config.label_html" v-html="option.label"></div>
                             <template v-else>{{ __(option.label) }}</template>
                             <button v-if="!readOnly" @click="deselect(option)" type="button" :aria-label="__('Deselect option')" class="vs__deselect">

--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -4,6 +4,9 @@
             ref="input"
             :input-id="fieldId"
             class="flex-1"
+            :class="{
+                'max-items-reached': !isReadOnly && (config.multiple && limitReached),
+            }"
             append-to-body
             :calculate-position="positionOptions"
             :name="name"
@@ -54,7 +57,7 @@
                         @input="update"
                     >
                     <div class="vs__selected-options-outside flex flex-wrap">
-                        <span v-for="option in selectedOptions" :key="option.value" class="vs__selected mt-2 sortable-item">
+                        <span v-for="option in selectedOptions" :key="option.value" class="vs__selected mt-2 sortable-item"">
                             <div v-if="config.label_html" v-html="option.label"></div>
                             <template v-else>{{ __(option.label) }}</template>
                             <button v-if="!readOnly" @click="deselect(option)" type="button" :aria-label="__('Deselect option')" class="vs__deselect">


### PR DESCRIPTION
This pull request fixes an issue on the Select fieldtype where a `not-allowed` cursor would be shown on selected options when the `max_items` setting has been reached.

To fix this, I've added an additional class to the `v-select` component when the `max_items` setting has been reached, which will be used to determine if the `not-allowed` cursor should be applied to selected options. Maybe there's a better way of fixing this?

Fixes #10431.