### PR TITLE
[5.x] Pass `config` to live preview targets url generator

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -1031,6 +1031,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
         }
 
         return (string) Antlers::parse($format, array_merge($this->routeData(), [
+            'config' => config()->all(),
             'site' => $this->site(),
             'uri' => $this->uri(),
             'url' => $this->url(),


### PR DESCRIPTION
This PR makes `config` available to live preview url generation, so you can use config values to determine the URL (eg by setting an .env value).