### PR TITLE
[5.x] Prevent dark mode gradient affecting custom logos

### DIFF
--- a/resources/views/partials/outside-logo.blade.php
+++ b/resources/views/partials/outside-logo.blade.php
@@ -1,4 +1,4 @@
-<div class="logo pt-20">
+<div class="logo pt-20 relative z-10">
     @if ($customLogo)
         <img src="{{ $customLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo dark:hidden">
         <img src="{{ $customDarkLogo }}" alt="{{ config('statamic.cp.custom_cms_name') }}" class="white-label-logo hidden dark:block">


### PR DESCRIPTION
This pull request prevents the Dark Mode gradiant from tinting custom logos on the authentication pages.

Fixes #10420.