### PR TITLE
[5.x] Clean up reference updater localization mapping logic

### DIFF
--- a/src/Listeners/Concerns/GetsItemsContainingData.php
+++ b/src/Listeners/Concerns/GetsItemsContainingData.php
@@ -18,7 +18,7 @@ trait GetsItemsContainingData
     {
         return collect()
             ->merge(Entry::all())
-            ->merge(Term::all()->map->term()->flatMap->localizations()) // See issue #3274
+            ->merge(Term::all())
             ->merge(GlobalSet::all()->flatMap->localizations())
             ->merge(User::all());
     }


### PR DESCRIPTION
We were doing some localization mapping on the collection level, which is [no longer needed](https://github.com/statamic/cms/issues/3274#issuecomment-1402636955) since https://github.com/statamic/cms/pull/6318.