### PR TITLE
[5.x] Ability for relationship/entries fieldtype to add "hints"

### DIFF
--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -6,7 +6,7 @@
     >
         <div class="item-move" v-if="sortable">&nbsp;</div>
         <div class="item-inner">
-            <div v-if="statusIcon" class="little-dot rtl:ml-2 ltr:mr-2 hidden@sm:block" :class="item.status" />
+            <div v-if="statusIcon" class="little-dot rtl:ml-2 ltr:mr-2 hidden @sm:block" :class="item.status" />
 
             <div
                 v-if="item.invalid"

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -27,7 +27,7 @@
             />
 
             <div class="flex items-center flex-1 justify-end">
-                <div v-if="item.collection" v-text="__(item.collection.title)" class="text-4xs text-gray-600 uppercase whitespace-nowrap rtl:ml-2 ltr:mr-2 hidden @sm:block" />
+                <div v-if="item.hint" v-text="item.hint" class="text-4xs text-gray-600 uppercase whitespace-nowrap rtl:ml-2 ltr:mr-2 hidden @sm:block" />
 
                 <div class="flex items-center" v-if="!readOnly">
                     <dropdown-list>

--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -19,8 +19,8 @@
 
         <loading-graphic v-if="initializing" :inline="true" />
 
-        <template v-if="!initializing && !usesSelectField">
-            <div ref="items" class="relationship-input-items space-y-1 outline-none">
+        <template v-if="!initializing">
+            <div ref="items" class="relationship-input-items space-y-1 outline-none" :class="{ 'mt-4': usesSelectField && items.length }">
                 <component
                     :is="itemComponent"
                     v-for="(item, i) in items"
@@ -178,7 +178,7 @@ export default {
         },
 
         canSelectOrCreate() {
-            return !this.readOnly && !this.maxItemsReached;
+            return !this.usesSelectField && !this.readOnly && !this.maxItemsReached;
         },
 
         usesSelectField() {
@@ -288,7 +288,7 @@ export default {
         },
 
         selectFieldSelected(selectedItemData) {
-            this.$emit('item-data-updated', selectedItemData.map(item => ({ id: item.id, title: item.title })));
+            this.$emit('item-data-updated', selectedItemData);
             this.update(selectedItemData.map(item => item.id));
         },
 

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -22,6 +22,12 @@
             @search:focus="$emit('focus')"
             @search:blur="$emit('blur')"
         >
+            <template #option="{ title, hint }">
+                <div class="flex justify-between">
+                    <div v-text="title" />
+                    <div v-if="hint" class="text-2xs text-gray-700" v-text="hint" />
+                </div>
+            </template>
             <template #selected-option-container v-if="multiple"><i class="hidden"></i></template>
             <template #search="{ events, attributes }" v-if="multiple">
                 <input

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -23,12 +23,12 @@
             @search:blur="$emit('blur')"
         >
             <template #option="{ title, hint, status }">
-                <div class="flex justify-between">
+                <div class="flex justify-between items-center">
                     <div class="flex items-center">
                         <div v-if="status" class="little-dot rtl:ml-2 ltr:mr-2 hidden@sm:block" :class="status" />
                         <div v-text="title" />
                     </div>
-                    <div v-if="hint" class="text-2xs text-gray-700" v-text="hint" />
+                    <div v-if="hint" class="text-4xs text-gray-600 uppercase whitespace-nowrap" v-text="hint" />
                 </div>
             </template>
             <template #selected-option-container v-if="multiple"><i class="hidden"></i></template>

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -41,28 +41,6 @@
              <template #no-options>
                 <div class="text-sm text-gray-700 rtl:text-right ltr:text-left py-2 px-4" v-text="__('No options to choose from.')" />
             </template>
-            <template #footer="{ deselect }" v-if="multiple">
-                <sortable-list
-                    item-class="sortable-item"
-                    handle-class="sortable-item"
-                    :value="items"
-                    :distance="5"
-                    :mirror="false"
-                    @input="input"
-                >
-                    <div class="vs__selected-options-outside flex flex-wrap">
-                        <span v-for="item in items" :key="item.id" class="vs__selected mt-2" :class="{ 'sortable-item': !readOnly }">
-                            {{ __(item.title) }}
-                            <button v-if="!readOnly" @click="deselect(item)" type="button" :aria-label="__('Deselect option')" class="vs__deselect">
-                                <span>×</span>
-                            </button>
-                            <button v-else type="button" class="vs__deselect">
-                                <span class="opacity-50">×</span>
-                            </button>
-                        </span>
-                    </div>
-                </sortable-list>
-            </template>
         </v-select>
     </div>
 

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -22,9 +22,12 @@
             @search:focus="$emit('focus')"
             @search:blur="$emit('blur')"
         >
-            <template #option="{ title, hint }">
+            <template #option="{ title, hint, status }">
                 <div class="flex justify-between">
-                    <div v-text="title" />
+                    <div class="flex items-center">
+                        <div v-if="status" class="little-dot rtl:ml-2 ltr:mr-2 hidden@sm:block" :class="status" />
+                        <div v-text="title" />
+                    </div>
                     <div v-if="hint" class="text-2xs text-gray-700" v-text="hint" />
                 </div>
             </template>

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -467,6 +467,6 @@ class Entries extends Relationship
     {
         return collect([
             count($this->getConfiguredCollections()) > 1 ? __($item->collection()->title()) : null,
-        ])->filter()->implode(', ');
+        ])->filter()->implode(' • ');
     }
 }

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -466,7 +466,7 @@ class Entries extends Relationship
     public function getItemOptionHint($item): ?string
     {
         return collect([
-            count($this->getConfiguredCollections()) > 1 ? $item->collection()->title() : null,
+            count($this->getConfiguredCollections()) > 1 ? __($item->collection()->title()) : null,
         ])->filter()->implode(', ');
     }
 }

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -16,7 +16,7 @@ use Statamic\Facades\Search;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Http\Resources\CP\Entries\EntriesFieldtypeEntries;
-use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
+use Statamic\Http\Resources\CP\Entries\EntriesFieldtypeEntry as EntryResource;
 use Statamic\Query\OrderedQueryBuilder;
 use Statamic\Query\Scopes\Filter;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
@@ -317,7 +317,7 @@ class Entries extends Relationship
             return $this->invalidItemArray($id);
         }
 
-        return (new EntryResource($entry))->resolve()['data'];
+        return (new EntryResource($entry, $this))->resolve()['data'];
     }
 
     protected function collect($value)

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -463,7 +463,7 @@ class Entries extends Relationship
         ]]);
     }
 
-    public function getItemOptionHint($item): ?string
+    public function getItemHint($item): ?string
     {
         return collect([
             count($this->getConfiguredCollections()) > 1 ? __($item->collection()->title()) : null,

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -15,7 +15,7 @@ use Statamic\Facades\Scope;
 use Statamic\Facades\Search;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
-use Statamic\Http\Resources\CP\Entries\Entries as EntriesResource;
+use Statamic\Http\Resources\CP\Entries\EntriesFieldtypeEntries;
 use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
 use Statamic\Query\OrderedQueryBuilder;
 use Statamic\Query\Scopes\Filter;
@@ -146,7 +146,7 @@ class Entries extends Relationship
 
     public function getResourceCollection($request, $items)
     {
-        return (new EntriesResource($items))
+        return (new EntriesFieldtypeEntries($items, $this))
             ->blueprint($this->getBlueprint($request))
             ->columnPreferenceKey("collections.{$this->getFirstCollectionFromRequest($request)->handle()}.columns")
             ->additional(['meta' => [
@@ -461,5 +461,12 @@ class Entries extends Relationship
             'expectsRoot' => $collection->structure()->expectsRoot(),
             'blueprints' => $blueprints,
         ]]);
+    }
+
+    public function getItemOptionHint($item): ?string
+    {
+        return collect([
+            count($this->getConfiguredCollections()) > 1 ? $item->collection()->title() : null,
+        ])->filter()->implode(', ');
     }
 }

--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -231,7 +231,7 @@ abstract class Relationship extends Fieldtype
         })->values();
     }
 
-    public function getItemOptionHint($item): ?string
+    public function getItemHint($item): ?string
     {
         return null;
     }

--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -231,6 +231,11 @@ abstract class Relationship extends Fieldtype
         })->values();
     }
 
+    public function getItemOptionHint($item): ?string
+    {
+        return null;
+    }
+
     abstract protected function toItemArray($id);
 
     protected function invalidItemArray($id)

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -19,7 +19,7 @@ use Statamic\Facades\Taxonomy;
 use Statamic\Facades\Term;
 use Statamic\Facades\User;
 use Statamic\GraphQL\Types\TermInterface;
-use Statamic\Http\Resources\CP\Taxonomies\Terms as TermsResource;
+use Statamic\Http\Resources\CP\Taxonomies\TermsFieldtypeTerms as TermsResource;
 use Statamic\Query\OrderedQueryBuilder;
 use Statamic\Query\Scopes\Filter;
 use Statamic\Query\Scopes\Filters\Fields\Terms as TermsFilter;
@@ -252,7 +252,7 @@ class Terms extends Relationship
 
     public function getResourceCollection($request, $items)
     {
-        return (new TermsResource($items))
+        return (new TermsResource($items, $this))
             ->blueprint($this->getBlueprint($request))
             ->columnPreferenceKey("taxonomies.{$this->getFirstTaxonomyFromRequest($request)->handle()}.columns");
     }
@@ -368,6 +368,7 @@ class Terms extends Relationship
             'published' => $term->published(),
             'private' => $term->private(),
             'edit_url' => $term->editUrl(),
+            'hint' => $this->getItemHint($term),
         ];
     }
 
@@ -477,5 +478,12 @@ class Terms extends Relationship
         }
 
         return $this->config('max_items') === 1 ? collect([$augmented]) : $augmented->get();
+    }
+
+    public function getItemHint($item): ?string
+    {
+        return collect([
+            count($this->getConfiguredTaxonomies()) > 1 ? __($item->taxonomy()->title()) : null,
+        ])->filter()->implode(' • ');
     }
 }

--- a/src/Http/Resources/CP/Entries/EntriesFieldtypeEntries.php
+++ b/src/Http/Resources/CP/Entries/EntriesFieldtypeEntries.php
@@ -8,7 +8,7 @@ use Statamic\Fieldtypes\Entries as EntriesFieldtype;
 class EntriesFieldtypeEntries extends Entries
 {
     private EntriesFieldtype $fieldtype;
-    public $collects = EntriesFieldtypeEntry::class;
+    public $collects = EntriesFieldtypeListedEntry::class;
 
     public function __construct($resource, EntriesFieldtype $fieldtype)
     {

--- a/src/Http/Resources/CP/Entries/EntriesFieldtypeEntries.php
+++ b/src/Http/Resources/CP/Entries/EntriesFieldtypeEntries.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Statamic\Http\Resources\CP\Entries;
+
+use Illuminate\Pagination\AbstractPaginator;
+use Statamic\Fieldtypes\Entries as EntriesFieldtype;
+
+class EntriesFieldtypeEntries extends Entries
+{
+    private EntriesFieldtype $fieldtype;
+    public $collects = EntriesFieldtypeEntry::class;
+
+    public function __construct($resource, EntriesFieldtype $fieldtype)
+    {
+        $this->fieldtype = $fieldtype;
+
+        parent::__construct($resource);
+    }
+
+    protected function collectResource($resource)
+    {
+        $collection = parent::collectResource($resource);
+
+        if ($collection instanceof AbstractPaginator) {
+            $collection->getCollection()->each->fieldtype($this->fieldtype);
+        } else {
+            $collection->each->fieldtype($this->fieldtype);
+        }
+
+        return $collection;
+    }
+}

--- a/src/Http/Resources/CP/Entries/EntriesFieldtypeEntry.php
+++ b/src/Http/Resources/CP/Entries/EntriesFieldtypeEntry.php
@@ -23,7 +23,7 @@ class EntriesFieldtypeEntry extends JsonResource
             'title' => $this->resource->value('title'),
             'status' => $this->resource->status(),
             'edit_url' => $this->resource->editUrl(),
-            'hint' => $this->fieldtype->getItemOptionHint($this->resource),
+            'hint' => $this->fieldtype->getItemHint($this->resource),
         ];
 
         return ['data' => $data];

--- a/src/Http/Resources/CP/Entries/EntriesFieldtypeEntry.php
+++ b/src/Http/Resources/CP/Entries/EntriesFieldtypeEntry.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Statamic\Http\Resources\CP\Entries;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Statamic\Fieldtypes\Entries as EntriesFieldtype;
+
+class EntriesFieldtypeEntry extends JsonResource
+{
+    private EntriesFieldtype $fieldtype;
+
+    public function __construct($resource, EntriesFieldtype $fieldtype)
+    {
+        $this->fieldtype = $fieldtype;
+
+        parent::__construct($resource);
+    }
+
+    public function toArray($request)
+    {
+        $data = [
+            'id' => $this->resource->id(),
+            'title' => $this->resource->value('title'),
+            'status' => $this->resource->status(),
+            'edit_url' => $this->resource->editUrl(),
+            'hint' => $this->fieldtype->getItemOptionHint($this->resource),
+        ];
+
+        return ['data' => $data];
+    }
+}

--- a/src/Http/Resources/CP/Entries/EntriesFieldtypeEntry.php
+++ b/src/Http/Resources/CP/Entries/EntriesFieldtypeEntry.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Statamic\Http\Resources\CP\Entries;
+
+use Statamic\Fieldtypes\Entries as EntriesFieldtype;
+
+class EntriesFieldtypeEntry extends ListedEntry
+{
+    private EntriesFieldtype $fieldtype;
+
+    public function fieldtype(EntriesFieldtype $fieldtype): self
+    {
+        $this->fieldtype = $fieldtype;
+
+        return $this;
+    }
+
+    public function toArray($request)
+    {
+        $arr = parent::toArray($request);
+
+        if (
+            in_array($this->fieldtype->config('mode'), ['select', 'typeahead'])
+            && ($hint = $this->fieldtype->getItemOptionHint($this->resource))
+        ) {
+            $arr['hint'] = $hint;
+        }
+
+        return $arr;
+    }
+}

--- a/src/Http/Resources/CP/Entries/EntriesFieldtypeListedEntry.php
+++ b/src/Http/Resources/CP/Entries/EntriesFieldtypeListedEntry.php
@@ -4,7 +4,7 @@ namespace Statamic\Http\Resources\CP\Entries;
 
 use Statamic\Fieldtypes\Entries as EntriesFieldtype;
 
-class EntriesFieldtypeEntry extends ListedEntry
+class EntriesFieldtypeListedEntry extends ListedEntry
 {
     private EntriesFieldtype $fieldtype;
 

--- a/src/Http/Resources/CP/Entries/EntriesFieldtypeListedEntry.php
+++ b/src/Http/Resources/CP/Entries/EntriesFieldtypeListedEntry.php
@@ -21,7 +21,7 @@ class EntriesFieldtypeListedEntry extends ListedEntry
 
         if (
             in_array($this->fieldtype->config('mode'), ['select', 'typeahead'])
-            && ($hint = $this->fieldtype->getItemOptionHint($this->resource))
+            && ($hint = $this->fieldtype->getItemHint($this->resource))
         ) {
             $arr['hint'] = $hint;
         }

--- a/src/Http/Resources/CP/Taxonomies/TermsFieldtypeListedTerm.php
+++ b/src/Http/Resources/CP/Taxonomies/TermsFieldtypeListedTerm.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Statamic\Http\Resources\CP\Taxonomies;
+
+use Statamic\Fieldtypes\Terms as TermsFieldtype;
+
+class TermsFieldtypeListedTerm extends ListedTerm
+{
+    private TermsFieldtype $fieldtype;
+
+    public function fieldtype(TermsFieldtype $fieldtype): self
+    {
+        $this->fieldtype = $fieldtype;
+
+        return $this;
+    }
+
+    public function toArray($request)
+    {
+        $arr = parent::toArray($request);
+
+        if (
+            in_array($this->fieldtype->config('mode'), ['select', 'typeahead'])
+            && ($hint = $this->fieldtype->getItemHint($this->resource))
+        ) {
+            $arr['hint'] = $hint;
+        }
+
+        return $arr;
+    }
+}

--- a/src/Http/Resources/CP/Taxonomies/TermsFieldtypeTerms.php
+++ b/src/Http/Resources/CP/Taxonomies/TermsFieldtypeTerms.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Statamic\Http\Resources\CP\Taxonomies;
+
+use Illuminate\Pagination\AbstractPaginator;
+use Statamic\Fieldtypes\Terms as TermsFieldtype;
+
+class TermsFieldtypeTerms extends Terms
+{
+    private TermsFieldtype $fieldtype;
+    public $collects = TermsFieldtypeListedTerm::class;
+
+    public function __construct($resource, TermsFieldtype $fieldtype)
+    {
+        $this->fieldtype = $fieldtype;
+
+        parent::__construct($resource);
+    }
+
+    protected function collectResource($resource)
+    {
+        $collection = parent::collectResource($resource);
+
+        if ($collection instanceof AbstractPaginator) {
+            $collection->getCollection()->each->fieldtype($this->fieldtype);
+        } else {
+            $collection->each->fieldtype($this->fieldtype);
+        }
+
+        return $collection;
+    }
+}


### PR DESCRIPTION
This PR adds the ability for the relationship fieldtype to display "hints".

Hints are necessary when you have multiple options that could have the same value. For example if you have two entries in different collections with the same title, you don't know which is which:

![CleanShot 2024-07-15 at 16 50 14](https://github.com/user-attachments/assets/c6b1646f-e584-46a6-85fe-0850a63f4775)

The entries fieldtype already had this solved when in "stacked" mode because the collection is displayed as a column in the listing as well as having the collection title as a hardcoded hint in the selected item.

![CleanShot 2024-07-15 at 16 53 49](https://github.com/user-attachments/assets/6d026d3a-d2f9-4c2c-9f2d-31a9333c2f55)

![CleanShot 2024-07-15 at 16 47 00](https://github.com/user-attachments/assets/8103e02e-42b4-418d-9d79-833c8594858c)

This PR makes the concept of these hints more generic across relationship fieldtypes.
- For the entries fieldtype specifically it uses the collection title to keep it behaving the same when in stacked mode.
- For the terms fieldtype it'll use the taxonomy titles.

This PR also improves the dropdown modes (select and typeahead) by adding hints and status icons to the dropdown options:

![CleanShot 2024-07-15 at 17 16 42](https://github.com/user-attachments/assets/c53b0f37-53c1-42e4-b30d-6397240934c9)

Lastly, this PR makes the selected items of the dropdown mode consistent with stacked mode:

![CleanShot 2024-07-15 at 16 59 23](https://github.com/user-attachments/assets/5d2b79e3-8c2e-471b-9fca-23cb25a02a63)

Aside from a consistent UI, this allows the dropdown mode to have inline editing by clicking the item titles.


Replaces / Fixes #9749
Closes https://github.com/statamic/ideas/issues/559
Allows #9229 to display the site name as part of the hint.
