### PR TITLE
[5.x] Add missing dark mode styles for license request failed warning

### DIFF
--- a/resources/views/partials/licensing-alerts.blade.php
+++ b/resources/views/partials/licensing-alerts.blade.php
@@ -3,7 +3,7 @@
 
 @if ($licenses->requestFailed())
     <div class="p-2 w-full fixed bottom-0 z-20">
-        <div class="py-3 px-4 text-sm w-full rounded-md bg-yellow border border-yellow-dark">
+        <div class="py-3 px-4 text-sm w-full rounded-md bg-yellow border border-yellow-dark dark:bg-dark-blue-100 dark:border-none">
         @if ($licenses->usingLicenseKeyFile())
             {{ __('statamic::messages.outpost_license_key_error') }}
         @elseif ($licenses->requestErrorCode() === 422)


### PR DESCRIPTION
This PR adds dark mode classes to the request failed warning at the bottom of the CP. That banner now has the same styling as warning banners on the licenses page.

Before:
<img width="1001" alt="before" src="https://github.com/user-attachments/assets/828a0e05-afe6-418a-9831-3314cd5148bb">

After:
<img width="1001" alt="after" src="https://github.com/user-attachments/assets/8f52a8d3-bfa4-452b-9da6-67d73a1ff45b">
