### PR TITLE
[5.x] Remove Antlers parser instance on tags within conditions

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1563,7 +1563,7 @@ class NodeProcessor
                         }
                         /** @var Tags $tag */
                         $tag = $this->loader->load($tagToLoad, [
-                            'parser' => $this->antlersParser,
+                            'parser' => $this->isConditionalProcessor ? null : $this->antlersParser,
                             'params' => $tagParameters,
                             'content' => $node->runtimeContent,
                             'context' => $tagActiveData,


### PR DESCRIPTION
This PR removes the `$this->parser` instance on tags when invoked inside Antlers conditions. Some tags, such as the `user:is` tag check this property to decide if they should return the parsed content, or simply return `true/false`.

After this PR, the following would Just Work™️ again:

```antlers
{{ if some_condition && {user:is role="the_role"} }}
    Ahoy!
{{ /if }}
```