### PR TITLE
[5.x] Radio Fieldtype gets custom button icons

### DIFF
--- a/resources/css/components/fieldtypes/radio.css
+++ b/resources/css/components/fieldtypes/radio.css
@@ -1,0 +1,21 @@
+.radio-fieldtype label {
+    @apply flex;
+}
+
+.radio-fieldtype input[type="radio"] {
+    @apply m-0 min-w-0 absolute opacity-0 -z-1 w-1 h-px w-px overflow-hidden;
+}
+
+.radio-fieldtype .radio-icon {
+    @apply cursor-pointer h-4 w-4 ltr:mr-2 rtl:ml-2 block;
+}
+
+.radio-fieldtype .option.disabled {
+    .radio-icon {
+        @apply cursor-not-allowed opacity-25;
+    }
+    label {
+        @apply cursor-text;
+    }
+}
+

--- a/resources/css/cp.css
+++ b/resources/css/cp.css
@@ -63,6 +63,7 @@
 @import "components/fieldtypes/hidden";
 @import "components/fieldtypes/markdown";
 @import "components/fieldtypes/partial";
+@import "components/fieldtypes/radio";
 @import "components/fieldtypes/relationship";
 @import "components/fieldtypes/replicator";
 @import "components/fieldtypes/section";

--- a/resources/js/components/fieldtypes/RadioFieldtype.vue
+++ b/resources/js/components/fieldtypes/RadioFieldtype.vue
@@ -4,8 +4,28 @@
             v-for="(option, $index) in options"
             :key="$index"
             class="option"
+            :class="{
+                'selected': value === option.value,
+                'disabled': isReadOnly
+            }"
         >
             <label>
+                <svg-icon
+                    name="regular/radio-deselected"
+                    class="radio-icon"
+                    :aria-hidden="value === option.value"
+                    @click="update($event.target.value)"
+                    v-show="value !== option.value"
+                    v-cloak
+                />
+                <svg-icon
+                    name="regular/radio-selected"
+                    class="radio-icon"
+                    :aria-hidden="value !== option.value"
+                    @click="update($event.target.value)"
+                    v-show="value === option.value"
+                    v-cloak
+                />
                 <input type="radio"
                     ref="radio"
                     :name="name"

--- a/resources/svg/icons/regular/radio-deselected.svg
+++ b/resources/svg/icons/regular/radio-deselected.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14"><path fill="currentColor" fill-rule="evenodd" d="M7 1.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM0 7a7 7 0 1114 0A7 7 0 010 7z" clip-rule="evenodd"/></svg>

--- a/resources/svg/icons/regular/radio-selected.svg
+++ b/resources/svg/icons/regular/radio-selected.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14"><path fill="currentColor" fill-rule="evenodd" d="M1.5 7a5.5 5.5 0 1111 0 5.5 5.5 0 01-11 0zM7 0a7 7 0 100 14A7 7 0 007 0zM3.25 7a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0z" clip-rule="evenodd"/></svg>


### PR DESCRIPTION
This gives us better control over contrast, dark/light, and disabled states — something native HTML cannot do, sadly. Closes #10427.

![CleanShot 2024-07-15 at 10 58 05@2x](https://github.com/user-attachments/assets/2fcae09b-df42-41cf-b80b-095098782f4c)

![CleanShot 2024-07-15 at 10 58 21@2x](https://github.com/user-attachments/assets/dcb83bf2-65f0-415a-8f7b-478358b86d62)

![CleanShot 2024-07-15 at 10 58 32@2x](https://github.com/user-attachments/assets/06442072-757d-4084-97c0-0c3dca4975cb)
