### PR TITLE
[5.x] Use StaticCache facade in Cache Manager utility

### DIFF
--- a/src/Http/Controllers/CP/Utilities/CacheController.php
+++ b/src/Http/Controllers/CP/Utilities/CacheController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
 use League\Glide\Server;
 use Statamic\Facades\Stache;
+use Statamic\Facades\StaticCache;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\StaticCaching\Cacher as StaticCacher;
 use Statamic\Support\Str;
@@ -96,7 +97,7 @@ class CacheController extends CpController
 
     protected function clearStaticCache()
     {
-        app(StaticCacher::class)->flush();
+        StaticCache::flush();
 
         return back()->withSuccess(__('Static page cache cleared.'));
     }

--- a/src/Http/Controllers/CP/Utilities/CacheController.php
+++ b/src/Http/Controllers/CP/Utilities/CacheController.php
@@ -8,7 +8,6 @@ use League\Glide\Server;
 use Statamic\Facades\Stache;
 use Statamic\Facades\StaticCache;
 use Statamic\Http\Controllers\CP\CpController;
-use Statamic\StaticCaching\Cacher as StaticCacher;
 use Statamic\Support\Str;
 
 class CacheController extends CpController
@@ -67,7 +66,7 @@ class CacheController extends CpController
         return [
             'enabled' => (bool) $strategy,
             'strategy' => $strategy ?? __('Disabled'),
-            'count' => app(StaticCacher::class)->getUrls()->count(),
+            'count' => StaticCache::driver()->getUrls()->count(),
         ];
     }
 


### PR DESCRIPTION
This pull request changes how the Cache Manager utility clears the static cache, to bring it inline with the `static:clear` command.

Currently, the `static:cache` command calls the `StaticCacheManager::flush()` method. However, the "Clear" button on the cache manager utlity calls the cacher's `flush` method (eg. `FileCacher::flush()` or `ApplicationCacher::flush()`).

The `flush` method on the `StaticCacheManager` does end up calling the cacher's `flush` method but it also deals with clearing other static caching related stuff from the cache (like nocache URLs).

This isn't causing any issues right now, however, as part of #10403, I'm adding a `StaticCacheCleared` event which I'd like to be able to dispatch in one place (the `StaticCacheManager`, rather than in two places).