### PR TITLE
[5.x] Hide data list pagination page links on collection widget

### DIFF
--- a/resources/js/components/data-list/Pagination.vue
+++ b/resources/js/components/data-list/Pagination.vue
@@ -16,6 +16,7 @@
 
             <li
                 v-for="(page, i) in pages"
+                v-if="showPageLinks"
                 :key="i"
                 :class="{ 'current': page == currentPage }"
             >
@@ -71,6 +72,10 @@ export default {
             required: true
         },
         scrollToTop: {
+            type: Boolean,
+            default: true,
+        },
+        showPageLinks: {
             type: Boolean,
             default: true,
         }

--- a/resources/js/components/entries/Widget.vue
+++ b/resources/js/components/entries/Widget.vue
@@ -31,6 +31,7 @@
                     :resource-meta="meta"
                     @page-selected="selectPage"
                     :scroll-to-top="false"
+                    :show-page-links="false"
                 />
             </div>
         </data-list>


### PR DESCRIPTION
Widgets are for quick glances, not browsing thousands of entries. Closes #10348.