### PR TITLE
[5.x] Add various events

### DIFF
--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -5,6 +5,8 @@ namespace Statamic\Actions;
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Support\Facades\Auth;
 use Statamic\Contracts\Auth\User as UserContract;
+use Statamic\Events\Event;
+use Statamic\Events\ImpersonationStarted;
 use Statamic\Facades\CP\Toast;
 use Statamic\Facades\User;
 
@@ -45,11 +47,14 @@ class Impersonate extends Action
         }
 
         try {
-            $currentUser = $guard->user();
+            $impersonater = $guard->user();
+            $impersonated = $users->first();
 
             $guard->login($users->first());
-            session()->put('statamic_impersonated_by', $currentUser->getKey());
-            Toast::success(__('You are now impersonating').' '.$users->first()->name());
+            session()->put('statamic_impersonated_by', $impersonater->getKey());
+            Toast::success(__('You are now impersonating').' '.$impersonated->name());
+
+            ImpersonationStarted::dispatch($impersonater, $impersonated);
         } finally {
             if ($dispatcher) {
                 $guard->setDispatcher($dispatcher);

--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -5,7 +5,6 @@ namespace Statamic\Actions;
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Support\Facades\Auth;
 use Statamic\Contracts\Auth\User as UserContract;
-use Statamic\Events\Event;
 use Statamic\Events\ImpersonationStarted;
 use Statamic\Facades\CP\Toast;
 use Statamic\Facades\User;

--- a/src/Console/Commands/GlideClear.php
+++ b/src/Console/Commands/GlideClear.php
@@ -4,6 +4,7 @@ namespace Statamic\Console\Commands;
 
 use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
+use Statamic\Events\GlideCacheCleared;
 use Statamic\Facades\File;
 use Statamic\Facades\Glide;
 use Statamic\Filesystem\Filesystem;
@@ -45,6 +46,8 @@ class GlideClear extends Command
         }
 
         $this->deleteEmptyDirectories($disk);
+
+        GlideCacheCleared::dispatch();
 
         $this->info('Your Glide image cache is now so very, very empty.');
     }

--- a/src/Console/Commands/LicenseSet.php
+++ b/src/Console/Commands/LicenseSet.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Statamic\Console\EnhancesCommands;
 use Statamic\Console\RunsInPlease;
+use Statamic\Events\LicenseSet as LicenseSetEvent;
 
 class LicenseSet extends Command
 {
@@ -41,6 +42,8 @@ class LicenseSet extends Command
         }
 
         $this->laravel['config']['statamic.system.license_key'] = $key;
+
+        LicenseSetEvent::dispatch();
 
         $this->checkInfo('Statamic license key set successfully.');
     }

--- a/src/Events/GlideCacheCleared.php
+++ b/src/Events/GlideCacheCleared.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Statamic\Events;
+
+class GlideCacheCleared extends Event
+{
+}

--- a/src/Events/ImpersonationEnded.php
+++ b/src/Events/ImpersonationEnded.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Statamic\Events;
+
+class ImpersonationEnded extends Event
+{
+    public function __construct(public $impersonator, public $impersonated)
+    {
+    }
+}

--- a/src/Events/ImpersonationStarted.php
+++ b/src/Events/ImpersonationStarted.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Statamic\Events;
+
+class ImpersonationStarted extends Event
+{
+    public function __construct(public $impersonator, public $impersonated)
+    {
+    }
+}

--- a/src/Events/LicenseSet.php
+++ b/src/Events/LicenseSet.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Statamic\Events;
+
+class LicenseSet extends Event
+{
+}

--- a/src/Events/LicensesSynced.php
+++ b/src/Events/LicensesSynced.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Statamic\Events;
+
+class LicensesSynced extends Event
+{
+}

--- a/src/Events/SearchIndexUpdated.php
+++ b/src/Events/SearchIndexUpdated.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Statamic\Events;
+
+class SearchIndexUpdated extends Event
+{
+    public function __construct(public $index)
+    {
+    }
+}

--- a/src/Events/StacheCleared.php
+++ b/src/Events/StacheCleared.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Statamic\Events;
+
+class StacheCleared extends Event
+{
+}

--- a/src/Events/StacheWarmed.php
+++ b/src/Events/StacheWarmed.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Statamic\Events;
+
+class StacheWarmed extends Event
+{
+
+}

--- a/src/Events/StacheWarmed.php
+++ b/src/Events/StacheWarmed.php
@@ -4,5 +4,4 @@ namespace Statamic\Events;
 
 class StacheWarmed extends Event
 {
-
 }

--- a/src/Events/StaticCacheCleared.php
+++ b/src/Events/StaticCacheCleared.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Statamic\Events;
+
+class StaticCacheCleared extends Event
+{
+}

--- a/src/Events/UserPasswordChanged.php
+++ b/src/Events/UserPasswordChanged.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Events;
+
+class UserPasswordChanged extends Event
+{
+    public $user;
+
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+}

--- a/src/Http/Controllers/CP/Auth/ImpersonationController.php
+++ b/src/Http/Controllers/CP/Auth/ImpersonationController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\CP\Auth;
 
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Support\Facades\Auth;
+use Statamic\Events\ImpersonationEnded;
 use Statamic\Facades\User;
 
 class ImpersonationController
@@ -19,6 +20,7 @@ class ImpersonationController
                 $guard->setDispatcher(new NullDispatcher($dispatcher));
             }
 
+            $impersonatedUser = User::current();
             $originalUser = User::find($originalUserId);
 
             if ($originalUser) {
@@ -28,6 +30,8 @@ class ImpersonationController
             if ($dispatcher) {
                 $guard->setDispatcher($dispatcher);
             }
+
+            ImpersonationEnded::dispatch($originalUser, $impersonatedUser);
         }
 
         return redirect()->route('statamic.cp.users.index');

--- a/src/Http/Controllers/CP/LicensingController.php
+++ b/src/Http/Controllers/CP/LicensingController.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Http\Controllers\CP;
 
+use Statamic\Events\LicensesSynced;
 use Statamic\Licensing\LicenseManager as Licenses;
 
 class LicensingController extends CpController
@@ -23,6 +24,8 @@ class LicensingController extends CpController
     public function refresh(Licenses $licenses)
     {
         $licenses->refresh();
+
+        LicensesSynced::dispatch();
 
         return redirect()
             ->cpRoute('utilities.licensing')

--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\CP\Users;
 
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rules\Password;
+use Statamic\Events\UserPasswordChanged;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
@@ -27,6 +28,8 @@ class PasswordController extends CpController
         $request->validate($rules);
 
         $user->password($request->password)->save();
+
+        UserPasswordChanged::dispatch($user);
 
         return response('', 204);
     }

--- a/src/Http/Controllers/CP/Utilities/UpdateSearchController.php
+++ b/src/Http/Controllers/CP/Utilities/UpdateSearchController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\CP\Utilities;
 
 use Illuminate\Http\Request;
+use Statamic\Events\SearchIndexUpdated;
 use Statamic\Facades\Search;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Support\Str;
@@ -17,10 +18,15 @@ class UpdateSearchController extends CpController
 
         $indexes->each(function ($index) {
             [$name, $locale] = explode('::', $index);
+
             if ($locale) {
                 $name = Str::before($name, '_'.$locale);
             }
-            Search::index($name, $locale ?: null)->update();
+
+            $index = Search::index($name, $locale ?: null);
+            $index->update();
+
+            SearchIndexUpdated::dispatch($index);
         });
 
         return back()->withSuccess(__('Update successful.'));

--- a/src/Search/Commands/Update.php
+++ b/src/Search/Commands/Update.php
@@ -4,6 +4,7 @@ namespace Statamic\Search\Commands;
 
 use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
+use Statamic\Events\SearchIndexUpdated;
 use Statamic\Facades\Search;
 use Statamic\Support\Str;
 
@@ -23,6 +24,9 @@ class Update extends Command
     {
         foreach ($this->getIndexes() as $index) {
             $index->update();
+
+            SearchIndexUpdated::dispatch($index);
+
             $this->info("Index <comment>{$index->name()}</comment> updated.");
         }
     }

--- a/src/Stache/Stache.php
+++ b/src/Stache/Stache.php
@@ -5,6 +5,7 @@ namespace Statamic\Stache;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Events\StacheCleared;
+use Statamic\Events\StacheWarmed;
 use Statamic\Extensions\FileStore;
 use Statamic\Facades\File;
 use Statamic\Stache\Stores\Store;
@@ -114,6 +115,8 @@ class Stache
         $this->stopTimer();
 
         $lock->release();
+
+        StacheWarmed::dispatch();
     }
 
     public function instance()

--- a/src/Stache/Stache.php
+++ b/src/Stache/Stache.php
@@ -4,6 +4,7 @@ namespace Statamic\Stache;
 
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Statamic\Events\StacheCleared;
 use Statamic\Extensions\FileStore;
 use Statamic\Facades\File;
 use Statamic\Stache\Stores\Store;
@@ -91,6 +92,8 @@ class Stache
         $this->duplicates()->clear();
 
         $this->cacheStore()->forget('stache::timing');
+
+        StacheCleared::dispatch();
 
         return $this;
     }

--- a/src/StaticCaching/StaticCacheManager.php
+++ b/src/StaticCaching/StaticCacheManager.php
@@ -4,6 +4,7 @@ namespace Statamic\StaticCaching;
 
 use Illuminate\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
+use Statamic\Events\StaticCacheCleared;
 use Statamic\Facades\Site;
 use Statamic\StaticCaching\Cachers\ApplicationCacher;
 use Statamic\StaticCaching\Cachers\FileCacher;
@@ -68,6 +69,8 @@ class StaticCacheManager extends Manager
         if ($this->hasCustomStore()) {
             $this->cacheStore()->flush();
 
+            StaticCacheCleared::dispatch();
+
             return;
         }
 
@@ -78,6 +81,8 @@ class StaticCacheManager extends Manager
         });
 
         $this->cacheStore()->forget('nocache::urls');
+
+        StaticCacheCleared::dispatch();
     }
 
     public function nocacheJs(string $js)


### PR DESCRIPTION
This pull request implements various events, for some non-content related actions:

* `ImpersonationStarted` and `ImpersonationEnded` events
  * These events will be dispatched whenever a user starts or finishes impersonating another user. Both the `$impersonator` and the `$impersonated` users are available in the event. 
* WIP

Related: #10403 (@jesseleite is working on the preference and site events in a separate PR).