### PR TITLE
[5.x] Add Site events

### DIFF
--- a/src/Events/SiteCreated.php
+++ b/src/Events/SiteCreated.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Events;
+
+use Statamic\Sites\Site;
+
+class SiteCreated extends Event
+{
+    public function __construct(public Site $site)
+    {
+        //
+    }
+}

--- a/src/Events/SiteDeleted.php
+++ b/src/Events/SiteDeleted.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Events;
+
+use Statamic\Sites\Site;
+
+class SiteDeleted extends Event
+{
+    public function __construct(public Site $site)
+    {
+        //
+    }
+}

--- a/src/Events/SiteSaved.php
+++ b/src/Events/SiteSaved.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Events;
+
+use Statamic\Sites\Site;
+
+class SiteSaved extends Event
+{
+    public function __construct(public Site $site)
+    {
+        //
+    }
+}

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -3,6 +3,7 @@
 namespace Statamic\Sites;
 
 use Closure;
+use Illuminate\Support\Collection;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\File;
 use Statamic\Facades\User;
@@ -100,7 +101,7 @@ class Sites
     {
         $sites ??= $this->getSavedSites();
 
-        $this->sites = collect($sites)->map(fn ($site, $handle) => new Site($handle, $site));
+        $this->sites = $this->hydrateConfig($sites);
 
         return $this;
     }
@@ -240,6 +241,11 @@ class Sites
             ->map
             ->rawConfig()
             ->all();
+    }
+
+    protected function hydrateConfig($config): Collection
+    {
+        return collect($config)->map(fn ($site, $handle) => new Site($handle, $site));
     }
 
     /**


### PR DESCRIPTION
Adds `SiteCreated`, `SiteSaved`, and `SiteDeleted` events.

References https://github.com/statamic/ideas/issues/1169
References https://github.com/statamic/cms/issues/10403
References https://github.com/statamic/cms/pull/10459