### PR TITLE
[5.x] Refactor sites to allow eloquent storage

### DIFF
--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -127,17 +127,20 @@ class Sites
 
     protected function getSavedSites()
     {
-        $default = [
+        return File::exists($sitesPath = $this->path())
+            ? YAML::file($sitesPath)->parse()
+            : $this->getDefaultSite();
+    }
+
+    protected function getDefaultSite()
+    {
+        return [
             'default' => [
                 'name' => '{{ config:app:name }}',
                 'url' => '/',
                 'locale' => 'en_US',
             ],
         ];
-
-        return File::exists($sitesPath = $this->path())
-            ? YAML::file($sitesPath)->parse()
-            : $default;
     }
 
     public function save()
@@ -146,8 +149,7 @@ class Sites
         $newSites = $this->getNewSites();
         $deletedSites = $this->getDeletedSites();
 
-        // Save to file
-        File::put($this->path(), YAML::dump($this->config()));
+        $this->saveToStore();
 
         // Dispatch our tracked `SiteCreated` and `SiteDeleted` events
         $newSites->each(fn ($site) => SiteCreated::dispatch($site));
@@ -155,6 +157,12 @@ class Sites
 
         // Dispatch `SiteSaved` events
         $this->sites->each(fn ($site) => SiteSaved::dispatch($site));
+    }
+
+    protected function saveToStore()
+    {
+        // Save to file
+        File::put($this->path(), YAML::dump($this->config()));
     }
 
     public function blueprint()


### PR DESCRIPTION
I'm working on eloquent storage for sites here: https://github.com/statamic/eloquent-driver/pull/322

This PR adds some refactoring to allow eloquent to save sites without having to recreate the event firing logic, and also pulls the default into its own function so we can call it too.