### PR TITLE
[5.x] Allow using `value` as a field handle

### DIFF
--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -99,7 +99,7 @@ abstract class AbstractAugmented implements Augmented
     {
         return method_exists($this->data, $method)
             && collect($this->keys())->contains(Str::snake($handle))
-            && ! in_array($handle, ['hook']);
+            && ! in_array($handle, ['hook', 'value']);
     }
 
     protected function getFromData($handle)

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -472,7 +472,6 @@ class Field implements Arrayable
             'resource',
             'status',
             'unless',
-            'value', // todo: can be removed when https://github.com/statamic/cms/issues/2495 is resolved
             'views',
         ];
 


### PR DESCRIPTION
This pull request fixes an issue where it wasn't possible to use `value` as a field handle, due to the fact that augmentation was calling the `->value()` method on the entry (which errored, due to not enough parameters being provided).

This PR fixes that by adding `value` to an "allow list" we have for field handles which match methods on data objects. 

Fixes #2495.