### PR TITLE
[5.x] Track sites.yaml path in git integration config

### DIFF
--- a/config/git.php
+++ b/config/git.php
@@ -102,6 +102,7 @@ return [
         resource_path('forms'),
         resource_path('users'),
         resource_path('preferences.yaml'),
+        resource_path('sites.yaml'),
         storage_path('forms'),
         public_path('assets'),
     ],

--- a/src/Events/Concerns/ListensForContentEvents.php
+++ b/src/Events/Concerns/ListensForContentEvents.php
@@ -40,6 +40,8 @@ trait ListensForContentEvents
         \Statamic\Events\RevisionSaved::class,
         \Statamic\Events\RoleDeleted::class,
         \Statamic\Events\RoleSaved::class,
+        \Statamic\Events\SiteDeleted::class,
+        \Statamic\Events\SiteSaved::class,
         \Statamic\Events\SubmissionDeleted::class,
         \Statamic\Events\SubmissionSaved::class,
         \Statamic\Events\TaxonomyDeleted::class,

--- a/src/Events/SiteDeleted.php
+++ b/src/Events/SiteDeleted.php
@@ -2,12 +2,18 @@
 
 namespace Statamic\Events;
 
+use Statamic\Contracts\Git\ProvidesCommitMessage;
 use Statamic\Sites\Site;
 
-class SiteDeleted extends Event
+class SiteDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public Site $site)
     {
         //
+    }
+
+    public function commitMessage()
+    {
+        return __('Site deleted', [], config('statamic.git.locale'));
     }
 }

--- a/src/Events/SiteSaved.php
+++ b/src/Events/SiteSaved.php
@@ -2,12 +2,18 @@
 
 namespace Statamic\Events;
 
+use Statamic\Contracts\Git\ProvidesCommitMessage;
 use Statamic\Sites\Site;
 
-class SiteSaved extends Event
+class SiteSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public Site $site)
     {
         //
+    }
+
+    public function commitMessage()
+    {
+        return __('Site saved', [], config('statamic.git.locale'));
     }
 }

--- a/tests/Git/GitEventTest.php
+++ b/tests/Git/GitEventTest.php
@@ -377,6 +377,31 @@ class GitEventTest extends TestCase
     }
 
     #[Test]
+    public function it_commits_when_site_is_saved_and_deleted()
+    {
+        // Ensure we have one `en` site to start
+        Facades\File::put(resource_path('sites.yaml'), Facades\YAML::dump([
+            'en' => [
+                'name' => 'English',
+                'url' => 'http://localhost/',
+                'locale' => 'en_US',
+            ],
+        ]));
+
+        Git::shouldReceive('dispatchCommit')->with('Site saved')->once();
+        Git::shouldReceive('dispatchCommit')->with('Site deleted')->once();
+
+        // Delete the `en` site and save a new `fr` site
+        Facades\Site::setSites([
+            'fr' => [
+                'name' => 'French',
+                'url' => 'http://localhost/',
+                'locale' => 'fr_FR',
+            ],
+        ])->save();
+    }
+
+    #[Test]
     public function it_commits_when_asset_container_is_saved_and_deleted()
     {
         Git::shouldReceive('dispatchCommit')->with('Asset container saved')->once();


### PR DESCRIPTION
We should git track sites.yaml by default too, now that we have the content file events to do so.

References https://github.com/statamic/cms/pull/10460