### PR TITLE
[5.x] Fix styling issues with the `save-button-options` component

### DIFF
--- a/resources/js/components/publish/SaveButtonOptions.vue
+++ b/resources/js/components/publish/SaveButtonOptions.vue
@@ -14,7 +14,7 @@
             </template>
             <h6 v-text="__('After Saving')" class="p-2" />
             <div class="publish-fields px-2">
-                <div class="publish-field save-and-continue-options">
+                <div class="publish-field save-and-continue-options radio-fieldtype">
                     <radio-fieldtype
                         handle="save_and_continue_options"
                         :config="options"

--- a/resources/js/components/publish/SaveButtonOptions.vue
+++ b/resources/js/components/publish/SaveButtonOptions.vue
@@ -13,7 +13,7 @@
                 </button>
             </template>
             <h6 v-text="__('After Saving')" class="p-2" />
-            <div class="publish-fields px-2">
+            <div class="publish-fields px-2 py-1">
                 <div class="publish-field save-and-continue-options radio-fieldtype">
                     <radio-fieldtype
                         handle="save_and_continue_options"


### PR DESCRIPTION
This pull request fixes an issue with the `save-button-options` component, where the Radio buttons were huge, after its recent refactoring in #10453.

The CSS to set the height/width of the icon was relying on a class automatically added to fields in publish forms. However, it wasn't there in the save buttons component, causing the huge icons.

This PR also adds a smidge of padding at the top and bottom of the radio buttons, to add some additional spacing, like it had before the recent refactor.

## Before

![CleanShot 2024-07-16 at 15 55 09](https://github.com/user-attachments/assets/e27c865c-da35-4cce-87ca-76eaa1a74d03)

## After

![CleanShot 2024-07-16 at 15 49 50](https://github.com/user-attachments/assets/8ba693aa-18ca-41b6-af94-f8edb9b246f0)
