### PR TITLE
[5.x] Prevent double login causing 419 CSRF token mismatch

### DIFF
--- a/resources/js/components/login/login.js
+++ b/resources/js/components/login/login.js
@@ -9,6 +9,12 @@ export default {
         }
     },
 
+    data() {
+        return {
+            busy: false
+        }
+    },
+
     mounted() {
         if (this.hasError) {
             this.$el.parentElement.parentElement.classList.add('animation-shake');

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -35,7 +35,7 @@
                 @endif
             @endif
 
-            <form method="POST" v-show="showEmailLogin" class="email-login select-none" @if ($oauth) v-cloak @endif>
+            <form method="POST" v-show="showEmailLogin" class="email-login select-none" @if ($oauth) v-cloak @endif @submit="busy = true">
                 {!! csrf_field() !!}
 
                 <input type="hidden" name="referer" value="{{ $referer }}" />
@@ -56,7 +56,7 @@
                         <input type="checkbox" name="remember" id="remember-me">
                         <span class="rtl:mr-2 ltr:ml-2">{{ __('Remember me') }}</span>
                     </label>
-                    <button type="submit" class="btn-primary">{{ __('Log in') }}</button>
+                    <button type="submit" class="btn-primary" :disabled="busy">{{ __('Log in') }}</button>
                 </div>
             </form>
         </div>

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -9,10 +9,9 @@
 
     <div class="max-w-xs rounded shadow-lg flex items-center justify-center relative mx-auto">
         <div class="outside-shadow absolute inset-0"></div>
-        <div class="card auth-card">
+        <div class="card auth-card" x-data="{ busy: false }" v-pre>
 
-
-            <form method="POST" action="{{ $action }}">
+            <form method="POST" action="{{ $action }}" x-on:submit="busy = true">
                 @csrf
 
                 <input type="hidden" name="token" value="{{ $token }}">
@@ -47,7 +46,7 @@
                     <input id="password-confirm" type="password" class="input-text input-text" name="password_confirmation" required>
                 </div>
 
-                <button type="submit" class="btn-primary">{{ $title }}</button>
+                <button type="submit" class="btn-primary" :disabled="busy">{{ $title }}</button>
 
             </form>
         </div>


### PR DESCRIPTION
This fixes an issue where some people were seeing 419 errors after logging in.

We found that the reason was typically due to submitting the form twice.

Either by:
- Clicking the log in button multiple time
- Using 1Password to auto-fill their credentials, which submits the form, and then the user clicking log in before the redirect happens.

It seems that the first time the form is submitted, you get logged in and your csrf token is updated. Then if you click it a second time, the old token is submitted but no longer matches your current one, resulting in the error.

This PR fixes that issue by disabling the submit button while the form is submitting, preventing you from submitting twice.

This PR gives the same treatment to the reset password form which has the same issue.