### PR TITLE
[5.x] Handle `required` fields when adding entries to nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Release Notes
 
+## 5.15.0 (2024-07-17)
+
+### What's new
+- Ability to specify the queue connection for the static:warm command [#8634](https://github.com/statamic/cms/issues/8634) by @grantholle
+- Show "after saving" actions when revisions are enabled [#9357](https://github.com/statamic/cms/issues/9357) by @duncanmcclean
+- Add site events [#10460](https://github.com/statamic/cms/issues/10460) by @jesseleite
+- Add a bunch of various events [#10459](https://github.com/statamic/cms/issues/10459) by @duncanmcclean
+- Track sites.yaml path in git integration config [#10463](https://github.com/statamic/cms/issues/10463) by @jesseleite
+- Display custom logo as plain text [#10350](https://github.com/statamic/cms/issues/10350) by @daun
+- Make `config` available to live preview targets [#10443](https://github.com/statamic/cms/issues/10443) by @ryanmitchell
+- Make the `<?xml` tag allowed when using PHP short open tags [#10389](https://github.com/statamic/cms/issues/10389) by @JohnathonKoster
+- Radio Fieldtype gets custom button icons [#10453](https://github.com/statamic/cms/issues/10453) by @jackmcdade
+
+### What's fixed
+- Prevent double login causing 419 CSRF token mismatch [#10465](https://github.com/statamic/cms/issues/10465) by @jasonvarga
+- Refactor sites to allow eloquent storage [#10461](https://github.com/statamic/cms/issues/10461) by @ryanmitchell
+- Prevent redundant static:warm queued jobs [#10405](https://github.com/statamic/cms/issues/10405) by @robdekort
+- Prevent updating time fieldtype value if it hasn't changed [#10409](https://github.com/statamic/cms/issues/10409) by @duncanmcclean
+- Fix styling issues with the `save-button-options` component [#10464](https://github.com/statamic/cms/issues/10464) by @duncanmcclean
+- Allow using `value` as a field handle [#10462](https://github.com/statamic/cms/issues/10462) by @duncanmcclean
+- Use StaticCache facade in Cache Manager utility [#10456](https://github.com/statamic/cms/issues/10456) by @duncanmcclean
+- Add missing dark mode styles for license request failed warning [#10448](https://github.com/statamic/cms/issues/10448) by @heidkaemper
+- Hide data list pagination page links on collection widget [#10458](https://github.com/statamic/cms/issues/10458) by @jackmcdade
+- Fix select fieldtype disabled cursor [#10457](https://github.com/statamic/cms/issues/10457) by @jackmcdade
+- Fix Replicator Preview images being too tall [#10455](https://github.com/statamic/cms/issues/10455) by @jackmcdade
+- Make Blueprint Picker scrollable [#10454](https://github.com/statamic/cms/issues/10454) by @jackmcdade
+- Clean up reference updater localization mapping logic [#10446](https://github.com/statamic/cms/issues/10446) by @jesseleite
+- Reverse spaces in RTL [#10184](https://github.com/statamic/cms/issues/10184) by @peimn
+- Merge additional params after SVG sanitization [#10400](https://github.com/statamic/cms/issues/10400) by @heidkaemper
+- Fix files fieldtype [#10441](https://github.com/statamic/cms/issues/10441) by @duncanmcclean
+- Warm structure trees during static warm [#10412](https://github.com/statamic/cms/issues/10412) by @jasonvarga
+- Prevent dark mode gradient affecting custom logos [#10444](https://github.com/statamic/cms/issues/10444) by @duncanmcclean
+
+
+
 ## 5.14.0 (2024-07-10)
 
 ### What's new

--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -316,6 +316,10 @@ export default {
             });
 
             this.$refs.tree.addPages(pages, this.targetParent);
+
+            if (pages.length === 1) {
+                this.editPage(pages[0], this.$refs.tree.$refs.tree, this.$refs.tree.$refs.tree.store);
+            }
         },
 
         isEntryBranch(branch) {

--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -216,6 +216,7 @@ export default {
             showPageDeletionConfirmation: false,
             pageBeingDeleted: null,
             pageDeletionConfirmCallback: null,
+            removePageOnCancel: false,
             preferencesPrefix: `navs.${this.handle}`,
             publishInfo: {},
         }
@@ -318,6 +319,7 @@ export default {
             this.$refs.tree.addPages(pages, this.targetParent);
 
             if (pages.length === 1) {
+                this.removePageOnCancel = true;
                 this.editPage(pages[0], this.$refs.tree.$refs.tree, this.$refs.tree.$refs.tree.store);
             }
         },
@@ -349,6 +351,11 @@ export default {
         },
 
         closePageEditor() {
+            if (this.removePageOnCancel) {
+                this.$refs.tree.$refs[`branch-${this.editingPage.page.id}`].remove();
+                this.removePageOnCancel = false;
+            }
+
             this.editingPage = false;
         },
 

--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -128,6 +128,7 @@
             ref="selector"
             :site="site"
             :collections="collections"
+            :max-items="maxPagesSelection"
             @selected="entriesSelected"
         />
 
@@ -250,6 +251,22 @@ export default {
 
         direction() {
             return this.$config.get('direction', 'ltr');
+        },
+
+        fields () {
+            return this.blueprint.tabs.reduce((fields, tab) => {
+                return tab.sections.reduce((fields, section) => {
+                    return fields.concat(section.fields);
+                }, []);
+            }, []);
+        },
+
+        maxPagesSelection() {
+            if (this.fields.filter(field => field.validate?.includes('required')).length > 0) {
+                return 1;
+            }
+
+            return null
         },
 
     },

--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -318,7 +318,7 @@ export default {
 
             this.$refs.tree.addPages(pages, this.targetParent);
 
-            if (pages.length === 1) {
+            if (this.maxPagesSelection === 1) {
                 this.removePageOnCancel = true;
                 this.editPage(pages[0], this.$refs.tree.$refs.tree, this.$refs.tree.$refs.tree.store);
             }

--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -267,7 +267,7 @@ export default {
                 return 1;
             }
 
-            return null
+            return
         },
 
     },

--- a/resources/js/components/structures/PageSelector.vue
+++ b/resources/js/components/structures/PageSelector.vue
@@ -14,6 +14,7 @@
             :columns="columns"
             :can-create="false"
             :can-reorder="false"
+            :max-items="maxItems"
             @item-data-updated="itemDataUpdated"
         />
 
@@ -27,6 +28,10 @@ export default {
     props: {
         site: String,
         collections: Array,
+        maxItems: {
+            type: Number,
+            required: false,
+        },
     },
 
     data() {

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -35,6 +35,7 @@
                 @nodeOpenChanged="saveTreeState"
             >
                 <tree-branch
+                    :ref="`branch-${page.id}`"
                     slot-scope="{ data: page, store, vm }"
                     :page="page"
                     :depth="vm.level"


### PR DESCRIPTION
This pull request makes some improvements around the handling of required fields in Navigation blueprints.

Currently, when you select entries to add to a navigation, you'll be able to get away without filling any required fields.

With this PR, you'll only be able to select a single entry at a time. After selecting, you'll be taken to the "Edit Page" stack where you'll be able to fill the required field.

Fixes #4582.