### PR TITLE
[5.x] Clarify difference between `default()` and `getFallbackConfig()` site methods

### DIFF
--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -129,10 +129,10 @@ class Sites
     {
         return File::exists($sitesPath = $this->path())
             ? YAML::file($sitesPath)->parse()
-            : $this->getDefaultSiteConfig();
+            : $this->getDefaultConfig();
     }
 
-    protected function getDefaultSiteConfig()
+    protected function getDefaultConfig()
     {
         return [
             'default' => [

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -129,10 +129,10 @@ class Sites
     {
         return File::exists($sitesPath = $this->path())
             ? YAML::file($sitesPath)->parse()
-            : $this->getDefaultConfig();
+            : $this->getFallbackConfig();
     }
 
-    protected function getDefaultConfig()
+    protected function getFallbackConfig()
     {
         return [
             'default' => [

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -149,6 +149,7 @@ class Sites
         $newSites = $this->getNewSites();
         $deletedSites = $this->getDeletedSites();
 
+        // Save sites to store
         $this->saveToStore();
 
         // Dispatch our tracked `SiteCreated` and `SiteDeleted` events
@@ -161,7 +162,6 @@ class Sites
 
     protected function saveToStore()
     {
-        // Save to file
         File::put($this->path(), YAML::dump($this->config()));
     }
 

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -129,10 +129,10 @@ class Sites
     {
         return File::exists($sitesPath = $this->path())
             ? YAML::file($sitesPath)->parse()
-            : $this->getDefaultSite();
+            : $this->getDefaultSiteConfig();
     }
 
-    protected function getDefaultSite()
+    protected function getDefaultSiteConfig()
     {
         return [
             'default' => [


### PR DESCRIPTION
Small method rename to @ryanmitchell's awesome #10461 PR, to better clarify difference between `getDefaultSite()` and `default()` (which returns default site instance, rather than default sites config).

References https://github.com/statamic/eloquent-driver/pull/322