### PR TITLE
[5.x] Add dark mode to saving overlay on ChangePassword component

### DIFF
--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -58,7 +58,6 @@
 
 .saving-overlay {
     @apply absolute inset-0 z-200 flex items-center rounded;
-    background: rgba(255, 255, 255, .9);
 
     .inner {
         @apply p-10 text-center mx-auto;

--- a/resources/js/components/users/ChangePassword.vue
+++ b/resources/js/components/users/ChangePassword.vue
@@ -5,7 +5,7 @@
             class="btn"
             v-text="__('Change Password')"
         />
-        <div class="saving-overlay bg-white opacity-90 flex justify-center text-center dark:bg-dark-900" v-if="saving">
+        <div class="saving-overlay bg-white opacity-90 flex justify-center text-center dark:bg-dark-600" v-if="saving">
             <loading-graphic :text="__('Saving')" />
         </div>
         <div class="publish-fields p-4 pb-0 w-96">

--- a/resources/js/components/users/ChangePassword.vue
+++ b/resources/js/components/users/ChangePassword.vue
@@ -5,7 +5,7 @@
             class="btn"
             v-text="__('Change Password')"
         />
-        <div class="saving-overlay flex justify-center text-center" v-if="saving">
+        <div class="saving-overlay bg-white opacity-90 flex justify-center text-center dark:bg-dark-900" v-if="saving">
             <loading-graphic :text="__('Saving')" />
         </div>
         <div class="publish-fields p-4 pb-0 w-96">


### PR DESCRIPTION
The saving overlay that is used on the change password popover does not support dark mode:
<img width="416" alt="image" src="https://github.com/user-attachments/assets/0d5f77cf-57b6-4bc7-a3a3-5faaca589648">

This PR resolves this by doing two things:
1. removes the white colour from the `.saving-overlay` class, and 
2. replaces it with Tailwind colours in the `ChangePassword.vue` to make it easier to work with the dark mode selector.

I believe this is the only piece of code that uses the `.saving-overlay` class.

Result:
<img width="444" alt="image" src="https://github.com/user-attachments/assets/b1e3726c-5330-4605-a0a1-34c6323cb311">

This is using `dark:bg-dark-600`, but `dark:bg-dark-800` isn't too bad either.