### PR TITLE
[5.x] Add hook to query on entries listing

### DIFF
--- a/src/Hooks/CP/EntriesIndexQuery.php
+++ b/src/Hooks/CP/EntriesIndexQuery.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Statamic\Hooks\CP;
+
+use Statamic\Support\Traits\Hookable;
+
+class EntriesIndexQuery
+{
+    use Hookable;
+
+    public function __construct(private $query)
+    {
+        //
+    }
+
+    public function paginate(int $perPage)
+    {
+        $query = $this->runHooks('query', $this->query);
+
+        return $query->paginate($perPage);
+    }
+}

--- a/src/Hooks/CP/EntriesIndexQuery.php
+++ b/src/Hooks/CP/EntriesIndexQuery.php
@@ -8,15 +8,18 @@ class EntriesIndexQuery
 {
     use Hookable;
 
-    public function __construct(private $query)
+    public function __construct(private $query, private $collection)
     {
         //
     }
 
     public function paginate(int $perPage)
     {
-        $query = $this->runHooks('query', $this->query);
+        $payload = $this->runHooksWith('query', [
+            'query' => $this->query,
+            'collection' => $this->collection,
+        ]);
 
-        return $query->paginate($perPage);
+        return $payload->query->paginate($perPage);
     }
 }

--- a/src/Hooks/CP/EntriesIndexQuery.php
+++ b/src/Hooks/CP/EntriesIndexQuery.php
@@ -13,7 +13,7 @@ class EntriesIndexQuery
         //
     }
 
-    public function paginate(int $perPage)
+    public function paginate(?int $perPage)
     {
         $payload = $this->runHooksWith('query', [
             'query' => $this->query,

--- a/src/Hooks/Payload.php
+++ b/src/Hooks/Payload.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Statamic\Hooks;
+
+class Payload
+{
+    public function __construct(private array $payload)
+    {
+        //
+    }
+
+    public function __get($key)
+    {
+        return $this->payload[$key] ?? null;
+    }
+
+    public function __set($key, $value)
+    {
+        $this->payload[$key] = $value;
+    }
+}

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -50,7 +50,7 @@ class EntriesController extends CpController
             $query->orderBy($sortField, $sortDirection);
         }
 
-        $entries = (new EntriesIndexQuery($query))->paginate(request('perPage'));
+        $entries = (new EntriesIndexQuery($query, $collection))->paginate(request('perPage'));
 
         if (request('search') && $collection->hasSearchIndex()) {
             $entries->setCollection($entries->getCollection()->map->getSearchable());

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -20,11 +20,13 @@ use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
+use Statamic\Support\Traits\Hookable;
 
 class EntriesController extends CpController
 {
     use ExtractsFromEntryFields,
-        QueriesFilters;
+        QueriesFilters,
+        Hookable;
 
     public function index(FilteredRequest $request, $collection)
     {
@@ -48,6 +50,8 @@ class EntriesController extends CpController
         if ($sortField) {
             $query->orderBy($sortField, $sortDirection);
         }
+
+        $query = $this->runHooks('index-query', $query);
 
         $entries = $query->paginate(request('perPage'));
 

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -25,8 +25,8 @@ use Statamic\Support\Traits\Hookable;
 class EntriesController extends CpController
 {
     use ExtractsFromEntryFields,
-        QueriesFilters,
-        Hookable;
+        Hookable,
+        QueriesFilters;
 
     public function index(FilteredRequest $request, $collection)
     {

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -13,6 +13,7 @@ use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
 use Statamic\Facades\User;
+use Statamic\Hooks\CP\EntriesIndexQuery;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Http\Resources\CP\Entries\Entries;
@@ -20,12 +21,10 @@ use Statamic\Http\Resources\CP\Entries\Entry as EntryResource;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
-use Statamic\Support\Traits\Hookable;
 
 class EntriesController extends CpController
 {
     use ExtractsFromEntryFields,
-        Hookable,
         QueriesFilters;
 
     public function index(FilteredRequest $request, $collection)
@@ -51,9 +50,7 @@ class EntriesController extends CpController
             $query->orderBy($sortField, $sortDirection);
         }
 
-        $query = $this->runHooks('index-query', $query);
-
-        $entries = $query->paginate(request('perPage'));
+        $entries = (new EntriesIndexQuery($query))->paginate(request('perPage'));
 
         if (request('search') && $collection->hasSearchIndex()) {
             $entries->setCollection($entries->getCollection()->map->getSearchable());

--- a/src/Support/Traits/Hookable.php
+++ b/src/Support/Traits/Hookable.php
@@ -4,6 +4,7 @@ namespace Statamic\Support\Traits;
 
 use Closure;
 use Illuminate\Pipeline\Pipeline;
+use Statamic\Hooks\Payload;
 
 trait Hookable
 {
@@ -45,5 +46,10 @@ trait Hookable
             ->send($payload)
             ->through($closures->all())
             ->thenReturn();
+    }
+
+    protected function runHooksWith(string $name, array $payload)
+    {
+        return $this->runHooks($name, new Payload($payload));
     }
 }


### PR DESCRIPTION
This pull request adds a [hook](https://statamic.dev/extending/hooks) that allows developers to modify the query used to return entries for the entries listing table.

Here's a super simple example of how you might use it to only display a user's posts on the news collection, which could go hand in hand with a policy:

```php
use Statamic\Hooks\CP\EntriesIndexQuery;

EntriesIndexQuery::hook('query', function ($payload, $next) {
    if ($payload->collection === 'news') {
        $query->where('author', User::current()->id());
    }

    return $next($payload);
});
```

Closes statamic/ideas#591.