### PR TITLE
[5.x] Restrict super user authorization to CP routes

### DIFF
--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -16,6 +16,7 @@ use Statamic\Contracts\Auth\UserGroupRepository;
 use Statamic\Contracts\Auth\UserRepository;
 use Statamic\Facades\User;
 use Statamic\Policies;
+use Statamic\Statamic;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -83,13 +84,15 @@ class AuthServiceProvider extends ServiceProvider
             return new UserProvider;
         });
 
-        Gate::before(function ($user, $ability) {
-            return optional(User::fromUser($user))->isSuper() ? true : null;
-        });
+        if (Statamic::isCpRoute()) {
+            Gate::before(function ($user, $ability) {
+                return optional(User::fromUser($user))->isSuper() ? true : null;
+            });
 
-        Gate::after(function ($user, $ability) {
-            return optional(User::fromUser($user))->hasPermission($ability) === true ? true : null;
-        });
+            Gate::after(function ($user, $ability) {
+                return optional(User::fromUser($user))->hasPermission($ability) === true ? true : null;
+            });
+        }
 
         foreach ($this->policies as $key => $policy) {
             Gate::policy($key, $policy);

--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -84,15 +84,17 @@ class AuthServiceProvider extends ServiceProvider
             return new UserProvider;
         });
 
-        if (Statamic::isCpRoute()) {
-            Gate::before(function ($user, $ability) {
+        Gate::before(function ($user, $ability) {
+            if (Statamic::isCpRoute()) {
                 return optional(User::fromUser($user))->isSuper() ? true : null;
-            });
+            }
+        });
 
-            Gate::after(function ($user, $ability) {
+        Gate::after(function ($user, $ability) {
+            if (Statamic::isCpRoute()) {
                 return optional(User::fromUser($user))->hasPermission($ability) === true ? true : null;
-            });
-        }
+            }
+        });
 
         foreach ($this->policies as $key => $policy) {
             Gate::policy($key, $policy);


### PR DESCRIPTION
This pull request aims to fix an issue where authorization for packages like Laravel Telescope and Horizon would always pass when logged in as a super user.

For example:

1. Install Laravel Telescope
2. In `app/Providers/TelescopeServiceProvider.php`, update the code in the `gate` method:

    ```php
    Gate::define('viewTelescope', function ($user) {
        return false;
    });
    ```

3. Login to Statamic as a super user, see that you can access `/telescope` even though you shouldn't have permission.
4. Login to Statamic as a non-super user, see that you aren't authorized to access the `/telescope` route.

This behaviour is happening due to Statamic calling `Gate::before` & `Gate::after` to ensure super users have all permissions across the CP. 

However, I don't think that same logic should be the case when authorization happens outside of the Statamic context (eg. in packages like Telescope or first-party policies). 

This PR attempts to fix the issue by wrapping our `Gate::before`/`Gate::after` code inside a `Statamic::isCpRoute()` conditional. Everything _seems_ to work fine for me, but feel free to reject if you feel it might cause other unintended side effects. 

Fixes #8337.