### PR TITLE
[5.x] Sync datetime dark mode with control panel

### DIFF
--- a/resources/css/components/fieldtypes/datetime.css
+++ b/resources/css/components/fieldtypes/datetime.css
@@ -2,40 +2,6 @@
    DATE & TIME FIELDTYPES
    ========================================================================== */
 
-.vc-container.vc-is-dark,
-.vc-container {
-    @apply dark:text-dark-150 dark:bg-dark-600 dark:border-dark-300;
-
-    .vc-title {
-        @apply dark:text-dark-150;
-    }
-
-    .vc-arrow {
-        @apply dark:hover:bg-dark-900;
-    }
-
-    .vc-weekday {
-        @apply dark:text-blue-300;
-    }
-
-    .vc-nav-popover-container {
-        @apply dark:bg-dark-700 dark:border-dark-650 dark:text-dark-150;
-
-        .vc-nav-title,
-        .vc-nav-item,
-        .vc-nav-arrow {
-            @apply dark:text-dark-150 dark:hover:bg-dark-900 dark:hover:text-dark-100;
-        }
-
-        .vc-nav-item.is-active {
-            @apply dark:text-dark-100 dark:bg-dark-800;
-        }
-        .vc-nav-item.is-current {
-            @apply dark:border-dark-200;
-        }
-    }
-}
-
 .daterange {
 	outline: none;
 	width: 100%;

--- a/resources/css/components/fieldtypes/datetime.css
+++ b/resources/css/components/fieldtypes/datetime.css
@@ -2,6 +2,40 @@
    DATE & TIME FIELDTYPES
    ========================================================================== */
 
+.vc-container.vc-is-dark,
+.vc-container {
+    @apply dark:text-dark-150 dark:bg-dark-600 dark:border-dark-300;
+
+    .vc-title {
+        @apply dark:text-dark-150;
+    }
+
+    .vc-arrow {
+        @apply dark:hover:bg-dark-900;
+    }
+
+    .vc-weekday {
+        @apply dark:text-blue-300;
+    }
+
+    .vc-nav-popover-container {
+        @apply dark:bg-dark-700 dark:border-dark-650 dark:text-dark-150;
+
+        .vc-nav-title,
+        .vc-nav-item,
+        .vc-nav-arrow {
+            @apply dark:text-dark-150 dark:hover:bg-dark-900 dark:hover:text-dark-100;
+        }
+
+        .vc-nav-item.is-active {
+            @apply dark:text-dark-100 dark:bg-dark-800;
+        }
+        .vc-nav-item.is-current {
+            @apply dark:border-dark-200;
+        }
+    }
+}
+
 .daterange {
 	outline: none;
 	width: 100%;

--- a/resources/js/components/DarkModeToggle.vue
+++ b/resources/js/components/DarkModeToggle.vue
@@ -54,8 +54,12 @@ export default {
                     : 'light';
             }
         },
-        theme(theme) {
-            document.documentElement.classList.toggle('dark', theme === 'dark');
+        theme: {
+            immediate: true,
+            handler(theme) {
+                document.documentElement.classList.toggle('dark', theme === 'dark');
+                Statamic.darkMode = theme === 'dark';
+            }
         }
     },
     created() {

--- a/resources/js/components/Statamic.js
+++ b/resources/js/components/Statamic.js
@@ -23,6 +23,7 @@ export default new Vue({
         return {
             bootingCallbacks: [],
             bootedCallbacks: [],
+            darkMode: null,
         }
     },
 

--- a/resources/js/components/fieldtypes/date/RangeInline.vue
+++ b/resources/js/components/fieldtypes/date/RangeInline.vue
@@ -21,7 +21,7 @@ export default {
     computed: {
 
         darkMode() {
-            return this.$preferences.get('theme') === 'dark'
+            return Statamic.darkMode;
         },
 
         pickerBindings() {

--- a/resources/js/components/fieldtypes/date/RangePopover.vue
+++ b/resources/js/components/fieldtypes/date/RangePopover.vue
@@ -108,7 +108,7 @@ export default {
     computed: {
 
         darkMode() {
-            return this.$preferences.get('theme') === 'dark'
+            return Statamic.darkMode;
         },
 
         pickerBindings() {

--- a/resources/js/components/fieldtypes/date/SingleInline.vue
+++ b/resources/js/components/fieldtypes/date/SingleInline.vue
@@ -21,7 +21,7 @@ export default {
     computed: {
 
         darkMode() {
-            return this.$preferences.get('theme') === 'dark'
+            return Statamic.darkMode;
         },
 
         pickerBindings() {

--- a/resources/js/components/fieldtypes/date/SinglePopover.vue
+++ b/resources/js/components/fieldtypes/date/SinglePopover.vue
@@ -65,7 +65,7 @@ export default {
     computed: {
 
         darkMode() {
-            return this.$preferences.get('theme') === 'dark'
+            return Statamic.darkMode;
         },
 
         inputEvents() {


### PR DESCRIPTION
The V-Calendar component features a dark mode using shades of blue, but it isn't synchronized with the control panel.

Fixes https://github.com/statamic/cms/issues/10482.