### PR TITLE
[5.x] Fix failing markdown tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,5 @@
 name: Run Tests
 
-
 on:
   push:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,6 @@
 name: Run Tests
 
+
 on:
   push:
     branches:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "james-heinrich/getid3": "^1.9.21",
         "laravel/framework": "^10.40 || ^11.0",
         "laravel/prompts": "^0.1.16",
-        "league/commonmark": "^2.2",
+        "league/commonmark": "2.4.4",
         "league/csv": "^9.0",
         "league/glide": "^2.3",
         "maennchen/zipstream-php": "^3.1",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "james-heinrich/getid3": "^1.9.21",
         "laravel/framework": "^10.40 || ^11.0",
         "laravel/prompts": "^0.1.16",
-        "league/commonmark": "2.4.4",
+        "league/commonmark": ">=2.2 <2.5",
         "league/csv": "^9.0",
         "league/glide": "^2.3",
         "maennchen/zipstream-php": "^3.1",


### PR DESCRIPTION
Tests are failing. This unfails them.

---

Turns out this is due to `league/commonmark` 2.5. As a temporary solution, this PR constrains that package to under 2.5.
