### PR TITLE
[5.x] Don't enforce a query length on comb searches

### DIFF
--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -834,7 +834,7 @@ class Comb
     {
         $length = strlen($query);
 
-        if ($length === 0) {
+        if ($length === 0 && $this->min_characters > 0) {
             throw new NoQuery('No query given.');
         }
 

--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -3,6 +3,7 @@
 namespace Statamic\Search\Comb;
 
 use Statamic\Search\Comb\Exceptions\Exception as CombException;
+use Statamic\Search\Comb\Exceptions\NoQuery;
 use Statamic\Search\Comb\Exceptions\NoResultsFound;
 use Statamic\Search\Comb\Exceptions\NotEnoughCharacters;
 use Statamic\Search\Comb\Exceptions\TooManyResults;
@@ -826,11 +827,18 @@ class Comb
      *
      * @param  string  $query  Query to test
      *
+     * @throws NoQuery
      * @throws NotEnoughCharacters
      */
     private function testValidQuery($query)
     {
-        if (strlen($query) < $this->min_characters) {
+        $length = strlen($query);
+
+        if ($length === 0) {
+            throw new NoQuery('No query given.');
+        }
+
+        if ($length < $this->min_characters) {
             throw new NotEnoughCharacters('Not enough characters entered.');
         }
     }

--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -3,7 +3,6 @@
 namespace Statamic\Search\Comb;
 
 use Statamic\Search\Comb\Exceptions\Exception as CombException;
-use Statamic\Search\Comb\Exceptions\NoQuery;
 use Statamic\Search\Comb\Exceptions\NoResultsFound;
 use Statamic\Search\Comb\Exceptions\NotEnoughCharacters;
 use Statamic\Search\Comb\Exceptions\TooManyResults;
@@ -827,18 +826,11 @@ class Comb
      *
      * @param  string  $query  Query to test
      *
-     * @throws NoQuery
      * @throws NotEnoughCharacters
      */
     private function testValidQuery($query)
     {
-        $length = strlen($query);
-
-        if ($length === 0) {
-            throw new NoQuery('No query given.');
-        }
-
-        if ($length < $this->min_characters) {
+        if (strlen($query) < $this->min_characters) {
             throw new NotEnoughCharacters('Not enough characters entered.');
         }
     }

--- a/src/Search/Comb/Index.php
+++ b/src/Search/Comb/Index.php
@@ -3,6 +3,7 @@
 namespace Statamic\Search\Comb;
 
 use Statamic\Facades\File;
+use Statamic\Search\Comb\Exceptions\NoQuery;
 use Statamic\Search\Comb\Exceptions\NoResultsFound;
 use Statamic\Search\Comb\Exceptions\NotEnoughCharacters;
 use Statamic\Search\Documents;
@@ -28,7 +29,7 @@ class Index extends BaseIndex
 
         try {
             $results = $comb->lookUp($query)['data'];
-        } catch (NoResultsFound|NotEnoughCharacters $e) {
+        } catch (NoResultsFound|NotEnoughCharacters|NoQuery $e) {
             return collect();
         }
 

--- a/src/Search/Comb/Index.php
+++ b/src/Search/Comb/Index.php
@@ -3,7 +3,6 @@
 namespace Statamic\Search\Comb;
 
 use Statamic\Facades\File;
-use Statamic\Search\Comb\Exceptions\NoQuery;
 use Statamic\Search\Comb\Exceptions\NoResultsFound;
 use Statamic\Search\Comb\Exceptions\NotEnoughCharacters;
 use Statamic\Search\Documents;
@@ -29,7 +28,7 @@ class Index extends BaseIndex
 
         try {
             $results = $comb->lookUp($query)['data'];
-        } catch (NoResultsFound|NotEnoughCharacters|NoQuery $e) {
+        } catch (NoResultsFound|NotEnoughCharacters $e) {
             return collect();
         }
 


### PR DESCRIPTION
Sometimes you want to show users a list of results, and then allow a query to be entered that filters that listing, rather than entering the query before showing the listing. 

As things stand that means using the collection tag for the non-query state, and then the search:results tag for the queried state. This is because the Comb search driver doesn't allow blank queries. This isn't ideal and means a lot of code repetition for what is the same thing.

This PR updates the logic to allow blank queries when you have `'min_characters' => 0` in your search index config. This allows you to use the search:results tag for both situations mentioned above:

```antlers
{{ search:results for="{get:q ?? '*'}" as="results" }}
```

This shouldn't break any existing installs as min_characters: 1 is the default (?).

I left the `NoQuery` class in place on the off chance someone might be using it.