### PR TITLE
[5.x] Position the "Learn More" link as desired

### DIFF
--- a/resources/js/components/AddonDetails.vue
+++ b/resources/js/components/AddonDetails.vue
@@ -21,7 +21,7 @@
                     <p v-text="`${__('messages.addon_install_command')}:`" />
                     <code-block copyable :text="`composer require ${package}`" />
                 </template>
-                <p>{{ __('Learn more about') }} <a href="https://statamic.dev/addons">{{ __('Addons') }}</a>.</p>
+                <p v-html="link"></p>
             </div>
         </confirmation-modal>
         <div>
@@ -86,6 +86,10 @@ import AddonEditions from './addons/Editions.vue';
                 low = low ? `$${low}` : __('Free');
                 high = high ? `$${high}` : __('Free');
                 return (low == high) ? low : `${low} - ${high}`;
+            },
+
+            link() {
+                return __('Learn more about :link', { link: `<a href="https://statamic.dev/addons" target="_blank">${__('Addons')}</a>`}) + '.';
             },
         },
 

--- a/resources/js/components/updater/Release.vue
+++ b/resources/js/components/updater/Release.vue
@@ -27,7 +27,7 @@
             <div class="prose">
                 <p v-text="confirmationText" />
                 <code-block copyable :text="command" />
-                <p>{{ __('Learn more about') }} <a href="https://statamic.dev/updating" target="_blank">{{ __('Updates') }}</a>.</p>
+                <p v-html="link"></p>
             </div>
          </confirmation-modal>
     </div>
@@ -89,7 +89,11 @@ export default {
             }
 
             return `composer require "${this.package} ${this.release.version}"`;
-        }
+        },
+
+        link() {
+            return __('Learn more about :link', { link: `<a href="https://statamic.dev/updating" target="_blank">${__('Updates')}</a>`}) + '.';
+        },
     }
 
 }

--- a/resources/js/components/updater/Updater.vue
+++ b/resources/js/components/updater/Updater.vue
@@ -53,7 +53,7 @@
             <div class="prose">
                 <p v-text="`${__('messages.updater_update_to_latest_command')}:`" />
                 <code-block copyable :text="`composer update ${package}`" />
-                <p>{{ __('Learn more about') }} <a href="https://statamic.dev/updating" target="_blank">{{ __('Updates') }}</a>.</p>
+                <p v-html="link"></p>
             </div>
         </confirmation-modal>
     </div>
@@ -112,6 +112,10 @@
 
             latestVersion() {
                 return this.latestRelease && this.latestRelease.version;
+            },
+
+            link() {
+                return __('Learn more about :link', { link: `<a href="https://statamic.dev/updating" target="_blank">${__('Updates')}</a>`}) + '.';
             },
         },
 

--- a/resources/lang/ar.json
+++ b/resources/lang/ar.json
@@ -549,7 +549,7 @@
     "Latest Date": "أحدث تاريخ",
     "Layout": "تخطيط",
     "Learn more": "معرفة المزيد",
-    "Learn more about": "معرفة المزيد عن :link",
+    "Learn more about :link": "معرفة المزيد عن :link",
     "Less than": "أقل من",
     "Less than or equals": "أقل من أو يساوي",
     "Licensing": "الترخيص",

--- a/resources/lang/ar.json
+++ b/resources/lang/ar.json
@@ -549,7 +549,7 @@
     "Latest Date": "أحدث تاريخ",
     "Layout": "تخطيط",
     "Learn more": "معرفة المزيد",
-    "Learn more about": "معرفة المزيد عن",
+    "Learn more about": "معرفة المزيد عن :link",
     "Less than": "أقل من",
     "Less than or equals": "أقل من أو يساوي",
     "Licensing": "الترخيص",

--- a/resources/lang/cs.json
+++ b/resources/lang/cs.json
@@ -442,7 +442,7 @@
     "Latest Date": "Poslední datum",
     "Layout": "Layout",
     "Learn more": "Dozvědět se více",
-    "Learn more about": "Dozvědět se více o :link",
+    "Learn more about :link": "Dozvědět se více o :link",
     "Licensing": "Licencování",
     "Light": "Světlý",
     "Light Mode": "Světlý režim",

--- a/resources/lang/cs.json
+++ b/resources/lang/cs.json
@@ -442,7 +442,7 @@
     "Latest Date": "Poslední datum",
     "Layout": "Layout",
     "Learn more": "Dozvědět se více",
-    "Learn more about": "Dozvědět se více o",
+    "Learn more about": "Dozvědět se více o :link",
     "Licensing": "Licencování",
     "Light": "Světlý",
     "Light Mode": "Světlý režim",

--- a/resources/lang/da.json
+++ b/resources/lang/da.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Sidste genopbygning",
     "Layout": "Layout",
     "Learn more": "Lær mere",
-    "Learn more about": "Lær mere om :link",
+    "Learn more about :link": "Lær mere om :link",
     "Licensing": "Licensering",
     "Light": "Lys",
     "Light Mode": "Lys tilstand",

--- a/resources/lang/da.json
+++ b/resources/lang/da.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Sidste genopbygning",
     "Layout": "Layout",
     "Learn more": "Lær mere",
-    "Learn more about": "Lær mere om",
+    "Learn more about": "Lær mere om :link",
     "Licensing": "Licensering",
     "Light": "Lys",
     "Light Mode": "Lys tilstand",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -549,7 +549,7 @@
     "Latest Date": "Spätestes Datum",
     "Layout": "Layout",
     "Learn more": "Mehr erfahren",
-    "Learn more about": "Erfahre mehr über :link",
+    "Learn more about :link": "Erfahre mehr über :link",
     "Less than": "Kleiner als",
     "Less than or equals": "Kleiner oder gleich als",
     "Licensing": "Lizenzierung",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -549,7 +549,7 @@
     "Latest Date": "Spätestes Datum",
     "Layout": "Layout",
     "Learn more": "Mehr erfahren",
-    "Learn more about": "Erfahre mehr über",
+    "Learn more about": "Erfahre mehr über :link",
     "Less than": "Kleiner als",
     "Less than or equals": "Kleiner oder gleich als",
     "Licensing": "Lizenzierung",

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -549,7 +549,7 @@
     "Latest Date": "Spätestes Datum",
     "Layout": "Layout",
     "Learn more": "Mehr erfahren",
-    "Learn more about": "Erfahre mehr über :link",
+    "Learn more about :link": "Erfahre mehr über :link",
     "Less than": "Kleiner als",
     "Less than or equals": "Kleiner oder gleich als",
     "Licensing": "Lizenzierung",

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -549,7 +549,7 @@
     "Latest Date": "Spätestes Datum",
     "Layout": "Layout",
     "Learn more": "Mehr erfahren",
-    "Learn more about": "Erfahre mehr über",
+    "Learn more about": "Erfahre mehr über :link",
     "Less than": "Kleiner als",
     "Less than or equals": "Kleiner oder gleich als",
     "Licensing": "Lizenzierung",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Última reconstrucción",
     "Layout": "Layout",
     "Learn more": "Conoce más",
-    "Learn more about": "Conocer más acerca de",
+    "Learn more about": "Conocer más acerca de :link",
     "Licensing": "Licenciamiento",
     "Light": "Claro",
     "Light Mode": "Modo claro",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Última reconstrucción",
     "Layout": "Layout",
     "Learn more": "Conoce más",
-    "Learn more about": "Conocer más acerca de :link",
+    "Learn more about :link": "Conocer más acerca de :link",
     "Licensing": "Licenciamiento",
     "Light": "Claro",
     "Light Mode": "Modo claro",

--- a/resources/lang/fa.json
+++ b/resources/lang/fa.json
@@ -601,7 +601,7 @@
     "Latest Date": "آخرین تاریخ",
     "Layout": "طرح (Layout)",
     "Learn more": "بیشتر بدانید",
-    "Learn more about": "توضیحات بیشتر در مورد",
+    "Learn more about :link": "درمورد :link بیشتر بدانید",
     "LESS": "لس (LESS)",
     "Less Than": "کمتر باشد از",
     "Less than": "کمتر از",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -549,7 +549,7 @@
     "Latest Date": "Dernière date",
     "Layout": "Mise en page",
     "Learn more": "En savoir plus",
-    "Learn more about": "En savoir plus sur les :link",
+    "Learn more about :link": "En savoir plus sur les :link",
     "Less than": "Inférieur à",
     "Less than or equals": "Inférieur ou égal à",
     "Licensing": "Licence",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -549,7 +549,7 @@
     "Latest Date": "Dernière date",
     "Layout": "Mise en page",
     "Learn more": "En savoir plus",
-    "Learn more about": "En savoir plus sur les",
+    "Learn more about": "En savoir plus sur les :link",
     "Less than": "Inférieur à",
     "Less than or equals": "Inférieur ou égal à",
     "Licensing": "Licence",

--- a/resources/lang/hu.json
+++ b/resources/lang/hu.json
@@ -426,7 +426,7 @@
     "Last rebuild": "Utolsó újraépítés",
     "Layout": "Elrendezés",
     "Learn more": "Tudj meg többet",
-    "Learn more about": "Tudj meg többet: :link",
+    "Learn more about :link": "Tudj meg többet: :link",
     "Licensing": "Licenszelés",
     "Light": "Világos",
     "Light Mode": "Világos mód",

--- a/resources/lang/hu.json
+++ b/resources/lang/hu.json
@@ -426,7 +426,7 @@
     "Last rebuild": "Utolsó újraépítés",
     "Layout": "Elrendezés",
     "Learn more": "Tudj meg többet",
-    "Learn more about": "Tudj meg többet: ",
+    "Learn more about": "Tudj meg többet: :link",
     "Licensing": "Licenszelés",
     "Light": "Világos",
     "Light Mode": "Világos mód",

--- a/resources/lang/id.json
+++ b/resources/lang/id.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Terakhir dibangun kembali",
     "Layout": "Tata letak",
     "Learn more": "Pelajari lebih lanjut",
-    "Learn more about": "Pelajari lebih lanjut tentang",
+    "Learn more about": "Pelajari lebih lanjut tentang :link",
     "Licensing": "Perizinan",
     "Light": "Terang",
     "Light Mode": "Mode Terang",

--- a/resources/lang/id.json
+++ b/resources/lang/id.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Terakhir dibangun kembali",
     "Layout": "Tata letak",
     "Learn more": "Pelajari lebih lanjut",
-    "Learn more about": "Pelajari lebih lanjut tentang :link",
+    "Learn more about :link": "Pelajari lebih lanjut tentang :link",
     "Licensing": "Perizinan",
     "Light": "Terang",
     "Light Mode": "Mode Terang",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Ultimo rebuild",
     "Layout": "Layout",
     "Learn more": "Maggiori informazioni",
-    "Learn more about": "Maggiori informazioni su",
+    "Learn more about": "Maggiori informazioni su :link",
     "Licensing": "Licenza",
     "Light": "Chiaro",
     "Light Mode": "Modalità chiara",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Ultimo rebuild",
     "Layout": "Layout",
     "Learn more": "Maggiori informazioni",
-    "Learn more about": "Maggiori informazioni su :link",
+    "Learn more about :link": "Maggiori informazioni su :link",
     "Licensing": "Licenza",
     "Light": "Chiaro",
     "Light Mode": "Modalità chiara",

--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -539,7 +539,7 @@
     "Latest Date": "最新の日付",
     "Layout": "レイアウト",
     "Learn more": "もっと詳しく知る",
-    "Learn more about": "詳しくはこちら :link",
+    "Learn more about :link": "詳しくはこちら :link",
     "Less than": "未満",
     "Less than or equals": "以下",
     "Licensing": "ライセンス",

--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -539,7 +539,7 @@
     "Latest Date": "最新の日付",
     "Layout": "レイアウト",
     "Learn more": "もっと詳しく知る",
-    "Learn more about": "詳しくはこちら",
+    "Learn more about": "詳しくはこちら :link",
     "Less than": "未満",
     "Less than or equals": "以下",
     "Licensing": "ライセンス",

--- a/resources/lang/ms.json
+++ b/resources/lang/ms.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Terakhir bina semula",
     "Layout": "Susun Atur",
     "Learn more": "Ketahui lebih lanjut",
-    "Learn more about": "Ketahui lebih lanjut tentang :link",
+    "Learn more about :link": "Ketahui lebih lanjut tentang :link",
     "Licensing": "Pelesenan",
     "Light": "Terang",
     "Light Mode": "Mod Terang",

--- a/resources/lang/ms.json
+++ b/resources/lang/ms.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Terakhir bina semula",
     "Layout": "Susun Atur",
     "Learn more": "Ketahui lebih lanjut",
-    "Learn more about": "Ketahui lebih lanjut tentang",
+    "Learn more about": "Ketahui lebih lanjut tentang :link",
     "Licensing": "Pelesenan",
     "Light": "Terang",
     "Light Mode": "Mod Terang",

--- a/resources/lang/nb.json
+++ b/resources/lang/nb.json
@@ -547,7 +547,7 @@
     "Latest Date": "Siste dato",
     "Layout": "Layout",
     "Learn more": "Lær mer",
-    "Learn more about": "Lær mer om :link",
+    "Learn more about :link": "Lær mer om :link",
     "Less than": "Mindre enn",
     "Less than or equals": "Mindre enn eller lik",
     "Licensing": "Lisensiering",

--- a/resources/lang/nb.json
+++ b/resources/lang/nb.json
@@ -547,7 +547,7 @@
     "Latest Date": "Siste dato",
     "Layout": "Layout",
     "Learn more": "Lær mer",
-    "Learn more about": "Lær mer om",
+    "Learn more about": "Lær mer om :link",
     "Less than": "Mindre enn",
     "Less than or equals": "Mindre enn eller lik",
     "Licensing": "Lisensiering",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -544,7 +544,7 @@
     "Latest Date": "Laatste datum",
     "Layout": "Layout",
     "Learn more": "Meer informatie",
-    "Learn more about": "Meer informatie over :link",
+    "Learn more about :link": "Meer informatie over :link",
     "Less than": "Kleiner dan",
     "Less than or equals": "Kleiner dan of gelijk aan",
     "Licensing": "Licenties",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -544,7 +544,7 @@
     "Latest Date": "Laatste datum",
     "Layout": "Layout",
     "Learn more": "Meer informatie",
-    "Learn more about": "Meer informatie over",
+    "Learn more about": "Meer informatie over :link",
     "Less than": "Kleiner dan",
     "Less than or equals": "Kleiner dan of gelijk aan",
     "Licensing": "Licenties",

--- a/resources/lang/pl.json
+++ b/resources/lang/pl.json
@@ -445,7 +445,7 @@
     "Latest Date": "Ostatnia data",
     "Layout": "Układ",
     "Learn more": "Dowiedz się więcej",
-    "Learn more about": "Dowiedz się więcej o",
+    "Learn more about": "Dowiedz się więcej o :link",
     "Licensing": "Licencje",
     "Light": "Jasny",
     "Light Mode": "Tryb jasny",

--- a/resources/lang/pl.json
+++ b/resources/lang/pl.json
@@ -445,7 +445,7 @@
     "Latest Date": "Ostatnia data",
     "Layout": "Układ",
     "Learn more": "Dowiedz się więcej",
-    "Learn more about": "Dowiedz się więcej o :link",
+    "Learn more about :link": "Dowiedz się więcej o :link",
     "Licensing": "Licencje",
     "Light": "Jasny",
     "Light Mode": "Tryb jasny",

--- a/resources/lang/pt.json
+++ b/resources/lang/pt.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Última reconstrução",
     "Layout": "Layout",
     "Learn more": "Aprende mais",
-    "Learn more about": "Aprender mais sobre",
+    "Learn more about": "Aprender mais sobre :link",
     "Licensing": "Licenciamento",
     "Light": "Claro",
     "Light Mode": "Modo Claro",

--- a/resources/lang/pt.json
+++ b/resources/lang/pt.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Última reconstrução",
     "Layout": "Layout",
     "Learn more": "Aprende mais",
-    "Learn more about": "Aprender mais sobre :link",
+    "Learn more about :link": "Aprender mais sobre :link",
     "Licensing": "Licenciamento",
     "Light": "Claro",
     "Light Mode": "Modo Claro",

--- a/resources/lang/pt_BR.json
+++ b/resources/lang/pt_BR.json
@@ -461,7 +461,7 @@
     "Latest Date": "Última data",
     "Layout": "Layout",
     "Learn more": "Saiba mais",
-    "Learn more about": "Saiba mais sobre",
+    "Learn more about": "Saiba mais sobre :link",
     "Licensing": "Licenciamento",
     "Light": "Claro",
     "Light Mode": "Modo Claro",

--- a/resources/lang/pt_BR.json
+++ b/resources/lang/pt_BR.json
@@ -461,7 +461,7 @@
     "Latest Date": "Última data",
     "Layout": "Layout",
     "Learn more": "Saiba mais",
-    "Learn more about": "Saiba mais sobre :link",
+    "Learn more about :link": "Saiba mais sobre :link",
     "Licensing": "Licenciamento",
     "Light": "Claro",
     "Light Mode": "Modo Claro",

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -546,7 +546,7 @@
     "Latest Date": "Последняя дата",
     "Layout": "Макет",
     "Learn more": "Дополнительная информация",
-    "Learn more about": "Справка - ",
+    "Learn more about": "Справка - :link",
     "Less than": "Меньше чем",
     "Less than or equals": "Меньше или равно",
     "Licensing": "Лицензирование",

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -546,7 +546,7 @@
     "Latest Date": "Последняя дата",
     "Layout": "Макет",
     "Learn more": "Дополнительная информация",
-    "Learn more about": "Справка - :link",
+    "Learn more about :link": "Справка - :link",
     "Less than": "Меньше чем",
     "Less than or equals": "Меньше или равно",
     "Licensing": "Лицензирование",

--- a/resources/lang/sl.json
+++ b/resources/lang/sl.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Zadnja obnova",
     "Layout": "Postavitev",
     "Learn more": "Nauči se več",
-    "Learn more about": "Več o :link",
+    "Learn more about :link": "Več o :link",
     "Licensing": "Licenciranje",
     "Light": "Svetloba",
     "Light Mode": "Način svetlobe",

--- a/resources/lang/sl.json
+++ b/resources/lang/sl.json
@@ -412,7 +412,7 @@
     "Last rebuild": "Zadnja obnova",
     "Layout": "Postavitev",
     "Learn more": "Nauči se več",
-    "Learn more about": "Več o",
+    "Learn more about": "Več o :link",
     "Licensing": "Licenciranje",
     "Light": "Svetloba",
     "Light Mode": "Način svetlobe",

--- a/resources/lang/sv.json
+++ b/resources/lang/sv.json
@@ -447,7 +447,7 @@
     "Latest Date": "Senaste datum",
     "Layout": "Layout",
     "Learn more": "Läs mer",
-    "Learn more about": "Läs mer om :link",
+    "Learn more about :link": "Läs mer om :link",
     "Licensing": "Licensiering",
     "Light": "Ljus",
     "Light Mode": "Ljust läge",

--- a/resources/lang/sv.json
+++ b/resources/lang/sv.json
@@ -447,7 +447,7 @@
     "Latest Date": "Senaste datum",
     "Layout": "Layout",
     "Learn more": "Läs mer",
-    "Learn more about": "Läs mer om",
+    "Learn more about": "Läs mer om :link",
     "Licensing": "Licensiering",
     "Light": "Ljus",
     "Light Mode": "Ljust läge",

--- a/resources/lang/tr.json
+++ b/resources/lang/tr.json
@@ -507,7 +507,7 @@
     "Latest Date": "Son tarih",
     "Layout": "Düzen",
     "Learn more": "Daha fazla bilgi edin",
-    "Learn more about": "Hakkında daha fazla öğren",
+    "Learn more about :link": ":link hakkında daha fazla öğren",
     "Licensing": "Lisanslama",
     "Light": "Aydınlık",
     "Light Mode": "Aydınlık Modu",

--- a/resources/lang/uk.json
+++ b/resources/lang/uk.json
@@ -540,7 +540,7 @@
     "Latest Date": "Остання дата",
     "Layout": "Макет",
     "Learn more": "Дізнатися більше",
-    "Learn more about": "Дізнатися більше про :link",
+    "Learn more about :link": "Дізнатися більше про :link",
     "Less than": "Менше ніж",
     "Less than or equals": "Менше або дорівнює",
     "Licensing": "Ліцензування",

--- a/resources/lang/uk.json
+++ b/resources/lang/uk.json
@@ -540,7 +540,7 @@
     "Latest Date": "Остання дата",
     "Layout": "Макет",
     "Learn more": "Дізнатися більше",
-    "Learn more about": "Дізнатися більше про",
+    "Learn more about": "Дізнатися більше про :link",
     "Less than": "Менше ніж",
     "Less than or equals": "Менше або дорівнює",
     "Licensing": "Ліцензування",

--- a/resources/lang/zh_CN.json
+++ b/resources/lang/zh_CN.json
@@ -457,7 +457,7 @@
     "Latest Date": "最新日期",
     "Layout": "布局",
     "Learn more": "了解更多",
-    "Learn more about": "了解更多关于 :link",
+    "Learn more about :link": "了解更多关于 :link",
     "Licensing": "许可",
     "Light": "浅色",
     "Light Mode": "浅色模式",

--- a/resources/lang/zh_CN.json
+++ b/resources/lang/zh_CN.json
@@ -457,7 +457,7 @@
     "Latest Date": "最新日期",
     "Layout": "布局",
     "Learn more": "了解更多",
-    "Learn more about": "了解更多关于",
+    "Learn more about": "了解更多关于 :link",
     "Licensing": "许可",
     "Light": "浅色",
     "Light Mode": "浅色模式",

--- a/resources/lang/zh_TW.json
+++ b/resources/lang/zh_TW.json
@@ -457,7 +457,7 @@
     "Latest Date": "最後修改",
     "Layout": "畫面配置",
     "Learn more": "瞭解更多",
-    "Learn more about": "瞭解更多有關 :link",
+    "Learn more about :link": "瞭解更多有關 :link",
     "Licensing": "授權",
     "Light": "淺色",
     "Light Mode": "淺色模式",

--- a/resources/lang/zh_TW.json
+++ b/resources/lang/zh_TW.json
@@ -457,7 +457,7 @@
     "Latest Date": "最後修改",
     "Layout": "畫面配置",
     "Learn more": "瞭解更多",
-    "Learn more about": "瞭解更多有關",
+    "Learn more about": "瞭解更多有關 :link",
     "Licensing": "授權",
     "Light": "淺色",
     "Light Mode": "淺色模式",

--- a/resources/views/partials/docs-callout.blade.php
+++ b/resources/views/partials/docs-callout.blade.php
@@ -2,6 +2,6 @@
 
 @if (config('statamic.cp.link_to_docs'))
     <div class="flex justify-center text-center mt-16">
-        <div class="bg-white dark:bg-dark-900 rounded-full px-6 py-2 shadow-sm text-sm text-gray-700 dark:text-dark-100">{{ $text ?? __('Learn more about') }} <a href="{{ $url }}" target="_blank" rel="noopener noopener" class="text-blue hover:text-blue-700">{{ $topic }}</a></div>
+        <div class="bg-white dark:bg-dark-900 rounded-full px-6 py-2 shadow-sm text-sm text-gray-700 dark:text-dark-100">{!! $text ?? __('Learn more about :link', ['link' => '<a href="'.$url.'" target="_blank" rel="noopener noopener" class="text-blue hover:text-blue-700">'.$topic.'</a>']) !!}</div>
     </div>
 @endif


### PR DESCRIPTION
Turkish typically follows a subject-object-verb (SOV) order for verb phrases, similar to languages like Persian, Japanese, and Korean. However, unlike these other languages, where the phrase can often be rewritten to place the object at the end, Turkish does not allow for such restructuring.
I've rewritten this term for Persian and Turkish, but I placed the link at the end of the terms in other languages.