### PR TITLE
[5.x] Fixes reducedVar must be array, null given error

### DIFF
--- a/src/View/Antlers/Language/Runtime/PathDataManager.php
+++ b/src/View/Antlers/Language/Runtime/PathDataManager.php
@@ -699,7 +699,7 @@ class PathDataManager
                     intval($pathItem->originalContent) == $pathItem->originalContent) {
                     $numericIndex = intval($pathItem->originalContent);
 
-                    if (array_key_exists($numericIndex, $this->reducedVar)) {
+                    if (is_array($this->reducedVar) && array_key_exists($numericIndex, $this->reducedVar)) {
                         $this->reducedVar = $this->reducedVar[$numericIndex];
                     } else {
                         $this->reducedVar = null;


### PR DESCRIPTION
This PR aims to fix the following error:
`array_key_exists(): Argument #2 ($array) must be of type array, null given`

`$this->reducedVar` is set to null on line 537 before the `$pathParts` loop. If `pathItem` is an instance of `VariableReference`, then the value of `reducedVar` never gets updated and so on line 702 it results in the error above.

This PR adds a simple check to ensure `reducedVar` is an array alongside the `array_key_exists()` check.

Unable to provide steps to reproduce, as this was a one time issue after adding a new entry to a collection.