### PR TITLE
[5.x] Fix button group and radio previews

### DIFF
--- a/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
@@ -45,7 +45,7 @@ export default {
         replicatorPreview() {
             if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
 
-            var option = _.findWhere(this.config.options, {value: this.value});
+            var option = _.findWhere(this.options, {value: this.value});
             return (option) ? option.label : this.value;
         },
     },

--- a/resources/js/components/fieldtypes/RadioFieldtype.vue
+++ b/resources/js/components/fieldtypes/RadioFieldtype.vue
@@ -34,7 +34,7 @@ export default {
         replicatorPreview() {
             if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
 
-            var option = _.findWhere(this.config.options, {value: this.value});
+            var option = _.findWhere(this.options, {value: this.value});
             return (option) ? option.label : this.value;
         },
     },


### PR DESCRIPTION
This PR fixes button group and radio replicator previews, they only show the keys not the display values currently:

![Screenshot 2024-07-24 at 13 01 30](https://github.com/user-attachments/assets/cb40cab2-1403-430a-b446-eeb05025f10a)

After:

![Screenshot 2024-07-24 at 13 02 41](https://github.com/user-attachments/assets/7333a7f4-bf89-4649-837a-1c8fc45cbe80)

(Middle one is select which works correctly)