### PR TITLE
[5.x] Prevent using `type` as a handle for fields in sets

### DIFF
--- a/resources/js/components/blueprints/Fields.vue
+++ b/resources/js/components/blueprints/Fields.vue
@@ -59,6 +59,7 @@
                 :fields="fields"
                 :config="pendingCreatedField.config"
                 :suggestable-condition-fields="suggestableConditionFields"
+                :is-inside-set="isInsideSet"
                 @committed="fieldCreated"
                 @closed="close"
             />
@@ -96,6 +97,10 @@ export default {
         editingField: {},
         suggestableConditionFields: Array,
         excludeFieldset: String,
+    },
+
+    inject: {
+        isInsideSet: { default: false },
     },
 
     data() {

--- a/resources/js/components/blueprints/RegularField.vue
+++ b/resources/js/components/blueprints/RegularField.vue
@@ -40,6 +40,7 @@
                             :config="fieldConfig"
                             :overrides="field.config_overrides || []"
                             :suggestable-condition-fields="suggestableConditionFields"
+                            :is-inside-set="isInsideSet"
                             @committed="settingsUpdated"
                             @closed="editorClosed"
                         />
@@ -69,6 +70,10 @@ export default {
     props: [
         'suggestableConditionFields'
     ],
+
+    inject: {
+        isInsideSet: { default: false },
+    },
 
      data() {
         return {

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -118,6 +118,7 @@ export default {
         root: Boolean,
         fields: Array,
         suggestableConditionFields: Array,
+        isInsideSet: Boolean,
     },
 
     provide: {
@@ -245,7 +246,8 @@ export default {
                 id: this.id,
                 type: this.type,
                 values: this.values,
-                fields: this.fields
+                fields: this.fields,
+                isInsideSet: this.isInsideSet,
             }).then(response => {
                 this.$emit('committed', response.data, this.editedFields);
                 this.close();

--- a/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/replicator/SetsFieldtype.vue
@@ -39,6 +39,10 @@ export default {
         }
     },
 
+    provide: {
+        isInsideSet: true,
+    },
+
     methods: {
 
         tabsUpdated(tabs) {

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -54,6 +54,7 @@ class FieldsController extends CpController
             'type' => 'required',
             'values' => 'required|array',
             'fields' => 'sometimes|array',
+            'isInsideSet' => 'sometimes|boolean',
         ]);
 
         $fieldtype = FieldtypeRepository::find($request->type);
@@ -94,6 +95,10 @@ class FieldsController extends CpController
 
         if (Str::contains($referer, 'forms/') && Str::contains($referer, '/blueprint') && $request->values['handle'] === 'date') {
             $extraRules['handle'][] = 'not_in:date';
+        }
+
+        if ($request->isInsideSet) {
+            $extraRules['handle'][] = 'not_in:type';
         }
 
         if ($request->type === 'date' && $request->values['handle'] === 'date') {


### PR DESCRIPTION
This pull request prevents `type` from being used as a handle for fields in Replicator sets. 

In Replicators, the `type` key is reserved for determining which set an item is using, so it shouldn't be possible for sets to have fields with the same name.

In order for the validation rule to only kick in when used inside a set, I'm passing a new `isInsideSet` prop to the `field-settings` component, which then gets passed to the backend when the field gets validated.

This PR doesn't cover the situation where fields are imported from a fieldset, since we don't do any validation when linking fieldsets. 

Closes #5087.