### PR TITLE
[5.x] Add frontMatter method to docblock for Parse facade

### DIFF
--- a/src/Facades/Parse.php
+++ b/src/Facades/Parse.php
@@ -9,6 +9,7 @@ use Statamic\View\Antlers\AntlersString;
  * @method static AntlersString template($str, $variables = [], $context = [], $php = false)
  * @method static string templateLoop($content, $data, $supplement = true, $context = [], $php = false)
  * @method static array YAML($str)
+ * @method static array frontMatter($string)
  * @method static mixed env($val)
  *
  * @see \Statamic\Facades\Endpoint\Parse


### PR DESCRIPTION
The `frontMatter()` method is not hinted by LSP when using the Parse facade; this PR fixes that by adding it to the docblock.

Method lives here:  https://github.com/statamic/cms/blob/5.x/src/Facades/Endpoint/Parse.php#L60-L72