### PR TITLE
[5.x] Prevent error when redirecting to first asset container

### DIFF
--- a/src/Http/Controllers/CP/Assets/RedirectsToFirstAssetContainer.php
+++ b/src/Http/Controllers/CP/Assets/RedirectsToFirstAssetContainer.php
@@ -13,7 +13,7 @@ trait RedirectsToFirstAssetContainer
     {
         $firstContainerInNav = Nav::build()->pluck('items')->flatten()
             ->filter(fn (NavItem $navItem) => $navItem->url() === cp_route('assets.index'))
-            ->map(fn (NavItem $navItem) => $navItem->children()?->first())
+            ->map(fn (NavItem $navItem) => $navItem->resolveChildren()->children()?->first())
             ->first();
 
         if ($firstContainerInNav) {


### PR DESCRIPTION
This pull request prevents a `Call to undefined method Closure::first()` error from happening when redirecting to the first asset container.

Sometimes, due to how the CP Nav gets cached, a nav item's `children` property may be a closure. In our case, we can simply call `->resolveChildren()` to ensure a nav item's children are "resolved" before we get them.

Fixes #10520.