### PR TITLE
[5.x] Replace percentages in filenames

### DIFF
--- a/src/Assets/AssetUploader.php
+++ b/src/Assets/AssetUploader.php
@@ -89,6 +89,7 @@ class AssetUploader extends Uploader
             '|' => '-',
             '?' => '-',
             '*' => '-',
+            '%' => '-',
         ];
 
         $str = Stringy::create(urldecode($string))->toAscii();

--- a/tests/Assets/AssetUploaderTest.php
+++ b/tests/Assets/AssetUploaderTest.php
@@ -30,6 +30,7 @@ class AssetUploaderTest extends TestCase
             'pipes' => ['one|two.jpg', 'one-two.jpg'],
             'question marks' => ['one?two.jpg', 'one-two.jpg'],
             'asterisks' => ['one*two.jpg', 'one-two.jpg'],
+            'percentage' => ['one%two.jpg', 'one-two.jpg'],
         ];
     }
 }


### PR DESCRIPTION
In rare cases where users upload assets with percentages in their filenames, Glide assets currently return 400 errors. 