### PR TITLE
[5.x] Avoid extending already-extended file cache store

### DIFF
--- a/src/Providers/CacheServiceProvider.php
+++ b/src/Providers/CacheServiceProvider.php
@@ -46,6 +46,12 @@ class CacheServiceProvider extends ServiceProvider
                 ), $this->app['config']['cache.stores.file']);
             });
 
+            // Don't extend the file store if it's already being extended.
+            $creators = (fn () => $this->customCreators)->call(Cache::getFacadeRoot());
+            if (isset($creators['file'])) {
+                return;
+            }
+
             Cache::extend('file', function ($app, $config) {
                 return Cache::repository(
                     (new FileStore($app['files'], $config['path'], $config['permission'] ?? null))


### PR DESCRIPTION
Statamic customizes the file cache store. In #10362 we reworked how this is wired up. This caused a problem when you are using a custom file cache store - our one would override it.

This PR makes it so that we only extend with ours if there's not already an extension.

Fixes the issue explained in [this comment](https://github.com/statamic/cms/pull/10362#issuecomment-2245589356).
