### PR TITLE
[5.x] Add where_in modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2897,7 +2897,7 @@ class CoreModifiers extends Modifier
     }
 
     /**
-     * Filters the data by a given key / value pair.
+     * Filters the data by a given key that matches an array of values.
      *
      * @param  array  $value
      * @param  array  $params

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2897,6 +2897,23 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Filters the data by a given key / value pair.
+     *
+     * @param  array  $value
+     * @param  array  $params
+     * @return array
+     */
+    public function whereIn($value, $params)
+    {
+        $key = Arr::get($params, 0);
+        $arr = Arr::get($params, 1);
+
+        $collection = collect($value)->whereIn($key, $arr);
+
+        return $collection->values()->all();
+    }
+
+    /**
      * Attempts to prevent widows in a string by adding
      * <nobr> tags between the last two words of each paragraph.
      *

--- a/tests/Antlers/Runtime/CoreModifiersTest.php
+++ b/tests/Antlers/Runtime/CoreModifiersTest.php
@@ -238,27 +238,6 @@ EOT;
         $this->assertSame('DominionNetrunner', $this->resultOf($template));
     }
 
-    public function test_where_in()
-    {
-        $template = <<<'EOT'
-{{ complex | where_in("last_name", ["Zebra", "Bravo"]) }}{{ first_name }}{{ /complex }}
-EOT;
-
-        $this->assertSame('ZealousBlathering', $this->resultOf($template));
-
-        $template = <<<'EOT'
-{{ complex where_in="{"last_name"}|{["Zebra", "Bravo"]}" }}{{ first_name }}{{ /complex }}
-EOT;
-
-        $this->assertSame('ZealousBlathering', $this->resultOf($template));
-
-        $template = <<<'EOT'
-{{ complex | where_in("last_name", "Zebra") }}{{ first_name }}{{ /complex }}
-EOT;
-
-        $this->assertSame('Zealous', $this->resultOf($template));
-    }
-
     public function test_unique()
     {
         $this->assertSame('zebra, hippo, hyena, giraffe', $this->resultOf('{{ checklist | unique | list }}'));

--- a/tests/Antlers/Runtime/CoreModifiersTest.php
+++ b/tests/Antlers/Runtime/CoreModifiersTest.php
@@ -238,6 +238,27 @@ EOT;
         $this->assertSame('DominionNetrunner', $this->resultOf($template));
     }
 
+    public function test_where_in()
+    {
+        $template = <<<'EOT'
+{{ complex | where_in("last_name", ["Zebra", "Bravo"]) }}{{ first_name }}{{ /complex }}
+EOT;
+
+        $this->assertSame('ZealousBlathering', $this->resultOf($template));
+
+        $template = <<<'EOT'
+{{ complex where_in="{"last_name"}|{["Zebra", "Bravo"]}" }}{{ first_name }}{{ /complex }}
+EOT;
+
+        $this->assertSame('ZealousBlathering', $this->resultOf($template));
+
+        $template = <<<'EOT'
+{{ complex | where_in("last_name", "Zebra") }}{{ first_name }}{{ /complex }}
+EOT;
+
+        $this->assertSame('Zealous', $this->resultOf($template));
+    }
+
     public function test_unique()
     {
         $this->assertSame('zebra, hippo, hyena, giraffe', $this->resultOf('{{ checklist | unique | list }}'));

--- a/tests/Modifiers/WhereInTest.php
+++ b/tests/Modifiers/WhereInTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Modifiers;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Modifiers\Modify;
+use Statamic\Support\Arr;
+use Tests\TestCase;
+
+#[Group('array')]
+class WhereInTest extends TestCase
+{
+    #[Test]
+    public function it_filters_data_by_key_and_multiple_values(): void
+    {
+        $collection = [
+            ['product' => 'Desk', 'price' => 200],
+            ['product' => 'Chair', 'price' => 100],
+            ['product' => 'Bookcase', 'price' => 150],
+            ['product' => 'Door', 'price' => 100],
+        ];
+        $modified = $this->modify($collection, ['price', [150, 200]]);
+        $this->assertEquals(['Desk', 'Bookcase'], Arr::pluck($modified, 'product'));
+    }
+
+    #[Test]
+    public function it_filters_data_by_key_and_single_value(): void
+    {
+        $collection = [
+            ['product' => 'Desk', 'price' => 200],
+            ['product' => 'Chair', 'price' => 100],
+            ['product' => 'Bookcase', 'price' => 150],
+            ['product' => 'Door', 'price' => 100],
+        ];
+        $modified = $this->modify($collection, ['price', 100]);
+        $this->assertEquals(['Chair', 'Door'], Arr::pluck($modified, 'product'));
+    }
+
+    private function modify($value, array $params)
+    {
+        return Modify::value($value)->whereIn($params)->fetch();
+    }
+}


### PR DESCRIPTION
This PR adds a ``where_in`` modifier that can come in handy in various situations where you want to check a value against an array.

```yaml
games:
  -
    feeling: love
    title: Dominion
  -
    feeling: happy
    title: Netrunner
  -
    feeling: hate
    title: Chutes and Ladders
```

```
<h2>I love...</h2>
{{ games | where_in('feeling', ['love', 'happy']) }}
  {{ title }}<br>
{{ /games }}
```

```html
Dominion
Netrunner
```

- [x] Add docs for the where_in modifier: statamic/docs#1423