### PR TITLE
[5.x] Fix error when changing dictionary type

### DIFF
--- a/resources/js/components/fieldtypes/DictionaryFields.vue
+++ b/resources/js/components/fieldtypes/DictionaryFields.vue
@@ -71,10 +71,10 @@ export default {
     },
 
     watch: {
-        dictionary() {
+        dictionary(dictionary) {
             this.update({
                 type: dictionary,
-                ...this.meta.dictionaries[this.dictionary]?.defaults
+                ...this.meta.dictionaries[dictionary]?.defaults
             })
         },
     },


### PR DESCRIPTION
This fixes an error when configuring a dictionary field. When you change the type to countries, the region subfield would be empty because there's a JS error.
