### PR TITLE
[5.x] Use form submission query count instead of collection count

### DIFF
--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -33,7 +33,7 @@ class FormsController extends CpController
                 return [
                     'id' => $form->handle(),
                     'title' => __($form->title()),
-                    'submissions' => $form->submissions()->count(),
+                    'submissions' => $form->querySubmissions()->count(),
                     'show_url' => $form->showUrl(),
                     'edit_url' => $form->editUrl(),
                     'blueprint_url' => cp_route('forms.blueprint.edit', $form->handle()),


### PR DESCRIPTION
Hello everyone!

We stumbled upon a bug on `/admin/forms`. We would get endless loading screens and eventually timeouts when visiting this page. We have quiet an amount of form submissions (~150.000), and the controller in the current setup retrieves all submissions, loads them in memory, to then return a count.

We're using Statamic 5 with the `statamic/eloquent-driver` implementation, and in that package it would retrieve the model for the submission, and then the model for the form. But it would do that for every submission. First we changed something there, but then realized a simple fix for this would be in the `FormsController` instead.

If you have any questions or comments about this, let me know!