### PR TITLE
[5.x] Fix confirmation modal submitted twice when pressing enter

### DIFF
--- a/resources/js/components/modals/ConfirmationModal.vue
+++ b/resources/js/components/modals/ConfirmationModal.vue
@@ -68,7 +68,11 @@ export default {
         dismiss() {
             this.$emit('cancel')
         },
-        submit() {
+        submit(e) {
+            if (e?.target?.nodeName === 'BUTTON') {
+                return;
+            }
+
             this.$emit('confirm')
         }
     },


### PR DESCRIPTION
If you use tab in the confirmation modal to navigate to the cancel or submit button, pressing enter would either fire the confirm event twice on the confirm button or fire one cancel and one confirm event on the cancel button. If you'd tab to the cancel button and press enter the modal would still be submitted because of the enter listener, which triggers the click listener on the buttons. This commit disables the global enter-key listener on any button in the confirmation modal to prevent double event firing.