### PR TITLE
[5.x] Add algolia prefix option

### DIFF
--- a/config/search.php
+++ b/config/search.php
@@ -61,6 +61,8 @@ return [
                 'id' => env('ALGOLIA_APP_ID', ''),
                 'secret' => env('ALGOLIA_SECRET', ''),
             ],
+
+            'prefix' => env('ALGOLIA_PREFIX', ''),
         ],
 
     ],

--- a/src/Search/IndexManager.php
+++ b/src/Search/IndexManager.php
@@ -119,6 +119,8 @@ class IndexManager extends Manager
 
         $client = SearchClient::create($credentials['id'], $credentials['secret']);
 
+        $name = config('statamic.search.drivers.algolia.prefix').$name;
+
         return new AlgoliaIndex($client, $name, $config, $locale);
     }
 

--- a/tests/Search/AlgoliaQueryTest.php
+++ b/tests/Search/AlgoliaQueryTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Search\Algolia\Index;
 use Statamic\Search\Algolia\Query;
 use Tests\TestCase;
+use Illuminate\Support\Facades\Config;
 
 class AlgoliaQueryTest extends TestCase
 {
@@ -14,6 +15,28 @@ class AlgoliaQueryTest extends TestCase
     public function it_adds_scores()
     {
         $index = Mockery::mock(Index::class);
+        $index->shouldReceive('searchUsingApi')->with('foo')->once()->andReturn(collect([
+            ['reference' => 'a'],
+            ['reference' => 'b'],
+            ['reference' => 'c'],
+        ]));
+
+        $query = new Query($index);
+
+        $this->assertEquals([
+            ['reference' => 'a', 'search_score' => 3],
+            ['reference' => 'b', 'search_score' => 2],
+            ['reference' => 'c', 'search_score' => 1],
+        ], $query->getSearchResults('foo')->all());
+    }
+
+    #[Test]
+    public function it_can_get_results_after_adding_prefix()
+    {
+        $index = Mockery::mock(Index::class);
+
+        Config::set('statamic.search.drivers.algolia.prefix', 'env_');
+
         $index->shouldReceive('searchUsingApi')->with('foo')->once()->andReturn(collect([
             ['reference' => 'a'],
             ['reference' => 'b'],

--- a/tests/Search/AlgoliaQueryTest.php
+++ b/tests/Search/AlgoliaQueryTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Search;
 
+use Illuminate\Support\Facades\Config;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Search\Algolia\Index;
 use Statamic\Search\Algolia\Query;
 use Tests\TestCase;
-use Illuminate\Support\Facades\Config;
 
 class AlgoliaQueryTest extends TestCase
 {


### PR DESCRIPTION
In Algolia it is common to have one "Application" with different indexes for different environments. These indexes can be prefixed, like 
* "local_pages", "production_pages", "staging_pages"
* "local_products", "production_products", "staging_products"

and so on.

Laravel scout has an easy solution for this by adding a "prefix" option in the scout config file.

My PR adds a similar solution by having an option in the Statamic `search` config file in the `drivers.algolia` array.

Closes statamic/ideas#1202