### PR TITLE
[5.x] Prevent parentheses and currencies in js slug

### DIFF
--- a/resources/js/components/slugs/Slug.js
+++ b/resources/js/components/slugs/Slug.js
@@ -54,19 +54,36 @@ export default class Slug {
     }
 
     #createSynchronously() {
-        const custom = Statamic.$config.get(`charmap.${this.#language}`) ?? {};
+        const symbols = Statamic.$config.get('asciiReplaceExtraSymbols');
+        const charmap = Statamic.$config.get('charmap');
+        let custom = charmap[this.#language] ?? {};
         custom["'"] = ""; // Remove apostrophes in all languages
         custom["’"] = ""; // Remove smart single quotes
         custom[" - "] = " "; // Prevent `Block - Hero` turning into `block_-_hero`
         custom['('] = ''; // Remove parentheses
         custom[')'] = ''; // Remove parentheses
+        custom = symbols
+            ? this.#replaceCurrencySymbols(custom, charmap)
+            : this.#removeCurrencySymbols(custom, charmap);
 
         return speakingUrl(this.#string, {
             separator: this.#separator,
             lang: this.#language,
             custom,
-            symbols: Statamic.$config.get('asciiReplaceExtraSymbols')
+            symbols
         });
+    }
+
+    #replaceCurrencySymbols(custom, charmap) {
+        return { ...custom, ...charmap.currency };
+    }
+
+    #removeCurrencySymbols(custom, charmap) {
+        for (const key in charmap.currency_short) {
+            custom[key] = '';
+        }
+
+        return custom;
     }
 
     #createAsynchronously() {

--- a/resources/js/components/slugs/Slug.js
+++ b/resources/js/components/slugs/Slug.js
@@ -58,6 +58,8 @@ export default class Slug {
         custom["'"] = ""; // Remove apostrophes in all languages
         custom["’"] = ""; // Remove smart single quotes
         custom[" - "] = " "; // Prevent `Block - Hero` turning into `block_-_hero`
+        custom['('] = ''; // Remove parentheses
+        custom[')'] = ''; // Remove parentheses
 
         return speakingUrl(this.#string, {
             separator: this.#separator,


### PR DESCRIPTION
Part of #10533

- Parenthesis are removed
- When `statamic.system.ascii_replace_extra_symbols` is ...
  - `true`, currencies will be converted to the word. (e.g. `$` to `dollar`)
  - `false`, currencies will be removed (e.g. `$` to nothing) 

These match how it works in PHP.