### PR TITLE
[5.x] Fix the Video fieldtype with Vimeo file URLs

### DIFF
--- a/resources/js/components/fieldtypes/VideoFieldtype.vue
+++ b/resources/js/components/fieldtypes/VideoFieldtype.vue
@@ -73,7 +73,8 @@ export default {
 
             if (embed_url.includes('vimeo')) {
                 embed_url = embed_url.replace('/vimeo.com', '/player.vimeo.com/video');
-                if (embed_url.split('/').length > 5) {
+
+                if (! this.data.includes('progressive_redirect') && embed_url.split('/').length > 5) {
                     let hash = embed_url.substr(embed_url.lastIndexOf('/') + 1);
                     embed_url = embed_url.substr(0, embed_url.lastIndexOf('/')) + '?h=' + hash.replace('?', '&');
                 }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -3196,7 +3196,8 @@ class CoreModifiers extends Modifier
     private function handleUnlistedVimeoUrls($url)
     {
         $hash = '';
-        if (Str::substrCount($url, '/') > 4) {
+
+        if (! Str::contains($url, 'progressive_redirect') && Str::substrCount($url, '/') > 4) {
             $hash = Str::afterLast($url, '/');
             $url = Str::beforeLast($url, '/');
 

--- a/tests/Modifiers/EmbedUrlTest.php
+++ b/tests/Modifiers/EmbedUrlTest.php
@@ -43,6 +43,20 @@ class EmbedUrlTest extends TestCase
     }
 
     #[Test]
+    public function it_transforms_vimeo_file_links()
+    {
+        $embedUrl = 'https://player.vimeo.com/progressive_redirect/playback/990169258/rendition/1080p/file.mp4?dnt=1&loc=external&log_user=0&signature=275be15f3630d1ca3e7a51456a911e11e3ba9fddf89911f49140f6de95357e05';
+
+        $this->assertEquals($embedUrl, $this->embed('https://player.vimeo.com/progressive_redirect/playback/990169258/rendition/1080p/file.mp4?loc=external&log_user=0&signature=275be15f3630d1ca3e7a51456a911e11e3ba9fddf89911f49140f6de95357e05'));
+
+        $this->assertEquals(
+            $embedUrl.'&foo=bar',
+            $this->embed('https://player.vimeo.com/progressive_redirect/playback/990169258/rendition/1080p/file.mp4?loc=external&log_user=0&signature=275be15f3630d1ca3e7a51456a911e11e3ba9fddf89911f49140f6de95357e05&foo=bar'),
+            'It appends the do not track query param if a query string already exists.'
+        );
+    }
+
+    #[Test]
     public function it_transforms_youtube_urls()
     {
         $embedUrl = 'https://www.youtube-nocookie.com/embed/s72r_wu_NVY';


### PR DESCRIPTION
This pull request fixes an issue with the Video fieldtype, where Vimeo "file URLs" were being parsed as if they were unlisted videos.

**Examples:**

* Unlisted / private video URL: `https://vimeo.com/735352648/fa55a4d0fc`
* File URLs: `https://player.vimeo.com/progressive_redirect/playback/990169258/rendition/1080p/file.mp4?loc=external&log_user=0&signature=275be15f3630d1ca3e7a51456a911e11e3ba9fddf89911f49140f6de95357e05`

Fixes #10508.