### PR TITLE
[5.x] Asset tag: Fail silently when no URL has been provided

### DIFF
--- a/src/Tags/Asset.php
+++ b/src/Tags/Asset.php
@@ -41,6 +41,10 @@ class Asset extends Assets
             return $this->context->value('asset');
         }
 
-        return AssetAPI::find($this->params->get(['url', 'src']));
+        if (! $asset = $this->params->get(['url', 'src'])) {
+            return null;
+        }
+
+        return AssetAPI::find($asset);
     }
 }


### PR DESCRIPTION
This pull request fixes an issue with the `{{ asset }}` tag where the `AssetAPI::find()` call would throw an exception if the value passed to it was `null`.

Instead of an exception being thrown in this case, the tag will simply fail silently and not return anything.

Fixes #10532.