### PR TITLE
[5.x] Add duplicate stacked row option to Grid fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/grid/Stacked.vue
+++ b/resources/js/components/fieldtypes/grid/Stacked.vue
@@ -39,6 +39,7 @@
                 :can-delete="canDeleteRows"
                 :can-add-rows="canAddRows"
                 @updated="(row, value) => $emit('updated', row, value)"
+                @duplicate="(row) => $emit('duplicate', row)"
                 @meta-updated="$emit('meta-updated', row._id, $event)"
                 @removed="(row) => $emit('removed', row)"
                 @focus="$emit('focus')"

--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -8,6 +8,9 @@
         <div class="replicator-set-header">
             <div class="item-move cursor-grab sortable-handle" :class="{ [sortableHandleClass]: grid.isReorderable }" />
             <div class="py-2 rtl:pr-2 ltr:pl-2 replicator-set-header-inner flex justify-end items-end w-full">
+                <button v-if="canAddRows" class="flex self-end group items-center rtl:ml-2 ltr:mr-2" @click="$emit('duplicate', index)" :aria-label="__('Duplicate Row')">
+                    <svg-icon name="light/duplicate" class="w-4 h-4 text-gray-600 group-hover:text-gray-900" />
+                </button>
                 <button v-if="canDelete" class="flex self-end group items-center" @click="$emit('removed', index)" :aria-label="__('Delete Row')">
                     <svg-icon name="micro/trash" class="w-4 h-4 text-gray-600 group-hover:text-gray-900" />
                 </button>


### PR DESCRIPTION
This PR adds a duplicate icon for the Stacked UI-Style of the Grid Fieldtype to be in line with the Duplicate option available in the Table UI-Style.

It also implement the canAddRows check to disable the button if the maximum number of entries is reached.

<img width="842" alt="Capture d’écran 2024-08-02 à 11 46 04" src="https://github.com/user-attachments/assets/d75159ec-da15-4995-95c6-9804b4c3e60f">
