### PR TITLE
[5.x] Fix NullLockStore (disabling of Stache locking)

### DIFF
--- a/src/Stache/NullLockStore.php
+++ b/src/Stache/NullLockStore.php
@@ -7,27 +7,27 @@ use Symfony\Component\Lock\Key;
 
 class NullLockStore implements BlockingStoreInterface
 {
-    public function save(Key $key)
+    public function save(Key $key): void
     {
         //
     }
 
-    public function delete(Key $key)
+    public function delete(Key $key): void
     {
         //
     }
 
-    public function exists(Key $key)
+    public function exists(Key $key): bool
+    {
+        return false;
+    }
+
+    public function putOffExpiration(Key $key, float $ttl): void
     {
         //
     }
 
-    public function putOffExpiration(Key $key, float $ttl)
-    {
-        //
-    }
-
-    public function waitAndSave(Key $key)
+    public function waitAndSave(Key $key): void
     {
         //
     }


### PR DESCRIPTION
If `statamic.stache.lock.enabled` is `false` PHP bails with:

`Got error 'PHP message: PHP Fatal error:  Declaration of Statamic\\Stache\\NullLockStore::exists(Symfony\\Component\\Lock\\Key $key) must be compatible with Symfony\\Component\\Lock\\PersistingStoreInterface::exists(Symfony\\Component\\Lock\\Key $key): bool in /vendor/statamic/cms/src/Stache/NullLockStore.php on line 20'`

This patch fixes up the `NullLockStore` method signatures to match interfaces.