### PR TITLE
[5.x] Clean up duplicate tailwind classes

### DIFF
--- a/resources/css/elements/buttons.css
+++ b/resources/css/elements/buttons.css
@@ -112,7 +112,7 @@ button {
 
 /*  Earth isn't flat but these buttons are */
 .btn-flat {
-    @apply text-white text-gray-800 dark:text-dark-150 bg-gray-300 dark:bg-dark-700 flex items-center;
+    @apply text-gray-800 dark:text-dark-150 bg-gray-300 dark:bg-dark-700 flex items-center;
     position: inherit;
 
     &:hover:not(:disabled), &:active:not(:disabled), &.active {

--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -109,7 +109,7 @@
 
         <template v-if="!initializing && canUseTree && view === 'tree'">
             <div class="flex flex-col h-full">
-                <div class="bg-white bg-gray-200 dark:bg-dark-550 shadow px-4 py-2 z-1 h-13 flex items-center justify-end">
+                <div class="bg-white dark:bg-dark-550 shadow px-4 py-2 z-1 h-13 flex items-center justify-end">
                     <h1 class="flex-1 flex items-center text-xl">{{ tree.title }}</h1>
                     <div class="btn-group rtl:mr-4 ltr:ml-4">
                         <button class="btn flex items-center px-4" @click="view = 'tree'" :class="{'active': view === 'tree'}" v-tooltip="__('Tree')">

--- a/resources/views/auth/protect/password.antlers.html
+++ b/resources/views/auth/protect/password.antlers.html
@@ -35,7 +35,7 @@
 
             {{ get_errors:all bag="passwordProtect" }}
                 {{ messages }}
-                    <div class="mt-6 text-sm text-red-500-600">{{ message }}</div>
+                    <div class="mt-6 text-sm text-red-500">{{ message }}</div>
                 {{ /messages }}
             {{ /get_errors:all }}
 


### PR DESCRIPTION
I stumbled across a couple of duplicate or incorrect Tailwind CSS utility classes. This pull request cleans them up.