### PR TITLE
[5.x] Add placeholder option to integer fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/IntegerFieldtype.vue
+++ b/resources/js/components/fieldtypes/IntegerFieldtype.vue
@@ -10,6 +10,7 @@
         :min="config.min"
         :prepend="__(config.prepend)"
         :append="__(config.append)"
+        :placeholder="__(config.placeholder)"
         @input="updateDebounced"
         @focus="$emit('focus')"
         @blur="$emit('blur')"

--- a/src/Fieldtypes/Integer.php
+++ b/src/Fieldtypes/Integer.php
@@ -17,6 +17,11 @@ class Integer extends Fieldtype
             [
                 'display' => __('Behavior'),
                 'fields' => [
+                    'placeholder' => [
+                        'display' => __('Placeholder'),
+                        'instructions' => __('statamic::fieldtypes.text.config.placeholder'),
+                        'type' => 'text',
+                    ],
                     'default' => [
                         'display' => __('Default Value'),
                         'instructions' => __('statamic::messages.fields_default_instructions'),


### PR DESCRIPTION
The `integer` fieldtype was missing a placeholder option. Figured I'd add it :)

<img width="534" alt="Screenshot 2024-08-04 at 13 43 39" src="https://github.com/user-attachments/assets/4db2b707-7a03-4cfa-b842-f94f8838e076">
