### PR TITLE
[5.x] Fix invisible links in Bard headings

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -335,7 +335,12 @@
     h1, h2, h3, h4, h5, h6 {
         margin-top: 1.275em;
         margin-bottom: .85em;
-        font-weight: 700
+        font-weight: 700;
+
+        b,
+        strong {
+            font-weight: 900;
+        }
     }
 
     h1 { font-size: 2em }

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -341,6 +341,17 @@
         strong {
             font-weight: 900;
         }
+
+        a {
+            @apply text-blue dark:text-dark-blue-100 underline break-words;
+        }
+
+        a:active,
+        a:focus,
+        a:hover {
+            outline: 0;
+            text-decoration: underline;
+        }
     }
 
     h1 { font-size: 2em }


### PR DESCRIPTION
Links inside Bard headings currently don't have any styles applied, making it impossible to scan for headings with links.

<img width="600" alt="Screenshot 2024-08-04 at 13 53 27" src="https://github.com/user-attachments/assets/c4d25ac7-b0a4-466d-a774-14a005f941ef">

This PR applies the same style to links within headings as applied in paragraphs and other block-level elements.

<img width="600" alt="Screenshot 2024-08-04 at 13 56 05" src="https://github.com/user-attachments/assets/eb1a6a0b-726b-428f-aedf-c697c5e24765">

While at it, I explicitly added a font-weight to bold sections in headings as Safari/Firefox (don't remember which one) wasn't getting the memo and required an explicit font-weight.