### PR TITLE
[5.x] Allow entry of hex colors without leading hash

### DIFF
--- a/resources/js/components/fieldtypes/ColorFieldtype.vue
+++ b/resources/js/components/fieldtypes/ColorFieldtype.vue
@@ -67,6 +67,7 @@
                 :readonly="isReadOnly"
                 :value="customColor"
                 @input="updateDebounced($event.target.value)"
+                @blur="sanitizeCustomColor"
             />
         </div>
 
@@ -111,6 +112,11 @@ export default {
             this.customColor = event.target.value;
         },
 
+        sanitizeCustomColor() {
+            this.customColor = this.sanitizeColor(this.customColor);
+            this.update(this.customColor);
+        },
+
         commitCustomColor() {
             this.update(this.customColor);
         },
@@ -119,6 +125,15 @@ export default {
             this.update(null);
         },
 
+        sanitizeColor(color) {
+            if (color && /^#?([a-fA-F0-9]{3,6})$/.test(color.trim())) {
+                color = color.replace(/[^a-fA-F0-9]/g, '');
+                if (color.length === 3) {
+                    color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
+                }
+                return `#${color}`;
+            }
+        }
     }
 
 };


### PR DESCRIPTION
Pasting colors into the color fieldtype requires they have a leading `#`. However, when copy-pasting from most layout apps, the colors come without the `#`, requiring editors to add it manually for each color field. This PR will make editors' lives a bit easier and sanitize any valid hex colors to the required format including the leading hash.

## Before: requires adding `#` manually

![Screen Recording 2024-08-04 at 15 16 58](https://github.com/user-attachments/assets/8bfcb9ee-3816-4308-9a6f-8ef2e9b6ced7)

## After: adds `#` automatically on blur

![Screen Recording 2024-08-04 at 15 17 33](https://github.com/user-attachments/assets/647d662d-c3a6-4e74-a797-597bd9182ec5)