### PR TITLE
[5.x] Display replicator preview of link fields

### DIFF
--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -92,7 +92,7 @@ export default {
                 case 'url':
                     return this.urlValue;
                 case 'first-child':
-                    return 'First child';
+                    return __('First child');
                 case 'entry':
                     return data_get(this.meta, 'entry.meta.data.0.title', this.entryValue);
                 case 'asset':

--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -52,6 +52,8 @@
 </template>
 
 <script>
+import { data_get } from '../../bootstrap/globals';
+
 import PositionsSelectOptions from '../../mixins/PositionsSelectOptions';
 
 export default {
@@ -83,6 +85,23 @@ export default {
             return this.selectedAssets.length
                 ? `asset::${this.selectedAssets[0]}`
                 : null
+        },
+
+        replicatorPreview() {
+            if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
+
+            switch (this.option) {
+                case 'url':
+                    return this.urlValue;
+                case 'first-child':
+                    return 'First child';
+                case 'entry':
+                    return data_get(this.meta, 'entry.meta.data.0.title', this.entryValue);
+                case 'asset':
+                    return data_get(this.meta, 'asset.meta.data.0.basename', this.assetValue);
+            }
+
+            return this.value;
         }
 
     },

--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -52,8 +52,6 @@
 </template>
 
 <script>
-import { data_get } from '../../bootstrap/globals';
-
 import PositionsSelectOptions from '../../mixins/PositionsSelectOptions';
 
 export default {


### PR DESCRIPTION
Render meaningful replicator previews of link fields.

## Before

<img width="896" alt="Screenshot 2024-08-04 at 16 36 08" src="https://github.com/user-attachments/assets/ad7daaab-3cd9-45df-ae65-15fc79b97efe">

## After

<img width="896" alt="Screenshot 2024-08-04 at 16 34 17" src="https://github.com/user-attachments/assets/91dca8fd-5342-4bf3-b366-7f27f81a1c7c">

## Field config

For reference and quick testing, this is the example fieldset I've been using to test this:

```yaml
-
  handle: link
  field:
    type: link
    display: Link
    collections:
      - pages
    container: assets
```