### PR TITLE
[5.x] Allow hiding border around group fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/GroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/GroupFieldtype.vue
@@ -37,8 +37,8 @@
                             />
                         </button>
                     </div>
-                    <div class="mb-4 border dark:border-dark-900 rounded shadow-sm replicator-set">
-                        <div class="replicator-set-body publish-fields @container">
+                    <div :class="{ 'mb-4 border dark:border-dark-900 rounded shadow-sm replicator-set': config.border }">
+                        <div class="publish-fields @container" :class="{ 'replicator-set-body': config.border, '-mx-4': !config.border }">
                             <set-field
                                 v-for="field in fields"
                                 :key="field.handle"

--- a/resources/js/components/fieldtypes/GroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/GroupFieldtype.vue
@@ -55,7 +55,6 @@
                                 @meta-updated="updateMeta(field.handle, $event)"
                                 @focus="$emit('focus')"
                                 @blur="$emit('blur')"
-                                class="p-4"
                             />
                         </div>
                     </div>

--- a/resources/js/components/fieldtypes/GroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/GroupFieldtype.vue
@@ -37,7 +37,7 @@
                             />
                         </button>
                     </div>
-                    <div :class="{ 'mb-4 border dark:border-dark-900 rounded shadow-sm replicator-set': config.border }">
+                    <div :class="{ 'border dark:border-dark-900 rounded shadow-sm replicator-set': config.border }">
                         <div class="publish-fields @container" :class="{ 'replicator-set-body': config.border, '-mx-4': !config.border }">
                             <set-field
                                 v-for="field in fields"

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -89,6 +89,7 @@ return [
     'grid.config.add_row' => 'Customize the label of the "Add Row" button.',
     'grid.config.fields' => 'Each field becomes a column in the grid table.',
     'grid.config.fullscreen' => 'Enable toggle for fullscreen mode.',
+    'grid.config.border' => 'Show a border and padding around fields in this group.',
     'grid.config.max_rows' => 'Set a maximum number of creatable rows.',
     'grid.config.min_rows' => 'Set a minimum number of creatable rows.',
     'grid.config.mode' => 'Choose your preferred layout style.',

--- a/src/Fieldtypes/Group.php
+++ b/src/Fieldtypes/Group.php
@@ -38,7 +38,7 @@ class Group extends Fieldtype
                         'default' => true,
                     ],
                     'border' => [
-                        'display' => __('Display Border'),
+                        'display' => __('Border'),
                         'instructions' => __('statamic::fieldtypes.grid.config.border'),
                         'type' => 'toggle',
                         'default' => true,

--- a/src/Fieldtypes/Group.php
+++ b/src/Fieldtypes/Group.php
@@ -37,6 +37,12 @@ class Group extends Fieldtype
                         'type' => 'toggle',
                         'default' => true,
                     ],
+                    'border' => [
+                        'display' => __('Display Border'),
+                        'instructions' => __('statamic::fieldtypes.grid.config.border'),
+                        'type' => 'toggle',
+                        'default' => true,
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
The group fieldtype is great to have the data scoped under a common key, but it tends to create visual clutter. Making the border optional solves this nicely :) Defaults to `true`, so no breaking change.

Also removed a superfluous padding class that was being added downstream anyway, as well as a bottom margin that looked a bit large. The screenshot below is after removing the bottom margin, which has plenty space already.

<img width="766" alt="Screenshot 2024-08-04 at 18 57 43" src="https://github.com/user-attachments/assets/6ae2dfd8-db18-4cf7-bc90-6cdbec6860c5">

Closes statamic/ideas#1137.