### PR TITLE
[5.x] Fix deprecated: third parameter of preg_replace() must not be null

### DIFF
--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -465,7 +465,7 @@ class Comb
         $output = '';
 
         if (! is_array($item)) {
-            return preg_replace('#\s+#ism', ' ', $item);
+            return preg_replace('#\s+#ism', ' ', (string) $item);
         }
 
         foreach ($item as $part) {


### PR DESCRIPTION
`Statamic\Search\Comb\Comb::flattenArray($item, $glue = ' ')`:   
The parameter `$item` is `mixed` (null as well). The third parameter of `preg_replace()` must be `array|string`. PHP 8.1+ triggers a deprecated error if `$item` is null.   

```php
// If $item is not array...
if (! is_array($item)) {
    // ...it must be string
    return preg_replace('#\s+#ism', ' ', (string) $item);
}
```
Test script (does not work in `Tests\Search\CombTest`):
```php
<?php

use Statamic\Search\Comb\Comb;

require_once __DIR__ . '/vendor/autoload.php';

ini_set('error_reporting', E_ALL);

$comb = new Comb([
    ['title' => 'John Doe', 'email' => null],
    ['title' => 'Jane Doe', 'email' => 'jane@doe.com'],
]);

var_dump($comb->lookUp('John'));
```
