### PR TITLE
[5.x] Sanitize asset folder name on creation

### DIFF
--- a/src/Actions/RenameAssetFolder.php
+++ b/src/Actions/RenameAssetFolder.php
@@ -3,7 +3,7 @@
 namespace Statamic\Actions;
 
 use Statamic\Contracts\Assets\AssetFolder;
-use Statamic\Rules\AllowedFolder;
+use Statamic\Rules\AlphaDashSpace;
 
 class RenameAssetFolder extends Action
 {
@@ -44,7 +44,7 @@ class RenameAssetFolder extends Action
         return [
             'name' => [
                 'type' => 'text',
-                'validate' => ['required', 'string', new AllowedFolder],
+                'validate' => ['required', 'string', new AlphaDashSpace],
                 'classes' => 'mousetrap',
                 'focus' => true,
                 'debounce' => false,

--- a/src/Actions/RenameAssetFolder.php
+++ b/src/Actions/RenameAssetFolder.php
@@ -3,6 +3,7 @@
 namespace Statamic\Actions;
 
 use Statamic\Contracts\Assets\AssetFolder;
+use Statamic\Rules\AllowedFolder;
 
 class RenameAssetFolder extends Action
 {
@@ -43,7 +44,7 @@ class RenameAssetFolder extends Action
         return [
             'name' => [
                 'type' => 'text',
-                'validate' => 'required|alpha_dash',
+                'validate' => ['required', 'string', new AllowedFolder],
                 'classes' => 'mousetrap',
                 'focus' => true,
                 'debounce' => false,

--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -3,6 +3,7 @@
 namespace Statamic\Assets;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Statamic\Assets\AssetUploader as Uploader;
 use Statamic\Contracts\Assets\AssetFolder as Contract;
 use Statamic\Events\AssetFolderDeleted;
 use Statamic\Events\AssetFolderSaved;
@@ -165,7 +166,7 @@ class AssetFolder implements Arrayable, Contract
             throw new \Exception('Folder cannot be moved to its own subfolder.');
         }
 
-        $name = $this->getSafeBasename($name ?? $this->basename());
+        $name = Uploader::getSafeFilename($name ?? $this->basename());
         $oldPath = $this->path();
         $newPath = Str::removeLeft(Path::tidy($parent.'/'.$name), '/');
 
@@ -183,21 +184,6 @@ class AssetFolder implements Arrayable, Contract
         $this->delete();
 
         return $folder;
-    }
-
-    /**
-     * Ensure safe basename string.
-     *
-     * @param  string  $string
-     * @return string
-     */
-    private function getSafeBasename($string)
-    {
-        if (config('statamic.assets.lowercase')) {
-            $string = strtolower($string);
-        }
-
-        return (string) $string;
     }
 
     /**

--- a/src/Http/Controllers/CP/Assets/FoldersController.php
+++ b/src/Http/Controllers/CP/Assets/FoldersController.php
@@ -7,7 +7,7 @@ use Illuminate\Validation\ValidationException;
 use Statamic\Assets\AssetUploader;
 use Statamic\Facades\Path;
 use Statamic\Http\Controllers\CP\CpController;
-use Statamic\Rules\AllowedFolder;
+use Statamic\Rules\AlphaDashSpace;
 
 class FoldersController extends CpController
 {
@@ -17,7 +17,7 @@ class FoldersController extends CpController
 
         $request->validate([
             'path' => 'required',
-            'directory' => ['required', 'string', new AllowedFolder],
+            'directory' => ['required', 'string', new AlphaDashSpace],
         ]);
 
         $name = AssetUploader::getSafeFilename($request->directory);

--- a/src/Http/Controllers/CP/Assets/FoldersController.php
+++ b/src/Http/Controllers/CP/Assets/FoldersController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\CP\Assets;
 
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
+use Statamic\Assets\AssetUploader;
 use Statamic\Facades\Path;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Rules\AllowedFolder;
@@ -19,7 +20,9 @@ class FoldersController extends CpController
             'directory' => ['required', 'string', new AllowedFolder],
         ]);
 
-        $path = ltrim(Path::assemble($request->path, $request->directory), '/');
+        $name = AssetUploader::getSafeFilename($request->directory);
+
+        $path = ltrim(Path::assemble($request->path, $name), '/');
 
         if ($container->disk()->exists($path)) {
             throw ValidationException::withMessages([

--- a/src/Http/Controllers/CP/Assets/FoldersController.php
+++ b/src/Http/Controllers/CP/Assets/FoldersController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\Path;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Rules\AllowedFolder;
 
 class FoldersController extends CpController
 {
@@ -15,7 +16,7 @@ class FoldersController extends CpController
 
         $request->validate([
             'path' => 'required',
-            'directory' => 'required|alpha_dash',
+            'directory' => ['required', 'string', new AllowedFolder],
         ]);
 
         $path = ltrim(Path::assemble($request->path, $request->directory), '/');

--- a/src/Rules/AllowedFolder.php
+++ b/src/Rules/AllowedFolder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Statamic\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class AllowedFolder implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        // Same as `alpha_dash`, but allows spaces
+        if (! preg_match('/\A[ \pL\pM\pN_-]+\z/u', $value)) {
+            $fail('statamic::validation.alpha_dash')->translate();
+        }
+    }
+}

--- a/src/Rules/AlphaDashSpace.php
+++ b/src/Rules/AlphaDashSpace.php
@@ -5,7 +5,7 @@ namespace Statamic\Rules;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 
-class AllowedFolder implements ValidationRule
+class AlphaDashSpace implements ValidationRule
 {
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {

--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -731,7 +731,7 @@ class AssetFolderTest extends TestCase
 
         Event::fake();
 
-        $folder->move('destination/folder', 'new: move');
+        $folder->move('destination/folder', 'new move');
 
         $disk->assertMissing('move');
         $disk->assertMissing('move/sub');

--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -709,6 +709,91 @@ class AssetFolderTest extends TestCase
     }
 
     #[Test]
+    public function it_sanitizes_when_moving_to_another_folder_with_a_new_folder_name()
+    {
+        $container = $this->containerWithDisk();
+        $disk = $container->disk()->filesystem();
+
+        $paths = collect([
+            'move/one.txt',
+            'move/two.txt',
+            'move/sub/three.txt',
+            'move/sub/subsub/four.txt',
+            'destination/folder/five.txt',
+        ]);
+
+        $paths->each(function ($path) use ($disk, $container) {
+            $disk->put($path, '');
+            $container->makeAsset($path)->save();
+        });
+
+        $folder = (new Folder)->container($container)->path('move');
+
+        Event::fake();
+
+        $folder->move('destination/folder', 'new: move');
+
+        $disk->assertMissing('move');
+        $disk->assertMissing('move/sub');
+        $disk->assertMissing('move/sub/subsub');
+
+        $disk->assertExists('destination/folder/new-move');
+        $disk->assertExists('destination/folder/new-move/sub');
+        $disk->assertExists('destination/folder/new-move/sub/subsub');
+
+        $this->assertEquals([
+            'destination',
+            'destination/folder',
+            'destination/folder/new-move',
+            'destination/folder/new-move/sub',
+            'destination/folder/new-move/sub/subsub',
+        ], $container->folders()->all());
+
+        $this->assertEquals([
+            'destination',
+            'destination/folder',
+            'destination/folder/five.txt',
+            'destination/folder/new-move',
+            'destination/folder/new-move/sub',
+            'destination/folder/new-move/sub/subsub',
+            'destination/folder/new-move/sub/subsub/four.txt',
+            'destination/folder/new-move/sub/three.txt',
+            'destination/folder/new-move/one.txt',
+            'destination/folder/new-move/two.txt',
+        ], $container->contents()->cached()->keys()->all());
+
+        // Assert asset folder events.
+        $paths = ['move', 'move/sub', 'move/sub/subsub'];
+        Event::assertDispatchedTimes(AssetFolderDeleted::class, count($paths));
+        Event::assertDispatchedTimes(AssetFolderSaved::class, count($paths));
+        foreach ($paths as $path) {
+            Event::assertDispatched(AssetFolderDeleted::class, function (AssetFolderDeleted $event) use ($path) {
+                return $event->folder->path() === $path;
+            });
+        }
+        $paths = ['new-move', 'new-move/sub', 'new-move/sub/subsub'];
+        foreach ($paths as $path) {
+            Event::assertDispatched(AssetFolderSaved::class, function (AssetFolderSaved $event) use ($path) {
+                return $event->folder->path() === 'destination/folder/'.$path;
+            });
+        }
+
+        // Assert asset events.
+        $paths = [
+            'destination/folder/new-move/one.txt',
+            'destination/folder/new-move/two.txt',
+            'destination/folder/new-move/sub/three.txt',
+            'destination/folder/new-move/sub/subsub/four.txt',
+        ];
+        Event::assertDispatchedTimes(AssetSaved::class, count($paths));
+        foreach ($paths as $path) {
+            Event::assertDispatched(AssetSaved::class, function (AssetSaved $event) use ($path) {
+                return $event->asset->path() === $path;
+            });
+        }
+    }
+
+    #[Test]
     public function it_cannot_be_moved_to_its_own_subfolder()
     {
         $container = $this->containerWithDisk();


### PR DESCRIPTION
When uploading assets, the filenames are automatically sanitized. This does the same for asset folders.

Closes statamic/ideas#503

![Screen Recording 2024-08-06 at 14 24 12](https://github.com/user-attachments/assets/25deac5d-41cd-4309-bda9-cfcf513cf6a3)

## Current behavior

Currently a completely valid folder name is required when creating/moving/renaming folders. Spaces in folder names lead to validation errors and require manual correction. This quickly becomes exhausting when editors need to create dozens of folders by copy-pasting from their local filesystem.

## Behavior after this change

With this change, folder name inputs allow spaces. For that, it introduces a new rule for valid folder name inputs: same as `alpha_dash`, but with spaces allowed. The spaces are then removed by re-using the basename sanitizer from the `FileUploader` class, which also sanitizes upload filenames. Handles creation and renaming/moving.

## Notes

~~Wasn't sure about the rule name `AllowedFolder` as it implies a check for a valid filesystem directory name, when actually it validates the pre-sanitized input value of folder name inputs.~~