### PR TITLE
[5.x] Avoid collections in dictionary fields fieldtype

### DIFF
--- a/src/Fieldtypes/DictionaryFields.php
+++ b/src/Fieldtypes/DictionaryFields.php
@@ -30,17 +30,17 @@ class DictionaryFields extends Fieldtype
         return [
             'type' => [
                 'fields' => $typeField->toPublishArray(),
-                'meta' => $typeField->meta(),
+                'meta' => $typeField->meta()->all(),
             ],
             'dictionaries' => Dictionary::all()->mapWithKeys(function (\Statamic\Dictionaries\Dictionary $dictionary) {
                 return [$dictionary->handle() => [
                     'fields' => $dictionary->fields()->toPublishArray(),
-                    'meta' => $dictionary->fields()->meta(),
+                    'meta' => $dictionary->fields()->meta()->all(),
                     'defaults' => $dictionary->fields()->all()->map(function ($field) {
                         return $field->fieldtype()->preProcess($field->defaultValue());
-                    }),
+                    })->all(),
                 ]];
-            }),
+            })->all(),
         ];
     }
 

--- a/tests/Fieldtypes/DictionaryFieldsTest.php
+++ b/tests/Fieldtypes/DictionaryFieldsTest.php
@@ -30,7 +30,7 @@ class DictionaryFieldsTest extends TestCase
                 'fields' => [
                     ['handle' => 'type', 'type' => 'select'],
                 ],
-                'meta' => collect(['type' => null]),
+                'meta' => ['type' => null],
             ],
         ], $preload);
 
@@ -39,10 +39,10 @@ class DictionaryFieldsTest extends TestCase
                 'fields' => [
                     ['handle' => 'category',  'type' => 'select'],
                 ],
-                'meta' => collect(['category' => null]),
-                'defaults' => collect(['category' => null]),
+                'meta' => ['category' => null],
+                'defaults' => ['category' => null],
             ],
-        ], $preload['dictionaries']->all());
+        ], $preload['dictionaries']);
     }
 
     #[Test]


### PR DESCRIPTION
This makes some things easier to resolve in #10467. 

There's no reason we need collections here anyway since it's just going to JavaScript.
