### PR TITLE
[5.x] Add Sites to `install:eloquent-driver` command

### DIFF
--- a/src/Console/Commands/InstallEloquentDriver.php
+++ b/src/Console/Commands/InstallEloquentDriver.php
@@ -101,6 +101,7 @@ class InstallEloquentDriver extends Command
             'navs' => 'Navigations',
             'nav_trees' => 'Navigation Trees',
             'revisions' => 'Revisions',
+            'sites' => 'Sites',
             'taxonomies' => 'Taxonomies',
             'terms' => 'Terms',
             'tokens' => 'Tokens',
@@ -148,6 +149,9 @@ class InstallEloquentDriver extends Command
                 case 'revisions':
                     return ! config('statamic.revisions.enabled')
                         || config('statamic.eloquent-driver.revisions.driver') === 'eloquent';
+
+                case 'sites':
+                    return config('statamic.eloquent-driver.sites.driver') === 'eloquent';
 
                 case 'taxonomies':
                     return config('statamic.eloquent-driver.taxonomies.driver') === 'eloquent';
@@ -517,6 +521,28 @@ class InstallEloquentDriver extends Command
 
             $this->components->info('Imported existing revisions');
         }
+    }
+
+    protected function migrateSites(): void
+    {
+        spin(
+            callback: function () {
+                $this->runArtisanCommand('vendor:publish --tag=statamic-eloquent-site-migrations');
+                $this->runArtisanCommand('migrate');
+
+                $this->switchToEloquentDriver('sites');
+            },
+            message: 'Migrating sites...'
+        );
+
+        $this->components->info('Configured sites');
+
+        spin(
+            callback: fn () => $this->runArtisanCommand('statamic:eloquent:import-sites'),
+            message: 'Importing existing sites...'
+        );
+
+        $this->components->info('Imported existing sites');
     }
 
     protected function migrateTaxonomies(): void

--- a/src/Console/Commands/InstallEloquentDriver.php
+++ b/src/Console/Commands/InstallEloquentDriver.php
@@ -531,18 +531,13 @@ class InstallEloquentDriver extends Command
                 $this->runArtisanCommand('migrate');
 
                 $this->switchToEloquentDriver('sites');
+
+                $this->runArtisanCommand('statamic:eloquent:import-sites');
             },
             message: 'Migrating sites...'
         );
 
-        $this->components->info('Configured sites');
-
-        spin(
-            callback: fn () => $this->runArtisanCommand('statamic:eloquent:import-sites'),
-            message: 'Importing existing sites...'
-        );
-
-        $this->components->info('Imported existing sites');
+        $this->components->info('Configured & imported sites');
     }
 
     protected function migrateTaxonomies(): void


### PR DESCRIPTION
This pull request adds the Sites repository as an option to the `install:eloquent-driver` command, after it being added in statamic/eloquent-driver#322.

Unlike other repositories, there's no "Do you want to import existing sites" option since not importing them could cause issues. 

![CleanShot 2024-08-07 at 11 04 18](https://github.com/user-attachments/assets/a077d472-997b-4de7-945c-3ee529443820)
