### PR TITLE
[5.x] Fix broken `RelationshipInput` after removing filter

### DIFF
--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -164,7 +164,9 @@ export default {
     computed: {
 
         items() {
-            return this.value.map(selection => {
+            if (this.value === null) return [];
+
+            return this.value?.map(selection => {
                 const data = _.find(this.data, (item) => item.id == selection);
 
                 if (! data) return { id: selection, title: selection };
@@ -174,7 +176,7 @@ export default {
         },
 
         maxItemsReached() {
-            return this.value.length >= this.maxItems;
+            return this.value?.length >= this.maxItems;
         },
 
         canSelectOrCreate() {


### PR DESCRIPTION
This pull request fixes an issue when using the `RelationshipInput` component inside a listing filter, where errors occur when the filter is removed.

When the filter is removed, `this.value` becomes null which the `items` and `maxItemsReached` computed properties aren't expecting.

Closes #10581.