### PR TITLE
[5.x] Fix error with Files Fieldtype in Forms when no files are uploaded

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -141,6 +141,10 @@ class Email extends Mailable
             ? collect([$value])->filter()
             : $value;
 
+        if (! $value) {
+            return;
+        }
+
         foreach ($value as $file) {
             $this->attachFromStorageDisk('local', 'statamic/file-uploads/'.$file);
         }


### PR DESCRIPTION
This pull request fixes an issue when using the Files Fieldtype in Forms, where an error would occur when no files have been uploaded.

Closes #10575.