### PR TITLE
[5.x] Prevent error when Laravel Telescope serializes a user before its created

### DIFF
--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -105,16 +105,28 @@ abstract class User implements Arrayable, ArrayAccess, Augmentable, Authenticata
 
     public function editUrl()
     {
-        return cp_route('users.edit', $this->id());
+        if (! $id = $this->id()) {
+            return null;
+        }
+
+        return cp_route('users.edit', $id);
     }
 
     public function updateUrl()
     {
-        return cp_route('users.update', $this->id());
+        if (! $id = $this->id()) {
+            return null;
+        }
+
+        return cp_route('users.update', $id);
     }
 
     public function apiUrl()
     {
+        if (! $id = $this->id()) {
+            return null;
+        }
+
         return Statamic::apiRoute('users.show', $this->id());
     }
 


### PR DESCRIPTION
This pull request fixes an issue where an error would occur when creating a new user, when the Laravel Telescope package is installed.

* When a user is being created, it dispatches two events: `UserCreating` and `UserSaving`. 
* Laravel Telescope listens for any events being dispatched and [attempts to serialize them](https://github.com/laravel/telescope/blob/5.x/src/ExtractProperties.php#L34) using `json_encode`.
* When the `User` object gets serialized, it'll end up augmenting the user via [`HasAugmentedInstance::jsonSerialize()`](https://github.com/statamic/cms/blob/d446b3b827490a123382f4113c1092e82c279a55/src/Data/HasAugmentedInstance.php#L105-L108).
* The `AugmentedUser::commonKeys()` array includes `edit_url` and `api_url`.
* When the `editUrl` and `apiUrl` methods are called on the `User`, they error out due to no ID being set, since the user hasn't been created yet.
  * We do a similar "if no id, return null" check for `editUrl` and `apiUrl` in entries. 
  * We don't do this check for things like taxonomies, because their URLs use slugs which exist on the object before the term is created.

Closes #10525.