### PR TITLE
[5.x] Always detach localizations when user is missing permissions to delete in other sites

### DIFF
--- a/resources/js/components/collections/View.vue
+++ b/resources/js/components/collections/View.vue
@@ -195,6 +195,8 @@ export default {
         reorderUrl: { type: String, required: true },
         initialSite: { type: String, required: true },
         sites: { type: Array },
+        totalSitesCount: { type: Number },
+        canChangeLocalizationDeleteBehavior: { type: Boolean },
         structurePagesUrl: { type: String },
         structureSubmitUrl: { type: String },
         structureMaxDepth: { type: Number, default: Infinity },
@@ -276,9 +278,17 @@ export default {
         },
 
         saveTree() {
-            if (this.sites.length === 1 || this.deletedEntries.length === 0) {
+            if (this.deletedEntries.length === 0) {
                 this.performTreeSaving();
                 return;
+            }
+
+            // When the user doesn't have permission to access the sites the entry is localized in,
+            // we should use the "copy" behavior to detach the entry from the site.
+            if (! this.canChangeLocalizationDeleteBehavior) {
+                this.deleteLocalizationBehavior = 'copy';
+                this.$nextTick(() => this.performTreeSaving());
+                return
             }
 
             this.showLocalizationDeleteBehaviorConfirmation = true;

--- a/resources/views/collections/show.blade.php
+++ b/resources/views/collections/show.blade.php
@@ -20,6 +20,7 @@
         reorder-url="{{ cp_route('collections.entries.reorder', $collection->handle()) }}"
         initial-site="{{ $site }}"
         :sites="{{ json_encode($sites) }}"
+        :can-change-localization-delete-behavior="{{ Statamic\Support\Str::bool($canChangeLocalizationDeleteBehavior) }}"
 
         @if ($collection->hasStructure())
         :structured="{{ Statamic\Support\Str::bool($user->can('reorder', $collection)) }}"

--- a/src/Actions/DeleteMultisiteEntry.php
+++ b/src/Actions/DeleteMultisiteEntry.php
@@ -68,9 +68,7 @@ class DeleteMultisiteEntry extends Delete
                 return false;
             }
 
-            return $entry->isRoot()
-                ? $entry->descendants()->every(fn ($descendant) => User::current()->can("access {$descendant->site()->handle()} site"))
-                : $entry->ancestors()->every(fn ($ancestor) => User::current()->can("access {$ancestor->site()->handle()} site"));
+            return $entry->descendants()->every(fn ($descendant) => User::current()->can("access {$descendant->site()->handle()} site"));
         });
     }
 }

--- a/src/Actions/DeleteMultisiteEntry.php
+++ b/src/Actions/DeleteMultisiteEntry.php
@@ -20,7 +20,7 @@ class DeleteMultisiteEntry extends Delete
 
     public function fieldItems()
     {
-        if (! $this->canChangeBehaviour()) {
+        if (! $this->canChangeBehavior()) {
             return [];
         }
 
@@ -46,7 +46,7 @@ class DeleteMultisiteEntry extends Delete
 
     public function run($items, $values)
     {
-        $behavior = $this->canChangeBehaviour() ? $values['behavior'] : 'copy';
+        $behavior = $this->canChangeBehavior() ? $values['behavior'] : 'copy';
 
         if ($behavior === 'copy') {
             $items->each->detachLocalizations();
@@ -57,7 +57,7 @@ class DeleteMultisiteEntry extends Delete
         $items->each->delete();
     }
 
-    private function canChangeBehaviour(): bool
+    private function canChangeBehavior(): bool
     {
         if (! Site::multiEnabled()) {
             return true;

--- a/src/Actions/DeleteMultisiteEntry.php
+++ b/src/Actions/DeleteMultisiteEntry.php
@@ -64,11 +64,8 @@ class DeleteMultisiteEntry extends Delete
         }
 
         return $this->items->every(function ($entry) {
-            if ($entry->descendants()->isEmpty()) {
-                return false;
-            }
-
-            return $entry->descendants()->every(fn ($descendant) => User::current()->can("access {$descendant->site()->handle()} site"));
+            return $entry->descendants()->isNotEmpty()
+                && $entry->descendants()->every(fn ($descendant) => User::current()->can("access {$descendant->site()->handle()} site"));
         });
     }
 }

--- a/src/Actions/DeleteMultisiteEntry.php
+++ b/src/Actions/DeleteMultisiteEntry.php
@@ -64,6 +64,10 @@ class DeleteMultisiteEntry extends Delete
         }
 
         return $this->items->every(function ($entry) {
+            if ($entry->descendants()->isEmpty()) {
+                return false;
+            }
+
             return $entry->isRoot()
                 ? $entry->descendants()->every(fn ($descendant) => User::current()->can("access {$descendant->site()->handle()} site"))
                 : $entry->ancestors()->every(fn ($ancestor) => User::current()->can("access {$ancestor->site()->handle()} site"));

--- a/src/Actions/DeleteMultisiteEntry.php
+++ b/src/Actions/DeleteMultisiteEntry.php
@@ -59,8 +59,10 @@ class DeleteMultisiteEntry extends Delete
     private function canChangeBehavior(): bool
     {
         return $this->items->every(function ($entry) {
-            return $entry->descendants()->isNotEmpty()
-                && $entry->descendants()->every(fn ($descendant) => User::current()->can("access {$descendant->site()->handle()} site"));
+            $descendants = $entry->descendants();
+
+            return $descendants->isNotEmpty()
+                && $descendants->every(fn ($descendant) => User::current()->can('view', $descendant->site()));
         });
     }
 }

--- a/src/Actions/DeleteMultisiteEntry.php
+++ b/src/Actions/DeleteMultisiteEntry.php
@@ -3,7 +3,6 @@
 namespace Statamic\Actions;
 
 use Statamic\Contracts\Entries\Entry;
-use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Statamic;
 
@@ -59,10 +58,6 @@ class DeleteMultisiteEntry extends Delete
 
     private function canChangeBehavior(): bool
     {
-        if (! Site::multiEnabled()) {
-            return true;
-        }
-
         return $this->items->every(function ($entry) {
             return $entry->descendants()->isNotEmpty()
                 && $entry->descendants()->every(fn ($descendant) => User::current()->can("access {$descendant->site()->handle()} site"));

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -277,6 +277,8 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
                     ->save();
             });
 
+        Blink::forget('entry-descendants-'.$this->id());
+
         return true;
     }
 

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -98,13 +98,12 @@ class CollectionsController extends CpController
                 'collection' => $collection->handle(),
                 'blueprints' => $blueprints->pluck('handle')->all(),
             ]),
-            'sites' => $this->getAuthorizedSitesForCollection($collection),
+            'sites' => $authorizedSites = $this->getAuthorizedSitesForCollection($collection),
             'createUrls' => $collection->sites()
                 ->mapWithKeys(fn ($site) => [$site => cp_route('collections.entries.create', [$collection->handle(), $site])])
                 ->all(),
             'canCreate' => User::current()->can('create', [EntryContract::class, $collection]) && $collection->hasVisibleEntryBlueprint(),
-            'canChangeLocalizationDeleteBehavior' => $collection->sites()->count() > 1
-                && $collection->sites()->every(fn ($site) => User::current()->can("access {$site} site")),
+            'canChangeLocalizationDeleteBehavior' => count($authorizedSites) == $collection->sites()->count(),
         ];
 
         if ($collection->queryEntries()->count() === 0) {

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -103,7 +103,7 @@ class CollectionsController extends CpController
                 ->mapWithKeys(fn ($site) => [$site => cp_route('collections.entries.create', [$collection->handle(), $site])])
                 ->all(),
             'canCreate' => User::current()->can('create', [EntryContract::class, $collection]) && $collection->hasVisibleEntryBlueprint(),
-            'canChangeLocalizationDeleteBehavior' => count($authorizedSites) == $collection->sites()->count(),
+            'canChangeLocalizationDeleteBehavior' => count($authorizedSites) > 1 && (count($authorizedSites) == $collection->sites()->count()),
         ];
 
         if ($collection->queryEntries()->count() === 0) {

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -103,6 +103,8 @@ class CollectionsController extends CpController
                 ->mapWithKeys(fn ($site) => [$site => cp_route('collections.entries.create', [$collection->handle(), $site])])
                 ->all(),
             'canCreate' => User::current()->can('create', [EntryContract::class, $collection]) && $collection->hasVisibleEntryBlueprint(),
+            'canChangeLocalizationDeleteBehavior' => $collection->sites()->count() > 1
+                && $collection->sites()->every(fn ($site) => User::current()->can("access {$site} site")),
         ];
 
         if ($collection->queryEntries()->count() === 0) {


### PR DESCRIPTION
This pull request fixes an issue where it was possible for users to delete localized entries in other sites, even if they don't have permissions to access that site.

Fixes #10519.