### PR TITLE
[5.x] License banner is snoozable

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -224,6 +224,10 @@ Statamic.app({
 
         wrapperClass() {
             return this.$config.get('wrapperClass', 'max-w-xl');
+        },
+
+        isLicensingBannerHidden() {
+            return document.cookie.includes('statamic_licensing_banner_hidden');
         }
 
     },
@@ -242,7 +246,7 @@ Statamic.app({
 
         this.fixAutofocus();
 
-        this.showBanner = Statamic.$config.get('hasLicenseBanner');
+        this.showBanner = ! this.isLicensingBannerHidden && Statamic.$config.get('hasLicenseBanner');
 
         this.$toast.intercept();
     },
@@ -292,6 +296,7 @@ Statamic.app({
 
         hideBanner() {
             this.showBanner = false;
+            document.cookie = `statamic_licensing_banner_hidden=true; expires=${new Date(Date.now() + 5 * 60 * 1000).toUTCString()}; path=/`;
         },
 
         fixAutofocus() {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -225,7 +225,7 @@ Statamic.app({
 
         wrapperClass() {
             return this.$config.get('wrapperClass', 'max-w-xl');
-        },
+        }
 
     },
 
@@ -293,7 +293,7 @@ Statamic.app({
 
         hideBanner() {
             this.showBanner = false;
-            localStorage.setItem(`statamic.snooze_license_banner`, new Date(Date.now() + 1 * 60 * 1000).valueOf());
+            localStorage.setItem(`statamic.snooze_license_banner`, new Date(Date.now() + 5 * 60 * 1000).valueOf());
         },
 
         fixAutofocus() {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -227,7 +227,8 @@ Statamic.app({
         },
 
         isLicensingBannerHidden() {
-            return document.cookie.includes('statamic_licensing_banner_hidden');
+            return localStorage.getItem(`statamic.licensing_banner_hidden_until`) !== undefined
+                && localStorage.getItem(`statamic.licensing_banner_hidden_until`) > new Date().valueOf();
         }
 
     },
@@ -246,7 +247,7 @@ Statamic.app({
 
         this.fixAutofocus();
 
-        this.showBanner = ! this.isLicensingBannerHidden && Statamic.$config.get('hasLicenseBanner');
+        this.showBanner = !this.isLicensingBannerHidden && Statamic.$config.get('hasLicenseBanner');
 
         this.$toast.intercept();
     },
@@ -296,7 +297,7 @@ Statamic.app({
 
         hideBanner() {
             this.showBanner = false;
-            document.cookie = `statamic_licensing_banner_hidden=true; expires=${new Date(Date.now() + 5 * 60 * 1000).toUTCString()}; path=/`;
+            localStorage.setItem(`statamic.licensing_banner_hidden_until`, new Date(Date.now() + 5 * 60 * 1000).valueOf());
         },
 
         fixAutofocus() {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -210,6 +210,7 @@ Statamic.app({
         showBanner: true,
         portals: [],
         appendedComponents: [],
+        isLicensingBannerSnoozed: localStorage.getItem(`statamic.snooze_license_banner`) > new Date().valueOf(),
     },
 
     computed: {
@@ -225,11 +226,6 @@ Statamic.app({
         wrapperClass() {
             return this.$config.get('wrapperClass', 'max-w-xl');
         },
-
-        isLicensingBannerHidden() {
-            return localStorage.getItem(`statamic.licensing_banner_hidden_until`) !== undefined
-                && localStorage.getItem(`statamic.licensing_banner_hidden_until`) > new Date().valueOf();
-        }
 
     },
 
@@ -247,7 +243,7 @@ Statamic.app({
 
         this.fixAutofocus();
 
-        this.showBanner = !this.isLicensingBannerHidden && Statamic.$config.get('hasLicenseBanner');
+        this.showBanner = !this.isLicensingBannerSnoozed && Statamic.$config.get('hasLicenseBanner');
 
         this.$toast.intercept();
     },
@@ -297,7 +293,7 @@ Statamic.app({
 
         hideBanner() {
             this.showBanner = false;
-            localStorage.setItem(`statamic.licensing_banner_hidden_until`, new Date(Date.now() + 5 * 60 * 1000).valueOf());
+            localStorage.setItem(`statamic.snooze_license_banner`, new Date(Date.now() + 1 * 60 * 1000).valueOf());
         },
 
         fixAutofocus() {

--- a/resources/views/partials/licensing-alerts.blade.php
+++ b/resources/views/partials/licensing-alerts.blade.php
@@ -19,7 +19,7 @@
     </div>
 @else
     @if ($licenses->invalid())
-        <div class="p-2 w-full fixed bottom-0 z-2" v-show="showBanner">
+        <div class="p-2 w-full fixed bottom-0 z-2" v-cloak v-show="showBanner">
             <div class="
                 py-3 px-4 text-sm w-full rounded-md
                 @if ($licenses->isOnTestDomain()) bg-gray-800 dark:bg-dark-500 text-gray-300 @endif


### PR DESCRIPTION
As suggested on [this issue](https://github.com/statamic/cms/issues/10564#issuecomment-2268675166), it'd be nice if clicking "Dismiss" on the license banner meant it'd actually go away when navigating to other pages.

This PR makes that a reality, dismissing the banner will hide it for 5 minutes.

Closes #10564.