### PR TITLE
[5.x] Allow uppercase characters in field handles

### DIFF
--- a/src/Rules/Handle.php
+++ b/src/Rules/Handle.php
@@ -9,7 +9,7 @@ class Handle implements ValidationRule
 {
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! preg_match('/^[a-z][a-z0-9]*(?:_{0,1}[a-z0-9])*$/', $value)) {
+        if (! preg_match('/^[a-zA-Z][a-zA-Z0-9]*(?:_{0,1}[a-zA-Z0-9])*$/', $value)) {
             $fail('statamic::validation.handle')->translate();
         }
     }

--- a/tests/Rules/HandleTest.php
+++ b/tests/Rules/HandleTest.php
@@ -22,6 +22,7 @@ class HandleTest extends TestCase
         $this->assertPasses('foo1');
         $this->assertPasses('foo123');
         $this->assertPasses('foo123_20bar');
+        $this->assertPasses('FooBar');
 
         $this->assertFails('foo-bar');
         $this->assertFails('_foo');

--- a/tests/Rules/SlugTest.php
+++ b/tests/Rules/SlugTest.php
@@ -13,7 +13,7 @@ class SlugTest extends TestCase
     protected static $customRule = Slug::class;
 
     #[Test]
-    public function it_validates_handles()
+    public function it_validates_slugs()
     {
         $this->assertPasses('foo');
         $this->assertPasses('foo-bar');


### PR DESCRIPTION
This pull request adjusts our field handle validation to allow for using uppercase characters in field handles.

Fixes #10572.