### PR TITLE
[5.x] Correct behavior of LabeledValue when used inside conditions

### DIFF
--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -1255,6 +1255,8 @@ class Environment
         if ($name instanceof VariableReference) {
             if (! $this->isEvaluatingTruthValue) {
                 $this->dataRetriever->setReduceFinal(false);
+            } else {
+                $this->dataRetriever->setIsReturningForConditions(true);
             }
 
             if ($originalNode != null && $originalNode->hasModifiers()) {

--- a/tests/Antlers/Runtime/TemplateTest.php
+++ b/tests/Antlers/Runtime/TemplateTest.php
@@ -18,6 +18,7 @@ use Statamic\Fields\ArrayableString;
 use Statamic\Fields\Blueprint;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
+use Statamic\Fields\LabeledValue;
 use Statamic\Fields\Value;
 use Statamic\Fields\Values;
 use Statamic\Tags\Tags;
@@ -462,6 +463,39 @@ EOT;
             $this->variables,
             true
         ));
+    }
+
+    #[Test]
+    public function ternary_condition_with_labeled_values_supplied_to_tags_resolve_correctly()
+    {
+        $this->withFakeViews();
+        $value = new LabeledValue(null, null);
+        $valueTwo = new LabeledValue('something', null);
+
+        $partial = <<<'EOT'
+{{ the_field ? 'true' : 'false' }}
+EOT;
+
+        $this->viewShouldReturnRaw('test', $partial);
+
+        $template = <<<'EOT'
+O: {{ the_field ? 'true' : 'false' }}
+P: {{ partial:test :the_field="the_field" }}
+EOT;
+
+        $expected = <<<'EXP'
+O: false
+P: false
+EXP;
+
+        $this->assertSame($expected, $this->renderString($template, ['the_field' => $value], true));
+
+        $expected = <<<'EXP'
+O: true
+P: true
+EXP;
+
+        $this->assertSame($expected, $this->renderString($template, ['the_field' => $valueTwo], true));
     }
 
     #[Test]


### PR DESCRIPTION
This PR fixes #10589 by improving some internal logic when handling `LabeledValue` inside condition checks. The root cause is that passing values to a tag using the `:some_var="var_name"` syntax removes the wrapper `Value` object. In the case of `LabeledValue`, this will ultimately resolve a value similar to the following when doing the "truthiness" check:

```
array:3 [
  'value' => null,
  'label' => null,
  'key' => null
]
```

The Environment will now let the internal data manager know it's trying to get a value suitable for a truthiness check, and if it is, it will prevent it from collapsing `LabeledValue` instances to their array version