### PR TITLE
[5.x] Warn when using legacy broadcasting env variable when installing the Collaboration addon

### DIFF
--- a/src/Console/Commands/InstallCollaboration.php
+++ b/src/Console/Commands/InstallCollaboration.php
@@ -49,7 +49,7 @@ class InstallCollaboration extends Command
 
             $this->components->info('Installed statamic/collaboration addon');
         }
-        
+
         $this->enableBroadcasting();
         $this->updateBroadcastingKeysInEnvironmentFiles();
         $this->installBroadcastingDriver();

--- a/src/Console/Commands/InstallCollaboration.php
+++ b/src/Console/Commands/InstallCollaboration.php
@@ -50,9 +50,9 @@ class InstallCollaboration extends Command
             $this->components->info('Installed statamic/collaboration addon');
         }
 
-//        $this->enableBroadcasting();
+        $this->enableBroadcasting();
         $this->updateBroadcastingKeysInEnvironmentFiles();
-//        $this->installBroadcastingDriver();
+        $this->installBroadcastingDriver();
     }
 
     protected function enableBroadcasting(): void

--- a/src/Console/Commands/InstallCollaboration.php
+++ b/src/Console/Commands/InstallCollaboration.php
@@ -97,9 +97,7 @@ class InstallCollaboration extends Command
                 continue;
             }
 
-            $contents = File::get($file);
-
-            if (Str::contains($contents, 'BROADCAST_DRIVER')) {
+            if (Str::contains($contents = File::get($file), 'BROADCAST_DRIVER')) {
                 $contents = Str::of($contents)
                     ->replace('BROADCAST_DRIVER', 'BROADCAST_CONNECTION')
                     ->__toString();

--- a/src/Console/Commands/InstallCollaboration.php
+++ b/src/Console/Commands/InstallCollaboration.php
@@ -87,6 +87,10 @@ class InstallCollaboration extends Command
 
     protected function updateBroadcastingKeysInEnvironmentFiles(): void
     {
+        if (version_compare(app()->version(), '11', '<')) {
+            return;
+        }
+
         $environmentFiles = [
             app()->environmentFile(),
             app()->environmentFile('.env.example'),

--- a/src/Console/Commands/InstallCollaboration.php
+++ b/src/Console/Commands/InstallCollaboration.php
@@ -51,7 +51,7 @@ class InstallCollaboration extends Command
         }
 
         $this->enableBroadcasting();
-        $this->updateBroadcastingKeysInEnvironmentFiles();
+        $this->warnAboutLegacyBroadcastDriverKey();
         $this->installBroadcastingDriver();
     }
 
@@ -85,31 +85,14 @@ class InstallCollaboration extends Command
         $this->components->info('Broadcasting enabled successfully.');
     }
 
-    protected function updateBroadcastingKeysInEnvironmentFiles(): void
+    protected function warnAboutLegacyBroadcastDriverKey(): void
     {
         if (version_compare(app()->version(), '11', '<')) {
             return;
         }
 
-        $environmentFiles = [
-            app()->environmentFile(),
-            app()->environmentFile('.env.example'),
-        ];
-
-        foreach ($environmentFiles as $file) {
-            if (File::missing($file)) {
-                continue;
-            }
-
-            if (Str::contains($contents = File::get($file), 'BROADCAST_DRIVER')) {
-                $contents = Str::of($contents)
-                    ->replace('BROADCAST_DRIVER', 'BROADCAST_CONNECTION')
-                    ->__toString();
-
-                File::put($file, $contents);
-
-                $this->components->warn("Laravel expects the BROADCAST_CONNECTION key in your .env file. You were using the legacy BROADCAST_DRIVER key. We've updated it for you. Remember to update the .env file on any servers you might have.");
-            }
+        if (Str::contains(File::get(app()->environmentFile()), 'BROADCAST_DRIVER')) {
+            $this->components->warn('The BROADCAST_DRIVER environment variable has been renamed to BROADCAST_CONNECTION in Laravel 11. You should update your .env file.');
         }
     }
 


### PR DESCRIPTION
This pull request fixes an issue when installing the Collaboration addon, and all the bootstrapping that happens behind the scenes to enable Laravel's broadcasting functionality.

In Laravel 11, the environment variable key used to determine an app's broadcasting driver is `BROADCAST_CONNECTION`. Previously, this key was `BROADCAST_DRIVER`

For applications upgraded to Laravel 11 manually (eg. not via Laravel Shift), they'll still have the legacy `BROADCAST_DRIVER` key in their `.env` files as the change wasn't part of the Laravel 11 upgrade guide.

So, when you install Laravel's broadcasting stuff into an upgraded Laravel 11 app, it'll be referencing the new key, rather than the old one present in the app's `.env`. 

This PR introduces a warning during the `install:collaboration` command which'll let users know if they should update the names of environment variables in their `.env` files:

![CleanShot 2024-08-09 at 11 46 59](https://github.com/user-attachments/assets/247ca1b6-4eca-408d-8f1b-ef86641e2952)

Closes statamic/collaboration#102.