### PR TITLE
[5.x] Render attributes inside single quotes when value contains double quotes

### DIFF
--- a/src/Tags/Concerns/RendersAttributes.php
+++ b/src/Tags/Concerns/RendersAttributes.php
@@ -28,7 +28,12 @@ trait RendersAttributes
                     ? ($value ? 'true' : 'false')
                     : $value;
 
-                return sprintf('%s="%s"', $attribute, $value);
+                $format = '%s="%s"';
+                if (str_contains($value, '"')) {
+                    $format = '%s=\'%s\'';
+                }
+
+                return sprintf($format, $attribute, $value);
             })
             ->filter()
             ->implode(' ');

--- a/tests/Tags/Concerns/RendersAttributesTest.php
+++ b/tests/Tags/Concerns/RendersAttributesTest.php
@@ -102,6 +102,21 @@ class RendersAttributesTest extends TestCase
 
         $this->assertEquals('class="m-0 mb-2" name="Han" src="avatar.jpg" focusable="false" disabled="true" autocomplete="true" aria-hidden="true"', $output);
     }
+
+    #[Test]
+    public function it_renders_params_with_double_quotes_inside_single_quotes()
+    {
+        $this->assertEquals('', $this->tag->renderAttributesFromParams());
+
+        $output = $this->tag
+            ->setContext(['first_name' => 'Han'])
+            ->setParameters([
+                'x-data' => '{"something":"here","something_else":"there"}',
+            ])
+            ->renderAttributesFromParams();
+
+        $this->assertEquals('x-data=\'{"something":"here","something_else":"there"}\'', $output);
+    }
 }
 
 class FakeTagWithRendersAttributes extends Tags


### PR DESCRIPTION
Something that always trips me up is adding attributes to forms tags that contain json (eg Alpine x-data). Currently if you do:

```
{{ form:create \x-data='{"something":"here"}' }} 
```

it will output the x-data inside double quotes (") which means on the browser side its invalid, eg.

```
<form x-data="{"something":"here"}">
```

This PR updates the attribute outputting to check for the presence of a double quote, and if it finds one it uses single quotes to wrap the attribute instead:


```
<form x-data='{"something":"here"}'>
```
