### PR TITLE
[5.x] Optimize hover titles of asset edit buttons

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -24,6 +24,7 @@
                 v-if="showFilename"
                 @click="editOrOpen"
                 class="flex items-center flex-1 rtl:mr-3 ltr:ml-3 text-xs rtl:text-right ltr:text-left truncate w-full"
+                :title="__('Edit')"
                 :aria-label="__('Edit Asset')"
             >
                 {{ asset.basename }}
@@ -43,6 +44,7 @@
             <button
                 class="flex items-center p-1 w-6 h-8 text-lg antialiased text-gray-600 dark:text-dark-150 hover:text-gray-900 dark:hover:text-dark-100"
                 @click="remove"
+                :title="__('Remove')"
                 :aria-label="__('Remove Asset')"
             >
                 ×

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -6,7 +6,7 @@
             'is-svg': canShowSvg,
             'is-file': !isImage && !canShowSvg,
         }"
-        :title="asset.filename"
+        :title="label"
     >
         <asset-editor
             v-if="editing"
@@ -29,7 +29,7 @@
                     <img :src="thumbnail" v-if="isImage" :title="label" />
 
                     <template v-else>
-                        <img v-if="canShowSvg" :src="asset.url" class="p-4" />
+                        <img v-if="canShowSvg" :src="asset.url" :title="label" class="p-4" />
                         <file-icon
                             v-else
                             :extension="asset.extension"
@@ -40,11 +40,11 @@
 
                 <div class="asset-controls" v-if="!readOnly">
                     <div class="h-full w-full flex items-center justify-center space-x-1 rtl:space-x-reverse">
-                        <button @click="edit" class="btn btn-icon" :alt="__('Edit')">
+                        <button @click="edit" class="btn btn-icon" :title="__('Edit')">
                             <svg-icon name="micro/sharp-pencil" class="h-4 my-2" />
                         </button>
 
-                        <button @click="remove" class="btn btn-icon" :alt="__('Remove')">
+                        <button @click="remove" class="btn btn-icon" :title="__('Remove')">
                             <span class="text-lg antialiased w-4">×</span>
                         </button>
                     </div>
@@ -55,7 +55,7 @@
                         v-if="asset.url && asset.isMedia && this.canDownload"
                         @click="open"
                         class="btn btn-icon"
-                        :alt="__('Open in a new window')"
+                        :title="__('Open in a new window')"
                     >
                         <svg-icon name="light/external-link" class="h-4 my-2" />
                     </button>
@@ -64,7 +64,7 @@
                         v-if="asset.allowDownloading && this.canDownload"
                         @click="download"
                         class="btn btn-icon"
-                        :alt="__('Download file')"
+                        :title="__('Download file')"
                     >
                         <svg-icon name="download" class="h-4 my-2" />
                     </button>


### PR DESCRIPTION
Improve the title attributes of asset edit buttons on hover.

- Include file extension in filename
- Add title to 'Edit' button
- Add title to 'Remove' button
- Remove invalid button `alt` attribute

## Before

![Screen Recording 2024-08-09 at 15 10 02](https://github.com/user-attachments/assets/7e452760-831c-4298-9ccd-597814c8bf13)

## After

![Screen Recording 2024-08-09 at 15 07 53](https://github.com/user-attachments/assets/d3362623-d073-4a14-9ec1-a2701b95b520)