### PR TITLE
[5.x] Implement NavCreating / NavSaving / NavCreated events

### DIFF
--- a/src/Events/NavCreated.php
+++ b/src/Events/NavCreated.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Events;
+
+class NavCreated extends Event
+{
+    public $nav;
+
+    public function __construct($nav)
+    {
+        $this->nav = $nav;
+    }
+}

--- a/src/Events/NavCreating.php
+++ b/src/Events/NavCreating.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class NavCreating extends Event
+{
+    public $nav;
+
+    public function __construct($nav)
+    {
+        $this->nav = $nav;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Events/NavSaving.php
+++ b/src/Events/NavSaving.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Statamic\Events;
+
+class NavSaving extends Event
+{
+    public $nav;
+
+    public function __construct($nav)
+    {
+        $this->nav = $nav;
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/tests/Stache/FeatureTest.php
+++ b/tests/Stache/FeatureTest.php
@@ -205,6 +205,7 @@ class FeatureTest extends TestCase
     {
         $structure = Structure::find('footer');
 
+        NavRepository::shouldReceive('find')->with('footer');
         NavRepository::shouldReceive('save')->with($structure)->once();
 
         $structure->save();


### PR DESCRIPTION
This pull request adds three new nav-related events:

* `NavCreating`
* `NavSaving`
* `NavCreated` 

Related: #10602