### PR TITLE
[5.x] Handle lock timeout in cache middleware

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -4,6 +4,7 @@ namespace Statamic\StaticCaching\Middleware;
 
 use Closure;
 use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
@@ -57,7 +58,11 @@ class Cache
 
         $lock = $this->createLock($request);
 
-        return $lock->block($this->lockFor, fn () => $this->handleRequest($request, $next));
+        try {
+            return $lock->block($this->lockFor, fn () => $this->handleRequest($request, $next));
+        } catch (LockTimeoutException $e) {
+            return $this->outputRefreshResponse($request);
+        }
     }
 
     private function handleRequest($request, Closure $next)
@@ -190,5 +195,14 @@ class Cache
     public static function isBeingUsedOnCurrentRoute()
     {
         return in_array(static::class, app('router')->gatherRouteMiddleware(request()->route()));
+    }
+
+    private function outputRefreshResponse($request)
+    {
+        $html = $request->ajax() || $request->wantsJson()
+            ? __('Service Unavailable')
+            : sprintf('<meta http-equiv="refresh" content="1; URL=\'%s\'" />', $request->getUri());
+
+        return response($html, 503, ['Retry-After' => 1]);
     }
 }


### PR DESCRIPTION
If you have static caching enabled, and you visit a page that is being generated in another process, your request will wait until the other request is done. If that takes longer than 30 seconds, you'll get an exception since #10370. Before that, I think the page would just time out.

This PR will now output a blank page that says unavailable and automatically refreshes. This is the [same thing that happens in the Stache locking middleware](https://github.com/statamic/cms/blob/457e056b6016f7ed2b5d84b20065abdc3611d41d/src/Http/Middleware/StacheLock.php#L21).
