### PR TITLE
[5.x] Change character_limit to integer on textarea

### DIFF
--- a/src/Fieldtypes/Textarea.php
+++ b/src/Fieldtypes/Textarea.php
@@ -24,7 +24,7 @@ class Textarea extends Fieldtype
                     'character_limit' => [
                         'display' => __('Character Limit'),
                         'instructions' => __('statamic::fieldtypes.text.config.character_limit'),
-                        'type' => 'text',
+                        'type' => 'integer',
                     ],
                     'default' => [
                         'display' => __('Default Value'),

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -477,7 +477,7 @@ class BlueprintTest extends TestCase
                                     'type' => 'textarea',
                                     'placeholder' => null,
                                     'validate' => 'min:2',
-                                    'character_limit' => null,
+                                    'character_limit' => 0,
                                     'default' => null,
                                     'antlers' => false,
                                     'component' => 'textarea',

--- a/tests/Fields/SectionTest.php
+++ b/tests/Fields/SectionTest.php
@@ -155,7 +155,7 @@ class SectionTest extends TestCase
                     'type' => 'textarea',
                     'validate' => 'min:2',
                     'placeholder' => null,
-                    'character_limit' => null,
+                    'character_limit' => 0,
                     'default' => null,
                     'antlers' => false,
                     'component' => 'textarea',

--- a/tests/Fields/TabTest.php
+++ b/tests/Fields/TabTest.php
@@ -180,7 +180,7 @@ class TabTest extends TestCase
                             'type' => 'textarea',
                             'validate' => 'min:2',
                             'placeholder' => null,
-                            'character_limit' => null,
+                            'character_limit' => 0,
                             'default' => null,
                             'antlers' => false,
                             'component' => 'textarea',


### PR DESCRIPTION
When you go to edit a textarea, the character_limit field is a text field. It should be an integer. 

Strings were being saved to the config, and you get a Vue warning saying the prop should have been an integer.

(The tests were updated to coincide with the `text` field a handful of lines above each change. Text fields have had character_limit 0 for a while now.)
