### PR TITLE
[5.x] Pass any appended form config to antlers

### DIFF
--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -65,7 +65,7 @@ class Tags extends BaseTags
         $jsDriver = $this->parseJsParamDriverAndOptions($this->params->get('js'), $form);
 
         $data['form_config'] = ($configFields = Form::extraConfigFor($form->handle()))
-            ? Blueprint::makeFromTabs($configFields)->fields()->addValues($form->data()->all())->process()->values()->all()
+            ? Blueprint::makeFromTabs($configFields)->fields()->addValues($form->data()->all())->values()->all()
             : [];
 
         $data['sections'] = $this->getSections($this->sessionHandle(), $jsDriver);

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -64,12 +64,9 @@ class Tags extends BaseTags
 
         $jsDriver = $this->parseJsParamDriverAndOptions($this->params->get('js'), $form);
 
-        $configFields = [];
-        foreach (Form::extraConfigFor($form->handle()) as $handle => $config) {
-            $configFields[$handle] = $config;
-        }
-
-        $data['form_config'] = $configFields ? Blueprint::makeFromTabs($configFields)->fields()->addValues($form->data()->all())->process()->values()->all() : [];
+        $data['form_config'] = ($configFields = Form::extraConfigFor($form->handle()))
+            ? Blueprint::makeFromTabs($configFields)->fields()->addValues($form->data()->all())->process()->values()->all()
+            : [];
 
         $data['sections'] = $this->getSections($this->sessionHandle(), $jsDriver);
 

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -6,6 +6,7 @@ use DebugBar\DataCollector\ConfigCollector;
 use DebugBar\DebugBarException;
 use Statamic\Contracts\Forms\Form as FormContract;
 use Statamic\Facades\Blink;
+use Statamic\Facades\Blueprint;
 use Statamic\Facades\Form;
 use Statamic\Facades\URL;
 use Statamic\Forms\JsDrivers\JsDriver;
@@ -62,6 +63,13 @@ class Tags extends BaseTags
         $data = $this->getFormSession($this->sessionHandle());
 
         $jsDriver = $this->parseJsParamDriverAndOptions($this->params->get('js'), $form);
+
+        $configFields = [];
+        foreach (Form::extraConfigFor($form->handle()) as $handle => $config) {
+            $configFields[$handle] = $config;
+        }
+
+        $data['form_config'] = $configFields ? Blueprint::makeFromTabs($configFields)->fields()->addValues($form->data()->all())->process()->values()->all() : [];
 
         $data['sections'] = $this->getSections($this->sessionHandle(), $jsDriver);
 

--- a/tests/Tags/Form/FormCreateTest.php
+++ b/tests/Tags/Form/FormCreateTest.php
@@ -979,13 +979,13 @@ EOT
     }
 
     #[Test]
-    public function it_adds_renders_appended_config_fields()
+    public function it_adds_appended_config_fields()
     {
         Form::appendConfigFields('*', 'Fields', [
             'test_config' => ['type' => 'text', 'display' => 'First injected into fields section'],
         ]);
 
-        $form = tap(Form::find('contact')->data(['test_config' => 'This is a test config value']))->save();
+        tap(Form::find('contact')->data(['test_config' => 'This is a test config value']))->save();
 
         $output = $this->tag('{{ form:contact redirect="/submitted" error_redirect="/errors" class="form" id="form" }}{{ form_config:test_config }}{{ /form:contact }}');
 

--- a/tests/Tags/Form/FormCreateTest.php
+++ b/tests/Tags/Form/FormCreateTest.php
@@ -977,4 +977,19 @@ EOT
         $this->assertArrayHasKey('errors', $json);
         $this->assertSame($json['error'], ['some' => 'error']);
     }
+
+    #[Test]
+    public function it_adds_renders_appended_config_fields()
+    {
+        Form::appendConfigFields('*', 'Fields', [
+            'test_config' => ['type' => 'text', 'display' => 'First injected into fields section'],
+        ]);
+
+        $form = tap(Form::find('contact')->data(['test_config' => 'This is a test config value']))->save();
+
+        $output = $this->tag('{{ form:contact redirect="/submitted" error_redirect="/errors" class="form" id="form" }}{{ form_config:test_config }}{{ /form:contact }}');
+
+        $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/forms/contact" class="form" id="form">', $output);
+        $this->assertStringContainsString('This is a test config value', $output);
+    }
 }


### PR DESCRIPTION
One thing I overlooked in https://github.com/statamic/cms/pull/8491 is that you may want to access the new config fields in antlers. 

This PR changes that by adding a `form_config` variable to the antlers scope in `form:create` tags. The name was the best I could come up with, I wanted to use `config` but it would clash with the [config](https://statamic.dev/variables/config) variable which is potentially being used in form tags.