### PR TITLE
[5.x] Stop hiding `hidden` field in namespaced blueprints

### DIFF
--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -66,8 +66,8 @@ export default {
         action: String,
         initialBlueprint: Object,
         showTitle: Boolean,
-        useTabs: {type: Boolean, default: true},
-        isFormBlueprint: {type: Boolean, default: false},
+        useTabs: { type: Boolean, default: true },
+        isFormBlueprint: { type: Boolean, default: false },
     },
 
     data() {
@@ -112,7 +112,7 @@ export default {
         initializeBlueprint() {
             let blueprint = clone(this.initialBlueprint);
 
-            if (!this.showTitle) delete blueprint.title;
+            if (! this.showTitle) delete blueprint.title;
 
             return blueprint;
         },

--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -24,7 +24,7 @@
                     </div>
                 </div>
 
-                <div class="form-group config-field" v-if="showHidden">
+                <div class="form-group config-field">
                     <div class="field-inner">
                         <label class="block">{{ __('Hidden') }}</label>
                         <p class="help-block">{{ __('messages.blueprints_hidden_instructions') }}</p>
@@ -66,9 +66,8 @@ export default {
         action: String,
         initialBlueprint: Object,
         showTitle: Boolean,
-        useTabs: { type: Boolean, default: true },
-        isFormBlueprint: { type: Boolean, default: false },
-        showHidden: { type: Boolean, default: true },
+        useTabs: {type: Boolean, default: true},
+        isFormBlueprint: {type: Boolean, default: false},
     },
 
     data() {
@@ -113,7 +112,7 @@ export default {
         initializeBlueprint() {
             let blueprint = clone(this.initialBlueprint);
 
-            if (! this.showTitle) delete blueprint.title;
+            if (!this.showTitle) delete blueprint.title;
 
             return blueprint;
         },

--- a/resources/views/blueprints/edit.blade.php
+++ b/resources/views/blueprints/edit.blade.php
@@ -14,7 +14,6 @@
         show-title
         action="{{ cp_route('blueprints.update', [$blueprint->namespace(), $blueprint->handle()]) }}"
         :initial-blueprint="{{ json_encode($blueprintVueObject) }}"
-        :show-hidden="false"
     ></blueprint-builder>
 
     @include('statamic::partials.docs-callout', [

--- a/src/Http/Controllers/CP/Fields/BlueprintController.php
+++ b/src/Http/Controllers/CP/Fields/BlueprintController.php
@@ -64,8 +64,6 @@ class BlueprintController extends CpController
             throw new NotFoundHttpException;
         }
 
-        $request->merge(['hidden' => false]); // we dont support hidden here
-
         $request->validate([
             'title' => 'required',
             'tabs' => 'array',


### PR DESCRIPTION
When working on https://github.com/statamic/cms/pull/8516 I decided to prevent custom namespaces blueprints from being hidden. I shouldn't have. This PR undoes that mistake.

Closes https://github.com/statamic/ideas/issues/1175