### PR TITLE
[5.x] Add padding to session expiry modal

### DIFF
--- a/resources/js/components/SessionExpiry.vue
+++ b/resources/js/components/SessionExpiry.vue
@@ -19,7 +19,7 @@
                 </div>
             </div>
 
-            <div v-if="!isUsingOauth" class="publish-fields">
+            <div v-if="!isUsingOauth" class="publish-fields p-3">
                 <div class="form-group w-full">
                     <label v-text="__('messages.session_expiry_enter_password')" />
                     <small

--- a/resources/js/components/SessionExpiry.vue
+++ b/resources/js/components/SessionExpiry.vue
@@ -6,7 +6,7 @@
 
         <modal name="session-timeout-login" v-if="isShowingLogin" height="auto" width="500px" :adaptive="true">
             <div class="-max-h-screen-px">
-            <div class="flex items-center p-6 bg-gray-200 dark:bg-dark-700 border-b dark:border-dark-900 text-center">
+            <div class="text-lg font-semibold px-5 py-3 bg-gray-200 dark:bg-dark-550 rounded-t-lg flex items-center justify-between border-b dark:border-dark-900">
                 {{ __('Resume Your Session') }}
             </div>
 
@@ -19,7 +19,7 @@
                 </div>
             </div>
 
-            <div v-if="!isUsingOauth" class="publish-fields p-3">
+            <div v-if="!isUsingOauth" class="publish-fields p-2">
                 <div class="form-group w-full">
                     <label v-text="__('messages.session_expiry_enter_password')" />
                     <small

--- a/resources/js/components/SessionExpiry.vue
+++ b/resources/js/components/SessionExpiry.vue
@@ -10,7 +10,7 @@
                 {{ __('Resume Your Session') }}
             </div>
 
-            <div v-if="isUsingOauth" class="p-6">
+            <div v-if="isUsingOauth" class="p-5">
                 <a :href="oauthProvider.loginUrl" target="_blank" class="btn-primary">
                     {{ __('Log in with :provider', {provider: oauthProvider.label}) }}
                 </a>


### PR DESCRIPTION
This PR adds padding and tweaks fonts of the session expiry modal so that the contents line up with the heading and look more like other modals.

Before:
![CleanShot 2024-08-13 at 10 16 52](https://github.com/user-attachments/assets/09969cf7-8050-4676-94ee-aeb908fa08f2)



After:
![CleanShot 2024-08-13 at 10 23 02](https://github.com/user-attachments/assets/49316205-4d1c-4459-b9d2-e98c0070ed28)

