### PR TITLE
[5.x] Fix asset tile buttons in read-only mode

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -66,7 +66,7 @@
                                 class="btn btn-icon"
                                 :title="__('Download file')"
                             >
-                                <svg-icon name="download" class="h-4 my-2" />
+                                <svg-icon name="light/download" class="h-4 my-2" />
                             </button>
                         </template>
                     </div>

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -38,37 +38,40 @@
                     </template>
                 </template>
 
-                <div class="asset-controls" v-if="!readOnly">
-                    <div class="h-full w-full flex items-center justify-center space-x-1 rtl:space-x-reverse">
-                        <button @click="edit" class="btn btn-icon" :title="__('Edit')">
-                            <svg-icon name="micro/sharp-pencil" class="h-4 my-2" />
-                        </button>
+                <div class="asset-controls">
+                    <div class="flex items-center justify-center space-x-1 rtl:space-x-reverse">
+                        <template v-if="!readOnly">
+                            <button @click="edit" class="btn btn-icon" :title="__('Edit')">
+                                <svg-icon name="micro/sharp-pencil" class="h-4 my-2" />
+                            </button>
 
-                        <button @click="remove" class="btn btn-icon" :title="__('Remove')">
-                            <span class="text-lg antialiased w-4">×</span>
-                        </button>
+                            <button @click="remove" class="btn btn-icon" :title="__('Remove')">
+                                <span class="text-lg antialiased w-4">×</span>
+                            </button>
+                        </template>
+
+                        <template v-else>
+                            <button
+                                v-if="asset.url && asset.isMedia && this.canDownload"
+                                @click="open"
+                                class="btn btn-icon"
+                                :title="__('Open in a new window')"
+                            >
+                                <svg-icon name="light/external-link" class="h-4 my-2" />
+                            </button>
+
+                            <button
+                                v-if="asset.allowDownloading && this.canDownload"
+                                @click="download"
+                                class="btn btn-icon"
+                                :title="__('Download file')"
+                            >
+                                <svg-icon name="download" class="h-4 my-2" />
+                            </button>
+                        </template>
                     </div>
                 </div>
 
-                <div class="asset-controls" v-if="readOnly">
-                    <button
-                        v-if="asset.url && asset.isMedia && this.canDownload"
-                        @click="open"
-                        class="btn btn-icon"
-                        :title="__('Open in a new window')"
-                    >
-                        <svg-icon name="light/external-link" class="h-4 my-2" />
-                    </button>
-
-                    <button
-                        v-if="asset.allowDownloading && this.canDownload"
-                        @click="download"
-                        class="btn btn-icon"
-                        :title="__('Download file')"
-                    >
-                        <svg-icon name="download" class="h-4 my-2" />
-                    </button>
-                </div>
             </div>
         </div>
 


### PR DESCRIPTION
The asset control bottons looked a bit off for read-only asset fields. I've added back a gap between buttons and updated the svg icon component to use the correct download icon. The current download icon seems to be a fallback icon.

| Before | After |
| --- | --- |
| <img width="260" alt="Screenshot 2024-08-13 at 17 58 21" src="https://github.com/user-attachments/assets/07cdbf2d-7b93-4228-9a6b-74f94d0ee0de"> | <img width="261" alt="Screenshot 2024-08-13 at 18 00 26" src="https://github.com/user-attachments/assets/768baa35-563f-4f54-84e9-c425b113abfc"> |
| <img width="262" alt="Screenshot 2024-08-13 at 17 58 34" src="https://github.com/user-attachments/assets/6f5d3512-cb61-4626-933b-7ec0b4347e95"> | <img width="258" alt="Screenshot 2024-08-13 at 18 00 16" src="https://github.com/user-attachments/assets/d41a94f6-8353-495a-97f7-6ac7393b4bb2"> |