### PR TITLE
[5.x] Adjust dark mode readonly label

### DIFF
--- a/resources/js/components/publish/Field.vue
+++ b/resources/js/components/publish/Field.vue
@@ -17,7 +17,7 @@
                 />
                 <i class="required rtl:ml-1 ltr:mr-1" v-if="showLabelText && config.required">*</i>
                 <avatar v-if="isLocked" :user="lockingUser" class="w-6 h-6 rounded-full -mt-px rtl:mr-2 ltr:ml-2 rtl:ml-2 ltr:mr-2" v-tooltip="lockingUser.name" />
-                <span v-if="isReadOnly && !isTab && !isSection" class="text-gray-500 font-normal text-2xs rtl:ml-1 ltr:mr-1">
+                <span v-if="isReadOnly && !isTab && !isSection" class="text-gray-500 dark:text-dark-300 font-normal text-2xs rtl:ml-1 ltr:mr-1">
                     {{ isLocked ? __('Locked') : __('Read Only') }}
                 </span>
                 <svg-icon name="translate" class="h-4 rtl:ml-1 ltr:mr-1 w-4 text-gray-600" v-if="isLocalizable && !isTab" v-tooltip.top="__('Localizable field')" />

--- a/resources/js/components/publish/Field.vue
+++ b/resources/js/components/publish/Field.vue
@@ -17,7 +17,7 @@
                 />
                 <i class="required rtl:ml-1 ltr:mr-1" v-if="showLabelText && config.required">*</i>
                 <avatar v-if="isLocked" :user="lockingUser" class="w-6 h-6 rounded-full -mt-px rtl:mr-2 ltr:ml-2 rtl:ml-2 ltr:mr-2" v-tooltip="lockingUser.name" />
-                <span v-if="isReadOnly && !isTab && !isSection" class="text-gray-500 dark:text-dark-300 font-normal text-2xs rtl:ml-1 ltr:mr-1">
+                <span v-if="isReadOnly && !isTab && !isSection" class="text-gray-500 dark:text-dark-300 font-normal text-2xs rtl:ml-1 ltr:mr-1 mt-0.5">
                     {{ isLocked ? __('Locked') : __('Read Only') }}
                 </span>
                 <svg-icon name="translate" class="h-4 rtl:ml-1 ltr:mr-1 w-4 text-gray-600" v-if="isLocalizable && !isTab" v-tooltip.top="__('Localizable field')" />

--- a/resources/js/components/publish/Field.vue
+++ b/resources/js/components/publish/Field.vue
@@ -17,7 +17,7 @@
                 />
                 <i class="required rtl:ml-1 ltr:mr-1" v-if="showLabelText && config.required">*</i>
                 <avatar v-if="isLocked" :user="lockingUser" class="w-6 h-6 rounded-full -mt-px rtl:mr-2 ltr:ml-2 rtl:ml-2 ltr:mr-2" v-tooltip="lockingUser.name" />
-                <span v-if="isReadOnly && !isTab && !isSection" class="text-gray-500 dark:text-dark-300 font-normal text-2xs rtl:ml-1 ltr:mr-1 mt-0.5">
+                <span v-if="isReadOnly && !isTab && !isSection" class="text-gray-500 dark:text-dark-200 font-normal text-2xs rtl:ml-1 ltr:mr-1 mt-0.5">
                     {{ isLocked ? __('Locked') : __('Read Only') }}
                 </span>
                 <svg-icon name="translate" class="h-4 rtl:ml-1 ltr:mr-1 w-4 text-gray-600" v-if="isLocalizable && !isTab" v-tooltip.top="__('Localizable field')" />


### PR DESCRIPTION
The readonly label looked a bit off in dark mode. In light mode, it's lighter than the field display label. I've adjusted the dark mode color to also slightly subdue the readonly label. Also nudged the label down a bit to put it on the typographic baseline.

## Before

<img width="331" alt="Screenshot 2024-08-13 at 18 18 37" src="https://github.com/user-attachments/assets/af694f10-a91a-40f1-be52-b45391558d0c">

## After

<img width="333" alt="Screenshot 2024-08-13 at 18 26 01" src="https://github.com/user-attachments/assets/f70156e5-4957-474d-a6c4-ddc5070192de">

## Light mode for comparison

<img width="351" alt="Screenshot 2024-08-13 at 18 18 46" src="https://github.com/user-attachments/assets/dca7e04c-6992-49af-87b1-45a6ec9a594f">
