### PR TITLE
[5.x] Fix rounded corners in asset fields

### DIFF
--- a/resources/css/components/assets.css
+++ b/resources/css/components/assets.css
@@ -59,6 +59,10 @@
 
 }
 
+.assets-fieldtype-picker + .asset-table-listing {
+    @apply rounded-t-none;
+}
+
 .asset-listing .actions {
     margin-bottom: 15px;
     display: flex;

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -67,7 +67,7 @@
                         :animate="false"
                         append-to="body"
                     >
-                        <div class="asset-grid-listing border dark:border-dark-900 rounded overflow-hidden rounded-t-none" ref="assets">
+                        <div class="asset-grid-listing border dark:border-dark-900 rounded overflow-hidden" :class="{ 'rounded-t-none': !isReadOnly && (showPicker || uploads.length) }" ref="assets">
                             <asset-tile
                                 v-for="asset in assets"
                                 :key="asset.id"


### PR DESCRIPTION
Fix two tiny inconsistencies I've encountered in the asset field. You really have to squint to see them, but once you did, there's no unseeing them 🤠

### 1. Round top corners of read-only asset grid

**Before**

<img width="516" alt="Screenshot 2024-08-13 at 18 48 45" src="https://github.com/user-attachments/assets/4aa9bb2a-745f-4aaf-933c-e2d7f21197ac">

**After**

<img width="502" alt="Screenshot 2024-08-13 at 18 50 37" src="https://github.com/user-attachments/assets/4104875f-efb8-4a23-b1ba-a60de25656ca">

### 2. Unround top corners of asset table when uploader is visible

**Before**

<img width="487" alt="Screenshot 2024-08-13 at 18 54 06" src="https://github.com/user-attachments/assets/0ebdcb31-ac27-4955-bf66-ffb61025183d">

**After**

<img width="506" alt="Screenshot 2024-08-13 at 18 52 00" src="https://github.com/user-attachments/assets/0355b65f-6309-46a5-92b0-4663adf87381">