### PR TITLE
[5.x] Cast to Array to Resolve Issues with Filters Returning `EntryCollection`

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fieldtypes;
 
+use Illuminate\Support\Collection;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\LabeledValue;
 use Statamic\GraphQL\Types\LabeledValueType;
@@ -23,7 +24,11 @@ trait HasSelectOptions
 
     protected function getOptions(): array
     {
-        $options = (array) $this->config('options') ?? [];
+        $options = $this->config('options') ?? [];
+
+        if ($options instanceof Collection) {
+            $options = $options->all();
+        }
 
         if (array_is_list($options) && ! is_array(Arr::first($options))) {
             $options = collect($options)

--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -23,7 +23,7 @@ trait HasSelectOptions
 
     protected function getOptions(): array
     {
-        $options = $this->config('options') ?? [];
+        $options = (array) $this->config('options') ?? [];
 
         if (array_is_list($options) && ! is_array(Arr::first($options))) {
             $options = collect($options)


### PR DESCRIPTION
Bug introduced in https://github.com/statamic/cms/pull/10467
Cast to array to prevent issues with listings when data is returned as a Statamic\Entries\EntryCollection

The issue will happen when filters don't return an array, but a EntryCollection like this.
```php
public function fieldItems()
    {
        $entries = \Statamic\Facades\Entry::query()->where('collection', 'locations')->get();

        return [
            'locations' => [
                'type' => 'select',
                'multiple' => true,
                'options' => $entries->mapWithKeys(function (\Statamic\Entries\Entry $item, int $key) {
                    return [$item->id() => $item->title];
                }),
            ],
        ];
    }
```