### PR TITLE
[5.x] Hide "Sortable" config option for Computed fields

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -537,6 +537,9 @@ class Field implements Arrayable
                 'instructions' => __('statamic::messages.fields_sortable_instructions'),
                 'type' => 'toggle',
                 'default' => true,
+                'unless' => [
+                    'visibility' => 'equals computed',
+                ],
             ],
             'visibility' => [
                 'display' => __('Visibility'),


### PR DESCRIPTION
This PR hides the "Sortable" config option for computed fields.

Closes #10610.