### PR TITLE
[5.x] Fix save button options not showing

### DIFF
--- a/resources/js/components/fieldtypes/ArrayFieldtype.vue
+++ b/resources/js/components/fieldtypes/ArrayFieldtype.vue
@@ -7,7 +7,7 @@
                      <select class="bg-transparent appearance-none shadow-none outline-none border-0 text-sm" @input="setKey($event.target.value)">
                         <option
                             v-for="(element, index) in keyedData"
-                            v-text="meta.keys[element.key] || element.key"
+                            v-text="keys[element.key] || element.key"
                             :key="element._id"
                             :value="element.key"
                             :selected="element.key === selectedKey" />
@@ -29,7 +29,7 @@
             <table class="array-table">
                 <tbody>
                     <tr v-if="data" v-for="(element, index) in keyedData" :key="element._id">
-                        <th class="w-1/4"><label :for="fieldId+'__'+element.key">{{ meta.keys[element.key] || element.key }}</label></th>
+                        <th class="w-1/4"><label :for="fieldId+'__'+element.key">{{ keys[element.key] || element.key }}</label></th>
                         <td>
                             <input type="text" class="input-text-minimal" :id="fieldId+'__'+element.key" v-model="data[index].value" :readonly="isReadOnly" />
                         </td>
@@ -129,8 +129,12 @@ export default {
     },
 
     computed: {
+        keys() {
+            return this.meta.keys || this.config.keys;
+        },
+
         isKeyed() {
-            return Boolean(Object.keys(this.meta.keys).length);
+            return Boolean(Object.keys(this.keys).length);
         },
 
         isDynamic() {
@@ -142,7 +146,7 @@ export default {
         },
 
         keyedData() {
-            return this.data.filter(element => this.meta.keys.hasOwnProperty(element.key));
+            return this.data.filter(element => this.keys.hasOwnProperty(element.key));
         },
 
         maxItems() {

--- a/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
@@ -39,7 +39,7 @@ export default {
 
     computed: {
         options() {
-            return this.normalizeInputOptions(this.meta.options);
+            return this.normalizeInputOptions(this.meta.options || this.config.options);
         },
 
         replicatorPreview() {

--- a/resources/js/components/fieldtypes/CheckboxesFieldtype.vue
+++ b/resources/js/components/fieldtypes/CheckboxesFieldtype.vue
@@ -30,7 +30,7 @@ export default {
 
     computed: {
         options() {
-            return this.normalizeInputOptions(this.meta.options);
+            return this.normalizeInputOptions(this.meta.options || this.config.options);
         },
 
         replicatorPreview() {

--- a/resources/js/components/fieldtypes/RadioFieldtype.vue
+++ b/resources/js/components/fieldtypes/RadioFieldtype.vue
@@ -48,7 +48,7 @@ export default {
 
     computed: {
         options() {
-            return this.normalizeInputOptions(this.meta.options);
+            return this.normalizeInputOptions(this.meta.options || this.config.options);
         },
 
         replicatorPreview() {

--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -106,7 +106,7 @@ export default {
         },
 
         options() {
-            return this.normalizeInputOptions(this.meta.options);
+            return this.normalizeInputOptions(this.meta.options || this.config.options);
         },
 
         replicatorPreview() {

--- a/resources/js/components/publish/SaveButtonOptions.vue
+++ b/resources/js/components/publish/SaveButtonOptions.vue
@@ -17,7 +17,7 @@
                 <div class="publish-field save-and-continue-options radio-fieldtype">
                     <radio-fieldtype
                         handle="save_and_continue_options"
-                        :meta="options"
+                        :config="options"
                         v-model="currentOption"
                     />
                 </div>

--- a/resources/js/components/publish/SaveButtonOptions.vue
+++ b/resources/js/components/publish/SaveButtonOptions.vue
@@ -17,7 +17,7 @@
                 <div class="publish-field save-and-continue-options radio-fieldtype">
                     <radio-fieldtype
                         handle="save_and_continue_options"
-                        :config="options"
+                        :meta="options"
                         v-model="currentOption"
                     />
                 </div>


### PR DESCRIPTION
This pull request fixes an issue where the radio buttons weren't showing in the `save-button-options` component, due to the fieldtype now expecting options to be passed in via the `meta` prop instead of the `config` prop.

Fixes #10632.
Related: https://github.com/statamic/cms/pull/10467