### PR TITLE
[5.x] Display special install commands for first-party addons

### DIFF
--- a/resources/js/components/AddonDetails.vue
+++ b/resources/js/components/AddonDetails.vue
@@ -19,7 +19,7 @@
                 </template>
                 <template v-else>
                     <p v-text="`${__('messages.addon_install_command')}:`" />
-                    <code-block copyable :text="`composer require ${package}`" />
+                    <code-block copyable :text="installCommand" />
                 </template>
                 <p v-html="link"></p>
             </div>
@@ -69,10 +69,6 @@ import AddonEditions from './addons/Editions.vue';
         },
 
         computed: {
-            toEleven() {
-                return {timeout: Statamic.$config.get('ajaxTimeout')};
-            },
-
             package() {
                 return this.addon.package;
             },
@@ -90,6 +86,19 @@ import AddonEditions from './addons/Editions.vue';
 
             link() {
                 return __('Learn more about :link', { link: `<a href="https://statamic.dev/addons" target="_blank">${__('Addons')}</a>`}) + '.';
+            },
+
+            installCommand() {
+                switch (this.package) {
+                    case 'statamic/collaboration':
+                        return 'php please install:collaboration';
+                    case 'statamic/eloquent-driver':
+                        return 'php please install:eloquent-driver';
+                    case 'statamic/ssg':
+                        return 'php please install:ssg';
+                    default:
+                        return `composer require ${this.package}`;
+                }
             },
         },
 


### PR DESCRIPTION
This pull request updates the `AddonDetail` component to display special install commands for some first-party addons, like the Eloquent Driver and the Collaboration addon.