### PR TITLE
[5.x] Fix nocache race condition

### DIFF
--- a/src/StaticCaching/NoCache/StringFragment.php
+++ b/src/StaticCaching/NoCache/StringFragment.php
@@ -47,9 +47,7 @@ class StringFragment
             $this->extension,
         ]);
 
-        if (! File::exists($path)) {
-            File::put($path, $this->contents);
-        }
+        File::put($path, $this->contents);
 
         return $path;
     }

--- a/src/StaticCaching/NoCache/StringFragment.php
+++ b/src/StaticCaching/NoCache/StringFragment.php
@@ -4,6 +4,7 @@ namespace Statamic\StaticCaching\NoCache;
 
 use Statamic\Facades\File;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class StringFragment
 {
@@ -27,22 +28,22 @@ class StringFragment
         view()->addNamespace('nocache', $this->directory);
         File::makeDirectory($this->directory);
 
-        $path = $this->createTemporaryView();
+        $path = $this->createTemporaryView($view = $this->region.Str::random());
 
         $this->data['__frontmatter'] = Arr::pull($this->data, 'view', []);
 
-        $rendered = view('nocache::'.$this->region, $this->data)->render();
+        $rendered = view('nocache::'.$view, $this->data)->render();
 
         File::delete($path);
 
         return $rendered;
     }
 
-    private function createTemporaryView(): string
+    private function createTemporaryView($view): string
     {
         $path = vsprintf('%s/%s.%s', [
             $this->directory,
-            $this->region,
+            $view,
             $this->extension,
         ]);
 


### PR DESCRIPTION
Fixes a race condition when rendering antlers views via nocache.

It's possible that two requests come in at almost the exact moment and one request's view is cleaned up before the other request has a chance to render it, resulting in a `view not found` exception.

This PR makes the view names unique so there's no overlap.

It also removes a file exists check that isn't related to the race condition but noticed it's not necessary while in there.
