### PR TITLE
[5.x] Support arrays in unique value rules

### DIFF
--- a/src/Rules/UniqueEntryValue.php
+++ b/src/Rules/UniqueEntryValue.php
@@ -29,7 +29,11 @@ class UniqueEntryValue implements ValidationRule
         }
 
         $existing = $query
-            ->where($attribute, $value)
+            ->when(
+                is_array($value),
+                fn ($query) => $query->whereIn($attribute, $value),
+                fn ($query) => $query->where($attribute, $value)
+            )
             ->first();
 
         if (! $existing) {

--- a/src/Rules/UniqueTermValue.php
+++ b/src/Rules/UniqueTermValue.php
@@ -29,7 +29,11 @@ class UniqueTermValue implements ValidationRule
         }
 
         $existing = $query
-            ->where($attribute, $value)
+            ->when(
+                is_array($value),
+                fn ($query) => $query->whereIn($attribute, $value),
+                fn ($query) => $query->where($attribute, $value)
+            )
             ->first();
 
         if (! $existing) {

--- a/src/Rules/UniqueUserValue.php
+++ b/src/Rules/UniqueUserValue.php
@@ -20,7 +20,11 @@ class UniqueUserValue implements ValidationRule
         $this->column ??= $attribute;
 
         $existing = User::query()
-            ->where($this->column, $value)
+            ->when(
+                is_array($value),
+                fn ($query) => $query->whereIn($this->column, $value),
+                fn ($query) => $query->where($this->column, $value)
+            )
             ->first();
 
         if (! $existing) {


### PR DESCRIPTION
This pull request adds support for arrays being passed to the "unique value" validation rules, allowing for validating unique entry fields (and similar).

Closes #10614.