### PR TITLE
[5.x] Form fields should continue to output a key/value array

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -212,4 +212,13 @@ trait HasSelectOptions
             },
         ];
     }
+
+    public function extraRenderableFieldData(): array
+    {
+        return [
+            'options' => collect($this->getOptions())
+                ->mapWithKeys(fn ($option) => [$option['value'] => $option['label']])
+                ->all(),
+        ];
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue caused by our recent changes in #10467, where options for various fieldtypes are saved in a new "expanded" format, allowing for integer keys in options.

However, these changes broke Checkboxes  / Radio Buttons / etc in frontend forms, since the templates assume `option` is just a key/value array, which it no longer is.

Closes #10645.