### PR TITLE
[5.x] Make config values available in form emails

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -234,7 +234,11 @@ class Email extends Mailable
         return collect($config)->map(function ($value) {
             $value = Parse::env($value); // deprecated
 
-            return (string) Antlers::parse($value, array_merge($this->getGlobalsData(), $this->submissionData));
+            return (string) Antlers::parse($value, array_merge(
+                ['config' => config()->all()],
+                $this->getGlobalsData(),
+                $this->submissionData,
+            ));
         });
     }
 }


### PR DESCRIPTION
This pull request makes config values available in form emails. 

This can be helpful if you want to control who receives form emails on a per-environment basis.

Closes https://github.com/statamic/cms/issues/10647.