### PR TITLE
[5.x] Fix suggested options in Field Conditions builder

### DIFF
--- a/resources/js/components/fieldtypes/HasInputOptions.js
+++ b/resources/js/components/fieldtypes/HasInputOptions.js
@@ -12,9 +12,18 @@ export default {
 
             return _.map(options, (option) => {
                 if (typeof option === 'object') {
+                    let valueKey = 'value';
+                    let labelKey = 'label';
+
+                    // Support both {key: '', value: ''} and {value: '', label: ''} formats.
+                    if (option.hasOwnProperty('key')) {
+                        valueKey = 'key';
+                        labelKey = 'value';
+                    }
+
                     return {
-                        'value': option.key || option.value,
-                        'label': __(option.label) || option.value
+                        'value': option[valueKey],
+                        'label': __(option[labelKey]) || option[valueKey]
                     };
                 }
 

--- a/resources/js/components/fieldtypes/HasInputOptions.js
+++ b/resources/js/components/fieldtypes/HasInputOptions.js
@@ -13,7 +13,7 @@ export default {
             return _.map(options, (option) => {
                 if (typeof option === 'object') {
                     return {
-                        'value': option.value,
+                        'value': option.key || option.value,
                         'label': __(option.label) || option.value
                     };
                 }

--- a/resources/js/tests/NormalizeInputOptions.test.js
+++ b/resources/js/tests/NormalizeInputOptions.test.js
@@ -46,10 +46,20 @@ it('normalizes input options with object', () => {
     ]);
 });
 
-it('normalizes input options with array of objects', () => {
+it('normalizes input options with array of objects with value label keys', () => {
     expect(normalizeInputOptions([
         {value: 'one', label: 'One'},
         {value: 'two', label: 'Two'}
+    ])).toEqual([
+        {value: 'one', label: 'Uno'},
+        {value: 'two', label: 'Two'}
+    ]);
+});
+
+it('normalizes input options with array of objects with key value keys', () => {
+    expect(normalizeInputOptions([
+        {key: 'one', value: 'One'},
+        {key: 'two', value: 'Two'}
     ])).toEqual([
         {value: 'one', label: 'Uno'},
         {value: 'two', label: 'Two'}


### PR DESCRIPTION
This pull request fixes an issue with the suggested fields in the Field Conditions builder, after changes to how field options are stored in #10467.

Say you have a Button Group or Select field that looks like this:

```yaml
-
  handle: developer_type
  field:
    options:
      -
        key: partner
        value: Partner
      -
        key: other
        value: Other
    default: other
    type: button_group
    display: 'Developer Type'
```

Then, when you add another field to the blueprint and configure a field condition, it'll save like this:

```yaml
if:
  developer_type: 'equals Partner'
```

The saved value for this field condition is the "label" for the option, not the key or the value. This means the field condition won't actually work.

This is happening due to the format the options are saved in. The `normalizeInputOptions` only picks up on the `value` (which is the "label"). It doesn't know about using the `key`, if it exists.