### PR TITLE
[5.x] Allow numbers at the start of field handles

### DIFF
--- a/src/Rules/Handle.php
+++ b/src/Rules/Handle.php
@@ -9,7 +9,7 @@ class Handle implements ValidationRule
 {
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! preg_match('/^[a-zA-Z][a-zA-Z0-9]*(?:_{0,1}[a-zA-Z0-9])*$/', $value)) {
+        if (! preg_match('/^[a-zA-Z0-9][a-zA-Z0-9]*(?:_{0,1}[a-zA-Z0-9])*$/', $value)) {
             $fail('statamic::validation.handle')->translate();
         }
     }

--- a/tests/Rules/HandleTest.php
+++ b/tests/Rules/HandleTest.php
@@ -23,6 +23,7 @@ class HandleTest extends TestCase
         $this->assertPasses('foo123');
         $this->assertPasses('foo123_20bar');
         $this->assertPasses('FooBar');
+        $this->assertPasses('1foo');
 
         $this->assertFails('foo-bar');
         $this->assertFails('_foo');
@@ -31,7 +32,6 @@ class HandleTest extends TestCase
         $this->assertFails('foo_bar_');
         $this->assertFails('foo__bar');
         $this->assertFails('foo___bar');
-        $this->assertFails('1foo');
         $this->assertFails('*foo');
         $this->assertFails('foo#');
         $this->assertFails('foo_!bar');


### PR DESCRIPTION
This pull request allows for using numbers at the start of field handles.

Closes #10652.