### PR TITLE
[5.x] Display text in modal instead of alert, to improve things on iOS

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -251,6 +251,7 @@ Statamic.app({
     },
 
     created() {
+        const app = this;
         const state = localStorage.getItem('statamic.nav') || 'open';
         this.navOpen = state === 'open';
 
@@ -259,8 +260,8 @@ Statamic.app({
                 await navigator.clipboard.writeText(url);
                 Statamic.$toast.success(__('Copied to clipboard'));
             } catch (err) {
-                Statamic.$app.copyToClipboardModalOpen = true;
-                Statamic.$app.copyToClipboardUrl = url;
+                app.copyToClipboardModalOpen = true;
+                app.copyToClipboardUrl = url;
             }
         });
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -211,8 +211,7 @@ Statamic.app({
         portals: [],
         appendedComponents: [],
         isLicensingBannerSnoozed: localStorage.getItem(`statamic.snooze_license_banner`) > new Date().valueOf(),
-        copyToClipboardModalOpen: false,
-        copyToClipboardUrl: null,
+        copyToClipboardModalUrl: null,
     },
 
     computed: {
@@ -260,8 +259,7 @@ Statamic.app({
                 await navigator.clipboard.writeText(url);
                 Statamic.$toast.success(__('Copied to clipboard'));
             } catch (err) {
-                app.copyToClipboardModalOpen = true;
-                app.copyToClipboardUrl = url;
+                app.copyToClipboardModalUrl = url;
             }
         });
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -211,6 +211,8 @@ Statamic.app({
         portals: [],
         appendedComponents: [],
         isLicensingBannerSnoozed: localStorage.getItem(`statamic.snooze_license_banner`) > new Date().valueOf(),
+        copyToClipboardModalOpen: false,
+        copyToClipboardUrl: null,
     },
 
     computed: {
@@ -257,7 +259,8 @@ Statamic.app({
                 await navigator.clipboard.writeText(url);
                 Statamic.$toast.success(__('Copied to clipboard'));
             } catch (err) {
-                await alert(url);
+                Statamic.$app.copyToClipboardModalOpen = true;
+                Statamic.$app.copyToClipboardUrl = url;
             }
         });
 

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -38,6 +38,18 @@
             v-on="component.events"
         ></component>
 
+        <confirmation-modal
+            v-if="copyToClipboardModalOpen"
+            :cancellable="false"
+            :button-text="__('OK')"
+            title="Copy to clipboard"
+            @confirm="copyToClipboardModalOpen = false; copyToClipboardUrl = null"
+        >
+            <div class="prose">
+                <code-block copyable :text="copyToClipboardUrl" />
+            </div>
+        </confirmation-modal>
+
         <keyboard-shortcuts-modal></keyboard-shortcuts-modal>
 
         <portal-targets></portal-targets>

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -46,7 +46,7 @@
             @confirm="copyToClipboardModalUrl = null"
         >
             <div class="prose">
-                <code-block copyable :text="copyToClipboardModalUrl" />
+                <code-block :text="copyToClipboardModalUrl" />
             </div>
         </confirmation-modal>
 

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -39,14 +39,14 @@
         ></component>
 
         <confirmation-modal
-            v-if="copyToClipboardModalOpen"
+            v-if="copyToClipboardModalUrl"
             :cancellable="false"
             :button-text="__('OK')"
             title="Copy to clipboard"
-            @confirm="copyToClipboardModalOpen = false; copyToClipboardUrl = null"
+            @confirm="copyToClipboardModalUrl = null"
         >
             <div class="prose">
-                <code-block copyable :text="copyToClipboardUrl" />
+                <code-block copyable :text="copyToClipboardModalUrl" />
             </div>
         </confirmation-modal>
 


### PR DESCRIPTION
This pull request improves the handling of "copy to clipboard" actions when on iOS.

iOS [only allows](https://stackoverflow.com/a/34046084) for copying to the user's clipboard from an `<input>` or `<textarea>`. 

This means that iOS browsers end up in the `catch` statement, with a browser alert containing the URL, which the user has to copy manually. However, some browsers like Chrome don't allow copying from alerts. 😬 

To workaround this, instead of showing a browser alert, it'll open up a modal with the ability to copy from there (the copy button here will work since it's copying text from a textarea).

Closes #6378.