### PR TITLE
[5.x] Translate set groups in set previews

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -11,7 +11,7 @@
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
                     <label class="text-xs rtl:ml-2 ltr:mr-2">
                         <span v-if="isSetGroupVisible">
-                            {{ setGroup.display }}
+                            {{ __(setGroup.display) }}
                             <svg-icon name="micro/chevron-right" class="w-4" />
                         </span>
                         {{ display || config.handle }}

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -9,7 +9,7 @@
                 <div class="flex items-center flex-1 p-2 replicator-set-header-inner cursor-pointer" :class="{'flex items-center': collapsed}" @click="toggleCollapsedState">
                     <label class="text-xs rtl:ml-2 ltr:mr-2 cursor-pointer">
                         <span v-if="isSetGroupVisible">
-                            {{ setGroup.display }}
+                            {{ __(setGroup.display) }}
                             <svg-icon name="micro/chevron-right" class="w-4" />
                         </span>
                         {{ display || config.handle }}


### PR DESCRIPTION
This pull request wraps the name of set groups in set previews in the `__()` helper so they can be translated.

Fixes #10657.