### PR TITLE
[5.x] Bard: When email address is selected, assume link is a mailto

### DIFF
--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -300,6 +300,14 @@ export default {
             return ['url', 'entry', 'asset'].includes(this.linkType);
         },
 
+        selectedTextIsEmail() {
+            const { view, state } = this.bard.editor
+            const { from, to } = view.state.selection
+            const text = state.doc.textBetween(from, to, '')
+
+            return text.match(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/)
+        },
+
     },
 
     watch: {
@@ -327,6 +335,11 @@ export default {
 
         this.bard.$on('link-selected', this.applyAttrs);
         this.bard.$on('link-deselected', () => this.$emit('deselected'));
+
+        if (_.isEmpty(this.linkAttrs) && this.selectedTextIsEmail) {
+            this.linkType = 'mailto'
+            this.urlData = { mailto: this.selectedTextIsEmail }
+        }
     },
 
     mounted() {


### PR DESCRIPTION
This pull request makes a small improvement to linking email addresses in Bard.

Previously, when you had an email address selected and clicked on the "Link" button in the toolbar, it would default to a normal URL.

Now, with this PR, when you have an email address selected and click on the "Link" button, it'll default to the "Email" link type and prefill the value:

![CleanShot 2024-08-19 at 18 20 42](https://github.com/user-attachments/assets/953fcc40-dacb-4c3f-b356-88885f043583)
