### PR TITLE
[5.x] Fix blueprint override logic

### DIFF
--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -227,20 +227,26 @@ class BlueprintRepository
             $directory = $this->directory.'/'.$namespaceDir;
 
             if (isset($this->additionalNamespaces[$namespace])) {
-                $directory = $this->additionalNamespaces[$namespace];
-
-                $overridePath = "{$this->directory}/vendor/{$namespaceDir}";
-
-                if (File::exists($overridePath)) {
-                    $directory = $overridePath;
-                }
+                $directory = "{$this->additionalNamespaces[$namespace]}";
             }
 
-            if (! File::exists(Str::removeRight($directory, '/'))) {
-                return collect();
+            $files = File::withAbsolutePaths()->getFilesByType($directory, 'yaml');
+
+            if ($files->isNotEmpty() && File::exists($overrideDir = $this->directory.'/vendor/'.$namespaceDir)) {
+                $overrides = File::withAbsolutePaths()->getFilesByType($overrideDir, 'yaml');
+
+                $files = $files->map(function ($path) use ($overrides, $overrideDir, $directory) {
+                    $filename = str($path)->after($directory.'/');
+
+                    if ($overrides->contains($overridePath = $overrideDir.'/'.$filename)) {
+                        return $overridePath;
+                    }
+
+                    return $path;
+                });
             }
 
-            return File::withAbsolutePaths()->getFilesByType($directory, 'yaml');
+            return $files;
         });
     }
 

--- a/tests/Fields/BlueprintRepositoryTest.php
+++ b/tests/Fields/BlueprintRepositoryTest.php
@@ -266,8 +266,9 @@ EOT;
     public function it_gets_blueprints_in_a_namespace()
     {
         $dir = '/path/to/resources/blueprints/collections/blog';
+        $overrideDir = '/path/to/resources/blueprints/vendor/collections/blog';
         File::shouldReceive('withAbsolutePaths')->once()->andReturnSelf();
-        File::shouldReceive('exists')->with($dir)->once()->andReturnTrue();
+        File::shouldReceive('exists')->with($overrideDir)->once()->andReturnFalse();
         File::shouldReceive('getFilesByType')->with($dir, 'yaml')->once()->andReturn(
             new FileCollection([$dir.'/first.yaml', $dir.'/second.yaml'])
         );
@@ -288,12 +289,71 @@ EOT;
     #[Test]
     public function it_returns_empty_collection_if_directory_doesnt_exist()
     {
-        File::shouldReceive('exists')->with('/path/to/resources/blueprints/test')->once()->andReturnFalse();
+        File::shouldReceive('withAbsolutePaths')->once()->andReturnSelf();
+        File::shouldReceive('getFilesByType')->with('/path/to/resources/blueprints/test', 'yaml')->once()->andReturn(new FileCollection);
 
         $all = $this->repo->in('test');
 
         $this->assertInstanceOf(Collection::class, $all);
         $this->assertCount(0, $all);
+    }
+
+    #[Test]
+    public function it_gets_blueprints_in_a_custom_namespace()
+    {
+        $dir = '/path/to/custom';
+        $overrideDir = '/path/to/resources/blueprints/vendor/custom';
+        File::shouldReceive('withAbsolutePaths')->once()->andReturnSelf();
+        File::shouldReceive('exists')->with($overrideDir)->once()->andReturnFalse();
+        File::shouldReceive('getFilesByType')->with($dir, 'yaml')->once()->andReturn(
+            new FileCollection([$dir.'/first.yaml', $dir.'/second.yaml'])
+        );
+        File::shouldReceive('get')->with($dir.'/first.yaml')->once()->andReturn('title: First Blueprint');
+        File::shouldReceive('get')->with($dir.'/second.yaml')->once()->andReturn('title: Second Blueprint');
+
+        $this->repo->addNamespace('custom', $dir);
+
+        $blueprints = $this->repo->in('custom');
+
+        $this->assertInstanceOf(Collection::class, $blueprints);
+        $this->assertCount(2, $blueprints);
+        $this->assertEveryItemIsInstanceOf(Blueprint::class, $blueprints);
+        $this->assertEquals(['first', 'second'], $blueprints->keys()->all());
+        $this->assertEquals(['first', 'second'], $blueprints->map->handle()->values()->all());
+        $this->assertEquals(['custom', 'custom'], $blueprints->map->namespace()->values()->all());
+        $this->assertEquals(['First Blueprint', 'Second Blueprint'], $blueprints->map->title()->values()->all());
+    }
+
+    #[Test]
+    public function it_gets_blueprints_in_a_custom_namespace_with_overrides()
+    {
+        File::shouldReceive('withAbsolutePaths')->twice()->andReturnSelf();
+        $dir = '/path/to/custom';
+        $overrideDir = '/path/to/resources/blueprints/vendor/custom';
+        File::shouldReceive('exists')->with($overrideDir)->andReturnTrue();
+        File::shouldReceive('getFilesByType')->with($dir, 'yaml')->once()->andReturn(
+            new FileCollection([$dir.'/first.yaml', $dir.'/second.yaml'])
+        );
+        File::shouldReceive('getFilesByType')->with($overrideDir, 'yaml')->once()->andReturn(
+            new FileCollection([
+                $overrideDir.'/second.yaml',
+                $overrideDir.'/third.yaml', // This one exists as an override but since there's no original it will be ignored. This behavior is up for debate.
+            ])
+        );
+        File::shouldReceive('get')->with($dir.'/first.yaml')->once()->andReturn('title: First Blueprint');
+        File::shouldReceive('get')->with($overrideDir.'/second.yaml')->once()->andReturn('title: Overridden Second Blueprint');
+
+        $this->repo->addNamespace('custom', $dir);
+
+        $blueprints = $this->repo->in('custom');
+
+        $this->assertInstanceOf(Collection::class, $blueprints);
+        $this->assertCount(2, $blueprints);
+        $this->assertEveryItemIsInstanceOf(Blueprint::class, $blueprints);
+        $this->assertEquals(['first', 'second'], $blueprints->keys()->all());
+        $this->assertEquals(['first', 'second'], $blueprints->map->handle()->values()->all());
+        $this->assertEquals(['custom', 'custom'], $blueprints->map->namespace()->values()->all());
+        $this->assertEquals(['First Blueprint', 'Overridden Second Blueprint'], $blueprints->map->title()->values()->all());
     }
 
     #[Test]


### PR DESCRIPTION
While reviewing #9327 I noticed that there's some behavioral issues with how blueprint overrides work.

- When you have a custom namespace, and the `vendor` override directory exists (e.g. `blueprints/vendor/custom`), if the directory is empty, you see no blueprints at all. Not even ones that haven't been overridden.
- If there are any overrides in that directory, only they are shown. Non-overridden ones do not get displayed.
- If you have a yaml file in the override directory that doesn't exist in the regular directory, it gets shown. It shouldn't. You shouldn't be able to override a blueprint that doesn't exist. You're overriding, not adding. (Up for debate I guess, but it was ambiguous so I went with this.)