### PR TITLE
[5.x] Require spatie/laravel-ray in dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "laravel/pint": "1.16.0",
         "mockery/mockery": "^1.3.3",
         "orchestra/testbench": "^8.14 || ^9.0",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^10.0",
+        "spatie/laravel-ray": "^1.37"
     },
     "config": {
         "optimize-autoloader": true,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -73,6 +73,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             \Rebing\GraphQL\GraphQLServiceProvider::class,
             \Wilderborn\Partyline\ServiceProvider::class,
             \Archetype\ServiceProvider::class,
+            \Spatie\LaravelRay\RayServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
We use ray constantly while developing. This requires it plus adds it to the providers which lets you chain `->ray()` onto collections.
