### PR TITLE
[5.x] Fix fatal windows cache key error

### DIFF
--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -135,15 +135,18 @@ abstract class Index
 
     public function cacheKey()
     {
+        $searches = ['.', '/'];
         $replacements = ['::', '->'];
 
         if (windows_os()) {
             $replacements[1] = '-]';
+            $searches[] = '->';
+            $replacements[] = '-]';
         }
 
         return vsprintf('stache::indexes::%s::%s', [
             $this->store->key(),
-            str_replace(['.', '/'], $replacements, $this->name),
+            str_replace($searches, $replacements, $this->name),
         ]);
     }
 


### PR DESCRIPTION
This fixes #10666

Which is caused by `->` not being a valid set of filename characters on windows.  Since there is already a condition used to sanitize the key for windows I re-used that and just added a replacement.