### PR TITLE
[5.x] Fix blueprint override logic, pt 2

### DIFF
--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -243,7 +243,7 @@ class BlueprintRepository
                 ->getFilesByType($directory, 'yaml')
                 ->mapWithKeys(fn ($path) => [Str::after($path, $directory.'/') => $path]);
 
-            if ($files->isNotEmpty() && File::exists($directory = $this->directory.'/vendor/'.$namespaceDir)) {
+            if (File::exists($directory = $this->directory.'/vendor/'.$namespaceDir)) {
                 $overrides = File::withAbsolutePaths()
                     ->getFilesByType($directory, 'yaml')
                     ->mapWithKeys(fn ($path) => [Str::after($path, $directory.'/') => $path]);

--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -239,20 +239,16 @@ class BlueprintRepository
                 $directory = "{$this->additionalNamespaces[$namespace]}";
             }
 
-            $files = File::withAbsolutePaths()->getFilesByType($directory, 'yaml');
+            $files = File::withAbsolutePaths()
+                ->getFilesByType($directory, 'yaml')
+                ->mapWithKeys(fn ($path) => [Str::after($path, $directory.'/') => $path]);
 
-            if ($files->isNotEmpty() && File::exists($overrideDir = $this->directory.'/vendor/'.$namespaceDir)) {
-                $overrides = File::withAbsolutePaths()->getFilesByType($overrideDir, 'yaml');
+            if ($files->isNotEmpty() && File::exists($directory = $this->directory.'/vendor/'.$namespaceDir)) {
+                $overrides = File::withAbsolutePaths()
+                    ->getFilesByType($directory, 'yaml')
+                    ->mapWithKeys(fn ($path) => [Str::after($path, $directory.'/') => $path]);
 
-                $files = $files->map(function ($path) use ($overrides, $overrideDir, $directory) {
-                    $filename = str($path)->after($directory.'/');
-
-                    if ($overrides->contains($overridePath = $overrideDir.'/'.$filename)) {
-                        return $overridePath;
-                    }
-
-                    return $path;
-                });
+                $files = $files->merge($overrides)->values();
             }
 
             return $files;

--- a/tests/Fields/BlueprintRepositoryTest.php
+++ b/tests/Fields/BlueprintRepositoryTest.php
@@ -337,23 +337,24 @@ EOT;
         File::shouldReceive('getFilesByType')->with($overrideDir, 'yaml')->once()->andReturn(
             new FileCollection([
                 $overrideDir.'/second.yaml',
-                $overrideDir.'/third.yaml', // This one exists as an override but since there's no original it will be ignored. This behavior is up for debate.
+                $overrideDir.'/third.yaml',
             ])
         );
         File::shouldReceive('get')->with($dir.'/first.yaml')->once()->andReturn('title: First Blueprint');
         File::shouldReceive('get')->with($overrideDir.'/second.yaml')->once()->andReturn('title: Overridden Second Blueprint');
+        File::shouldReceive('get')->with($overrideDir.'/third.yaml')->once()->andReturn('title: Third Blueprint only in overrides');
 
         $this->repo->addNamespace('custom', $dir);
 
         $blueprints = $this->repo->in('custom');
 
         $this->assertInstanceOf(Collection::class, $blueprints);
-        $this->assertCount(2, $blueprints);
+        $this->assertCount(3, $blueprints);
         $this->assertEveryItemIsInstanceOf(Blueprint::class, $blueprints);
-        $this->assertEquals(['first', 'second'], $blueprints->keys()->all());
-        $this->assertEquals(['first', 'second'], $blueprints->map->handle()->values()->all());
-        $this->assertEquals(['custom', 'custom'], $blueprints->map->namespace()->values()->all());
-        $this->assertEquals(['First Blueprint', 'Overridden Second Blueprint'], $blueprints->map->title()->values()->all());
+        $this->assertEquals(['first', 'second', 'third'], $blueprints->keys()->all());
+        $this->assertEquals(['first', 'second', 'third'], $blueprints->map->handle()->values()->all());
+        $this->assertEquals(['custom', 'custom', 'custom'], $blueprints->map->namespace()->values()->all());
+        $this->assertEquals(['First Blueprint', 'Overridden Second Blueprint', 'Third Blueprint only in overrides'], $blueprints->map->title()->values()->all());
     }
 
     #[Test]


### PR DESCRIPTION
In #10661, I made it so that it ignores any blueprints in the override directory that don't exist in the original directory and said that behavior was up for debate. Well, someone debated it and showed they were relying on that behavior.

This PR brings it back.
