### PR TITLE
[5.x] Add `LocalizedTermSaved` & `LocalizedTermDeleted` events

### DIFF
--- a/src/Events/LocalizedTermDeleted.php
+++ b/src/Events/LocalizedTermDeleted.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Events;
+
+class LocalizedTermDeleted extends Event
+{
+    public $term;
+
+    public function __construct($term)
+    {
+        $this->term = $term;
+    }
+}

--- a/src/Events/LocalizedTermSaved.php
+++ b/src/Events/LocalizedTermSaved.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\Events;
+
+class LocalizedTermSaved extends Event
+{
+    public $term;
+
+    public function __construct($term)
+    {
+        $this->term = $term;
+    }
+}

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -22,6 +22,8 @@ use Statamic\Data\Publishable;
 use Statamic\Data\TracksLastModified;
 use Statamic\Data\TracksQueriedColumns;
 use Statamic\Data\TracksQueriedRelations;
+use Statamic\Events\LocalizedTermDeleted;
+use Statamic\Events\LocalizedTermSaved;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades;
 use Statamic\Facades\Antlers;
@@ -430,7 +432,11 @@ class LocalizedTerm implements Arrayable, ArrayAccess, Augmentable, BulkAugmenta
 
     public function save()
     {
-        return $this->term->save();
+        $save = $this->term->save();
+
+        LocalizedTermSaved::dispatch($this);
+
+        return $save;
     }
 
     public function deleteQuietly()
@@ -440,7 +446,11 @@ class LocalizedTerm implements Arrayable, ArrayAccess, Augmentable, BulkAugmenta
 
     public function delete()
     {
-        return $this->term->delete();
+        $delete = $this->term->delete();
+
+        LocalizedTermDeleted::dispatch($this);
+
+        return $delete;
     }
 
     public function private()


### PR DESCRIPTION
This pull request implements `LocalizedTermSaved` & `LocalizedTermDeleted` events. 

These events are fired after the `TermSaved` and `TermDeleted` events, however, instead of the generic `Term` object being passed in, the `LocalizedTerm` object will be passed, allowing for determining which site the term was just updated in (which will be helpful in #10669).

