### PR TITLE
[5.x] Add blade `@cascade` directive

### DIFF
--- a/src/Exceptions/CascadeDataNotFoundException.php
+++ b/src/Exceptions/CascadeDataNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Statamic\Exceptions;
+
+class CascadeDataNotFoundException extends \Exception
+{
+    protected $key;
+
+    public function __construct($key)
+    {
+        parent::__construct("Cascade data [{$key}] not found");
+
+        $this->key = $key;
+    }
+}

--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -160,6 +160,9 @@ class ViewServiceProvider extends ServiceProvider
         Blade::directive('tags', function ($expression) {
             return "<?php extract(\Statamic\View\Blade\TagsDirective::handle($expression)) ?>";
         });
+        Blade::directive('cascade', function ($expression) {
+            return "<?php extract(\Statamic\View\Blade\CascadeDirective::handle($expression)) ?>";
+        });
     }
 
     public function boot()

--- a/src/View/Blade/CascadeDirective.php
+++ b/src/View/Blade/CascadeDirective.php
@@ -9,9 +9,7 @@ class CascadeDirective
 {
     public static function handle($keys): array
     {
-        $data = Cascade::toArray();
-        if (! $data) {
-            dump('hydrating!');
+        if (! $data = Cascade::toArray()) {
             $data = Cascade::hydrate()->toArray();
         }
 

--- a/src/View/Blade/CascadeDirective.php
+++ b/src/View/Blade/CascadeDirective.php
@@ -14,7 +14,7 @@ class CascadeDirective
             $data = Cascade::hydrate()->toArray();
         }
 
-        if (! $keys) {
+        if (! isset($keys)) {
             return $data;
         }
 

--- a/src/View/Blade/CascadeDirective.php
+++ b/src/View/Blade/CascadeDirective.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Statamic\View\Blade;
+
+use Illuminate\Support\Arr;
+use Statamic\Facades\Cascade;
+
+class CascadeDirective
+{
+    public static function handle($keys): array
+    {
+        $data = Cascade::toArray();
+        if (! $data) {
+            dump('hydrating!');
+            $data = Cascade::hydrate()->toArray();
+        }
+
+        return collect($keys)
+            ->mapWithKeys(function ($default, $key) use ($data) {
+                if (is_numeric($key)) {
+                    $key = $default;
+                    $default = null;
+                    if (! array_key_exists($key, $data)) {
+                        throw new \Exception("Key [{$key}] not found in cascade data.");
+                    }
+                }
+
+                return [$key => Arr::get($data, $key, $default)];
+            })
+            ->all();
+    }
+}

--- a/src/View/Blade/CascadeDirective.php
+++ b/src/View/Blade/CascadeDirective.php
@@ -3,14 +3,19 @@
 namespace Statamic\View\Blade;
 
 use Illuminate\Support\Arr;
+use Statamic\Exceptions\CascadeDataNotFoundException;
 use Statamic\Facades\Cascade;
 
 class CascadeDirective
 {
-    public static function handle($keys): array
+    public static function handle($keys = null): array
     {
         if (! $data = Cascade::toArray()) {
             $data = Cascade::hydrate()->toArray();
+        }
+
+        if (! $keys) {
+            return $data;
         }
 
         return collect($keys)
@@ -19,7 +24,7 @@ class CascadeDirective
                     $key = $default;
                     $default = null;
                     if (! array_key_exists($key, $data)) {
-                        throw new \Exception("Key [{$key}] not found in cascade data.");
+                        throw new CascadeDataNotFoundException($key);
                     }
                 }
 

--- a/tests/View/Blade/CascadeDirectiveTest.php
+++ b/tests/View/Blade/CascadeDirectiveTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\View\Blade;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Exceptions\CascadeDataNotFoundException;
+use Statamic\View\Blade\CascadeDirective;
+use Tests\TestCase;
+
+class CascadeDirectiveTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    #[Test]
+    public function it_gets_all_data()
+    {
+        $data = CascadeDirective::handle();
+
+        $this->assertArrayHasKey('environment', $data);
+        $this->assertArrayHasKey('config', $data);
+        $this->assertArrayHasKey('site', $data);
+    }
+
+    #[Test]
+    public function it_gets_specific_data()
+    {
+        $data = CascadeDirective::handle([
+            'homepage',
+            'is_homepage',
+        ]);
+
+        $this->assertCount(2, $data);
+        $this->assertArrayHasKey('homepage', $data);
+        $this->assertArrayHasKey('is_homepage', $data);
+        $this->assertEquals($data['homepage'], 'http://localhost');
+        $this->assertEquals($data['is_homepage'], true);
+    }
+
+    #[Test]
+    public function it_throws_exception_for_missing_data()
+    {
+        $this->expectException(CascadeDataNotFoundException::class);
+
+        CascadeDirective::handle([
+            'live_preview',
+        ]);
+    }
+
+    #[Test]
+    public function it_uses_default_for_missing_data()
+    {
+        $data = CascadeDirective::handle([
+            'live_preview' => false,
+        ]);
+
+        $this->assertCount(1, $data);
+        $this->assertArrayHasKey('live_preview', $data);
+        $this->assertEquals($data['live_preview'], false);
+    }
+}

--- a/tests/View/Blade/CascadeDirectiveTest.php
+++ b/tests/View/Blade/CascadeDirectiveTest.php
@@ -4,6 +4,7 @@ namespace Tests\View\Blade;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Exceptions\CascadeDataNotFoundException;
+use Statamic\Facades\Cascade;
 use Statamic\View\Blade\CascadeDirective;
 use Tests\TestCase;
 
@@ -19,9 +20,17 @@ class CascadeDirectiveTest extends TestCase
     {
         $data = CascadeDirective::handle();
 
-        $this->assertArrayHasKey('environment', $data);
-        $this->assertArrayHasKey('config', $data);
-        $this->assertArrayHasKey('site', $data);
+        $expected = Cascade::toArray();
+
+        $this->assertEquals($expected, $data);
+    }
+
+    #[Test]
+    public function it_gets_no_data()
+    {
+        $data = CascadeDirective::handle([]);
+
+        $this->assertEmpty($data);
     }
 
     #[Test]
@@ -32,11 +41,13 @@ class CascadeDirectiveTest extends TestCase
             'is_homepage',
         ]);
 
+        $expected = Cascade::toArray();
+
         $this->assertCount(2, $data);
         $this->assertArrayHasKey('homepage', $data);
         $this->assertArrayHasKey('is_homepage', $data);
-        $this->assertEquals($data['homepage'], 'http://localhost');
-        $this->assertEquals($data['is_homepage'], true);
+        $this->assertEquals($data['homepage'], $expected['homepage']);
+        $this->assertEquals($data['is_homepage'], $expected['is_homepage']);
     }
 
     #[Test]
@@ -58,10 +69,12 @@ class CascadeDirectiveTest extends TestCase
             'live_preview' => false,
         ]);
 
+        $expected = Cascade::toArray();
+
         $this->assertCount(2, $data);
         $this->assertArrayHasKey('homepage', $data);
         $this->assertArrayHasKey('live_preview', $data);
-        $this->assertEquals($data['homepage'], 'http://localhost');
+        $this->assertEquals($data['homepage'], $expected['homepage']);
         $this->assertEquals($data['live_preview'], false);
     }
 }

--- a/tests/View/Blade/CascadeDirectiveTest.php
+++ b/tests/View/Blade/CascadeDirectiveTest.php
@@ -50,7 +50,7 @@ class CascadeDirectiveTest extends TestCase
     }
 
     #[Test]
-    public function it_uses_default_for_missing_data()
+    public function it_uses_fallback_for_missing_data()
     {
         $data = CascadeDirective::handle([
             'live_preview' => false,

--- a/tests/View/Blade/CascadeDirectiveTest.php
+++ b/tests/View/Blade/CascadeDirectiveTest.php
@@ -43,6 +43,7 @@ class CascadeDirectiveTest extends TestCase
     public function it_throws_exception_for_missing_data()
     {
         $this->expectException(CascadeDataNotFoundException::class);
+        $this->expectExceptionMessage('Cascade data [live_preview] not found');
 
         CascadeDirective::handle([
             'live_preview',
@@ -53,11 +54,14 @@ class CascadeDirectiveTest extends TestCase
     public function it_uses_fallback_for_missing_data()
     {
         $data = CascadeDirective::handle([
+            'homepage',
             'live_preview' => false,
         ]);
 
-        $this->assertCount(1, $data);
+        $this->assertCount(2, $data);
+        $this->assertArrayHasKey('homepage', $data);
         $this->assertArrayHasKey('live_preview', $data);
+        $this->assertEquals($data['homepage'], 'http://localhost');
         $this->assertEquals($data['live_preview'], false);
     }
 }


### PR DESCRIPTION
When using blade the cascade data is only available in the entry's main template, and the layout if you're using `@extends `. This can leave situations where you don't have quick access to the cascade data (without workarounds), for example:

1. When inside blade components, particularly when using them for the layout
2. When in standard views loaded by non-Statamic routes/controllers

This PR adds a new blade directive called `@cascade` which will add cascade data to the current scope.

It works in exactly the same way as the `@props` directive used in blade components, with the ability to require certain values or provide default fallback values:

```blade
{{-- Fetch my_global and site, will throw an exception if either are missing from the cascade --}}
@cascade([
    'my_global',
    'site',
])

{{ $site->locale }}
```

```blade
{{-- Fetch live_preview and page, use fallback if they're missing from the cascade --}}
@cascade([
    'live_preview' => true,
    'page' => null,
])

{{ $page?->title }}
```

Specifying only the data you want is probably the best way to go in most situations, especially in components where the cascade variables could overwrite prop variables. However it is also possible to add the entire cascade if needed:

```blade
{{-- Fetch everything from the cascade --}}
@cascade
```