### PR TITLE
[5.x] Fix github workflow for changes in JS tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           files: |
-            **.{js,vue,ts}
+            **/*.{js,vue,ts}
             package.json
             .github/workflows/tests.yml
 

--- a/resources/js/tests/FieldConditionsValidator.test.js
+++ b/resources/js/tests/FieldConditionsValidator.test.js
@@ -1,5 +1,6 @@
 // test change
 // test change
+// test change
 
 import Vue from 'vue';
 import Vuex from 'vuex';

--- a/resources/js/tests/FieldConditionsValidator.test.js
+++ b/resources/js/tests/FieldConditionsValidator.test.js
@@ -1,4 +1,5 @@
 // test change
+// test change
 
 import Vue from 'vue';
 import Vuex from 'vuex';

--- a/resources/js/tests/FieldConditionsValidator.test.js
+++ b/resources/js/tests/FieldConditionsValidator.test.js
@@ -1,3 +1,5 @@
+// test change
+
 import Vue from 'vue';
 import Vuex from 'vuex';
 import ValidatesFieldConditions from '../components/field-conditions/ValidatorMixin.js';

--- a/resources/js/tests/FieldConditionsValidator.test.js
+++ b/resources/js/tests/FieldConditionsValidator.test.js
@@ -1,7 +1,3 @@
-// test change
-// test change
-// test change
-
 import Vue from 'vue';
 import Vuex from 'vuex';
 import ValidatesFieldConditions from '../components/field-conditions/ValidatorMixin.js';


### PR DESCRIPTION
We figured out there was a small issue in our glob pattern for changed JS files. It used to work on JS files at the root level, but not in subdirectories.

Before:

![CleanShot 2024-08-21 at 15 17 30](https://github.com/user-attachments/assets/07b368d7-b799-4175-8b5c-f120965a8619)

After:

![CleanShot 2024-08-21 at 15 18 15](https://github.com/user-attachments/assets/4479597b-cd88-4ac9-9b27-069729aaebab)

References https://github.com/statamic/cms/pull/8269