### PR TITLE
[5.x] Prevent nocache overhead when static caching is disabled

### DIFF
--- a/src/StaticCaching/NoCache/Tags.php
+++ b/src/StaticCaching/NoCache/Tags.php
@@ -3,6 +3,7 @@
 namespace Statamic\StaticCaching\NoCache;
 
 use Statamic\Facades\Antlers;
+use Statamic\Facades\StaticCache;
 use Statamic\StaticCaching\Middleware\Cache;
 
 class Tags extends \Statamic\Tags\Tags
@@ -22,7 +23,7 @@ class Tags extends \Statamic\Tags\Tags
 
     public function index()
     {
-        if (! Cache::isBeingUsedOnCurrentRoute()) {
+        if (! StaticCache::enabled() || ! Cache::isBeingUsedOnCurrentRoute()) {
             return $this->parse();
         }
 

--- a/src/StaticCaching/Replacers/NoCacheReplacer.php
+++ b/src/StaticCaching/Replacers/NoCacheReplacer.php
@@ -22,6 +22,10 @@ class NoCacheReplacer implements Replacer
 
     public function prepareResponseToCache(Response $responseToBeCached, Response $initialResponse)
     {
+        if (! StaticCache::enabled()) {
+            return;
+        }
+
         $this->replaceInResponse($initialResponse);
 
         $this->modifyFullMeasureResponse($responseToBeCached);

--- a/src/StaticCaching/StaticCacheManager.php
+++ b/src/StaticCaching/StaticCacheManager.php
@@ -14,6 +14,11 @@ use Statamic\Support\Manager;
 
 class StaticCacheManager extends Manager
 {
+    public function enabled()
+    {
+        return $this->getDefaultDriver() !== 'null';
+    }
+
     protected function invalidImplementationMessage($name)
     {
         return "Static cache strategy [{$name}] is not defined.";


### PR DESCRIPTION
When static caching is disabled, the `nocache` still does its thing - stores data, outputs a placeholder, then the middleware does replacements.

This PR makes the nocache evaluate its contents inline as if it wasn't being used, if static caching is disabled.
It also prevents the replacer doing anything during the middleware when static caching is disabled.
