### PR TITLE
[5.x] Improves "where" modifier value check

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2921,7 +2921,7 @@ class CoreModifiers extends Modifier
         if (! $opr && Str::contains($key, ':')) {
             [$key, $opr] = explode(':', $key);
         }
-        if (! $val && $val !== 0) {
+        if (count($params) < 3) {
             $val = $opr;
             $opr = '==';
         }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2921,7 +2921,7 @@ class CoreModifiers extends Modifier
         if (! $opr && Str::contains($key, ':')) {
             [$key, $opr] = explode(':', $key);
         }
-        if (! $val) {
+        if (! $val && $val !== 0) {
             $val = $opr;
             $opr = '==';
         }

--- a/tests/Modifiers/WhereTest.php
+++ b/tests/Modifiers/WhereTest.php
@@ -88,6 +88,12 @@ class WhereTest extends TestCase
         $modified = $this->modify($data, ['whimsy_level', '!=', 0]);
         $this->assertEquals($expected, Arr::pluck($modified, 'name'));
 
+        $modified = $this->modify($data, ['whimsy_level', '!=', '0']);
+        $this->assertEquals($expected, Arr::pluck($modified, 'name'));
+
+        $modified = $this->modify($data, ['whimsy_level', '!==', '0']);
+        $this->assertEquals($data, $modified);
+
         $expected = [
             'Sir Bubblesworth',
             'Professor Whiskerbottom',

--- a/tests/Modifiers/WhereTest.php
+++ b/tests/Modifiers/WhereTest.php
@@ -53,6 +53,53 @@ class WhereTest extends TestCase
         $this->assertEquals($expected, Arr::pluck($modified, 'title'));
     }
 
+    #[Test]
+    public function it_accepts_zero_as_a_parameter()
+    {
+        $data = [
+            [
+                'name' => 'Fluffy McSparkles',
+                'whimsy_level' => 42,
+            ],
+            [
+                'name' => 'Sir Bubblesworth',
+                'whimsy_level' => 0,
+            ],
+            [
+                'name' => 'Captain Fuzzybeard',
+                'whimsy_level' => 13,
+            ],
+            [
+                'name' => 'Professor Whiskerbottom',
+                'whimsy_level' => 0,
+            ],
+            [
+                'name' => 'Duchess Snugglefluff',
+                'whimsy_level' => 76,
+            ],
+        ];
+
+        $expected = [
+            'Fluffy McSparkles',
+            'Captain Fuzzybeard',
+            'Duchess Snugglefluff',
+        ];
+
+        $modified = $this->modify($data, ['whimsy_level', '!=', 0]);
+        $this->assertEquals($expected, Arr::pluck($modified, 'name'));
+
+        $expected = [
+            'Sir Bubblesworth',
+            'Professor Whiskerbottom',
+        ];
+
+        $modified = $this->modify($data, ['whimsy_level', 0]);
+        $this->assertEquals($expected, Arr::pluck($modified, 'name'));
+
+        $modified = $this->modify($data, ['whimsy_level', '==', 0]);
+        $this->assertEquals($expected, Arr::pluck($modified, 'name'));
+    }
+
     private function modify($value, array $params)
     {
         return Modify::value($value)->where($params)->fetch();


### PR DESCRIPTION
This PR closes #10679 by only applying the default `==` operator if the number of supplied parameters is less than 3.