### PR TITLE
[5.x] Hide "Create Term" button when all taxonomy blueprints are hidden

### DIFF
--- a/resources/views/taxonomies/show.blade.php
+++ b/resources/views/taxonomies/show.blade.php
@@ -33,12 +33,12 @@
                 @endcan
             </dropdown-list>
 
-            @can('create', ['Statamic\Contracts\Taxonomies\Term', $taxonomy])
+            @if($canCreate)
                 <create-term-button
                     url="{{ cp_route('taxonomies.terms.create', [$taxonomy->handle(), $site]) }}"
                     :blueprints="{{ $blueprints->toJson() }}">
                 </create-term-button>
-            @endcan
+            @endif
         </div>
     </header>
 

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\CP\Taxonomies;
 
 use Illuminate\Http\Request;
 use Statamic\Contracts\Taxonomies\Taxonomy as TaxonomyContract;
+use Statamic\Contracts\Taxonomies\Term as TermContract;
 use Statamic\Contracts\Taxonomies\TermRepository;
 use Statamic\CP\Column;
 use Statamic\Facades\Blueprint;
@@ -18,7 +19,6 @@ use Statamic\Rules\Handle;
 use Statamic\Stache\Repositories\TermRepository as StacheTermRepository;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
-use Statamic\Contracts\Taxonomies\Term as TermContract;
 
 class TaxonomiesController extends CpController
 {

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -18,6 +18,7 @@ use Statamic\Rules\Handle;
 use Statamic\Stache\Repositories\TermRepository as StacheTermRepository;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
+use Statamic\Contracts\Taxonomies\Term as TermContract;
 
 class TaxonomiesController extends CpController
 {
@@ -80,6 +81,7 @@ class TaxonomiesController extends CpController
                 'taxonomy' => $taxonomy->handle(),
                 'blueprints' => $blueprints->pluck('handle')->all(),
             ]),
+            'canCreate' => User::current()->can('create', [TermContract::class, $taxonomy]) && $taxonomy->hasVisibleTermBlueprint(),
         ];
 
         if ($taxonomy->queryTerms()->count() === 0) {

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -166,6 +166,11 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
         return $blueprint;
     }
 
+    public function hasVisibleTermBlueprint()
+    {
+        return $this->termBlueprints()->reject->hidden()->isNotEmpty();
+    }
+
     public function sortField()
     {
         return 'title'; // todo


### PR DESCRIPTION
This pull request hides the "Create Term" button on the taxonomy show page when all of the taxonomy's blueptints are marked as hidden.

This PR copies the behaviour from #9744.

Closes #10675.