### PR TITLE
[5.x] Fix `preg_replace` error when uploading assets

### DIFF
--- a/src/Assets/AssetUploader.php
+++ b/src/Assets/AssetUploader.php
@@ -99,7 +99,7 @@ class AssetUploader extends Uploader
 
                 return $stringable;
             })
-            ->when(config('statamic.assets.case_sensitive'), function ($stringable) {
+            ->when(config('statamic.assets.lowercase'), function ($stringable) {
                 return $stringable->lower();
             })
             ->ascii();

--- a/src/Assets/AssetUploader.php
+++ b/src/Assets/AssetUploader.php
@@ -92,13 +92,7 @@ class AssetUploader extends Uploader
         ];
 
         return (string) Str::of(urldecode($string))
-            ->when(true, function ($stringable) use ($replacements) {
-                foreach ($replacements as $from => $to) {
-                    $stringable = $stringable->replace($from, $to);
-                }
-
-                return $stringable;
-            })
+            ->replace(array_keys($replacements), array_values($replacements))
             ->when(config('statamic.assets.lowercase'), fn ($stringable) => $stringable->lower())
             ->ascii();
     }

--- a/src/Assets/AssetUploader.php
+++ b/src/Assets/AssetUploader.php
@@ -92,16 +92,17 @@ class AssetUploader extends Uploader
             '%' => '-',
         ];
 
-        $str = Stringy::create(urldecode($string))->toAscii();
+        return (string) Str::of(urldecode($string))
+            ->when(true, function ($stringable) use ($replacements) {
+                foreach ($replacements as $from => $to) {
+                    $stringable = $stringable->replace($from, $to);
+                }
 
-        foreach ($replacements as $from => $to) {
-            $str = $str->replace($from, $to);
-        }
-
-        if (config('statamic.assets.lowercase')) {
-            $str = strtolower($str);
-        }
-
-        return (string) $str;
+                return $stringable;
+            })
+            ->when(config('statamic.assets.case_sensitive'), function ($stringable) {
+                return $stringable->lower();
+            })
+            ->ascii();
     }
 }

--- a/src/Assets/AssetUploader.php
+++ b/src/Assets/AssetUploader.php
@@ -7,7 +7,6 @@ use Statamic\Facades\Image;
 use Statamic\Facades\Path;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
-use Stringy\Stringy;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class AssetUploader extends Uploader

--- a/src/Assets/AssetUploader.php
+++ b/src/Assets/AssetUploader.php
@@ -99,9 +99,7 @@ class AssetUploader extends Uploader
 
                 return $stringable;
             })
-            ->when(config('statamic.assets.lowercase'), function ($stringable) {
-                return $stringable->lower();
-            })
+            ->when(config('statamic.assets.lowercase'), fn ($stringable) => $stringable->lower())
             ->ascii();
     }
 }

--- a/tests/Assets/AssetUploaderTest.php
+++ b/tests/Assets/AssetUploaderTest.php
@@ -31,6 +31,7 @@ class AssetUploaderTest extends TestCase
             'question marks' => ['one?two.jpg', 'one-two.jpg'],
             'asterisks' => ['one*two.jpg', 'one-two.jpg'],
             'percentage' => ['one%two.jpg', 'one-two.jpg'],
+            'ascii' => ['fòô-bàř', 'foo-bar'],
         ];
     }
 }


### PR DESCRIPTION
This pull request attempts to fix an issue with the "safe filename" code which seems to be erroring out (sometimes) when uploading assets.

I haven't been able to replicate the issue myself yet, however, since we're just doing some simple string replacements, I don't think we really need to be touching regex functions for it, so I've refactored it to use Laravel's `Stringable` class instead.

Closes #10672.