### PR TITLE
[5.x] Improve the output of the `search:update` command

### DIFF
--- a/src/Search/Commands/Update.php
+++ b/src/Search/Commands/Update.php
@@ -7,6 +7,7 @@ use Statamic\Console\RunsInPlease;
 use Statamic\Events\SearchIndexUpdated;
 use Statamic\Facades\Search;
 use Statamic\Support\Str;
+use function Laravel\Prompts\select;
 
 class Update extends Command
 {
@@ -27,7 +28,7 @@ class Update extends Command
 
             SearchIndexUpdated::dispatch($index);
 
-            $this->info("Index <comment>{$index->name()}</comment> updated.");
+            $this->components->info("Index <comment>{$index->name()}</comment> updated.");
         }
     }
 
@@ -45,13 +46,13 @@ class Update extends Command
             return $this->indexes();
         }
 
-        $selection = $this->choice(
-            'Select an index to update',
-            collect(['all'])->merge($this->indexes()->keys())->all(),
-            0
+        $selection = select(
+            label: 'Select an index to update',
+            options: collect(['All'])->merge($this->indexes()->keys())->all(),
+            default: 0
         );
 
-        return ($selection == 'all') ? $this->indexes() : [$this->indexes()->get($selection)];
+        return ($selection == 'All') ? $this->indexes() : [$this->indexes()->get($selection)];
     }
 
     private function indexes()

--- a/src/Search/Commands/Update.php
+++ b/src/Search/Commands/Update.php
@@ -7,6 +7,7 @@ use Statamic\Console\RunsInPlease;
 use Statamic\Events\SearchIndexUpdated;
 use Statamic\Facades\Search;
 use Statamic\Support\Str;
+
 use function Laravel\Prompts\select;
 
 class Update extends Command


### PR DESCRIPTION
This pull request improves the output of the `php please search:update` command.

## Before

![CleanShot 2024-08-23 at 12 57 24](https://github.com/user-attachments/assets/b3ef1d6d-f2fb-403f-9b5d-7f7e75e8507f)

## After

![CleanShot 2024-08-23 at 12 59 26](https://github.com/user-attachments/assets/707439ef-5ac9-4d0e-9baf-5bddf1a94234)
