### PR TITLE
[5.x] Fix search index race condition

### DIFF
--- a/src/Search/Comb/Index.php
+++ b/src/Search/Comb/Index.php
@@ -44,7 +44,7 @@ class Index extends BaseIndex
 
     protected function data()
     {
-        return collect(json_decode($this->raw(), true));
+        return collect(json_decode($this->raw(), true, flags: JSON_THROW_ON_ERROR));
     }
 
     protected function settings()

--- a/src/Search/Comb/Index.php
+++ b/src/Search/Comb/Index.php
@@ -73,7 +73,7 @@ class Index extends BaseIndex
             throw new IndexNotFoundException;
         }
 
-        return File::get($this->path());
+        return app('files')->get($this->path(), lock: true);
     }
 
     public function exists()
@@ -117,7 +117,7 @@ class Index extends BaseIndex
 
     protected function save($documents)
     {
-        File::put($this->path(), $documents->toJson());
+        app('files')->put($this->path(), $documents->toJson(), lock: true);
     }
 
     public function extraAugmentedResultData(Result $result)


### PR DESCRIPTION
This PR solves a race condition when reading and writing a Comb-driven search index.

It's possible that one request will try to read the JSON file when another is writing to it, causing the JSON parsing to return invalid JSON.

Invalid JSON would return null. Passing null to `collect()` would be an empty collection. If this happened when you are trying to insert something into the index, it would result in that index **only** containing the inserted data.

This is solved by throwing an exception when encountering invalid JSON. This would prevent the search index being emptied out but of course now results in an exception.

Additionally, file locks are now used when reading and writing those files to prevent getting into that situation where the exception would be thrown to begin with.
