### PR TITLE
[5.x] Add `push` modifier for arrays

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1826,6 +1826,20 @@ class CoreModifiers extends Modifier
     }
 
     /**
+     * Add a variable onto the end of an array
+     *
+     * @return array
+     */
+    public function push($value, $params, $context)
+    {
+        $push = Arr::get($context, $params[0], $params[0]);
+
+        array_push($value, $push);
+
+        return $value;
+    }
+
+    /**
      * Selects certain values from each item in a collection.
      *
      * @param  array|Collection  $value

--- a/tests/Modifiers/PushTest.php
+++ b/tests/Modifiers/PushTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+#[Group('array')]
+class PushTest extends TestCase
+{
+    #[Test]
+    public function it_pushes_an_item_to_an_array(): void
+    {
+        $checklist = [
+            'zebra',
+            'hippo',
+        ];
+
+        $expected = [
+            'zebra',
+            'hippo',
+            'hyena',
+        ];
+
+        $modified = $this->modify($checklist, ['hyena']);
+
+        $this->assertEquals($expected, $modified);
+    }
+
+    private function modify($value, array $params)
+    {
+        return Modify::value($value)->push($params)->fetch();
+    }
+}


### PR DESCRIPTION
This just came up on discord (https://discord.com/channels/489818810157891584/1153390699161587823/1277561682406805576) - might be handy to have a `push` modifier.

`{{ my_array | push('value') }}`