### PR TITLE
Add submitting state for confirmation modal to better visualise a running action

### DIFF
--- a/resources/js/components/assets/Browser/CreateFolder.vue
+++ b/resources/js/components/assets/Browser/CreateFolder.vue
@@ -3,6 +3,7 @@
     <confirmation-modal
         name="folder-editor"
         :title="modalTitle"
+        :submitting="creating"
         @cancel="cancel"
         @confirm="submit"
     >
@@ -42,6 +43,7 @@ export default {
             buttonText: __('Create'),
             directory: this.initialDirectory,
             errors: {},
+            creating: false,
         }
     },
 
@@ -59,11 +61,15 @@ export default {
                 title: this.title
             };
 
+            this.creating = true;
+
             this.$axios.post(url, payload).then(response => {
                 this.$toast.success(__('Folder created'));
                 this.$emit('created', response.data);
             }).catch(e => {
                 this.handleErrors(e);
+            }).finally(() => {
+                this.creating = false;
             });
         },
 

--- a/resources/js/components/assets/Browser/CreateFolder.vue
+++ b/resources/js/components/assets/Browser/CreateFolder.vue
@@ -3,7 +3,7 @@
     <confirmation-modal
         name="folder-editor"
         :title="modalTitle"
-        :submitting="creating"
+        :submitting="submitting"
         @cancel="cancel"
         @confirm="submit"
     >
@@ -43,7 +43,7 @@ export default {
             buttonText: __('Create'),
             directory: this.initialDirectory,
             errors: {},
-            creating: false,
+            submitting: false,
         }
     },
 
@@ -61,7 +61,7 @@ export default {
                 title: this.title
             };
 
-            this.creating = true;
+            this.submitting = true;
 
             this.$axios.post(url, payload).then(response => {
                 this.$toast.success(__('Folder created'));
@@ -69,7 +69,7 @@ export default {
             }).catch(e => {
                 this.handleErrors(e);
             }).finally(() => {
-                this.creating = false;
+                this.submitting = false;
             });
         },
 

--- a/resources/js/components/assets/Browser/CreateFolder.vue
+++ b/resources/js/components/assets/Browser/CreateFolder.vue
@@ -87,7 +87,6 @@ export default {
     },
 
     created() {
-        this.$keys.bindGlobal('enter', this.submit)
         this.$keys.bindGlobal('esc', this.cancel)
     },
 

--- a/resources/js/components/blueprints/BlueprintResetter.vue
+++ b/resources/js/components/blueprints/BlueprintResetter.vue
@@ -5,6 +5,7 @@
         :bodyText="modalBody"
         :buttonText="__('Reset')"
         :danger="true"
+        :submitting="submitting"
         @confirm="confirmed"
         @cancel="cancel"
     >
@@ -36,6 +37,7 @@ export default {
         return {
             resetting: false,
             redirectFromServer: null,
+            submitting: false,
         }
     },
 
@@ -69,6 +71,8 @@ export default {
         },
 
         confirmed() {
+            this.submitting = true;
+
             this.$axios.delete(this.resetUrl)
                 .then(response => {
                     this.redirectFromServer = data_get(response, 'data.redirect');
@@ -76,6 +80,7 @@ export default {
                 })
                 .catch(() => {
                     this.$toast.error(__('Something went wrong'));
+                    this.submitting = false;
                 });
         },
 
@@ -92,6 +97,7 @@ export default {
 
             this.$toast.success(__('Reset'));
             this.$emit('reset');
+            this.submitting = false;
         },
 
         cancel() {

--- a/resources/js/components/data-list/Action.vue
+++ b/resources/js/components/data-list/Action.vue
@@ -8,6 +8,7 @@
             :title="action.title"
             :danger="action.dangerous"
             :buttonText="runButtonText"
+            :submitting="running"
             @confirm="confirm"
             @cancel="reset"
         >
@@ -71,6 +72,7 @@ export default {
             confirming: false,
             fieldset: {tabs:[{fields:this.action.fields}]},
             values: this.action.values,
+            running: false,
         }
     },
 
@@ -113,6 +115,9 @@ export default {
     },
 
     methods: {
+        onDone() {
+            this.running = false;
+        },
 
         select() {
             if (this.action.confirm) {
@@ -120,11 +125,13 @@ export default {
                 return;
             }
 
-            this.$emit('selected', this.action, this.values);
+            this.running = true;
+            this.$emit('selected', this.action, this.values, this.onDone);
         },
 
         confirm() {
-            this.$emit('selected', this.action, this.values);
+            this.running = true;
+            this.$emit('selected', this.action, this.values, this.onDone);
         },
 
         reset() {

--- a/resources/js/components/data-list/Actions.js
+++ b/resources/js/components/data-list/Actions.js
@@ -30,8 +30,7 @@ export default {
     },
 
     methods: {
-
-        run(action, values) {
+        run(action, values, done) {
             this.$emit('started');
 
             this.errors = {};
@@ -43,11 +42,15 @@ export default {
                 values
             };
 
-            this.$axios.post(this.url, payload, { responseType: 'blob' }).then(response => {
-                response.headers['content-disposition']
-                    ? this.handleFileDownload(response) // Pass blob response for downloads
-                    : this.handleActionSuccess(response); // Otherwise handle as normal, converting from JSON
-            }).catch(error => this.handleActionError(error.response));
+            this.$axios
+                .post(this.url, payload, { responseType: 'blob' })
+                .then((response) => {
+                    response.headers['content-disposition']
+                        ? this.handleFileDownload(response) // Pass blob response for downloads
+                        : this.handleActionSuccess(response); // Otherwise handle as normal, converting from JSON
+                })
+                .catch((error) => this.handleActionError(error.response))
+                .finally(() => done());
         },
 
         handleActionSuccess(response) {

--- a/resources/js/components/modals/ConfirmationModal.vue
+++ b/resources/js/components/modals/ConfirmationModal.vue
@@ -15,7 +15,7 @@
                     </slot>
                 </div>
                 <div v-if="submitting" class="absolute inset-0 flex items-center justify-center">
-                    <loading-graphic text="" :size="42"  />
+                    <loading-graphic text="" />
                 </div>
             </div>
 
@@ -66,7 +66,6 @@ export default {
     data() {
         return {
             escBinding: null,
-            enterBinding: null,
         }
     },
 

--- a/resources/js/components/modals/ConfirmationModal.vue
+++ b/resources/js/components/modals/ConfirmationModal.vue
@@ -4,17 +4,25 @@
             <header v-if="title" class="text-lg font-semibold px-5 py-3 bg-gray-200 dark:bg-dark-550 rounded-t-lg flex items-center justify-between border-b dark:border-dark-900">
                 {{ __(title) }}
             </header>
-            <div class="flex-1 px-5 py-6 text-gray dark:text-dark-150">
-                <slot name="body">
-                    <p v-if="bodyText" v-text="bodyText" />
-                    <slot v-else>
-                        <p>{{ __('Are you sure?') }}</p>
+
+            <div class="relative">
+                <div class="flex-1 px-5 py-6 text-gray dark:text-dark-150" :class="submitting ? ['opacity-50', 'select-none', 'pointer-events-none'] : []">
+                    <slot name="body">
+                        <p v-if="bodyText" v-text="bodyText"/>
+                        <slot v-else>
+                            <p>{{ __('Are you sure?') }}</p>
+                        </slot>
                     </slot>
-                </slot>
+                </div>
+                <div v-if="submitting" class="absolute inset-0 flex items-center justify-center">
+                    <loading-graphic text="" :size="42"  />
+                </div>
             </div>
-            <div class="px-5 py-3 bg-gray-200 dark:bg-dark-550 rounded-b-lg border-t dark:border-dark-900 flex items-center justify-end text-sm">
-                <button class="btn-flat" @click.prevent="$emit('cancel')" v-text="__(cancelText)" v-if="cancellable" />
-                <button class="rtl:mr-4 ltr:ml-4" :class="buttonClass" :disabled="disabled" v-text="__(buttonText)" />
+
+            <div
+                class="px-5 py-3 bg-gray-200 dark:bg-dark-550 rounded-b-lg border-t dark:border-dark-900 flex items-center justify-end text-sm">
+                <button class="btn-flat" @click.prevent="$emit('cancel')" v-text="__(cancelText)" v-if="cancellable" :disabled="submitting"/>
+                <button class="rtl:mr-4 ltr:ml-4" :class="buttonClass" :disabled="disabled || submitting" v-text="__(buttonText)"/>
             </div>
         </form>
     </modal>
@@ -48,6 +56,10 @@ export default {
         disabled: {
             type: Boolean,
             default: false,
+        },
+        submitting: {
+            type: Boolean,
+            default: false,
         }
     },
 
@@ -69,7 +81,7 @@ export default {
             this.$emit('cancel')
         },
         submit() {
-            this.$emit('confirm')
+            this.$emit('confirm');
         }
     },
 
@@ -77,7 +89,7 @@ export default {
         this.escBinding = this.$keys.bind('esc', this.dismiss)
     },
 
-     beforeDestroy() {
+    beforeDestroy() {
         this.escBinding.destroy()
     },
 }

--- a/resources/js/components/modals/ConfirmationModal.vue
+++ b/resources/js/components/modals/ConfirmationModal.vue
@@ -6,7 +6,7 @@
             </header>
 
             <div class="relative">
-                <div class="flex-1 px-5 py-6 text-gray dark:text-dark-150" :class="submitting ? ['opacity-50', 'select-none', 'pointer-events-none'] : []">
+                <div class="flex-1 px-5 py-6 text-gray dark:text-dark-150" :class="submitting ? ['blur-[2px]', 'opacity-75', 'select-none', 'pointer-events-none'] : []">
                     <slot name="body">
                         <p v-if="bodyText" v-text="bodyText"/>
                         <slot v-else>

--- a/vite-svg-loader.js
+++ b/vite-svg-loader.js
@@ -51,7 +51,9 @@ module.exports = function svgLoader (options = {}) {
         transformAssetUrls: false
       })
 
-      return `${code}\nexport default { render: render }`
+      const template = code instanceof Promise ? await code : code;
+
+      return `${template}\nexport default { render: render }`
     }
   }
 }


### PR DESCRIPTION
I noticed that when confirming an action that is running for a few seconds it is hard to determine if something is actually happening. This PR adds a nice (hopefully nice enough) loader to visualise that there is an action running in the background. 

Also fixes in issue with the "Create Folder" action, which submitted the form twice when pressing enter on the submit button.