### PR TITLE
[5.x] Fix CP Asset Sort After Search issue

### DIFF
--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -143,6 +143,12 @@ class BrowserController extends CpController
             $query->where('folder', $path);
         }
 
+        if ($request->sort) {
+            $query->orderBy($request->sort, $request->order ?? 'asc');
+        } else {
+            $query->orderBy($container->sortField(), $container->sortDirection());
+        }
+
         $this->applyQueryScopes($query, $request->all());
 
         $assets = $query->paginate(request('perPage'));

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -145,8 +145,6 @@ class BrowserController extends CpController
 
         if ($request->sort) {
             $query->orderBy($request->sort, $request->order ?? 'asc');
-        } else {
-            $query->orderBy($container->sortField(), $container->sortDirection());
         }
 
         $this->applyQueryScopes($query, $request->all());


### PR DESCRIPTION
This resolves issue #10708
In the control panel assets table view, column sort was not functioning after a search term was used. This allows searched assets to be sorted in table view.
