### PR TITLE
[5.x] Filter out Spacer fields from form emails

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -153,11 +153,11 @@ class Email extends Mailable
     protected function addData()
     {
         $augmented = $this->submission->toAugmentedArray();
-        $fields = $this->getRenderableFieldData(Arr::except($augmented, ['id', 'date', 'form']));
-
-        if (Arr::has($this->config, 'attachments')) {
-            $fields = $fields->reject(fn ($field) => in_array($field['fieldtype'], ['assets', 'files']));
-        }
+        $fields = $this->getRenderableFieldData(Arr::except($augmented, ['id', 'date', 'form']))
+            ->reject(fn ($field) => $field['fieldtype'] === 'spacer')
+            ->when(Arr::has($this->config, 'attachments'), function ($fields) {
+                return $fields->reject(fn ($field) => in_array($field['fieldtype'], ['assets', 'files']));
+            });
 
         $data = array_merge($augmented, $this->getGlobalsData(), [
             'config' => config()->all(),


### PR DESCRIPTION
This pull request filters out the Spacer fieldtype from being output in form emails.

Related: https://github.com/statamic/cms/issues/10305#issuecomment-2312768574