### PR TITLE
[5.x] Fix translations on password protected pages

### DIFF
--- a/src/Auth/Protect/Protectors/Password/Controller.php
+++ b/src/Auth/Protect/Protectors/Password/Controller.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Auth\Protect\Protectors\Password;
 
+use Statamic\Facades\Site;
 use Statamic\Http\Controllers\Controller as BaseController;
 use Statamic\View\View;
 
@@ -12,6 +13,10 @@ class Controller extends BaseController
 
     public function show()
     {
+        $site = Site::findByUrl(request('url'));
+
+        app()->setLocale($site->shortLocale());
+
         return View::make('statamic::auth.protect.password');
     }
 

--- a/src/Auth/Protect/Protectors/Password/PasswordProtector.php
+++ b/src/Auth/Protect/Protectors/Password/PasswordProtector.php
@@ -47,7 +47,7 @@ class PasswordProtector extends Protector
 
     protected function redirectToPasswordForm()
     {
-        $url = $this->getPasswordFormUrl().'?token='.$this->generateToken();
+        $url = $this->getPasswordFormUrl().'?token='.$this->generateToken().'&url='.urlencode($this->url);
 
         abort(redirect($url));
     }


### PR DESCRIPTION
This pull request fixes an issue where translations weren't happening in multisites using subdirectory routes.

This is achieved by passing along the original URL to the password protection page, and using that to determine the locale for the page.

![CleanShot 2024-08-27 at 16 48 43](https://github.com/user-attachments/assets/a0a12a57-506e-4e2c-8309-35c140809afe)

Fixes #10707.