### PR TITLE
[5.x] Prevent error when writing to Comb index file

### DIFF
--- a/src/Search/Comb/Index.php
+++ b/src/Search/Comb/Index.php
@@ -117,6 +117,8 @@ class Index extends BaseIndex
 
     protected function save($documents)
     {
+        app('files')->ensureDirectoryExists(pathinfo($this->path())['dirname']);
+
         app('files')->put($this->path(), $documents->toJson(), lock: true);
     }
 


### PR DESCRIPTION
This pull request fixes an issue caused by #10695 where an error would be thrown when attempting to write the index's JSON file if the `storage/statamic/search` directory doesn't exist.

This was happening [under the hood](https://github.com/statamic/cms/blob/5.x/src/Filesystem/AbstractAdapter.php#L27) when we were using the Flysystem stuff.