### PR TITLE
[5.x] Show field handle on hover for fields in Bard & Replicator sets

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Field.vue
+++ b/resources/js/components/fieldtypes/replicator/Field.vue
@@ -3,7 +3,7 @@
     <div class="p-4 m-0 @container" :class="classes">
 
         <label class="block" :for="fieldId" v-if="showLabel">
-            <span v-if="showLabelText">{{ display }}</span>
+            <span v-if="showLabelText" v-tooltip="{content: field.handle, delay: 500, autoHide: false}">{{ display }}</span>
             <i class="required" v-if="field.required">*</i>
             <span v-if="isReadOnly" class="text-gray-500 font-normal text-2xs mx-1" v-text="__('Read Only')" />
         </label>


### PR DESCRIPTION
This pull request makes it so field handles are displayed when hovering over fields in Bard & Replicator sets.

![CleanShot 2024-08-28 at 15 04 28](https://github.com/user-attachments/assets/e9e05fda-370a-47ff-bd00-1bd8d49f02ed)


Closes #10717.