### PR TITLE
[5.x] Fix augmentation of select options

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -138,7 +138,7 @@ trait HasSelectOptions
             $value = $this->castFromBoolean($value);
         }
 
-        $option = collect($this->getOptions())->firstWhere('value', $value);
+        $option = collect($this->getOptions())->filter(fn ($option) => $option['value'] === $value)->first();
 
         return $option ? $option['label'] : $actualValue;
     }

--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -138,16 +138,9 @@ trait HasSelectOptions
             $value = $this->castFromBoolean($value);
         }
 
-        return $this->isOption($value)
-            ? __(Arr::get($this->config('options'), $value) ?? $value)
-            : $actualValue;
-    }
+        $option = collect($this->getOptions())->firstWhere('value', $value);
 
-    private function isOption($value)
-    {
-        return Arr::isAssoc($options = $this->config('options') ?? [])
-            ? in_array($value, array_keys($options), true)
-            : in_array($value, $options, true);
+        return $option ? $option['label'] : $actualValue;
     }
 
     private function castToBoolean($value)


### PR DESCRIPTION
This pull request fixes an issue where select options stored in the new format (see #10467) wouldn't be augmented properly.

Fixes #10696.