### PR TITLE
[5.x] Add enter binding when editing blueprint sections

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -126,6 +126,7 @@ export default {
             editingSection: false,
             editingField: null,
             handleSyncedWithDisplay: false,
+            enterBinding: null,
         }
     },
 
@@ -158,6 +159,15 @@ export default {
             if (this.editingSection && this.handleSyncedWithDisplay) {
                 this.editingSection.handle = snake_case(display);
             }
+        },
+
+        editingSection(editingSection) {
+            if (! editingSection) {
+                this.enterBinding = null;
+                return;
+            }
+
+            this.enterBinding = this.$keys.bind('enter', this.editConfirmed);
         }
 
     },


### PR DESCRIPTION
This pull request adds a keybinding to the "enter" key when editing a section in a blueprint or fieldset.

This PR doesn't do it for tabs - I need to come back to them since I couldn't seem to get them working the same way. 🤔

Closes #10702.