### PR TITLE
[5.x] Prevent saving value of `parent` field to entry data

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -248,7 +248,7 @@ class EntriesController extends CpController
                         ->save();
                 });
 
-                $values->forget('parent');
+                $entry->remove('parent');
             }
         }
 


### PR DESCRIPTION
This pull request fixes an issue where the value of the `parent` field would be persisted to entry data, when it shouldn't have been.

Closes #5457.