### PR TITLE
[5.x] Fix broken state of "Parent" field when saving Home entry with Revisions

### DIFF
--- a/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
+++ b/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
@@ -19,8 +19,8 @@ trait ExtractsFromEntryFields
         if ($entry->hasStructure()) {
             $values['parent'] = array_filter([optional($entry->parent())->id()]);
 
-            if ($entry->revisionsEnabled() && $entry->has('parent')) {
-                $values['parent'] = [$entry->get('parent')];
+            if ($entry->revisionsEnabled() && $parent = $entry->get('parent')) {
+                $values['parent'] = [$parent];
             }
         }
 


### PR DESCRIPTION
This pull request fixes an issue where the "Parent" field on a Home entry could get into a weird state when you save it using revisions.

Fixes #10724.