### PR TITLE
[5.x] Link to "Reserved Words" docs page from field settings.

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -90,7 +90,7 @@ return [
     'fields_display_instructions' => 'The field\'s label shown in the Control Panel.',
     'fields_duplicate_instructions' => 'Whether this field should be included when duplicating the item.',
     'fields_fieldsets_description' => 'Fieldsets are simple, flexible, and completely optional groupings of fields that help to organize reusable, pre-configured fields.',
-    'fields_handle_instructions' => 'The field\'s template variable. Some handles are reserved and cannot be used, for a full list please [review the documentation](https://statamic.dev/tips/reserved-words#as-field-names) for a full list.',
+    'fields_handle_instructions' => 'The field\'s template variable. Avoid using [reserved words](https://statamic.dev/tips/reserved-words#as-field-names) as handles.',
     'fields_instructions_instructions' => 'Provide additional field instructions like this very text. Markdown formatting is supported.',
     'fields_instructions_position_instructions' => 'Show instructions above or below the field.',
     'fields_listable_instructions' => 'Control the listing column visibility.',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -90,7 +90,7 @@ return [
     'fields_display_instructions' => 'The field\'s label shown in the Control Panel.',
     'fields_duplicate_instructions' => 'Whether this field should be included when duplicating the item.',
     'fields_fieldsets_description' => 'Fieldsets are simple, flexible, and completely optional groupings of fields that help to organize reusable, pre-configured fields.',
-    'fields_handle_instructions' => 'The field\'s template variable.',
+    'fields_handle_instructions' => 'The field\'s template variable. Some handles are reserved and cannot be used, for a full list please [review the documentation](https://statamic.dev/tips/reserved-words#as-field-names) for a full list.',
     'fields_instructions_instructions' => 'Provide additional field instructions like this very text. Markdown formatting is supported.',
     'fields_instructions_position_instructions' => 'Show instructions above or below the field.',
     'fields_listable_instructions' => 'Control the listing column visibility.',


### PR DESCRIPTION
This pull request adds a link to the "Reserved Words" page on the Statamic Documentation from the instructions of the "Handle" field, to make it a little eaqsier to see what you can & can't name fields.

Closes #6794.