### PR TITLE
[5.x] Allow specifying permissions for Glide cache

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -70,6 +70,17 @@ return [
         'cache' => false,
         'cache_path' => public_path('img'),
 
+        'cache_permissions' => [
+            'file' => [
+                'public' => 0644,
+                'private' => 0600,
+            ],
+            'dir' => [
+                'public' => 0755,
+                'private' => 0700,
+            ],
+        ],
+
         /*
         |--------------------------------------------------------------------------
         | Image Manipulation Defaults

--- a/src/Imaging/GlideManager.php
+++ b/src/Imaging/GlideManager.php
@@ -60,6 +60,7 @@ class GlideManager
             'driver' => 'local',
             'root' => $root,
             'visibility' => 'public',
+            'permissions' => config('statamic.assets.image_manipulation.cache_permissions'),
         ]);
     }
 


### PR DESCRIPTION
This pull request allows for overriding the permissions used to write to the Glide image cache.

Closes #8199.