### PR TITLE
[5.x] Fix twirldown on navigation show page

### DIFF
--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -8,7 +8,7 @@
             <div class="flex items-center">
                 <h1 class="flex-1" v-text="__(title)" />
 
-                <dropdown-list v-if="editable" class="rtl:ml-2 ltr:mr-2">
+                <dropdown-list v-if="canEdit" class="rtl:ml-2 ltr:mr-2">
                     <slot name="twirldown" />
                 </dropdown-list>
 


### PR DESCRIPTION
This pull request fixes an issue where the twirldown wouldn't be shown on the navigations show page in the Control Panel due to it checking something that dioesn't exist. 🤦‍♂️

Caused by #9265.