### PR TITLE
[5.x] Allow using `entry` as a field handle in navigation blueprints

### DIFF
--- a/src/Data/AbstractAugmented.php
+++ b/src/Data/AbstractAugmented.php
@@ -99,7 +99,7 @@ abstract class AbstractAugmented implements Augmented
     {
         return method_exists($this->data, $method)
             && collect($this->keys())->contains(Str::snake($handle))
-            && ! in_array($handle, ['hook', 'value']);
+            && ! in_array($handle, ['hook', 'value', 'entry']);
     }
 
     protected function getFromData($handle)


### PR DESCRIPTION
This pull request adds `entry` to one of the augmentaion "allow lists", allowing for `entry` to be used as a field on navigation blueprints.

Fixes #8657.