### PR TITLE
[5.x] Fix relationship fieldtypes showing ID instead of item title

### DIFF
--- a/resources/js/components/data-list/Filter.vue
+++ b/resources/js/components/data-list/Filter.vue
@@ -5,7 +5,7 @@
             class="p-3"
             v-if="filter.fields.length"
             :name="`filter-${filter.handle}`"
-            :meta="{}"
+            :meta="meta"
             :values="containerValues"
             :track-dirty-state="false"
             @updated="updateValues"
@@ -15,6 +15,7 @@
                 :fields="filter.fields"
                 :name-prefix="`filter-${filter.handle}`"
                 @updated="setFieldValue"
+                @meta-updated="updateMeta"
             />
         </publish-container>
 
@@ -48,6 +49,12 @@ export default {
         values: Object,
     },
 
+    data() {
+        return {
+            meta: {},
+        };
+    },
+
     computed: {
         defaultValues() {
             return this.filter.values || {};
@@ -72,6 +79,10 @@ export default {
         resetAll() {
             this.$emit('changed', null);
             this.$emit('cleared');
+        },
+
+        updateMeta(value) {
+            this.meta = value;
         },
 
         close() {

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -52,7 +52,11 @@ export default {
         InlineEditForm
     },
 
-    inject: ['storeName'],
+    inject: {
+        storeName: {
+            default: null
+        }
+    },
 
     props: {
         item: Object,

--- a/resources/js/components/publish/FieldMeta.vue
+++ b/resources/js/components/publish/FieldMeta.vue
@@ -28,6 +28,7 @@ export default {
             meta: this.meta,
             value: this.value,
             loading: this.loading,
+            updateMeta: this.updateMeta,
         });
     },
 
@@ -67,6 +68,10 @@ export default {
                 this.value = response.data.value;
                 this.loading = false;
             });
+        },
+
+        updateMeta(value) {
+            this.meta = value;
         }
 
     }

--- a/resources/js/components/users/Wizard.vue
+++ b/resources/js/components/users/Wizard.vue
@@ -61,15 +61,17 @@
                 <label class="font-bold text-base mb-1" for="role">{{ __('Roles') }}</label>
                 <publish-field-meta
                     :config="{ handle: 'user.roles', type: 'user_roles' }"
-                    :initial-value="user.roles">
-                    <div slot-scope="{ meta, value, loading }">
+                    :initial-value="user.roles"
+                >
+                    <div slot-scope="{ meta, value, loading, updateMeta }">
                         <relationship-fieldtype
                             v-if="!loading"
                             handle="user.roles"
                             :config="{ type: 'user_roles', mode: 'select' }"
                             :value="value"
                             :meta="meta"
-                            @input="user.roles = $event" />
+                            @input="user.roles = $event"
+                            @meta-updated="updateMeta" />
                     </div>
                 </publish-field-meta>
             </div>
@@ -79,15 +81,17 @@
                 <label class="font-bold text-base mb-1" for="group">{{ __('Groups') }}</label>
                 <publish-field-meta
                     :config="{ handle: 'user.groups', type: 'user_groups' }"
-                    :initial-value="user.groups">
-                    <div slot-scope="{ meta, value, loading }">
+                    :initial-value="user.groups"
+                >
+                    <div slot-scope="{ meta, value, loading, updateMeta }">
                         <relationship-fieldtype
                             v-if="!loading"
                             handle="user.groups"
                             :config="{ type: 'user_groups', mode: 'select' }"
                             :value="value"
                             :meta="meta"
-                            @input="user.groups = $event" />
+                            @input="user.groups = $event"
+                            @meta-updated="updateMeta"/>
                     </div>
                 </publish-field-meta>
             </div>


### PR DESCRIPTION
This pull request fixes two instances where the ID of a selected relationship item as being displayed instead of the item's title.

This was happening due to the item data not flowing back to the field meta's "source of truth" properly.

Fixes #8363.
Fixes #10673.