### PR TITLE
[5.x] Twirldown should be shown even if the user doesn't have edit collection permissions

### DIFF
--- a/resources/views/collections/show.blade.php
+++ b/resources/views/collections/show.blade.php
@@ -35,6 +35,7 @@
             auth()->user()->can('edit', $collection)
             || auth()->user()->can('delete', $collection)
             || auth()->user()->can('configure fields')
+            || $actions->isNotEmpty()
         )
         <template #twirldown="{ actionCompleted }">
             @can('edit', $collection)


### PR DESCRIPTION
This pull request fixes an issue I spotted at the weekend where the Twirldown on the collection show page wouldn't be displayed unless the user had "edit collection" permissions for that collection, even if actions were available.

Related: #10471