### PR TITLE
[5.x] Update docblock in action class stub

### DIFF
--- a/src/Console/Commands/stubs/action.php.stub
+++ b/src/Console/Commands/stubs/action.php.stub
@@ -9,7 +9,7 @@ class DummyClass extends Action
     /**
      * The run method
      *
-     * @return void
+     * @return mixed
      */
     public function run($items, $values)
     {


### PR DESCRIPTION
This pull request updates the return type of the `run` method in the action class stub, as it's not always going to return void, it's [very possible](https://statamic.dev/extending/actions#responses) a string or array might be returned.

No issue for this, but just a small thing I noticed.