### PR TITLE
[5.x] Support querying by any status

### DIFF
--- a/src/Stache/Query/QueriesEntryStatus.php
+++ b/src/Stache/Query/QueriesEntryStatus.php
@@ -8,6 +8,10 @@ trait QueriesEntryStatus
 {
     public function whereStatus(string $status)
     {
+        if ($status === 'any') {
+            return $this;
+        }
+
         if (! in_array($status, ['published', 'draft', 'scheduled', 'expired'])) {
             throw new \Exception("Invalid status [$status]");
         }

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -153,6 +153,7 @@ class APITest extends TestCase
         $this->assertEndpointDataCount('/api/collections/pages/entries?filter[status:is]=draft', 2);
         $this->assertEndpointDataCount('/api/collections/pages/entries?filter[published:is]=true', 1);
         $this->assertEndpointDataCount('/api/collections/pages/entries?filter[published:is]=false', 2);
+        $this->assertEndpointDataCount('/api/collections/pages/entries?filter[status:is]=any', 3);
     }
 
     #[Test]

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -342,6 +342,7 @@ class EntriesTest extends TestCase
         $this->assertCount(1, $this->getEntries(['status:is' => 'published']));
         $this->assertCount(3, $this->getEntries(['status:not' => 'published']));
         $this->assertCount(3, $this->getEntries(['status:in' => 'published|draft']));
+        $this->assertCount(4, $this->getEntries(['status:is' => 'any']));
     }
 
     #[Test]


### PR DESCRIPTION
References statamic/eloquent-driver#347

Doing `$query->whereStatus('any')` would be the same as not calling `whereStatus` at all. This is useful in situations like the collection tag or REST/GraphQL APIs where it filters by the `published` status by default.

```
{{ collection:articles status:is="any" }}
```
```
entries(
  collection: "articles",
  filter: {status: "any"}
)
```
```
/api/collections/articles/entries?filter[status]=published
```
