### PR TITLE
[5.x] Prevent button group fieldtype from submitting actions

### DIFF
--- a/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
@@ -5,6 +5,7 @@
                 v-for="(option, $index) in options"
                 :key="$index"
                 ref="button"
+                type="button"
                 :name="name"
                 @click="update($event.target.value)"
                 :value="option.value"


### PR DESCRIPTION
This pull request fixes an issue with the "Delete Entry" action where clicking on one of the button group buttons automatically submits the form, instead of it being submitted when you click the big red button.

Fixes #10754.