### PR TITLE
[5.x] Prevent error when `cascadeContent`  is an Eloquent Model

### DIFF
--- a/src/View/Debugbar/AddRequestMessage.php
+++ b/src/View/Debugbar/AddRequestMessage.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\View\Debugbar;
 
+use Illuminate\Database\Eloquent\Model;
 use Statamic\Routing\Route;
 use Statamic\View\Events\ViewRendered;
 
@@ -31,6 +32,10 @@ class AddRequestMessage
     {
         if ($item instanceof Route) {
             return 'Route '.$item->url();
+        }
+
+        if ($item instanceof Model) {
+            return class_basename($item).' '.$item->getKey();
         }
 
         return class_basename($item).' '.$item->id();


### PR DESCRIPTION
This pull request fixes an issue when passing an Eloquent Model into a view's `->cascadeContents() method.

I'm currently fixing a bug in Runway, with its frontend routing feature, where the `page` variable isn't available in Blade views (see statamic-rad-pack/runway#590). 

The [`page` variable](https://github.com/statamic/cms/blob/dd4ad041859660a80a96aa9c9145225463336986/src/View/Cascade.php#L169) is only set when the view has `cascadeContent` set, whereas previously we were only passing an array of the augmented model into the `View::with()` method.

However, when passing the model to `View::cascadeContents()`, it resulted in an error because the model doesn't have an `id` method on it.

I could add an ID method but that has caused issues in the past where folks have already implemented their own `id` methods.

Ideally, for Eloquent Models, it'd use the model's key anyway.

Anyways, feel free to reject if you don't want this in Core and I'll try and find another way around it.