### PR TITLE
[5.x] Fix Ignition Views

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "rebing/graphql-laravel": "^9.5",
         "rhukster/dom-sanitizer": "^1.0.6",
         "spatie/blink": "^1.3",
-        "spatie/laravel-ignition": "^2.8",
+        "spatie/ignition": "^1.12",
         "statamic/stringy": "^3.1.2",
         "symfony/lock": "^6.4",
         "symfony/var-exporter": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "rebing/graphql-laravel": "^9.5",
         "rhukster/dom-sanitizer": "^1.0.6",
         "spatie/blink": "^1.3",
-        "spatie/ignition": "^1.12",
+        "spatie/laravel-ignition": "^2.8",
         "statamic/stringy": "^3.1.2",
         "symfony/lock": "^6.4",
         "symfony/var-exporter": "^6.0",

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -2,11 +2,11 @@
 
 namespace Statamic\View\Antlers\Language\Runtime;
 
-use Facade\Ignition\Exceptions\ViewException;
-use Facade\Ignition\Exceptions\ViewExceptionWithSolution;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use ReflectionProperty;
 use Spatie\Ignition\Contracts\ProvidesSolution;
+use Spatie\LaravelIgnition\Exceptions\ViewException;
+use Spatie\LaravelIgnition\Exceptions\ViewExceptionWithSolution;
 use Statamic\Contracts\View\Antlers\Parser;
 use Statamic\Fields\Value;
 use Statamic\Modifiers\ModifierNotFoundException;


### PR DESCRIPTION
In #9745 I added ignition as a dependency to get solution working. Looks like I did a find/replace for the contracts, but there were a couple that were dependent on the laravel-ignition package.

The changes in this PR makes the views re-appear in the exceptions.

Like this:

![CleanShot 2024-09-04 at 17 31 51](https://github.com/user-attachments/assets/922d67de-1a84-4a74-a172-df163a3dc29c)

Without this PR, only the exception is shown and it would be difficult to figure out what view it came from.