### PR TITLE
[5.x] Private asset container url method should return null

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -134,6 +134,10 @@ class AssetContainer implements Arrayable, ArrayAccess, AssetContainerContract, 
      */
     public function url()
     {
+        if ($this->private()) {
+            return null;
+        }
+
         $url = rtrim($this->disk()->url('/'), '/');
 
         return ($url === '') ? '/' : $url;

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -144,11 +144,13 @@ class AssetContainerTest extends TestCase
         $container = (new AssetContainer)->disk('test');
         $this->assertTrue($container->private());
         $this->assertFalse($container->accessible());
+        $this->assertNull($container->url());
 
         Storage::fake('test', ['url' => '/url']);
 
         $this->assertFalse($container->private());
         $this->assertTrue($container->accessible());
+        $this->assertEquals('/url', $container->url());
     }
 
     #[Test]


### PR DESCRIPTION
This was always the intention, but it didn't.

Doing `$asset->url()` on a private asset would already return `null`, it's just calling on the container itself that had the issue.

This was discovered by doing `Asset::findByUrl($url)` and having a private S3 container.
https://github.com/statamic/cms/blob/a9f4e41478cbef40312ae54b5343d3317cca89c5/src/Assets/AssetRepository.php#L75-L83
It would loop through all containers, get their urls, and figure out a matching container. When you had a private s3 container, getting its URL here would throw an exception. Now since it returns null the exception is avoided. The private container is skipped in findByUrl as expected, since they don't have URLs.