### PR TITLE
[5.x] Fix border radius for data tables

### DIFF
--- a/resources/css/components/cards.css
+++ b/resources/css/components/cards.css
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .card {
-    @apply shadow bg-white rounded-md p-2;
+    @apply shadow bg-white rounded-md p-2 overflow-hidden;
     @apply dark:bg-dark-600 dark:shadow-dark;
 }
 


### PR DESCRIPTION
This pull request fixes a small UI issue on some data tables where the border radius wouldn't be there.

Fixes  #10760.