### PR TITLE
[5.x] Allow bind of ImageGenerator by removing last `new` call

### DIFF
--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -35,11 +35,11 @@ class GlideController extends Controller
     /**
      * GlideController constructor.
      */
-    public function __construct(Server $server, Request $request)
+    public function __construct(Server $server, Request $request, ImageGenerator $generator)
     {
         $this->server = $server;
         $this->request = $request;
-        $this->generator = new ImageGenerator($server);
+        $this->generator = $generator;
     }
 
     /**


### PR DESCRIPTION
Replace a `new ImageGenerator` call with dependency injection to allow binding the ImageGenerator and overwriting it.

All other places in the code already use the ImageGenerator this way. This ocurrence is the only one using the `new`.
