### PR TITLE
[5.x] Remove legacy code that likely caused issues typing 'f' in asset file rename field

### DIFF
--- a/resources/js/components/data-list/HasFilters.js
+++ b/resources/js/components/data-list/HasFilters.js
@@ -55,13 +55,6 @@ export default {
 
     },
 
-    created() {
-        this.$keys.bind('f', e => {
-            e.preventDefault();
-            this.handleShowFilters();
-        });
-    },
-
     methods: {
 
         searchChanged(query) {


### PR DESCRIPTION
Fixes #10776

@925dk identified the likely cause of the reported issue as being this small piece of code 'leftover from the filter refactor'.

This PR removes that code.

I am a novice Statamic contributor so this will need thorough double-checking, but I haven't seen any other issues in my testing as a result of this change.