### PR TITLE
[5.x] Only index entries with published status

### DIFF
--- a/src/Search/Searchables/Entries.php
+++ b/src/Search/Searchables/Entries.php
@@ -58,6 +58,6 @@ class Entries extends Provider
 
     protected function defaultFilter()
     {
-        return fn ($item) => $item->published();
+        return fn ($item) => $item->status() === 'published';
     }
 }


### PR DESCRIPTION
At the moment, we index any entries marked as published. i.e. not drafts. (Since https://github.com/statamic/cms/pull/6318)
However, this would include scheduled or expired entries.

This PR makes it so that only entries with a status of published are indexed. Not drafts, scheduled, or expired.
