### PR TITLE
[5.x] Prevent user from being logged out when ending impersonation

### DIFF
--- a/src/Http/Controllers/CP/Auth/ImpersonationController.php
+++ b/src/Http/Controllers/CP/Auth/ImpersonationController.php
@@ -6,9 +6,16 @@ use Illuminate\Events\NullDispatcher;
 use Illuminate\Support\Facades\Auth;
 use Statamic\Events\ImpersonationEnded;
 use Statamic\Facades\User;
+use Statamic\Http\Controllers\Controller;
+use Statamic\Http\Middleware\CP\AuthenticateSession;
 
-class ImpersonationController
+class ImpersonationController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware(AuthenticateSession::class);
+    }
+
     public function stop()
     {
         if ($originalUserId = session()->pull('statamic_impersonated_by')) {


### PR DESCRIPTION
This pull request fixes an issue where ending impersonation would result in the impersonator being logged out, rather than redirected back to the Control Panel.

This was happening due to the `stop-impersonation` route existing outside the middleware group with the `AuthenticateSession` middleware. Adding it directly to that controller does the trick!

Fixes #10772.