### PR TITLE
[5.x] Changed default sort order for global site selector

### DIFF
--- a/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
+++ b/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
@@ -127,6 +127,6 @@ class GlobalVariablesController extends CpController
             ->globalSet()
             ->localizations()
             ->sort()
-            ->filter(fn($set) => User::current()->can('edit', $set));
+            ->filter(fn ($set) => User::current()->can('edit', $set));
     }
 }

--- a/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
+++ b/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
@@ -126,6 +126,7 @@ class GlobalVariablesController extends CpController
         return $variables
             ->globalSet()
             ->localizations()
-            ->filter(fn ($set) => User::current()->can('edit', $set));
+            ->sort()
+            ->filter(fn($set) => User::current()->can('edit', $set));
     }
 }


### PR DESCRIPTION
When editing Globals set the default sort order of the Sites dropdown to sort by handle.
If a project has many Sites it is much easier to switch them. Currently it is sorted the order of the Sites inside the sites.yaml or the primary key if eloquent driver is used.