### PR TITLE
[5.x] Improve ImageGenerator Exception handling

### DIFF
--- a/src/Http/Controllers/CP/Assets/ThumbnailController.php
+++ b/src/Http/Controllers/CP/Assets/ThumbnailController.php
@@ -3,7 +3,9 @@
 namespace Statamic\Http\Controllers\CP\Assets;
 
 use Illuminate\Support\Facades\Cache;
+use League\Glide\Filesystem\FileNotFoundException;
 use League\Glide\Server;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Config;
 use Statamic\Facades\Image;
@@ -110,6 +112,8 @@ class ThumbnailController extends Controller
                 $this->asset,
                 $preset ? ['p' => $preset] : []
             );
+        } catch(FileNotFoundException $e) {
+            throw new NotFoundHttpException;
         } finally {
             Cache::forget($this->mutex());
         }

--- a/src/Http/Controllers/CP/Assets/ThumbnailController.php
+++ b/src/Http/Controllers/CP/Assets/ThumbnailController.php
@@ -112,7 +112,7 @@ class ThumbnailController extends Controller
                 $this->asset,
                 $preset ? ['p' => $preset] : []
             );
-        } catch(FileNotFoundException $e) {
+        } catch (FileNotFoundException $e) {
             throw new NotFoundHttpException;
         } finally {
             Cache::forget($this->mutex());

--- a/src/Http/Controllers/CP/Assets/ThumbnailController.php
+++ b/src/Http/Controllers/CP/Assets/ThumbnailController.php
@@ -3,7 +3,7 @@
 namespace Statamic\Http\Controllers\CP\Assets;
 
 use Illuminate\Support\Facades\Cache;
-use League\Glide\Filesystem\FileNotFoundException;
+use League\Flysystem\UnableToReadFile;
 use League\Glide\Server;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Asset;
@@ -112,7 +112,7 @@ class ThumbnailController extends Controller
                 $this->asset,
                 $preset ? ['p' => $preset] : []
             );
-        } catch (FileNotFoundException $e) {
+        } catch (UnableToReadFile $e) {
             throw new NotFoundHttpException;
         } finally {
             Cache::forget($this->mutex());

--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers;
 
 use Illuminate\Http\Request;
 use League\Flysystem\UnableToReadFile;
+use League\Glide\Filesystem\FileNotFoundException;
 use League\Glide\Server;
 use League\Glide\Signatures\SignatureException;
 use League\Glide\Signatures\SignatureFactory;
@@ -113,7 +114,7 @@ class GlideController extends Controller
 
         try {
             return $this->generator->$method($item, $this->request->all());
-        } catch (UnableToReadFile $e) {
+        } catch (UnableToReadFile|FileNotFoundException $e) {
             throw new NotFoundHttpException;
         }
     }

--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -4,7 +4,6 @@ namespace Statamic\Http\Controllers;
 
 use Illuminate\Http\Request;
 use League\Flysystem\UnableToReadFile;
-use League\Glide\Filesystem\FileNotFoundException;
 use League\Glide\Server;
 use League\Glide\Signatures\SignatureException;
 use League\Glide\Signatures\SignatureFactory;
@@ -114,7 +113,7 @@ class GlideController extends Controller
 
         try {
             return $this->generator->$method($item, $this->request->all());
-        } catch (UnableToReadFile|FileNotFoundException $e) {
+        } catch (UnableToReadFile $e) {
             throw new NotFoundHttpException;
         }
     }

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -6,6 +6,7 @@ use Facades\Statamic\Imaging\ImageValidator;
 use Illuminate\Support\Facades\Storage;
 use League\Flysystem\Filesystem;
 use League\Flysystem\UnableToReadFile;
+use League\Glide\Filesystem\FileNotFoundException as GlideFileNotFoundException;
 use League\Glide\Manipulators\Watermark;
 use League\Glide\Server;
 use Statamic\Contracts\Assets\Asset;
@@ -253,7 +254,11 @@ class ImageGenerator
             $this->validateImage();
         }
 
-        $path = $this->server->makeImage($image, $this->params);
+        try {
+            $path = $this->server->makeImage($image, $this->params);
+        } catch (GlideFileNotFoundException $e) {
+            throw UnableToReadFile::fromLocation($image);
+        }
 
         GlideImageGenerated::dispatch($path, $this->params);
 

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -6,12 +6,10 @@ use Facades\Statamic\Imaging\ImageValidator;
 use Illuminate\Support\Facades\Storage;
 use League\Flysystem\Filesystem;
 use League\Flysystem\UnableToReadFile;
-use League\Glide\Filesystem\FileNotFoundException as GlideFileNotFoundException;
 use League\Glide\Manipulators\Watermark;
 use League\Glide\Server;
 use Statamic\Contracts\Assets\Asset;
 use Statamic\Events\GlideImageGenerated;
-use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Asset as Assets;
 use Statamic\Facades\Config;
 use Statamic\Facades\File;
@@ -255,11 +253,7 @@ class ImageGenerator
             $this->validateImage();
         }
 
-        try {
-            $path = $this->server->makeImage($image, $this->params);
-        } catch (GlideFileNotFoundException $e) {
-            throw new NotFoundHttpException;
-        }
+        $path = $this->server->makeImage($image, $this->params);
 
         GlideImageGenerated::dispatch($path, $this->params);
 


### PR DESCRIPTION
In the old situation `src/Imaging/ImageGenerator.php` throws http exceptions while by namespace it has nothing to do with http.
This causes confusing errors when used to pregenerate images since getting the actual error message is impossible and instead you get a 404.

This PR moves throwing the 404 for this error to the controllers running the generator, so exceptions are thrown according to the task that class should perform.
This will make debugging and error handling much better.

caused by: https://github.com/statamic/cms/pull/3450/files#diff-a241fa0e16c263728c96b0f5b5b590e06e14a79e2e7260a3501bba22ceb88755R152
fixes: https://github.com/statamic/cms/issues/10788