### PR TITLE
[5.x] Add user login custom error bag name

### DIFF
--- a/src/Http/Requests/UserLoginRequest.php
+++ b/src/Http/Requests/UserLoginRequest.php
@@ -47,7 +47,7 @@ class UserLoginRequest extends FormRequest
 
         $errorResponse = $this->has('_error_redirect') ? redirect($this->input('_error_redirect')) : back();
 
-        throw (new ValidationException($validator, $errorResponse->withInput()->withErrors(__('Invalid credentials.'))));
+        throw (new ValidationException($validator, $errorResponse->withInput()->withErrors(__('Invalid credentials.'), 'user.login')));
     }
 
     public function validateResolved()


### PR DESCRIPTION
Currently the user login form is using the default error bag name, wich can interfere with other forms on the same page (if using popups for login and reset forms for example)

The PR adds a specific error bag name for user login form