### PR TITLE
[5.x] Update CSRF token when session expiry login modal is closed

### DIFF
--- a/resources/js/components/SessionExpiry.vue
+++ b/resources/js/components/SessionExpiry.vue
@@ -121,6 +121,10 @@ export default {
             }
 
             this.lastCount = Vue.moment();
+        },
+
+        isShowingLogin(showing, wasShowing) {
+            if (showing && !wasShowing) this.updateCsrfToken();
         }
 
     },


### PR DESCRIPTION
Fixes #10793

If the login modal closes automatically it would have been before the session was renewed elsewhere.

At the moment the token is only updated when you submit the form. Since you don't actually submit the form in this case, the token was never updated. Now it will.
