### PR TITLE
[5.x] Reset previous filters when you finish reordering

### DIFF
--- a/resources/js/components/collections/View.vue
+++ b/resources/js/components/collections/View.vue
@@ -96,6 +96,7 @@
             :reordering="reordering"
             :reorder-url="reorderUrl"
             :site="site"
+            :sites="sites"
             @reordered="reordering = false"
             @site-changed="site = $event"
         />

--- a/resources/js/components/collections/View.vue
+++ b/resources/js/components/collections/View.vue
@@ -96,7 +96,6 @@
             :reordering="reordering"
             :reorder-url="reorderUrl"
             :site="site"
-            :sites="sites"
             @reordered="reordering = false"
             @site-changed="site = $event"
         />

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -220,9 +220,7 @@ export default {
             // When reordering, we *need* a site, since mixing them up would be awkward.
             // If we're dealing with multiple sites, it's possible the user "cleared"
             // the site filter so we'll want to fall back to the initial site.
-            if (this.sites.length > 1) {
-                this.setSiteFilter(this.currentSite || this.initialSite);
-            }
+            if (this.sites.length > 1) this.setSiteFilter(this.currentSite || this.initialSite);
 
             this.page = 1;
             this.sortColumn = 'order';
@@ -232,9 +230,7 @@ export default {
         cancelReordering() {
             this.filtersReset();
 
-            if (this.sites.length > 1) {
-                this.setSiteFilter(this.currentSite || this.initialSite);
-            }
+            if (this.sites.length > 1) this.setSiteFilter(this.currentSite || this.initialSite);
 
             this.request();
         },
@@ -263,9 +259,7 @@ export default {
                 .then(response => {
                     this.filtersReset();
 
-                    if (this.sites.length > 1) {
-                        this.setSiteFilter(this.currentSite || this.initialSite);
-                    }
+                    if (this.sites.length > 1) this.setSiteFilter(this.currentSite || this.initialSite);
 
                     this.$emit('reordered');
                     this.$toast.success(__('Entries successfully reordered'))

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -220,7 +220,9 @@ export default {
             // When reordering, we *need* a site, since mixing them up would be awkward.
             // If we're dealing with multiple sites, it's possible the user "cleared"
             // the site filter so we'll want to fall back to the initial site.
-            this.setSiteFilter(this.currentSite || this.initialSite);
+            if (this.sites.length > 1) {
+                this.setSiteFilter(this.currentSite || this.initialSite);
+            }
 
             this.page = 1;
             this.sortColumn = 'order';

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -130,7 +130,6 @@ export default {
         reordering: Boolean,
         reorderUrl: String,
         site: String,
-        sites: Array,
     },
 
     data() {

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -220,9 +220,7 @@ export default {
             // When reordering, we *need* a site, since mixing them up would be awkward.
             // If we're dealing with multiple sites, it's possible the user "cleared"
             // the site filter so we'll want to fall back to the initial site.
-            if (this.sites.length > 1) {
-                this.setSiteFilter(this.currentSite || this.initialSite);
-            }
+             this.setSiteFilter(this.currentSite || this.initialSite);
 
             this.page = 1;
             this.sortColumn = 'order';
@@ -230,6 +228,12 @@ export default {
         },
 
         cancelReordering() {
+            this.filtersReset();
+
+            if (this.sites.length > 1) {
+                this.setSiteFilter(this.currentSite || this.initialSite);
+            }
+
             this.request();
         },
 
@@ -255,6 +259,12 @@ export default {
 
             this.$axios.post(this.reorderUrl, payload)
                 .then(response => {
+                    this.filtersReset();
+
+                    if (this.sites.length > 1) {
+                        this.setSiteFilter(this.currentSite || this.initialSite);
+                    }
+
                     this.$emit('reordered');
                     this.$toast.success(__('Entries successfully reordered'))
                 })

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -220,7 +220,7 @@ export default {
             // When reordering, we *need* a site, since mixing them up would be awkward.
             // If we're dealing with multiple sites, it's possible the user "cleared"
             // the site filter so we'll want to fall back to the initial site.
-             this.setSiteFilter(this.currentSite || this.initialSite);
+            this.setSiteFilter(this.currentSite || this.initialSite);
 
             this.page = 1;
             this.sortColumn = 'order';

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -141,6 +141,7 @@ export default {
             currentSite: this.site,
             initialSite: this.site,
             pushQuery: true,
+            previousFilters: null,
         }
     },
 
@@ -215,6 +216,7 @@ export default {
         },
 
         reorder() {
+            this.previousFilters = this.activeFilters;
             this.filtersReset();
 
             // When reordering, we *need* a site, since mixing them up would be awkward.
@@ -228,9 +230,7 @@ export default {
         },
 
         cancelReordering() {
-            this.filtersReset();
-
-            if (this.sites.length > 1) this.setSiteFilter(this.currentSite || this.initialSite);
+            this.resetToPreviousFilters();
 
             this.request();
         },
@@ -257,10 +257,6 @@ export default {
 
             this.$axios.post(this.reorderUrl, payload)
                 .then(response => {
-                    this.filtersReset();
-
-                    if (this.sites.length > 1) this.setSiteFilter(this.currentSite || this.initialSite);
-
                     this.$emit('reordered');
                     this.$toast.success(__('Entries successfully reordered'))
                 })
@@ -269,6 +265,14 @@ export default {
                     this.$toast.error(__('Something went wrong'));
                 });
         },
+
+        resetToPreviousFilters() {
+            this.filtersReset();
+
+            if (this.previousFilters) this.filtersChanged(this.previousFilters);
+
+            this.previousFilters = null;
+        }
     }
 
 }

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -130,6 +130,7 @@ export default {
         reordering: Boolean,
         reorderUrl: String,
         site: String,
+        sites: Array,
     },
 
     data() {
@@ -219,7 +220,9 @@ export default {
             // When reordering, we *need* a site, since mixing them up would be awkward.
             // If we're dealing with multiple sites, it's possible the user "cleared"
             // the site filter so we'll want to fall back to the initial site.
-            this.setSiteFilter(this.currentSite || this.initialSite);
+            if (this.sites.length > 1) {
+                this.setSiteFilter(this.currentSite || this.initialSite);
+            }
 
             this.page = 1;
             this.sortColumn = 'order';

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -220,7 +220,7 @@ export default {
             // When reordering, we *need* a site, since mixing them up would be awkward.
             // If we're dealing with multiple sites, it's possible the user "cleared"
             // the site filter so we'll want to fall back to the initial site.
-            if (this.sites.length > 1) this.setSiteFilter(this.currentSite || this.initialSite);
+            this.setSiteFilter(this.currentSite || this.initialSite);
 
             this.page = 1;
             this.sortColumn = 'order';


### PR DESCRIPTION
This pull request prevents the "Site" filter from showing after re-ordering entries in a single-site setup.

It also resets your filters to what you had active before you clicked "reorder". (Clicking reorder will remove any filters since we need to show you all the entries).

Closes #10796.