### PR TITLE
[5.x] Fix CP nav ordering for when preferences are stored in JSON SQL columns

### DIFF
--- a/src/CP/Navigation/NavPreferencesNormalizer.php
+++ b/src/CP/Navigation/NavPreferencesNormalizer.php
@@ -191,7 +191,9 @@ class NavPreferencesNormalizer
         }
 
         // Normalize `reorder` bool.
-        $normalized->put('reorder', (bool) $reorder = $normalized->get('reorder', false));
+        if ($reorder = $normalized->get('reorder', false)) {
+            $normalized->put('reorder', (bool) $reorder);
+        }
 
         // Normalize `children`.
         $children = $this

--- a/src/CP/Navigation/NavPreferencesNormalizer.php
+++ b/src/CP/Navigation/NavPreferencesNormalizer.php
@@ -244,11 +244,14 @@ class NavPreferencesNormalizer
             ];
         }
 
-        if (is_array($itemConfig)) {
-            Arr::forget($itemConfig, 'children');
+        $normalized = $this->normalizeItemConfig($itemId, $itemConfig, $sectionKey, false);
+
+        if (is_array($normalized)) {
+            Arr::forget($normalized, 'reorder');
+            Arr::forget($normalized, 'children');
         }
 
-        return $this->normalizeItemConfig($itemId, $itemConfig, $sectionKey, false);
+        return $normalized;
     }
 
     /**

--- a/src/CP/Navigation/NavPreferencesNormalizer.php
+++ b/src/CP/Navigation/NavPreferencesNormalizer.php
@@ -73,11 +73,12 @@ class NavPreferencesNormalizer
     {
         $navConfig = collect($this->preferences);
 
-        $normalized = collect()->put('reorder', $reorder = $navConfig->get('reorder', false));
+        $normalized = collect()->put('reorder', (bool) $reorder = $navConfig->get('reorder', false));
 
         $sections = collect($navConfig->get('sections') ?? $navConfig->except('reorder'));
 
-        $sections = $sections
+        $sections = $this
+            ->normalizeToInheritsFromReorder($sections, $reorder)
             ->prepend($sections->pull('top_level') ?? '@inherit', 'top_level')
             ->map(fn ($config, $section) => $this->normalizeSectionConfig($config, $section))
             ->reject(fn ($config) => $config['action'] === '@inherit' && ! $reorder)

--- a/src/CP/Navigation/NavPreferencesNormalizer.php
+++ b/src/CP/Navigation/NavPreferencesNormalizer.php
@@ -117,7 +117,7 @@ class NavPreferencesNormalizer
 
         $normalized->put('display', $sectionConfig->get('display', false));
 
-        $normalized->put('reorder', $reorder = $sectionConfig->get('reorder', false));
+        $normalized->put('reorder', (bool) $reorder = $sectionConfig->get('reorder', false));
 
         $items = collect($sectionConfig->get('items') ?? $sectionConfig->except([
             'action',
@@ -125,7 +125,8 @@ class NavPreferencesNormalizer
             'reorder',
         ]));
 
-        $items = $items
+        $items = $this
+            ->normalizeToInheritsFromReorder($items, $reorder)
             ->map(fn ($config, $itemId) => $this->normalizeItemConfig($itemId, $config, $sectionKey))
             ->keyBy(fn ($config, $itemId) => $this->normalizeItemId($itemId, $config))
             ->filter()

--- a/src/CP/Navigation/NavPreferencesNormalizer.php
+++ b/src/CP/Navigation/NavPreferencesNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\CP\Navigation;
 
+use Illuminate\Support\Collection;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
@@ -270,6 +271,21 @@ class NavPreferencesNormalizer
     protected function itemIsInOriginalSection($itemId, $currentSectionKey)
     {
         return Str::startsWith($itemId, "$currentSectionKey::");
+    }
+
+    /**
+     * Normalize to legacy style inherits from new `reorder: []` array schema, introduced to sidestep ordering issues in SQL.
+     */
+    protected function normalizeToInheritsFromReorder(array|Collection $items, array|bool $reorder): Collection
+    {
+        if (! is_array($reorder)) {
+            return collect($items);
+        }
+
+        return collect($reorder)
+            ->flip()
+            ->map(fn () => '@inherit')
+            ->merge($items);
     }
 
     /**

--- a/src/CP/Navigation/NavTransformer.php
+++ b/src/CP/Navigation/NavTransformer.php
@@ -356,9 +356,7 @@ class NavTransformer
 
         $section['items'] = collect($section['items'])
             ->map(fn ($item) => $this->minifyItem($item))
-            ->all();
-
-        $section['items'] = $this->rejectInherits($section['items']);
+            ->pipe(fn ($items) => $this->rejectInherits($items));
 
         if (! $section['reorder']) {
             Arr::forget($section, 'reorder');
@@ -392,9 +390,7 @@ class NavTransformer
     {
         $item['children'] = collect($item['children'] ?? [])
             ->map(fn ($item) => $this->minifyItem($item, true))
-            ->all();
-
-        $item['children'] = $this->rejectInherits($item['children']);
+            ->pipe(fn ($items) => $this->rejectInherits($items));
 
         if (! $item['reorder']) {
             Arr::forget($item, 'reorder');

--- a/src/CP/Navigation/NavTransformer.php
+++ b/src/CP/Navigation/NavTransformer.php
@@ -59,8 +59,8 @@ class NavTransformer
     protected function transform()
     {
         $this->config['reorder'] = $this->getReorderedItems(
-            $this->coreNav->pluck('display_original'),
-            collect($this->submitted)->pluck('display_original'),
+            $this->coreNav->map(fn ($section) => $this->transformSectionKey($section)),
+            collect($this->submitted)->map(fn ($section) => $this->transformSectionKey($section)),
         );
 
         $this->config['sections'] = collect($this->submitted)
@@ -325,7 +325,7 @@ class NavTransformer
             ->pipe(fn ($sections) => $this->rejectInherits($sections));
 
         $reorder = collect(Arr::get($this->config, 'reorder') ?: [])
-            ->reject(fn ($section) => $section === 'Top Level')
+            ->reject(fn ($section) => $section === 'top_level')
             ->values()
             ->all();
 

--- a/src/CP/Navigation/NavTransformer.php
+++ b/src/CP/Navigation/NavTransformer.php
@@ -432,7 +432,7 @@ class NavTransformer
      * @param  array  $items
      * @return array
      */
-    protected function rejectAllInherits($items)
+    protected function rejectInherits($items)
     {
         $items = collect($items)->reject(fn ($item) => $item === '@inherit');
 

--- a/src/CP/Navigation/NavTransformer.php
+++ b/src/CP/Navigation/NavTransformer.php
@@ -304,7 +304,7 @@ class NavTransformer
             })
             ->count();
 
-        $this->reorderedMinimums[$parentKey] = max(1, $minimumItemsCount - 1);
+        return $this->reorderedMinimums[$parentKey] = max(1, $minimumItemsCount - 1);
     }
 
     /**

--- a/src/CP/Navigation/NavTransformer.php
+++ b/src/CP/Navigation/NavTransformer.php
@@ -444,37 +444,6 @@ class NavTransformer
     }
 
     /**
-     * Reject unessessary `@inherit`s at end of array.
-     *
-     * @param  array  $items
-     * @param  string  $parentKey
-     * @return array
-     */
-    protected function rejectUnessessaryInherits($items, $parentKey)
-    {
-        if (! $reorderedMinimum = $this->reorderedMinimums[$parentKey] ?? false) {
-            return $items;
-        }
-
-        $keyValuePairs = collect($items)
-            ->map(fn ($item, $key) => ['key' => $key, 'value' => $item])
-            ->values()
-            ->keyBy(fn ($keyValuePair, $index) => $index + 1);
-
-        $trailingInherits = $keyValuePairs
-            ->reverse()
-            ->takeUntil(fn ($item) => $item['value'] !== '@inherit');
-
-        $modifiedMinimum = $keyValuePairs->count() - $trailingInherits->count();
-
-        $actualMinimum = max($reorderedMinimum, $modifiedMinimum);
-
-        return collect($items)
-            ->take($actualMinimum)
-            ->all();
-    }
-
-    /**
      * Get config.
      *
      * @return array

--- a/src/CP/Navigation/NavTransformer.php
+++ b/src/CP/Navigation/NavTransformer.php
@@ -320,17 +320,18 @@ class NavTransformer
      */
     protected function minify()
     {
-        $this->config['sections'] = collect($this->config['sections'])
+        $sections = collect($this->config['sections'])
             ->map(fn ($section) => $this->minifySection($section))
+            ->pipe(fn ($sections) => $this->rejectInherits($sections));
+
+        $reorder = collect(Arr::get($this->config, 'reorder') ?: [])
+            ->reject(fn ($section) => $section === 'Top Level')
+            ->values()
             ->all();
 
-        $sections = $this->rejectInherits($this->config['sections']);
-
-        if ($this->config['reorder']) {
-            $this->config['sections'] = $sections;
-        } else {
-            $this->config = $sections;
-        }
+        $this->config = $reorder
+            ? array_filter(compact('reorder', 'sections'))
+            : $sections;
 
         // If the config is completely null after minifying, ensure we save an empty array.
         // For example, if we're transforming this config for a user's nav preferences,

--- a/src/CP/Navigation/NavTransformer.php
+++ b/src/CP/Navigation/NavTransformer.php
@@ -330,10 +330,12 @@ class NavTransformer
             ->map(fn ($section, $key) => $this->minifySection($section, $key))
             ->all();
 
-        if ($this->config['reorder'] === true) {
-            $this->config['sections'] = $this->rejectUnessessaryInherits($this->config['sections'], 'sections');
+        $sections = $this->rejectInherits($this->config['sections']);
+
+        if ($this->config['reorder']) {
+            $this->config['sections'] = $sections;
         } else {
-            $this->config = $this->rejectAllInherits($this->config['sections']);
+            $this->config = $sections;
         }
 
         // If the config is completely null after minifying, ensure we save an empty array.
@@ -362,10 +364,9 @@ class NavTransformer
             ->map(fn ($item, $key) => $this->minifyItem($item, $key))
             ->all();
 
-        if ($section['reorder'] === true) {
-            $section['items'] = $this->rejectUnessessaryInherits($section['items'], $sectionKey);
-        } else {
-            $section['items'] = $this->rejectAllInherits($section['items']);
+        $section['items'] = $this->rejectInherits($section['items']);
+
+        if (! $section['reorder']) {
             Arr::forget($section, 'reorder');
         }
 
@@ -401,10 +402,9 @@ class NavTransformer
             ->map(fn ($item, $childId) => $this->minifyItem($item, $childId, true))
             ->all();
 
-        if ($item['reorder'] === true) {
-            $item['children'] = $this->rejectUnessessaryInherits($item['children'], $itemKey);
-        } else {
-            $item['children'] = $this->rejectAllInherits($item['children']);
+        $item['children'] = $this->rejectInherits($item['children']);
+
+        if (! $item['reorder']) {
             Arr::forget($item, 'reorder');
         }
 

--- a/src/CP/Navigation/NavTransformer.php
+++ b/src/CP/Navigation/NavTransformer.php
@@ -12,7 +12,6 @@ class NavTransformer
     protected $coreNav;
     protected $submitted;
     protected $config;
-    protected $reorderedMinimums;
 
     /**
      * Instantiate nav transformer.
@@ -274,21 +273,18 @@ class NavTransformer
             return false;
         }
 
-        $minimum = $this->trackReorderedMinimums($originalList, $newList, $parentKey);
-
         return collect($newList)
-            ->take($minimum)
+            ->take($this->calculateMinimumItemsForReorder($originalList, $newList))
             ->all();
     }
 
     /**
-     * Track minimum number of items needed for reorder config.
+     * Calculate minimum number of items needed for reorder config.
      *
      * @param  array  $originalList
      * @param  array  $newList
-     * @param  string  $parentKey
      */
-    protected function trackReorderedMinimums($originalList, $newList, $parentKey): int
+    protected function calculateMinimumItemsForReorder($originalList, $newList): int
     {
         $continueRejecting = true;
 
@@ -304,7 +300,7 @@ class NavTransformer
             })
             ->count();
 
-        return $this->reorderedMinimums[$parentKey] = max(1, $minimumItemsCount - 1);
+        return max(1, $minimumItemsCount - 1);
     }
 
     /**

--- a/tests/CP/Navigation/NavPreferencesNormalizerTest.php
+++ b/tests/CP/Navigation/NavPreferencesNormalizerTest.php
@@ -684,4 +684,158 @@ class NavPreferencesNormalizerTest extends TestCase
 
         $this->assertSame($expected, $nav);
     }
+
+    #[Test]
+    public function it_normalizes_example_config_with_legacy_reordering_style()
+    {
+        $nav = $this->normalize([
+            'reorder' => true,
+            'sections' => [
+                'fields' => '@inherit',
+                'content' => [
+                    'reorder' => true,
+                    'items' => [
+                        'content::globals' => '@inherit',
+                        'content::collections' => [
+                            'action' => '@modify',
+                            'reorder' => true,
+                            'children' => [
+                                'content::collections::pages' => '@inherit',
+                                'content::collections::articles' => [
+                                    'action' => '@modify',
+                                    'display' => 'Featured Articles',
+                                ],
+                            ],
+                        ],
+                        'content::assets' => '@inherit',
+                    ],
+                ],
+            ],
+        ]);
+
+        $expected = [
+            'reorder' => true,
+            'sections' => [
+                'top_level' => [
+                    'action' => false,
+                    'display' => false,
+                    'reorder' => false,
+                    'items' => [],
+                ],
+                'fields' => [
+                    'action' => false,
+                    'display' => false,
+                    'reorder' => false,
+                    'items' => [],
+                ],
+                'content' => [
+                    'action' => false,
+                    'display' => false,
+                    'reorder' => true,
+                    'items' => [
+                        'content::globals' => [
+                            'action' => '@inherit',
+                        ],
+                        'content::collections' => [
+                            'action' => '@modify',
+                            'reorder' => true,
+                            'children' => [
+                                'content::collections::pages' => [
+                                    'action' => '@inherit',
+                                ],
+                                'content::collections::articles' => [
+                                    'action' => '@modify',
+                                    'display' => 'Featured Articles',
+                                ],
+                            ],
+                        ],
+                        'content::assets' => [
+                            'action' => '@inherit',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $nav);
+    }
+
+    #[Test]
+    public function it_normalizes_example_config_with_new_array_reordering_style()
+    {
+        $nav = $this->normalize([
+            'reorder' => [
+                'fields',
+            ],
+            'sections' => [
+                'content' => [
+                    'reorder' => [
+                        'content::globals',
+                        'content::collections',
+                        'content::assets',
+                    ],
+                    'items' => [
+                        'content::collections' => [
+                            'action' => '@modify',
+                            'reorder' => [
+                                'content::collections::pages',
+                            ],
+                            'children' => [
+                                'content::collections::articles' => [
+                                    'action' => '@modify',
+                                    'display' => 'Featured Articles',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $expected = [
+            'reorder' => true,
+            'sections' => [
+                'top_level' => [
+                    'action' => false,
+                    'display' => false,
+                    'reorder' => false,
+                    'items' => [],
+                ],
+                'fields' => [
+                    'action' => false,
+                    'display' => false,
+                    'reorder' => false,
+                    'items' => [],
+                ],
+                'content' => [
+                    'action' => false,
+                    'display' => false,
+                    'reorder' => true,
+                    'items' => [
+                        'content::globals' => [
+                            'action' => '@inherit',
+                        ],
+                        'content::collections' => [
+                            'action' => '@modify',
+                            'reorder' => true,
+                            'children' => [
+                                'content::collections::pages' => [
+                                    'action' => '@inherit',
+                                ],
+                                'content::collections::articles' => [
+                                    'action' => '@modify',
+                                    'display' => 'Featured Articles',
+                                ],
+                            ],
+                        ],
+                        'content::assets' => [
+                            'action' => '@inherit',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $nav);
+    }
 }

--- a/tests/CP/Navigation/NavPreferencesNormalizerTest.php
+++ b/tests/CP/Navigation/NavPreferencesNormalizerTest.php
@@ -642,12 +642,12 @@ class NavPreferencesNormalizerTest extends TestCase
             'sections' => [
                 'top_level' => [
                     'action' => false,
-                    'reorder' => false,
                     'display' => false,
+                    'reorder' => false,
                     'items' => [
                         'top_level::dashboard' => [
-                            'action' => '@modify',
                             'display' => 'Dashboard Confessional',
+                            'action' => '@modify',
                         ],
                         $topLevelBlueprintsId => [
                             'action' => '@alias',
@@ -659,12 +659,12 @@ class NavPreferencesNormalizerTest extends TestCase
                 ],
                 'content' => [
                     'action' => false,
-                    'reorder' => false,
                     'display' => false,
+                    'reorder' => false,
                     'items' => [
                         $contentBlueprintsId => [
-                            'action' => '@alias',
                             'display' => 'Content Blueprints',
+                            'action' => '@alias',
                         ],
                         'user::profiles' => [
                             'action' => '@create',
@@ -675,13 +675,13 @@ class NavPreferencesNormalizerTest extends TestCase
                 ],
                 'fields' => [
                     'action' => '@hide',
-                    'reorder' => false,
                     'display' => false,
+                    'reorder' => false,
                     'items' => [],
                 ],
             ],
         ];
 
-        $this->assertEquals($expected, $nav);
+        $this->assertSame($expected, $nav);
     }
 }

--- a/tests/CP/Navigation/NavPreferencesNormalizerTest.php
+++ b/tests/CP/Navigation/NavPreferencesNormalizerTest.php
@@ -265,7 +265,7 @@ class NavPreferencesNormalizerTest extends TestCase
             'content' => [
                 'reorder' => true,
                 'content::collections::pages' => [
-                    $modifier => 'test',
+                    $modifier => [],
                 ],
             ],
         ]), 'sections.content.items.content::collections::pages.action'));
@@ -276,7 +276,7 @@ class NavPreferencesNormalizerTest extends TestCase
                 'reorder' => true,
                 'items' => [
                     'content::collections::pages' => [
-                        $modifier => 'test',
+                        $modifier => [],
                     ],
                 ],
             ],

--- a/tests/CP/Navigation/NavPreferencesNormalizerTest.php
+++ b/tests/CP/Navigation/NavPreferencesNormalizerTest.php
@@ -134,9 +134,25 @@ class NavPreferencesNormalizerTest extends TestCase
             'top_level' => ['content::collections::pages' => '@alias'],
         ])['sections']));
 
+        // With `reorder: []` array
+        $this->assertEquals(['top_level', 'content'], array_keys($this->normalize([
+            'reorder' => ['content', 'top_level'],
+            'content' => ['fields::blueprints' => '@alias'],
+            'top_level' => ['content::collections::pages' => '@alias'],
+        ])['sections']));
+
         // With `reorder: true` and sections properly nested
         $this->assertEquals(['top_level', 'content'], array_keys($this->normalize([
             'reorder' => true,
+            'sections' => [
+                'content' => ['fields::blueprints' => '@alias'],
+                'top_level' => ['content::collections::pages' => '@alias'],
+            ],
+        ])['sections']));
+
+        // With `reorder: []` array and sections properly nested
+        $this->assertEquals(['top_level', 'content'], array_keys($this->normalize([
+            'reorder' => ['content', 'top_level'],
             'sections' => [
                 'content' => ['fields::blueprints' => '@alias'],
                 'top_level' => ['content::collections::pages' => '@alias'],
@@ -199,6 +215,14 @@ class NavPreferencesNormalizerTest extends TestCase
             'tools' => '@inherit',
         ])['sections']));
 
+        // With `reorder: []` array
+        $this->assertEquals(['top_level', 'users', 'tools'], array_keys($this->normalize([
+            'reorder' => ['top_level', 'users', 'tools'],
+            'users' => [
+                'content::collections::profiles' => '@move',
+            ],
+        ])['sections']));
+
         // With `reorder: true` and sections properly nested
         $this->assertEquals(['top_level', 'users', 'tools'], array_keys($this->normalize([
             'reorder' => true,
@@ -208,6 +232,16 @@ class NavPreferencesNormalizerTest extends TestCase
                     'content::collections::profiles' => '@move',
                 ],
                 'tools' => '@inherit',
+            ],
+        ])['sections']));
+
+        // With `reorder: []` array and sections properly nested
+        $this->assertEquals(['top_level', 'users', 'tools'], array_keys($this->normalize([
+            'reorder' => ['top_level', 'users', 'tools'],
+            'sections' => [
+                'users' => [
+                    'content::collections::profiles' => '@move',
+                ],
             ],
         ])['sections']));
     }
@@ -243,6 +277,18 @@ class NavPreferencesNormalizerTest extends TestCase
             ],
         ])['sections']['content']['items']));
 
+        // With `reorder: []` array
+        $this->assertEquals($expected, array_keys($this->normalize([
+            'content' => [
+                'reorder' => [
+                    'content::collections::pages',
+                    'content::collections::posts',
+                    'content::collections::profiles',
+                ],
+                'content::collections::posts' => ['display' => 'Posterinos'],
+            ],
+        ])['sections']['content']['items']));
+
         // With `reorder: true` and sections properly nested
         $this->assertEquals($expected, array_keys($this->normalize([
             'content' => [
@@ -251,6 +297,20 @@ class NavPreferencesNormalizerTest extends TestCase
                     'content::collections::pages' => '@inherit',
                     'content::collections::posts' => ['display' => 'Posterinos'],
                     'content::collections::profiles' => '@inherit',
+                ],
+            ],
+        ])['sections']['content']['items']));
+
+        // With `reorder: []` array and sections properly nested
+        $this->assertEquals($expected, array_keys($this->normalize([
+            'content' => [
+                'reorder' => [
+                    'content::collections::pages',
+                    'content::collections::posts',
+                    'content::collections::profiles',
+                ],
+                'items' => [
+                    'content::collections::posts' => ['display' => 'Posterinos'],
                 ],
             ],
         ])['sections']['content']['items']));
@@ -270,10 +330,36 @@ class NavPreferencesNormalizerTest extends TestCase
             ],
         ]), 'sections.content.items.content::collections::pages.action'));
 
+        // With `reorder: []` array
+        $this->assertEquals('@modify', Arr::get($this->normalize([
+            'content' => [
+                'reorder' => [
+                    'content::collections::pages',
+                ],
+                'content::collections::pages' => [
+                    $modifier => [],
+                ],
+            ],
+        ]), 'sections.content.items.content::collections::pages.action'));
+
         // With `reorder: true` and sections properly nested
         $this->assertEquals('@modify', Arr::get($this->normalize([
             'content' => [
                 'reorder' => true,
+                'items' => [
+                    'content::collections::pages' => [
+                        $modifier => [],
+                    ],
+                ],
+            ],
+        ]), 'sections.content.items.content::collections::pages.action'));
+
+        // With `reorder: []` array and sections properly nested
+        $this->assertEquals('@modify', Arr::get($this->normalize([
+            'content' => [
+                'reorder' => [
+                    'content::collections::pages',
+                ],
                 'items' => [
                     'content::collections::pages' => [
                         $modifier => [],
@@ -299,12 +385,30 @@ class NavPreferencesNormalizerTest extends TestCase
             ],
         ]), 'sections.content.items.content::collections::pages.action'));
 
+        // With `reorder: []` array
+        $this->assertEquals('@inherit', Arr::get($this->normalize([
+            'content' => [
+                'reorder' => [
+                    'content::collections::pages',
+                ],
+            ],
+        ]), 'sections.content.items.content::collections::pages.action'));
+
         // With `reorder: true` and sections properly nested
         $this->assertEquals('@inherit', Arr::get($this->normalize([
             'content' => [
                 'reorder' => true,
                 'items' => [
                     'content::collections::pages' => [],
+                ],
+            ],
+        ]), 'sections.content.items.content::collections::pages.action'));
+
+        // With `reorder: []` array and sections properly nested
+        $this->assertEquals('@inherit', Arr::get($this->normalize([
+            'content' => [
+                'reorder' => [
+                    'content::collections::pages',
                 ],
             ],
         ]), 'sections.content.items.content::collections::pages.action'));

--- a/tests/CP/Navigation/NavTransformerTest.php
+++ b/tests/CP/Navigation/NavTransformerTest.php
@@ -820,13 +820,12 @@ class NavTransformerTest extends TestCase
 
         $expected = [
             'content' => [
-                'reorder' => true,
-                'items' => [
-                    'content::navigation' => '@inherit',
-                    'content::taxonomies' => '@inherit',
-                    'content::assets' => '@inherit',
+                'reorder' => [
+                    'content::navigation',
+                    'content::taxonomies',
+                    'content::assets',
+                    // 'Collections' and 'Globals' items are omitted because they are redundant in this case
                 ],
-                // 'Collections' and 'Globals' items are omitted because they are redundant in this case
             ],
         ];
 
@@ -864,16 +863,18 @@ class NavTransformerTest extends TestCase
 
         $expected = [
             'content' => [
-                'reorder' => true,
+                'reorder' => [
+                    'content::navigation',
+                    'content::taxonomies',
+                    'content::assets',
+                    'content::collections',
+                    'content::globals',
+                ],
                 'items' => [
-                    'content::navigation' => '@inherit',
                     'content::taxonomies' => [
                         'action' => '@modify',
                         'display' => 'Favourite Taxonomies',
                     ],
-                    'content::assets' => '@inherit',
-                    'content::collections' => '@inherit',
-                    'content::globals' => '@inherit',
                     'content::custom_item' => [
                         'action' => '@create',
                         'display' => 'Custom Item',
@@ -1039,11 +1040,10 @@ class NavTransformerTest extends TestCase
         ]);
 
         $expected = [
-            'reorder' => true,
-            'sections' => [
-                'top_level' => '@inherit',
-                'fields' => '@inherit',
-                'tools' => '@inherit',
+            'reorder' => [
+                // 'Top Level' is omitted because it'll always be top level
+                'fields',
+                'tools',
                 // 'Content', 'Settings', and 'Users' sections are omitted because they are redundant in this case
             ],
         ];
@@ -1085,15 +1085,16 @@ class NavTransformerTest extends TestCase
         ]);
 
         $expected = [
-            'reorder' => true,
+            'reorder' => [
+                'fields',
+                'tools',
+                'content',
+                'users',
+            ],
             'sections' => [
-                'top_level' => '@inherit',
                 'fields' => [
                     'content::collections' => '@alias',
                 ],
-                'tools' => '@inherit',
-                'content' => '@inherit',
-                'users' => '@inherit',
                 'custom_section' => [
                     'display' => 'Custom Section',
                     'action' => '@create',
@@ -1247,7 +1248,11 @@ class NavTransformerTest extends TestCase
         $transformed = $this->transform(json_decode('[{"display":"Top Level","display_original":"Top Level","action":false,"items":[{"id":"top_level::dashboard","manipulations":[],"children":[]},{"id":"content::collections::posts","manipulations":{"action":"@alias"},"children":[]},{"id":"tools::updates","manipulations":{"action":"@move"},"children":[]},{"id":"new_top_level_item","manipulations":{"action":"@create","display":"New Top Level Item","url":"\/new-top-level-item"},"children":[{"id":"new_child_item","manipulations":{"action":"@create","display":"New Child Item","url":"\/new-child-item"},"children":[]}]}]},{"display":"Fields","display_original":"Fields","action":false,"items":[{"id":"fields::blueprints","manipulations":{"display":"Blueprints Renamed","action":"@modify"},"children":[]},{"id":"fields::fieldsets","manipulations":[],"children":[]}]},{"display":"Content Renamed","display_original":"Content","action":false,"items":[{"id":"content::collections::pages","manipulations":{"action":"@move"},"children":[]},{"id":"content::collections","manipulations":{"action":"@modify"},"children":[{"id":"content::collections::posts","manipulations":{"display":"Posterinos","action":"@modify"},"children":[]}]},{"id":"content::navigation","manipulations":[],"children":[{"id":"content::navigation::nav_test","manipulations":[],"children":[]}]},{"id":"content::taxonomies","manipulations":[],"children":[]},{"id":"content::assets","manipulations":[],"children":[{"id":"content::assets::assets","manipulations":[],"children":[]},{"id":"content::assets::essthree","manipulations":[],"children":[]}]}]},{"display":"Custom Section","display_original":"Custom Section","action":"@create","items":[{"id":"custom_section::new_item","manipulations":{"action":"@create","display":"New Item","url":"\/new-item"},"children":[]},{"id":"content::taxonomies::tags","manipulations":{"action":"@move"},"children":[]},{"id":"content::globals","manipulations":{"action":"@move"},"children":[{"id":"content::globals::global","manipulations":[],"children":[]}]}]},{"display":"Tools","display_original":"Tools","action":false,"items":[{"id":"tools::forms","manipulations":[],"children":[{"id":"tools::forms::test","manipulations":[],"children":[]}]},{"id":"tools::addons","manipulations":[],"children":[]},{"id":"tools::utilities","manipulations":[],"children":[{"id":"tools::utilities::cache","manipulations":[],"children":[]},{"id":"tools::utilities::email","manipulations":[],"children":[]},{"id":"tools::utilities::licensing","manipulations":[],"children":[]},{"id":"tools::utilities::php_info","manipulations":[],"children":[]},{"id":"tools::utilities::search","manipulations":[],"children":[]}]}]},{"display":"Users","display_original":"Users","action":false,"items":[{"id":"users::users","manipulations":[],"children":[]},{"id":"users::groups","manipulations":[],"children":[]},{"id":"users::permissions","manipulations":[],"children":[{"id":"users::permissions::author","manipulations":[],"children":[]},{"id":"users::permissions::not_social_media_manager","manipulations":[],"children":[]},{"id":"users::permissions::social_media_manager","manipulations":[],"children":[]}]}]}]', true));
 
         $expected = [
-            'reorder' => true,
+            'reorder' => [
+                'fields',
+                'content',
+                'custom_section',
+            ],
             'sections' => [
                 'top_level' => [
                     'content::collections::posts' => '@alias',
@@ -1273,7 +1278,12 @@ class NavTransformerTest extends TestCase
                 ],
                 'content' => [
                     'display' => 'Content Renamed',
-                    'reorder' => true,
+                    'reorder' => [
+                        'content::collections::pages',
+                        'content::collections',
+                        'content::navigation',
+                        'content::taxonomies',
+                    ],
                     'items' => [
                         'content::collections::pages' => '@move',
                         'content::collections' => [
@@ -1285,8 +1295,6 @@ class NavTransformerTest extends TestCase
                                 ],
                             ],
                         ],
-                        'content::navigation' => '@inherit',
-                        'content::taxonomies' => '@inherit',
                     ],
                 ],
                 'custom_section' => [


### PR DESCRIPTION
At a high level, this PR changes the YAML schema in saved CP Nav preferences to use a new array format...

```yaml
nav:
  reorder:
    - fields
    - content
  sections:
    ...
```

Reordering the old way required object key order to be preserved, but this breaks down once saved to JSON column in MySQL, and it tries to order keys alphabetically instead...

```yaml
nav:
  reorder: true
  sections:
    fields: @inherit
    content: @inherit # This would end up first, because `c` comes before `f`
```

This new format solves that ordering issue in SQL, but should also work just fine in flat file scenarios. I have also taken care to ensure the old legacy format can still be read when building navs from existing users' preferences as well.

### TODO:

- [x] Save new schema to YAML
    - [x] At the section level
    - [x] At the item level
    - [x] At the deeper child level
- [x] Read new schema from YAML when building nav
    - [x] At the section level
    - [x] At the item level
    - [x] At the deeper child level
- [x] Ensure it can still read the legacy schema when building nav
    - [x] At the section level
    - [x] At the item level
    - [x] At the deeper child level
- [x] Tests