### PR TITLE
[5.x] Set path on asset folder when moving

### DIFF
--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -133,7 +133,7 @@ class AssetFolder implements Arrayable, Contract
         });
         $cache->save();
 
-        AssetFolderDeleted::dispatch($this);
+        AssetFolderDeleted::dispatch(clone $this);
 
         return $this;
     }
@@ -182,6 +182,8 @@ class AssetFolder implements Arrayable, Contract
         $this->container()->assetFolders($oldPath)->each->move($newPath);
         $this->container()->assets($oldPath)->each->move($newPath);
         $this->delete();
+
+        $this->path($newPath);
 
         return $folder;
     }


### PR DESCRIPTION
When moving an asset folder, the new path should be set. If you do `$folder->path()` currently the old path is shown.
Now the new one would be shown.

This already happens when you move an asset. https://github.com/statamic/cms/blob/d795c89acaa0f3e5584439ec43813d0622a8c5ed/src/Assets/Asset.php#L756

When dispatching the deleted event, we clone the object so `$folder->path()` within the listener *does* output the old path. That was the one that was deleted. If we didn't clone, since the object is passed by reference, the path would be the new one.
