### PR TITLE
[5.x] Prevent concurrent requests to the Marketplace API

### DIFF
--- a/src/Marketplace/Client.php
+++ b/src/Marketplace/Client.php
@@ -6,9 +6,9 @@ use Facades\GuzzleHttp\Client as Guzzle;
 use Illuminate\Cache\NoLock;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\LockTimeoutException;
+use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\Facades\Cache;
 use InvalidArgumentException;
-use Illuminate\Contracts\Cache\Store;
 
 class Client
 {


### PR DESCRIPTION
This pull request implements locking around Marketplace API requests to ensure only a single request is being made to the API at once.

This works in a similar fasion to how we handle locking in the Outpost, see #9000.
