### PR TITLE
[5.x] Add option to exclude flag emojis from countries dictionary

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -69,6 +69,7 @@ return [
     'collections_sort_direction_instructions' => 'The default sort direction.',
     'collections_preview_target_refresh_instructions' => 'Automatically refresh the preview while editing. Disabling this will use postMessage.',
     'collections_taxonomies_instructions' => 'Connect entries in this collection to taxonomies. Fields will be automatically added to publish forms.',
+    'dictionaries_countries_emojis_instructions' => 'Whether flag emojis should be included in the labels.',
     'dictionaries_countries_region_instructions' => 'Optionally filter the countries by region.',
     'duplicate_action_warning_localization' => 'This entry is a localization. The origin entry will be duplicated.',
     'duplicate_action_warning_localizations' => 'One or more selected entries are localizations. In those cases, the origin entry will be duplicated instead.',

--- a/src/Dictionaries/Countries.php
+++ b/src/Dictionaries/Countries.php
@@ -19,7 +19,10 @@ class Countries extends BasicDictionary
 
     protected function getItemLabel(array $item): string
     {
-        return "{$item['emoji']} {$item['name']}";
+        return vsprintf('%s%s', [
+            ($this->config['emojis'] ?? true) ? "{$item['emoji']} " : '',
+            $item['name'],
+        ]);
     }
 
     protected function fieldItems()
@@ -30,6 +33,12 @@ class Countries extends BasicDictionary
                 'instructions' => __('statamic::messages.dictionaries_countries_region_instructions'),
                 'type' => 'select',
                 'options' => $this->regions,
+            ],
+            'emojis' => [
+                'display' => __('Emojis'),
+                'instructions' => __('statamic::messages.dictionaries_countries_emojis_instructions'),
+                'type' => 'toggle',
+                'default' => true,
             ],
         ];
     }


### PR DESCRIPTION
By default flag emojis are shown. This adds an option to disable them.
