### PR TITLE
[5.x] Make limit modifier work with query builders

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Data\Augmentable;
+use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Compare;
@@ -1451,6 +1452,10 @@ class CoreModifiers extends Modifier
     public function limit($value, $params)
     {
         $limit = Arr::get($params, 0, 0);
+
+        if ($value instanceof Builder) {
+            return $value->limit($limit);
+        }
 
         if ($value instanceof Collection) {
             return $value->take($limit);

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Data\Augmentable;
-use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Compare;
@@ -1453,7 +1452,7 @@ class CoreModifiers extends Modifier
     {
         $limit = Arr::get($params, 0, 0);
 
-        if ($value instanceof Builder) {
+        if (Compare::isQueryBuilder($value)) {
             return $value->limit($limit);
         }
 

--- a/tests/Modifiers/LimitTest.php
+++ b/tests/Modifiers/LimitTest.php
@@ -42,7 +42,7 @@ class LimitTest extends TestCase
         $query->shouldReceive('limit')->with(2)->once()->andReturnSelf();
 
         $limited = $this->modify($query, 2);
-        $this->assertInstanceOf(Builder::class, $limited);
+        $this->assertSame($query, $limited);
     }
 
     public function modify($value, $limit)

--- a/tests/Modifiers/LimitTest.php
+++ b/tests/Modifiers/LimitTest.php
@@ -2,22 +2,16 @@
 
 namespace Tests\Modifiers;
 
-use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Query\Builder;
-use Statamic\Facades\Collection as CollectionFacade;
-use Statamic\Facades\Entry;
 use Statamic\Modifiers\Modify;
-use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 #[Group('array')]
 class LimitTest extends TestCase
 {
-    use PreventSavingStacheItemsToDisk;
-
     #[Test]
     public function it_limits_arrays(): void
     {
@@ -44,19 +38,11 @@ class LimitTest extends TestCase
     #[Test]
     public function it_limits_builders(): void
     {
-        CollectionFacade::make('posts')->save();
+        $query = \Mockery::mock(Builder::class);
+        $query->shouldReceive('limit')->with(2)->once()->andReturnSelf();
 
-        EntryFactory::id('id-1')->collection('posts')->create();
-        EntryFactory::id('id-2')->collection('posts')->create();
-        EntryFactory::id('id-3')->collection('posts')->create();
-
-        $limited = $this->modify(Entry::query(), 2);
+        $limited = $this->modify($query, 2);
         $this->assertInstanceOf(Builder::class, $limited);
-        $this->assertEquals(2, $limited->count());
-
-        $limited = $this->modify(Entry::query(), 3);
-        $this->assertInstanceOf(Builder::class, $limited);
-        $this->assertEquals(3, $limited->count());
     }
 
     public function modify($value, $limit)

--- a/tests/Modifiers/LimitTest.php
+++ b/tests/Modifiers/LimitTest.php
@@ -2,16 +2,16 @@
 
 namespace Tests\Modifiers;
 
-use Tests\TestCase;
+use Facades\Tests\Factories\EntryFactory;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Contracts\Query\Builder;
+use Statamic\Facades\Collection as CollectionFacade;
 use Statamic\Facades\Entry;
 use Statamic\Modifiers\Modify;
-use Illuminate\Support\Collection;
-use Statamic\Contracts\Query\Builder;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\Group;
-use Facades\Tests\Factories\EntryFactory;
 use Tests\PreventSavingStacheItemsToDisk;
-use Statamic\Facades\Collection as CollectionFacade;
+use Tests\TestCase;
 
 #[Group('array')]
 class LimitTest extends TestCase


### PR DESCRIPTION
I ran into a scenario in Antlers where I needed to limit the selected entries of an entries fieldtype. This PR extends the `limit` modifier to also support query builders.

**Fieldset**

```yaml
handle: galleries
field:
  collections:
    - galleries
  type: entries
```

**Content**

```md
galleries:
  - a56a6437-5a5d-4479-a6dc-38095322ba8a
  - 97e4e258-5fec-4ef3-8f54-64d855224ac1
  - bdf45d98-d6fb-471b-81b0-d11714551e24
  - 5429adf7-0a63-4e21-9163-feee07faf1f6
  - 86b1c86b-f1dc-47c1-841b-156bfca33660
limit: 3
```

**Template**

```antlers
{{ galleries | limit({limit}) }}
```