### PR TITLE
[5.x] Allow for large field configs in filters

### DIFF
--- a/resources/js/components/publish/FieldMeta.vue
+++ b/resources/js/components/publish/FieldMeta.vue
@@ -63,7 +63,7 @@ export default {
                 value: this.value,
             };
 
-            this.$axios.get(cp_url('fields/field-meta'), { params }).then(response => {
+            this.$axios.post(cp_url('fields/field-meta'), params).then(response => {
                 this.meta = response.data.meta;
                 this.value = response.data.value;
                 this.loading = false;

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -252,6 +252,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::post('edit', [FieldsController::class, 'edit'])->name('fields.edit');
         Route::post('update', [FieldsController::class, 'update'])->name('fields.update');
         Route::get('field-meta', [MetaController::class, 'show']);
+        Route::post('field-meta', [MetaController::class, 'show']);
         Route::delete('fieldsets/{fieldset}/reset', [FieldsetController::class, 'reset'])->name('fieldsets.reset');
         Route::resource('fieldsets', FieldsetController::class)->except(['show']);
         Route::get('blueprints', [BlueprintController::class, 'index'])->name('blueprints.index');


### PR DESCRIPTION
This pull request fixes an issue with filters, where a config field (usually a Select field with lots of options) could cause a request to go over the server's max headers size.

This can be easily resolved by sending the encryped field config in a POST request, rather than a GET request, since POST requests can handle larger payloads.

I've kept the `GET` version of the `field-meta` endpoint for now, as it's being used in third-party addons ([example](https://github.com/tv2regionerne/statamic-filter-builder/blob/d3a117b25ba4d3d4580b3806e77aa46aad9ddacc/resources/js/components/fieldtypes/Mixins/UsesFields.vue#L74)).

For easier testing, here's a filter with lots of select options: https://gist.github.com/duncanmcclean/171e55a861273d111c6ca037d8650aad