### PR TITLE
[5.x] Allow filtering/sorting/paginating with the `form:submissions` tag

### DIFF
--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -18,13 +18,13 @@ use Statamic\Tags\Tags as BaseTags;
 class Tags extends BaseTags
 {
     use Concerns\GetsFormSession,
+        Concerns\GetsQueryResults,
         Concerns\GetsRedirects,
         Concerns\OutputsItems,
-        Concerns\RendersForms,
-        Concerns\GetsQueryResults,
         Concerns\QueriesConditions,
         Concerns\QueriesOrderBys,
-        Concerns\QueriesScopes;
+        Concerns\QueriesScopes,
+        Concerns\RendersForms;
 
     const HANDLE_PARAM = ['handle', 'is', 'in', 'form', 'formset'];
 

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -188,20 +188,13 @@ class Tags extends BaseTags
      */
     public function submissions()
     {
-        $query = $this->submissionsQuery();
-
-        return $this->output($this->results($query));
-    }
-
-    protected function submissionsQuery()
-    {
         $query = $this->form()->querySubmissions();
 
         $this->queryConditions($query);
         $this->queryScopes($query);
         $this->queryOrderBys($query);
 
-        return $query;
+        return $this->output($this->results($query));
     }
 
     /**

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -20,7 +20,11 @@ class Tags extends BaseTags
     use Concerns\GetsFormSession,
         Concerns\GetsRedirects,
         Concerns\OutputsItems,
-        Concerns\RendersForms;
+        Concerns\RendersForms,
+        Concerns\GetsQueryResults,
+        Concerns\QueriesConditions,
+        Concerns\QueriesOrderBys,
+        Concerns\QueriesScopes;
 
     const HANDLE_PARAM = ['handle', 'is', 'in', 'form', 'formset'];
 
@@ -184,9 +188,20 @@ class Tags extends BaseTags
      */
     public function submissions()
     {
-        $submissions = $this->form()->submissions();
+        $query = $this->submissionsQuery();
 
-        return $this->output($submissions);
+        return $this->output($this->results($query));
+    }
+
+    protected function submissionsQuery()
+    {
+        $query = $this->form()->querySubmissions();
+
+        $this->queryConditions($query);
+        $this->queryScopes($query);
+        $this->queryOrderBys($query);
+
+        return $query;
     }
 
     /**

--- a/src/Stache/Query/SubmissionQueryBuilder.php
+++ b/src/Stache/Query/SubmissionQueryBuilder.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Stache\Query;
 
-use Illuminate\Support\Collection;
 use Statamic\Contracts\Forms\SubmissionQueryBuilder as QueryBuilderContract;
 use Statamic\Data\DataCollection;
 use Statamic\Facades;

--- a/src/Stache/Query/SubmissionQueryBuilder.php
+++ b/src/Stache/Query/SubmissionQueryBuilder.php
@@ -4,6 +4,7 @@ namespace Statamic\Stache\Query;
 
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Forms\SubmissionQueryBuilder as QueryBuilderContract;
+use Statamic\Data\DataCollection;
 use Statamic\Facades;
 use Statamic\Query\OrderBy;
 
@@ -46,7 +47,7 @@ class SubmissionQueryBuilder extends Builder implements QueryBuilderContract
 
     protected function collect($items = [])
     {
-        return Collection::make($items);
+        return DataCollection::make($items);
     }
 
     protected function getFilteredKeys()


### PR DESCRIPTION
This pull request implements filtering, sorting and pagination to the `{{ form:submissions }}` tag, since form submissions have their own query builder now (after #6455).

Related: https://github.com/statamic/ideas/issues/450#issuecomment-2366918848