### PR TITLE
[5.x] Fix toasts in actions not being shown

### DIFF
--- a/resources/js/components/ToastBus.js
+++ b/resources/js/components/ToastBus.js
@@ -19,9 +19,18 @@ class ToastBus {
 
     intercept() {
         this.instance.$axios.interceptors.response.use(response => {
-            const toasts = response?.data?._toasts ?? []
+            const data = response?.data;
 
-            toasts.forEach(toast => this.instance.$toast[toast.type](toast.message, {duration: toast.duration}))
+            if (!data) return response;
+
+            const promise = data instanceof Blob
+                ? data.text().then(text => JSON.parse(text))
+                : new Promise(resolve => resolve(data));
+
+            promise.then(json => {
+                const toasts = json._toasts ?? [];
+                toasts.forEach(toast => this.instance.$toast[toast.type](toast.message, {duration: toast.duration}))
+            });
 
             return response;
         });


### PR DESCRIPTION
When using the `Toast` facade in an action request, the toast would not be shown.

This is because the action requests were expecting blob types, not json, so they weren't being picked up.

I noticed this in #10264 when adding a toast in an `EntryDeleting` listener.

```php
Event::listen(function (EntryDeleting $event) {
    Toast::error('Cannot save entry ['.$event->entry->title.'] because of a reason.');
    return false;
});
```

The action would complete, but the entry would be deleted, and you'd get no feedback. With this PR you will at least get the toast about why it wasn't deleted.

![CleanShot 2024-09-23 at 11 42 26](https://github.com/user-attachments/assets/653abfb8-d4f2-488a-b3df-be043cab8ae1)

(In #10264 you will get feedback about the action not being successful too).