### PR TITLE
[5.x] Use existing getUrlsCacheKey method instead of duplicating the creation logic

### DIFF
--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -139,7 +139,7 @@ abstract class AbstractCacher implements Cacher
     public function getUrls($domain = null)
     {
         $key = $this->getUrlsCacheKey($domain);
-        
+
         return collect($this->cache->get($key, []));
     }
 

--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -139,10 +139,10 @@ abstract class AbstractCacher implements Cacher
     public function getUrls($domain = null)
     {
         $domain = $domain ?: $this->getBaseUrl();
-
-        $domain = $this->makeHash($domain);
-
-        return collect($this->cache->get($this->normalizeKey($domain.'.urls'), []));
+        
+        $key = $this->getUrlsCacheKey($domain);
+        
+        return collect($this->cache->get($key, []));
     }
 
     /**

--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -138,8 +138,6 @@ abstract class AbstractCacher implements Cacher
      */
     public function getUrls($domain = null)
     {
-        $domain = $domain ?: $this->getBaseUrl();
-        
         $key = $this->getUrlsCacheKey($domain);
         
         return collect($this->cache->get($key, []));


### PR DESCRIPTION
While overriding the ApplicationCacher with my own Cacher, to change the logic behind cache key creation, I found I had to override 2 methods instead of one because the logic was duplicated... 

There is no breaking change in here, just using an already existing method instead.
