### PR TITLE
Fix 'Call to undefined method App\Models\User::id()' on Password Reset

### DIFF
--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -17,7 +17,7 @@ class PasswordController extends CpController
     {
         throw_unless($user = User::find($user), new NotFoundHttpException);
 
-        $updatingOwnPassword = $user->id() == $request->user()->id();
+        $updatingOwnPassword = $user->id() == User::fromUser($request->user())->id();
 
         $this->authorize('editPassword', $user);
 


### PR DESCRIPTION
This PR fixes the following error when changing the password of a user within the control panel:

![image](https://github.com/user-attachments/assets/60d2ba98-fbf6-49ac-9f01-76a7b78724ee)

![image](https://github.com/user-attachments/assets/1a9fb8b9-53d7-4626-b34b-0bc7bc88d6ae)

The controller was trying to deal with the user as an Eloquent model, rather than using Statamic's facade.