### PR TITLE
[5.x] Fix User Accessor in Password Reset

### DIFF
--- a/src/Http/Controllers/CP/Users/PasswordController.php
+++ b/src/Http/Controllers/CP/Users/PasswordController.php
@@ -17,7 +17,7 @@ class PasswordController extends CpController
     {
         throw_unless($user = User::find($user), new NotFoundHttpException);
 
-        $updatingOwnPassword = $user->id() == $request->user()->id();
+        $updatingOwnPassword = $user->id() == User::fromUser($request->user())->id();
 
         $this->authorize('editPassword', $user);
 


### PR DESCRIPTION
This PR fixes the following error when changing the password of a user within the control panel:

![image](https://github.com/user-attachments/assets/b2a4beea-1717-402c-8e73-a4d142d30b29)

![image](https://github.com/user-attachments/assets/c56e3d6a-a029-45cb-b4ae-c6ffad7b0b2d)

The controller was trying to deal with the user as an Eloquent model, rather than using Statamic's facade.