### PR TITLE
[5.x] Fix "Undefined variable $key" error with Marketplace API Client

### DIFF
--- a/src/Marketplace/Client.php
+++ b/src/Marketplace/Client.php
@@ -55,12 +55,11 @@ class Client
     {
         $lock = $this->lock(static::LOCK_KEY, 10);
 
+        $endpoint = collect([$this->domain, self::API_PREFIX, $endpoint])->implode('/');
+        $key = 'marketplace-'.md5($endpoint.json_encode($params));
+
         try {
             $lock->block(5);
-
-            $endpoint = collect([$this->domain, self::API_PREFIX, $endpoint])->implode('/');
-
-            $key = 'marketplace-'.md5($endpoint.json_encode($params));
 
             return $this->cache()->rememberWithExpiration($key, function () use ($endpoint, $params) {
                 $response = Guzzle::request('GET', $endpoint, [


### PR DESCRIPTION
In #10815, we introduced caching and locking around requests to Statamic's Marketplace API. 

However, when the lock times out and we want to serve the cached response, an error would occur complainging that the `$key` variable was undefined. This PR should fix that by defining it outside of the try/catch statement.