### PR TITLE
[5.x] Add get method to Dictionary Item

### DIFF
--- a/src/Dictionaries/Item.php
+++ b/src/Dictionaries/Item.php
@@ -21,6 +21,11 @@ class Item extends LabeledValue implements \ArrayAccess
         return Arr::except($this->extra, ['label']);
     }
 
+    public function get($key, $fallback = null)
+    {
+        return Arr::get($this->data(), $key, $fallback);
+    }
+
     public function offsetExists(mixed $offset): bool
     {
         return true;

--- a/tests/Dictionaries/ItemTest.php
+++ b/tests/Dictionaries/ItemTest.php
@@ -20,6 +20,8 @@ class ItemTest extends TestCase
         $this->assertEquals('apple', $item->value());
         $this->assertEquals('🍎 Apple', $item->label());
         $this->assertEquals(['color' => 'red', 'emoji' => '🍎'], $item->data());
+        $this->assertEquals('red', $item->get('color'));
+        $this->assertEquals('red', $item->get('colour', 'red'));
         $this->assertEquals([
             'key' => 'apple',
             'value' => 'apple',


### PR DESCRIPTION
Thank you for the great Dictionary field type. 
It replaces so much custom code when dealing with Enums or API calls. 

Such "dictionaries" typcially do not have not only value and label . We put a lot of data inside the extra array and need to access it often and repeatedly retrieve this extra data via keys.

Can we get a little get-helper inside the `Item` class to access the `extra` data more easily?

