### PR TITLE
[5.x] Prevent Empty Folder Value When Uploading Asset

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -229,10 +229,10 @@ export default {
             let folder = this.configuredFolder;
 
             if (this.isUsingDynamicFolder) {
-                folder = folder + '/' + (this.lockedDynamicFolder || this.dynamicFolder);
+                folder = folder.replace(/^\/+/, '') + '/' + (this.lockedDynamicFolder || this.dynamicFolder);
             }
 
-            return folder.replace(/^\/+/, '');
+            return folder;
         },
 
         configuredFolder() {


### PR DESCRIPTION
Prevents an empty folder value when using root `/`. Move regex string `/` removal into dynamic function condition. Retested Dynamic folder functionality.

Fixes #10859 & #10856