### PR TITLE
[5.x] Fix duplicate IDs icon

### DIFF
--- a/resources/views/nav/duplicates.blade.php
+++ b/resources/views/nav/duplicates.blade.php
@@ -1,6 +1,6 @@
 <li class="{{ $item->isActive() ? 'current' : '' }}">
     <a href="{{ $item->url() }}">
-        <i>{!! $item->icon() !!}</i><span>{{ __($item->name()) }}</span>
+        <i>{!! $item->svg() !!}</i><span>{{ __($item->name()) }}</span>
         <span class="badge-sm bg-red-500 dark:bg-blue-900 rtl:mr-2 ltr:ml-2">{{ Statamic\Facades\Stache::duplicates()->count() }}</span>
     </a>
 </li>


### PR DESCRIPTION
Fix duplicate IDs icon regression, caused by #8023.

Fixes #10779