### PR TITLE
[5.x] Fix assets not being uploadable when not using dynamic folders

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -232,7 +232,9 @@ export default {
                 folder = folder + '/' + (this.lockedDynamicFolder || this.dynamicFolder);
             }
 
-            return folder.replace(/^\/+/, '');
+            folder = folder.replace(/^\/+/, '');
+
+            return folder === '' ? '/' : folder;
         },
 
         configuredFolder() {


### PR DESCRIPTION
When you have an assets field that does _not_ have the new dynamic feature enabled and no `folder` set (so you
are intending the assets to go directly in the container) it results in a validation error.

The issue was that slashes were being stripped so the required `folder` should have been `'/'` but it became `''`
resulting in a validation error.

Bug introduced in #10808
Fixes #10856
