### PR TITLE
[5.x] Show toggle UI in conditions builder for revealer fields

### DIFF
--- a/resources/js/components/field-conditions/Condition.vue
+++ b/resources/js/components/field-conditions/Condition.vue
@@ -103,7 +103,7 @@ export default {
 
         showValueToggle() {
             return this.field
-                && ['toggle'].includes(this.field.config.type)
+                && ['toggle', 'revealer'].includes(this.field.config.type)
                 && ['equals', 'not', '===', '!=='].includes(this.condition.operator);
         },
 


### PR DESCRIPTION
If referenced field is a `revealer`, show condition value as boolean toggle, just like we do for `toggle` fieldtypes...

![CleanShot 2024-09-30 at 20 29 13](https://github.com/user-attachments/assets/db2b2d06-05a0-4334-82f6-1bf76cc21b6d)