### PR TITLE
[5.x] Improve `AssetFolderPolicy` performance

### DIFF
--- a/src/Policies/AssetFolderPolicy.php
+++ b/src/Policies/AssetFolderPolicy.php
@@ -34,7 +34,7 @@ class AssetFolderPolicy
                 ->isEmpty();
         }
 
-        return true;
+        return $assetFolder->container()->allowMoving();
     }
 
     public function rename($user, $assetFolder)
@@ -52,7 +52,7 @@ class AssetFolderPolicy
                 ->isEmpty();
         }
 
-        return true;
+        return $assetFolder->container()->allowRenaming();
     }
 
     public function delete($user, $assetFolder)

--- a/src/Policies/AssetFolderPolicy.php
+++ b/src/Policies/AssetFolderPolicy.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Policies;
 
+use Illuminate\Support\Facades\Gate;
+use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Facades\User;
 
 class AssetFolderPolicy
@@ -25,10 +27,14 @@ class AssetFolderPolicy
             return false;
         }
 
-        return $assetFolder
-            ->assets(true)
-            ->reject(fn ($asset) => $user->can('move', $asset))
-            ->isEmpty();
+        if ($this->isUsingCustomAssetPolicy()) {
+            return $assetFolder
+                ->assets(true)
+                ->reject(fn ($asset) => $user->can('move', $asset))
+                ->isEmpty();
+        }
+
+        return true;
     }
 
     public function rename($user, $assetFolder)
@@ -39,10 +45,14 @@ class AssetFolderPolicy
             return false;
         }
 
-        return $assetFolder
-            ->assets(true)
-            ->reject(fn ($asset) => $user->can('rename', $asset))
-            ->isEmpty();
+        if ($this->isUsingCustomAssetPolicy()) {
+            return $assetFolder
+                ->assets(true)
+                ->reject(fn ($asset) => $user->can('rename', $asset))
+                ->isEmpty();
+        }
+
+        return true;
     }
 
     public function delete($user, $assetFolder)
@@ -53,9 +63,18 @@ class AssetFolderPolicy
             return false;
         }
 
-        return $assetFolder
-            ->assets(true)
-            ->reject(fn ($asset) => $user->can('delete', $asset))
-            ->isEmpty();
+        if ($this->isUsingCustomAssetPolicy()) {
+            return $assetFolder
+                ->assets(true)
+                ->reject(fn ($asset) => $user->can('delete', $asset))
+                ->isEmpty();
+        }
+
+        return true;
+    }
+
+    protected function isUsingCustomAssetPolicy()
+    {
+        return Gate::policies()[AssetContract::class] !== AssetPolicy::class;
     }
 }


### PR DESCRIPTION
In our `AssetFolderPolicy`, we are currently performing a whole bunch of redundant ability checks, which [really slows down performance in super large asset containers](https://github.com/statamic/cms/issues/9710).

For example, this ability check is done in our `AssetFolderPolicy`:

![CleanShot 2024-09-30 at 19 56 06](https://github.com/user-attachments/assets/f465aa27-9d95-49a7-8578-fba54acfffa0)

But then right after that, you can see we loop over every asset in the folder:

![CleanShot 2024-09-30 at 19 57 03](https://github.com/user-attachments/assets/9f8a0801-18f9-495d-901e-9b6684a2fece)

Which essentially just does the same ability check within `AssetPolicy`:

![CleanShot 2024-09-30 at 19 58 13](https://github.com/user-attachments/assets/08f5e454-a612-43e9-a9d8-34114ec49d1e)

This PR changes improves performance by only looping over each asset if a custom `AssetPolicy` class is registered. If a custom policy is registered, there is likely extra logic that run to be checked on an asset-by-asset basis, so we'll do the more thorough check only in those scenarios.

Fixes #9710