### PR TITLE
[5.x] Add reorder() query builder method

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -83,6 +83,17 @@ abstract class Builder implements Contract
         return $this->orderBy($column, 'desc');
     }
 
+    public function reorder($column = null, $direction = 'asc')
+    {
+        $this->orderBys = [];
+
+        if ($column) {
+            return $this->orderBy($column, $direction);
+        }
+
+        return $this;
+    }
+
     abstract public function inRandomOrder();
 
     public function where($column, $operator = null, $value = null, $boolean = 'and')

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -386,6 +386,19 @@ abstract class EloquentQueryBuilder implements Builder
         return $this;
     }
 
+    public function reorder($column = null, $direction = 'asc')
+    {
+        if ($column) {
+            $this->builder->reorder($this->column($column), $direction);
+
+            return $this;
+        }
+
+        $this->builder->reorder();
+
+        return $this;
+    }
+
     protected function column($column)
     {
         return $column;

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -769,6 +769,16 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function entries_can_be_reordered()
+    {
+        $this->createDummyCollectionAndEntries();
+
+        $this->assertSame(['post-3', 'post-2', 'post-1'], Entry::query()->orderBy('title', 'desc')->get()->map->slug()->all());
+
+        $this->assertSame(['post-1', 'post-2', 'post-3'], Entry::query()->orderBy('title', 'desc')->reorder()->orderBy('asc', 'desc')->get()->map->slug()->all());
+    }
+
+    #[Test]
     public function filtering_using_where_status_column_writes_deprecation_log()
     {
         $this->withoutDeprecationHandling();


### PR DESCRIPTION
This PR adds a reorder() method to the query builders, allowing any existing orders to be cleared and a new one optionally set.

eg.

```php
$query->reorder(); // clears all orders
$query->reorder('title', 'desc'); // clears all orders and orders by title descending
```