### PR TITLE
[5.x] Run query scopes after all other query methods so the query can be changed

### DIFF
--- a/src/Tags/Collection/Entries.php
+++ b/src/Tags/Collection/Entries.php
@@ -190,8 +190,8 @@ class Entries
         $this->queryTaxonomies($query);
         $this->queryRedirects($query);
         $this->queryConditions($query);
-        $this->queryScopes($query);
         $this->queryOrderBys($query);
+        $this->queryScopes($query);
 
         return $query;
     }


### PR DESCRIPTION
This PR updates the collection tag to query scopes after orderBys, which allows the scope to modify the default orderBy set.

For example, in the linked issue, inside the scope you could:

```php
public function apply($query, $values)
{
    $query->reorder('my_column', 'desc');
}
```

Requires: https://github.com/statamic/cms/pull/10871
Closes https://github.com/statamic/cms/issues/10230