### PR TITLE
[5.x] Prevent autoloading addon files causing exception when called early

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -345,7 +345,7 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootCommands()
     {
-        if ($this->app->runningInConsole()) {
+        if ($this->app->isBooted() && $this->app->runningInConsole()) {
             $commands = collect($this->commands)
                 ->merge($this->autoloadFilesFromFolder('Commands', Command::class))
                 ->merge($this->autoloadFilesFromFolder('Console/Commands', Command::class))

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -345,7 +345,7 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootCommands()
     {
-        if ($this->app->isBooted() && $this->app->runningInConsole()) {
+        if ($this->app->runningInConsole()) {
             $commands = collect($this->commands)
                 ->merge($this->autoloadFilesFromFolder('Commands', Command::class))
                 ->merge($this->autoloadFilesFromFolder('Console/Commands', Command::class))
@@ -704,7 +704,15 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function autoloadFilesFromFolder($folder, $requiredClass)
     {
-        $addon = $this->getAddon();
+        try {
+            $addon = $this->getAddon();
+        } catch (NotBootedException $e) {
+            // This would be thrown if a developer has tried to call a method
+            // that triggers autoloading before Statamic has booted. Perhaps
+            // they have placed it in the boot method instead of bootAddon.
+            return [];
+        }
+
         $path = $addon->directory().$addon->autoload().'/'.$folder;
 
         if (! $this->app['files']->exists($path)) {


### PR DESCRIPTION
Since https://github.com/statamic/cms/pull/9270 issues have been reported with add-ons that include console commands (https://github.com/statamic/cms/issues/10873)

This PR updates the logic around the command autoloading to ensure we only run that once the app is booted.

Closes https://github.com/statamic/cms/issues/10873