### PR TITLE
Increase `trackDirtyStateTimeout`

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -606,7 +606,7 @@ export default {
                         clearTimeout(this.trackDirtyStateTimeout)
                         this.trackDirtyState = false
                         this.values = this.resetValuesFromResponse(response.data.data.values);
-                        this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350)
+                        this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 500)
                         this.$nextTick(() => this.$emit('saved', response));
                         return;
                     }
@@ -630,7 +630,7 @@ export default {
                         clearTimeout(this.trackDirtyStateTimeout);
                         this.trackDirtyState = false;
                         this.values = this.resetValuesFromResponse(response.data.data.values);
-                        this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350);
+                        this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 500);
                         this.initialPublished = response.data.data.published;
                         this.activeLocalization.published = response.data.data.published;
                         this.activeLocalization.status = response.data.data.status;
@@ -719,7 +719,7 @@ export default {
                 this.initialPublished = data.values.published;
                 this.readOnly = data.readOnly;
 
-                this.trackDirtyStateTimeout = setTimeout(() => this.trackDirtyState = true, 300); // after any fieldtypes do a debounced update
+                this.trackDirtyStateTimeout = setTimeout(() => this.trackDirtyState = true, 500); // after any fieldtypes do a debounced update
             })
         },
 
@@ -802,7 +802,7 @@ export default {
                 clearTimeout(this.trackDirtyStateTimeout);
                 this.trackDirtyState = false;
                 this.values = this.resetValuesFromResponse(response.data.data.values);
-                this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350);
+                this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 500);
                 this.activeLocalization.title = response.data.data.title;
                 this.activeLocalization.published = response.data.data.published;
                 this.activeLocalization.status = response.data.data.status;
@@ -859,7 +859,7 @@ export default {
                 clearTimeout(this.trackDirtyStateTimeout);
                 this.trackDirtyState = false;
                 this.values = this.resetValuesFromResponse(response.data.values);
-                this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350);
+                this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 500);
                 this.initialPublished = response.data.published;
                 this.activeLocalization.published = response.data.published;
                 this.activeLocalization.status = response.data.status;


### PR DESCRIPTION
We're running into an issue where large publish forms take so long to update the values after save that the dirty state timeout expires before it's finished, triggering an invalid dirty sate and leaving the publish button disabled.

This PR increases the timeout from 350 to 500ms. I know this isn't really a good long-term solution, 500ms is just another "magic number", and another approach to managing the tracking of dirty state is probably needed, but I'm not too sure what that should be.