### PR TITLE
[5.x] Allow searching by labels in Dictionary fieldtype

### DIFF
--- a/src/Dictionaries/BasicDictionary.php
+++ b/src/Dictionaries/BasicDictionary.php
@@ -52,7 +52,7 @@ abstract class BasicDictionary extends Dictionary
     {
         $query = strtolower($query);
 
-        foreach ($item->data() as $key => $value) {
+        foreach ($item->extra() as $key => $value) {
             if (! empty($this->searchable) && ! in_array($key, $this->searchable)) {
                 continue;
             }


### PR DESCRIPTION
This pull request fixes an issue when searching for a multi-word option in the Dictionary fieldtype because it was only taking option "values" into account and not their labels.

For example: you couldn't search `Cold Cases`, you'd have to search `Cold-Cases` for a result to be returned.

Fixes #10823.