### PR TITLE
[5.x] Blink cache Algolia search API calls

### DIFF
--- a/src/Search/Algolia/Query.php
+++ b/src/Search/Algolia/Query.php
@@ -2,13 +2,18 @@
 
 namespace Statamic\Search\Algolia;
 
+use Statamic\Facades\Blink;
 use Statamic\Search\QueryBuilder;
 
 class Query extends QueryBuilder
 {
     public function getSearchResults($query)
     {
-        $results = $this->index->searchUsingApi($query);
+        $key = "search-algolia-{$this->index->name()}-".md5($query);
+
+        $results = Blink::once($key, function () use ($query) {
+            return $this->index->searchUsingApi($query);
+        });
 
         return $results->map(function ($result, $i) use ($results) {
             $result['search_score'] = $results->count() - $i;

--- a/src/Search/Algolia/Query.php
+++ b/src/Search/Algolia/Query.php
@@ -9,11 +9,10 @@ class Query extends QueryBuilder
 {
     public function getSearchResults($query)
     {
-        $key = "search-algolia-{$this->index->name()}-".md5($query);
-
-        $results = Blink::once($key, function () use ($query) {
-            return $this->index->searchUsingApi($query);
-        });
+        $results = Blink::once(
+            "search-algolia-{$this->index->name()}-".md5($query),
+            fn () => $this->index->searchUsingApi($query)
+        );
 
         return $results->map(function ($result, $i) use ($results) {
             $result['search_score'] = $results->count() - $i;

--- a/tests/Search/AlgoliaQueryTest.php
+++ b/tests/Search/AlgoliaQueryTest.php
@@ -14,6 +14,7 @@ class AlgoliaQueryTest extends TestCase
     public function it_adds_scores()
     {
         $index = Mockery::mock(Index::class);
+        $index->shouldReceive('name');
         $index->shouldReceive('searchUsingApi')->with('foo')->once()->andReturn(collect([
             ['reference' => 'a'],
             ['reference' => 'b'],


### PR DESCRIPTION
If you have pagination enabled in the search tag the index is queried twice, once when fetching the results themselves and once when counting the results for pagination. With the Algolia driver both of these queries are identical but consume two of your search requests.

This PR blink caches the API call so that the first request can be reused for the count.