### PR TITLE
[5.x] Auto-load addon routes

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -463,15 +463,35 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     protected function bootRoutes()
     {
-        if ($web = Arr::get($this->routes, 'web')) {
+        $directory = $this->getAddon()->directory();
+
+        $web = Arr::get(
+            array: $this->routes,
+            key: 'web',
+            default: $this->app['files']->exists($path = $directory.'routes/web.php') ? $path : null
+        );
+
+        if ($web) {
             $this->registerWebRoutes($web);
         }
 
-        if ($cp = Arr::get($this->routes, 'cp')) {
+        $cp = Arr::get(
+            array: $this->routes,
+            key: 'cp',
+            default: $this->app['files']->exists($path = $directory.'routes/cp.php') ? $path : null
+        );
+
+        if ($cp) {
             $this->registerCpRoutes($cp);
         }
 
-        if ($actions = Arr::get($this->routes, 'actions')) {
+        $actions = Arr::get(
+            array: $this->routes,
+            key: 'actions',
+            default: $this->app['files']->exists($path = $directory.'routes/actions.php') ? $path : null
+        );
+
+        if ($actions) {
             $this->registerActionRoutes($actions);
         }
 


### PR DESCRIPTION
It's pretty common for an addon to have `routes/web.php`, `routes/cp.php`, `routes/actions.php` route files. Right now, you have to configure these yourself in the addon's `ServiceProvider`:

```php
protected $routes = [
    'web' => __DIR__.'/../routes/web.php',
    'cp' => __DIR__.'/../routes/cp.php',
    'actions' => __DIR__.'/../routes/actions.php',
];
```

However, if you're following convention, it would be nice if Statamic would automatically register an addon's route files, in a similar fashion to how fieldtypes, tags, etc are autoloaded.

Inspired by #9270.