### PR TITLE
[5.x] Better timezone dictionary test

### DIFF
--- a/tests/Dictionaries/TimezonesTest.php
+++ b/tests/Dictionaries/TimezonesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Dictionaries;
 
+use DateTimeZone;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -16,7 +17,7 @@ class TimezonesTest extends TestCase
     {
         $options = (new Timezones)->options();
 
-        $this->assertCount(419, $options);
+        $this->assertCount(count(DateTimeZone::listIdentifiers()), $options);
         $this->assertEquals([
             'Africa/Abidjan' => 'Africa/Abidjan (+00:00)',
             'Africa/Accra' => 'Africa/Accra (+00:00)',


### PR DESCRIPTION
There were some recent random looking failure on Windows.
Rather than checking against a hardcoded number, check against what we'd get back from PHP.
