### PR TITLE
[5.x] Prevent autoloading of abstract classes and interfaces

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -740,6 +740,11 @@ abstract class AddonServiceProvider extends ServiceProvider
         foreach ($this->app['files']->files($path) as $file) {
             $class = $file->getBasename('.php');
             $fqcn = $this->namespace().'\\'.str_replace('/', '\\', $folder).'\\'.$class;
+
+            if ((new \ReflectionClass($fqcn))->isAbstract() || (new \ReflectionClass($fqcn))->isInterface()) {
+                continue;
+            }
+
             if (is_subclass_of($fqcn, $requiredClass)) {
                 $autoloadable[] = $fqcn;
             }


### PR DESCRIPTION
This pull request fixes an issue with the addon auto-loading feature introduced in #9270, where it would attempt to autoload abstract classes and interfaces, which obviously won't work.

For example, in my Simple Commerce addon I was extending Statamic's abstract `GeneratorCommand` class. However, it was still trying to be loaded by the autoloading stuff, resulting in this error:

![CleanShot 2024-10-01 at 16 22 06](https://github.com/user-attachments/assets/a8c9b04a-9c3f-488f-a87d-28c2c3fcd403)

Fixes duncanmcclean/simple-commerce#1163.