### PR TITLE
[5.x] Don't show updates badge count for local/dev installations

### DIFF
--- a/resources/views/updater/index.blade.php
+++ b/resources/views/updater/index.blade.php
@@ -44,24 +44,26 @@
             </table>
         </div>
 
-        <h6 class="mt-8">{{ __('Addons') }}</h6>
-        <div class="card p-0 mt-2">
-            <table class="data-table">
-                @foreach ($addons as $addon)
-                <tr>
-                    <td class="w-64"><a href="{{ route('statamic.cp.updater.product', $addon -> slug()) }}"
-                            class="text-blue font-bold rtl:ml-2 ltr:mr-2">{{ $addon -> name() }}</a>
-                    <td>{{ $addon -> version() }}</td>
-                    @if ($count = $addon->changelog()->availableUpdatesCount())
-                    <td class="rtl:text-left ltr:text-right"><span
-                            class="badge-sm bg-green-600 btn-xs">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
-                    @else
-                    <td class="rtl:text-left ltr:text-right">{{ __('Up to date') }}</td>
-                    @endif
-                </tr>
-                @endforeach
-            </table>
-        </div>
+        @if($addons->count())
+            <h6 class="mt-8">{{ __('Addons') }}</h6>
+            <div class="card p-0 mt-2">
+                <table class="data-table">
+                    @foreach ($addons as $addon)
+                    <tr>
+                        <td class="w-64"><a href="{{ route('statamic.cp.updater.product', $addon -> slug()) }}"
+                                class="text-blue font-bold rtl:ml-2 ltr:mr-2">{{ $addon -> name() }}</a>
+                        <td>{{ $addon -> version() }}</td>
+                        @if ($count = $addon->changelog()->availableUpdatesCount())
+                        <td class="rtl:text-left ltr:text-right"><span
+                                class="badge-sm bg-green-600 btn-xs">{{ trans_choice('1 update|:count updates', $count) }}</span></td>
+                        @else
+                        <td class="rtl:text-left ltr:text-right">{{ __('Up to date') }}</td>
+                        @endif
+                    </tr>
+                    @endforeach
+                </table>
+            </div>
+        @endif
 
         @if($unlistedAddons->count())
             <h6 class="mt-8">{{ __('Unlisted Addons') }}</h6>

--- a/src/Extend/Addon.php
+++ b/src/Extend/Addon.php
@@ -371,6 +371,10 @@ final class Addon
 
     public function isLatestVersion()
     {
+        if (Str::startsWith($this->version, 'dev-') || Str::endsWith($this->version, '-dev')) {
+            return true;
+        }
+
         if (! $this->latestVersion) {
             return true;
         }

--- a/src/Http/Controllers/CP/Updater/UpdaterController.php
+++ b/src/Http/Controllers/CP/Updater/UpdaterController.php
@@ -19,7 +19,7 @@ class UpdaterController extends CpController
     {
         $this->authorize('view updates');
 
-        $addons = $this->getUpdatableAddons();
+        $addons = Addon::all();
 
         if ($addons->isEmpty()) {
             return redirect()->route('statamic.cp.updater.product', Statamic::CORE_SLUG);
@@ -28,8 +28,8 @@ class UpdaterController extends CpController
         return view('statamic::updater.index', [
             'requestError' => $licenses->requestFailed(),
             'statamic' => Marketplace::statamic()->changelog(),
-            'addons' => Addon::all()->filter->existsOnMarketplace(),
-            'unlistedAddons' => Addon::all()->reject->existsOnMarketplace(),
+            'addons' => $addons->filter->existsOnMarketplace(),
+            'unlistedAddons' => $addons->reject->existsOnMarketplace(),
         ]);
     }
 
@@ -41,15 +41,5 @@ class UpdaterController extends CpController
         $this->authorize('view updates');
 
         return UpdatesOverview::count();
-    }
-
-    /**
-     * Get updatable addons.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    private function getUpdatableAddons()
-    {
-        return Addon::all()->filter->marketplaceSlug();
     }
 }

--- a/src/Updater/UpdatesOverview.php
+++ b/src/Updater/UpdatesOverview.php
@@ -6,6 +6,8 @@ use Carbon\Carbon;
 use Facades\Statamic\Marketplace\Marketplace;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\Addon;
+use Statamic\Statamic;
+use Statamic\Support\Str;
 
 class UpdatesOverview
 {
@@ -93,6 +95,12 @@ class UpdatesOverview
      */
     protected function checkForStatamicUpdates()
     {
+        $version = Statamic::version();
+
+        if (Str::startsWith($version, 'dev-') || Str::endsWith($version, '-dev')) {
+            return $this;
+        }
+
         if (Marketplace::statamic()->changelog()->latest()->type === 'upgrade') {
             $this->statamic = true;
             $this->count++;


### PR DESCRIPTION
Hide this updates badge count for local/dev installations...

![CleanShot 2024-10-01 at 15 22 57](https://github.com/user-attachments/assets/5001d82a-22b3-4c7b-aacd-ddfaf337b57d)