### PR TITLE
[5.x] Dictionary tag

### DIFF
--- a/src/Dictionaries/BasicDictionary.php
+++ b/src/Dictionaries/BasicDictionary.php
@@ -17,10 +17,16 @@ abstract class BasicDictionary extends Dictionary
 
     public function options(?string $search = null): array
     {
+        return collect($this->optionItems($search))
+            ->mapWithKeys(fn (Item $item) => [$item->value() => $item->label()])
+            ->all();
+    }
+
+    public function optionItems(?string $search = null): array
+    {
         return $this
             ->getFilteredItems()
             ->when($search, fn ($collection) => $collection->filter(fn ($item) => $this->matchesSearchQuery($search, $item)))
-            ->mapWithKeys(fn (Item $item) => [$item->value() => $item->label()])
             ->all();
     }
 

--- a/src/Dictionaries/Dictionary.php
+++ b/src/Dictionaries/Dictionary.php
@@ -68,4 +68,11 @@ abstract class Dictionary
 
         return GraphQL::string();
     }
+
+    public function optionItems(?string $search = null): array
+    {
+        return collect($this->options($search))
+            ->map(fn ($label, $value) => new Item($value, $label, $this->get($value)->extra()))
+            ->all();
+    }
 }

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -166,6 +166,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Tags\Collection\Collection::class,
         Tags\Cookie::class,
         Tags\Dd::class,
+        Tags\Dictionary\Dictionary::class,
         Tags\Dump::class,
         Tags\GetContent::class,
         Tags\GetError::class,

--- a/src/Tags/Dictionary/Dictionary.php
+++ b/src/Tags/Dictionary/Dictionary.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Statamic\Tags\Dictionary;
+
+use Statamic\Data\DataCollection;
+use Statamic\Exceptions\DictionaryNotFoundException;
+use Statamic\Facades\Dictionary as Dictionaries;
+use Statamic\Query\ItemQueryBuilder;
+use Statamic\Tags\Concerns;
+use Statamic\Tags\Tags;
+
+class Dictionary extends Tags
+{
+    use Concerns\GetsQueryResults,
+        Concerns\OutputsItems,
+        Concerns\QueriesConditions,
+        Concerns\QueriesOrderBys,
+        Concerns\QueriesScopes;
+
+    protected $defaultAsKey = 'options';
+
+    /**
+     * {{ dictionary:* }} ... {{ /dictionary:* }}.
+     */
+    public function wildcard($tag)
+    {
+        $this->params['handle'] = $tag;
+
+        return $this->index();
+    }
+
+    /**
+     * {{ dictionary handle="" }} ... {{ /dictionary }}.
+     */
+    public function index()
+    {
+        if (! $handle = $this->params->pull('handle')) {
+            return [];
+        }
+
+        $search = $this->params->pull('search');
+        $supplement = $this->params->pull('supplement_data');
+
+        if (! $dictionary = Dictionaries::find($handle, $this->params->all())) {
+            throw new DictionaryNotFoundException($handle);
+        }
+
+        $options = collect($dictionary->options($search))
+            ->map(fn ($label, $value) => new DictionaryItem($supplement ? $dictionary->get($value)->extra() : ['label' => $label, 'value' => $value]))
+            ->values();
+
+        $query = (new ItemQueryBuilder)->withItems(new DataCollection($options));
+
+        $this->queryConditions($query);
+        $this->queryOrderBys($query);
+        $this->queryScopes($query);
+
+        $options = $this->results($query);
+
+        return $this->output($options);
+    }
+}

--- a/src/Tags/Dictionary/Dictionary.php
+++ b/src/Tags/Dictionary/Dictionary.php
@@ -47,8 +47,8 @@ class Dictionary extends Tags
             throw new DictionaryNotFoundException($handle);
         }
 
-        $options = (new DataCollection($dictionary->options($search)))
-            ->map(fn ($label, $value) => new DictionaryItem($dictionary->get($value)->toArray()))
+        $options = (new DataCollection($dictionary->optionItems($search)))
+            ->map(fn ($item) => new DictionaryItem($item->toArray()))
             ->values();
 
         $query = (new ItemQueryBuilder)->withItems($options);

--- a/src/Tags/Dictionary/Dictionary.php
+++ b/src/Tags/Dictionary/Dictionary.php
@@ -39,14 +39,13 @@ class Dictionary extends Tags
         }
 
         $search = $this->params->pull('search');
-        $supplement = $this->params->pull('supplement_data');
 
         if (! $dictionary = Dictionaries::find($handle, $this->params->all())) {
             throw new DictionaryNotFoundException($handle);
         }
 
         $options = collect($dictionary->options($search))
-            ->map(fn ($label, $value) => new DictionaryItem($supplement ? $dictionary->get($value)->extra() : ['label' => $label, 'value' => $value]))
+            ->map(fn ($label, $value) => new DictionaryItem(array_merge(['label' => $label, 'value' => $value], $dictionary->get($value)->extra())))
             ->values();
 
         $query = (new ItemQueryBuilder)->withItems(new DataCollection($options));

--- a/src/Tags/Dictionary/DictionaryItem.php
+++ b/src/Tags/Dictionary/DictionaryItem.php
@@ -12,7 +12,6 @@ class DictionaryItem implements Arrayable
 
     public function __construct(public array $data)
     {
-
     }
 
     public function get($key, $default = null)
@@ -22,6 +21,6 @@ class DictionaryItem implements Arrayable
 
     public function toArray()
     {
-        return array_merge($this->data, $this->supplements() ?? []);
+        return array_merge($this->data, $this->supplements ?? []);
     }
 }

--- a/src/Tags/Dictionary/DictionaryItem.php
+++ b/src/Tags/Dictionary/DictionaryItem.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Statamic\Tags\Dictionary;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
+use Statamic\Data\ContainsSupplementalData;
+
+class DictionaryItem implements Arrayable
+{
+    use ContainsSupplementalData;
+
+    public function __construct(public array $data)
+    {
+
+    }
+
+    public function get($key, $default = null)
+    {
+        return Arr::get($this->toArray(), $key, $default);
+    }
+
+    public function toArray()
+    {
+        return array_merge($this->data, $this->supplements() ?? []);
+    }
+}

--- a/tests/Tags/DictionaryTagTest.php
+++ b/tests/Tags/DictionaryTagTest.php
@@ -45,15 +45,11 @@ class DictionaryTagTest extends TestCase
     }
 
     #[Test]
-    public function it_can_supplement_data()
+    public function it_pulls_extra_data_data()
     {
-        $template = '{{ dictionary:countries search="Alg" supplement_data="true" }}{{ region }} - {{ iso2 }}{{ /dictionary:countries }}';
+        $template = '{{ dictionary:countries search="Alg" }}{{ region }} - {{ iso2 }}{{ /dictionary:countries }}';
 
         $this->assertEquals('Africa - DZ', $this->tag($template));
-
-        $template = '{{ dictionary:countries search="Alg" supplement_data="false" }}{{ region }} - {{ iso2 }}{{ /dictionary:countries }}';
-
-        $this->assertEquals(' - ', $this->tag($template));
     }
 
     #[Test]
@@ -71,7 +67,7 @@ class DictionaryTagTest extends TestCase
     #[Test]
     public function it_can_be_filtered_using_conditions()
     {
-        $template = '{{ dictionary:countries supplement_data="true" iso3:is="AUS" }}{{ name }}{{ /dictionary:countries }}';
+        $template = '{{ dictionary:countries iso3:is="AUS" }}{{ name }}{{ /dictionary:countries }}';
 
         $this->assertEquals('Australia', $this->tag($template));
     }
@@ -81,7 +77,7 @@ class DictionaryTagTest extends TestCase
     {
         app('statamic.scopes')[TestScope::handle()] = TestScope::class;
 
-        $template = '{{ dictionary:countries supplement_data="true" query_scope="test_scope" }}{{ name }}{{ /dictionary:countries }}';
+        $template = '{{ dictionary:countries query_scope="test_scope" }}{{ name }}{{ /dictionary:countries }}';
 
         $this->assertEquals('Australia', $this->tag($template));
     }

--- a/tests/Tags/DictionaryTagTest.php
+++ b/tests/Tags/DictionaryTagTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Tags;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Parse;
+use Statamic\Query\Scopes\Scope;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class DictionaryTagTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_gets_countries()
+    {
+        $template = '{{ dictionary:countries limit="1" }}{{ value }}{{ /dictionary:countries }}';
+
+        $this->assertEquals('AFG', $this->tag($template));
+    }
+
+    #[Test]
+    public function it_gets_dictionary_by_handle()
+    {
+        $template = '{{ dictionary handle="countries" limit="1" }}{{ value }}{{ /dictionary }}';
+
+        $this->assertEquals('AFG', $this->tag($template));
+    }
+
+    #[Test]
+    public function it_gets_timezones()
+    {
+        $template = '{{ dictionary:timezones limit="1" }}{{ value }}{{ /dictionary:timezones }}';
+
+        $this->assertEquals('Africa/Abidjan', $this->tag($template));
+    }
+
+    #[Test]
+    public function it_can_search()
+    {
+        $template = '{{ dictionary:countries search="Alg" }}{{ value }}{{ /dictionary:countries }}';
+
+        $this->assertEquals('DZA', $this->tag($template));
+    }
+
+    #[Test]
+    public function it_can_supplement_data()
+    {
+        $template = '{{ dictionary:countries search="Alg" supplement_data="true" }}{{ region }} - {{ iso2 }}{{ /dictionary:countries }}';
+
+        $this->assertEquals('Africa - DZ', $this->tag($template));
+
+        $template = '{{ dictionary:countries search="Alg" supplement_data="false" }}{{ region }} - {{ iso2 }}{{ /dictionary:countries }}';
+
+        $this->assertEquals(' - ', $this->tag($template));
+    }
+
+    #[Test]
+    public function it_can_paginate()
+    {
+        $template = '{{ dictionary:countries paginate="4" }}{{ options | count }}{{ /dictionary:countries }}';
+
+        $this->assertEquals('4', $this->tag($template));
+
+        $template = '{{ dictionary:countries paginate="4" as="countries" }}{{ countries | count }}{{ /dictionary:countries }}';
+
+        $this->assertEquals('4', $this->tag($template));
+    }
+
+    #[Test]
+    public function it_can_be_filtered_using_conditions()
+    {
+        $template = '{{ dictionary:countries supplement_data="true" iso3:is="AUS" }}{{ name }}{{ /dictionary:countries }}';
+
+        $this->assertEquals('Australia', $this->tag($template));
+    }
+
+    #[Test]
+    public function it_can_be_filtered_using_a_query_scope()
+    {
+        app('statamic.scopes')[TestScope::handle()] = TestScope::class;
+
+        $template = '{{ dictionary:countries supplement_data="true" query_scope="test_scope" }}{{ name }}{{ /dictionary:countries }}';
+
+        $this->assertEquals('Australia', $this->tag($template));
+    }
+
+    private function tag($tag, $data = [])
+    {
+        return (string) Parse::template($tag, $data);
+    }
+}
+
+class TestScope extends Scope
+{
+    public function apply($query, $params)
+    {
+        $query->where('iso3', 'AUS');
+    }
+}


### PR DESCRIPTION
This PR adds a `{{ dictionary }}` tag to Antlers, allowing you to use dictionaries outside the field type.

### Usage: 

`{{ dictionary:countries }}{{ label }} {{ value }}{{ /dictionary:countries }}`

or

`{{ dictionary handle="countries" }}{{ label }} {{ value }}{{ /dictionary}}`

It also gets any ‘extra’ data:

`{{ dictionary handle="countries" }}{{ emoji }} {{ value }}{{ /dictionary}}`


### Searching: 

`{{ dictionary:countries search="Aus" }}{{ label }} {{ value }}{{ /dictionary:countries }}`


### Passing config: 

Any params passed that arent handle or search will be passed as config... eg

`{{ dictionary:countries emojis="false" }}{{ label }} {{ value }}{{ /dictionary:countries }}`


### conditions, pagination, chunking and limiting: 
It supports conditions, pagination, chunking and limiting eg

`{{ dictionary:countries iso2:is="AUS" paginate="4" }}{{ label }} {{ value }}{{ /dictionary:countries }}`


### query scopes
You can also use query scopes:
`{{ dictionary:countries query_scope="my_scope" }}{{ label }} {{ value }}{{ /dictionary:countries }}`


### Files: 
Where this gets really powerful is pulling in arbitrary files and being able to filter, paginate and output them:
`{{ dictionary:file filename="products.json" label="Name" value="Code" paginate="4" }}`


Note: 
Under the hood its using an Item query builder to allow filtering, ordering etc. 

Closes statamic/ideas#1214.