### PR TITLE
[5.x] Prevent autoloading non-PHP files

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -746,6 +746,10 @@ abstract class AddonServiceProvider extends ServiceProvider
         $autoloadable = [];
 
         foreach ($this->app['files']->files($path) as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
             $class = $file->getBasename('.php');
             $fqcn = $this->namespace().'\\'.str_replace('/', '\\', $folder).'\\'.$class;
 


### PR DESCRIPTION
This pull request fixes an issue where Statamic would try and load non-PHP files in autoloaded directories, such as `src/Commands`.