### PR TITLE
[5.x] Fix static cache locking

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -59,9 +59,13 @@ class Cache
         $lock = $this->createLock($request);
 
         try {
-            return $lock->block($this->lockFor, fn () => $this->handleRequest($request, $next));
+            $lock->block($this->lockFor / 2);
+
+            return $this->handleRequest($request, $next);
         } catch (LockTimeoutException $e) {
             return $this->outputRefreshResponse($request);
+        } finally {
+            $lock->release();
         }
     }
 


### PR DESCRIPTION
This pull request attempts to fix a race condition with full-measure Static Caching, where if multiple requests come in for a URL at the same time, they might all try to write to the same file at the same time, causing mangled HTML, like seen in #10829.

I haven't been able to replicate the issue on my sandbox site, but I have been able to replicate it on a site @robdekort provided, using `spatie/fork` to perform concurrent requests.

To fix it, I've adjusted how we handle locking in the `StaticCaching\Cache` middleware, replicating how we do it elsewhere in the app. From my testing, it _seems_ to fix the issue. 🤞

We made some changes to the static cache locking code in #10607. However, from memory, when I was last debugging this issue, I could reproduce it even after reverting that PR.

Fixes #10829.