### PR TITLE
[5.x] Support query scopes in REST API

### DIFF
--- a/src/API/FilterAuthorizer.php
+++ b/src/API/FilterAuthorizer.php
@@ -6,6 +6,8 @@ use Statamic\Support\Arr;
 
 class FilterAuthorizer extends AbstractAuthorizer
 {
+    protected $configKey = 'allowed_filters';
+
     /**
      * Get allowed filters for resource.
      *
@@ -17,7 +19,7 @@ class FilterAuthorizer extends AbstractAuthorizer
      */
     public function allowedForResource($configFile, $queriedResource)
     {
-        $config = config("statamic.{$configFile}.resources.{$queriedResource}.allowed_filters");
+        $config = config("statamic.{$configFile}.resources.{$queriedResource}.{$this->configKey}");
 
         // Use explicitly configured `allowed_filters` array, otherwise no filters should be allowed.
         return is_array($config)
@@ -54,7 +56,7 @@ class FilterAuthorizer extends AbstractAuthorizer
 
         // Determine if any of our queried resources have filters explicitly disabled.
         $disabled = $resources
-            ->filter(fn ($resource) => Arr::get($config, "{$resource}.allowed_filters") === false)
+            ->filter(fn ($resource) => Arr::get($config, "{$resource}.{$this->configKey}") === false)
             ->isNotEmpty();
 
         // If any queried resource is explicitly disabled, then no filters should be allowed.
@@ -65,10 +67,10 @@ class FilterAuthorizer extends AbstractAuthorizer
         // Determine `allowed_filters` by filtering out any that don't appear in all of them.
         // A resource named `*` will apply to all enabled resources at once.
         return $resources
-            ->map(fn ($resource) => $config[$resource]['allowed_filters'] ?? [])
+            ->map(fn ($resource) => $config[$resource][$this->configKey] ?? [])
             ->reduce(function ($carry, $allowedFilters) use ($config) {
-                return $carry->intersect($allowedFilters)->merge($config['*']['allowed_filters'] ?? []);
-            }, collect($config[$resources[0] ?? '']['allowed_filters'] ?? []))
+                return $carry->intersect($allowedFilters)->merge($config['*'][$this->configKey] ?? []);
+            }, collect($config[$resources[0] ?? ''][$this->configKey] ?? []))
             ->all();
     }
 }

--- a/src/API/QueryScopeAuthorizer.php
+++ b/src/API/QueryScopeAuthorizer.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Statamic\API;
+
+class QueryScopeAuthorizer extends FilterAuthorizer
+{
+    protected $configKey = 'allowed_query_scopes';
+}

--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -87,7 +87,7 @@ class ApiController extends Controller
      */
     protected function filterSortAndPaginate($query)
     {
-        return $this->filterSortScopeAndPaginate($query);
+        return $this->updateAndPaginate($query);
     }
 
     /**
@@ -96,7 +96,7 @@ class ApiController extends Controller
      * @param  \Statamic\Query\Builder  $query
      * @return \Statamic\Extensions\Pagination\LengthAwarePaginator
      */
-    protected function filterSortScopeAndPaginate($query)
+    protected function updateAndPaginate($query)
     {
         return $this
             ->filter($query)

--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -5,8 +5,10 @@ namespace Statamic\Http\Controllers\API;
 use Facades\Statamic\API\ResourceAuthorizer;
 use Statamic\Exceptions\ApiValidationException;
 use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Scope;
 use Statamic\Facades\Site;
 use Statamic\Http\Controllers\Controller;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Tags\Concerns\QueriesConditions;
 
@@ -80,12 +82,26 @@ class ApiController extends Controller
      *
      * @param  \Statamic\Query\Builder  $query
      * @return \Statamic\Extensions\Pagination\LengthAwarePaginator
+     *
+     * @deprecated
      */
     protected function filterSortAndPaginate($query)
+    {
+        return $this->filterSortScopeAndPaginate($query);
+    }
+
+    /**
+     * Filter, sort, scope, and paginate query for API resource output.
+     *
+     * @param  \Statamic\Query\Builder  $query
+     * @return \Statamic\Extensions\Pagination\LengthAwarePaginator
+     */
+    protected function filterSortScopeAndPaginate($query)
     {
         return $this
             ->filter($query)
             ->sort($query)
+            ->scope($query)
             ->paginate($query);
     }
 
@@ -169,6 +185,52 @@ class ApiController extends Controller
                 return explode(':', $param)[0];
             })
             ->contains($field);
+    }
+
+    /**
+     * Apply query scopes a query based on conditions in the query_scope parameter.
+     *
+     * /endpoint?query_scope[scope_handle]=foo&query_scope[another_scope]=bar
+     *
+     * @param  \Statamic\Query\Builder  $query
+     * @return $this
+     */
+    protected function scope($query)
+    {
+        $this->getScopes()
+            ->each(function ($value, $handle) use ($query) {
+                Scope::find($handle)?->apply($query, Arr::wrap($value));
+            });
+
+        return $this;
+    }
+
+    /**
+     * Get scopes for querying.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getScopes()
+    {
+        if (! method_exists($this, 'allowedQueryScopes')) {
+            return collect();
+        }
+
+        $scopes = collect(request()->query_scope ?? []);
+
+        $allowedScopes = collect($this->allowedQueryScopes());
+
+        $forbidden = $scopes
+            ->keys()
+            ->filter(fn ($handle) => ! Scope::find($handle) || ! $allowedScopes->contains($handle));
+
+        if ($forbidden->isNotEmpty()) {
+            throw ApiValidationException::withMessages([
+                'query_scope' => Str::plural('Forbidden query scope', $forbidden).': '.$forbidden->join(', '),
+            ]);
+        }
+
+        return $scopes;
     }
 
     /**

--- a/src/Http/Controllers/API/AssetsController.php
+++ b/src/Http/Controllers/API/AssetsController.php
@@ -23,7 +23,7 @@ class AssetsController extends ApiController
             ->filter->isRelationship()->keys()->all();
 
         return app(AssetResource::class)::collection(
-            $this->filterSortAndPaginate($assetContainer->queryAssets()->with($with))
+            $this->updateAndPaginate($assetContainer->queryAssets()->with($with))
         );
     }
 

--- a/src/Http/Controllers/API/AssetsController.php
+++ b/src/Http/Controllers/API/AssetsController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\API;
 
 use Facades\Statamic\API\FilterAuthorizer;
+use Facades\Statamic\API\QueryScopeAuthorizer;
 use Statamic\Http\Resources\API\AssetResource;
 
 class AssetsController extends ApiController
@@ -36,5 +37,10 @@ class AssetsController extends ApiController
     protected function allowedFilters()
     {
         return FilterAuthorizer::allowedForSubResources('api', 'assets', $this->containerHandle);
+    }
+
+    protected function allowedQueryScopes()
+    {
+        return QueryScopeAuthorizer::allowedForSubResources('api', 'assets', $this->containerHandle);
     }
 }

--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -30,7 +30,7 @@ class CollectionEntriesController extends ApiController
             ->filter->isRelationship()->keys()->all();
 
         return app(EntryResource::class)::collection(
-            $this->filterSortAndPaginate($collection->queryEntries()->with($with))
+            $this->updateAndPaginate($collection->queryEntries()->with($with))
         );
     }
 

--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\API;
 
 use Facades\Statamic\API\FilterAuthorizer;
+use Facades\Statamic\API\QueryScopeAuthorizer;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Entry;
 use Statamic\Http\Resources\API\EntryResource;
@@ -80,5 +81,10 @@ class CollectionEntriesController extends ApiController
     protected function allowedFilters()
     {
         return FilterAuthorizer::allowedForSubResources('api', 'collections', $this->collectionHandle);
+    }
+
+    protected function allowedQueryScopes()
+    {
+        return QueryScopeAuthorizer::allowedForSubResources('api', 'collections', $this->collectionHandle);
     }
 }

--- a/src/Http/Controllers/API/CollectionTreeController.php
+++ b/src/Http/Controllers/API/CollectionTreeController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\API;
 
 use Facades\Statamic\API\FilterAuthorizer;
+use Facades\Statamic\API\QueryScopeAuthorizer;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Http\Resources\API\TreeResource;
 use Statamic\Query\ItemQueryBuilder;
@@ -47,5 +48,10 @@ class CollectionTreeController extends ApiController
     protected function allowedFilters()
     {
         return FilterAuthorizer::allowedForSubResources('api', 'collections', $this->collectionHandle);
+    }
+
+    protected function allowedQueryScopes()
+    {
+        return QueryScopeAuthorizer::allowedForSubResources('api', 'collections', $this->collectionHandle);
     }
 }

--- a/src/Http/Controllers/API/TaxonomyTermEntriesController.php
+++ b/src/Http/Controllers/API/TaxonomyTermEntriesController.php
@@ -47,7 +47,7 @@ class TaxonomyTermEntriesController extends ApiController
         $with = $this->getRelationshipFieldsFromCollections($taxonomy);
 
         return app(EntryResource::class)::collection(
-            $this->filterSortAndPaginate($query->with($with))
+            $this->updateAndPaginate($query->with($with))
         );
     }
 

--- a/src/Http/Controllers/API/TaxonomyTermEntriesController.php
+++ b/src/Http/Controllers/API/TaxonomyTermEntriesController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\API;
 
 use Facades\Statamic\API\FilterAuthorizer;
+use Facades\Statamic\API\QueryScopeAuthorizer;
 use Facades\Statamic\API\ResourceAuthorizer;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Collection;
@@ -71,5 +72,10 @@ class TaxonomyTermEntriesController extends ApiController
     protected function allowedFilters()
     {
         return FilterAuthorizer::allowedForSubResources('api', 'collections', $this->allowedCollections);
+    }
+
+    protected function allowedQueryScopes()
+    {
+        return QueryScopeAuthorizer::allowedForSubResources('api', 'collections', $this->allowedCollections);
     }
 }

--- a/src/Http/Controllers/API/TaxonomyTermsController.php
+++ b/src/Http/Controllers/API/TaxonomyTermsController.php
@@ -25,7 +25,7 @@ class TaxonomyTermsController extends ApiController
             ->filter->isRelationship()->keys()->all();
 
         return app(TermResource::class)::collection(
-            $this->filterSortAndPaginate($taxonomy->queryTerms()->with($with))
+            $this->updateAndPaginate($taxonomy->queryTerms()->with($with))
         );
     }
 

--- a/src/Http/Controllers/API/TaxonomyTermsController.php
+++ b/src/Http/Controllers/API/TaxonomyTermsController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\API;
 
 use Facades\Statamic\API\FilterAuthorizer;
+use Facades\Statamic\API\QueryScopeAuthorizer;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Term;
 use Statamic\Http\Resources\API\TermResource;
@@ -42,5 +43,10 @@ class TaxonomyTermsController extends ApiController
     protected function allowedFilters()
     {
         return FilterAuthorizer::allowedForSubResources('api', 'taxonomies', $this->taxonomyHandle);
+    }
+
+    protected function allowedQueryScopes()
+    {
+        return QueryScopeAuthorizer::allowedForSubResources('api', 'taxonomies', $this->taxonomyHandle);
     }
 }

--- a/src/Http/Controllers/API/UsersController.php
+++ b/src/Http/Controllers/API/UsersController.php
@@ -17,7 +17,7 @@ class UsersController extends ApiController
         $this->abortIfDisabled();
 
         return app(UserResource::class)::collection(
-            $this->filterSortAndPaginate(User::query())
+            $this->updateAndPaginate(User::query())
         );
     }
 

--- a/src/Http/Controllers/API/UsersController.php
+++ b/src/Http/Controllers/API/UsersController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\API;
 
 use Facades\Statamic\API\FilterAuthorizer;
+use Facades\Statamic\API\QueryScopeAuthorizer;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\User;
 use Statamic\Http\Resources\API\UserResource;
@@ -41,5 +42,10 @@ class UsersController extends ApiController
         return collect(FilterAuthorizer::allowedForResource('api', 'users'))
             ->reject(fn ($field) => in_array($field, ['password', 'password_hash']))
             ->all();
+    }
+
+    protected function allowedQueryScopes()
+    {
+        return QueryScopeAuthorizer::allowedForResource('api', 'users');
     }
 }

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -10,6 +10,7 @@ use Statamic\Facades;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Token;
 use Statamic\Facades\User;
+use Statamic\Query\Scopes\Scope;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -134,6 +135,25 @@ class APITest extends TestCase
         $response = $this->get('/api/collections/test/entries')->assertSuccessful();
         $this->assertCount(1, $response->getData()->data);
         $response->assertJsonPath('data.0.id', 'a');
+    }
+
+    #[Test]
+    public function it_can_use_a_query_scope_on_collection_entries_when_configuration_allows_for_it()
+    {
+        app('statamic.scopes')['test_scope'] = TestScope::class;
+
+        Facades\Config::set('statamic.api.resources.collections.pages', [
+            'allowed_query_scopes' => ['test_scope'],
+        ]);
+
+        Facades\Collection::make('pages')->save();
+
+        Facades\Entry::make()->collection('pages')->id('about')->slug('about')->published(true)->save();
+        Facades\Entry::make()->collection('pages')->id('dance')->slug('dance')->published(true)->save();
+        Facades\Entry::make()->collection('pages')->id('nectar')->slug('nectar')->published(true)->save();
+
+        $this->assertEndpointDataCount('/api/collections/pages/entries?query_scope[test_scope][]=is&query_scope[test_scope][]=about', 1);
+        $this->assertEndpointDataCount('/api/collections/pages/entries?query_scope[test_scope][]=isnt&query_scope[test_scope][]=about', 2);
     }
 
     #[Test]
@@ -590,5 +610,13 @@ class FakeTokenHandler
     public function handle(\Statamic\Contracts\Tokens\Token $token, \Illuminate\Http\Request $request, \Closure $next)
     {
         return $next($token);
+    }
+}
+
+class TestScope extends Scope
+{
+    public function apply($query, $values)
+    {
+        $query->where('id', $values[0] == 'is' ? '=' : '!=', $values[1]);
     }
 }

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -152,8 +152,8 @@ class APITest extends TestCase
         Facades\Entry::make()->collection('pages')->id('dance')->slug('dance')->published(true)->save();
         Facades\Entry::make()->collection('pages')->id('nectar')->slug('nectar')->published(true)->save();
 
-        $this->assertEndpointDataCount('/api/collections/pages/entries?query_scope[test_scope][]=is&query_scope[test_scope][]=about', 1);
-        $this->assertEndpointDataCount('/api/collections/pages/entries?query_scope[test_scope][]=isnt&query_scope[test_scope][]=about', 2);
+        $this->assertEndpointDataCount('/api/collections/pages/entries?query_scope[test_scope][operator]=is&query_scope[test_scope][value]=about', 1);
+        $this->assertEndpointDataCount('/api/collections/pages/entries?query_scope[test_scope][operator]=isnt&query_scope[test_scope][value]=about', 2);
     }
 
     #[Test]
@@ -617,6 +617,6 @@ class TestScope extends Scope
 {
     public function apply($query, $values)
     {
-        $query->where('id', $values[0] == 'is' ? '=' : '!=', $values[1]);
+        $query->where('id', $values['operator'] == 'is' ? '=' : '!=', $values['value']);
     }
 }


### PR DESCRIPTION
This PR adds support for using query scopes in the REST API.

The URL format follows the same approach as filters:

`https://mysite.com/api/collections/pages/entries?query_scope[my_scope]=value`

or, if you have multiple values

`https://mysite.com/api/collections/pages/entries?query_scope[my_scope][value_key]=value&query_scope[my_scope][another_value_key]=value2`

I've made a few changes to FilterAuthorizer to allow it to be easily extended by the new QueryScopeAuthorizer, seeing as they are basically doing the same thing with just a difference in the key being checked.

Closes https://github.com/statamic/cms/issues/3310
