### PR TITLE
[5.x] Fix error when deleting collections

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -18,18 +18,6 @@
                             :actions="collection.actions"
                             @completed="actionCompleted"
                         ></data-list-inline-actions>
-                        <dropdown-item
-                            v-if="collection.deleteable"
-                            :text="__('Delete Collection')"
-                            class="warning"
-                            @click="$refs[`deleter_${collection.id}`].confirm()"
-                        >
-                            <resource-deleter
-                                :ref="`deleter_${collection.id}`"
-                                :resource="collection"
-                                @deleted="removeRow(collection)">
-                            </resource-deleter>
-                        </dropdown-item>
                     </dropdown-list>
                 </template>
             </data-list-table>

--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -1,5 +1,5 @@
 <template>
-    <data-list ref="dataList" :columns="columns" :rows="rows">
+    <data-list ref="dataList" :columns="columns" :rows="items">
         <div class="card overflow-hidden p-0" slot-scope="{ filteredRows: rows }">
             <data-list-table :rows="rows">
                 <template slot="cell-title" slot-scope="{ row: collection }">
@@ -52,7 +52,7 @@ export default {
     data() {
         return {
             initializedRequest: false,
-            rows: this.initialRows,
+            items: this.initialRows,
             requestUrl: cp_url(`collections`),
         }
     },

--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -68,7 +68,7 @@ export default {
             }
 
             Listing.methods.request.call(this);
-        },
+        }
     }
 
 }

--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -68,7 +68,14 @@ export default {
             }
 
             Listing.methods.request.call(this);
-        }
+        },
+
+        removeRow(row) {
+            let id = row.id;
+            let i = _.indexOf(this.items, _.findWhere(this.items, { id }));
+            this.items.splice(i, 1);
+            if (this.items.length === 0) location.reload();
+        },
     }
 
 }

--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -1,5 +1,5 @@
 <template>
-    <data-list ref="dataList" :columns="columns" :rows="items">
+    <data-list ref="dataList" :columns="columns" :rows="rows">
         <div class="card overflow-hidden p-0" slot-scope="{ filteredRows: rows }">
             <data-list-table :rows="rows">
                 <template slot="cell-title" slot-scope="{ row: collection }">
@@ -52,7 +52,7 @@ export default {
     data() {
         return {
             initializedRequest: false,
-            items: this.initialRows,
+            rows: this.initialRows,
             requestUrl: cp_url(`collections`),
         }
     },
@@ -68,13 +68,6 @@ export default {
             }
 
             Listing.methods.request.call(this);
-        },
-
-        removeRow(row) {
-            let id = row.id;
-            let i = _.indexOf(this.items, _.findWhere(this.items, { id }));
-            this.items.splice(i, 1);
-            if (this.items.length === 0) location.reload();
         },
     }
 

--- a/resources/lang/ar.json
+++ b/resources/lang/ar.json
@@ -302,7 +302,6 @@
     "Delete": "حذف",
     "Delete :resource": "حذف :resource",
     "Delete child entry|Delete :count child entries": "حذف الإدخال الفرعي|حذف :count الإدخالات الفرعية",
-    "Delete Collection": "حذف المجموعة",
     "Delete Column": "حذف العمود",
     "Delete Container": "حذف الحاوية",
     "Delete Entry": "حذف الإدخال",

--- a/resources/lang/az.json
+++ b/resources/lang/az.json
@@ -318,7 +318,6 @@
   "Delete": "Sil",
   "Delete :resource": "Bunu sil: :resource",
   "Delete child entry|Delete :count child entries": "Uşaq girişi sil|:count uşaq girişi sil",
-  "Delete Collection": "Kolleksiyanı Sil",
   "Delete Column": "Sütunu Sil",
   "Delete Container": "Konteyneri Sil",
   "Delete Entry": "Girişi Sil",

--- a/resources/lang/cs.json
+++ b/resources/lang/cs.json
@@ -227,7 +227,6 @@
     "Delete": "Smazat",
     "Delete :resource": "Smazat :resource",
     "Delete child entry|Delete :count child entries": "Smazat podzáznam|Smazat :count podzáznamů",
-    "Delete Collection": "Smazat kolekci",
     "Delete Column": "Smazat sloupec",
     "Delete Container": "Smazat kontejner",
     "Delete Entry": "Smazat záznam",

--- a/resources/lang/da.json
+++ b/resources/lang/da.json
@@ -211,7 +211,6 @@
     "Delete": "Slet",
     "Delete :resource": "Slet :resource",
     "Delete child entry|Delete :count child entries": "Slet underordnet post | Slet :count underordnede poster",
-    "Delete Collection": "Slet samling",
     "Delete Column": "Slet kolonne",
     "Delete Container": "Slet beholder",
     "Delete Entry": "Slet post",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -313,7 +313,6 @@
     "Delete": "Löschen",
     "Delete :resource": ":resource löschen",
     "Delete child entry|Delete :count child entries": "Untergeordneten Eintrag löschen|:count untergeordnete Einträge löschen",
-    "Delete Collection": "Sammlung löschen",
     "Delete Column": "Spalte löschen",
     "Delete Container": "Container löschen",
     "Delete Entry": "Eintrag löschen",

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -313,7 +313,6 @@
     "Delete": "Löschen",
     "Delete :resource": ":resource löschen",
     "Delete child entry|Delete :count child entries": "Untergeordneten Eintrag löschen|:count untergeordnete Einträge löschen",
-    "Delete Collection": "Sammlung löschen",
     "Delete Column": "Spalte löschen",
     "Delete Container": "Container löschen",
     "Delete Entry": "Eintrag löschen",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -211,7 +211,6 @@
     "Delete": "Eliminar",
     "Delete :resource": "Eliminar :resource",
     "Delete child entry|Delete :count child entries": "Eliminar entrada interna|Eliminar :count entradas internas",
-    "Delete Collection": "Eliminar colección",
     "Delete Column": "Eliminar columna",
     "Delete Container": "Eliminar contenedor",
     "Delete Entry": "Eliminar entrada",

--- a/resources/lang/fa.json
+++ b/resources/lang/fa.json
@@ -329,7 +329,6 @@
     "Delete": "حذف",
     "Delete :resource": "حذف :resource",
     "Delete child entry|Delete :count child entries": "حذف مطلب فرزند|حذف :count مطلب فرزند",
-    "Delete Collection": "حذف کالکشن",
     "Delete Column": "حذف ستون",
     "Delete Container": "حذف کانتینر",
     "Delete Entry": "حذف مطلب",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -313,7 +313,6 @@
     "Delete": "Supprimer",
     "Delete :resource": "Supprimer :resource",
     "Delete child entry|Delete :count child entries": "Supprimer l'entrée enfant|Supprimer :count entrées enfants",
-    "Delete Collection": "Supprimer la collection",
     "Delete Column": "Supprimer la colonne",
     "Delete Container": "Supprimer le conteneur",
     "Delete Entry": "Supprimer l'entrée",

--- a/resources/lang/hu.json
+++ b/resources/lang/hu.json
@@ -217,7 +217,6 @@
     "Delete": "Töröl",
     "Delete :resource": ":resource törlése",
     "Delete child entry|Delete :count child entries": "Gyermek bejegyzés törlése|:count gyermek bejegyzés törlése",
-    "Delete Collection": "Gyűjtemény törlése",
     "Delete Column": "Oszlop törlése",
     "Delete Container": "Tároló törlése",
     "Delete Entry": "Bejegyzés törlése",

--- a/resources/lang/id.json
+++ b/resources/lang/id.json
@@ -211,7 +211,6 @@
     "Delete": "Hapus",
     "Delete :resource": "Hapus :resource",
     "Delete child entry|Delete :count child entries": "Hapus entri anak|Hapus :count entru anak",
-    "Delete Collection": "Hapus Koleksi",
     "Delete Column": "Hapus Kolom",
     "Delete Container": "Hapus Penampung",
     "Delete Entry": "Hapus Entri",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -211,7 +211,6 @@
     "Delete": "Elimina",
     "Delete :resource": "Elimina :resource",
     "Delete child entry|Delete :count child entries": "Elimina voce figlio|Elimina :count voci figlio",
-    "Delete Collection": "Elimina raccolta",
     "Delete Column": "Elimina colonna",
     "Delete Container": "Elimina contenitore",
     "Delete Entry": "Elimina voce",

--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -295,7 +295,6 @@
     "Delete": "消去",
     "Delete :resource": "削除:resource",
     "Delete child entry|Delete :count child entries": "子エントリの削除| :countの子エントリを削除",
-    "Delete Collection": "コレクションの削除",
     "Delete Column": "列の削除",
     "Delete Container": "コンテナの削除",
     "Delete Entry": "記入を消す",

--- a/resources/lang/ms.json
+++ b/resources/lang/ms.json
@@ -211,7 +211,6 @@
     "Delete": "Hapus",
     "Delete :resource": "Hapus :resource",
     "Delete child entry|Delete :count child entries": "Hapus entri anak|Hapus :count entri anak",
-    "Delete Collection": "Hapus Koleksi",
     "Delete Column": "Hapus Lajur",
     "Delete Container": "Hapus Penampung",
     "Delete Entry": "Hapus Entri",

--- a/resources/lang/nb.json
+++ b/resources/lang/nb.json
@@ -302,7 +302,6 @@
     "Delete": "Slett",
     "Delete :resource": "Slett :resource",
     "Delete child entry|Delete :count child entries": "Slett underordnet oppføring|Slett :count underordnede oppføringer",
-    "Delete Collection": "Slett samling",
     "Delete Column": "Slett kolonne",
     "Delete Container": "Slett beholder",
     "Delete Entry": "Slett oppføring",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -302,7 +302,6 @@
     "Delete": "Verwijderen",
     "Delete :resource": "Verwijder :resource",
     "Delete child entry|Delete :count child entries": "Verwijder child entry|Verwijder :count child entries",
-    "Delete Collection": "Verwijderd collectie",
     "Delete Column": "Verwijderd kolom",
     "Delete Container": "Verwijder container",
     "Delete Entry": "Verwijder entry",

--- a/resources/lang/pl.json
+++ b/resources/lang/pl.json
@@ -229,7 +229,6 @@
     "Delete": "Usuń",
     "Delete :resource": "Usuń :resource",
     "Delete child entry|Delete :count child entries": "Usuń podrzędnyrekord|Usuń :count rekordy/ów podrzędne",
-    "Delete Collection": "Usuń kolekcję",
     "Delete Column": "Usuń kolumnę",
     "Delete Container": "Usuń kontener",
     "Delete Entry": "Usuń rekord",

--- a/resources/lang/pt.json
+++ b/resources/lang/pt.json
@@ -211,7 +211,6 @@
     "Delete": "Eliminar",
     "Delete :resource": "Eliminar :resource",
     "Delete child entry|Delete :count child entries": "Eliminar entrada-filho:Eliminar :count entrada(s)-filho(s)",
-    "Delete Collection": "Eliminar Coleção",
     "Delete Column": "Eliminar Coluna",
     "Delete Container": "Eliminar Biblioteca",
     "Delete Entry": "Eliminar Entrada",

--- a/resources/lang/pt_BR.json
+++ b/resources/lang/pt_BR.json
@@ -237,7 +237,6 @@
     "Delete": "Excluir",
     "Delete :resource": "Excluir :resource",
     "Delete child entry|Delete :count child entries": "Excluir entrada-filha|Excluir :count entradas-filhas",
-    "Delete Collection": "Excluir Coleção",
     "Delete Column": "Exlucir Coluna",
     "Delete Container": "Excluir Contêiner",
     "Delete Entry": "Excluir Entrada",

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -296,7 +296,6 @@
     "Delete": "Удалить",
     "Delete :resource": "Удалить :resource",
     "Delete child entry|Delete :count child entries": "Удалить дочернюю запись|Удалить :count дочерние записи|Удалить :count дочерних записей",
-    "Delete Collection": "Удалить коллекцию",
     "Delete Column": "Удалить столбец",
     "Delete Container": "Удалить контейнер",
     "Delete Entry": "Удалить запись",

--- a/resources/lang/sl.json
+++ b/resources/lang/sl.json
@@ -211,7 +211,6 @@
     "Delete": "Izbriši",
     "Delete :resource": "Izbriši :resource",
     "Delete child entry|Delete :count child entries": "Izbriši podrejeni vnos | Izbriši :count podrejene vnose",
-    "Delete Collection": "Izbriši zbirko",
     "Delete Column": "Izbriši stolpec",
     "Delete Container": "Izbriši vsebnik",
     "Delete Entry": "Izbriši vnos",

--- a/resources/lang/sv.json
+++ b/resources/lang/sv.json
@@ -229,7 +229,6 @@
     "Delete": "Radera",
     "Delete :resource": "Radera :resource",
     "Delete child entry|Delete :count child entries": "Radera underordnat inlägg|Radera :count underordnade inlägg",
-    "Delete Collection": "Radera samling",
     "Delete Column": "Radera kolumn",
     "Delete Container": "Radera behållare",
     "Delete Entry": "Radera inlägg",

--- a/resources/lang/tr.json
+++ b/resources/lang/tr.json
@@ -334,7 +334,6 @@
     "Delete": "Sil",
     "Delete :resource": ":resource sil",
     "Delete child entry|Delete :count child entries": "Alt girdiyi sil|:count alt girdiyi sil",
-    "Delete Collection": "Koleksiyonu Sil",
     "Delete Column": "Sütunu Sil",
     "Delete Container": "Konteyneri Sil",
     "Delete Entry": "Girişi Sil",

--- a/resources/lang/uk.json
+++ b/resources/lang/uk.json
@@ -295,7 +295,6 @@
     "Delete": "Видалити",
     "Delete :resource": "Видалити :resource",
     "Delete child entry|Delete :count child entries": "Видалити дочірній запис|Видалити :count дочірніх записів",
-    "Delete Collection": "Видалити колекцію",
     "Delete Column": "Видалити стовпець",
     "Delete Container": "Видалити контейнер",
     "Delete Entry": "Видалити запис",

--- a/resources/lang/zh_CN.json
+++ b/resources/lang/zh_CN.json
@@ -236,7 +236,6 @@
     "Delete": "删除",
     "Delete :resource": "删除 :resource",
     "Delete child entry|Delete :count child entries": "删除子条目|删除 :count 子条目",
-    "Delete Collection": "删除条目集合",
     "Delete Column": "删除列",
     "Delete Container": "删除容器",
     "Delete Entry": "删除条目",

--- a/resources/lang/zh_TW.json
+++ b/resources/lang/zh_TW.json
@@ -236,7 +236,6 @@
     "Delete": "刪除",
     "Delete :resource": "刪除 :resource",
     "Delete child entry|Delete :count child entries": "刪除子條目|刪除 :count 個子條目",
-    "Delete Collection": "刪除條目集",
     "Delete Column": "刪除欄位",
     "Delete Container": "刪除容器",
     "Delete Entry": "刪除條目",

--- a/resources/views/collections/show.blade.php
+++ b/resources/views/collections/show.blade.php
@@ -53,17 +53,6 @@
                 :actions="{{ $actions }}"
                 @completed="actionCompleted"
             ></data-list-inline-actions>
-            @can('delete', $collection)
-                <dropdown-item :text="__('Delete Collection')" class="warning" @click="$refs.deleter.confirm()">
-                    <resource-deleter
-                        ref="deleter"
-                        resource-title="{{ $collection->title() }}"
-                        route="{{ cp_route('collections.destroy', $collection->handle()) }}"
-                        redirect="{{ cp_route('collections.index') }}"
-                    ></resource-deleter>
-                </dropdown-item>
-            @endcan
-
         </template>
         @endif
     </collection-view>

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -19,6 +19,7 @@ class Delete extends Action
             case $item instanceof Contracts\Entries\Entry && $item->collection()->sites()->count() === 1:
                 return ! $item->page()?->isRoot();
                 break;
+            case $item instanceof Contracts\Entries\Collection:
             case $item instanceof Contracts\Taxonomies\Term:
             case $item instanceof Contracts\Assets\Asset:
             case $item instanceof Contracts\Assets\AssetFolder:
@@ -85,6 +86,8 @@ class Delete extends Action
         $item = $items->first();
 
         switch (true) {
+            case $item instanceof Contracts\Entries\Collection:
+                return cp_route('collections.index');
             case $item instanceof Contracts\Entries\Entry:
                 return cp_route('collections.show', $item->collection()->handle());
             case $item instanceof Contracts\Taxonomies\Term:

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -53,6 +53,14 @@ class Delete extends Action
         return 'Are you sure you want to delete this?|Are you sure you want to delete these :count items?';
     }
 
+    public function warningText()
+    {
+        if ($this->items->first() instanceof Contracts\Entries\Collection) {
+            /** @translation */
+            return 'This will delete the collection and all of its entries.|This will delete the collections and all of their entries.';
+        }
+    }
+
     public function bypassesDirtyWarning(): bool
     {
         return true;

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -121,7 +121,7 @@ class CollectionsController extends CpController
                 ->all(),
             'canCreate' => User::current()->can('create', [EntryContract::class, $collection]) && $collection->hasVisibleEntryBlueprint(),
             'canChangeLocalizationDeleteBehavior' => count($authorizedSites) > 1 && (count($authorizedSites) == $collection->sites()->count()),
-            'actions' => Action::for($collection),
+            'actions' => Action::for($collection, ['view' => 'form']),
         ];
 
         if ($collection->queryEntries()->count() === 0) {

--- a/tests/Feature/Collections/ViewCollectionListingTest.php
+++ b/tests/Feature/Collections/ViewCollectionListingTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Collections;
 
 use Facades\Tests\Factories\EntryFactory;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Actions\Delete;
 use Statamic\Auth\User;
 use Statamic\Entries\Collection;
 use Statamic\Facades;
@@ -44,7 +45,7 @@ class ViewCollectionListingTest extends TestCase
                     'editable' => true,
                     'blueprint_editable' => true,
                     'available_in_selected_site' => true,
-                    'actions' => collect(),
+                    'actions' => Facades\Action::for($collectionA, ['view' => 'list']),
                     'actions_url' => 'http://localhost/cp/collections/foo/actions',
                 ],
                 [
@@ -61,7 +62,7 @@ class ViewCollectionListingTest extends TestCase
                     'editable' => true,
                     'blueprint_editable' => true,
                     'available_in_selected_site' => true,
-                    'actions' => collect(),
+                    'actions' => Facades\Action::for($collectionB, ['view' => 'list']),
                     'actions_url' => 'http://localhost/cp/collections/bar/actions',
                 ],
             ]))

--- a/tests/Feature/Collections/ViewCollectionListingTest.php
+++ b/tests/Feature/Collections/ViewCollectionListingTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Collections;
 
 use Facades\Tests\Factories\EntryFactory;
 use PHPUnit\Framework\Attributes\Test;
-use Statamic\Actions\Delete;
 use Statamic\Auth\User;
 use Statamic\Entries\Collection;
 use Statamic\Facades;


### PR DESCRIPTION
This pull request fixes an issue where you'd see a console error when attempting to delete collections. 

This issue was caused by the rename of `rows` to `items` in #10471. This PR fixes it by doing away with the `<resource-deleter>` component, in favour of the `Delete` action we use elsewhere.

This PR also fixes a bug with the context passed to collection actions on the "collection show", where `view` was wrongly `list` instead of `form`.