### PR TITLE
[5.x] Ensure default values for globals are available in templates

### DIFF
--- a/src/Globals/AugmentedVariables.php
+++ b/src/Globals/AugmentedVariables.php
@@ -14,7 +14,9 @@ class AugmentedVariables extends AbstractAugmented
             return $this->cachedKeys;
         }
 
-        return $this->cachedKeys = $this->data->values()->keys()->all();
+        return $this->cachedKeys = $this->data->values()->keys()
+            ->merge($this->blueprintFields()->keys())
+            ->unique()->sort()->values()->all();
     }
 
     public function site()


### PR DESCRIPTION
This pull request fixes an issue where the default values for Globals weren't available in templates. 

This was due to the fact that the `AugmentedVariables` class was only making available fields with *actual* values, unlike entries where we also merge in the keys of all blueprint fields.

Fixes #10901.