### PR TITLE
[5.x] Autoload event listeners and subscribers

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -246,7 +246,11 @@ abstract class AddonServiceProvider extends ServiceProvider
             ->unique()
             ->each(fn ($listener, $event) => Event::listen($event, $listener));
 
-        foreach ($this->subscribe as $subscriber) {
+        $subscribers = collect($this->subscribe)
+            ->merge($this->autoloadFilesFromFolder('Subscribers'))
+            ->unique();
+        
+        foreach ($subscribers as $subscriber) {
             Event::subscribe($subscriber);
         }
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -249,7 +249,7 @@ abstract class AddonServiceProvider extends ServiceProvider
         $subscribers = collect($this->subscribe)
             ->merge($this->autoloadFilesFromFolder('Subscribers'))
             ->unique();
-        
+
         foreach ($subscribers as $subscriber) {
             Event::subscribe($subscriber);
         }


### PR DESCRIPTION
Currently, things like fieldtypes, tags and route files in addons are autoloaded if they follow convention.

However, when I was tidying up a `ServiceProvider` in one of my addons the other day, I realised that event listeners and subscribers weren't being autoloaded.

This pull request makes that possible by using Reflection to extract the event being listened to from the listener's typehints.