### PR TITLE
[5.x] Handle empty nodes in bard_text modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -281,6 +281,11 @@ class CoreModifiers extends Modifier
         $text = '';
         while (count($value)) {
             $item = array_shift($value);
+
+            if (! isset($item['type'])) {
+                continue;
+            }
+
             if ($item['type'] === 'text') {
                 $text .= ' '.($item['text'] ?? '');
             }

--- a/tests/Modifiers/BardTextTest.php
+++ b/tests/Modifiers/BardTextTest.php
@@ -113,6 +113,7 @@ class BardTextTest extends TestCase
                 ],
             ],
             [
+                // no type
             ],
             [
                 'type' => 'paragraph',

--- a/tests/Modifiers/BardTextTest.php
+++ b/tests/Modifiers/BardTextTest.php
@@ -98,6 +98,35 @@ class BardTextTest extends TestCase
         $this->assertEquals('', $this->modify(null));
     }
 
+    #[Test]
+    public function it_skips_nodes_with_no_typevend()
+    {
+        $data = [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    ['type' => 'text', 'text' => 'This is a paragraph with '],
+                    ['type' => 'text', 'marks' => [['type' => 'bold']], 'text' => 'bold'],
+                    ['type' => 'text', 'text' => ' and '],
+                    ['type' => 'text', 'marks' => [['type' => 'italic']], 'text' => 'italic'],
+                    ['type' => 'text', 'text' => ' text.'],
+                ],
+            ],
+            [
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Another paragraph.'],
+                ],
+            ],
+        ];
+
+        $expected = 'This is a paragraph with bold and italic text. Another paragraph.';
+
+        $this->assertEquals($expected, $this->modify($data));
+    }
+
     public function modify($arr, ...$args)
     {
         return Modify::value($arr)->bard_text($args)->fetch();

--- a/tests/Modifiers/BardTextTest.php
+++ b/tests/Modifiers/BardTextTest.php
@@ -99,7 +99,7 @@ class BardTextTest extends TestCase
     }
 
     #[Test]
-    public function it_skips_nodes_with_no_typevend()
+    public function it_skips_nodes_with_no_type()
     {
         $data = [
             [


### PR DESCRIPTION
This PR ensures that if no 'type' is present the node is skipped.

Closes https://github.com/statamic/cms/issues/10912