### PR TITLE
[5.x] Use directory paths from stache config instead of static paths

### DIFF
--- a/src/Console/Commands/Multisite.php
+++ b/src/Console/Commands/Multisite.php
@@ -93,17 +93,20 @@ class Multisite extends Command
             return false;
         }
 
-        return File::isDirectory("content/collections/{$collection->handle()}/{$siteHandle}");
+        $directory = Config::get('statamic.stache.stores.entries.directory') . DIRECTORY_SEPARATOR . $collection->handle() . DIRECTORY_SEPARATOR . $siteHandle;
+        return File::isDirectory($directory);
     }
 
     private function globalsHaveBeenMoved(string $siteHandle): bool
     {
-        return File::isDirectory("content/globals/{$siteHandle}");
+        $directory = Config::get('statamic.stache.stores.globals.directory') . DIRECTORY_SEPARATOR . $siteHandle;
+        return File::isDirectory($directory);
     }
 
     private function navsHaveBeenMoved(string $siteHandle): bool
     {
-        return File::isDirectory("content/navigation/{$siteHandle}");
+        $directory = Config::get('statamic.stache.stores.navigation.directory') . DIRECTORY_SEPARATOR . $siteHandle;
+        return File::isDirectory($directory);
     }
 
     private function promptForSiteHandle(): bool
@@ -227,9 +230,7 @@ class Multisite extends Command
     {
         Config::set('statamic.system.multisite', false);
 
-        $handle = $collection->handle();
-
-        $base = "content/collections/{$handle}";
+        $base = Config::get("statamic.stache.stores.entries.directory") . DIRECTORY_SEPARATOR . $collection->handle();
 
         File::makeDirectory("{$base}/{$this->siteHandle}");
 

--- a/src/Console/Commands/Multisite.php
+++ b/src/Console/Commands/Multisite.php
@@ -93,19 +93,19 @@ class Multisite extends Command
             return false;
         }
 
-        $directory = Config::get('statamic.stache.stores.entries.directory') . DIRECTORY_SEPARATOR . $collection->handle() . DIRECTORY_SEPARATOR . $siteHandle;
+        $directory = Config::get('statamic.stache.stores.entries.directory').DIRECTORY_SEPARATOR.$collection->handle().DIRECTORY_SEPARATOR.$siteHandle;
         return File::isDirectory($directory);
     }
 
     private function globalsHaveBeenMoved(string $siteHandle): bool
     {
-        $directory = Config::get('statamic.stache.stores.globals.directory') . DIRECTORY_SEPARATOR . $siteHandle;
+        $directory = Config::get('statamic.stache.stores.globals.directory').DIRECTORY_SEPARATOR.$siteHandle;
         return File::isDirectory($directory);
     }
 
     private function navsHaveBeenMoved(string $siteHandle): bool
     {
-        $directory = Config::get('statamic.stache.stores.navigation.directory') . DIRECTORY_SEPARATOR . $siteHandle;
+        $directory = Config::get('statamic.stache.stores.navigation.directory').DIRECTORY_SEPARATOR.$siteHandle;
         return File::isDirectory($directory);
     }
 
@@ -230,7 +230,7 @@ class Multisite extends Command
     {
         Config::set('statamic.system.multisite', false);
 
-        $base = Config::get("statamic.stache.stores.entries.directory") . DIRECTORY_SEPARATOR . $collection->handle();
+        $base = Config::get("statamic.stache.stores.entries.directory").DIRECTORY_SEPARATOR.$collection->handle();
 
         File::makeDirectory("{$base}/{$this->siteHandle}");
 

--- a/src/Console/Commands/Multisite.php
+++ b/src/Console/Commands/Multisite.php
@@ -94,18 +94,21 @@ class Multisite extends Command
         }
 
         $directory = Config::get('statamic.stache.stores.entries.directory').DIRECTORY_SEPARATOR.$collection->handle().DIRECTORY_SEPARATOR.$siteHandle;
+
         return File::isDirectory($directory);
     }
 
     private function globalsHaveBeenMoved(string $siteHandle): bool
     {
         $directory = Config::get('statamic.stache.stores.globals.directory').DIRECTORY_SEPARATOR.$siteHandle;
+
         return File::isDirectory($directory);
     }
 
     private function navsHaveBeenMoved(string $siteHandle): bool
     {
         $directory = Config::get('statamic.stache.stores.navigation.directory').DIRECTORY_SEPARATOR.$siteHandle;
+
         return File::isDirectory($directory);
     }
 
@@ -230,7 +233,7 @@ class Multisite extends Command
     {
         Config::set('statamic.system.multisite', false);
 
-        $base = Config::get("statamic.stache.stores.entries.directory").DIRECTORY_SEPARATOR.$collection->handle();
+        $base = Config::get('statamic.stache.stores.entries.directory').DIRECTORY_SEPARATOR.$collection->handle();
 
         File::makeDirectory("{$base}/{$this->siteHandle}");
 


### PR DESCRIPTION
While it is possible to place your content outside the statamic project by just connfiguring the stores in the config/statamic/stache.php, it's necessary to use these paths in the multiside command as well.