### PR TITLE
[5.x] Update "Bug Report" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,8 +24,7 @@ body:
     attributes:
       label: Environment
       description: |
-        Details about your environment. Versions of Statamic, PHP, Laravel, any addons that are installed, etc.
-        (Go ahead and just paste the output of the `php please support:details` command.)
+        Please paste the *full* output of the `php please support:details` command. It gives us some context about your project.
       render: yaml # the format of the command is close to yaml and gets highlighted nicely
     validations:
       required: true


### PR DESCRIPTION
This pull request tweaks the description of the "Environment" textare in the "Bug Report" issue template, to make it clearer that it should be the _full_ output of the command, not just the partial output.