### PR TITLE
[5.x] Add `{{ taxonomy:count }}` tag

### DIFF
--- a/src/Tags/Taxonomy/Taxonomy.php
+++ b/src/Tags/Taxonomy/Taxonomy.php
@@ -31,6 +31,14 @@ class Taxonomy extends Tags
         return $this->output($terms);
     }
 
+    /**
+     * {{ taxonomy:count from="" }}
+     */
+    public function count()
+    {
+        return $this->terms()->count();
+    }
+
     protected function terms()
     {
         return new Terms($this->params);


### PR DESCRIPTION
This PR adds a `count` method to the `taxonomy` tag. This is a simple copy of the existing `{{ collection:count }}` tag.

```antlers
{{ taxonomy:count in="categories" collection="galleries" }}
```

I needed this for the upcoming photography starter kit.