### PR TITLE
[5.x] Make sort modifier work with query builders

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2360,6 +2360,12 @@ class CoreModifiers extends Modifier
         $key = Arr::get($params, 0, 'true');
         $desc = strtolower(Arr::get($params, 1, 'asc')) == 'desc';
 
+        if (Compare::isQueryBuilder($value)) {
+            return ($key === 'random')
+                ? $value->inRandomOrder()
+                : $value->orderBy($key, Arr::get($params, 1, 'asc'));
+        }
+
         $value = $value instanceof Collection ? $value : collect($value);
 
         // Working with a DataCollection

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2358,12 +2358,13 @@ class CoreModifiers extends Modifier
     public function sort($value, $params)
     {
         $key = Arr::get($params, 0, 'true');
-        $desc = strtolower(Arr::get($params, 1, 'asc')) == 'desc';
+        $order = strtolower(Arr::get($params, 1, 'asc'));
+        $desc = $order == 'desc';
 
         if (Compare::isQueryBuilder($value)) {
             return ($key === 'random')
                 ? $value->inRandomOrder()
-                : $value->orderBy($key, Arr::get($params, 1, 'asc'));
+                : $value->orderBy($key, $order);
         }
 
         $value = $value instanceof Collection ? $value : collect($value);

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2362,9 +2362,7 @@ class CoreModifiers extends Modifier
         $desc = $order == 'desc';
 
         if (Compare::isQueryBuilder($value)) {
-            return ($key === 'random')
-                ? $value->inRandomOrder()
-                : $value->orderBy($key, $order);
+            return $key === 'random' ? $value->inRandomOrder() : $value->orderBy($key, $order);
         }
 
         $value = $value instanceof Collection ? $value : collect($value);


### PR DESCRIPTION
This PR adds support for query builders to the `sort` modifier. I ran into this on a collection term details page where I wanted to sort the entries by title.

Now you can do this:
```antlers
<a-components.galleries-grid :entries="entries | sort('title')" />
```

Also needed this for the photography starter kit.