### PR TITLE
[5.x] Prevent protected pages being cached

### DIFF
--- a/src/Auth/Protect/Protection.php
+++ b/src/Auth/Protect/Protection.php
@@ -67,6 +67,8 @@ class Protection
             ->setUrl($this->url())
             ->setData($this->data())
             ->protect();
+
+        return $this->scheme() !== null;
     }
 
     protected function url()

--- a/src/Auth/Protect/Protection.php
+++ b/src/Auth/Protect/Protection.php
@@ -67,8 +67,6 @@ class Protection
             ->setUrl($this->url())
             ->setData($this->data())
             ->protect();
-
-        return $this->scheme() !== null;
     }
 
     protected function url()

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -91,11 +91,11 @@ class DataResponse implements Responsable
 
     protected function protect()
     {
-        $isProtected = app(Protection::class)
-            ->setData($this->data)
-            ->protect();
+        $protection = app(Protection::class)->setData($this->data);
 
-        if ($isProtected) {
+        $protection->protect();
+
+        if ($protection->scheme()) {
             $this->headers['X-Statamic-Protected'] = true;
         }
 

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -91,9 +91,13 @@ class DataResponse implements Responsable
 
     protected function protect()
     {
-        app(Protection::class)
+        $isProtected = app(Protection::class)
             ->setData($this->data)
             ->protect();
+
+        if ($isProtected) {
+            $this->headers['X-Statamic-Protected'] = true;
+        }
 
         return $this;
     }

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -179,8 +179,12 @@ class Cache
             return false;
         }
 
-        // Draft and private pages should not be cached.
-        if ($response->headers->has('X-Statamic-Draft') || $response->headers->has('X-Statamic-Private')) {
+        // Draft, private and protected pages should not be cached.
+        if (
+            $response->headers->has('X-Statamic-Draft')
+            || $response->headers->has('X-Statamic-Private')
+            || $response->headers->has('X-Statamic-Protected')
+        ) {
             return false;
         }
 

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -355,6 +355,19 @@ class FrontendTest extends TestCase
     }
 
     #[Test]
+    public function header_is_added_to_protected_responses()
+    {
+        $page = $this->createPage('about');
+        $page->set('protect', 'logged_in')->save();
+
+        $this
+            ->actingAs(User::make())
+            ->get('/about')
+            ->assertOk()
+            ->assertHeader('X-Statamic-Protected', true);
+    }
+
+    #[Test]
     public function key_variables_key_added()
     {
         $page = $this->createPage('about');

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -358,6 +358,12 @@ class FrontendTest extends TestCase
     public function header_is_added_to_protected_responses()
     {
         $page = $this->createPage('about');
+
+        $this
+            ->get('/about')
+            ->assertOk()
+            ->assertHeaderMissing('X-Statamic-Protected');
+
         $page->set('protect', 'logged_in')->save();
 
         $this


### PR DESCRIPTION
This pull request fixes an issue where protected pages would be staticly cached, unless manually excluded in the `static_caching.php` config file.

Closes statamic/ideas#190.