### PR TITLE
[5.x] Fix text direction in the Markdown fieldtype when using RTL mode

### DIFF
--- a/resources/css/vendors/codemirror.css
+++ b/resources/css/vendors/codemirror.css
@@ -270,8 +270,6 @@
 
   .CodeMirror-widget {}
 
-  .CodeMirror-rtl pre { direction: ltr; }
-
   .CodeMirror-code {
     outline: none;
   }


### PR DESCRIPTION
This pull request fixes an issue with the Markdown fieldtype when using the Control Panel with an RTL locale, like Persian. 

I've fixed this by removing a CSS rule which was causing the text to show left-to-right, even when the CP is in right-to-left mode. 

This CSS rule was updated in #9447. Maybe there's a reason for it... but it doesn't match how other fieldtypes (like the Textarea fieldtype) handle RTL.

Fixes #10928.