### PR TITLE
[5.x] Only show the sync/de-synced state for syncable fields

### DIFF
--- a/resources/js/components/publish/Sections.vue
+++ b/resources/js/components/publish/Sections.vue
@@ -12,6 +12,7 @@
                     :fields="section.fields"
                     :read-only="readOnly"
                     :syncable="syncable"
+                    :syncable-fields="syncableFields"
                     @updated="(handle, value) => $emit('updated', handle, value)"
                     @meta-updated="(handle, value) => $emit('meta-updated', handle, value)"
                     @synced="$emit('synced', $event)"


### PR DESCRIPTION
This pull request fixes an issue where the synced/de-synced state was showing for fields that weren't on the linked entry's blueprint.

Fixes #10930.