### PR TITLE
[5.x] Allow sorting folders in asset browser

### DIFF
--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -97,6 +97,17 @@ class AssetFolder implements Arrayable, Contract
         return $date;
     }
 
+    public function size()
+    {
+        $size = 0;
+
+        foreach ($this->assets() as $asset) {
+            $size += $asset->size();
+        }
+
+        return $size;
+    }
+
     public function save()
     {
         $this->disk()->put($this->path().'/.gitkeep', '');

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\CP\Assets;
 
 use Illuminate\Http\Request;
 use Illuminate\Pagination\Paginator;
+use Statamic\Assets\AssetFolder;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
 use Statamic\Exceptions\AuthorizationException;
 use Statamic\Facades\Asset;
@@ -91,6 +92,16 @@ class BrowserController extends CpController
             $query = $folder->queryAssets();
 
             if ($request->sort) {
+                $sortByMethod = $request->order === 'desc' ? 'sortByDesc' : 'sortBy';
+
+                $folders = $folders->$sortByMethod(function (AssetFolder $folder) use ($request) {
+                    return match ($request->sort) {
+                        'basename' => $folder->basename(),
+                        'last_modified' => $folder->lastModified(),
+                        default => $folder->basename(),
+                    };
+                });
+
                 $query->orderBy($request->sort, $request->order ?? 'asc');
             } else {
                 $query->orderBy($container->sortField(), $container->sortDirection());

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -95,12 +95,9 @@ class BrowserController extends CpController
                 $sortByMethod = $request->order === 'desc' ? 'sortByDesc' : 'sortBy';
 
                 $folders = $folders->$sortByMethod(function (AssetFolder $folder) use ($request) {
-                    return match ($request->sort) {
-                        'basename' => $folder->basename(),
-                        'size' => $folder->size(),
-                        'last_modified' => $folder->lastModified(),
-                        default => $folder->basename(),
-                    };
+                    $method = $request->sort;
+
+                    return method_exists($folder, $method) ? $folder->$method() : $folder->basename();
                 });
 
                 $query->orderBy($request->sort, $request->order ?? 'asc');

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -97,6 +97,7 @@ class BrowserController extends CpController
                 $folders = $folders->$sortByMethod(function (AssetFolder $folder) use ($request) {
                     return match ($request->sort) {
                         'basename' => $folder->basename(),
+                        'size' => $folder->size(),
                         'last_modified' => $folder->lastModified(),
                         default => $folder->basename(),
                     };

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -91,18 +91,24 @@ class BrowserController extends CpController
         if ($page >= $lastFolderPage) {
             $query = $folder->queryAssets();
 
-            if ($request->sort) {
+            if ($sort = $request->sort) {
                 $sortByMethod = $request->order === 'desc' ? 'sortByDesc' : 'sortBy';
 
-                $folders = $folders->$sortByMethod(function (AssetFolder $folder) use ($request) {
-                    $method = $request->sort;
-
-                    return method_exists($folder, $method) ? $folder->$method() : $folder->basename();
-                });
+                $folders = $folders->$sortByMethod(
+                    fn (AssetFolder $folder) => method_exists($folder, $sort) ? $folder->$sort() : $folder->basename()
+                );
 
                 $query->orderBy($request->sort, $request->order ?? 'asc');
             } else {
-                $query->orderBy($container->sortField(), $container->sortDirection());
+                $sort = $container->sortField();
+                $order = $container->sortDirection();
+                $sortByMethod = $request->order === 'desc' ? 'sortByDesc' : 'sortBy';
+
+                $folders = $folders->$sortByMethod(
+                    fn (AssetFolder $folder) => method_exists($folder, $sort) ? $folder->$sort() : $folder->basename()
+                );
+
+                $query->orderBy($sort, $order);
             }
 
             $this->applyQueryScopes($query, $request->all());


### PR DESCRIPTION
This pull request makes it possible to sort folders in the Asset Browser. Previously, changing the sort order wouldn't have any affect on folders.

Closes #10919.