### PR TITLE
[5.x] Fix ordering search results by date

### DIFF
--- a/src/Search/Result.php
+++ b/src/Search/Result.php
@@ -132,7 +132,7 @@ class Result implements ContainsQueryableValues, Contract
 
     public function get($key, $fallback = null)
     {
-        if ($key === 'date') {
+        if ($key === 'date' && method_exists($this->searchable, 'date')) {
             return $this->searchable->date();
         }
 

--- a/src/Search/Result.php
+++ b/src/Search/Result.php
@@ -132,6 +132,10 @@ class Result implements ContainsQueryableValues, Contract
 
     public function get($key, $fallback = null)
     {
+        if ($key === 'date') {
+            return $this->searchable->date();
+        }
+
         return $this->searchable->get($key, $fallback);
     }
 


### PR DESCRIPTION
This pull request fixes an issue where it wasn't possible to order entry search results by `date`.

Essentially, when you order search results, it uses the `DataCollection::multisort()` method to perform the ordering. As part of that, it tries to get the value of the `date` field using this code below:

https://github.com/statamic/cms/blob/7bf2816e97d40a081c366d64b383711371140f12/src/Data/DataCollection.php#L99-L101

The `->get()` here defers to the `Result::get()` method, which will do `->get('date')` on the entry. However, since dates aren't part of an entry's data, it was trying to order results by `null`.

This PR fixes that by checking if the `$key` is `date` and deferring to the entry's `date` method instead.

Fixes #10892.