### PR TITLE
[5.x] Auto-load from `src/Filters`

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -255,6 +255,7 @@ abstract class AddonServiceProvider extends ServiceProvider
     {
         $scopes = collect($this->scopes)
             ->merge($this->autoloadFilesFromFolder('Scopes', Scope::class))
+            ->merge($this->autoloadFilesFromFolder('Filters', Scope::class))
             ->unique();
 
         foreach ($scopes as $class) {


### PR DESCRIPTION
This pull request allows for Filters to be autoloaded from an addon's `src/Filters` directory, rather than having to live in `src/Scopes`.