### PR TITLE
[5.x] Improve UX of rename asset action

### DIFF
--- a/src/Actions/RenameAsset.php
+++ b/src/Actions/RenameAsset.php
@@ -54,6 +54,7 @@ class RenameAsset extends Action
                 'default' => $value = $this->items->containsOneItem() ? $this->items->first()->filename() : null,
                 'placeholder' => $value,
                 'debounce' => false,
+                'autoselect' => true,
             ],
         ];
     }

--- a/src/Actions/RenameAsset.php
+++ b/src/Actions/RenameAsset.php
@@ -51,7 +51,8 @@ class RenameAsset extends Action
                 'validate' => 'required', // TODO: Better filename validation
                 'classes' => 'mousetrap',
                 'focus' => true,
-                'placeholder' => $this->items->containsOneItem() ? $this->items->first()->filename() : null,
+                'default' => $value = $this->items->containsOneItem() ? $this->items->first()->filename() : null,
+                'placeholder' => $value,
                 'debounce' => false,
             ],
         ];


### PR DESCRIPTION
When using the Rename Asset action, the value will now be prepopulated and autoselected, allowing you to immediately type. This is very handy if you only need to tweak a character for example, which is a common reason to rename an asset. You no longer need to retype the whole filename.