### PR TITLE
[5.x] `make:` commands dont need to register addon components

### DIFF
--- a/src/Console/Commands/MakeAction.php
+++ b/src/Console/Commands/MakeAction.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\Console\Commands;
 
-use Archetype\Facades\PHPFile;
-use PhpParser\BuilderFactory;
 use Statamic\Console\RunsInPlease;
 
 class MakeAction extends GeneratorCommand
@@ -37,38 +35,4 @@ class MakeAction extends GeneratorCommand
      * @var string
      */
     protected $stub = 'action.php.stub';
-
-    /**
-     * Execute the console command.
-     *
-     * @return bool|null
-     */
-    public function handle()
-    {
-        if (parent::handle() === false) {
-            return false;
-        }
-
-        if ($this->argument('addon')) {
-            $this->updateServiceProvider();
-        }
-    }
-
-    /**
-     * Update the Service Provider to register the Action component.
-     */
-    protected function updateServiceProvider()
-    {
-        $factory = new BuilderFactory();
-
-        $actionClassValue = $factory->classConstFetch('Actions\\'.$this->getNameInput(), 'class');
-
-        try {
-            PHPFile::load("addons/{$this->package}/src/ServiceProvider.php")
-                ->add()->protected()->property('actions', $actionClassValue)
-                ->save();
-        } catch (\Exception $e) {
-            $this->comment("Don't forget to register the Action class in your addon's service provider.");
-        }
-    }
 }

--- a/src/Console/Commands/MakeDictionary.php
+++ b/src/Console/Commands/MakeDictionary.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\Console\Commands;
 
-use Archetype\Facades\PHPFile;
-use PhpParser\BuilderFactory;
 use Statamic\Console\RunsInPlease;
 
 class MakeDictionary extends GeneratorCommand
@@ -47,28 +45,6 @@ class MakeDictionary extends GeneratorCommand
     {
         if (parent::handle() === false) {
             return false;
-        }
-
-        if ($this->argument('addon')) {
-            $this->updateServiceProvider();
-        }
-    }
-
-    /**
-     * Update the Service Provider to register dictionary components.
-     */
-    protected function updateServiceProvider()
-    {
-        $factory = new BuilderFactory();
-
-        $dictionaryClassValue = $factory->classConstFetch('Dictionaries\\'.$this->getNameInput(), 'class');
-
-        try {
-            PHPFile::load("addons/{$this->package}/src/ServiceProvider.php")
-                ->add()->protected()->property('dictionaries', $dictionaryClassValue)
-                ->save();
-        } catch (\Exception $e) {
-            $this->comment("Don't forget to register the Dictionary class in your addon's service provider.");
         }
     }
 }

--- a/src/Console/Commands/MakeFieldtype.php
+++ b/src/Console/Commands/MakeFieldtype.php
@@ -3,7 +3,6 @@
 namespace Statamic\Console\Commands;
 
 use Archetype\Facades\PHPFile;
-use PhpParser\BuilderFactory;
 use Statamic\Console\RunsInPlease;
 use Statamic\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
@@ -148,20 +147,15 @@ class MakeFieldtype extends GeneratorCommand
      */
     protected function updateServiceProvider()
     {
-        $factory = new BuilderFactory();
-
-        $fieldtypeClassValue = $factory->classConstFetch('Fieldtypes\\'.$this->getNameInput(), 'class');
-
         try {
             PHPFile::load("addons/{$this->package}/src/ServiceProvider.php")
                 ->add()->protected()->property('vite', [
                     'input' => ['resources/js/addon.js'],
                     'publicDirectory' => 'resources/dist',
                 ])
-                ->add()->protected()->property('fieldtypes', $fieldtypeClassValue)
                 ->save();
         } catch (\Exception $e) {
-            $this->comment("Don't forget to register the Fieldtype class and scripts in your addon's service provider.");
+            $this->comment("Don't forget to configure Vite in your addon's service provider.");
         }
     }
 

--- a/src/Console/Commands/MakeFilter.php
+++ b/src/Console/Commands/MakeFilter.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\Console\Commands;
 
-use Archetype\Facades\PHPFile;
-use PhpParser\BuilderFactory;
 use Statamic\Console\RunsInPlease;
 
 class MakeFilter extends GeneratorCommand
@@ -37,38 +35,4 @@ class MakeFilter extends GeneratorCommand
      * @var string
      */
     protected $stub = 'filter.php.stub';
-
-    /**
-     * Execute the console command.
-     *
-     * @return bool|null
-     */
-    public function handle()
-    {
-        if (parent::handle() === false) {
-            return false;
-        }
-
-        if ($this->argument('addon')) {
-            $this->updateServiceProvider();
-        }
-    }
-
-    /**
-     * Update the Service Provider to register the Filter component.
-     */
-    protected function updateServiceProvider()
-    {
-        $factory = new BuilderFactory();
-
-        $filterClassValue = $factory->classConstFetch('Filters\\'.$this->getNameInput(), 'class');
-
-        try {
-            PHPFile::load("addons/{$this->package}/src/ServiceProvider.php")
-                ->add()->protected()->property('filters', $filterClassValue)
-                ->save();
-        } catch (\Exception $e) {
-            $this->comment("Don't forget to register the Filter class in your addon's service provider.");
-        }
-    }
 }

--- a/src/Console/Commands/MakeModifier.php
+++ b/src/Console/Commands/MakeModifier.php
@@ -37,38 +37,4 @@ class MakeModifier extends GeneratorCommand
      * @var string
      */
     protected $stub = 'modifier.php.stub';
-
-    /**
-     * Execute the console command.
-     *
-     * @return bool|null
-     */
-    public function handle()
-    {
-        if (parent::handle() === false) {
-            return false;
-        }
-
-        if ($this->argument('addon')) {
-            $this->updateServiceProvider();
-        }
-    }
-
-    /**
-     * Update the Service Provider to register fieldtype components.
-     */
-    protected function updateServiceProvider()
-    {
-        $factory = new BuilderFactory();
-
-        $modifierClassValue = $factory->classConstFetch('Modifiers\\'.$this->getNameInput(), 'class');
-
-        try {
-            PHPFile::load("addons/{$this->package}/src/ServiceProvider.php")
-                ->add()->protected()->property('modifiers', $modifierClassValue)
-                ->save();
-        } catch (\Exception $e) {
-            $this->comment("Don't forget to register the Modifier class in your addon's service provider.");
-        }
-    }
 }

--- a/src/Console/Commands/MakeModifier.php
+++ b/src/Console/Commands/MakeModifier.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\Console\Commands;
 
-use Archetype\Facades\PHPFile;
-use PhpParser\BuilderFactory;
 use Statamic\Console\RunsInPlease;
 
 class MakeModifier extends GeneratorCommand

--- a/src/Console/Commands/MakeScope.php
+++ b/src/Console/Commands/MakeScope.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\Console\Commands;
 
-use Archetype\Facades\PHPFile;
-use PhpParser\BuilderFactory;
 use Statamic\Console\RunsInPlease;
 
 class MakeScope extends GeneratorCommand

--- a/src/Console/Commands/MakeScope.php
+++ b/src/Console/Commands/MakeScope.php
@@ -37,38 +37,4 @@ class MakeScope extends GeneratorCommand
      * @var string
      */
     protected $stub = 'scope.php.stub';
-
-    /**
-     * Execute the console command.
-     *
-     * @return bool|null
-     */
-    public function handle()
-    {
-        if (parent::handle() === false) {
-            return false;
-        }
-
-        if ($this->argument('addon')) {
-            $this->updateServiceProvider();
-        }
-    }
-
-    /**
-     * Update the Service Provider to register the scope component.
-     */
-    protected function updateServiceProvider()
-    {
-        $factory = new BuilderFactory();
-
-        $scopeClassValue = $factory->classConstFetch('Scopes\\'.$this->getNameInput(), 'class');
-
-        try {
-            PHPFile::load("addons/{$this->package}/src/ServiceProvider.php")
-                ->add()->protected()->property('scopes', $scopeClassValue)
-                ->save();
-        } catch (\Exception $e) {
-            $this->comment("Don't forget to register the Scope class in your addon's service provider.");
-        }
-    }
 }

--- a/src/Console/Commands/MakeTag.php
+++ b/src/Console/Commands/MakeTag.php
@@ -40,40 +40,6 @@ class MakeTag extends GeneratorCommand
     protected $stub = 'tag.php.stub';
 
     /**
-     * Execute the console command.
-     *
-     * @return bool|null
-     */
-    public function handle()
-    {
-        if (parent::handle() === false) {
-            return false;
-        }
-
-        if ($this->argument('addon')) {
-            $this->updateServiceProvider();
-        }
-    }
-
-    /**
-     * Update the Service Provider to register the Tag component.
-     */
-    protected function updateServiceProvider()
-    {
-        $factory = new BuilderFactory();
-
-        $tagsClassValue = $factory->classConstFetch('Tags\\'.$this->getNameInput(), 'class');
-
-        try {
-            PHPFile::load("addons/{$this->package}/src/ServiceProvider.php")
-                ->add()->protected()->property('tags', $tagsClassValue)
-                ->save();
-        } catch (\Exception $e) {
-            $this->comment("Don't forget to register the Tag class in your addon's service provider.");
-        }
-    }
-
-    /**
      * Build the class with the given name.
      *
      * @param  string  $name

--- a/src/Console/Commands/MakeTag.php
+++ b/src/Console/Commands/MakeTag.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\Console\Commands;
 
-use Archetype\Facades\PHPFile;
-use PhpParser\BuilderFactory;
 use Statamic\Console\RunsInPlease;
 use Statamic\Support\Str;
 

--- a/src/Console/Commands/MakeWidget.php
+++ b/src/Console/Commands/MakeWidget.php
@@ -51,10 +51,6 @@ class MakeWidget extends GeneratorCommand
         }
 
         $this->generateWidgetView();
-
-        if ($this->argument('addon')) {
-            $this->updateServiceProvider();
-        }
     }
 
     /**
@@ -78,24 +74,6 @@ class MakeWidget extends GeneratorCommand
             $path."/resources/views/widgets/{$filename}.blade.php",
             $data
         );
-    }
-
-    /**
-     * Update the Service Provider to register the widget component.
-     */
-    protected function updateServiceProvider()
-    {
-        $factory = new BuilderFactory();
-
-        $widgetClassValue = $factory->classConstFetch('Widgets\\'.$this->getNameInput(), 'class');
-
-        try {
-            PHPFile::load("addons/{$this->package}/src/ServiceProvider.php")
-                ->add()->protected()->property('widgets', $widgetClassValue)
-                ->save();
-        } catch (\Exception $e) {
-            $this->info("Don't forget to register the Widget class in your addon's service provider.");
-        }
     }
 
     /**

--- a/src/Console/Commands/MakeWidget.php
+++ b/src/Console/Commands/MakeWidget.php
@@ -2,8 +2,6 @@
 
 namespace Statamic\Console\Commands;
 
-use Archetype\Facades\PHPFile;
-use PhpParser\BuilderFactory;
 use Statamic\Console\RunsInPlease;
 use Statamic\Support\Str;
 


### PR DESCRIPTION
Now that addon "components" are being autoloaded behind the scenes by Statamic, we don't need to be manually setting the protected properties on addon service providers anymore.