### PR TITLE
[5.x] Fix errors in upload queue

### DIFF
--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -170,9 +170,11 @@ export default {
         },
 
         processUploadQueue() {
-            if (this.uploads.length === 0) return;
+            const uploads = this.uploads.filter(u => !u.errorMessage);
 
-            const upload = this.uploads[0];
+            if (uploads.length === 0) return;
+
+            const upload = uploads[0];
             const id = upload.id;
 
             upload.instance.upload().then(response => {


### PR DESCRIPTION
When you use the uploader (for example, in the asset browser) and one file error is, any subsequent erroring files will just sit there and spin and not show their own errors. Or rather, the first erroring file will have its error message updated with the next error, although its usually the same message so you don't notice.

This is because the upload queue always tries to grab the first upload in the queue, even if it has errored.

This PR makes it so that it will grab the next non-erroring upload in the queue.
