### PR TITLE
[5.x] Fix issue if submitted password is null

### DIFF
--- a/src/Auth/Protect/Protectors/Password/Controller.php
+++ b/src/Auth/Protect/Protectors/Password/Controller.php
@@ -33,7 +33,7 @@ class Controller extends BaseController
             return back()->withErrors(['token' => __('statamic::messages.password_protect_token_invalid')], 'passwordProtect');
         }
 
-        if (! $this->driver()->isValidPassword($this->password)) {
+        if (is_null($this->password) || ! $this->driver()->isValidPassword($this->password)) {
             return back()->withErrors(['password' => __('statamic::messages.password_protect_incorrect_password')], 'passwordProtect');
         }
 

--- a/src/Auth/Protect/Protectors/Password/PasswordProtector.php
+++ b/src/Auth/Protect/Protectors/Password/PasswordProtector.php
@@ -66,17 +66,17 @@ class PasswordProtector extends Protector
         return false;
     }
 
-    public function isValidPassword(string $password): bool
+    public function isValidPassword(?string $password): bool
     {
         return $this->isValidSchemePassword($password) || $this->isValidLocalPassword($password);
     }
 
-    public function isValidSchemePassword(string $password): bool
+    public function isValidSchemePassword(?string $password): bool
     {
         return in_array($password, $this->schemePasswords());
     }
 
-    public function isValidLocalPassword(string $password): bool
+    public function isValidLocalPassword(?string $password): bool
     {
         return in_array($password, $this->localPasswords());
     }

--- a/src/Auth/Protect/Protectors/Password/PasswordProtector.php
+++ b/src/Auth/Protect/Protectors/Password/PasswordProtector.php
@@ -66,17 +66,17 @@ class PasswordProtector extends Protector
         return false;
     }
 
-    public function isValidPassword(?string $password): bool
+    public function isValidPassword(string $password): bool
     {
         return $this->isValidSchemePassword($password) || $this->isValidLocalPassword($password);
     }
 
-    public function isValidSchemePassword(?string $password): bool
+    public function isValidSchemePassword(string $password): bool
     {
         return in_array($password, $this->schemePasswords());
     }
 
-    public function isValidLocalPassword(?string $password): bool
+    public function isValidLocalPassword(string $password): bool
     {
         return in_array($password, $this->localPasswords());
     }


### PR DESCRIPTION
This PR resolves an issue that would occur if you clicked the submit button on the password protect page without having entered a password.

**Issue before PR**

![CleanShot 2024-10-12 at 18 04 46@2x](https://github.com/user-attachments/assets/7e985b2e-a132-4894-8ed4-69b461e7363f)

**After PR**

![CleanShot 2024-10-12 at 18 05 17@2x](https://github.com/user-attachments/assets/4d4f55d7-4d60-4fbb-9fbf-55af8c9ed29a)
