### PR TITLE
[5.x] Make data of password-protected available in the view

### DIFF
--- a/src/Auth/Protect/Protectors/Password/Controller.php
+++ b/src/Auth/Protect/Protectors/Password/Controller.php
@@ -17,11 +17,12 @@ class Controller extends BaseController
     {
         if ($this->tokenData = session('statamic:protect:password.tokens.'.request('token'))) {
             $site = Site::findByUrl($this->getUrl());
+            $data = Data::find($this->tokenData['reference']);
 
             app()->setLocale($site->lang());
         }
 
-        return View::make('statamic::auth.protect.password');
+        return View::make('statamic::auth.protect.password')->cascadeContent($data ?? null);
     }
 
     public function store()


### PR DESCRIPTION
This PR makes the data of a password-protected page available in the view. This is useful in situations like the following example, where you want to show things like a title or images.

![CleanShot 2024-10-12 at 20 19 34@2x](https://github.com/user-attachments/assets/2d97b904-07da-4edf-985e-6a8bfbe99bbc)
