### PR TITLE
[5.x] Throw 401 on password protected page

### DIFF
--- a/src/Auth/Protect/Protectors/Password/Controller.php
+++ b/src/Auth/Protect/Protectors/Password/Controller.php
@@ -15,13 +15,14 @@ class Controller extends BaseController
 
     public function show()
     {
-        if ($this->tokenData = session('statamic:protect:password.tokens.'.request('token'))) {
-            $site = Site::findByUrl($this->getUrl());
-
-            app()->setLocale($site->lang());
+        if (! $this->tokenData = session('statamic:protect:password.tokens.'.request('token'))) {
+            abort(401);
         }
 
-        return View::make('statamic::auth.protect.password');
+        app()->setLocale(Site::findByUrl($this->getUrl())->lang());
+
+        return View::make('statamic::auth.protect.password')
+            ->cascadeContent(Data::find($this->tokenData['reference']));
     }
 
     public function store()


### PR DESCRIPTION
When working on a custom password-protected page design, I noticed that the flow felt a little off if a token is invalid or missing. It's [common practice for signed URLs](https://laravel.com/docs/11.x/urls#validating-signed-route-requests) to throw a `401` if the signature is invalid.

I understand that there's the `no_token` variable that can be used to display a message if the token is missing. However, it still feels a little weird to show a message to the user instead of aborting. Also, the current approach doesn't handle situations where a token is invalid. It only handles situations where the token parameter is missing altogether.

This PR is technically a breaking change and should probably target Statamic 6.x.

A non-breaking change could be implemented with a new `abort` tag and throwing it in the view instead.

```antlers
{{ if no_token }}
    {{ abort:401 }}
{{ /if }}
```