### PR TITLE
[5.x] Fix asset browser history navigation

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -453,6 +453,10 @@ export default {
             this.loadAssets();
         },
 
+        selectedPath(selectedPath) {
+            this.path = selectedPath;
+        },
+
         parameters(after, before) {
             if (this.initializing || JSON.stringify(before) === JSON.stringify(after)) return;
             this.loadAssets();


### PR DESCRIPTION
History navigation currently doesn't work inside the asset browser. Going back and forth updates the url and shows a loading indicator, but it doesn't update the current folder or its contents. This PR re-enables it by watching the selected path prop and updating the current path from the watcher whenever the passed-in path changes.

Closes #10920