### PR TITLE
[5.x] Make email config data accessible in email templates

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -160,6 +160,7 @@ class Email extends Mailable
             });
 
         $data = array_merge($augmented, $this->getGlobalsData(), [
+            'email_config' => $this->config,
             'config' => config()->all(),
             'fields' => $fields,
             'site_url' => Config::getSiteUrl(),

--- a/tests/Forms/EmailTest.php
+++ b/tests/Forms/EmailTest.php
@@ -149,6 +149,7 @@ class EmailTest extends TestCase
             'social',
 
             // manual "system" vars added to email
+            'email_config',
             'config',
             'date',
             'fields',


### PR DESCRIPTION
In some of our projects, we are using some of the form email configuration data in the email content. (Specifically, we added a custom field that lets us set email content in this configuration---however you may also consider using the email subject, for example).

Before a recent Laravel update (11.16.0 to be exact), we were able to get the right data in a sort of hacky way. However, this doesn't work anymore as a side effect of a small change in the Laravel mailer where the email data only gets built after setting the content, rather than before.

This small change fixes our *very* specific use case when having more than 1 email for a form active and wanting to use some of the email configuration fields inside of those emails' content :)