### PR TITLE
[5.x] Improve UX of rename asset folder action

### DIFF
--- a/src/Actions/RenameAssetFolder.php
+++ b/src/Actions/RenameAssetFolder.php
@@ -47,7 +47,10 @@ class RenameAssetFolder extends Action
                 'validate' => ['required', 'string', new AlphaDashSpace],
                 'classes' => 'mousetrap',
                 'focus' => true,
+                'default' => $value = $this->items->containsOneItem() ? $this->items->first()->basename() : null,
+                'placeholder' => $value,
                 'debounce' => false,
+                'autoselect' => true,
             ],
         ];
     }

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Pagination\Paginator;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
 use Statamic\Exceptions\AuthorizationException;
+use Statamic\Facades\Action;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Scope;
 use Statamic\Facades\User;
@@ -112,7 +113,14 @@ class BrowserController extends CpController
             'data' => [
                 'assets' => FolderAsset::collection($assets ?? collect())->resolve(),
                 'folder' => array_merge((new Folder($folder))->resolve(), [
-                    'folders' => $folders->values(),
+                    'folders' => $folders->values()->map(function ($folder) use ($container) {
+                        return array_merge($folder->toArray(), [
+                            'actions' => Action::for($folder, [
+                                'container' => $container->handle(),
+                                'folder' => $folder->path(),
+                            ]),
+                        ]);
+                    }),
                 ]),
             ],
             'links' => [

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 use Illuminate\Pagination\Paginator;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
 use Statamic\Exceptions\AuthorizationException;
-use Statamic\Facades\Action;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Scope;
 use Statamic\Facades\User;
@@ -113,14 +112,7 @@ class BrowserController extends CpController
             'data' => [
                 'assets' => FolderAsset::collection($assets ?? collect())->resolve(),
                 'folder' => array_merge((new Folder($folder))->resolve(), [
-                    'folders' => $folders->values()->map(function ($folder) use ($container) {
-                        return array_merge($folder->toArray(), [
-                            'actions' => Action::for($folder, [
-                                'container' => $container->handle(),
-                                'folder' => $folder->path(),
-                            ]),
-                        ]);
-                    }),
+                    'folders' => Folder::collection($folders->values()),
                 ]),
             ],
             'links' => [


### PR DESCRIPTION
Following on from #10941, this PR will autopopulate the current name of a folder when using the "Rename Folder" action.

This PR also fixes an issue where actions weren't being returned for individual folders, only for the "current" folder. This was probably caused by #10419.