### PR TITLE
[5.x] Prompt for license when installing starter kit

### DIFF
--- a/src/Console/Commands/StarterKitInstall.php
+++ b/src/Console/Commands/StarterKitInstall.php
@@ -52,7 +52,7 @@ class StarterKitInstall extends Command
             return;
         }
 
-        $licenseManager = StarterKitLicenseManager::validate($package, $this->option('license'), $this);
+        $licenseManager = StarterKitLicenseManager::validate($package, $this->option('license'), $this, $this->input->isInteractive());
 
         if (! $licenseManager->isValid()) {
             return;

--- a/src/StarterKits/LicenseManager.php
+++ b/src/StarterKits/LicenseManager.php
@@ -6,6 +6,8 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Http;
 use Statamic\Console\NullConsole;
 
+use function Laravel\Prompts\text;
+
 final class LicenseManager
 {
     const OUTPOST_ENDPOINT = 'https://outpost.statamic.com/v3/starter-kits/';

--- a/src/StarterKits/LicenseManager.php
+++ b/src/StarterKits/LicenseManager.php
@@ -13,25 +13,27 @@ final class LicenseManager
     private $package;
     private $licenseKey;
     private $console;
+    private $isInteractive;
     private $details;
     private $valid = false;
 
     /**
      * Instantiate starter kit license manager.
      */
-    public function __construct(string $package, ?string $licenseKey = null, ?Command $console = null)
+    public function __construct(string $package, ?string $licenseKey = null, ?Command $console = null, bool $isInteractive = false)
     {
         $this->package = $package;
         $this->licenseKey = $licenseKey ?? config('statamic.system.license_key');
         $this->console = $console ?? new NullConsole;
+        $this->isInteractive = $isInteractive;
     }
 
     /**
      * Instantiate starter kit license manager.
      */
-    public static function validate(string $package, ?string $licenceKey = null, ?Command $console = null): self
+    public static function validate(string $package, ?string $licenceKey = null, ?Command $console = null, bool $isInteractive = false): self
     {
-        return (new self($package, $licenceKey, $console))->performValidation();
+        return (new self($package, $licenceKey, $console, $isInteractive))->performValidation();
     }
 
     /**
@@ -74,10 +76,18 @@ final class LicenseManager
         $marketplaceUrl = "https://statamic.com/starter-kits/{$sellerSlug}/{$kitSlug}";
 
         if (! $this->licenseKey) {
-            return $this
-                ->error("License required for [{$this->package}]!")
+            if (! $this->isInteractive) {
+                return $this
+                    ->error("License required for [{$this->package}]!")
+                    ->comment('This is a paid starter kit. If you haven\'t already, you may purchase a license at:')
+                    ->comment($marketplaceUrl);
+            }
+
+            $this
                 ->comment('This is a paid starter kit. If you haven\'t already, you may purchase a license at:')
                 ->comment($marketplaceUrl);
+
+            $this->licenseKey = text('Please enter your license key', required: true);
         }
 
         if ($this->outpostValidatesLicense()) {


### PR DESCRIPTION
Currently, when you try to install a paid starter kit into an existing site *without* the `--license` parameter, it'll error out:

![CleanShot 2024-10-14 at 12 50 29](https://github.com/user-attachments/assets/1ca9748a-fbc8-4d2b-9bd8-89a41804a3a8)

However, I thought it'd be nice if it could prompt you for your license key instead of erroring out straight away:

![CleanShot 2024-10-14 at 12 49 44](https://github.com/user-attachments/assets/6401d34b-1bc8-4bbf-9cdd-2e7bdebcab14)

Inspired by https://github.com/statamic/docs/issues/1480.