### PR TITLE
[5.x] Tweak `make:` command descriptions

### DIFF
--- a/src/Console/Commands/MakeDictionary.php
+++ b/src/Console/Commands/MakeDictionary.php
@@ -22,7 +22,7 @@ class MakeDictionary extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Create a new dictionary addon';
+    protected $description = 'Create a new dictionary';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/MakeFieldtype.php
+++ b/src/Console/Commands/MakeFieldtype.php
@@ -24,7 +24,7 @@ class MakeFieldtype extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Create a new fieldtype addon';
+    protected $description = 'Create a new fieldtype';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/MakeFilter.php
+++ b/src/Console/Commands/MakeFilter.php
@@ -22,7 +22,7 @@ class MakeFilter extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Create a new filter addon';
+    protected $description = 'Create a new filter';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/MakeModifier.php
+++ b/src/Console/Commands/MakeModifier.php
@@ -22,7 +22,7 @@ class MakeModifier extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Create a new modifier addon';
+    protected $description = 'Create a new modifier';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/MakeScope.php
+++ b/src/Console/Commands/MakeScope.php
@@ -22,7 +22,7 @@ class MakeScope extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Create a new query scope addon';
+    protected $description = 'Create a new query scope';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/MakeTag.php
+++ b/src/Console/Commands/MakeTag.php
@@ -23,7 +23,7 @@ class MakeTag extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Create a new tag addon';
+    protected $description = 'Create a new tag';
 
     /**
      * The type of class being generated.

--- a/src/Console/Commands/MakeWidget.php
+++ b/src/Console/Commands/MakeWidget.php
@@ -23,7 +23,7 @@ class MakeWidget extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Create a new widget addon';
+    protected $description = 'Create a new widget';
 
     /**
      * The type of class being generated.


### PR DESCRIPTION
Some of the `make:` command descriptions mention making addons, which is left over from v2 where you had to create addons to do anything custom.