### PR TITLE
[5.x] Prevent timeout during `install:eloquent-driver` command

### DIFF
--- a/src/Console/Commands/InstallEloquentDriver.php
+++ b/src/Console/Commands/InstallEloquentDriver.php
@@ -652,7 +652,7 @@ class InstallEloquentDriver extends Command
             explode(' ', $command)
         );
 
-        $result = Process::run($components, function ($type, $line) use ($writeOutput) {
+        $result = Process::forever()->run($components, function ($type, $line) use ($writeOutput) {
             if ($writeOutput) {
                 $this->output->write($line);
             }


### PR DESCRIPTION
This pull request prevents commands from timing out and causing errors during the `install:eloquent-driver` command.

The import commands can take a while to run, especially when there's a lot of existing content being imported.

Fixes statamic/eloquent-driver#364.
