### PR TITLE
[5.x] Introduce `invalid_token` variable for password protected page

### DIFF
--- a/src/Auth/Protect/Tags.php
+++ b/src/Auth/Protect/Tags.php
@@ -15,14 +15,17 @@ class Tags extends BaseTags
 
     public function passwordForm()
     {
-        if (! $token = Html::entities(request('token'))) {
+        if (! session('statamic:protect:password.tokens.'.request('token'))) {
             $data = [
                 'errors' => [],
                 'no_token' => true,
+                'invalid_token' => true,
             ];
 
             return $this->parser ? $this->parse($data) : $data;
         }
+
+        $token = Html::entities(request('token'));
 
         $errors = session('errors', new ViewErrorBag)->passwordProtect;
 


### PR DESCRIPTION
This PR replaces https://github.com/statamic/cms/pull/10947 and takes another stab at making the password protect page flow a little better. 

It introduces a new `invalid_token` variable that can be used instead of the existing `no_token` variable. Both variables are available when the token is missing or invalid. Previously, the `no_token` variable was only available when the token was missing. Functionally, both variables are the same, but `invalid_token` might make a little more sense to use.