### PR TITLE
[5.x] Enable `foreach` to work with Values

### DIFF
--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -11,6 +11,7 @@ use Statamic\Contracts\View\Antlers\Parser;
 use Statamic\Facades\Compare;
 use Statamic\Support\Str;
 use Statamic\View\Antlers\Language\Parser\DocumentTransformer;
+use Traversable;
 
 class Value implements IteratorAggregate, JsonSerializable
 {
@@ -111,7 +112,9 @@ class Value implements IteratorAggregate, JsonSerializable
     #[\ReturnTypeWillChange]
     public function getIterator()
     {
-        return new ArrayIterator($this->value());
+        $value = $this->value();
+
+        return $value instanceof Traversable ? $value : new ArrayIterator($value);
     }
 
     public function shouldParseAntlers()

--- a/src/Tags/Iterate.php
+++ b/src/Tags/Iterate.php
@@ -39,8 +39,6 @@ class Iterate extends Tags
     {
         [$keyKey, $valueKey] = $this->getKeyNames();
 
-        $items = $items instanceof Value ? $items->value() : $items;
-
         $items = collect($items)
             ->map(function ($value, $key) use ($keyKey, $valueKey) {
                 return [$keyKey => $key, $valueKey => $value];

--- a/src/Tags/Iterate.php
+++ b/src/Tags/Iterate.php
@@ -39,6 +39,8 @@ class Iterate extends Tags
     {
         [$keyKey, $valueKey] = $this->getKeyNames();
 
+        $items = $items instanceof Value ? $items->value() : $items;
+
         $items = collect($items)
             ->map(function ($value, $key) use ($keyKey, $valueKey) {
                 return [$keyKey => $key, $valueKey => $value];

--- a/tests/Fields/ValueTest.php
+++ b/tests/Fields/ValueTest.php
@@ -213,6 +213,36 @@ class ValueTest extends TestCase
             $this->assertSame(false, $value->value());
         });
     }
+
+    #[Test]
+    public function it_can_iterate()
+    {
+        $value = new Value(['alfa' => 'one', 'bravo' => 'two']);
+
+        $result = [];
+
+        foreach ($value as $key => $item) {
+            $result[] = $key.','.$item;
+        }
+
+        $this->assertEquals(['alfa,one', 'bravo,two'], $result);
+    }
+
+    #[Test]
+    public function it_can_iterate_if_value_is_already_iterable()
+    {
+        $value = new Value(
+            collect(['alfa' => 'one', 'bravo' => 'two'])
+        );
+
+        $result = [];
+
+        foreach ($value as $key => $item) {
+            $result[] = $key.','.$item;
+        }
+
+        $this->assertEquals(['alfa,one', 'bravo,two'], $result);
+    }
 }
 
 class DummyAugmentable implements \Statamic\Contracts\Data\Augmentable

--- a/tests/Tags/IterateTest.php
+++ b/tests/Tags/IterateTest.php
@@ -9,37 +9,14 @@ use Tests\TestCase;
 class IterateTest extends TestCase
 {
     #[Test]
-    public function arrays_work()
+    public function it_iterates()
     {
-        $template = '{{ foreach:group_field }}{{ key }} - {{ value }} {{ /foreach:group_field }}';
+        $template = '{{ foreach:fieldname }}<{{ key }},{{ value }}>{{ /foreach:fieldname }}';
 
-        $this->assertSame(
-            'first - One second - Two ',
-            $this->tag($template, [
-                'group_field' => [
-                    'first' => 'One',
-                    'second' => 'Two',
-                ],
-            ])
-        );
-    }
-
-    #[Test]
-    public function values_work()
-    {
-        $this->markTestSkipped('needs implementation');
-
-        $template = '{{ foreach:group_field }}{{ key }} - {{ value }} {{ /foreach:group_field }}';
-
-        $this->assertSame(
-            'first - One second - Two ',
-            $this->tag($template, [
-                'group_field' => [
-                    'first' => 'One',
-                    'second' => 'Two',
-                ],
-            ])
-        );
+        $this->assertSame('<alfa,one><bravo,two>', $this->tag($template, ['fieldname' => [
+            'alfa' => 'one',
+            'bravo' => 'two',
+        ]]));
     }
 
     private function tag($tag, $context = [])

--- a/tests/Tags/IterateTest.php
+++ b/tests/Tags/IterateTest.php
@@ -8,28 +8,42 @@ use Tests\TestCase;
 
 class IterateTest extends TestCase
 {
-    protected $data = [
-        'group_field' => [
-            'first' => 'One',
-            'second' => 'Two',
-        ],
-    ];
+    #[Test]
+    public function arrays_work()
+    {
+        $template = '{{ foreach:group_field }}{{ key }} - {{ value }} {{ /foreach:group_field }}';
+
+        $this->assertSame(
+            'first - One second - Two ',
+            $this->tag($template, [
+                'group_field' => [
+                    'first' => 'One',
+                    'second' => 'Two',
+                ],
+            ])
+        );
+    }
+
+    #[Test]
+    public function values_work()
+    {
+        $this->markTestSkipped('needs implementation');
+
+        $template = '{{ foreach:group_field }}{{ key }} - {{ value }} {{ /foreach:group_field }}';
+
+        $this->assertSame(
+            'first - One second - Two ',
+            $this->tag($template, [
+                'group_field' => [
+                    'first' => 'One',
+                    'second' => 'Two',
+                ],
+            ])
+        );
+    }
 
     private function tag($tag, $context = [])
     {
         return (string) Parse::template($tag, $context);
-    }
-
-    #[Test]
-    public function arrays_work()
-    {
-        $template = <<<'EOT'
-{{ foreach:group_field }}{{ key }} - {{ value }} {{ /foreach:group_field }}
-EOT;
-
-        $this->assertSame(
-            'first - One second - Two ',
-            $this->tag($template, $this->data)
-        );
     }
 }

--- a/tests/Tags/IterateTest.php
+++ b/tests/Tags/IterateTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Tags;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Parse;
+use Tests\TestCase;
+
+class IterateTest extends TestCase
+{
+    protected $data = [
+        'group_field' => [
+            'first' => 'One',
+            'second' => 'Two',
+        ],
+    ];
+
+    private function tag($tag, $context = [])
+    {
+        return (string) Parse::template($tag, $context);
+    }
+
+    #[Test]
+    public function arrays_work()
+    {
+        $template = <<<'EOT'
+{{ foreach:group_field }}{{ key }} - {{ value }} {{ /foreach:group_field }}
+EOT;
+
+        $this->assertSame(
+            'first - One second - Two ',
+            $this->tag($template, $this->data)
+        );
+    }
+}


### PR DESCRIPTION
Bug mentioned here: https://discord.com/channels/489818810157891584/1153390699161587823/1295310204568866877

Code that fixes this is `$items = $items instanceof Value ? $items->value() : $items;`