### PR TITLE
[5.x] Add filter_empty modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -700,6 +700,13 @@ class CoreModifiers extends Modifier
         return pathinfo($value, PATHINFO_EXTENSION);
     }
 
+    public function filter_empty($value)
+    {
+        return collect($value)
+            ->filter(fn($item) => ! empty($item))
+            ->when(is_array($value), fn($collection) => $collection->all());
+    }
+
     /**
      * Generate a link to a Favicon file.
      *

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -703,8 +703,8 @@ class CoreModifiers extends Modifier
     public function filter_empty($value)
     {
         return collect($value)
-            ->filter(fn($item) => ! empty($item))
-            ->when(is_array($value), fn($collection) => $collection->all());
+            ->filter(fn ($item) => ! empty($item))
+            ->when(is_array($value), fn ($collection) => $collection->all());
     }
 
     /**

--- a/tests/Antlers/Runtime/CoreModifiersTest.php
+++ b/tests/Antlers/Runtime/CoreModifiersTest.php
@@ -50,6 +50,18 @@ class CoreModifiersTest extends ParserTestCase
                 'hippo',
                 'hippo',
             ],
+            'filter' => $filter_data = [
+                'one',
+                '',
+                'two',
+                null,
+                'three',
+                [],
+                'four',
+                false,
+                'five',
+            ],
+            'filter_collection' => collect($filter_data),
             'complex' => [
                 [
                     'last_name' => 'Zebra',
@@ -86,6 +98,12 @@ class CoreModifiersTest extends ParserTestCase
     protected function resultOf($text)
     {
         return $this->renderString($text, $this->data, true);
+    }
+
+    public function test_filter_empty()
+    {
+        $this->assertSame("one, two, three, four, five", $this->resultOf('{{ filter | filter_empty | join(", ") }}'));
+        $this->assertSame("one, two, three, four, five", $this->resultOf('{{ filter_collection | filter_empty | join(", ") }}'));
     }
 
     public function test_starts_with_accepts_special_characters()

--- a/tests/Antlers/Runtime/CoreModifiersTest.php
+++ b/tests/Antlers/Runtime/CoreModifiersTest.php
@@ -102,8 +102,8 @@ class CoreModifiersTest extends ParserTestCase
 
     public function test_filter_empty()
     {
-        $this->assertSame("one, two, three, four, five", $this->resultOf('{{ filter | filter_empty | join(", ") }}'));
-        $this->assertSame("one, two, three, four, five", $this->resultOf('{{ filter_collection | filter_empty | join(", ") }}'));
+        $this->assertSame('one, two, three, four, five', $this->resultOf('{{ filter | filter_empty | join(", ") }}'));
+        $this->assertSame('one, two, three, four, five', $this->resultOf('{{ filter_collection | filter_empty | join(", ") }}'));
     }
 
     public function test_starts_with_accepts_special_characters()


### PR DESCRIPTION
Ran into this issue a few times and noticed a few references #7678 https://github.com/statamic/ideas/issues/1222

There are sometimes you have data that may contain empty strings, null values, or empty arrays.  In these cases it would be nice to be able to filter out these empty values similar to the `collect()->filter()` method.

This PR implements a `filter_empty` modifier.  I was specific in how I named it so that people hopefully won't confuse it with the `collect()->filter()` method as that method allows you to pass a custom callback to perform extra filtering which this modifier does not support.

Let me know what you think.