### PR TITLE
[5.x] Remove deprecated options from PHPUnit stub

### DIFF
--- a/src/Console/Commands/stubs/addon/phpunit.xml.stub
+++ b/src/Console/Commands/stubs/addon/phpunit.xml.stub
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" beStrictAboutTestsThatDoNotTestAnything="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" processIsolation="false" stopOnFailure="false" beStrictAboutTestsThatDoNotTestAnything="false">
   <coverage/>
   <testsuites>
     <testsuite name="Test Suite">


### PR DESCRIPTION
This pull request removes some deprecated config options from the `phpunit.xml` stub which gets included with new addons.

The deprecated config options were causing a deprecation warning to show when running the test suite:

![CleanShot 2024-10-16 at 11 08 10](https://github.com/user-attachments/assets/1792d3e7-ffa4-4e41-9983-f0fb786e64f4)
