### PR TITLE
[5.x] Fix regression where editing an asset loads the `/edit` url in the browser

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -454,7 +454,10 @@ export default {
         },
 
         selectedPath(selectedPath) {
-            this.path = selectedPath;
+            // The selected path might change from outside due to a popstate navigation
+            if (!selectedPath.endsWith('/edit')) {
+                this.path = selectedPath;
+            }
         },
 
         parameters(after, before) {


### PR DESCRIPTION
PR #10948 tried to enable history browsing in the asset browser and inadvertently introduced a bug where editing an asset would try to load the `filename.txt/edit` url in the asset browser. This fixes the regression by ignoring path updates pointing at the asset editor.

Fixes #10957