### PR TITLE
[5.x] Fix error when editing Bard field with set and no fields

### DIFF
--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -55,7 +55,7 @@ class Sets extends Fieldtype
                         'instructions' => $set['instructions'] ?? null,
                         'icon' => $set['icon'] ?? null,
                         'hide' => $set['hide'] ?? null,
-                        'fields' => collect($set['fields'])->map(function ($field, $i) use ($setId) {
+                        'fields' => collect($set['fields'] ?? [])->map(function ($field, $i) use ($setId) {
                             return array_merge(FieldTransformer::toVue($field), ['_id' => $setId.'-'.$i]);
                         })->all(),
                     ];


### PR DESCRIPTION
This pull request fixes an issue I just spotted where it wasn't possible to edit a Bard field when one of the sets has no fields.
