### PR TITLE
[5.x] Remove mention of installing addons via CP from addon stub

### DIFF
--- a/src/Console/Commands/stubs/addon/README.md.stub
+++ b/src/Console/Commands/stubs/addon/README.md.stub
@@ -12,7 +12,7 @@ This addon does:
 
 ## How to Install
 
-You can search for this addon in the `Tools > Addons` section of the Statamic control panel and click **install**, or run the following command from your project root:
+You can install this addon via Composer:
 
 ``` bash
 composer require {{ package }}


### PR DESCRIPTION
This pull request removes mention of installing addons via the Control Panel from the `README.md` stub which gets published when you run `php please make:addon`. 