### PR TITLE
[5.x] Duplicate form data when duplicating the form

### DIFF
--- a/src/Actions/DuplicateForm.php
+++ b/src/Actions/DuplicateForm.php
@@ -52,7 +52,8 @@ class DuplicateForm extends Action
                 ->title($values['title'])
                 ->honeypot($original->honeypot())
                 ->store($original->store())
-                ->email($original->email());
+                ->email($original->email())
+                ->data($origina->data());
 
             $form->save();
 


### PR DESCRIPTION
As spotted by @robdekort when you duplicate forms the data doesn't duplicate the data.

This fixes that and makes him a little happier.