### PR TITLE
[5.x] Avoid showing asset upload fixes when inappropriate

### DIFF
--- a/resources/js/components/assets/Upload.vue
+++ b/resources/js/components/assets/Upload.vue
@@ -21,7 +21,7 @@
 
         <div class="ml-4 px-2 flex items-center gap-2" v-if="status === 'error'">
             {{ error }}
-            <dropdown-list v-if="errorStatus === 422">
+            <dropdown-list v-if="errorStatus === 409">
                 <template #trigger>
                     <button class="ml-4 btn btn-xs" v-text="`${__('Fix')}...`" />
                 </template>

--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -213,7 +213,7 @@ export default {
                     msg = __('Upload failed. The file might be larger than is allowed by your server.');
                 }
             } else {
-                if (status === 422) {
+                if ([422, 409].includes(status)) {
                     msg = Object.values(response.errors)[0][0]; // Get first validation message.
                 }
             }

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\CP\Assets;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 use Statamic\Assets\AssetUploader;
 use Statamic\Assets\UploadedReplacementFile;
 use Statamic\Contracts\Assets\Asset as AssetContract;
@@ -97,7 +98,11 @@ class AssetsController extends CpController
         $validator = Validator::make(['path' => $path], ['path' => new UploadableAssetPath($container)]);
 
         if (! in_array($request->option, ['timestamp', 'overwrite'])) {
-            $validator->validate();
+            try {
+                $validator->validate();
+            } catch (ValidationException $e) {
+                throw $e->status(409);
+            }
         }
 
         $asset = $container->asset($path) ?? $container->makeAsset($path);

--- a/tests/Feature/Assets/StoreAssetTest.php
+++ b/tests/Feature/Assets/StoreAssetTest.php
@@ -115,7 +115,7 @@ class StoreAssetTest extends TestCase
         $this
             ->actingAs($this->userWithPermission())
             ->submit()
-            ->assertStatus(422)
+            ->assertStatus(409)
             ->assertInvalid(['path' => 'A file already exists with this name.']);
     }
 
@@ -130,7 +130,7 @@ class StoreAssetTest extends TestCase
             ->submit([
                 'file' => UploadedFile::fake()->image('tEsT.jpg'),
             ])
-            ->assertStatus(422)
+            ->assertStatus(409)
             ->assertInvalid(['path' => 'A file already exists with this name.']);
     }
 


### PR DESCRIPTION
Fixes #10980

I went with a [409 Conflict status](https://www.webfx.com/web-development/glossary/http-status-codes/what-is-a-409-status-code/) as it seems the most appropriate:

> The request could not be completed due to a conflict with the current state of the target resource. This code is used in situations where the user might be able to resolve the conflict and resubmit the request.

Now you will only get the option to "fix" the upload when its due to being a duplicate. Regular validation errors and file size limit issues will not.

![CleanShot 2024-10-21 at 11 48 36](https://github.com/user-attachments/assets/7cabb6a4-cd45-43e5-bb88-ff58cccc0d6e)

