### PR TITLE
[5.x] Optimize display of long titles in edit forms

### DIFF
--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -56,6 +56,11 @@
     width: fit-content;
 }
 
+.break-overflowing-words {
+    word-break: break-word;
+    overflow-wrap: break-word;
+}
+
 .saving-overlay {
     @apply absolute inset-0 z-200 flex items-center rounded;
     background: rgba(255, 255, 255, .9);

--- a/resources/js/components/GlobalSearch.vue
+++ b/resources/js/components/GlobalSearch.vue
@@ -25,7 +25,7 @@
 
         <div v-show="focused && (hasResults || hasFavorites)" class="global-search-results">
 
-            <div v-if="hasResults" v-for="(result, index) in results" class="global-search-result-item p-2 flex items-center" :class="{ 'active': current == index }" @click="hit" @mousemove="setActive(index)">
+            <div v-if="hasResults" v-for="(result, index) in results" class="global-search-result-item break-overflowing-words p-2 flex items-start" :class="{ 'active': current == index }" @click="hit" @mousemove="setActive(index)">
                 <svg-icon :name="`light/${getResultIcon(result)}`" class="icon"></svg-icon>
                 <div class="flex-1 rtl:mr-2 ltr:ml-2 title" v-html="result.title"></div>
                 <span class="global-search-result-badge" v-text="result.badge" />

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -7,7 +7,7 @@
             <h1 class="flex-1 self-start rtl:ml-4 ltr:mr-4">
                 <div class="flex items-baseline">
                     <span v-if="! isCreating" class="little-dot rtl:ml-2 ltr:mr-2 -top-1" :class="activeLocalization.status" v-tooltip="__(activeLocalization.status)" />
-                    <span v-html="$options.filters.striptags(__(title))" />
+                    <span class="break-overflowing-words" v-html="$options.filters.striptags(__(title))" />
                 </div>
             </h1>
 

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -3,10 +3,10 @@
     <div>
         <breadcrumb v-if="breadcrumbs" :url="breadcrumbs[1].url" :title="breadcrumbs[1].text" />
 
-        <div class="flex items-center mb-6">
-            <h1 class="flex-1">
-                <div class="flex items-center">
-                    <span v-if="! isCreating" class="little-dot rtl:ml-2 ltr:mr-2" :class="activeLocalization.status" v-tooltip="__(activeLocalization.status)" />
+        <div class="flex items-baseline mb-6">
+            <h1 class="flex-1 self-start rtl:ml-4 ltr:mr-4">
+                <div class="flex items-baseline">
+                    <span v-if="! isCreating" class="little-dot rtl:ml-2 ltr:mr-2 -top-1" :class="activeLocalization.status" v-tooltip="__(activeLocalization.status)" />
                     <span v-html="$options.filters.striptags(__(title))" />
                 </div>
             </h1>

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -3,13 +3,13 @@
     <div>
         <breadcrumb v-if="breadcrumbs" :url="breadcrumbs[1].url" :title="breadcrumbs[1].text" />
 
-        <div class="flex items-center mb-6">
-            <h1 class="flex-1">
-                <div class="flex items-center">
+        <div class="flex items-baseline mb-6">
+            <h1 class="flex-1 self-start rtl:ml-4 ltr:mr-4">
+                <div class="flex items-baseline">
                     <span v-if="! isCreating"
-                        class="little-dot rtl:ml-2 ltr:mr-2"
+                        class="little-dot rtl:ml-2 ltr:mr-2 -top-1"
                         :class="{ 'bg-green-600': published, 'bg-gray-600': !published }" />
-                    <span v-html="$options.filters.striptags(title)" />
+                    <span class="break-overflowing-words" v-html="$options.filters.striptags(title)" />
                 </div>
             </h1>
 


### PR DESCRIPTION
Adjust a few styles to better accommodate long entry and term titles. Avoids a situation where the Save button was pushed off the screen.

The examples might seem a bit contrived, but I'm literally working on a project where an entry is titled `Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!!!!!!` and editors expect it to render okay in the control panel.

I had to create a new utility class since the included one in tailwind [doesn't quite do what it says](https://github.com/tailwindlabs/tailwindcss/discussions/2213).

 

## 1) Align title, status dot and save button on baseline

### Before

<img width="1112" alt="Screenshot 2024-10-22 at 00 39 18" src="https://github.com/user-attachments/assets/b8f0fbc0-9fc7-4662-aa3d-b5ff6e384271">

### After

<img width="1112" alt="Screenshot 2024-10-22 at 00 37 48" src="https://github.com/user-attachments/assets/7d6325b6-572f-4f3a-957e-b83b15998224">

 

 

## 2) Avoid save button being pushed off-screen

### Before

<img width="1111" alt="Screenshot 2024-10-22 at 00 42 47" src="https://github.com/user-attachments/assets/7f8b3d08-5139-4fa5-a8bc-d97f15b53301">

### After

<img width="1113" alt="Screenshot 2024-10-22 at 00 49 03" src="https://github.com/user-attachments/assets/9b2e7d40-ffab-4c91-a6a8-d0b357fcf5a9">

 

 

## 3) Contain entry title in search overlay

### Before

<img width="814" alt="Screenshot 2024-10-22 at 00 53 13" src="https://github.com/user-attachments/assets/36c96cef-c614-4a0b-850e-bbf255a99e7f">

### After

<img width="810" alt="Screenshot 2024-10-22 at 00 53 56" src="https://github.com/user-attachments/assets/523aaff8-bb2c-4a3e-9716-b4b63db3ba7e">