### PR TITLE
[5.x] Revert markdown field RTL PR 10931 

### DIFF
--- a/resources/css/vendors/codemirror.css
+++ b/resources/css/vendors/codemirror.css
@@ -270,6 +270,8 @@
 
   .CodeMirror-widget {}
 
+  .CodeMirror-rtl pre { direction: ltr; }
+
   .CodeMirror-code {
     outline: none;
   }


### PR DESCRIPTION
This reverts #10931

It was pointed out how awkward it is when using RTL in markdown when you are mixing RTL text and markup.

It looks like CodeMirror has support for handling these situations. We should solve it properly later. https://codemirror.net/examples/bidi/
