### PR TITLE
[5.x] Avoid error when marketplace client returns null

### DIFF
--- a/src/Marketplace/Marketplace.php
+++ b/src/Marketplace/Marketplace.php
@@ -20,10 +20,16 @@ class Marketplace
         }
 
         return Cache::rememberWithExpiration("marketplace-$uri", function () use ($uri) {
+            $fallback = [5 => null];
+
             try {
-                return [60 => Client::get($uri)['data']];
+                if (! $response = Client::get($uri)) {
+                    return $fallback;
+                }
+
+                return [60 => $response['data']];
             } catch (RequestException $e) {
-                return [5 => null];
+                return $fallback;
             }
         });
     }
@@ -34,9 +40,15 @@ class Marketplace
 
         return Cache::rememberWithExpiration("marketplace-$uri", function () use ($uri) {
             try {
-                return [60 => collect(Client::get($uri)['data'])];
+                $fallback = [5 => collect()];
+
+                if (! $response = Client::get($uri)) {
+                    return $fallback;
+                }
+
+                return [60 => collect($response['data'])];
             } catch (RequestException $e) {
-                return [5 => collect()];
+                return $fallback;
             }
         });
     }

--- a/src/Marketplace/Marketplace.php
+++ b/src/Marketplace/Marketplace.php
@@ -39,9 +39,9 @@ class Marketplace
         $uri = "packages/$package/releases";
 
         return Cache::rememberWithExpiration("marketplace-$uri", function () use ($uri) {
-            try {
-                $fallback = [5 => collect()];
+            $fallback = [5 => collect()];
 
+            try {
                 if (! $response = Client::get($uri)) {
                     return $fallback;
                 }


### PR DESCRIPTION
This fixes an error when the marketplace client returns null for whatever reason.
It looks like there could be a problem with the lock in some situations, and Client::get() returns null, causing errors further up.
This PR will prevent the error, but there will be missing addon data. That's less of a problem for those affected.
