### PR TITLE
[5.x] Add `allowed_extensions` option to Files fieldtype

### DIFF
--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -32,7 +32,11 @@ export default {
         },
         container: String,
         path: String,
-        url: { type: String, default: () => cp_url('assets') }
+        url: { type: String, default: () => cp_url('assets') },
+        extraData: {
+            type: Object,
+            default: () => ({})
+        }
     },
 
 
@@ -41,19 +45,6 @@ export default {
             dragging: false,
             uploads: []
         }
-    },
-
-
-    computed: {
-
-        extraData() {
-            return {
-                container: this.container,
-                folder: this.path,
-                _token: Statamic.$config.get('csrfToken')
-            };
-        }
-
     },
 
 
@@ -164,8 +155,15 @@ export default {
 
             form.append('file', file);
 
-            for (let key in this.extraData) {
-                form.append(key, this.extraData[key]);
+            let parameters = {
+                ...this.extraData,
+                container: this.container,
+                folder: this.path,
+                _token: Statamic.$config.get('csrfToken')
+            }
+
+            for (let key in parameters) {
+                form.append(key, parameters[key]);
             }
 
             for (let key in data) {

--- a/resources/js/components/fieldtypes/FilesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FilesFieldtype.vue
@@ -5,6 +5,7 @@
         <uploader
             ref="uploader"
             :url="meta.uploadUrl"
+            :extra-data="{ config: configParameter }"
             :container="config.container"
             @updated="uploadsUpdated"
             @upload-complete="uploadComplete"
@@ -85,6 +86,12 @@ export default {
         return {
             uploads: [],
         }
+    },
+
+    computed: {
+        configParameter() {
+            return utf8btoa(JSON.stringify(this.config));
+        },
     },
 
     methods: {

--- a/src/Http/Controllers/CP/Fieldtypes/FilesFieldtypeController.php
+++ b/src/Http/Controllers/CP/Fieldtypes/FilesFieldtypeController.php
@@ -2,8 +2,10 @@
 
 namespace Statamic\Http\Controllers\CP\Fieldtypes;
 
+use Facades\Statamic\Fields\FieldtypeRepository as Fieldtype;
 use Illuminate\Http\Request;
 use Statamic\Assets\FileUploader as Uploader;
+use Statamic\Fields\Field;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Rules\AllowedFile;
 
@@ -11,8 +13,10 @@ class FilesFieldtypeController extends CpController
 {
     public function upload(Request $request)
     {
+        $fieldtype = $request->config ? $this->fieldtype($request) : null;
+
         $request->validate([
-            'file' => ['file', new AllowedFile],
+            'file' => ['file', new AllowedFile($fieldtype?->config('allowed_extensions'))],
         ]);
 
         $file = $request->file('file');
@@ -20,5 +24,31 @@ class FilesFieldtypeController extends CpController
         $path = Uploader::container($request->container)->upload($file);
 
         return ['data' => ['id' => $path]];
+    }
+
+    protected function fieldtype($request)
+    {
+        $config = $this->getConfig($request);
+
+        return Fieldtype::find($config['type'])->setField(
+            new Field('file', $config)
+        );
+    }
+
+    private function getConfig($request)
+    {
+        // The fieldtype base64-encodes the config.
+        $json = base64_decode($request->config);
+
+        // The json may include unicode characters, so we'll try to convert it to UTF-8.
+        // See https://github.com/statamic/cms/issues/566
+        $utf8 = mb_convert_encoding($json, 'UTF-8', mb_list_encodings());
+
+        // In PHP 8.1 there's a bug where encoding will return null. It's fixed in 8.1.2.
+        // In this case, we'll fall back to the original JSON, but without the encoding.
+        // Issue #566 may still occur, but it's better than failing completely.
+        $json = empty($utf8) ? $json : $utf8;
+
+        return json_decode($json, true);
     }
 }

--- a/src/Rules/AllowedFile.php
+++ b/src/Rules/AllowedFile.php
@@ -109,6 +109,10 @@ class AllowedFile implements ValidationRule
         'zip',
     ];
 
+    public function __construct(public ?array $allowedExtensions = null)
+    {
+    }
+
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (! $this->isAllowedExtension($value)) {
@@ -118,7 +122,10 @@ class AllowedFile implements ValidationRule
 
     private function isAllowedExtension(UploadedFile $file): bool
     {
-        $extensions = array_merge(static::EXTENSIONS, config('statamic.assets.additional_uploadable_extensions', []));
+        $extensions = array_merge(
+            $this->allowedExtensions ?? static::EXTENSIONS,
+            config('statamic.assets.additional_uploadable_extensions', [])
+        );
 
         return in_array(trim(strtolower($file->getClientOriginalExtension())), $extensions);
     }

--- a/src/Rules/AllowedFile.php
+++ b/src/Rules/AllowedFile.php
@@ -122,10 +122,7 @@ class AllowedFile implements ValidationRule
 
     private function isAllowedExtension(UploadedFile $file): bool
     {
-        $extensions = array_merge(
-            $this->allowedExtensions ?? static::EXTENSIONS,
-            config('statamic.assets.additional_uploadable_extensions', [])
-        );
+        $extensions = $this->allowedExtensions ?? array_merge(static::EXTENSIONS, config('statamic.assets.additional_uploadable_extensions', []));
 
         return in_array(trim(strtolower($file->getClientOriginalExtension())), $extensions);
     }


### PR DESCRIPTION
This pull request adds an `allowed_extensions` config option to the Files fieldtype, allowing you to override which file extensions are allowed.

For example: in the case of the Importer addon, I want to allow `.csv` and `.xml` files to be uploaded, but not any other file extensions.