### PR TITLE
[5.x] Fix issues with the Files fieldtype in Dark Mode

### DIFF
--- a/resources/js/components/assets/Upload.vue
+++ b/resources/js/components/assets/Upload.vue
@@ -13,7 +13,7 @@
 
         <div
             v-if="status !== 'error'"
-            class="bg-white dark:bg-dark-600 flex-1 h-4 mx-2 rounded"
+            class="bg-white flex-1 h-4 mx-2 rounded"
         >
             <div class="bg-blue h-full rounded"
                 :style="{ width: percent+'%' }" />

--- a/resources/js/components/assets/Upload.vue
+++ b/resources/js/components/assets/Upload.vue
@@ -23,14 +23,14 @@
             {{ error }}
             <dropdown-list v-if="errorStatus === 409">
                 <template #trigger>
-                    <button class="ml-4 btn btn-xs" v-text="`${__('Fix')}...`" />
+                    <button type="button" class="ml-4 btn btn-xs" v-text="`${__('Fix')}...`" />
                 </template>
                 <dropdown-item @click="retryAndOverwrite" :text="__('messages.uploader_overwrite_existing')" />
                 <dropdown-item @click="openNewFilenameModal" :text="`${__('messages.uploader_choose_new_filename')}...`" />
                 <dropdown-item @click="retryWithTimestamp" :text="__('messages.uploader_append_timestamp')" />
                 <dropdown-item @click="selectExisting" v-if="allowSelectingExisting" :text="__('messages.uploader_discard_use_existing')" />
             </dropdown-list>
-            <button class="btn btn-xs" @click="clear" v-text="__('Discard')" />
+            <button type="button" class="btn btn-xs" @click="clear" v-text="__('Discard')" />
         </div>
 
         <confirmation-modal

--- a/resources/js/components/assets/Upload.vue
+++ b/resources/js/components/assets/Upload.vue
@@ -23,14 +23,14 @@
             {{ error }}
             <dropdown-list v-if="errorStatus === 409">
                 <template #trigger>
-                    <button type="button" class="ml-4 btn btn-xs" v-text="`${__('Fix')}...`" />
+                    <button class="ml-4 btn btn-xs" v-text="`${__('Fix')}...`" />
                 </template>
                 <dropdown-item @click="retryAndOverwrite" :text="__('messages.uploader_overwrite_existing')" />
                 <dropdown-item @click="openNewFilenameModal" :text="`${__('messages.uploader_choose_new_filename')}...`" />
                 <dropdown-item @click="retryWithTimestamp" :text="__('messages.uploader_append_timestamp')" />
                 <dropdown-item @click="selectExisting" v-if="allowSelectingExisting" :text="__('messages.uploader_discard_use_existing')" />
             </dropdown-list>
-            <button type="button" class="btn btn-xs" @click="clear" v-text="__('Discard')" />
+            <button class="btn btn-xs" @click="clear" v-text="__('Discard')" />
         </div>
 
         <confirmation-modal

--- a/resources/js/components/assets/Upload.vue
+++ b/resources/js/components/assets/Upload.vue
@@ -13,7 +13,7 @@
 
         <div
             v-if="status !== 'error'"
-            class="bg-white flex-1 h-4 mx-2 rounded"
+            class="bg-white dark:bg-dark-600 flex-1 h-4 mx-2 rounded"
         >
             <div class="bg-blue h-full rounded"
                 :style="{ width: percent+'%' }" />

--- a/resources/js/components/fieldtypes/FilesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FilesFieldtype.vue
@@ -53,7 +53,7 @@
                                 <td class="p-0 w-8 rtl:text-left ltr:text-right align-middle">
                                     <button
                                         @click="remove(i)"
-                                        class="flex items-center p-2 w-full h-full text-gray-600 hover:text-gray-900"
+                                        class="flex items-center p-2 w-full h-full text-gray-600 dark:text-dark-150 hover:text-gray-950 dark:hover:text-dark-100"
                                     >
                                         <svg-icon name="micro/trash" class="w-6 h-6" />
                                     </button>

--- a/resources/js/components/fieldtypes/FilesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FilesFieldtype.vue
@@ -37,7 +37,7 @@
                             <tr
                                 v-for="(file, i) in value"
                                 :key="file"
-                                class="asset-row bg-white hover:bg-gray-100"
+                                class="asset-row bg-white dark:bg-dark-600 hover:bg-gray-100"
                             >
                                 <td class="flex items-center">
                                     <div


### PR DESCRIPTION
This pull request fixes a couple of issues when the Files fieldtype is used in Dark Mode.

**Before:**

![CleanShot 2024-10-23 at 13 01 39](https://github.com/user-attachments/assets/950422b7-85cb-4dea-8c12-6eb4197742fd)

**After:**

![CleanShot 2024-10-23 at 13 04 14](https://github.com/user-attachments/assets/18daed8f-1231-430f-8d3a-80ba38812afb)
