### PR TITLE
[5.x] Add `password` option to `make:user` command

### DIFF
--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -43,7 +43,7 @@ class MakeUser extends Command
     protected $email;
 
     /**
-     *  The user's password.
+     * The user's password.
      *
      * @var string
      */
@@ -72,6 +72,10 @@ class MakeUser extends Command
     {
         if (! Statamic::pro() && User::query()->count() > 0) {
             return error(__('Statamic Pro is required.'));
+        }
+
+        if ($password = $this->option('password')) {
+            $this->password = $password;
         }
 
         // If email argument exists, non-interactively create user.
@@ -140,7 +144,11 @@ class MakeUser extends Command
      */
     protected function promptPassword()
     {
-        $this->data['password'] = password(label: 'Password', required: true);
+        if ($this->password) {
+            return $this;
+        }
+
+        $this->password = password(label: 'Password', required: true);
 
         if ($this->passwordValidationFails()) {
             return $this->promptPassword();
@@ -179,8 +187,8 @@ class MakeUser extends Command
 
         $user = User::make()
             ->email($this->email)
-            ->password($this->option('password'))
-            ->data($this->data);
+            ->data($this->data)
+            ->password($this->password);
 
         if ($this->super || $this->option('super')) {
             $user->makeSuper();
@@ -209,7 +217,7 @@ class MakeUser extends Command
     protected function passwordValidationFails()
     {
         return $this->validationFails(
-            $this->data['password'],
+            $this->password,
             ['required', Password::default()]
         );
     }

--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -43,6 +43,12 @@ class MakeUser extends Command
     protected $email;
 
     /**
+     *  The user's password.
+     * @var string
+     */
+    protected $password;
+
+    /**
      * The user's data.
      *
      * @var array
@@ -172,6 +178,7 @@ class MakeUser extends Command
 
         $user = User::make()
             ->email($this->email)
+            ->password($this->option('password'))
             ->data($this->data);
 
         if ($this->super || $this->option('super')) {
@@ -241,6 +248,7 @@ class MakeUser extends Command
     {
         return array_merge(parent::getOptions(), [
             ['super', '', InputOption::VALUE_NONE, 'Generate a super user with permission to do everything'],
+            ['password', '', InputOption::VALUE_OPTIONAL, 'Generate a user with given password'],
         ]);
     }
 }

--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -44,6 +44,7 @@ class MakeUser extends Command
 
     /**
      *  The user's password.
+     *
      * @var string
      */
     protected $password;

--- a/tests/Console/Commands/MakeUserTest.php
+++ b/tests/Console/Commands/MakeUserTest.php
@@ -110,11 +110,11 @@ class MakeUserTest extends TestCase
     #[Test]
     public function it_can_make_a_user_with_password_option()
     {
-        $this->withoutMockingConsoleOutput();
-
         $this->assertEmpty(User::all());
 
-        $this->artisan('statamic:make:user', ['email' => 'duncan@likesteatime.com', '--password' => 'PacManMoonwalk#84'])
+        $password = 'PacManMoonwalk#84';
+
+        $this->artisan('statamic:make:user', ['email' => 'duncan@likesteatime.com', '--password' => $password])
             ->expectsOutputToContain('User created successfully.');
 
         $user = User::all()->first();
@@ -122,5 +122,6 @@ class MakeUserTest extends TestCase
         $this->assertNotEmpty($user->id());
         $this->assertEquals('duncan@likesteatime.com', $user->email());
         $this->assertNotEmpty($user->password());
+        $this->assertTrue(password_verify($password, $user->password()));
     }
 }

--- a/tests/Console/Commands/MakeUserTest.php
+++ b/tests/Console/Commands/MakeUserTest.php
@@ -124,4 +124,25 @@ class MakeUserTest extends TestCase
         $this->assertNotEmpty($user->password());
         $this->assertTrue(password_verify($password, $user->password()));
     }
+
+    #[Test]
+    public function if_password_option_is_passed_it_will_not_prompt_for_password()
+    {
+        $this->assertEmpty(User::all());
+
+        $password = 'PacManMoonwalk#84';
+
+        $this->artisan('statamic:make:user', ['--password' => $password])
+            ->expectsQuestion('Email', 'duncan@likesteatime.com')
+            ->expectsQuestion('Name', 'Duncan')
+            ->expectsQuestion('Super user?', false)
+            ->assertExitCode(0);
+
+        $user = User::all()->first();
+
+        $this->assertNotEmpty($user->id());
+        $this->assertEquals('duncan@likesteatime.com', $user->email());
+        $this->assertNotEmpty($user->password());
+        $this->assertTrue(password_verify($password, $user->password()));
+    }
 }

--- a/tests/Console/Commands/MakeUserTest.php
+++ b/tests/Console/Commands/MakeUserTest.php
@@ -106,4 +106,21 @@ class MakeUserTest extends TestCase
         $this->assertTrue($jason->isSuper());
         $this->assertFalse($girl->isSuper());
     }
+
+    #[Test]
+    public function it_can_make_a_user_with_password_option()
+    {
+        $this->withoutMockingConsoleOutput();
+
+        $this->assertEmpty(User::all());
+
+        $this->artisan('statamic:make:user', ['email' => 'duncan@likesteatime.com', '--password' => 'PacManMoonwalk#84'])
+            ->expectsOutputToContain('User created successfully.');
+
+        $user = User::all()->first();
+
+        $this->assertNotEmpty($user->id());
+        $this->assertEquals('duncan@likesteatime.com', $user->email());
+        $this->assertNotEmpty($user->password());
+    }
 }


### PR DESCRIPTION
Adds support for a `password` option to the `make:user` command to enable certain integrations.

<img width="742" alt="image" src="https://github.com/user-attachments/assets/44ef2483-cdad-49d7-af3c-baefa7697859">
