### PR TITLE
[5.x] Include Algolia highlights and snippets

### DIFF
--- a/src/Search/Algolia/Index.php
+++ b/src/Search/Algolia/Index.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Statamic\Search\Documents;
 use Statamic\Search\Index as BaseIndex;
 use Statamic\Search\IndexNotFoundException;
+use Statamic\Search\Result;
 use Statamic\Support\Str;
 
 class Index extends BaseIndex
@@ -119,5 +120,13 @@ class Index extends BaseIndex
         }
 
         throw $e;
+    }
+
+    public function extraAugmentedResultData(Result $result)
+    {
+        return [
+            'search_highlights' => $result->getRawResult()['_highlightResult'] ?? null,
+            'search_snippets' => $result->getRawResult()['_snippetResult'] ?? null,
+        ];
     }
 }


### PR DESCRIPTION
This PR adds Algolia's highlights and snippets to the result data. Highlights are usually included by default, snippets can be included with these [settings](https://www.algolia.com/doc/api-reference/api-parameters/attributesToSnippet/):

```php
'default' => [
    'driver' => 'algolia',
    'settings' => [
        'attributesToSnippet' => ['content:40'],
        'highlightPreTag' => '<mark>',
        'highlightPostTag' => '</mark>',
    ],
],
```

You can then use them in results:

```antlers
<a href="{{ $url }}">
    <h2>{{ search_highlights:title:value }}</h2>
    <p>{{ search_snippets:content:value }}</p>
</a>
```

![Screenshot 2024-10-25 at 09 42 49](https://github.com/user-attachments/assets/a07c987d-729b-4983-a4b7-021c5bc923af)

The key names are based on the convention established in the comb driver for snippets.

