### PR TITLE
[5.x] Introduce additional form tag hooks

### DIFF
--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -102,6 +102,7 @@ class Tags extends BaseTags
         if ($jsDriver) {
             $attrs = array_merge($attrs, $jsDriver->addToFormAttributes($form));
         }
+        $attrs = $this->runHooks('attrs', ['attrs' => $attrs, 'data' => $data])['attrs'];
 
         $params = [];
 
@@ -121,11 +122,13 @@ class Tags extends BaseTags
         }
 
         $html = $this->formOpen($action, $method, $knownParams, $attrs);
+        $html = $this->runHooks('after-open', ['html' => $html, 'data' => $data])['html'];
 
         $html .= $this->formMetaFields($params);
 
         $html .= $this->parse($data);
 
+        $html = $this->runHooks('before-close', ['html' => $html, 'data' => $data])['html'];
         $html .= $this->formClose();
 
         if ($jsDriver) {


### PR DESCRIPTION
This PR introduces three new hooks into form tag processing. These hooks allow add-ons to do the following:

- Add additional attributes to generated form tags
- Add additional content at the start of the form
- Add additional content before the end of the form