### PR TITLE
[5.x] Decouple CSRF token from nocache script

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use Statamic\Http\Controllers\User\RegisterController;
 use Statamic\Http\Middleware\AuthGuard;
 use Statamic\Http\Middleware\CP\AuthGuard as CPAuthGuard;
 use Statamic\Statamic;
+use Statamic\StaticCaching\NoCache\CsrfTokenController;
 use Statamic\StaticCaching\NoCache\NoCacheController;
 use Statamic\StaticCaching\NoCache\NoCacheLocalize;
 
@@ -51,6 +52,9 @@ Route::name('statamic.')->group(function () {
 
         Route::post('nocache', NoCacheController::class)
             ->middleware(NoCacheLocalize::class)
+            ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken']);
+
+        Route::post('csrf', CsrfTokenController::class)
             ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken']);
 
         Statamic::additionalActionRoutes();

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,13 +49,12 @@ Route::name('statamic.')->group(function () {
             Route::post('activate', [ActivateAccountController::class, 'reset'])->name('account.activate.action');
         });
 
+        Route::post('nocache', NoCacheController::class)
+            ->middleware(NoCacheLocalize::class)
+            ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken']);
+
         Statamic::additionalActionRoutes();
     });
-
-    Route::prefix(config('statamic.routes.action'))
-        ->post('nocache', NoCacheController::class)
-        ->middleware(NoCacheLocalize::class)
-        ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken']);
 
     if (OAuth::enabled()) {
         Route::get(config('statamic.oauth.routes.login'), [OAuthController::class, 'redirectToProvider'])->name('oauth.login');

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,7 +19,7 @@ use Statamic\Http\Controllers\User\RegisterController;
 use Statamic\Http\Middleware\AuthGuard;
 use Statamic\Http\Middleware\CP\AuthGuard as CPAuthGuard;
 use Statamic\Statamic;
-use Statamic\StaticCaching\NoCache\Controller as NoCacheController;
+use Statamic\StaticCaching\NoCache\NoCacheController;
 use Statamic\StaticCaching\NoCache\NoCacheLocalize;
 
 Route::name('statamic.')->group(function () {

--- a/src/StaticCaching/NoCache/CsrfTokenController.php
+++ b/src/StaticCaching/NoCache/CsrfTokenController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Statamic\StaticCaching\NoCache;
+
+class CsrfTokenController
+{
+    public function __invoke()
+    {
+        return csrf_token();
+    }
+}

--- a/src/StaticCaching/NoCache/CsrfTokenController.php
+++ b/src/StaticCaching/NoCache/CsrfTokenController.php
@@ -6,6 +6,8 @@ class CsrfTokenController
 {
     public function __invoke()
     {
-        return csrf_token();
+        return [
+            'csrf' => csrf_token(),
+        ];
     }
 }

--- a/src/StaticCaching/NoCache/NoCacheController.php
+++ b/src/StaticCaching/NoCache/NoCacheController.php
@@ -29,7 +29,6 @@ class NoCacheController
         $replacer = new NoCacheReplacer($session);
 
         return [
-            'csrf' => csrf_token(),
             'regions' => $session
                 ->regions()
                 ->map->render()

--- a/src/StaticCaching/NoCache/NoCacheController.php
+++ b/src/StaticCaching/NoCache/NoCacheController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use Statamic\StaticCaching\Replacers\NoCacheReplacer;
 use Statamic\Support\Str;
 
-class Controller
+class NoCacheController
 {
     public function __invoke(Request $request, Session $session)
     {

--- a/src/StaticCaching/Replacers/NoCacheReplacer.php
+++ b/src/StaticCaching/Replacers/NoCacheReplacer.php
@@ -3,7 +3,6 @@
 namespace Statamic\StaticCaching\Replacers;
 
 use Illuminate\Http\Response;
-use Illuminate\Support\Str;
 use Statamic\Facades\StaticCache;
 use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\Cachers\FileCacher;
@@ -79,40 +78,12 @@ class NoCacheReplacer implements Replacer
         $contents = $response->getContent();
 
         if ($cacher->shouldOutputJs()) {
-            $contents = match ($pos = $this->insertPosition()) {
-                'head' => $this->insertJsInHead($contents, $cacher),
-                'body' => $this->insertJsInBody($contents, $cacher),
-                default => throw new \Exception('Invalid nocache js insert position ['.$pos.']'),
-            };
+            $js = $cacher->getNocacheJs();
+            $contents = str_replace('</body>', '<script type="text/javascript">'.$js.'</script></body>', $contents);
         }
 
         $contents = str_replace('NOCACHE_PLACEHOLDER', $cacher->getNocachePlaceholder(), $contents);
 
         $response->setContent($contents);
-    }
-
-    private function insertPosition()
-    {
-        return config('statamic.static_caching.nocache_js_position', 'body');
-    }
-
-    private function insertJsInHead($contents, $cacher)
-    {
-        $insertBefore = collect([
-            Str::position($contents, '<link'),
-            Str::position($contents, '<script'),
-            Str::position($contents, '</head>'),
-        ])->filter()->min();
-
-        $js = "<script type=\"text/javascript\">{$cacher->getNocacheJs()}</script>";
-
-        return Str::substrReplace($contents, $js, $insertBefore, 0);
-    }
-
-    private function insertJsInBody($contents, $cacher)
-    {
-        $js = $cacher->getNocacheJs();
-
-        return str_replace('</body>', '<script type="text/javascript">'.$js.'</script></body>', $contents);
     }
 }

--- a/tests/StaticCaching/FullMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/FullMeasureStaticCachingTest.php
@@ -5,6 +5,7 @@ namespace Tests\StaticCaching;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\File;
 use Statamic\Facades\StaticCache;
+use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\NoCache\Session;
 use Tests\FakesContent;
 use Tests\FakesViews;
@@ -135,12 +136,14 @@ class FullMeasureStaticCachingTest extends TestCase
     public function it_should_add_the_javascript_if_there_is_a_csrf_token()
     {
         $this->withFakeViews();
-        $this->viewShouldReturnRaw('layout', '<html><body>{{ template_content }}</body></html>');
+        $this->viewShouldReturnRaw('layout', '<html><head></head><body>{{ template_content }}</body></html>');
         $this->viewShouldReturnRaw('default', '{{ csrf_token }}');
 
         $this->createPage('about');
 
         StaticCache::nocacheJs('js here');
+
+        $csrfTokenScript = '<script type="text/javascript">'.app(Cacher::class)->getCsrfTokenJs().'</script>';
 
         $this->assertFalse(file_exists($this->dir.'/about_.html'));
 
@@ -149,11 +152,11 @@ class FullMeasureStaticCachingTest extends TestCase
             ->assertOk();
 
         // Initial response should be dynamic and not contain javascript.
-        $this->assertEquals('<html><body>'.csrf_token().'</body></html>', $response->getContent());
+        $this->assertEquals('<html><head></head><body>'.csrf_token().'</body></html>', $response->getContent());
 
         // The cached response should have the token placeholder, and the javascript.
         $this->assertTrue(file_exists($this->dir.'/about_.html'));
-        $this->assertEquals(vsprintf('<html><body>STATAMIC_CSRF_TOKEN%s</body></html>', [
+        $this->assertEquals(vsprintf('<html><head>'.$csrfTokenScript.'</head><body>STATAMIC_CSRF_TOKEN%s</body></html>', [
             '<script type="text/javascript">js here</script>',
         ]), file_get_contents($this->dir.'/about_.html'));
     }

--- a/tests/StaticCaching/NocacheRouteTest.php
+++ b/tests/StaticCaching/NocacheRouteTest.php
@@ -46,7 +46,6 @@ class NocacheRouteTest extends TestCase
             ->postJson('/!/nocache', ['url' => 'http://localhost/test'])
             ->assertOk()
             ->assertExactJson([
-                'csrf' => csrf_token(),
                 'regions' => [
                     $regionOne->key() => 'First 1 Dustin Test',
                     $regionTwo->key() => 'Second 2 Will Test',


### PR DESCRIPTION
This PR takes another stab at https://github.com/statamic/cms/pull/10306 which was reverted in https://github.com/statamic/cms/pull/10898. The `nocache_js_position` config option introduced in the latter PR isn't optimal as you've got to pick your poison and choose between Livewire or nocache to work as expected.

This PR picks up on the [idea pointed out here](https://github.com/statamic/cms/pull/10898#issuecomment-2395106918) and extracts the CSRF token replacer script from the nocache replacer script. The CSRF replacer script is inserted as the first script in the `head`, while the nocache replacer script is placed at the end of the `body`. This way, you don't have to pick the script's position and can have both Livewire and nocache work alongside each other.

Removing the `nocache_js_position` config option shouldn't be a breaking change. It is simply obsolete now. [And it hasn't even been documented yet](https://github.com/statamic/docs/issues/1469).

However, one minor breaking change is introduced. The `statamic:nocache.replaced` event is no longer dispatched when the CSRF token is replaced. A new `statamic:csrf.replaced` event is dispatched instead. You might decide to also dispatch the `statamic:nocache.replaced` event when the CSRF token is replaced. This should make this PR unbreaking. However, the event would now be dispatched twice. And dispatching the `statamic:nocache.replaced` event when the CSRF token is replaced doesn't make much sense either.

Also, the `StaticCache::nocacheJs('js here')` method now only replaces the nocache script. It doesn't touch the CSRF token script. But I think this should be fine. 

Let me know what you think.
