### PR TITLE
[5.x] Support unions in addon event listener discovery

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Reflector;
 use Illuminate\Support\ServiceProvider;
 use Statamic\Actions\Action;
 use Statamic\Dictionaries\Dictionary;
@@ -225,36 +226,11 @@ abstract class AddonServiceProvider extends ServiceProvider
 
     public function bootEvents()
     {
-        collect($this->autoloadFilesFromFolder('Listeners'))
-            ->mapWithKeys(function ($class) {
-                $reflection = new \ReflectionClass($class);
-
-                if (
-                    $reflection->hasMethod('handle')
-                    && isset($reflection->getMethod('handle')->getParameters()[0])
-                    && $reflection->getMethod('handle')->getParameters()[0]->hasType()
-                ) {
-                    $event = $reflection->getMethod('handle')->getParameters()[0]->getType()->getName();
-
-                    return [$event => $class];
-                }
-
-                if (
-                    $reflection->hasMethod('__invoke')
-                    && isset($reflection->getMethod('__invoke')->getParameters()[0])
-                    && $reflection->getMethod('__invoke')->getParameters()[0]->hasType()
-                ) {
-                    $event = $reflection->getMethod('__invoke')->getParameters()[0]->getType()->getName();
-
-                    return [$event => $class];
-                }
-
-                return [];
-            })
-            ->filter()
-            ->merge(collect($this->listen)->flatMap(fn ($listeners, $event) => collect($listeners)->mapWithKeys(fn ($listener) => [$event => $listener])))
-            ->unique()
-            ->each(fn ($listener, $event) => Event::listen($event, $listener));
+        $this->getEventListeners()->each(function ($listeners, $event) {
+            foreach ($listeners as $listener) {
+                Event::listen($event, $listener);
+            }
+        });
 
         $subscribers = collect($this->subscribe)
             ->merge($this->autoloadFilesFromFolder('Subscribers'))
@@ -265,6 +241,45 @@ abstract class AddonServiceProvider extends ServiceProvider
         }
 
         return $this;
+    }
+
+    private function getEventListeners()
+    {
+        $arr = [];
+
+        foreach ($this->discoverListenerEvents() as $listener => $events) {
+            foreach ($events as $event) {
+                $arr[$event][] = $listener;
+            }
+        }
+
+        foreach ($this->listen as $event => $listeners) {
+            foreach ($listeners as $listener) {
+                $arr[$event][] = $listener;
+            }
+        }
+
+        return collect($arr);
+    }
+
+    private function discoverListenerEvents()
+    {
+        return collect($this->autoloadFilesFromFolder('Listeners'))->mapWithKeys(function ($class) {
+            $listener = new \ReflectionClass($class);
+            $events = [];
+
+            foreach ($listener->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                if ((! Str::is('handle*', $method->name) && ! Str::is('__invoke', $method->name)) || ! isset($method->getParameters()[0])) {
+                    continue;
+                }
+
+                $key = Str::is(['__invoke', 'handle'], $method->name) ? $class : $class.'@'.$method->name;
+
+                $events[$key] = Reflector::getParameterClassNames($method->getParameters()[0]);
+            }
+
+            return $events;
+        });
     }
 
     protected function bootTags()


### PR DESCRIPTION
Fixes #11012

This adjusts the code to allow for unions, eg. `handle(EventOne|EventTwo $event) { }` which is where the error in #11012 was coming from.

It also adds support for `handleWhatever(EventName $event) { }` syntax, since I've lifted the code from Laravel. This is probably a lesser known thing but it works in Laravel so should here.