### PR TITLE
[5.x] Add support for avif image format

### DIFF
--- a/resources/js/components/FileIcon.vue
+++ b/resources/js/components/FileIcon.vue
@@ -81,6 +81,7 @@ export default {
                     return 'video';
                 case 'xml':
                     return 'xml';
+                case 'avif':
                 case 'bmp':
                 case 'gif':
                 case 'ico':

--- a/resources/js/components/FileIcon.vue
+++ b/resources/js/components/FileIcon.vue
@@ -91,6 +91,7 @@ export default {
                 case 'raw':
                 case 'nef':
                 case 'tiff':
+                case 'webp':
                     return 'image';
                 default:
                     return 'generic';

--- a/resources/js/components/fieldtypes/assets/Asset.js
+++ b/resources/js/components/fieldtypes/assets/Asset.js
@@ -41,7 +41,7 @@ export default {
         },
 
         canBeTransparent() {
-            return ['png', 'svg'].includes(this.asset.extension)
+            return ['png', 'svg', 'webp', 'avif'].includes(this.asset.extension)
         },
 
         canDownload() {

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -488,7 +488,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      */
     public function isImage()
     {
-        return $this->extensionIsOneOf(['jpg', 'jpeg', 'png', 'gif', 'webp']);
+        return $this->extensionIsOneOf(['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif']);
     }
 
     /**

--- a/src/Fieldtypes/Assets/ImageRule.php
+++ b/src/Fieldtypes/Assets/ImageRule.php
@@ -25,7 +25,7 @@ class ImageRule implements Rule
      */
     public function passes($attribute, $value)
     {
-        $extensions = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg', 'webp'];
+        $extensions = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg', 'webp', 'avif'];
 
         return collect($value)->every(function ($id) use ($extensions) {
             if ($id instanceof UploadedFile) {

--- a/src/Filesystem/AbstractAdapter.php
+++ b/src/Filesystem/AbstractAdapter.php
@@ -100,7 +100,7 @@ abstract class AbstractAdapter implements Filesystem
     {
         return in_array(
             strtolower($this->extension($path)),
-            ['jpg', 'jpeg', 'png', 'gif']
+            ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif']
         );
     }
 

--- a/src/Http/Resources/CP/Assets/FolderAsset.php
+++ b/src/Http/Resources/CP/Assets/FolderAsset.php
@@ -22,7 +22,7 @@ class FolderAsset extends JsonResource
                 return [
                     'is_image' => true,
                     'thumbnail' => $this->thumbnailUrl('small'),
-                    'can_be_transparent' => $this->isSvg() || $this->extension() === 'png',
+                    'can_be_transparent' => $this->isSvg() || $this->extensionIsOneOf(['svg', 'png', 'webp', 'avif']),
                     'alt' => $this->alt,
                 ];
             }),

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -601,7 +601,7 @@ class AssetTest extends TestCase
     #[Test]
     public function it_checks_if_its_an_image_file()
     {
-        $extensions = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+        $extensions = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif'];
 
         foreach ($extensions as $ext) {
             $this->assertTrue((new Asset)->path("path/to/asset.$ext")->isImage());

--- a/tests/Filesystem/FilesystemAdapterTests.php
+++ b/tests/Filesystem/FilesystemAdapterTests.php
@@ -170,6 +170,8 @@ trait FilesystemAdapterTests
         $this->assertTrue($this->adapter->isImage('test.JPEG'));
         $this->assertTrue($this->adapter->isImage('test.PNG'));
         $this->assertTrue($this->adapter->isImage('test.GIF'));
+        $this->assertTrue($this->adapter->isImage('test.webp'));
+        $this->assertTrue($this->adapter->isImage('test.WEBP'));
         $this->assertTrue($this->adapter->isImage('test.avif'));
         $this->assertTrue($this->adapter->isImage('test.AVIF'));
         $this->assertFalse($this->adapter->isImage('test.txt'));

--- a/tests/Filesystem/FilesystemAdapterTests.php
+++ b/tests/Filesystem/FilesystemAdapterTests.php
@@ -170,6 +170,8 @@ trait FilesystemAdapterTests
         $this->assertTrue($this->adapter->isImage('test.JPEG'));
         $this->assertTrue($this->adapter->isImage('test.PNG'));
         $this->assertTrue($this->adapter->isImage('test.GIF'));
+        $this->assertTrue($this->adapter->isImage('test.avif'));
+        $this->assertTrue($this->adapter->isImage('test.AVIF'));
         $this->assertFalse($this->adapter->isImage('test.txt'));
     }
 

--- a/tests/Imaging/ImageValidatorTest.php
+++ b/tests/Imaging/ImageValidatorTest.php
@@ -20,7 +20,7 @@ class ImageValidatorTest extends TestCase
         ]]);
 
         // We'll test `isValidExtension()` functionality separately below, and just mock here...
-        ImageValidator::shouldReceive('isValidExtension')->andReturnTrue()->times(23);
+        ImageValidator::shouldReceive('isValidExtension')->andReturnTrue()->times(24);
         ImageValidator::makePartial();
 
         $this->assertTrue(ImageValidator::isValidImage('jpg', 'image/jpeg'));

--- a/tests/Imaging/ImageValidatorTest.php
+++ b/tests/Imaging/ImageValidatorTest.php
@@ -30,6 +30,7 @@ class ImageValidatorTest extends TestCase
         $this->assertTrue(ImageValidator::isValidImage('png', 'image/png'));
         $this->assertTrue(ImageValidator::isValidImage('gif', 'image/gif'));
         $this->assertTrue(ImageValidator::isValidImage('webp', 'image/webp'));
+        $this->assertTrue(ImageValidator::isValidImage('avif', 'image/avif'));
         $this->assertTrue(ImageValidator::isValidImage('tif', 'image/tiff'));
         $this->assertTrue(ImageValidator::isValidImage('bmp', 'image/bmp'));
         $this->assertTrue(ImageValidator::isValidImage('bmp', 'image/x-bmp'));
@@ -90,6 +91,7 @@ class ImageValidatorTest extends TestCase
         $this->assertFalse(ImageValidator::isValidExtension('svg'));
         $this->assertFalse(ImageValidator::isValidExtension('pdf'));
         $this->assertFalse(ImageValidator::isValidExtension('eps'));
+        $this->assertFalse(ImageValidator::isValidExtension('avif'));
     }
 
     #[Test]
@@ -101,6 +103,7 @@ class ImageValidatorTest extends TestCase
             'svg',
             'pdf',
             'eps',
+            'avif',
         ]]);
 
         $this->assertTrue(ImageValidator::isValidExtension('jpeg'));
@@ -116,6 +119,7 @@ class ImageValidatorTest extends TestCase
         $this->assertTrue(ImageValidator::isValidExtension('svg'));
         $this->assertTrue(ImageValidator::isValidExtension('pdf'));
         $this->assertTrue(ImageValidator::isValidExtension('eps'));
+        $this->assertTrue(ImageValidator::isValidExtension('avif'));
 
         // Not configured, should still be false...
         $this->assertFalse(ImageValidator::isValidExtension('exe'));


### PR DESCRIPTION
- Add `avif` to the list of known image formats
- Add `webp` where it was still missing as well, for good measure :)

<img width="1167" alt="Screenshot 2024-10-26 at 02 11 34" src="https://github.com/user-attachments/assets/0930716e-7ef0-4a60-86c6-c6722fe2e215">
