### PR TITLE
[5.x] Configurable Template Scaffolding

### DIFF
--- a/config/templates.php
+++ b/config/templates.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'engine' => 'antlers',
+];

--- a/src/Http/Controllers/CP/Collections/ScaffoldCollectionController.php
+++ b/src/Http/Controllers/CP/Collections/ScaffoldCollectionController.php
@@ -3,12 +3,18 @@
 namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Statamic\Contracts\Entries\Collection as CollectionContract;
 use Statamic\Facades\File;
 use Statamic\Http\Controllers\CP\CpController;
 
 class ScaffoldCollectionController extends CpController
 {
+    protected array $templateExtensions = [
+        'antlers' => '.antlers.html',
+        'blade' => '.blade.php',
+    ];
+
     public function index($collection)
     {
         $this->authorize('store', CollectionContract::class, __('You are not authorized to scaffold resources.'));
@@ -37,9 +43,20 @@ class ScaffoldCollectionController extends CpController
         ];
     }
 
+    private function getTemplateFile($filename)
+    {
+        $extension = Arr::get(
+            $this->templateExtensions,
+            config('statamic.templates.engine', 'antlers'),
+            '.antlers.html'
+        );
+
+        return resource_path("views/{$filename}{$extension}");
+    }
+
     private function makeTemplate($filename)
     {
-        $file = resource_path("views/{$filename}.antlers.html");
+        $file = $this->getTemplateFile($filename);
 
         // Don't overwrite existing
         if (! File::get($file)) {


### PR DESCRIPTION
🚧🚧 WIP 🚧🚧

This PR is the start of making Blade feel more at home in other places, and is complimentary to #10967. The changes add a new `config/statamic/templates.php` configuration file. So far it only allows for setting the templating engine. When set to `blade`, the scaffolded collection views from the Control Panel will now use the `.blade.php` extension, saving people from having to rename things manually 💅

Stuff to do/think through:

[ ] Command to go Blade (invokable from CLI)
[ ] Corresponding Statamic CLI update to ask (nicely, of course)
[ ] How this will interact with other things (yet to be determined)
[ ] Maybe configurable scaffolded default contents?
[ ] Where's the beef?