### PR TITLE
[5.x] Allow setting tag pair content from fluent tags

### DIFF
--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -78,7 +78,7 @@ class FluentTag implements \ArrayAccess, \IteratorAggregate
      * @param  string  $content
      * @return $this
      */
-    public function content($content)
+    public function withContent($content)
     {
         $this->content = $content;
 

--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -14,6 +14,11 @@ class FluentTag implements \ArrayAccess, \IteratorAggregate
     protected $name;
 
     /**
+     * @var string
+     */
+    protected $content = '';
+
+    /**
      * @var array
      */
     protected $context = [];
@@ -68,6 +73,19 @@ class FluentTag implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
+     * Set the content between tag pairs.
+     *
+     * @param  string  $content
+     * @return $this
+     */
+    public function content($content)
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
      * Set the context.
      *
      * @param  array  $context
@@ -109,7 +127,7 @@ class FluentTag implements \ArrayAccess, \IteratorAggregate
         $tag = app(Loader::class)->load($name, [
             'parser' => null,
             'params' => $this->params,
-            'content' => '',
+            'content' => $this->content,
             'context' => $this->context,
             'tag' => $tagName,
             'tag_method' => $originalMethod,

--- a/tests/Tags/FluentTagTest.php
+++ b/tests/Tags/FluentTagTest.php
@@ -103,7 +103,7 @@ class FluentTagTest extends TestCase
             ->once()
             ->andReturn($tag);
 
-        $fluentTag = FluentTag::make('foo')->content('the content');
+        $fluentTag = FluentTag::make('foo')->withContent('the content');
 
         $this->assertInstanceOf(FluentTag::class, $fluentTag);
 

--- a/tests/Tags/FluentTagTest.php
+++ b/tests/Tags/FluentTagTest.php
@@ -90,6 +90,27 @@ class FluentTagTest extends TestCase
     }
 
     #[Test]
+    public function it_handles_content_fluently()
+    {
+        $tag = Mockery::mock(Tags::class)->makePartial();
+        $tag->shouldReceive('index')->andReturn('the content');
+
+        $this->mock(Loader::class)
+            ->shouldReceive('load')
+            ->withArgs(
+                fn ($arg1, $arg2) => $arg1 === 'foo' && Arr::get($arg2, 'content') === 'the content'
+            )
+            ->once()
+            ->andReturn($tag);
+
+        $fluentTag = FluentTag::make('foo')->content('the content');
+
+        $this->assertInstanceOf(FluentTag::class, $fluentTag);
+
+        $this->assertEquals('the content', $fluentTag->fetch());
+    }
+
+    #[Test]
     public function it_can_iterate_over_tag_results()
     {
         $this->mockTagThatReturns(collect([


### PR DESCRIPTION
Some of our recent projects use third-party templating languages and would benefit from being able to set the content of tag pairs when emulating Antlers tags. That's what this PR would allow.

So to emulate...

```antlers
{{ dictionary handle="countries" }}
    {{ label }}
{{ /dictionary }}
```

One could do the following...

```php
Statamic::tag('dictionary')
  ->params(['handle' => 'countries'])
  ->withContent('{{ label }}')
  ->fetch();
```