### PR TITLE
[5.x] Fix helpBlock error with custom js validation rule

### DIFF
--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -176,7 +176,7 @@ export default {
                 return false;
             }
 
-            let rule = _.chain(RULES)
+            let rule = _.chain([...RULES, ...Statamic.$config.get('extensionRules')])
                 .filter(rule => rule.value === this.selectedLaravelRule)
                 .first()
                 .value();

--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -176,7 +176,7 @@ export default {
                 return false;
             }
 
-            let rule = _.chain([...RULES, ...Statamic.$config.get('extensionRules')])
+            let rule = _.chain(this.allRules)
                 .filter(rule => rule.value === this.selectedLaravelRule)
                 .first()
                 .value();


### PR DESCRIPTION
I was encountering an error when using the example field while trying to extend rules this way in cp.js.
```
Statamic.booting(() => {
    Statamic.$config.set('extensionRules',
    [
        {
            label: 'Email Authenticator',
            value: 'email_authenticator:',
            example: 'email_authenticator:form'
        },
    ]);
});
```

```
TypeError: Cannot read properties of undefined (reading 'example')
    at q.helpBlock (app-4350e625.js:392:218858)
    at M.get (app-4350e625.js:5:42279)
    at M.evaluate (app-4350e625.js:5:43343)
    at q.helpBlock (app-4350e625.js:5:45757)
    at q.M (app-4350e625.js:392:221720)
    at M._render (app-4350e625.js:5:24987)
    at q.N (app-4350e625.js:5:29723)
    at M.get (app-4350e625.js:5:42279)
    at M.run (app-4350e625.js:5:43050)
    at flushSchedulerQueue (app-4350e625.js:5:32642)

TypeError: Cannot read properties of undefined (reading '$refs')
    at q.<anonymous> (app-4350e625.js:392:219887)
    at Array.<anonymous> (app-4350e625.js:5:39048)
    at flushCallbacks (app-4350e625.js:5:38224)
```

So i am submitting this PR because I've resolved this issue.