### PR TITLE
[5.x] Add a config for specifying the default layout

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -53,4 +53,14 @@ return [
 
     'middleware' => 'web',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Layout
+    |--------------------------------------------------------------------------
+    |
+    | Define the default layout that will be used by front end routes.
+    |
+    */
+
+    'layout' => env('STATAMIC_FRONTEND_ROUTES_LAYOUT', 'layout'),
 ];

--- a/config/routes.php
+++ b/config/routes.php
@@ -53,14 +53,4 @@ return [
 
     'middleware' => 'web',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Layout
-    |--------------------------------------------------------------------------
-    |
-    | Define the default layout that will be used by front end routes.
-    |
-    */
-
-    'layout' => env('STATAMIC_FRONTEND_ROUTES_LAYOUT', 'layout'),
 ];

--- a/config/system.php
+++ b/config/system.php
@@ -194,4 +194,15 @@ return [
 
     'fake_sql_queries' => config('app.debug'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Layout
+    |--------------------------------------------------------------------------
+    |
+    | Define the default layout that will be used by views.
+    |
+    */
+
+    'layout' => env('STATAMIC_LAYOUT', 'layout'),
+
 ];

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -442,7 +442,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
         return $this
             ->fluentlyGetOrSet('layout')
             ->getter(function ($layout) {
-                return $layout ?? 'layout';
+                return $layout ?? config('statamic.routes.layout', 'layout');
             })
             ->args(func_get_args());
     }

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -442,7 +442,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
         return $this
             ->fluentlyGetOrSet('layout')
             ->getter(function ($layout) {
-                return $layout ?? config('statamic.routes.layout', 'layout');
+                return $layout ?? config('statamic.system.layout', 'layout');
             })
             ->args(func_get_args());
     }

--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -45,7 +45,7 @@ class FrontendController extends Controller
 
         $view = app(View::class)
             ->template($view)
-            ->layout(Arr::get($data, 'layout', 'layout'))
+            ->layout(Arr::get($data, 'layout', config('statamic.routes.layout', 'layout')))
             ->with($data)
             ->cascadeContent($this->getLoadedRouteItem($data));
 

--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -45,7 +45,7 @@ class FrontendController extends Controller
 
         $view = app(View::class)
             ->template($view)
-            ->layout(Arr::get($data, 'layout', config('statamic.routes.layout', 'layout')))
+            ->layout(Arr::get($data, 'layout', config('statamic.system.layout', 'layout')))
             ->with($data)
             ->cascadeContent($this->getLoadedRouteItem($data));
 

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -436,7 +436,7 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
         return $this
             ->fluentlyGetOrSet('layout')
             ->getter(function ($layout) {
-                return $layout ?? config('statamic.routes.layout', 'layout');
+                return $layout ?? config('statamic.system.layout', 'layout');
             })
             ->args(func_get_args());
     }

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -436,7 +436,7 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
         return $this
             ->fluentlyGetOrSet('layout')
             ->getter(function ($layout) {
-                return $layout ?? 'layout';
+                return $layout ?? config('statamic.routes.layout', 'layout');
             })
             ->args(func_get_args());
     }

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -341,4 +341,16 @@ class RoutesTest extends TestCase
         $this->get('/bindings/term/title/Blog2')
             ->assertNotFound();
     }
+
+    #[Test]
+    public function it_uses_a_non_default_layout()
+    {
+        config()->set('statamic.routes.layout', 'custom-layout');
+        $this->viewShouldReturnRaw('custom-layout', 'Custom layout {{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        $this->get('/basic-route-with-data')
+            ->assertOk()
+            ->assertSee('Custom layout');
+    }
 }

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -345,7 +345,7 @@ class RoutesTest extends TestCase
     #[Test]
     public function it_uses_a_non_default_layout()
     {
-        config()->set('statamic.routes.layout', 'custom-layout');
+        config()->set('statamic.system.layout', 'custom-layout');
         $this->viewShouldReturnRaw('custom-layout', 'Custom layout {{ template_content }}');
         $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
 


### PR DESCRIPTION
This PR adds a new config `statamic.routes.layout` that allow the default layout to be changed to something other than `layout`. I've also set it to look for an .env variable (`STATAMIC_FRONTEND_ROUTES_LAYOUT`).

Our use is we have a site where the same codebase is shared across slightly different site versions and need to adapt the layout significantly per site - but other than that the codebase is the same.

If it helps make the case - Livewire [allow the layout to be changed in a config](https://github.com/livewire/livewire/blob/82e2b40361f1779f541c18ee30d2d0d201ae768b/config/livewire.php#L41).