### PR TITLE
[5.x] Fix Filesystem AbstractAdapter put method return

### DIFF
--- a/src/Filesystem/AbstractAdapter.php
+++ b/src/Filesystem/AbstractAdapter.php
@@ -26,7 +26,7 @@ abstract class AbstractAdapter implements Filesystem
     {
         $this->makeDirectory(pathinfo($path)['dirname']);
 
-        $this->filesystem->put($this->normalizePath($path), $contents);
+        return $this->filesystem->put($this->normalizePath($path), $contents);
     }
 
     public function delete($path)


### PR DESCRIPTION
I learned about this the hard way.  I spent over an hour trying to figure out why a custom media importer I had built was failing on the step only to find out `$assetContainer->disk()->put()` returns null instead of the normal true/false on success/fail.

Example of what I am trying to solve:
```php
$success = \Statamic\Facades\AssetContainer::find('assets')->disk()->put('test.txt', 'test');
```
You'd expect if the file is created `$success` would be true, but it is not.  It is null.

This is true of all other methods in the AbstractAdapter so I believe this being left out is just a typo/bug.

One could make an argument this should target 6.x since it changes a return type, but since null was always being returned there should be no logic dependent upon it.