### PR TITLE
Show Hidden fieldtype in form submission

### DIFF
--- a/resources/css/components/fieldtypes/hidden.css
+++ b/resources/css/components/fieldtypes/hidden.css
@@ -2,6 +2,6 @@
    HIDDEN FIELDTYPE
    ========================================================================== */
 
-.hidden-fieldtype {
+.hidden-fieldtype:not(.form-submission-field) {
     display: none; /*  So fancy */
 }

--- a/resources/js/components/fieldtypes/HiddenFieldtype.vue
+++ b/resources/js/components/fieldtypes/HiddenFieldtype.vue
@@ -1,9 +1,27 @@
 <template>
-    <input type="hidden" :name="name" :value="value" />
+    <div>
+        <text-input
+            v-if="this.isInsideFormSubmission"
+            type="text"
+            :name="name"
+            :value="value"
+            isReadOnly="true"
+        />
+        <input
+            v-else
+            type="hidden"
+            :name="name"
+            :value="value"
+        />
+    </div>
 </template>
 
 <script>
 export default {
-    mixins: [Fieldtype]
+    mixins: [Fieldtype],
+
+    inject: {
+        isInsideFormSubmission: { default: false },
+    },
 };
 </script>

--- a/resources/js/components/publish/Field.vue
+++ b/resources/js/components/publish/Field.vue
@@ -112,6 +112,7 @@ export default {
     inject: {
         storeName: { default: null },
         isInsideConfigFields: { default: false },
+        isInsideFormSubmission: { default: false },
     },
 
     computed: {
@@ -159,6 +160,7 @@ export default {
                 `${this.config.component || this.config.type}-fieldtype`,,
                 this.isReadOnly ? 'read-only-field' : '',
                 this.isInsideConfigFields ? 'config-field' : `${tailwind_width_class(this.config.width)}`,
+                this.isInsideFormSubmission ? 'form-submission-field' : '',
                 this.config.classes || '',
                 this.config.full_width_setting ? 'full-width-setting' : '',
                 { 'has-error': this.hasError || this.hasNestedError }

--- a/resources/js/components/publish/PublishForm.vue
+++ b/resources/js/components/publish/PublishForm.vue
@@ -5,7 +5,7 @@
         :name="name"
         :blueprint="blueprint"
         v-model="currentValues"
-        reference="collection"
+        :reference="initialReference"
         :meta="meta"
         :errors="errors"
         v-slot="{ setFieldValue, setFieldMeta }"
@@ -40,7 +40,14 @@ export default {
         breadcrumbs: Array,
         action: String,
         method: { type: String, default: 'post' },
-        readOnly: { type: Boolean, default: false }
+        readOnly: { type: Boolean, default: false },
+        initialReference: { type: String, default: 'collection' },
+    },
+
+    provide() {
+        return {
+            isInsideFormSubmission: this.initialReference.startsWith('submission::'),
+        }
     },
 
     data() {

--- a/resources/views/forms/submission.blade.php
+++ b/resources/views/forms/submission.blade.php
@@ -14,6 +14,7 @@
         :meta='@json($meta)'
         :values='@json($values)'
         read-only
+        initial-reference="{{ $reference }}"
     ></publish-form>
 
 @endsection

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -268,6 +268,11 @@ class Submission implements Augmentable, SubmissionContract
         return $this->data()->all();
     }
 
+    public function reference()
+    {
+        return "submission::{$this->id()}";
+    }
+
     public function __get($key)
     {
         return $this->get($key);

--- a/src/Http/Controllers/CP/Forms/FormSubmissionsController.php
+++ b/src/Http/Controllers/CP/Forms/FormSubmissionsController.php
@@ -91,6 +91,7 @@ class FormSubmissionsController extends CpController
             'values' => $fields->values(),
             'meta' => $fields->meta(),
             'title' => $submission->formattedDate(),
+            'reference' => $submission->reference(),
         ]);
     }
 }


### PR DESCRIPTION
This PR fixes a paper cut issue I've been running into in many projects. I'm using the `Hidden` fieldtype in a lot of forms to submit, well, hidden data. The problem is, that you can't see that field in the form submission view, as the Hidden fieldtype is hidden. This PR unhides hidden fields when viewing form submissions. The fieldtype stays hidden in all other scenarios.