### PR TITLE
[5.x] Select correct site when using multiple domains

### DIFF
--- a/src/Http/Middleware/CP/SelectedSite.php
+++ b/src/Http/Middleware/CP/SelectedSite.php
@@ -10,13 +10,20 @@ class SelectedSite
 {
     public function handle($request, Closure $next)
     {
-        $this->updateSelectedSite();
+        $this->updateSelectedSite($request);
 
         return $next($request);
     }
 
-    private function updateSelectedSite()
+    private function updateSelectedSite($request)
     {
+        $siteByUrl = Site::findByUrl($request->getSchemeAndHttpHost());
+
+        /* Ensure that we only make this automatic selection when first loggin in */
+        if (! session('statamic.cp.selected-site') && $siteByUrl) {
+            Site::setSelected($siteByUrl->handle());
+        }
+
         if (User::current()->can('view', Site::selected())) {
             return;
         }


### PR DESCRIPTION
This PR updates the `SelectedSite` middleware to set the correct site in the CP when using different domains.

Consider this sites config.

```yaml
'sites' => [
    'english' => [
        'url' => 'https://english.com',
    ],
    'french' => [
        'url' => 'https://french.com',
    ]
]
```

Users can access the CP through `https://english.com/cp` and `https://french.com/cp`. 

So far, the global sites selector would pick the default site when first logging in. No matter what domain you're on. This PR changes this to select the site by URL. This selection only happens when first logging in. So subsequent changes to the selected site will still work and not be overridden by this automatic selection.