### PR TITLE
[5.x] Add `default` config for select starter kit modules

### DIFF
--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -338,7 +338,7 @@ final class Installer
 
         if ($shouldPrompt && $this->isInteractive && ! confirm(Arr::get($config, 'prompt', "Would you like to install the [{$name}] module?"), $default)) {
             return false;
-        } elseif ($shouldPrompt && ! $this->isInteractive) {
+        } elseif ($shouldPrompt && ! $this->isInteractive && ! $default) {
             return false;
         }
 

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -334,7 +334,9 @@ final class Installer
 
         $name = str_replace('_', ' ', $key);
 
-        if ($shouldPrompt && $this->isInteractive && ! confirm(Arr::get($config, 'prompt', "Would you like to install the [{$name}] module?"), false)) {
+        $default = Arr::get($config, 'default', false);
+
+        if ($shouldPrompt && $this->isInteractive && ! confirm(Arr::get($config, 'prompt', "Would you like to install the [{$name}] module?"), $default)) {
             return false;
         } elseif ($shouldPrompt && ! $this->isInteractive) {
             return false;

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -362,6 +362,7 @@ final class Installer
             $choice = select(
                 label: Arr::get($config, 'prompt', "Would you like to install one of the following [{$name}] modules?"),
                 options: $options,
+                default: Arr::get($config, 'default'),
             );
         } elseif (! $this->isInteractive && ! $choice = Arr::get($config, 'default')) {
             return false;

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -780,12 +780,18 @@ EOT;
             ],
             'modules' => [
                 'seo' => [
-                    'prompt' => false, // Setting `prompt: false` skips confirmation, so this module should still get installed
+                    'prompt' => false, // Setting `prompt: false` normally skips confirmation and ensures it always gets installed
                     'export_paths' => [
                         'resources/css/seo.css',
                     ],
                     'dependencies' => [
                         'statamic/seo-pro' => '^0.2.0',
+                    ],
+                ],
+                'hockey' => [
+                    'default' => true, // Setting `default: true` will still ask user for confirmation, but should still get installed non-interactively
+                    'export_paths' => [
+                        'resources/css/hockey.css',
                     ],
                 ],
                 'bobsled' => [
@@ -797,13 +803,13 @@ EOT;
                     ],
                 ],
                 'jamaica' => [
-                    'prompt' => false, // Setting `prompt: false` skips confirmation, so this module should still get installed
+                    'prompt' => false, // Setting `prompt: false` normally skips confirmation and ensures it always gets installed
                     'export_as' => [
                         'resources/css/theme.css' => 'resources/css/jamaica.css',
                     ],
                 ],
                 'js' => [
-                    'default' => 'vue', // Setting a `default` option, so this module should still get installed
+                    'default' => 'vue', // Setting a `default` option will still ask user for confirmation, but should still get installed non-interactively
                     'options' => [
                         'react' => [
                             'label' => 'React JS',
@@ -834,6 +840,7 @@ EOT;
 
         $this->assertFileDoesNotExist(base_path('copied.md'));
         $this->assertFileDoesNotExist(base_path('resources/css/seo.css'));
+        $this->assertFileDoesNotExist(base_path('resources/css/hockey.css'));
         $this->assertFileDoesNotExist(base_path('resources/css/bobsled.css'));
         $this->assertFileDoesNotExist(base_path('resources/css/theme.css'));
         $this->assertComposerJsonDoesntHave('statamic/seo-pro');
@@ -846,6 +853,7 @@ EOT;
 
         $this->assertFileExists(base_path('copied.md'));
         $this->assertFileExists(base_path('resources/css/seo.css'));
+        $this->assertFileExists(base_path('resources/css/hockey.css'));
         $this->assertFileDoesNotExist(base_path('resources/css/bobsled.css'));
         $this->assertFileExists(base_path('resources/css/theme.css'));
         $this->assertComposerJsonHasPackageVersion('require', 'statamic/seo-pro', '^0.2.0');

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -780,7 +780,7 @@ EOT;
             ],
             'modules' => [
                 'seo' => [
-                    'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed non-interactively
+                    'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed
                     'export_paths' => [
                         'resources/css/seo.css',
                     ],
@@ -797,9 +797,37 @@ EOT;
                     ],
                 ],
                 'jamaica' => [
-                    'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed non-interactively
+                    'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed
                     'export_as' => [
                         'resources/css/theme.css' => 'resources/css/jamaica.css',
+                    ],
+                ],
+                'js' => [
+                    'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed
+                    'default' => 'vue', // And a `default` is required so that we know which one to install
+                    'options' => [
+                        'react' => [
+                            'label' => 'React JS',
+                            'export_paths' => [
+                                'resources/js/react.js',
+                            ],
+                        ],
+                        'vue' => [
+                            'label' => 'Vue JS',
+                            'export_paths' => [
+                                'resources/js/vue.js',
+                            ],
+                        ],
+                    ],
+                ],
+                'js_invalid' => [
+                    'prompt' => false, // Setting prompt to false without a `default`, is not valid config
+                    'options' => [
+                        'svelte' => [
+                            'export_paths' => [
+                                'resources/js/svelte.js',
+                            ],
+                        ],
                     ],
                 ],
             ],
@@ -811,6 +839,9 @@ EOT;
         $this->assertFileDoesNotExist(base_path('resources/css/theme.css'));
         $this->assertComposerJsonDoesntHave('statamic/seo-pro');
         $this->assertComposerJsonDoesntHave('bobsled/speed-calculator');
+        $this->assertFileDoesNotExist(base_path('resources/js/react.js'));
+        $this->assertFileDoesNotExist(base_path('resources/js/vue.js'));
+        $this->assertFileDoesNotExist(base_path('resources/js/svelte.js'));
 
         $this->installCoolRunnings();
 
@@ -820,6 +851,9 @@ EOT;
         $this->assertFileExists(base_path('resources/css/theme.css'));
         $this->assertComposerJsonHasPackageVersion('require', 'statamic/seo-pro', '^0.2.0');
         $this->assertComposerJsonDoesntHave('bobsled/speed-calculator');
+        $this->assertFileDoesNotExist(base_path('resources/js/react.js'));
+        $this->assertFileExists(base_path('resources/js/vue.js'));
+        $this->assertFileDoesNotExist(base_path('resources/js/svelte.js'));
     }
 
     #[Test]
@@ -1179,6 +1213,24 @@ EOT;
                                         'resources/dictionaries/canadian_players.yaml',
                                     ],
                                 ],
+                                'js' => [
+                                    'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed
+                                    'default' => 'vue', // And a `default` is required so that we know which one to install
+                                    'options' => [
+                                        'react' => [
+                                            'label' => 'React JS',
+                                            'export_paths' => [
+                                                'resources/js/react.js',
+                                            ],
+                                        ],
+                                        'vue' => [
+                                            'label' => 'Vue JS',
+                                            'export_paths' => [
+                                                'resources/js/vue.js',
+                                            ],
+                                        ],
+                                    ],
+                                ],
                             ],
                         ],
                     ],
@@ -1192,6 +1244,8 @@ EOT;
         $this->assertFileDoesNotExist(base_path('resources/dictionaries/players.yaml'));
         $this->assertFileDoesNotExist(base_path('resources/dictionaries/american_players.yaml'));
         $this->assertFileDoesNotExist(base_path('resources/dictionaries/canadian_players.yaml'));
+        $this->assertFileDoesNotExist(base_path('resources/js/react.js'));
+        $this->assertFileDoesNotExist(base_path('resources/js/vue.js'));
 
         $this->installCoolRunnings();
 
@@ -1201,6 +1255,8 @@ EOT;
         $this->assertFileExists(base_path('resources/dictionaries/players.yaml'));
         $this->assertFileDoesNotExist(base_path('resources/dictionaries/american_players.yaml'));
         $this->assertFileExists(base_path('resources/dictionaries/canadian_players.yaml'));
+        $this->assertFileDoesNotExist(base_path('resources/js/react.js'));
+        $this->assertFileExists(base_path('resources/js/vue.js'));
     }
 
     #[Test]

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -772,7 +772,7 @@ EOT;
     }
 
     #[Test]
-    public function it_installs_modules_with_prompt_false_config_by_default_when_running_non_interactively()
+    public function it_can_still_install_modules_with_prompt_false_or_default_config()
     {
         $this->setConfig([
             'export_paths' => [
@@ -780,7 +780,7 @@ EOT;
             ],
             'modules' => [
                 'seo' => [
-                    'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed
+                    'prompt' => false, // Setting `prompt: false` skips confirmation, so this module should still get installed
                     'export_paths' => [
                         'resources/css/seo.css',
                     ],
@@ -797,14 +797,13 @@ EOT;
                     ],
                 ],
                 'jamaica' => [
-                    'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed
+                    'prompt' => false, // Setting `prompt: false` skips confirmation, so this module should still get installed
                     'export_as' => [
                         'resources/css/theme.css' => 'resources/css/jamaica.css',
                     ],
                 ],
                 'js' => [
-                    'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed
-                    'default' => 'vue', // And a `default` is required so that we know which one to install
+                    'default' => 'vue', // Setting a `default` option, so this module should still get installed
                     'options' => [
                         'react' => [
                             'label' => 'React JS',
@@ -821,7 +820,7 @@ EOT;
                     ],
                 ],
                 'js_invalid' => [
-                    'prompt' => false, // Setting prompt to false without a `default`, is not valid config
+                    'prompt' => false, // Setting `prompt: false` doesn't do anything for select modules, should use `default` like above
                     'options' => [
                         'svelte' => [
                             'export_paths' => [
@@ -1180,7 +1179,7 @@ EOT;
     }
 
     #[Test]
-    public function it_installs_nested_modules_with_prompt_false_config_by_default_when_running_non_interactively()
+    public function it_can_still_install_nested_modules_with_prompt_false_or_default_config()
     {
         $this->setConfig([
             'export_paths' => [
@@ -1188,13 +1187,13 @@ EOT;
             ],
             'modules' => [
                 'canada' => [
-                    'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed non-interactively
+                    'prompt' => false, // Setting `prompt: false` skips confirmation, so this module should still get installed
                     'export_paths' => [
                         'resources/css/hockey.css',
                     ],
                     'modules' => [
                         'hockey_players' => [
-                            'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed non-interactively
+                            'prompt' => false, // Setting `prompt: false` skips confirmation, so this module should still get installed
                             'export_paths' => [
                                 'resources/dictionaries/players.yaml',
                             ],
@@ -1208,14 +1207,13 @@ EOT;
                                     ],
                                 ],
                                 'hockey_night_in_canada' => [
-                                    'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed non-interactively
+                                    'prompt' => false, // Setting `prompt: false` skips confirmation, so this module should still get installed
                                     'export_paths' => [
                                         'resources/dictionaries/canadian_players.yaml',
                                     ],
                                 ],
                                 'js' => [
-                                    'prompt' => false, // Setting prompt to false skips confirmation, so this module should still get installed
-                                    'default' => 'vue', // And a `default` is required so that we know which one to install
+                                    'default' => 'vue', // Setting a `default` option, so this module should still get installed
                                     'options' => [
                                         'react' => [
                                             'label' => 'React JS',

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -959,7 +959,120 @@ EOT;
     }
 
     #[Test]
-    public function it_display_custom_module_prompts()
+    public function it_allows_user_to_skip_in_select_module_prompts()
+    {
+        $this->setConfig([
+            'modules' => [
+                'js' => [
+                    'prompt' => 'Want one of these fancy JS options?',
+                    'options' => [
+                        'react' => [
+                            'label' => 'React JS',
+                            'export_paths' => [
+                                'resources/js/react.js',
+                            ],
+                        ],
+                        'vue' => [
+                            'label' => 'Vue JS',
+                            'export_paths' => [
+                                'resources/js/vue.js',
+                            ],
+                        ],
+                        'svelte' => [
+                            'export_paths' => [
+                                'resources/js/svelte.js',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertFileDoesNotExist(base_path('resources/js/react.js'));
+        $this->assertFileDoesNotExist(base_path('resources/js/vue.js'));
+        $this->assertFileDoesNotExist(base_path('resources/js/svelte.js'));
+
+        $command = $this->installCoolRunningsModules();
+
+        // Some fixes to `expectsChoice()` were merged for us, but are not available on 11.20.0 and below
+        // See: https://github.com/laravel/framework/pull/52408
+        if (version_compare(app()->version(), '11.20.0', '>')) {
+            $command->expectsChoice('Want one of these fancy JS options?', 'skip_module', [
+                'skip_module' => 'No',
+                'react' => 'React JS',
+                'vue' => 'Vue JS',
+                'svelte' => 'Svelte',
+            ]);
+        } else {
+            $command->expectsQuestion('Want one of these fancy JS options?', 'skip_module');
+        }
+
+        $command->run();
+
+        $this->assertFileDoesNotExist(base_path('resources/js/react.js'));
+        $this->assertFileDoesNotExist(base_path('resources/js/vue.js'));
+        $this->assertFileDoesNotExist(base_path('resources/js/svelte.js'));
+    }
+
+    #[Test]
+    public function it_can_disable_skip_option_in_select_module_prompts()
+    {
+        $this->setConfig([
+            'modules' => [
+                'js' => [
+                    'prompt' => 'Want one of these fancy JS options?',
+                    'skip_option' => false,
+                    'options' => [
+                        'react' => [
+                            'label' => 'React JS',
+                            'export_paths' => [
+                                'resources/js/react.js',
+                            ],
+                        ],
+                        'vue' => [
+                            'label' => 'Vue JS',
+                            'export_paths' => [
+                                'resources/js/vue.js',
+                            ],
+                        ],
+                        'svelte' => [
+                            'export_paths' => [
+                                'resources/js/svelte.js',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertFileDoesNotExist(base_path('resources/js/react.js'));
+        $this->assertFileDoesNotExist(base_path('resources/js/vue.js'));
+        $this->assertFileDoesNotExist(base_path('resources/js/svelte.js'));
+
+        $command = $this->installCoolRunningsModules();
+
+        // Some fixes to `expectsChoice()` were merged for us, but are not available on 11.20.0 and below
+        // See: https://github.com/laravel/framework/pull/52408
+        if (version_compare(app()->version(), '11.20.0', '>')) {
+            $command->expectsChoice('Want one of these fancy JS options?', 'svelte', [
+                // 'skip_module' => 'No', // This should not be here anymore, because of `skip_option: false`
+                'react' => 'React JS',
+                'vue' => 'Vue JS',
+                'svelte' => 'Svelte',
+            ]);
+        } else {
+            $command->expectsQuestion('Want one of these fancy JS options?', 'svelte');
+        }
+
+        $command->run();
+
+        $this->assertFileDoesNotExist(base_path('resources/js/react.js'));
+        $this->assertFileDoesNotExist(base_path('resources/js/vue.js'));
+        $this->assertFileExists(base_path('resources/js/svelte.js'));
+    }
+
+    #[Test]
+    public function it_display_custom_module_prompts_and_option_labels()
     {
         $this->setConfig([
             'modules' => [
@@ -971,6 +1084,7 @@ EOT;
                 ],
                 'js' => [
                     'prompt' => 'Want one of these fancy JS options?',
+                    'skip_option' => 'No, thank you!',
                     'options' => [
                         'react' => [
                             'label' => 'React JS',
@@ -1007,7 +1121,7 @@ EOT;
         // See: https://github.com/laravel/framework/pull/52408
         if (version_compare(app()->version(), '11.20.0', '>')) {
             $command->expectsChoice('Want one of these fancy JS options?', 'svelte', [
-                'skip_module' => 'No',
+                'skip_module' => 'No, thank you!',
                 'react' => 'React JS',
                 'vue' => 'Vue JS',
                 'svelte' => 'Svelte',


### PR DESCRIPTION
This PR adds a `default` config, to help with module installation flow when spamming the enter key, or when running non-interactively. More specifically...

### For standard confirmation-style modules (where user selects yes/no):

- `default: true` will ensure it gets installed when spamming enter or running non-interactively
- `prompt: false` will skip the confirmation prompt altogether, forcing the module to be installed
	- this is current behaviour, [as documented here](https://statamic.dev/starter-kits/creating-a-starter-kit#skipping-confirmation) for organizational purposes

### For select-style modules with options (where user selects A or B or C):

- `default: antlers` will ensure the `antlers` modules gets installed when spamming enter or running non-interactively
- `skip_option: false` will disable the option to skip the prompt altogether
    - if runing interactively, this forces the user to select an option
    - if running non-interactively, the `default` option will be installed

### Examples...

```yaml
modules:
  seo:
    default: true  # this still allows user to opt out, but defaults 'yes' when spamming enter or running non-interactively
    dependencies:
      - statamic/seo-pro
  js:
    default: mootools  # this will ensure the mootools module option gets installed if run non-interactively
    skip_option: false  # you can specify string for skip option label, or `false` to force user to select an option
    options:
      vue:
        label: 'VueJS'
        export_paths:
          - resources/js/vue.js
      react:
        label: 'ReactJS'
        export_paths:
          - resources/js/react.js
      mootools:
        label: 'MooTools (will never die!)'
        export_paths:
          - resources/js/mootools.js
```

### TODO:

- [x] Finish implementation
- [x] Test coverage
- [x] Docs PR https://github.com/statamic/docs/pull/1558