### PR TITLE
[5.x] Register App extensions also for Classes in Subfolders

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -336,7 +336,7 @@ class ExtensionServiceProvider extends ServiceProvider
         }
 
         foreach ($this->app['files']->allFiles($path) as $file) {
-            $relativePathOfFolder = str_replace(app_path('/'),'' ,$file->getPath());
+            $relativePathOfFolder = str_replace(app_path('/'), '', $file->getPath());
             $namespace = str_replace('/', '\\', $relativePathOfFolder);
             $class = $file->getBasename('.php');
 

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -335,9 +335,12 @@ class ExtensionServiceProvider extends ServiceProvider
             return;
         }
 
-        foreach ($this->app['files']->files($path) as $file) {
+        foreach ($this->app['files']->allFiles($path) as $file) {
+            $relativePathOfFolder = str_replace(app_path('/'),'' ,$file->getPath());
+            $namespace = str_replace('/', '\\', $relativePathOfFolder);
             $class = $file->getBasename('.php');
-            $fqcn = $this->app->getNamespace()."{$folder}\\{$class}";
+
+            $fqcn = $this->app->getNamespace()."{$namespace}\\{$class}";
             if (is_subclass_of($fqcn, $requiredClass)) {
                 $fqcn::register();
             }


### PR DESCRIPTION
In the current version of Statamic the App extensions - such as custom Modifiers, Scopes, Tags, Fieldtypes etc. - only auto register if they are directly in their respective folders but not if they are in a subfolder.

e.g.
app/scope/MyScope.php               will register
app/scope/order/MyScope2.php   will not register.

For order/organisational purposes this change would be preferred.

This PR doesn’t solve the Problem that two classes with the same Name in different namespaces receive the same handle and therefore overwrite each other but since that problem already exists between plugins and the handle can be customized with “protected static $handle” I wasn’t sure this problem needed solving.


Targets branch 5.x
Tests:  I didn't find any test for the Serviceprovider and don't know the convention where to add onto. If it's required I'll try to add it.

Closes #11047.