### PR TITLE
Fix addon events dispatched twice if registered manually

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -255,7 +255,9 @@ abstract class AddonServiceProvider extends ServiceProvider
 
         foreach ($this->listen as $event => $listeners) {
             foreach ($listeners as $listener) {
-                $arr[$event][] = $listener;
+                if (!in_array($listener, $arr[$event] ?? [])) {
+                    $arr[$event][] = $listener;
+                }
             }
         }
 


### PR DESCRIPTION
It seems that Statamic v5.36.0 introduced a breaking change in the way event listeners are registered. 

Recently a change was made to automatically register event listeners, although it is still possible to register them manually by using `protected $listen = ...` in an `AddonServerProvider`. Manually registered event listeners will now be registered twice, which will also dispatch their events twice. 

This leads to broken logic, e.g. when an event listener verifies a recaptcha response, which is only possible once, making it impossible to submit a form, unless the manual event listener registration is removed from the `AddonServiceProvider` in the corresponding addon.