### PR TITLE
[5.x] Fix query parameters in external script URLs being wrongly encoded

### DIFF
--- a/resources/views/partials/scripts.blade.php
+++ b/resources/views/partials/scripts.blade.php
@@ -1,5 +1,5 @@
 @foreach (Statamic::availableExternalScripts(request()) as $url)
-    <script src="{{ $url }}" defer></script>
+    <script src="{!! $url !!}" defer></script>
 @endforeach
 
 @foreach (Statamic::availableScripts(request()) as $package => $paths)


### PR DESCRIPTION
This pull request fixes an issue reported via support, where external script URLs containing query parameters like `?foo=bar&bar=baz` were being returned as `?foo=bar&amp;bar=baz`.

