### PR TITLE
[5.x] Improved fieldtype search using keywords

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "codemirror": "^5.58.2",
         "cookies-js": "^1.2.2",
         "floating-vue": "^1.0.0-beta.19",
-        "fuse.js": "^3.4.6",
+        "fuse.js": "^7.0.0",
         "highlight.js": "^11.7.0",
         "imask": "^6.6.0-alpha.0",
         "laravel-echo": "^1.16.0",
@@ -5333,11 +5333,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/fuse.js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.6.1.tgz",
-      "integrity": "sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "codemirror": "^5.58.2",
     "cookies-js": "^1.2.2",
     "floating-vue": "^1.0.0-beta.19",
-    "fuse.js": "^3.4.6",
+    "fuse.js": "^7.0.0",
     "highlight.js": "^11.7.0",
     "imask": "^6.6.0-alpha.0",
     "laravel-echo": "^1.16.0",

--- a/resources/js/components/data-list/DataList.vue
+++ b/resources/js/components/data-list/DataList.vue
@@ -135,7 +135,7 @@ export default {
                 keys: this.searchableColumns,
             });
 
-            return fuse.search(this.searchQuery);
+            return fuse.search(this.searchQuery).map(result => result.item);
         },
 
         sortRows(rows) {

--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -131,7 +131,6 @@ export default {
                 const fuse = new Fuse(options, {
                     findAllMatches: true,
                     threshold: 0.1,
-                    minMatchCharLength: 2,
                     keys: ['text'],
                 });
 

--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -135,7 +135,7 @@ export default {
                     keys: ['text'],
                 });
 
-                options = fuse.search(this.search);
+                options = fuse.search(this.search).map(result => result.item);
             }
 
             return options;

--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -131,7 +131,10 @@ export default {
                 const fuse = new Fuse(options, {
                     findAllMatches: true,
                     threshold: 0.1,
-                    keys: ['text'],
+                    keys: [
+                        {name: 'text', weight: 1},
+                        {name: 'categories', weight: 0.1}
+                    ],
                 });
 
                 options = fuse.search(this.search).map(result => result.item);

--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -134,7 +134,7 @@ export default {
                     keys: [
                         {name: 'text', weight: 1},
                         {name: 'categories', weight: 0.1},
-                        {name: 'keywords', weight: 0.8},
+                        {name: 'keywords', weight: 0.4},
                     ],
                 });
 

--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -99,7 +99,7 @@ export default {
             if (!this.fieldtypesLoaded) return [];
 
             let options = this.fieldtypes.map(fieldtype => {
-                return {text: fieldtype.title, value: fieldtype.handle, categories: fieldtype.categories, icon: fieldtype.icon};
+                return {text: fieldtype.title, value: fieldtype.handle, categories: fieldtype.categories, keywords: fieldtype.keywords, icon: fieldtype.icon};
             });
 
             if (this.allowDate) options.unshift({text: __('Publish Date'), value: 'date', categories: ['system'], isMeta: true, icon: 'date'});
@@ -133,7 +133,8 @@ export default {
                     threshold: 0.1,
                     keys: [
                         {name: 'text', weight: 1},
-                        {name: 'categories', weight: 0.1}
+                        {name: 'categories', weight: 0.1},
+                        {name: 'keywords', weight: 0.8},
                     ],
                 });
 

--- a/src/Dictionaries/Countries.php
+++ b/src/Dictionaries/Countries.php
@@ -8,6 +8,7 @@ class Countries extends BasicDictionary
 {
     protected string $valueKey = 'iso3';
     protected array $searchable = ['name', 'iso3'];
+    protected array $keywords = ['countries', 'country'];
     private array $regions;
     private array $subregions;
 

--- a/src/Dictionaries/Currencies.php
+++ b/src/Dictionaries/Currencies.php
@@ -5,6 +5,7 @@ namespace Statamic\Dictionaries;
 class Currencies extends BasicDictionary
 {
     protected string $valueKey = 'code';
+    protected array $keywords = ['currencies', 'currency', 'money', 'dollar'];
 
     protected function getItemLabel(array $item): string
     {

--- a/src/Dictionaries/Dictionary.php
+++ b/src/Dictionaries/Dictionary.php
@@ -15,6 +15,7 @@ abstract class Dictionary
 
     protected array $fields = [];
     protected array $config = [];
+    protected array $keywords = [];
 
     abstract public function options(?string $search = null): array;
 
@@ -74,5 +75,10 @@ abstract class Dictionary
         return collect($this->options($search))
             ->map(fn ($label, $value) => new Item($value, $label, $this->get($value)->extra()))
             ->all();
+    }
+
+    public function keywords(): array
+    {
+        return $this->keywords;
     }
 }

--- a/src/Dictionaries/File.php
+++ b/src/Dictionaries/File.php
@@ -7,6 +7,8 @@ use Statamic\Facades\YAML;
 
 class File extends BasicDictionary
 {
+    protected array $keywords = ['files', 'file', 'json', 'csv', 'yaml', 'yml'];
+
     protected function fieldItems()
     {
         return [

--- a/src/Dictionaries/Timezones.php
+++ b/src/Dictionaries/Timezones.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Carbon;
 class Timezones extends BasicDictionary
 {
     protected string $valueKey = 'name';
+    protected array $keywords = ['timezone', 'tz', 'zone', 'time', 'date'];
 
     protected function getItemLabel(array $item): string
     {

--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -29,6 +29,7 @@ abstract class Fieldtype implements Arrayable
     protected $selectableInForms = false;
     protected $relationship = false;
     protected $categories = [];
+    protected $keywords = [];
     protected $rules = [];
     protected $extraRules = [];
     protected $defaultValue;
@@ -113,6 +114,11 @@ abstract class Fieldtype implements Arrayable
         return $this->categories;
     }
 
+    public function keywords(): array
+    {
+        return $this->keywords;
+    }
+
     public function filter()
     {
         return new FieldtypeFilter($this);
@@ -167,6 +173,7 @@ abstract class Fieldtype implements Arrayable
             'validatable' => $this->validatable(),
             'defaultable' => $this->defaultable(),
             'categories' => $this->categories(),
+            'keywords' => $this->keywords(),
             'icon' => $this->icon(),
             'config' => $this->configFields()->toPublishArray(),
         ];

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -24,6 +24,7 @@ use Statamic\Support\Str;
 class Assets extends Fieldtype
 {
     protected $categories = ['media', 'relationship'];
+    protected $keywords = ['file', 'files', 'image', 'images', 'video', 'videos', 'audio', 'upload'];
     protected $selectableInForms = true;
 
     protected function configFieldItems(): array

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -38,7 +38,7 @@ class Bard extends Replicator
     ];
 
     protected $categories = ['text', 'structured'];
-    protected $keywords = ['rich', 'richtext', 'rich text', 'editor', 'wysiwg', 'builder', 'page builder', 'gutenberg'];
+    protected $keywords = ['rich', 'richtext', 'rich text', 'editor', 'wysiwg', 'builder', 'page builder', 'gutenberg', 'content'];
     protected $rules = [];
 
     protected function configFieldItems(): array

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -38,6 +38,7 @@ class Bard extends Replicator
     ];
 
     protected $categories = ['text', 'structured'];
+    protected $keywords = ['rich', 'richtext', 'rich text', 'editor', 'wysiwg', 'builder', 'page builder', 'gutenberg'];
     protected $rules = [];
 
     protected function configFieldItems(): array

--- a/src/Fieldtypes/Collections.php
+++ b/src/Fieldtypes/Collections.php
@@ -10,6 +10,7 @@ use Statamic\GraphQL\Types\CollectionType;
 class Collections extends Relationship
 {
     protected $categories = ['relationship'];
+    protected $keywords = ['entries'];
     protected $canEdit = false;
     protected $canCreate = false;
     protected $canSearch = false;

--- a/src/Fieldtypes/Color.php
+++ b/src/Fieldtypes/Color.php
@@ -7,6 +7,7 @@ use Statamic\Fields\Fieldtype;
 class Color extends Fieldtype
 {
     protected $categories = ['special'];
+    protected $keywords = ['rgb', 'hex', 'colour'];
 
     protected function configFieldItems(): array
     {

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -18,6 +18,7 @@ use Statamic\Support\DateFormat;
 class Date extends Fieldtype
 {
     protected $categories = ['special'];
+    protected $keywords = ['datetime', 'time'];
 
     const DEFAULT_DATE_FORMAT = 'Y-m-d';
     const DEFAULT_DATETIME_FORMAT = 'Y-m-d H:i';

--- a/src/Fieldtypes/Dictionary.php
+++ b/src/Fieldtypes/Dictionary.php
@@ -170,4 +170,15 @@ class Dictionary extends Fieldtype
     {
         GraphQL::addType($this->dictionary()->getGqlType());
     }
+
+    public function keywords(): array
+    {
+        return \Statamic\Facades\Dictionary::all()
+            ->flatMap(fn ($dictionary) => [
+                str($dictionary->handle())->replace('_', ' ')->toString(),
+                ...$dictionary->keywords(),
+            ])
+            ->merge(['select', 'option', 'choice', 'dropdown', 'list'])
+            ->unique()->values()->all();
+    }
 }

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -32,6 +32,7 @@ class Entries extends Relationship
     use QueriesFilters;
 
     protected $categories = ['relationship'];
+    protected $keywords = ['entry'];
     protected $canEdit = true;
     protected $canCreate = true;
     protected $canSearch = true;

--- a/src/Fieldtypes/Markdown.php
+++ b/src/Fieldtypes/Markdown.php
@@ -10,6 +10,7 @@ use Statamic\Support\Html;
 class Markdown extends Fieldtype
 {
     protected $categories = ['text'];
+    protected $keywords = ['md'];
 
     use Concerns\ResolvesStatamicUrls;
 

--- a/src/Fieldtypes/Markdown.php
+++ b/src/Fieldtypes/Markdown.php
@@ -10,7 +10,7 @@ use Statamic\Support\Html;
 class Markdown extends Fieldtype
 {
     protected $categories = ['text'];
-    protected $keywords = ['md'];
+    protected $keywords = ['md', 'content', 'html'];
 
     use Concerns\ResolvesStatamicUrls;
 

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -17,6 +17,7 @@ use Statamic\Support\Str;
 class Replicator extends Fieldtype
 {
     protected $categories = ['structured'];
+    protected $keywords = ['builder', 'page builder', 'content'];
     protected $rules = ['array'];
 
     protected function configFieldItems(): array

--- a/src/Fieldtypes/Select.php
+++ b/src/Fieldtypes/Select.php
@@ -9,6 +9,7 @@ class Select extends Fieldtype
     use HasSelectOptions;
 
     protected $categories = ['controls'];
+    protected $keywords = ['select', 'option', 'choice', 'dropdown', 'list'];
     protected $selectableInForms = true;
     protected $indexComponent = 'tags';
 

--- a/src/Fieldtypes/Toggle.php
+++ b/src/Fieldtypes/Toggle.php
@@ -9,6 +9,7 @@ use Statamic\Query\Scopes\Filters\Fields\Toggle as ToggleFilter;
 class Toggle extends Fieldtype
 {
     protected $categories = ['controls'];
+    protected $keywords = ['checkbox', 'bool', 'boolean'];
     protected $selectableInForms = true;
     protected $defaultValue = false;
 

--- a/src/Fieldtypes/Yaml.php
+++ b/src/Fieldtypes/Yaml.php
@@ -9,6 +9,7 @@ use Statamic\Yaml\ParseException;
 class Yaml extends Fieldtype
 {
     protected $categories = ['special'];
+    protected $keywords = ['yml'];
 
     protected function configFieldItems(): array
     {

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -157,6 +157,7 @@ class FieldtypeTest extends TestCase
             'validatable' => true,
             'defaultable' => true,
             'categories' => [],
+            'keywords' => [],
             'icon' => 'test',
             'config' => [],
         ], $fieldtype->toArray());


### PR DESCRIPTION
This PR allows fieldtypes to define keywords that will be used in the selector.

For example, if you search for "rich text" or "gutenberg" you will now see Bard as a result.

Dictionaries can also define keywords and will get pulled in by the fieldtype. So for example searching "country" will show the dictionary fieldtype as a result.

This also updates Fuse.js to the latest version but I don't believe that's an issue as it's only used in core. It's not exposed to the public.
