### PR TITLE
[5.x] Files Fieldtype: Don't truncate existing filename

### DIFF
--- a/resources/js/components/fieldtypes/FilesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FilesFieldtype.vue
@@ -48,7 +48,7 @@
                                     </div>
                                     <div
                                         class="flex items-center flex-1 rtl:mr-2 ltr:ml-2 text-xs rtl:text-right ltr:text-left truncate"
-                                        v-text="file.slice(11)"
+                                        v-text="file"
                                     />
                                 </td>
                                 <td class="p-0 w-8 rtl:text-left ltr:text-right align-middle">


### PR DESCRIPTION
This pull request prevents the filenames of existing files from being truncated in the Files fieldtype.

**For example:** in the importer, I'm passing the basename of the file to the Files fieldtype, allowing users to see the currently uploaded file and replace it, if needed.

I thought that since we're [not truncating filenames in the `Upload` component](https://github.com/statamic/cms/blob/5.x/resources/js/components/assets/Upload.vue#L11), we don't need to be here. Although, I might be wrong.

### Before

![CleanShot 2024-11-05 at 14 35 23](https://github.com/user-attachments/assets/36161891-8665-4fcd-8506-e3ed7aeda7d6)

### After

![CleanShot 2024-11-05 at 14 45 42](https://github.com/user-attachments/assets/637331cd-3afe-403e-b7de-cd5b0dab6b78)

