### PR TITLE
[5.x] Fix edit form errors after change of term slug

### DIFF
--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -463,6 +463,7 @@ export default {
                 }
                 this.title = response.data.data.title;
                 this.permalink = response.data.data.permalink;
+                this.actions = response.data.actions;
                 this.isWorkingCopy = true;
                 if (!this.isCreating) this.$toast.success(__('Saved'));
                 this.$refs.container.saved();

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -508,6 +508,10 @@ export default {
                     // the hooks are resolved because if this form is being shown in a stack, we only
                     // want to close it once everything's done.
                     else {
+                        // Make sure slug changes are reflected in the edit form URL
+                        if (window.location.href !== this.actions.edit) {
+                            window.history.replaceState({}, '', this.actions.edit);
+                        }
                         this.values = this.resetValuesFromResponse(response.data.data.values);
                         this.$nextTick(() => this.$emit('saved', response));
                     }

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -463,7 +463,6 @@ export default {
                 }
                 this.title = response.data.data.title;
                 this.permalink = response.data.data.permalink;
-                this.actions = response.data.actions;
                 this.isWorkingCopy = true;
                 if (!this.isCreating) this.$toast.success(__('Saved'));
                 this.$refs.container.saved();
@@ -504,14 +503,15 @@ export default {
                         window.location = this.listingUrl;
                     }
 
+                    // If the edit URL was changed (i.e. the term slug was updated), redirect them there.
+                    else if (window.location.href !== response.data.data.edit_url) {
+                        window.location = response.data.data.edit_url;
+                    }
+
                     // Otherwise, leave them on the edit form and emit an event. We need to wait until after
                     // the hooks are resolved because if this form is being shown in a stack, we only
                     // want to close it once everything's done.
                     else {
-                        // Make sure slug changes are reflected in the edit form URL
-                        if (window.location.href !== this.actions.edit) {
-                            window.history.replaceState({}, '', this.actions.edit);
-                        }
                         this.values = this.resetValuesFromResponse(response.data.data.values);
                         this.$nextTick(() => this.$emit('saved', response));
                     }

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -102,7 +102,6 @@ class TermsController extends CpController
             'reference' => $term->reference(),
             'editing' => true,
             'actions' => [
-                'edit' => $term->editUrl(),
                 'save' => $term->updateUrl(),
                 'publish' => $term->publishUrl(),
                 'unpublish' => $term->unpublishUrl(),
@@ -216,16 +215,6 @@ class TermsController extends CpController
                 'saved' => $saved,
                 'data' => [
                     'values' => $values,
-                ],
-                'actions' => [
-                    'edit' => $term->editUrl(),
-                    'save' => $term->updateUrl(),
-                    'publish' => $term->publishUrl(),
-                    'unpublish' => $term->unpublishUrl(),
-                    'revisions' => $term->revisionsUrl(),
-                    'restore' => $term->restoreRevisionUrl(),
-                    'createRevision' => $term->createRevisionUrl(),
-                    'editBlueprint' => cp_route('taxonomies.blueprints.edit', [$taxonomy, $term->blueprint()]),
                 ],
             ]);
     }

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -102,6 +102,7 @@ class TermsController extends CpController
             'reference' => $term->reference(),
             'editing' => true,
             'actions' => [
+                'edit' => $term->editUrl(),
                 'save' => $term->updateUrl(),
                 'publish' => $term->publishUrl(),
                 'unpublish' => $term->unpublishUrl(),

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -217,6 +217,16 @@ class TermsController extends CpController
                 'data' => [
                     'values' => $values,
                 ],
+                'actions' => [
+                    'edit' => $term->editUrl(),
+                    'save' => $term->updateUrl(),
+                    'publish' => $term->publishUrl(),
+                    'unpublish' => $term->unpublishUrl(),
+                    'revisions' => $term->revisionsUrl(),
+                    'restore' => $term->restoreRevisionUrl(),
+                    'createRevision' => $term->createRevisionUrl(),
+                    'editBlueprint' => cp_route('taxonomies.blueprints.edit', [$taxonomy, $term->blueprint()]),
+                ],
             ]);
     }
 


### PR DESCRIPTION
Updating a term slug currently results in two related issues:

1. The browser url is now showing the old slug and results in a 404 on reload
2. Submitting the form again results in a server error since the form will try and post to the old slug's update url

Fixed by comparing the response's `edit_url` value and the current url, and redirecting if they don't match.

I was originally going for a more complicated solution of sending along the action urls with the JSON resource and updating it in the publish form, but there was too many edge cases to be worth it. Changing the slug won't happen too often, so the reload will probably not be a major nuisance.

Closes #11020.