### PR TITLE
[5.x] Addon uninstallers

### DIFF
--- a/src/Console/Commands/AddonsUninstall.php
+++ b/src/Console/Commands/AddonsUninstall.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Statamic\Console\Commands;
+
+use Illuminate\Console\Command;
+use Statamic\Console\RunsInPlease;
+use Statamic\Extend\Uninstaller;
+use Statamic\Facades\Addon;
+
+class AddonsUninstall extends Command
+{
+    use RunsInPlease;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'statamic:addons:uninstall package
+        { package : The Composer package of the addon }';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Allows an addon to clean up before being uninstalled';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $addon = Addon::get($this->argument('package'));
+
+        // This command will get called for every package regardless of whether
+        // it's an addon or not. If it's not an addon, we'll just ignore it.
+        if (! $addon) {
+            return;
+        }
+
+        if (class_exists($class = $addon->namespace().'\\Uninstall')) {
+            /** @var Uninstaller $class */
+            $class = app($class);
+            $class->setOutput($this->output)->setAddon($addon)->handle();
+        }
+    }
+}

--- a/src/Console/Composer/Scripts.php
+++ b/src/Console/Composer/Scripts.php
@@ -13,4 +13,12 @@ class Scripts
     {
         Lock::backup();
     }
+
+    public static function prePackageUninstall($event)
+    {
+        passthru(sprintf(
+            'php artisan statamic:addons:uninstall %s --no-interaction',
+            $event->getOperation()->getPackage()->getName()
+        ));
+    }
 }

--- a/src/Extend/Uninstaller.php
+++ b/src/Extend/Uninstaller.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Statamic\Extend;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class Uninstaller
+{
+    protected OutputInterface $output;
+    protected Addon $addon;
+
+    public function setOutput(OutputInterface $output): self
+    {
+        $this->output = $output;
+
+        return $this;
+    }
+
+    public function setAddon(Addon $addon): self
+    {
+        $this->addon = $addon;
+
+        return $this;
+    }
+
+    abstract public function handle();
+}

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -11,6 +11,7 @@ class ConsoleServiceProvider extends ServiceProvider
     protected $commands = [
         Commands\ListCommand::class,
         Commands\AddonsDiscover::class,
+        Commands\AddonsUninstall::class,
         Commands\AssetsGeneratePresets::class,
         Commands\AssetsMeta::class,
         Commands\GlideClear::class,


### PR DESCRIPTION
This PR allows addons to run pre-removal or "uninstall" logic, letting them clean up after themselves.

If an addon has an `Uninstall.php` in their `src` directory, it's `handle` method will be run automatically.

```
my-addon
|-- src
|   |-- ServiceProvider.php
|   |-- Uninstall.php
|-- composer.json
```

```php
<?php

namespace Me\MyAddon;

use Statamic\Extend\Uninstaller;
use Statamic\Facades\File;

class Uninstall extends Uninstaller
{
    public function handle()
    {
        File::delete(base_path('content/my-addon'));

        $this->output->writeln('Done!');
    }
}
```

A script will be need to be added to the project's `composer.json`. This will be added to the `statamic/statamic` skeleton so it will work for new Statamic sites.

```diff
    "scripts": {
        "pre-update-cmd": [
            "Statamic\\Console\\Composer\\Scripts::preUpdateCmd"
        ],
+       "pre-package-uninstall": [
+           "Statamic\\Console\\Composer\\Scripts::prePackageUninstall"
+       ]
    },
```

Naming is tough, but I went with "uninstall" because the convention is that you `composer require` a package, then you run `artisan packagename:install` to set it up. Here it's the opposite. You'd `composer remove` the addon, which would "uninstall" it just before it gets removed.

Closes https://github.com/statamic/ideas/issues/1255