### PR TITLE
[5.x] Fix term reference updates after slug change

### DIFF
--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -168,6 +168,8 @@ class TermsController extends CpController
 
         $term = $term->fromWorkingCopy();
 
+        $term->term()->syncOriginal();
+
         $fields = $term->blueprint()->fields()->addValues($request->except('id'));
 
         $fields->validate([


### PR DESCRIPTION
Fix an issue where updating a term's slug through the control panel would not update the references to that term in existing entries, even though `system.update_references` is enabled.

The root of the issue appears to be that the auto-bound Term instance in the CP controller lacks its original data because there is no initial `syncOriginal()` call. The first call to `syncOriginal` happens only after saving, which is not helpful here. I’m not sure why this doesn't also happen with Entries, but it seems to work there.

The existing tests haven't caught this as it only happens in the CP controller, not when creating and updating terms in a test environment. Would love to contribute tests here as well, but that's a bit over my head how to test this reliably across the CP routes/controllers.

Closes #10938 

Related: #11021