### PR TITLE
[5.x] Fix typeahead relationship input corrupting data

### DIFF
--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -57,7 +57,7 @@ abstract class Relationship extends Fieldtype
 
     public function preProcess($data)
     {
-        return ($data = Arr::wrap($data)) ? array_values($data) : $data;
+        return Arr::wrap($data);
     }
 
     public function preProcessConfig($data)

--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -57,7 +57,7 @@ abstract class Relationship extends Fieldtype
 
     public function preProcess($data)
     {
-        return Arr::wrap($data);
+        return ($data = Arr::wrap($data)) ? array_values($data) : $data;
     }
 
     public function preProcessConfig($data)

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -207,6 +207,7 @@ class Terms extends Relationship
                 return explode('::', $id, 2)[1];
             })
                 ->unique()
+                ->values()
                 ->all();
 
             if ($this->field->get('max_items') === 1) {


### PR DESCRIPTION
When creating new taxonomy terms in a typeahead select, it currently allows creating new terms even if that term already exists. Both the existing as well as the newly created term can be selected and submitted. On save, the data is deduplicated, but the keys aren't reset. The resulting data structure is now an array with skipped keys, which in JSON turns into an object, and the input refuses to display the data. See issue #11019 for details and screenshots.

This PR fixes the latter part (the corrupted data and broken input state) by always making sure that relationship field data is returned as a list, without skipping array keys.

Partially closes #11019.