### PR TITLE
[5.x] Integer fields should render with `type="number"`

### DIFF
--- a/resources/views/extend/forms/fields/integer.antlers.html
+++ b/resources/views/extend/forms/fields/integer.antlers.html
@@ -1,0 +1,10 @@
+<input
+    type="number"
+    name="{{ handle }}"
+    value="{{ value }}"
+    {{ if placeholder }}placeholder="{{ placeholder }}"{{ /if }}
+    {{ if character_limit }}maxlength="{{ character_limit }}"{{ /if }}
+    {{ if autocomplete }}autocomplete="{{ autocomplete }}"{{ /if }}
+    {{ if js_driver }}{{ js_attributes }}{{ /if }}
+    {{ if validate|contains:required }}required{{ /if }}
+>


### PR DESCRIPTION
This pull request adds a template for Integer fields in forms to ensure `type="number"`, instead of being a text input.

Fixes #11063.