### PR TITLE
[5.x] Add `fresh` method to `Blueprint` & `Fieldset` classes

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -130,6 +130,19 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
         ]));
     }
 
+    public function fullyQualifiedHandle(): string
+    {
+        $handle = $this->handle();
+
+        if ($this->namespace()) {
+            $handle = $this->isNamespaced()
+                ? $this->namespace().'::'.$handle
+                : $this->namespace().'.'.$handle;
+        }
+
+        return $handle;
+    }
+
     public function setContents(array $contents)
     {
         $this->contents = $contents;
@@ -515,6 +528,11 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
         BlueprintReset::dispatch($this);
 
         return true;
+    }
+
+    public function fresh()
+    {
+        return BlueprintRepository::find($this->fullyQualifiedHandle());
     }
 
     public function ensureField($handle, $fieldConfig, $tab = null, $prepend = false)

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -291,6 +291,11 @@ class Fieldset
         return true;
     }
 
+    public function fresh()
+    {
+        return Facades\Fieldset::find($this->handle());
+    }
+
     public static function __callStatic($method, $parameters)
     {
         return Facades\Fieldset::{$method}(...$parameters);


### PR DESCRIPTION
This pull request implements a `fresh` method on the `Blueprint` and `Fieldset` classes, making it easier to get the latest instance of a blueprint/fieldset.

I also added a `fullyQualifiedHandle` method to the `Blueprint` class as the handle format differs depending on if it's a namespaced blueprint or not and whether it has a `namespace` set or not. Feel free to rename this method if you can think of a better name 😄