### PR TITLE
[5.x] Update addon `.gitignore` stub

### DIFF
--- a/src/Console/Commands/stubs/addon/.gitignore.stub
+++ b/src/Console/Commands/stubs/addon/.gitignore.stub
@@ -1,3 +1,4 @@
 node_modules
 vendor
-mix-manifest.json
+composer.lock
+.phpunit.result.cache


### PR DESCRIPTION
This pull request updates the `.gitignore` stub used when creating addons. 

* The `mix-manifest.json` file doesn't exist anymore (addons now use Vite). 
* It's generally discouraged to commit `composer.lock` files inside packages. 
* No one wants to commit the PHPUnit results cache 😅