### PR TITLE
[5.x] Fix error after deleting role when storing users in the database

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -105,7 +105,7 @@ class User extends BaseUser
         return $this->roles = $this->roles
             ?? (new Roles($this))->all()->map(function ($row) {
                 return Role::find($row->role_id);
-            })->keyBy->handle();
+            })->filter()->keyBy->handle();
     }
 
     protected function saveRoles()


### PR DESCRIPTION
This pull request fixes an error which would occur after a user's role had been deleted.

Fixes #11067.