### PR TITLE
[5.x] Offer to enable Pro during make user command

### DIFF
--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -71,7 +71,13 @@ class MakeUser extends Command
     public function handle()
     {
         if (! Statamic::pro() && User::query()->count() > 0) {
-            return error(__('Statamic Pro is required.'));
+            error(__('Statamic Pro is required.'));
+
+            if (confirm(__('Enable Statamic Pro?'))) {
+                $this->call('statamic:pro:enable');
+            } else {
+                return self::SUCCESS;
+            }
         }
 
         if ($password = $this->option('password')) {


### PR DESCRIPTION
If you have Pro disabled, already have a user, and run `make:user`, currently it tells you Pro is required and exits.

![CleanShot 2024-11-06 at 11 12 52](https://github.com/user-attachments/assets/1e7f989b-7170-4582-9636-4fa4bd7d64d9)

This PR will now offer you to enable Pro and then continue with the command.

![CleanShot 2024-11-06 at 11 12 25](https://github.com/user-attachments/assets/89f727a1-77ef-4ed7-ab9a-5501d5076fc8)

