### PR TITLE
[5.x] Fix Ignition Runnable Error Solutions

### DIFF
--- a/src/Exceptions/ComposerJsonMissingPreUpdateCmdException.php
+++ b/src/Exceptions/ComposerJsonMissingPreUpdateCmdException.php
@@ -3,8 +3,8 @@
 namespace Statamic\Exceptions;
 
 use Exception;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
 use Statamic\Ignition\Solutions\EnableComposerUpdateScripts;
 
 class ComposerJsonMissingPreUpdateCmdException extends Exception implements ProvidesSolution

--- a/src/Exceptions/StatamicProRequiredException.php
+++ b/src/Exceptions/StatamicProRequiredException.php
@@ -3,8 +3,8 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Ignition\Solutions\EnableStatamicPro;
 
 class StatamicProRequiredException extends Exception implements ProvidesSolution

--- a/src/Ignition/Solutions/EnableComposerUpdateScripts.php
+++ b/src/Ignition/Solutions/EnableComposerUpdateScripts.php
@@ -4,7 +4,7 @@ namespace Statamic\Ignition\Solutions;
 
 use Exception;
 use Facades\Statamic\UpdateScripts\Manager as UpdateScriptManager;
-use Spatie\Ignition\Contracts\RunnableSolution;
+use Spatie\ErrorSolutions\Contracts\RunnableSolution;
 use Statamic\Console\Composer\Json as ComposerJson;
 use Statamic\Console\NullConsole;
 use Statamic\Statamic;

--- a/src/Ignition/Solutions/EnableStatamicPro.php
+++ b/src/Ignition/Solutions/EnableStatamicPro.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Ignition\Solutions;
 
-use Spatie\Ignition\Contracts\RunnableSolution;
+use Spatie\ErrorSolutions\Contracts\RunnableSolution;
 use Statamic\Statamic;
 
 class EnableStatamicPro implements RunnableSolution


### PR DESCRIPTION
Runnable solutions weren't actually showing the option to run them.

For example, the StatamicProRequiredException should show the button to enable it for you. It wasn't appearing.

![CleanShot 2024-11-06 at 11 43 57](https://github.com/user-attachments/assets/bbad9236-793c-423f-b25a-2b7dd7156bb5)

Now it does again.

![CleanShot 2024-11-06 at 11 44 08](https://github.com/user-attachments/assets/5a32e9da-dc88-4524-a998-6b38a7e2dcfb)

