### PR TITLE
[5.x] Adjust legacy ignition classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "rebing/graphql-laravel": "^9.5",
         "rhukster/dom-sanitizer": "^1.0.6",
         "spatie/blink": "^1.3",
-        "spatie/ignition": "^1.12",
+        "spatie/ignition": "^1.15",
         "statamic/stringy": "^3.1.2",
         "stillat/blade-parser": "^1.10.1",
         "symfony/lock": "^6.4",

--- a/src/Exceptions/AssetContainerNotFoundException.php
+++ b/src/Exceptions/AssetContainerNotFoundException.php
@@ -6,7 +6,7 @@ use Exception;
 use Spatie\ErrorSolutions\Contracts\BaseSolution;
 use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\ErrorSolutions\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Facades\AssetContainer;
 use Statamic\Statamic;
 

--- a/src/Exceptions/AssetContainerNotFoundException.php
+++ b/src/Exceptions/AssetContainerNotFoundException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Spatie\LaravelIgnition\Support\StringComparator;
 use Statamic\Facades\AssetContainer;
 use Statamic\Statamic;

--- a/src/Exceptions/BlueprintNotFoundException.php
+++ b/src/Exceptions/BlueprintNotFoundException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Spatie\LaravelIgnition\Support\StringComparator;
 use Statamic\Facades\Blueprint;
 use Statamic\Statamic;

--- a/src/Exceptions/BlueprintNotFoundException.php
+++ b/src/Exceptions/BlueprintNotFoundException.php
@@ -6,7 +6,7 @@ use Exception;
 use Spatie\ErrorSolutions\Contracts\BaseSolution;
 use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\ErrorSolutions\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Facades\Blueprint;
 use Statamic\Statamic;
 

--- a/src/Exceptions/CollectionNotFoundException.php
+++ b/src/Exceptions/CollectionNotFoundException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Spatie\LaravelIgnition\Support\StringComparator;
 use Statamic\Facades\Collection;
 use Statamic\Statamic;

--- a/src/Exceptions/CollectionNotFoundException.php
+++ b/src/Exceptions/CollectionNotFoundException.php
@@ -6,7 +6,7 @@ use Exception;
 use Spatie\ErrorSolutions\Contracts\BaseSolution;
 use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\ErrorSolutions\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Facades\Collection;
 use Statamic\Statamic;
 

--- a/src/Exceptions/ComposerJsonMissingPreUpdateCmdException.php
+++ b/src/Exceptions/ComposerJsonMissingPreUpdateCmdException.php
@@ -3,8 +3,8 @@
 namespace Statamic\Exceptions;
 
 use Exception;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\ErrorSolutions\Contracts\Solution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
 use Statamic\Ignition\Solutions\EnableComposerUpdateScripts;
 
 class ComposerJsonMissingPreUpdateCmdException extends Exception implements ProvidesSolution

--- a/src/Exceptions/DuplicateFieldException.php
+++ b/src/Exceptions/DuplicateFieldException.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Exceptions;
 
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class DuplicateFieldException extends \Exception implements ProvidesSolution

--- a/src/Exceptions/FieldsetNotFoundException.php
+++ b/src/Exceptions/FieldsetNotFoundException.php
@@ -6,7 +6,7 @@ use Exception;
 use Spatie\ErrorSolutions\Contracts\BaseSolution;
 use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\ErrorSolutions\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Facades\Fieldset;
 use Statamic\Statamic;
 

--- a/src/Exceptions/FieldsetNotFoundException.php
+++ b/src/Exceptions/FieldsetNotFoundException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Spatie\LaravelIgnition\Support\StringComparator;
 use Statamic\Facades\Fieldset;
 use Statamic\Statamic;

--- a/src/Exceptions/FieldsetRecursionException.php
+++ b/src/Exceptions/FieldsetRecursionException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 
 class FieldsetRecursionException extends Exception implements ProvidesSolution
 {

--- a/src/Exceptions/FieldtypeNotFoundException.php
+++ b/src/Exceptions/FieldtypeNotFoundException.php
@@ -4,9 +4,9 @@ namespace Statamic\Exceptions;
 
 use Exception;
 use Facades\Statamic\Fields\FieldtypeRepository;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Spatie\LaravelIgnition\Support\StringComparator;
 use Statamic\Statamic;
 

--- a/src/Exceptions/FieldtypeNotFoundException.php
+++ b/src/Exceptions/FieldtypeNotFoundException.php
@@ -7,7 +7,7 @@ use Facades\Statamic\Fields\FieldtypeRepository;
 use Spatie\ErrorSolutions\Contracts\BaseSolution;
 use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\ErrorSolutions\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Statamic;
 
 class FieldtypeNotFoundException extends Exception implements ProvidesSolution

--- a/src/Exceptions/NavigationNotFoundException.php
+++ b/src/Exceptions/NavigationNotFoundException.php
@@ -6,7 +6,7 @@ use Exception;
 use Spatie\ErrorSolutions\Contracts\BaseSolution;
 use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\ErrorSolutions\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Facades\Nav;
 use Statamic\Statamic;
 

--- a/src/Exceptions/NavigationNotFoundException.php
+++ b/src/Exceptions/NavigationNotFoundException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Spatie\LaravelIgnition\Support\StringComparator;
 use Statamic\Facades\Nav;
 use Statamic\Statamic;

--- a/src/Exceptions/NotBootedException.php
+++ b/src/Exceptions/NotBootedException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class NotBootedException extends Exception implements ProvidesSolution

--- a/src/Exceptions/SiteNotFoundException.php
+++ b/src/Exceptions/SiteNotFoundException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class SiteNotFoundException extends Exception implements ProvidesSolution

--- a/src/Exceptions/TaxonomyNotFoundException.php
+++ b/src/Exceptions/TaxonomyNotFoundException.php
@@ -6,7 +6,7 @@ use Exception;
 use Spatie\ErrorSolutions\Contracts\BaseSolution;
 use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\ErrorSolutions\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Facades\Taxonomy;
 use Statamic\Statamic;
 

--- a/src/Exceptions/TaxonomyNotFoundException.php
+++ b/src/Exceptions/TaxonomyNotFoundException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Spatie\LaravelIgnition\Support\StringComparator;
 use Statamic\Facades\Taxonomy;
 use Statamic\Statamic;

--- a/src/Exceptions/TermsFieldtypeBothOptionsUsedException.php
+++ b/src/Exceptions/TermsFieldtypeBothOptionsUsedException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class TermsFieldtypeBothOptionsUsedException extends Exception implements ProvidesSolution

--- a/src/Exceptions/TermsFieldtypeTaxonomyOptionUsed.php
+++ b/src/Exceptions/TermsFieldtypeTaxonomyOptionUsed.php
@@ -3,9 +3,9 @@
 namespace Statamic\Exceptions;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class TermsFieldtypeTaxonomyOptionUsed extends Exception implements ProvidesSolution

--- a/src/Fieldtypes/Assets/UndefinedContainerException.php
+++ b/src/Fieldtypes/Assets/UndefinedContainerException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Fieldtypes\Assets;
 
 use LogicException;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class UndefinedContainerException extends LogicException implements ProvidesSolution

--- a/src/Fieldtypes/MultipleValuesEncounteredException.php
+++ b/src/Fieldtypes/MultipleValuesEncounteredException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Fieldtypes;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 
 class MultipleValuesEncounteredException extends Exception implements ProvidesSolution
 {

--- a/src/Forms/Exceptions/BlueprintUndefinedException.php
+++ b/src/Forms/Exceptions/BlueprintUndefinedException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Forms\Exceptions;
 
 use LogicException;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Forms\Form;
 use Statamic\Statamic;
 

--- a/src/Forms/Exceptions/FileContentTypeRequiredException.php
+++ b/src/Forms/Exceptions/FileContentTypeRequiredException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Forms\Exceptions;
 
 use LogicException;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class FileContentTypeRequiredException extends LogicException implements ProvidesSolution

--- a/src/Ignition/SolutionProviders/OAuthDisabled.php
+++ b/src/Ignition/SolutionProviders/OAuthDisabled.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Ignition\SolutionProviders;
 
-use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
+use Spatie\ErrorSolutions\Contracts\HasSolutionsForThrowable;
 use Statamic\Ignition\Solutions\EnableOAuth;
 use Throwable;
 

--- a/src/Ignition/SolutionProviders/UsingOldClass.php
+++ b/src/Ignition/SolutionProviders/UsingOldClass.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Ignition\SolutionProviders;
 
-use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
+use Spatie\ErrorSolutions\Contracts\HasSolutionsForThrowable;
 use Statamic\Ignition\Solutions\UpdateClassReference;
 use Statamic\Statamic;
 use Statamic\Support\Arr;

--- a/src/Ignition/Solutions/EnableOAuth.php
+++ b/src/Ignition/Solutions/EnableOAuth.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Ignition\Solutions;
 
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class EnableOAuth implements Solution

--- a/src/Ignition/Solutions/UpdateClassReference.php
+++ b/src/Ignition/Solutions/UpdateClassReference.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Ignition\Solutions;
 
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 
 class UpdateClassReference implements Solution
 {

--- a/src/Modifiers/ModifierNotFoundException.php
+++ b/src/Modifiers/ModifierNotFoundException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Modifiers;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Spatie\LaravelIgnition\Support\StringComparator;
 use Statamic\Statamic;
 

--- a/src/Modifiers/ModifierNotFoundException.php
+++ b/src/Modifiers/ModifierNotFoundException.php
@@ -6,7 +6,7 @@ use Exception;
 use Spatie\ErrorSolutions\Contracts\BaseSolution;
 use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\ErrorSolutions\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Statamic;
 
 class ModifierNotFoundException extends Exception implements ProvidesSolution

--- a/src/Providers/IgnitionServiceProvider.php
+++ b/src/Providers/IgnitionServiceProvider.php
@@ -4,7 +4,7 @@ namespace Statamic\Providers;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\ServiceProvider;
-use Spatie\Ignition\Contracts\SolutionProviderRepository;
+use Spatie\ErrorSolutions\Contracts\SolutionProviderRepository;
 use Statamic\Ignition\SolutionProviders\OAuthDisabled;
 use Statamic\Ignition\SolutionProviders\UsingOldClass;
 

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -4,7 +4,7 @@ namespace Statamic\View\Antlers\Language\Runtime;
 
 use Illuminate\Http\Exceptions\HttpResponseException;
 use ReflectionProperty;
-use Spatie\Ignition\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\LaravelIgnition\Exceptions\ViewException;
 use Spatie\LaravelIgnition\Exceptions\ViewExceptionWithSolution;
 use Statamic\Contracts\View\Antlers\Parser;

--- a/src/Widgets/WidgetNotFoundException.php
+++ b/src/Widgets/WidgetNotFoundException.php
@@ -6,7 +6,7 @@ use Exception;
 use Spatie\ErrorSolutions\Contracts\BaseSolution;
 use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\ErrorSolutions\Contracts\Solution;
-use Spatie\LaravelIgnition\Support\StringComparator;
+use Spatie\ErrorSolutions\Support\Laravel\StringComparator;
 use Statamic\Statamic;
 
 class WidgetNotFoundException extends Exception implements ProvidesSolution

--- a/src/Widgets/WidgetNotFoundException.php
+++ b/src/Widgets/WidgetNotFoundException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Widgets;
 
 use Exception;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Spatie\LaravelIgnition\Support\StringComparator;
 use Statamic\Statamic;
 

--- a/src/Yaml/ParseException.php
+++ b/src/Yaml/ParseException.php
@@ -3,9 +3,9 @@
 namespace Statamic\Yaml;
 
 use ErrorException;
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;
 
 class ParseException extends ErrorException implements ProvidesSolution


### PR DESCRIPTION
This PR is just cleaning up references to legacy classes.

Spatie\Ignition to Spatie\ErrorSolutions

There are no functional changes.

Ideally we would also rename the Statamic\Ignition namespace to Statamic\ErrorSolutions but that's a breaking change. We can do it in v6.
