### PR TITLE
[5.x] Add `--clear` option for `starter-kit:export`

### DIFF
--- a/src/Console/Commands/StarterKitExport.php
+++ b/src/Console/Commands/StarterKitExport.php
@@ -20,7 +20,9 @@ class StarterKitExport extends Command
      *
      * @var string
      */
-    protected $signature = 'statamic:starter-kit:export { path : Specify the path you are exporting to }';
+    protected $signature = 'statamic:starter-kit:export
+        { path : Specify the path you are exporting to }
+        { --clear : Clear out everything at target export path before exporting }';
 
     /**
      * The console command description.

--- a/src/Console/Commands/StarterKitExport.php
+++ b/src/Console/Commands/StarterKitExport.php
@@ -44,7 +44,8 @@ class StarterKitExport extends Command
             $this->askToCreateExportPath($path);
         }
 
-        $exporter = new StarterKitExporter($path);
+        $exporter = (new StarterKitExporter($path))
+            ->clear($this->option('clear'));
 
         try {
             $exporter->export();

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -63,8 +63,6 @@ final class Installer
     public function branch(?string $branch = null): self|bool|null
     {
         return $this->fluentlyGetOrSet('branch')->args(func_get_args());
-
-        return $this;
     }
 
     /**
@@ -73,8 +71,6 @@ final class Installer
     public function fromLocalRepo(bool $fromLocalRepo = false): self|bool|null
     {
         return $this->fluentlyGetOrSet('fromLocalRepo')->args(func_get_args());
-
-        return $this;
     }
 
     /**
@@ -83,8 +79,6 @@ final class Installer
     public function withConfig(bool $withConfig = false): self|bool|null
     {
         return $this->fluentlyGetOrSet('withConfig')->args(func_get_args());
-
-        return $this;
     }
 
     /**
@@ -101,8 +95,6 @@ final class Installer
     public function withUserPrompt(bool $withUserPrompt = false): self|bool|null
     {
         return $this->fluentlyGetOrSet('withUserPrompt')->args(func_get_args());
-
-        return $this;
     }
 
     /**
@@ -119,8 +111,6 @@ final class Installer
     public function usingSubProcess(bool $usingSubProcess = false): self|bool|null
     {
         return $this->fluentlyGetOrSet('usingSubProcess')->args(func_get_args());
-
-        return $this;
     }
 
     /**

--- a/tests/StarterKits/ExportTest.php
+++ b/tests/StarterKits/ExportTest.php
@@ -150,6 +150,45 @@ class ExportTest extends TestCase
     }
 
     #[Test]
+    public function it_can_clear_target_export_path_with_clear_option()
+    {
+        $paths = $this->cleanPaths([
+            base_path('one'),
+            base_path('two'),
+        ]);
+
+        // Imagine this exists from previous export
+        $this->files->makeDirectory($this->exportPath('one'), 0777, true, true);
+        $this->files->put($this->exportPath('one/file.md'), 'One.');
+
+        $this->files->makeDirectory(base_path('two'), 0777, true, true);
+        $this->files->put(base_path('two/file.md'), 'Two.');
+
+        $this->setExportPaths([
+            'two/file.md',
+        ]);
+
+        $this->assertFileExists($this->exportPath('one'));
+        $this->assertFileDoesNotExist($this->exportPath('two'));
+
+        $this->exportCoolRunnings();
+
+        // Our 'one' folder should exist after exporting normally
+        $this->assertFileExists($this->exportPath('one'));
+        $this->assertFileExists($this->exportPath('two'));
+
+        $this->exportCoolRunnings(['--clear' => true]);
+
+        // But 'one' folder should exist after exporting with `--clear` option
+        $this->assertFileDoesNotExist($this->exportPath('one'));
+        $this->assertFileExists($this->exportPath('two'));
+
+        $this->exportCoolRunnings();
+
+        $this->cleanPaths($paths);
+    }
+
+    #[Test]
     public function it_copies_export_config()
     {
         $this->setExportPaths([
@@ -1533,12 +1572,12 @@ EOT
         );
     }
 
-    private function exportCoolRunnings()
+    private function exportCoolRunnings($options = [])
     {
-        return $this->artisan('statamic:starter-kit:export', [
+        return $this->artisan('statamic:starter-kit:export', array_merge([
             'path' => '../cool-runnings',
             '--no-interaction' => true,
-        ]);
+        ], $options));
     }
 
     private function assertFileHasContent($expected, $path)


### PR DESCRIPTION
This PR adds `--clear` option for `starter-kit:export` command.

We talked about whether or not to make this the default behaviour, but it gets complicated for various reasons...

- Say you intentionally have `.github` directory in your starter kit repo, but also different `.github` directory in your sandbox/demo app repo, you wouldn't want to add this to your `export_paths`, but you also wouldn't want `--clear` to clear this stuff.

- Or maybe you want to make changes to the stubbed composer.json, should `--clear` also clear that file?

- etc.

We could find ways to make this behaviour more magical, but we opted to go with a simple opt-in `--clear` option.

When explicitly exporting with this option, the starter kit dev _knows_ that it's going to clear everything out first, and then they can discard whatever overzealously cleared git changes they don't want before commiting 👍

It's more `--clear` this way 😎