### PR TITLE
[5.x] Extra values for entry field conditions, including depth

### DIFF
--- a/resources/js/components/entries/BaseCreateForm.vue
+++ b/resources/js/components/entries/BaseCreateForm.vue
@@ -10,6 +10,7 @@
         :collection-has-routes="collectionHasRoutes"
         :initial-fieldset="fieldset"
         :initial-values="values"
+        :initial-extra-values="extraValues"
         :initial-meta="meta"
         :initial-localizations="localizations"
         :initial-has-origin="false"
@@ -37,6 +38,7 @@ export default {
         'collectionHasRoutes',
         'fieldset',
         'values',
+        'extraValues',
         'meta',
         'localizations',
         'revisions',

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -68,6 +68,7 @@
             :name="publishContainer"
             :blueprint="fieldset"
             :values="values"
+            :extra-values="extraValues"
             :reference="initialReference"
             :meta="meta"
             :errors="errors"
@@ -335,6 +336,7 @@ export default {
         initialReference: String,
         initialFieldset: Object,
         initialValues: Object,
+        initialExtraValues: Object,
         initialMeta: Object,
         initialTitle: String,
         initialLocalizations: Array,
@@ -375,6 +377,7 @@ export default {
             title: this.initialTitle,
             values: _.clone(this.initialValues),
             meta: _.clone(this.initialMeta),
+            extraValues: _.clone(this.initialExtraValues),
             localizations: _.clone(this.initialLocalizations),
             localizedFields: this.initialLocalizedFields,
             hasOrigin: this.initialHasOrigin,
@@ -606,6 +609,7 @@ export default {
                         clearTimeout(this.trackDirtyStateTimeout)
                         this.trackDirtyState = false
                         this.values = this.resetValuesFromResponse(response.data.data.values);
+                        this.extraValues = response.data.data.extraValues;
                         this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 500)
                         this.$nextTick(() => this.$emit('saved', response));
                         return;
@@ -630,6 +634,7 @@ export default {
                         clearTimeout(this.trackDirtyStateTimeout);
                         this.trackDirtyState = false;
                         this.values = this.resetValuesFromResponse(response.data.data.values);
+                        this.extraValues = response.data.data.extraValues;
                         this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 500);
                         this.initialPublished = response.data.data.published;
                         this.activeLocalization.published = response.data.data.published;

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -124,6 +124,9 @@ export default {
                     setValues(state, values) {
                         state.values = values;
                     },
+                    setExtraValues(state, values) {
+                        state.extraValues = values;
+                    },
                     setHiddenField(state, field) {
                         state.hiddenFields[field.dottedKey] = {
                             hidden: field.hidden,
@@ -211,6 +214,9 @@ export default {
                         context.commit('setValues', payload);
                         vm.emitUpdatedEvent(context.state.values);
                     },
+                    setExtraValues(context, payload) {
+                        context.commit('setExtraValues', payload);
+                    },
                     setMeta(context, payload) {
                         context.commit('setMeta', payload);
                     }
@@ -273,6 +279,14 @@ export default {
             handler(after, before) {
                 if (_.isEqual(before, after)) return;
                 this.$store.commit(`publish/${this.name}/setValues`, after);
+            }
+        },
+
+        extraValues: {
+            deep: true,
+            handler(after, before) {
+                if (_.isEqual(before, after)) return;
+                this.$store.commit(`publish/${this.name}/setExtraValues`, after);
             }
         },
 

--- a/resources/views/entries/create.blade.php
+++ b/resources/views/entries/create.blade.php
@@ -10,6 +10,7 @@
         :collection-has-routes="{{ Statamic\Support\Str::bool($collectionHasRoutes) }}"
         :fieldset="{{ json_encode($blueprint) }}"
         :values="{{ json_encode($values) }}"
+        :extra-values="{{ json_encode($extraValues) }}"
         :meta="{{ json_encode($meta) }}"
         :published="{{ json_encode($published) }}"
         :localizations="{{ json_encode($localizations) }}"

--- a/resources/views/entries/edit.blade.php
+++ b/resources/views/entries/edit.blade.php
@@ -15,6 +15,7 @@
         initial-reference="{{ $reference }}"
         :initial-fieldset="{{ json_encode($blueprint) }}"
         :initial-values="{{ json_encode($values) }}"
+        :initial-extra-values="{{ json_encode($extraValues) }}"
         :initial-localized-fields="{{ json_encode($localizedFields) }}"
         :initial-meta="{{ json_encode($meta) }}"
         initial-permalink="{{ $permalink }}"

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -46,6 +46,7 @@ class Entries extends Relationship
         'initialReference' => 'reference',
         'initialFieldset' => 'blueprint',
         'initialValues' => 'values',
+        'initialExtraValues' => 'extraValues',
         'initialLocalizedFields' => 'localizedFields',
         'initialMeta' => 'meta',
         'initialPermalink' => 'permalink',

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -101,7 +101,7 @@ class EntriesController extends CpController
             $blueprint->ensureFieldHasConfig('author', ['visibility' => 'read_only']);
         }
 
-        [$values, $meta] = $this->extractFromFields($entry, $blueprint);
+        [$values, $meta, $extraValues] = $this->extractFromFields($entry, $blueprint);
 
         if ($hasOrigin = $entry->hasOrigin()) {
             [$originValues, $originMeta] = $this->extractFromFields($entry->origin(), $blueprint);
@@ -121,6 +121,7 @@ class EntriesController extends CpController
                 'editBlueprint' => cp_route('collections.blueprints.edit', [$collection, $blueprint]),
             ],
             'values' => array_merge($values, ['id' => $entry->id()]),
+            'extraValues' => $extraValues,
             'meta' => $meta,
             'collection' => $collection->handle(),
             'collectionHasRoutes' => ! is_null($collection->route($entry->locale())),
@@ -270,11 +271,12 @@ class EntriesController extends CpController
             $saved = $entry->updateLastModified(User::current())->save();
         }
 
-        [$values] = $this->extractFromFields($entry, $blueprint);
+        [$values, $meta, $extraValues] = $this->extractFromFields($entry, $blueprint);
 
         return [
             'data' => array_merge((new EntryResource($entry->fresh()))->resolve()['data'], [
                 'values' => $values,
+                'extraValues' => $extraValues,
             ]),
             'saved' => $saved,
         ];
@@ -321,6 +323,9 @@ class EntriesController extends CpController
                 'save' => cp_route('collections.entries.store', [$collection->handle(), $site->handle()]),
             ],
             'values' => $values->all(),
+            'extraValues' => [
+                'depth' => 1,
+            ],
             'meta' => $fields->meta(),
             'collection' => $collection->handle(),
             'collectionCreateLabel' => $collection->createLabel(),

--- a/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
+++ b/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
@@ -41,6 +41,10 @@ trait ExtractsFromEntryFields
             'published' => $entry->published(),
         ]);
 
-        return [$values->all(), $fields->meta()];
+        $extraValues = [
+            'depth' => $entry->page()?->depth(),
+        ];
+
+        return [$values->all(), $fields->meta(), $extraValues];
     }
 }


### PR DESCRIPTION
Continues from #10588.

This allows entries to base field conditions on "extra" values.

At the moment, that's just `depth`. For example, you could show a field if its depth in the structure is above 2.

```yaml
if:
  depth: '> 2'
```
