### PR TITLE
[5.x] Use layout config in errors too

### DIFF
--- a/src/Exceptions/Concerns/RendersHttpExceptions.php
+++ b/src/Exceptions/Concerns/RendersHttpExceptions.php
@@ -48,7 +48,7 @@ trait RendersHttpExceptions
         $layouts = collect([
             'errors.layout',
             'layouts.layout',
-            'layout',
+            config('statamic.system.layout', 'layout'),
             'statamic::blank',
         ]);
 


### PR DESCRIPTION
In https://github.com/statamic/cms/pull/11025 I missed front end error rendering - they also need to respect the new config.