### PR TITLE
[5.x] Create edit/{id} route for control panel access

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -28,6 +28,7 @@ use Statamic\Http\Controllers\CP\Collections\CollectionActionController;
 use Statamic\Http\Controllers\CP\Collections\CollectionBlueprintsController;
 use Statamic\Http\Controllers\CP\Collections\CollectionsController;
 use Statamic\Http\Controllers\CP\Collections\CollectionTreeController;
+use Statamic\Http\Controllers\CP\Collections\EditRedirectController;
 use Statamic\Http\Controllers\CP\Collections\EntriesController;
 use Statamic\Http\Controllers\CP\Collections\EntryActionController;
 use Statamic\Http\Controllers\CP\Collections\EntryPreviewController;
@@ -360,6 +361,8 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
     Route::get('session-timeout', SessionTimeoutController::class)->name('session.timeout');
 
     Route::view('/playground', 'statamic::playground')->name('playground');
+
+    Route::get('edit/{id}', EditRedirectController::class);
 
     Route::get('{segments}', [CpController::class, 'pageNotFound'])->where('segments', '.*')->name('404');
 });

--- a/src/Http/Controllers/CP/Collections/EditRedirectController.php
+++ b/src/Http/Controllers/CP/Collections/EditRedirectController.php
@@ -3,15 +3,18 @@
 namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
-use Statamic\Facades\Entry;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Data;
 use Statamic\Http\Controllers\CP\CpController;
 
 class EditRedirectController extends CpController
 {
     public function __invoke(Request $request)
     {
-        return redirect(
-            Entry::findOrFail($request->id)->editUrl()
-        );
+        if ($data = Data::find($request->id)) {
+            return redirect($data->editUrl());
+        }
+
+        throw new NotFoundHttpException;
     }
 }

--- a/src/Http/Controllers/CP/Collections/EditRedirectController.php
+++ b/src/Http/Controllers/CP/Collections/EditRedirectController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Statamic\Http\Controllers\CP\Collections;
+
+use Illuminate\Http\Request;
+use Statamic\Facades\Entry;
+use Statamic\Http\Controllers\CP\CpController;
+
+class EditRedirectController extends CpController
+{
+    public function __invoke(Request $request)
+    {
+        return redirect(
+            Entry::findOrFail($request->id)->editUrl()
+        );
+    }
+}

--- a/tests/CP/EditRedirectControllerTest.php
+++ b/tests/CP/EditRedirectControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\CP;
+
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Data;
+use Statamic\Facades\User;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class EditRedirectControllerTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_redirects_to_edit_page()
+    {
+        $item = Mockery::mock();
+        $item->shouldReceive('editUrl')->once()->andReturn($targetUrl = '/somewhere');
+        Data::shouldReceive('find')->with('123')->once()->andReturn($item);
+
+        $this
+            ->actingAs(tap(User::make()->makeSuper())->save())
+            ->get('/cp/edit/123')
+            ->assertRedirect($targetUrl);
+    }
+
+    #[Test]
+    public function it_404s_if_id_doesnt_exist()
+    {
+        Data::shouldReceive('find')->with('123')->once()->andReturnNull();
+
+        $this
+            ->actingAs(tap(User::make()->makeSuper())->save())
+            ->get('/cp/edit/123')
+            ->assertNotFound();
+    }
+}


### PR DESCRIPTION
This is more of an invisible nicety that I think is really useful in Craft CMS.

Sometimes I have just the ID of a given entry and I want to get to the control panel edit screen with that information alone. I can simply go to `/admin/edit/{id}` and it will take me to the correct spot in the admin area. Now this is possible with Statamic.

- Given an entry that has an ID of `72edf157-4010-4ebc-9c8c-146181c12c4c` and is in the "Blog" collection
- If you go to `/admin/edit/72edf157-4010-4ebc-9c8c-146181c12c4c`
- You will be redirected (and prompted to sign in if not already) to `/admin/collections/blog/entries/72edf157-4010-4ebc-9c8c-146181c12c4c`