### PR TITLE
[5.x] Add `fullyQualifiedHandle` method to `Blueprint`

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -71,6 +71,19 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
         return $this->namespace;
     }
 
+    public function fullyQualifiedHandle(): string
+    {
+        $handle = $this->handle();
+
+        if ($this->namespace()) {
+            $handle = $this->isNamespaced()
+                ? $this->namespace().'::'.$handle
+                : $this->namespace().'.'.$handle;
+        }
+
+        return $handle;
+    }
+
     public function setOrder($order)
     {
         if (! is_null($order)) {


### PR DESCRIPTION
This pull request adds a `fullyQualifiedHandle` method to the `Blueprint` class as the format of the handle (eg. what you use when doing `Blueprint::find()`) is different depending on if it has a namespace or not, or if it's coming from an addon.

I initially added this method as part of #11066. However, even with no `->fresh()` method, I still feel like this would be a useful method to have if folks want to "refresh" blueprints themselves.
