### PR TITLE
[5.x] German translations

### DIFF
--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -845,7 +845,7 @@
     "Search...": "Suchen…",
     "Searchable": "Durchsuchbar",
     "Searchables": "Suchbares",
-    "Searching in:": "Suche in:",
+    "Searching in: ": "Suchen in: ",
     "Select": "Auswählen",
     "Select Across Sites": "Websiteübergreifend auswählen",
     "Select asset container": "Datei-Container auswählen",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -401,6 +401,7 @@
     "Enable Pro Mode": "Pro-Modus aktivieren",
     "Enable Publish Dates": "Erscheinungsdaten aktivieren",
     "Enable Revisions": "Revisionen aktivieren",
+    "Enable Statamic Pro?": "Statamic Pro aktivieren?",
     "Encryption": "Verschlüsselung",
     "Enter any internal or external URL.": "Beliebige interne oder externe URL eingeben.",
     "Enter URL": "URL eingeben",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -423,7 +423,7 @@
     "Entry link": "Link zum Eintrag",
     "Entry published|Entries published": "Eintrag veröffentlicht|Einträge veröffentlicht",
     "Entry saved": "Eintrag gespeichert",
-    "Entry schedule reached": "Anmeldezeitplan erreicht",
+    "Entry schedule reached": "Zeitplan für Eintrag erreicht",
     "Entry unpublished|Entries unpublished": "Eintrag nicht veröffentlicht|Einträge nicht veröffentlicht",
     "equals": "ist gleich",
     "Equals": "Gleich",

--- a/resources/lang/de/fieldtypes.php
+++ b/resources/lang/de/fieldtypes.php
@@ -19,7 +19,7 @@ return [
     'assets.config.restrict' => 'Verhindern, dass Benutzer:innen zu anderen Ordnern navigieren können.',
     'assets.config.show_filename' => 'Dateiname neben dem Vorschaubild anzeigen.',
     'assets.config.show_set_alt' => 'Einen Link zum Erfassen des Alt-Texts bei allen Bildern anzeigen.',
-    'assets.dynamic_folder_pending_field' => 'Dieser Upload-Ordner wird verfügbar sein, sobald :field festgelegt ist.',
+    'assets.dynamic_folder_pending_field' => 'Dieses Feld ist verfügbar, sobald :field festgelegt ist.',
     'assets.dynamic_folder_pending_save' => 'Dieses Feld ist nach dem Speichern verfügbar.',
     'assets.title' => 'Dateien',
     'bard.config.allow_source' => 'Ermöglicht beim Schreiben das Anzeigen des HTML-Quellcodes.',

--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -237,7 +237,7 @@ return [
     'updater_require_version_command' => 'Führe den folgenden Befehl aus, um eine bestimmte Version anzufordern',
     'updater_update_to_latest_command' => 'Führe den folgenden Befehl aus, um die aktuelle Version zu installieren',
     'uploader_append_timestamp' => 'Zeitstempel anhängen',
-    'uploader_choose_new_filename' => 'Neuer Dateinamen wählen',
+    'uploader_choose_new_filename' => 'Neuer Dateiname wählen',
     'uploader_discard_use_existing' => 'Verwerfen und bestehende Datei verwenden',
     'uploader_overwrite_existing' => 'Bestehende Datei überschreiben',
     'user_activation_email_not_sent_error' => 'Die Aktivierungs-E-Mail konnte nicht gesendet werden. Bitte prüfe deine E-Mail-Konfiguration und versuche es erneut.',

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -845,7 +845,7 @@
     "Search...": "Suchen…",
     "Searchable": "Durchsuchbar",
     "Searchables": "Suchbares",
-    "Searching in:": "Suche in:",
+    "Searching in: ": "Suchen in: ",
     "Select": "Auswählen",
     "Select Across Sites": "Websiteübergreifend auswählen",
     "Select asset container": "Datei-Container auswählen",

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -401,6 +401,7 @@
     "Enable Pro Mode": "Pro-Modus aktivieren",
     "Enable Publish Dates": "Erscheinungsdaten aktivieren",
     "Enable Revisions": "Revisionen aktivieren",
+    "Enable Statamic Pro?": "Statamic Pro aktivieren?",
     "Encryption": "Verschlüsselung",
     "Enter any internal or external URL.": "Beliebige interne oder externe URL eingeben.",
     "Enter URL": "URL eingeben",

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -423,7 +423,7 @@
     "Entry link": "Link zum Eintrag",
     "Entry published|Entries published": "Eintrag veröffentlicht|Einträge veröffentlicht",
     "Entry saved": "Eintrag gespeichert",
-    "Entry schedule reached": "Anmeldezeitplan erreicht",
+    "Entry schedule reached": "Zeitplan für Eintrag erreicht",
     "Entry unpublished|Entries unpublished": "Eintrag nicht veröffentlicht|Einträge nicht veröffentlicht",
     "equals": "ist gleich",
     "Equals": "Gleich",

--- a/resources/lang/de_CH/fieldtypes.php
+++ b/resources/lang/de_CH/fieldtypes.php
@@ -19,7 +19,7 @@ return [
     'assets.config.restrict' => 'Verhindern, dass Benutzer:innen zu anderen Ordnern navigieren können.',
     'assets.config.show_filename' => 'Dateiname neben dem Vorschaubild anzeigen.',
     'assets.config.show_set_alt' => 'Einen Link zum Erfassen des Alt-Texts bei allen Bildern anzeigen.',
-    'assets.dynamic_folder_pending_field' => 'Dieser Upload-Ordner wird verfügbar sein, sobald :field festgelegt ist.',
+    'assets.dynamic_folder_pending_field' => 'Dieses Feld ist verfügbar, sobald :field festgelegt ist.',
     'assets.dynamic_folder_pending_save' => 'Dieses Feld ist nach dem Speichern verfügbar.',
     'assets.title' => 'Dateien',
     'bard.config.allow_source' => 'Ermöglicht beim Schreiben das Anzeigen des HTML-Quellcodes.',

--- a/resources/lang/de_CH/messages.php
+++ b/resources/lang/de_CH/messages.php
@@ -237,7 +237,7 @@ return [
     'updater_require_version_command' => 'Führe den folgenden Befehl aus, um eine bestimmte Version anzufordern',
     'updater_update_to_latest_command' => 'Führe den folgenden Befehl aus, um die aktuelle Version zu installieren',
     'uploader_append_timestamp' => 'Zeitstempel anhängen',
-    'uploader_choose_new_filename' => 'Neuer Dateinamen wählen',
+    'uploader_choose_new_filename' => 'Neuer Dateiname wählen',
     'uploader_discard_use_existing' => 'Verwerfen und bestehende Datei verwenden',
     'uploader_overwrite_existing' => 'Bestehende Datei überschreiben',
     'user_activation_email_not_sent_error' => 'Das Aktivierungs-E-Mail konnte nicht gesendet werden. Bitte prüfe deine E-Mail-Konfiguration und versuche es erneut.',


### PR DESCRIPTION
Brings back the space after the semicolon in this string: `__('Searching in: ')` in `resources/js/components/data-list/HasFilters.hs` has a space at the end, but `translator generate` command stripes it out