### PR TITLE
[5.x] Add "Container" option to Asset Folders fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/AssetFolderFieldtype.vue
+++ b/resources/js/components/fieldtypes/AssetFolderFieldtype.vue
@@ -1,7 +1,5 @@
 <template>
     <div class="asset-folder-fieldtype-wrapper">
-        <small class="help-block text-gray-600" v-if="!container">{{ __('Select asset container') }}</small>
-
         <relationship-fieldtype
             v-if="container"
             :handle="handle"
@@ -23,7 +21,7 @@ export default {
     computed: {
 
         container() {
-            return data_get(this.$store.state.publish[this.storeName].values.container, '0', null);
+            return data_get(this.$store.state.publish[this.storeName].values.container, '0', this.config.container);
         },
 
         relationshipMeta() {

--- a/resources/js/components/fieldtypes/AssetFolderFieldtype.vue
+++ b/resources/js/components/fieldtypes/AssetFolderFieldtype.vue
@@ -5,7 +5,7 @@
             :handle="handle"
             :value="value"
             :meta="relationshipMeta"
-            :config="{ type: 'asset_folder' }"
+            :config="{ type: 'asset_folder', max_items: this.config.max_items }"
             @input="update"
         />
     </div>

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -22,6 +22,7 @@ return [
     'assets.dynamic_folder_pending_field' => 'This field will be available once :field is set.',
     'assets.dynamic_folder_pending_save' => 'This field will be available after saving.',
     'assets.title' => 'Assets',
+    'asset_folders.config.container' => 'Choose which asset container to use for this field.',
     'bard.config.allow_source' => 'Enable to view the HTML source code while writing.',
     'bard.config.always_show_set_button' => 'Enable to always show the "Add Set" button.',
     'bard.config.buttons' => 'Choose which buttons to show in the toolbar.',

--- a/src/Fieldtypes/AssetFolder.php
+++ b/src/Fieldtypes/AssetFolder.php
@@ -13,6 +13,40 @@ class AssetFolder extends Relationship
     protected $canCreate = false;
     protected $selectable = false;
 
+    protected function configFieldItems(): array
+    {
+        return [
+            [
+                'display' => __('Appearance & Behavior'),
+                'fields' => [
+                    'max_items' => [
+                        'display' => __('Max Items'),
+                        'instructions' => __('statamic::messages.max_items_instructions'),
+                        'min' => 1,
+                        'type' => 'integer',
+                    ],
+                    'mode' => [
+                        'display' => __('UI Mode'),
+                        'instructions' => __('statamic::fieldtypes.relationship.config.mode'),
+                        'type' => 'radio',
+                        'default' => 'default',
+                        'options' => [
+                            'default' => __('Stack Selector'),
+                            'select' => __('Select Dropdown'),
+                            'typeahead' => __('Typeahead Field'),
+                        ],
+                    ],
+                    'container' => [
+                        'display' => __('Container'),
+                        'instructions' => __('statamic::fieldtypes.asset_folders.config.container'),
+                        'type' => 'asset_container',
+                        'max_items' => 1,
+                    ],
+                ],
+            ],
+        ];
+    }
+
     protected function toItemArray($id, $site = null)
     {
         return ['title' => $id, 'id' => $id];


### PR DESCRIPTION
Currently, the Asset Folders fieldtype relies on there being a `container` field in the same publish form.

This pull request adds the ability to specify the container as a config option on the fieldtype so it can be determined in the blueprint.