### PR TITLE
[5.x] Accept collections in ampersand list modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -96,6 +96,10 @@ class CoreModifiers extends Modifier
      */
     public function ampersandList($value, $params)
     {
+        if ($value instanceof Collection) {
+            $value = $value->all();
+        }
+
         if (! is_array($value)) {
             return $value;
         }

--- a/tests/Modifiers/AmbersandListTest.php
+++ b/tests/Modifiers/AmbersandListTest.php
@@ -36,6 +36,17 @@ class AmbersandListTest extends TestCase
     }
 
     #[Test]
+    public function it_creates_an_list_from_collection(): void
+    {
+        $modified = $this->modify(collect([
+            'apples',
+            'bananas',
+            'jerky',
+        ]));
+        $this->assertEquals('apples, bananas & jerky', $modified);
+    }
+
+    #[Test]
     public function it_creates_an_list_with_custom_glue(): void
     {
         $modified = $this->modify([


### PR DESCRIPTION
- The `sentence_list` modifier accepts arrays and collections
- The `ampersand_list` modifier only accepts arrays
- Now it accepts both :)
- Very useful after plucking values from a query builder