### PR TITLE
[5.x] Allow customizing term create label

### DIFF
--- a/resources/js/components/terms/BaseCreateForm.vue
+++ b/resources/js/components/terms/BaseCreateForm.vue
@@ -5,7 +5,7 @@
         publish-container="base"
         :initial-actions="actions"
         method="post"
-        :initial-title="__('Create')"
+        :initial-title="taxonomyCreateLabel"
         :taxonomy-handle="taxonomyHandle"
         :breadcrumbs="breadcrumbs"
         :initial-fieldset="fieldset"
@@ -31,6 +31,7 @@ export default {
     props: [
         'actions',
         'taxonomyHandle',
+        'taxonomyCreateLabel',
         'breadcrumbs',
         'fieldset',
         'values',

--- a/resources/js/components/terms/CreateTermButton.vue
+++ b/resources/js/components/terms/CreateTermButton.vue
@@ -6,7 +6,7 @@
                 class="btn-primary flex items-center"
                 @click="create"
             >
-                <span v-text="__('Create Term')" />
+                <span v-text="text" />
                 <svg-icon name="micro/chevron-down-xs" class="rtl:mr-2 ltr:ml-2 -mr-2 w-2" v-if="blueprints.length > 1" />
             </button>
         </template>
@@ -25,7 +25,8 @@ export default {
 
     props: {
         url: String,
-        blueprints: Array
+        blueprints: Array,
+        text: { type: String, default: () => __('Create Term') },
     },
 
     methods: {

--- a/resources/views/taxonomies/show.blade.php
+++ b/resources/views/taxonomies/show.blade.php
@@ -36,7 +36,7 @@
             @if($canCreate)
                 <create-term-button
                     url="{{ cp_route('taxonomies.terms.create', [$taxonomy->handle(), $site]) }}"
-                    :text="{{ $taxonomy->createLabel() }}"
+                    text="{{ $taxonomy->createLabel() }}"
                     :blueprints="{{ $blueprints->toJson() }}">
                 </create-term-button>
             @endif

--- a/resources/views/taxonomies/show.blade.php
+++ b/resources/views/taxonomies/show.blade.php
@@ -36,6 +36,7 @@
             @if($canCreate)
                 <create-term-button
                     url="{{ cp_route('taxonomies.terms.create', [$taxonomy->handle(), $site]) }}"
+                    :text="{{ $taxonomy->createLabel() }}"
                     :blueprints="{{ $blueprints->toJson() }}">
                 </create-term-button>
             @endif

--- a/resources/views/terms/create.blade.php
+++ b/resources/views/terms/create.blade.php
@@ -1,11 +1,12 @@
 @extends('statamic::layout')
-@section('title', $breadcrumbs->title('Create Term'))
+@section('title', $breadcrumbs->title($taxonomyCreateLabel))
 @section('wrapper_class', 'max-w-3xl')
 
 @section('content')
     <base-term-create-form
         :actions="{{ json_encode($actions) }}"
         taxonomy-handle="{{ $taxonomy }}"
+        taxonomy-create-label="{{ $taxonomyCreateLabel }}"
         :breadcrumbs="{{ $breadcrumbs->toJson() }}"
         :fieldset="{{ json_encode($blueprint) }}"
         :values="{{ json_encode($values) }}"

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -240,13 +240,14 @@ class TermsController extends CpController
         ]);
 
         $viewData = [
-            'title' => __('Create Term'),
+            'title' => $taxonomy->createLabel(),
             'actions' => [
                 'save' => cp_route('taxonomies.terms.store', [$taxonomy->handle(), $site->handle()]),
             ],
             'values' => $values,
             'meta' => $fields->meta(),
             'taxonomy' => $taxonomy->handle(),
+            'taxonomyCreateLabel' => $taxonomy->createLabel(),
             'blueprint' => $blueprint->toPublishArray(),
             'published' => $taxonomy->defaultPublishState(),
             'locale' => $site->handle(),

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -441,6 +441,19 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
             ->args(func_get_args());
     }
 
+    public function createLabel()
+    {
+        $key = "messages.{$this->handle()}_taxonomy_create_term";
+
+        $translation = __($key);
+
+        if ($translation === $key) {
+            return __('Create Term');
+        }
+
+        return $translation;
+    }
+
     public function searchIndex($index = null)
     {
         return $this

--- a/tests/Data/Taxonomies/TaxonomyTest.php
+++ b/tests/Data/Taxonomies/TaxonomyTest.php
@@ -430,6 +430,13 @@ class TaxonomyTest extends TestCase
     }
 
     #[Test]
+    public function it_gets_and_sets_the_create_label()
+    {
+        $taxonomy = (new Taxonomy)->handle('tags');
+        $this->assertEquals('Create Term', $taxonomy->createLabel());
+    }
+
+    #[Test]
     public function it_cannot_view_taxonomies_from_sites_that_the_user_is_not_authorized_to_see()
     {
         $this->setSites([


### PR DESCRIPTION
Allow customizing the label of the `Create Term` button. This already works for collections, just not for taxonomies. Mostly copy-and-paste from the implementation for entries.

```php
// lang/en/messages.php

return [
    'tags_taxonomy_create_term' => 'New Tag'
];
```

<img width="563" alt="Screenshot 2024-11-10 at 20 08 06" src="https://github.com/user-attachments/assets/f346e373-7db8-4d82-bbae-3fefc8342100">

