### PR TITLE
[5.x] Fix multisite command not moving directories

### DIFF
--- a/src/Console/Commands/Multisite.php
+++ b/src/Console/Commands/Multisite.php
@@ -93,21 +93,21 @@ class Multisite extends Command
             return false;
         }
 
-        $directory = Config::get('statamic.stache.stores.entries.directory').DIRECTORY_SEPARATOR.$collection->handle().DIRECTORY_SEPARATOR.$siteHandle;
+        $directory = Stache::store('entries')->directory().DIRECTORY_SEPARATOR.$collection->handle().DIRECTORY_SEPARATOR.$siteHandle;
 
         return File::isDirectory($directory);
     }
 
     private function globalsHaveBeenMoved(string $siteHandle): bool
     {
-        $directory = Config::get('statamic.stache.stores.globals.directory').DIRECTORY_SEPARATOR.$siteHandle;
+        $directory = Stache::store('globals')->directory().DIRECTORY_SEPARATOR.$siteHandle;
 
         return File::isDirectory($directory);
     }
 
     private function navsHaveBeenMoved(string $siteHandle): bool
     {
-        $directory = Config::get('statamic.stache.stores.navigation.directory').DIRECTORY_SEPARATOR.$siteHandle;
+        $directory = Stache::store('navigation')->directory().DIRECTORY_SEPARATOR.$siteHandle;
 
         return File::isDirectory($directory);
     }
@@ -233,7 +233,7 @@ class Multisite extends Command
     {
         Config::set('statamic.system.multisite', false);
 
-        $base = Config::get('statamic.stache.stores.entries.directory').DIRECTORY_SEPARATOR.$collection->handle();
+        $base = Stache::store('entries')->directory().DIRECTORY_SEPARATOR.$collection->handle();
 
         File::makeDirectory("{$base}/{$this->siteHandle}");
 


### PR DESCRIPTION
This pull request fixes an issue where the `php please multisite` command wasn't moving content directories correctly.

After some investigation, it looks like this was due to `Config::get('statamic.stache.stores')` returning an empty array, so the base directory was `/collection-handle`.

I haven't been able to track down exactly _when_ this started happening. It might have had something to do with the config merging changes in Laravel 11 but surely we would have had reports way before now if that was the case? 🤔

Anyways, this pull request fixes it by getting the directories from the Stache store class.

Fixes #11087.