### PR TITLE
[5.x] Hide "Localizable" button on non-localizable blueprints

### DIFF
--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -43,6 +43,7 @@
             :single-tab="!useTabs"
             :initial-tabs="tabs"
             :errors="errors.tabs"
+            :can-define-localizable="canDefineLocalizable"
             @updated="tabsUpdated"
         />
 
@@ -53,10 +54,11 @@
 <script>
 import SuggestsConditionalFields from './SuggestsConditionalFields';
 import Tabs from './Tabs.vue';
+import CanDefineLocalizable from "../fields/CanDefineLocalizable";
 
 export default {
 
-    mixins: [SuggestsConditionalFields],
+    mixins: [SuggestsConditionalFields, CanDefineLocalizable],
 
     components: {
         Tabs,

--- a/resources/js/components/blueprints/TabContent.vue
+++ b/resources/js/components/blueprints/TabContent.vue
@@ -12,6 +12,7 @@
             :edit-section-text="editSectionText"
             :show-section-handle-field="showSectionHandleField"
             :show-section-hide-field="showSectionHideField"
+            :can-define-localizable="canDefineLocalizable"
             @updated="sectionsUpdated($event)"
         />
     </div>
@@ -19,8 +20,11 @@
 
 <script>
 import Sections from './Sections.vue';
+import CanDefineLocalizable from "../fields/CanDefineLocalizable";
 
 export default {
+
+    mixins: [CanDefineLocalizable],
 
     components: {
         Sections,

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -37,6 +37,7 @@
             :new-section-text="newSectionText"
             :edit-section-text="editSectionText"
             :add-section-text="addSectionText"
+            :can-define-localizable="canDefineLocalizable"
             @updated="updateTab(tab._id, $event)"
         />
     </div>
@@ -47,8 +48,11 @@ import {Sortable, Plugins} from '@shopify/draggable';
 import uniqid from 'uniqid';
 import Tab from './Tab.vue';
 import TabContent from './TabContent.vue';
+import CanDefineLocalizable from "../fields/CanDefineLocalizable";
 
 export default {
+
+    mixins: [CanDefineLocalizable],
 
     components: {
         Tab,

--- a/resources/views/forms/blueprints/edit.blade.php
+++ b/resources/views/forms/blueprints/edit.blade.php
@@ -15,6 +15,7 @@
         :initial-blueprint="{{ json_encode($blueprintVueObject) }}"
         :use-tabs="false"
         :is-form-blueprint="true"
+        :can-define-localizable="false"
     ></blueprint-builder>
 
     @include('statamic::partials.docs-callout', [

--- a/resources/views/usergroups/blueprints/edit.blade.php
+++ b/resources/views/usergroups/blueprints/edit.blade.php
@@ -13,6 +13,7 @@
     <blueprint-builder
         action="{{ cp_route('user-groups.blueprint.update') }}"
         :initial-blueprint="{{ json_encode($blueprintVueObject) }}"
+        :can-define-localizable="false"
     ></blueprint-builder>
 
     @include('statamic::partials.docs-callout', [

--- a/resources/views/users/blueprints/edit.blade.php
+++ b/resources/views/users/blueprints/edit.blade.php
@@ -13,6 +13,7 @@
     <blueprint-builder
         action="{{ cp_route('users.blueprint.update') }}"
         :initial-blueprint="{{ json_encode($blueprintVueObject) }}"
+        :can-define-localizable="false"
     ></blueprint-builder>
 
     @include('statamic::partials.docs-callout', [


### PR DESCRIPTION
This pull request hides the "Localizable" button on non-localizable blueprints, like users, groups and forms.

Fixes #11048.