### PR TITLE
[5.x] Prevent duplicate nocache regions in session

### DIFF
--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -123,7 +123,7 @@ class Session
     {
         $session = StaticCache::cacheStore()->get('nocache::session.'.md5($this->url));
 
-        $this->regions = $this->regions->merge($session['regions'] ?? []);
+        $this->regions = $this->regions->merge($session['regions'] ?? [])->unique()->values();
         $this->cascade = $this->restoreCascade();
 
         $this->resolvePageAndPathForPagination();


### PR DESCRIPTION
This pull request prevent duplicate nocache regions from being saved to a nocache sessio, which should hopefully reduce memory a little bit for some sites.

Fixes #10973.