### PR TITLE
[5.x] Enhancement: Make button groups clearable

### DIFF
--- a/resources/css/components/fieldtypes/button-group.css
+++ b/resources/css/components/fieldtypes/button-group.css
@@ -5,6 +5,10 @@
     @apply flex-wrap;
 }
 
+.button-group-fieldtype-wrapper .btn-group {
+    @apply cursor-default;
+}
+
 .btn-group.btn-vertical {
     @apply flex-col items-stretch justify-start p-0 h-auto;
 

--- a/resources/css/components/fieldtypes/button-group.css
+++ b/resources/css/components/fieldtypes/button-group.css
@@ -5,10 +5,6 @@
     @apply flex-wrap;
 }
 
-.button-group-fieldtype-wrapper .btn-group {
-    @apply cursor-default;
-}
-
 .btn-group.btn-vertical {
     @apply flex-col items-stretch justify-start p-0 h-auto;
 

--- a/resources/css/elements/buttons.css
+++ b/resources/css/elements/buttons.css
@@ -190,7 +190,7 @@ button {
   ========================================================================== */
 
 .btn-group {
-    @apply flex items-center justify-start p-0;
+    @apply flex items-center justify-start p-0 cursor-auto;
     height: 2.375rem;
 
     button {

--- a/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
@@ -7,7 +7,7 @@
                 ref="button"
                 type="button"
                 :name="name"
-                @click="update($event.target.value)"
+                @click="updateSelectedOption($event.target.value)"
                 :value="option.value"
                 :disabled="isReadOnly"
                 :class="{'active': value === option.value}"
@@ -52,6 +52,10 @@ export default {
     },
 
     methods: {
+
+        updateSelectedOption(newValue) {
+            this.update(this.value == newValue && this.config.clearable ? null : newValue);
+        },
 
         setupResizeObserver() {
             this.resizeObserver = new ResizeObserver(() => {

--- a/src/Fieldtypes/ButtonGroup.php
+++ b/src/Fieldtypes/ButtonGroup.php
@@ -25,6 +25,12 @@ class ButtonGroup extends Fieldtype
                         'value_header' => __('Label').' ('.__('Optional').')',
                         'add_button' => __('Add Option'),
                     ],
+                    'clearable' => [
+                        'display' => __('Clearable'),
+                        'instructions' => __('statamic::fieldtypes.select.config.clearable'),
+                        'type' => 'toggle',
+                        'default' => false,
+                    ],
                     'default' => [
                         'display' => __('Default Value'),
                         'instructions' => __('statamic::messages.fields_default_instructions'),


### PR DESCRIPTION
This PR makes two small adjustments to the Button Group fieldtype:

1. Adds a `clearable` option to the config. When enabled, this works like the Select fieldtype but without a dedicated ✖ button. Instead, you can now just click the currently-selected option to deselect it. 
2. Previously, hovering anywhere to the right of grouped buttons (ie, in the blank, unused space after the group) would show a pointer cursor, as if there was an invisible button. Quick little CSS patch on the wrapper to use `cursor-default` instead.

Let me know if there are any edits I can help with, here!