### PR TITLE
[5.x] Allow transformResults to be called separately from getBaseItems

### DIFF
--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -55,7 +55,7 @@ abstract class QueryBuilder extends BaseQueryBuilder
         return $this->transformResults($results);
     }
 
-    public function transformResults()
+    public function transformResults($results)
     {
         if (! $this->withData) {
             return $this->collect($results)

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -52,6 +52,11 @@ abstract class QueryBuilder extends BaseQueryBuilder
     {
         $results = $this->getSearchResults($this->query);
 
+        return $this->transformResults($results);
+    }
+
+    public function transformResults()
+    {
         if (! $this->withData) {
             return $this->collect($results)
                 ->map(fn ($result) => new PlainResult($result))


### PR DESCRIPTION
Would it be possible to split this logic out so transformResults could be called separately?

Im working on an update to Typesense to handle pagination on the API side (rather than getting all the results then paginating in Statamic), so I need to be able to transform inside my query builder paginate() function.

PR here if it helps make sense of what we need: https://github.com/statamic-rad-pack/typesense/pull/7