### PR TITLE
[5.x] Fix wrong blueprint parent after revision publish

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -321,7 +321,7 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
     {
         $this->parent = $parent;
 
-        $this->resetFieldsCache();
+        $this->resetBlueprintCache()->resetFieldsCache();
 
         return $this;
     }

--- a/src/Revisions/Revisable.php
+++ b/src/Revisions/Revisable.php
@@ -108,6 +108,10 @@ trait Revisable
 
         $item->deleteWorkingCopy();
 
+        if ($item instanceof Entry) {
+            $item->blueprint()->setParent($item);
+        }
+
         return $item;
     }
 
@@ -132,6 +136,10 @@ trait Revisable
             ->save();
 
         $item->deleteWorkingCopy();
+
+        if ($item instanceof Entry) {
+            $item->blueprint()->setParent($item);
+        }
 
         return $item;
     }


### PR DESCRIPTION
This PR fixes an issue where after publishing a revision the `parent` set on the blueprint and field objects will still refer to the previous version of the entry.

This can cause issues during the `preProcess` calls fired by `PublishedEntriesController::extractFromFields` if you're using the parent. The issue we had is that we do something in `preProcess` that depends on the value of another field. We fetch the value of that field from the parent data, but if the parent is the previous version the value might be wrong. 

The reason updating the parent isn't done [just after clone](https://github.com/statamic/cms/blob/0d2403d69d467055e649815841ce401a4c2a210d/src/Entries/Entry.php#L682) (which would be the obvious place) is that the `save` calls further up in `publishWorkingCopy`/`unpublishWorkingCopy` can also result in the associated blueprint/parent objects getting out of sync, so the same issue persists, although I think that's unique to the eloquent driver.