### PR TITLE
[5.x] Hide "Localizable" button in asset blueprints

### DIFF
--- a/resources/views/assets/containers/blueprints/edit.blade.php
+++ b/resources/views/assets/containers/blueprints/edit.blade.php
@@ -14,6 +14,7 @@
         action="{{ cp_route('asset-containers.blueprint.update', $container->handle()) }}"
         :initial-blueprint="{{ json_encode($blueprintVueObject) }}"
         :use-tabs="false"
+        :can-define-localizable="false"
     ></blueprint-builder>
 
     @include('statamic::partials.docs-callout', [


### PR DESCRIPTION
Continuation of #11107.