### PR TITLE
[5.x] Fix bad import of FieldtypeRepository in Field

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -2,13 +2,13 @@
 
 namespace Statamic\Fields;
 
-use Facades\Statamic\Fields\FieldtypeRepository;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Lang;
 use Rebing\GraphQL\Support\Field as GqlField;
 use Statamic\Contracts\Forms\Form;
 use Statamic\Facades\GraphQL;
+use Statamic\Fields\FieldtypeRepository;
 use Statamic\Rules\Handle;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Lang;
 use Rebing\GraphQL\Support\Field as GqlField;
 use Statamic\Contracts\Forms\Form;
 use Statamic\Facades\GraphQL;
-use Statamic\Fields\FieldtypeRepository;
 use Statamic\Rules\Handle;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;


### PR DESCRIPTION
`Facade\Statamic\Fields\FieldtypeRepository` does not exist and I believe it should be `Statamic\Fields\FieldtypeRepository`

This caused an exception to appear in our Sentry logs.