### PR TITLE
[5.x] Fix bard text trimming when CP is on root URL

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -96,7 +96,11 @@ class AppServiceProvider extends ServiceProvider
             return optional($this->statamicToken())->handler() === LivePreview::class;
         });
 
-        TrimStrings::skipWhen(fn (Request $request) => $request->is(config('statamic.cp.route').'/*'));
+        TrimStrings::skipWhen(function (Request $request) {
+            $route = config('statamic.cp.route');
+
+            return ! $route || $request->is($route.'/*');
+        });
 
         $this->addAboutCommandInfo();
 


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/11125

If the CP route is empty (ie. in headless mode with the CP at the root of the domain) the original request check that disables the default TrimStrings middleware fails. This PR fixes it by assuming all requests are CP requests if the route is empty.