### PR TITLE
[5.x] Fix autoloading when addon has multiple service providers

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -783,7 +783,8 @@ abstract class AddonServiceProvider extends ServiceProvider
             return [];
         }
 
-        $path = $addon->directory().$addon->autoload().'/'.$folder;
+        $reflection = new \ReflectionClass(static::class);
+        $path = dirname($reflection->getFileName()).'/'.$folder;
 
         if (! $this->app['files']->exists($path)) {
             return [];


### PR DESCRIPTION
This pull request changes the "base path" used when autoloading addon components, to prevent addons with multiple service providers from booting the same stuff multiple times.

Fixes #11082.