### PR TITLE
[5.x] Prevent comma completing tags when defining container validation rules

### DIFF
--- a/resources/js/components/fieldtypes/TagsFieldtype.vue
+++ b/resources/js/components/fieldtypes/TagsFieldtype.vue
@@ -9,7 +9,7 @@
         :multiple="true"
         :placeholder="__(config.placeholder)"
         :searchable="true"
-        :select-on-key-codes="[9, 13, 188]"
+        :select-on-key-codes="keyCodes"
         :taggable="true"
         :append-to-body="true"
         :value="value"
@@ -71,6 +71,18 @@ export default {
     },
 
     mixins: [Fieldtype, HasInputOptions],
+
+    computed: {
+        keyCodes() {
+            let keyCodes = [9, 13];
+
+            if (this.config.select_on_commas) {
+                keyCodes.push(188);
+            }
+
+            return keyCodes;
+        },
+    },
 
     methods: {
         focus() {

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -172,6 +172,7 @@ return [
     'table.title' => 'Table',
     'taggable.config.options' => 'Provide pre-defined tags that can be selected.',
     'taggable.config.placeholder' => 'Type and press ↩ Enter',
+    'taggable.config.select_on_commas' => 'Should a comma automatically select the tag?',
     'taggable.title' => 'Taggable',
     'taxonomies.title' => 'Taxonomies',
     'template.config.blueprint' => 'Adds a "map to blueprint" option. Learn more in the [documentation](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',

--- a/src/Fieldtypes/Taggable.php
+++ b/src/Fieldtypes/Taggable.php
@@ -26,6 +26,12 @@ class Taggable extends Fieldtype
                 'type' => 'list',
                 'add_button' => __('Add Option'),
             ],
+            'select_on_commas' => [
+                'display' => __('Select on Commas'),
+                'instructions' => __('statamic::fieldtypes.taggable.config.select_on_commas'),
+                'type' => 'toggle',
+                'default' => true,
+            ],
         ];
     }
 

--- a/src/Http/Controllers/CP/Assets/AssetContainersController.php
+++ b/src/Http/Controllers/CP/Assets/AssetContainersController.php
@@ -271,6 +271,7 @@ class AssetContainersController extends CpController
                         'type' => 'taggable',
                         'display' => __('Validation Rules'),
                         'instructions' => __('statamic::messages.asset_container_validation_rules_instructions'),
+                        'select_on_commas' => false,
                     ],
                 ],
             ],


### PR DESCRIPTION
This pull request fixes an issue with the Taggable fieldtype when it's used for defining an asset container's validation rules, where a comma in a rule completes the tag, which can be frustrating in the context of validation rules.

Fixes #11122.