### PR TITLE
[5.x] Fix issue when preprocessing dictionary config

### DIFF
--- a/src/Fieldtypes/DictionaryFields.php
+++ b/src/Fieldtypes/DictionaryFields.php
@@ -51,7 +51,7 @@ class DictionaryFields extends Fieldtype
         }
 
         if (is_string($data)) {
-            return ['type' => $data];
+            $data = ['type' => $data];
         }
 
         $dictionary = Dictionary::find($data['type']);

--- a/tests/Fieldtypes/DictionaryFieldsTest.php
+++ b/tests/Fieldtypes/DictionaryFieldsTest.php
@@ -84,6 +84,7 @@ class DictionaryFieldsTest extends TestCase
 
         $this->assertEquals([
             'type' => 'fake_dictionary',
+            'category' => null,
         ], $preProcess);
     }
 


### PR DESCRIPTION
This pull request fixes an issue with the `DictionaryFields` fieldtype, responsible for the configuration of Dictionary fields. 

When a dictionary _doesn't_ have any config fields, it'll be saved as `dictionary: artists`.

When a dictionary *does* have config fields, it'll be saved as an array, like:

```yaml
dictionary:
  type: artists
  category: rock
```

However, if a dictionary field was configured before any config fields were added, it would fail to be preprocessed correctly, due to just the dictionary select itself being processed, causing issues with some fieldtypes.

Fixes #11124.