### PR TITLE
[5.x] Prevent asset folder path traversal

### DIFF
--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -3,6 +3,7 @@
 namespace Statamic\Assets;
 
 use Illuminate\Contracts\Support\Arrayable;
+use League\Flysystem\PathTraversalDetected;
 use Statamic\Assets\AssetUploader as Uploader;
 use Statamic\Contracts\Assets\AssetFolder as Contract;
 use Statamic\Events\AssetFolderDeleted;
@@ -35,7 +36,13 @@ class AssetFolder implements Arrayable, Contract
 
     public function path($path = null)
     {
-        return $this->fluentlyGetOrSet('path')->args(func_get_args());
+        return $this->fluentlyGetOrSet('path')
+            ->setter(function ($path) {
+                if (str_contains($path, '..')) {
+                    throw PathTraversalDetected::forPath($path);
+                }
+            })
+            ->args(func_get_args());
     }
 
     public function basename()

--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -41,6 +41,8 @@ class AssetFolder implements Arrayable, Contract
                 if (str_contains($path, '..')) {
                     throw PathTraversalDetected::forPath($path);
                 }
+
+                return $path;
             })
             ->args(func_get_args());
     }

--- a/src/Http/Controllers/CP/Assets/FolderActionController.php
+++ b/src/Http/Controllers/CP/Assets/FolderActionController.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Http\Controllers\CP\Assets;
 
+use League\Flysystem\PathTraversalDetected;
 use Statamic\Assets\AssetFolder;
+use Statamic\Exceptions\ValidationException;
 use Statamic\Http\Controllers\CP\ActionController as Controller;
 
 class FolderActionController extends Controller
@@ -12,7 +14,11 @@ class FolderActionController extends Controller
     protected function getSelectedItems($items, $context)
     {
         return $items->map(function ($path) use ($context) {
-            return AssetFolder::find("{$context['container']}::{$path}");
+            try {
+                return AssetFolder::find("{$context['container']}::{$path}");
+            } catch (PathTraversalDetected $e) {
+                throw ValidationException::withMessages(['selections' => $e->getMessage()]);
+            }
         });
     }
 }

--- a/tests/Actions/DeleteAssetFolderTest.php
+++ b/tests/Actions/DeleteAssetFolderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Actions;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Assets\AssetContainer;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class DeleteAssetFolderTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    private $container;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('test');
+
+        $this->container = tap(
+            (new AssetContainer)->handle('test_container')->disk('test')
+        )->save();
+    }
+
+    private function createAsset($filename)
+    {
+        $file = UploadedFile::fake()->image($filename, 30, 60);
+        Storage::disk('test')->putFileAs($file, $filename);
+    }
+
+    private function assertAssetExists($file)
+    {
+        Storage::disk('test')->assertExists($file);
+        $this->assertNotNull($this->container->asset($file));
+    }
+
+    private function assertAssetDoesNotExist($file)
+    {
+        Storage::disk('test')->assertMissing($file);
+        $this->assertNull($this->container->asset($file));
+    }
+
+    private function deleteFolder($folder)
+    {
+        return $this->post(cp_route('assets.folders.actions.run', ['asset_container' => 'test_container']), [
+            'action' => 'delete',
+            'context' => ['container' => 'test_container'],
+            'selections' => [$folder],
+            'values' => [],
+        ]);
+    }
+
+    #[Test]
+    public function it_deletes()
+    {
+        $this->createAsset('foo/alfa.jpg');
+        $this->createAsset('foo/bravo.jpg');
+        $this->createAsset('bar/charlie.jpg');
+        $this->createAsset('delta.jpg');
+        Storage::disk('test')->assertExists('foo');
+
+        $this
+            ->actingAs(tap(User::make()->makeSuper())->save())
+            ->deleteFolder('foo')
+            ->assertOk();
+
+        Storage::disk('test')->assertMissing('foo');
+        $this->assertAssetDoesNotExist('foo/alfa.jpg');
+        $this->assertAssetDoesNotExist('foo/bravo.jpg');
+        $this->assertAssetExists('bar/charlie.jpg');
+        $this->assertAssetExists('delta.jpg');
+    }
+
+    #[Test]
+    public function no_path_traversal()
+    {
+        $this->createAsset('foo/alfa.jpg');
+        $this->createAsset('foo/bravo.jpg');
+        $this->createAsset('bar/charlie.jpg');
+        $this->createAsset('delta.jpg');
+        Storage::disk('test')->assertExists('foo');
+
+        $this
+            ->actingAs(tap(User::make()->makeSuper())->save())
+            ->deleteFolder('foo/..')
+            ->assertSessionHasErrors(['selections' => 'Path traversal detected: foo/..']);
+
+        Storage::disk('test')->assertExists('foo');
+        $this->assertAssetExists('foo/alfa.jpg');
+        $this->assertAssetExists('foo/bravo.jpg');
+        $this->assertAssetExists('bar/charlie.jpg');
+        $this->assertAssetExists('delta.jpg');
+    }
+}

--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use League\Flysystem\PathTraversalDetected;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Assets\Asset;
 use Statamic\Assets\AssetContainerContents;
@@ -53,6 +54,15 @@ class AssetFolderTest extends TestCase
         $this->assertEquals($folder, $return);
         $this->assertEquals('path/to/folder', $folder->path());
         $this->assertEquals('folder', $folder->basename());
+    }
+
+    #[Test]
+    public function path_traversal_not_allowed()
+    {
+        $this->expectException(PathTraversalDetected::class);
+        $this->expectExceptionMessage('Path traversal detected: path/to/../folder');
+
+        (new Folder)->path('path/to/../folder');
     }
 
     #[Test]


### PR DESCRIPTION
This prevents potential for path traversal when instantiating asset folders.
