### PR TITLE
[5.x] Prevent unnecessary requests to the Outpost when PHP version is different

### DIFF
--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -159,7 +159,7 @@ class Outpost
 
     private function payloadHasChanged($previous, $current)
     {
-        $exclude = ['ip'];
+        $exclude = ['ip', 'php_version'];
 
         return Arr::except($previous, $exclude) !== Arr::except($current, $exclude);
     }


### PR DESCRIPTION
This pull request prevents unnecessary requests from being made to the Outpost when the PHP version in the payload differs from the cached version.

For example: if you have a load balanced setup w/ multiple servers and you're rolling out PHP updates one at a time, your users might see the licensing banner if the Outpost's rate limiting kicks in.

Closes #11135.