### PR TITLE
[5.x] Add upload path traversal tests

### DIFF
--- a/tests/Feature/Assets/StoreAssetTest.php
+++ b/tests/Feature/Assets/StoreAssetTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Assets;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Assets\AssetContainer;
 use Statamic\Facades;
@@ -37,22 +38,35 @@ class StoreAssetTest extends TestCase
     }
 
     #[Test]
-    public function it_uploads_an_asset()
+    #[DataProvider('uploadProvider')]
+    public function it_uploads_an_asset($filename, $expected)
     {
-        Storage::disk('test')->assertMissing('path/to/test.jpg');
+        Storage::disk('test')->assertMissing($expected);
 
         $this
             ->actingAs($this->userWithPermission())
-            ->submit()
-            ->assertOk()
+            ->submit([
+                'file' => UploadedFile::fake()->image($filename),
+            ])
             ->assertJson([
                 'data' => [
-                    'id' => 'test_container::path/to/test.jpg',
-                    'path' => 'path/to/test.jpg',
+                    'id' => 'test_container::'.$expected,
+                    'path' => $expected,
                 ],
             ]);
 
-        Storage::disk('test')->assertExists('path/to/test.jpg');
+        Storage::disk('test')->assertExists($expected);
+    }
+
+    public static function uploadProvider()
+    {
+        return [
+            'test.jpg' => ['test.jpg', 'path/to/test.jpg'],
+
+            // path traversal naughtiness
+            '../test.jpg urlencoded' => ['%2e%2e%2ftest.jpg', 'path/to/..-test.jpg'],
+            'foo/../test.jpg urlencoded' => ['foo%2f%2e%2e%2ftest.jpg', 'path/to/foo-..-test.jpg'],
+        ];
     }
 
     #[Test]
@@ -187,24 +201,39 @@ class StoreAssetTest extends TestCase
     }
 
     #[Test]
-    public function it_can_upload_to_relative_path()
+    #[DataProvider('relativePathProvider')]
+    public function it_can_upload_to_relative_path($filename, $expected)
     {
-        Storage::disk('test')->assertMissing('path/to/test.jpg');
-        Storage::disk('test')->assertMissing('path/to/sub/folder/test.jpg');
+        Storage::disk('test')->assertMissing('path/to/'.$filename);
+        Storage::disk('test')->assertMissing($expected);
 
         $this
             ->actingAs($this->userWithPermission())
-            ->submit(['relativePath' => 'sub/folder'])
+            ->submit([
+                'relativePath' => 'sub/folder',
+                'file' => UploadedFile::fake()->image($filename),
+            ])
             ->assertOk()
             ->assertJson([
                 'data' => [
-                    'id' => 'test_container::path/to/sub/folder/test.jpg',
-                    'path' => 'path/to/sub/folder/test.jpg',
+                    'id' => 'test_container::'.$expected,
+                    'path' => $expected,
                 ],
             ]);
 
-        Storage::disk('test')->assertMissing('path/to/test.jpg');
-        Storage::disk('test')->assertExists('path/to/sub/folder/test.jpg');
+        Storage::disk('test')->assertMissing('path/to/'.$filename);
+        Storage::disk('test')->assertExists($expected);
+    }
+
+    public static function relativePathProvider()
+    {
+        return [
+            'test.jpg' => ['test.jpg', 'path/to/sub/folder/test.jpg'],
+
+            // path traversal naughtiness
+            '../test.jpg urlencoded' => ['%2e%2e%2ftest.jpg', 'path/to/sub/folder/..-test.jpg'],
+            'foo/../test.jpg urlencoded' => ['foo%2f%2e%2e%2ftest.jpg', 'path/to/sub/folder/foo-..-test.jpg'],
+        ];
     }
 
     #[Test]


### PR DESCRIPTION
There was a path traversal issue fixed in #10423 even when that wasn't the intention of the PR. A happy coincidence.

This PR adds test coverage for it.
