### PR TITLE
[5.x] More path traversal fixes

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -7,6 +7,7 @@ use Facades\Statamic\Assets\Attributes;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use League\Flysystem\PathTraversalDetected;
 use Statamic\Assets\AssetUploader as Uploader;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
@@ -367,6 +368,13 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
     {
         return $this
             ->fluentlyGetOrSet('path')
+            ->setter(function ($path) {
+                if (str_contains($path, '../')) {
+                    throw PathTraversalDetected::forPath($path);
+                }
+
+                return $path;
+            })
             ->getter(function ($path) {
                 return $path ? ltrim($path, '/') : null;
             })

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Storage;
 use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\DirectoryListing;
 use League\Flysystem\FileAttributes;
+use League\Flysystem\PathTraversalDetected;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Assets\Asset;
@@ -809,6 +810,16 @@ class AssetContainerTest extends TestCase
         $this->assertInstanceOf(Asset::class, $asset);
         $this->assertEquals($container, $asset->container());
         $this->assertEquals('path/to/test.txt', $asset->path());
+    }
+
+    #[Test]
+    public function it_cannot_make_an_asset_using_path_traversal()
+    {
+        $this->expectException(PathTraversalDetected::class);
+        $this->expectExceptionMessage('Path traversal detected: foo/../test.txt');
+
+        $container = $this->containerWithDisk();
+        $container->makeAsset('foo/../test.txt');
     }
 
     #[Test]

--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -57,12 +57,22 @@ class AssetFolderTest extends TestCase
     }
 
     #[Test]
-    public function path_traversal_not_allowed()
+    public function it_cannot_use_traversal_in_path()
     {
-        $this->expectException(PathTraversalDetected::class);
-        $this->expectExceptionMessage('Path traversal detected: path/to/../folder');
+        $folder = (new Folder)->path('path/to/folder');
 
-        (new Folder)->path('path/to/../folder');
+        try {
+            $folder->path('path/to/../folder');
+        } catch (PathTraversalDetected $e) {
+            $this->assertEquals('Path traversal detected: path/to/../folder', $e->getMessage());
+
+            // Even if exception was thrown, make sure that the path didn't somehow get updated.
+            $this->assertEquals('path/to/folder', $folder->path());
+
+            return;
+        }
+
+        $this->fail('Exception was not thrown.');
     }
 
     #[Test]


### PR DESCRIPTION
Continuation of #11136

Throws exceptions if you try setting `../` in the paths of assets too.