### PR TITLE
[5.x] Fix error when using user ID as folder name for avatar asset field in non-admin context

### DIFF
--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -230,7 +230,7 @@ class Assets extends Fieldtype
         $action = Action::for($assetFolder, [
             'container' => $container->handle(),
             'folder' => $folder,
-        ])->first(fn ($action) => get_class($action) === RenameAssetFolder::class)->toArray();
+        ])->first(fn ($action) => get_class($action) === RenameAssetFolder::class)?->toArray();
 
         return [
             'url' => cp_route('assets.folders.actions.run', $container),


### PR DESCRIPTION
## Problem
When configuring the `assets` field in the User Blueprint to use the user ID as the folder name, non-admin users encounter an error. This happens because the `first()` method can return `false` when no matching action is found, causing the subsequent call to `toArray()` to fail.

## Root Cause
The issue arises from the following code:
```php
$action = Action::for($assetFolder, [
    'container' => $container->handle(),
    'folder' => $folder,
])->first(fn ($action) => get_class($action) === RenameAssetFolder::class)->toArray();
```
If no matching `RenameAssetFolder` action is found, `first()` returns `false`. The `toArray()` method is then called on this `false` value, leading to an error.

## Solution
The fix ensures that the `first()` method's return value is properly handled using the null-safe operator `?->` before attempting to call `toArray()`:
```php
$action = Action::for($assetFolder, [
    'container' => $container->handle(),
    'folder' => $folder,
])->first(fn ($action) => get_class($action) === RenameAssetFolder::class)?->toArray();
```

This prevents the error when no matching action is found and maintains compatibility for non-admin users.