### PR TITLE
[5.x] Ensure file cacher honors allow/disallow query string configs

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -68,7 +68,7 @@ class FileCacher extends AbstractCacher
         $content = $this->normalizeContent($content);
 
         $path = $this->getFilePath($url);
-        
+
         if (! $this->writer->write($path, $content, $this->config('lock_hold_length'))) {
             return;
         }

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -68,7 +68,7 @@ class FileCacher extends AbstractCacher
         $content = $this->normalizeContent($content);
 
         $path = $this->getFilePath($url);
-
+        
         if (! $this->writer->write($path, $content, $this->config('lock_hold_length'))) {
             return;
         }
@@ -300,6 +300,15 @@ EOT;
         }
 
         $qs = HeaderUtils::parseQuery($qs);
+
+        if ($allowedQueryStrings = $this->config('allowed_query_strings')) {
+            $qs = array_intersect_key($qs, array_flip($allowedQueryStrings));
+        }
+
+        if ($disallowedQueryStrings = $this->config('disallowed_query_strings')) {
+            $disallowedQueryStrings = array_flip($disallowedQueryStrings);
+            $qs = array_diff_key($qs, $disallowedQueryStrings);
+        }
 
         return $url.'?'.http_build_query($qs, '', '&', \PHP_QUERY_RFC3986);
     }


### PR DESCRIPTION
This PR updates the file cacher to respect the allow/disallow query string params. 
As it was using its own getUrl() function these were being ignored.

I cant think of any reason why they should be... maybe I'm missing something.

Closes https://github.com/statamic/cms/pull/11143