### PR TITLE
[5.x] Prevent `str_replace` warning when using Debugbar

### DIFF
--- a/src/View/Debugbar/AntlersProfiler/PerformanceCollector.php
+++ b/src/View/Debugbar/AntlersProfiler/PerformanceCollector.php
@@ -75,6 +75,10 @@ class PerformanceCollector extends DataCollector implements AssetProvider, Rende
      */
     protected function replaceSitesPath($filePath)
     {
+        if (! config('debugbar.remote_sites_path')) {
+            return $filePath;
+        }
+
         return str_replace(config('debugbar.remote_sites_path'), config('debugbar.local_sites_path'), $filePath);
     }
 


### PR DESCRIPTION
This pull request prevents a warning from showing when using the Antlers Debugbar integration, without having a `remote_sites_path` set in the Debugbar config.

Fixes #11147.