### PR TITLE
[5.x] Fix incorrect namespaces in tests

### DIFF
--- a/tests/Antlers/Runtime/ArithmeticTest.php
+++ b/tests/Antlers/Runtime/ArithmeticTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Antlers\Runtime;
+
 use Tests\Antlers\ParserTestCase;
 
 class ArithmeticTest extends ParserTestCase

--- a/tests/Console/Commands/MakeDictionaryTest.php
+++ b/tests/Console/Commands/MakeDictionaryTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Console\Commands;
+namespace Tests\Console\Commands;
 
 use Facades\Statamic\Console\Processes\Composer;
 use Illuminate\Filesystem\Filesystem;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\Console\Commands\Concerns;
 use Tests\TestCase;
 
 class MakeDictionaryTest extends TestCase

--- a/tests/Extend/AddonTest.php
+++ b/tests/Extend/AddonTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Statamic\Testing\Extend;
+namespace Tests\Extend;
 
 use Facades\Statamic\Licensing\LicenseManager;
 use Foo\Bar\TestAddonServiceProvider;

--- a/tests/Feature/GraphQL/Fieldtypes/DictionaryFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/DictionaryFieldtypeTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace Feature\GraphQL\Fieldtypes;
+namespace Tests\Feature\GraphQL\Fieldtypes;
 
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\Feature\GraphQL\Fieldtypes\FieldtypeTestCase;
 
 #[Group('graphql')]
 class DictionaryFieldtypeTest extends FieldtypeTestCase

--- a/tests/Feature/SlugTest.php
+++ b/tests/Feature/SlugTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature;
+namespace Tests\Feature;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Feature/Taxonomies/UpdateTermTest.php
+++ b/tests/Feature/Taxonomies/UpdateTermTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Feature\Taxonomies;
+
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Taxonomy;
 use Statamic\Facades\Term;

--- a/tests/Feature/Users/UpdateUserTest.php
+++ b/tests/Feature/Users/UpdateUserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Feature\Users;
+
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\User;
 use Tests\FakesRoles;

--- a/tests/Fieldtypes/ArrayTest.php
+++ b/tests/Fieldtypes/ArrayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fieldtypes;
+namespace Tests\Fieldtypes;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Modifiers/ToJsonTest.php
+++ b/tests/Modifiers/ToJsonTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modifiers;
+namespace Tests\Modifiers;
 
 use Facades\Tests\Factories\EntryFactory;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/tests/Modifiers/ToQsTest.php
+++ b/tests/Modifiers/ToQsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modifiers;
+namespace Tests\Modifiers;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Modifiers\Modify;

--- a/tests/Modifiers/WhereInTest.php
+++ b/tests/Modifiers/WhereInTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modifiers;
+namespace Tests\Modifiers;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Routing/RouteBindingTest.php
+++ b/tests/Routing/RouteBindingTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Routing;
 
+use Closure;
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Contracts\Routing\BindingRegistrar;
 use Illuminate\Routing\Middleware\SubstituteBindings;

--- a/tests/Routing/RouteBindingTest.php
+++ b/tests/Routing/RouteBindingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Routing;
+
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Contracts\Routing\BindingRegistrar;
 use Illuminate\Routing\Middleware\SubstituteBindings;

--- a/tests/Validation/UniqueEntryValueTest.php
+++ b/tests/Validation/UniqueEntryValueTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Validation;
+
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Facades\Validator;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Validation/UniqueTermValueTest.php
+++ b/tests/Validation/UniqueTermValueTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Validation;
+
 use Illuminate\Support\Facades\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Taxonomy;

--- a/tests/Validation/UniqueUserValueTest.php
+++ b/tests/Validation/UniqueUserValueTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Validation;
+
 use Illuminate\Support\Facades\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\User;


### PR DESCRIPTION
While working on #11114, I noticed that quite a few of our test classes have incorrect namespaces, leading to warnings when you run `composer dump-autoload`:

![CleanShot 2024-11-20 at 16 25 07](https://github.com/user-attachments/assets/928aaa43-9e93-4c10-a743-45998ec5530e)

This PR fixes the namespaces for *most* of the classes mentioned in the above screenshots. I've ignored the ones coming from fixtures since they don't really need namespaces.

![CleanShot 2024-11-20 at 16 28 54](https://github.com/user-attachments/assets/e4e468a6-0f77-4ceb-a0e8-e42160f65588)
