### PR TITLE
[5.x] Check whether initiator variable exists before using it

### DIFF
--- a/src/Events/EntrySaved.php
+++ b/src/Events/EntrySaved.php
@@ -23,6 +23,9 @@ class EntrySaved extends Event implements ProvidesCommitMessage
 
     public function isInitial()
     {
+        if (! $this->entry || ! $this->initiator) {
+            return false;
+        }
         return $this->entry->id() === $this->initiator->id();
     }
 }

--- a/src/Events/EntrySaved.php
+++ b/src/Events/EntrySaved.php
@@ -26,6 +26,7 @@ class EntrySaved extends Event implements ProvidesCommitMessage
         if (! $this->initiator) {
             return false;
         }
+
         return $this->entry->id() === $this->initiator->id();
     }
 }

--- a/src/Events/EntrySaved.php
+++ b/src/Events/EntrySaved.php
@@ -23,7 +23,7 @@ class EntrySaved extends Event implements ProvidesCommitMessage
 
     public function isInitial()
     {
-        if (! $this->entry || ! $this->initiator) {
+        if (! $this->initiator) {
             return false;
         }
         return $this->entry->id() === $this->initiator->id();


### PR DESCRIPTION
When using an `EntrySaved` listener and in the case that an initiator does not exist here and you try to use the `isInitial()` function on this event, you will get an error in the Statamic frontend when trying to save an entry.

Right now we work around this by checking whether these exist ourselves, however this should probably not be necessary 🙂