### PR TITLE
[5.x] Include store in field action payload

### DIFF
--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -7,6 +7,13 @@ export default {
         HasFieldActions,
     ],
 
+    inject: {
+        fieldActionStoreName: {
+            from: 'storeName',
+            default: null,
+        }
+    },
+
     props: {
         value: {
             required: true
@@ -94,6 +101,8 @@ export default {
                 update: this.update,
                 updateMeta: this.updateMeta,
                 isReadOnly: this.isReadOnly,
+                store: this.$store,
+                storeName: this.fieldActionStoreName,
             };
         },
 

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -95,7 +95,7 @@ export default {
         HasFieldActions,
     ],
 
-    inject: ['bard', 'bardSets'],
+    inject: ['bard', 'bardSets', 'storeName'],
 
     computed: {
 
@@ -203,7 +203,9 @@ export default {
                 meta: this.meta,
                 update: (handle, value) => this.updated(handle, value),
                 updateMeta: (handle, value) => this.metaUpdated(handle, value),
-                isReadOnly: this.isReadOnly
+                isReadOnly: this.isReadOnly,
+                store: this.$store,
+                storeName: this.storeName,
             };
         },
 

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -92,7 +92,7 @@ export default {
         HasFieldActions,
     ],
 
-    inject: ['replicatorSets'],
+    inject: ['replicatorSets', 'storeName'],
 
     props: {
         config: {
@@ -208,6 +208,8 @@ export default {
                 update: (handle, value) => this.updated(handle, value),
                 updateMeta: (handle, value) => this.metaUpdated(handle, value),
                 isReadOnly: this.isReadOnly,
+                store: this.$store,
+                storeName: this.storeName,
             };
         },
 


### PR DESCRIPTION
This PR adds the `store` and `storeName` to field action payloads, so it's easy to access other fields:

```js
Statamic.$fieldActions.add('text-fieldtype', {
      title: 'Example',
      run: ({ store, storeName }) => {
          const values = store.state.publish[storeName].values;
          // ...
      },
  });
```

The reason it's aliased in the fieldtype mixin is that calling it `storeName` seems to cause errors in some fieldtypes, like slug. It also has a default value because some fieldtypes are used outside of a publish form, like radio in the SaveButtonOptions component, where no store name is provided.