### PR TITLE
[5.x] Allow Values object and Group fieldtype to be iterated

### DIFF
--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -12,6 +12,7 @@ use Statamic\Contracts\View\Antlers\Parser;
 use Statamic\Facades\Compare;
 use Statamic\Support\Str;
 use Statamic\View\Antlers\Language\Parser\DocumentTransformer;
+use Traversable;
 
 class Value implements ArrayAccess, IteratorAggregate, JsonSerializable
 {
@@ -96,10 +97,6 @@ class Value implements ArrayAccess, IteratorAggregate, JsonSerializable
             $value = $value->get();
         }
 
-        if ($value instanceof Collection) {
-            $value = $value->all();
-        }
-
         return $value;
     }
 
@@ -127,7 +124,9 @@ class Value implements ArrayAccess, IteratorAggregate, JsonSerializable
     #[\ReturnTypeWillChange]
     public function getIterator()
     {
-        return new ArrayIterator($this->iteratorValue());
+        $value = $this->iteratorValue();
+
+        return $value instanceof Traversable ? $value : new ArrayIterator($value);
     }
 
     public function shouldParseAntlers()

--- a/tests/Fields/ValueTest.php
+++ b/tests/Fields/ValueTest.php
@@ -8,6 +8,7 @@ use Statamic\Facades\Blueprint;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Value;
+use Statamic\Fields\Values;
 use Statamic\Query\Builder;
 use Tests\TestCase;
 
@@ -288,6 +289,26 @@ class ValueTest extends TestCase
         ]));
 
         $val = new Value($builder);
+
+        $arr = [];
+
+        foreach ($val as $key => $value) {
+            $arr[$key] = $value;
+        }
+
+        $this->assertEquals([
+            'a' => 'alfa',
+            'b' => 'bravo',
+        ], $arr);
+    }
+
+    #[Test]
+    public function it_can_iterate_over_values()
+    {
+        $val = new Value(new Values([
+            'a' => 'alfa',
+            'b' => 'bravo',
+        ]));
 
         $arr = [];
 

--- a/tests/Tags/IterateTest.php
+++ b/tests/Tags/IterateTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Tags;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Parse;
+use Statamic\Fields\Value;
+use Statamic\Fields\Values;
+use Tests\TestCase;
+
+class IterateTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('iterateProvider')]
+    public function it_iterates($value)
+    {
+        $template = '{{ foreach:fieldname }}<{{ key }},{{ value }}>{{ /foreach:fieldname }}';
+
+        $this->assertSame('<alfa,one><bravo,two>', $this->tag($template, ['fieldname' => $value]));
+    }
+
+    public static function iterateProvider()
+    {
+        return [
+            'array' => [
+                ['alfa' => 'one', 'bravo' => 'two'],
+            ],
+            'collection' => [
+                collect(['alfa' => 'one', 'bravo' => 'two']),
+            ],
+            'values' => [
+                new Values(['alfa' => 'one', 'bravo' => 'two']),
+            ],
+            'value with array' => [
+                new Value(['alfa' => 'one', 'bravo' => 'two']),
+            ],
+            'value with collection' => [
+                new Value(collect(['alfa' => 'one', 'bravo' => 'two'])),
+            ],
+            'value with values' => [
+                new Value(new Values(['alfa' => 'one', 'bravo' => 'two'])),
+            ],
+        ];
+    }
+
+    private function tag($tag, $context = [])
+    {
+        return (string) Parse::template($tag, $context);
+    }
+}


### PR DESCRIPTION
This replaces #10958.

This fixes an issue where you could not use the `foreach` tag to loop over a `group` fieldtype.

The underlying issue is that when you have a `Value` instance that evaluates to a `Values` instance (which is what the `group` fieldtype does), it wasn't properly iterable. `getIterator` expects a `Traversable` to be returned.

In the included test, the last dataset (value with values) is the one that would fail, and is fixed by this PR.
