### PR TITLE
[5.x] Fixed an issue where stache indexing can cause an infinite loop for workers

### DIFF
--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -65,15 +65,18 @@ abstract class Index
             return $this;
         }
 
-        static::$currentlyLoading = $this->store->key().'/'.$this->name;
+        $loadingKey = $this->store->key().'/'.$this->name;
+        $currentlyLoadingThis = static::$currentlyLoading === $loadingKey;
+
+        static::$currentlyLoading = $loadingKey;
 
         $this->loaded = true;
 
-        if (Statamic::isWorker()) {
+        if (Statamic::isWorker() && ! $currentlyLoadingThis) {
             $this->loaded = false;
         }
 
-        debugbar()->addMessage("Loading index: {$this->store->key()}/{$this->name}", 'stache');
+        debugbar()->addMessage("Loading index: {$loadingKey}", 'stache');
 
         $this->items = Stache::cacheStore()->get($this->cacheKey());
 

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\View;
 use LogicException;
 use Mockery;
@@ -34,6 +35,7 @@ use Statamic\Fields\Blueprint;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Value;
 use Statamic\Sites\Site;
+use Statamic\Statamic;
 use Statamic\Structures\CollectionStructure;
 use Statamic\Structures\CollectionTree;
 use Statamic\Structures\Page;
@@ -1375,6 +1377,40 @@ class EntryTest extends TestCase
         $property->setAccessible(true);
         $withEvents = $property->getValue($cached);
         $this->assertTrue($withEvents);
+    }
+
+    #[Test]
+    public function infinite_loops_are_prevented_when_running_workers()
+    {
+        // NOTE: We are not using the `config(['cache.default' => 'file'])` override as that
+        //       will cause an infinite loop on failure instead of a segfault.
+
+        // `Statamic::isWorker()` should return false by default.
+        $this->assertFalse(Statamic::isWorker());
+
+        // Swap the request with one that will cause `Statamic::isWorker()` to return `true`.
+        // NOTE: Cannot use `Tests\Fakes\FakeArtisanRequest` as that does not have the cookies
+        //       object initialised and `auth()->user()` will throw an Exception.
+        Request::swap(request()->duplicate(server: [
+            'argv' => [
+                'artisan',
+                'queue:work',
+            ],
+            'argc' => 2,
+        ]));
+
+        // `Statamic::isWorker()` should return true when being called from any command beginning with `queue:`.
+        $this->assertTrue(Statamic::isWorker());
+
+        // Create a collection.
+        $collection = tap(Collection::make('test'))->save();
+
+        // Create some entries.
+        EntryFactory::id('alfa-id')->collection('test')->slug('alfa')->data(['title' => 'Alfa'])->create();
+        EntryFactory::id('bravo-id')->collection('test')->slug('bravo')->data(['title' => 'Bravo'])->create();
+        EntryFactory::id('charlie-id')->collection('test')->slug('charlie')->data(['title' => 'Charlie'])->create();
+        EntryFactory::id('donkus-id')->collection('test')->slug('donkus')->data(['title' => 'Donkus'])->create();
+        EntryFactory::id('eggbert-id')->collection('test')->slug('eggbert')->data(['title' => 'Eggbert'])->create();
     }
 
     #[Test]

--- a/tests/Stache/WorkerInfiniteLoopTest.php
+++ b/tests/Stache/WorkerInfiniteLoopTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Stache;
+
+use Facades\Tests\Factories\EntryFactory;
+use Illuminate\Support\Facades\Request;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Entries\Collection;
+use Statamic\Statamic;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class WorkerInfiniteLoopTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function infinite_loops_are_prevented_when_running_workers()
+    {
+        // NOTE: We are not using the `config(['cache.default' => 'file'])` override as that
+        //       will cause an infinite loop on failure instead of a segfault.
+
+        // `Statamic::isWorker()` should return false by default.
+        $this->assertFalse(Statamic::isWorker());
+
+        // Swap the request with one that will cause `Statamic::isWorker()` to return `true`.
+        // NOTE: Cannot use `Tests\Fakes\FakeArtisanRequest` as that does not have the cookies
+        //       object initialised and `auth()->user()` will throw an Exception.
+        Request::swap(request()->duplicate(server: [
+            'argv' => ['artisan', 'queue:work'],
+            'argc' => 2,
+        ]));
+
+        // `Statamic::isWorker()` should return true when being called from any command beginning with `queue:`.
+        $this->assertTrue(Statamic::isWorker());
+
+        Collection::make('test')->save();
+        EntryFactory::id('alfa-id')->collection('test')->slug('alfa')->data(['title' => 'Alfa'])->create();
+        EntryFactory::id('bravo-id')->collection('test')->slug('bravo')->data(['title' => 'Bravo'])->create();
+        EntryFactory::id('charlie-id')->collection('test')->slug('charlie')->data(['title' => 'Charlie'])->create();
+        EntryFactory::id('donkus-id')->collection('test')->slug('donkus')->data(['title' => 'Donkus'])->create();
+        EntryFactory::id('eggbert-id')->collection('test')->slug('eggbert')->data(['title' => 'Eggbert'])->create();
+    }
+}

--- a/tests/Stache/WorkerInfiniteLoopTest.php
+++ b/tests/Stache/WorkerInfiniteLoopTest.php
@@ -36,9 +36,5 @@ class WorkerInfiniteLoopTest extends TestCase
 
         Collection::make('test')->save();
         EntryFactory::id('alfa-id')->collection('test')->slug('alfa')->data(['title' => 'Alfa'])->create();
-        EntryFactory::id('bravo-id')->collection('test')->slug('bravo')->data(['title' => 'Bravo'])->create();
-        EntryFactory::id('charlie-id')->collection('test')->slug('charlie')->data(['title' => 'Charlie'])->create();
-        EntryFactory::id('donkus-id')->collection('test')->slug('donkus')->data(['title' => 'Donkus'])->create();
-        EntryFactory::id('eggbert-id')->collection('test')->slug('eggbert')->data(['title' => 'Eggbert'])->create();
     }
 }


### PR DESCRIPTION
This PR fixes an issue where stache indexing can cause an infinite loop when being executed by a worker. The new test `infinite_loops_are_prevented_when_running_workers` can be used to verify the issue in the `5.x` branch.

This was also addressed as part of https://github.com/statamic/cms/pull/10574 but that PR is yet to be reviewed and merged.

Fixes #11187.