### PR TITLE
[5.x] Ensure updating references gets all global variables

### DIFF
--- a/src/Listeners/Concerns/GetsItemsContainingData.php
+++ b/src/Listeners/Concerns/GetsItemsContainingData.php
@@ -19,7 +19,7 @@ trait GetsItemsContainingData
         return collect()
             ->merge(Entry::all())
             ->merge(Term::all())
-            ->merge(GlobalSet::all()->flatMap->localizations())
+            ->merge(GlobalSet::all()->flatMap(fn ($set) => $set->localizations()->values()))
             ->merge(User::all());
     }
 }


### PR DESCRIPTION
This PR updates the logic in the `GetsItemsContainingData` trait to return the global set localizations `values()` rather than a keyed collection. 

Without this change it was only returning one variables for each localization, as the flatMap was using the localization's key.

Closes https://github.com/statamic/cms/issues/11177