### PR TITLE
[5.x] Add an `--uncached` option to the static warm command

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -36,6 +36,7 @@ class StaticWarm extends Command
         {--u|user= : HTTP authentication user}
         {--p|password= : HTTP authentication password}
         {--insecure : Skip SSL verification}
+        {--eco : Only warm uncached URLs}
     ';
 
     protected $description = 'Warms the static cache by visiting all URLs';
@@ -178,6 +179,12 @@ class StaticWarm extends Command
             ->merge($this->additionalUris())
             ->unique()
             ->reject(function ($uri) use ($cacher) {
+                if ($this->option('eco') &&
+                    $cacher->hasCachedPage(\Illuminate\Http\Request::create($uri))
+                ) {
+                    return true;
+                }
+
                 Site::resolveCurrentUrlUsing(fn () => $uri);
 
                 return $cacher->isExcluded($uri);

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -36,7 +36,7 @@ class StaticWarm extends Command
         {--u|user= : HTTP authentication user}
         {--p|password= : HTTP authentication password}
         {--insecure : Skip SSL verification}
-        {--eco : Only warm uncached URLs}
+        {--uncached : Only warm uncached URLs}
     ';
 
     protected $description = 'Warms the static cache by visiting all URLs';
@@ -179,7 +179,7 @@ class StaticWarm extends Command
             ->merge($this->additionalUris())
             ->unique()
             ->reject(function ($uri) use ($cacher) {
-                if ($this->option('eco') &&
+                if ($this->option('uncached') &&
                     $cacher->hasCachedPage(\Illuminate\Http\Request::create($uri))
                 ) {
                     return true;

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Console\Command;
+use Illuminate\Http\Request as HttpRequest;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Collection;
 use Statamic\Console\EnhancesCommands;
@@ -179,9 +180,7 @@ class StaticWarm extends Command
             ->merge($this->additionalUris())
             ->unique()
             ->reject(function ($uri) use ($cacher) {
-                if ($this->option('uncached') &&
-                    $cacher->hasCachedPage(\Illuminate\Http\Request::create($uri))
-                ) {
+                if ($this->option('uncached') && $cacher->hasCachedPage(HttpRequest::create($uri))) {
                     return true;
                 }
 

--- a/tests/Console/Commands/StaticWarmTest.php
+++ b/tests/Console/Commands/StaticWarmTest.php
@@ -53,7 +53,7 @@ class StaticWarmTest extends TestCase
 
         config(['statamic.static_caching.strategy' => 'half']);
 
-        $this->artisan('statamic:static:warm', ['--eco' => true])
+        $this->artisan('statamic:static:warm', ['--uncached' => true])
             ->expectsOutput('Visiting 1 URLs...')
             ->assertExitCode(0);
     }


### PR DESCRIPTION
This adds an `--eco` option to the static warm command. In eco mode, only uncached URLs are visited. 

This is perfect for when you just want to 'fill in the gaps' in your cache after some URLs were invalidated, without visiting every single URL in your website. This avoids unnecessary server load.

Using this option will definitely lower your carbon footprint :innocent:
