### PR TITLE
[5.x] Fix entry links when Bard value is HTML

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -370,7 +370,7 @@ class Bard extends Replicator
         }
 
         if (is_string($value)) {
-            $value = str_replace('statamic://', '', $value);
+            $value = str_replace('src="statamic://', 'src="', $value);
             $doc = (new Augmentor($this))->renderHtmlToProsemirror($value);
             $value = $doc['content'];
         } elseif ($this->isLegacyData($value)) {

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -413,7 +413,7 @@ class BardTest extends TestCase
                 'content' => [
                     ['type' => 'text', 'text' => 'Second '],
                     ['type' => 'text', 'text' => 'paragraph', 'marks' => [
-                        ['type' => 'link', 'attrs' => ['href' => 'entry::foo']],
+                        ['type' => 'link', 'attrs' => ['href' => 'statamic://entry::foo']],
                     ]],
                     ['type' => 'text', 'text' => '. '],
                     ['type' => 'image', 'attrs' => [


### PR DESCRIPTION
This pull request fixes an issue where the `statamic://` prefix was being stripped off links in Bard fields then the value was a string, rather than a ProseMirror array.

The prefix only needs to be stripped from images URLs.

Fixes #11168.