### PR TITLE
[5.x] Throw an error when running `static:clear` when static caching is disabled

### DIFF
--- a/src/Console/Commands/FlatCamp.php
+++ b/src/Console/Commands/FlatCamp.php
@@ -40,7 +40,7 @@ class FlatCamp extends Command
 {
     use RunsInPlease;
 
-    protected $signature = 'flat:camp';
+    protected $signature = 'statamic:flat:camp';
     protected $description = 'Flat Camp';
 
     protected $quotes = [

--- a/src/Console/Commands/FlatCamp.php
+++ b/src/Console/Commands/FlatCamp.php
@@ -40,7 +40,7 @@ class FlatCamp extends Command
 {
     use RunsInPlease;
 
-    protected $signature = 'statamic:flat:camp';
+    protected $signature = 'flat:camp';
     protected $description = 'Flat Camp';
 
     protected $quotes = [

--- a/src/Console/Commands/StaticClear.php
+++ b/src/Console/Commands/StaticClear.php
@@ -36,7 +36,7 @@ class StaticClear extends Command
         if (! config('statamic.static_caching.strategy')) {
             $this->components->error('Static caching is not enabled.');
 
-            return 1;
+            return 0;
         }
 
         spin(callback: fn () => StaticCache::flush(), message: 'Clearing the static page cache...');

--- a/src/Console/Commands/StaticClear.php
+++ b/src/Console/Commands/StaticClear.php
@@ -33,6 +33,12 @@ class StaticClear extends Command
      */
     public function handle()
     {
+        if (! config('statamic.static_caching.strategy')) {
+            $this->components->error('Static caching is not enabled.');
+
+            return 1;
+        }
+
         spin(callback: fn () => StaticCache::flush(), message: 'Clearing the static page cache...');
 
         $this->components->info('Your static page cache is now so very, very empty.');

--- a/tests/Console/PleaseTest.php
+++ b/tests/Console/PleaseTest.php
@@ -21,7 +21,6 @@ class PleaseTest extends TestCase
     public function it_can_run_an_artisan_command_with_statamic_prefix()
     {
         Stache::shouldReceive('clear')->once();
-
         $this->artisan('statamic:stache:clear');
     }
 
@@ -29,7 +28,6 @@ class PleaseTest extends TestCase
     public function statamic_prefixed_commands_will_throw_exception_when_running_in_artisan_without_prefix()
     {
         $this->expectException(CommandNotFoundException::class);
-
         $this->artisan('flat:camp');
     }
 
@@ -37,7 +35,6 @@ class PleaseTest extends TestCase
     public function it_can_run_a_please_command_without_statamic_prefix()
     {
         Stache::shouldReceive('clear')->once();
-
         $this->please('stache:clear');
     }
 
@@ -45,7 +42,6 @@ class PleaseTest extends TestCase
     public function it_can_run_a_please_command_with_statamic_prefix()
     {
         Stache::shouldReceive('clear')->once();
-
         $this->please('statamic:stache:clear');
     }
 

--- a/tests/Console/PleaseTest.php
+++ b/tests/Console/PleaseTest.php
@@ -27,8 +27,9 @@ class PleaseTest extends TestCase
     #[Test]
     public function statamic_prefixed_commands_will_throw_exception_when_running_in_artisan_without_prefix()
     {
+        Stache::shouldReceive('clear')->never();
         $this->expectException(CommandNotFoundException::class);
-        $this->artisan('flat:camp');
+        $this->artisan('stache:clear');
     }
 
     #[Test]

--- a/tests/Console/PleaseTest.php
+++ b/tests/Console/PleaseTest.php
@@ -4,6 +4,7 @@ namespace Tests\Console;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Console\Please\Kernel;
+use Statamic\Facades\Stache;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Tests\TestCase;
 
@@ -19,26 +20,33 @@ class PleaseTest extends TestCase
     #[Test]
     public function it_can_run_an_artisan_command_with_statamic_prefix()
     {
-        $this->artisan('statamic:flat:camp');
+        Stache::shouldReceive('clear')->once();
+
+        $this->artisan('statamic:stache:clear');
     }
 
     #[Test]
     public function statamic_prefixed_commands_will_throw_exception_when_running_in_artisan_without_prefix()
     {
         $this->expectException(CommandNotFoundException::class);
+
         $this->artisan('flat:camp');
     }
 
     #[Test]
     public function it_can_run_a_please_command_without_statamic_prefix()
     {
-        $this->please('flat:camp');
+        Stache::shouldReceive('clear')->once();
+
+        $this->please('stache:clear');
     }
 
     #[Test]
     public function it_can_run_a_please_command_with_statamic_prefix()
     {
-        $this->please('statamic:flat:camp');
+        Stache::shouldReceive('clear')->once();
+
+        $this->please('statamic:stache:clear');
     }
 
     public function please($command, $parameters = [])

--- a/tests/Console/PleaseTest.php
+++ b/tests/Console/PleaseTest.php
@@ -4,7 +4,6 @@ namespace Tests\Console;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Console\Please\Kernel;
-use Statamic\Facades\StaticCache;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Tests\TestCase;
 
@@ -20,30 +19,26 @@ class PleaseTest extends TestCase
     #[Test]
     public function it_can_run_an_artisan_command_with_statamic_prefix()
     {
-        StaticCache::shouldReceive('flush')->once();
-        $this->artisan('statamic:static:clear');
+        $this->artisan('statamic:flat:camp');
     }
 
     #[Test]
     public function statamic_prefixed_commands_will_throw_exception_when_running_in_artisan_without_prefix()
     {
-        StaticCache::shouldReceive('flush')->never();
         $this->expectException(CommandNotFoundException::class);
-        $this->artisan('static:clear');
+        $this->artisan('flat:camp');
     }
 
     #[Test]
     public function it_can_run_a_please_command_without_statamic_prefix()
     {
-        StaticCache::shouldReceive('flush')->once();
-        $this->please('static:clear');
+        $this->please('flat:camp');
     }
 
     #[Test]
     public function it_can_run_a_please_command_with_statamic_prefix()
     {
-        StaticCache::shouldReceive('flush')->once();
-        $this->please('statamic:static:clear');
+        $this->please('statamic:flat:camp');
     }
 
     public function please($command, $parameters = [])


### PR DESCRIPTION
Currently, when you run `php please static:clear` with static caching disabled, it won't do anything but it'll say the static cache has been cleared, which is misleading if you've just disabled static caching, but still have files in `public/static` since you'll continue to be served the cached pages.

This pull request mirrors the `php please static:warm` command by showing a warning if you try to run the command while static caching is disabled.