### PR TITLE
[5.x] Fix localized error messages on forms when previous URL is incorrect

### DIFF
--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -91,7 +91,7 @@ class Tags extends BaseTags
         }
 
         $knownParams = array_merge(static::HANDLE_PARAM, [
-            'redirect', 'error_redirect', 'allow_request_redirect', 'csrf', 'files', 'js',
+            'redirect', 'error_redirect', 'allow_request_redirect', 'csrf', 'files', 'js', 'original_url',
         ]);
 
         $action = $this->params->get('action', $form->actionUrl());
@@ -104,7 +104,9 @@ class Tags extends BaseTags
         }
         $attrs = $this->runHooks('attrs', ['attrs' => $attrs, 'data' => $data])['attrs'];
 
-        $params = [];
+        $params = [
+            'original_url' => request()->url(),
+        ];
 
         if ($redirect = $this->getRedirectUrl()) {
             $params['redirect'] = $this->parseRedirect($redirect);

--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -120,7 +120,7 @@ class FrontendFormRequest extends FormRequest
         // If this was submitted from a front-end form, we want to use the appropriate language
         // for the translation messages. If there's no previous url, it was likely submitted
         // directly in a headless format. In that case, we'll just use the default lang.
-        $site = ($previousUrl = session()->previousUrl()) ? Site::findByUrl($previousUrl) : null;
+        $site = ($previousUrl = $this->input('_original_url')) ? Site::findByUrl($previousUrl) : null;
 
         return $this->withLocale($site?->lang(), fn () => parent::validateResolved());
     }


### PR DESCRIPTION
This pull request fixes an issue where form error messages weren't being localized correctly if the user's previous URL was incorrect.

The previous URL could be incorrect if an image referenced on the page 404s, causing a Statamic/Laravel 404 page to be displayed.

Fixes #11179.