### PR TITLE
[5.x] Ability to have custom user class

### DIFF
--- a/src/Auth/Eloquent/UserRepository.php
+++ b/src/Auth/Eloquent/UserRepository.php
@@ -110,7 +110,7 @@ class UserRepository extends BaseRepository
     public static function bindings(): array
     {
         return [
-            UserContract::class => User::class,
+            UserContract::class => config('statamic.users.class', User::class),
         ];
     }
 

--- a/src/Stache/Repositories/UserRepository.php
+++ b/src/Stache/Repositories/UserRepository.php
@@ -84,7 +84,7 @@ class UserRepository extends BaseRepository
     public static function bindings(): array
     {
         return [
-            User::class => FileUser::class,
+            User::class => config('statamic.users.repositories.file.class', FileUser::class),
         ];
     }
 }

--- a/src/Stache/Repositories/UserRepository.php
+++ b/src/Stache/Repositories/UserRepository.php
@@ -15,9 +15,13 @@ use Statamic\Stache\Stache;
 class UserRepository extends BaseRepository
 {
     protected $stache;
+
     protected $store;
+
     protected $config;
+
     protected $roleRepository = RoleRepository::class;
+
     protected $userGroupRepository = UserGroupRepository::class;
 
     public function __construct(Stache $stache, array $config = [])
@@ -84,7 +88,7 @@ class UserRepository extends BaseRepository
     public static function bindings(): array
     {
         return [
-            User::class => config('statamic.users.repositories.file.class', FileUser::class),
+            User::class => config('statamic.users.class', FileUser::class),
         ];
     }
 }

--- a/src/Stache/Repositories/UserRepository.php
+++ b/src/Stache/Repositories/UserRepository.php
@@ -15,13 +15,9 @@ use Statamic\Stache\Stache;
 class UserRepository extends BaseRepository
 {
     protected $stache;
-
     protected $store;
-
     protected $config;
-
     protected $roleRepository = RoleRepository::class;
-
     protected $userGroupRepository = UserGroupRepository::class;
 
     public function __construct(Stache $stache, array $config = [])

--- a/tests/Auth/EloquentUserRepositoryTest.php
+++ b/tests/Auth/EloquentUserRepositoryTest.php
@@ -55,6 +55,13 @@ class EloquentUserRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function it_gets_the_custom_class()
+    {
+        Config::set('statamic.users.class', FakeEloquentUser::class);
+        $this->assertInstanceOf(FakeEloquentUser::class, User::make());
+    }
+
+    #[Test]
     public function it_normalizes_to_statamic_user_from_model()
     {
         $user = User::make()->email('foo@bar.com')->data(['name' => 'foo', 'password' => 'foo']);

--- a/tests/Auth/EloquentUserRepositoryTest.php
+++ b/tests/Auth/EloquentUserRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Auth;
 
+use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\User;

--- a/tests/Auth/StacheUserRepositoryTest.php
+++ b/tests/Auth/StacheUserRepositoryTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Auth;
 
+use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Auth\File\User;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -22,7 +24,16 @@ class StacheUserRepositoryTest extends TestCase
     {
         return FakeStacheUser::class;
     }
+
+    #[Test]
+    public function it_gets_the_custom_class()
+    {
+        Config::set('statamic.users.repositories.file.class', CustomFileUser::class);
+        $this->assertInstanceOf(CustomFileUser::class, User::make());
+    }
 }
+
+class CustomFileUser extends \Statamic\Auth\File\User {}
 
 class FakeStacheUser extends \Statamic\Auth\File\User
 {

--- a/tests/Auth/StacheUserRepositoryTest.php
+++ b/tests/Auth/StacheUserRepositoryTest.php
@@ -28,12 +28,10 @@ class StacheUserRepositoryTest extends TestCase
     #[Test]
     public function it_gets_the_custom_class()
     {
-        Config::set('statamic.users.class', CustomFileUser::class);
-        $this->assertInstanceOf(CustomFileUser::class, User::make());
+        Config::set('statamic.users.class', FakeStacheUser::class);
+        $this->assertInstanceOf(FakeStacheUser::class, User::make());
     }
 }
-
-class CustomFileUser extends \Statamic\Auth\File\User {}
 
 class FakeStacheUser extends \Statamic\Auth\File\User
 {

--- a/tests/Auth/StacheUserRepositoryTest.php
+++ b/tests/Auth/StacheUserRepositoryTest.php
@@ -28,7 +28,7 @@ class StacheUserRepositoryTest extends TestCase
     #[Test]
     public function it_gets_the_custom_class()
     {
-        Config::set('statamic.users.repositories.file.class', CustomFileUser::class);
+        Config::set('statamic.users.class', CustomFileUser::class);
         $this->assertInstanceOf(CustomFileUser::class, User::make());
     }
 }


### PR DESCRIPTION
I've often wanted to add some domain specific or helper classes on the user class to keep my code organized.