### PR TITLE
[5.x] Added the ability for Protectors to allow static caching

### DIFF
--- a/config/protect.php
+++ b/config/protect.php
@@ -17,6 +17,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Static caching.
+    |--------------------------------------------------------------------------
+    |
+    | Default setting for whether or not to allow protected pages in the static
+    | cache.
+    |
+    */
+
+    'cacheable' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Protection Schemes
     |--------------------------------------------------------------------------
     |
@@ -33,6 +45,9 @@ return [
         'ip_address' => [
             'driver' => 'ip_address',
             'allowed' => ['127.0.0.1'],
+            // NOTE: Set `cacheable` to true/false to allow static caching for
+            //       this driver.
+            // 'cacheable' => null,
         ],
 
         'logged_in' => [

--- a/src/Auth/Protect/Protection.php
+++ b/src/Auth/Protect/Protection.php
@@ -71,8 +71,8 @@ class Protection
 
     public function cacheable()
     {
-        $this->driver()
-            ->cacheable();
+        return $this->driver()
+                    ->cacheable();
     }
 
     protected function url()

--- a/src/Auth/Protect/Protection.php
+++ b/src/Auth/Protect/Protection.php
@@ -69,6 +69,12 @@ class Protection
             ->protect();
     }
 
+    public function cacheable()
+    {
+        $this->driver()
+            ->cacheable();
+    }
+
     protected function url()
     {
         return URL::tidy(request()->fullUrl());

--- a/src/Auth/Protect/Protection.php
+++ b/src/Auth/Protect/Protection.php
@@ -72,7 +72,7 @@ class Protection
     public function cacheable()
     {
         return $this->driver()
-                    ->cacheable();
+            ->cacheable();
     }
 
     protected function url()

--- a/src/Auth/Protect/Protectors/Protector.php
+++ b/src/Auth/Protect/Protectors/Protector.php
@@ -36,4 +36,9 @@ abstract class Protector
 
         return $this;
     }
+
+    public function cacheable()
+    {
+        return $this->config['cacheable'] ?? config('statamic.protect.cacheable', false);
+    }
 }

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -95,7 +95,7 @@ class DataResponse implements Responsable
 
         $protection->protect();
 
-        if ($protection->scheme() && ! $protection->driver()?->cacheable()) {
+        if ($protection->scheme() && ! $protection->cacheable()) {
             $this->headers['X-Statamic-Protected'] = true;
         }
 

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -95,7 +95,7 @@ class DataResponse implements Responsable
 
         $protection->protect();
 
-        if ($protection->scheme()) {
+        if ($protection->scheme() && ! $protection->driver()?->cacheable()) {
             $this->headers['X-Statamic-Protected'] = true;
         }
 

--- a/tests/Auth/Protect/ProtectionTest.php
+++ b/tests/Auth/Protect/ProtectionTest.php
@@ -147,6 +147,45 @@ class ProtectionTest extends TestCase
         $this->assertTrue($state->protected);
     }
 
+    #[Test]
+    public function default_configuration_allows_static_caching()
+    {
+        config(['statamic.protect.default' => 'logged_in']);
+        config(['statamic.protect.cacheable' => true]);
+
+        $this->assertTrue($this->protection->cacheable());
+    }
+
+    #[Test]
+    public function driver_allows_static_caching()
+    {
+        config(['statamic.protect.default' => 'logged_in']);
+        config(['statamic.protect.schemes.logged_in' => [
+            'driver' => 'auth',
+            'form_url' => '/login',
+            'cacheable' => true,
+        ]]);
+
+        $this->assertTrue($this->protection->cacheable());
+        $this->assertTrue($this->protection->driver()->cacheable());
+    }
+
+    #[Test]
+    public function driver_disallows_static_caching()
+    {
+        config(['statamic.protect.cacheable' => true]);
+        config(['statamic.protect.default' => 'logged_in']);
+        config(['statamic.protect.schemes.logged_in' => [
+            'driver' => 'auth',
+            'form_url' => '/login',
+            'cacheable' => false,
+        ]]);
+
+        $this->assertTrue(config('statamic.protect.cacheable'));
+        $this->assertFalse($this->protection->cacheable());
+        $this->assertFalse($this->protection->driver()->cacheable());
+    }
+
     private function createEntryWithScheme($scheme)
     {
         return EntryFactory::id('test')

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -374,6 +374,48 @@ class FrontendTest extends TestCase
     }
 
     #[Test]
+    public function header_is_not_added_to_cacheable_protected_responses()
+    {
+        config()->set('statamic.protect.cacheable', true);
+
+        $page = $this->createPage('about');
+
+        $this
+            ->get('/about')
+            ->assertOk()
+            ->assertHeaderMissing('X-Statamic-Protected');
+
+        $page->set('protect', 'logged_in')->save();
+
+        $this
+            ->actingAs(User::make())
+            ->get('/about')
+            ->assertOk()
+            ->assertHeaderMissing('X-Statamic-Protected');
+    }
+
+    #[Test]
+    public function header_is_not_added_to_cacheable_protected_responses_for_driver()
+    {
+        config()->set('statamic.protect.schemes.logged_in.cacheable', true);
+
+        $page = $this->createPage('about');
+
+        $this
+            ->get('/about')
+            ->assertOk()
+            ->assertHeaderMissing('X-Statamic-Protected');
+
+        $page->set('protect', 'logged_in')->save();
+
+        $this
+            ->actingAs(User::make())
+            ->get('/about')
+            ->assertOk()
+            ->assertHeaderMissing('X-Statamic-Protected');
+    }
+
+    #[Test]
     public function key_variables_key_added()
     {
         $page = $this->createPage('about');


### PR DESCRIPTION
This PR provides the ability for protected entries to be allowed in the static cache and addresses the concerns outlined in the comments on https://github.com/statamic/cms/pull/10929

It also may be worth considering either defaulting `statamic.protect.cacheable` to `true` on update of `statamic/cms` so that the original behaviour doesn't change for existing deployments. Any thoughts/feedback on this?

Closes statamic/ideas#1234.