### PR TITLE
[5.x] Fix REST API errors when CP route is empty

### DIFF
--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -105,12 +105,12 @@ class RouteServiceProvider extends ServiceProvider
             return false;
         }
 
-        if ($this->isCpRoute($route)) {
-            return true;
-        }
-
         if ($this->isApiRoute($route)) {
             return false;
+        }
+
+        if ($this->isCpRoute($route)) {
+            return true;
         }
 
         return $this->isFrontendBindingEnabled();
@@ -191,12 +191,12 @@ class RouteServiceProvider extends ServiceProvider
             return false;
         }
 
-        if ($this->isCpRoute($route)) {
-            return true;
-        }
-
         if ($this->isApiRoute($route)) {
             return false;
+        }
+
+        if ($this->isCpRoute($route)) {
+            return true;
         }
 
         return $this->isFrontendBindingEnabled();
@@ -382,12 +382,12 @@ class RouteServiceProvider extends ServiceProvider
             return false;
         }
 
-        if ($this->isCpRoute($route)) {
-            return true;
-        }
-
         if ($this->isApiRoute($route)) {
             return false;
+        }
+
+        if ($this->isCpRoute($route)) {
+            return true;
         }
 
         return $this->isFrontendBindingEnabled();

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -384,6 +384,22 @@ class APITest extends TestCase
     }
 
     #[Test]
+    public function can_view_entries_when_cp_route_is_empty()
+    {
+        Facades\Config::set('statamic.cp.route', '');
+        Facades\Config::set('statamic.api.resources.collections', true);
+
+        Facades\Collection::make('pages')->save();
+        Facades\Entry::make()->collection('pages')->id('home')->data(['title' => 'Home'])->save();
+
+        $this->get('/api/collections/pages/entries/home')->assertJson([
+            'data' => [
+                'title' => 'Home',
+            ],
+        ]);
+    }
+
+    #[Test]
     #[DataProvider('userPasswordFilterProvider')]
     public function it_never_allows_filtering_users_by_password($filter)
     {
@@ -526,6 +542,22 @@ class APITest extends TestCase
             'invalid term id' => ['/api/taxonomies/tags/terms/missing', false],
             'valid term id but wrong collection' => ['/api/taxonomies/categories/terms/test', false],
         ];
+    }
+
+    #[Test]
+    public function can_view_terms_when_cp_route_is_empty()
+    {
+        Facades\Config::set('statamic.cp.route', '');
+        Facades\Config::set('statamic.api.resources.taxonomies', true);
+
+        Facades\Taxonomy::make('topics')->save();
+        Facades\Term::make()->taxonomy('topics')->inDefaultLocale()->slug('dance')->data(['title' => 'Dance'])->save();
+
+        $this->get('/api/taxonomies/topics/terms/dance')->assertJson([
+            'data' => [
+                'title' => 'Dance',
+            ],
+        ]);
     }
 
     private function makeCollection($handle)


### PR DESCRIPTION
This pull request fixes an error with the REST API when the CP route is empty, where attempting to view a single entry or term would result in an error.

This was happening because the `needsEntryBinding`/`needsTermBinding` methods were under the impression it was a CP route so they were enabling the CP route bindings, causing errors in our API controllers. 

Fixes #10842.