### PR TITLE
[5.x] Add new `starter-kit:init` command

### DIFF
--- a/src/Console/Commands/Concerns/MigratesLegacyStarterKitConfig.php
+++ b/src/Console/Commands/Concerns/MigratesLegacyStarterKitConfig.php
@@ -8,6 +8,8 @@ use function Laravel\Prompts\confirm;
 
 trait MigratesLegacyStarterKitConfig
 {
+    protected $migrated = false;
+
     /**
      * Determine if dev sandbox has starter-kit.yaml at root and/or customized composer.json at target path.
      */
@@ -19,7 +21,7 @@ trait MigratesLegacyStarterKitConfig
     /**
      * Determine if dev sandbox has starter-kit.yaml at root and/or customized composer.json at target path.
      */
-    protected function migrateLegacyStarterKitConfig(): self
+    protected function migrateLegacyConfig(?string $exportPath = null): self
     {
         if (! $this->isUsingLegacyExporterConventions()) {
             return $this;
@@ -45,11 +47,21 @@ trait MigratesLegacyStarterKitConfig
             $this->components->info('Starter kit post-install hook moved to [package/StarterKitPostInstall.php].');
         }
 
-        if (File::exists($packageComposerJson = $this->getAbsolutePath().'/composer.json')) {
+        if ($exportPath && File::exists($packageComposerJson = $exportPath.'/composer.json')) {
             File::move($packageComposerJson, base_path('package/composer.json'));
             $this->components->info('Composer package config moved to [package/composer.json].');
         }
 
+        $this->migrated = true;
+
         return $this;
+    }
+
+    /**
+     * Check if migration logic was ran.
+     */
+    protected function migratedLegacyConfig(): bool
+    {
+        return $this->migrated;
     }
 }

--- a/src/Console/Commands/Concerns/MigratesLegacyStarterKitConfig.php
+++ b/src/Console/Commands/Concerns/MigratesLegacyStarterKitConfig.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Statamic\Console\Commands\Concerns;
+
+use Statamic\Facades\File;
+
+use function Laravel\Prompts\confirm;
+
+trait MigratesLegacyStarterKitConfig
+{
+    /**
+     * Determine if dev sandbox has starter-kit.yaml at root and/or customized composer.json at target path.
+     */
+    protected function isUsingLegacyExporterConventions(): bool
+    {
+        return File::exists(base_path('starter-kit.yaml'));
+    }
+
+    /**
+     * Determine if dev sandbox has starter-kit.yaml at root and/or customized composer.json at target path.
+     */
+    protected function migrateLegacyStarterKitConfig(): self
+    {
+        if (! $this->isUsingLegacyExporterConventions()) {
+            return $this;
+        }
+
+        if ($this->input->isInteractive()) {
+            if (! confirm('Config should now live in the [package] folder. Would you like Statamic to move it for you?', true)) {
+                return $this;
+            }
+        }
+
+        if (! File::exists($dir = base_path('package'))) {
+            File::makeDirectory($dir, 0755, true);
+        }
+
+        if (File::exists($starterKitConfig = base_path('starter-kit.yaml'))) {
+            File::move($starterKitConfig, base_path('package/starter-kit.yaml'));
+            $this->components->info('Starter kit config moved to [package/starter-kit.yaml].');
+        }
+
+        if (File::exists($postInstallHook = base_path('StarterKitPostInstall.php'))) {
+            File::move($postInstallHook, base_path('package/StarterKitPostInstall.php'));
+            $this->components->info('Starter kit post-install hook moved to [package/StarterKitPostInstall.php].');
+        }
+
+        if (File::exists($packageComposerJson = $this->getAbsolutePath().'/composer.json')) {
+            File::move($packageComposerJson, base_path('package/composer.json'));
+            $this->components->info('Composer package config moved to [package/composer.json].');
+        }
+
+        return $this;
+    }
+}

--- a/src/Console/Commands/StarterKitExport.php
+++ b/src/Console/Commands/StarterKitExport.php
@@ -3,6 +3,7 @@
 namespace Statamic\Console\Commands;
 
 use Illuminate\Console\Command;
+use Statamic\Console\Commands\Concerns\MigratesLegacyStarterKitConfig;
 use Statamic\Console\RunsInPlease;
 use Statamic\Facades\File;
 use Statamic\Facades\Path;
@@ -13,7 +14,7 @@ use function Laravel\Prompts\confirm;
 
 class StarterKitExport extends Command
 {
-    use RunsInPlease;
+    use MigratesLegacyStarterKitConfig, RunsInPlease;
 
     /**
      * The name and signature of the console command.
@@ -36,9 +37,7 @@ class StarterKitExport extends Command
      */
     public function handle()
     {
-        if ($this->isUsingLegacyExporterConventions()) {
-            $this->askToMigrateToPackageFolder();
-        }
+        $this->migrateLegacyStarterKitConfig();
 
         if (! File::exists($path = $this->getAbsolutePath())) {
             $this->askToCreateExportPath($path);
@@ -84,44 +83,5 @@ class StarterKitExport extends Command
         File::makeDirectory($path, 0755, true);
 
         $this->components->info("A new directory has been created at [{$path}].");
-    }
-
-    /**
-     * Determine if dev sandbox has starter-kit.yaml at root and/or customized composer.json at target path.
-     */
-    protected function isUsingLegacyExporterConventions(): bool
-    {
-        return File::exists(base_path('starter-kit.yaml'));
-    }
-
-    /**
-     * Determine if dev sandbox has starter-kit.yaml at root and/or customized composer.json at target path.
-     */
-    protected function askToMigrateToPackageFolder(): void
-    {
-        if ($this->input->isInteractive()) {
-            if (! confirm('Config should now live in the [package] folder. Would you like Statamic to move it for you?', true)) {
-                return;
-            }
-        }
-
-        if (! File::exists($dir = base_path('package'))) {
-            File::makeDirectory($dir, 0755, true);
-        }
-
-        if (File::exists($starterKitConfig = base_path('starter-kit.yaml'))) {
-            File::move($starterKitConfig, base_path('package/starter-kit.yaml'));
-            $this->components->info('Starter kit config moved to [package/starter-kit.yaml].');
-        }
-
-        if (File::exists($postInstallHook = base_path('StarterKitPostInstall.php'))) {
-            File::move($postInstallHook, base_path('package/StarterKitPostInstall.php'));
-            $this->components->info('Starter kit post-install hook moved to [package/StarterKitPostInstall.php].');
-        }
-
-        if (File::exists($packageComposerJson = $this->getAbsolutePath().'/composer.json')) {
-            File::move($packageComposerJson, base_path('package/composer.json'));
-            $this->components->info('Composer package config moved to [package/composer.json].');
-        }
     }
 }

--- a/src/Console/Commands/StarterKitExport.php
+++ b/src/Console/Commands/StarterKitExport.php
@@ -56,6 +56,10 @@ class StarterKitExport extends Command
             return 1;
         }
 
+        if (version_compare(app()->version(), '11', '<')) {
+            return $this->components->info("Starter kit was successfully exported to [$path].");
+        }
+
         $this->components->success("Starter kit was successfully exported to [$path].");
     }
 

--- a/src/Console/Commands/StarterKitExport.php
+++ b/src/Console/Commands/StarterKitExport.php
@@ -55,7 +55,7 @@ class StarterKitExport extends Command
             return 1;
         }
 
-        $this->components->info("Starter kit was successfully exported to [$path].");
+        $this->components->success("Starter kit was successfully exported to [$path].");
     }
 
     /**

--- a/src/Console/Commands/StarterKitExport.php
+++ b/src/Console/Commands/StarterKitExport.php
@@ -37,9 +37,11 @@ class StarterKitExport extends Command
      */
     public function handle()
     {
-        $this->migrateLegacyStarterKitConfig();
+        $path = $this->getAbsolutePath();
 
-        if (! File::exists($path = $this->getAbsolutePath())) {
+        $this->migrateLegacyConfig($path);
+
+        if (! File::exists($path)) {
             $this->askToCreateExportPath($path);
         }
 

--- a/src/Console/Commands/StarterKitInit.php
+++ b/src/Console/Commands/StarterKitInit.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Statamic\Console\Commands;
+
+use Illuminate\Console\Command;
+use Statamic\Console\RunsInPlease;
+use Statamic\Console\ValidatesInput;
+use Statamic\Facades\File;
+use Statamic\Rules\ComposerPackage;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\text;
+
+class StarterKitInit extends Command
+{
+    use RunsInPlease, ValidatesInput;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'statamic:starter-kit:init
+        { name? : Specify a name for the starter kit }
+        { description? : Specify a description of the starter kit }
+        { package? : Specify a package for the starter kit (ie. vendor/starter-kit) }';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new starter kit config';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $name = $this->getKitName();
+        $description = $this->getKitDescription();
+        $package = $this->getKitPackage();
+
+        if (! $name || ! $package || ! $description) {
+            $this->components->info('You can manage your starter kit\'s package config in [package/composer.json] at any time.');
+        }
+
+        $this
+            ->createFolder()
+            // ->migrateLegacy() // TODO: Consolidate logic to trait from other PR
+            ->createConfig()
+            ->createComposerJson($name, $description, $package);
+
+        $this->components->success('Starter kit config was successfully created in [package/] folder.');
+    }
+
+    /**
+     * Get starter kit name for composer.json (optional).
+     */
+    protected function getKitName(): ?string
+    {
+        return $this->argument('name') ?: text('Starter Kit Name');
+    }
+
+    /**
+     * Get starter kit description for composer.json (optional).
+     */
+    protected function getKitDescription(): ?string
+    {
+        return $this->argument('description') ?: text('Starter Kit Description');
+    }
+
+    /**
+     * Get starter kit package for composer.json (optional).
+     */
+    protected function getKitPackage(bool $promptingAgain = false): ?string
+    {
+        $promptText = 'Starter Kit Package (eg. hasselhoff/kung-fury)';
+
+        if ($promptingAgain) {
+            $package = text($promptText);
+        } else {
+            $package = $this->argument('package') ?: text($promptText);
+        }
+
+        $fails = $this->validationFails($package, new ComposerPackage);
+
+        if ($package && $fails && $this->input->isInteractive()) {
+            return $this->getKitPackage(true);
+        } elseif ($package && $fails) {
+            return null;
+        }
+
+        return $package;
+    }
+
+    /**
+     * Create composer.json config from stub.
+     */
+    protected function createFolder(): self
+    {
+        if (! File::exists($dir = base_path('package'))) {
+            File::makeDirectory($dir, 0755, true);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Create starter-kit.yaml config from stub.
+     */
+    protected function createConfig(): self
+    {
+        $contents = File::get(__DIR__.'/stubs/starter-kits/starter-kit.yaml.stub');
+
+        $targetPath = base_path('package/starter-kit.yaml');
+
+        if (File::exists($targetPath) && $this->input->isInteractive()) {
+            if (! confirm('A [starter-kit.yaml] config already exists. Would you like to overwrite it?', false)) {
+                return $this;
+            }
+        }
+
+        // TODO: Ask if updatable, and if so prepend `updatable: true` to yaml and create service provider too?
+
+        File::put($targetPath, $contents);
+
+        return $this;
+    }
+
+    /**
+     * Create composer.json config from stub.
+     */
+    protected function createComposerJson(?string $name, ?string $description, ?string $package): self
+    {
+        $contents = File::get(__DIR__.'/stubs/starter-kits/composer.json.stub');
+
+        $targetPath = base_path('package/composer.json');
+
+        if (File::exists($targetPath) && $this->input->isInteractive()) {
+            if (! confirm('A [composer.json] config already exists. Would you like to overwrite it?', false)) {
+                return $this;
+            }
+        }
+
+        if ($name) {
+            $contents = str_replace('Example Name', $name, $contents);
+        }
+
+        if ($description) {
+            $contents = str_replace('A description of your starter kit', $description, $contents);
+        }
+
+        if ($package) {
+            $contents = str_replace('example/starter-kit-package', $package, $contents);
+        }
+
+        File::put($targetPath, $contents);
+
+        return $this;
+    }
+}

--- a/src/Console/Commands/StarterKitInit.php
+++ b/src/Console/Commands/StarterKitInit.php
@@ -24,7 +24,8 @@ class StarterKitInit extends Command
     protected $signature = 'statamic:starter-kit:init
         { package? : Specify a package for the starter kit (ie. vendor/starter-kit) }
         { --name : Specify a name for the starter kit }
-        { --description : Specify a description of the starter kit }';
+        { --description : Specify a description of the starter kit }
+        { --force : Force overwrite if files already exist }';
 
     /**
      * The console command description.
@@ -120,7 +121,7 @@ class StarterKitInit extends Command
 
         $targetPath = base_path('package/starter-kit.yaml');
 
-        if (File::exists($targetPath) && $this->input->isInteractive()) {
+        if (File::exists($targetPath) && $this->input->isInteractive() && ! $this->option('force')) {
             if (! confirm('A [starter-kit.yaml] config already exists. Would you like to overwrite it?', false)) {
                 return $this;
             }
@@ -142,7 +143,7 @@ class StarterKitInit extends Command
 
         $targetPath = base_path('package/composer.json');
 
-        if (File::exists($targetPath) && $this->input->isInteractive()) {
+        if (File::exists($targetPath) && $this->input->isInteractive() && ! $this->option('force')) {
             if (! confirm('A [composer.json] config already exists. Would you like to overwrite it?', false)) {
                 return $this;
             }

--- a/src/Console/Commands/StarterKitInit.php
+++ b/src/Console/Commands/StarterKitInit.php
@@ -91,6 +91,10 @@ class StarterKitInit extends Command
             ->createComposerJson()
             ->createServiceProvider();
 
+        if (version_compare(app()->version(), '11', '<')) {
+            return $this->components->info('Your starter kit config was successfully created in your project\'s [package] folder.');
+        }
+
         $this->components->success('Your starter kit config was successfully created in your project\'s [package] folder.');
     }
 

--- a/src/Console/Commands/StarterKitInit.php
+++ b/src/Console/Commands/StarterKitInit.php
@@ -25,8 +25,8 @@ class StarterKitInit extends Command
      */
     protected $signature = 'statamic:starter-kit:init
         { package? : Specify a package for the starter kit (ie. vendor/starter-kit) }
-        { --name : Specify a name for the starter kit }
-        { --description : Specify a description of the starter kit }
+        { --name= : Specify a name for the starter kit }
+        { --description= : Specify a description of the starter kit }
         { --updatable : Specify whether the starter kit is to be updatable }
         { --force : Force overwrite if files already exist }';
 
@@ -69,8 +69,10 @@ class StarterKitInit extends Command
 
         if ($promptingAgain) {
             $package = text($promptText);
-        } else {
+        } elseif ($this->input->isInteractive()) {
             $package = $this->argument('package') ?: text($promptText);
+        } else {
+            $package = $this->argument('package');
         }
 
         $fails = $this->validationFails($package, new ComposerPackage);
@@ -89,6 +91,10 @@ class StarterKitInit extends Command
      */
     protected function getKitName(): ?string
     {
+        if (! $this->input->isInteractive()) {
+            return $this->option('name');
+        }
+
         return $this->option('name') ?: text('Starter Kit Name (eg. Kung Fury)');
     }
 
@@ -97,6 +103,10 @@ class StarterKitInit extends Command
      */
     protected function getKitDescription(): ?string
     {
+        if (! $this->input->isInteractive()) {
+            return $this->option('description');
+        }
+
         return $this->option('description') ?: text('Starter Kit Description');
     }
 
@@ -105,6 +115,10 @@ class StarterKitInit extends Command
      */
     protected function getKitUpdatable(): bool
     {
+        if (! $this->input->isInteractive()) {
+            return $this->option('updatable');
+        }
+
         return $this->option('updatable') ?: confirm(
             label: 'Would you like to make this starter-kit updatable?',
             default: false,

--- a/src/Console/Commands/StarterKitInit.php
+++ b/src/Console/Commands/StarterKitInit.php
@@ -121,13 +121,21 @@ class StarterKitInit extends Command
 
         $targetPath = base_path('package/starter-kit.yaml');
 
-        if (File::exists($targetPath) && $this->input->isInteractive() && ! $this->option('force')) {
+        if ($this->input->isInteractive() && File::exists($targetPath) && ! $this->option('force')) {
             if (! confirm('A [starter-kit.yaml] config already exists. Would you like to overwrite it?', false)) {
                 return $this;
             }
         }
 
-        // TODO: Ask if updatable, and if so prepend `updatable: true` to yaml and create service provider too?
+        if ($this->input->isInteractive()) {
+            if (confirm(
+                label: 'Would you like to make this starter-kit updatable?',
+                default: false,
+                hint: 'Read more: https://statamic.dev/starter-kits/creating-a-starter-kit#making-starter-kits-updatable',
+            )) {
+                $contents = "updatable: true\n".$contents;
+            }
+        }
 
         File::put($targetPath, $contents);
 
@@ -143,7 +151,7 @@ class StarterKitInit extends Command
 
         $targetPath = base_path('package/composer.json');
 
-        if (File::exists($targetPath) && $this->input->isInteractive() && ! $this->option('force')) {
+        if ($this->input->isInteractive() && File::exists($targetPath) && ! $this->option('force')) {
             if (! confirm('A [composer.json] config already exists. Would you like to overwrite it?', false)) {
                 return $this;
             }

--- a/src/Console/Commands/StarterKitInit.php
+++ b/src/Console/Commands/StarterKitInit.php
@@ -169,6 +169,8 @@ class StarterKitInit extends Command
             $contents = str_replace('A description of your starter kit', $description, $contents);
         }
 
+        // TODO: PSR-4 autoload `src`? Does dir have to exist first?
+
         File::put($targetPath, $contents);
 
         return $this;

--- a/src/Console/Commands/StarterKitInit.php
+++ b/src/Console/Commands/StarterKitInit.php
@@ -75,12 +75,14 @@ class StarterKitInit extends Command
             $package = $this->argument('package');
         }
 
-        $fails = $this->validationFails($package, new ComposerPackage);
+        if ($package) {
+            $fails = $this->validationFails($package, new ComposerPackage);
+        }
 
         if ($package && $fails && $this->input->isInteractive()) {
             return $this->getKitPackage(true);
         } elseif ($package && $fails) {
-            return null;
+            exit;
         }
 
         return $package;

--- a/src/Console/Commands/StarterKitInit.php
+++ b/src/Console/Commands/StarterKitInit.php
@@ -88,7 +88,8 @@ class StarterKitInit extends Command
             ->migrateLegacyConfig()
             ->createFolder()
             ->createConfig()
-            ->createComposerJson();
+            ->createComposerJson()
+            ->createServiceProvider();
 
         $this->components->success('Your starter kit config was successfully created in your project\'s [package] folder.');
     }
@@ -245,6 +246,34 @@ class StarterKitInit extends Command
         }
 
         File::put($targetPath, json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $this;
+    }
+
+    /**
+     * Create service provider.
+     */
+    protected function createServiceProvider(): self
+    {
+        if (! $this->updatable) {
+            return $this;
+        }
+
+        $this->createFolder(base_path('package/src'));
+
+        $contents = File::get(__DIR__.'/stubs/starter-kits/ServiceProvider.php.stub');
+
+        $targetPath = base_path('package/src/ServiceProvider.php');
+
+        if ($this->input->isInteractive() && File::exists($targetPath) && ! $this->option('force')) {
+            if (! confirm('A service provider already exists at [src/ServiceProvider.php]. Would you like to overwrite it?', false)) {
+                return $this;
+            }
+        }
+
+        $contents = str_replace('DummyNamespace', $this->kitNamespace(), $contents);
+
+        File::put($targetPath, $contents);
 
         return $this;
     }

--- a/src/Console/Commands/StarterKitInit.php
+++ b/src/Console/Commands/StarterKitInit.php
@@ -8,6 +8,7 @@ use Statamic\Console\RunsInPlease;
 use Statamic\Console\ValidatesInput;
 use Statamic\Facades\File;
 use Statamic\Rules\ComposerPackage;
+use Statamic\StarterKits\Exceptions\StarterKitException;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
@@ -42,10 +43,14 @@ class StarterKitInit extends Command
      */
     public function handle()
     {
-        $package = $this->getKitPackage();
-        $name = $this->getKitName();
-        $description = $this->getKitDescription();
-        $updatable = $this->getKitUpdatable();
+        try {
+            $package = $this->getKitPackage();
+            $name = $this->getKitName();
+            $description = $this->getKitDescription();
+            $updatable = $this->getKitUpdatable();
+        } catch (StarterKitException $exception) {
+            return 1;
+        }
 
         if (! $package || ! $name || ! $description) {
             $this->components->info('You can manage your starter kit\'s package config in [package/composer.json] at any time.');
@@ -82,7 +87,7 @@ class StarterKitInit extends Command
         if ($package && $fails && $this->input->isInteractive()) {
             return $this->getKitPackage(true);
         } elseif ($package && $fails) {
-            exit;
+            throw new StarterKitException;
         }
 
         return $package;

--- a/src/Console/Commands/StarterKitInit.php
+++ b/src/Console/Commands/StarterKitInit.php
@@ -3,6 +3,7 @@
 namespace Statamic\Console\Commands;
 
 use Illuminate\Console\Command;
+use Statamic\Console\Commands\Concerns\MigratesLegacyStarterKitConfig;
 use Statamic\Console\RunsInPlease;
 use Statamic\Console\ValidatesInput;
 use Statamic\Facades\File;
@@ -13,7 +14,7 @@ use function Laravel\Prompts\text;
 
 class StarterKitInit extends Command
 {
-    use RunsInPlease, ValidatesInput;
+    use MigratesLegacyStarterKitConfig, RunsInPlease, ValidatesInput;
 
     /**
      * The name and signature of the console command.
@@ -46,8 +47,8 @@ class StarterKitInit extends Command
         }
 
         $this
+            ->migrateLegacyConfig()
             ->createFolder()
-            // ->migrateLegacy() // TODO: Consolidate logic to trait from other PR
             ->createConfig()
             ->createComposerJson($package, $name, $description);
 
@@ -111,6 +112,10 @@ class StarterKitInit extends Command
      */
     protected function createConfig(): self
     {
+        if ($this->migratedLegacyConfig()) {
+            return $this;
+        }
+
         $contents = File::get(__DIR__.'/stubs/starter-kits/starter-kit.yaml.stub');
 
         $targetPath = base_path('package/starter-kit.yaml');

--- a/src/Console/Commands/StarterKitInstall.php
+++ b/src/Console/Commands/StarterKitInstall.php
@@ -49,7 +49,7 @@ class StarterKitInstall extends Command
         [$package, $branch] = $this->getPackageAndBranch();
 
         if ($this->validationFails($package, new ComposerPackage)) {
-            return;
+            return 1;
         }
 
         $licenseManager = StarterKitLicenseManager::validate($package, $this->option('license'), $this, $this->input->isInteractive());
@@ -90,7 +90,7 @@ class StarterKitInstall extends Command
             $this->comment('composer global update statamic/cli'.PHP_EOL);
         }
 
-        $this->components->info("Starter kit [$package] was successfully installed.");
+        $this->components->success("Starter kit [$package] was successfully installed.");
     }
 
     /**

--- a/src/Console/Commands/StarterKitInstall.php
+++ b/src/Console/Commands/StarterKitInstall.php
@@ -90,6 +90,10 @@ class StarterKitInstall extends Command
             $this->comment('composer global update statamic/cli'.PHP_EOL);
         }
 
+        if (version_compare(app()->version(), '11', '<')) {
+            return $this->components->info("Starter kit [$package] was successfully installed.");
+        }
+
         $this->components->success("Starter kit [$package] was successfully installed.");
     }
 

--- a/src/Console/Commands/stubs/starter-kits/ServiceProvider.php.stub
+++ b/src/Console/Commands/stubs/starter-kits/ServiceProvider.php.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace DummyNamespace;
+
+use Statamic\Providers\AddonServiceProvider;
+
+class ServiceProvider extends AddonServiceProvider
+{
+    public function bootAddon()
+    {
+        //
+    }
+}

--- a/src/Console/Commands/stubs/starter-kits/composer.json.stub
+++ b/src/Console/Commands/stubs/starter-kits/composer.json.stub
@@ -1,9 +1,0 @@
-{
-    "name": "example/starter-kit-package",
-    "extra": {
-        "statamic": {
-            "name": "Example Name",
-            "description": "A description of your starter kit"
-        }
-    }
-}

--- a/src/Console/Commands/stubs/starter-kits/composer.json.stub
+++ b/src/Console/Commands/stubs/starter-kits/composer.json.stub
@@ -1,9 +1,9 @@
 {
-    "name": "dummy/package",
+    "name": "example/starter-kit-package",
     "extra": {
         "statamic": {
-            "name": "DummyTitle",
-            "description": "DummyTitle starter kit"
+            "name": "Example Name",
+            "description": "A description of your starter kit"
         }
     }
 }

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -36,6 +36,7 @@ class ConsoleServiceProvider extends ServiceProvider
         Commands\StacheWarm::class,
         Commands\StacheDoctor::class,
         Commands\StarterKitExport::class,
+        Commands\StarterKitInit::class,
         Commands\StarterKitInstall::class,
         Commands\StarterKitRunPostInstall::class,
         Commands\StaticClear::class,

--- a/tests/StarterKits/InitTest.php
+++ b/tests/StarterKits/InitTest.php
@@ -54,7 +54,7 @@ class InitTest extends TestCase
         $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
 
-        $this->assertEquals(<<<'YAML'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'YAML'
 # export_paths:
 #   - content
 #   - config/filesystems.php
@@ -68,7 +68,7 @@ class InitTest extends TestCase
 #   - vite.config.js
 YAML, trim($this->files->get($configPath)));
 
-        $this->assertEquals(<<<'JSON'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'JSON'
 {
     "name": "example/starter-kit-package",
     "extra": {
@@ -101,7 +101,7 @@ JSON, trim($this->files->get($composerJsonPath)));
         $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
 
-        $this->assertEquals(<<<'YAML'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'YAML'
 # export_paths:
 #   - content
 #   - config/filesystems.php
@@ -115,7 +115,7 @@ JSON, trim($this->files->get($composerJsonPath)));
 #   - vite.config.js
 YAML, trim($this->files->get($configPath)));
 
-        $this->assertEquals(<<<'JSON'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'JSON'
 {
     "name": "example/starter-kit-package",
     "extra": {
@@ -147,7 +147,7 @@ JSON, trim($this->files->get($composerJsonPath)));
         $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
 
-        $this->assertEquals(<<<'JSON'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'JSON'
 {
     "name": "statamic/starter-kit-cool-writings",
     "extra": {
@@ -195,7 +195,7 @@ JSON, trim($this->files->get($composerJsonPath)));
         $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
 
-        $this->assertEquals(<<<'JSON'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'JSON'
 {
     "name": "statamic/starter-kit-cool-writings",
     "extra": {
@@ -224,7 +224,7 @@ JSON, trim($this->files->get($composerJsonPath)));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
         $this->assertFileExists($serviceProviderPath = $this->packagePath('src/ServiceProvider.php'));
 
-        $this->assertEquals(<<<'YAML'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'YAML'
 updatable: true
 # export_paths:
 #   - content
@@ -239,7 +239,7 @@ updatable: true
 #   - vite.config.js
 YAML, trim($this->files->get($configPath)));
 
-        $this->assertEquals(<<<'JSON'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'JSON'
 {
     "name": "example/starter-kit-package",
     "extra": {
@@ -266,7 +266,7 @@ YAML, trim($this->files->get($configPath)));
 }
 JSON, trim($this->files->get($composerJsonPath)));
 
-        $this->assertEquals(<<<'PHP'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'PHP'
 <?php
 
 namespace Example\StarterKitNamespace;
@@ -303,7 +303,7 @@ PHP, trim($this->files->get($serviceProviderPath)));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
         $this->assertFileExists($serviceProviderPath = $this->packagePath('src/ServiceProvider.php'));
 
-        $this->assertEquals(<<<'YAML'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'YAML'
 updatable: true
 # export_paths:
 #   - content
@@ -318,7 +318,7 @@ updatable: true
 #   - vite.config.js
 YAML, trim($this->files->get($configPath)));
 
-        $this->assertEquals(<<<'JSON'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'JSON'
 {
     "name": "example/starter-kit-package",
     "extra": {
@@ -345,7 +345,7 @@ YAML, trim($this->files->get($configPath)));
 }
 JSON, trim($this->files->get($composerJsonPath)));
 
-        $this->assertEquals(<<<'PHP'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'PHP'
 <?php
 
 namespace Example\StarterKitNamespace;
@@ -383,7 +383,7 @@ PHP, trim($this->files->get($serviceProviderPath)));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
         $this->assertFileExists($serviceProviderPath = $this->packagePath('src/ServiceProvider.php'));
 
-        $this->assertEquals(<<<'JSON'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'JSON'
 {
     "name": "statamic-rad-pack/starter-kit-cool-writings",
     "extra": {
@@ -410,7 +410,7 @@ PHP, trim($this->files->get($serviceProviderPath)));
 }
 JSON, trim($this->files->get($composerJsonPath)));
 
-        $this->assertEquals(<<<'PHP'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'PHP'
 <?php
 
 namespace StatamicRadPack\CoolWritings;
@@ -447,7 +447,7 @@ PHP, trim($this->files->get($serviceProviderPath)));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
         $this->assertFileExists($serviceProviderPath = $this->packagePath('src/ServiceProvider.php'));
 
-        $this->assertEquals(<<<'JSON'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'JSON'
 {
     "name": "statamic-rad-pack/starter-kit-cool-writings",
     "extra": {
@@ -474,7 +474,7 @@ PHP, trim($this->files->get($serviceProviderPath)));
 }
 JSON, trim($this->files->get($composerJsonPath)));
 
-        $this->assertEquals(<<<'PHP'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'PHP'
 <?php
 
 namespace StatamicRadPack\CoolWritings;
@@ -564,7 +564,7 @@ PHP, trim($this->files->get($serviceProviderPath)));
         $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
 
-        $this->assertEquals(<<<'YAML'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'YAML'
 # export_paths:
 #   - content
 #   - config/filesystems.php
@@ -578,7 +578,7 @@ PHP, trim($this->files->get($serviceProviderPath)));
 #   - vite.config.js
 YAML, trim($this->files->get($configPath)));
 
-        $this->assertEquals(<<<'JSON'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'JSON'
 {
     "name": "statamic/starter-kit-cool-writings",
     "extra": {
@@ -608,7 +608,7 @@ JSON, trim($this->files->get($composerJsonPath)));
         $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
 
-        $this->assertEquals(<<<'YAML'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'YAML'
 # export_paths:
 #   - content
 #   - config/filesystems.php
@@ -622,7 +622,7 @@ JSON, trim($this->files->get($composerJsonPath)));
 #   - vite.config.js
 YAML, trim($this->files->get($configPath)));
 
-        $this->assertEquals(<<<'JSON'
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'JSON'
 {
     "name": "statamic/starter-kit-cool-writings",
     "extra": {

--- a/tests/StarterKits/InitTest.php
+++ b/tests/StarterKits/InitTest.php
@@ -218,10 +218,11 @@ JSON, trim($this->files->get($composerJsonPath)));
             ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
             ->assertOk();
 
-        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+        $this->assertCount(3, $this->files->allFiles($this->packagePath()));
 
         $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+        $this->assertFileExists($serviceProviderPath = $this->packagePath('src/ServiceProvider.php'));
 
         $this->assertEquals(<<<'YAML'
 updatable: true
@@ -264,6 +265,22 @@ YAML, trim($this->files->get($configPath)));
     }
 }
 JSON, trim($this->files->get($composerJsonPath)));
+
+        $this->assertEquals(<<<'PHP'
+<?php
+
+namespace Example\StarterKitNamespace;
+
+use Statamic\Providers\AddonServiceProvider;
+
+class ServiceProvider extends AddonServiceProvider
+{
+    public function bootAddon()
+    {
+        //
+    }
+}
+PHP, trim($this->files->get($serviceProviderPath)));
     }
 
     #[Test]
@@ -280,10 +297,11 @@ JSON, trim($this->files->get($composerJsonPath)));
             ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
             ->assertOk();
 
-        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+        $this->assertCount(3, $this->files->allFiles($this->packagePath()));
 
         $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+        $this->assertFileExists($serviceProviderPath = $this->packagePath('src/ServiceProvider.php'));
 
         $this->assertEquals(<<<'YAML'
 updatable: true
@@ -326,6 +344,22 @@ YAML, trim($this->files->get($configPath)));
     }
 }
 JSON, trim($this->files->get($composerJsonPath)));
+
+        $this->assertEquals(<<<'PHP'
+<?php
+
+namespace Example\StarterKitNamespace;
+
+use Statamic\Providers\AddonServiceProvider;
+
+class ServiceProvider extends AddonServiceProvider
+{
+    public function bootAddon()
+    {
+        //
+    }
+}
+PHP, trim($this->files->get($serviceProviderPath)));
     }
 
     #[Test]
@@ -343,10 +377,11 @@ JSON, trim($this->files->get($composerJsonPath)));
             ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
             ->assertOk();
 
-        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+        $this->assertCount(3, $this->files->allFiles($this->packagePath()));
 
         $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+        $this->assertFileExists($serviceProviderPath = $this->packagePath('src/ServiceProvider.php'));
 
         $this->assertEquals(<<<'JSON'
 {
@@ -374,6 +409,22 @@ JSON, trim($this->files->get($composerJsonPath)));
     }
 }
 JSON, trim($this->files->get($composerJsonPath)));
+
+        $this->assertEquals(<<<'PHP'
+<?php
+
+namespace StatamicRadPack\CoolWritings;
+
+use Statamic\Providers\AddonServiceProvider;
+
+class ServiceProvider extends AddonServiceProvider
+{
+    public function bootAddon()
+    {
+        //
+    }
+}
+PHP, trim($this->files->get($serviceProviderPath)));
     }
 
     #[Test]
@@ -390,10 +441,11 @@ JSON, trim($this->files->get($composerJsonPath)));
             ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
             ->assertOk();
 
-        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+        $this->assertCount(3, $this->files->allFiles($this->packagePath()));
 
         $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+        $this->assertFileExists($serviceProviderPath = $this->packagePath('src/ServiceProvider.php'));
 
         $this->assertEquals(<<<'JSON'
 {
@@ -421,6 +473,22 @@ JSON, trim($this->files->get($composerJsonPath)));
     }
 }
 JSON, trim($this->files->get($composerJsonPath)));
+
+        $this->assertEquals(<<<'PHP'
+<?php
+
+namespace StatamicRadPack\CoolWritings;
+
+use Statamic\Providers\AddonServiceProvider;
+
+class ServiceProvider extends AddonServiceProvider
+{
+    public function bootAddon()
+    {
+        //
+    }
+}
+PHP, trim($this->files->get($serviceProviderPath)));
     }
 
     #[Test]
@@ -436,12 +504,14 @@ JSON, trim($this->files->get($composerJsonPath)));
             ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
             ->assertOk();
 
-        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+        $this->assertCount(3, $this->files->allFiles($this->packagePath()));
 
         $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+        $this->assertFileExists($serviceProviderPath = $this->packagePath('src/ServiceProvider.php'));
 
         $this->assertStringContainsString('"Example\\\\CoolWritingsKitABC\\\\": "src"', $this->files->get($composerJsonPath));
         $this->assertStringContainsString('"Example\\\\CoolWritingsKitABC\\\\ServiceProvider"', $this->files->get($composerJsonPath));
+        $this->assertStringContainsString('namespace Example\\CoolWritingsKitABC;', $this->files->get($serviceProviderPath));
     }
 
     #[Test]

--- a/tests/StarterKits/InitTest.php
+++ b/tests/StarterKits/InitTest.php
@@ -1,0 +1,591 @@
+<?php
+
+namespace Tests\StarterKits;
+
+use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class InitTest extends TestCase
+{
+    use Concerns\BacksUpComposerJson;
+
+    protected $files;
+    protected $packagePath;
+    protected $targetPath;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = app(Filesystem::class);
+        $this->packagePath = base_path('package');
+
+        $this->cleanUp();
+    }
+
+    public function tearDown(): void
+    {
+        $this->cleanUp();
+
+        parent::tearDown();
+    }
+
+    private function cleanUp()
+    {
+        if ($this->files->exists($this->packagePath)) {
+            $this->files->deleteDirectory($this->packagePath);
+        }
+    }
+
+    #[Test]
+    public function it_can_init_basic_config()
+    {
+        $this->assertFileDoesNotExist($this->packagePath());
+
+        $this
+            ->initStarterKit()
+            ->expectsOutputToContain('You can manage your starter kit\'s package config in [package/composer.json] at any time.')
+            ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertOk();
+
+        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+
+        $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
+        $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+
+        $this->assertEquals(<<<'YAML'
+# export_paths:
+#   - content
+#   - config/filesystems.php
+#   - config/statamic/assets.php
+#   - resources/blueprints
+#   - resources/css/site.css
+#   - resources/views
+#   - public/build
+#   - package.json
+#   - tailwind.config.js
+#   - vite.config.js
+YAML, trim($this->files->get($configPath)));
+
+        $this->assertEquals(<<<'JSON'
+{
+    "name": "example/starter-kit-package",
+    "extra": {
+        "statamic": {
+            "name": "Example Name",
+            "description": "A description of your starter kit"
+        }
+    }
+}
+JSON, trim($this->files->get($composerJsonPath)));
+    }
+
+    #[Test]
+    public function it_can_interactively_init_basic_config()
+    {
+        $this->assertFileDoesNotExist($this->packagePath());
+
+        $this
+            ->initStarterKitInteractively()
+            ->expectsQuestion('Starter Kit Package (eg. hasselhoff/kung-fury)', null)
+            ->expectsQuestion('Starter Kit Name (eg. Kung Fury)', null)
+            ->expectsQuestion('Starter Kit Description', null)
+            ->expectsConfirmation('Would you like to make this starter-kit updatable?', 'no')
+            ->expectsOutputToContain('You can manage your starter kit\'s package config in [package/composer.json] at any time.')
+            ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertOk();
+
+        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+
+        $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
+        $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+
+        $this->assertEquals(<<<'YAML'
+# export_paths:
+#   - content
+#   - config/filesystems.php
+#   - config/statamic/assets.php
+#   - resources/blueprints
+#   - resources/css/site.css
+#   - resources/views
+#   - public/build
+#   - package.json
+#   - tailwind.config.js
+#   - vite.config.js
+YAML, trim($this->files->get($configPath)));
+
+        $this->assertEquals(<<<'JSON'
+{
+    "name": "example/starter-kit-package",
+    "extra": {
+        "statamic": {
+            "name": "Example Name",
+            "description": "A description of your starter kit"
+        }
+    }
+}
+JSON, trim($this->files->get($composerJsonPath)));
+    }
+
+    #[Test]
+    public function it_can_init_with_custom_package_info()
+    {
+        $this->assertFileDoesNotExist($this->packagePath());
+
+        $this
+            ->initStarterKit([
+                'package' => 'statamic/starter-kit-cool-writings',
+                '--name' => 'Cool Writings',
+                '--description' => 'A Cool Runnings inspired starter kit.',
+            ])
+            ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertOk();
+
+        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+
+        $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
+        $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+
+        $this->assertEquals(<<<'JSON'
+{
+    "name": "statamic/starter-kit-cool-writings",
+    "extra": {
+        "statamic": {
+            "name": "Cool Writings",
+            "description": "A Cool Runnings inspired starter kit."
+        }
+    }
+}
+JSON, trim($this->files->get($composerJsonPath)));
+    }
+
+    #[Test]
+    public function it_validates_package()
+    {
+        $this->assertFileDoesNotExist($this->packagePath());
+
+        $this
+            ->initStarterKit([
+                'package' => 'statamic',
+            ])
+            ->expectsOutputToContain('Must be a valid composer package name (eg. hasselhoff/kung-fury).')
+            ->doesntExpectOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertFailed();
+
+        $this->assertFileDoesNotExist($this->packagePath());
+    }
+
+    #[Test]
+    public function it_can_interactively_init_with_custom_package_info()
+    {
+        $this->assertFileDoesNotExist($this->packagePath());
+
+        $this
+            ->initStarterKitInteractively()
+            ->expectsQuestion('Starter Kit Package (eg. hasselhoff/kung-fury)', 'statamic/starter-kit-cool-writings')
+            ->expectsQuestion('Starter Kit Name (eg. Kung Fury)', 'Cool Writings')
+            ->expectsQuestion('Starter Kit Description', 'A Cool Runnings inspired starter kit.')
+            ->expectsConfirmation('Would you like to make this starter-kit updatable?', 'no')
+            ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertOk();
+
+        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+
+        $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
+        $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+
+        $this->assertEquals(<<<'JSON'
+{
+    "name": "statamic/starter-kit-cool-writings",
+    "extra": {
+        "statamic": {
+            "name": "Cool Writings",
+            "description": "A Cool Runnings inspired starter kit."
+        }
+    }
+}
+JSON, trim($this->files->get($composerJsonPath)));
+    }
+
+    #[Test]
+    public function it_can_init_updatable_kit()
+    {
+        $this->assertFileDoesNotExist($this->packagePath());
+
+        $this
+            ->initStarterKit(['--updatable' => true])
+            ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertOk();
+
+        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+
+        $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
+        $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+
+        $this->assertEquals(<<<'YAML'
+updatable: true
+# export_paths:
+#   - content
+#   - config/filesystems.php
+#   - config/statamic/assets.php
+#   - resources/blueprints
+#   - resources/css/site.css
+#   - resources/views
+#   - public/build
+#   - package.json
+#   - tailwind.config.js
+#   - vite.config.js
+YAML, trim($this->files->get($configPath)));
+
+        $this->assertEquals(<<<'JSON'
+{
+    "name": "example/starter-kit-package",
+    "extra": {
+        "statamic": {
+            "name": "Example Name",
+            "description": "A description of your starter kit"
+        },
+        "laravel": {
+            "providers": [
+                "Example\\StarterKitNamespace\\ServiceProvider"
+            ]
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Example\\StarterKitNamespace\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests"
+        }
+    }
+}
+JSON, trim($this->files->get($composerJsonPath)));
+    }
+
+    #[Test]
+    public function it_can_interactively_init_updatable_kit()
+    {
+        $this->assertFileDoesNotExist($this->packagePath());
+
+        $this
+            ->initStarterKitInteractively()
+            ->expectsQuestion('Starter Kit Package (eg. hasselhoff/kung-fury)', null)
+            ->expectsQuestion('Starter Kit Name (eg. Kung Fury)', null)
+            ->expectsQuestion('Starter Kit Description', null)
+            ->expectsConfirmation('Would you like to make this starter-kit updatable?', 'yes')
+            ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertOk();
+
+        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+
+        $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
+        $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+
+        $this->assertEquals(<<<'YAML'
+updatable: true
+# export_paths:
+#   - content
+#   - config/filesystems.php
+#   - config/statamic/assets.php
+#   - resources/blueprints
+#   - resources/css/site.css
+#   - resources/views
+#   - public/build
+#   - package.json
+#   - tailwind.config.js
+#   - vite.config.js
+YAML, trim($this->files->get($configPath)));
+
+        $this->assertEquals(<<<'JSON'
+{
+    "name": "example/starter-kit-package",
+    "extra": {
+        "statamic": {
+            "name": "Example Name",
+            "description": "A description of your starter kit"
+        },
+        "laravel": {
+            "providers": [
+                "Example\\StarterKitNamespace\\ServiceProvider"
+            ]
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Example\\StarterKitNamespace\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests"
+        }
+    }
+}
+JSON, trim($this->files->get($composerJsonPath)));
+    }
+
+    #[Test]
+    public function it_can_init_updatable_kit_with_custom_package_info()
+    {
+        $this->assertFileDoesNotExist($this->packagePath());
+
+        $this
+            ->initStarterKit([
+                'package' => 'statamic-rad-pack/starter-kit-cool-writings',
+                '--name' => 'Cool Writings',
+                '--description' => 'A Cool Runnings inspired starter kit.',
+                '--updatable' => true,
+            ])
+            ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertOk();
+
+        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+
+        $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
+        $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+
+        $this->assertEquals(<<<'JSON'
+{
+    "name": "statamic-rad-pack/starter-kit-cool-writings",
+    "extra": {
+        "statamic": {
+            "name": "Cool Writings",
+            "description": "A Cool Runnings inspired starter kit."
+        },
+        "laravel": {
+            "providers": [
+                "StatamicRadPack\\CoolWritings\\ServiceProvider"
+            ]
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "StatamicRadPack\\CoolWritings\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests"
+        }
+    }
+}
+JSON, trim($this->files->get($composerJsonPath)));
+    }
+
+    #[Test]
+    public function it_can_interactively_init_updatable_kit_with_custom_package_info()
+    {
+        $this->assertFileDoesNotExist($this->packagePath());
+
+        $this
+            ->initStarterKitInteractively()
+            ->expectsQuestion('Starter Kit Package (eg. hasselhoff/kung-fury)', 'statamic-rad-pack/starter-kit-cool-writings')
+            ->expectsQuestion('Starter Kit Name (eg. Kung Fury)', 'Cool Writings')
+            ->expectsQuestion('Starter Kit Description', 'A Cool Runnings inspired starter kit.')
+            ->expectsConfirmation('Would you like to make this starter-kit updatable?', 'yes')
+            ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertOk();
+
+        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+
+        $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
+        $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+
+        $this->assertEquals(<<<'JSON'
+{
+    "name": "statamic-rad-pack/starter-kit-cool-writings",
+    "extra": {
+        "statamic": {
+            "name": "Cool Writings",
+            "description": "A Cool Runnings inspired starter kit."
+        },
+        "laravel": {
+            "providers": [
+                "StatamicRadPack\\CoolWritings\\ServiceProvider"
+            ]
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "StatamicRadPack\\CoolWritings\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests"
+        }
+    }
+}
+JSON, trim($this->files->get($composerJsonPath)));
+    }
+
+    #[Test]
+    public function it_properly_camel_cases_namespace()
+    {
+        $this->assertFileDoesNotExist($this->packagePath());
+
+        $this
+            ->initStarterKit([
+                '--name' => 'Cool-Writings_Kit ABC',
+                '--updatable' => true,
+            ])
+            ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertOk();
+
+        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+
+        $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+
+        $this->assertStringContainsString('"Example\\\\CoolWritingsKitABC\\\\": "src"', $this->files->get($composerJsonPath));
+        $this->assertStringContainsString('"Example\\\\CoolWritingsKitABC\\\\ServiceProvider"', $this->files->get($composerJsonPath));
+    }
+
+    #[Test]
+    public function it_asks_to_overwrite_existing_files_interactively()
+    {
+        $this->files->makeDirectory($this->packagePath());
+        $this->files->put($configPath = $this->packagePath('starter-kit.yaml'), $config = 'existing starter-kit.yaml!');
+        $this->files->put($composerJsonPath = $this->packagePath('composer.json'), $composerJson = 'existing composer.json!');
+
+        $this
+            ->initStarterKitInteractively()
+            ->expectsQuestion('Starter Kit Package (eg. hasselhoff/kung-fury)', 'statamic/starter-kit-cool-writings')
+            ->expectsQuestion('Starter Kit Name (eg. Kung Fury)', 'Cool Writings')
+            ->expectsQuestion('Starter Kit Description', 'A Cool Runnings inspired starter kit.')
+            ->expectsConfirmation('Would you like to make this starter-kit updatable?', 'no')
+            ->expectsConfirmation('A [starter-kit.yaml] config already exists. Would you like to overwrite it?', 'no')
+            ->expectsConfirmation('A [composer.json] config already exists. Would you like to overwrite it?', 'no')
+            ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertOk();
+
+        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+
+        $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
+        $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+
+        $this->assertEquals($config, trim($this->files->get($configPath)));
+        $this->assertEquals($composerJson, trim($this->files->get($composerJsonPath)));
+    }
+
+    #[Test]
+    public function it_can_overwrite_existing_files_interactively()
+    {
+        $this->files->makeDirectory($this->packagePath());
+        $this->files->put($configPath = $this->packagePath('starter-kit.yaml'), $config = 'existing starter-kit.yaml!');
+        $this->files->put($composerJsonPath = $this->packagePath('composer.json'), $composerJson = 'existing composer.json!');
+
+        $this
+            ->initStarterKitInteractively()
+            ->expectsQuestion('Starter Kit Package (eg. hasselhoff/kung-fury)', 'statamic/starter-kit-cool-writings')
+            ->expectsQuestion('Starter Kit Name (eg. Kung Fury)', 'Cool Writings')
+            ->expectsQuestion('Starter Kit Description', 'A Cool Runnings inspired starter kit.')
+            ->expectsConfirmation('Would you like to make this starter-kit updatable?', 'no')
+            ->expectsConfirmation('A [starter-kit.yaml] config already exists. Would you like to overwrite it?', 'yes')
+            ->expectsConfirmation('A [composer.json] config already exists. Would you like to overwrite it?', 'yes')
+            ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertOk();
+
+        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+
+        $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
+        $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+
+        $this->assertEquals(<<<'YAML'
+# export_paths:
+#   - content
+#   - config/filesystems.php
+#   - config/statamic/assets.php
+#   - resources/blueprints
+#   - resources/css/site.css
+#   - resources/views
+#   - public/build
+#   - package.json
+#   - tailwind.config.js
+#   - vite.config.js
+YAML, trim($this->files->get($configPath)));
+
+        $this->assertEquals(<<<'JSON'
+{
+    "name": "statamic/starter-kit-cool-writings",
+    "extra": {
+        "statamic": {
+            "name": "Cool Writings",
+            "description": "A Cool Runnings inspired starter kit."
+        }
+    }
+}
+JSON, trim($this->files->get($composerJsonPath)));
+    }
+
+    #[Test]
+    public function it_always_overwrites_existing_files_when_run_non_interactively()
+    {
+        $this->files->makeDirectory($this->packagePath());
+        $this->files->put($configPath = $this->packagePath('starter-kit.yaml'), $config = 'existing starter-kit.yaml!');
+        $this->files->put($composerJsonPath = $this->packagePath('composer.json'), $composerJson = 'existing composer.json!');
+
+        $this
+            ->initStarterKit(['package' => 'statamic/starter-kit-cool-writings'])
+            ->expectsOutputToContain('Your starter kit config was successfully created in your project\'s [package] folder.')
+            ->assertOk();
+
+        $this->assertCount(2, $this->files->allFiles($this->packagePath()));
+
+        $this->assertFileExists($configPath = $this->packagePath('starter-kit.yaml'));
+        $this->assertFileExists($composerJsonPath = $this->packagePath('composer.json'));
+
+        $this->assertEquals(<<<'YAML'
+# export_paths:
+#   - content
+#   - config/filesystems.php
+#   - config/statamic/assets.php
+#   - resources/blueprints
+#   - resources/css/site.css
+#   - resources/views
+#   - public/build
+#   - package.json
+#   - tailwind.config.js
+#   - vite.config.js
+YAML, trim($this->files->get($configPath)));
+
+        $this->assertEquals(<<<'JSON'
+{
+    "name": "statamic/starter-kit-cool-writings",
+    "extra": {
+        "statamic": {
+            "name": "Example Name",
+            "description": "A description of your starter kit"
+        }
+    }
+}
+JSON, trim($this->files->get($composerJsonPath)));
+    }
+
+    private function packagePath($path = null)
+    {
+        return collect([$this->packagePath, $path])->filter()->implode('/');
+    }
+
+    private function initStarterKit($options = [])
+    {
+        return $this->artisan('statamic:starter-kit:init', array_merge([
+            '--no-interaction' => true,
+        ], $options));
+    }
+
+    private function initStarterKitInteractively($options = [])
+    {
+        return $this->artisan('statamic:starter-kit:init', $options);
+    }
+
+    private function assertFileHasContent($expected, $path)
+    {
+        $this->assertFileExists($path);
+
+        $this->assertStringContainsString($expected, $this->files->get($path));
+    }
+}


### PR DESCRIPTION
In #11119, we're removing scaffolding logic from `starter-kit:export`, in order to simplify the export.

This PR implements a complimentary `starter-kit:init` command to re-implement that scaffolding logic, but with better UX.

![CleanShot 2024-12-03 at 23 06 19](https://github.com/user-attachments/assets/5a837adb-b09d-4347-a1e3-33f64cb53745)