### PR TITLE
[5.x] Fix null coalescence operator evaluation

### DIFF
--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -1167,7 +1167,6 @@ class Environment
     private function evaluateNullCoalescence(NullCoalescenceGroup $group)
     {
         $leftVal = $this->getValue($group->left);
-        $rightVal = $this->getValue($group->right);
 
         if ($leftVal instanceof ArrayableString) {
             $leftVal = $leftVal->value();
@@ -1177,7 +1176,7 @@ class Environment
             return $leftVal;
         }
 
-        return $rightVal;
+        return $this->getValue($group->right);
     }
 
     /**

--- a/tests/View/Antlers/ViewTest.php
+++ b/tests/View/Antlers/ViewTest.php
@@ -129,6 +129,17 @@ class ViewTest extends TestCase
     }
 
     #[Test]
+    public function uses_proper_evaluation_order_for_null_coalescing_operator()
+    {
+        $this->viewShouldReturnRaw('template', file_get_contents(__DIR__.'/fixtures/template-with-null-coalescence-opperator.antlers.html'));
+
+        $view = (new View)->template('template');
+
+        $this->assertEquals('Hello World', $view->render());
+    }
+
+
+    #[Test]
     public function gets_first()
     {
         $this->viewShouldReturnRaw('template', file_get_contents(__DIR__.'/fixtures/template-with-noparse.antlers.html'));

--- a/tests/View/Antlers/fixtures/template-with-null-coalescence-opperator.antlers.html
+++ b/tests/View/Antlers/fixtures/template-with-null-coalescence-opperator.antlers.html
@@ -1,0 +1,1 @@
+{{ hello = "Hello" }}{{ world = "World" }}{{ hello ?? (world = "Earth") }} {{ world }}


### PR DESCRIPTION
@marcorieser Brought up in discord that the null coalescence operator is not functioning like you'd expect.

It is expected that if the left side of the operator is not null then the right side would never be evaluated.

This is a contrived example that showcases the behavior:
```antlers
{{ hello = "Hello" }}
{{ world = "World" }}
{{ hello ?? (world = "Earth") }} {{ world }}
```

Based on the order of operations and evaluation order, you'd expect the above to output:
```
Hello World
```

But it instead outputs:
```
Hello Earth
```

Because the right side of the operator is evaluated regardless of the left side being nullish.

This PR adds a test and fixes that behavior.