### PR TITLE
[5.x] Table Fieldtype: Add `max_columns` and `max_rows` options

### DIFF
--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -169,6 +169,8 @@ return [
     'slug.config.show_regenerate' => 'Show the regenerate button to re-slugify from the target field.',
     'slug.title' => 'Slug',
     'structures.title' => 'Structures',
+    'table.config.max_columns' => 'Set a maximum number of columns.',
+    'table.config.max_rows' => 'Set a maximum number of rows.',
     'table.title' => 'Table',
     'taggable.config.options' => 'Provide pre-defined tags that can be selected.',
     'taggable.config.placeholder' => 'Type and press ↩ Enter',

--- a/src/Fieldtypes/Table.php
+++ b/src/Fieldtypes/Table.php
@@ -18,6 +18,16 @@ class Table extends Fieldtype
                 'instructions' => __('statamic::messages.fields_default_instructions'),
                 'type' => 'table',
             ],
+            'max_rows' => [
+                'display' => __('Max Columns'),
+                'instructions' => __('statamic::fieldtypes.table.config.max_rows'),
+                'type' => 'integer',
+            ],
+            'max_columns' => [
+                'display' => __('Max Columns'),
+                'instructions' => __('statamic::fieldtypes.table.config.max_columns'),
+                'type' => 'integer',
+            ],
         ];
     }
 

--- a/src/Fieldtypes/Table.php
+++ b/src/Fieldtypes/Table.php
@@ -19,7 +19,7 @@ class Table extends Fieldtype
                 'type' => 'table',
             ],
             'max_rows' => [
-                'display' => __('Max Columns'),
+                'display' => __('Max Rows'),
                 'instructions' => __('statamic::fieldtypes.table.config.max_rows'),
                 'type' => 'integer',
             ],


### PR DESCRIPTION
This pull request adds "Max Columns" and "Max Rows" config options to the Table fieldtype. They're already used in the fieldtype's Vue component, they were just missing options in the UI.

Closes statamic/ideas#1276.