### PR TITLE
[5.x] Fix asset upload concurrency on folder upload

### DIFF
--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -68,6 +68,15 @@ export default {
     },
 
 
+    computed: {
+
+        activeUploads() {
+            return this.uploads.filter(u => u.instance.state === 'started');
+        }
+
+    },
+
+
     methods: {
 
         browse() {
@@ -230,6 +239,9 @@ export default {
         },
 
         processUploadQueue() {
+            // If we're already uploading, don't start another
+            if (this.activeUploads.length) return;
+
             // Make sure we're not grabbing a running or failed upload
             const upload = this.uploads.find(u => u.instance.state === 'new' && !u.errorMessage);
             if (!upload) return;
@@ -248,6 +260,8 @@ export default {
                 response.status === 200
                     ? this.handleUploadSuccess(id, json)
                     : this.handleUploadError(id, response.status, json);
+
+                this.processUploadQueue();
             });
         },
 


### PR DESCRIPTION
The folder upload feature from #10583 has a little flaw: while dropping a bunch of files has always uploaded the files in sequence, dropping a folder will upload all contained files at once. With lots of nested files, this might overwhelm the server and lead to corrupted uploads.

This PR fixes that by only ever allowing a single concurrent upload.

I can imagine this being a config flag to allow e.g. 3 or 5 concurrent uploads if the system can handle it.

**Before**

![Screen Recording 2024-12-06 at 16 33 12](https://github.com/user-attachments/assets/30426079-6f98-4a45-b4a8-8b6099e0bb41)

**After**

![Screen Recording 2024-12-06 at 16 46 11](https://github.com/user-attachments/assets/98ca5d7b-a93c-412b-945e-2650122ba990)
