### PR TITLE
[5.x] Adjusts app extension namespace logic

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -333,6 +333,7 @@ class ExtensionServiceProvider extends ServiceProvider
     public static function getNamespaceFromFile(SplFileInfo $file, string $basePath, string $appNamespace): ?string
     {
         // Normalize some things.
+        $basePath = str_replace('\\', '/', $basePath);
         $basePath = realpath($basePath);
         $filePath = realpath($file->getPath()); // Note: Not using getRealPath() to avoid the filename at this point.
 

--- a/tests/Extend/AppExtensionsTest.php
+++ b/tests/Extend/AppExtensionsTest.php
@@ -51,7 +51,8 @@ class AppExtensionsTest extends TestCase
                     foreach ($appVariations as $variation) {
                         $this->assertSame(
                             $expectedNamespace,
-                            ExtensionServiceProvider::getNamespaceFromFile($file, $basePath, $variation)
+                            ExtensionServiceProvider::getNamespaceFromFile($file, $basePath, $variation),
+                            "App Namespace: {$appNamespace} Variation: {$variation} Base Path: {$basePath}"
                         );
                     }
                 }

--- a/tests/Extend/AppExtensionsTest.php
+++ b/tests/Extend/AppExtensionsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Extend;
+
+use PHPUnit\Framework\Attributes\Test;
+use SplFileInfo;
+use Statamic\Providers\ExtensionServiceProvider;
+use Tests\TestCase;
+
+class AppExtensionsTest extends TestCase
+{
+    #[Test]
+    public function it_resolves_namespaces_correctly()
+    {
+        $files = collect($this->app['files']->allFiles(__DIR__.'/../__fixtures__/classes/app'))
+            ->map(fn (SplFileInfo $file) => [$file, trim(file_get_contents($file->getPathname()))]);
+
+        $basePaths = [
+            __DIR__.'/../__fixtures__/classes/app',
+            __DIR__.'/../__fixtures__/classes/app\\',
+            __DIR__.'/../__fixtures__/classes/app/',
+            __DIR__.'/..\\__fixtures__/classes/app/',
+        ];
+
+        $appNamespaces = [
+            'App' => [
+                'App',
+                'App\\',
+                'App////',
+                'App/\\',
+                '\\App/',
+                '\\App/\\',
+            ],
+            'Something\\Nested\\Here' => [
+                'Something\\Nested\\Here',
+                'Something\\Nested\\Here\\',
+                'Something\\Nested\\Here/',
+                'Something\\Nested\\Here/\\',
+                '\\Something\\Nested\\Here/',
+                '\\Something\\Nested\\Here/\\',
+            ],
+        ];
+
+        foreach ($files as $info) {
+            [$file, $expectedRelativeClassName] = $info;
+
+            foreach ($appNamespaces as $appNamespace => $appVariations) {
+                $expectedNamespace = "{$appNamespace}\\{$expectedRelativeClassName}";
+
+                foreach ($basePaths as $basePath) {
+                    foreach ($appVariations as $variation) {
+                        $this->assertSame(
+                            $expectedNamespace,
+                            ExtensionServiceProvider::getNamespaceFromFile($file, $basePath, $variation)
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/__fixtures__/classes/app/Dictionaries/DictionaryOne.php
+++ b/tests/__fixtures__/classes/app/Dictionaries/DictionaryOne.php
@@ -1,0 +1,1 @@
+Dictionaries\DictionaryOne

--- a/tests/__fixtures__/classes/app/Dictionaries/Nested/DictionaryTwo.php
+++ b/tests/__fixtures__/classes/app/Dictionaries/Nested/DictionaryTwo.php
@@ -1,0 +1,1 @@
+Dictionaries\Nested\DictionaryTwo

--- a/tests/__fixtures__/classes/app/Tags/Nested/TagTwo.php
+++ b/tests/__fixtures__/classes/app/Tags/Nested/TagTwo.php
@@ -1,0 +1,1 @@
+Tags\Nested\TagTwo

--- a/tests/__fixtures__/classes/app/Tags/Nested/not_a_tag.txt
+++ b/tests/__fixtures__/classes/app/Tags/Nested/not_a_tag.txt
@@ -1,0 +1,1 @@
+Tags\Nested\not_a_tag.txt

--- a/tests/__fixtures__/classes/app/Tags/TagOne.php
+++ b/tests/__fixtures__/classes/app/Tags/TagOne.php
@@ -1,0 +1,1 @@
+Tags\TagOne


### PR DESCRIPTION
This PR fixes #11231 

If the path contains backslashes, the nested directory handling introduced in #11046 will cause auto-loading to fail, even for classes that are not in sub-directories.

This PR refactors how namespaces are determined and adds some test coverage (just testing the namespaces produced from different base path and app namespace combinations).