### PR TITLE
[5.x] Adds "no_results" to automatic array variables

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -2550,6 +2550,7 @@ class NodeProcessor
             $value['count'] = $index + 1;
             $value['index'] = $index;
             $value['total_results'] = $total;
+            $value['no_results'] = false;
             $value['first'] = $index === 0;
             $value['last'] = $index === $lastIndex;
 


### PR DESCRIPTION
This PR fixes #11218  by adding `no_results` to the automatic array variables that are added when looping.

The issue is ultimately caused by the cascading logic. Tags that output `no_results: true` don't output `no_results: false`, which causes Antlers to search until it finds a variable with the same name.