### PR TITLE
[5.x] Add option to add filters from collection/taxonomy list to breadcrumb »back« link in single view

### DIFF
--- a/config/cp.php
+++ b/config/cp.php
@@ -157,4 +157,20 @@ return [
     'thumbnail_presets' => [
         // 'medium' => 800,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Breadcrumbs
+    |--------------------------------------------------------------------------
+    |
+    | Here you can define if the breadcrumb on a collection entry or
+    | taxonomy term single view that points back to the list view should
+    | contain the filters that were used on that list before entering
+    | the single view.
+    |
+    */
+
+    'breadcrumbs' => [
+        'add_filters_from_overview' => false
+    ],
 ];

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -4,9 +4,11 @@ namespace Statamic\Entries;
 
 use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Facades\Request;
 use InvalidArgumentException;
 use Statamic\Contracts\Data\Augmentable as AugmentableContract;
 use Statamic\Contracts\Entries\Collection as Contract;
+use Statamic\CP\Breadcrumbs;
 use Statamic\Data\ContainsCascadingData;
 use Statamic\Data\ExistsAsFile;
 use Statamic\Data\HasAugmentedData;
@@ -263,6 +265,28 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
     public function showUrl()
     {
         return cp_route('collections.show', $this->handle());
+    }
+
+    public function breadcrumbUrl()
+    {
+        $cpRoute = config('statamic.cp.route');
+        if (! Breadcrumbs::addFiltersFromReferer("{$cpRoute}/collections/{collection}", $this->handle())) {
+            return $this->showUrl();
+        }
+
+        $refererRequest = Request::create(request()->headers->get('referer'));
+
+        $search = $refererRequest->input('search');
+        $sort = $refererRequest->input('sort');
+        $order = $refererRequest->input('order');
+        $filters = $refererRequest->input('filters');
+
+        return cp_route('collections.show', array_merge((array) $this->handle(), [
+            'sort' => $sort,
+            'order' => $order,
+            'filters' => $filters,
+            'search' => $search,
+        ]));
     }
 
     public function editUrl()

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -545,7 +545,7 @@ class EntriesController extends CpController
             ],
             [
                 'text' => $collection->title(),
-                'url' => $collection->showUrl(),
+                'url' => $collection->breadcrumbUrl(),
             ],
         ]);
     }

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -354,7 +354,7 @@ class TermsController extends CpController
             ],
             [
                 'text' => $taxonomy->title(),
-                'url' => $taxonomy->showUrl(),
+                'url' => $taxonomy->breadcrumbUrl(),
             ],
         ]);
     }

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -5,8 +5,10 @@ namespace Statamic\Taxonomies;
 use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Facades\Request;
 use Statamic\Contracts\Data\Augmentable as AugmentableContract;
 use Statamic\Contracts\Taxonomies\Taxonomy as Contract;
+use Statamic\CP\Breadcrumbs;
 use Statamic\Data\ContainsCascadingData;
 use Statamic\Data\ContainsSupplementalData;
 use Statamic\Data\ExistsAsFile;
@@ -79,6 +81,28 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
     public function showUrl()
     {
         return cp_route('taxonomies.show', $this->handle());
+    }
+
+    public function breadcrumbUrl()
+    {
+        $cpRoute = config('statamic.cp.route');
+        if (! Breadcrumbs::addFiltersFromReferer("{$cpRoute}/taxonomies/{taxonomy}", $this->handle())) {
+            return $this->showUrl();
+        }
+
+        $refererRequest = Request::create(request()->headers->get('referer'));
+
+        $search = $refererRequest->input('search');
+        $sort = $refererRequest->input('sort');
+        $order = $refererRequest->input('order');
+        $filters = $refererRequest->input('filters');
+
+        return cp_route('taxonomies.show', array_merge((array) $this->handle(), [
+            'sort' => $sort,
+            'order' => $order,
+            'filters' => $filters,
+            'search' => $search,
+        ]));
     }
 
     public function editUrl()


### PR DESCRIPTION
I got the request from a client if it’s possible to change the link that points back to the collection list from the edit view, so that it includes search/filter/sort params that were set before the user entered the single view from the list. I found a corresponding feature request in statamic/ideas https://github.com/statamic/ideas/issues/1049, and this PR aims to add that functionality that can be enabled via a config key.

I’m not sure if that is the best place for the config key (and if the name is clear enough), and if it’s a good idea to extend the `Breadcrumbs` class, but I couldn’t fint another place where the method could go. Thought about adding a Trait, but left it this way for now.