### PR TITLE
[5.x] Fix type error in `HandleEntrySchedule` job

### DIFF
--- a/src/Entries/MinuteEntries.php
+++ b/src/Entries/MinuteEntries.php
@@ -2,14 +2,13 @@
 
 namespace Statamic\Entries;
 
-use Carbon\Carbon;
-use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 
 class MinuteEntries
 {
-    public function __construct(private readonly Carbon|CarbonImmutable $minute)
+    public function __construct(private readonly CarbonInterface $minute)
     {
     }
 


### PR DESCRIPTION
This pull request fixes a type error caused by a `CarbonImmutable` instance being passed into the `MinuteEntries` class, rather than a plain `Carbon` instance.

Fixes #11239.