### PR TITLE
[5.x] Fix collection title_format when using translations

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -1008,7 +1008,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
 
         // Since the slug is generated from the title, we'll avoid augmenting
         // the slug which could result in an infinite loop in some cases.
-        $title = $this->withLocale($this->site()->locale(), fn () => (string) Antlers::parse($format, $this->augmented()->except('slug')->all()));
+        $title = $this->withLocale($this->site()->lang(), fn () => (string) Antlers::parse($format, $this->augmented()->except('slug')->all()));
 
         return trim($title);
     }


### PR DESCRIPTION
We are using a custom title_format in an entry collection that relies on translations. Unfortunately, when saving an entry, Statamic appears to set `app()->locale()` to the full site locale (e.g., `de_DE`), while Laravel expects the "short" locale or language (e.g., `de`). As a result, the translation is not found, and the fallback translation is used instead.

I traced this issue to the [following line](https://github.com/statamic/cms/blob/d62cc13484aa28ec532f814669630f8c5c4a3915/src/Entries/Entry.php#L1011). Is there a specific reason for using `$this->withLocale($this->site()->locale(), ...)` instead of `$this->withLocale($site->lang(), ...)`? Using `$site->lang()` resolves the issue for us.

Could this be adjusted, or do you have any other suggestions for solving this issue?

I noticed that all other occurrences of `$this->withLocale` already use `$site->lang()`. 

Thanks!