### PR TITLE
[5.x] Move bard source button into field actions

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -31,9 +31,6 @@
                         :config="config"
                         :bard="_self"
                         :editor="editor" />
-                    <button class="bard-toolbar-button" @click="showSource = !showSource" v-if="allowSource" v-tooltip="__('Show HTML Source')" :aria-label="__('Show HTML Source')">
-                        <svg-icon name="show-source" class="w-4 h-4 "/>
-                    </button>
                 </div>
             </div>
         </publish-field-fullscreen-header>
@@ -49,9 +46,6 @@
                     :config="config"
                     :bard="_self"
                     :editor="editor" />
-                <button class="bard-toolbar-button" @click="showSource = !showSource" v-if="allowSource" v-tooltip="__('Show HTML Source')" :aria-label="__('Show HTML Source')">
-                    <svg-icon name="show-source" class="w-4 h-4 "/>
-                </button>
             </div>
         </div>
 
@@ -369,6 +363,12 @@ export default {
                     run: this.toggleFullscreen,
                     visibleWhenReadOnly: true,
                     visible: this.config.fullscreen,
+                },
+                {
+                    title: __('Show HTML Source'),
+                    run: () => this.showSource = !this.showSource,
+                    visibleWhenReadOnly: true,
+                    visible: this.allowSource,
                 },
             ];
         },


### PR DESCRIPTION
Bard's view source button doesn't show when you have the toolbar set to floating.

It's also fairly useless in our opinion since it's not a true representation of the final html. Plus, it's not editable, and many people think it is.

We'll remove it completely in v6, but for now it's being moved into the field actions dropdown. This makes it usable regardless of your toolbar setting.

![CleanShot 2024-12-12 at 11 19 09](https://github.com/user-attachments/assets/3cecb337-9c44-43ce-b212-01d1401239e0)


Resolves https://github.com/statamic/cms/discussions/11226
Related: #11227 
