### PR TITLE
[5.x] Update `embed_url` and `trackable_embed_url` modifiers to be valid with additional query strings

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -3106,6 +3106,10 @@ class CoreModifiers extends Modifier
             $url = str_replace('//youtube-nocookie.com', '//www.youtube-nocookie.com', $url);
         }
 
+        if (Str::contains($url, '&') && ! Str::contains($url, '?')) {
+            $url = Str::replaceFirst('&', '?', $url);
+        }
+
         return $url;
     }
 
@@ -3133,6 +3137,10 @@ class CoreModifiers extends Modifier
 
         if (Str::contains($url, 'youtube.com/watch?v=')) {
             $url = str_replace('watch?v=', 'embed/', $url);
+        }
+
+        if (Str::contains($url, '&') && ! Str::contains($url, '?')) {
+            $url = Str::replaceFirst('&', '?', $url);
         }
 
         return $url;

--- a/tests/Modifiers/EmbedUrlTest.php
+++ b/tests/Modifiers/EmbedUrlTest.php
@@ -113,7 +113,7 @@ class EmbedUrlTest extends TestCase
         );
     }
 
-        public function embed($url)
+    public function embed($url)
     {
         return Modify::value($url)->embedUrl()->fetch();
     }

--- a/tests/Modifiers/EmbedUrlTest.php
+++ b/tests/Modifiers/EmbedUrlTest.php
@@ -84,7 +84,36 @@ class EmbedUrlTest extends TestCase
         );
     }
 
-    public function embed($url)
+    #[Test]
+    public function it_ensures_url_with_query_parameters_are_valid()
+    {
+        $embedUrl = 'https://www.youtube-nocookie.com/embed/s72r_wu_NVY?pp=player_params';
+
+        $this->assertEquals(
+            $embedUrl,
+            $this->embed('https://www.youtube.com/watch?v=s72r_wu_NVY&pp=player_params'),
+            'It transforms the youtube video link with additional query string params'
+        );
+        $this->assertEquals(
+            $embedUrl,
+            $this->embed('https://youtu.be/s72r_wu_NVY?pp=player_params'),
+            'It transforms shortened youtube video sharing links with additional query string params'
+        );
+
+        $this->assertEquals(
+            'https://www.youtube-nocookie.com/embed/s72r_wu_NVY?start=559&pp=player_params',
+            $this->embed('https://youtu.be/s72r_wu_NVY?t=559&pp=player_params'),
+            'It transforms the start time parameter of shortened sharing links with additional query string params'
+        );
+
+        $this->assertEquals(
+            'https://www.youtube-nocookie.com/embed/hyJ7CBs_2RQ?start=2&pp=player_params',
+            $this->embed('https://www.youtube.com/watch?v=hyJ7CBs_2RQ&t=2&pp=player_params'),
+            'It transforms the start time parameter of full youtube links with additional query string params'
+        );
+    }
+
+        public function embed($url)
     {
         return Modify::value($url)->embedUrl()->fetch();
     }

--- a/tests/Modifiers/TrackableEmbedUrlTest.php
+++ b/tests/Modifiers/TrackableEmbedUrlTest.php
@@ -50,6 +50,34 @@ class TrackableEmbedUrlTest extends TestCase
         );
     }
 
+    public function it_ensures_url_with_query_parameters_are_valid()
+    {
+        $embedUrl = 'https://www.youtube-nocookie.com/embed/s72r_wu_NVY?pp=player_params';
+
+        $this->assertEquals(
+            $embedUrl,
+            $this->embed('https://www.youtube.com/watch?v=s72r_wu_NVY&pp=player_params'),
+            'It transforms the youtube video link with additional query string params'
+        );
+        $this->assertEquals(
+            $embedUrl,
+            $this->embed('https://youtu.be/s72r_wu_NVY?pp=player_params'),
+            'It transforms shortened youtube video sharing links with additional query string params'
+        );
+
+        $this->assertEquals(
+            'https://www.youtube-nocookie.com/embed/s72r_wu_NVY?start=559&pp=player_params',
+            $this->embed('https://youtu.be/s72r_wu_NVY?t=559&pp=player_params'),
+            'It transforms the start time parameter of shortened sharing links with additional query string params'
+        );
+
+        $this->assertEquals(
+            'https://www.youtube-nocookie.com/embed/hyJ7CBs_2RQ?start=2&pp=player_params',
+            $this->embed('https://www.youtube.com/watch?v=hyJ7CBs_2RQ&t=2&pp=player_params'),
+            'It transforms the start time parameter of full youtube links with additional query string params'
+        );
+    }
+
     public function embed($url)
     {
         return Modify::value($url)->trackableEmbedUrl()->fetch();


### PR DESCRIPTION
Youtube can attach new parameters when copying URLs, such as:
https://www.youtube.com/watch?v=xose4ruJXQ0&pp=ygUQaGFkZXN0b3duIGxvbmRvbg%3D%3D

The `embed_url` and `trackable_embed_url` modifiers were incorrectly outputting the URL:
https://www.youtube-nocookie.com/embed/xose4ruJXQ0&pp=ygUQaGFkZXN0b3duIGxvbmRvbg%3D%3D 

This is not a valid URL, and will not play. It is missing the query string question mark.

However, the Video fieldtype does correctly embed the video - so the author would believe the video would embed correctly.

This PR updates these two modifiers to check that if an ampersand exists in the URL (i.e. there is more than one query string property) then there is also a question mark.

With this PR in place, the embedded URL will be:
https://www.youtube-nocookie.com/embed/xose4ruJXQ0?pp=ygUQaGFkZXN0b3duIGxvbmRvbg%3D%3D 

Given users may not be technically minded, and may just copy-and-paste from YouTube, this is a quality of life improvement to reduce the chance of errors.