### PR TITLE
[5.x] Fix term filter on entries listing

### DIFF
--- a/src/Query/Scopes/Filters/Fields/Terms.php
+++ b/src/Query/Scopes/Filters/Fields/Terms.php
@@ -3,7 +3,6 @@
 namespace Statamic\Query\Scopes\Filters\Fields;
 
 use Statamic\Facades;
-use Statamic\Support\Str;
 
 class Terms extends FieldtypeFilter
 {
@@ -21,12 +20,7 @@ class Terms extends FieldtypeFilter
 
     public function apply($query, $handle, $values)
     {
-        $term = $values['term'];
-
-        $term = Str::ensureLeft($term, '%');
-        $term = Str::ensureRight($term, '%');
-
-        $query->where($handle, 'like', $term);
+        $query->whereJsonContains($handle, $values['term']);
     }
 
     public function badge($values)


### PR DESCRIPTION
This pull request fixes an issue when filtering by term fields on the entry listing, where if the selected term's slug is *part* of the slug of another term, the wrong results might have been returned.

For example: if you were filtering by a term with the slug of `ev`, it would query for entries where the term slug contained `ev`, meaning entries associated with other terms like `beverages` could be returned.

This PR addresses the issue by replacing the `like` condition with `->whereJsonContains()` which seems to return the correct results.

Fixes #11262.