### PR TITLE
[5.x] Prevent "Set Alt" button from running Replace Asset action prematurely

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -34,6 +34,7 @@
         <td class="w-24" v-if="showSetAlt">
             <button
                 class="asset-set-alt text-blue dark:text-dark-blue-100 px-4 text-sm hover:text-black dark:hover:text-dark-100"
+                type="button"
                 @click="editOrOpen"
                 v-if="needsAlt"
             >

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -85,6 +85,7 @@
             </div>
             <button
                 class="asset-meta-btn"
+                type="button"
                 @click="edit"
                 v-if="showSetAlt && needsAlt"
             >


### PR DESCRIPTION
This pull request prevents the "Set Alt" button from running the Replace Asset action prematurely. Without explicitly setting the `type` attribute on buttons, it'll automatically submit the `<form>` it's located in, which was the issue here.

Fixes #11260.