### PR TITLE
[5.x] Prevent duplicate roles & groups

### DIFF
--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -171,11 +171,13 @@ class User extends BaseUser
 
     public function assignRole($role)
     {
-        $roles = collect(Arr::wrap($role))->map(function ($role) {
-            return is_string($role) ? $role : $role->handle();
-        })->all();
+        $roles = collect(Arr::wrap($role))
+            ->map(fn ($role) => is_string($role) ? $role : $role->handle())
+            ->merge($this->get('roles', []))
+            ->unique()
+            ->all();
 
-        $this->set('roles', array_merge($this->get('roles', []), $roles));
+        $this->set('roles', $roles);
 
         return $this;
     }
@@ -198,11 +200,13 @@ class User extends BaseUser
 
     public function addToGroup($group)
     {
-        $groups = collect(Arr::wrap($group))->map(function ($group) {
-            return is_string($group) ? $group : $group->handle();
-        })->all();
+        $groups = collect(Arr::wrap($group))
+            ->map(fn ($group) => is_string($group) ? $group : $group->handle())
+            ->merge($this->get('groups', []))
+            ->unique()
+            ->all();
 
-        $this->set('groups', array_merge($this->get('groups', []), $groups));
+        $this->set('groups', $groups);
 
         return $this;
     }

--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -175,6 +175,7 @@ class User extends BaseUser
             ->merge(Arr::wrap($role))
             ->map(fn ($role) => is_string($role) ? $role : $role->handle())
             ->unique()
+            ->values()
             ->all();
 
         $this->set('roles', $roles);
@@ -204,6 +205,7 @@ class User extends BaseUser
             ->merge(Arr::wrap($group))
             ->map(fn ($group) => is_string($group) ? $group : $group->handle())
             ->unique()
+            ->values()
             ->all();
 
         $this->set('groups', $groups);

--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -171,9 +171,9 @@ class User extends BaseUser
 
     public function assignRole($role)
     {
-        $roles = collect(Arr::wrap($role))
+        $roles = collect($this->get('roles', []))
+            ->merge(Arr::wrap($role))
             ->map(fn ($role) => is_string($role) ? $role : $role->handle())
-            ->merge($this->get('roles', []))
             ->unique()
             ->all();
 
@@ -200,9 +200,9 @@ class User extends BaseUser
 
     public function addToGroup($group)
     {
-        $groups = collect(Arr::wrap($group))
+        $groups = collect($this->get('groups', []))
+            ->merge(Arr::wrap($group))
             ->map(fn ($group) => is_string($group) ? $group : $group->handle())
-            ->merge($this->get('groups', []))
             ->unique()
             ->all();
 

--- a/tests/Auth/FileUserTest.php
+++ b/tests/Auth/FileUserTest.php
@@ -9,7 +9,9 @@ use Statamic\Auth\File\User;
 use Statamic\Contracts\Auth\Role as RoleContract;
 use Statamic\Contracts\Auth\UserGroup as UserGroupContract;
 use Statamic\Facades\Role;
+use Statamic\Facades\Role as RoleAPI;
 use Statamic\Facades\UserGroup;
+use Statamic\Facades\UserGroup as UserGroupAPI;
 use Statamic\Support\Arr;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -122,5 +124,48 @@ class FileUserTest extends TestCase
 
         // Doing it a second time should give the same result but without multiple calls.
         $this->assertEquals($expectedPermissions, $user->permissions()->all());
+    }
+
+    #[Test]
+    public function it_prevents_saving_duplicate_roles()
+    {
+        $roleA = (new \Statamic\Auth\File\Role)->handle('a');
+        $roleB = (new \Statamic\Auth\File\Role)->handle('b');
+        $roleC = (new \Statamic\Auth\File\Role)->handle('c');
+
+        RoleAPI::shouldReceive('find')->with('a')->andReturn($roleA);
+        RoleAPI::shouldReceive('find')->with('b')->andReturn($roleB);
+        RoleAPI::shouldReceive('find')->with('c')->andReturn($roleC);
+        RoleAPI::shouldReceive('all')->andReturn(collect([$roleA, $roleB])); // the stache calls this when getting a user. unrelated to test.
+
+        $user = $this->createPermissible();
+        $user->assignRole('a');
+
+        $this->assertEquals(['a'], $user->get('roles'));
+
+        $user->assignRole(['a', 'b', 'c']);
+
+        $this->assertEquals(['a', 'b', 'c'], $user->get('roles'));
+    }
+
+    #[Test]
+    public function it_prevents_saving_duplicate_groups()
+    {
+        $groupA = (new \Statamic\Auth\File\UserGroup)->handle('a');
+        $groupB = (new \Statamic\Auth\File\UserGroup)->handle('b');
+        $groupC = (new \Statamic\Auth\File\UserGroup)->handle('c');
+
+        UserGroupAPI::shouldReceive('find')->with('a')->andReturn($groupA);
+        UserGroupAPI::shouldReceive('find')->with('b')->andReturn($groupB);
+        UserGroupAPI::shouldReceive('find')->with('c')->andReturn($groupC);
+
+        $user = $this->createPermissible();
+        $user->addToGroup('a');
+
+        $this->assertEquals(['a'], $user->get('groups'));
+
+        $user->addToGroup(['a', 'b', 'c']);
+
+        $this->assertEquals(['a', 'b', 'c'], $user->get('groups'));
     }
 }

--- a/tests/Auth/PermissibleContractTests.php
+++ b/tests/Auth/PermissibleContractTests.php
@@ -82,51 +82,6 @@ trait PermissibleContractTests
     }
 
     #[Test]
-    public function it_prevents_duplicate_roles_being_assigned()
-    {
-        // Prevent the anonymous role classes throwing errors when getting serialized
-        // during event handling unrelated to this test.
-        Event::fake();
-
-        $roleA = new class extends Role
-        {
-            public function handle(?string $handle = null)
-            {
-                return 'a';
-            }
-        };
-        $roleB = new class extends Role
-        {
-            public function handle(?string $handle = null)
-            {
-                return 'b';
-            }
-        };
-        $roleC = new class extends Role
-        {
-            public function handle(?string $handle = null)
-            {
-                return 'c';
-            }
-        };
-
-        RoleAPI::shouldReceive('find')->with('a')->andReturn($roleA);
-        RoleAPI::shouldReceive('find')->with('b')->andReturn($roleB);
-        RoleAPI::shouldReceive('find')->with('c')->andReturn($roleC);
-        RoleAPI::shouldReceive('all')->andReturn(collect([$roleA, $roleB])); // the stache calls this when getting a user. unrelated to test.
-
-        $user = $this->createPermissible();
-        $user->assignRole('a');
-        $user->save();
-
-        $this->assertEquals(['a'], $user->get('roles'));
-
-        $user->assignRole(['a', 'b', 'c']);
-
-        $this->assertEquals(['a', 'b', 'c'], $user->get('roles'));
-    }
-
-    #[Test]
     public function it_removes_a_role_assignment()
     {
         // Prevent the anonymous role classes throwing errors when getting serialized
@@ -387,31 +342,6 @@ trait PermissibleContractTests
         $this->assertTrue($user->isInGroup($groupA));
         $this->assertFalse($user->isInGroup($groupB));
         $this->assertTrue($user->isInGroup($groupC));
-    }
-
-    #[Test]
-    public function it_prevents_adding_duplicate_groups_to_a_user()
-    {
-        $groupA = (new UserGroup)->handle('a');
-        $groupB = (new UserGroup)->handle('b');
-        $groupC = (new UserGroup)->handle('c');
-        $user = $this->createPermissible();
-
-        $this->assertFalse($user->isInGroup($groupA));
-        $this->assertFalse($user->isInGroup($groupB));
-        $this->assertFalse($user->isInGroup($groupC));
-
-        UserGroupAPI::shouldReceive('find')->with('a')->andReturn($groupA);
-        UserGroupAPI::shouldReceive('find')->with('b')->andReturn($groupB);
-        UserGroupAPI::shouldReceive('find')->with('c')->andReturn($groupC);
-
-        $user->addToGroup('a');
-
-        $this->assertEquals(['a'], $user->get('groups'));
-
-        $user->addToGroup(['a', 'b', 'c']);
-
-        $this->assertEquals(['a', 'b', 'c'], $user->get('groups'));
     }
 
     #[Test]

--- a/tests/Auth/PermissibleContractTests.php
+++ b/tests/Auth/PermissibleContractTests.php
@@ -82,6 +82,51 @@ trait PermissibleContractTests
     }
 
     #[Test]
+    public function it_prevents_duplicate_roles_being_assigned()
+    {
+        // Prevent the anonymous role classes throwing errors when getting serialized
+        // during event handling unrelated to this test.
+        Event::fake();
+
+        $roleA = new class extends Role
+        {
+            public function handle(?string $handle = null)
+            {
+                return 'a';
+            }
+        };
+        $roleB = new class extends Role
+        {
+            public function handle(?string $handle = null)
+            {
+                return 'b';
+            }
+        };
+        $roleC = new class extends Role
+        {
+            public function handle(?string $handle = null)
+            {
+                return 'c';
+            }
+        };
+
+        RoleAPI::shouldReceive('find')->with('a')->andReturn($roleA);
+        RoleAPI::shouldReceive('find')->with('b')->andReturn($roleB);
+        RoleAPI::shouldReceive('find')->with('c')->andReturn($roleC);
+        RoleAPI::shouldReceive('all')->andReturn(collect([$roleA, $roleB])); // the stache calls this when getting a user. unrelated to test.
+
+        $user = $this->createPermissible();
+        $user->assignRole('a');
+        $user->save();
+
+        $this->assertEquals(['a'], $user->get('roles'));
+
+        $user->assignRole(['a', 'b', 'c']);
+
+        $this->assertEquals(['a', 'b', 'c'], $user->get('roles'));
+    }
+
+    #[Test]
     public function it_removes_a_role_assignment()
     {
         // Prevent the anonymous role classes throwing errors when getting serialized
@@ -342,6 +387,31 @@ trait PermissibleContractTests
         $this->assertTrue($user->isInGroup($groupA));
         $this->assertFalse($user->isInGroup($groupB));
         $this->assertTrue($user->isInGroup($groupC));
+    }
+
+    #[Test]
+    public function it_prevents_adding_duplicate_groups_to_a_user()
+    {
+        $groupA = (new UserGroup)->handle('a');
+        $groupB = (new UserGroup)->handle('b');
+        $groupC = (new UserGroup)->handle('c');
+        $user = $this->createPermissible();
+
+        $this->assertFalse($user->isInGroup($groupA));
+        $this->assertFalse($user->isInGroup($groupB));
+        $this->assertFalse($user->isInGroup($groupC));
+
+        UserGroupAPI::shouldReceive('find')->with('a')->andReturn($groupA);
+        UserGroupAPI::shouldReceive('find')->with('b')->andReturn($groupB);
+        UserGroupAPI::shouldReceive('find')->with('c')->andReturn($groupC);
+
+        $user->addToGroup('a');
+
+        $this->assertEquals(['a'], $user->get('groups'));
+
+        $user->addToGroup(['a', 'b', 'c']);
+
+        $this->assertEquals(['a', 'b', 'c'], $user->get('groups'));
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where it was possible to end up with duplicate roles/groups on flat-file users. It doesn't look like this issue affects database-driven users.

Fixes #11256.