### PR TITLE
[5.x] Handle hidden fields on nav page edit form

### DIFF
--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -74,7 +74,13 @@
 </template>
 
 <script>
+import HasHiddenFields from "../publish/HasHiddenFields";
+
 export default {
+
+    mixins: [
+        HasHiddenFields,
+    ],
 
     props: {
         id: String,
@@ -186,9 +192,9 @@ export default {
 
             this.$axios.post(postUrl, {
                 type: this.type,
-                values: this.values
+                values: this.visibleValues
             }).then(response => {
-                this.$emit('submitted', this.values);
+                this.$emit('submitted', this.visibleValues);
             }).catch(e => {
                 this.validating = false;
                 if (e.response && e.response.status === 422) {

--- a/src/Http/Controllers/CP/Navigation/NavigationTreeController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationTreeController.php
@@ -66,7 +66,8 @@ class NavigationTreeController extends CpController
                 ->addValues($branch['values'] ?? [])
                 ->process()
                 ->values()
-                ->only($branch['localizedFields'] ?? []);
+                ->only($branch['localizedFields'] ?? [])
+                ->filter();
 
             if ($branch['new'] ?? false) {
                 $newId = BranchIdGenerator::generate();

--- a/src/Http/Controllers/CP/Navigation/NavigationTreeController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationTreeController.php
@@ -66,8 +66,7 @@ class NavigationTreeController extends CpController
                 ->addValues($branch['values'] ?? [])
                 ->process()
                 ->values()
-                ->only($branch['localizedFields'] ?? [])
-                ->filter();
+                ->only($branch['localizedFields'] ?? []);
 
             if ($branch['new'] ?? false) {
                 $newId = BranchIdGenerator::generate();


### PR DESCRIPTION
This pull request fixes an issue where hidden fields on nav pages were being persisted, even when `always_save` was `false`.

This was addressed in #5101 for the other publish forms (entries / terms / etc), so I've just implemented the `HasHiddenFields` mixin introduced in that PR.

Fixes #11249.