### PR TITLE
[5.x] Static warm: recheck whether page is cached for queued requests

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -94,8 +94,12 @@ class StaticWarm extends Command
             $queue = config('statamic.static_caching.warm_queue');
             $this->line(sprintf('Adding %s requests onto %squeue...', count($requests), $queue ? $queue.' ' : ''));
 
+            $jobClass = $this->option('uncached')
+                ? StaticWarmUncachedJob::class
+                : StaticWarmJob::class;
+
             foreach ($requests as $request) {
-                StaticWarmJob::dispatch($request, $this->clientConfig())
+                $jobClass::dispatch($request, $this->clientConfig())
                     ->onConnection($this->queueConnection)
                     ->onQueue($queue);
             }

--- a/src/Console/Commands/StaticWarmUncachedJob.php
+++ b/src/Console/Commands/StaticWarmUncachedJob.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Statamic\Console\Commands;
+
+use Illuminate\Http\Request;
+use Statamic\StaticCaching\Cacher;
+
+class StaticWarmUncachedJob extends StaticWarmJob
+{
+    public function handle()
+    {
+        $cacher = app(Cacher::class);
+
+        if ($cacher->hasCachedPage(Request::create($this->request->getUri()))) {
+            return;
+        }
+
+        parent::handle();
+    }
+}

--- a/tests/Console/Commands/StaticWarmUncachedJobTest.php
+++ b/tests/Console/Commands/StaticWarmUncachedJobTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Console\Commands;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Console\Commands\StaticWarmUncachedJob;
+use Statamic\StaticCaching\Cacher;
+use Tests\TestCase;
+
+class StaticWarmUncachedJobTest extends TestCase
+{
+    #[Test]
+    public function it_sends_a_get_request()
+    {
+        $mock = new MockHandler([
+            new Response(200),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+
+        $job = new StaticWarmUncachedJob(new Request('GET', '/about'), ['handler' => $handlerStack]);
+
+        $job->handle();
+
+        $this->assertEquals('/about', $mock->getLastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function it_does_not_send_a_request_if_the_page_is_cached()
+    {
+        $mockCacher = Mockery::mock(Cacher::class);
+        $mockCacher->shouldReceive('hasCachedPage')->once()->andReturn(true);
+        $mockCacher->allows('isExcluded')->andReturn(false);
+        app()->instance(Cacher::class, $mockCacher);
+
+        $mock = new MockHandler([
+            new Response(200),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+
+        $job = new StaticWarmUncachedJob(new Request('GET', '/about'), ['handler' => $handlerStack]);
+
+        $job->handle();
+
+        $this->assertNull($mock->getLastRequest());
+    }
+}


### PR DESCRIPTION
When using both the `--queue` and `--uncached` parameters:

By the time a queued job gets executed, the page was possibly already cached in the meantime. The dedicated `StaticWarmUncachedJob` checks again if the page is cached, and if so, it won't send the request.