### PR TITLE
[5.x] Add formStackSize option for inline publish form stacks

### DIFF
--- a/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
+++ b/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
@@ -19,6 +19,7 @@
         :creatables="creatables"
         :form-component="formComponent"
         :form-component-props="formComponentProps"
+        :form-stack-size="formStackSize"
         :status-icons="statusIcons"
         :columns="columns"
         :search="canSearch"
@@ -129,6 +130,10 @@ export default {
 
         formComponentProps() {
             return this.meta.formComponentProps;
+        },
+
+        formStackSize() {
+            return this.meta.formStackSize;
         },
 
         taggable() {

--- a/resources/js/components/inputs/relationship/CreateButton.vue
+++ b/resources/js/components/inputs/relationship/CreateButton.vue
@@ -26,6 +26,7 @@
             :item-url="creatable.url"
             :component="component"
             :component-props="componentProps"
+            :stack-size="stackSize"
             @created="itemCreated"
             @closed="stopCreating"
         />
@@ -47,6 +48,7 @@ export default {
         creatables: Array,
         component: String,
         componentProps: Object,
+        stackSize: String,
     },
 
     data() {

--- a/resources/js/components/inputs/relationship/InlinePublishForm.vue
+++ b/resources/js/components/inputs/relationship/InlinePublishForm.vue
@@ -3,6 +3,9 @@
     <div>
     <stack name="inline-editor"
         :before-close="shouldClose"
+        :narrow="stackSize === 'narrow'"
+        :half="stackSize === 'half'"
+        :full="stackSize === 'full'"
         @closed="close"
     >
     <div class="h-full overflow-scroll overflow-x-auto p-6 bg-gray-300 dark:bg-dark-800">
@@ -44,6 +47,7 @@ export default {
     props: {
         component: String,
         componentProps: Object,
+        stackSize: String,
     },
 
     data() {

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -22,6 +22,7 @@
                 :item="item"
                 :component="formComponent"
                 :component-props="formComponentProps"
+                :stack-size="formStackSize"
                 @updated="itemUpdated"
                 @closed="isEditing = false"
             />
@@ -67,6 +68,7 @@ export default {
         readOnly: Boolean,
         formComponent: String,
         formComponentProps: Object,
+        formStackSize: String,
     },
 
     data() {

--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -33,6 +33,7 @@
                     :read-only="readOnly"
                     :form-component="formComponent"
                     :form-component-props="formComponentProps"
+                    :form-stack-size="formStackSize"
                     class="item outline-none"
                     @removed="remove(i)"
                 />
@@ -51,6 +52,7 @@
                             :site="site"
                             :component="formComponent"
                             :component-props="formComponentProps"
+                            :stack-size="formStackSize"
                             @created="itemCreated"
                         />
                     </div>
@@ -122,6 +124,7 @@ export default {
         creatables: Array,
         formComponent: String,
         formComponentProps: Object,
+        formStackSize: String,
         mode: {
             type: String,
             default: 'default',

--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -26,6 +26,7 @@ abstract class Relationship extends Fieldtype
     protected $formComponentProps = [
         '_' => '_', // forces an object in js
     ];
+    protected $formStackSize;
 
     protected function configFieldItems(): array
     {
@@ -133,6 +134,7 @@ abstract class Relationship extends Fieldtype
             'creatables' => $this->canCreate() ? $this->getCreatables() : [],
             'formComponent' => $this->getFormComponent(),
             'formComponentProps' => $this->getFormComponentProps(),
+            'formStackSize' => $this->getFormStackSize(),
             'taggable' => $this->getTaggable(),
             'initialSortColumn' => $this->initialSortColumn(),
             'initialSortDirection' => $this->initialSortDirection(),
@@ -180,6 +182,11 @@ abstract class Relationship extends Fieldtype
     protected function getFormComponentProps()
     {
         return $this->formComponentProps;
+    }
+
+    protected function getFormStackSize()
+    {
+        return $this->formStackSize;
     }
 
     protected function getColumns()


### PR DESCRIPTION
This pull request adds a `$formStackSize` property to the `Relationship` fieldtype class, allowing developers to customize the size of the stack the inline publish form gets rendered in.

The property accepts three values: `narrow`, `half` and `full`.

```php
protected $formStackSize = 'narrow';
```

## Use case

In my Simple Commerce addon, I have a relationship fieldtype with a single field. It doesn't make sense to take up 3/4ths of the screen with a stack with one input, so it would be nice to use the `narrow` option in this case.