### PR TITLE
[5.x] Add `--max-requests` option to the static warm command

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -41,6 +41,7 @@ class StaticWarm extends Command
         {--max-depth= : Maximum depth of URLs to warm}
         {--include= : Only warm specific URLs}
         {--exclude= : Exclude specific URLs}
+        {--max-requests= : Maximum number of requests to warm}
     ';
 
     protected $description = 'Warms the static cache by visiting all URLs';
@@ -175,7 +176,7 @@ class StaticWarm extends Command
 
         $cacher = app(StaticCacher::class);
 
-        return $this->uris = collect()
+        $this->uris = collect()
             ->merge($this->entryUris())
             ->merge($this->taxonomyUris())
             ->merge($this->termUris())
@@ -196,6 +197,12 @@ class StaticWarm extends Command
             })
             ->sort()
             ->values();
+
+        if ($max = $this->option('max-requests')) {
+            $this->uris = $this->uris->take($max);
+        }
+
+        return $this->uris;
     }
 
     private function shouldInclude($uri): bool

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -176,7 +176,7 @@ class StaticWarm extends Command
 
         $cacher = app(StaticCacher::class);
 
-        $this->uris = collect()
+        return $this->uris = collect()
             ->merge($this->entryUris())
             ->merge($this->taxonomyUris())
             ->merge($this->termUris())
@@ -196,13 +196,8 @@ class StaticWarm extends Command
                 return $cacher->isExcluded($uri);
             })
             ->sort()
-            ->values();
-
-        if ($max = $this->option('max-requests')) {
-            $this->uris = $this->uris->take($max);
-        }
-
-        return $this->uris;
+            ->values()
+            ->when($this->option('max-requests'), fn ($uris, $max) => $uris->take($max));
     }
 
     private function shouldInclude($uri): bool

--- a/tests/Console/Commands/StaticWarmTest.php
+++ b/tests/Console/Commands/StaticWarmTest.php
@@ -142,6 +142,16 @@ class StaticWarmTest extends TestCase
     }
 
     #[Test]
+    public function it_limits_the_number_of_requests_when_max_requests_is_set()
+    {
+        config(['statamic.static_caching.strategy' => 'half']);
+
+        $this->artisan('statamic:static:warm', ['--max-requests' => 1])
+            ->expectsOutput('Visiting 1 URLs...')
+            ->assertExitCode(0);
+    }
+
+    #[Test]
     public function it_doesnt_queue_the_requests_when_connection_is_set_to_sync()
     {
         config(['statamic.static_caching.strategy' => 'half']);


### PR DESCRIPTION
Still working on keeping the static cache warm and the CPU cool.

This one adds a `--max-requests` option.  It limits the number of requests. Probably makes most sense in combination with the `--uncached` option. 

Using this option, you can warm the cache in smaller batches.