### PR TITLE
[5.x] Fix CP thumbnail placeholder

### DIFF
--- a/src/Http/Controllers/CP/Assets/ThumbnailController.php
+++ b/src/Http/Controllers/CP/Assets/ThumbnailController.php
@@ -174,7 +174,7 @@ class ThumbnailController extends Controller
     /**
      * If an image is deemed too large for thumbnail generation, we'll give it a placeholder icon.
      *
-     * @return \Illuminate\Http\RedirectResponse|null
+     * @return \Illuminate\Http\Response
      */
     private function getPlaceholderResponse()
     {
@@ -185,6 +185,6 @@ class ThumbnailController extends Controller
             return;
         }
 
-        return redirect(Statamic::cpAssetUrl('svg/filetypes/picture.svg'));
+        return response(Statamic::svg('filetypes/picture'))->header('Content-Type', 'image/svg+xml');
     }
 }


### PR DESCRIPTION
This pull request fixes an issue with the placeholder thumbnail images displayed when an image's dimentions are larger than the configured limits.

The `ThumbnailController` was redirecting to a file that doesn't exist in the `public/vendor/statamic/cp` directory. 

This file used to exist when we were using Laravel Mix, but when we switched to Vite in 4.0 (), the `dist.tar.zip` files we ship with Statamic releases stopped including SVGs.

This PR fixes the issue by returning the contents of the SVG directly from our controller, rather than redirecting to another URL.

Fixes #11228.