### PR TITLE
[5.x] Fix replicator preview for Group fields

### DIFF
--- a/resources/js/components/fieldtypes/GroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/GroupFieldtype.vue
@@ -91,7 +91,7 @@ export default {
         replicatorPreview() {
             if (! this.showFieldPreviews || ! this.config.replicator_preview) return;
 
-            return this.previewText;
+            return replicatorPreviewHtml(this.previewText);
         },
         internalFieldActions() {
             return [


### PR DESCRIPTION
This pull request fixes replicator previews for the Group fieldtype. It was previously joining all items into a string, which didn't work for fieldtypes which store values as arrays (like Bard), resulting in output like this:

![image](https://github.com/user-attachments/assets/f6a49b62-f189-42f7-bf9e-ea22c70a0a86)

This PR fixes that by mirroring how Replicator sets collect the emitted previews from fields and passes them along to the `ManagesPreviewText` mixin to do it's work.

Fixes #11235.