### PR TITLE
[5.x] Improve starter kit installer error handling

### DIFF
--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -631,14 +631,14 @@ EOT;
      */
     public function rollbackWithError(string $error, ?string $output = null): void
     {
+        if ($output) {
+            $this->console->line($this->tidyComposerErrorOutput($output));
+        }
+
         $this
             ->removeStarterKit()
             ->restoreComposerJson()
             ->removeComposerJsonBackup();
-
-        if ($output) {
-            $this->console->line($this->tidyComposerErrorOutput($output));
-        }
 
         throw new StarterKitException($error);
     }


### PR DESCRIPTION
If github oauth fails, then this error output never shows, because `removeStarterKit()` ends up erroring.

This PR just moves error output to the start of `rollbackWithError()`, to ensure it always outputs nicely, no matter what.

For example, https://github.com/studio1902/statamic-peak/issues/408 had an installation issue related to github oauth, but this wasn't obvious. Now the user should see this...

```
Composer could not authenticate with GitHub!
Please generate a personal access token at: https://github.com/settings/tokens/new
```