### PR TITLE
[5.x] Fix autoload error on Windows

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -17,6 +17,7 @@ use Statamic\Extend\Manifest;
 use Statamic\Facades\Addon;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Fieldset;
+use Statamic\Facades\Path;
 use Statamic\Fields\Fieldtype;
 use Statamic\Forms\JsDrivers\JsDriver;
 use Statamic\Modifiers\Modifier;
@@ -860,6 +861,9 @@ abstract class AddonServiceProvider extends ServiceProvider
         // i.e. It's the "root" provider. If it's in a subdirectory maybe the developer
         // is organizing their providers. Things like tags etc. can be autoloaded but
         // root level things like routes, views, config, blueprints, etc. will not.
-        return dirname((new \ReflectionClass(static::class))->getFileName()) === $addon->directory().$addon->autoload();
+        $thisDir = Path::tidy(dirname((new \ReflectionClass(static::class))->getFileName()));
+        $autoloadDir = $addon->directory().$addon->autoload();
+
+        return $thisDir === $autoloadDir;
     }
 }


### PR DESCRIPTION
Fixes #11277
Caused by #11128
Related: https://github.com/studio1902/statamic-peak/issues/408

Root level items weren't being loaded on addons on Windows due to the directory check added in #11128.
The directory separators were different. e.g. It was comparing `C:\foo\bar` and `C:/foo/bar`.

This PR uses `Path::tidy()` to normalize the slashes in the reflected path. The `$addon->directory()` and `->autoload()` methods are already normalized.
