### PR TITLE
[5.x] Fix static properties in addon providers

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -105,6 +105,9 @@ class AppServiceProvider extends ServiceProvider
         $this->addAboutCommandInfo();
 
         $this->app->make(Schedule::class)->job(new HandleEntrySchedule)->everyMinute();
+
+        $this->app->instance('statamic.booted-addons', collect());
+        $this->app->instance('statamic.autoloaded-addon-classes', collect());
     }
 
     public function register()


### PR DESCRIPTION
Some addon's tests started failing due to the static property usage introduced in #11128.

The `shouldBootRootItems` would return false when it checked if the addon was already booted on subsequent tests, since within a test suite static properties stick around.

Technically you'd see the same issue in the browser if you were using Octane. For regular browser usage, there was no issue.

This PR fixes it by using collections resolved out of the container. They get shared across addons, but only for that lifecycle.
