### PR TITLE
[5.x] Fix addon service provider autoloading

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -105,9 +105,6 @@ class AppServiceProvider extends ServiceProvider
         $this->addAboutCommandInfo();
 
         $this->app->make(Schedule::class)->job(new HandleEntrySchedule)->everyMinute();
-
-        $this->app->instance('statamic.booted-addons', collect());
-        $this->app->instance('statamic.autoloaded-addon-classes', collect());
     }
 
     public function register()


### PR DESCRIPTION
Fixes #11284

Service providers that come before `statamic` alphabetically were trying to access a binding that wasn't bound yet, which caused the error.

This PR changes to methods that will lazily bind the collections.
