### PR TITLE
[5.x] Improve error handling when using entry publish actions

### DIFF
--- a/resources/js/components/entries/PublishActions.vue
+++ b/resources/js/components/entries/PublishActions.vue
@@ -216,8 +216,17 @@ export default {
         },
 
         handleAxiosError(e) {
-            this.saving = false;
-            this.$toast.error(e || __('Something went wrong'));
+            if (e.response && e.response.status === 422) {
+                const { message, errors } = e.response.data;
+                this.error = message;
+                this.errors = errors;
+                this.$toast.error(message);
+                this.$reveal.invalid();
+            } else if (e.response) {
+                this.$toast.error(e.response.data.message);
+            } else {
+                this.$toast.error(e || 'Something went wrong');
+            }
         }
 
     }

--- a/resources/js/components/entries/PublishActions.vue
+++ b/resources/js/components/entries/PublishActions.vue
@@ -227,6 +227,8 @@ export default {
             } else {
                 this.$toast.error(e || 'Something went wrong');
             }
+
+            this.saving = false;
         }
 
     }

--- a/resources/js/components/entries/PublishActions.vue
+++ b/resources/js/components/entries/PublishActions.vue
@@ -229,8 +229,7 @@ export default {
             }
 
             this.saving = false;
-
-            this.$progress.complete()
+            this.$emit('failed');
         }
 
     }

--- a/resources/js/components/entries/PublishActions.vue
+++ b/resources/js/components/entries/PublishActions.vue
@@ -229,6 +229,8 @@ export default {
             }
 
             this.saving = false;
+
+            this.$progress.complete()
         }
 
     }


### PR DESCRIPTION
When firing an exception in a EntrySaving event (to create a toast) I noticed that PublishActions don't handle response the same way as PublishForms.

This PR brings the code inline - literally copy/pasting.

Guided by @duncanmcclean 