### PR TITLE
[5.x] Add url friendly base64 en-/decoding for Glide

### DIFF
--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -73,7 +73,7 @@ class GlideController extends Controller
     {
         $this->validateSignature();
 
-        $url = base64_decode($url);
+        $url = Str::fromBase64Url($url);
 
         return $this->createResponse($this->generateBy('url', $url));
     }
@@ -90,7 +90,7 @@ class GlideController extends Controller
     {
         $this->validateSignature();
 
-        $decoded = base64_decode($encoded);
+        $decoded = Str::fromBase64Url($encoded);
 
         // The string before the first slash is the container
         [$container, $path] = explode('/', $decoded, 2);

--- a/src/Imaging/GlideUrlBuilder.php
+++ b/src/Imaging/GlideUrlBuilder.php
@@ -36,15 +36,15 @@ class GlideUrlBuilder extends ImageUrlBuilder
 
         switch ($this->itemType()) {
             case 'url':
-                $path = 'http/'.base64_encode($item);
+                $path = 'http/'.Str::toBase64Url($item);
                 $filename = Str::afterLast($item, '/');
                 break;
             case 'asset':
-                $path = 'asset/'.base64_encode($this->item->containerId().'/'.$this->item->path());
+                $path = 'asset/'.Str::toBase64Url($this->item->containerId().'/'.$this->item->path());
                 $filename = Str::afterLast($this->item->path(), '/');
                 break;
             case 'id':
-                $path = 'asset/'.base64_encode(str_replace('::', '/', $this->item));
+                $path = 'asset/'.Str::toBase64Url(str_replace('::', '/', $this->item));
                 break;
             case 'path':
                 $path = URL::encode($this->item);
@@ -61,7 +61,7 @@ class GlideUrlBuilder extends ImageUrlBuilder
 
         if (isset($params['mark']) && $params['mark'] instanceof Asset) {
             $asset = $params['mark'];
-            $params['mark'] = 'asset::'.base64_encode($asset->containerId().'/'.$asset->path());
+            $params['mark'] = 'asset::'.Str::toBase64Url($asset->containerId().'/'.$asset->path());
         }
 
         return URL::prependSiteRoot($builder->getUrl($path, $params));

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -199,7 +199,7 @@ class ImageGenerator
     private function getWatermarkFilesystemAndParam($item)
     {
         if (is_string($item) && Str::startsWith($item, 'asset::')) {
-            $decoded = base64_decode(Str::after($item, 'asset::'));
+            $decoded = Str::fromBase64Url(Str::after($item, 'asset::'));
             [$container, $path] = explode('/', $decoded, 2);
             $item = Assets::find($container.'::'.$path);
         }

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -298,6 +298,16 @@ class Str
         return IlluminateStr::finish($string, $cap);
     }
 
+    public static function toBase64Url($url): string
+    {
+        return rtrim(strtr(base64_encode($url), '+/', '-_'), '=');
+    }
+
+    public static function fromBase64Url($url, $strict = false)
+    {
+        return base64_decode(strtr($url, '-_', '+/'), $strict);
+    }
+
     /**
      * Implicitly defer all other method calls to either \Stringy\StaticStringy or \Illuminate\Support\Str.
      *

--- a/tests/Imaging/GlideUrlBuilderTest.php
+++ b/tests/Imaging/GlideUrlBuilderTest.php
@@ -5,6 +5,7 @@ namespace Tests\Imaging;
 use Statamic\Assets\Asset;
 use Statamic\Assets\AssetContainer;
 use Statamic\Imaging\GlideUrlBuilder;
+use Statamic\Support\Str;
 use Tests\TestCase;
 
 class GlideUrlBuilderTest extends TestCase
@@ -54,7 +55,7 @@ class GlideUrlBuilderTest extends TestCase
         $asset->container((new AssetContainer)->handle('main'));
         $asset->path('img/foo.jpg');
 
-        $encoded = base64_encode('main/img/foo.jpg');
+        $encoded = Str::toBase64Url('main/img/foo.jpg');
 
         $this->assertEquals(
             "/img/asset/$encoded/foo.jpg?w=100",
@@ -64,7 +65,7 @@ class GlideUrlBuilderTest extends TestCase
 
     public function testId()
     {
-        $encoded = base64_encode('main/img/foo.jpg');
+        $encoded = Str::toBase64Url('main/img/foo.jpg');
 
         $this->assertEquals(
             "/img/asset/$encoded?w=100",
@@ -78,7 +79,7 @@ class GlideUrlBuilderTest extends TestCase
         $asset->container((new AssetContainer)->handle('main'));
         $asset->path('img/foo.jpg');
 
-        $encoded = base64_encode('main/img/foo.jpg');
+        $encoded = Str::toBase64Url('main/img/foo.jpg');
 
         $this->assertEquals(
             "/img/asset/$encoded/foo.jpg?w=100",
@@ -92,7 +93,7 @@ class GlideUrlBuilderTest extends TestCase
         $asset->container((new AssetContainer)->handle('main'));
         $asset->path('img/foo.jpg');
 
-        $encoded = rawurlencode(base64_encode('main/img/foo.jpg'));
+        $encoded = rawurlencode(Str::toBase64Url('main/img/foo.jpg'));
 
         $this->assertEquals(
             "/img/foo.jpg?w=100&mark=asset%3A%3A$encoded",


### PR DESCRIPTION
This PR implements the two custom implementations (mentioned [here](https://github.com/statamic/cms/issues/11176#issuecomment-2503190882)) for `base64_encode` and `base64_decode` in Glide. Sometimes the internal `base64_encode` produced URLs with undesired slashes, which then broke the routing for Glide.

Fixes: https://github.com/statamic/cms/issues/11176