### PR TITLE
[5.x] Update MakeFieldtype.php console message

### DIFF
--- a/src/Console/Commands/MakeFieldtype.php
+++ b/src/Console/Commands/MakeFieldtype.php
@@ -78,7 +78,7 @@ class MakeFieldtype extends GeneratorCommand
             $this->components->info("Fieldtype Vue component [{$relativePath}] created successfully.");
 
             $this->components->bulletList([
-                "Don't forget to import and register your fieldtype's Vue component in resources/js/addon.js",
+                "Don't forget to import and register your fieldtype's Vue component in resources/js/cp.js",
                 'For more information, see the documentation: <comment>https://statamic.dev/fieldtypes#vue-components</comment>',
             ]);
 


### PR DESCRIPTION
the ```php please make:fieldtype``` command has help text that specifies registering new vue components in addon.js, but the docs specify registering in cp.js.
