### PR TITLE
[5.x] Throw better exception when asset isn't found

### DIFF
--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -161,7 +161,7 @@ class Assets extends Fieldtype
         $max_files = (int) $this->config('max_files');
 
         $values = collect($data)->map(function ($id) {
-            return Asset::find($id)->path();
+            return Asset::findOrFail($id)->path();
         });
 
         return $this->config('max_files') === 1 ? $values->first() : $values->all();


### PR DESCRIPTION
We are getting a ton of `Call to a member function path() on null` and it's coming from this code in `Assets.php`:

```
    public function process($data)
    {
        $max_files = (int) $this->config('max_files');

        $values = collect($data)->map(function ($id) {
            return Asset::find($id)->path();
        });
```

I'd like to know which asset is causing the issue, so let's throw a better exception.