### PR TITLE
Changing Stache index name from collection to collectionHandle

### DIFF
--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -160,7 +160,7 @@ class CollectionEntriesStore extends ChildStore
         $indexes = collect([
             'slug',
             'uri',
-            'collection',
+            'collectionHandle',
             'published',
             'title',
             'site' => Indexes\Site::class,


### PR DESCRIPTION
Fixes #11323

A chain of though here ....

1. Collection filtering in `EntryQueryBuilder.php`:

```php
public function where($column, $operator = null, $value = null, $boolean = 'and')
{
    if ($column === 'collection') {
        $this->collections[] = $operator;
        return $this;
    }
    // ...
}
```

When someone does a collection query `{{ collection:blog }}` (`Entry::query()->where('collection', 'blog')`), the `collection` condition is intercepted and stored in a separate `$collections` property instead of being handled as a normal where clause.

2. Then in the status queries in `EntryQueryBuilder.php`:

```php
protected function addCollectionWhereToStatusQuery($query, $collection): void
{
    // Using collectionHandle instead of collection because we intercept collection
    // and put it on a property. In this case we actually want the indexed value.
    $query->where('collectionHandle', $collection);
}
```

The code explicitly uses 'collectionHandle' because it needs to bypass the interception of 'collection' queries that happens in the where() method.

Seems like we should only have 'collectionHandle' because:
1. It's what's actually used for index-based lookups
2. 'collection' queries get handled through a different mechanism
3. Having both would duplicate data unnecessarily
4. Creating it during Stache::warm() ensures it's available when needed for status queries

I hope Im right here ...