### PR TITLE
[5.x] Fix CMS multi-select values being wrapped in arrays

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -52,7 +52,7 @@ trait HasSelectOptions
     {
         $values = $this->preProcess($value);
 
-        $values = collect(is_array($values) ? $values : [$values]);
+        $values = collect($values)->toArray();
 
         return $values->map(function ($value) {
             return $this->getLabel($value);
@@ -67,7 +67,7 @@ trait HasSelectOptions
             return [];
         }
 
-        $value = is_array($value) ? $value : [$value];
+        $value = collect($value)->toArray();
 
         $values = collect($value)->map(function ($value) {
             return $this->config('cast_booleans') ? $this->castFromBoolean($value) : $value;


### PR DESCRIPTION
Fixes multiple values being treated as a single array of values in a multi-select input, instead of correctly showing each value individually

Fixes #11333.