### PR TITLE
[5.x] Fixed ordering search results by origin value

### DIFF
--- a/src/Data/DataCollection.php
+++ b/src/Data/DataCollection.php
@@ -96,17 +96,19 @@ class DataCollection extends IlluminateCollection
             return $this->normalizeSortableValue($item[$sort] ?? null);
         }
 
-        $method = Str::camel($sort);
-
         if ($item instanceof Result && ! $item instanceof PlainResult) {
             $item = $item->getSearchable() ?? $item;
         }
 
-        $value = (method_exists($item, $method))
-            ? call_user_func([$item, $method])
-            : $item->get($sort);
+        if (method_exists($item, $method = Str::camel($sort))) {
+            return $this->normalizeSortableValue(call_user_func([$item, $method]));
+        }
 
-        return $this->normalizeSortableValue($value);
+        if (method_exists($item, 'value')) {
+            return $this->normalizeSortableValue($item->value($sort));
+        }
+
+        return $this->normalizeSortableValue($item->get($sort));
     }
 
     /**


### PR DESCRIPTION
This pull request fixes an issue when attempting to order search results by an origin value. 

Instead of calling `->get()` on the `$item`, it'll call the `->value()` method if it exists allowing it to fallback to the origin value if it's not set on the localized item. 

Fixes #11314.