### PR TITLE
[5.x] Update error indexes when sets/rows are removed

### DIFF
--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -155,6 +155,10 @@ export default {
             ];
         },
 
+        storeState() {
+            return this.$store.state.publish[this.storeName] || {};
+        },
+
     },
 
     watch: {
@@ -206,6 +210,30 @@ export default {
 
         removed(index) {
             if (! confirm(__('Are you sure?'))) return;
+
+            let errors = this.storeState.errors || {};
+
+            errors = Object.keys(errors).reduce((acc, key) => {
+                if (key.startsWith(`${this.fieldPathPrefix || this.handle}.${index}.`)) {
+                    return acc;
+                }
+
+                if (key.startsWith(`${this.fieldPathPrefix || this.handle}.`)) {
+                    const parts = key.split('.');
+                    const rowIndex = parseInt(parts[1], 10);
+
+                    if (rowIndex > index) {
+                        parts[1] = (rowIndex - 1).toString();
+                        acc[parts.join('.')] = errors[key];
+                    } else {
+                        acc[key] = errors[key];
+                    }
+                }
+
+                return acc;
+            }, {});
+
+            this.$store.commit(`publish/${this.storeName}/setErrors`, errors);
 
             this.update([
                 ...this.value.slice(0, index),

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -194,6 +194,30 @@ export default {
         },
 
         removed(set, index) {
+            let errors = this.storeState.errors || {};
+
+            errors = Object.keys(errors).reduce((acc, key) => {
+                if (key.startsWith(`${this.fieldPathPrefix || this.handle}.${index}.`)) {
+                    return acc;
+                }
+
+                if (key.startsWith(`${this.fieldPathPrefix || this.handle}.`)) {
+                    const parts = key.split('.');
+                    const setIndex = parseInt(parts[1], 10);
+
+                    if (setIndex > index) {
+                        parts[1] = (setIndex - 1).toString();
+                        acc[parts.join('.')] = errors[key];
+                    } else {
+                        acc[key] = errors[key];
+                    }
+                }
+
+                return acc;
+            }, {});
+
+            this.$store.commit(`publish/${this.storeName}/setErrors`, errors);
+
             this.removeSetMeta(set._id);
 
             this.update([...this.value.slice(0, index), ...this.value.slice(index + 1)]);


### PR DESCRIPTION
This pull request attempts to fix an issue where errors in Replicator/Grid fields would be displayed on the wrong set/row after a set/row has been removed.

This PR attempts to fix it by updating the indexes in error keys whenever sets/rows are removed.

It's a bit gnarly... I'm not entirely convinced this is the _right_ solution, so let me know if you can think of a better one. 

Fixes #10704.
Fixes #11286.