### PR TITLE
[5.x] User Groups Fieldtype: Group name should be translatable

### DIFF
--- a/src/Fieldtypes/UserGroups.php
+++ b/src/Fieldtypes/UserGroups.php
@@ -17,7 +17,7 @@ class UserGroups extends Relationship
     {
         if ($group = UserGroup::find($id)) {
             return [
-                'title' => $group->title(),
+                'title' => __($group->title()),
                 'id' => $group->handle(),
             ];
         }
@@ -30,7 +30,7 @@ class UserGroups extends Relationship
         return UserGroup::all()->sortBy('title')->map(function ($group) {
             return [
                 'id' => $group->handle(),
-                'title' => $group->title(),
+                'title' => __($group->title()),
             ];
         })->values();
     }


### PR DESCRIPTION
This pull request fixes an issue where the group name wasn't translatable in the user groups fieldtype.