### PR TITLE
[6.x] Return exit code 1 from `static:clear` when static caching is disabled

### DIFF
--- a/src/Console/Commands/StaticClear.php
+++ b/src/Console/Commands/StaticClear.php
@@ -36,7 +36,7 @@ class StaticClear extends Command
         if (! config('statamic.static_caching.strategy')) {
             $this->components->error('Static caching is not enabled.');
 
-            return 0;
+            return 1;
         }
 
         spin(callback: fn () => StaticCache::flush(), message: 'Clearing the static page cache...');


### PR DESCRIPTION
This pull request changes the exit code returned by the `static:clear` command when static caching is disabled. 

We couldn't change it to `1` in #11193 as it might have caused deployments to fail.