### PR TITLE
[6.x] Drop GET method for `field-meta` endpoint

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -253,7 +253,6 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::get('/', [FieldsController::class, 'index'])->name('fields.index');
         Route::post('edit', [FieldsController::class, 'edit'])->name('fields.edit');
         Route::post('update', [FieldsController::class, 'update'])->name('fields.update');
-        Route::get('field-meta', [MetaController::class, 'show']);
         Route::post('field-meta', [MetaController::class, 'show']);
         Route::delete('fieldsets/{fieldset}/reset', [FieldsetController::class, 'reset'])->name('fieldsets.reset');
         Route::resource('fieldsets', FieldsetController::class)->except(['show']);


### PR DESCRIPTION
In #10822, we started using `POST` instead of `GET` for the `field-meta` endpoint so we can push larger field configs than the maximum allowed by many servers.

This PR drops support for the `GET` method to keep things tidy. 
