### PR TITLE
[6.x] Rename Statamic\Ignition namespace to Statamic\ErrorSolutions

### DIFF
--- a/src/ErrorSolutions/SolutionProviders/OAuthDisabled.php
+++ b/src/ErrorSolutions/SolutionProviders/OAuthDisabled.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Statamic\Ignition\SolutionProviders;
+namespace Statamic\ErrorSolutions\SolutionProviders;
 
 use Spatie\ErrorSolutions\Contracts\HasSolutionsForThrowable;
-use Statamic\Ignition\Solutions\EnableOAuth;
+use Statamic\ErrorSolutions\Solutions\EnableOAuth;
 use Throwable;
 
 class OAuthDisabled implements HasSolutionsForThrowable

--- a/src/ErrorSolutions/SolutionProviders/UsingOldClass.php
+++ b/src/ErrorSolutions/SolutionProviders/UsingOldClass.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Statamic\Ignition\SolutionProviders;
+namespace Statamic\ErrorSolutions\SolutionProviders;
 
 use Spatie\ErrorSolutions\Contracts\HasSolutionsForThrowable;
-use Statamic\Ignition\Solutions\UpdateClassReference;
+use Statamic\ErrorSolutions\Solutions\UpdateClassReference;
 use Statamic\Statamic;
 use Statamic\Support\Arr;
 use Throwable;

--- a/src/ErrorSolutions/Solutions/EnableComposerUpdateScripts.php
+++ b/src/ErrorSolutions/Solutions/EnableComposerUpdateScripts.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Statamic\Ignition\Solutions;
+namespace Statamic\ErrorSolutions\Solutions;
 
 use Exception;
 use Facades\Statamic\UpdateScripts\Manager as UpdateScriptManager;

--- a/src/ErrorSolutions/Solutions/EnableOAuth.php
+++ b/src/ErrorSolutions/Solutions/EnableOAuth.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Statamic\Ignition\Solutions;
+namespace Statamic\ErrorSolutions\Solutions;
 
 use Spatie\ErrorSolutions\Contracts\Solution;
 use Statamic\Statamic;

--- a/src/ErrorSolutions/Solutions/EnableStatamicPro.php
+++ b/src/ErrorSolutions/Solutions/EnableStatamicPro.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Statamic\Ignition\Solutions;
+namespace Statamic\ErrorSolutions\Solutions;
 
 use Spatie\ErrorSolutions\Contracts\RunnableSolution;
 use Statamic\Statamic;

--- a/src/ErrorSolutions/Solutions/UpdateClassReference.php
+++ b/src/ErrorSolutions/Solutions/UpdateClassReference.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Statamic\Ignition\Solutions;
+namespace Statamic\ErrorSolutions\Solutions;
 
 use Spatie\ErrorSolutions\Contracts\Solution;
 

--- a/src/ErrorSolutions/Value.php
+++ b/src/ErrorSolutions/Value.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Statamic\Ignition;
+namespace Statamic\ErrorSolutions;
 
 use Statamic\Fields\Value as FieldValue;
 

--- a/src/Exceptions/ComposerJsonMissingPreUpdateCmdException.php
+++ b/src/Exceptions/ComposerJsonMissingPreUpdateCmdException.php
@@ -5,7 +5,7 @@ namespace Statamic\Exceptions;
 use Exception;
 use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\ErrorSolutions\Contracts\Solution;
-use Statamic\Ignition\Solutions\EnableComposerUpdateScripts;
+use Statamic\ErrorSolutions\Solutions\EnableComposerUpdateScripts;
 
 class ComposerJsonMissingPreUpdateCmdException extends Exception implements ProvidesSolution
 {

--- a/src/Exceptions/StatamicProRequiredException.php
+++ b/src/Exceptions/StatamicProRequiredException.php
@@ -5,7 +5,7 @@ namespace Statamic\Exceptions;
 use Exception;
 use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
 use Spatie\ErrorSolutions\Contracts\Solution;
-use Statamic\Ignition\Solutions\EnableStatamicPro;
+use Statamic\ErrorSolutions\Solutions\EnableStatamicPro;
 
 class StatamicProRequiredException extends Exception implements ProvidesSolution
 {

--- a/src/Providers/IgnitionServiceProvider.php
+++ b/src/Providers/IgnitionServiceProvider.php
@@ -5,8 +5,8 @@ namespace Statamic\Providers;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\ServiceProvider;
 use Spatie\ErrorSolutions\Contracts\SolutionProviderRepository;
-use Statamic\Ignition\SolutionProviders\OAuthDisabled;
-use Statamic\Ignition\SolutionProviders\UsingOldClass;
+use Statamic\ErrorSolutions\SolutionProviders\OAuthDisabled;
+use Statamic\ErrorSolutions\SolutionProviders\UsingOldClass;
 
 class IgnitionServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
This pull request renames the `Statamic\Ignition` namespace to `Statamic\ErrorSolutions`, as suggested in #11073.