### PR TITLE
[6.x] Uncomment `validationRules` method in AssetContainer contract

### DIFF
--- a/src/Contracts/Assets/AssetContainer.php
+++ b/src/Contracts/Assets/AssetContainer.php
@@ -108,5 +108,5 @@ interface AssetContainer
      * @param  null|array  $rules
      * @return array
      */
-    // public function validationRules($rules = null);
+    public function validationRules($rules = null);
 }


### PR DESCRIPTION
The `validationRules` method was added in #10227, however, we couldn't add it to the contract in that PR as it would have introduced a breaking change.
