### PR TITLE
[5.x] Carbon 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "league/glide": "^2.3",
         "maennchen/zipstream-php": "^3.1",
         "michelf/php-smartypants": "^1.8.1",
-        "nesbot/carbon": "^2.62.1 || ^3.0",
+        "nesbot/carbon": "^3.0",
         "pixelfear/composer-dist-plugin": "^0.1.4",
         "rebing/graphql-laravel": "^9.7",
         "rhukster/dom-sanitizer": "^1.0.6",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "league/glide": "^2.3",
         "maennchen/zipstream-php": "^3.1",
         "michelf/php-smartypants": "^1.8.1",
-        "nesbot/carbon": "^2.62.1",
+        "nesbot/carbon": "^3.0",
         "pixelfear/composer-dist-plugin": "^0.1.4",
         "rebing/graphql-laravel": "^9.7",
         "rhukster/dom-sanitizer": "^1.0.6",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "league/glide": "^2.3",
         "maennchen/zipstream-php": "^3.1",
         "michelf/php-smartypants": "^1.8.1",
-        "nesbot/carbon": "^3.0",
+        "nesbot/carbon": "^2.62.1 || ^3.0",
         "pixelfear/composer-dist-plugin": "^0.1.4",
         "rebing/graphql-laravel": "^9.7",
         "rhukster/dom-sanitizer": "^1.0.6",

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -589,7 +589,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      */
     public function lastModified()
     {
-        return Carbon::createFromTimestamp($this->meta('last_modified'));
+        return Carbon::createFromTimestamp($this->meta('last_modified'), config('app.timezone'));
     }
 
     /**

--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -116,7 +116,7 @@ class User extends BaseUser
             ? File::disk('users')->lastModified($path)
             : time();
 
-        return Carbon::createFromTimestamp($timestamp);
+        return Carbon::createFromTimestamp($timestamp, config('app.timezone'));
     }
 
     /**
@@ -298,7 +298,7 @@ class User extends BaseUser
     {
         $last_login = $this->getMeta('last_login');
 
-        return $last_login ? Carbon::createFromTimestamp($last_login) : $last_login;
+        return $last_login ? Carbon::createFromTimestamp($last_login, config('app.timezone')) : $last_login;
     }
 
     public function setLastLogin($carbon)

--- a/src/Auth/Passwords/TokenRepository.php
+++ b/src/Auth/Passwords/TokenRepository.php
@@ -70,7 +70,7 @@ class TokenRepository extends DatabaseTokenRepository
         $record = $this->getResets()->get($user->email());
 
         return $record &&
-            ! $this->tokenExpired(Carbon::createFromTimestamp($record['created_at']))
+            ! $this->tokenExpired(Carbon::createFromTimestamp($record['created_at'], config('app.timezone')))
             && $this->hasher->check($token, $record['token']);
     }
 

--- a/src/Data/ExistsAsFile.php
+++ b/src/Data/ExistsAsFile.php
@@ -74,7 +74,7 @@ trait ExistsAsFile
             return Carbon::now();
         }
 
-        return Carbon::createFromTimestamp(File::lastModified($this->path()));
+        return Carbon::createFromTimestamp(File::lastModified($this->path()), config('app.timezone'));
     }
 
     public function fileExtension()

--- a/src/Data/TracksLastModified.php
+++ b/src/Data/TracksLastModified.php
@@ -10,7 +10,7 @@ trait TracksLastModified
     public function lastModified()
     {
         return $this->has('updated_at')
-            ? Carbon::createFromTimestamp($this->get('updated_at'))
+            ? Carbon::createFromTimestamp($this->get('updated_at'), config('app.timezone'))
             : $this->fileLastModified();
     }
 

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -693,7 +693,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
             ->slug($attrs['slug']);
 
         if ($this->collection()->dated() && ($date = Arr::get($attrs, 'date'))) {
-            $entry->date(Carbon::createFromTimestamp($date));
+            $entry->date(Carbon::createFromTimestamp($date, config('app.timezone')));
         }
 
         return $entry;

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -101,7 +101,7 @@ class Submission implements Augmentable, SubmissionContract
      */
     public function date()
     {
-        return Carbon::createFromTimestamp($this->id());
+        return Carbon::createFromTimestamp($this->id(), config('app.timezone'));
     }
 
     /**

--- a/src/Http/Controllers/CP/SessionTimeoutController.php
+++ b/src/Http/Controllers/CP/SessionTimeoutController.php
@@ -13,7 +13,7 @@ class SessionTimeoutController extends CpController
         // remember me would have already been served a 403 error and wouldn't have got this far.
         $lastActivity = session('last_activity', now()->timestamp);
 
-        return Carbon::createFromTimestamp($lastActivity)
+        return Carbon::createFromTimestamp($lastActivity, config('app.timezone'))
             ->addMinutes(config('session.lifetime'))
             ->diffInSeconds();
     }

--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -5,8 +5,10 @@ namespace Statamic\Http\Middleware;
 use Carbon\Carbon;
 use Closure;
 use Illuminate\Support\Facades\Date;
+use ReflectionClass;
 use Statamic\Facades\Site;
 use Statamic\Statamic;
+use Statamic\Support\Arr;
 
 class Localize
 {
@@ -30,9 +32,8 @@ class Localize
 
         // Get original Carbon format so it can be restored later.
         // There's no getter for it, so we'll use reflection.
-        $format = (new \ReflectionClass(Carbon::class))->getProperty('toStringFormat');
-        $format->setAccessible(true);
-        $originalToStringFormat = $format->getValue();
+        $reflection = (new ReflectionClass($date = Date::now()))->getMethod('getFactory');
+        $originalToStringFormat = Arr::get($reflection->invoke($date)->getSettings(), 'toStringFormat');
         Date::setToStringFormat(Statamic::dateFormat());
 
         $response = $next($request);

--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -31,9 +31,7 @@ class Localize
         app()->setLocale($site->lang());
 
         // Get original Carbon format so it can be restored later.
-        // There's no getter for it, so we'll use reflection.
-        $reflection = (new ReflectionClass($date = Date::now()))->getMethod('getFactory');
-        $originalToStringFormat = Arr::get($reflection->invoke($date)->getSettings(), 'toStringFormat');
+        $originalToStringFormat = $this->getToStringFormat();
         Date::setToStringFormat(Statamic::dateFormat());
 
         $response = $next($request);
@@ -45,5 +43,30 @@ class Localize
         Date::setToStringFormat($originalToStringFormat);
 
         return $response;
+    }
+
+    /**
+     * This method is used to get the current toStringFormat for Carbon, in order for us
+     * to restore it later. There's no getter for it, so we need to use reflection.
+     *
+     * @throws \ReflectionException
+     */
+    private function getToStringFormat(): ?string
+    {
+        $reflection = new ReflectionClass($date = Date::now());
+
+        // Carbon 2.x
+        if ($reflection->hasProperty('toStringFormat')) {
+            $format = $reflection->getProperty('toStringFormat');
+            $format->setAccessible(true);
+
+            return $format->getValue();
+        }
+
+        // Carbon 3.x
+        $factory = $reflection->getMethod('getFactory');
+        $factory->setAccessible(true);
+
+        return Arr::get($factory->invoke($date)->getSettings(), 'toStringFormat');
     }
 }

--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -31,10 +31,7 @@ class Localize
         app()->setLocale($site->lang());
 
         // Get original Carbon format so it can be restored later.
-        $reflection = new ReflectionClass($date = Date::now());
-        $factory = $reflection->getMethod('getFactory');
-        $factory->setAccessible(true);
-        $originalToStringFormat = Arr::get($factory->invoke($date)->getSettings(), 'toStringFormat');
+        $originalToStringFormat = $this->getToStringFormat();
         Date::setToStringFormat(Statamic::dateFormat());
 
         $response = $next($request);
@@ -46,5 +43,30 @@ class Localize
         Date::setToStringFormat($originalToStringFormat);
 
         return $response;
+    }
+
+    /**
+     * This method is used to get the current toStringFormat for Carbon, in order for us
+     * to restore it later. There's no getter for it, so we need to use reflection.
+     *
+     * @throws \ReflectionException
+     */
+    private function getToStringFormat(): ?string
+    {
+        $reflection = new ReflectionClass($date = Date::now());
+
+        // Carbon 2.x
+        if ($reflection->hasProperty('toStringFormat')) {
+            $format = $reflection->getProperty('toStringFormat');
+            $format->setAccessible(true);
+
+            return $format->getValue();
+        }
+
+        // Carbon 3.x
+        $factory = $reflection->getMethod('getFactory');
+        $factory->setAccessible(true);
+
+        return Arr::get($factory->invoke($date)->getSettings(), 'toStringFormat');
     }
 }

--- a/src/Licensing/LicenseManager.php
+++ b/src/Licensing/LicenseManager.php
@@ -35,7 +35,7 @@ class LicenseManager
     public function failedRequestRetrySeconds()
     {
         return $this->requestRateLimited()
-            ? (int) Carbon::createFromTimestamp($this->response('expiry'))->diffInSeconds(absolute: true)
+            ? (int) Carbon::createFromTimestamp($this->response('expiry'), config('app.timezone'))->diffInSeconds(absolute: true)
             : null;
     }
 

--- a/src/Licensing/LicenseManager.php
+++ b/src/Licensing/LicenseManager.php
@@ -35,7 +35,7 @@ class LicenseManager
     public function failedRequestRetrySeconds()
     {
         return $this->requestRateLimited()
-            ? Carbon::createFromTimestamp($this->response('expiry'))->diffInSeconds()
+            ? (int) Carbon::createFromTimestamp($this->response('expiry'))->diffInSeconds(absolute: true)
             : null;
     }
 

--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -199,7 +199,7 @@ class Outpost
 
     private function cacheAndReturnRateLimitResponse($e)
     {
-        $seconds = $e->getResponse()->getHeader('Retry-After')[0];
+        $seconds = (int) $e->getResponse()->getHeader('Retry-After')[0];
 
         return $this->cacheResponse(now()->addSeconds($seconds), ['error' => 429]);
     }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1617,7 +1617,7 @@ class CoreModifiers extends Modifier
      */
     public function minutesAgo($value, $params)
     {
-        return $this->carbon($value)->diffInMinutes(Arr::get($params, 0));
+        return (int) $this->carbon($value)->diffInMinutes(Arr::get($params, 0));
     }
 
     /**
@@ -3045,7 +3045,7 @@ class CoreModifiers extends Modifier
      */
     public function yearsAgo($value, $params)
     {
-        return $this->carbon($value)->diffInYears(Arr::get($params, 0));
+        return (int) $this->carbon($value)->diffInYears(Arr::get($params, 0));
     }
 
     /**

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -3210,7 +3210,7 @@ class CoreModifiers extends Modifier
     private function carbon($value)
     {
         if (! $value instanceof Carbon) {
-            $value = (is_numeric($value)) ? Date::createFromTimestamp($value) : Date::parse($value);
+            $value = (is_numeric($value)) ? Date::createFromTimestamp($value, config('app.timezone')) : Date::parse($value);
         }
 
         return $value;

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -546,7 +546,7 @@ class CoreModifiers extends Modifier
      */
     public function daysAgo($value, $params)
     {
-        return $this->carbon($value)->diffInDays(Arr::get($params, 0));
+        return (int) $this->carbon($value)->diffInDays(Arr::get($params, 0));
     }
 
     /**
@@ -1055,7 +1055,7 @@ class CoreModifiers extends Modifier
      */
     public function hoursAgo($value, $params)
     {
-        return $this->carbon($value)->diffInHours(Arr::get($params, 0));
+        return (int) $this->carbon($value)->diffInHours(Arr::get($params, 0));
     }
 
     /**
@@ -1652,7 +1652,7 @@ class CoreModifiers extends Modifier
      */
     public function monthsAgo($value, $params)
     {
-        return $this->carbon($value)->diffInMonths(Arr::get($params, 0));
+        return (int) $this->carbon($value)->diffInMonths(Arr::get($params, 0));
     }
 
     /**
@@ -2234,7 +2234,7 @@ class CoreModifiers extends Modifier
      */
     public function secondsAgo($value, $params)
     {
-        return $this->carbon($value)->diffInSeconds(Arr::get($params, 0));
+        return (int) $this->carbon($value)->diffInSeconds(Arr::get($params, 0));
     }
 
     /**
@@ -2933,7 +2933,7 @@ class CoreModifiers extends Modifier
      */
     public function weeksAgo($value, $params)
     {
-        return $this->carbon($value)->diffInWeeks(Arr::get($params, 0));
+        return (int) $this->carbon($value)->diffInWeeks(Arr::get($params, 0));
     }
 
     /**

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -546,7 +546,7 @@ class CoreModifiers extends Modifier
      */
     public function daysAgo($value, $params)
     {
-        return (int) $this->carbon($value)->diffInDays(Arr::get($params, 0));
+        return (int) abs($this->carbon($value)->diffInDays(Arr::get($params, 0)));
     }
 
     /**
@@ -1055,7 +1055,7 @@ class CoreModifiers extends Modifier
      */
     public function hoursAgo($value, $params)
     {
-        return (int) $this->carbon($value)->diffInHours(Arr::get($params, 0));
+        return (int) abs($this->carbon($value)->diffInHours(Arr::get($params, 0)));
     }
 
     /**
@@ -1617,7 +1617,7 @@ class CoreModifiers extends Modifier
      */
     public function minutesAgo($value, $params)
     {
-        return (int) $this->carbon($value)->diffInMinutes(Arr::get($params, 0));
+        return (int) abs($this->carbon($value)->diffInMinutes(Arr::get($params, 0)));
     }
 
     /**
@@ -1652,7 +1652,7 @@ class CoreModifiers extends Modifier
      */
     public function monthsAgo($value, $params)
     {
-        return (int) $this->carbon($value)->diffInMonths(Arr::get($params, 0));
+        return (int) abs($this->carbon($value)->diffInMonths(Arr::get($params, 0)));
     }
 
     /**
@@ -2234,7 +2234,7 @@ class CoreModifiers extends Modifier
      */
     public function secondsAgo($value, $params)
     {
-        return (int) $this->carbon($value)->diffInSeconds(Arr::get($params, 0));
+        return (int) abs($this->carbon($value)->diffInSeconds(Arr::get($params, 0)));
     }
 
     /**
@@ -2933,7 +2933,7 @@ class CoreModifiers extends Modifier
      */
     public function weeksAgo($value, $params)
     {
-        return (int) $this->carbon($value)->diffInWeeks(Arr::get($params, 0));
+        return (int) abs($this->carbon($value)->diffInWeeks(Arr::get($params, 0)));
     }
 
     /**
@@ -3045,7 +3045,7 @@ class CoreModifiers extends Modifier
      */
     public function yearsAgo($value, $params)
     {
-        return (int) $this->carbon($value)->diffInYears(Arr::get($params, 0));
+        return (int) abs($this->carbon($value)->diffInYears(Arr::get($params, 0)));
     }
 
     /**

--- a/src/Revisions/RevisionRepository.php
+++ b/src/Revisions/RevisionRepository.php
@@ -69,7 +69,7 @@ class RevisionRepository implements Contract
             ->key($key)
             ->action($yaml['action'] ?? false)
             ->id($date = $yaml['date'])
-            ->date(Carbon::createFromTimestamp($date))
+            ->date(Carbon::createFromTimestamp($date, config('app.timezone')))
             ->user($yaml['user'] ?? false)
             ->message($yaml['message'] ?? false)
             ->attributes($yaml['attributes']);

--- a/src/Stache/Stache.php
+++ b/src/Stache/Stache.php
@@ -176,7 +176,7 @@ class Stache
             return null;
         }
 
-        return Carbon::createFromTimestamp($cache['date']);
+        return Carbon::createFromTimestamp($cache['date'], config('app.timezone'));
     }
 
     public function disableUpdatingIndexes()

--- a/src/Support/FileCollection.php
+++ b/src/Support/FileCollection.php
@@ -212,7 +212,7 @@ class FileCollection extends Collection
                 'size_mb' => $kb,
                 'size_gb' => $kb,
                 'is_file' => File::isImage($path),
-                'last_modified' => Carbon::createFromTimestamp(File::lastModified($path)),
+                'last_modified' => Carbon::createFromTimestamp(File::lastModified($path), config('app.timezone')),
             ];
         }
 

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -485,7 +485,7 @@ class LocalizedTerm implements Arrayable, ArrayAccess, Augmentable, BulkAugmenta
     public function lastModified()
     {
         return $this->has('updated_at')
-            ? Carbon::createFromTimestamp($this->get('updated_at'))
+            ? Carbon::createFromTimestamp($this->get('updated_at'), config('app.timezone'))
             : $this->term->fileLastModified();
     }
 

--- a/src/Tokens/FileTokenRepository.php
+++ b/src/Tokens/FileTokenRepository.php
@@ -55,7 +55,7 @@ class FileTokenRepository extends TokenRepository
 
         return $this
             ->make($token, $yaml['handler'], $yaml['data'] ?? [])
-            ->expireAt(Carbon::createFromTimestamp($yaml['expires_at']));
+            ->expireAt(Carbon::createFromTimestamp($yaml['expires_at'], config('app.timezone')));
     }
 
     public static function bindings(): array

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -2017,7 +2017,7 @@ class AssetTest extends TestCase
     public function it_appends_timestamp_to_uploaded_files_filename_if_it_already_exists()
     {
         Event::fake();
-        Carbon::setTestNow(Carbon::createFromTimestamp(1549914700));
+        Carbon::setTestNow(Carbon::createFromTimestamp(1549914700, config('app.timezone')));
         $asset = $this->container->makeAsset('path/to/asset.jpg');
         Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
         Storage::disk('test')->put('path/to/asset.jpg', '');

--- a/tests/Feature/Assets/StoreAssetTest.php
+++ b/tests/Feature/Assets/StoreAssetTest.php
@@ -171,7 +171,7 @@ class StoreAssetTest extends TestCase
     #[Test]
     public function it_can_upload_and_append_timestamp()
     {
-        Carbon::setTestNow(Carbon::createFromTimestamp(1697379288));
+        Carbon::setTestNow(Carbon::createFromTimestamp(1697379288, config('app.timezone')));
         Storage::disk('test')->put('path/to/test.jpg', 'contents');
         Storage::disk('test')->assertExists('path/to/test.jpg');
         $this->assertCount(1, Storage::disk('test')->files('path/to'));

--- a/tests/Feature/Entries/EntryRevisionsTest.php
+++ b/tests/Feature/Entries/EntryRevisionsTest.php
@@ -283,7 +283,7 @@ class EntryRevisionsTest extends TestCase
 
         $revision = tap((new Revision)
             ->key('collections/blog/en/123')
-            ->date(Carbon::createFromTimestamp('1553546421'))
+            ->date(Carbon::createFromTimestamp('1553546421', config('app.timezone')))
             ->attributes([
                 'published' => false,
                 'slug' => 'existing-slug',
@@ -345,7 +345,7 @@ class EntryRevisionsTest extends TestCase
 
         $revision = tap((new Revision)
             ->key('collections/blog/en/123')
-            ->date(Carbon::createFromTimestamp('1553546421'))
+            ->date(Carbon::createFromTimestamp('1553546421', config('app.timezone')))
             ->attributes([
                 'published' => true,
                 'slug' => 'existing-slug',

--- a/tests/Feature/Fieldtypes/FilesTest.php
+++ b/tests/Feature/Fieldtypes/FilesTest.php
@@ -44,7 +44,7 @@ class FilesTest extends TestCase
             ? UploadedFile::fake()->image('test.jpg', 50, 75)
             : UploadedFile::fake()->create('test.txt');
 
-        Date::setTestNow(Date::createFromTimestamp(1671484636));
+        Date::setTestNow(Date::createFromTimestamp(1671484636, config('app.timezone')));
 
         $disk = Storage::fake('local');
 

--- a/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
@@ -16,6 +16,12 @@ class DateFieldtypeTest extends FieldtypeTestCase
         parent::setUp();
 
         Carbon::macro('getToStringFormat', function () {
+            // Carbon 2.x
+            if (property_exists(static::this(), 'toStringFormat')) {
+                return static::$toStringFormat;
+            }
+
+            // Carbon 3.x
             $reflection = new ReflectionClass(self::this());
             $factory = $reflection->getMethod('getFactory');
             $factory->setAccessible(true);

--- a/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
@@ -17,7 +17,7 @@ class DateFieldtypeTest extends FieldtypeTestCase
 
         Carbon::macro('getToStringFormat', function () {
             // Carbon 2.x
-            if (isset(static::$toStringFormat)) {
+            if (property_exists(static::this(), 'toStringFormat')) {
                 return static::$toStringFormat;
             }
 

--- a/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
@@ -16,12 +16,6 @@ class DateFieldtypeTest extends FieldtypeTestCase
         parent::setUp();
 
         Carbon::macro('getToStringFormat', function () {
-            // Carbon 2.x
-            if (property_exists(static::this(), 'toStringFormat')) {
-                return static::$toStringFormat;
-            }
-
-            // Carbon 3.x
             $reflection = new ReflectionClass(self::this());
             $factory = $reflection->getMethod('getFactory');
             $factory->setAccessible(true);

--- a/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
@@ -5,6 +5,8 @@ namespace Tests\Feature\GraphQL\Fieldtypes;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use Statamic\Support\Arr;
 
 #[Group('graphql')]
 class DateFieldtypeTest extends FieldtypeTestCase
@@ -14,7 +16,17 @@ class DateFieldtypeTest extends FieldtypeTestCase
         parent::setUp();
 
         Carbon::macro('getToStringFormat', function () {
-            return static::$toStringFormat;
+            // Carbon 2.x
+            if (isset(static::$toStringFormat)) {
+                return static::$toStringFormat;
+            }
+
+            // Carbon 3.x
+            $reflection = new ReflectionClass(self::this());
+            $factory = $reflection->getMethod('getFactory');
+            $factory->setAccessible(true);
+
+            return Arr::get($factory->invoke(self::this())->getSettings(), 'toStringFormat');
         });
     }
 

--- a/tests/Modifiers/DaysAgoTest.php
+++ b/tests/Modifiers/DaysAgoTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class DaysAgoTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('dateProvider')]
+    public function it_outputs_days_ago($input, $expected)
+    {
+        Carbon::setTestNow(Carbon::parse('2025-02-20 00:00'));
+
+        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+    }
+
+    public static function dateProvider()
+    {
+        return [
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same time' => ['2025-02-20 00:00', 0],
+            'less than a day ago' => ['2025-02-19 11:00', 0],
+            '1 day ago' => ['2025-02-19 00:00', 1],
+            '2 days ago' => ['2025-02-18 00:00', 2],
+
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one day from now' => ['2025-02-21 00:00', 1],
+            'less than a day from now' => ['2025-02-20 13:00', 0],
+            'more than a day from now' => ['2025-02-21 13:00', 1],
+        ];
+    }
+
+    public function modify($value)
+    {
+        return Modify::value($value)->daysAgo()->fetch();
+    }
+}

--- a/tests/Modifiers/HoursAgoTest.php
+++ b/tests/Modifiers/HoursAgoTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class HoursAgoTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('dateProvider')]
+    public function it_outputs_minutes_ago($input, $expected)
+    {
+        Carbon::setTestNow(Carbon::parse('2025-02-20 13:10:00'));
+
+        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+    }
+
+    public static function dateProvider()
+    {
+        return [
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same time' => ['2025-02-20 13:10:00', 0], // 0.0
+            'less than a hour ago' => ['2025-02-20 13:00:00', 0], // 0.17
+            '1 hour ago' => ['2025-02-20 12:10:00', 1], // 1.0
+            '2 hours ago' => ['2025-02-20 11:10:00', 2], // 2.0
+
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one hour from now' => ['2025-02-20 14:10:00', 1], // -1.0
+            'less than a hour from now' => ['2025-02-20 13:30:00', 0], // -0.33
+            'more than a hour from now' => ['2025-02-20 15:10:00', 2], // -2.0
+        ];
+    }
+
+    public function modify($value)
+    {
+        return Modify::value($value)->hoursAgo()->fetch();
+    }
+}

--- a/tests/Modifiers/MinutesAgoTest.php
+++ b/tests/Modifiers/MinutesAgoTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class MinutesAgoTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('dateProvider')]
+    public function it_outputs_minutes_ago($input, $expected)
+    {
+        Carbon::setTestNow(Carbon::parse('2025-02-20 13:10:00'));
+
+        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+    }
+
+    public static function dateProvider()
+    {
+        return [
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same time' => ['2025-02-20 13:10:00', 0], // 0.0
+            'less than a minute ago' => ['2025-02-20 13:09:30', 0], // 0.5
+            '1 minute ago' => ['2025-02-20 13:09:00', 1], // 1.0
+            '2 minutes ago' => ['2025-02-20 13:08:00', 2], // 2.0
+
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one minute from now' => ['2025-02-20 13:11:00', 1], // -1.0
+            'less than a minute from now' => ['2025-02-20 13:10:30', 0], // -0.5
+            'more than a minute from now' => ['2025-02-20 13:11:30', 1], // -1.5
+        ];
+    }
+
+    public function modify($value)
+    {
+        return Modify::value($value)->minutesAgo()->fetch();
+    }
+}

--- a/tests/Modifiers/MonthsAgoTest.php
+++ b/tests/Modifiers/MonthsAgoTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class MonthsAgoTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('dateProvider')]
+    public function it_outputs_months_ago($input, $expected)
+    {
+        Carbon::setTestNow(Carbon::parse('2025-02-20'));
+
+        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+    }
+
+    public static function dateProvider()
+    {
+        return [
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same month' => ['2025-02-20', 0], // 0.0
+            'less than a month ago' => ['2025-02-10', 0], // 0.36
+            '1 month ago' => ['2025-01-20', 1], // 1.0
+            '2 months ago' => ['2024-12-20', 2], // 2.0
+
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one month from now' => ['2025-03-20', 1], // -1.0
+            'less than a month from now' => ['2025-02-25', 0], // -0.18
+            'more than a month from now' => ['2025-04-20', 2], // -2.0
+        ];
+    }
+
+    public function modify($value)
+    {
+        return Modify::value($value)->monthsAgo()->fetch();
+    }
+}

--- a/tests/Modifiers/SecondsAgoTest.php
+++ b/tests/Modifiers/SecondsAgoTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class SecondsAgoTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('dateProvider')]
+    public function it_outputs_seconds_ago($input, $expected)
+    {
+        Carbon::setTestNow(Carbon::parse('2025-02-20 13:10:30'));
+
+        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+    }
+
+    public static function dateProvider()
+    {
+        return [
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same second' => ['2025-02-20 13:10:30', 0], // 0.0
+            '1 second ago' => ['2025-02-20 13:10:29', 1], // 1.0
+            '2 seconds ago' => ['2025-02-20 13:10:28', 2], // 2.0
+
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one second from now' => ['2025-02-20 13:10:31', 1], // -1.0
+            'two seconds from now' => ['2025-02-20 13:10:32', 2], // -2.0
+        ];
+    }
+
+    public function modify($value)
+    {
+        return Modify::value($value)->secondsAgo()->fetch();
+    }
+}

--- a/tests/Modifiers/WeeksAgoTest.php
+++ b/tests/Modifiers/WeeksAgoTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class WeeksAgoTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('dateProvider')]
+    public function it_outputs_weeks_ago($input, $expected)
+    {
+        Carbon::setTestNow(Carbon::parse('2025-02-20'));
+
+        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+    }
+
+    public static function dateProvider()
+    {
+        return [
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same day' => ['2025-02-20', 0], // 0.0
+            'same week' => ['2025-02-19', 0], // 0.14
+            'less than a week ago' => ['2025-02-17', 0], // 0.43
+            '1 week ago' => ['2025-02-13', 1], // 1.0
+            '2 weeks ago' => ['2025-02-06', 2], // 2.0
+
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one week from now' => ['2025-02-27', 1], // -1.0
+            'less than a week from now' => ['2025-02-22', 0], // -0.29
+            'more than a week from now' => ['2025-03-08', 2], // -2.29
+        ];
+    }
+
+    public function modify($value)
+    {
+        return Modify::value($value)->weeksAgo()->fetch();
+    }
+}

--- a/tests/Modifiers/YearsAgoTest.php
+++ b/tests/Modifiers/YearsAgoTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class YearsAgoTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('dateProvider')]
+    public function it_outputs_years_ago($input, $expected)
+    {
+        Carbon::setTestNow(Carbon::parse('2025-02-20 00:00'));
+
+        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+    }
+
+    public static function dateProvider()
+    {
+        return [
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            '2 years' => ['2023-02-20', 2], // 2.0
+            'not quite 3 years' => ['2022-08-20', 2], // 2.5
+            '3 years' => ['2022-02-20', 3], // 3.0
+
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            '1 year from now' => ['2026-02-20', 1], // -1.0
+            'less than a year from now' => ['2025-12-20', 0], // -0.83
+        ];
+    }
+
+    public function modify($value)
+    {
+        return Modify::value($value)->yearsAgo()->fetch();
+    }
+}


### PR DESCRIPTION
This pull request adds support for Carbon 3, allowing us to support Laravel 12 when it's released.

While Statamic 5 is backwards compatible with Carbon 2, you might find that Carbon 3 is installed as a result of this update. If you'd rather stay with Carbon 2, you may require it using Composer:


```
composer require nesbot/carbon:^2
```