### PR TITLE
[5.x] Fix bard undefined href error

### DIFF
--- a/src/Fieldtypes/Bard/LinkMark.php
+++ b/src/Fieldtypes/Bard/LinkMark.php
@@ -25,13 +25,12 @@ class LinkMark extends Link
         return [
             'href' => [
                 'renderHTML' => function ($attributes) {
-                    $href = $attributes->href;
-                    if (! isset($href)) {
+                    if (! isset($attributes->href)) {
                         return null;
                     }
 
                     return [
-                        'href' => $this->convertHref($href) ?? '',
+                        'href' => $this->convertHref($attributes->href) ?? '',
                     ];
                 },
             ],


### PR DESCRIPTION
This PR fixes an `Undefined property: stdClass::$href` error when a bard link mark has no `href` attribute defined.

This can only occur if you've manually imported content and missed the `href`, but there's already a null check in place it so doesn't hurt to make it a little more forgiving.