### PR TITLE
[5.x] Add empty/not empty filters for replicator, bard and grid

### DIFF
--- a/src/Query/Scopes/Filters/Fields/Bard.php
+++ b/src/Query/Scopes/Filters/Fields/Bard.php
@@ -2,7 +2,58 @@
 
 namespace Statamic\Query\Scopes\Filters\Fields;
 
-class Bard extends Textarea
+use Statamic\Support\Arr;
+use Statamic\Support\Str;
+
+class Bard extends FieldtypeFilter
 {
-    //
+    public function fieldItems()
+    {
+        return [
+            'operator' => [
+                'type' => 'select',
+                'placeholder' => __('Select Operator'),
+                'options' => [
+                    'like' => __('Contains'),
+                    'null' => __('Empty'),
+                    'not-null' => __('Not empty'),
+                ],
+                'default' => 'like',
+            ],
+            'value' => [
+                'type' => 'text',
+                'if' => [
+                    'operator' => 'like',
+                ],
+                'required' => false,
+            ],
+        ];
+    }
+
+    public function apply($query, $handle, $values)
+    {
+        $operator = $values['operator'];
+        $value = $values['value'];
+
+        if ($operator === 'like') {
+            $value = Str::ensureLeft($value, '%');
+            $value = Str::ensureRight($value, '%');
+        }
+
+        match ($operator) {
+            'null' => $query->whereNull($handle),
+            'not-null' => $query->whereNotNull($handle),
+            default => $query->where($handle, $operator, $value),
+        };
+    }
+
+    public function badge($values)
+    {
+        $field = $this->fieldtype->field()->display();
+        $operator = $values['operator'];
+        $translatedOperator = Arr::get($this->fieldItems(), "operator.options.{$operator}");
+        $value = $values['value'];
+
+        return $field.' '.strtolower($translatedOperator).' '.$value;
+    }
 }

--- a/src/Query/Scopes/Filters/Fields/Grid.php
+++ b/src/Query/Scopes/Filters/Fields/Grid.php
@@ -2,7 +2,58 @@
 
 namespace Statamic\Query\Scopes\Filters\Fields;
 
-class Grid extends Textarea
+use Statamic\Support\Str;
+use Statamic\Support\Arr;
+
+class Grid extends FieldtypeFilter
 {
-    //
+    public function fieldItems()
+    {
+        return [
+            'operator' => [
+                'type' => 'select',
+                'placeholder' => __('Select Operator'),
+                'options' => [
+                    'like' => __('Contains'),
+                    'null' => __('Empty'),
+                    'not-null' => __('Not empty'),
+                ],
+                'default' => 'like',
+            ],
+            'value' => [
+                'type' => 'text',
+                'if' => [
+                    'operator' => 'like',
+                ],
+                'required' => false,
+            ],
+        ];
+    }
+
+    public function apply($query, $handle, $values)
+    {
+        $operator = $values['operator'];
+        $value = $values['value'];
+
+        if ($operator === 'like') {
+            $value = Str::ensureLeft($value, '%');
+            $value = Str::ensureRight($value, '%');
+        }
+
+        match ($operator) {
+            'null' => $query->whereNull($handle),
+            'not-null' => $query->whereNotNull($handle),
+            default => $query->where($handle, $operator, $value),
+        };
+    }
+
+    public function badge($values)
+    {
+        $field = $this->fieldtype->field()->display();
+        $operator = $values['operator'];
+        $translatedOperator = Arr::get($this->fieldItems(), "operator.options.{$operator}");
+        $value = $values['value'];
+
+        return $field.' '.strtolower($translatedOperator).' '.$value;
+    }
 }

--- a/src/Query/Scopes/Filters/Fields/Grid.php
+++ b/src/Query/Scopes/Filters/Fields/Grid.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Query\Scopes\Filters\Fields;
 
-use Statamic\Support\Str;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class Grid extends FieldtypeFilter
 {

--- a/src/Query/Scopes/Filters/Fields/Replicator.php
+++ b/src/Query/Scopes/Filters/Fields/Replicator.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\Query\Scopes\Filters\Fields;
 
-use Statamic\Support\Str;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class Replicator extends FieldtypeFilter
 {

--- a/src/Query/Scopes/Filters/Fields/Replicator.php
+++ b/src/Query/Scopes/Filters/Fields/Replicator.php
@@ -2,7 +2,58 @@
 
 namespace Statamic\Query\Scopes\Filters\Fields;
 
-class Replicator extends Textarea
+use Statamic\Support\Str;
+use Statamic\Support\Arr;
+
+class Replicator extends FieldtypeFilter
 {
-    //
+    public function fieldItems()
+    {
+        return [
+            'operator' => [
+                'type' => 'select',
+                'placeholder' => __('Select Operator'),
+                'options' => [
+                    'like' => __('Contains'),
+                    'null' => __('Empty'),
+                    'not-null' => __('Not empty'),
+                ],
+                'default' => 'like',
+            ],
+            'value' => [
+                'type' => 'text',
+                'if' => [
+                    'operator' => 'like',
+                ],
+                'required' => false,
+            ],
+        ];
+    }
+
+    public function apply($query, $handle, $values)
+    {
+        $operator = $values['operator'];
+        $value = $values['value'];
+
+        if ($operator === 'like') {
+            $value = Str::ensureLeft($value, '%');
+            $value = Str::ensureRight($value, '%');
+        }
+
+        match ($operator) {
+            'null' => $query->whereNull($handle),
+            'not-null' => $query->whereNotNull($handle),
+            default => $query->where($handle, $operator, $value),
+        };
+    }
+
+    public function badge($values)
+    {
+        $field = $this->fieldtype->field()->display();
+        $operator = $values['operator'];
+        $translatedOperator = Arr::get($this->fieldItems(), "operator.options.{$operator}");
+        $value = $values['value'];
+
+        return $field.' '.strtolower($translatedOperator).' '.$value;
+    }
 }


### PR DESCRIPTION
This PR adds empty and not empty filter options for the replicator, bard and grid fieldtypes:

![Screenshot 2025-01-14 at 13 59 38](https://github.com/user-attachments/assets/18ba1976-e9ca-4fb0-9e8b-d2c6d9ccfab8)

**Edit:**

I was about to add this to bard as well, and do another copy-paste, and then I realised these could just be added to textarea class that these three were already extending since it would work for text as well. But then I wasn't really sure if replicator extending textarea really makes sense in the first place? What do you think? Should they all use some kind of generic base class or just stick with textarea?