### PR TITLE
[6.x] Fix default values not working after saving an entry

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -608,6 +608,7 @@ export default {
                     if (this.revisionsEnabled) {
                         clearTimeout(this.trackDirtyStateTimeout)
                         this.trackDirtyState = false
+                        this.meta = response.data.data.meta;
                         this.values = this.resetValuesFromResponse(response.data.data.values);
                         this.extraValues = response.data.data.extraValues;
                         this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 500)
@@ -633,6 +634,7 @@ export default {
                     else {
                         clearTimeout(this.trackDirtyStateTimeout);
                         this.trackDirtyState = false;
+                        this.meta = response.data.data.meta;
                         this.values = this.resetValuesFromResponse(response.data.data.values);
                         this.extraValues = response.data.data.extraValues;
                         this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 500);

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -486,6 +486,7 @@ export default {
                 .then(() => {
                     // If revisions are enabled, just emit event.
                     if (this.revisionsEnabled) {
+                        this.meta = response.data.data.meta;
                         this.values = this.resetValuesFromResponse(response.data.data.values);
                         this.$nextTick(() => this.$emit('saved', response));
                         return;
@@ -507,6 +508,7 @@ export default {
                     // the hooks are resolved because if this form is being shown in a stack, we only
                     // want to close it once everything's done.
                     else {
+                        this.meta = response.data.data.meta;
                         this.values = this.resetValuesFromResponse(response.data.data.values);
                         this.$nextTick(() => this.$emit('saved', response));
                     }

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -275,6 +275,7 @@ class EntriesController extends CpController
 
         return [
             'data' => array_merge((new EntryResource($entry->fresh()))->resolve()['data'], [
+                'meta' => $meta,
                 'values' => $values,
                 'extraValues' => $extraValues,
             ]),

--- a/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
+++ b/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
@@ -11,7 +11,7 @@ trait ExtractsFromEntryFields
         $values = collect();
         $target = $entry;
         while ($target) {
-            $values = $target->data()->merge($target->computedData())->merge($values);
+            $values = $target->data()->filter()->merge($target->computedData())->merge($values);
             $target = $target->origin();
         }
         $values = $values->all();

--- a/src/Http/Controllers/CP/Taxonomies/ExtractsFromTermFields.php
+++ b/src/Http/Controllers/CP/Taxonomies/ExtractsFromTermFields.php
@@ -10,7 +10,7 @@ trait ExtractsFromTermFields
         // We don't want injected taxonomy values, which $term->values() would have given us.
         $values = $term->inDefaultLocale()->data()->merge(
             $term->data()
-        );
+        )->filter();
 
         $fields = $blueprint
             ->fields()

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -208,12 +208,13 @@ class TermsController extends CpController
             $saved = $term->updateLastModified(User::current())->save();
         }
 
-        [$values] = $this->extractFromFields($term, $term->blueprint());
+        [$values, $meta] = $this->extractFromFields($term, $term->blueprint());
 
         return (new TermResource($term))
             ->additional([
                 'saved' => $saved,
                 'data' => [
+                    'meta' => $meta,
                     'values' => $values,
                 ],
             ]);


### PR DESCRIPTION
This pull request fixes an issue where default values weren't working after saving entries & terms.

When entries and terms are saved, empty values are filtered out before they get saved to the Markdown file (see `Entry::fileData()`). However, that doesn't affect the data on the *current* `Entry`/`Term` instance, the empty values remain.

This PR addresses that by filtering out empty values when extracting publish form values for the response. 

It also updates the publish form's `meta`, to address an issue where fieldtype meta would be out-of-date (in the case of the Grid fieldtype, the default values are for the *old* row IDs, not the new ones).

Fixes #11355.
Fixes #11396.