### PR TITLE
[5.x] Fix dates in localizations when duplicating entries

### DIFF
--- a/src/Actions/DuplicateEntry.php
+++ b/src/Actions/DuplicateEntry.php
@@ -88,7 +88,7 @@ class DuplicateEntry extends Action
             $entry->slug($slug);
         }
 
-        if ($original->hasDate()) {
+        if ($original->hasExplicitDate()) {
             $entry->date($original->date());
         }
 

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -622,6 +622,11 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
         return $this->blueprint()->field('date')->fieldtype()->secondsEnabled();
     }
 
+    public function hasExplicitDate(): bool
+    {
+        return $this->hasDate() && $this->date;
+    }
+
     public function sites()
     {
         return $this->collection()->sites();


### PR DESCRIPTION
This pull request fixes an issue when duplicating entries in a multi-site where dates would be set on duplicated localizations, even though a date wasn't explicitly set on the localization it's duplicating.

Since #10282 was merged, `Entry::date()` falls back to the origin's date if the entry doesn't have its own date. 

However, this causes an issue when duplicating because it means all localizations will have an _explicit_ date set when they should be falling back to the origin's date, like the original entries do.

Fixes #11360.