### PR TITLE
[5.x] Fix localized terms being returned incorrectly in the REST API

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -117,7 +117,15 @@ class Terms extends Relationship
     {
         $single = $this->config('max_items') === 1;
 
-        if ($single && Blink::has($key = 'terms-augment-'.json_encode($values))) {
+        // The parent is the item this terms fieldtype exists on. Most commonly an
+        // entry, but could also be something else, like another taxonomy term.
+        $parent = $this->field->parent();
+
+        $site = $parent && $parent instanceof Localization
+            ? $parent->locale()
+            : Site::current()->handle(); // Use the "current" site so this will get localized appropriately on the front-end.
+
+        if ($single && Blink::has($key = 'terms-augment-'.$site.'-'.json_encode($values))) {
             return Blink::get($key);
         }
 


### PR DESCRIPTION
This pull request fixes an issue in the REST API when two entries relate to the _same_ taxaonomy term, but the entries are on different sites.

Due to the Blink cache key being the same, it would always return the same term, even if the term doesn't exist on the same site as the entry.

The issue is best explained by the screenshot on the related issue.

Fixes #11342.