### PR TITLE
[5.x] Fix case insensitive Comb search for UTF-8 characters

### DIFF
--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -539,11 +539,11 @@ class Comb
                 $escaped_chunk = preg_quote($chunk, '#');
                 $chunk_is_word = ! preg_match('#\s#', $chunk);
                 $regex = [
-                    'partial_anywhere' => '#'.$escaped_chunk.'#i',
-                    'partial_from_start_anywhere' => '#(^|\s)'.$escaped_chunk.'#i',
-                    'whole_anywhere' => '#(^|\s)'.$escaped_chunk.'($|\s)#i',
-                    'partial_from_start' => '#^'.$escaped_chunk.'#i',
-                    'whole' => '#^'.$escaped_chunk.'$#i',
+                    'partial_anywhere' => '#'.$escaped_chunk.'#iu',
+                    'partial_from_start_anywhere' => '#(^|\s)'.$escaped_chunk.'#iu',
+                    'whole_anywhere' => '#(^|\s)'.$escaped_chunk.'($|\s)#iu',
+                    'partial_from_start' => '#^'.$escaped_chunk.'#iu',
+                    'whole' => '#^'.$escaped_chunk.'$#iu',
                 ];
 
                 // loop over each data property
@@ -710,8 +710,8 @@ class Comb
      */
     private function removeDisallowedMatches($params)
     {
-        $disallowed = '#'.implode('|', $params['disallowed']).'#i';
-        $required = '#(?=.*'.implode(')(?=.*', $params['required']).')#i';
+        $disallowed = '#'.implode('|', $params['disallowed']).'#iu';
+        $required = '#(?=.*'.implode(')(?=.*', $params['required']).')#iu';
         $new_data = [];
 
         // this only applies to boolean mode
@@ -1058,7 +1058,7 @@ class Comb
         $escaped_chunks = collect($chunks)
             ->map(fn ($chunk) => preg_quote($chunk, '#'))
             ->join('|');
-        $regex = '#(.*?)('.$escaped_chunks.')(.{0,'.$length.'}(?:\s|$))#i';
+        $regex = '#(.*?)('.$escaped_chunks.')(.{0,'.$length.'}(?:\s|$))#iu';
         if (! preg_match_all($regex, $value, $matches, PREG_SET_ORDER)) {
             return [];
         }
@@ -1081,7 +1081,7 @@ class Comb
             }
             $snippets[] = trim($snippet);
         }
-        if (preg_match('#('.$escaped_chunks.')#i', $surplus)) {
+        if (preg_match('#('.$escaped_chunks.')#iu', $surplus)) {
             $snippets[] = trim($surplus);
         }
 

--- a/tests/Search/CombTest.php
+++ b/tests/Search/CombTest.php
@@ -239,6 +239,20 @@ EOT;
         $this->assertSame(1, $result['info']['total_results']);
     }
 
+    #[Test]
+    public function it_can_search_for_umlauts()
+    {
+        $comb = new Comb([
+            ['content' => 'Üppercase umlaut'],
+            ['content' => 'Lowercase ümlaut'],
+        ]);
+
+        $result = $comb->lookUp('ü');
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertSame(2, $result['info']['total_results']);
+    }
+
     public static function searchesProvider()
     {
         return [


### PR DESCRIPTION
This pull request fixes an error in the Comb search.

The search normally operates case insensitive. To ensure that this also works with UTF-8 characters (e.g. german umlauts), the regex patterns require the "u" modifier:
https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php

We had this problem with a german website. Lets say there is the word “Ökoland” indexed. A search for “Öko” returns the correct result. But a search for “öko” (lowercase) does not. This has now been resolved with the modifier.