### PR TITLE
[5.x] Allow addons cache path to be set by an environment variable

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Statamic\Providers;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Env;
 use Illuminate\Support\ServiceProvider;
 use Statamic\Actions;
 use Statamic\Actions\Action;
@@ -258,10 +259,16 @@ class ExtensionServiceProvider extends ServiceProvider
 
     protected function registerAddonManifest()
     {
+        $cachePath = $this->app->bootstrapPath().'/cache/addons.php';
+
+        if (! is_null($env = Env::get('STATAMIC_ADDONS_CACHE'))) {
+            $cachePath = Str::startsWith($env, ['/', '\\']) ? $env : $this->app->basePath($env);
+        }
+
         $this->app->instance(Manifest::class, new Manifest(
             new Filesystem,
             $this->app->basePath(),
-            $this->app->bootstrapPath().'/cache/addons.php'
+            $cachePath
         ));
     }
 


### PR DESCRIPTION
When deploying on Vercel I'm running into an issue with the addon cache not being writeable as its hard coded to boostrap/cache/addons.php

```
Exception:
The /var/task/user/bootstrap/cache directory must be present and writable.

  at /var/task/user/vendor/laravel/framework/src/Illuminate/Foundation/PackageManifest.php:178
  at Illuminate\Foundation\PackageManifest->write(array('statamic-rad-pack/shopify' => array('id' => 'statamic-rad-pack/shopify', 'slug' => null, 'editions' => array(), 'marketplaceId' => null, 'marketplaceSlug' => null, 'marketplaceUrl' => null, 'marketplaceSellerSlug' => null, 'latestVersion' => null, 'version' => '2.0.0-beta1', 'namespace' => 'StatamicRadPack\\Shopify', 'autoload' => 'src', 'provider' => 'StatamicRadPack\\Shopify\\ServiceProvider', 'name' => 'Shopify', 'url' => null, 'description' => 'Shopify Addon for Statamic', 'developer' => 'Jack Whiting', 'developerUrl' => 'https://jackwhiting.co.uk', 'email' => null)))
     (/var/task/user/vendor/statamic/cms/src/Extend/Manifest.php:25)
```

Laravel allow environment variables to be set to override their cache paths - see examples at:
https://github.com/laravel/framework/blob/2e5054a19ba55b335bf8df43a8ae7e032244f671/src/Illuminate/Foundation/Application.php#L1256-L1269

This PR adds support for a `STATAMIC_ADDONS_CACHE` environment variable to set the path to this cache, in the same way Laravel allows, for example `STATAMIC_ADDONS_CACHE="/tmp/addons.php"`. This will allow deploying on Vercel to work again.

Ideally we'd use their normalizeCachePath() function but it's not public.