### PR TITLE
[5.x] Page children as value for field conditions

### DIFF
--- a/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
+++ b/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
@@ -43,7 +43,6 @@ trait ExtractsFromEntryFields
 
         $extraValues = [
             'depth' => $entry->page()?->depth(),
-            'has-children' => $entry->page()?->hasChildren(),
         ];
 
         return [$values->all(), $fields->meta(), $extraValues];

--- a/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
+++ b/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
@@ -43,6 +43,7 @@ trait ExtractsFromEntryFields
 
         $extraValues = [
             'depth' => $entry->page()?->depth(),
+            'has-children' => $entry->page()?->hasChildren(),
         ];
 
         return [$values->all(), $fields->meta(), $extraValues];

--- a/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
+++ b/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
@@ -43,6 +43,7 @@ trait ExtractsFromEntryFields
 
         $extraValues = [
             'depth' => $entry->page()?->depth(),
+            'children' => $entry->page()?->flattenedPages()->pluck('id')->all(),
         ];
 
         return [$values->all(), $fields->meta(), $extraValues];

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -284,11 +284,6 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Entr
         return $this;
     }
 
-    public function hasChildren()
-    {
-        return !! $this->children;
-    }
-
     public function setPageData(array $data): self
     {
         $this->data = $data;

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -284,6 +284,11 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Entr
         return $this;
     }
 
+    public function hasChildren()
+    {
+        return !! $this->children;
+    }
+
     public function setPageData(array $data): self
     {
         $this->data = $data;


### PR DESCRIPTION
This PR relates to #11080 

Sometimes it would be helpful to conditionally render a field when the page is part of a structure and has / has not children.

```
if:
  children: 'not empty'
```
Or even something like this:

```
if:
  children: 'contains c534de98-24c8-479b-b1a0-0e8945b76020'
```

By the way, this PR started with the need for a `has-children` field condition. But I switched to `children` because I think it's a bit more flexible.