### PR TITLE
[6.x] Link Fieldtype: Provide more context for entry links

### DIFF
--- a/src/Fieldtypes/Link/ArrayableLink.php
+++ b/src/Fieldtypes/Link/ArrayableLink.php
@@ -21,7 +21,7 @@ class ArrayableLink extends ArrayableString
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
-        return $this->url(); // Use a string for backwards compatibility in the REST API, etc.
+        return $this->toArray();
     }
 
     public function url()


### PR DESCRIPTION
This pull request changes how the Link fieldtype is returned in the REST API, in order to provide more context about linked entries.

Right now, the URL of the linked entry is returned. However, that's not very helpful if you want more information (like the title of the linked entry). 

You'd have to loop through each collection, filter by the `uri` and return the first entry that appears. A lot of work that shouldn't really be necessary.

This PR fixes that by returning the entry object, instead of _just_ the URL. 

Since changing the API response is a breaking change, this PR targets `master` (for Statamic 6).