### PR TITLE
[5.x] Use constructor property promotion in events

### DIFF
--- a/src/Events/AssetContainerBlueprintFound.php
+++ b/src/Events/AssetContainerBlueprintFound.php
@@ -4,14 +4,7 @@ namespace Statamic\Events;
 
 class AssetContainerBlueprintFound extends Event
 {
-    public $blueprint;
-    public $container;
-    public $asset;
-
-    public function __construct($blueprint, $container = null, $asset = null)
+    public function __construct(public $blueprint, public $container = null, public $asset = null)
     {
-        $this->blueprint = $blueprint;
-        $this->container = $container;
-        $this->asset = $asset;
     }
 }

--- a/src/Events/AssetContainerCreated.php
+++ b/src/Events/AssetContainerCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class AssetContainerCreated extends Event
 {
-    public $container;
-
-    public function __construct($container)
+    public function __construct(public $container)
     {
-        $this->container = $container;
     }
 }

--- a/src/Events/AssetContainerCreating.php
+++ b/src/Events/AssetContainerCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class AssetContainerCreating extends Event
 {
-    public $container;
-
-    public function __construct($container)
+    public function __construct(public $container)
     {
-        $this->container = $container;
     }
 
     /**

--- a/src/Events/AssetContainerDeleted.php
+++ b/src/Events/AssetContainerDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class AssetContainerDeleted extends Event implements ProvidesCommitMessage
 {
-    public $container;
-
-    public function __construct($container)
+    public function __construct(public $container)
     {
-        $this->container = $container;
     }
 
     public function commitMessage()

--- a/src/Events/AssetContainerDeleting.php
+++ b/src/Events/AssetContainerDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class AssetContainerDeleting extends Event
 {
-    public $container;
-
-    public function __construct($container)
+    public function __construct(public $container)
     {
-        $this->container = $container;
     }
 
     /**

--- a/src/Events/AssetContainerSaved.php
+++ b/src/Events/AssetContainerSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class AssetContainerSaved extends Event implements ProvidesCommitMessage
 {
-    public $container;
-
-    public function __construct($container)
+    public function __construct(public $container)
     {
-        $this->container = $container;
     }
 
     public function commitMessage()

--- a/src/Events/AssetContainerSaving.php
+++ b/src/Events/AssetContainerSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class AssetContainerSaving extends Event
 {
-    public $container;
-
-    public function __construct($container)
+    public function __construct(public $container)
     {
-        $this->container = $container;
     }
 
     /**

--- a/src/Events/AssetCreated.php
+++ b/src/Events/AssetCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class AssetCreated extends Event
 {
-    public $asset;
-
-    public function __construct($asset)
+    public function __construct(public $asset)
     {
-        $this->asset = $asset;
     }
 }

--- a/src/Events/AssetCreating.php
+++ b/src/Events/AssetCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class AssetCreating extends Event
 {
-    public $asset;
-
-    public function __construct($asset)
+    public function __construct(public $asset)
     {
-        $this->asset = $asset;
     }
 
     /**

--- a/src/Events/AssetDeleted.php
+++ b/src/Events/AssetDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class AssetDeleted extends Event implements ProvidesCommitMessage
 {
-    public $asset;
-
-    public function __construct($asset)
+    public function __construct(public $asset)
     {
-        $this->asset = $asset;
     }
 
     public function commitMessage()

--- a/src/Events/AssetDeleting.php
+++ b/src/Events/AssetDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class AssetDeleting extends Event
 {
-    public $asset;
-
-    public function __construct($asset)
+    public function __construct(public $asset)
     {
-        $this->asset = $asset;
     }
 
     /**

--- a/src/Events/AssetFolderDeleted.php
+++ b/src/Events/AssetFolderDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class AssetFolderDeleted extends Event implements ProvidesCommitMessage
 {
-    public $folder;
-
-    public function __construct($folder)
+    public function __construct(public $folder)
     {
-        $this->folder = $folder;
     }
 
     public function commitMessage()

--- a/src/Events/AssetFolderSaved.php
+++ b/src/Events/AssetFolderSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class AssetFolderSaved extends Event implements ProvidesCommitMessage
 {
-    public $folder;
-
-    public function __construct($folder)
+    public function __construct(public $folder)
     {
-        $this->folder = $folder;
     }
 
     public function commitMessage()

--- a/src/Events/AssetReferencesUpdated.php
+++ b/src/Events/AssetReferencesUpdated.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class AssetReferencesUpdated extends Event implements ProvidesCommitMessage
 {
-    public $asset;
-
-    public function __construct($asset)
+    public function __construct(public $asset)
     {
-        $this->asset = $asset;
     }
 
     public function commitMessage()

--- a/src/Events/AssetReplaced.php
+++ b/src/Events/AssetReplaced.php
@@ -4,12 +4,7 @@ namespace Statamic\Events;
 
 class AssetReplaced extends Event
 {
-    public $originalAsset;
-    public $newAsset;
-
-    public function __construct($originalAsset, $newAsset)
+    public function __construct(public $originalAsset, public $newAsset)
     {
-        $this->originalAsset = $originalAsset;
-        $this->newAsset = $newAsset;
     }
 }

--- a/src/Events/AssetReuploaded.php
+++ b/src/Events/AssetReuploaded.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class AssetReuploaded extends Event implements ProvidesCommitMessage
 {
-    public $asset;
-
-    public function __construct($asset)
+    public function __construct(public $asset)
     {
-        $this->asset = $asset;
     }
 
     public function commitMessage()

--- a/src/Events/AssetSaved.php
+++ b/src/Events/AssetSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class AssetSaved extends Event implements ProvidesCommitMessage
 {
-    public $asset;
-
-    public function __construct($asset)
+    public function __construct(public $asset)
     {
-        $this->asset = $asset;
     }
 
     public function commitMessage()

--- a/src/Events/AssetSaving.php
+++ b/src/Events/AssetSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class AssetSaving extends Event
 {
-    public $asset;
-
-    public function __construct($asset)
+    public function __construct(public $asset)
     {
-        $this->asset = $asset;
     }
 
     /**

--- a/src/Events/AssetUploaded.php
+++ b/src/Events/AssetUploaded.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class AssetUploaded extends Event implements ProvidesCommitMessage
 {
-    public $asset;
-
-    public function __construct($asset)
+    public function __construct(public $asset)
     {
-        $this->asset = $asset;
     }
 
     public function commitMessage()

--- a/src/Events/BlueprintCreated.php
+++ b/src/Events/BlueprintCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class BlueprintCreated extends Event
 {
-    public $blueprint;
-
-    public function __construct($blueprint)
+    public function __construct(public $blueprint)
     {
-        $this->blueprint = $blueprint;
     }
 }

--- a/src/Events/BlueprintCreating.php
+++ b/src/Events/BlueprintCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class BlueprintCreating extends Event
 {
-    public $blueprint;
-
-    public function __construct($blueprint)
+    public function __construct(public $blueprint)
     {
-        $this->blueprint = $blueprint;
     }
 
     /**

--- a/src/Events/BlueprintDeleted.php
+++ b/src/Events/BlueprintDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class BlueprintDeleted extends Event implements ProvidesCommitMessage
 {
-    public $blueprint;
-
-    public function __construct($blueprint)
+    public function __construct(public $blueprint)
     {
-        $this->blueprint = $blueprint;
     }
 
     public function commitMessage()

--- a/src/Events/BlueprintDeleting.php
+++ b/src/Events/BlueprintDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class BlueprintDeleting extends Event
 {
-    public $blueprint;
-
-    public function __construct($blueprint)
+    public function __construct(public $blueprint)
     {
-        $this->blueprint = $blueprint;
     }
 
     /**

--- a/src/Events/BlueprintReset.php
+++ b/src/Events/BlueprintReset.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class BlueprintReset extends Event implements ProvidesCommitMessage
 {
-    public $blueprint;
-
-    public function __construct($blueprint)
+    public function __construct(public $blueprint)
     {
-        $this->blueprint = $blueprint;
     }
 
     public function commitMessage()

--- a/src/Events/BlueprintSaved.php
+++ b/src/Events/BlueprintSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class BlueprintSaved extends Event implements ProvidesCommitMessage
 {
-    public $blueprint;
-
-    public function __construct($blueprint)
+    public function __construct(public $blueprint)
     {
-        $this->blueprint = $blueprint;
     }
 
     public function commitMessage()

--- a/src/Events/BlueprintSaving.php
+++ b/src/Events/BlueprintSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class BlueprintSaving extends Event
 {
-    public $blueprint;
-
-    public function __construct($blueprint)
+    public function __construct(public $blueprint)
     {
-        $this->blueprint = $blueprint;
     }
 
     /**

--- a/src/Events/CollectionCreated.php
+++ b/src/Events/CollectionCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class CollectionCreated extends Event
 {
-    public $collection;
-
-    public function __construct($collection)
+    public function __construct(public $collection)
     {
-        $this->collection = $collection;
     }
 }

--- a/src/Events/CollectionCreating.php
+++ b/src/Events/CollectionCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class CollectionCreating extends Event
 {
-    public $collection;
-
-    public function __construct($collection)
+    public function __construct(public $collection)
     {
-        $this->collection = $collection;
     }
 
     /**

--- a/src/Events/CollectionDeleted.php
+++ b/src/Events/CollectionDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class CollectionDeleted extends Event implements ProvidesCommitMessage
 {
-    public $collection;
-
-    public function __construct($collection)
+    public function __construct(public $collection)
     {
-        $this->collection = $collection;
     }
 
     public function commitMessage()

--- a/src/Events/CollectionDeleting.php
+++ b/src/Events/CollectionDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class CollectionDeleting extends Event
 {
-    public $collection;
-
-    public function __construct($collection)
+    public function __construct(public $collection)
     {
-        $this->collection = $collection;
     }
 
     /**

--- a/src/Events/CollectionSaved.php
+++ b/src/Events/CollectionSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class CollectionSaved extends Event implements ProvidesCommitMessage
 {
-    public $collection;
-
-    public function __construct($collection)
+    public function __construct(public $collection)
     {
-        $this->collection = $collection;
     }
 
     public function commitMessage()

--- a/src/Events/CollectionSaving.php
+++ b/src/Events/CollectionSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class CollectionSaving extends Event
 {
-    public $collection;
-
-    public function __construct($collection)
+    public function __construct(public $collection)
     {
-        $this->collection = $collection;
     }
 
     /**

--- a/src/Events/CollectionTreeDeleted.php
+++ b/src/Events/CollectionTreeDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class CollectionTreeDeleted extends Event implements ProvidesCommitMessage
 {
-    public $tree;
-
-    public function __construct($tree)
+    public function __construct(public $tree)
     {
-        $this->tree = $tree;
     }
 
     public function commitMessage()

--- a/src/Events/CollectionTreeSaved.php
+++ b/src/Events/CollectionTreeSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class CollectionTreeSaved extends Event implements ProvidesCommitMessage
 {
-    public $tree;
-
-    public function __construct($tree)
+    public function __construct(public $tree)
     {
-        $this->tree = $tree;
     }
 
     public function commitMessage()

--- a/src/Events/CollectionTreeSaving.php
+++ b/src/Events/CollectionTreeSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class CollectionTreeSaving extends Event
 {
-    public $tree;
-
-    public function __construct($tree)
+    public function __construct(public $tree)
     {
-        $this->tree = $tree;
     }
 
     /**

--- a/src/Events/EntryBlueprintFound.php
+++ b/src/Events/EntryBlueprintFound.php
@@ -4,12 +4,7 @@ namespace Statamic\Events;
 
 class EntryBlueprintFound extends Event
 {
-    public $blueprint;
-    public $entry;
-
-    public function __construct($blueprint, $entry = null)
+    public function __construct(public $blueprint, public $entry = null)
     {
-        $this->blueprint = $blueprint;
-        $this->entry = $entry;
     }
 }

--- a/src/Events/EntryCreated.php
+++ b/src/Events/EntryCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class EntryCreated extends Event
 {
-    public $entry;
-
-    public function __construct($entry)
+    public function __construct(public $entry)
     {
-        $this->entry = $entry;
     }
 }

--- a/src/Events/EntryCreating.php
+++ b/src/Events/EntryCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class EntryCreating extends Event
 {
-    public $entry;
-
-    public function __construct($entry)
+    public function __construct(public $entry)
     {
-        $this->entry = $entry;
     }
 
     /**

--- a/src/Events/EntryDeleted.php
+++ b/src/Events/EntryDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class EntryDeleted extends Event implements ProvidesCommitMessage
 {
-    public $entry;
-
-    public function __construct($entry)
+    public function __construct(public $entry)
     {
-        $this->entry = $entry;
     }
 
     public function commitMessage()

--- a/src/Events/EntryDeleting.php
+++ b/src/Events/EntryDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class EntryDeleting extends Event
 {
-    public $entry;
-
-    public function __construct($entry)
+    public function __construct(public $entry)
     {
-        $this->entry = $entry;
     }
 
     /**

--- a/src/Events/EntrySaved.php
+++ b/src/Events/EntrySaved.php
@@ -7,12 +7,10 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class EntrySaved extends Event implements ProvidesCommitMessage
 {
-    public $entry;
     public $initiator;
 
-    public function __construct($entry)
+    public function __construct(public $entry)
     {
-        $this->entry = $entry;
         $this->initiator = InitiatorStack::entry($entry)->initiator();
     }
 

--- a/src/Events/EntrySaving.php
+++ b/src/Events/EntrySaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class EntrySaving extends Event
 {
-    public $entry;
-
-    public function __construct($entry)
+    public function __construct(public $entry)
     {
-        $this->entry = $entry;
     }
 
     /**

--- a/src/Events/EntryScheduleReached.php
+++ b/src/Events/EntryScheduleReached.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class EntryScheduleReached extends Event implements ProvidesCommitMessage
 {
-    public $entry;
-
-    public function __construct($entry)
+    public function __construct(public $entry)
     {
-        $this->entry = $entry;
     }
 
     public function commitMessage()

--- a/src/Events/FieldsetCreated.php
+++ b/src/Events/FieldsetCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class FieldsetCreated extends Event
 {
-    public $fieldset;
-
-    public function __construct($fieldset)
+    public function __construct(public $fieldset)
     {
-        $this->fieldset = $fieldset;
     }
 }

--- a/src/Events/FieldsetCreating.php
+++ b/src/Events/FieldsetCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class FieldsetCreating extends Event
 {
-    public $fieldset;
-
-    public function __construct($fieldset)
+    public function __construct(public $fieldset)
     {
-        $this->fieldset = $fieldset;
     }
 
     /**

--- a/src/Events/FieldsetDeleted.php
+++ b/src/Events/FieldsetDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class FieldsetDeleted extends Event implements ProvidesCommitMessage
 {
-    public $fieldset;
-
-    public function __construct($fieldset)
+    public function __construct(public $fieldset)
     {
-        $this->fieldset = $fieldset;
     }
 
     public function commitMessage()

--- a/src/Events/FieldsetDeleting.php
+++ b/src/Events/FieldsetDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class FieldsetDeleting extends Event
 {
-    public $fieldset;
-
-    public function __construct($fieldset)
+    public function __construct(public $fieldset)
     {
-        $this->fieldset = $fieldset;
     }
 
     /**

--- a/src/Events/FieldsetReset.php
+++ b/src/Events/FieldsetReset.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class FieldsetReset extends Event implements ProvidesCommitMessage
 {
-    public $fieldset;
-
-    public function __construct($fieldset)
+    public function __construct(public $fieldset)
     {
-        $this->fieldset = $fieldset;
     }
 
     public function commitMessage()

--- a/src/Events/FieldsetSaved.php
+++ b/src/Events/FieldsetSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class FieldsetSaved extends Event implements ProvidesCommitMessage
 {
-    public $fieldset;
-
-    public function __construct($fieldset)
+    public function __construct(public $fieldset)
     {
-        $this->fieldset = $fieldset;
     }
 
     public function commitMessage()

--- a/src/Events/FieldsetSaving.php
+++ b/src/Events/FieldsetSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class FieldsetSaving extends Event
 {
-    public $fieldset;
-
-    public function __construct($fieldset)
+    public function __construct(public $fieldset)
     {
-        $this->fieldset = $fieldset;
     }
 
     /**

--- a/src/Events/FormBlueprintFound.php
+++ b/src/Events/FormBlueprintFound.php
@@ -4,12 +4,7 @@ namespace Statamic\Events;
 
 class FormBlueprintFound extends Event
 {
-    public $blueprint;
-    public $form;
-
-    public function __construct($blueprint, $form = null)
+    public function __construct(public $blueprint, public $form = null)
     {
-        $this->blueprint = $blueprint;
-        $this->form = $form;
     }
 }

--- a/src/Events/FormCreated.php
+++ b/src/Events/FormCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class FormCreated extends Event
 {
-    public $form;
-
-    public function __construct($form)
+    public function __construct(public $form)
     {
-        $this->form = $form;
     }
 }

--- a/src/Events/FormCreating.php
+++ b/src/Events/FormCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class FormCreating extends Event
 {
-    public $form;
-
-    public function __construct($form)
+    public function __construct(public $form)
     {
-        $this->form = $form;
     }
 
     /**

--- a/src/Events/FormDeleted.php
+++ b/src/Events/FormDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class FormDeleted extends Event implements ProvidesCommitMessage
 {
-    public $form;
-
-    public function __construct($form)
+    public function __construct(public $form)
     {
-        $this->form = $form;
     }
 
     public function commitMessage()

--- a/src/Events/FormDeleting.php
+++ b/src/Events/FormDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class FormDeleting extends Event
 {
-    public $form;
-
-    public function __construct($form)
+    public function __construct(public $form)
     {
-        $this->form = $form;
     }
 
     /**

--- a/src/Events/FormSaved.php
+++ b/src/Events/FormSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class FormSaved extends Event implements ProvidesCommitMessage
 {
-    public $form;
-
-    public function __construct($form)
+    public function __construct(public $form)
     {
-        $this->form = $form;
     }
 
     public function commitMessage()

--- a/src/Events/FormSaving.php
+++ b/src/Events/FormSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class FormSaving extends Event
 {
-    public $form;
-
-    public function __construct($form)
+    public function __construct(public $form)
     {
-        $this->form = $form;
     }
 
     /**

--- a/src/Events/FormSubmitted.php
+++ b/src/Events/FormSubmitted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Forms\Submission;
 
 class FormSubmitted extends Event
 {
-    public $submission;
-
-    public function __construct(Submission $submission)
+    public function __construct(public Submission $submission)
     {
-        $this->submission = $submission;
     }
 
     /**

--- a/src/Events/GlideImageGenerated.php
+++ b/src/Events/GlideImageGenerated.php
@@ -4,12 +4,7 @@ namespace Statamic\Events;
 
 class GlideImageGenerated extends Event
 {
-    public $path;
-    public $params;
-
-    public function __construct($path, $params)
+    public function __construct(public $path, public $params)
     {
-        $this->path = $path;
-        $this->params = $params;
     }
 }

--- a/src/Events/GlobalSetCreated.php
+++ b/src/Events/GlobalSetCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class GlobalSetCreated extends Event
 {
-    public $globals;
-
-    public function __construct($globals)
+    public function __construct(public $globals)
     {
-        $this->globals = $globals;
     }
 }

--- a/src/Events/GlobalSetCreating.php
+++ b/src/Events/GlobalSetCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class GlobalSetCreating extends Event
 {
-    public $globals;
-
-    public function __construct($globals)
+    public function __construct(public $globals)
     {
-        $this->globals = $globals;
     }
 
     /**

--- a/src/Events/GlobalSetDeleted.php
+++ b/src/Events/GlobalSetDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class GlobalSetDeleted extends Event implements ProvidesCommitMessage
 {
-    public $globals;
-
-    public function __construct($globals)
+    public function __construct(public $globals)
     {
-        $this->globals = $globals;
     }
 
     public function commitMessage()

--- a/src/Events/GlobalSetDeleting.php
+++ b/src/Events/GlobalSetDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class GlobalSetDeleting extends Event
 {
-    public $globals;
-
-    public function __construct($globals)
+    public function __construct(public $globals)
     {
-        $this->globals = $globals;
     }
 
     /**

--- a/src/Events/GlobalSetSaved.php
+++ b/src/Events/GlobalSetSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class GlobalSetSaved extends Event implements ProvidesCommitMessage
 {
-    public $globals;
-
-    public function __construct($globals)
+    public function __construct(public $globals)
     {
-        $this->globals = $globals;
     }
 
     public function commitMessage()

--- a/src/Events/GlobalSetSaving.php
+++ b/src/Events/GlobalSetSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class GlobalSetSaving extends Event
 {
-    public $globals;
-
-    public function __construct($globals)
+    public function __construct(public $globals)
     {
-        $this->globals = $globals;
     }
 
     /**

--- a/src/Events/GlobalVariablesBlueprintFound.php
+++ b/src/Events/GlobalVariablesBlueprintFound.php
@@ -4,12 +4,7 @@ namespace Statamic\Events;
 
 class GlobalVariablesBlueprintFound extends Event
 {
-    public $blueprint;
-    public $globals;
-
-    public function __construct($blueprint, $globals = null)
+    public function __construct(public $blueprint, public $globals = null)
     {
-        $this->blueprint = $blueprint;
-        $this->globals = $globals;
     }
 }

--- a/src/Events/GlobalVariablesCreated.php
+++ b/src/Events/GlobalVariablesCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class GlobalVariablesCreated extends Event
 {
-    public $variables;
-
-    public function __construct($variables)
+    public function __construct(public $variables)
     {
-        $this->variables = $variables;
     }
 }

--- a/src/Events/GlobalVariablesCreating.php
+++ b/src/Events/GlobalVariablesCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class GlobalVariablesCreating extends Event
 {
-    public $variables;
-
-    public function __construct($variables)
+    public function __construct(public $variables)
     {
-        $this->variables = $variables;
     }
 
     /**

--- a/src/Events/GlobalVariablesDeleted.php
+++ b/src/Events/GlobalVariablesDeleted.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class GlobalVariablesDeleted extends Event
 {
-    public $variables;
-
-    public function __construct($variables)
+    public function __construct(public $variables)
     {
-        $this->variables = $variables;
     }
 }

--- a/src/Events/GlobalVariablesDeleting.php
+++ b/src/Events/GlobalVariablesDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class GlobalVariablesDeleting extends Event
 {
-    public $variables;
-
-    public function __construct($variables)
+    public function __construct(public $variables)
     {
-        $this->variables = $variables;
     }
 
     /**

--- a/src/Events/GlobalVariablesSaved.php
+++ b/src/Events/GlobalVariablesSaved.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class GlobalVariablesSaved extends Event
 {
-    public $variables;
-
-    public function __construct($variables)
+    public function __construct(public $variables)
     {
-        $this->variables = $variables;
     }
 }

--- a/src/Events/GlobalVariablesSaving.php
+++ b/src/Events/GlobalVariablesSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class GlobalVariablesSaving extends Event
 {
-    public $variables;
-
-    public function __construct($variables)
+    public function __construct(public $variables)
     {
-        $this->variables = $variables;
     }
 
     /**

--- a/src/Events/LocalizedTermDeleted.php
+++ b/src/Events/LocalizedTermDeleted.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class LocalizedTermDeleted extends Event
 {
-    public $term;
-
-    public function __construct($term)
+    public function __construct(public $term)
     {
-        $this->term = $term;
     }
 }

--- a/src/Events/LocalizedTermSaved.php
+++ b/src/Events/LocalizedTermSaved.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class LocalizedTermSaved extends Event
 {
-    public $term;
-
-    public function __construct($term)
+    public function __construct(public $term)
     {
-        $this->term = $term;
     }
 }

--- a/src/Events/NavBlueprintFound.php
+++ b/src/Events/NavBlueprintFound.php
@@ -4,12 +4,7 @@ namespace Statamic\Events;
 
 class NavBlueprintFound extends Event
 {
-    public $blueprint;
-    public $nav;
-
-    public function __construct($blueprint, $nav = null)
+    public function __construct(public $blueprint, public $nav = null)
     {
-        $this->blueprint = $blueprint;
-        $this->nav = $nav;
     }
 }

--- a/src/Events/NavCreated.php
+++ b/src/Events/NavCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class NavCreated extends Event
 {
-    public $nav;
-
-    public function __construct($nav)
+    public function __construct(public $nav)
     {
-        $this->nav = $nav;
     }
 }

--- a/src/Events/NavCreating.php
+++ b/src/Events/NavCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class NavCreating extends Event
 {
-    public $nav;
-
-    public function __construct($nav)
+    public function __construct(public $nav)
     {
-        $this->nav = $nav;
     }
 
     /**

--- a/src/Events/NavDeleted.php
+++ b/src/Events/NavDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class NavDeleted extends Event implements ProvidesCommitMessage
 {
-    public $nav;
-
-    public function __construct($nav)
+    public function __construct(public $nav)
     {
-        $this->nav = $nav;
     }
 
     public function commitMessage()

--- a/src/Events/NavDeleting.php
+++ b/src/Events/NavDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class NavDeleting extends Event
 {
-    public $nav;
-
-    public function __construct($nav)
+    public function __construct(public $nav)
     {
-        $this->nav = $nav;
     }
 
     /**

--- a/src/Events/NavSaved.php
+++ b/src/Events/NavSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class NavSaved extends Event implements ProvidesCommitMessage
 {
-    public $nav;
-
-    public function __construct($nav)
+    public function __construct(public $nav)
     {
-        $this->nav = $nav;
     }
 
     public function commitMessage()

--- a/src/Events/NavSaving.php
+++ b/src/Events/NavSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class NavSaving extends Event
 {
-    public $nav;
-
-    public function __construct($nav)
+    public function __construct(public $nav)
     {
-        $this->nav = $nav;
     }
 
     /**

--- a/src/Events/NavTreeDeleted.php
+++ b/src/Events/NavTreeDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class NavTreeDeleted extends Event implements ProvidesCommitMessage
 {
-    public $tree;
-
-    public function __construct($tree)
+    public function __construct(public $tree)
     {
-        $this->tree = $tree;
     }
 
     public function commitMessage()

--- a/src/Events/NavTreeSaved.php
+++ b/src/Events/NavTreeSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class NavTreeSaved extends Event implements ProvidesCommitMessage
 {
-    public $tree;
-
-    public function __construct($tree)
+    public function __construct(public $tree)
     {
-        $this->tree = $tree;
     }
 
     public function commitMessage()

--- a/src/Events/NavTreeSaving.php
+++ b/src/Events/NavTreeSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class NavTreeSaving extends Event
 {
-    public $tree;
-
-    public function __construct($tree)
+    public function __construct(public $tree)
     {
-        $this->tree = $tree;
     }
 
     /**

--- a/src/Events/ResponseCreated.php
+++ b/src/Events/ResponseCreated.php
@@ -6,16 +6,7 @@ use Illuminate\Http\Response;
 
 class ResponseCreated extends Event
 {
-    /**
-     * @var Response
-     */
-    public $response;
-
-    public $data;
-
-    public function __construct(Response $response, $data)
+    public function __construct(public Response $response, public $data)
     {
-        $this->response = $response;
-        $this->data = $data;
     }
 }

--- a/src/Events/RevisionDeleted.php
+++ b/src/Events/RevisionDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class RevisionDeleted extends Event implements ProvidesCommitMessage
 {
-    public $revision;
-
-    public function __construct($revision)
+    public function __construct(public $revision)
     {
-        $this->revision = $revision;
     }
 
     public function commitMessage()

--- a/src/Events/RevisionSaved.php
+++ b/src/Events/RevisionSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class RevisionSaved extends Event implements ProvidesCommitMessage
 {
-    public $revision;
-
-    public function __construct($revision)
+    public function __construct(public $revision)
     {
-        $this->revision = $revision;
     }
 
     public function commitMessage()

--- a/src/Events/RevisionSaving.php
+++ b/src/Events/RevisionSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class RevisionSaving extends Event
 {
-    public $revision;
-
-    public function __construct($revision)
+    public function __construct(public $revision)
     {
-        $this->revision = $revision;
     }
 
     /**

--- a/src/Events/RoleDeleted.php
+++ b/src/Events/RoleDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class RoleDeleted extends Event implements ProvidesCommitMessage
 {
-    public $role;
-
-    public function __construct($role)
+    public function __construct(public $role)
     {
-        $this->role = $role;
     }
 
     public function commitMessage()

--- a/src/Events/RoleSaved.php
+++ b/src/Events/RoleSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class RoleSaved extends Event implements ProvidesCommitMessage
 {
-    public $role;
-
-    public function __construct($role)
+    public function __construct(public $role)
     {
-        $this->role = $role;
     }
 
     public function commitMessage()

--- a/src/Events/SiteCreated.php
+++ b/src/Events/SiteCreated.php
@@ -8,6 +8,5 @@ class SiteCreated extends Event
 {
     public function __construct(public Site $site)
     {
-        //
     }
 }

--- a/src/Events/SiteDeleted.php
+++ b/src/Events/SiteDeleted.php
@@ -9,7 +9,6 @@ class SiteDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public Site $site)
     {
-        //
     }
 
     public function commitMessage()

--- a/src/Events/SiteSaved.php
+++ b/src/Events/SiteSaved.php
@@ -9,7 +9,6 @@ class SiteSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public Site $site)
     {
-        //
     }
 
     public function commitMessage()

--- a/src/Events/SubmissionCreated.php
+++ b/src/Events/SubmissionCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class SubmissionCreated extends Event
 {
-    public $submission;
-
-    public function __construct($submission)
+    public function __construct(public $submission)
     {
-        $this->submission = $submission;
     }
 }

--- a/src/Events/SubmissionCreating.php
+++ b/src/Events/SubmissionCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class SubmissionCreating extends Event
 {
-    public $submission;
-
-    public function __construct($submission)
+    public function __construct(public $submission)
     {
-        $this->submission = $submission;
     }
 
     /**

--- a/src/Events/SubmissionDeleted.php
+++ b/src/Events/SubmissionDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class SubmissionDeleted extends Event implements ProvidesCommitMessage
 {
-    public $submission;
-
-    public function __construct($submission)
+    public function __construct(public $submission)
     {
-        $this->submission = $submission;
     }
 
     public function commitMessage()

--- a/src/Events/SubmissionSaved.php
+++ b/src/Events/SubmissionSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class SubmissionSaved extends Event implements ProvidesCommitMessage
 {
-    public $submission;
-
-    public function __construct($submission)
+    public function __construct(public $submission)
     {
-        $this->submission = $submission;
     }
 
     public function commitMessage()

--- a/src/Events/SubmissionSaving.php
+++ b/src/Events/SubmissionSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class SubmissionSaving extends Event
 {
-    public $submission;
-
-    public function __construct($submission)
+    public function __construct(public $submission)
     {
-        $this->submission = $submission;
     }
 
     /**

--- a/src/Events/TaxonomyCreated.php
+++ b/src/Events/TaxonomyCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class TaxonomyCreated extends Event
 {
-    public $taxonomy;
-
-    public function __construct($taxonomy)
+    public function __construct(public $taxonomy)
     {
-        $this->taxonomy = $taxonomy;
     }
 }

--- a/src/Events/TaxonomyCreating.php
+++ b/src/Events/TaxonomyCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class TaxonomyCreating extends Event
 {
-    public $taxonomy;
-
-    public function __construct($taxonomy)
+    public function __construct(public $taxonomy)
     {
-        $this->taxonomy = $taxonomy;
     }
 
     /**

--- a/src/Events/TaxonomyDeleted.php
+++ b/src/Events/TaxonomyDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class TaxonomyDeleted extends Event implements ProvidesCommitMessage
 {
-    public $taxonomy;
-
-    public function __construct($taxonomy)
+    public function __construct(public $taxonomy)
     {
-        $this->taxonomy = $taxonomy;
     }
 
     public function commitMessage()

--- a/src/Events/TaxonomyDeleting.php
+++ b/src/Events/TaxonomyDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class TaxonomyDeleting extends Event
 {
-    public $taxonomy;
-
-    public function __construct($taxonomy)
+    public function __construct(public $taxonomy)
     {
-        $this->taxonomy = $taxonomy;
     }
 
     /**

--- a/src/Events/TaxonomySaved.php
+++ b/src/Events/TaxonomySaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class TaxonomySaved extends Event implements ProvidesCommitMessage
 {
-    public $taxonomy;
-
-    public function __construct($taxonomy)
+    public function __construct(public $taxonomy)
     {
-        $this->taxonomy = $taxonomy;
     }
 
     public function commitMessage()

--- a/src/Events/TaxonomySaving.php
+++ b/src/Events/TaxonomySaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class TaxonomySaving extends Event
 {
-    public $taxonomy;
-
-    public function __construct($taxonomy)
+    public function __construct(public $taxonomy)
     {
-        $this->taxonomy = $taxonomy;
     }
 
     /**

--- a/src/Events/TermBlueprintFound.php
+++ b/src/Events/TermBlueprintFound.php
@@ -4,12 +4,7 @@ namespace Statamic\Events;
 
 class TermBlueprintFound extends Event
 {
-    public $blueprint;
-    public $term;
-
-    public function __construct($blueprint, $term = null)
+    public function __construct(public $blueprint, public $term = null)
     {
-        $this->blueprint = $blueprint;
-        $this->term = $term;
     }
 }

--- a/src/Events/TermCreated.php
+++ b/src/Events/TermCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class TermCreated extends Event
 {
-    public $term;
-
-    public function __construct($term)
+    public function __construct(public $term)
     {
-        $this->term = $term;
     }
 }

--- a/src/Events/TermCreating.php
+++ b/src/Events/TermCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class TermCreating extends Event
 {
-    public $term;
-
-    public function __construct($term)
+    public function __construct(public $term)
     {
-        $this->term = $term;
     }
 
     /**

--- a/src/Events/TermDeleted.php
+++ b/src/Events/TermDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class TermDeleted extends Event implements ProvidesCommitMessage
 {
-    public $term;
-
-    public function __construct($term)
+    public function __construct(public $term)
     {
-        $this->term = $term;
     }
 
     public function commitMessage()

--- a/src/Events/TermDeleting.php
+++ b/src/Events/TermDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class TermDeleting extends Event
 {
-    public $term;
-
-    public function __construct($term)
+    public function __construct(public $term)
     {
-        $this->term = $term;
     }
 
     /**

--- a/src/Events/TermReferencesUpdated.php
+++ b/src/Events/TermReferencesUpdated.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class TermReferencesUpdated extends Event implements ProvidesCommitMessage
 {
-    public $term;
-
-    public function __construct($term)
+    public function __construct(public $term)
     {
-        $this->term = $term;
     }
 
     public function commitMessage()

--- a/src/Events/TermSaved.php
+++ b/src/Events/TermSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class TermSaved extends Event implements ProvidesCommitMessage
 {
-    public $term;
-
-    public function __construct($term)
+    public function __construct(public $term)
     {
-        $this->term = $term;
     }
 
     public function commitMessage()

--- a/src/Events/TermSaving.php
+++ b/src/Events/TermSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class TermSaving extends Event
 {
-    public $term;
-
-    public function __construct($term)
+    public function __construct(public $term)
     {
-        $this->term = $term;
     }
 
     /**

--- a/src/Events/UserBlueprintFound.php
+++ b/src/Events/UserBlueprintFound.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class UserBlueprintFound extends Event
 {
-    public $blueprint;
-
-    public function __construct($blueprint)
+    public function __construct(public $blueprint)
     {
-        $this->blueprint = $blueprint;
     }
 }

--- a/src/Events/UserCreated.php
+++ b/src/Events/UserCreated.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class UserCreated extends Event
 {
-    public $user;
-
-    public function __construct($user)
+    public function __construct(public $user)
     {
-        $this->user = $user;
     }
 }

--- a/src/Events/UserCreating.php
+++ b/src/Events/UserCreating.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class UserCreating extends Event
 {
-    public $user;
-
-    public function __construct($user)
+    public function __construct(public $user)
     {
-        $this->user = $user;
     }
 
     /**

--- a/src/Events/UserDeleted.php
+++ b/src/Events/UserDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class UserDeleted extends Event implements ProvidesCommitMessage
 {
-    public $user;
-
-    public function __construct($user)
+    public function __construct(public $user)
     {
-        $this->user = $user;
     }
 
     public function commitMessage()

--- a/src/Events/UserDeleting.php
+++ b/src/Events/UserDeleting.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class UserDeleting extends Event
 {
-    public $user;
-
-    public function __construct($user)
+    public function __construct(public $user)
     {
-        $this->user = $user;
     }
 
     /**

--- a/src/Events/UserGroupBlueprintFound.php
+++ b/src/Events/UserGroupBlueprintFound.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class UserGroupBlueprintFound extends Event
 {
-    public $blueprint;
-
-    public function __construct($blueprint)
+    public function __construct(public $blueprint)
     {
-        $this->blueprint = $blueprint;
     }
 }

--- a/src/Events/UserGroupDeleted.php
+++ b/src/Events/UserGroupDeleted.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class UserGroupDeleted extends Event implements ProvidesCommitMessage
 {
-    public $group;
-
-    public function __construct($group)
+    public function __construct(public $group)
     {
-        $this->group = $group;
     }
 
     public function commitMessage()

--- a/src/Events/UserGroupSaved.php
+++ b/src/Events/UserGroupSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class UserGroupSaved extends Event implements ProvidesCommitMessage
 {
-    public $group;
-
-    public function __construct($group)
+    public function __construct(public $group)
     {
-        $this->group = $group;
     }
 
     public function commitMessage()

--- a/src/Events/UserRegistered.php
+++ b/src/Events/UserRegistered.php
@@ -4,10 +4,7 @@ namespace Statamic\Events;
 
 class UserRegistered extends Event
 {
-    public $user;
-
-    public function __construct($user)
+    public function __construct(public $user)
     {
-        $this->user = $user;
     }
 }

--- a/src/Events/UserRegistering.php
+++ b/src/Events/UserRegistering.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class UserRegistering extends Event
 {
-    public $user;
-
-    public function __construct($user)
+    public function __construct(public $user)
     {
-        $this->user = $user;
     }
 
     /**

--- a/src/Events/UserSaved.php
+++ b/src/Events/UserSaved.php
@@ -6,11 +6,8 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class UserSaved extends Event implements ProvidesCommitMessage
 {
-    public $user;
-
-    public function __construct($user)
+    public function __construct(public $user)
     {
-        $this->user = $user;
     }
 
     public function commitMessage()

--- a/src/Events/UserSaving.php
+++ b/src/Events/UserSaving.php
@@ -4,11 +4,8 @@ namespace Statamic\Events;
 
 class UserSaving extends Event
 {
-    public $user;
-
-    public function __construct($user)
+    public function __construct(public $user)
     {
-        $this->user = $user;
     }
 
     /**


### PR DESCRIPTION
This pull request refactors events to use PHP 8's [constructor property promotion](https://stitcher.io/blog/constructor-promotion-in-php-8) feature. It makes the events a little bit cleaner and takes advantage of a fairly new feature in PHP.

Apologies for the number of files changed - we have a lot of events 😄