### PR TITLE
[5.x] Fix additional url segments matching taxonomy terms

### DIFF
--- a/src/Stache/Repositories/TermRepository.php
+++ b/src/Stache/Repositories/TermRepository.php
@@ -102,6 +102,10 @@ class TermRepository implements RepositoryContract
             return null;
         }
 
+        if ($term->uri() !== '/'.$uri) {
+            return null;
+        }
+
         return $term->collection($collection);
     }
 

--- a/tests/Data/Taxonomies/ViewsTest.php
+++ b/tests/Data/Taxonomies/ViewsTest.php
@@ -88,6 +88,14 @@ class ViewsTest extends TestCase
     }
 
     #[Test]
+    public function it_doesnt_load_the_term_url_if_there_are_additional_segments()
+    {
+        $this->viewShouldReturnRaw('tags.show', 'showing {{ title }}');
+
+        $this->get('/tags/test/extra/segments')->assertNotFound();
+    }
+
+    #[Test]
     public function it_loads_the_localized_term_url_if_the_view_exists()
     {
         $this->viewShouldReturnRaw('tags.show', 'showing {{ title }}');


### PR DESCRIPTION
This fixes an issue where if you visited `/term-url/any/number/of/segments` it would act like you're on `/term-url`. It should 404.
