### PR TITLE
Improve Bard link UX

### DIFF
--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -313,6 +313,7 @@ export default {
     watch: {
 
         linkType() {
+            this.setTarget();
             this.autofocus();
         },
 
@@ -364,9 +365,7 @@ export default {
             this.rel = attrs.href
                 ? attrs.rel
                 : this.defaultRel;
-            this.targetBlank = attrs.href
-                ? attrs.target === '_blank'
-                : this.config.target_blank;
+            this.targetBlank = true;
         },
 
         autofocus() {
@@ -377,6 +376,18 @@ export default {
                     }, 50);
                 });
             }
+        },
+
+        setTarget() {
+            if (this.linkType === 'url') {
+                this.targetBlank = true;
+                this.title = 'Open in new window';
+
+                return;
+            }
+
+            this.targetBlank = this.config.target_blank;
+            this.title = null;
         },
 
         setUrl(type, url) {


### PR DESCRIPTION
It's best practice to never open internal links in a new window, but also always open external links in a new window, while setting the title to `Open in a new window`.