### PR TITLE
[5.x] Add empty/not empty field filters

### DIFF
--- a/src/Query/Scopes/Filters/Fields/Date.php
+++ b/src/Query/Scopes/Filters/Fields/Date.php
@@ -17,6 +17,8 @@ class Date extends FieldtypeFilter
                     '<' => __('Before'),
                     '>' => __('After'),
                     'between' => __('Between'),
+                    'null' => __('Empty'),
+                    'not-null' => __('Not empty'),
                 ],
             ],
             'value' => [
@@ -54,7 +56,11 @@ class Date extends FieldtypeFilter
 
         $value = Carbon::parse($values['value']);
 
-        $query->where($handle, $operator, $value);
+        match ($operator) {
+            'null' => $query->whereNull($handle),
+            'not-null' => $query->whereNotNull($handle),
+            default => $query->where($handle, $operator, $value),
+        };
     }
 
     public function badge($values)

--- a/src/Query/Scopes/Filters/Fields/Entries.php
+++ b/src/Query/Scopes/Filters/Fields/Entries.php
@@ -25,6 +25,8 @@ class Entries extends FieldtypeFilter
                     'like' => __('Contains'),
                     '=' => __('Is'),
                     '!=' => __('Isn\'t'),
+                    'null' => __('Empty'),
+                    'not-null' => __('Not empty'),
                 ],
                 'default' => 'like',
             ],
@@ -32,8 +34,9 @@ class Entries extends FieldtypeFilter
                 'type' => 'text',
                 'placeholder' => __('Value'),
                 'if' => [
-                    'operator' => 'not empty',
+                    'operator' => 'contains_any like, =, !=',
                 ],
+                'required' => false,
             ],
         ];
     }
@@ -44,6 +47,15 @@ class Entries extends FieldtypeFilter
         $maxItems = $config['max_items'] ?? 0;
         $operator = $values['operator'];
         $value = $values['value'];
+
+        if (in_array($operator, ['null', 'not-null'])) {
+            match ($operator) {
+                'null' => $query->whereNull($handle),
+                'not-null' => $query->whereNotNull($handle),
+            };
+
+            return;
+        }
 
         if ($operator === 'like') {
             $value = Str::ensureLeft($value, '%');

--- a/src/Query/Scopes/Filters/Fields/FieldtypeFilter.php
+++ b/src/Query/Scopes/Filters/Fields/FieldtypeFilter.php
@@ -27,6 +27,8 @@ class FieldtypeFilter
                     'like' => __('Contains'),
                     '=' => __('Is'),
                     '<>' => __('Isn\'t'),
+                    'null' => __('Empty'),
+                    'not-null' => __('Not empty'),
                 ],
                 'default' => 'like',
             ],
@@ -34,8 +36,9 @@ class FieldtypeFilter
                 'type' => 'text',
                 'placeholder' => __('Value'),
                 'if' => [
-                    'operator' => 'not empty',
+                    'operator' => 'contains_any like, =, <>',
                 ],
+                'required' => false,
             ],
         ];
     }
@@ -50,7 +53,11 @@ class FieldtypeFilter
             $value = Str::ensureRight($value, '%');
         }
 
-        $query->where($handle, $operator, $value);
+        match ($operator) {
+            'null' => $query->whereNull($handle),
+            'not-null' => $query->whereNotNull($handle),
+            default => $query->where($handle, $operator, $value),
+        };
     }
 
     public function badge($values)

--- a/src/Query/Scopes/Filters/Fields/Number.php
+++ b/src/Query/Scopes/Filters/Fields/Number.php
@@ -21,6 +21,8 @@ abstract class Number extends FieldtypeFilter
                     '>=' => __('Greater than or equals'),
                     '<' => __('Less than'),
                     '<=' => __('Less than or equals'),
+                    'null' => __('Empty'),
+                    'not-null' => __('Not empty'),
                 ],
                 'default' => '=',
             ],
@@ -28,7 +30,7 @@ abstract class Number extends FieldtypeFilter
                 'type' => $this->valueFieldtype(),
                 'placeholder' => __('Value'),
                 'if' => [
-                    'operator' => 'not empty',
+                    'operator' => 'contains_any <>, >, >=, <, <=, =',
                 ],
             ],
         ];
@@ -39,7 +41,11 @@ abstract class Number extends FieldtypeFilter
         $operator = $values['operator'];
         $value = $values['value'];
 
-        $query->where($handle, $operator, $value);
+        match ($operator) {
+            'null' => $query->whereNull($handle),
+            'not-null' => $query->whereNotNull($handle),
+            default => $query->where($handle, $operator, $value),
+        };
     }
 
     public function badge($values)

--- a/src/Query/Scopes/Filters/Fields/Terms.php
+++ b/src/Query/Scopes/Filters/Fields/Terms.php
@@ -3,29 +3,55 @@
 namespace Statamic\Query\Scopes\Filters\Fields;
 
 use Statamic\Facades;
+use Statamic\Support\Arr;
 
 class Terms extends FieldtypeFilter
 {
     public function fieldItems()
     {
         return [
+            'operator' => [
+                'type' => 'select',
+                'options' => [
+                    'like' => __('Contains'),
+                    'null' => __('Empty'),
+                    'not-null' => __('Not empty'),
+                ],
+                'default' => 'like',
+            ],
             'term' => [
                 'type' => 'select',
                 'options' => $this->options()->all(),
-                'placeholder' => __('Contains'),
+                'placeholder' => __('Term'),
                 'clearable' => true,
+                'if' => [
+                    'operator' => 'contains_any like',
+                ],
             ],
         ];
     }
 
     public function apply($query, $handle, $values)
     {
-        $query->whereJsonContains($handle, $values['term']);
+        $operator = $values['operator'];
+
+        match ($operator) {
+            'like' => $query->whereJsonContains($handle, $values['term']),
+            'null' => $query->whereNull($handle),
+            'not-null' => $query->whereNotNull($handle),
+        };
     }
 
     public function badge($values)
     {
         $field = $this->fieldtype->field()->display();
+        $operator = $values['operator'];
+
+        if (in_array($operator, ['null', 'not-null'])) {
+            $translatedOperator = Arr::get($this->fieldItems(), "operator.options.{$operator}");
+
+            return $field.' '.strtolower($translatedOperator);
+        }
 
         $id = $this->fieldtype->usingSingleTaxonomy()
             ? $this->fieldtype->taxonomies()[0].'::'.$values['term']

--- a/src/Query/Scopes/Filters/Fields/User.php
+++ b/src/Query/Scopes/Filters/Fields/User.php
@@ -3,22 +3,48 @@
 namespace Statamic\Query\Scopes\Filters\Fields;
 
 use Statamic\Facades\User as Users;
+use Statamic\Support\Arr;
 
 class User extends FieldtypeFilter
 {
     public function fieldItems()
     {
         return [
+            'operator' => [
+                'type' => 'select',
+                'placeholder' => __('Select Operator'),
+                'options' => [
+                    '=' => __('Is'),
+                    'null' => __('Empty'),
+                    'not-null' => __('Not empty'),
+                ],
+                'default' => '=',
+            ],
             'value' => [
                 'type' => 'users',
                 'max_items' => 1,
                 'mode' => 'select',
+                'if' => [
+                    'operator' => 'contains_any like, =, !=',
+                ],
+                'required' => false,
             ],
         ];
     }
 
     public function apply($query, $handle, $values)
     {
+        $operator = $values['operator'];
+
+        if (in_array($operator, ['null', 'not-null'])) {
+            match ($operator) {
+                'null' => $query->whereNull($handle),
+                'not-null' => $query->whereNotNull($handle),
+            };
+
+            return;
+        }
+
         if (! $user = $values['value']) {
             return;
         }
@@ -30,12 +56,19 @@ class User extends FieldtypeFilter
 
     public function badge($values)
     {
+        $field = $this->fieldtype->field()->display();
+        $operator = $values['operator'];
+
+        if (in_array($operator, ['null', 'not-null'])) {
+            $translatedOperator = Arr::get($this->fieldItems(), "operator.options.{$operator}");
+
+            return $field.' '.strtolower($translatedOperator);
+        }
+
         if (! $user = $values['value']) {
             return null;
         }
 
-        $field = $this->fieldtype->field()->display();
-        $operator = __('Is');
         $user = Users::find($user)->name();
 
         return $field.' '.strtolower($operator).' '.$user;


### PR DESCRIPTION
Follow up to https://github.com/statamic/cms/pull/11354

This PR adds empty/not empty field filter options for all other field types, except toggle because I don't think that can be empty?