### PR TITLE
[5.x] Prevent infinite loops with Laravel Telescope

### DIFF
--- a/src/Data/HasAugmentedInstance.php
+++ b/src/Data/HasAugmentedInstance.php
@@ -97,6 +97,11 @@ trait HasAugmentedInstance
         return null;
     }
 
+    public function formatForTelescope(): array
+    {
+        return $this->toShallowAugmentedArray();
+    }
+
     public function toArray()
     {
         return $this->toEvaluatedAugmentedArray();


### PR DESCRIPTION
This pull request fixes an issue with Laravel Telescope installed, where an infinite loop would occur if you had entries which link to each other.

Right now, when Telescope encounters an `Entry` object (whether that be in an event, or in an authorization gate), it'll attempt to serialize it using `->jsonSerialize()` which'll return an evaluated array of the augmented entry.

However, if you have an entry which relates back to itself, this evaluated array can cause an infinite loop.

This PR addresses that by returning a shallow augmented array instead, which prevents relationships from being evaluated in the same way, therefore preventing the infinite loop issue.

This fix relies on the `formatForTelescope` method, added in these Telescope PRs:

* https://github.com/laravel/telescope/pull/1562
* https://github.com/laravel/telescope/pull/1566

Fixes #10782.