### PR TITLE
[5.x] Fix "Curaçao" item in countries dictionary

### DIFF
--- a/resources/lang/en/dictionary-countries.php
+++ b/resources/lang/en/dictionary-countries.php
@@ -91,7 +91,7 @@ return [
         'CIV' => 'Cote D\'Ivoire (Ivory Coast)',
         'HRV' => 'Croatia',
         'CUB' => 'Cuba',
-        'CUW' => 'Cura\\u00e7ao',
+        'CUW' => 'Curaçao',
         'CYP' => 'Cyprus',
         'CZE' => 'Czech Republic',
         'COD' => 'Democratic Republic of the Congo',


### PR DESCRIPTION
This pull request fixes an issue with the name of "Curaçao" in the countries dictionary. Not sure how, but looks like the special character messed things up.

Replaces #11393.