### PR TITLE
[5.x] Fix emptiness check on Value properties

### DIFF
--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -224,6 +224,11 @@ class Value implements ArrayAccess, IteratorAggregate, JsonSerializable
         return $this->value()->{$name}(...$arguments);
     }
 
+    public function __isset($key)
+    {
+        return isset($this->value()?->{$key});
+    }
+
     public function __get($key)
     {
         return $this->value()?->{$key} ?? null;

--- a/tests/Fields/ValueTest.php
+++ b/tests/Fields/ValueTest.php
@@ -323,6 +323,18 @@ class ValueTest extends TestCase
     }
 
     #[Test]
+    public function it_can_check_emptiness_on_properties()
+    {
+        $val = new Value((object) [
+            'a' => 'alfa',
+            'b' => '',
+        ]);
+
+        $this->assertNotTrue(empty($val->a));
+        $this->assertTrue(empty($val->b));
+    }
+
+    #[Test]
     public function it_can_proxy_methods_to_value()
     {
         // This is useful when the value is an object like an Entry, you could

--- a/tests/Fields/ValueTest.php
+++ b/tests/Fields/ValueTest.php
@@ -323,15 +323,33 @@ class ValueTest extends TestCase
     }
 
     #[Test]
+    public function it_can_check_isset_on_properties()
+    {
+        $val = new Value((object) [
+            'a' => 'alfa',
+            'b' => '',
+            'c' => null,
+        ]);
+
+        $this->assertTrue(isset($val->a));
+        $this->assertTrue(isset($val->b));
+        $this->assertFalse(isset($val->c));
+        $this->assertFalse(isset($val->d));
+    }
+
+    #[Test]
     public function it_can_check_emptiness_on_properties()
     {
         $val = new Value((object) [
             'a' => 'alfa',
             'b' => '',
+            'c' => null,
         ]);
 
-        $this->assertNotTrue(empty($val->a));
+        $this->assertFalse(empty($val->a));
         $this->assertTrue(empty($val->b));
+        $this->assertTrue(empty($val->c));
+        $this->assertTrue(empty($val->d));
     }
 
     #[Test]


### PR DESCRIPTION
Tricky behavior ran into by Erin - https://discord.com/channels/489818810157891584/489830535565148169/1333967156861468694

This won't directly solve what he was dealing with (as he had a custom class), but it will fix it for future devs checking if a property on a Value is empty.

Currently, if you have an object wrapped by a Value and then check the emptiness of a property on that object it returns true no matter what:

![image](https://github.com/user-attachments/assets/b4545ee8-2f7d-489c-9e37-888f7ec95e4e)

This is due to https://www.php.net/manual/en/function.empty.php#99959
> Calling non existing object property, `empty($object->prop)`, will trigger `__isset()`, the same way as `isset($object->prop)` does, but there is one difference. If `__isset()` returns `TRUE`, another call to `__get()` will be made and actual return value will be result of `empty()` and result of `__get()`.

In other words, since Value doesn't have the `__isset()` method on it every single `empty()` check on a property inside of it will fail.

This PR fixes that and adds a test :)