### PR TITLE
[5.x] Allow config values to be used in forms

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -17,6 +17,7 @@ use Statamic\Events\FormDeleted;
 use Statamic\Events\FormDeleting;
 use Statamic\Events\FormSaved;
 use Statamic\Events\FormSaving;
+use Statamic\Facades\Antlers;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\File;
 use Statamic\Facades\Form as FormFacade;
@@ -261,6 +262,12 @@ class Form implements Arrayable, Augmentable, FormContract
     public function hydrate()
     {
         $contents = YAML::parse(File::get($this->path()));
+        $variables = ['config' => config()->all()];
+        array_walk_recursive($contents, function (&$value) use ($variables) {
+            if (is_string($value)) {
+                $value = (string) Antlers::parse($value, $variables);
+            }
+        });
 
         $methods = [
             'title',


### PR DESCRIPTION
Issue is described here: https://github.com/statamic-rad-pack/mailchimp/issues/137

It's not a breaking change, but is necessary for the above issue to be resolved - unless there's another mysterious way to hook into data to fix it?