### PR TITLE
[5.x] Live Preview: Allow changing the position of "Responsive" device option

### DIFF
--- a/resources/js/components/live-preview/LivePreview.vue
+++ b/resources/js/components/live-preview/LivePreview.vue
@@ -149,7 +149,7 @@ export default {
                 return { value: device, label: __(device) };
             }));
 
-            if (! options.filter((option) => option.label === __('Responsive'))) {
+            if (options.filter((option) => option.label === __('Responsive')).length === 0) {
                 options.unshift({ value: null, label: __('Responsive') });
             }
 

--- a/resources/js/components/live-preview/LivePreview.vue
+++ b/resources/js/components/live-preview/LivePreview.vue
@@ -142,9 +142,17 @@ export default {
 
         deviceSelectOptions() {
             let options = Object.values(_.mapObject(this.$config.get('livePreview.devices'), (dimensions, device) => {
+                if (device === 'Responsive') {
+                    return { value: null, label: __('Responsive') };
+                }
+
                 return { value: device, label: __(device) };
             }));
-            options.unshift({ value: null, label: __('Responsive') });
+
+            if (! options.filter((option) => option.label === __('Responsive'))) {
+                options.unshift({ value: null, label: __('Responsive') });
+            }
+
             return options;
         },
 
@@ -217,6 +225,7 @@ export default {
     },
 
     created() {
+        this.previewDevice = this.deviceSelectOptions[0].value;
         this.editorWidth = localStorage.getItem(widthLocalStorageKey) || 400
 
         this.keybinding = this.$keys.bindGlobal('mod+shift+p', () => {


### PR DESCRIPTION
Right now, in Live Preview, the "Responsive" option is always the first and default option.

However, if most of your users are viewing your articles on mobile, you might want to change the order of the options so "Mobile" is at the top:

![CleanShot 2025-01-29 at 11 39 01](https://github.com/user-attachments/assets/184949e3-e863-4ad5-a276-976b94818c72)


This pull request allows you to do that. Simply add a `Responsive` device to the `live-preview.devices` config option, and it'll work.

```diff
'devices' => [
        'Laptop' => ['width' => 1440, 'height' => 900],
        'Tablet' => ['width' => 1024, 'height' => 786],
        'Mobile' => ['width' => 375, 'height' => 812],
+       'Responsive' => [],
],
```

![CleanShot 2025-01-29 at 11 38 22](https://github.com/user-attachments/assets/3346050a-4730-4a4b-99f7-d31d55ec7849)


The Live Preview will also default to whatever the first option in the devices list is.