### PR TITLE
[5.x] Make active toolbar buttons of Bard more visible in dark mode

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -49,11 +49,11 @@
     }
 
     .bard-toolbar-button:hover {
-        @apply bg-gray-200 dark:bg-dark-700;
+        @apply bg-gray-200 dark:bg-dark-650;
     }
 
     .bard-toolbar-button.active {
-        @apply bg-gray-300 dark:bg-dark-800 text-black dark:text-dark-100;
+        @apply bg-gray-300 dark:bg-dark-600 text-black dark:text-white;
     }
 
     .bard-toolbar-button:focus {


### PR DESCRIPTION
# Problem:

In dark mode, the active toolbar buttons of Bard are barely visible:

![dark-mode-before](https://github.com/user-attachments/assets/399d1782-ce15-4d19-85cf-2cf2a38a91a1)

Compare that to light mode:

![light-mode](https://github.com/user-attachments/assets/4bdaad1b-4687-4df9-85aa-83d526d7a69e)

# Solution:

White text color for a nice "glowing" effect and less darker shade (600 instead of 800) for active buttons. For hover, I reduced that from 700 to 650 for a little more visibility, but not too much to steal the active button's show!

![dark-mode-after](https://github.com/user-attachments/assets/95faae85-a17b-4b3a-ae4f-c2a14c5572ab)

