### PR TITLE
[5.x] Support arguments in user can/cant tags

### DIFF
--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -453,9 +453,10 @@ class UserTags extends Tags
         }
 
         $permissions = Arr::wrap($this->params->explode(['permission', 'do']));
+        $arguments = $this->params->except(['permission', 'do'])->all();
 
         foreach ($permissions as $permission) {
-            if ($user->can($permission)) {
+            if ($user->can($permission, $arguments)) {
                 return $this->parser ? $this->parse() : true;
             }
         }
@@ -477,11 +478,12 @@ class UserTags extends Tags
         }
 
         $permissions = Arr::wrap($this->params->explode(['permission', 'do']));
+        $arguments = $this->params->except(['permission', 'do'])->all();
 
         $can = false;
 
         foreach ($permissions as $permission) {
-            if ($user->can($permission)) {
+            if ($user->can($permission, $arguments)) {
                 $can = true;
                 break;
             }

--- a/tests/Tags/User/UserTagsTest.php
+++ b/tests/Tags/User/UserTagsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Tags\User;
 
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Support\Facades\Gate;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Parse;
 use Statamic\Facades\Role;
@@ -50,6 +51,22 @@ class UserTagsTest extends TestCase
         // Test if user has any of these permissions
         $this->assertEquals('yes', $this->tag('{{ user:can do="access cp|configure collections" }}yes{{ /user:can }}'));
         $this->assertEquals('', $this->tag('{{ user:cant do="access cp|configure collections" }}yes{{ /user:cant }}'));
+    }
+
+    #[Test]
+    public function it_renders_user_can_with_aurguments_tag_content()
+    {
+        $this->actingAs(User::make()->save());
+
+        Gate::define('test gate', function ($user, $value) {
+            return $value === 'foo';
+        });
+
+        $this->assertEquals('yes', $this->tag('{{ user:can do="test gate" value="foo" }}yes{{ /user:can }}'));
+        $this->assertEquals('', $this->tag('{{ user:cant do="test gate" value="foo" }}yes{{ /user:cant }}'));
+        
+        $this->assertEquals('', $this->tag('{{ user:can do="test gate" value="bar" }}yes{{ /user:can }}'));
+        $this->assertEquals('yes', $this->tag('{{ user:cant do="test gate" value="bar" }}yes{{ /user:cant }}'));
     }
 
     #[Test]

--- a/tests/Tags/User/UserTagsTest.php
+++ b/tests/Tags/User/UserTagsTest.php
@@ -64,7 +64,7 @@ class UserTagsTest extends TestCase
 
         $this->assertEquals('yes', $this->tag('{{ user:can do="test gate" value="foo" }}yes{{ /user:can }}'));
         $this->assertEquals('', $this->tag('{{ user:cant do="test gate" value="foo" }}yes{{ /user:cant }}'));
-        
+
         $this->assertEquals('', $this->tag('{{ user:can do="test gate" value="bar" }}yes{{ /user:can }}'));
         $this->assertEquals('yes', $this->tag('{{ user:cant do="test gate" value="bar" }}yes{{ /user:cant }}'));
     }


### PR DESCRIPTION
This PR adds support for passing additional arguments to gates via the `{{ user:can }}`/`{{ user:cant }}` tags.

```php
Gate::define('view secret', function ($user, $secret) {
    return $user->hasAccessToSecret($secret);
});
```

```antlers
{{ user:can do="view secret" secret="foo" }}
    ...
{{ /user:can }}
```