### PR TITLE
[5.x] Allow custom render callback for overridden exceptions

### DIFF
--- a/src/Exceptions/Concerns/RendersHttpExceptions.php
+++ b/src/Exceptions/Concerns/RendersHttpExceptions.php
@@ -12,7 +12,9 @@ use Statamic\View\View;
 
 trait RendersHttpExceptions
 {
-    public function render()
+    public static ?\Closure $renderCallback = null;
+
+    public function render(Request $request)
     {
         if (Statamic::isCpRoute()) {
             return response()->view('statamic::errors.'.$this->getStatusCode(), [], $this->getStatusCode());
@@ -20,6 +22,10 @@ trait RendersHttpExceptions
 
         if (Statamic::isApiRoute()) {
             return response()->json(['message' => $this->getApiMessage()], $this->getStatusCode());
+        }
+
+        if (static::$renderCallback && ($response = call_user_func(static::$renderCallback, $request))) {
+            return $response;
         }
 
         if ($cached = $this->getCachedError()) {


### PR DESCRIPTION
Upgrading from Statamic 4 and Laravel 10 to Statamic 5 and  Laravel 11 I wanted to migrate this custom exception handler:
```php
public function render($request, \Throwable $e)
{
    if ($e instanceof NotFoundHttpException) {
        $eventsMount = Collection::findByHandle('events')->mount();
        if (Str::before($request->path(), '/') === $eventsMount->slug()) {
            return response()->redirectTo($eventsMount->url());
        }
    }

    return parent::render($request, $e);
}
```
Following Laravel's [documentation](https://laravel.com/docs/11.x/errors#rendering-exceptions) I couldn't understand why it didn't work, until I dived into the exception and saw it implements a `render` method which takes over.

This PR introduces a static callback you can use to implement your own handling:
```php
NotFoundHttpException::$renderCallback = function (Request $request) {
    $eventsMount = Collection::findByHandle('events')->mount();
    if (Str::before($request->path(), '/') === $eventsMount->slug()) {
        return response()->redirectTo($eventsMount->url());
    }
};
```