### PR TITLE
[5.x] Adjust video fit in asset editor

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -107,7 +107,7 @@
                             <div class="w-full shadow-none" v-else-if="asset.isAudio"><audio :src="asset.url" class="w-full" controls preload="auto"></audio></div>
 
                             <!-- Video -->
-                            <div class="w-full shadow-none" v-else-if="asset.isVideo"><video :src="asset.url" class="w-full" controls></video></div>
+                            <video :src="asset.url" class="asset-thumb" controls v-else-if="asset.isVideo"></video>
                         </div>
                     </div>
 


### PR DESCRIPTION
Improve how videos are rendered in the asset editor. In certain conditions, the video would either be cropped or extend into the meta fields, making it impossible to play the video or edit the metadata.

### Before

![statamic test_cp_assets_browse_assets_video mp4_edit](https://github.com/user-attachments/assets/2f2e7057-cf9c-483f-aedd-a078c15637f8)

### After

![statamic test_cp_assets_browse_assets_video mp4_edit (1)](https://github.com/user-attachments/assets/14b8ef7d-d483-42f4-b332-e2eb3883a76c)
