### PR TITLE
[5.x] Pass form_config to email view

### DIFF
--- a/tests/Forms/EmailTest.php
+++ b/tests/Forms/EmailTest.php
@@ -149,6 +149,7 @@ class EmailTest extends TestCase
             'social',
 
             // manual "system" vars added to email
+            'form_config',
             'email_config',
             'config',
             'date',


### PR DESCRIPTION
This PR passes the ``form_config`` variable to the email template as well, making it accessible, allowing for some nifty templating. See #10616 for reference.

Should we add a similar test as in #10616 checking the actual data?