### PR TITLE
[6.x] Add git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Apply Prettier
+95ff14ba8923d6979d592b20a0209e81171c2019


### PR DESCRIPTION
This adds `.git-blame-ignore-revs` with the sha of the commit for #11416.

Any revisions listed in this file will be ignored in GitHub within blames.

GitHub will use this automatically. Locally, you can use this by running `git config blame.ignoreRevsFile .git-blame-ignore-revs` (once). Code editors will typically respect this in their diff UIs if you have added that config. 

It's nice to not see "Apply Prettier" in the blame within a billion files.

More info: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view
