### PR TITLE
[5.x] Pass original upload filename into `AssetUploaded` event

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -917,7 +917,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
             ->syncOriginal()
             ->save();
 
-        AssetUploaded::dispatch($this);
+        AssetUploaded::dispatch($this, $file->getClientOriginalName());
 
         AssetCreated::dispatch($this);
 
@@ -935,7 +935,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
         $this->clearCaches();
         $this->writeMeta($this->generateMeta());
 
-        AssetReuploaded::dispatch($this);
+        AssetReuploaded::dispatch($this, $file->basename());
 
         return $this;
     }

--- a/src/Assets/ReplacementFile.php
+++ b/src/Assets/ReplacementFile.php
@@ -24,6 +24,11 @@ class ReplacementFile
         return pathinfo($this->path, PATHINFO_EXTENSION);
     }
 
+    public function basename()
+    {
+        return pathinfo($this->path, PATHINFO_BASENAME);
+    }
+
     public function writeTo(Filesystem $disk, $path)
     {
         $disk->put(

--- a/src/Events/AssetReuploaded.php
+++ b/src/Events/AssetReuploaded.php
@@ -6,7 +6,7 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class AssetReuploaded extends Event implements ProvidesCommitMessage
 {
-    public function __construct(public $asset)
+    public function __construct(public $asset, public $originalFilename)
     {
     }
 

--- a/src/Events/AssetUploaded.php
+++ b/src/Events/AssetUploaded.php
@@ -6,7 +6,7 @@ use Statamic\Contracts\Git\ProvidesCommitMessage;
 
 class AssetUploaded extends Event implements ProvidesCommitMessage
 {
-    public function __construct(public $asset)
+    public function __construct(public $asset, public $originalFilename)
     {
     }
 

--- a/tests/Assets/GeneratePresetImageManipulationsOnUpload.php
+++ b/tests/Assets/GeneratePresetImageManipulationsOnUpload.php
@@ -28,10 +28,10 @@ class GeneratePresetImageManipulationsOnUpload extends TestCase
 
     #[Test]
     #[DataProvider('presetProvider')]
-    public function presets_are_generated_for_images($event, $extension, $shouldGenerate)
+    public function presets_are_generated_for_images($event, $basename, $shouldGenerate)
     {
         $generator = Mockery::mock(PresetGenerator::class);
-        $asset = (new Asset)->path('foo.'.$extension);
+        $asset = (new Asset)->path($basename);
 
         if ($shouldGenerate) {
             $generator->shouldReceive('generate')->once()->with($asset);
@@ -41,19 +41,19 @@ class GeneratePresetImageManipulationsOnUpload extends TestCase
 
         $listener = new GeneratePresetImageManipulations($generator);
 
-        $listener->handle(new $event($asset));
+        $listener->handle(new $event($asset, $basename));
     }
 
     public static function presetProvider()
     {
         return [
-            [AssetUploaded::class, 'jpg', true],
-            [AssetUploaded::class, 'svg', false],
-            [AssetUploaded::class, 'txt', false],
+            [AssetUploaded::class, 'foo.jpg', true],
+            [AssetUploaded::class, 'foo.svg', false],
+            [AssetUploaded::class, 'foo.txt', false],
 
-            [AssetReuploaded::class, 'jpg', true],
-            [AssetReuploaded::class, 'svg', false],
-            [AssetReuploaded::class, 'txt', false],
+            [AssetReuploaded::class, 'foo.jpg', true],
+            [AssetReuploaded::class, 'foo.svg', false],
+            [AssetReuploaded::class, 'foo.txt', false],
         ];
     }
 }

--- a/tests/Feature/Assets/ClearAssetGlideCacheTest.php
+++ b/tests/Feature/Assets/ClearAssetGlideCacheTest.php
@@ -42,7 +42,7 @@ class ClearAssetGlideCacheTest extends TestCase
         $asset = Mockery::mock(Asset::class);
         Glide::shouldReceive('clearAsset')->with($asset)->once();
 
-        app(ClearAssetGlideCache::class)->handleReuploaded(new AssetReuploaded($asset));
+        app(ClearAssetGlideCache::class)->handleReuploaded(new AssetReuploaded($asset, 'foo.jpg'));
     }
 
     #[Test]

--- a/tests/Feature/Assets/ReuploadAssetTest.php
+++ b/tests/Feature/Assets/ReuploadAssetTest.php
@@ -75,6 +75,6 @@ class ReuploadAssetTest extends TestCase
         Glide::shouldReceive('clearAsset')->withArgs(fn ($arg1) => $arg1->id() === $asset->id())->once()->globally()->ordered();
         $this->mock(PresetGenerator::class)->shouldReceive('generate')->withArgs(fn ($arg1) => $arg1->id() === $asset->id())->once()->globally()->ordered();
 
-        AssetReuploaded::dispatch($asset);
+        AssetReuploaded::dispatch($asset, 'test.jpg');
     }
 }

--- a/tests/Git/GitEventTest.php
+++ b/tests/Git/GitEventTest.php
@@ -442,6 +442,7 @@ class GitEventTest extends TestCase
 
         $file = Mockery::mock(ReplacementFile::class);
         $file->shouldReceive('extension')->andReturn('txt');
+        $file->shouldReceive('basename')->andReturn('file.txt');
         $file->shouldReceive('writeTo');
 
         $this->makeAsset()->reupload($file);


### PR DESCRIPTION
### Suggested change

Pass the original filename into the `AssetUploaded` and `AssetReuploaded` events.

### Use case

This will allow saving the original filename into the asset metadata from a custom listener. Mostly applicable to download buttons or zip features that benefit from keeping the original file including capitalization and any `©` marks.

```antlers
{{ assets }}
  <a href="{{ url }}" download="{{ original_filename }}">Download</a>
{{ /assets }}
```

```html
<a href="image--photographer.jpg" download="Image © Photographer.jpg">Download</a>
```

### Semver

- Technically, this is only adding an argument, so it should be non-breaking
- However, any addons/consumers "faking" those Events will get errors from the now-missing required argument

### Alternatives considered

- Just save the original filename into the asset meta on creation? Wouldn't require updates to the event signatures

### Closes 

Closes statamic/ideas#1282