### PR TITLE
[5.x] Fix info message

### DIFF
--- a/src/Console/Commands/InstallEloquentDriver.php
+++ b/src/Console/Commands/InstallEloquentDriver.php
@@ -657,7 +657,7 @@ class InstallEloquentDriver extends Command
             return;
         }
 
-        $this->components->info('Configured asset containers');
+        $this->components->info($message);
     }
 
     private function switchToEloquentDriver(string $repository): void


### PR DESCRIPTION
The info message wasn't actually passed through and always read "Configured asset containers". This fixes it.