### PR TITLE
[5.x] Ensure consistent order of `get_content` results

### DIFF
--- a/src/Tags/GetContent.php
+++ b/src/Tags/GetContent.php
@@ -5,6 +5,7 @@ namespace Statamic\Tags;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
+use Statamic\Query\OrderedQueryBuilder;
 use Statamic\Support\Str;
 use Statamic\Tags\Concerns\OutputsItems;
 
@@ -57,6 +58,11 @@ class GetContent extends Tags
         $query = Entry::query()
             ->where('site', $this->params->get(['site', 'locale'], Site::current()->handle()))
             ->whereIn($usingUris ? 'uri' : 'id', $items);
+
+        // Ensure correct order of results
+        if (! $usingUris) {
+            $query = new OrderedQueryBuilder($query, $items);
+        }
 
         return $this->output($query->get());
     }

--- a/tests/Tags/GetContentTagTest.php
+++ b/tests/Tags/GetContentTagTest.php
@@ -62,6 +62,19 @@ class GetContentTagTest extends TestCase
     }
 
     #[Test]
+    public function it_maintains_order_of_multiple_items()
+    {
+        $this->assertParseEquals(
+            '<First><Second>',
+            '{{ get_content from="123|456" }}<{{ title }}>{{ /get_content }}'
+        );
+        $this->assertParseEquals(
+            '<Second><First>',
+            '{{ get_content from="456|123" }}<{{ title }}>{{ /get_content }}'
+        );
+    }
+
+    #[Test]
     public function it_gets_multiple_items_by_pipe_delimited_uris()
     {
         $this->assertParseEquals(


### PR DESCRIPTION
Use an `OrderedQueryBuilder` in the `get_content` tag to make sure the order of results matches the order of the entry IDs that were passed in. Currently, the order is arbitrary.

Since the `OrderedQueryBuilder` only supports sorting by `id`, we can't apply this when urls are passed in. Happy to also make the necessary adjustments to the query builder class if that's something you're willing to support.