### PR TITLE
[5.x] Improve performance of the data reference updaters

### DIFF
--- a/src/Listeners/Concerns/GetsItemsContainingData.php
+++ b/src/Listeners/Concerns/GetsItemsContainingData.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Listeners\Concerns;
 
+use Illuminate\Support\LazyCollection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Term;
@@ -16,10 +17,25 @@ trait GetsItemsContainingData
      */
     public function getItemsContainingData()
     {
-        return collect()
-            ->merge(Entry::all())
-            ->merge(Term::all())
-            ->merge(GlobalSet::all()->flatMap(fn ($set) => $set->localizations()->values()))
-            ->merge(User::all());
+        $collections = [
+            LazyCollection::make(function () {
+                yield from Entry::query()->lazy();
+            }),
+            LazyCollection::make(function () {
+                yield from Term::query()->lazy();
+            }),
+            LazyCollection::make(function () {
+                yield from GlobalSet::all()->flatMap(fn ($set) => $set->localizations()->values());
+            }),
+            LazyCollection::make(function () {
+                yield from User::query()->lazy();
+            }),
+        ];
+
+        return LazyCollection::make(function () use ($collections) {
+            foreach ($collections as $collection) {
+                yield from $collection;
+            }
+        });
     }
 }

--- a/src/Listeners/Concerns/GetsItemsContainingData.php
+++ b/src/Listeners/Concerns/GetsItemsContainingData.php
@@ -13,7 +13,7 @@ trait GetsItemsContainingData
     /**
      * Get items containing data.
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\LazyCollection
      */
     public function getItemsContainingData()
     {


### PR DESCRIPTION
This pull request makes some performance improvements to the `GetsItemsContainingData` trait, responsible for gathering all content items (all entries, terms, globals and users). 

It's currently used within the asset & term reference updaters, however, it'll soon be used in the UTC dates update script (#11409).

Essentially, instead of loading all items into memory at once (which will cause issues with larger sites), we'll use Laravel's [Lazy Collections](https://laravel.com/docs/master/collections#lazy-collections) feature to ensure items can be looped through in a more efficient manner.