### PR TITLE
[5.x] Fix search results missing search_snippets

### DIFF
--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -605,7 +605,7 @@ class Comb
                     }
 
                     // snippet extraction (only needs to run during one chunk)
-                    if ($matched && $j === 0) {
+                    if ($matched && ! isset($snippets[$name]) ) {
                         $snippets[$name] = $this->extractSnippets($property, $params['chunks']);
                     }
                 }

--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -605,7 +605,7 @@ class Comb
                     }
 
                     // snippet extraction (only needs to run during one chunk)
-                    if ($matched && !isset($snippets[$name])) {
+                    if ($matched && ! isset($snippets[$name])) {
                         $snippets[$name] = $this->extractSnippets($property, $params['chunks']);
                     }
                 }

--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -605,7 +605,7 @@ class Comb
                     }
 
                     // snippet extraction (only needs to run during one chunk)
-                    if ($matched && ! isset($snippets[$name]) ) {
+                    if ($matched && !isset($snippets[$name])) {
                         $snippets[$name] = $this->extractSnippets($property, $params['chunks']);
                     }
                 }


### PR DESCRIPTION
As written in the issue #11398, there are problem with the search_snippets when two or more words are searched.
The search_snippets array is populated only when the item found contains both words (even if they aren't on the same line). However, if the search result contains only one of the searched words, the search_snippets array remains empty.
This happens using the the native local driver, not algolia.

Fixes #11398.
