### PR TITLE
[5.x] Add support for `$view` parameter closure with `Statamic::route()`

### DIFF
--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -54,7 +54,7 @@ class FrontendController extends Controller
             $view = $resolvedView->name();
             $data = $resolvedView->getData();
         } elseif (isset($resolvedView)) {
-            return $view;
+            return $resolvedView;
         }
 
         $data = array_merge($params, is_callable($data) ? $data(...$params) : $data);

--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -39,9 +39,14 @@ class FrontendController extends Controller
     public function route(Request $request, ...$args)
     {
         $params = $request->route()->parameters();
+
+        $segments = Arr::except($params, ['view', 'data']);
+
         $view = Arr::pull($params, 'view');
+        $view = is_callable($view) ? $view(...$segments) : $view;
+
         $data = Arr::pull($params, 'data');
-        $data = array_merge($params, is_callable($data) ? $data(...$params) : $data);
+        $data = array_merge($params, is_callable($data) ? $data(...$segments) : $data);
 
         $view = app(View::class)
             ->template($view)

--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -44,18 +44,18 @@ class FrontendController extends Controller
         $view = Arr::pull($params, 'view');
         $data = Arr::pull($params, 'data');
 
-        $data = array_merge($params, is_callable($data) ? $data(...$params) : $data);
-
         if (is_callable($view)) {
-            $view = $view(...$params);
+            $resolvedView = $view(...$params);
         }
 
-        if ($view instanceof IlluminateView) {
-            $data = array_merge($view->getData(), $data);
-            $view = $view->name();
-        } elseif (! is_string($view)) {
-            // TODO: What else can they return from view closure?
+        if (isset($resolvedView) && $resolvedView instanceof IlluminateView) {
+            $view = $resolvedView->name();
+            $data = $resolvedView->getData();
+        } elseif (isset($resolvedView)) {
+            return $view;
         }
+
+        $data = array_merge($params, is_callable($data) ? $data(...$params) : $data);
 
         $view = app(View::class)
             ->template($view)

--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -44,7 +44,7 @@ class FrontendController extends Controller
         $view = Arr::pull($params, 'view');
         $data = Arr::pull($params, 'data');
 
-        $data = array_merge($params, ray()->pass(is_callable($data) ? $data(...$params) : $data));
+        $data = array_merge($params, is_callable($data) ? $data(...$params) : $data);
 
         if (is_callable($view)) {
             $view = $view(...$params);

--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -44,6 +44,8 @@ class FrontendController extends Controller
         $view = Arr::pull($params, 'view');
         $data = Arr::pull($params, 'data');
 
+        throw_if(is_callable($view) && $data, new \Exception('Parameter [$data] not supported with [$view] closure!'));
+
         if (is_callable($view)) {
             $resolvedView = $view(...$params);
         }

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -37,11 +37,23 @@ class RoutesTest extends TestCase
                 return ['hello' => 'world'];
             });
 
+            Route::statamic('/basic-route-with-view-and-data-closures', function () {
+                return 'test';
+            }, function () {
+                return ['hello' => 'world'];
+            });
+
             Route::statamic('/basic-route-without-data', 'test');
 
             Route::statamic('/route/with/placeholders/{foo}/{bar}/{baz}', 'test');
 
             Route::statamic('/route/with/placeholders/closure/{foo}/{bar}/{baz}', 'test', function ($foo, $bar, $baz) {
+                return ['hello' => "$foo $bar $baz"];
+            });
+
+            Route::statamic('/route/with/placeholders/both/closures/{foo}/{bar}/{baz}', function ($foo, $bar, $baz) {
+                return $foo.$bar.$baz;
+            }, function ($foo, $bar, $baz) {
                 return ['hello' => "$foo $bar $baz"];
             });
 
@@ -126,6 +138,17 @@ class RoutesTest extends TestCase
     }
 
     #[Test]
+    public function it_renders_both_view_and_data_from_closures()
+    {
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        $this->get('/basic-route-with-view-and-data-closures')
+            ->assertOk()
+            ->assertSee('Hello world');
+    }
+
+    #[Test]
     public function it_renders_a_view_without_data()
     {
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
@@ -156,6 +179,18 @@ class RoutesTest extends TestCase
         $this->get('/route/with/placeholders/closure/one/two/three')
             ->assertOk()
             ->assertSee('Hello one two three');
+    }
+
+    #[Test]
+    public function it_renders_with_placeholders_using_both_view_and_data_closures()
+    {
+        $this->withoutExceptionHandling();
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        $this->get('/route/with/placeholders/both/closures/te/s/t')
+            ->assertOk()
+            ->assertSee('Hello te s t');
     }
 
     #[Test]

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -33,11 +33,11 @@ class RoutesTest extends TestCase
         $app->booted(function () {
             Route::statamic('/basic-route-with-data', 'test', ['hello' => 'world']);
 
-            Route::statamic('/basic-route-with-view-from-closure', function () {
+            Route::statamic('/basic-route-with-view-closure', function () {
                 return view('test', ['hello' => 'world']);
             });
 
-            Route::statamic('/basic-route-with-data-from-closure', 'test', function () {
+            Route::statamic('/basic-route-with-data-closure', 'test', function () {
                 return ['hello' => 'world'];
             });
 
@@ -123,23 +123,23 @@ class RoutesTest extends TestCase
     }
 
     #[Test]
-    public function it_renders_a_view_using_a_closure()
+    public function it_renders_a_view_using_a_view_closure()
     {
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
         $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
 
-        $this->get('/basic-route-with-view-from-closure')
+        $this->get('/basic-route-with-view-closure')
             ->assertOk()
             ->assertSee('Hello world');
     }
 
     #[Test]
-    public function it_renders_a_view_with_data_from_a_closure()
+    public function it_renders_a_view_using_a_data_closure()
     {
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
         $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
 
-        $this->get('/basic-route-with-data-from-closure')
+        $this->get('/basic-route-with-data-closure')
             ->assertOk()
             ->assertSee('Hello world');
     }

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Routing;
 
+use Exception;
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -40,6 +41,10 @@ class RoutesTest extends TestCase
             Route::statamic('/basic-route-with-data-closure', 'test', function () {
                 return ['hello' => 'world'];
             });
+
+            Route::statamic('/you-cannot-use-data-param-with-view-closure', function () {
+                return view('test', ['hello' => 'world']);
+            }, 'hello');
 
             Route::statamic('/basic-route-without-data', 'test');
 
@@ -142,6 +147,16 @@ class RoutesTest extends TestCase
         $this->get('/basic-route-with-data-closure')
             ->assertOk()
             ->assertSee('Hello world');
+    }
+
+    #[Test]
+    public function it_throws_exception_if_you_try_to_pass_data_parameter_when_using_view_closure()
+    {
+        $this->withoutExceptionHandling();
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Parameter [$data] not supported with [$view] closure!');
+
+        $this->get('/you-cannot-use-data-param-with-view-closure');
     }
 
     #[Test]

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Routing;
 
 use Facades\Tests\Factories\EntryFactory;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -57,8 +58,24 @@ class RoutesTest extends TestCase
                 return view('test', ['hello' => "$foo $bar $baz"]);
             });
 
+            Route::statamic('/route/with/placeholders/view/closure/request/{foo}/{bar}/{baz}', function (Request $request, $foo, $bar, $baz) {
+                return view('test', ['hello' => "$foo $bar $baz $request->val"]);
+            });
+
+            Route::statamic('/route/with/placeholders/view/closure/request-at-end/{foo}/{bar}/{baz}', function ($foo, $bar, $baz, Request $request) {
+                return view('test', ['hello' => "$foo $bar $baz $request->val"]);
+            });
+
             Route::statamic('/route/with/placeholders/data/closure/{foo}/{bar}/{baz}', 'test', function ($foo, $bar, $baz) {
                 return ['hello' => "$foo $bar $baz"];
+            });
+
+            Route::statamic('/route/with/placeholders/data/closure/request/{foo}/{bar}/{baz}', 'test', function (Request $request, $foo, $bar, $baz) {
+                return ['hello' => "$foo $bar $baz $request->val"];
+            });
+
+            Route::statamic('/route/with/placeholders/data/closure/request-at-end/{foo}/{bar}/{baz}', 'test', function ($foo, $bar, $baz, Request $request) {
+                return ['hello' => "$foo $bar $baz $request->val"];
             });
 
             Route::statamic('/route-with-custom-layout', 'test', [
@@ -209,6 +226,28 @@ class RoutesTest extends TestCase
     }
 
     #[Test]
+    public function it_renders_a_view_with_placeholders_using_a_view_closure_with_typehinted_request()
+    {
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        $this->get('/route/with/placeholders/view/closure/request/one/two/three?val=four')
+            ->assertOk()
+            ->assertSee('Hello one two three four');
+    }
+
+    #[Test]
+    public function it_renders_a_view_with_placeholders_using_a_view_closure_with_typehinted_request_at_end()
+    {
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        $this->get('/route/with/placeholders/view/closure/request-at-end/one/two/three?val=four')
+            ->assertOk()
+            ->assertSee('Hello one two three four');
+    }
+
+    #[Test]
     public function it_renders_a_view_with_placeholders_using_a_data_closure()
     {
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
@@ -217,6 +256,28 @@ class RoutesTest extends TestCase
         $this->get('/route/with/placeholders/data/closure/one/two/three')
             ->assertOk()
             ->assertSee('Hello one two three');
+    }
+
+    #[Test]
+    public function it_renders_a_view_with_placeholders_using_a_data_closure_with_typehinted_request()
+    {
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        $this->get('/route/with/placeholders/data/closure/request/one/two/three?val=four')
+            ->assertOk()
+            ->assertSee('Hello one two three four');
+    }
+
+    #[Test]
+    public function it_renders_a_view_with_placeholders_using_a_data_closure_with_typehinted_request_at_end()
+    {
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        $this->get('/route/with/placeholders/data/closure/request-at-end/one/two/three?val=four')
+            ->assertOk()
+            ->assertSee('Hello one two three four');
     }
 
     #[Test]

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -214,7 +214,6 @@ class RoutesTest extends TestCase
     #[Test]
     public function it_renders_with_placeholders_using_both_view_and_data_closures()
     {
-        $this->withoutExceptionHandling();
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
         $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
 
@@ -239,7 +238,6 @@ class RoutesTest extends TestCase
     #[DataProvider('undefinedLayoutRouteProvider')]
     public function it_renders_a_view_without_a_layout($route)
     {
-        $this->withoutExceptionHandling();
         $this->viewShouldReturnRaw('layout', 'The layout {{ template_content }}');
         $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
 
@@ -287,7 +285,6 @@ class RoutesTest extends TestCase
     #[Test]
     public function it_renders_a_view_with_custom_content_type()
     {
-        $this->withoutExceptionHandling();
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
         $this->viewShouldReturnRaw('test', '{"hello":"{{ hello }}"}');
 

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -38,6 +38,10 @@ class RoutesTest extends TestCase
                 return view('test', ['hello' => 'world']);
             });
 
+            Route::statamic('/basic-route-with-view-closure-and-custom-return', function () {
+                return ['message' => 'not a view instance'];
+            });
+
             Route::statamic('/basic-route-with-data-closure', 'test', function () {
                 return ['hello' => 'world'];
             });
@@ -136,6 +140,16 @@ class RoutesTest extends TestCase
         $this->get('/basic-route-with-view-closure')
             ->assertOk()
             ->assertSee('Hello world');
+    }
+
+    #[Test]
+    public function it_renders_a_view_using_a_custom_view_closure_that_does_not_return_a_view_instance()
+    {
+        $this->get('/basic-route-with-view-closure-and-custom-return')
+            ->assertOk()
+            ->assertJson([
+                'message' => 'not a view instance',
+            ]);
     }
 
     #[Test]

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -41,12 +41,6 @@ class RoutesTest extends TestCase
                 return ['hello' => 'world'];
             });
 
-            Route::statamic('/basic-route-with-both-view-and-data-closures', function () {
-                return view('test');
-            }, function () {
-                return ['hello' => 'world'];
-            });
-
             Route::statamic('/basic-route-without-data', 'test');
 
             Route::statamic('/route/with/placeholders/{foo}/{bar}/{baz}', 'test');
@@ -56,12 +50,6 @@ class RoutesTest extends TestCase
             });
 
             Route::statamic('/route/with/placeholders/data/closure/{foo}/{bar}/{baz}', 'test', function ($foo, $bar, $baz) {
-                return ['hello' => "$foo $bar $baz"];
-            });
-
-            Route::statamic('/route/with/placeholders/both/closures/{foo}/{bar}/{baz}', function ($foo, $bar, $baz) {
-                return view($foo.$bar.$baz);
-            }, function ($foo, $bar, $baz) {
                 return ['hello' => "$foo $bar $baz"];
             });
 
@@ -157,17 +145,6 @@ class RoutesTest extends TestCase
     }
 
     #[Test]
-    public function it_renders_both_view_and_data_from_closures()
-    {
-        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
-        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
-
-        $this->get('/basic-route-with-both-view-and-data-closures')
-            ->assertOk()
-            ->assertSee('Hello world');
-    }
-
-    #[Test]
     public function it_renders_a_view_without_data()
     {
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
@@ -209,17 +186,6 @@ class RoutesTest extends TestCase
         $this->get('/route/with/placeholders/data/closure/one/two/three')
             ->assertOk()
             ->assertSee('Hello one two three');
-    }
-
-    #[Test]
-    public function it_renders_with_placeholders_using_both_view_and_data_closures()
-    {
-        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
-        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
-
-        $this->get('/route/with/placeholders/both/closures/te/s/t')
-            ->assertOk()
-            ->assertSee('Hello te s t');
     }
 
     #[Test]

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -38,12 +38,20 @@ class RoutesTest extends TestCase
                 return view('test', ['hello' => 'world']);
             });
 
+            Route::statamic('/basic-route-with-view-closure-and-dependency-injection', function (Request $request, FooClass $foo) {
+                return view('test', ['hello' => "view closure dependencies: $request->value $foo->value"]);
+            });
+
             Route::statamic('/basic-route-with-view-closure-and-custom-return', function () {
                 return ['message' => 'not a view instance'];
             });
 
             Route::statamic('/basic-route-with-data-closure', 'test', function () {
                 return ['hello' => 'world'];
+            });
+
+            Route::statamic('/basic-route-with-data-closure-and-dependency-injection', 'test', function (Request $request, FooClass $foo) {
+                return ['hello' => "data closure dependencies: $request->value $foo->value"];
             });
 
             Route::statamic('/you-cannot-use-data-param-with-view-closure', function () {
@@ -55,27 +63,27 @@ class RoutesTest extends TestCase
             Route::statamic('/route/with/placeholders/{foo}/{bar}/{baz}', 'test');
 
             Route::statamic('/route/with/placeholders/view/closure/{foo}/{bar}/{baz}', function ($foo, $bar, $baz) {
-                return view('test', ['hello' => "$foo $bar $baz"]);
+                return view('test', ['hello' => "view closure placeholders: $foo $bar $baz"]);
             });
 
-            Route::statamic('/route/with/placeholders/view/closure/request/{foo}/{bar}/{baz}', function (Request $request, $foo, $bar, $baz) {
-                return view('test', ['hello' => "$foo $bar $baz $request->val"]);
+            Route::statamic('/route/with/placeholders/view/closure-dependency-injection/{baz}/{qux}', function (Request $request, FooClass $foo, BarClass $bar, $baz, $qux) {
+                return view('test', ['hello' => "view closure dependencies: $request->value $foo->value $bar->value $baz $qux"]);
             });
 
-            Route::statamic('/route/with/placeholders/view/closure/request-at-end/{foo}/{bar}/{baz}', function ($foo, $bar, $baz, Request $request) {
-                return view('test', ['hello' => "$foo $bar $baz $request->val"]);
+            Route::statamic('/route/with/placeholders/view/closure-dependency-order-doesnt-matter/{baz}/{qux}', function (FooClass $foo, $baz, BarClass $bar, Request $request, $qux) {
+                return view('test', ['hello' => "view closure dependencies: $request->value $foo->value $bar->value $baz $qux"]);
             });
 
             Route::statamic('/route/with/placeholders/data/closure/{foo}/{bar}/{baz}', 'test', function ($foo, $bar, $baz) {
-                return ['hello' => "$foo $bar $baz"];
+                return ['hello' => "data closure placeholders: $foo $bar $baz"];
             });
 
-            Route::statamic('/route/with/placeholders/data/closure/request/{foo}/{bar}/{baz}', 'test', function (Request $request, $foo, $bar, $baz) {
-                return ['hello' => "$foo $bar $baz $request->val"];
+            Route::statamic('/route/with/placeholders/data/closure-dependency-injection/{baz}/{qux}', 'test', function (Request $request, FooClass $foo, BarClass $bar, $baz, $qux) {
+                return ['hello' => "data closure dependencies: $request->value $foo->value $bar->value $baz $qux"];
             });
 
-            Route::statamic('/route/with/placeholders/data/closure/request-at-end/{foo}/{bar}/{baz}', 'test', function ($foo, $bar, $baz, Request $request) {
-                return ['hello' => "$foo $bar $baz $request->val"];
+            Route::statamic('/route/with/placeholders/data/closure-dependency-order-doesnt-matter/{baz}/{qux}', 'test', function (FooClass $foo, $baz, BarClass $bar, Request $request, $qux) {
+                return ['hello' => "data closure dependencies: $request->value $foo->value $bar->value $baz $qux"];
             });
 
             Route::statamic('/route-with-custom-layout', 'test', [
@@ -159,6 +167,35 @@ class RoutesTest extends TestCase
     }
 
     #[Test]
+    public function it_renders_a_view_using_a_view_closure_with_dependency_injection()
+    {
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        $this->get('/basic-route-with-view-closure-and-dependency-injection?value=request_value')
+            ->assertOk()
+            ->assertSee('Hello view closure dependencies: request_value foo_class');
+    }
+
+    #[Test]
+    public function it_renders_a_view_using_a_view_closure_with_dependency_injection_from_container()
+    {
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        app()->bind(FooClass::class, function () {
+            $foo = new FooClass;
+            $foo->value = 'foo_modified';
+
+            return $foo;
+        });
+
+        $this->get('/basic-route-with-view-closure-and-dependency-injection?value=request_value')
+            ->assertOk()
+            ->assertSee('Hello view closure dependencies: request_value foo_modified');
+    }
+
+    #[Test]
     public function it_renders_a_view_using_a_custom_view_closure_that_does_not_return_a_view_instance()
     {
         $this->get('/basic-route-with-view-closure-and-custom-return')
@@ -177,6 +214,35 @@ class RoutesTest extends TestCase
         $this->get('/basic-route-with-data-closure')
             ->assertOk()
             ->assertSee('Hello world');
+    }
+
+    #[Test]
+    public function it_renders_a_view_using_a_data_closure_with_dependency_injection()
+    {
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        $this->get('/basic-route-with-data-closure-and-dependency-injection?value=request_value')
+            ->assertOk()
+            ->assertSee('Hello data closure dependencies: request_value foo_class');
+    }
+
+    #[Test]
+    public function it_renders_a_view_using_a_data_closure_with_dependency_injection_from_container()
+    {
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
+
+        app()->bind(FooClass::class, function () {
+            $foo = new FooClass;
+            $foo->value = 'foo_modified';
+
+            return $foo;
+        });
+
+        $this->get('/basic-route-with-data-closure-and-dependency-injection?value=request_value')
+            ->assertOk()
+            ->assertSee('Hello data closure dependencies: request_value foo_modified');
     }
 
     #[Test]
@@ -222,29 +288,36 @@ class RoutesTest extends TestCase
 
         $this->get('/route/with/placeholders/view/closure/one/two/three')
             ->assertOk()
-            ->assertSee('Hello one two three');
+            ->assertSee('Hello view closure placeholders: one two three');
     }
 
     #[Test]
-    public function it_renders_a_view_with_placeholders_using_a_view_closure_with_typehinted_request()
+    public function it_renders_a_view_with_placeholders_using_a_view_closure_with_dependency_injection()
     {
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
         $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
 
-        $this->get('/route/with/placeholders/view/closure/request/one/two/three?val=four')
+        $this->get('/route/with/placeholders/view/closure-dependency-injection/one/two?value=request_value')
             ->assertOk()
-            ->assertSee('Hello one two three four');
+            ->assertSee('Hello view closure dependencies: request_value foo_class bar_class one two');
     }
 
     #[Test]
-    public function it_renders_a_view_with_placeholders_using_a_view_closure_with_typehinted_request_at_end()
+    public function it_renders_a_view_with_placeholders_using_a_view_closure_and_dependency_order_doesnt_matter()
     {
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
         $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
 
-        $this->get('/route/with/placeholders/view/closure/request-at-end/one/two/three?val=four')
+        app()->bind(BarClass::class, function () {
+            $foo = new BarClass;
+            $foo->value = 'bar_class_modified';
+
+            return $foo;
+        });
+
+        $this->get('/route/with/placeholders/view/closure-dependency-order-doesnt-matter/one/two?value=request_value')
             ->assertOk()
-            ->assertSee('Hello one two three four');
+            ->assertSee('Hello view closure dependencies: request_value foo_class bar_class_modified one two');
     }
 
     #[Test]
@@ -255,29 +328,36 @@ class RoutesTest extends TestCase
 
         $this->get('/route/with/placeholders/data/closure/one/two/three')
             ->assertOk()
-            ->assertSee('Hello one two three');
+            ->assertSee('Hello data closure placeholders: one two three');
     }
 
     #[Test]
-    public function it_renders_a_view_with_placeholders_using_a_data_closure_with_typehinted_request()
+    public function it_renders_a_view_with_placeholders_using_a_data_closure_with_dependency_injection()
     {
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
         $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
 
-        $this->get('/route/with/placeholders/data/closure/request/one/two/three?val=four')
+        $this->get('/route/with/placeholders/data/closure-dependency-injection/one/two?value=request_value')
             ->assertOk()
-            ->assertSee('Hello one two three four');
+            ->assertSee('Hello data closure dependencies: request_value foo_class bar_class one two');
     }
 
     #[Test]
-    public function it_renders_a_view_with_placeholders_using_a_data_closure_with_typehinted_request_at_end()
+    public function it_renders_a_view_with_placeholders_using_a_data_closure_and_dependency_order_doesnt_matter()
     {
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
         $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
 
-        $this->get('/route/with/placeholders/data/closure/request-at-end/one/two/three?val=four')
+        app()->bind(BarClass::class, function () {
+            $foo = new BarClass;
+            $foo->value = 'bar_class_modified';
+
+            return $foo;
+        });
+
+        $this->get('/route/with/placeholders/data/closure-dependency-order-doesnt-matter/one/two?value=request_value')
             ->assertOk()
-            ->assertSee('Hello one two three four');
+            ->assertSee('Hello data closure dependencies: request_value foo_class bar_class_modified one two');
     }
 
     #[Test]
@@ -473,4 +553,14 @@ class RoutesTest extends TestCase
             ->assertOk()
             ->assertSee('Custom layout');
     }
+}
+
+class FooClass
+{
+    public $value = 'foo_class';
+}
+
+class BarClass
+{
+    public $value = 'bar_class';
 }

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Routing;
 
-use Exception;
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -166,11 +165,14 @@ class RoutesTest extends TestCase
     #[Test]
     public function it_throws_exception_if_you_try_to_pass_data_parameter_when_using_view_closure()
     {
-        $this->withoutExceptionHandling();
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Parameter [$data] not supported with [$view] closure!');
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
 
-        $this->get('/you-cannot-use-data-param-with-view-closure');
+        $response = $this
+            ->get('/you-cannot-use-data-param-with-view-closure')
+            ->assertInternalServerError();
+
+        $this->assertEquals('Parameter [$data] not supported with [$view] closure!', $response->exception->getMessage());
     }
 
     #[Test]


### PR DESCRIPTION
This PR adds support for optional `$view` parameter closure with `Statamic::route()`, so that you can dynamically render a view from a route segment.

For example, this works fine in Laravel...

```php
Route::get('/components/{component}', function ($component) {
    return view($component);
});
```

So this should work with Statamic routes as well...

```php
Route::statamic('/components/{component}', function ($component) {
    return view($component);
});
```

This PR makes it work like this...

![image](https://github.com/user-attachments/assets/20840530-2030-4ab9-9061-11a7a96a2673)

### TODO

- [x] Support closure in second `$view` parameter
- [x] Support closure in third `$data` parameter
    - This was already supported, but we just want to make sure we don't regress here
- [x] Support type-hinted service-container-friendly dependency injection like Laravel does
- [x] Throw helpful exception if they try to use both closures
    - This wouldn't make sense. If you're returning `view($template, $data)` in Laravel, it's expected you'll pass your dynamic data directly into that 👍
- [x] Add test coverage
- [x] Add docs
    - https://github.com/statamic/docs/pull/1614

References https://github.com/statamic/cms/pull/9953