### PR TITLE
[5.x] Fix test state issues around sites cache

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,9 +6,7 @@ use Illuminate\Testing\Assert as IlluminateAssert;
 use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\Assert;
 use Statamic\Facades\Config;
-use Statamic\Facades\File;
 use Statamic\Facades\Site;
-use Statamic\Facades\YAML;
 use Statamic\Http\Middleware\CP\AuthenticateSession;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
@@ -44,17 +42,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         }
 
         $this->addGqlMacros();
-
-        // We changed the default sites setup but the tests assume defaults like the following.
-        File::put(resource_path('sites.yaml'), YAML::dump($sites = [
-            'en' => [
-                'name' => 'English',
-                'url' => 'http://localhost/',
-                'locale' => 'en_US',
-            ],
-        ]));
-
-        $this->setSites($sites);
     }
 
     public function tearDown(): void
@@ -135,6 +122,15 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $viewPaths[] = __DIR__.'/__fixtures__/views/';
 
         $app['config']->set('view.paths', $viewPaths);
+
+        // We changed the default sites setup but the tests assume defaults like the following.
+        // We write the file early so its ready the first time Site facade is used.
+        $app['files']->put(resource_path('sites.yaml'), <<<'YAML'
+en:
+    name: English
+    url: http://localhost/
+    locale: en_US
+YAML);
     }
 
     protected function setSites($sites)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -46,13 +46,15 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $this->addGqlMacros();
 
         // We changed the default sites setup but the tests assume defaults like the following.
-        File::put(resource_path('sites.yaml'), YAML::dump([
+        File::put(resource_path('sites.yaml'), YAML::dump($sites = [
             'en' => [
                 'name' => 'English',
                 'url' => 'http://localhost/',
                 'locale' => 'en_US',
             ],
         ]));
+
+        $this->setSites($sites);
     }
 
     public function tearDown(): void


### PR DESCRIPTION
## The problem

We were intermittently seeing test errors related to sites, but only when running certain tests with no cache state. For example, this would fail...

```
rm -rf vendor
composer update
phpunit --filter SubstitutesEntryForLivePreviewTest
```

![CleanShot 2025-02-14 at 10 29 25](https://github.com/user-attachments/assets/908135e3-2c7c-4135-9faf-5e7d18976c44)

...but only on the first run. That test would pass on subsequent runs, or when running the whole suite, because sites state had been built up already.

## The solution

The way our `Sites` class works, it caches `$sites` as a property cache, and has some fallback logic as well. We intentionally set up a default sites.yaml in our `TestCase` class, so we should just be making sure that also gets set on the `Sites` cache.