### PR TITLE
[5.x] Add hook into the `multisite` command

### DIFF
--- a/src/Console/Commands/Multisite.php
+++ b/src/Console/Commands/Multisite.php
@@ -27,7 +27,7 @@ use function Laravel\Prompts\text;
 
 class Multisite extends Command
 {
-    use ConfirmableTrait, EnhancesCommands, RunsInPlease, ValidatesInput, Hookable;
+    use ConfirmableTrait, EnhancesCommands, Hookable, RunsInPlease, ValidatesInput;
 
     protected $signature = 'statamic:multisite';
 

--- a/src/Console/Commands/Multisite.php
+++ b/src/Console/Commands/Multisite.php
@@ -57,7 +57,7 @@ class Multisite extends Command
             ->addPermissions()
             ->clearCache();
 
-        $this->runHooks('end');
+        $this->runHooks('after');
 
         $this->components->info('Successfully converted from single to multisite installation!');
 

--- a/src/Console/Commands/Multisite.php
+++ b/src/Console/Commands/Multisite.php
@@ -19,6 +19,7 @@ use Statamic\Facades\Stache;
 use Statamic\Facades\YAML;
 use Statamic\Rules\Handle;
 use Statamic\Statamic;
+use Statamic\Support\Traits\Hookable;
 use Wilderborn\Partyline\Facade as Partyline;
 
 use function Laravel\Prompts\confirm;
@@ -26,7 +27,7 @@ use function Laravel\Prompts\text;
 
 class Multisite extends Command
 {
-    use ConfirmableTrait, EnhancesCommands, RunsInPlease, ValidatesInput;
+    use ConfirmableTrait, EnhancesCommands, RunsInPlease, ValidatesInput, Hookable;
 
     protected $signature = 'statamic:multisite';
 
@@ -55,6 +56,8 @@ class Multisite extends Command
             ->convertNavs()
             ->addPermissions()
             ->clearCache();
+
+        $this->runHooks('end');
 
         $this->components->info('Successfully converted from single to multisite installation!');
 


### PR DESCRIPTION
This pull request adds a hook to the `php please multisite` command, allowing addon developers to run their own code when a site is being converted from a single site to a multisite.

For example:

```php
// ServiceProvider.php

public function bootAddon()
{
    Multisite::hook('after', function () {
        // Maybe move some files around...
        // Update a config file or two...

        $this->components->info('Done some multisite magic!');
    });
}
```

~I'm not totally sold on the name of the hook (`end`). I'm sure we can come up with a better name.~ Named it `after`.