### PR TITLE
[5.x] Fix issue with AssetsFieldtype upload controls hidden on @sm size

### DIFF
--- a/resources/css/components/fieldtypes/assets.css
+++ b/resources/css/components/fieldtypes/assets.css
@@ -14,7 +14,7 @@
     }
 
     .asset-upload-control {
-      @apply @sm:rtl:mr-4 @sm:ltr:ml-4 text-xs text-gray-600 leading-tight;
+      @apply text-xs text-gray-600 leading-tight;
     }
 
     .upload-text-button {

--- a/resources/css/components/fieldtypes/assets.css
+++ b/resources/css/components/fieldtypes/assets.css
@@ -7,14 +7,14 @@
 }
 
 .assets-fieldtype .assets-fieldtype-picker {
-    @apply flex items-center px-4 py-2 bg-gray-200 dark:bg-dark-650 border dark:border-dark-900 rounded;
+    @apply flex flex-wrap items-center px-4 py-2 bg-gray-200 dark:bg-dark-650 border dark:border-dark-900 rounded;
 
     &.is-expanded {
         @apply border-b-0 rounded-b-none;
     }
 
     .asset-upload-control {
-      @apply mt-2 @sm:rtl:mr-4 @sm:ltr:ml-4 @sm:mt-0 text-xs text-gray-600 leading-tight;
+      @apply @sm:rtl:mr-4 @sm:ltr:ml-4 @sm:mt-0 text-xs text-gray-600 leading-tight;
     }
 
     .upload-text-button {
@@ -30,7 +30,7 @@
 }
 
 .assets-fieldtype .asset-upload-control {
-    @apply hidden @xs:inline-block;
+    @apply inline-block;
 }
 
 

--- a/resources/css/components/fieldtypes/assets.css
+++ b/resources/css/components/fieldtypes/assets.css
@@ -14,7 +14,7 @@
     }
 
     .asset-upload-control {
-      @apply @sm:rtl:mr-4 @sm:ltr:ml-4 @sm:mt-0 text-xs text-gray-600 leading-tight;
+      @apply @sm:rtl:mr-4 @sm:ltr:ml-4 text-xs text-gray-600 leading-tight;
     }
 
     .upload-text-button {

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -25,7 +25,7 @@
 
                 <div
                     v-if="!isReadOnly && showPicker"
-                    class="assets-fieldtype-picker space-x-4"
+                    class="assets-fieldtype-picker gap-x-4 gap-y-2"
                     :class="{
                         'is-expanded': expanded,
                         'bard-drag-handle': isInBardField


### PR DESCRIPTION
This PR fixes an issue where the `AssetsFieldtype` does not show the upload controls when the field does not have enough space to be shown.

It does so by flex-wrapping the content of the `.assets-fieldtype .assets-fieldtype-picker` selector:

https://github.com/user-attachments/assets/16f72ef0-69cb-49e1-9c24-a3c48ad6ac93

## Remove extra top margin in alt text 
It also removes the extra top margin in the asset upload control

Before:
<img width="388" alt="image" src="https://github.com/user-attachments/assets/8cd8fa4c-e538-42ee-a57a-afbe959cd997" />

After:
<img width="388" alt="image" src="https://github.com/user-attachments/assets/2773c614-0e0e-4eae-9d63-67375eaeb78f" />

## Fixes
Fixes #11436 
