### PR TITLE
[5.x] Fixes empty asset alt <td> element in AssetsFieldtype

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -31,12 +31,11 @@
             </button>
             <div v-text="asset.size" class="hidden @xs:inline asset-filesize text-xs text-gray-600 px-2" />
         </td>
-        <td class="w-24" v-if="showSetAlt">
+        <td class="w-24" v-if="showSetAlt && needsAlt">
             <button
                 class="asset-set-alt text-blue dark:text-dark-blue-100 px-4 text-sm hover:text-black dark:hover:text-dark-100"
                 type="button"
                 @click="editOrOpen"
-                v-if="needsAlt"
             >
                 {{ asset.values.alt ? "✅" : __("Set Alt") }}
             </button>

--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -29,16 +29,16 @@
             >
                 {{ asset.basename }}
             </button>
-            <div v-text="asset.size" class="hidden @xs:inline asset-filesize text-xs text-gray-600 px-2" />
-        </td>
-        <td class="w-24" v-if="showSetAlt && needsAlt">
+
             <button
+                v-if="showSetAlt && needsAlt"
                 class="asset-set-alt text-blue dark:text-dark-blue-100 px-4 text-sm hover:text-black dark:hover:text-dark-100"
                 type="button"
                 @click="editOrOpen"
             >
                 {{ asset.values.alt ? "✅" : __("Set Alt") }}
             </button>
+            <div v-text="asset.size" class="hidden @xs:inline asset-filesize text-xs text-gray-600 px-2" />
         </td>
         <td class="p-0 w-8 rtl:text-left ltr:text-right align-middle" v-if="!readOnly">
             <button


### PR DESCRIPTION
This PR modifies the layout logic in the `AssetsFieldtype` to only reserve space for the "Set alt" button when it's actually needed.

## Currently

Currently, when "showSetAlt" is set to true and there is an alt text, the space for the "Set alt" Button is reserved but not used, leading to a shorter file name place.

When the file needs an alt text:
<img width="400" alt="Capture d’écran 2025-02-16 à 21 50 35" src="https://github.com/user-attachments/assets/04e2479a-5691-482c-9dc0-b05271ebee94" />

When the file does not need an alt text:
 _(notice how the file name is cropped even when there is a lot of white space)_
<img width="394" alt="Capture d’écran 2025-02-16 à 21 50 49" src="https://github.com/user-attachments/assets/7944dc40-e09e-41cb-93a1-0269f3e30fd7" />


## Fix

As shown in the last screenshot, when needsAlt = false, the file name now uses the full available width :

<img width="396" alt="Capture d’écran 2025-02-16 à 21 51 25" src="https://github.com/user-attachments/assets/e0d870aa-e0a3-41a2-8891-5601d3e5c235" />

Also works for files that doesdo not need an alt text:
<img width="393" alt="Capture d’écran 2025-02-16 à 22 01 37" src="https://github.com/user-attachments/assets/bfe2947d-bdd1-4d2d-8f67-8653a671cb04" />

## Notes

The text var could also be simplified, but not sure if that was done so for some magic purpose or not ;-) :
Old: `{{ asset.values.alt ? "✅" : __("Set Alt") }}`
New: `{{ __("Set Alt") }}`