### PR TITLE
[6.x] Fix hidden fields mixin store reference

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -200,6 +200,7 @@
                     <!-- Fields Area -->
                     <publish-container
                         v-if="fields"
+                        ref="container"
                         :name="publishContainer"
                         :blueprint="fieldset"
                         :values="values"
@@ -344,6 +345,10 @@ export default {
     },
 
     computed: {
+        store() {
+            return this.$refs.container.store;
+        },
+
         isImage() {
             if (!this.asset) return false;
 

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -450,6 +450,10 @@ export default {
     },
 
     computed: {
+        store() {
+            return this.$refs.container.store;
+        },
+
         formattedTitle() {
             return striptags(__(this.title));
         },

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -149,6 +149,10 @@ export default {
     },
 
     computed: {
+        store() {
+            return this.$refs.container.store;
+        },
+
         hasErrors() {
             return this.error || Object.keys(this.errors).length;
         },

--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -116,6 +116,10 @@ export default {
     },
 
     computed: {
+        store() {
+            return this.$refs.container.store;
+        },
+
         headerText() {
             return this.entry ? __('Link to Entry') : __('Nav Item');
         },

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -371,6 +371,10 @@ export default {
     },
 
     computed: {
+        store() {
+            return this.$refs.container.store;
+        },
+
         formattedTitle() {
             return striptags(__(this.title));
         },

--- a/resources/js/components/user-groups/PublishForm.vue
+++ b/resources/js/components/user-groups/PublishForm.vue
@@ -70,6 +70,10 @@ export default {
     },
 
     computed: {
+        store() {
+            return this.$refs.container.store;
+        },
+
         hasErrors() {
             return this.error || Object.keys(this.errors).length;
         },

--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -98,6 +98,10 @@ export default {
     },
 
     computed: {
+        store() {
+            return this.$refs.container.store;
+        },
+
         hasErrors() {
             return this.error || Object.keys(this.errors).length;
         },


### PR DESCRIPTION
Components that use the HasHiddenFields mixin now need a `store` property that references the Pinia store since #11446 

This fixes an error when saving publish forms.