### PR TITLE
[5.x] Change revision whereKey to return a collection

### DIFF
--- a/src/Revisions/RevisionRepository.php
+++ b/src/Revisions/RevisionRepository.php
@@ -29,13 +29,15 @@ class RevisionRepository implements Contract
 
         $files = Folder::getFiles($directory);
 
-        return FileCollection::make($files)->filterByExtension('yaml')->reject(function ($path) {
+        $revisions = FileCollection::make($files)->filterByExtension('yaml')->reject(function ($path) {
             return Str::endsWith($path, 'working.yaml');
         })->map(function ($path) use ($key) {
             return $this->makeRevisionFromFile($key, $path);
         })->keyBy(function ($revision) {
             return $revision->date()->timestamp;
         });
+
+        return collect($revisions->all());
     }
 
     public function findWorkingCopyByKey($key)

--- a/tests/Revisions/RepositoryTest.php
+++ b/tests/Revisions/RepositoryTest.php
@@ -28,4 +28,12 @@ class RepositoryTest extends TestCase
         $this->assertCount(2, $revisions);
         $this->assertContainsOnlyInstancesOf(Revision::class, $revisions);
     }
+
+    #[Test]
+    public function it_can_call_to_array_on_a_revision_collection()
+    {
+        $revisions = $this->repo->whereKey('123');
+
+        $this->assertIsArray($revisions->toArray());
+    }
 }


### PR DESCRIPTION
The stache revision repository whereKey method currently returns a FileCollection by nature of how the revisions are found, but doesn't seem to use any of the methods. When you call ->toArray() on this it errors out.

This PR updates the return to be a normal collection, which allows it to behave as you would expect.

Closes https://github.com/statamic/cms/issues/11454