### PR TITLE
[5.x] If nav:from references an invalid entry, ensure nothing is returned

### DIFF
--- a/src/Structures/TreeBuilder.php
+++ b/src/Structures/TreeBuilder.php
@@ -31,7 +31,13 @@ class TreeBuilder
 
         $tree->withEntries();
 
-        $entry = ($from && $from !== '/') ? Entry::findByUri(Str::start($from, '/'), $params['site']) : null;
+        $entry = null;
+
+        if ($from && $from !== '/') {
+            if (! $entry = Entry::findByUri(Str::start($from, '/'), $params['site'])) {
+                return [];
+            }
+        }
 
         if ($entry) {
             $page = $tree->find($entry->id());

--- a/tests/Tags/StructureTagTest.php
+++ b/tests/Tags/StructureTagTest.php
@@ -456,6 +456,41 @@ EOT;
         $this->assertEquals('[1=parent][1-1=parent][1-1-1=parent][1-1-1-1=current][2]', $result);
     }
 
+    #[Test]
+    public function it_doesnt_render_anything_when_nav_from_is_invalid()
+    {
+        $this->createCollectionAndNav();
+        Entry::shouldReceive('findByUri')->andReturn(null);
+
+        // The html uses <i> tags (could be any tag, but i is short) to prevent whitespace comparison issues in the assertion.
+        $template = <<<'EOT'
+<ul>
+{{ nav from="something-invalid" }}
+    <li>
+        <i>{{ title }}</i>
+        {{ if children }}
+        <ul>
+            {{ *recursive children* }}
+        </ul>
+        {{ /if }}
+    </li>
+{{ /nav }}
+</ul>
+EOT;
+
+        $expected = <<<'EOT'
+<ul>
+    <li>
+        <i>outer title</i>
+    </li>
+</ul>
+EOT;
+
+        $this->assertXmlStringEqualsXmlString($expected, (string) Antlers::parse($template, [
+            'title' => 'outer title', // to test that cascade the page's data takes precedence over the cascading data.
+        ]));
+    }
+
     private function makeNav($tree)
     {
         $nav = Nav::make('test');


### PR DESCRIPTION
This fix is possibly a breaking change, let me know if you want it to retarget main.

If you pass an invalid entry to nav:from then it currently treats it as if you have not passed anything to from, which feels like incorrect behaviour. Instead it should return nothing.

Closes https://github.com/statamic/cms/issues/11392