### PR TITLE
[5.x] Support Sections in form GraphQL queries

### DIFF
--- a/src/GraphQL/TypeRegistrar.php
+++ b/src/GraphQL/TypeRegistrar.php
@@ -21,6 +21,7 @@ use Statamic\GraphQL\Types\NavTreeBranchType;
 use Statamic\GraphQL\Types\NavType;
 use Statamic\GraphQL\Types\PageInterface;
 use Statamic\GraphQL\Types\RoleType;
+use Statamic\GraphQL\Types\SectionType;
 use Statamic\GraphQL\Types\SiteType;
 use Statamic\GraphQL\Types\TableRowType;
 use Statamic\GraphQL\Types\TaxonomyType;
@@ -62,6 +63,7 @@ class TypeRegistrar
         GraphQL::addType(AssetInterface::class);
         GraphQL::addType(GlobalSetInterface::class);
         GraphQL::addType(FieldType::class);
+        GraphQL::addType(SectionType::class);
 
         PageInterface::addTypes();
         EntryInterface::addTypes();

--- a/src/GraphQL/Types/FormType.php
+++ b/src/GraphQL/Types/FormType.php
@@ -38,6 +38,12 @@ class FormType extends \Rebing\GraphQL\Support\Type
                     return $form->blueprint()->fields()->validator()->rules();
                 },
             ],
+            'sections' => [
+                'type' => GraphQL::listOf(GraphQL::type(SectionType::NAME)),
+                'resolve' => function ($form, $args, $context, $info) {
+                    return $form->blueprint()->tabs()->first()->sections()->all();
+                },
+            ],
         ])->map(function (array $arr) {
             $arr['resolve'] = $arr['resolve'] ?? $this->resolver();
 

--- a/src/GraphQL/Types/SectionType.php
+++ b/src/GraphQL/Types/SectionType.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Statamic\GraphQL\Types;
+
+use Statamic\Facades\GraphQL;
+
+class SectionType extends \Rebing\GraphQL\Support\Type
+{
+    const NAME = 'Section';
+
+    protected $attributes = [
+        'name' => self::NAME,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'display' => [
+                'type' => GraphQL::string(),
+                'resolve' => function ($section) {
+                    return $section->display();
+                },
+            ],
+            'instructions' => [
+                'type' => GraphQL::string(),
+                'resolve' => function ($section) {
+                    return $section->instructions();
+                },
+            ],
+            'fields' => [
+                'type' => GraphQL::listOf(GraphQL::type(FieldType::NAME)),
+                'resolve' => function ($section) {
+                    return $section->fields()->all();
+                },
+            ],
+        ];
+    }
+}

--- a/tests/Feature/GraphQL/FormTest.php
+++ b/tests/Feature/GraphQL/FormTest.php
@@ -236,6 +236,13 @@ GQL;
             'message' => ['type' => 'textarea', 'width' => 33],
         ]);
 
+        // Set section display and instructions. You wouldn't really do this for a form blueprint,
+        // but this is just to test the section type which doesn't get tested anywhere else.
+        $contents = $blueprint->contents();
+        $contents['tabs']['main']['sections'][0]['display'] = 'My Section';
+        $contents['tabs']['main']['sections'][0]['instructions'] = 'The section instructions';
+        $blueprint->setContents($contents);
+
         BlueprintRepository::shouldReceive('find')->with('forms.contact')->andReturn($blueprint);
 
         $query = <<<'GQL'
@@ -265,8 +272,8 @@ GQL;
                 'form' => [
                     'sections' => [
                         [
-                            'display' => null,
-                            'instructions' => null,
+                            'display' => 'My Section',
+                            'instructions' => 'The section instructions',
                             'fields' => [
                                 [
                                     'handle' => 'name',


### PR DESCRIPTION
This PR adds support for sections in GraphQL queries:

```
query MyQuery {
  form(handle: "test") {
    title
    rules
    honeypot
    handle
    sections {
      instructions
      display
      fields {
         instructions
         type
         display
         handle
         config
         width
      }
    }
  }
}
```

Closes https://github.com/statamic/cms/issues/8482