### PR TITLE
[5.x] Add Unlink All action to relationship fields

### DIFF
--- a/resources/js/components/field-actions/DropdownActions.vue
+++ b/resources/js/components/field-actions/DropdownActions.vue
@@ -3,6 +3,7 @@
         <button
             v-for="action in actions"
             @click="run(action)"
+            :class="{ warning: action.dangerous }"
             v-text="action.title" />
     </div>
 </template>

--- a/resources/js/components/field-actions/FieldAction.js
+++ b/resources/js/components/field-actions/FieldAction.js
@@ -7,6 +7,7 @@ export default class FieldAction {
     #visibleWhenReadOnly;
     #icon;
     #quick;
+    #dangerous;
     #confirm;
 
     constructor(action, payload) {
@@ -17,6 +18,7 @@ export default class FieldAction {
         this.#visibleWhenReadOnly = action.visibleWhenReadOnly ?? false;
         this.#icon = action.icon ?? 'image';
         this.#quick = action.quick ?? false;
+        this.#dangerous = action.dangerous ?? false;
         this.title = action.title;
     }
 
@@ -30,6 +32,10 @@ export default class FieldAction {
 
     get quick() {
         return typeof this.#quick === 'function' ? this.#quick(this.#payload) : this.#quick;
+    }
+
+    get dangerous() {
+        return typeof this.#dangerous === 'function' ? this.#dangerous(this.#payload) : this.#dangerous;
     }
 
     get icon() {

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -442,7 +442,18 @@ export default {
             return this.config.dynamic === 'id'
                 ? __('statamic::fieldtypes.assets.dynamic_folder_pending_save')
                 : __('statamic::fieldtypes.assets.dynamic_folder_pending_field', {field: `<code>${this.config.dynamic}</code>`});
-        }
+        },
+
+        internalFieldActions() {
+            return [
+                {
+                    title: __('Remove All'),
+                    dangerous: true,
+                    run: this.removeAll,
+                    visible: this.value.length > 0,
+                },
+            ];
+        },
 
     },
 
@@ -530,6 +541,13 @@ export default {
         assetRemoved(asset) {
             const index = _(this.assets).findIndex({ id: asset.id });
             this.assets.splice(index, 1);
+        },
+
+        /**
+         * Remove all assets from the field.
+         */
+        removeAll() {
+            this.assets = [];
         },
 
         /**

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -450,7 +450,7 @@ export default {
                     title: __('Remove All'),
                     dangerous: true,
                     run: this.removeAll,
-                    visible: this.value.length > 0,
+                    visible: this.assets.length > 0,
                 },
             ];
         },

--- a/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
+++ b/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
@@ -147,7 +147,18 @@ export default {
                 const item = _.findWhere(this.meta.data, { id });
                 return item ? item.title : id;
             });
-        }
+        },
+
+        internalFieldActions() {
+            return [
+                {
+                    title: __('Unlink All'),
+                    dangerous: true,
+                    run: this.unlinkAll,
+                    visible: this.value.length > 0,
+                },
+            ];
+        },
 
     },
 
@@ -162,7 +173,15 @@ export default {
 
         linkExistingItem() {
             this.$refs.input.$refs.existing.click();
-        }
+        },
+
+        unlinkAll() {
+            this.update([]);
+            this.updateMeta({
+                ...this.meta,
+                data: [], 
+            });
+        },
 
     }
 


### PR DESCRIPTION
This PR adds an Unlink/Remove All action to relationship and assets fields:

![1](https://github.com/user-attachments/assets/fa92bacc-e3df-4776-a082-5b08253bf8e3)

It also adds a new `dangerous` property to field actions.

Closes https://github.com/statamic/ideas/issues/1313