### PR TITLE
[5.x] Fix cannot use paginate/limit error when one is null

### DIFF
--- a/src/Tags/Concerns/GetsQueryResults.php
+++ b/src/Tags/Concerns/GetsQueryResults.php
@@ -44,7 +44,7 @@ trait GetsQueryResults
 
     protected function preventIncompatiblePaginationParameters()
     {
-        if ($this->params->int('paginate') && $this->params->has('limit')) {
+        if ($this->params->int('paginate') && $this->params->int('limit')) {
             throw new \Exception('Cannot use [paginate] integer in combination with [limit] param.');
         }
 

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -143,6 +143,19 @@ class EntriesTest extends TestCase
     }
 
     #[Test]
+    public function it_should_not_throw_exception_if_trying_to_paginate_or_limit_and_the_other_is_null()
+    {
+        $this->makeEntry('a')->save();
+        $this->makeEntry('b')->save();
+        $this->makeEntry('c')->save();
+        $this->makeEntry('d')->save();
+        $this->makeEntry('e')->save();
+
+        $this->assertCount(3, $this->getEntries(['paginate' => 3, 'limit' => null]));
+        $this->assertCount(3, $this->getEntries(['paginate' => null, 'limit' => 3]));
+    }
+
+    #[Test]
     public function it_should_throw_exception_if_trying_to_paginate_and_chunk_at_same_time()
     {
         $this->makeEntry('a')->save();


### PR DESCRIPTION
https://github.com/statamic/cms/pull/10415 introduced a check to ensure that paginate and limit aren't used at the same time. However due to the `has` check a `null` limit value will pass as true even though it wouldn't be applied.

This becomes a problem when trying to pass variables through to tags where limit or paginate might be used:

```antlers
{{ collection:articles :paginate="paginate" :limit="limit" }}
```

```php
Statamic::tag('collection:articles', [
	'paginate' => $paginate,
	'limit' => $limit,
]);
```

I know you could filter the array or maybe use `void` in antlers, but it would be nice if you didn't have to worry about it. In this example there are conditions further up that ensure only one of those variables would be set.

The PR changes the check to use `int` so that a null value wont pass as true. The limit param check in the `results` method also uses `int`.