### PR TITLE
[5.x] Fix handle dimensions of rotated videos

### DIFF
--- a/src/Assets/Attributes.php
+++ b/src/Assets/Attributes.php
@@ -94,13 +94,13 @@ class Attributes
 
         // Adjust width and height if the video is rotated
         if (in_array($rotate, [90, 270, -90, -270])) {
-            list($width, $height) = [$height, $width];
+            [$width, $height] = [$height, $width];
         }
 
         return [
             'width' => $width,
             'height' => $height,
-            'duration' => Arr::get($id3, 'playtime_seconds')
+            'duration' => Arr::get($id3, 'playtime_seconds'),
         ];
     }
 }

--- a/src/Assets/Attributes.php
+++ b/src/Assets/Attributes.php
@@ -88,10 +88,19 @@ class Attributes
     {
         $id3 = ExtractInfo::fromAsset($this->asset);
 
+        $width = Arr::get($id3, 'video.resolution_x');
+        $height = Arr::get($id3, 'video.resolution_y');
+        $rotate = Arr::get($id3, 'video.rotate', 0);
+
+        // Adjust width and height if the video is rotated
+        if (in_array($rotate, [90, 270, -90, -270])) {
+            list($width, $height) = [$height, $width];
+        }
+
         return [
-            'width' => Arr::get($id3, 'video.resolution_x'),
-            'height' => Arr::get($id3, 'video.resolution_y'),
-            'duration' => Arr::get($id3, 'playtime_seconds'),
+            'width' => $width,
+            'height' => $height,
+            'duration' => Arr::get($id3, 'playtime_seconds')
         ];
     }
 }


### PR DESCRIPTION
This PR enables the correct output of video dimensions of videos that have rotated video streams. Currently, videos with rotated streams do not output proper dimensions, width and height are swapped.

Fixes #11480