### PR TITLE
[5.x] Allow custom asset container contents cache store

### DIFF
--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -1151,6 +1151,23 @@ class AssetFolderTest extends TestCase
         ], $folder->toArray());
     }
 
+    #[Test]
+    public function it_uses_a_custom_cache_store()
+    {
+        config([
+            'cache.stores.asset_container_contents' => [
+                'driver' => 'file',
+                'path' => storage_path('statamic/asset-container-contents'),
+            ],
+        ]);
+
+        Storage::fake('local');
+
+        $container = Facades\AssetContainer::make('test')->disk('local');
+
+        $this->assertSame('asset_container_contents', $container->contents()->cacheStore()->getName());
+    }
+
     private function containerWithDisk()
     {
         Storage::fake('local');

--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -1163,9 +1163,15 @@ class AssetFolderTest extends TestCase
 
         Storage::fake('local');
 
-        $container = Facades\AssetContainer::make('test')->disk('local');
+        $store = Facades\AssetContainer::make('test')->disk('local')->contents()->cacheStore();
 
-        $this->assertSame('asset_container_contents', $container->contents()->cacheStore()->getName());
+        $obj = new \ReflectionObject($store);
+        $method = $obj->getMethod('getName');
+        $method->setAccessible(true);
+
+        $storeName = $method->invoke($store, 'getName');
+
+        $this->assertSame('asset_container_contents', $storeName);
     }
 
     private function containerWithDisk()

--- a/tests/Assets/AssetFolderTest.php
+++ b/tests/Assets/AssetFolderTest.php
@@ -1165,13 +1165,8 @@ class AssetFolderTest extends TestCase
 
         $store = Facades\AssetContainer::make('test')->disk('local')->contents()->cacheStore();
 
-        $obj = new \ReflectionObject($store);
-        $method = $obj->getMethod('getName');
-        $method->setAccessible(true);
-
-        $storeName = $method->invoke($store, 'getName');
-
-        $this->assertSame('asset_container_contents', $storeName);
+        // ideally we would have checked the store name, but laravel 10 doesnt give us a way to do that
+        $this->assertStringContainsString('asset-container-contents', $store->getStore()->getDirectory());
     }
 
     private function containerWithDisk()


### PR DESCRIPTION
Currently the asset container contents are generated and cached in the default cache store, which means if you clear the application cache it needs to rebuilt.  When you are using a driver such as S3 this can be quite slow and resource intensive.

This PR provides the option to specify a `asset_container_contents` cache store, similar to the approach used in https://github.com/statamic/cms/pull/9405