### PR TITLE
[5.x] Fix issue with localization files named like handles

### DIFF
--- a/src/Auth/CorePermissions.php
+++ b/src/Auth/CorePermissions.php
@@ -12,6 +12,8 @@ use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
 use Statamic\Facades\Utility;
 
+use function Statamic\trans as __;
+
 class CorePermissions
 {
     public function boot()

--- a/src/Auth/Permission.php
+++ b/src/Auth/Permission.php
@@ -4,6 +4,8 @@ namespace Statamic\Auth;
 
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
+use function Statamic\trans as __;
+
 class Permission
 {
     use FluentlyGetsAndSets;

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -28,6 +28,8 @@ use Statamic\Facades\Path;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
 {
     use ExistsAsFile, HasAugmentedData;

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -13,6 +13,8 @@ use Statamic\Rules\Handle;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Field implements Arrayable
 {
     protected $handle;

--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -12,6 +12,8 @@ use Statamic\Query\Scopes\Filters\Fields\FieldtypeFilter;
 use Statamic\Statamic;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 abstract class Fieldtype implements Arrayable
 {
     use HasHandle, RegistersItself {

--- a/src/Fields/Tab.php
+++ b/src/Fields/Tab.php
@@ -5,6 +5,8 @@ namespace Statamic\Fields;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Tab
 {
     protected $handle;


### PR DESCRIPTION
We were encountering an issue `placeholderLabel(): Argument #1 ($label) must be of type ?string, array given` that appeared when there is a localization file that is named like a global set. Similar issues can appear with fieldsets. They are related to the way laravel localization works when a translation file is named like a translation key, e.g. `__('search")` and `lang/en/search.php`. In this case the whole contents of a file are returned instead of a string.

The underlying issue was already encountered and had been fixed for some parts of statamic 4, so I applied the same fix to the relevant files. https://github.com/statamic/cms/pull/9525/files