### PR TITLE
[5.x] Entries Fieldtype: Hide tree view when using query scopes

### DIFF
--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -80,6 +80,7 @@
                     :exclusions="exclusions"
                     :type="config.type"
                     :tree="tree"
+                    :can-use-tree="!! tree && config.query_scopes?.length === 0"
                     @selected="selectionsUpdated"
                     @closed="close"
                 />

--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -224,6 +224,7 @@ export default {
             default: () => []
         },
         tree: Object,
+        canUseTree: Boolean,
     },
 
     data() {
@@ -269,10 +270,6 @@ export default {
 
         singleSelect() {
             return this.maxSelections === 1;
-        },
-
-        canUseTree() {
-            return !! this.tree;
         },
 
         initialView() {


### PR DESCRIPTION
Currently, when you specify one or more `query_scopes` on the Entries Fieldtype, you'll see the _scoped_ entries in the "List" view, but you'll see _unscoped_ entries in the "Tree view".

Since the tree view isn't really built to be filtered, this pull request ensures it's hidden when a query scope is being used.

Closes #11477.