### PR TITLE
[5.x] Only show spatie/fork prompt when pcntl extension is loaded

### DIFF
--- a/src/Console/Commands/InstallSsg.php
+++ b/src/Console/Commands/InstallSsg.php
@@ -68,6 +68,7 @@ class InstallSsg extends Command
 
         if (
             ! Composer::isInstalled('spatie/fork')
+            && extension_loaded('pcntl')
             && confirm('Would you like to install spatie/fork? It allows for running multiple workers at once.')
         ) {
             spin(


### PR DESCRIPTION
This pull request prevents the spatie/fork prompt from showing unless the required `pcntl` extension is available. 

Closes #11490.