### PR TITLE
[5.x] Remove duplicate translation line from `translator` command

### DIFF
--- a/resources/lang/az.json
+++ b/resources/lang/az.json
@@ -528,7 +528,7 @@
     "Icon": "İkon",
     "ID": "ID",
     "ID regenerated and Stache cleared": "ID yenidən yaradıldı və Stache təmizləndi",
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Əgər \":actionText\" düyməsini tıklamaqda çətinlik çəkirsinizsə, aşağıdakı URL-ni kopyalayıb veb brauzerinizə yapışdırın:",
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Əgər \":actionText\" düyməsini tıklamaqda çətinlik çəkirsinizsə, aşağıdakı URL-ni kopyalayıb veb brauzerinizə yapışdırın:",
     "Image": "Şəkil",
     "Image Cache": "Şəkil Keşi",
     "Image cache cleared.": "Şəkil keşi təmizləndi.",

--- a/resources/lang/cs.json
+++ b/resources/lang/cs.json
@@ -528,7 +528,7 @@
     "Icon": "Ikona",
     "ID": "ID",
     "ID regenerated and Stache cleared": "ID obnoveno a Stache vyprázdněno",
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Pokud máte problém s kliknutím na tlačítko \":actionText\", zkopírujte a vložte URL níže do webového prohlížeče:",
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Pokud máte problém s kliknutím na tlačítko \":actionText\", zkopírujte a vložte URL níže do webového prohlížeče:",
     "Image": "Obrázek",
     "Image Cache": "Cache obrázků",
     "Image cache cleared.": "Cache obrázků smazána.",

--- a/resources/lang/da.json
+++ b/resources/lang/da.json
@@ -528,7 +528,7 @@
     "Icon": "Ikon",
     "ID": "ID",
     "ID regenerated and Stache cleared": "ID regenereret og Stache ryddet",
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Hvis du har problemer med at klikke på knappen \" :actionText \", skal du kopiere og indsætte nedenstående URL i din webbrowser:",
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Hvis du har problemer med at klikke på knappen \" :actionText \", skal du kopiere og indsætte nedenstående URL i din webbrowser:",
     "Image": "Billede",
     "Image Cache": "Billedcache",
     "Image cache cleared.": "Billedcache ryddet.",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -528,7 +528,7 @@
     "Icon": "Icon",
     "ID": "ID",
     "ID regenerated and Stache cleared": "ID regeneriert und Stache gelöscht",
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Wenn du beim Klicken auf den Button „:actionText“ Probleme hast, kopiere die folgende URL und füge sie in deinem Browser ein:",
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Wenn du beim Klicken auf den Button „:actionText“ Probleme hast, kopiere die folgende URL und füge sie in deinem Browser ein:",
     "Image": "Bild",
     "Image Cache": "Bildercache",
     "Image cache cleared.": "Der Bildercache wurde gelöscht.",

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -528,7 +528,7 @@
     "Icon": "Icon",
     "ID": "ID",
     "ID regenerated and Stache cleared": "ID regeneriert und Stache gelöscht",
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Wenn du beim Klicken auf den Button «:actionText» Probleme hast, kopiere die folgende URL und füge sie in deinem Browser ein:",
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Wenn du beim Klicken auf den Button «:actionText» Probleme hast, kopiere die folgende URL und füge sie in deinem Browser ein:",
     "Image": "Bild",
     "Image Cache": "Bildercache",
     "Image cache cleared.": "Der Bildercache wurde gelöscht.",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -528,7 +528,7 @@
     "Icon": "Icono",
     "ID": "IDENTIFICACIÓN",
     "ID regenerated and Stache cleared": "ID regenerada y bigote limpiado",
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Si tienes problemas para hacer clic en el botón de \":actionText\", copia y pega el siguiente URL en tu navegador:",
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Si tienes problemas para hacer clic en el botón de \":actionText\", copia y pega el siguiente URL en tu navegador:",
     "Image": "Imagen",
     "Image Cache": "Caché de imágenes",
     "Image cache cleared.": "Caché de imágenes borrado.",

--- a/resources/lang/fa.json
+++ b/resources/lang/fa.json
@@ -528,7 +528,7 @@
     "Icon": "آیکون",
     "ID": "شناسه",
     "ID regenerated and Stache cleared": "شناسه با موفقیت از نو ساخته و کش خالی شد",
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "اگر مشکلی در خصوص کلیلک روی دکمه‌ی \":actionText\" وجود دارد، می‌توانید آدرس زیر را کپی و در آدرس بار مرورگر پیست کنید:",
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "اگر مشکلی در خصوص کلیلک روی دکمه‌ی \":actionText\" وجود دارد، می‌توانید آدرس زیر را کپی و در آدرس بار مرورگر پیست کنید:",
     "Image": "تصویر",
     "Image Cache": "کش تصویر",
     "Image cache cleared.": "کش تصویر پاک شد",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -528,7 +528,7 @@
     "Icon": "Icône",
     "ID": "ID",
     "ID regenerated and Stache cleared": "ID regénéré et Stache effacé",
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Si vous ne parvenez pas à cliquer sur le bouton \":actionText\", copiez et collez l'URL ci-dessous dans votre navigateur Web :",
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Si vous ne parvenez pas à cliquer sur le bouton \":actionText\", copiez et collez l'URL ci-dessous dans votre navigateur Web :",
     "Image": "Image",
     "Image Cache": "Cache des images",
     "Image cache cleared.": "Cache des images effacé.",

--- a/resources/lang/hu.json
+++ b/resources/lang/hu.json
@@ -528,7 +528,7 @@
     "Icon": "Ikon",
     "ID": "ID",
     "ID regenerated and Stache cleared": "ID újragenerálva, Stache törölve",
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Ha nem tudja megkattintani a(z) \":actionText\" gombot, másolja ki és illessze be az alábbi URL-t a böngészőjébe:",
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Ha nem tudja megkattintani a(z) \":actionText\" gombot, másolja ki és illessze be az alábbi URL-t a böngészőjébe:",
     "Image": "Kép",
     "Image Cache": "Képgyorsítótár",
     "Image cache cleared.": "A képgyorsítótár törölve.",

--- a/translator
+++ b/translator
@@ -46,7 +46,6 @@ $additionalStrings = [
     'Whoops!',
     'Regards',
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:",
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:", // laravel <8.48.0
     'All rights reserved.',
     'The given data was invalid.',
     'Protected Page',


### PR DESCRIPTION
This pull request hopefully fixes #11489, where duplicate lines were added when running the `translator` command. 