### PR TITLE
[5.x] Fix carbon integer casting

### DIFF
--- a/src/API/AbstractCacher.php
+++ b/src/API/AbstractCacher.php
@@ -55,6 +55,6 @@ abstract class AbstractCacher implements Cacher
      */
     public function cacheExpiry()
     {
-        return Carbon::now()->addMinutes($this->config('expiry'));
+        return Carbon::now()->addMinutes((int) $this->config('expiry'));
     }
 }

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -85,7 +85,7 @@ class Git
     public function dispatchCommit($message = null)
     {
         if ($delay = config('statamic.git.dispatch_delay')) {
-            $delayInMinutes = now()->addMinutes($delay);
+            $delayInMinutes = now()->addMinutes((int) $delay);
             $message = null;
         }
 

--- a/src/GraphQL/ResponseCache/DefaultCache.php
+++ b/src/GraphQL/ResponseCache/DefaultCache.php
@@ -19,7 +19,7 @@ class DefaultCache implements ResponseCache
     {
         $key = $this->track($request);
 
-        $ttl = Carbon::now()->addMinutes(config('statamic.graphql.cache.expiry', 60));
+        $ttl = Carbon::now()->addMinutes((int) config('statamic.graphql.cache.expiry', 60));
 
         Cache::put($key, $response, $ttl);
     }

--- a/src/Http/Controllers/CP/SessionTimeoutController.php
+++ b/src/Http/Controllers/CP/SessionTimeoutController.php
@@ -14,7 +14,7 @@ class SessionTimeoutController extends CpController
         $lastActivity = session('last_activity', now()->timestamp);
 
         return Carbon::createFromTimestamp($lastActivity, config('app.timezone'))
-            ->addMinutes(config('session.lifetime'))
+            ->addMinutes((int) config('session.lifetime'))
             ->diffInSeconds();
     }
 }

--- a/src/Providers/CacheServiceProvider.php
+++ b/src/Providers/CacheServiceProvider.php
@@ -76,7 +76,7 @@ class CacheServiceProvider extends ServiceProvider
 
             $keyValuePair = $callback();
             $value = reset($keyValuePair);
-            $expiration = Carbon::now()->addMinutes(key($keyValuePair));
+            $expiration = Carbon::now()->addMinutes((int) key($keyValuePair));
 
             return Cache::remember($cacheKey, $expiration, function () use ($value) {
                 return $value;

--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -66,7 +66,7 @@ abstract class AbstractCacher implements Cacher
      */
     public function getDefaultExpiration()
     {
-        return $this->config('expiry');
+        return (int) $this->config('expiry');
     }
 
     /**


### PR DESCRIPTION
If you use environment variables, they come through as strings. Carbon 2 didn't care and would deal with strings for you but Carbon 3 wants an integer.

Fixes #11492 which solves the API, but the same thing could happen in other places like the graphql api, static caching, etc.