### PR TITLE
[5.x] Fix: Include port in CSP for Live Preview

### DIFF
--- a/src/Tokens/Handlers/LivePreview.php
+++ b/src/Tokens/Handlers/LivePreview.php
@@ -39,8 +39,8 @@ class LivePreview
     {
         $parts = parse_url($site->absoluteUrl());
 
-        $port = isset($parts['port']) ? ':' . $parts['port'] : '';
+        $port = isset($parts['port']) ? ':'.$parts['port'] : '';
 
-        return $parts['scheme'] . '://' . $parts['host'] . $port;
+        return $parts['scheme'].'://'.$parts['host'].$port;
     }
 }

--- a/src/Tokens/Handlers/LivePreview.php
+++ b/src/Tokens/Handlers/LivePreview.php
@@ -22,7 +22,7 @@ class LivePreview
         if (Sites::multiEnabled()) {
             /** @var Collection */
             $siteURLs = Sites::all()
-                ->map(fn(Site $site) => $this->getSchemeAndHost($site))
+                ->map(fn (Site $site) => $this->getSchemeAndHost($site))
                 ->values()
                 ->unique()
                 ->join(' ');

--- a/src/Tokens/Handlers/LivePreview.php
+++ b/src/Tokens/Handlers/LivePreview.php
@@ -22,7 +22,7 @@ class LivePreview
         if (Sites::multiEnabled()) {
             /** @var Collection */
             $siteURLs = Sites::all()
-                ->map(fn (Site $site) => $this->getSchemeAndHost($site))
+                ->map(fn(Site $site) => $this->getSchemeAndHost($site))
                 ->values()
                 ->unique()
                 ->join(' ');
@@ -39,6 +39,8 @@ class LivePreview
     {
         $parts = parse_url($site->absoluteUrl());
 
-        return $parts['scheme'].'://'.$parts['host'];
+        $port = isset($parts['port']) ? ':' . $parts['port'] : '';
+
+        return $parts['scheme'] . '://' . $parts['host'] . $port;
     }
 }

--- a/tests/Feature/Entries/AddsHeadersToLivePreviewTest.php
+++ b/tests/Feature/Entries/AddsHeadersToLivePreviewTest.php
@@ -60,9 +60,12 @@ class AddsHeadersToLivePreviewTest extends TestCase
         config()->set('statamic.system.multisite', true);
 
         $this->setSites([
-            'en' => ['url' => 'http://localhost/', 'locale' => 'en'],
-            'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
-            'third' => ['url' => 'http://third/', 'locale' => 'en'],
+            'one' => ['url' => 'http://withport.com:8080/', 'locale' => 'en'],
+            'two' => ['url' => 'http://withport.com:8080/fr/', 'locale' => 'fr'],
+            'three' => ['url' => 'http://withoutport.com/', 'locale' => 'en'],
+            'four' => ['url' => 'http://withoutport.com/fr/', 'locale' => 'fr'],
+            'five' => ['url' => 'http://third.com/', 'locale' => 'en'],
+            'six' => ['url' => 'http://third.com/fr/', 'locale' => 'fr'],
         ]);
 
         $substitute = EntryFactory::collection('test')->id('2')->slug('charlie')->data(['title' => 'Substituted title', 'foo' => 'Substituted foo'])->make();
@@ -71,26 +74,6 @@ class AddsHeadersToLivePreviewTest extends TestCase
 
         $this->get('/test?token=test-token')
             ->assertHeader('X-Statamic-Live-Preview', true)
-            ->assertHeader('Content-Security-Policy', 'frame-ancestors http://localhost http://third');
-    }
-
-    #[Test]
-    public function it_includes_ports_in_csp_header()
-    {
-        config()->set('statamic.system.multisite', true);
-
-        $this->setSites([
-            'en' => ['url' => 'http://localhost:8080', 'locale' => 'en'],
-            'fr' => ['url' => 'http://localhost:8080/fr/', 'locale' => 'fr'],
-            'third' => ['url' => 'http://third/', 'locale' => 'en'],
-        ]);
-
-        $substitute = EntryFactory::collection('test')->id('2')->slug('charlie')->data(['title' => 'Substituted title', 'foo' => 'Substituted foo'])->make();
-
-        LivePreview::tokenize('test-token', $substitute);
-
-        $this->get('/test?token=test-token')
-            ->assertHeader('X-Statamic-Live-Preview', true)
-            ->assertHeader('Content-Security-Policy', 'frame-ancestors http://localhost:8080 http://third');
+            ->assertHeader('Content-Security-Policy', 'frame-ancestors http://withport.com:8080 http://withoutport.com http://third.com');
     }
 }

--- a/tests/Feature/Entries/AddsHeadersToLivePreviewTest.php
+++ b/tests/Feature/Entries/AddsHeadersToLivePreviewTest.php
@@ -58,11 +58,13 @@ class AddsHeadersToLivePreviewTest extends TestCase
     public function it_sets_header_when_multisite()
     {
         config()->set('statamic.system.multisite', true);
+
         $this->setSites([
             'en' => ['url' => 'http://localhost/', 'locale' => 'en'],
             'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
             'third' => ['url' => 'http://third/', 'locale' => 'en'],
         ]);
+
         $substitute = EntryFactory::collection('test')->id('2')->slug('charlie')->data(['title' => 'Substituted title', 'foo' => 'Substituted foo'])->make();
 
         LivePreview::tokenize('test-token', $substitute);
@@ -70,5 +72,25 @@ class AddsHeadersToLivePreviewTest extends TestCase
         $this->get('/test?token=test-token')
             ->assertHeader('X-Statamic-Live-Preview', true)
             ->assertHeader('Content-Security-Policy', 'frame-ancestors http://localhost http://third');
+    }
+
+    #[Test]
+    public function it_includes_ports_in_csp_header()
+    {
+        config()->set('statamic.system.multisite', true);
+
+        $this->setSites([
+            'en' => ['url' => 'http://localhost:8080', 'locale' => 'en'],
+            'fr' => ['url' => 'http://localhost:8080/fr/', 'locale' => 'fr'],
+            'third' => ['url' => 'http://third/', 'locale' => 'en'],
+        ]);
+
+        $substitute = EntryFactory::collection('test')->id('2')->slug('charlie')->data(['title' => 'Substituted title', 'foo' => 'Substituted foo'])->make();
+
+        LivePreview::tokenize('test-token', $substitute);
+
+        $this->get('/test?token=test-token')
+            ->assertHeader('X-Statamic-Live-Preview', true)
+            ->assertHeader('Content-Security-Policy', 'frame-ancestors http://localhost:8080 http://third');
     }
 }


### PR DESCRIPTION
This fixes #11497 where Live Preview's Content Security Policy (CSP) does not include the port number in the frame-ancestors directive when determining allowed origins. 

This issue affects configurations where the control panel is served on a custom port (e.g., http://127.0.0.1:8000/ or http://localhost:8080/). Since CSP treats http://127.0.0.1/ and http://127.0.0.1:8000/ as distinct origins, the live preview fails to load within an iframe.