### PR TITLE
[6.x] Convert `$casts` property to method on Eloquent models

### DIFF
--- a/src/Auth/Eloquent/RoleModel.php
+++ b/src/Auth/Eloquent/RoleModel.php
@@ -10,12 +10,15 @@ class RoleModel extends Eloquent
 
     protected $table = 'roles';
 
-    protected $casts = [
-        'permissions' => 'json',
-        'preferences' => 'json',
-        'created_at' => 'datetime',
-        'updated_at' => 'datetime',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'permissions' => 'json',
+            'preferences' => 'json',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
 
     public function __construct(array $attributes = [])
     {

--- a/src/Auth/Eloquent/UserGroupModel.php
+++ b/src/Auth/Eloquent/UserGroupModel.php
@@ -10,12 +10,15 @@ class UserGroupModel extends Eloquent
 
     protected $table = 'groups';
 
-    protected $casts = [
-        'roles' => 'json',
-        'data' => 'json',
-        'created_at' => 'datetime',
-        'updated_at' => 'datetime',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'roles' => 'json',
+            'data' => 'json',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
 
     public function __construct(array $attributes = [])
     {

--- a/src/StaticCaching/NoCache/DatabaseRegion.php
+++ b/src/StaticCaching/NoCache/DatabaseRegion.php
@@ -12,7 +12,10 @@ class DatabaseRegion extends Model
 
     protected $primaryKey = 'key';
 
-    protected $casts = [
-        'key' => 'string',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'key' => 'string',
+        ];
+    }
 }


### PR DESCRIPTION
This pull request converts the `$casts` property on models to a method, now that Laravel 11 is the minimum version.

Related: https://github.com/statamic/eloquent-driver/pull/400
