### PR TITLE
[6.x] Drop Carbon 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "league/glide": "^2.3",
         "maennchen/zipstream-php": "^3.1",
         "michelf/php-smartypants": "^1.8.1",
-        "nesbot/carbon": "^2.62.1 || ^3.0",
+        "nesbot/carbon": "^3.0",
         "pixelfear/composer-dist-plugin": "^0.1.4",
         "rebing/graphql-laravel": "^9.7",
         "rhukster/dom-sanitizer": "^1.0.6",

--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -55,15 +55,6 @@ class Localize
     {
         $reflection = new ReflectionClass($date = Date::now());
 
-        // Carbon 2.x
-        if ($reflection->hasProperty('toStringFormat')) {
-            $format = $reflection->getProperty('toStringFormat');
-            $format->setAccessible(true);
-
-            return $format->getValue();
-        }
-
-        // Carbon 3.x
         $factory = $reflection->getMethod('getFactory');
         $factory->setAccessible(true);
 

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -546,7 +546,7 @@ class CoreModifiers extends Modifier
      */
     public function daysAgo($value, $params)
     {
-        return (int) abs($this->carbon($value)->diffInDays(Arr::get($params, 0)));
+        return $this->carbon($value)->diffInDays(Arr::get($params, 0));
     }
 
     /**
@@ -1055,7 +1055,7 @@ class CoreModifiers extends Modifier
      */
     public function hoursAgo($value, $params)
     {
-        return (int) abs($this->carbon($value)->diffInHours(Arr::get($params, 0)));
+        return $this->carbon($value)->diffInHours(Arr::get($params, 0));
     }
 
     /**
@@ -1617,7 +1617,7 @@ class CoreModifiers extends Modifier
      */
     public function minutesAgo($value, $params)
     {
-        return (int) abs($this->carbon($value)->diffInMinutes(Arr::get($params, 0)));
+        return $this->carbon($value)->diffInMinutes(Arr::get($params, 0));
     }
 
     /**
@@ -1652,7 +1652,7 @@ class CoreModifiers extends Modifier
      */
     public function monthsAgo($value, $params)
     {
-        return (int) abs($this->carbon($value)->diffInMonths(Arr::get($params, 0)));
+        return $this->carbon($value)->diffInMonths(Arr::get($params, 0));
     }
 
     /**
@@ -2234,7 +2234,7 @@ class CoreModifiers extends Modifier
      */
     public function secondsAgo($value, $params)
     {
-        return (int) abs($this->carbon($value)->diffInSeconds(Arr::get($params, 0)));
+        return $this->carbon($value)->diffInSeconds(Arr::get($params, 0));
     }
 
     /**
@@ -2933,7 +2933,7 @@ class CoreModifiers extends Modifier
      */
     public function weeksAgo($value, $params)
     {
-        return (int) abs($this->carbon($value)->diffInWeeks(Arr::get($params, 0)));
+        return $this->carbon($value)->diffInWeeks(Arr::get($params, 0));
     }
 
     /**

--- a/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
@@ -16,13 +16,8 @@ class DateFieldtypeTest extends FieldtypeTestCase
         parent::setUp();
 
         Carbon::macro('getToStringFormat', function () {
-            // Carbon 2.x
-            if (property_exists(static::this(), 'toStringFormat')) {
-                return static::$toStringFormat;
-            }
-
-            // Carbon 3.x
             $reflection = new ReflectionClass(self::this());
+
             $factory = $reflection->getMethod('getFactory');
             $factory->setAccessible(true);
 

--- a/tests/Modifiers/DaysAgoTest.php
+++ b/tests/Modifiers/DaysAgoTest.php
@@ -23,13 +23,13 @@ class DaysAgoTest extends TestCase
     {
         return [
             'same time' => ['2025-02-20 00:00', 0.0],
-            'less than a day ago' => ['2025-02-19 11:00', 0.0],
+            'less than a day ago' => ['2025-02-19 11:00', 1.0],
             '1 day ago' => ['2025-02-19 00:00', 1.0],
             '2 days ago' => ['2025-02-18 00:00', 2.0],
 
             'one day from now' => ['2025-02-21 00:00', -1.0],
-            'less than a day from now' => ['2025-02-20 13:00', -0.0],
-            'more than a day from now' => ['2025-02-21 13:00', -1.0],
+            'less than a day from now' => ['2025-02-20 13:00', -1.0],
+            'more than a day from now' => ['2025-02-21 13:00', -2.0],
         ];
     }
 

--- a/tests/Modifiers/DaysAgoTest.php
+++ b/tests/Modifiers/DaysAgoTest.php
@@ -16,19 +16,20 @@ class DaysAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20 00:00'));
 
-        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+        $this->assertSame($expected, round($this->modify(Carbon::parse($input))));
     }
 
     public static function dateProvider()
     {
         return [
             'same time' => ['2025-02-20 00:00', 0.0],
-            'less than a day ago' => ['2025-02-19 11:00', 0.5416666666666666],
+            'less than a day ago' => ['2025-02-19 11:00', 0.0],
             '1 day ago' => ['2025-02-19 00:00', 1.0],
             '2 days ago' => ['2025-02-18 00:00', 2.0],
+
             'one day from now' => ['2025-02-21 00:00', -1.0],
-            'less than a day from now' => ['2025-02-20 13:00', -0.5416666666666666],
-            'more than a day from now' => ['2025-02-21 13:00', -1.5416666666666667],
+            'less than a day from now' => ['2025-02-20 13:00', -0.0],
+            'more than a day from now' => ['2025-02-21 13:00', -1.0],
         ];
     }
 

--- a/tests/Modifiers/DaysAgoTest.php
+++ b/tests/Modifiers/DaysAgoTest.php
@@ -22,18 +22,13 @@ class DaysAgoTest extends TestCase
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same time' => ['2025-02-20 00:00', 0],
-            'less than a day ago' => ['2025-02-19 11:00', 0],
-            '1 day ago' => ['2025-02-19 00:00', 1],
-            '2 days ago' => ['2025-02-18 00:00', 2],
-
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one day from now' => ['2025-02-21 00:00', 1],
-            'less than a day from now' => ['2025-02-20 13:00', 0],
-            'more than a day from now' => ['2025-02-21 13:00', 1],
+            'same time' => ['2025-02-20 00:00', 0.0],
+            'less than a day ago' => ['2025-02-19 11:00', 0.5416666666666666],
+            '1 day ago' => ['2025-02-19 00:00', 1.0],
+            '2 days ago' => ['2025-02-18 00:00', 2.0],
+            'one day from now' => ['2025-02-21 00:00', -1.0],
+            'less than a day from now' => ['2025-02-20 13:00', -0.5416666666666666],
+            'more than a day from now' => ['2025-02-21 13:00', -1.5416666666666667],
         ];
     }
 

--- a/tests/Modifiers/DaysAgoTest.php
+++ b/tests/Modifiers/DaysAgoTest.php
@@ -16,20 +16,19 @@ class DaysAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20 00:00'));
 
-        $this->assertSame($expected, round($this->modify(Carbon::parse($input))));
+        $this->assertSame($expected, round($this->modify(Carbon::parse($input)), 2));
     }
 
     public static function dateProvider()
     {
         return [
             'same time' => ['2025-02-20 00:00', 0.0],
-            'less than a day ago' => ['2025-02-19 11:00', 0.0],
+            'less than a day ago' => ['2025-02-19 11:00', 0.54],
             '1 day ago' => ['2025-02-19 00:00', 1.0],
             '2 days ago' => ['2025-02-18 00:00', 2.0],
-
             'one day from now' => ['2025-02-21 00:00', -1.0],
-            'less than a day from now' => ['2025-02-20 13:00', -0.0],
-            'more than a day from now' => ['2025-02-21 13:00', -1.0],
+            'less than a day from now' => ['2025-02-20 13:00', -0.54],
+            'more than a day from now' => ['2025-02-21 13:00', -1.54],
         ];
     }
 

--- a/tests/Modifiers/DaysAgoTest.php
+++ b/tests/Modifiers/DaysAgoTest.php
@@ -23,13 +23,13 @@ class DaysAgoTest extends TestCase
     {
         return [
             'same time' => ['2025-02-20 00:00', 0.0],
-            'less than a day ago' => ['2025-02-19 11:00', 1.0],
+            'less than a day ago' => ['2025-02-19 11:00', 0.0],
             '1 day ago' => ['2025-02-19 00:00', 1.0],
             '2 days ago' => ['2025-02-18 00:00', 2.0],
 
             'one day from now' => ['2025-02-21 00:00', -1.0],
-            'less than a day from now' => ['2025-02-20 13:00', -1.0],
-            'more than a day from now' => ['2025-02-21 13:00', -2.0],
+            'less than a day from now' => ['2025-02-20 13:00', -0.0],
+            'more than a day from now' => ['2025-02-21 13:00', -1.0],
         ];
     }
 

--- a/tests/Modifiers/HoursAgoTest.php
+++ b/tests/Modifiers/HoursAgoTest.php
@@ -16,19 +16,24 @@ class HoursAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20 13:10:00'));
 
-        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+        $this->assertSame($expected, round($this->modify(Carbon::parse($input))));
     }
 
     public static function dateProvider()
     {
         return [
-            'same time' => ['2025-02-20 13:10:00', 0.0],
-            'less than a hour ago' => ['2025-02-20 13:00:00', 0.16666666666666666],
-            '1 hour ago' => ['2025-02-20 12:10:00', 1.0],
-            '2 hours ago' => ['2025-02-20 11:10:00', 2.0],
-            'one hour from now' => ['2025-02-20 14:10:00', -1.0],
-            'less than a hour from now' => ['2025-02-20 13:30:00', -0.3333333333333333],
-            'more than a hour from now' => ['2025-02-20 15:10:00', -2.0],
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same time' => ['2025-02-20 13:10:00', 0], // 0.0
+            'less than a hour ago' => ['2025-02-20 13:00:00', 0], // 0.17
+            '1 hour ago' => ['2025-02-20 12:10:00', 1], // 1.0
+            '2 hours ago' => ['2025-02-20 11:10:00', 2], // 2.0
+
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one hour from now' => ['2025-02-20 14:10:00', 1], // -1.0
+            'less than a hour from now' => ['2025-02-20 13:30:00', 0], // -0.33
+            'more than a hour from now' => ['2025-02-20 15:10:00', 2], // -2.0
         ];
     }
 

--- a/tests/Modifiers/HoursAgoTest.php
+++ b/tests/Modifiers/HoursAgoTest.php
@@ -22,18 +22,14 @@ class HoursAgoTest extends TestCase
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same time' => ['2025-02-20 13:10:00', 0], // 0.0
-            'less than a hour ago' => ['2025-02-20 13:00:00', 0], // 0.17
-            '1 hour ago' => ['2025-02-20 12:10:00', 1], // 1.0
-            '2 hours ago' => ['2025-02-20 11:10:00', 2], // 2.0
+            'same time' => ['2025-02-20 13:10:00', 0.0], // 0.0
+            'less than a hour ago' => ['2025-02-20 13:00:00', 0.0], // 0.17
+            '1 hour ago' => ['2025-02-20 12:10:00', 1.0], // 1.0
+            '2 hours ago' => ['2025-02-20 11:10:00', 2.0], // 2.0
 
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one hour from now' => ['2025-02-20 14:10:00', 1], // -1.0
-            'less than a hour from now' => ['2025-02-20 13:30:00', 0], // -0.33
-            'more than a hour from now' => ['2025-02-20 15:10:00', 2], // -2.0
+            'one hour from now' => ['2025-02-20 14:10:00', -1.0], // -1.0
+            'less than a hour from now' => ['2025-02-20 13:30:00', -0.0], // -0.33
+            'more than a hour from now' => ['2025-02-20 15:10:00', -2.0], // -2.0
         ];
     }
 

--- a/tests/Modifiers/HoursAgoTest.php
+++ b/tests/Modifiers/HoursAgoTest.php
@@ -16,24 +16,19 @@ class HoursAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20 13:10:00'));
 
-        $this->assertSame($expected, round($this->modify(Carbon::parse($input))));
+        $this->assertSame($expected, round($this->modify(Carbon::parse($input)), 2));
     }
 
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same time' => ['2025-02-20 13:10:00', 0], // 0.0
-            'less than a hour ago' => ['2025-02-20 13:00:00', 0], // 0.17
-            '1 hour ago' => ['2025-02-20 12:10:00', 1], // 1.0
-            '2 hours ago' => ['2025-02-20 11:10:00', 2], // 2.0
-
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one hour from now' => ['2025-02-20 14:10:00', 1], // -1.0
-            'less than a hour from now' => ['2025-02-20 13:30:00', 0], // -0.33
-            'more than a hour from now' => ['2025-02-20 15:10:00', 2], // -2.0
+            'same time' => ['2025-02-20 13:10:00', 0.0],
+            'less than a hour ago' => ['2025-02-20 13:00:00', 0.17],
+            '1 hour ago' => ['2025-02-20 12:10:00', 1.0],
+            '2 hours ago' => ['2025-02-20 11:10:00', 2.0],
+            'one hour from now' => ['2025-02-20 14:10:00', -1.0],
+            'less than a hour from now' => ['2025-02-20 13:30:00', -0.33],
+            'more than a hour from now' => ['2025-02-20 15:10:00', -2.0],
         ];
     }
 

--- a/tests/Modifiers/HoursAgoTest.php
+++ b/tests/Modifiers/HoursAgoTest.php
@@ -22,14 +22,18 @@ class HoursAgoTest extends TestCase
     public static function dateProvider()
     {
         return [
-            'same time' => ['2025-02-20 13:10:00', 0.0], // 0.0
-            'less than a hour ago' => ['2025-02-20 13:00:00', 0.0], // 0.17
-            '1 hour ago' => ['2025-02-20 12:10:00', 1.0], // 1.0
-            '2 hours ago' => ['2025-02-20 11:10:00', 2.0], // 2.0
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same time' => ['2025-02-20 13:10:00', 0], // 0.0
+            'less than a hour ago' => ['2025-02-20 13:00:00', 0], // 0.17
+            '1 hour ago' => ['2025-02-20 12:10:00', 1], // 1.0
+            '2 hours ago' => ['2025-02-20 11:10:00', 2], // 2.0
 
-            'one hour from now' => ['2025-02-20 14:10:00', -1.0], // -1.0
-            'less than a hour from now' => ['2025-02-20 13:30:00', -0.0], // -0.33
-            'more than a hour from now' => ['2025-02-20 15:10:00', -2.0], // -2.0
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one hour from now' => ['2025-02-20 14:10:00', 1], // -1.0
+            'less than a hour from now' => ['2025-02-20 13:30:00', 0], // -0.33
+            'more than a hour from now' => ['2025-02-20 15:10:00', 2], // -2.0
         ];
     }
 

--- a/tests/Modifiers/HoursAgoTest.php
+++ b/tests/Modifiers/HoursAgoTest.php
@@ -22,18 +22,13 @@ class HoursAgoTest extends TestCase
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same time' => ['2025-02-20 13:10:00', 0], // 0.0
-            'less than a hour ago' => ['2025-02-20 13:00:00', 0], // 0.17
-            '1 hour ago' => ['2025-02-20 12:10:00', 1], // 1.0
-            '2 hours ago' => ['2025-02-20 11:10:00', 2], // 2.0
-
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one hour from now' => ['2025-02-20 14:10:00', 1], // -1.0
-            'less than a hour from now' => ['2025-02-20 13:30:00', 0], // -0.33
-            'more than a hour from now' => ['2025-02-20 15:10:00', 2], // -2.0
+            'same time' => ['2025-02-20 13:10:00', 0.0],
+            'less than a hour ago' => ['2025-02-20 13:00:00', 0.16666666666666666],
+            '1 hour ago' => ['2025-02-20 12:10:00', 1.0],
+            '2 hours ago' => ['2025-02-20 11:10:00', 2.0],
+            'one hour from now' => ['2025-02-20 14:10:00', -1.0],
+            'less than a hour from now' => ['2025-02-20 13:30:00', -0.3333333333333333],
+            'more than a hour from now' => ['2025-02-20 15:10:00', -2.0],
         ];
     }
 

--- a/tests/Modifiers/MinutesAgoTest.php
+++ b/tests/Modifiers/MinutesAgoTest.php
@@ -22,13 +22,18 @@ class MinutesAgoTest extends TestCase
     public static function dateProvider()
     {
         return [
-            'same time' => ['2025-02-20 13:10:00', 0.0],
-            'less than a minute ago' => ['2025-02-20 13:09:30', 0.5],
-            '1 minute ago' => ['2025-02-20 13:09:00', 1.0],
-            '2 minutes ago' => ['2025-02-20 13:08:00', 2.0],
-            'one minute from now' => ['2025-02-20 13:11:00', -1.0],
-            'less than a minute from now' => ['2025-02-20 13:10:30', -0.5],
-            'more than a minute from now' => ['2025-02-20 13:11:30', -1.5],
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same time' => ['2025-02-20 13:10:00', 0], // 0.0
+            'less than a minute ago' => ['2025-02-20 13:09:30', 0], // 0.5
+            '1 minute ago' => ['2025-02-20 13:09:00', 1], // 1.0
+            '2 minutes ago' => ['2025-02-20 13:08:00', 2], // 2.0
+
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one minute from now' => ['2025-02-20 13:11:00', 1], // -1.0
+            'less than a minute from now' => ['2025-02-20 13:10:30', 0], // -0.5
+            'more than a minute from now' => ['2025-02-20 13:11:30', 1], // -1.5
         ];
     }
 

--- a/tests/Modifiers/MinutesAgoTest.php
+++ b/tests/Modifiers/MinutesAgoTest.php
@@ -16,20 +16,24 @@ class MinutesAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20 13:10:00'));
 
-        $this->assertSame($expected, round($this->modify(Carbon::parse($input))));
+        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
     }
 
     public static function dateProvider()
     {
         return [
-            'same time' => ['2025-02-20 13:10:00', 0.0], // 0.0
-            'less than a minute ago' => ['2025-02-20 13:09:30', 1.0], // 0.5
-            '1 minute ago' => ['2025-02-20 13:09:00', 1.0], // 1.0
-            '2 minutes ago' => ['2025-02-20 13:08:00', 2.0], // 2.0
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same time' => ['2025-02-20 13:10:00', 0], // 0.0
+            'less than a minute ago' => ['2025-02-20 13:09:30', 0], // 0.5
+            '1 minute ago' => ['2025-02-20 13:09:00', 1], // 1.0
+            '2 minutes ago' => ['2025-02-20 13:08:00', 2], // 2.0
 
-            'one minute from now' => ['2025-02-20 13:11:00', -1.0], // -1.0
-            'less than a minute from now' => ['2025-02-20 13:10:30', -1.0], // -0.5
-            'more than a minute from now' => ['2025-02-20 13:11:30', -2.0], // -1.5
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one minute from now' => ['2025-02-20 13:11:00', 1], // -1.0
+            'less than a minute from now' => ['2025-02-20 13:10:30', 0], // -0.5
+            'more than a minute from now' => ['2025-02-20 13:11:30', 1], // -1.5
         ];
     }
 

--- a/tests/Modifiers/MinutesAgoTest.php
+++ b/tests/Modifiers/MinutesAgoTest.php
@@ -22,18 +22,13 @@ class MinutesAgoTest extends TestCase
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same time' => ['2025-02-20 13:10:00', 0], // 0.0
-            'less than a minute ago' => ['2025-02-20 13:09:30', 0], // 0.5
-            '1 minute ago' => ['2025-02-20 13:09:00', 1], // 1.0
-            '2 minutes ago' => ['2025-02-20 13:08:00', 2], // 2.0
-
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one minute from now' => ['2025-02-20 13:11:00', 1], // -1.0
-            'less than a minute from now' => ['2025-02-20 13:10:30', 0], // -0.5
-            'more than a minute from now' => ['2025-02-20 13:11:30', 1], // -1.5
+            'same time' => ['2025-02-20 13:10:00', 0.0],
+            'less than a minute ago' => ['2025-02-20 13:09:30', 0.5],
+            '1 minute ago' => ['2025-02-20 13:09:00', 1.0],
+            '2 minutes ago' => ['2025-02-20 13:08:00', 2.0],
+            'one minute from now' => ['2025-02-20 13:11:00', -1.0],
+            'less than a minute from now' => ['2025-02-20 13:10:30', -0.5],
+            'more than a minute from now' => ['2025-02-20 13:11:30', -1.5],
         ];
     }
 

--- a/tests/Modifiers/MinutesAgoTest.php
+++ b/tests/Modifiers/MinutesAgoTest.php
@@ -16,24 +16,19 @@ class MinutesAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20 13:10:00'));
 
-        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+        $this->assertSame($expected, round($this->modify(Carbon::parse($input)), 2));
     }
 
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same time' => ['2025-02-20 13:10:00', 0], // 0.0
-            'less than a minute ago' => ['2025-02-20 13:09:30', 0], // 0.5
-            '1 minute ago' => ['2025-02-20 13:09:00', 1], // 1.0
-            '2 minutes ago' => ['2025-02-20 13:08:00', 2], // 2.0
-
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one minute from now' => ['2025-02-20 13:11:00', 1], // -1.0
-            'less than a minute from now' => ['2025-02-20 13:10:30', 0], // -0.5
-            'more than a minute from now' => ['2025-02-20 13:11:30', 1], // -1.5
+            'same time' => ['2025-02-20 13:10:00', 0.0],
+            'less than a minute ago' => ['2025-02-20 13:09:30', 0.5],
+            '1 minute ago' => ['2025-02-20 13:09:00', 1.0],
+            '2 minutes ago' => ['2025-02-20 13:08:00', 2.0],
+            'one minute from now' => ['2025-02-20 13:11:00', -1.0],
+            'less than a minute from now' => ['2025-02-20 13:10:30', -0.5],
+            'more than a minute from now' => ['2025-02-20 13:11:30', -1.5],
         ];
     }
 

--- a/tests/Modifiers/MinutesAgoTest.php
+++ b/tests/Modifiers/MinutesAgoTest.php
@@ -16,24 +16,20 @@ class MinutesAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20 13:10:00'));
 
-        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+        $this->assertSame($expected, round($this->modify(Carbon::parse($input))));
     }
 
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same time' => ['2025-02-20 13:10:00', 0], // 0.0
-            'less than a minute ago' => ['2025-02-20 13:09:30', 0], // 0.5
-            '1 minute ago' => ['2025-02-20 13:09:00', 1], // 1.0
-            '2 minutes ago' => ['2025-02-20 13:08:00', 2], // 2.0
+            'same time' => ['2025-02-20 13:10:00', 0.0], // 0.0
+            'less than a minute ago' => ['2025-02-20 13:09:30', 1.0], // 0.5
+            '1 minute ago' => ['2025-02-20 13:09:00', 1.0], // 1.0
+            '2 minutes ago' => ['2025-02-20 13:08:00', 2.0], // 2.0
 
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one minute from now' => ['2025-02-20 13:11:00', 1], // -1.0
-            'less than a minute from now' => ['2025-02-20 13:10:30', 0], // -0.5
-            'more than a minute from now' => ['2025-02-20 13:11:30', 1], // -1.5
+            'one minute from now' => ['2025-02-20 13:11:00', -1.0], // -1.0
+            'less than a minute from now' => ['2025-02-20 13:10:30', -1.0], // -0.5
+            'more than a minute from now' => ['2025-02-20 13:11:30', -2.0], // -1.5
         ];
     }
 

--- a/tests/Modifiers/MonthsAgoTest.php
+++ b/tests/Modifiers/MonthsAgoTest.php
@@ -16,20 +16,24 @@ class MonthsAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20'));
 
-        $this->assertSame($expected, round($this->modify(Carbon::parse($input))));
+        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
     }
 
     public static function dateProvider()
     {
         return [
-            'same month' => ['2025-02-20', 0.0], // 0.0
-            'less than a month ago' => ['2025-02-10', 0.0], // 0.36
-            '1 month ago' => ['2025-01-20', 1.0], // 1.0
-            '2 months ago' => ['2024-12-20', 2.0], // 2.0
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same month' => ['2025-02-20', 0], // 0.0
+            'less than a month ago' => ['2025-02-10', 0], // 0.36
+            '1 month ago' => ['2025-01-20', 1], // 1.0
+            '2 months ago' => ['2024-12-20', 2], // 2.0
 
-            'one month from now' => ['2025-03-20', -1.0], // -1.0
-            'less than a month from now' => ['2025-02-25', -0.0], // -0.18
-            'more than a month from now' => ['2025-04-20', -2.0], // -2.0
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one month from now' => ['2025-03-20', 1], // -1.0
+            'less than a month from now' => ['2025-02-25', 0], // -0.18
+            'more than a month from now' => ['2025-04-20', 2], // -2.0
         ];
     }
 

--- a/tests/Modifiers/MonthsAgoTest.php
+++ b/tests/Modifiers/MonthsAgoTest.php
@@ -16,24 +16,19 @@ class MonthsAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20'));
 
-        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+        $this->assertSame($expected, round($this->modify(Carbon::parse($input)), 2));
     }
 
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same month' => ['2025-02-20', 0], // 0.0
-            'less than a month ago' => ['2025-02-10', 0], // 0.36
-            '1 month ago' => ['2025-01-20', 1], // 1.0
-            '2 months ago' => ['2024-12-20', 2], // 2.0
-
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one month from now' => ['2025-03-20', 1], // -1.0
-            'less than a month from now' => ['2025-02-25', 0], // -0.18
-            'more than a month from now' => ['2025-04-20', 2], // -2.0
+            'same month' => ['2025-02-20', 0.0],
+            'less than a month ago' => ['2025-02-10', 0.36],
+            '1 month ago' => ['2025-01-20', 1.0],
+            '2 months ago' => ['2024-12-20', 2.0],
+            'one month from now' => ['2025-03-20', -1.0],
+            'less than a month from now' => ['2025-02-25', -0.18],
+            'more than a month from now' => ['2025-04-20', -2.0],
         ];
     }
 

--- a/tests/Modifiers/MonthsAgoTest.php
+++ b/tests/Modifiers/MonthsAgoTest.php
@@ -16,24 +16,20 @@ class MonthsAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20'));
 
-        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+        $this->assertSame($expected, round($this->modify(Carbon::parse($input))));
     }
 
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same month' => ['2025-02-20', 0], // 0.0
-            'less than a month ago' => ['2025-02-10', 0], // 0.36
-            '1 month ago' => ['2025-01-20', 1], // 1.0
-            '2 months ago' => ['2024-12-20', 2], // 2.0
+            'same month' => ['2025-02-20', 0.0], // 0.0
+            'less than a month ago' => ['2025-02-10', 0.0], // 0.36
+            '1 month ago' => ['2025-01-20', 1.0], // 1.0
+            '2 months ago' => ['2024-12-20', 2.0], // 2.0
 
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one month from now' => ['2025-03-20', 1], // -1.0
-            'less than a month from now' => ['2025-02-25', 0], // -0.18
-            'more than a month from now' => ['2025-04-20', 2], // -2.0
+            'one month from now' => ['2025-03-20', -1.0], // -1.0
+            'less than a month from now' => ['2025-02-25', -0.0], // -0.18
+            'more than a month from now' => ['2025-04-20', -2.0], // -2.0
         ];
     }
 

--- a/tests/Modifiers/MonthsAgoTest.php
+++ b/tests/Modifiers/MonthsAgoTest.php
@@ -22,13 +22,18 @@ class MonthsAgoTest extends TestCase
     public static function dateProvider()
     {
         return [
-            'same month' => ['2025-02-20', 0.0],
-            'less than a month ago' => ['2025-02-10', 0.35714285714285715],
-            '1 month ago' => ['2025-01-20', 1.0],
-            '2 months ago' => ['2024-12-20', 2.0],
-            'one month from now' => ['2025-03-20', -1.0],
-            'less than a month from now' => ['2025-02-25', -0.17857142857142858],
-            'more than a month from now' => ['2025-04-20', -2.0],
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same month' => ['2025-02-20', 0], // 0.0
+            'less than a month ago' => ['2025-02-10', 0], // 0.36
+            '1 month ago' => ['2025-01-20', 1], // 1.0
+            '2 months ago' => ['2024-12-20', 2], // 2.0
+
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one month from now' => ['2025-03-20', 1], // -1.0
+            'less than a month from now' => ['2025-02-25', 0], // -0.18
+            'more than a month from now' => ['2025-04-20', 2], // -2.0
         ];
     }
 

--- a/tests/Modifiers/MonthsAgoTest.php
+++ b/tests/Modifiers/MonthsAgoTest.php
@@ -22,18 +22,13 @@ class MonthsAgoTest extends TestCase
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same month' => ['2025-02-20', 0], // 0.0
-            'less than a month ago' => ['2025-02-10', 0], // 0.36
-            '1 month ago' => ['2025-01-20', 1], // 1.0
-            '2 months ago' => ['2024-12-20', 2], // 2.0
-
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one month from now' => ['2025-03-20', 1], // -1.0
-            'less than a month from now' => ['2025-02-25', 0], // -0.18
-            'more than a month from now' => ['2025-04-20', 2], // -2.0
+            'same month' => ['2025-02-20', 0.0],
+            'less than a month ago' => ['2025-02-10', 0.35714285714285715],
+            '1 month ago' => ['2025-01-20', 1.0],
+            '2 months ago' => ['2024-12-20', 2.0],
+            'one month from now' => ['2025-03-20', -1.0],
+            'less than a month from now' => ['2025-02-25', -0.17857142857142858],
+            'more than a month from now' => ['2025-04-20', -2.0],
         ];
     }
 

--- a/tests/Modifiers/SecondsAgoTest.php
+++ b/tests/Modifiers/SecondsAgoTest.php
@@ -16,18 +16,22 @@ class SecondsAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20 13:10:30'));
 
-        $this->assertSame($expected, round($this->modify(Carbon::parse($input))));
+        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
     }
 
     public static function dateProvider()
     {
         return [
-            'same second' => ['2025-02-20 13:10:30', 0.0], // 0.0
-            '1 second ago' => ['2025-02-20 13:10:29', 1.0], // 1.0
-            '2 seconds ago' => ['2025-02-20 13:10:28', 2.0], // 2.0
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same second' => ['2025-02-20 13:10:30', 0], // 0.0
+            '1 second ago' => ['2025-02-20 13:10:29', 1], // 1.0
+            '2 seconds ago' => ['2025-02-20 13:10:28', 2], // 2.0
 
-            'one second from now' => ['2025-02-20 13:10:31', -1.0], // -1.0
-            'two seconds from now' => ['2025-02-20 13:10:32', -2.0], // -2.0
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one second from now' => ['2025-02-20 13:10:31', 1], // -1.0
+            'two seconds from now' => ['2025-02-20 13:10:32', 2], // -2.0
         ];
     }
 

--- a/tests/Modifiers/SecondsAgoTest.php
+++ b/tests/Modifiers/SecondsAgoTest.php
@@ -22,11 +22,16 @@ class SecondsAgoTest extends TestCase
     public static function dateProvider()
     {
         return [
-            'same second' => ['2025-02-20 13:10:30', 0.0],
-            '1 second ago' => ['2025-02-20 13:10:29', 1.0],
-            '2 seconds ago' => ['2025-02-20 13:10:28', 2.0],
-            'one second from now' => ['2025-02-20 13:10:31', -1.0],
-            'two seconds from now' => ['2025-02-20 13:10:32', -2.0],
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same second' => ['2025-02-20 13:10:30', 0], // 0.0
+            '1 second ago' => ['2025-02-20 13:10:29', 1], // 1.0
+            '2 seconds ago' => ['2025-02-20 13:10:28', 2], // 2.0
+
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one second from now' => ['2025-02-20 13:10:31', 1], // -1.0
+            'two seconds from now' => ['2025-02-20 13:10:32', 2], // -2.0
         ];
     }
 

--- a/tests/Modifiers/SecondsAgoTest.php
+++ b/tests/Modifiers/SecondsAgoTest.php
@@ -22,16 +22,11 @@ class SecondsAgoTest extends TestCase
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same second' => ['2025-02-20 13:10:30', 0], // 0.0
-            '1 second ago' => ['2025-02-20 13:10:29', 1], // 1.0
-            '2 seconds ago' => ['2025-02-20 13:10:28', 2], // 2.0
-
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one second from now' => ['2025-02-20 13:10:31', 1], // -1.0
-            'two seconds from now' => ['2025-02-20 13:10:32', 2], // -2.0
+            'same second' => ['2025-02-20 13:10:30', 0.0],
+            '1 second ago' => ['2025-02-20 13:10:29', 1.0],
+            '2 seconds ago' => ['2025-02-20 13:10:28', 2.0],
+            'one second from now' => ['2025-02-20 13:10:31', -1.0],
+            'two seconds from now' => ['2025-02-20 13:10:32', -2.0],
         ];
     }
 

--- a/tests/Modifiers/SecondsAgoTest.php
+++ b/tests/Modifiers/SecondsAgoTest.php
@@ -16,22 +16,17 @@ class SecondsAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20 13:10:30'));
 
-        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+        $this->assertSame($expected, round($this->modify(Carbon::parse($input)), 2));
     }
 
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same second' => ['2025-02-20 13:10:30', 0], // 0.0
-            '1 second ago' => ['2025-02-20 13:10:29', 1], // 1.0
-            '2 seconds ago' => ['2025-02-20 13:10:28', 2], // 2.0
-
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one second from now' => ['2025-02-20 13:10:31', 1], // -1.0
-            'two seconds from now' => ['2025-02-20 13:10:32', 2], // -2.0
+            'same second' => ['2025-02-20 13:10:30', 0.0],
+            '1 second ago' => ['2025-02-20 13:10:29', 1.0],
+            '2 seconds ago' => ['2025-02-20 13:10:28', 2.0],
+            'one second from now' => ['2025-02-20 13:10:31', -1.0],
+            'two seconds from now' => ['2025-02-20 13:10:32', -2.0],
         ];
     }
 

--- a/tests/Modifiers/SecondsAgoTest.php
+++ b/tests/Modifiers/SecondsAgoTest.php
@@ -16,22 +16,18 @@ class SecondsAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20 13:10:30'));
 
-        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+        $this->assertSame($expected, round($this->modify(Carbon::parse($input))));
     }
 
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same second' => ['2025-02-20 13:10:30', 0], // 0.0
-            '1 second ago' => ['2025-02-20 13:10:29', 1], // 1.0
-            '2 seconds ago' => ['2025-02-20 13:10:28', 2], // 2.0
+            'same second' => ['2025-02-20 13:10:30', 0.0], // 0.0
+            '1 second ago' => ['2025-02-20 13:10:29', 1.0], // 1.0
+            '2 seconds ago' => ['2025-02-20 13:10:28', 2.0], // 2.0
 
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one second from now' => ['2025-02-20 13:10:31', 1], // -1.0
-            'two seconds from now' => ['2025-02-20 13:10:32', 2], // -2.0
+            'one second from now' => ['2025-02-20 13:10:31', -1.0], // -1.0
+            'two seconds from now' => ['2025-02-20 13:10:32', -2.0], // -2.0
         ];
     }
 

--- a/tests/Modifiers/WeeksAgoTest.php
+++ b/tests/Modifiers/WeeksAgoTest.php
@@ -22,14 +22,19 @@ class WeeksAgoTest extends TestCase
     public static function dateProvider()
     {
         return [
-            'same day' => ['2025-02-20', 0.0],
-            'same week' => ['2025-02-19', 0.14285714285714285],
-            'less than a week ago' => ['2025-02-17', 0.42857142857142855],
-            '1 week ago' => ['2025-02-13', 1.0],
-            '2 weeks ago' => ['2025-02-06', 2.0],
-            'one week from now' => ['2025-02-27', -1.0],
-            'less than a week from now' => ['2025-02-22', -0.2857142857142857],
-            'more than a week from now' => ['2025-03-08', -2.2857142857142856],
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same day' => ['2025-02-20', 0], // 0.0
+            'same week' => ['2025-02-19', 0], // 0.14
+            'less than a week ago' => ['2025-02-17', 0], // 0.43
+            '1 week ago' => ['2025-02-13', 1], // 1.0
+            '2 weeks ago' => ['2025-02-06', 2], // 2.0
+
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one week from now' => ['2025-02-27', 1], // -1.0
+            'less than a week from now' => ['2025-02-22', 0], // -0.29
+            'more than a week from now' => ['2025-03-08', 2], // -2.29
         ];
     }
 

--- a/tests/Modifiers/WeeksAgoTest.php
+++ b/tests/Modifiers/WeeksAgoTest.php
@@ -22,19 +22,14 @@ class WeeksAgoTest extends TestCase
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same day' => ['2025-02-20', 0], // 0.0
-            'same week' => ['2025-02-19', 0], // 0.14
-            'less than a week ago' => ['2025-02-17', 0], // 0.43
-            '1 week ago' => ['2025-02-13', 1], // 1.0
-            '2 weeks ago' => ['2025-02-06', 2], // 2.0
-
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one week from now' => ['2025-02-27', 1], // -1.0
-            'less than a week from now' => ['2025-02-22', 0], // -0.29
-            'more than a week from now' => ['2025-03-08', 2], // -2.29
+            'same day' => ['2025-02-20', 0.0],
+            'same week' => ['2025-02-19', 0.14285714285714285],
+            'less than a week ago' => ['2025-02-17', 0.42857142857142855],
+            '1 week ago' => ['2025-02-13', 1.0],
+            '2 weeks ago' => ['2025-02-06', 2.0],
+            'one week from now' => ['2025-02-27', -1.0],
+            'less than a week from now' => ['2025-02-22', -0.2857142857142857],
+            'more than a week from now' => ['2025-03-08', -2.2857142857142856],
         ];
     }
 

--- a/tests/Modifiers/WeeksAgoTest.php
+++ b/tests/Modifiers/WeeksAgoTest.php
@@ -16,21 +16,25 @@ class WeeksAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20'));
 
-        $this->assertSame($expected, round($this->modify(Carbon::parse($input))));
+        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
     }
 
     public static function dateProvider()
     {
         return [
-            'same day' => ['2025-02-20', 0.0], // 0.0
-            'same week' => ['2025-02-19', 0.0], // 0.14
-            'less than a week ago' => ['2025-02-17', 0.0], // 0.43
-            '1 week ago' => ['2025-02-13', 1.0], // 1.0
-            '2 weeks ago' => ['2025-02-06', 2.0], // 2.0
+            // Carbon 3 would return floats but to preserve backwards compatibility
+            // with Carbon 2 we will cast to integers.
+            'same day' => ['2025-02-20', 0], // 0.0
+            'same week' => ['2025-02-19', 0], // 0.14
+            'less than a week ago' => ['2025-02-17', 0], // 0.43
+            '1 week ago' => ['2025-02-13', 1], // 1.0
+            '2 weeks ago' => ['2025-02-06', 2], // 2.0
 
-            'one week from now' => ['2025-02-27', -1.0], // -1.0
-            'less than a week from now' => ['2025-02-22', -0.0], // -0.29
-            'more than a week from now' => ['2025-03-08', -2.0], // -2.29
+            // Future dates would return negative numbers in Carbon 3 but to preserve
+            // backwards compatibility with Carbon 2, we keep them positive.
+            'one week from now' => ['2025-02-27', 1], // -1.0
+            'less than a week from now' => ['2025-02-22', 0], // -0.29
+            'more than a week from now' => ['2025-03-08', 2], // -2.29
         ];
     }
 

--- a/tests/Modifiers/WeeksAgoTest.php
+++ b/tests/Modifiers/WeeksAgoTest.php
@@ -16,25 +16,21 @@ class WeeksAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20'));
 
-        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+        $this->assertSame($expected, round($this->modify(Carbon::parse($input))));
     }
 
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same day' => ['2025-02-20', 0], // 0.0
-            'same week' => ['2025-02-19', 0], // 0.14
-            'less than a week ago' => ['2025-02-17', 0], // 0.43
-            '1 week ago' => ['2025-02-13', 1], // 1.0
-            '2 weeks ago' => ['2025-02-06', 2], // 2.0
+            'same day' => ['2025-02-20', 0.0], // 0.0
+            'same week' => ['2025-02-19', 0.0], // 0.14
+            'less than a week ago' => ['2025-02-17', 0.0], // 0.43
+            '1 week ago' => ['2025-02-13', 1.0], // 1.0
+            '2 weeks ago' => ['2025-02-06', 2.0], // 2.0
 
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one week from now' => ['2025-02-27', 1], // -1.0
-            'less than a week from now' => ['2025-02-22', 0], // -0.29
-            'more than a week from now' => ['2025-03-08', 2], // -2.29
+            'one week from now' => ['2025-02-27', -1.0], // -1.0
+            'less than a week from now' => ['2025-02-22', -0.0], // -0.29
+            'more than a week from now' => ['2025-03-08', -2.0], // -2.29
         ];
     }
 

--- a/tests/Modifiers/WeeksAgoTest.php
+++ b/tests/Modifiers/WeeksAgoTest.php
@@ -16,25 +16,20 @@ class WeeksAgoTest extends TestCase
     {
         Carbon::setTestNow(Carbon::parse('2025-02-20'));
 
-        $this->assertSame($expected, $this->modify(Carbon::parse($input)));
+        $this->assertSame($expected, round($this->modify(Carbon::parse($input)), 2));
     }
 
     public static function dateProvider()
     {
         return [
-            // Carbon 3 would return floats but to preserve backwards compatibility
-            // with Carbon 2 we will cast to integers.
-            'same day' => ['2025-02-20', 0], // 0.0
-            'same week' => ['2025-02-19', 0], // 0.14
-            'less than a week ago' => ['2025-02-17', 0], // 0.43
-            '1 week ago' => ['2025-02-13', 1], // 1.0
-            '2 weeks ago' => ['2025-02-06', 2], // 2.0
-
-            // Future dates would return negative numbers in Carbon 3 but to preserve
-            // backwards compatibility with Carbon 2, we keep them positive.
-            'one week from now' => ['2025-02-27', 1], // -1.0
-            'less than a week from now' => ['2025-02-22', 0], // -0.29
-            'more than a week from now' => ['2025-03-08', 2], // -2.29
+            'same day' => ['2025-02-20', 0.0],
+            'same week' => ['2025-02-19', 0.14],
+            'less than a week ago' => ['2025-02-17', 0.43],
+            '1 week ago' => ['2025-02-13', 1.0],
+            '2 weeks ago' => ['2025-02-06', 2.0],
+            'one week from now' => ['2025-02-27', -1.0],
+            'less than a week from now' => ['2025-02-22', -0.29],
+            'more than a week from now' => ['2025-03-08', -2.29],
         ];
     }
 


### PR DESCRIPTION
This pull request drops support for Carbon 2 in Statamic 6.

## Breaking changes

Carbon 3 introduced a change to the `->diffIn...()` methods, where they'll return floats instead of integers and past dates will return negative numbers.

This change will be reflected by Statamic's `months_ago`, `weeks_ago`, `days_ago`, `hours_ago`, `minutes_ago`, and `seconds_ago` modifiers