### PR TITLE
[5.x] Fix session expiry component

### DIFF
--- a/src/Http/Controllers/CP/SessionTimeoutController.php
+++ b/src/Http/Controllers/CP/SessionTimeoutController.php
@@ -13,8 +13,8 @@ class SessionTimeoutController extends CpController
         // remember me would have already been served a 403 error and wouldn't have got this far.
         $lastActivity = session('last_activity', now()->timestamp);
 
-        return Carbon::createFromTimestamp($lastActivity, config('app.timezone'))
+        return abs((int) Carbon::createFromTimestamp($lastActivity, config('app.timezone'))
             ->addMinutes((int) config('session.lifetime'))
-            ->diffInSeconds();
+            ->diffInSeconds());
     }
 }


### PR DESCRIPTION
tldr: This PR brings back the expected (carbon 2) behavior. It provides the remaining session seconds as a positive integer which prevents the session expiry modal appearing when not necessary.

![CleanShot 2025-02-25 at 11 34 27](https://github.com/user-attachments/assets/8e598713-daa8-42a4-829a-2e375d413af3)

---

The session expiry component exists on every control panel panel. It receives the session lifetime in sections and will begin a countdown. When it gets to about a minute, it will perform an ajax request to a route that will give the real remaining time left in the session.

If another tab was using the site in the mean time, the session would have been extended. The ajax request should reflect it.

Carbon 3 will return "diffInSeconds" as a negative number for times in the future. Since the component now receives a 
negative number, it will show the "your session has expired" modal and ask you to log back in, even if it's not necessary.

This issue was only noticeable if you left a tab open for longer than the session lifetime, and were on the latest Statamic version that uses Carbon 3.