### PR TITLE
[6.x] Restore page tree branch styling

### DIFF
--- a/resources/js/components/structures/Branch.vue
+++ b/resources/js/components/structures/Branch.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex">
+    <div class="page-tree-branch flex">
         <slot name="branch-action" :branch="page">
             <div v-if="editable" class="page-move w-6" />
         </slot>


### PR DESCRIPTION
I must have broken it near the end of the Vue 3 PR. It works for the CP nav builder but not the collection or navigation UIs.

Turns this:
![CleanShot 2025-02-26 at 15 40 17](https://github.com/user-attachments/assets/c534523e-332c-4b6f-80f1-7d80548a9874)

Back into this:
![CleanShot 2025-02-26 at 15 41 14](https://github.com/user-attachments/assets/ac492d1e-9064-41ac-a836-4c976ed4819b)
