### PR TITLE
[5.x] Improve validation message when handle starts with a number

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -156,6 +156,7 @@ return [
 
     'arr_fieldtype' => 'This is invalid.',
     'handle' => 'Must contain only lowercase letters and numbers with underscores as separators.',
+    'handle_starts_with_number' => 'Cannot start with a number.',
     'slug' => 'Must contain only letters and numbers with dashes or underscores as separators.',
     'code_fieldtype_rulers' => 'This is invalid.',
     'composer_package' => 'Must be a valid composer package name (eg. hasselhoff/kung-fury).',

--- a/src/Rules/Handle.php
+++ b/src/Rules/Handle.php
@@ -12,6 +12,8 @@ class Handle implements ValidationRule
     {
         if (Str::startsWith($value, range(0, 9))) {
             $fail('statamic::validation.handle_starts_with_number')->translate();
+
+            return;
         }
 
         if (! preg_match('/^[a-zA-Z][a-zA-Z0-9]*(?:_{0,1}[a-zA-Z0-9])*$/', $value)) {

--- a/src/Rules/Handle.php
+++ b/src/Rules/Handle.php
@@ -4,11 +4,16 @@ namespace Statamic\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Str;
 
 class Handle implements ValidationRule
 {
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
+        if (Str::startsWith($value, range(0, 9))) {
+            $fail('statamic::validation.handle_starts_with_number')->translate();
+        }
+
         if (! preg_match('/^[a-zA-Z][a-zA-Z0-9]*(?:_{0,1}[a-zA-Z0-9])*$/', $value)) {
             $fail('statamic::validation.handle')->translate();
         }

--- a/tests/Rules/HandleTest.php
+++ b/tests/Rules/HandleTest.php
@@ -43,4 +43,10 @@ class HandleTest extends TestCase
     {
         $this->assertValidationErrorOutput(trans('statamic::validation.handle'), '_bad_input');
     }
+
+    #[Test]
+    public function it_outputs_helpful_validation_error_when_string_starts_with_number()
+    {
+        $this->assertValidationErrorOutput(trans('statamic::validation.handle_starts_with_number'), '1bad_input');
+    }
 }


### PR DESCRIPTION
This pull request improves the validation message that gets thrown when a handle starts with a number, as the existing validation message only talks about the types of characters that can be used.

## Before

![CleanShot 2025-02-27 at 10 16 06](https://github.com/user-attachments/assets/8c4410cf-9a13-4063-a87d-782d0fcc8bd2)


## After

![CleanShot 2025-02-27 at 10 15 23](https://github.com/user-attachments/assets/f63c2743-1aad-480c-a80c-44b20b9fb89c)


---

Related: #11503