### PR TITLE
[5.x] Allow a custom asset meta cache store to be specified

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -248,7 +248,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
             return $meta;
         }
 
-        return $this->meta = Cache::rememberForever($this->metaCacheKey(), function () {
+        return $this->meta = $this->cacheStore()->rememberForever($this->metaCacheKey(), function () {
             if ($contents = $this->disk()->get($path = $this->metaPath())) {
                 return YAML::file($path)->parse($contents);
             }
@@ -267,7 +267,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
             return $value;
         }
 
-        Cache::forget($this->metaCacheKey());
+        $this->cacheStore()->forget($this->metaCacheKey());
 
         $this->writeMeta($meta = $this->generateMeta());
 
@@ -689,7 +689,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
     protected function clearCaches()
     {
         $this->meta = null;
-        Cache::forget($this->metaCacheKey());
+        $this->cacheStore()->forget($this->metaCacheKey());
     }
 
     /**
@@ -1128,5 +1128,14 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
         ] : [];
 
         return array_merge($this->container->warmPresets(), $cpPresets);
+    }
+    public function cacheStore()
+    {
+        return Cache::store($this->hasCustomStore() ? 'asset_meta' : null);
+    }
+
+    private function hasCustomStore(): bool
+    {
+        return config()->has('cache.stores.asset_meta');
     }
 }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -1129,6 +1129,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
 
         return array_merge($this->container->warmPresets(), $cpPresets);
     }
+
     public function cacheStore()
     {
         return Cache::store($this->hasCustomStore() ? 'asset_meta' : null);

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -2639,4 +2639,22 @@ YAML;
         Facades\Asset::shouldNotHaveReceived('delete');
         Event::assertNotDispatched(AssetDeleted::class);
     }
+
+    #[Test]
+    public function it_uses_a_custom_cache_store()
+    {
+        config([
+            'cache.stores.asset_meta' => [
+                'driver' => 'file',
+                'path' => storage_path('statamic/asset-meta'),
+            ],
+        ]);
+
+        Storage::fake('local');
+
+        $store = (new Asset)->cacheStore();
+
+        // ideally we would have checked the store name, but laravel 10 doesnt give us a way to do that
+        $this->assertStringContainsString('asset-meta', $store->getStore()->getDirectory());
+    }
 }


### PR DESCRIPTION
Following on from https://github.com/statamic/cms/pull/11481 it might make sense to allow meta to also have its own cache store, so it doesn't need to get purged on every cache clear?

This is all coming from a discord conversation by the way - https://discord.com/channels/489818810157891584/1342431350145290251