### PR TITLE
[5.x] Query for entry origin within the same collection

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -946,7 +946,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
 
     protected function getOriginByString($origin)
     {
-        return Facades\Entry::find($origin);
+        return $this->collection()->queryEntries()->where('id', $origin)->first();
     }
 
     protected function getOriginFallbackValues()

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionClass;
 use Statamic\Contracts\Data\Augmentable;
+use Statamic\Contracts\Entries\QueryBuilder;
 use Statamic\Data\AugmentedCollection;
 use Statamic\Entries\AugmentedEntry;
 use Statamic\Entries\Collection;
@@ -1727,7 +1728,12 @@ class EntryTest extends TestCase
         $originEntry = $this->mock(Entry::class);
         $originEntry->shouldReceive('id')->andReturn('123');
 
-        Facades\Entry::shouldReceive('find')->with('123')->andReturn($originEntry);
+        $builder = $this->mock(QueryBuilder::class);
+        $builder->shouldReceive('where')->with('collection', 'test')->andReturnSelf();
+        $builder->shouldReceive('where')->with('id', 123)->andReturnSelf();
+        $builder->shouldReceive('first')->andReturn($originEntry);
+        Facades\Entry::shouldReceive('query')->andReturn($builder);
+
         $originEntry->shouldReceive('values')->andReturn(collect([]));
         $originEntry->shouldReceive('blueprint')->andReturn(
             $this->mock(Blueprint::class)->shouldReceive('handle')->andReturn('test')->getMock()
@@ -1805,12 +1811,16 @@ class EntryTest extends TestCase
 
         $originEntry = $this->mock(Entry::class);
         $originEntry->shouldReceive('id')->andReturn('123');
-
-        Facades\Entry::shouldReceive('find')->with('123')->andReturn($originEntry);
         $originEntry->shouldReceive('values')->andReturn(collect([]));
         $originEntry->shouldReceive('blueprint')->andReturn(
             $this->mock(Blueprint::class)->shouldReceive('handle')->andReturn('another')->getMock()
         );
+
+        $builder = $this->mock(QueryBuilder::class);
+        $builder->shouldReceive('where')->with('collection', 'test')->andReturnSelf();
+        $builder->shouldReceive('where')->with('id', 123)->andReturnSelf();
+        $builder->shouldReceive('first')->andReturn($originEntry);
+        Facades\Entry::shouldReceive('query')->andReturn($builder);
 
         $entry = (new Entry)
             ->collection('test')
@@ -1831,12 +1841,16 @@ class EntryTest extends TestCase
 
         $originEntry = $this->mock(Entry::class);
         $originEntry->shouldReceive('id')->andReturn('123');
-
-        Facades\Entry::shouldReceive('find')->with('123')->andReturn($originEntry);
         $originEntry->shouldReceive('values')->andReturn(collect([]));
         $originEntry->shouldReceive('blueprint')->andReturn(
             $this->mock(Blueprint::class)->shouldReceive('handle')->andReturn('another')->getMock()
         );
+
+        $builder = $this->mock(QueryBuilder::class);
+        $builder->shouldReceive('where')->with('collection', 'test')->andReturnSelf();
+        $builder->shouldReceive('where')->with('id', 123)->andReturnSelf();
+        $builder->shouldReceive('first')->andReturn($originEntry);
+        Facades\Entry::shouldReceive('query')->andReturn($builder);
 
         $entry = (new Entry)
             ->collection('test')


### PR DESCRIPTION
Seems to fix #10025

I'm honestly a bit skeptical about this fixing the issue, however in my tests, it definitely made a difference.

What I was doing was this...

In Tinkerwell, run this:

```php
use Illuminate\Support\Facades\Http;
use Illuminate\Support\Collection;
use Illuminate\Http\Client\Pool;

$responses = collect(
  Http::pool(
    fn(Pool $pool) => Collection::times(
      50,
      fn() => $pool->get("http://the-site.test")
    )
  )
);

$responses->map
  ->status()
  ->countBy()
  ->all();
```

This will fire off 50 requests to the home page and output the number of each response status code.

While that's going, I would run `artisan cache:clear` from the site.

Before the PR, I would fairly consistently see the routeData on null error multiple times.

```php
[
    200 => 43,
    500 => 7
]
```

After, I wouldn't see it. (I would occasionally see some other sorts of sporadic failures, but they were unrelated.)

```php
[
    200 => 50,
]
```

The reason this seemingly unrelated line has anything to do with the error is because at some point along the way during building an index it needs to grab the origin. When you do `Entry::find()` (which is really just `Entry::query()->where('id', $id)->first()`) it'll need to load up all the `id` indexes for all collections. If you provide a `collection` to an entry query, it'll only load the `id` indexes for the collection(s) you pass it. In this case it'll load an index that's already loaded.