### PR TITLE
[5.x] Support `as` on nav tag

### DIFF
--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -66,7 +66,7 @@ class Structure extends Tags
 
         $value = $this->toArray($tree);
 
-        if ($as = $this->params->get('as')) {
+        if ($this->parser && ($as = $this->params->get('as'))) {
             return [$as => $value];
         }
 

--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -64,7 +64,13 @@ class Structure extends Tags
             'max_depth' => $this->params->get('max_depth'),
         ]);
 
-        return $this->toArray($tree);
+        $value = $this->toArray($tree);
+
+        if ($as = $this->params->get('as')) {
+            return [$as => $value];
+        }
+
+        return $value;
     }
 
     protected function ensureStructureExists(string $handle): void

--- a/tests/Tags/StructureTagTest.php
+++ b/tests/Tags/StructureTagTest.php
@@ -221,6 +221,48 @@ EOT;
     }
 
     #[Test]
+    public function it_renders_a_nav_with_as()
+    {
+        $this->createCollectionAndNav();
+
+        // The html uses <i> tags (could be any tag, but i is short) to prevent whitespace comparison issues in the assertion.
+        $template = <<<'EOT'
+<ul>
+{{ nav:test as="navtastic" }}
+    <li>Something before the loop</li>
+    {{ navtastic }}
+    <li>
+        <i>{{ nav_title or title }} {{ foo }}</i>
+    </li>
+    {{ /navtastic }}
+{{ /nav:test }}
+</ul>
+EOT;
+
+        $expected = <<<'EOT'
+<ul>
+    <li>Something before the loop</li>
+    <li>
+        <i>Navtitle One bar</i>
+    </li>
+    <li>
+        <i>Two notbar</i>
+    </li>
+    <li>
+        <i>Three bar</i>
+    </li>
+    <li>
+        <i>Title only bar</i>
+    </li>
+</ul>
+EOT;
+
+        $this->assertXmlStringEqualsXmlString($expected, (string) Antlers::parse($template, [
+            'foo' => 'bar', // to test that cascade is inherited.
+        ]));
+    }
+
+    #[Test]
     public function it_hides_unpublished_entries_by_default()
     {
         $this->createCollectionAndNav();


### PR DESCRIPTION
This PR adds support for `as` as a parameter on nav tags, so you can do things like

```
{{ nav:main as="navnav" }} 
    {{ navnav | chunk(3) }}
        chunk
    {{ /navnav }}
{{ /nav:main }}
```