### PR TITLE
[5.x] Icon fieldtype performance

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -50,6 +50,7 @@ use Statamic\Http\Controllers\CP\Fields\FieldtypesController;
 use Statamic\Http\Controllers\CP\Fields\MetaController;
 use Statamic\Http\Controllers\CP\Fieldtypes\DictionaryFieldtypeController;
 use Statamic\Http\Controllers\CP\Fieldtypes\FilesFieldtypeController;
+use Statamic\Http\Controllers\CP\Fieldtypes\IconFieldtypeController;
 use Statamic\Http\Controllers\CP\Fieldtypes\MarkdownFieldtypeController;
 use Statamic\Http\Controllers\CP\Fieldtypes\RelationshipFieldtypeController;
 use Statamic\Http\Controllers\CP\Forms\ActionController as FormActionController;
@@ -318,6 +319,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::post('markdown', [MarkdownFieldtypeController::class, 'preview'])->name('markdown.preview');
         Route::post('files/upload', [FilesFieldtypeController::class, 'upload'])->name('files.upload');
         Route::get('dictionaries/{dictionary}', DictionaryFieldtypeController::class)->name('dictionary-fieldtype');
+        Route::post('icons', IconFieldtypeController::class)->name('icon-fieldtype');
     });
 
     Route::group(['prefix' => 'field-action-modal'], function () {

--- a/src/Fieldtypes/Icon.php
+++ b/src/Fieldtypes/Icon.php
@@ -22,15 +22,21 @@ class Icon extends Fieldtype
     {
         [$path, $directory, $folder, $hasConfiguredDirectory] = $this->resolveParts();
 
-        $icons = collect(Folder::getFilesByType($path, 'svg'))->mapWithKeys(fn ($path) => [
-            pathinfo($path)['filename'] => $hasConfiguredDirectory ? File::get($path) : null,
-        ]);
-
         return [
+            'url' => cp_route('icon-fieldtype'),
             'native' => ! $hasConfiguredDirectory,
+            'directory' => $directory,
             'set' => $folder,
-            'icons' => $icons->all(),
         ];
+    }
+
+    public function icons()
+    {
+        [$path, $directory, $folder, $hasConfiguredDirectory] = $this->resolveParts();
+
+        return collect(Folder::getFilesByType($path, 'svg'))->mapWithKeys(fn ($path) => [
+            pathinfo($path)['filename'] => $hasConfiguredDirectory ? File::get($path) : null,
+        ])->all();
     }
 
     protected function configFieldItems(): array

--- a/src/Http/Controllers/CP/Fieldtypes/IconFieldtypeController.php
+++ b/src/Http/Controllers/CP/Fieldtypes/IconFieldtypeController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Statamic\Http\Controllers\CP\Fieldtypes;
+
+use Facades\Statamic\Fields\FieldtypeRepository as Fieldtype;
+use Illuminate\Http\Request;
+use Statamic\Fields\Field;
+use Statamic\Http\Controllers\CP\CpController;
+
+class IconFieldtypeController extends CpController
+{
+    public function __invoke(Request $request)
+    {
+        $fieldtype = $this->fieldtype($request);
+
+        return [
+            'icons' => $fieldtype->icons(),
+        ];
+    }
+
+    protected function fieldtype($request)
+    {
+        $config = $this->getConfig($request);
+
+        return Fieldtype::find('icon')->setField(
+            new Field('icon', $config)
+        );
+    }
+
+    private function getConfig($request)
+    {
+        // The fieldtype base64-encodes the config.
+        $json = base64_decode($request->config);
+
+        // The json may include unicode characters, so we'll try to convert it to UTF-8.
+        // See https://github.com/statamic/cms/issues/566
+        $utf8 = mb_convert_encoding($json, 'UTF-8', mb_list_encodings());
+
+        // In PHP 8.1 there's a bug where encoding will return null. It's fixed in 8.1.2.
+        // In this case, we'll fall back to the original JSON, but without the encoding.
+        // Issue #566 may still occur, but it's better than failing completely.
+        $json = empty($utf8) ? $json : $utf8;
+
+        return json_decode($json, true);
+    }
+}


### PR DESCRIPTION
Fixes statamic/ideas#1310

As pointed out in the issue, the icon fieldtype would read all the svg files in the specified directory on the server and send it down in the metadata. It would do it for all icon fields even if they reuse the same icon directory. You end up with huge arrays being passed down as JSON, potentially multiple times, causing a large initial document size.

This PR avoids doing that work on the server. Instead, an AJAX request will be made to get the icons.

Additionally, if multiple fields configured with the same directory are on the page, only one request will be made. There are shared icon caches and loading states across the components.

It would be possible to make the requests happen only when interacting with the field for the first time, but that adds some complexity. It could be done later.