### PR TITLE
[5.x] Allow passing computed fields via an associative array

### DIFF
--- a/src/Data/StoresComputedFieldCallbacks.php
+++ b/src/Data/StoresComputedFieldCallbacks.php
@@ -9,8 +9,19 @@ trait StoresComputedFieldCallbacks
 {
     protected $computedFieldCallbacks;
 
-    public function computed(string $field, Closure $callback)
+    /**
+     * @param  string|array $field
+     */
+    public function computed($field, ?Closure $callback = null)
     {
+        if (is_array($field)) {
+            foreach ($field as $field_name => $field_callback) {
+                $this->computedFieldCallbacks[$field_name] = $field_callback;
+            }
+
+            return;
+        }
+        
         $this->computedFieldCallbacks[$field] = $callback;
     }
 

--- a/src/Data/StoresComputedFieldCallbacks.php
+++ b/src/Data/StoresComputedFieldCallbacks.php
@@ -10,7 +10,7 @@ trait StoresComputedFieldCallbacks
     protected $computedFieldCallbacks;
 
     /**
-     * @param  string|array $field
+     * @param  string|array  $field
      */
     public function computed($field, ?Closure $callback = null)
     {

--- a/src/Data/StoresComputedFieldCallbacks.php
+++ b/src/Data/StoresComputedFieldCallbacks.php
@@ -21,7 +21,7 @@ trait StoresComputedFieldCallbacks
 
             return;
         }
-        
+
         $this->computedFieldCallbacks[$field] = $callback;
     }
 

--- a/src/Data/StoresScopedComputedFieldCallbacks.php
+++ b/src/Data/StoresScopedComputedFieldCallbacks.php
@@ -14,13 +14,23 @@ trait StoresScopedComputedFieldCallbacks
 
     /**
      * @param  string|array  $scopes
+     * @param  string|array $field
      */
-    public function computed($scopes, string $field, Closure $callback)
+    public function computed($scopes, $field, ?Closure $callback = null)
     {
         foreach (Arr::wrap($scopes) as $scope) {
+            if (is_array($field)) {
+                foreach ($field as $field_name => $field_callback) {
+                    $this->computedFieldCallbacks["$scope.$field_name"] = $field_callback;
+                }
+
+                continue;
+            }
+
             $this->computedFieldCallbacks["$scope.$field"] = $callback;
         }
     }
+
 
     public function getComputedCallbacks(string $scope): Collection
     {

--- a/src/Data/StoresScopedComputedFieldCallbacks.php
+++ b/src/Data/StoresScopedComputedFieldCallbacks.php
@@ -14,7 +14,7 @@ trait StoresScopedComputedFieldCallbacks
 
     /**
      * @param  string|array  $scopes
-     * @param  string|array $field
+     * @param  string|array  $field
      */
     public function computed($scopes, $field, ?Closure $callback = null)
     {
@@ -30,7 +30,6 @@ trait StoresScopedComputedFieldCallbacks
             $this->computedFieldCallbacks["$scope.$field"] = $callback;
         }
     }
-
 
     public function getComputedCallbacks(string $scope): Collection
     {

--- a/src/Facades/Collection.php
+++ b/src/Facades/Collection.php
@@ -18,7 +18,7 @@ use Statamic\Contracts\Entries\CollectionRepository;
  * @method static void delete(\Statamic\Entries\Collection $collection)
  * @method static \Illuminate\Support\Collection whereStructured()
  * @method static \Illuminate\Support\Collection additionalPreviewTargets(string $handle)
- * @method static void computed(string|array $scopes, string $field, \Closure $callback)
+ * @method static void computed(string|array $scopes, string|array $field, ?\Closure $callback = null)
  * @method static \Illuminate\Support\Collection getComputedCallbacks($collection)
  *
  * @see CollectionRepository

--- a/src/Facades/User.php
+++ b/src/Facades/User.php
@@ -21,7 +21,7 @@ use Statamic\OAuth\Provider;
  * @method static void delete(\Statamic\Contracts\Auth\User $user);
  * @method static \Statamic\Fields\Blueprint blueprint();
  * @method static \Illuminate\Support\Collection getComputedCallbacks()
- * @method static void computed(string $field, \Closure $callback)
+ * @method static void computed(string|array $field, ?\Closure $callback = null)
  *
  * @see \Statamic\Contracts\Auth\UserRepository
  * @see \Statamic\Auth\User

--- a/tests/Auth/UserContractTests.php
+++ b/tests/Auth/UserContractTests.php
@@ -93,7 +93,7 @@ trait UserContractTests
         Facades\User::computed('balance', function ($user) {
             return $user->name().'\'s balance is $25 owing.';
         });
-        
+
         Facades\User::computed([
             'ocupation' => function ($user) {
                 return 'Smuggler';

--- a/tests/Auth/UserContractTests.php
+++ b/tests/Auth/UserContractTests.php
@@ -93,6 +93,15 @@ trait UserContractTests
         Facades\User::computed('balance', function ($user) {
             return $user->name().'\'s balance is $25 owing.';
         });
+        
+        Facades\User::computed([
+            'ocupation' => function ($user) {
+                return 'Smuggler';
+            },
+            'vehicle' => function ($user) {
+                return 'Millennium Falcon';
+            },
+        ]);
 
         $user = $this->makeUser()->data(['name' => 'Han Solo']);
 
@@ -102,6 +111,8 @@ trait UserContractTests
 
         $expectedComputedData = [
             'balance' => 'Han Solo\'s balance is $25 owing.',
+            'ocupation' => 'Smuggler',
+            'vehicle' => 'Millennium Falcon',
         ];
 
         $expectedValues = array_merge($expectedData, $expectedComputedData);

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -396,7 +396,7 @@ class EntryTest extends TestCase
             'tags' => function ($entry) {
                 return ['music', 'pop'];
             },
-           'featured' => function ($entry) {
+            'featured' => function ($entry) {
                 return true;
             },
         ]);

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -392,6 +392,15 @@ class EntryTest extends TestCase
             return $entry->get('title').' AND MORE!';
         });
 
+        Facades\Collection::computed('articles', [
+            'tags' => function ($entry) {
+                return ['music', 'pop'];
+            },
+           'featured' => function ($entry) {
+                return true;
+            },
+        ]);
+
         $collection = tap(Collection::make('articles'))->save();
         $entry = (new Entry)->collection($collection)->data(['title' => 'Pop Rocks']);
 
@@ -401,6 +410,8 @@ class EntryTest extends TestCase
 
         $expectedComputedData = [
             'description' => 'Pop Rocks AND MORE!',
+            'tags' => ['music', 'pop'],
+            'featured' => true,
         ];
 
         $expectedValues = array_merge($expectedData, $expectedComputedData);

--- a/tests/Data/StoresComputedFieldCallbacksTest.php
+++ b/tests/Data/StoresComputedFieldCallbacksTest.php
@@ -26,6 +26,26 @@ class StoresComputedFieldCallbacksTest extends TestCase
             'another_field' => $closureB,
         ], $repository->getComputedCallbacks()->all());
     }
+
+    #[Test]
+    public function it_can_store_multiple_computed_callbacks()
+    {
+        $repository = new FakeRepository;
+
+        $repository->computed([
+            'some_field' => $closureA = function ($item, $value) {
+                //
+            },
+            'another_field' => $closureB = function ($item, $value) {
+                //
+            },
+        ]);
+
+        $this->assertEquals([
+            'some_field' => $closureA,
+            'another_field' => $closureB,
+        ], $repository->getComputedCallbacks()->all());
+    }
 }
 
 class FakeRepository

--- a/tests/Data/StoresScopedComputedFieldCallbacksTest.php
+++ b/tests/Data/StoresScopedComputedFieldCallbacksTest.php
@@ -54,6 +54,63 @@ class StoresScopedComputedFieldCallbacksTest extends TestCase
             'some_field' => $closure,
         ], $repository->getComputedCallbacks('articles')->all());
     }
+
+    #[Test]
+    public function it_can_store_multiple_scoped_computed_callbacks()
+    {
+        $repository = new FakeRepositoryWithScopedCallbacks;
+
+        $repository->computed('events', [
+            'some_field' => $closureA = function ($item, $value) {
+                //
+            },
+        ]);
+
+        $repository->computed('articles', [
+            'some_field' => $closureB = function ($item, $value) {
+                //
+            },
+            'another_field' => $closureC = function ($item, $value) {
+                //
+            },
+        ]);
+
+        $this->assertEquals([
+            'some_field' => $closureA,
+        ], $repository->getComputedCallbacks('events')->all());
+
+        $this->assertEquals([
+            'some_field' => $closureB,
+            'another_field' => $closureC,
+        ], $repository->getComputedCallbacks('articles')->all());
+
+        $this->assertEquals([], $repository->getComputedCallbacks('products')->all());
+    }
+
+    #[Test]
+    public function it_can_store_multiple_scoped_computed_callbacks_for_multiple_scopes()
+    {
+        $repository = new FakeRepositoryWithScopedCallbacks;
+
+        $repository->computed(['events', 'articles'], [
+            'some_field' => $closureA = function ($item, $value) {
+                //
+            },
+            'another_field' => $closureB = function ($item, $value) {
+                //
+            },
+        ]);
+
+        $this->assertEquals([
+            'some_field' => $closureA,
+            'another_field' => $closureB,
+        ], $repository->getComputedCallbacks('events')->all());
+
+        $this->assertEquals([
+            'some_field' => $closureA,
+            'another_field' => $closureB,
+        ], $repository->getComputedCallbacks('articles')->all());
+    }
 }
 
 class FakeRepositoryWithScopedCallbacks


### PR DESCRIPTION
We have a number of computed properties for a specific collection and our AppServiceProvider is getting rather long with all the computed properties.

This PR helps solve this by allowing for an associative array to be passed as the 2nd parameter:
```php
Collection::computed('properties', [
  'pdf_url' => fn ($entry, $value) => route('properties.pdf', $entry->id()),
  'deletion_date' => fn ($entry, $value) => $this->generateDeletionDate($entry),
]);
```

Let me know if you'd like me to add tests