### PR TITLE
[5.x] Return validation error when AllowedFile is not an UploadedFile

### DIFF
--- a/src/Rules/AllowedFile.php
+++ b/src/Rules/AllowedFile.php
@@ -120,8 +120,12 @@ class AllowedFile implements ValidationRule
         }
     }
 
-    private function isAllowedExtension(UploadedFile $file): bool
+    private function isAllowedExtension(mixed $file): bool
     {
+        if (! $file instanceof UploadedFile) {
+            return false;
+        }
+
         $extensions = $this->allowedExtensions ?? array_merge(static::EXTENSIONS, config('statamic.assets.additional_uploadable_extensions', []));
 
         return in_array(trim(strtolower($file->getClientOriginalExtension())), $extensions);


### PR DESCRIPTION
This PR updates the isAllowedExtension method in AllowedFile validation rule to handle a value that isn't an UploadedFile being passed to it.

I couldn't see where to put a test - happy to add one if you can point me in the right direction?

Closes https://github.com/statamic/cms/issues/11525