### PR TITLE
[6.x] Add vite plugin and adjust aliases

### DIFF
--- a/resources/js/components/ElementContainer.vue
+++ b/resources/js/components/ElementContainer.vue
@@ -1,6 +1,6 @@
 <script>
 import ResizeObserver from 'resize-observer-polyfill';
-import throttle from '@/util/throttle.js';
+import throttle from '@statamic/util/throttle.js';
 
 export default {
     emits: ['resized'],

--- a/resources/js/components/GlobalSearch.vue
+++ b/resources/js/components/GlobalSearch.vue
@@ -68,7 +68,7 @@
 </template>
 
 <script>
-import debounce from '@/util/debounce.js';
+import debounce from '@statamic/util/debounce.js';
 
 export default {
     props: {

--- a/resources/js/components/data-list/FieldFilter.vue
+++ b/resources/js/components/data-list/FieldFilter.vue
@@ -53,7 +53,7 @@
 import Validator from '../field-conditions/Validator.js';
 import PublishField from '../publish/Field.vue';
 import { sortBy } from 'lodash-es';
-import debounce from '@/util/debounce.js';
+import debounce from '@statamic/util/debounce.js';
 
 export default {
     components: { PublishField },

--- a/resources/js/components/data-list/Search.vue
+++ b/resources/js/components/data-list/Search.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import debounce from '@/util/debounce.js';
+import debounce from '@statamic/util/debounce.js';
 
 export default {
     props: ['value'],

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -357,7 +357,7 @@ import HasPreferences from '../data-list/HasPreferences';
 import HasHiddenFields from '../publish/HasHiddenFields';
 import HasActions from '../publish/HasActions';
 import striptags from 'striptags';
-import clone from '@/util/clone.js';
+import clone from '@statamic/util/clone.js';
 
 export default {
     mixins: [HasPreferences, HasHiddenFields, HasActions],

--- a/resources/js/components/fieldtypes/DictionaryFieldtype.vue
+++ b/resources/js/components/fieldtypes/DictionaryFieldtype.vue
@@ -94,7 +94,7 @@ import Fieldtype from './Fieldtype.vue';
 import HasInputOptions from './HasInputOptions.js';
 import { SortableList } from '../sortable/Sortable';
 import PositionsSelectOptions from '../../mixins/PositionsSelectOptions';
-import debounce from '@/util/debounce.js';
+import debounce from '@statamic/util/debounce.js';
 
 export default {
     mixins: [Fieldtype, HasInputOptions, PositionsSelectOptions],

--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -1,6 +1,6 @@
 <script>
 import HasFieldActions from '../field-actions/HasFieldActions';
-import debounce from '@/util/debounce.js';
+import debounce from '@statamic/util/debounce.js';
 
 export default {
     emits: ['update:value', 'focus', 'blur', 'meta-updated', 'replicator-preview-updated'],

--- a/resources/js/components/fieldtypes/VideoFieldtype.vue
+++ b/resources/js/components/fieldtypes/VideoFieldtype.vue
@@ -32,7 +32,7 @@
 
 <script>
 import Fieldtype from './Fieldtype.vue';
-import debounce from '@/util/debounce.js';
+import debounce from '@statamic/util/debounce.js';
 
 export default {
     mixins: [Fieldtype],

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -175,7 +175,7 @@ import { availableButtons, addButtonHtml } from '../bard/buttons';
 import readTimeEstimate from 'read-time-estimate';
 import { common, createLowlight } from 'lowlight';
 import 'highlight.js/styles/github.css';
-import importTiptap from '@/util/tiptap.js';
+import importTiptap from '@statamic/util/tiptap.js';
 
 const lowlight = createLowlight(common);
 let tiptap = null;

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -192,7 +192,7 @@ import Fieldtype from '../Fieldtype.vue';
 import { marked } from 'marked';
 import { markRaw } from 'vue';
 import PlainTextRenderer from 'marked-plaintext';
-import throttle from '@/util/throttle.js';
+import throttle from '@statamic/util/throttle.js';
 
 import CodeMirror from 'codemirror/lib/codemirror';
 import 'codemirror/addon/edit/closebrackets';

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -92,7 +92,7 @@
 <script>
 import SiteSelector from '../SiteSelector.vue';
 import HasHiddenFields from '../publish/HasHiddenFields';
-import clone from '@/util/clone.js';
+import clone from '@statamic/util/clone.js';
 
 export default {
     mixins: [HasHiddenFields],

--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -236,7 +236,7 @@
 <script>
 import HasFilters from '../../data-list/HasFilters';
 import { defineAsyncComponent } from 'vue';
-import clone from '@/util/clone.js';
+import clone from '@statamic/util/clone.js';
 
 export default {
     mixins: [HasFilters],

--- a/resources/js/components/live-preview/LivePreview.vue
+++ b/resources/js/components/live-preview/LivePreview.vue
@@ -88,7 +88,7 @@ import Provider from '../portals/Provider.vue';
 import Resizer from './Resizer.vue';
 import UpdatesIframe from './UpdatesIframe';
 import { mapValues } from 'lodash-es';
-import debounce from '@/util/debounce.js';
+import debounce from '@statamic/util/debounce.js';
 
 let source;
 const widthLocalStorageKey = 'statamic.live-preview.editor-width';

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -3,9 +3,9 @@ import { defineStore } from 'pinia';
 import uniqid from 'uniqid';
 import Component from '../Component';
 import { getCurrentInstance, computed } from 'vue';
-import { usePublishContainerStore } from '@/stores/publish-container.js';
+import { usePublishContainerStore } from '@statamic/stores/publish-container.js';
 import { isEqual } from 'lodash-es';
-import clone from '@/util/clone.js';
+import clone from '@statamic/util/clone.js';
 
 export default {
     emits: ['updated', 'focus', 'blur'],

--- a/resources/js/components/slugs/Slug.js
+++ b/resources/js/components/slugs/Slug.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import speakingUrl from 'speakingurl';
-import debounce from '@/util/debounce.js';
+import debounce from '@statamic/util/debounce.js';
 
 export default class Slug {
     busy = false;

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -292,7 +292,7 @@ import HasPreferences from '../data-list/HasPreferences';
 import HasHiddenFields from '../publish/HasHiddenFields';
 import HasActions from '../publish/HasActions';
 import striptags from 'striptags';
-import clone from '@/util/clone.js';
+import clone from '@statamic/util/clone.js';
 
 export default {
     mixins: [HasPreferences, HasHiddenFields, HasActions],

--- a/resources/js/components/user-groups/PublishForm.vue
+++ b/resources/js/components/user-groups/PublishForm.vue
@@ -41,7 +41,7 @@
 
 <script>
 import HasHiddenFields from '../publish/HasHiddenFields';
-import clone from '@/util/clone.js';
+import clone from '@statamic/util/clone.js';
 
 export default {
     mixins: [HasHiddenFields],

--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -64,7 +64,7 @@
 import ChangePassword from './ChangePassword.vue';
 import HasHiddenFields from '../publish/HasHiddenFields';
 import HasActions from '../publish/HasActions';
-import clone from '@/util/clone.js';
+import clone from '@statamic/util/clone.js';
 
 export default {
     mixins: [HasHiddenFields, HasActions],

--- a/resources/js/tests/FieldConditionsValidator.test.js
+++ b/resources/js/tests/FieldConditionsValidator.test.js
@@ -4,8 +4,8 @@ import { nextTick } from 'vue';
 import { createPinia } from 'pinia';
 import ValidatesFieldConditions from '../components/field-conditions/ValidatorMixin.js';
 import { data_get } from '../bootstrap/globals';
-import FieldConditions from '@/components/FieldConditions';
-import PublishContainer from '@/components/publish/Container.vue';
+import FieldConditions from '@statamic/components/FieldConditions';
+import PublishContainer from '@statamic/components/publish/Container.vue';
 
 let Store;
 let Fields;

--- a/resources/js/tests/components/fieldtypes/TextFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/TextFieldtype.test.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { expect, test } from 'vitest';
-import TextFieldtype from '@/components/fieldtypes/TextFieldtype.vue';
-import TextInput from '@/components/inputs/Text.vue';
+import TextFieldtype from '@statamic/components/fieldtypes/TextFieldtype.vue';
+import TextInput from '@statamic/components/inputs/Text.vue';
 
 test('value can be updated', async () => {
     const wrapper = mount(TextFieldtype, {

--- a/resources/js/vite-plugin/index.js
+++ b/resources/js/vite-plugin/index.js
@@ -1,0 +1,23 @@
+import path from 'path';
+
+function addAliases(config) {
+    if (!config.resolve) config.resolve = {};
+
+    const jsDir = path.resolve('/@fs' + __dirname + '/../');
+
+    const aliases = {
+        '@statamic': jsDir,
+        statamic: `${jsDir}/exports.js`,
+    };
+
+    config.resolve.alias = { ...aliases, ...config.resolve.alias };
+}
+
+export default function () {
+    return {
+        name: 'statamic',
+        config(config) {
+            addAliases(config);
+        },
+    };
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -29,7 +29,7 @@ export default defineConfig(({ mode }) => {
         resolve: {
             alias: {
                 vue: 'vue/dist/vue.esm-bundler.js',
-                '@': path.resolve(__dirname, 'resources/js'),
+                '@statamic': path.resolve(__dirname, 'resources/js'),
             },
         },
         optimizeDeps: {


### PR DESCRIPTION
We were using `@` in parts of our JS as an alias to the root js directory to avoid needing relative paths.

This was fine in our own Vite build. However, when you are running Vite in an addon and you reference a Statamic file, the `@` will resolve to their own directory, not Statamic's. So we are using `@statamic` instead so `@` can remain appropriate for the user.

This introduces a second problem though: When an addon is using Vite, they won't have our `@statamic` alias defined so Vite will fail.

To address both these issues, I've included a Vite plugin that addons can reference. Now we can ask developers to use our plugin (similar to the Laravel plugin) and we will wire up the ugly bits for them automatically.

```diff
// vite.config.js
import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';
import vue from '@vitejs/plugin-vue';
+import statamic from '../path/to/vendor/statamic/cms/resources/js/vite-plugin';

export default defineConfig({
    plugins: [
+       statamic(),
        laravel(...),
        vue(),
    ]
});
```