### PR TITLE
[5.x] When NavPageInterface has no blueprint fields return something

### DIFF
--- a/src/GraphQL/Types/NavPageInterface.php
+++ b/src/GraphQL/Types/NavPageInterface.php
@@ -4,6 +4,7 @@ namespace Statamic\GraphQL\Types;
 
 use Rebing\GraphQL\Support\InterfaceType;
 use Statamic\Contracts\Structures\Nav;
+use Statamic\Facades\GraphQL;
 use Statamic\Support\Str;
 
 class NavPageInterface extends InterfaceType
@@ -18,7 +19,15 @@ class NavPageInterface extends InterfaceType
 
     public function fields(): array
     {
-        return $this->nav->blueprint()->fields()->toGql()->all();
+        if ($fields = $this->nav->blueprint()->fields()->toGql()->all()) {
+            return $fields;
+        }
+
+        return collect([
+            '_' => [
+                'type' => GraphQL::string(),
+            ],
+        ])->all();
     }
 
     public static function buildName(Nav $nav): string


### PR DESCRIPTION
This isn't the best fix, but when a nav blueprint has no fields defined it should return something to prevent the GraphQL schema erroring out.

I chose something unlikely (_) as the name, but maybe you have a better suggestion?

Closes https://github.com/statamic/cms/issues/10621