### PR TITLE
[5.x] Fix password protection on 404 pages

### DIFF
--- a/src/Auth/Protect/Protectors/Password/PasswordProtector.php
+++ b/src/Auth/Protect/Protectors/Password/PasswordProtector.php
@@ -57,7 +57,8 @@ class PasswordProtector extends Protector
         }
 
         if (
-            ($password = session("statamic:protect:password.passwords.ref.{$this->data->reference()}"))
+            $this->data
+            && ($password = session("statamic:protect:password.passwords.ref.{$this->data->reference()}"))
             && $this->isValidLocalPassword($password)
         ) {
             return true;
@@ -105,7 +106,7 @@ class PasswordProtector extends Protector
         session()->put("statamic:protect:password.tokens.$token", [
             'scheme' => $this->scheme,
             'url' => $this->url,
-            'reference' => $this->data->reference(),
+            'reference' => $this->data?->reference(),
         ]);
 
         return $token;

--- a/tests/Auth/Protect/PasswordProtectionTest.php
+++ b/tests/Auth/Protect/PasswordProtectionTest.php
@@ -36,6 +36,27 @@ class PasswordProtectionTest extends PageProtectionTestCase
     }
 
     #[Test]
+    public function redirects_to_password_form_url_and_generates_token_on_a_404_url()
+    {
+        config()->set('statamic.protect.default', 'password-scheme');
+        config(['statamic.protect.schemes.password-scheme' => [
+            'driver' => 'password',
+            'allowed' => ['test'],
+        ]]);
+
+        Token::shouldReceive('generate')->andReturn('test-token');
+
+        $this
+            ->get('this-page-does-not-exist')
+            ->assertRedirect('http://localhost/!/protect/password?token=test-token')
+            ->assertSessionHas('statamic:protect:password.tokens.test-token', [
+                'scheme' => 'password-scheme',
+                'url' => 'http://localhost/this-page-does-not-exist',
+                'reference' => null,
+            ]);
+    }
+
+    #[Test]
     public function password_form_url_can_be_overridden()
     {
         config(['statamic.protect.schemes.password-scheme' => [


### PR DESCRIPTION
This pull request fixes an issue with password protection on 404 pages, where errors were occuring due to the URL having no "data".

Fixes #11541.
