### PR TITLE
[6.x] Fix asset publish forms

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -329,6 +329,7 @@ export default {
             loading: true,
             saving: false,
             asset: null,
+            publishContainer: 'asset',
             values: {},
             extraValues: {},
             meta: {},
@@ -344,10 +345,6 @@ export default {
     computed: {
         store() {
             return this.$refs.container.store;
-        },
-
-        publishContainer() {
-            return `asset-${this.$.uid}`;
         },
 
         isImage() {

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -329,7 +329,6 @@ export default {
             loading: true,
             saving: false,
             asset: null,
-            publishContainer: 'asset',
             values: {},
             extraValues: {},
             meta: {},
@@ -345,6 +344,10 @@ export default {
     computed: {
         store() {
             return this.$refs.container.store;
+        },
+
+        publishContainer() {
+            return `asset-${this.$.uid}`;
         },
 
         isImage() {

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -1,5 +1,5 @@
 <script>
-import { defineStore } from 'pinia';
+import { defineStore, getActivePinia } from 'pinia';
 import uniqid from 'uniqid';
 import Component from '../Component';
 import { getCurrentInstance, computed } from 'vue';
@@ -78,6 +78,7 @@ export default {
 
     beforeUnmount() {
         this.store.$dispose();
+        delete getActivePinia().state.value[this.store.$id];
     },
 
     unmounted() {

--- a/resources/js/stores/publish-container.js
+++ b/resources/js/stores/publish-container.js
@@ -74,7 +74,7 @@ export const usePublishContainerStore = function (name, initial) {
             setErrors(errors) {
                 this.errors = errors;
             },
-            setSite(statesite) {
+            setSite(site) {
                 this.site = site;
             },
             setLocalizedFields(fields) {


### PR DESCRIPTION
This pull request fixes an issue I spotted where state (specifically field values) was being persisted across assets. I assume this has something to do with the migration to Pinia.

To workaround this, I've made the publish container name unique, like we do for inline publish forms.

I've also fixed a typo in the `publish-container.js` file.