### PR TITLE
[5.x] Enable unselecting fieldtypes for forms

### DIFF
--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -111,6 +111,11 @@ abstract class Fieldtype implements Arrayable
         FieldtypeRepository::makeSelectableInForms(self::handle());
     }
 
+    public static function makeUnselectableInForms()
+    {
+        FieldtypeRepository::makeUnselectableInForms(self::handle());
+    }
+
     public function categories(): array
     {
         return $this->categories;

--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -103,7 +103,11 @@ abstract class Fieldtype implements Arrayable
 
     public function selectableInForms(): bool
     {
-        return $this->selectableInForms ?: FieldtypeRepository::hasBeenMadeSelectableInForms($this->handle());
+        if (FieldtypeRepository::selectableInFormIsOverriden($this->handle())) {
+            return FieldtypeRepository::hasBeenMadeSelectableInForms($this->handle());
+        }
+
+        return $this->selectableInForms;
     }
 
     public static function makeSelectableInForms()

--- a/src/Fields/FieldtypeRepository.php
+++ b/src/Fields/FieldtypeRepository.php
@@ -44,6 +44,13 @@ class FieldtypeRepository
         $this->madeSelectableInForms[] = $handle;
     }
 
+    public function makeUnselectableInForms($handle)
+    {
+        if ($this->hasBeenMadeSelectableInForms($handle)) {
+            $this->madeSelectableInForms = array_diff($this->madeSelectableInForms, [$handle]);
+        }
+    }
+
     public function hasBeenMadeSelectableInForms($handle)
     {
         return in_array($handle, $this->madeSelectableInForms);

--- a/src/Fields/FieldtypeRepository.php
+++ b/src/Fields/FieldtypeRepository.php
@@ -51,7 +51,6 @@ class FieldtypeRepository
 
     public function hasBeenMadeSelectableInForms($handle)
     {
-        dump([$handle, $this->selectableInForms]);
         return $this->selectableInForms[$handle] ?? false;
     }
 

--- a/src/Fields/FieldtypeRepository.php
+++ b/src/Fields/FieldtypeRepository.php
@@ -4,7 +4,7 @@ namespace Statamic\Fields;
 
 class FieldtypeRepository
 {
-    protected $madeSelectableInForms = [];
+    protected $selectableInForms = [];
     private $fieldtypes = [];
 
     public function preloadable()
@@ -41,18 +41,22 @@ class FieldtypeRepository
 
     public function makeSelectableInForms($handle)
     {
-        $this->madeSelectableInForms[] = $handle;
+        $this->selectableInForms[$handle] = true;
     }
 
     public function makeUnselectableInForms($handle)
     {
-        if ($this->hasBeenMadeSelectableInForms($handle)) {
-            $this->madeSelectableInForms = array_diff($this->madeSelectableInForms, [$handle]);
-        }
+        $this->selectableInForms[$handle] = false;
     }
 
     public function hasBeenMadeSelectableInForms($handle)
     {
-        return in_array($handle, $this->madeSelectableInForms);
+        dump([$handle, $this->selectableInForms]);
+        return $this->selectableInForms[$handle] ?? false;
+    }
+
+    public function selectableInFormIsOverriden($handle)
+    {
+        return array_key_exists($handle, $this->selectableInForms);
     }
 }

--- a/tests/Fields/FieldtypeRepositoryTest.php
+++ b/tests/Fields/FieldtypeRepositoryTest.php
@@ -62,6 +62,25 @@ class FieldtypeRepositoryTest extends TestCase
         $this->expectExceptionMessage('Fieldtype [test] not found');
         $this->repo->find('test');
     }
+
+    #[Test]
+    public function it_makes_fields_selectable_in_forms()
+    {
+        $this->assertFalse($this->repo->hasBeenMadeSelectableInForms('test'));
+        
+        $this->repo->makeSelectableInForms('test');
+        $this->assertTrue($this->repo->hasBeenMadeSelectableInForms('test'));
+    }
+
+    #[Test]
+    public function it_makes_fields_unselectable_in_forms()
+    {
+        $this->repo->makeSelectableInForms('test');
+        $this->assertTrue($this->repo->hasBeenMadeSelectableInForms('test'));
+
+        $this->repo->makeUnselectableInForms('test');
+        $this->assertFalse($this->repo->hasBeenMadeSelectableInForms('test'));
+    }
 }
 
 class FooFieldtype extends Fieldtype

--- a/tests/Fields/FieldtypeRepositoryTest.php
+++ b/tests/Fields/FieldtypeRepositoryTest.php
@@ -67,7 +67,7 @@ class FieldtypeRepositoryTest extends TestCase
     public function it_makes_fields_selectable_in_forms()
     {
         $this->assertFalse($this->repo->hasBeenMadeSelectableInForms('test'));
-        
+
         $this->repo->makeSelectableInForms('test');
         $this->assertTrue($this->repo->hasBeenMadeSelectableInForms('test'));
     }

--- a/tests/Fields/FieldtypeRepositoryTest.php
+++ b/tests/Fields/FieldtypeRepositoryTest.php
@@ -66,20 +66,22 @@ class FieldtypeRepositoryTest extends TestCase
     #[Test]
     public function it_makes_fields_selectable_in_forms()
     {
-        $this->assertFalse($this->repo->hasBeenMadeSelectableInForms('test'));
+        $this->assertFalse($this->repo->hasBeenMadeSelectableInForms('test-selectable'));
 
-        $this->repo->makeSelectableInForms('test');
-        $this->assertTrue($this->repo->hasBeenMadeSelectableInForms('test'));
+        $this->repo->makeSelectableInForms('test-selectable');
+        $this->assertTrue($this->repo->hasBeenMadeSelectableInForms('test-selectable'));
+        $this->assertTrue($this->repo->selectableInFormIsOverriden('test-selectable'));
     }
 
     #[Test]
     public function it_makes_fields_unselectable_in_forms()
     {
-        $this->repo->makeSelectableInForms('test');
-        $this->assertTrue($this->repo->hasBeenMadeSelectableInForms('test'));
+        $this->repo->makeSelectableInForms('test-unselectable');
+        $this->assertTrue($this->repo->hasBeenMadeSelectableInForms('test-unselectable'));
 
-        $this->repo->makeUnselectableInForms('test');
-        $this->assertFalse($this->repo->hasBeenMadeSelectableInForms('test'));
+        $this->repo->makeUnselectableInForms('test-unselectable');
+        $this->assertFalse($this->repo->hasBeenMadeSelectableInForms('test-unselectable'));
+        $this->assertTrue($this->repo->selectableInFormIsOverriden('test-unselectable'));
     }
 }
 

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -555,16 +555,17 @@ class FieldtypeTest extends TestCase
     {
         $fieldtype = new class extends Fieldtype
         {
-            public static $handle = 'test';
+            public static $handle = 'test-selectable';
+            protected $selectableInForms = false;
         };
 
         $this->assertFalse($fieldtype->selectableInForms());
-        $this->assertFalse(FieldtypeRepository::hasBeenMadeSelectableInForms('test'));
 
         $fieldtype::makeSelectableInForms();
 
         $this->assertTrue($fieldtype->selectableInForms());
-        $this->assertTrue(FieldtypeRepository::hasBeenMadeSelectableInForms('test'));
+        $this->assertTrue(FieldtypeRepository::hasBeenMadeSelectableInForms('test-selectable'));
+        $this->assertTrue(FieldtypeRepository::selectableInFormIsOverriden('test-selectable'));
     }
 
     #[Test]
@@ -572,18 +573,17 @@ class FieldtypeTest extends TestCase
     {
         $fieldtype = new class extends Fieldtype
         {
-            public static $handle = 'test';
+            public static $handle = 'test-unselectable';
+            protected $selectableInForms = true;
         };
 
-        $fieldtype::makeSelectableInForms();
-
         $this->assertTrue($fieldtype->selectableInForms());
-        $this->assertTrue(FieldtypeRepository::hasBeenMadeSelectableInForms('test'));
 
         $fieldtype::makeUnselectableInForms();
 
         $this->assertFalse($fieldtype->selectableInForms());
-        $this->assertFalse(FieldtypeRepository::hasBeenMadeSelectableInForms('test'));
+        $this->assertFalse(FieldtypeRepository::hasBeenMadeSelectableInForms('test-unselectable'));
+        $this->assertTrue(FieldtypeRepository::selectableInFormIsOverriden('test-unselectable'));
     }
 }
 

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -576,7 +576,7 @@ class FieldtypeTest extends TestCase
         };
 
         $fieldtype::makeSelectableInForms();
-        
+
         $this->assertTrue($fieldtype->selectableInForms());
         $this->assertTrue(FieldtypeRepository::hasBeenMadeSelectableInForms('test'));
 

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -566,6 +566,25 @@ class FieldtypeTest extends TestCase
         $this->assertTrue($fieldtype->selectableInForms());
         $this->assertTrue(FieldtypeRepository::hasBeenMadeSelectableInForms('test'));
     }
+
+    #[Test]
+    public function it_can_make_a_fieldtype_unselectable_in_forms()
+    {
+        $fieldtype = new class extends Fieldtype
+        {
+            public static $handle = 'test';
+        };
+
+        $fieldtype::makeSelectableInForms();
+        
+        $this->assertTrue($fieldtype->selectableInForms());
+        $this->assertTrue(FieldtypeRepository::hasBeenMadeSelectableInForms('test'));
+
+        $fieldtype::makeUnselectableInForms();
+
+        $this->assertFalse($fieldtype->selectableInForms());
+        $this->assertFalse(FieldtypeRepository::hasBeenMadeSelectableInForms('test'));
+    }
 }
 
 class TestFieldtype extends Fieldtype


### PR DESCRIPTION
Sometimes it might be necessary to disable certain fieldtypes for frontend forms - per discord conversion with Marco - https://discord.com/channels/489818810157891584/489818810157891586/1349028284142194699

This PR adds a new method to accomplish that on the FieldtypeRepository and Fieldtype classes: makeUnselectableInForms()