### PR TITLE
[5.x] Fix icon fieldtype

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -44,9 +44,9 @@
                         <publish-field-meta
                             :config="{ handle: 'icon', type: 'icon', directory: this.iconBaseDirectory, folder: this.iconSubFolder }"
                             :initial-value="editingSection.icon"
-                            v-slot="{ meta, value, loading }"
+                            v-slot="{ meta, value, loading, config }"
                         >
-                            <icon-fieldtype v-if="!loading" handle="icon" :meta="meta" :value="value" @input="editingSection.icon = $event" />
+                            <icon-fieldtype v-if="!loading" handle="icon" :config="config" :meta="meta" :value="value" @input="editingSection.icon = $event" />
                         </publish-field-meta>
                     </div>
                     <div class="form-group w-full" v-if="showHideField">

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -60,9 +60,9 @@
                     <publish-field-meta
                         :config="{ handle: 'icon', type: 'icon', directory: this.iconBaseDirectory, folder: this.iconSubFolder }"
                         :initial-value="icon"
-                        v-slot="{ meta, value, loading }"
+                        v-slot="{ meta, value, loading, config }"
                     >
-                        <icon-fieldtype v-if="!loading" handle="icon" :meta="meta" :value="value" @input="fieldUpdated('icon', $event)" />
+                        <icon-fieldtype v-if="!loading" handle="icon" :config="config" :meta="meta" :value="value" @input="fieldUpdated('icon', $event)" />
                     </publish-field-meta>
                 </div>
             </div>

--- a/resources/js/components/fieldtypes/IconFieldtype.vue
+++ b/resources/js/components/fieldtypes/IconFieldtype.vue
@@ -56,6 +56,10 @@ export default {
 
     computed: {
 
+        cacheKey() {
+            return `${this.meta.directory}/${this.meta.set}`;
+        },
+
         options() {
             let options = [];
             for (let [name, html] of Object.entries(this.icons)) {
@@ -77,9 +81,9 @@ export default {
         this.request();
 
         watch(
-            () => loaders.value[this.meta.directory],
+            () => loaders.value[this.cacheKey],
             (loading) => {
-                this.icons = iconsCache.value[this.meta.directory];
+                this.icons = iconsCache.value[this.cacheKey];
                 this.loading = loading;
             }
         );
@@ -99,19 +103,19 @@ export default {
         },
 
         request() {
-            if (loaders.value[this.meta.directory]) return;
+            if (loaders.value[this.cacheKey]) return;
 
-            loaders.value = {...loaders.value, [this.meta.directory]: true};
+            loaders.value = {...loaders.value, [this.cacheKey]: true};
 
             this.$axios.post(this.meta.url, {
                 config: utf8btoa(JSON.stringify(this.config)),
             }).then(response => {
                 const icons = response.data.icons;
                 this.icons = icons;
-                iconsCache.value = {...iconsCache.value, [this.meta.directory]: icons};
+                iconsCache.value = {...iconsCache.value, [this.cacheKey]: icons};
             })
             .finally(() => {
-                loaders.value = {...loaders.value , [this.meta.directory]: false};
+                loaders.value = {...loaders.value , [this.cacheKey]: false};
             });
         }
     }

--- a/resources/js/components/publish/FieldMeta.vue
+++ b/resources/js/components/publish/FieldMeta.vue
@@ -29,6 +29,7 @@ export default {
             value: this.value,
             loading: this.loading,
             updateMeta: this.updateMeta,
+            config: this.config
         });
     },
 


### PR DESCRIPTION
Fixes #11558, caused by #11523

Only the directory was being included in the cache keys. It wasn't taking into account the folder if provided.

Additionally, the icon fieldtypes used in the replicator section/tab editors weren't passing in the config which is needed to make the correct ajax request.
