### PR TITLE
[5.x] Fix carbon deprecation warning

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -348,6 +348,10 @@ class Date extends Fieldtype
 
     private function parseSaved($value)
     {
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
         try {
             return Carbon::createFromFormat($this->saveFormat(), $value);
         } catch (InvalidFormatException|InvalidArgumentException $e) {


### PR DESCRIPTION
Fixes #11553

This is already fixed in v6 but this backports it.

Context:

```
try {
    return Carbon::createFromFormat($this->saveFormat(), $value);
} catch (InvalidFormatException|InvalidArgumentException $e) {
    return Carbon::parse($value);
}
```

Sometimes `$value` is already a `Carbon` instance.
When you pass a Carbon instance to `createFromFormat`, you get an `InvalidFormatException`.
The `catch` will catch it, and pass the Carbon instance into `parse`, which just returns the instance back and logs the deprecation warning. We can avoid all that by just returning a Carbon instance early.
