### PR TITLE
[6.x] UTC form submission dates 

### DIFF
--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -101,7 +101,7 @@ class Submission implements Augmentable, SubmissionContract
      */
     public function date()
     {
-        return Carbon::createFromTimestamp($this->id(), config('app.timezone'));
+        return Carbon::createFromTimestamp($this->id());
     }
 
     /**
@@ -111,7 +111,7 @@ class Submission implements Augmentable, SubmissionContract
      */
     public function formattedDate()
     {
-        return $this->date()->format(
+        return $this->date()->tz(config('app.timezone'))->format(
             $this->form()->dateFormat()
         );
     }

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -58,7 +58,9 @@ class Submission implements Augmentable, SubmissionContract
     {
         return $this->fluentlyGetOrSet('id')
             ->getter(function ($id) {
-                return $this->id = $id ?: str_replace(',', '.', microtime(true));
+                $micro = Carbon::now()->timestamp + Carbon::now()->micro / 1000000;
+
+                return $this->id = $id ?: str_replace(',', '.', $micro);
             })
             ->args(func_get_args());
     }

--- a/src/Http/Resources/CP/Submissions/ListedSubmission.php
+++ b/src/Http/Resources/CP/Submissions/ListedSubmission.php
@@ -32,7 +32,7 @@ class ListedSubmission extends JsonResource
         return [
             'id' => $this->resource->id(),
             $this->merge($this->values([
-                'datestamp' => $this->resource->date()->format($form->dateFormat()),
+                'datestamp' => $this->resource->date()->tz(config('app.timezone'))->format($form->dateFormat()),
             ])),
             'url' => cp_route('forms.submissions.show', [$form->handle(), $this->resource->id()]),
             'deleteable' => User::current()->can('delete', $this->resource),

--- a/tests/Forms/SubmissionTest.php
+++ b/tests/Forms/SubmissionTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Forms;
 
+use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Events\SubmissionCreated;
 use Statamic\Events\SubmissionCreating;
@@ -47,6 +49,28 @@ class SubmissionTest extends TestCase
         $this->assertStringNotContainsString(',', $submission->id());
 
         setlocale(LC_TIME, $originalLocale);
+    }
+
+    #[Test]
+    #[DataProvider('utcProvider')]
+    public function the_date_is_utc($tz, $expectedFormatted)
+    {
+        config(['app.timezone' => $tz]);
+
+        Carbon::setTestNow(Carbon::parse('2025-03-12 02:13:25', 'UTC'));
+
+        $submission = Form::make('test')->makeSubmission();
+
+        $this->assertEquals('2025-03-12T02:13:25+00:00', $submission->date()->toIso8601String());
+        $this->assertEquals($expectedFormatted, $submission->formattedDate());
+    }
+
+    public static function utcProvider()
+    {
+        return [
+            'utc' => ['UTC', 'March 12th, 2025 02:13'],
+            'not utc' => ['America/New_York', 'March 11th, 2025 22:13'],
+        ];
     }
 
     #[Test]


### PR DESCRIPTION
Form submission dates should also be UTC as per #11409

It also changes the id generation from `microtime` to Carbon so it can be tested. It's the exact same functionality though.