### PR TITLE
[5.x] fix unique entry value validation for date fields

### DIFF
--- a/src/Rules/UniqueEntryValue.php
+++ b/src/Rules/UniqueEntryValue.php
@@ -4,6 +4,7 @@ namespace Statamic\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Carbon;
 use Statamic\Facades\Entry;
 
 class UniqueEntryValue implements ValidationRule
@@ -26,6 +27,10 @@ class UniqueEntryValue implements ValidationRule
 
         if ($this->site) {
             $query->where('site', $this->site);
+        }
+
+        if ($value instanceof Carbon) {
+            $value = $value->toDateString();
         }
 
         $existing = $query


### PR DESCRIPTION
The `UniqueEntryValue` validation doesn't work with date fields. [The query](https://github.com/statamic/cms/blob/68c61a9460f8a8bfd3ac660b3ea26ac0bd5d83a1/src/Rules/UniqueEntryValue.php#L31-L37) doesn't seem to work if `$value` is a carbon instance:

```php
$existing = $query
    ->when(
        is_array($value),
        fn ($query) => $query->whereIn($attribute, $value),
        fn ($query) => $query->where($attribute, $value)
    )
    ->first();
```

In this PR I simply add `toDateString()` to `$value` if it is a Carbon instance.