### PR TITLE
[5.x] Fix implied route views

### DIFF
--- a/src/Mixins/Router.php
+++ b/src/Mixins/Router.php
@@ -3,7 +3,6 @@
 namespace Statamic\Mixins;
 
 use Statamic\Http\Controllers\FrontendController;
-use Statamic\Support\Str;
 
 class Router
 {
@@ -11,7 +10,7 @@ class Router
     {
         return function ($uri, $view = null, $data = []) {
             if (! $view) {
-                $view = Str::of($uri)->ltrim('/');
+                $view = ltrim($uri, '/');
             }
 
             return $this->get($uri, [FrontendController::class, 'route'])

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -32,6 +32,8 @@ class RoutesTest extends TestCase
         parent::resolveApplicationConfiguration($app);
 
         $app->booted(function () {
+            Route::statamic('/basic-route');
+
             Route::statamic('/basic-route-with-data', 'test', ['hello' => 'world']);
 
             Route::statamic('/basic-route-with-view-closure', function () {
@@ -159,6 +161,17 @@ class RoutesTest extends TestCase
         $this->viewShouldReturnRaw('test', 'Hello {{ hello }}');
 
         $this->get('/basic-route-with-data')
+            ->assertOk()
+            ->assertSee('Hello world');
+    }
+
+    #[Test]
+    public function it_renders_a_view_implied_from_the_route()
+    {
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('basic-route', 'Hello world');
+
+        $this->get('/basic-route')
             ->assertOk()
             ->assertSee('Hello world');
     }


### PR DESCRIPTION
This pull request fixes an error when using implied route views, like this:

```php
Route::statamic('my-page'); // Implies 'my-page'
```

The error was happening because the provided `$view` was a `Stringable` object, rather than an actual string. I've replaced `Str::of(...)->ltrim(...)` with a simple `ltrim`. 

Fixes #11568.