### PR TITLE
[5.x] Password reset action should use custom password reset notification 

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -316,6 +316,15 @@ class User extends BaseUser
         return $this->model()->getRememberTokenName();
     }
 
+    public function sendPasswordResetNotification($token)
+    {
+        if (method_exists($this->model(), 'sendPasswordResetNotification')) {
+            return $this->model()->sendPasswordResetNotification($token);
+        }
+
+        parent::sendPasswordResetNotification($token);
+    }
+
     public function lastLogin()
     {
         if (! $date = $this->model()->last_login) {

--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -325,6 +325,15 @@ class User extends BaseUser
         parent::sendPasswordResetNotification($token);
     }
 
+    public function sendActivateAccountNotification($token)
+    {
+        if (method_exists($this->model(), 'sendActivateAccountNotification')) {
+            return $this->model()->sendActivateAccountNotification($token);
+        }
+
+        parent::sendActivateAccountNotification($token);
+    }
+
     public function lastLogin()
     {
         if (! $date = $this->model()->last_login) {


### PR DESCRIPTION
This pull request fixes an issue where the "Send Password Reset" action wasn't using the custom notification defined in the `User` model, whereas it would get used by the CP's forgot password feature.

Fixes #11554.