### PR TITLE
[6.x] Improve date timezone tests

### DIFF
--- a/resources/js/tests/components/fieldtypes/DateFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/DateFieldtype.test.js
@@ -11,7 +11,16 @@ window.matchMedia = () => ({
     addEventListener: () => {},
 });
 
-process.env.TZ = 'America/New_York';
+let originalDate;
+function setMockDate(dateString) {
+    originalDate = Date; // Store the original Date object
+    global.Date = class extends Date {
+        constructor(...args) {
+            if (args.length) return super(...args);
+            return new originalDate(dateString);
+        }
+    };
+}
 
 const makeDateField = (props = {}) => {
     return mount(DateFieldtype, {
@@ -48,113 +57,162 @@ const makeDateField = (props = {}) => {
     });
 };
 
-test('date and time is localized to the users timezone', async () => {
+test.each([
+    ['UTC', '2025-12-25', '02:23'],
+    ['America/New_York', '2025-12-24', '21:23'],
+])('date and time is localized to the users timezone (%s)', async (tz, expectedDate, expectedTime) => {
+    process.env.TZ = tz;
+
     const dateField = makeDateField({
-        value: { date: '2025-01-01', time: '15:00' },
+        value: { date: '2025-12-25', time: '02:23' },
     });
 
     expect(dateField.vm.localValue).toMatchObject({
-        date: '2025-01-01',
-        time: '10:00',
+        date: expectedDate,
+        time: expectedTime,
     });
 });
 
-test('date can be updated', async () => {
+test.each([
+    {
+        tz: 'UTC',
+        expectedEmittedValue: { date: '2024-12-19', time: '00:00' },
+        expectedLocalValue: { date: '2024-12-19', time: '00:00' },
+    },
+    {
+        tz: 'America/New_York',
+        expectedEmittedValue: { date: '2024-12-19', time: '05:00' },
+        expectedLocalValue: { date: '2024-12-19', time: '00:00' },
+    },
+])('date can be updated ($tz)', async ({ tz, expectedEmittedValue, expectedLocalValue }) => {
+    process.env.TZ = tz;
+
     const dateField = makeDateField({
-        value: { date: '2025-01-01', time: '10:00' },
+        value: { date: '2025-12-25', time: '02:13' },
     });
 
-    await dateField.vm.setLocalDate('2024-12-10');
+    await dateField.vm.setLocalDate('2024-12-19');
 
-    expect(dateField.emitted('update:value')[0]).toEqual([
-        {
-            date: '2024-12-10',
-            time: '05:00',
-        },
-    ]);
-
-    expect(dateField.vm.localValue).toMatchObject({
-        date: '2024-12-10',
-        time: '00:00',
-    });
+    expect(dateField.emitted('update:value')[0][0]).toEqual(expectedEmittedValue);
+    expect(dateField.vm.localValue).toMatchObject(expectedLocalValue);
 });
 
-test('date can be updated without resetting the time when time_enabled is true', async () => {
+test.each([
+    {
+        tz: 'UTC',
+        expectedEmittedValue: { date: '2024-12-19', time: '02:13' },
+        expectedLocalValue: { date: '2024-12-19', time: '02:13' },
+    },
+    {
+        tz: 'America/New_York',
+        expectedEmittedValue: { date: '2024-12-20', time: '02:13' },
+        expectedLocalValue: { date: '2024-12-19', time: '21:13' },
+    },
+])(
+    'date can be updated without resetting the time when time_enabled is true ($tz)',
+    async ({ tz, expectedEmittedValue, expectedLocalValue }) => {
+        process.env.TZ = tz;
+
+        const dateField = makeDateField({
+            config: {
+                earliest_date: { date: null, time: null },
+                latest_date: { date: null, time: null },
+                time_enabled: true,
+            },
+            value: { date: '2025-12-25', time: '02:13' },
+        });
+
+        await dateField.vm.setLocalDate('2024-12-19');
+
+        expect(dateField.emitted('update:value')[0][0]).toEqual(expectedEmittedValue);
+        expect(dateField.vm.localValue).toMatchObject(expectedLocalValue);
+    },
+);
+
+test.each([
+    {
+        tz: 'UTC',
+        expectedEmittedValue: { date: '2025-12-25', time: '23:11' },
+        expectedLocalValue: { date: '2025-12-25', time: '23:11' },
+    },
+    {
+        tz: 'America/New_York',
+        expectedEmittedValue: { date: '2025-12-25', time: '04:11' },
+        expectedLocalValue: { date: '2025-12-24', time: '23:11' },
+    },
+])('time can be updated ($tz)', async ({ tz, expectedEmittedValue, expectedLocalValue }) => {
+    process.env.TZ = tz;
+
     const dateField = makeDateField({
         config: {
             earliest_date: { date: null, time: null },
             latest_date: { date: null, time: null },
             time_enabled: true,
         },
-        value: { date: '2025-01-01', time: '10:00' },
-    });
-
-    await dateField.vm.setLocalDate('2024-12-10');
-
-    expect(dateField.emitted('update:value')[0]).toEqual([
-        {
-            date: '2024-12-10',
-            time: '10:00',
-        },
-    ]);
-
-    expect(dateField.vm.localValue).toMatchObject({
-        date: '2024-12-10',
-        time: '05:00',
-    });
-});
-
-test('time can be updated', async () => {
-    const dateField = makeDateField({
-        config: {
-            earliest_date: { date: null, time: null },
-            latest_date: { date: null, time: null },
-            time_enabled: true,
-        },
-        value: { date: '2025-01-01', time: '15:00' },
+        value: { date: '2025-12-25', time: '02:13' },
     });
 
     await dateField.vm.setLocalTime('23:11');
 
-    expect(dateField.emitted('update:value')[0]).toEqual([
-        {
-            date: '2025-01-02',
-            time: '04:11',
-        },
-    ]);
-
-    expect(dateField.vm.localValue).toMatchObject({
-        date: '2025-01-01',
-        time: '23:11',
-    });
+    expect(dateField.emitted('update:value')[0][0]).toEqual(expectedEmittedValue);
+    expect(dateField.vm.localValue).toMatchObject(expectedLocalValue);
 });
 
-test('time with seconds can be updated', async () => {
+test.each([
+    {
+        tz: 'UTC',
+        expectedEmittedValue: { date: '2025-12-25', time: '23:11:29' },
+        expectedLocalValue: { date: '2025-12-25', time: '23:11:29' },
+    },
+    {
+        tz: 'America/New_York',
+        expectedEmittedValue: { date: '2025-12-25', time: '04:11:29' },
+        expectedLocalValue: { date: '2025-12-24', time: '23:11:29' },
+    },
+])('time with seconds can be updated ($tz)', async ({ tz, expectedEmittedValue, expectedLocalValue }) => {
+    process.env.TZ = tz;
+
     const dateField = makeDateField({
         config: {
             earliest_date: { date: null, time: null },
             latest_date: { date: null, time: null },
             time_seconds_enabled: true,
         },
-        value: { date: '2025-01-01', time: '15:00:00' },
+        value: { date: '2025-12-25', time: '02:13:00' },
     });
 
-    await dateField.vm.setLocalTime('23:11:11');
+    await dateField.vm.setLocalTime('23:11:29');
 
-    expect(dateField.emitted('update:value')[0]).toEqual([
-        {
-            date: '2025-01-02',
-            time: '04:11:11',
-        },
-    ]);
-
-    expect(dateField.vm.localValue).toMatchObject({
-        date: '2025-01-01',
-        time: '23:11:11',
-    });
+    expect(dateField.emitted('update:value')[0][0]).toEqual(expectedEmittedValue);
+    expect(dateField.vm.localValue).toMatchObject(expectedLocalValue);
 });
 
-test('date range can be updated', async () => {
+test.each([
+    {
+        tz: 'UTC',
+        expectedEmittedValue: {
+            start: { date: '2025-01-12', time: '00:00' },
+            end: { date: '2025-01-14', time: '23:59' },
+        },
+        expectedLocalValue: {
+            start: { date: '2025-01-12', time: '00:00' },
+            end: { date: '2025-01-14', time: '23:59' },
+        },
+    },
+    {
+        tz: 'America/New_York',
+        expectedEmittedValue: {
+            start: { date: '2025-01-12', time: '05:00' },
+            end: { date: '2025-01-15', time: '04:59' },
+        },
+        expectedLocalValue: {
+            start: { date: '2025-01-12', time: '00:00' },
+            end: { date: '2025-01-14', time: '23:59' },
+        },
+    },
+])('date range can be updated ($tz)', async ({ tz, expectedEmittedValue, expectedLocalValue }) => {
+    process.env.TZ = tz;
+
     const dateField = makeDateField({
         config: {
             earliest_date: { date: null, time: null },
@@ -162,57 +220,68 @@ test('date range can be updated', async () => {
             mode: 'range',
         },
         value: {
-            start: { date: '2025-01-01', time: '05:00' },
-            end: { date: '2025-01-08', time: '04:59' },
+            start: { date: '2025-12-25', time: '02:13' },
+            end: { date: '2025-12-28', time: '09:04' },
         },
     });
 
     await dateField.vm.setLocalDate({
-        start: '2025-01-01',
-        end: '2025-01-30',
+        start: '2025-01-12',
+        end: '2025-01-14',
     });
 
-    expect(dateField.emitted('update:value')[0]).toEqual([
-        {
-            start: { date: '2025-01-01', time: '05:00' },
-            end: { date: '2025-01-31', time: '04:59' },
-        },
-    ]);
-
-    expect(dateField.vm.localValue).toMatchObject({
-        start: { date: '2025-01-01', time: '00:00' },
-        end: { date: '2025-01-30', time: '23:59' },
-    });
+    expect(dateField.emitted('update:value')[0][0]).toEqual(expectedEmittedValue);
+    expect(dateField.vm.localValue).toMatchObject(expectedLocalValue);
 });
 
-test('required date range field with null value is automatically populated', async () => {
+test.each([
+    [
+        'UTC',
+        { start: { date: '2021-12-25', time: '00:00' }, end: { date: '2021-12-25', time: '23:59' } },
+        { start: { date: '2021-12-25', time: '00:00' }, end: { date: '2021-12-25', time: '23:59' } },
+    ],
+    [
+        'America/New_York',
+        { start: { date: '2021-12-25', time: '05:00' }, end: { date: '2021-12-26', time: '04:59' } },
+        { start: { date: '2021-12-25', time: '00:00' }, end: { date: '2021-12-25', time: '23:59' } },
+    ],
+])(
+    'required date range field with null value is automatically populated (%s)',
+    async (tz, expectedEmittedValue, expectedLocalValue) => {
+        process.env.TZ = tz;
+
+        setMockDate('2021-12-25T12:13:14Z');
+
+        const dateField = makeDateField({
+            config: {
+                earliest_date: { date: null, time: null },
+                latest_date: { date: null, time: null },
+                mode: 'range',
+                required: true,
+            },
+            value: null,
+        });
+
+        await dateField.vm.$nextTick();
+        expect(dateField.emitted('update:value')[0][0]).toEqual(expectedEmittedValue);
+        expect(dateField.vm.localValue).toMatchObject(expectedLocalValue);
+    },
+);
+
+test.each([
+    ['UTC', '2025-12-25', '02:15'],
+    ['America/New_York', '2025-12-24', '21:15'],
+])('local time is updated when value prop is updated (%s)', async (tz, expectedDate, expectedTime) => {
+    process.env.TZ = tz;
+
     const dateField = makeDateField({
-        config: {
-            earliest_date: { date: null, time: null },
-            latest_date: { date: null, time: null },
-            mode: 'range',
-            required: true,
-        },
-        value: null,
+        value: { date: '1984-01-01', time: '15:00' },
     });
 
-    const today = new Date().toISOString().split('T')[0];
+    await dateField.setProps({ value: { date: '2025-12-25', time: '02:15' } });
 
     expect(dateField.vm.localValue).toMatchObject({
-        start: { date: today, time: '00:00' },
-        end: { date: today, time: '23:59' },
-    });
-});
-
-test('local time is updated when value prop is updated', async () => {
-    const dateField = makeDateField({
-        value: { date: '2025-01-01', time: '15:00' },
-    });
-
-    await dateField.setProps({ value: { date: '2025-01-01', time: '10:00' } });
-
-    expect(dateField.vm.localValue).toMatchObject({
-        date: '2025-01-01',
-        time: '05:00',
+        date: expectedDate,
+        time: expectedTime,
     });
 });

--- a/resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js
@@ -9,8 +9,6 @@ window.matchMedia = () => ({
     addEventListener: () => {},
 });
 
-process.env.TZ = 'America/New_York';
-
 const makeDateIndexField = (value = {}) => {
     return mount(DateIndexFieldtype, {
         props: {
@@ -28,46 +26,66 @@ const makeDateIndexField = (value = {}) => {
     });
 };
 
-test('date is localized to the users timezone', async () => {
+test.each([
+    ['UTC', '2025-12-25'],
+    ['America/New_York', '2025-12-24'],
+])('date is localized to the users timezone (%s)', async (tz, expected) => {
+    process.env.TZ = tz;
+
     const dateIndexField = makeDateIndexField({
-        date: '2025-01-01',
-        time: '05:00',
+        date: '2025-12-25',
+        time: '02:13',
         mode: 'single',
         display_format: 'YYYY-MM-DD',
     });
 
-    expect(dateIndexField.vm.formatted).toBe('2025-01-01');
+    expect(dateIndexField.vm.formatted).toBe(expected);
 });
 
-test('date and time is localized to the users timezone', async () => {
+test.each([
+    ['UTC', '2025-12-25 02:13'],
+    ['America/New_York', '2025-12-24 21:13'],
+])('date and time is localized to the users timezone (%s)', async (tz, expected) => {
+    process.env.TZ = tz;
+
     const dateIndexField = makeDateIndexField({
-        date: '2025-01-01',
-        time: '15:00',
+        date: '2025-12-25',
+        time: '02:13',
         mode: 'single',
         display_format: 'YYYY-MM-DD HH:mm',
     });
 
-    expect(dateIndexField.vm.formatted).toBe('2025-01-01 10:00');
+    expect(dateIndexField.vm.formatted).toBe(expected);
 });
 
-test('date range is localized to the users timezone', async () => {
+test.each([
+    ['UTC', '2025-12-25 – 2025-12-28'],
+    ['America/New_York', '2025-12-24 – 2025-12-27'],
+])('date range is localized to the users timezone (%s)', async (tz, expected) => {
+    process.env.TZ = tz;
+
     const dateIndexField = makeDateIndexField({
-        start: { date: '2025-01-01', time: '05:00' },
-        end: { date: '2025-01-11', time: '04:59' },
+        start: { date: '2025-12-25', time: '02:13' },
+        end: { date: '2025-12-28', time: '03:59' },
         mode: 'range',
         display_format: 'YYYY-MM-DD',
     });
 
-    expect(dateIndexField.vm.formatted).toBe('2025-01-01 – 2025-01-10');
+    expect(dateIndexField.vm.formatted).toBe(expected);
 });
 
-test('configured display format is respected', async () => {
+test.each([
+    ['UTC', '25/12/2025 02:13:15'],
+    ['America/New_York', '24/12/2025 21:13:15'],
+])('configured display format is respected (%s)', async (tz, expected) => {
+    process.env.TZ = tz;
+
     const dateIndexField = makeDateIndexField({
-        date: '2025-01-01',
-        time: '15:00:15',
+        date: '2025-12-25',
+        time: '02:13:15',
         mode: 'single',
         display_format: 'DD/MM/YYYY HH:mm:ss',
     });
 
-    expect(dateIndexField.vm.formatted).toBe('01/01/2025 10:00:15');
+    expect(dateIndexField.vm.formatted).toBe(expected);
 });


### PR DESCRIPTION
This adjusts the JS tests added in #11409 to test across multiple timezones.

The test uses date/times that would cause the day to change when converting from UTC to New York.
