### PR TITLE
[5.x] Fix control panel crashes when titles share name with existing translation file

### DIFF
--- a/src/Exceptions/ControlPanelExceptionHandler.php
+++ b/src/Exceptions/ControlPanelExceptionHandler.php
@@ -8,6 +8,8 @@ use Illuminate\Validation\ValidationException;
 use Statamic\Exceptions\ValidationException as StatamicValidationException;
 use Throwable;
 
+use function Statamic\trans as __;
+
 class ControlPanelExceptionHandler extends Handler
 {
     use Concerns\RendersControlPanelExceptions;

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -27,6 +27,8 @@ use Statamic\Search\Index;
 use Statamic\Search\Result;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Entries extends Relationship
 {
     use QueriesFilters;

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -26,6 +26,8 @@ use Statamic\Query\Scopes\Filters\Fields\Terms as TermsFilter;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Terms extends Relationship
 {
     protected $canEdit = true;

--- a/src/Fieldtypes/UserGroups.php
+++ b/src/Fieldtypes/UserGroups.php
@@ -7,6 +7,8 @@ use Statamic\Facades\Scope;
 use Statamic\Facades\UserGroup;
 use Statamic\GraphQL\Types\UserGroupType;
 
+use function Statamic\trans as __;
+
 class UserGroups extends Relationship
 {
     protected $canEdit = false;

--- a/src/Fieldtypes/UserRoles.php
+++ b/src/Fieldtypes/UserRoles.php
@@ -7,6 +7,8 @@ use Statamic\Facades\Role;
 use Statamic\Facades\Scope;
 use Statamic\GraphQL\Types\RoleType;
 
+use function Statamic\trans as __;
+
 class UserRoles extends Relationship
 {
     protected $canEdit = false;

--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -14,6 +14,8 @@ use Statamic\Sites\Site;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Email extends Mailable
 {
     use Queueable, SerializesModels;

--- a/src/Forms/Exporters/Exporter.php
+++ b/src/Forms/Exporters/Exporter.php
@@ -7,6 +7,8 @@ use Statamic\Contracts\Forms\Form;
 use Statamic\Facades\File;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
+use function Statamic\trans as __;
+
 abstract class Exporter
 {
     protected static string $title;

--- a/src/Forms/Fieldtype.php
+++ b/src/Forms/Fieldtype.php
@@ -12,6 +12,8 @@ use Statamic\GraphQL\Types\FormType;
 use Statamic\Query\ItemQueryBuilder;
 use Statamic\Query\Scopes\Filter;
 
+use function Statamic\trans as __;
+
 class Fieldtype extends Relationship
 {
     protected static $handle = 'form';

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -20,6 +20,8 @@ use Statamic\Structures\CollectionStructure;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class CollectionsController extends CpController
 {
     public function index(Request $request)

--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -14,6 +14,8 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Rules\Handle;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class FormsController extends CpController
 {
     public function index(Request $request)

--- a/src/Http/Controllers/CP/Preferences/Nav/RoleNavController.php
+++ b/src/Http/Controllers/CP/Preferences/Nav/RoleNavController.php
@@ -8,6 +8,8 @@ use Statamic\Facades\Preference;
 use Statamic\Facades\Role;
 use Statamic\Http\Controllers\Controller;
 
+use function Statamic\trans as __;
+
 class RoleNavController extends Controller
 {
     use Concerns\HasNavBuilder;

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -20,6 +20,8 @@ use Statamic\Stache\Repositories\TermRepository as StacheTermRepository;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class TaxonomiesController extends CpController
 {
     public function index()

--- a/src/Http/Controllers/CP/Users/RolesController.php
+++ b/src/Http/Controllers/CP/Users/RolesController.php
@@ -12,6 +12,8 @@ use Statamic\Http\Middleware\RequireStatamicPro;
 use Statamic\Rules\Handle;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class RolesController extends CpController
 {
     public function __construct()

--- a/src/Query/Scopes/Filters/Fields.php
+++ b/src/Query/Scopes/Filters/Fields.php
@@ -10,6 +10,8 @@ use Statamic\Facades\User;
 use Statamic\Query\Scopes\Filter;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Fields extends Filter
 {
     protected $pinned = true;

--- a/src/Query/Scopes/Filters/Site.php
+++ b/src/Query/Scopes/Filters/Site.php
@@ -7,6 +7,8 @@ use Statamic\Facades;
 use Statamic\Facades\Collection;
 use Statamic\Query\Scopes\Filter;
 
+use function Statamic\trans as __;
+
 class Site extends Filter
 {
     protected $pinned = true;

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -31,6 +31,8 @@ use Statamic\Statamic;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
+use function Statamic\trans as __;
+
 class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract, Responsable
 {
     use ContainsCascadingData, ContainsSupplementalData, ExistsAsFile, FluentlyGetsAndSets, HasAugmentedData;


### PR DESCRIPTION
- Fix #11577
- Applies the same fix from #11422 in more places
- Use the internal translation helper to avoid exceptions if translation keys return arrays
- Applicable if a blueprint/collection/taxonomy has the same title as an existing translation file