### PR TITLE
[5.x] Change default value of update command selection

### DIFF
--- a/src/Search/Commands/Update.php
+++ b/src/Search/Commands/Update.php
@@ -50,7 +50,7 @@ class Update extends Command
         $selection = select(
             label: 'Which search index would you like to update?',
             options: collect(['All'])->merge($this->indexes()->keys())->all(),
-            default: 0
+            default: 'All'
         );
 
         return ($selection == 'All') ? $this->indexes() : [$this->indexes()->get($selection)];


### PR DESCRIPTION
*Note: This only applies if you have more than one index defined.*

When adding the `statamic:search:update` command to the Laravel scheduler, if you don't also explicitly define the indexes to update (e.g. with `--all`) like so:

```
Schedule::command('statamic:search:update')->daily();
```

Then the scheduler will throw the following error upon running this command:

```
In Update.php line 28: Call to a member function update() on null
```

With this error it's a bit cryptic to figure out what went wrong.

I've made this change based on my own assumption that scheduling the command like this, without an option, should by default run it as if it were run with `--all` (this is the default selected option after all when you manually run it).