### PR TITLE
[5.x] Fix escaped braces in concurrent requests not getting replaced

### DIFF
--- a/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
+++ b/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
@@ -229,6 +229,7 @@ class GlobalRuntimeState
         StackReplacementManager::clearStackState();
         LiteralReplacementManager::resetLiteralState();
         RecursiveNodeManager::resetRecursiveNodeState();
+        RuntimeParser::clearRenderNodeCache();
     }
 
     public static function createIndicatorVariable($indicator)

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -898,4 +898,12 @@ INFO;
     {
         return $this;
     }
+
+    /**
+     * Clears the standard render node cache.
+     */
+    public static function clearRenderNodeCache()
+    {
+        self::$standardRenderNodeCache = [];
+    }
 }

--- a/tests/Antlers/Runtime/ParserIsolationTest.php
+++ b/tests/Antlers/Runtime/ParserIsolationTest.php
@@ -229,4 +229,49 @@ EXPECTED;
 
         $this->assertSame($expected, $result);
     }
+
+    public function test_escaped_braces_in_concurrent_requests()
+    {
+        Collection::make('pages')->routes(['en' => '{slug}'])->save();
+        EntryFactory::collection('pages')->id('1')->slug('page-one')->data([
+            'title' => 'Page One',
+            'template' => 'escaped_braces'
+        ])->create();
+        EntryFactory::collection('pages')->id('2')->slug('page-two')->data([
+            'title' => 'Page Two',
+            'template' => 'escaped_braces'
+        ])->create();
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+
+        $template = <<<'EOT'
+{{ title }}
+{{ "string @{foo@} bar" }}
+{{ "another @{example@} here" }}
+EOT;
+
+        $this->viewShouldReturnRaw('escaped_braces', $template);
+
+        $expectedOne = <<<'EXPECTED'
+Page One
+string {foo} bar
+another {example} here
+EXPECTED;
+
+        $expectedTwo = <<<'EXPECTED'
+Page Two
+string {foo} bar
+another {example} here
+EXPECTED;
+
+        $responseOne = $this->get('page-one')->assertOk();
+        $contentOne = StringUtilities::normalizeLineEndings(trim($responseOne->content()));
+
+        $responseTwo = $this->get('page-two')->assertOk();
+        $contentTwo = StringUtilities::normalizeLineEndings(trim($responseTwo->content()));
+
+        $this->assertSame($expectedOne, $contentOne);
+        $this->assertSame($expectedTwo, $contentTwo);
+    }
 }

--- a/tests/Antlers/Runtime/ParserIsolationTest.php
+++ b/tests/Antlers/Runtime/ParserIsolationTest.php
@@ -235,11 +235,11 @@ EXPECTED;
         Collection::make('pages')->routes(['en' => '{slug}'])->save();
         EntryFactory::collection('pages')->id('1')->slug('page-one')->data([
             'title' => 'Page One',
-            'template' => 'escaped_braces'
+            'template' => 'escaped_braces',
         ])->create();
         EntryFactory::collection('pages')->id('2')->slug('page-two')->data([
             'title' => 'Page Two',
-            'template' => 'escaped_braces'
+            'template' => 'escaped_braces',
         ])->create();
 
         $this->withFakeViews();


### PR DESCRIPTION
Fixes https://github.com/statamic/ssg/issues/196

It seems that the cached nodes contain the escape sequences with the environment ID from the first request, which is why the second request is not correctly replacing the escape sequences. This is why I clear the $standardRenderNodeCache when the global state is reset. 