### PR TITLE
[6.x] Prevent defineProps import warning

### DIFF
--- a/resources/js/components/DateTime.vue
+++ b/resources/js/components/DateTime.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, defineProps } from 'vue';
+import { computed } from 'vue';
 import DateFormatter from '@statamic/components/DateFormatter.js';
 
 const props = defineProps({


### PR DESCRIPTION
You don't need to import `defineProps`. You get this warning from Vite:

```
[@vue/compiler-sfc] `defineProps` is a compiler macro and no longer needs to be imported.
```
