### PR TITLE
[5.x] Prevent null data from being saved to eloquent users

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -282,6 +282,12 @@ class User extends BaseUser
             $value = Hash::make($value);
         }
 
+        if ($value === null) {
+            unset($this->model()->$key);
+
+            return $this;
+        }
+
         $this->model()->$key = $value;
 
         return $this;
@@ -296,7 +302,7 @@ class User extends BaseUser
 
     public function merge($data)
     {
-        $this->data($this->data()->merge($data));
+        $this->data($this->data()->merge(collect($data)->filter(fn ($v) => $v !== null)->all()));
 
         return $this;
     }

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -319,7 +319,7 @@ class EloquentUserTest extends TestCase
 
         $user->merge([
             'null_field' => null,
-            'not_null_field' => false
+            'not_null_field' => false,
         ]);
 
         $attributes = $user->model()->getAttributes();

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -303,4 +303,28 @@ class EloquentUserTest extends TestCase
         $this->assertFalse($user->super);
         $this->assertFalse($user->model()->super);
     }
+
+    #[Test]
+    public function it_does_not_save_null_values_on_the_model()
+    {
+        $user = $this->user();
+
+        $user->set('null_field', null);
+        $user->set('not_null_field', true);
+
+        $attributes = $user->model()->getAttributes();
+
+        $this->assertArrayNotHasKey('null_field', $attributes);
+        $this->assertTrue($attributes['not_null_field']);
+
+        $user->merge([
+            'null_field' => null,
+            'not_null_field' => false
+        ]);
+
+        $attributes = $user->model()->getAttributes();
+
+        $this->assertArrayNotHasKey('null_field', $attributes);
+        $this->assertFalse($attributes['not_null_field']);
+    }
 }


### PR DESCRIPTION
This PR updates eloquent-driven users to ensure any NULL values are not saved, bringing it inline with the same behaviour as file-driven users.

Related: https://github.com/statamic/eloquent-driver/pull/412
Closes: https://github.com/statamic/cms/issues/5977