### PR TITLE
[5.x] Allow revisions path to be configurable with an .env

### DIFF
--- a/config/revisions.php
+++ b/config/revisions.php
@@ -25,6 +25,6 @@ return [
     |
     */
 
-    'path' => storage_path('statamic/revisions'),
+    'path' => env('STATAMIC_REVISIONS_PATH', storage_path('statamic/revisions')),
 
 ];


### PR DESCRIPTION
It always frustrates me that revisions are in storage not content. Ideally I'd like the default to be changed but realise thats breaking.

As a move in the right direction, can the revisions path be .env configurable so at least we can change it on our installs more easily?

Please 🙏 