### PR TITLE
[5.x] Ability to exclude parents from nav tag

### DIFF
--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -136,7 +136,6 @@ class Structure extends Tags
 
             return array_merge($data, [
                 'children' => $children,
-                'parent' => $parent,
                 'depth' => $depth,
                 'index' => $index,
                 'count' => $index + 1,
@@ -145,7 +144,7 @@ class Structure extends Tags
                 'is_current' => ! is_null($url) && rtrim($url, '/') === rtrim($this->currentUrl, '/'),
                 'is_parent' => ! is_null($url) && $this->siteAbsoluteUrl !== $absoluteUrl && URL::isAncestorOf($this->currentUrl, $url),
                 'is_external' => URL::isExternal((string) $absoluteUrl),
-            ]);
+            ], $this->params->bool('include_parents', true) ? ['parent' => $parent] : []);
         })->filter()->values();
 
         $this->updateIsParent($pages);


### PR DESCRIPTION
You can add `include_parents="false"` to a `nav` tag to prevent `parent` keys being added.

Fixes #11595
