### PR TITLE
[6.x] Fix uploader component

### DIFF
--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -4,22 +4,23 @@ import uniqid from 'uniqid';
 import { h } from 'vue';
 
 export default {
+    emits: ['updated', 'upload-complete', 'error'],
+
     render() {
         const fileField = h('input', {
             class: { hidden: true },
-            attrs: { type: 'file', multiple: true },
+            type: 'file',
+            multiple: true,
             ref: 'nativeFileField',
         });
 
         return h(
             'div',
             {
-                on: {
-                    dragenter: this.dragenter,
-                    dragover: this.dragover,
-                    dragleave: this.dragleave,
-                    drop: this.drop,
-                },
+                onDragenter: this.dragenter,
+                onDragover: this.dragover,
+                onDragleave: this.dragleave,
+                onDrop: this.drop,
             },
             [
                 h('div', { class: { 'pointer-events-none': this.dragging } }, [
@@ -60,9 +61,12 @@ export default {
     },
 
     watch: {
-        uploads(uploads) {
-            this.$emit('updated', uploads);
-            this.processUploadQueue();
+        uploads: {
+            deep: true,
+            handler(uploads) {
+                this.$emit('updated', uploads);
+                this.processUploadQueue();
+            },
         },
     },
 


### PR DESCRIPTION
This fixes the uploader component.

- `uploads` watcher needs to be `deep` now. Fixes nothing happening when a file is selected/dragged.
- `h`/`createElement` works differently. Fixes the dom not rendering as expected. 
