### PR TITLE
[5.x] Autoload scopes from `Query/Scopes` and `Query/Scopes/Filters`

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -308,6 +308,8 @@ abstract class AddonServiceProvider extends ServiceProvider
     {
         $scopes = collect($this->scopes)
             ->merge($this->autoloadFilesFromFolder('Scopes', Scope::class))
+            ->merge($this->autoloadFilesFromFolder('Query/Scopes', Scope::class))
+            ->merge($this->autoloadFilesFromFolder('Query/Scopes/Filters', Scope::class))
             ->unique();
 
         foreach ($scopes as $class) {


### PR DESCRIPTION
This pull request adds the `Query/Scopes` and `Query/Scopes/Filters` directories to the paths Statamic uses to autoload query scopes in addons.

The `php please make:scope` command creates query scopes & filters in the `src/Scopes` directory.

However, if you're following the same directory structure of Statamic Core in your addon, your scopes/filters might live in different folders. Here's an example from my addon:

![CleanShot 2025-03-20 at 12 26 05](https://github.com/user-attachments/assets/d943b605-3f2b-4c69-9ae9-088a10b869f2)

