### PR TITLE
[5.x] Fix issue with localication files named like fieldset handles

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -32,6 +32,8 @@ use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
+use function Statamic\trans as __;
+
 class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contract
 {
     use ContainsCascadingData, ExistsAsFile, FluentlyGetsAndSets, HasAugmentedData;

--- a/src/Extend/HasTitle.php
+++ b/src/Extend/HasTitle.php
@@ -4,6 +4,8 @@ namespace Statamic\Extend;
 
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 trait HasTitle
 {
     protected static $title;

--- a/src/Git/CommitCommand.php
+++ b/src/Git/CommitCommand.php
@@ -6,6 +6,8 @@ use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
 use Statamic\Facades\Git;
 
+use function Statamic\trans as __;
+
 class CommitCommand extends Command
 {
     use RunsInPlease;

--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -11,6 +11,8 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Middleware\CP\RedirectIfAuthorized;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class LoginController extends CpController
 {
     use ThrottlesLogins;

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -11,6 +11,8 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Middleware\CP\CanManageBlueprints;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class FieldsController extends CpController
 {
     public function __construct()

--- a/src/Http/Controllers/CP/Fields/FieldsetController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsetController.php
@@ -12,6 +12,8 @@ use Statamic\Rules\Handle;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class FieldsetController extends CpController
 {
     public function __construct()


### PR DESCRIPTION
Another PR related to translation keys, I’ve already fixed this issue here https://github.com/statamic/cms/pull/11482 and have identified a few more places when testing fieldsets where it could also break.