### PR TITLE
[5.x] Handle collection instances in `first` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -738,6 +738,10 @@ class CoreModifiers extends Modifier
             return Arr::first($value);
         }
 
+        if ($value instanceof Collection) {
+            return $value->first();
+        }
+
         return Stringy::first($value, Arr::get($params, 0));
     }
 

--- a/tests/Modifiers/FirstTest.php
+++ b/tests/Modifiers/FirstTest.php
@@ -45,6 +45,27 @@ class FirstTest extends TestCase
         ];
     }
 
+    #[Test]
+    #[DataProvider('collectionProvider')]
+    public function it_gets_the_first_value_of_a_collection($value, $expected)
+    {
+        $this->assertEquals($expected, $this->modify($value));
+    }
+
+    public static function collectionProvider()
+    {
+        return [
+            'list' => [
+                collect(['alfa', 'bravo', 'charlie']),
+                'alfa',
+            ],
+            'associative' => [
+                collect(['alfa' => 'bravo', 'charlie' => 'delta']),
+                'bravo',
+            ],
+        ];
+    }
+
     private function modify($value, $arg = null)
     {
         return Modify::value($value)->first($arg)->fetch();


### PR DESCRIPTION
Today I tried to grab the first item from a collection of assets in Antleres but the `first` modifier returned me a string. After a quick sanity check with Duncan, I propose the modifier should handle collection instances the same way it does with arrays.
