### PR TITLE
[5.x] Added option to exclude asset containers from generating presets

### DIFF
--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -64,7 +64,7 @@ class AssetsGeneratePresets extends Command
         }
 
         AssetContainer::all()->filter(function ($container) use ($excludedContainers) {
-            return ! in_array($container->handle(), $excludedContainers);
+            return ! in_array($container->handle(), $excludedContainers ?? []);
         })->sortBy('title')->each(function ($container) {
             note('Generating presets for <comment>'.$container->title().'</comment>...');
             $this->generatePresets($container);

--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -24,7 +24,9 @@ class AssetsGeneratePresets extends Command
      *
      * @var string
      */
-    protected $signature = 'statamic:assets:generate-presets {--queue : Queue the image generation.}';
+    protected $signature = 'statamic:assets:generate-presets
+        {--queue : Queue the image generation.}
+        {--excluded-containers= : Comma separated list of container handles to exclude.}';
 
     /**
      * The console command description.
@@ -55,7 +57,15 @@ class AssetsGeneratePresets extends Command
             $this->shouldQueue = false;
         }
 
-        AssetContainer::all()->sortBy('title')->each(function ($container) {
+        $excludedContainers = $this->option('excluded-containers');
+
+        if ($excludedContainers) {
+            $excludedContainers = explode(',', $excludedContainers);
+        }
+
+        AssetContainer::all()->filter(function ($container) use ($excludedContainers) {
+            return ! in_array($container->handle(), $excludedContainers);
+        })->sortBy('title')->each(function ($container) {
             note('Generating presets for <comment>'.$container->title().'</comment>...');
             $this->generatePresets($container);
             $this->newLine();


### PR DESCRIPTION
It would be helpful to add an option to the statamic:assets:generate-presets command to exclude certain asset containers from preset generation.

In our case, we had an asset container for storing assets uploaded through our forms. However, running this command generated presets for these assets, which was not desirable.

This PR is related to [Issue #1644](https://github.com/statamic/docs/issues/1644).