### PR TITLE
Escape start_page Preference to avoid invalid Redirect

### DIFF
--- a/src/Http/Controllers/CP/StartPageController.php
+++ b/src/Http/Controllers/CP/StartPageController.php
@@ -10,7 +10,7 @@ class StartPageController extends CpController
     {
         session()->reflash();
 
-        $url = config('statamic.cp.route').'/'.Preference::get('start_page', config('statamic.cp.start_page'));
+        $url = config('statamic.cp.route').'/'.urlencode(Preference::get('start_page', config('statamic.cp.start_page')));
 
         return redirect($url);
     }


### PR DESCRIPTION
A user can add their own Startpage after logging into the control panel. This user generated content is not properly escaped before a redirect is triggered on logging in.

A user might be able to set their start_page Preference Value for example to "test\npage" (a string with Line Break). This is usually prevented on frontend but not validated/sanitized on backend!

Upon redirection there is a 500 error:  

> Header may not contain more than a single header, new line detected {"userId":1,"exception":"[object] (ErrorException(code: 0): Header may not contain more than a single header, new line detected at

This small fix url-encodes the user's Preference so that the Header redirect value is url-safe. 