### PR TITLE
[5.x] Use deep copy of objects in replicator set

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -205,7 +205,7 @@ export default {
 
         addSet(handle, index) {
             const set = {
-                ...this.meta.defaults[handle],
+                ...clone(this.meta.defaults[handle]),
                 _id: uniqid(),
                 type: handle,
                 enabled: true,
@@ -228,7 +228,7 @@ export default {
             const index = this.value.findIndex(v => v._id === old_id);
             const old = this.value[index];
             const set = {
-                ...old,
+                ...clone(old),
                 _id: uniqid(),
             };
 

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -205,7 +205,7 @@ export default {
 
         addSet(handle, index) {
             const set = {
-                ...clone(this.meta.defaults[handle]),
+                ...JSON.parse(JSON.stringify(this.meta.defaults[handle])),
                 _id: uniqid(),
                 type: handle,
                 enabled: true,
@@ -228,7 +228,7 @@ export default {
             const index = this.value.findIndex(v => v._id === old_id);
             const old = this.value[index];
             const set = {
-                ...clone(old),
+                ...JSON.parse(JSON.stringify(old)),
                 _id: uniqid(),
             };
 


### PR DESCRIPTION
This PR fixes https://github.com/statamic/cms/issues/11619

Instead of a shallow copy, a deep copy of the (default) values is used when adding or duplicating an item in the replicator-set.

Unfortunately I do not know how to test this in an automated way.

When using statamic from [this](https://github.com/faltjo/statamic-cms/tree/fix-replicator-set-bug) branch, the problems are gone in the example repo: https://github.com/faltjo/replicator-set-bug
