### PR TITLE
[5.x] Add Edit Blueprint links to create publish forms

### DIFF
--- a/resources/js/components/entries/BaseCreateForm.vue
+++ b/resources/js/components/entries/BaseCreateForm.vue
@@ -20,6 +20,7 @@
         :breadcrumbs="breadcrumbs"
         :initial-site="site"
         :can-manage-publish-state="canManagePublishState"
+        :can-edit-blueprint="canEditBlueprint"
         :create-another-url="createAnotherUrl"
         :initial-listing-url="listingUrl"
         :preview-targets="previewTargets"
@@ -45,6 +46,7 @@ export default {
         'breadcrumbs',
         'site',
         'canManagePublishState',
+        'canEditBlueprint',
         'createAnotherUrl',
         'listingUrl',
         'previewTargets',

--- a/resources/js/components/terms/BaseCreateForm.vue
+++ b/resources/js/components/terms/BaseCreateForm.vue
@@ -17,6 +17,7 @@
         :initial-is-root="true"
         :initial-origin-values="{}"
         :initial-site="site"
+        :can-edit-blueprint="canEditBlueprint"
         :create-another-url="createAnotherUrl"
         :listing-url="listingUrl"
         :preview-targets="previewTargets"
@@ -39,6 +40,7 @@ export default {
         'published',
         'localizations',
         'site',
+        'canEditBlueprint',
         'createAnotherUrl',
         'listingUrl',
         'previewTargets',

--- a/resources/views/entries/create.blade.php
+++ b/resources/views/entries/create.blade.php
@@ -1,3 +1,4 @@
+@inject('str', 'Statamic\Support\Str')
 @extends('statamic::layout')
 @section('title', $breadcrumbs->title($collectionCreateLabel))
 @section('wrapper_class', 'max-w-3xl')
@@ -19,6 +20,7 @@
         site="{{ $locale }}"
         create-another-url="{{ cp_route('collections.entries.create', [$collection, $locale, 'blueprint' => $blueprint['handle'], 'parent' => $values['parent'] ?? null]) }}"
         listing-url="{{ cp_route('collections.show', $collection) }}"
+        :can-edit-blueprint="{{ $str::bool($user->can('configure fields')) }}"
         :can-manage-publish-state="{{ Statamic\Support\Str::bool($canManagePublishState) }}"
         :preview-targets="{{ json_encode($previewTargets) }}"
     ></base-entry-create-form>

--- a/resources/views/terms/create.blade.php
+++ b/resources/views/terms/create.blade.php
@@ -1,3 +1,4 @@
+@inject('str', 'Statamic\Support\Str')
 @extends('statamic::layout')
 @section('title', $breadcrumbs->title($taxonomyCreateLabel))
 @section('wrapper_class', 'max-w-3xl')
@@ -14,6 +15,7 @@
         :published="{{ json_encode($published) }}"
         :localizations="{{ json_encode($localizations) }}"
         site="{{ $locale }}"
+        :can-edit-blueprint="{{ $str::bool($user->can('configure fields')) }}"
         create-another-url="{{ cp_route('taxonomies.terms.create', [$taxonomy, $locale]) }}"
         listing-url="{{ cp_route('taxonomies.show', $taxonomy) }}"
         :preview-targets="{{ json_encode($previewTargets) }}"

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -321,6 +321,7 @@ class EntriesController extends CpController
             'title' => $collection->createLabel(),
             'actions' => [
                 'save' => cp_route('collections.entries.store', [$collection->handle(), $site->handle()]),
+                'editBlueprint' => cp_route('collections.blueprints.edit', [$collection, $blueprint]),
             ],
             'values' => $values->all(),
             'extraValues' => [

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -243,6 +243,7 @@ class TermsController extends CpController
             'title' => $taxonomy->createLabel(),
             'actions' => [
                 'save' => cp_route('taxonomies.terms.store', [$taxonomy->handle(), $site->handle()]),
+                'editBlueprint' => cp_route('taxonomies.blueprints.edit', [$taxonomy, $blueprint]),
             ],
             'values' => $values,
             'meta' => $fields->meta(),


### PR DESCRIPTION
You can already jump to the blueprint to make changes from entry/term edit publish forms, this PR adds the same links to the create forms.

![Screenshot 2025-03-26 at 16 35 52](https://github.com/user-attachments/assets/03d25257-ad3e-4642-96ab-9bdaa30b612d)