### PR TITLE
[6.x] Glide 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "laravel/prompts": "^0.3.0",
         "league/commonmark": "^2.2",
         "league/csv": "^9.0",
-        "league/glide": "^2.3",
+        "league/glide": "^3.0",
         "maennchen/zipstream-php": "^3.1",
         "michelf/php-smartypants": "^1.8.1",
         "nesbot/carbon": "^3.0",

--- a/config/assets.php
+++ b/config/assets.php
@@ -43,21 +43,6 @@ return [
 
         /*
         |--------------------------------------------------------------------------
-        | Additional Image Extensions
-        |--------------------------------------------------------------------------
-        |
-        | Define any additional image file extensions you would like Statamic to
-        | process. You should ensure that both your server and the selected
-        | image manipulation driver properly supports these extensions.
-        |
-        */
-
-        'additional_extensions' => [
-            // 'heic',
-        ],
-
-        /*
-        |--------------------------------------------------------------------------
         | Save Cached Images
         |--------------------------------------------------------------------------
         |

--- a/config/assets.php
+++ b/config/assets.php
@@ -35,7 +35,7 @@ return [
         |--------------------------------------------------------------------------
         |
         | The driver that will be used under the hood for image manipulation.
-        | Supported: "gd" or "imagick" (if installed on your server)
+        | Supported: "gd", "imagick" or "libvips" (if installed on your server)
         |
         */
 

--- a/config/assets.php
+++ b/config/assets.php
@@ -35,7 +35,7 @@ return [
         |--------------------------------------------------------------------------
         |
         | The driver that will be used under the hood for image manipulation.
-        | Supported: "gd", "imagick" or "libvips" (if installed on your server)
+        | Supported: "gd", "imagick" or a class name of a custom driver.
         |
         */
 

--- a/src/Imaging/GlideManager.php
+++ b/src/Imaging/GlideManager.php
@@ -27,7 +27,7 @@ class GlideManager
             'source' => base_path(), // this gets overridden on the fly by the image generator
             'cache' => $this->cacheDisk()->getDriver(),
             'response' => new LaravelResponseFactory(app('request')),
-            'driver' => $this->getDriver(),
+            'driver' => Config::get('statamic.assets.image_manipulation.driver'),
             'cache_with_file_extensions' => true,
             'presets' => Image::manipulationPresets(),
             'watermarks' => public_path(),
@@ -78,21 +78,6 @@ class GlideManager
         return $this->shouldServeDirectly()
             ? Config::get('statamic.assets.image_manipulation.cache_path')
             : storage_path('statamic/glide');
-    }
-
-    private function getDriver(): string
-    {
-        $driver = Config::get('statamic.assets.image_manipulation.driver');
-
-        if ($driver == 'libvips') {
-            if (! class_exists(\Intervention\Image\Drivers\Vips\Driver::class)) {
-                throw new \Exception('You must install the [intervention/image-driver-vips] package to use the [libvips] driver.');
-            }
-
-            return \Intervention\Image\Drivers\Vips\Driver::class;
-        }
-
-        return $driver;
     }
 
     public function shouldServeDirectly()

--- a/src/Imaging/GlideManager.php
+++ b/src/Imaging/GlideManager.php
@@ -27,7 +27,7 @@ class GlideManager
             'source' => base_path(), // this gets overridden on the fly by the image generator
             'cache' => $this->cacheDisk()->getDriver(),
             'response' => new LaravelResponseFactory(app('request')),
-            'driver' => Config::get('statamic.assets.image_manipulation.driver'),
+            'driver' => $this->getDriver(),
             'cache_with_file_extensions' => true,
             'presets' => Image::manipulationPresets(),
             'watermarks' => public_path(),
@@ -78,6 +78,21 @@ class GlideManager
         return $this->shouldServeDirectly()
             ? Config::get('statamic.assets.image_manipulation.cache_path')
             : storage_path('statamic/glide');
+    }
+
+    private function getDriver(): string
+    {
+        $driver = Config::get('statamic.assets.image_manipulation.driver');
+
+        if ($driver == 'libvips') {
+            if (! class_exists(\Intervention\Image\Drivers\Vips\Driver::class)) {
+                throw new \Exception('You must install the [intervention/image-driver-vips] package to use the [libvips] driver.');
+            }
+
+            return \Intervention\Image\Drivers\Vips\Driver::class;
+        }
+
+        return $driver;
     }
 
     public function shouldServeDirectly()

--- a/src/Imaging/ImageValidator.php
+++ b/src/Imaging/ImageValidator.php
@@ -45,8 +45,8 @@ class ImageValidator
             $allowed = ['jpeg', 'jpg', 'png', 'gif', 'webp'];
         } elseif ($driver == 'imagick') {
             $allowed = ['jpeg', 'jpg', 'png', 'gif', 'tif', 'bmp', 'psd', 'webp'];
-        } elseif ($driver == 'libvips') {
-            $allowed = ['jpeg', 'jpg', 'png', 'gif', 'tif', 'webp', 'heic'];
+        } elseif ($driver == \Intervention\Image\Drivers\Vips\Driver::class) {
+            $allowed = ['jpeg', 'jpg', 'png', 'gif', 'tif', 'bmp', 'psd', 'webp'];
         } else {
             throw new \Exception("Unsupported image manipulation driver [$driver]");
         }

--- a/src/Imaging/ImageValidator.php
+++ b/src/Imaging/ImageValidator.php
@@ -2,11 +2,20 @@
 
 namespace Statamic\Imaging;
 
+use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\DriverInterface;
+use Intervention\Image\Interfaces\ImageManagerInterface;
+use League\Glide\ServerFactory;
+use Statamic\Facades\Glide;
 use Statamic\Support\Str;
 use Symfony\Component\Mime\MimeTypes;
 
 class ImageValidator
 {
+    public function __construct(private DriverInterface $driver)
+    {
+    }
+
     /**
      * Check if image has valid extension and mimetype.
      *
@@ -39,24 +48,7 @@ class ImageValidator
      */
     public function isValidExtension($extension)
     {
-        $driver = config('statamic.assets.image_manipulation.driver');
-
-        if ($driver == 'gd') {
-            $allowed = ['jpeg', 'jpg', 'png', 'gif', 'webp'];
-        } elseif ($driver == 'imagick') {
-            $allowed = ['jpeg', 'jpg', 'png', 'gif', 'tif', 'bmp', 'psd', 'webp'];
-        } elseif ($driver == \Intervention\Image\Drivers\Vips\Driver::class) {
-            $allowed = ['jpeg', 'jpg', 'png', 'gif', 'tif', 'bmp', 'psd', 'webp'];
-        } else {
-            throw new \Exception("Unsupported image manipulation driver [$driver]");
-        }
-
-        $additional = config('statamic.assets.image_manipulation.additional_extensions', []);
-
-        return collect($allowed)
-            ->merge($additional)
-            ->map(fn ($extension) => Str::lower($extension))
-            ->contains(Str::lower($extension));
+        return $this->driver->supports($extension);
     }
 
     /**

--- a/src/Imaging/ImageValidator.php
+++ b/src/Imaging/ImageValidator.php
@@ -2,12 +2,7 @@
 
 namespace Statamic\Imaging;
 
-use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\DriverInterface;
-use Intervention\Image\Interfaces\ImageManagerInterface;
-use League\Glide\ServerFactory;
-use Statamic\Facades\Glide;
-use Statamic\Support\Str;
 use Symfony\Component\Mime\MimeTypes;
 
 class ImageValidator

--- a/src/Imaging/ImageValidator.php
+++ b/src/Imaging/ImageValidator.php
@@ -45,6 +45,8 @@ class ImageValidator
             $allowed = ['jpeg', 'jpg', 'png', 'gif', 'webp'];
         } elseif ($driver == 'imagick') {
             $allowed = ['jpeg', 'jpg', 'png', 'gif', 'tif', 'bmp', 'psd', 'webp'];
+        } elseif ($driver == 'libvips') {
+            $allowed = ['jpeg', 'jpg', 'png', 'gif', 'tif', 'webp', 'heic'];
         } else {
             throw new \Exception("Unsupported image manipulation driver [$driver]");
         }

--- a/src/Imaging/ImageValidator.php
+++ b/src/Imaging/ImageValidator.php
@@ -43,6 +43,10 @@ class ImageValidator
      */
     public function isValidExtension($extension)
     {
+        if (! $extension) {
+            return false;
+        }
+
         return $this->driver->supports($extension);
     }
 

--- a/src/Providers/GlideServiceProvider.php
+++ b/src/Providers/GlideServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Statamic\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Intervention\Image\ImageManager;
 use League\Glide\Server;
 use Statamic\Contracts\Imaging\ImageManipulator;
 use Statamic\Contracts\Imaging\UrlBuilder;
@@ -11,6 +12,7 @@ use Statamic\Facades\Glide;
 use Statamic\Imaging\GlideImageManipulator;
 use Statamic\Imaging\GlideUrlBuilder;
 use Statamic\Imaging\ImageGenerator;
+use Statamic\Imaging\ImageValidator;
 use Statamic\Imaging\PresetGenerator;
 use Statamic\Imaging\StaticUrlBuilder;
 
@@ -38,6 +40,18 @@ class GlideServiceProvider extends ServiceProvider
             return new PresetGenerator(
                 $app->make(ImageGenerator::class)
             );
+        });
+
+        $this->app->bind(ImageValidator::class, function ($app) {
+            $driver = config('statamic.assets.image_manipulation.driver', 'gd');
+
+            $imageManager = match ($driver) {
+                'gd' => ImageManager::gd(),
+                'imagick' => ImageManager::imagick(),
+                default => ImageManager::withDriver($driver),
+            };
+
+            return new ImageValidator($imageManager->driver());
         });
     }
 

--- a/tests/Imaging/ImageValidatorTest.php
+++ b/tests/Imaging/ImageValidatorTest.php
@@ -95,6 +95,29 @@ class ImageValidatorTest extends TestCase
     }
 
     #[Test]
+    public function it_checks_if_image_extension_is_allowed_for_manipulation_with_libvips_driver()
+    {
+        config(['statamic.assets.image_manipulation.driver' => 'libvips']);
+
+        $this->assertTrue(ImageValidator::isValidExtension('jpeg'));
+        $this->assertTrue(ImageValidator::isValidExtension('jpg'));
+        $this->assertTrue(ImageValidator::isValidExtension('png'));
+        $this->assertTrue(ImageValidator::isValidExtension('gif'));
+        $this->assertTrue(ImageValidator::isValidExtension('webp'));
+        $this->assertTrue(ImageValidator::isValidExtension('tif'));
+
+        // Not supported by libvips...
+        $this->assertFalse(ImageValidator::isValidExtension('bmp'));
+        $this->assertFalse(ImageValidator::isValidExtension('psd'));
+        $this->assertFalse(ImageValidator::isValidExtension('eps'));
+
+        // Supported by libvips, but requires `additional_extensions` configuration...
+        $this->assertFalse(ImageValidator::isValidExtension('svg'));
+        $this->assertFalse(ImageValidator::isValidExtension('pdf'));
+        $this->assertFalse(ImageValidator::isValidExtension('avif'));
+    }
+
+    #[Test]
     public function it_checks_if_custom_image_extension_is_allowed_for_manipulation_with_proper_config()
     {
         config(['statamic.assets.image_manipulation.driver' => 'imagick']);

--- a/tests/Imaging/ImageValidatorTest.php
+++ b/tests/Imaging/ImageValidatorTest.php
@@ -11,7 +11,7 @@ class ImageValidatorTest extends TestCase
     #[Test]
     public function it_checks_if_image_has_valid_extension_and_mimetype()
     {
-        config(['statamic.assets.image_manipulation.driver' => 'imagick']);
+        config(['statamic.assets.image_manipulation.driver' => 'gd']);
 
         // We'll test `isValidExtension()` functionality separately below, and just mock here...
         ImageValidator::shouldReceive('isValidExtension')->andReturnTrue()->times(24);

--- a/tests/Imaging/ImageValidatorTest.php
+++ b/tests/Imaging/ImageValidatorTest.php
@@ -97,7 +97,7 @@ class ImageValidatorTest extends TestCase
     #[Test]
     public function it_checks_if_image_extension_is_allowed_for_manipulation_with_libvips_driver()
     {
-        config(['statamic.assets.image_manipulation.driver' => 'libvips']);
+        config(['statamic.assets.image_manipulation.driver' => \Intervention\Image\Drivers\Vips\Driver::class]);
 
         $this->assertTrue(ImageValidator::isValidExtension('jpeg'));
         $this->assertTrue(ImageValidator::isValidExtension('jpg'));
@@ -105,15 +105,13 @@ class ImageValidatorTest extends TestCase
         $this->assertTrue(ImageValidator::isValidExtension('gif'));
         $this->assertTrue(ImageValidator::isValidExtension('webp'));
         $this->assertTrue(ImageValidator::isValidExtension('tif'));
+        $this->assertTrue(ImageValidator::isValidExtension('bmp'));
+        $this->assertTrue(ImageValidator::isValidExtension('psd'));
 
-        // Not supported by libvips...
-        $this->assertFalse(ImageValidator::isValidExtension('bmp'));
-        $this->assertFalse(ImageValidator::isValidExtension('psd'));
-        $this->assertFalse(ImageValidator::isValidExtension('eps'));
-
-        // Supported by libvips, but requires `additional_extensions` configuration...
+        // Supported by libvps, but requires `additional_extensions` configuration...
         $this->assertFalse(ImageValidator::isValidExtension('svg'));
         $this->assertFalse(ImageValidator::isValidExtension('pdf'));
+        $this->assertFalse(ImageValidator::isValidExtension('eps'));
         $this->assertFalse(ImageValidator::isValidExtension('avif'));
     }
 

--- a/tests/Imaging/ImageValidatorTest.php
+++ b/tests/Imaging/ImageValidatorTest.php
@@ -13,12 +13,6 @@ class ImageValidatorTest extends TestCase
     {
         config(['statamic.assets.image_manipulation.driver' => 'imagick']);
 
-        config(['statamic.assets.image_manipulation.additional_extensions' => [
-            'svg',
-            'pdf',
-            'eps',
-        ]]);
-
         // We'll test `isValidExtension()` functionality separately below, and just mock here...
         ImageValidator::shouldReceive('isValidExtension')->andReturnTrue()->times(24);
         ImageValidator::makePartial();
@@ -52,97 +46,17 @@ class ImageValidatorTest extends TestCase
     }
 
     #[Test]
-    public function it_checks_if_image_extension_is_allowed_for_manipulation_with_gd_driver()
+    public function it_checks_if_image_extension_is_allowed_for_manipulation()
     {
         config(['statamic.assets.image_manipulation.driver' => 'gd']);
 
-        $this->assertTrue(ImageValidator::isValidExtension('jpeg'));
-        $this->assertTrue(ImageValidator::isValidExtension('jpg'));
-        $this->assertTrue(ImageValidator::isValidExtension('png'));
-        $this->assertTrue(ImageValidator::isValidExtension('gif'));
-        $this->assertTrue(ImageValidator::isValidExtension('webp'));
+        $mock = \Mockery::mock(\Intervention\Image\Interfaces\DriverInterface::class);
+        $mock->shouldReceive('supports')->with('one')->andReturnTrue();
+        $mock->shouldReceive('supports')->with('two')->andReturnFalse();
 
-        // Supported by imagick only...
-        $this->assertFalse(ImageValidator::isValidExtension('tif'));
-        $this->assertFalse(ImageValidator::isValidExtension('bmp'));
-        $this->assertFalse(ImageValidator::isValidExtension('psd'));
+        $imageValidator = new \Statamic\Imaging\ImageValidator($mock);
 
-        // Supported by imagick only, but requires `additional_extensions` configuration...
-        $this->assertFalse(ImageValidator::isValidExtension('svg'));
-        $this->assertFalse(ImageValidator::isValidExtension('pdf'));
-        $this->assertFalse(ImageValidator::isValidExtension('eps'));
-    }
-
-    #[Test]
-    public function it_checks_if_image_extension_is_allowed_for_manipulation_with_imagick_driver()
-    {
-        config(['statamic.assets.image_manipulation.driver' => 'imagick']);
-
-        $this->assertTrue(ImageValidator::isValidExtension('jpeg'));
-        $this->assertTrue(ImageValidator::isValidExtension('jpg'));
-        $this->assertTrue(ImageValidator::isValidExtension('png'));
-        $this->assertTrue(ImageValidator::isValidExtension('gif'));
-        $this->assertTrue(ImageValidator::isValidExtension('webp'));
-        $this->assertTrue(ImageValidator::isValidExtension('tif'));
-        $this->assertTrue(ImageValidator::isValidExtension('bmp'));
-        $this->assertTrue(ImageValidator::isValidExtension('psd'));
-
-        // Supported by imagick, but requires `additional_extensions` configuration...
-        $this->assertFalse(ImageValidator::isValidExtension('svg'));
-        $this->assertFalse(ImageValidator::isValidExtension('pdf'));
-        $this->assertFalse(ImageValidator::isValidExtension('eps'));
-        $this->assertFalse(ImageValidator::isValidExtension('avif'));
-    }
-
-    #[Test]
-    public function it_checks_if_image_extension_is_allowed_for_manipulation_with_libvips_driver()
-    {
-        config(['statamic.assets.image_manipulation.driver' => \Intervention\Image\Drivers\Vips\Driver::class]);
-
-        $this->assertTrue(ImageValidator::isValidExtension('jpeg'));
-        $this->assertTrue(ImageValidator::isValidExtension('jpg'));
-        $this->assertTrue(ImageValidator::isValidExtension('png'));
-        $this->assertTrue(ImageValidator::isValidExtension('gif'));
-        $this->assertTrue(ImageValidator::isValidExtension('webp'));
-        $this->assertTrue(ImageValidator::isValidExtension('tif'));
-        $this->assertTrue(ImageValidator::isValidExtension('bmp'));
-        $this->assertTrue(ImageValidator::isValidExtension('psd'));
-
-        // Supported by libvps, but requires `additional_extensions` configuration...
-        $this->assertFalse(ImageValidator::isValidExtension('svg'));
-        $this->assertFalse(ImageValidator::isValidExtension('pdf'));
-        $this->assertFalse(ImageValidator::isValidExtension('eps'));
-        $this->assertFalse(ImageValidator::isValidExtension('avif'));
-    }
-
-    #[Test]
-    public function it_checks_if_custom_image_extension_is_allowed_for_manipulation_with_proper_config()
-    {
-        config(['statamic.assets.image_manipulation.driver' => 'imagick']);
-
-        config(['statamic.assets.image_manipulation.additional_extensions' => [
-            'svg',
-            'pdf',
-            'eps',
-            'avif',
-        ]]);
-
-        $this->assertTrue(ImageValidator::isValidExtension('jpeg'));
-        $this->assertTrue(ImageValidator::isValidExtension('jpg'));
-        $this->assertTrue(ImageValidator::isValidExtension('png'));
-        $this->assertTrue(ImageValidator::isValidExtension('gif'));
-        $this->assertTrue(ImageValidator::isValidExtension('webp'));
-        $this->assertTrue(ImageValidator::isValidExtension('tif'));
-        $this->assertTrue(ImageValidator::isValidExtension('bmp'));
-        $this->assertTrue(ImageValidator::isValidExtension('psd'));
-
-        // Should now be supported due to `additional_extensions` config...
-        $this->assertTrue(ImageValidator::isValidExtension('svg'));
-        $this->assertTrue(ImageValidator::isValidExtension('pdf'));
-        $this->assertTrue(ImageValidator::isValidExtension('eps'));
-        $this->assertTrue(ImageValidator::isValidExtension('avif'));
-
-        // Not configured, should still be false...
-        $this->assertFalse(ImageValidator::isValidExtension('exe'));
+        $this->assertTrue($imageValidator->isValidExtension('one'));
+        $this->assertFalse($imageValidator->isValidExtension('two'));
     }
 }


### PR DESCRIPTION
This pull request updates Statamic to use the recently released [Glide 3](https://github.com/thephpleague/glide/releases/tag/3.0.0).

This PR also refactors our image file extension check, by checking against the image manipulation driver (GD / Imagick) instead of a static array of file extensions.