### PR TITLE
[6.x] Run Windows tests against Laravel 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,11 +22,11 @@ jobs:
         os: [ubuntu-latest]
         include:
           - os: windows-latest
-            php: 8.3
+            php: 8.4
             laravel: 11.*
             stability: prefer-stable
           - os: windows-latest
-            php: 8.3
+            php: 8.4
             laravel: 12.*
             stability: prefer-stable
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,10 @@ jobs:
             php: 8.3
             laravel: 11.*
             stability: prefer-stable
+          - os: windows-latest
+            php: 8.3
+            laravel: 12.*
+            stability: prefer-stable
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 


### PR DESCRIPTION
On `5.x`, the Windows tests are running against both Laravel 10 and 11:

https://github.com/statamic/cms/blob/8d477deaea868b7bf3c7ea0dbe95cb8acfa8e842/.github/workflows/tests.yml#L23-L31

However, right now on `master`, we're only running Windows tests against Laravel 11. This pull request adds Laravel 12 to the matrix. It also adjusts the PHP version they're run on to PHP 8.4.