### PR TITLE
[5.x] Fix values being wrapped in arrays causing multiple selected options 

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -52,7 +52,7 @@ trait HasSelectOptions
     {
         $values = $this->preProcess($value);
 
-        $values = collect(is_array($values) ? $values : [$values]);
+        $values = collect($values)->toArray();
 
         return $values->map(function ($value) {
             return $this->getLabel($value);
@@ -67,7 +67,7 @@ trait HasSelectOptions
             return [];
         }
 
-        $value = is_array($value) ? $value : [$value];
+        $value = collect($value)->toArray();
 
         $values = collect($value)->map(function ($value) {
             return $this->config('cast_booleans') ? $this->castFromBoolean($value) : $value;

--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -52,9 +52,8 @@ trait HasSelectOptions
     {
         $values = $this->preProcess($value);
 
-        $values = collect($values)->toArray();
-
-        return $values->map(function ($value) {
+        // NOTE: Null-coalescing into `[null]` as that matches old behaviour.
+        return collect($values ?? [null])->map(function ($value) {
             return $this->getLabel($value);
         })->all();
     }
@@ -67,9 +66,8 @@ trait HasSelectOptions
             return [];
         }
 
-        $value = collect($value)->toArray();
-
-        $values = collect($value)->map(function ($value) {
+        // NOTE: Null-coalescing into `[null]` as that matches old behaviour.
+        $values = collect($value ?? [null])->map(function ($value) {
             return $this->config('cast_booleans') ? $this->castFromBoolean($value) : $value;
         });
 


### PR DESCRIPTION
Following on from https://github.com/statamic/cms/issues/11333 and the related PR https://github.com/statamic-rad-pack/runway/pull/654 this fix ensures that the `HasSelectOptions` field type trait correctly casts pre-processed values to an array even if they are collections.

This addresses issues caused both when extending a select fieldtype to utilise collections and issues caused by Runway changes where collection values are no longer being cast to arrays.

Fixes https://github.com/statamic/cms/issues/11333
Replaces https://github.com/statamic-rad-pack/runway/pull/654