### PR TITLE
[5.x] Hide read only and computed fields in user creation wizard

### DIFF
--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -140,6 +140,7 @@ class UsersController extends CpController
 
         $additional = $fields->all()
             ->reject(fn ($field) => in_array($field->handle(), ['roles', 'groups', 'super']))
+            ->reject(fn ($field) => in_array($field->visibility(), ['read_only', 'computed']))
             ->keys();
 
         $viewData = [


### PR DESCRIPTION
This pull request hides fields marked as "read only" and "computed" from the user creation wizard, as they're pretty useless.

## Before

![CleanShot 2025-03-28 at 17 57 07](https://github.com/user-attachments/assets/548face5-15f2-4d76-bc3d-182e4e7ab47b)

## After

![CleanShot 2025-03-28 at 17 57 23](https://github.com/user-attachments/assets/01489eb3-fa71-490a-a73a-78b265f0d682)
