### PR TITLE
[5.x] Restore error message on asset upload server errors

### DIFF
--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -287,7 +287,7 @@ export default {
                 }
             }
 
-            this.handleToasts(response._toasts ?? []);
+            this.handleToasts(response?._toasts ?? []);
 
             upload.errorMessage = msg;
             upload.errorStatus = status;


### PR DESCRIPTION
Fixes #11641 by accounting for empty json responses after asset uploads. This restores error messages when uploading files that are larger than allowed by the server.