### PR TITLE
[5.x] Update nocache map on response

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -224,6 +224,13 @@ class FileCacher extends AbstractCacher
     })
     .then((response) => response.json())
     .then((data) => {
+        var els = document.getElementsByClassName('nocache');
+        var map = {};
+        for (var i = 0; i < els.length; i++) {
+            var section = els[i].getAttribute('data-nocache');
+            map[section] = els[i];
+        }
+
         const regions = data.regions;
         for (var key in regions) {
             if (map[key]) map[key].outerHTML = regions[key];

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -207,12 +207,17 @@ class FileCacher extends AbstractCacher
 
         $default = <<<EOT
 (function() {
-    var els = document.getElementsByClassName('nocache');
-    var map = {};
-    for (var i = 0; i < els.length; i++) {
-        var section = els[i].getAttribute('data-nocache');
-        map[section] = els[i];
+    function createMap() {
+        var map = {};
+        var els = document.getElementsByClassName('nocache');
+        for (var i = 0; i < els.length; i++) {
+            var section = els[i].getAttribute('data-nocache');
+            map[section] = els[i];
+        }
+        return map;
     }
+
+    var map = createMap();
 
     fetch('/!/nocache', {
         method: 'POST',
@@ -224,12 +229,7 @@ class FileCacher extends AbstractCacher
     })
     .then((response) => response.json())
     .then((data) => {
-        var els = document.getElementsByClassName('nocache');
-        var map = {};
-        for (var i = 0; i < els.length; i++) {
-            var section = els[i].getAttribute('data-nocache');
-            map[section] = els[i];
-        }
+        map = createMap(); // Recreate map in case the DOM changed.
 
         const regions = data.regions;
         for (var key in regions) {


### PR DESCRIPTION
This improves compatibility with frameworks like Vue where Html gets replaced once it has booted.

Why do we need this?
When placing the nocache tag within Vue's scope (usually id="app") our nocache tags aren't actually being replaced anymore.

Why does this happen?
Vue Replaces the html with it's computed html from the virtualdom when booting.
This means the references to the elements we've saved are stale.
Now we update our mapping after the fetch has completed so we can correctly replace our data
