### PR TITLE
[5.x] Revert "Escape start_page Preference to avoid invalid Redirect"

### DIFF
--- a/src/Http/Controllers/CP/StartPageController.php
+++ b/src/Http/Controllers/CP/StartPageController.php
@@ -10,7 +10,7 @@ class StartPageController extends CpController
     {
         session()->reflash();
 
-        $url = config('statamic.cp.route').'/'.urlencode(Preference::get('start_page', config('statamic.cp.start_page')));
+        $url = config('statamic.cp.route').'/'.Preference::get('start_page', config('statamic.cp.start_page'));
 
         return redirect($url);
     }

--- a/tests/CP/StartPageTest.php
+++ b/tests/CP/StartPageTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace CP;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\File;
+use Statamic\Facades\Preference;
+use Statamic\Facades\User;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class StartPageTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        File::delete(resource_path('preferences.yaml'));
+    }
+
+    #[Test]
+    public function it_uses_start_page_preference()
+    {
+        config('statamic.cp.start_page', 'dashboard');
+
+        Preference::default()->setPreference('start_page', 'collections/pages')->save();
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->get('/cp')
+            ->assertRedirect('/cp/collections/pages');
+    }
+
+    #[Test]
+    public function it_falls_back_to_start_page_config_option_when_preference_is_missing()
+    {
+        config('statamic.cp.start_page', 'dashboard');
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->get('/cp')
+            ->assertRedirect('/cp/dashboard');
+    }
+}


### PR DESCRIPTION
This pull request reverts #11616, as it seems to have caused an issue with some folks who use slashes in their start page URLs, which is pretty common.

I've reverted the escaping introduced in #11616, and added some additional tests.

Fixes #11649.