### PR TITLE
[5.x] Fix dirty state on preferences edit form

### DIFF
--- a/resources/js/components/preferences/EditForm.vue
+++ b/resources/js/components/preferences/EditForm.vue
@@ -108,7 +108,8 @@ export default {
                 .patch(url, this.currentValues)
                 .then(() => {
                     this.$refs.container.saved();
-                    location.reload();
+
+                    this.$nextTick(() => location.reload());
                 })
                 .catch(e => this.handleAxiosError(e));
         },


### PR DESCRIPTION
This pull request prevents a dirty state warning from showing when saving the preferences edit form.

Fixes #11636.