### PR TITLE
[5.x] Fix icon selector in nav builder

### DIFF
--- a/resources/js/components/nav/ItemEditor.vue
+++ b/resources/js/components/nav/ItemEditor.vue
@@ -43,7 +43,7 @@
                                     :initial-value="config.icon"
                                     v-slot="{ meta, value, loading, config }"
                                 >
-                                    <icon-fieldtype v-if="!loading" handle="icon" :config="config" :meta="meta" :value="value" @input="config.icon = $event" />
+                                    <icon-fieldtype v-if="!loading" handle="icon" :config="config" :meta="meta" :value="value" @input="iconUpdated" />
                                 </publish-field-meta>
                             </div>
                         </div>
@@ -132,6 +132,10 @@ export default {
             }
 
             this.$emit('updated', this.config, this.item);
+        },
+
+        iconUpdated(icon) {
+            this.config.icon = icon;
         },
 
     },

--- a/resources/js/components/nav/ItemEditor.vue
+++ b/resources/js/components/nav/ItemEditor.vue
@@ -41,9 +41,9 @@
                                 <publish-field-meta
                                     :config="{ handle: 'icon', type: 'icon', folder: 'light' }"
                                     :initial-value="config.icon"
-                                    v-slot="{ meta, value, loading, config }"
+                                    v-slot="{ meta, value, loading, config: fieldtypeConfig }"
                                 >
-                                    <icon-fieldtype v-if="!loading" handle="icon" :config="config" :meta="meta" :value="value" @input="iconUpdated" />
+                                    <icon-fieldtype v-if="!loading" handle="icon" :config="fieldtypeConfig" :meta="meta" :value="value" @input="config.icon = $event" />
                                 </publish-field-meta>
                             </div>
                         </div>
@@ -132,10 +132,6 @@ export default {
             }
 
             this.$emit('updated', this.config, this.item);
-        },
-
-        iconUpdated(icon) {
-            this.config.icon = icon;
         },
 
     },


### PR DESCRIPTION
This pull request fixes an issue with the icon field in the CP Nav Customizer. 

In #11618, a new `config` slot was made available from the `PublishFieldMeta` component. However, `config` is also a data property on the `ItemEditor` component, so when the icon was updated, the wrong bit of state was getting changed, causing things to break.

Fixes #11623.