### PR TITLE
[5.x] Allow dynamic counter names in `increment` tag

### DIFF
--- a/src/Tags/Increment.php
+++ b/src/Tags/Increment.php
@@ -36,12 +36,24 @@ class Increment extends Tags implements ResetsState
         return '';
     }
 
-    public function wildcard($tag)
+    public function index()
     {
-        if (! isset(self::$arr[$tag])) {
-            return self::$arr[$tag] = $this->params->get('from', 0);
+        $counter = $this->params->get('counter', null);
+
+        return $this->increment($counter);
+    }
+
+    public function wildcard($counter)
+    {
+        return $this->increment($counter);
+    }
+
+    protected function increment($counter)
+    {
+        if (! isset(self::$arr[$counter])) {
+            return self::$arr[$counter] = $this->params->get('from', 0);
         }
 
-        return self::$arr[$tag] = self::$arr[$tag] + $this->params->get('by', 1);
+        return self::$arr[$counter] = self::$arr[$counter] + $this->params->get('by', 1);
     }
 }

--- a/tests/Tags/IncrementTest.php
+++ b/tests/Tags/IncrementTest.php
@@ -11,12 +11,14 @@ class IncrementTest extends TestCase
     protected $data = [
         'data' => [
             [
+                'category' => 'A',
                 'articles' => [
                     ['title' => 'One'],
                     ['title' => 'Two'],
                 ],
             ],
             [
+                'category' => 'B',
                 'articles' => [
                     ['title' => 'Three'],
                     ['title' => 'Four'],
@@ -39,6 +41,19 @@ EOT;
 
         $this->assertSame(
             '0-10-20-30-',
+            $this->tag($template, $this->data)
+        );
+    }
+
+    #[Test]
+    public function increment_with_dynamic_name_works()
+    {
+        $template = <<<'EOT'
+{{ data }}{{ category }}-{{ articles }}{{ increment :counter="category" by="10" }}-{{ /articles }}{{ /data }}
+EOT;
+
+        $this->assertSame(
+            'A-0-10-B-0-10-',
             $this->tag($template, $this->data)
         );
     }


### PR DESCRIPTION
Currently, there is no way of using a dynamic counter name in the `increment` tag. Dynamic variable names don't seem to work as tag methods. This PR adds a `counter` param to allow dynamic counter names. Tests are added.

**Does not work**

```antlers
{{ articles }}
  {{ increment:@category }}st article in category {{ category }}
{{ /article }}
```

**Will now work**

```antlers
{{ articles }}
  {{ increment :counter="category" }}st article in category {{ category }}
{{ /article }}
```
