### PR TITLE
[5.x] Reindex numerical array keys in `filter_empty` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -724,7 +724,7 @@ class CoreModifiers extends Modifier
     {
         return collect($value)
             ->filter()
-            ->when(array_is_list($value), fn ($collection) => $collection->values())
+            ->when(is_array($value) && array_is_list($value), fn ($collection) => $collection->values())
             ->when(is_array($value), fn ($collection) => $collection->all());
     }
 

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -724,6 +724,7 @@ class CoreModifiers extends Modifier
     {
         return collect($value)
             ->filter()
+            ->when(array_is_list($value), fn ($collection) => $collection->values())
             ->when(is_array($value), fn ($collection) => $collection->all());
     }
 

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -722,9 +722,11 @@ class CoreModifiers extends Modifier
      */
     public function filterEmpty($value)
     {
+        $isList = array_is_list(collect($value)->all());
+
         return collect($value)
             ->filter()
-            ->when(is_array($value) && array_is_list($value), fn ($collection) => $collection->values())
+            ->when($isList, fn ($collection) => $collection->values())
             ->when(is_array($value), fn ($collection) => $collection->all());
     }
 

--- a/tests/Modifiers/FilterEmptyTest.php
+++ b/tests/Modifiers/FilterEmptyTest.php
@@ -18,10 +18,24 @@ class FilterEmptyTest extends TestCase
     }
 
     #[Test]
+    public function it_reindexes_numerical_arrays(): void
+    {
+        $modified = $this->modify(['one', null, 'two', null, 'four']);
+        $this->assertEquals([0 => 'one', 1 => 'two', 2 => 'four'], $modified);
+    }
+
+    #[Test]
     public function it_removes_null_values_from_a_collection(): void
     {
         $modified = $this->modify(collect(['one' => 'one', null, 'two' => 'two', 'three' => null, 'four' => 'four']));
         $this->assertEquals(['one' => 'one', 'two' => 'two', 'four' => 'four'], $modified->all());
+    }
+
+    #[Test]
+    public function it_reindexes_numerical_collections(): void
+    {
+        $modified = $this->modify(collect(['one', null, 'two', null, 'four']));
+        $this->assertEquals([0 => 'one', 1 => 'two', 2 => 'four'], $modified->all());
     }
 
     private function modify($value, $params = [])


### PR DESCRIPTION
Currently, the `filter_empty` modifier only filters the results without reindexing keys, which results in skipped indexes on numerical arrays. This becomes a problem when casting to json. Since the array has missing indexes, it gets stringified into an object instead of an array, breaking js functionality. 

This fix consists in making sure that numerical arrays going into the modifier also come out as numerical arrays. Associative arrays and collections are left as is.

## Example

```antlers
<div x-data='{ categories: {{ categories | filter_empty | to_json }} }'>
```

**Before**

```html
<div x-data='{ categories: { "1": "shirts", "3": "pants" }'>
```

**After**

```html
<div x-data='{ categories: ["shirts", "pants"] }'>
```