### PR TITLE
[6.x] Fix a bug where Saving entry would move it to the last place in the parent hierarchy

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -244,9 +244,11 @@ class EntriesController extends CpController
                         $parent = null;
                     }
 
-                    $tree
-                        ->move($entry->id(), $parent)
-                        ->save();
+                    if(!$tree->isAlreadyInParent($entry->id(), $parent)){
+                        $tree
+                            ->move($entry->id(), $parent)
+                            ->save();
+                    }
                 });
 
                 $entry->remove('parent');

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -244,7 +244,7 @@ class EntriesController extends CpController
                         $parent = null;
                     }
 
-                    if(!$tree->isAlreadyInParent($entry->id(), $parent)){
+                    if (! $tree->isAlreadyInParent($entry->id(), $parent)) {
                         $tree
                             ->move($entry->id(), $parent)
                             ->save();

--- a/src/Revisions/Revisable.php
+++ b/src/Revisions/Revisable.php
@@ -94,9 +94,11 @@ trait Revisable
                 $parent = null;
             }
 
-            $tree
-                ->move($this->id(), $parent)
-                ->save();
+            if($tree->isAlreadyInParent($item->id(), $parent)){
+                $tree
+                    ->move($this->id(), $parent)
+                    ->save();
+            }
         }
 
         $item

--- a/src/Revisions/Revisable.php
+++ b/src/Revisions/Revisable.php
@@ -94,7 +94,7 @@ trait Revisable
                 $parent = null;
             }
 
-            if($tree->isAlreadyInParent($item->id(), $parent)){
+            if ($tree->isAlreadyInParent($item->id(), $parent)) {
                 $tree
                     ->move($this->id(), $parent)
                     ->save();

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -284,6 +284,11 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Entr
         return $this;
     }
 
+    public function getChildren():array
+    {
+        return $this->children;
+    }
+
     public function setPageData(array $data): self
     {
         $this->data = $data;

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -284,7 +284,7 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Entr
         return $this;
     }
 
-    public function getChildren():array
+    public function getChildren(): array
     {
         return $this->children;
     }

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -394,4 +394,18 @@ abstract class Tree implements Contract, Localization
             'tree' => $this->tree,
         ];
     }
+
+    public function isAlreadyInParent($entryId, $parentId = null): bool
+    {
+        if ($parentId) {
+            $parentPage = $this->find($parentId);
+            if (! $parentPage) {
+                return false;
+            }
+            $childrenIds = Arr::pluck($parentPage->getChildren(), $this->idKey());
+        } else {
+            $childrenIds = collect($this->tree)->pluck($this->idKey())->all();
+        }
+        return in_array($entryId, $childrenIds);
+    }
 }

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -406,6 +406,7 @@ abstract class Tree implements Contract, Localization
         } else {
             $childrenIds = collect($this->tree)->pluck($this->idKey())->all();
         }
+
         return in_array($entryId, $childrenIds);
     }
 }


### PR DESCRIPTION
Hey team! 👋

I found a bug related to structured, orderable collections.

🔍 Issue:
Whenever you save an entry that already has a parent in the structure, it’s always moved to the bottom of the parent’s hierarchy, even if its position shouldn’t change.

🛠️ Fix:
I’ve added a check to prevent reordering if the entry is already under the same parent. This preserves the current structure unless a move is truly needed.

🧪 To reproduce:
	1.	Create an orderable collection with structure.
	2.	Add a few entries — some nested under others.
	3.	Edit and save a nested entry.
👉 You’ll see it gets pushed to the bottom of its parent’s children.

I’ve implemented the fix in my own codebase. If it’s helpful for core, happy to contribute it.
Let me know if you’d like me to adjust anything or improve the approach — happy to collaborate! 🙌

Thanks! 🚀
