### PR TITLE
[6.x] Fix `show_field` escaping when using `form:create` and `form:fields` tags in blade

### DIFF
--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -3,9 +3,11 @@
 namespace Statamic\Tags\Concerns;
 
 use Closure;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\MessageBag;
 use Statamic\Fields\Field;
 use Statamic\Forms\RenderableField;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
 trait RendersForms
@@ -165,6 +167,10 @@ trait RendersForms
 
         if ($manipulateDataCallback instanceof Closure) {
             $data = $manipulateDataCallback($data, $field);
+        }
+
+        if ($showField = Arr::get($data, 'show_field')) {
+            $data['show_field'] = new HtmlString($showField);
         }
 
         $data['field'] = new RenderableField($field, $data);

--- a/tests/Tags/Form/FormCreateCustomDriverTest.php
+++ b/tests/Tags/Form/FormCreateCustomDriverTest.php
@@ -57,9 +57,9 @@ EOT
     {
         $output = $this->tag(<<<'EOT'
 {{ form:contact js="custom_driver" }}
-    {{ fields }}
+    {{ form:fields }}
         <script>{{ custom_field_js }}</script>
-    {{ /fields }}
+    {{ /form:fields }}
 {{ /form:contact }}
 EOT
         );
@@ -74,9 +74,9 @@ EOT
     {
         $output = $this->normalizeHtml($this->tag(<<<'EOT'
 {{ form:contact js="custom_driver" }}
-    {{ fields }}
+    {{ form:fields }}
         {{ field }}
-    {{ /fields }}
+    {{ /form:fields }}
 {{ /form:contact }}
 EOT
         ));
@@ -100,9 +100,9 @@ EOT
     {
         $output = $this->tag(<<<'EOT'
 {{ form:contact js="custom_driver" }}
-    {{ fields }}
+    {{ form:fields }}
         <script>{{ show_field }}</script>
-    {{ /fields }}
+    {{ /form:fields }}
 {{ /form:contact }}
 EOT
         );

--- a/tests/Tags/Form/FormTestCase.php
+++ b/tests/Tags/Form/FormTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Tags\Form;
 
+use Illuminate\Support\Facades\Blade;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Form;
 use Statamic\Facades\Parse;
@@ -67,9 +68,14 @@ abstract class FormTestCase extends TestCase
         ], $headers));
     }
 
-    protected function tag($tag, $params = [])
+    protected function tag($string, $context = [])
     {
-        return Parse::template($tag, $params);
+        return Parse::template($string, $context);
+    }
+
+    protected function blade($string, $context = [])
+    {
+        return Blade::render($string, $context);
     }
 
     protected function createForm($blueprintContents = null, $handle = null)


### PR DESCRIPTION
Missed this in https://github.com/statamic/cms/pull/10976.

This PR allows you to use `{{ ... }}` braces around `show_field` in blade, [as documented](https://github.com/statamic/docs/pull/1606).