### PR TITLE
[5.x] Handle translation issues in collection widget

### DIFF
--- a/resources/views/widgets/collection.blade.php
+++ b/resources/views/widgets/collection.blade.php
@@ -1,4 +1,5 @@
 @php use Statamic\Facades\Site; @endphp
+@php use function Statamic\trans as __; @endphp
 
 <div class="card p-0 overflow-hidden h-full flex flex-col">
     <div class="flex justify-between items-center p-4 border-b dark:bg-dark-650 dark:border-b dark:border-dark-900">


### PR DESCRIPTION
Fix exceptions in case a string is translated that also exists as a translation file. Same as #11422 and #11578 but for the `collection` cp widget.

