### PR TITLE
[5.x] Show folders when replacing assets

### DIFF
--- a/src/Actions/ReplaceAsset.php
+++ b/src/Actions/ReplaceAsset.php
@@ -63,7 +63,6 @@ class ReplaceAsset extends Action
                 'max_files' => 1,
                 'validate' => 'required',
                 'mode' => 'list',
-                'restrict' => true,
                 'allow_uploads' => true,
                 'show_filename' => true,
             ],


### PR DESCRIPTION
Currently, when you replace an asset, it's not possible to select assets within folders. 

I can't see any reason it shouldn't be possible (and it seems to work for me), so I've removed the `restrict` option from the assets field.

Fixes #11676.