### PR TITLE
[5.x] Fix appended form config fields when user locale differs from app locale

### DIFF
--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -361,7 +361,7 @@ class FormsController extends CpController
         foreach (Form::extraConfigFor($form->handle()) as $handle => $config) {
             $merged = false;
             foreach ($fields as $sectionHandle => $section) {
-                if ($section['display'] == $config['display']) {
+                if ($section['display'] == __($config['display'])) {
                     $fields[$sectionHandle]['fields'] += $config['fields'];
                     $merged = true;
                 }


### PR DESCRIPTION
This pull request fixes an issue with appended form config fields when the user's locale differs from the application's locale.

For example: if you append fields to the existing "Fields" section, and a user is viewing the Control Panel in German, your appended fields would show but the existing fields wouldn't. 

```php
\Statamic\Facades\Form::appendConfigFields('*', 'Fields', [
    'a' => ['type' => 'text', 'display' => 'First injected into fields section'],
    'b' => ['type' => 'text', 'display' => 'Second injected into fields section'],
]);
```

![CleanShot 2025-04-15 at 12 43 19](https://github.com/user-attachments/assets/e94b0cb4-55c7-4e6e-b341-5f23176d8667)


This pull request fixes it by translating the section's `display` in the fields merging logic.

Fixes #11672.