### PR TITLE
[5.x] Ensure asset references are updated correctly

### DIFF
--- a/src/Listeners/UpdateAssetReferences.php
+++ b/src/Listeners/UpdateAssetReferences.php
@@ -85,16 +85,21 @@ class UpdateAssetReferences extends Subscriber implements ShouldQueue
 
         $container = $asset->container()->handle();
 
-        $updatedItems = $this
+        $hasUpdatedItems = false;
+
+        $this
             ->getItemsContainingData()
-            ->map(function ($item) use ($container, $originalPath, $newPath) {
-                return AssetReferenceUpdater::item($item)
+            ->each(function ($item) use ($container, $originalPath, $newPath, &$hasUpdatedItems) {
+                $updated = AssetReferenceUpdater::item($item)
                     ->filterByContainer($container)
                     ->updateReferences($originalPath, $newPath);
-            })
-            ->filter();
 
-        if ($updatedItems->isNotEmpty()) {
+                if ($updated) {
+                    $hasUpdatedItems = true;
+                }
+            });
+
+        if ($hasUpdatedItems) {
             AssetReferencesUpdated::dispatch($asset);
         }
     }


### PR DESCRIPTION
This pull request ensures that references to assets in content are updated correctly, fixing an issue where only the first instance of an asset was being updated.

This was caused by the introduction of returning `LazyCollections` from `->getItemsContainingData()` in #11442. It seems like `->map()` wasn't getting further than the first instance, whereas `->each()` works as expected.

Fixes #11662 
Fixes #11690