### PR TITLE
[5.x] Remove `templates`/`themes` methods from `CpController`

### DIFF
--- a/src/Http/Controllers/CP/CpController.php
+++ b/src/Http/Controllers/CP/CpController.php
@@ -5,13 +5,8 @@ namespace Statamic\Http\Controllers\CP;
 use Illuminate\Auth\Access\AuthorizationException as LaravelAuthException;
 use Illuminate\Http\Request;
 use Statamic\Exceptions\AuthorizationException;
-use Statamic\Facades\File;
-use Statamic\Facades\Folder;
-use Statamic\Facades\YAML;
 use Statamic\Http\Controllers\Controller;
 use Statamic\Statamic;
-use Statamic\Support\Arr;
-use Statamic\Support\Str;
 
 /**
  * The base control panel controller.
@@ -29,43 +24,6 @@ class CpController extends Controller
     public function __construct(Request $request)
     {
         $this->request = $request;
-    }
-
-    /**
-     * Get all the template names from the current theme.
-     *
-     * @return array
-     */
-    public function templates()
-    {
-        $templates = [];
-
-        foreach (Folder::disk('resources')->getFilesByTypeRecursively('templates', 'html') as $path) {
-            $parts = explode('/', $path);
-            array_shift($parts);
-            $templates[] = Str::removeRight(implode('/', $parts), '.html');
-        }
-
-        return $templates;
-    }
-
-    public function themes()
-    {
-        $themes = [];
-
-        foreach (Folder::disk('themes')->getFolders('/') as $folder) {
-            $name = $folder;
-
-            // Get the name if one exists in a meta file
-            if (File::disk('themes')->exists($folder.'/meta.yaml')) {
-                $meta = YAML::parse(File::disk('themes')->get($folder.'/meta.yaml'));
-                $name = Arr::get($meta, 'name', $folder);
-            }
-
-            $themes[] = compact('folder', 'name');
-        }
-
-        return $themes;
     }
 
     /**


### PR DESCRIPTION
I stumbled across these methods the other day, which seem to be leftover from v2 when we had the concepts of themes and templates.

We don't seem to be using them anywhere, and I'm not sure if they even work, so it should be pretty safe to remove them.