### PR TITLE
[6.x] Replace fuse.js with fuzzysort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "codemirror": "5.65.12",
         "cookies-js": "^1.2.2",
         "floating-vue": "^5.2.2",
-        "fuse.js": "^7.0.0",
         "fuzzysort": "^3.1.0",
         "highlight.js": "^11.7.0",
         "imask": "^7.6.1",
@@ -3532,14 +3531,6 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
-      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fuzzysort": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "cookies-js": "^1.2.2",
         "floating-vue": "^5.2.2",
         "fuse.js": "^7.0.0",
+        "fuzzysort": "^3.1.0",
         "highlight.js": "^11.7.0",
         "imask": "^7.6.1",
         "laravel-echo": "^1.16.0",
@@ -3540,6 +3541,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/fuzzysort": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
+      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
+      "license": "MIT"
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "cookies-js": "^1.2.2",
     "floating-vue": "^5.2.2",
     "fuse.js": "^7.0.0",
+    "fuzzysort": "^3.1.0",
     "highlight.js": "^11.7.0",
     "imask": "^7.6.1",
     "laravel-echo": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "codemirror": "5.65.12",
     "cookies-js": "^1.2.2",
     "floating-vue": "^5.2.2",
-    "fuse.js": "^7.0.0",
     "fuzzysort": "^3.1.0",
     "highlight.js": "^11.7.0",
     "imask": "^7.6.1",

--- a/resources/js/components/data-list/DataList.vue
+++ b/resources/js/components/data-list/DataList.vue
@@ -1,5 +1,5 @@
 <script>
-import Fuse from 'fuse.js';
+import fuzzysort from 'fuzzysort';
 import { sortBy } from 'lodash-es';
 
 export default {
@@ -125,14 +125,12 @@ export default {
         filterBySearch(rows) {
             if (!this.searchQuery) return rows;
 
-            const fuse = new Fuse(rows, {
-                findAllMatches: true,
-                threshold: 0.1,
-                minMatchCharLength: 2,
-                keys: this.searchableColumns,
-            });
-
-            return fuse.search(this.searchQuery).map((result) => result.item);
+            return fuzzysort
+                .go(this.searchQuery, rows, {
+                    all: true,
+                    keys: this.searchableColumns,
+                })
+                .map(result => result.obj);
         },
 
         sortRows(rows) {

--- a/resources/js/components/data-list/FieldFilter.vue
+++ b/resources/js/components/data-list/FieldFilter.vue
@@ -52,7 +52,7 @@
 <script>
 import Validator from '../field-conditions/Validator.js';
 import PublishField from '../publish/Field.vue';
-import { sortBy } from 'lodash-es';
+import { sortBy, mapValues } from 'lodash-es';
 import debounce from '@statamic/util/debounce.js';
 
 export default {
@@ -103,20 +103,18 @@ export default {
         isFilterComplete() {
             if (!this.filter) return false;
 
-            let visibleFields = _.chain(this.filter.fields)
+            let visibleFields = this.filter.fields
                 .filter(function (field) {
                     let validator = new Validator(field, this.fieldValues);
                     return validator.passesConditions();
-                }, this)
-                .mapObject((field) => field.handle)
-                .values()
-                .value();
+                }, this);
 
-            let allFieldsFilled =
-                _.chain(this.fieldValues)
-                    .filter((value, handle) => visibleFields.includes(handle) && value)
-                    .values()
-                    .value().length === visibleFields.length;
+            visibleFields = mapValues(visibleFields, field => field.handle);
+            visibleFields = Object.values(visibleFields);
+
+            let allFieldsFilled = Object.entries(this.fieldValues || {})
+                .filter(([handle, value]) => visibleFields.includes(handle) && value)
+                .length === visibleFields.length;
 
             return this.field !== null && allFieldsFilled;
         },

--- a/resources/js/components/data-list/Search.vue
+++ b/resources/js/components/data-list/Search.vue
@@ -3,7 +3,7 @@
         type="text"
         ref="input"
         :placeholder="__(placeholder)"
-        :value="value"
+        :value="modelValue"
         @input="emitEvent"
         @keyup.esc="reset"
         autofocus
@@ -15,14 +15,12 @@
 import debounce from '@statamic/util/debounce.js';
 
 export default {
-    props: ['value'],
-
     props: {
         placeholder: {
             type: String,
             default: 'Search...',
         },
-        value: {
+        modelValue: {
             type: String,
             default: '',
         },
@@ -30,11 +28,11 @@ export default {
 
     methods: {
         emitEvent: debounce(function (event) {
-            this.$emit('input', event.target.value);
+            this.$emit('update:model-value', event.target.value);
         }, 300),
 
         reset() {
-            this.$emit('input', '');
+            this.$emit('update:model-value', '');
         },
 
         focus() {


### PR DESCRIPTION
This PR replaces our usages of fuse.js with [fuzzysort](https://github.com/farzher/fuzzysort) (since we're now using fuzzysort with the new [command palette](https://github.com/statamic/cms/pull/11699)).

It also fixes a few small regressions that were missed from the Vue3 and lodash upgrades.

References https://github.com/statamic/cms/pull/11699
References https://github.com/statamic/cms/pull/11339
References https://github.com/statamic/cms/pull/11529