### PR TITLE
[5.x] Fix static caching of requests with trailing dot in host

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -178,12 +178,22 @@ class FileCacher extends AbstractCacher
         $pathParts = pathinfo($urlParts['path']);
         $slug = $pathParts['basename'];
         $query = $this->config('ignore_query_strings') ? '' : Arr::get($urlParts, 'query', '');
+        $sitePath = $this->getCachePath($site);
 
         if ($this->isBasenameTooLong($basename = $slug.'_'.$query.'.html')) {
             $basename = $slug.'_lqs_'.md5($query).'.html';
         }
 
-        return $this->getCachePath($site).$pathParts['dirname'].'/'.$basename;
+        if ($this->isHostnameWithPeriod($urlParts['host'])) {
+            $sitePath .= '.';
+        }
+
+        return $sitePath.$pathParts['dirname'].'/'.$basename;
+    }
+
+    private function isHostnameWithPeriod($hostname)
+    {
+        return str_ends_with($hostname, '.');
     }
 
     private function isBasenameTooLong($basename)

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -184,7 +184,7 @@ class FileCacher extends AbstractCacher
             $basename = $slug.'_lqs_'.md5($query).'.html';
         }
 
-        if ($this->hasTrailingDot($urlParts['host'])) {
+        if ($this->hasTrailingDot($urlParts['host'] ?? '')) {
             $sitePath .= '.';
         }
 

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -184,14 +184,14 @@ class FileCacher extends AbstractCacher
             $basename = $slug.'_lqs_'.md5($query).'.html';
         }
 
-        if ($this->isHostnameWithPeriod($urlParts['host'])) {
+        if ($this->hasTrailingDot($urlParts['host'])) {
             $sitePath .= '.';
         }
 
         return $sitePath.$pathParts['dirname'].'/'.$basename;
     }
 
-    private function isHostnameWithPeriod($hostname)
+    private function hasTrailingDot($hostname)
     {
         return str_ends_with($hostname, '.');
     }

--- a/tests/StaticCaching/FileCacherTest.php
+++ b/tests/StaticCaching/FileCacherTest.php
@@ -154,8 +154,8 @@ class FileCacherTest extends TestCase
         ]);
 
         $this->assertEquals(
-            'test/path./foo_.html',
-            $cacher->getFilePath('http://domain.com./foo')
+            'test/path./foo/bar_.html',
+            $cacher->getFilePath('http://domain.com./foo/bar')
         );
     }
 

--- a/tests/StaticCaching/FileCacherTest.php
+++ b/tests/StaticCaching/FileCacherTest.php
@@ -147,6 +147,19 @@ class FileCacherTest extends TestCase
     }
 
     #[Test]
+    public function gets_file_path_with_trailing_dot()
+    {
+        $cacher = $this->fileCacher([
+            'path' => 'test/path',
+        ]);
+
+        $this->assertEquals(
+            'test/path./foo_.html',
+            $cacher->getFilePath('http://domain.com./foo')
+        );
+    }
+
+    #[Test]
     public function flushing_the_cache_deletes_from_all_cache_locations()
     {
         $writer = \Mockery::spy(Writer::class);


### PR DESCRIPTION
Fixes #11504

I've added a quick check here that makes sure any requests with a trailing dot get cached in a separate folder, as well as a test case that makes sure that it works.

Alternatively, we could just not make it cache these at all? I'm not sure what the best approach here is.