### PR TITLE
[5.x] Make Live Preview force reload JS modules optional

### DIFF
--- a/config/live_preview.php
+++ b/config/live_preview.php
@@ -38,7 +38,7 @@ return [
     | Force Reload Javascript Modules
     |--------------------------------------------------------------------------
     |
-    | To force a reload, Live Preview appends a timestamp to the URL on 
+    | To force a reload, Live Preview appends a timestamp to the URL on
     | script tags of type 'module'. You may disable this behavior here.
     |
     */

--- a/config/live_preview.php
+++ b/config/live_preview.php
@@ -33,4 +33,16 @@ return [
         //
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Force Reload Javascript Modules
+    |--------------------------------------------------------------------------
+    |
+    | To force a reload, Live Preview appends a timestamp to the URL on 
+    | script tags of type 'module'. You may disable this behavior here.
+    |
+    */
+
+    'force_reload_js_modules' => true,
+
 ];

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -149,7 +149,7 @@ class DataResponse implements Responsable
     {
         $contents = $this->view()->render();
 
-        if ($this->request->isLivePreview()) {
+        if ($this->request->isLivePreview() && config('statamic.live_preview.force_reload_js_modules', true)) {
             $contents = $this->versionJavascriptModules($contents);
         }
 


### PR DESCRIPTION
Force reloading JS modules in Live Preview seems to break Vue hydration when using async components, resulting in a blank website (in Live Preview), or hydration errors in the console.

This was introduced a few years ago, here: https://github.com/statamic/cms/pull/3524

This PR makes "Force Reload JS Modules in Live Preview" optional.