### PR TITLE
[5.x] Allow custom nocache db connection

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -115,7 +115,9 @@ return [
     | Nocache
     |--------------------------------------------------------------------------
     |
-    | Here you may define where the nocache data is stored.
+    | Here you may define where the nocache data is stored. You can also
+    | optionally set a different database connection for the
+    | `nocache_regions` table.
     |
     | https://statamic.dev/tags/nocache#database
     |
@@ -124,6 +126,8 @@ return [
     */
 
     'nocache' => 'cache',
+
+    'nocache_db_connection' => env('STATAMIC_NOCACHE_DB_CONNECTION', null),
 
     'nocache_js_position' => 'body',
 

--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -125,7 +125,7 @@ return [
 
     'nocache' => 'cache',
 
-    'nocache_db_connection' => env('STATAMIC_NOCACHE_DB_CONNECTION', null),
+    'nocache_db_connection' => env('STATAMIC_NOCACHE_DB_CONNECTION'),
 
     'nocache_js_position' => 'body',
 

--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -115,9 +115,7 @@ return [
     | Nocache
     |--------------------------------------------------------------------------
     |
-    | Here you may define where the nocache data is stored. You can also
-    | optionally set a different database connection for the
-    | `nocache_regions` table.
+    | Here you may define where the nocache data is stored.
     |
     | https://statamic.dev/tags/nocache#database
     |

--- a/src/Console/Commands/NocacheMigration.php
+++ b/src/Console/Commands/NocacheMigration.php
@@ -37,14 +37,6 @@ class NocacheMigration extends Command
 
         $this->components->info("Migration [$file] created successfully.");
 
-        // Inform the user about the connection being used
-        $connection = config('statamic.static_caching.nocache_db_connection');
-        if ($connection) {
-            $this->components->info("The migration will use the '{$connection}' database connection.");
-        } else {
-            $this->components->info('The migration will use the default database connection.');
-        }
-
         $this->composer->dumpAutoloads();
     }
 }

--- a/src/Console/Commands/NocacheMigration.php
+++ b/src/Console/Commands/NocacheMigration.php
@@ -37,6 +37,14 @@ class NocacheMigration extends Command
 
         $this->components->info("Migration [$file] created successfully.");
 
+        // Inform the user about the connection being used
+        $connection = config('statamic.static_caching.nocache_db_connection');
+        if ($connection) {
+            $this->components->info("The migration will use the '{$connection}' database connection.");
+        } else {
+            $this->components->info('The migration will use the default database connection.');
+        }
+
         $this->composer->dumpAutoloads();
     }
 }

--- a/src/Console/Commands/stubs/statamic_nocache_tables.php.stub
+++ b/src/Console/Commands/stubs/statamic_nocache_tables.php.stub
@@ -8,12 +8,9 @@ class StatamicNocacheTables extends Migration
 {
     public function up()
     {
-        // Use the configured connection if available
-        $connection = config('statamic.static_caching.nocache_db_connection');
-
-        $schema = $connection ? Schema::connection($connection) : Schema::class;
-
-        $schema->create('NOCACHE_TABLE', function (Blueprint $table) {
+        Schema::connection(
+            config('statamic.static_caching.nocache_db_connection')
+        )->create('NOCACHE_TABLE', function (Blueprint $table) {
             $table->string('key')->index()->primary();
             $table->string('url')->index();
             $table->longText('region');
@@ -23,11 +20,8 @@ class StatamicNocacheTables extends Migration
 
     public function down()
     {
-        // Use the configured connection if available
-        $connection = config('statamic.static_caching.nocache_db_connection');
-
-        $schema = $connection ? Schema::connection($connection) : Schema::class;
-
-        $schema->dropIfExists('NOCACHE_TABLE');
+        Schema::connection(
+            config('statamic.static_caching.nocache_db_connection')
+        )->dropIfExists('NOCACHE_TABLE');
     }
 }

--- a/src/Console/Commands/stubs/statamic_nocache_tables.php.stub
+++ b/src/Console/Commands/stubs/statamic_nocache_tables.php.stub
@@ -8,7 +8,12 @@ class StatamicNocacheTables extends Migration
 {
     public function up()
     {
-        Schema::create('NOCACHE_TABLE', function (Blueprint $table) {
+        // Use the configured connection if available
+        $connection = config('statamic.static_caching.nocache_db_connection');
+
+        $schema = $connection ? Schema::connection($connection) : Schema::class;
+
+        $schema->create('NOCACHE_TABLE', function (Blueprint $table) {
             $table->string('key')->index()->primary();
             $table->string('url')->index();
             $table->longText('region');
@@ -18,6 +23,11 @@ class StatamicNocacheTables extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('nocache_regions');
+        // Use the configured connection if available
+        $connection = config('statamic.static_caching.nocache_db_connection');
+
+        $schema = $connection ? Schema::connection($connection) : Schema::class;
+
+        $schema->dropIfExists('NOCACHE_TABLE');
     }
 }

--- a/src/StaticCaching/NoCache/DatabaseRegion.php
+++ b/src/StaticCaching/NoCache/DatabaseRegion.php
@@ -15,4 +15,15 @@ class DatabaseRegion extends Model
     protected $casts = [
         'key' => 'string',
     ];
+
+    /**
+     * Get the database connection for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName(): ?string
+    {
+        // Use the connection from config, or fall back to parent (default connection)
+        return config('statamic.static_caching.nocache_db_connection') ?: parent::getConnectionName();
+    }
 }

--- a/src/StaticCaching/NoCache/DatabaseRegion.php
+++ b/src/StaticCaching/NoCache/DatabaseRegion.php
@@ -16,7 +16,7 @@ class DatabaseRegion extends Model
         'key' => 'string',
     ];
 
-    public function getConnectionName(): ?string
+    public function getConnectionName()
     {
         return config('statamic.static_caching.nocache_db_connection') ?: parent::getConnectionName();
     }

--- a/src/StaticCaching/NoCache/DatabaseRegion.php
+++ b/src/StaticCaching/NoCache/DatabaseRegion.php
@@ -16,12 +16,8 @@ class DatabaseRegion extends Model
         'key' => 'string',
     ];
 
-    /**
-     * Get the database connection for the model.
-     */
     public function getConnectionName(): ?string
     {
-        // Use the connection from config, or fall back to parent (default connection)
         return config('statamic.static_caching.nocache_db_connection') ?: parent::getConnectionName();
     }
 }

--- a/src/StaticCaching/NoCache/DatabaseRegion.php
+++ b/src/StaticCaching/NoCache/DatabaseRegion.php
@@ -18,8 +18,6 @@ class DatabaseRegion extends Model
 
     /**
      * Get the database connection for the model.
-     *
-     * @return string|null
      */
     public function getConnectionName(): ?string
     {


### PR DESCRIPTION
## The Problem
Users cannot specify a separate database connection for the nocache_regions table without modifying Statamic core code. Sometimes, this table can get really big and you may not want to include it on frequent backups. You may also want to move this table specifically closer to the Statamic install to reduce latency.
## The Solution
This PR adds a configuration option to allow specifying a different database connection for the `nocache_regions` table.
## Backward Compatibility
This change is fully backward compatible as it defaults to the current behavior (using the default database connection) when no configuration is provided.
## Usage Example
```php
// In .env file
STATAMIC_NOCACHE_DB_CONNECTION=nocache

// Or in config/statamic/static_caching.php
'nocache_db_connection' => 'nocache',

// In config/database.php
        'nocache' => [
            'driver' => 'mysql',
            'host' => env('NOCACHE_DB_HOST', env('DB_HOST', '127.0.0.1')),
            'port' => env('NOCACHE_DB_PORT', env('DB_PORT', '3306')),
            'database' => env('NOCACHE_DB_DATABASE', 'nocache'),
            'username' => env('NOCACHE_DB_USERNAME', env('DB_USERNAME')),
            'password' => env('NOCACHE_DB_PASSWORD', env('DB_PASSWORD')),
            'charset' => 'utf8mb4',
            'collation' => 'utf8mb4_unicode_ci',
            'prefix' => '',
            'strict' => true,
            'engine' => null,
        ],
```