### PR TITLE
[5.x] Safer check on parent tag

### DIFF
--- a/src/Tags/ParentTags.php
+++ b/src/Tags/ParentTags.php
@@ -26,13 +26,7 @@ class ParentTags extends Tags
     {
         $var_name = Stringy::removeLeft($this->tag, 'parent:');
 
-        $parent = $this->getParent();
-
-        if (! $parent) {
-            return null;
-        }
-
-        return Arr::get($parent, $var_name)->value();
+        return Arr::get($this->getParent(), $var_name)?->value();
     }
 
     /**

--- a/src/Tags/ParentTags.php
+++ b/src/Tags/ParentTags.php
@@ -60,10 +60,8 @@ class ParentTags extends Tags
 
     /**
      * Get the parent data.
-     *
-     * @return ?array
      */
-    private function getParent()
+    private function getParent(): ?array
     {
         $segments = explode('/', Str::start(Str::after(URL::getCurrent(), Site::current()->url()), '/'));
         $segment_count = count($segments);

--- a/src/Tags/ParentTags.php
+++ b/src/Tags/ParentTags.php
@@ -26,7 +26,13 @@ class ParentTags extends Tags
     {
         $var_name = Stringy::removeLeft($this->tag, 'parent:');
 
-        return Arr::get($this->getParent(), $var_name)->value();
+        $parent = $this->getParent();
+
+        if (! $parent) {
+            return null;
+        }
+
+        return Arr::get($parent, $var_name)->value();
     }
 
     /**
@@ -61,7 +67,7 @@ class ParentTags extends Tags
     /**
      * Get the parent data.
      *
-     * @return string
+     * @return ?array
      */
     private function getParent()
     {


### PR DESCRIPTION
This PR addresses a 500 error that can be created if the tag is called on an entry without a parent. It also fixes the return type in a PHPDoc comment later in the tag class that is used by the function I edited as it expects an array (and the function clearly returns an array, not a string).

Original error:
```
Call to a member function value() on null
```
![CleanShot 2025-04-19 at 20 49 15@2x](https://github.com/user-attachments/assets/d7f9345b-b87e-4f20-9e62-302ee349b124)
