### PR TITLE
[5.x] Remove blocking duplicate exception for tree sort with pagination

### DIFF
--- a/src/Structures/CollectionStructure.php
+++ b/src/Structures/CollectionStructure.php
@@ -68,10 +68,6 @@ class CollectionStructure extends Structure
 
         $entryIds = $this->getEntryIdsFromTree($tree);
 
-        if ($entryId = $entryIds->duplicates()->first()) {
-            throw new \Exception("Duplicate entry [{$entryId}] in [{$this->collection()->handle()}] collection's structure.");
-        }
-
         $thisCollectionsEntries = $this->collection()->queryEntries()
             ->where('site', $locale)
             ->pluck('id');


### PR DESCRIPTION
Issue: https://github.com/statamic/cms/issues/11209

Problem: 
When you try to reorder entries and the entries can only be moved 1 deep the reorder has issues with pagination.
It causes duplicate entries in the tree yaml order.

Solution:
Remove the throw new \Exception the problem already gets solved without this exception.