### PR TITLE
[6.x] Fix `DefaultInvalidatorTest`

### DIFF
--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -187,7 +187,6 @@ class DefaultInvalidator implements Invalidator
             ->map(fn (string $rule) => Str::removeRight($variables->site()->url(), '/').Str::ensureLeft($rule, '/'))
             ->all();
 
-            Arr::get($this->rules, "globals.{$variables->globalSet()->handle()}.urls")
         $this->cacher->invalidateUrls([
             ...$absoluteUrls,
             ...$prefixedRelativeUrls,

--- a/tests/StaticCaching/DefaultInvalidatorTest.php
+++ b/tests/StaticCaching/DefaultInvalidatorTest.php
@@ -10,7 +10,6 @@ use Statamic\Contracts\Entries\Collection;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Contracts\Forms\Form;
 use Statamic\Contracts\Globals\GlobalSet;
-use Statamic\Contracts\Globals\Variables;
 use Statamic\Contracts\Structures\Nav;
 use Statamic\Contracts\Taxonomies\Taxonomy;
 use Statamic\Contracts\Taxonomies\Term;


### PR DESCRIPTION
This pull request fixes [failing tests](https://github.com/statamic/cms/actions/runs/14603158271) in the `DefaultInvalidator` test after `5.x` was merged into `master` yesterday.