### PR TITLE
[6.x] Add `get`, `only`, and `except` params to `form:fields` tag

### DIFF
--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -179,9 +179,9 @@ class Tags extends BaseTags
         if ($handle = $this->params->get('get')) {
             $context['fields'] = $this->dottedContextFields($fields, recursive: true)->only($handle)->values()->all();
         } elseif ($only = $this->params->get('only')) {
-            $context['fields'] = $this->dottedContextFields($fields, recursive: false)->only(explode('|', $only))->values()->all();
+            $context['fields'] = $this->dottedContextFields($fields)->only(explode('|', $only))->values()->all();
         } elseif ($except = $this->params->get('except')) {
-            $context['fields'] = $this->dottedContextFields($fields, recursive: false)->except(explode('|', $except))->values()->all();
+            $context['fields'] = $this->dottedContextFields($fields)->except(explode('|', $except))->values()->all();
         }
 
         return Antlers::parse('{{ fields '.$params.' }}'.$this->content.'{{ /fields }}', $context);

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -162,16 +162,6 @@ class Tags extends BaseTags
         collect($this->context['fields'])
             ->each(fn ($field) => $field['field']->slot($slot));
 
-        if ($isBlade) {
-            return $this->tagRenderer->render('@foreach($fields as $field)'.$this->content.'@endforeach', $this->context->all());
-        }
-
-        $params = '';
-
-        if ($scope) {
-            $params = Html::attributes(['scope' => $scope]);
-        }
-
         $context = $this->context->all();
 
         $fields = Arr::get($context, 'fields', []);
@@ -182,6 +172,16 @@ class Tags extends BaseTags
             $context['fields'] = $this->dottedContextFields($fields)->only(explode('|', $only))->values()->all();
         } elseif ($except = $this->params->get('except')) {
             $context['fields'] = $this->dottedContextFields($fields)->except(explode('|', $except))->values()->all();
+        }
+
+        if ($isBlade) {
+            return $this->tagRenderer->render('@foreach($fields as $field)'.$this->content.'@endforeach', $context);
+        }
+
+        $params = '';
+
+        if ($scope) {
+            $params = Html::attributes(['scope' => $scope]);
         }
 
         return Antlers::parse('{{ fields '.$params.' }}'.$this->content.'{{ /fields }}', $context);

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -4,6 +4,7 @@ namespace Statamic\Forms;
 
 use DebugBar\DataCollector\ConfigCollector;
 use DebugBar\DebugBarException;
+use Illuminate\Support\Collection;
 use Statamic\Contracts\Forms\Form as FormContract;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Blink;
@@ -171,7 +172,19 @@ class Tags extends BaseTags
             $params = Html::attributes(['scope' => $scope]);
         }
 
-        return Antlers::parse('{{ fields '.$params.' }}'.$this->content.'{{ /fields }}', $this->context->all());
+        $context = $this->context->all();
+
+        $fields = Arr::get($context, 'fields', []);
+
+        if ($handle = $this->params->get('get')) {
+            $context['fields'] = $this->dottedContextFields($fields, recursive: true)->only($handle)->values()->all();
+        } elseif ($only = $this->params->get('only')) {
+            $context['fields'] = $this->dottedContextFields($fields, recursive: false)->only(explode('|', $only))->values()->all();
+        } elseif ($except = $this->params->get('except')) {
+            $context['fields'] = $this->dottedContextFields($fields, recursive: false)->except(explode('|', $except))->values()->all();
+        }
+
+        return Antlers::parse('{{ fields '.$params.' }}'.$this->content.'{{ /fields }}', $context);
     }
 
     /**
@@ -426,5 +439,18 @@ class Tags extends BaseTags
         return URL::prependSiteUrl(
             config('statamic.routes.action').'/form/'.$url
         );
+    }
+
+    private function dottedContextFields(array $fields, $recursive = false, array &$dotted = []): Collection
+    {
+        foreach ($fields as $field) {
+            $dotted[$field['handle']] = $field;
+
+            if ($recursive && $fields = Arr::get($field, 'fields')) {
+                $this->dottedContextFields($fields, $recursive, $dotted);
+            }
+        }
+
+        return collect($dotted);
     }
 }

--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -150,7 +150,7 @@ trait RendersForms
             'id' => $this->generateFieldId($field->handle(), $formHandle),
             'instructions' => $field->instructions(),
             'error' => $errors->first($field->handle()) ?: null,
-            'default' => $field->value() ?? $field->defaultValue(),
+            'default' => $default,
             'old' => old($field->handle()),
             'value' => $value,
         ], $field->fieldtype()->extraRenderableFieldData());

--- a/tests/Tags/Form/FormCreateTest.php
+++ b/tests/Tags/Form/FormCreateTest.php
@@ -261,6 +261,66 @@ EOT
     }
 
     #[Test]
+    public function it_dynamically_renders_specific_fields_using_params()
+    {
+        $this->createForm([
+            'tabs' => [
+                'main' => [
+                    'sections' => [
+                        [
+                            'display' => 'Section One',
+                            'fields' => [
+                                ['handle' => 'first_name', 'field' => ['type' => 'text']],
+                                ['handle' => 'middle_name', 'field' => ['type' => 'text', 'display' => 'Middle Name']],
+                                ['handle' => 'last_name', 'field' => ['type' => 'text', 'display' => 'Last Name']],
+                                [
+                                    'handle' => 'group_one',
+                                    'field' => [
+                                        'type' => 'group',
+                                        'display' => 'Group One',
+                                        'fields' => [
+                                            ['handle' => 'nested_one', 'field' => ['type' => 'text', 'display' => 'Nested One']],
+                                            ['handle' => 'nested_two', 'field' => ['type' => 'text', 'display' => 'Nested Two']],
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    'handle' => 'group_two',
+                                    'field' => [
+                                        'type' => 'group',
+                                        'display' => 'Group Two',
+                                        'fields' => [
+                                            ['handle' => 'nested_three', 'field' => ['type' => 'text', 'display' => 'Nested One']],
+                                            ['handle' => 'nested_four', 'field' => ['type' => 'text', 'display' => 'Nested Two']],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], 'survey');
+
+        $output = $this->normalizeHtml($this->tag(<<<'EOT'
+{{ form:survey }}
+    <div class="get-top-level-field">{{ form:fields get="middle_name" }}{{ handle }},{{ /form:fields }}</div>
+    <div class="get-group-field">{{ form:fields get="group_one" }}{{ handle }},{{ /form:fields }}</div>
+    <div class="get-nested-field">{{ form:fields get="group_one.nested_two" }}{{ handle }},{{ /form:fields }}</div>
+    <div class="only-piped-fields">{{ form:fields only="middle_name|group_one" }}{{ handle }},{{ /form:fields }}</div>
+    <div class="except-piped-fields">{{ form:fields except="middle_name|group_one" }}{{ handle }},{{ /form:fields }}</div>
+{{ /form:survey }}
+EOT
+        ));
+
+        $this->assertStringContainsString('<div class="get-top-level-field">middle_name,</div>', $output);
+        $this->assertStringContainsString('<div class="get-group-field">group_one,</div>', $output);
+        $this->assertStringContainsString('<div class="get-nested-field">group_one.nested_two,</div>', $output);
+        $this->assertStringContainsString('<div class="only-piped-fields">middle_name,group_one,</div>', $output);
+        $this->assertStringContainsString('<div class="except-piped-fields">first_name,last_name,group_two,</div>', $output);
+    }
+
+    #[Test]
     public function it_dynamically_renders_fields_with_form_handle()
     {
         foreach (['contact', 'contact-form', 'kontakt_formular'] as $handle) {


### PR DESCRIPTION
Adds support for `get`, `only`, and `except` params to `form:fields` tag.

This allows the dev to lean on all the nice dynamic form rendering stuff provided by the `form:create` tag, but gives them more control over pulling out specific fields form custom column-based layouts, etc.

![image](https://github.com/user-attachments/assets/3eaebd45-46ab-465b-b6e2-0b748391aca8)

References: https://github.com/statamic/docs/pull/1606