### PR TITLE
[6.x] Fix navigation edit form state issues

### DIFF
--- a/resources/js/components/fieldtypes/grid/Row.vue
+++ b/resources/js/components/fieldtypes/grid/Row.vue
@@ -61,7 +61,8 @@ export default {
         },
         meta: {
             type: Object,
-            required: true
+            required: true,
+            default: () => ({})
         },
         name: {
             type: String,

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -101,7 +101,8 @@ export default {
         },
         meta: {
             type: Object,
-            required: true
+            required: true,
+            default: () => ({})
         },
         index: {
             type: Number,

--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -135,6 +135,8 @@
 
         <page-editor
             v-if="editingPage"
+            :publishContainer="editingPage.editorId"
+            :persist-state="true"
             :site="site"
             :id="editingPage.page.id"
             :entry="editingPage.page.entry"
@@ -152,6 +154,8 @@
         <page-editor
             v-if="creatingPage"
             creating
+            :publishContainer="creatingPage.editorId"
+            :persist-state="true"
             :site="site"
             :blueprint="blueprint"
             :handle="handle"
@@ -339,7 +343,7 @@ export default {
         },
 
         editPage(page, vm, store) {
-            this.editingPage = { page, vm, store };
+            this.editingPage = { page, vm, store, editorId: `tree-page-${page.id}` };
         },
 
         updatePage(values) {
@@ -362,7 +366,12 @@ export default {
         },
 
         openPageCreator() {
-            this.creatingPage = { info: null };
+            const uniqueId = uniqid();
+            this.creatingPage = {
+                info: null,
+                uniqueId: uniqueId,
+                editorId: `tree-page-${uniqueId}`
+            };
         },
 
         closePageCreator() {
@@ -371,7 +380,7 @@ export default {
 
         pageCreated(values) {
             const page = {
-                id: uniqid(),
+                id: this.creatingPage.uniqueId,
                 title: values.title,
                 url: values.url,
                 children: []

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -59,7 +59,7 @@ export default {
     },
 
     created() {
-        if (! this.$store.state.publish || ! this.$store.state.publish.hasOwnProperty(this.name)) {
+        if (!this.$store.hasModule(['publish', this.name])) {
             this.registerVuexModule();
         }
         this.$events.$emit('publish-container-created', this);
@@ -82,8 +82,6 @@ export default {
     methods: {
 
         registerVuexModule() {
-            const vm = this;
-
             const initial = {
                 blueprint: _.clone(this.blueprint),
                 values: _.clone(this.values),
@@ -210,14 +208,12 @@ export default {
                 actions: {
                     setFieldValue(context, payload) {
                         context.commit('setFieldValue', payload);
-                        vm.emitUpdatedEvent(context.state.values);
                     },
                     setFieldMeta(context, payload) {
                         context.commit('setFieldMeta', payload);
                     },
                     setValues(context, payload) {
                         context.commit('setValues', payload);
-                        vm.emitUpdatedEvent(context.state.values);
                     },
                     setExtraValues(context, payload) {
                         context.commit('setExtraValues', payload);
@@ -262,6 +258,7 @@ export default {
                 handle, value,
                 user: Statamic.user.id
             });
+            this.emitUpdatedEvent(this.$store.state.publish[this.name].values);
         },
 
         setFieldMeta(handle, value) {
@@ -269,6 +266,7 @@ export default {
                 handle, value,
                 user: Statamic.user.id
             });
+            this.$emit('meta-updated', this.$store.state.publish[this.name].meta);
         },
 
         dirty() {

--- a/resources/js/components/publish/Container.vue
+++ b/resources/js/components/publish/Container.vue
@@ -10,6 +10,7 @@ export default {
     },
 
     props: {
+        persistState: { type: Boolean, default: false },
         reference: {
             type: String
         },
@@ -58,12 +59,16 @@ export default {
     },
 
     created() {
-        this.registerVuexModule();
+        if (! this.$store.state.publish || ! this.$store.state.publish.hasOwnProperty(this.name)) {
+            this.registerVuexModule();
+        }
         this.$events.$emit('publish-container-created', this);
     },
 
     destroyed() {
-        this.removeVuexModule();
+        if (!this.persistState) {
+            this.removeVuexModule();
+        }
         this.clearDirtyState();
         this.$events.$emit('publish-container-destroyed', this);
     },

--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -23,6 +23,7 @@
                 <publish-container
                     ref="container"
                     :name="publishContainer"
+                    :persist-state="persistState"
                     :blueprint="adjustedBlueprint"
                     :values="values"
                     :extra-values="extraValues"
@@ -83,6 +84,8 @@ export default {
     ],
 
     props: {
+        publishContainer: { type: String, required: true },
+        persistState: Boolean,
         id: String,
         entry: String,
         site: String,
@@ -109,7 +112,6 @@ export default {
             errors: {},
             validating: false,
             saveKeyBinding: null,
-            publishContainer: 'tree-page'
         }
     },
 


### PR DESCRIPTION
Fixes #10630 & #11588

This commit fixes issues where the meta field state for the Navigation EditForm was incorrect when closed. It also resolves related errors / warnings when using Grid, Replicator and Relationship fieldtypes.