### PR TITLE
[5.x] Cleanup roles after running `SitesTest@gets_authorized_sites`

### DIFF
--- a/tests/Sites/SitesTest.php
+++ b/tests/Sites/SitesTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Sites;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Role;
 use Statamic\Facades\User;
@@ -33,6 +34,13 @@ class SitesTest extends TestCase
             'fr' => ['url' => 'http://fr.test.com/'],
             'de' => ['url' => 'http://test.com/de/'],
         ]);
+    }
+
+    public function tearDown(): void
+    {
+        File::delete(resource_path('users/roles.yaml'));
+
+        parent::tearDown();
     }
 
     #[Test]


### PR DESCRIPTION
This pull request ensures the role created in [`SitesTest@gets_authorized_sites`](https://github.com/statamic/cms/blob/573d366fe749ea1f6b847f1aafcbe1883d04e255/tests/Sites/SitesTest.php#L52) is cleaned up after running, to prevent it leaking into other tests.

Discovered while looking into failing tests in #11664.