### PR TITLE
[5.x] GraphQL should return float fieldtype values as floats

### DIFF
--- a/src/Fieldtypes/Floatval.php
+++ b/src/Fieldtypes/Floatval.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Fieldtypes;
 
+use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 use Statamic\Query\Scopes\Filters\Fields\Floatval as FloatFilter;
 
@@ -55,5 +56,10 @@ class Floatval extends Fieldtype
     public function filter()
     {
         return new FloatFilter($this);
+    }
+
+    public function toGqlType()
+    {
+        return GraphQL::type(GraphQL::float());
     }
 }

--- a/tests/Feature/GraphQL/Fieldtypes/FloatvalFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/FloatvalFieldtypeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature\GraphQL\Fieldtypes;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+#[Group('graphql')]
+class FloatvalFieldtypeTest extends FieldtypeTestCase
+{
+    #[Test]
+    public function it_gets_a_float()
+    {
+        $this->createEntryWithFields([
+            'filled' => [
+                'value' => 7.34,
+                'field' => ['type' => 'float'],
+            ],
+            'undefined' => [
+                'value' => null,
+                'field' => ['type' => 'float'],
+            ],
+        ]);
+
+        $this->assertGqlEntryHas('filled, undefined', [
+            'filled' => 7.34,
+            'undefined' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
If you have a Float field type in your blueprint and return values in GraphQL they currently come back as strings. They should really be floats as thats what the field type is there for.