### PR TITLE
[6.x] Fix change password popover

### DIFF
--- a/resources/js/components/users/ChangePassword.vue
+++ b/resources/js/components/users/ChangePassword.vue
@@ -1,6 +1,8 @@
 <template>
     <popover placement="bottom" ref="popper">
-        <button slot="trigger" class="btn" v-text="__('Change Password')" />
+        <template #trigger>
+            <button class="btn" v-text="__('Change Password')" />
+        </template>
         <div class="saving-overlay flex justify-center text-center" v-if="saving">
             <loading-graphic :text="__('Saving')" />
         </div>

--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -26,7 +26,7 @@
                     v-if="canEditPassword"
                     :save-url="actions.password"
                     :requires-current-password="requiresCurrentPassword"
-                    class="ltr:mr-4 rtl:ml-4"
+                    trigger-class="ltr:mr-4 rtl:ml-4"
                 />
 
                 <button class="btn-primary" @click.prevent="save" v-text="__('Save')" />


### PR DESCRIPTION
The change password button at the top of the user publish form isn't visible since the Vue 3 upgrade. This fixes it.