### PR TITLE
[5.x] Fix creating terms in non-default sites

### DIFF
--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -296,7 +296,7 @@ class TermsController extends CpController
 
         $slug = $request->slug;
         $published = $request->get('published'); // TODO
-        $defaultSite = Site::default()->handle();
+        $defaultSite = $term->taxonomy()->sites()->first();
 
         // If the term is *not* being created in the default site, we'll copy all the
         // appropriate values into the default localization since it needs to exist.


### PR DESCRIPTION
This pull request fixes an issue when creating terms when the taxonomy's default/first site is different from Statamic's default/first site.

Fixes #11733.