### PR TITLE
[5.x] Fix ensured author field when sidebar has empty section

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -628,7 +628,7 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
     private function getTabFields($tab)
     {
         return collect($this->contents['tabs'][$tab]['sections'])->flatMap(function ($section, $sectionIndex) {
-            return collect($section['fields'])->map(function ($field, $fieldIndex) use ($sectionIndex) {
+            return collect($section['fields'] ?? [])->map(function ($field, $fieldIndex) use ($sectionIndex) {
                 return $field + ['fieldIndex' => $fieldIndex, 'sectionIndex' => $sectionIndex];
             });
         })->keyBy('handle');


### PR DESCRIPTION
This pull request fixes an issue with the author permissions feature when it attempts to ensure the `author` field in the sidebar.

If the sidebar contained an empty section (eg. without any fields), it would cause an `Undefined array key "fields"` error.

Fixes #11728.