### PR TITLE
[5.x] Hide "Edit" button on relationship fieldtypes when user is missing permissions

### DIFF
--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -28,7 +28,7 @@
                     :item="item"
                     :config="config"
                     :status-icon="statusIcons"
-                    :editable="canEdit"
+                    :editable="canEdit && (item.editable || item.editable === undefined)"
                     :sortable="!readOnly && canReorder"
                     :read-only="readOnly"
                     :form-component="formComponent"

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -373,6 +373,7 @@ class Terms extends Relationship
             'published' => $term->published(),
             'private' => $term->private(),
             'edit_url' => $term->editUrl(),
+            'editable' => User::current()->can('edit', $term),
             'hint' => $this->getItemHint($term),
         ];
     }

--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -90,6 +90,7 @@ class Users extends Relationship
                 'title' => $user->name(),
                 'id' => $id,
                 'edit_url' => $user->editUrl(),
+                'editable' => User::current()->can('edit', $user),
             ];
         }
 

--- a/src/Http/Resources/CP/Entries/EntriesFieldtypeEntry.php
+++ b/src/Http/Resources/CP/Entries/EntriesFieldtypeEntry.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Resources\CP\Entries;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use Statamic\Facades\User;
 use Statamic\Fieldtypes\Entries as EntriesFieldtype;
 
 class EntriesFieldtypeEntry extends JsonResource
@@ -23,6 +24,7 @@ class EntriesFieldtypeEntry extends JsonResource
             'title' => $this->resource->value('title'),
             'status' => $this->resource->status(),
             'edit_url' => $this->resource->editUrl(),
+            'editable' => User::current()->can('edit', $this->resource),
             'hint' => $this->fieldtype->getItemHint($this->resource),
         ];
 


### PR DESCRIPTION
This pull request fixes an issue where the "Edit" button (and the edit link) would show on relationship fieldtypes, even when the logged in user is missing the relevant permissions.

Fixes #11718.