### PR TITLE
[6.x] Elevate session on login

### DIFF
--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -66,6 +66,8 @@ class LoginController extends CpController
         }
 
         if ($this->attemptLogin($request)) {
+            session()->elevate();
+
             return $this->sendLoginResponse($request);
         }
 

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -50,6 +50,8 @@ class OAuthController
             Auth::guard($request->session()->get('statamic.oauth.guard'))
                 ->login($user, config('statamic.oauth.remember_me', true));
 
+            session()->elevate();
+
             return redirect()->to($this->successRedirectUrl());
         }
 

--- a/tests/Auth/ElevatedSessionTest.php
+++ b/tests/Auth/ElevatedSessionTest.php
@@ -175,4 +175,10 @@ class ElevatedSessionTest extends TestCase
             ->get('/requires-elevated-session')
             ->assertOk();
     }
+
+    #[Test]
+    public function the_session_is_elevated_upon_login_with_oauth()
+    {
+        $this->markTestIncomplete('Implementation is done but is missing a test.');
+    }
 }

--- a/tests/Auth/ElevatedSessionTest.php
+++ b/tests/Auth/ElevatedSessionTest.php
@@ -22,7 +22,7 @@ class ElevatedSessionTest extends TestCase
     {
         parent::setUp();
 
-        $this->user = User::make()->makeSuper()->password('secret');
+        $this->user = User::make()->email('foo@bar.com')->makeSuper()->password('secret');
         $this->user->save();
     }
 
@@ -159,5 +159,20 @@ class ElevatedSessionTest extends TestCase
             ->getJson('/requires-elevated-session')
             ->assertStatus(403)
             ->assertJson(['message' => __('Requires an elevated session.')]);
+    }
+
+    #[Test]
+    public function the_session_is_elevated_upon_login()
+    {
+        $this
+            ->post(cp_route('login'), [
+                'email' => 'foo@bar.com',
+                'password' => 'secret',
+            ])
+            ->assertRedirectToRoute('statamic.cp.index');
+
+        $this
+            ->get('/requires-elevated-session')
+            ->assertOk();
     }
 }


### PR DESCRIPTION
If you log in then immediately go and do something that requires an elevated session, it will still prompt you for your password.

This PR will elevate your session on initial login. You've just entered your password.
