### PR TITLE
[5.x] Improve error handling in entries fieldtype

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -179,7 +179,11 @@ class Entries extends Relationship
             $collections = $this->getConfiguredCollections();
         }
 
-        return Collection::findByHandle(Arr::first($collections));
+        $collection = Collection::findByHandle($collectionHandle = Arr::first($collections));
+
+        throw_if(! $collection, new CollectionNotFoundException($collectionHandle));
+
+        return $collection;
     }
 
     public function getSortColumn($request)


### PR DESCRIPTION
Currently, when you view an entry where the first configured collection has been deleted, you'll get a `Call to a member function entryBlueprint() on null` error.

Unless you look at the code, the cause of this error isn't immediately obvious, so this PR ensures that a `CollectionNotFoundException` is thrown the collection can't be found.

Related: #11753
