### PR TITLE
[5.x] Add --header option to static warm command

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -42,7 +42,7 @@ class StaticWarm extends Command
         {--include= : Only warm specific URLs}
         {--exclude= : Exclude specific URLs}
         {--max-requests= : Maximum number of requests to warm}
-        {--headers= : Set custom headers (e.g. --headers="Authorization: Bearer your_token", can be used multiple times)}
+        {--header=* : Set custom header (e.g. "Authorization: Bearer your_token")}
     ';
 
     protected $description = 'Warms the static cache by visiting all URLs';
@@ -168,7 +168,7 @@ class StaticWarm extends Command
 
     private function requests()
     {
-        $headers = $this->parseHeaders($this->option('headers'));
+        $headers = $this->parseHeaders($this->option('header'));
 
         return $this->uris()->map(function ($uri) use ($headers) {
             return new Request('GET', $uri, $headers);

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -42,6 +42,7 @@ class StaticWarm extends Command
         {--include= : Only warm specific URLs}
         {--exclude= : Exclude specific URLs}
         {--max-requests= : Maximum number of requests to warm}
+        {--headers= : Set custom headers (e.g. --headers="Authorization: Bearer your_token", can be used multiple times)}
     ';
 
     protected $description = 'Warms the static cache by visiting all URLs';
@@ -167,8 +168,10 @@ class StaticWarm extends Command
 
     private function requests()
     {
-        return $this->uris()->map(function ($uri) {
-            return new Request('GET', $uri);
+        $headers = $this->parseHeaders($this->option('headers'));
+
+        return $this->uris()->map(function ($uri) use ($headers) {
+            return new Request('GET', $uri, $headers);
         })->all();
     }
 
@@ -373,5 +376,26 @@ class StaticWarm extends Command
         $this->line("\x1B[1A\x1B[2K<info>[✔]</info> Additional");
 
         return $uris->map(fn ($uri) => URL::makeAbsolute($uri));
+    }
+
+    private function parseHeaders($headerOptions): array
+    {
+        $headers = [];
+        if (empty($headerOptions)) {
+            return $headers;
+        }
+        if (! is_array($headerOptions)) {
+            $headerOptions = [$headerOptions];
+        }
+        foreach ($headerOptions as $header) {
+            if (strpos($header, ':') !== false) {
+                [$key, $value] = explode(':', $header, 2);
+                $headers[trim($key)] = trim($value);
+            } else {
+                $this->line("<fg=yellow;options=bold>Warning:</> Invalid header format: '$header'. Headers should be in 'Key: Value' format.");
+            }
+        }
+
+        return $headers;
     }
 }

--- a/tests/Console/Commands/StaticWarmTest.php
+++ b/tests/Console/Commands/StaticWarmTest.php
@@ -271,6 +271,24 @@ class StaticWarmTest extends TestCase
         ];
     }
 
+    #[Test]
+    public function it_sets_custom_headers_on_requests()
+    {
+        config(['statamic.static_caching.strategy' => 'half']);
+
+        $mock = Mockery::mock(\GuzzleHttp\Client::class);
+        $mock->shouldReceive('send')->andReturnUsing(function ($request) {
+            $this->assertEquals('Bearer testtoken', $request->getHeaderLine('Authorization'));
+
+            return Mockery::mock(\GuzzleHttp\Psr7\Response::class);
+        });
+        $this->app->instance(\GuzzleHttp\Client::class, $mock);
+
+        $this->artisan('statamic:static:warm', [
+            '--headers' => ['Authorization: Bearer testtoken'],
+        ])->assertExitCode(0);
+    }
+
     private function createPage($slug, $attributes = [])
     {
         $this->makeCollection()->save();

--- a/tests/Console/Commands/StaticWarmTest.php
+++ b/tests/Console/Commands/StaticWarmTest.php
@@ -279,13 +279,14 @@ class StaticWarmTest extends TestCase
         $mock = Mockery::mock(\GuzzleHttp\Client::class);
         $mock->shouldReceive('send')->andReturnUsing(function ($request) {
             $this->assertEquals('Bearer testtoken', $request->getHeaderLine('Authorization'));
+            $this->assertEquals('Bar', $request->getHeaderLine('X-Foo'));
 
             return Mockery::mock(\GuzzleHttp\Psr7\Response::class);
         });
         $this->app->instance(\GuzzleHttp\Client::class, $mock);
 
         $this->artisan('statamic:static:warm', [
-            '--headers' => ['Authorization: Bearer testtoken'],
+            '--header' => ['Authorization: Bearer testtoken', 'X-Foo: Bar'],
         ])->assertExitCode(0);
     }
 


### PR DESCRIPTION
## Add support for custom headers in `static:warm` command

This PR introduces a new `--headers` option to the `static:warm` command, allowing users to specify custom HTTP headers for requests made during cache warming, e.g. for:

- Pages requiring authentication or API tokens for access.
- Need to trigger static cache refreshes even when static files are being served, using custom server rules. Especially useful for zero-cache-downtime scenarios

Related docs here: https://github.com/statamic/docs/pull/1674