### PR TITLE
[5.x] Use deep copy of set's data in bard field

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -457,8 +457,8 @@ export default {
     methods: {
         addSet(handle) {
             const id = uniqid();
-            const values = Object.assign({}, { type: handle }, this.meta.defaults[handle]);
-
+            const deepCopy = JSON.parse(JSON.stringify(this.meta.defaults[handle]));
+            const values = Object.assign({}, { type: handle }, deepCopy);
             let previews = {};
             Object.keys(this.meta.defaults[handle]).forEach(key => previews[key] = null);
             this.previews = Object.assign({}, this.previews, { [id]: previews });
@@ -481,7 +481,8 @@ export default {
         duplicateSet(old_id, attrs, pos) {
             const id = uniqid();
             const enabled = attrs.enabled;
-            const values = Object.assign({}, attrs.values);
+            const deepCopy = JSON.parse(JSON.stringify(attrs.values));
+            const values = Object.assign({}, deepCopy);
 
             let previews = Object.assign({}, this.previews[old_id]);
             this.previews = Object.assign({}, this.previews, { [id]: previews });


### PR DESCRIPTION
This PR fixes #11765

Instead of a shallow copy, a deep copy of the (default) values is used when adding or duplicating set defined for a bard field.

When using statamic from [this](https://github.com/faltjo/statamic-cms/tree/fix-bard-set-replicator-bug) branch, the problems are gone in the example repo: https://github.com/faltjo/fix-bard-field-set-bug

Note that this is very similar to https://github.com/statamic/cms/pull/11621