### PR TITLE
[5.x] PHPUnit: Use `#[Test]` attribute instead of `/** @test */`

### DIFF
--- a/tests/Feature/Forms/UpdateFormTest.php
+++ b/tests/Feature/Forms/UpdateFormTest.php
@@ -108,7 +108,7 @@ class UpdateFormTest extends TestCase
         ], $updated->email());
     }
 
-    /** @test */
+    #[Test]
     public function it_updates_data()
     {
         $form = tap(Form::make('test'))->save();

--- a/tests/Forms/FormRepositoryTest.php
+++ b/tests/Forms/FormRepositoryTest.php
@@ -43,7 +43,7 @@ class FormRepositoryTest extends TestCase
         $this->repo->findOrFail('does-not-exist');
     }
 
-    /** @test */
+    #[Test]
     public function it_registers_config()
     {
         $this->repo->appendConfigFields('test_form', 'Test Config', [

--- a/tests/Modifiers/SelectTest.php
+++ b/tests/Modifiers/SelectTest.php
@@ -5,6 +5,7 @@ namespace Tests\Modifiers;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Query\Builder;
 use Statamic\Entries\EntryCollection;
 use Statamic\Modifiers\Modify;

--- a/tests/Modifiers/SelectTest.php
+++ b/tests/Modifiers/SelectTest.php
@@ -12,7 +12,7 @@ use Tests\TestCase;
 
 class SelectTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_selects_certain_values_from_array_of_items()
     {
         $items = $this->items();
@@ -38,7 +38,7 @@ class SelectTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_selects_certain_values_from_collections_of_items()
     {
         $items = Collection::make($this->items());
@@ -64,7 +64,7 @@ class SelectTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_selects_certain_values_from_query_builder()
     {
         $builder = Mockery::mock(Builder::class);
@@ -91,7 +91,7 @@ class SelectTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_selects_certain_values_from_array_of_items_with_origins()
     {
         $items = $this->itemsWithOrigins();
@@ -121,7 +121,7 @@ class SelectTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_selects_certain_values_from_collections_of_items_with_origins()
     {
         $items = EntryCollection::make($this->itemsWithOrigins());
@@ -151,7 +151,7 @@ class SelectTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_selects_certain_values_from_array_of_items_of_type_array()
     {
         $items = $this->itemsOfTypeArray();
@@ -177,7 +177,7 @@ class SelectTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_selects_certain_values_from_collections_of_items_of_type_array()
     {
         $items = EntryCollection::make($this->itemsOfTypeArray());
@@ -203,7 +203,7 @@ class SelectTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_selects_certain_values_from_array_of_items_of_type_arrayaccess()
     {
         $items = $this->itemsOfTypeArrayAccess();


### PR DESCRIPTION
We already do this in most tests (thanks to #10351). However, while resolving merge conflicts on an old PR, I noticed some tests still using `/** @test */`.