### PR TITLE
[5.x] Ability to select entries from all sites from Bard link

### DIFF
--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -265,6 +265,7 @@ export default {
                 type: 'entries',
                 collections: this.collections,
                 max_items: 1,
+                select_across_sites: this.config.select_across_sites,
             };
         },
 

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -44,6 +44,7 @@ return [
     'bard.config.section.editor.instructions' => 'Configure the editor\'s appearance and general behavior.',
     'bard.config.section.links.instructions' => 'Configure how links are handled in this instance of Bard.',
     'bard.config.section.sets.instructions' => 'Configure blocks of fields that can be inserted anywhere in your Bard content.',
+    'bard.config.select_across_sites' => 'Allow selecting entries from other sites. This also disables localizing options on the front-end. Learn more in the [documentation](https://statamic.dev/fieldtypes/entries#select-across-sites).',
     'bard.config.smart_typography' => 'Convert common text patterns with the proper typographic characters.',
     'bard.config.target_blank' => 'Set `target="_blank"` on all links.',
     'bard.config.toolbar_mode' => '**Fixed** mode will keep the toolbar visible at all times, while **floating** only appears while selecting text.',

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -182,6 +182,11 @@ class Bard extends Replicator
                         'type' => 'collections',
                         'mode' => 'select',
                     ],
+                    'select_across_sites' => [
+                        'display' => __('Select Across Sites'),
+                        'instructions' => __('statamic::fieldtypes.bard.config.select_across_sites'),
+                        'type' => 'toggle',
+                    ],
                     'container' => [
                         'display' => __('Container'),
                         'instructions' => __('statamic::fieldtypes.bard.config.container'),


### PR DESCRIPTION
Follow up to https://github.com/statamic/cms/pull/9229, this adds the same feature to links in Bard fields.