### PR TITLE
[5.x] Ensure null values are filtered out when saving dictionary field config

### DIFF
--- a/src/Fieldtypes/DictionaryFields.php
+++ b/src/Fieldtypes/DictionaryFields.php
@@ -71,7 +71,7 @@ class DictionaryFields extends Fieldtype
             return $dictionary->handle();
         }
 
-        return array_merge(['type' => $dictionary->handle()], $values->all());
+        return array_merge(['type' => $dictionary->handle()], $values->filter()->all());
     }
 
     public function extraRules(): array

--- a/tests/Fieldtypes/DictionaryFieldsTest.php
+++ b/tests/Fieldtypes/DictionaryFieldsTest.php
@@ -117,6 +117,23 @@ class DictionaryFieldsTest extends TestCase
     }
 
     #[Test]
+    public function it_processes_dictionary_fields_and_filters_out_null_values()
+    {
+        $fieldtype = FieldtypeRepository::find('dictionary_fields');
+
+        $process = $fieldtype->process([
+            'type' => 'fake_dictionary',
+            'category' => 'foo',
+            'foo' => null,
+        ]);
+
+        $this->assertEquals([
+            'type' => 'fake_dictionary',
+            'category' => 'foo',
+        ], $process);
+    }
+
+    #[Test]
     public function it_returns_validation_rules()
     {
         $field = (new Field('test', ['type' => 'dictionary_fields']))->setValue(['type' => 'fake_dictionary']);


### PR DESCRIPTION
This pull request fixes an issue I spotted where `null` values weren't being filtered out when saving a dictionary field's config options.

```yaml
-
  handle: dictionary_field
  field:
    dictionary:
      type: countries
      region: null
      emojis: true
    type: dictionary
    display: 'Dictionary Field'
```

^ In this example, the `region` key shouldn't be persisted when its `null`.