### PR TITLE
[5.x] Clone internal data collections

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -116,6 +116,12 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
         $this->supplements = collect();
     }
 
+    public function __clone()
+    {
+        $this->data = clone $this->data;
+        $this->supplements = clone $this->supplements;
+    }
+
     public function id($id = null)
     {
         if ($id) {

--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -39,6 +39,12 @@ class User extends BaseUser
         $this->supplements = collect();
     }
 
+    public function __clone()
+    {
+        $this->data = clone $this->data;
+        $this->supplements = clone $this->supplements;
+    }
+
     public function data($data = null)
     {
         if (func_num_args() === 0) {

--- a/src/Auth/UserGroup.php
+++ b/src/Auth/UserGroup.php
@@ -27,6 +27,14 @@ abstract class UserGroup implements Arrayable, ArrayAccess, Augmentable, UserGro
     {
         $this->roles = collect();
         $this->data = collect();
+        $this->supplements = collect();
+    }
+
+    public function __clone()
+    {
+        $this->roles = clone $this->roles;
+        $this->data = clone $this->data;
+        $this->supplements = clone $this->supplements;
     }
 
     public function title(?string $title = null)

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -88,6 +88,12 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
         $this->supplements = collect();
     }
 
+    public function __clone()
+    {
+        $this->data = clone $this->data;
+        $this->supplements = clone $this->supplements;
+    }
+
     public function id($id = null)
     {
         return $this->fluentlyGetOrSet('id')->args(func_get_args());

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -45,6 +45,13 @@ class Form implements Arrayable, Augmentable, FormContract
     public function __construct()
     {
         $this->data = collect();
+        $this->supplements = collect();
+    }
+
+    public function __clone()
+    {
+        $this->data = clone $this->data;
+        $this->supplements = clone $this->supplements;
     }
 
     /**

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -48,6 +48,12 @@ class Submission implements Augmentable, SubmissionContract
         $this->supplements = collect();
     }
 
+    public function __clone()
+    {
+        $this->data = clone $this->data;
+        $this->supplements = clone $this->supplements;
+    }
+
     /**
      * Get or set the ID.
      *

--- a/src/Globals/Variables.php
+++ b/src/Globals/Variables.php
@@ -44,6 +44,12 @@ class Variables implements Arrayable, ArrayAccess, Augmentable, Contract, Locali
         $this->supplements = collect();
     }
 
+    public function __clone()
+    {
+        $this->data = clone $this->data;
+        $this->supplements = clone $this->supplements;
+    }
+
     public function globalSet($set = null)
     {
         return $this->fluentlyGetOrSet('set')

--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -52,6 +52,12 @@ class LocalizedTerm implements Arrayable, ArrayAccess, Augmentable, BulkAugmenta
         $this->supplements = collect();
     }
 
+    public function __clone()
+    {
+        $this->term = clone $this->term;
+        $this->supplements = clone $this->supplements;
+    }
+
     public function get($key, $fallback = null)
     {
         return $this->data()->get($key, $fallback);

--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -37,6 +37,14 @@ class Term implements TermContract
         $this->data = collect();
     }
 
+    public function __clone()
+    {
+        $this->data = clone $this->data;
+        $this->data->transform(function ($data) {
+            return clone $data;
+        });
+    }
+
     public function id()
     {
         return $this->taxonomyHandle().'::'.$this->slug();

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -2657,4 +2657,22 @@ YAML;
         // ideally we would have checked the store name, but laravel 10 doesnt give us a way to do that
         $this->assertStringContainsString('asset-meta', $store->getStore()->getDirectory());
     }
+
+    #[Test]
+    public function it_clones_internal_collections()
+    {
+        $asset = (new Asset)->container($this->container)->path('foo/test.txt');
+        $asset->set('foo', 'A');
+        $asset->setSupplement('bar', 'A');
+
+        $clone = clone $asset;
+        $clone->set('foo', 'B');
+        $clone->setSupplement('bar', 'B');
+
+        $this->assertEquals('A', $asset->get('foo'));
+        $this->assertEquals('B', $clone->get('foo'));
+
+        $this->assertEquals('A', $asset->getSupplement('bar'));
+        $this->assertEquals('B', $clone->getSupplement('bar'));
+    }
 }

--- a/tests/Auth/FileUserTest.php
+++ b/tests/Auth/FileUserTest.php
@@ -168,4 +168,22 @@ class FileUserTest extends TestCase
 
         $this->assertEquals(['a', 'b', 'c'], $user->get('groups'));
     }
+
+    #[Test]
+    public function it_clones_internal_collections()
+    {
+        $user = $this->user();
+        $user->set('foo', 'A');
+        $user->setSupplement('bar', 'A');
+
+        $clone = clone $user;
+        $clone->set('foo', 'B');
+        $clone->setSupplement('bar', 'B');
+
+        $this->assertEquals('A', $user->get('foo'));
+        $this->assertEquals('B', $clone->get('foo'));
+
+        $this->assertEquals('A', $user->getSupplement('bar'));
+        $this->assertEquals('B', $clone->getSupplement('bar'));
+    }
 }

--- a/tests/Auth/UserGroupTest.php
+++ b/tests/Auth/UserGroupTest.php
@@ -374,4 +374,22 @@ class UserGroupTest extends TestCase
         $this->assertEquals($group->get('one'), $data['one']);
         $this->assertEquals($group->get('two'), $data['two']);
     }
+
+    #[Test]
+    public function it_clones_internal_collections()
+    {
+        $group = UserGroup::make();
+        $group->set('foo', 'A');
+        $group->setSupplement('bar', 'A');
+
+        $clone = clone $group;
+        $clone->set('foo', 'B');
+        $clone->setSupplement('bar', 'B');
+
+        $this->assertEquals('A', $group->get('foo'));
+        $this->assertEquals('B', $clone->get('foo'));
+
+        $this->assertEquals('A', $group->getSupplement('bar'));
+        $this->assertEquals('B', $clone->getSupplement('bar'));
+    }
 }

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -2597,4 +2597,22 @@ class EntryTest extends TestCase
             ['7', '7'],
         ], $events->map(fn ($event) => [$event->entry->id(), $event->initiator->id()])->all());
     }
+
+    #[Test]
+    public function it_clones_internal_collections()
+    {
+        $entry = EntryFactory::collection('test')->create();
+        $entry->set('foo', 'A');
+        $entry->setSupplement('bar', 'A');
+
+        $clone = clone $entry;
+        $clone->set('foo', 'B');
+        $clone->setSupplement('bar', 'B');
+
+        $this->assertEquals('A', $entry->get('foo'));
+        $this->assertEquals('B', $clone->get('foo'));
+
+        $this->assertEquals('A', $entry->getSupplement('bar'));
+        $this->assertEquals('B', $clone->getSupplement('bar'));
+    }
 }

--- a/tests/Data/Globals/VariablesTest.php
+++ b/tests/Data/Globals/VariablesTest.php
@@ -387,4 +387,23 @@ EOT;
             'charlie' => ['augmented c', 'augmented d'],
         ], Arr::only($variables->selectedQueryRelations(['charlie'])->toArray(), ['alfa', 'bravo', 'charlie']));
     }
+
+    #[Test]
+    public function it_clones_internal_collections()
+    {
+        $global = GlobalSet::make('test');
+        $variables = $global->makeLocalization('en');
+        $variables->set('foo', 'A');
+        $variables->setSupplement('bar', 'A');
+
+        $clone = clone $variables;
+        $clone->set('foo', 'B');
+        $clone->setSupplement('bar', 'B');
+
+        $this->assertEquals('A', $variables->get('foo'));
+        $this->assertEquals('B', $clone->get('foo'));
+
+        $this->assertEquals('A', $variables->getSupplement('bar'));
+        $this->assertEquals('B', $clone->getSupplement('bar'));
+    }
 }

--- a/tests/Data/Taxonomies/TermTest.php
+++ b/tests/Data/Taxonomies/TermTest.php
@@ -481,4 +481,24 @@ class TermTest extends TestCase
 
         $this->assertTrue($return);
     }
+
+    #[Test]
+    public function it_clones_internal_collections()
+    {
+        $taxonomy = (new TaxonomiesTaxonomy)->handle('tags')->save();
+        $term = (new Term)->taxonomy('tags')->slug('foo')->data(['foo' => 'bar'])->inDefaultLocale();
+        
+        $term->set('foo', 'A');
+        $term->setSupplement('bar', 'A');
+
+        $clone = clone $term;
+        $clone->set('foo', 'B');
+        $clone->setSupplement('bar', 'B');
+
+        $this->assertEquals('A', $term->get('foo'));
+        $this->assertEquals('B', $clone->get('foo'));
+
+        $this->assertEquals('A', $term->getSupplement('bar'));
+        $this->assertEquals('B', $clone->getSupplement('bar'));
+    }
 }

--- a/tests/Data/Taxonomies/TermTest.php
+++ b/tests/Data/Taxonomies/TermTest.php
@@ -487,7 +487,7 @@ class TermTest extends TestCase
     {
         $taxonomy = (new TaxonomiesTaxonomy)->handle('tags')->save();
         $term = (new Term)->taxonomy('tags')->slug('foo')->data(['foo' => 'bar'])->inDefaultLocale();
-        
+
         $term->set('foo', 'A');
         $term->setSupplement('bar', 'A');
 

--- a/tests/Forms/FormTest.php
+++ b/tests/Forms/FormTest.php
@@ -250,4 +250,22 @@ class FormTest extends TestCase
 
         $this->assertTrue($return);
     }
+
+    #[Test]
+    public function it_clones_internal_collections()
+    {
+        $form = Form::make('contact_us');
+        $form->set('foo', 'A');
+        $form->setSupplement('bar', 'A');
+
+        $clone = clone $form;
+        $clone->set('foo', 'B');
+        $clone->setSupplement('bar', 'B');
+
+        $this->assertEquals('A', $form->get('foo'));
+        $this->assertEquals('B', $clone->get('foo'));
+
+        $this->assertEquals('A', $form->getSupplement('bar'));
+        $this->assertEquals('B', $clone->getSupplement('bar'));
+    }
 }

--- a/tests/Forms/SubmissionTest.php
+++ b/tests/Forms/SubmissionTest.php
@@ -208,4 +208,24 @@ class SubmissionTest extends TestCase
 
         $this->assertTrue($return);
     }
+
+    #[Test]
+    public function it_clones_internal_collections()
+    {
+        $form = Form::make('contact_us');
+        $form->save();
+        $submission = $form->makeSubmission();
+        $submission->set('foo', 'A');
+        $submission->setSupplement('bar', 'A');
+
+        $clone = clone $submission;
+        $clone->set('foo', 'B');
+        $clone->setSupplement('bar', 'B');
+
+        $this->assertEquals('A', $submission->get('foo'));
+        $this->assertEquals('B', $clone->get('foo'));
+
+        $this->assertEquals('A', $submission->getSupplement('bar'));
+        $this->assertEquals('B', $clone->getSupplement('bar'));
+    }
 }


### PR DESCRIPTION
The classes that use `ContainsData` and `ContainsSupplementalData` store their data as collection objects not plain arrays. Because of this when you clone an entry object the clone still points to the same `data` collection object, so if you set something on the clone it also gets set on the original (same for supplemental data).

This PR fixes that by cloning the internal data collections when the main objects are cloned.

It also clones the user group `roles`, and the localised term `term` (as that's required to clone the term `data`).

It also adds a couple of missing `$this->supplements = collect();` constructor lines.