### PR TITLE
[5.x] Allow conditional sending of form submission emails

### DIFF
--- a/src/Events/FormSendingEmails.php
+++ b/src/Events/FormSendingEmails.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Statamic\Events;
+
+use Statamic\Contracts\Forms\Submission;
+
+class FormSendingEmails extends Event
+{
+    public function __construct(public Submission $submission)
+    {
+    }
+
+    /**
+     * Dispatch the event with the given arguments, and halt on first non-null listener response.
+     *
+     * @return mixed
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()), [], true);
+    }
+}

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\URL;
 use Illuminate\Support\MessageBag;
 use Illuminate\Validation\ValidationException;
 use Statamic\Contracts\Forms\Submission;
+use Statamic\Events\FormSendingEmails;
 use Statamic\Events\FormSubmitted;
 use Statamic\Events\SubmissionCreated;
 use Statamic\Exceptions\SilentFormFailureException;
@@ -83,7 +84,7 @@ class FormController extends Controller
             SubmissionCreated::dispatch($submission);
         }
 
-        SendEmails::dispatch($submission, $site);
+        SendEmails::dispatchUnless(FormSendingEmails::dispatch($submission) === false, $submission, $site);
 
         return $this->formSuccess($params, $submission);
     }


### PR DESCRIPTION
**Overview**
Introduces a new `FormSendingEmails` event that is dispatched prior to `SendEmails` (the job that sends emails when new form submissions are received). 

If a listener of `FormSendingEmails` returns `false`, the `SendEmails` event will not be dispatched (similar to how `FormSubmitted` works).

This enables the conditional sending of form submission emails.

**Motivation**
I have a use case where I'd like to examine a form submission and only send the email(s) based on certain criteria.

I think a good example for this would be spam detection: if a submission is flagged as spam, perhaps we don't want to send an email about it. However, we still want the submission to be saved so that it can be manually reviewed at a later date.

Example listener implementation:
```php
<?php

namespace App\Listeners;

use Statamic\Events\FormSendingEmails;

class HandleFormSendingEmails
{
    public function handle(FormSendingEmails $event)
    {
        if (SpamDetector::check($event->submission)) {
            return false; // No emails will be sent if we reach here.
        }
    }
}
```