### PR TITLE
[5.x] Ensure asset validation rules are returned as strings to GraphQL

### DIFF
--- a/src/Fieldtypes/Assets/DimensionsRule.php
+++ b/src/Fieldtypes/Assets/DimensionsRule.php
@@ -124,4 +124,9 @@ class DimensionsRule implements Rule
 
         return abs($numerator / $denominator - $width / $height) > $precision;
     }
+
+    public function __toString()
+    {
+        return 'dimensions:'.implode(',', $this->parameters);
+    }
 }

--- a/src/Fieldtypes/Assets/ImageRule.php
+++ b/src/Fieldtypes/Assets/ImageRule.php
@@ -49,4 +49,9 @@ class ImageRule implements Rule
     {
         return __((Statamic::isCpRoute() ? 'statamic::' : '').'validation.image');
     }
+
+    public function __toString()
+    {
+        return 'image:'.implode(',', $this->parameters);
+    }
 }

--- a/src/Fieldtypes/Assets/MimesRule.php
+++ b/src/Fieldtypes/Assets/MimesRule.php
@@ -51,4 +51,9 @@ class MimesRule implements Rule
     {
         return str_replace(':values', implode(', ', $this->parameters), __((Statamic::isCpRoute() ? 'statamic::' : '').'validation.mimes'));
     }
+
+    public function __toString()
+    {
+        return 'mimes:'.implode(',', $this->parameters);
+    }
 }

--- a/src/Fieldtypes/Assets/MimetypesRule.php
+++ b/src/Fieldtypes/Assets/MimetypesRule.php
@@ -46,4 +46,9 @@ class MimetypesRule implements Rule
     {
         return str_replace(':values', implode(', ', $this->parameters), __((Statamic::isCpRoute() ? 'statamic::' : '').'validation.mimetypes'));
     }
+
+    public function __toString()
+    {
+        return 'mimetypes:'.implode(',', $this->parameters);
+    }
 }

--- a/src/Fieldtypes/Assets/SizeBasedRule.php
+++ b/src/Fieldtypes/Assets/SizeBasedRule.php
@@ -66,4 +66,9 @@ abstract class SizeBasedRule implements Rule
 
         return false;
     }
+
+    public function __toString()
+    {
+        return 'size:'.implode(',', $this->parameters);
+    }
 }

--- a/src/GraphQL/Types/FormType.php
+++ b/src/GraphQL/Types/FormType.php
@@ -35,7 +35,21 @@ class FormType extends \Rebing\GraphQL\Support\Type
             'rules' => [
                 'type' => GraphQL::type(ArrayType::NAME),
                 'resolve' => function ($form, $args, $context, $info) {
-                    return $form->blueprint()->fields()->validator()->rules();
+                    return collect($form->blueprint()->fields()->validator()->rules())
+                        ->map(function ($rules) {
+                            return collect($rules)->map(function ($rule) {
+                                if (is_string($rule)) {
+                                    return $rule;
+                                }
+
+                                if (method_exists($rule, '__toString')) {
+                                    return (string) $rule;
+                                }
+
+                                return $rule;
+                            });
+                        })
+                        ->all();
                 },
             ],
             'sections' => [

--- a/src/GraphQL/Types/FormType.php
+++ b/src/GraphQL/Types/FormType.php
@@ -42,7 +42,7 @@ class FormType extends \Rebing\GraphQL\Support\Type
                                     return $rule;
                                 }
 
-                                if (method_exists($rule, '__toString')) {
+                                if ($rule instanceof \Stringable) {
                                     return (string) $rule;
                                 }
 

--- a/tests/Feature/GraphQL/FormTest.php
+++ b/tests/Feature/GraphQL/FormTest.php
@@ -333,7 +333,7 @@ GQL;
                     'dimensions:1024',
                     'size:1000',
                     'image:jpeg',
-                ]
+                ],
             ],
         ]);
 

--- a/tests/Feature/GraphQL/FormTest.php
+++ b/tests/Feature/GraphQL/FormTest.php
@@ -317,4 +317,53 @@ GQL;
                 ],
             ]]);
     }
+
+    #[Test]
+    public function it_returns_string_based_validation_rules_for_mimes_mimetypes_dimension_size_and_image()
+    {
+        Form::make('contact')->title('Contact Us')->save();
+
+        $blueprint = Blueprint::makeFromFields([
+            'name' => [
+                'type' => 'assets',
+                'display' => 'Asset',
+                'validate' => [
+                    'mimes:image/jpeg,image/png',
+                    'mimetypes:image/jpeg,image/png',
+                    'dimensions:1024',
+                    'size:1000',
+                    'image:jpeg',
+                ]
+            ],
+        ]);
+
+        BlueprintRepository::shouldReceive('find')->with('forms.contact')->andReturn($blueprint);
+
+        $query = <<<'GQL'
+{
+    form(handle: "contact") {
+        rules
+    }
+}
+GQL;
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => [
+                'form' => [
+                    'rules' => [
+                        'name' => [
+                            'mimes:image/jpeg,image/png',
+                            'mimetypes:image/jpeg,image/png',
+                            'dimensions:1024',
+                            'size:1000',
+                            'image:jpeg',
+                            'array',
+                            'nullable',
+                        ],
+                    ],
+                ],
+            ]]);
+    }
 }


### PR DESCRIPTION
This PR ensures that the custom asset validation rules provided to GraphQL are returned as strings. Currently as they are class based they are returned as '{}'.

Closes https://github.com/statamic/cms/issues/7986