### PR TITLE
[5.x] Add `increment`/`decrement` methods to `ContainsData`

### DIFF
--- a/src/Data/ContainsData.php
+++ b/src/Data/ContainsData.php
@@ -25,6 +25,18 @@ trait ContainsData
         return $this;
     }
 
+    public function increment($key, $amount = 1)
+    {
+        $this->data[$key] = ($this->data[$key] ?? 0) + $amount;
+
+        return $this;
+    }
+
+    public function decrement($key, $amount = 1)
+    {
+        return $this->increment($key, -$amount);
+    }
+
     public function remove($key)
     {
         unset($this->data[$key]);


### PR DESCRIPTION
This pull request adds `increment` and `decrement` methods to the `ContainsData` trait, which is used pretty much everywhere.

So, instead of needing to do this:

```php
$entry->set('inventory', $entry->get('inventory') + 1);
```

You can now do this:

```php
$entry->increment('inventory');
```

Not related to an existing feature request, but something I thought might be useful last night while working on a personal project.