### PR TITLE
[5.x] Fix filtering group fieldtype null values

### DIFF
--- a/src/Fieldtypes/Group.php
+++ b/src/Fieldtypes/Group.php
@@ -50,7 +50,7 @@ class Group extends Fieldtype
 
     public function process($data)
     {
-        return $this->fields()->addValues($data ?? [])->process()->values()->all();
+        return $this->fields()->addValues($data ?? [])->process()->values()->filter()->all();
     }
 
     public function preProcess($data)


### PR DESCRIPTION
Null values should no longer be saved to content, but the group fieldtype is doing that.

This PR fixes it.