### PR TITLE
[5.x] Asset validation rules as string in GraphQL, part 2

### DIFF
--- a/src/Contracts/GraphQL/CastableToValidationString.php
+++ b/src/Contracts/GraphQL/CastableToValidationString.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Statamic\Contracts\GraphQL;
+
+interface CastableToValidationString
+{
+    public function toGqlValidationString(): string;
+}

--- a/src/Fieldtypes/Assets/DimensionsRule.php
+++ b/src/Fieldtypes/Assets/DimensionsRule.php
@@ -3,11 +3,12 @@
 namespace Statamic\Fieldtypes\Assets;
 
 use Illuminate\Contracts\Validation\Rule;
+use Statamic\Contracts\GraphQL\CastableToValidationString;
 use Statamic\Facades\Asset;
 use Statamic\Statamic;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class DimensionsRule implements Rule
+class DimensionsRule implements CastableToValidationString, Rule
 {
     protected $parameters;
 
@@ -125,7 +126,7 @@ class DimensionsRule implements Rule
         return abs($numerator / $denominator - $width / $height) > $precision;
     }
 
-    public function __toString()
+    public function toGqlValidationString(): string
     {
         return 'dimensions:'.implode(',', $this->parameters);
     }

--- a/src/Fieldtypes/Assets/ImageRule.php
+++ b/src/Fieldtypes/Assets/ImageRule.php
@@ -3,11 +3,12 @@
 namespace Statamic\Fieldtypes\Assets;
 
 use Illuminate\Contracts\Validation\Rule;
+use Statamic\Contracts\GraphQL\CastableToValidationString;
 use Statamic\Facades\Asset;
 use Statamic\Statamic;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class ImageRule implements Rule
+class ImageRule implements CastableToValidationString, Rule
 {
     protected $parameters;
 
@@ -50,7 +51,7 @@ class ImageRule implements Rule
         return __((Statamic::isCpRoute() ? 'statamic::' : '').'validation.image');
     }
 
-    public function __toString()
+    public function toGqlValidationString(): string
     {
         return 'image:'.implode(',', $this->parameters);
     }

--- a/src/Fieldtypes/Assets/MimesRule.php
+++ b/src/Fieldtypes/Assets/MimesRule.php
@@ -3,11 +3,12 @@
 namespace Statamic\Fieldtypes\Assets;
 
 use Illuminate\Contracts\Validation\Rule;
+use Statamic\Contracts\GraphQL\CastableToValidationString;
 use Statamic\Facades\Asset;
 use Statamic\Statamic;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class MimesRule implements Rule
+class MimesRule implements CastableToValidationString, Rule
 {
     protected $parameters;
 
@@ -52,7 +53,7 @@ class MimesRule implements Rule
         return str_replace(':values', implode(', ', $this->parameters), __((Statamic::isCpRoute() ? 'statamic::' : '').'validation.mimes'));
     }
 
-    public function __toString()
+    public function toGqlValidationString(): string
     {
         return 'mimes:'.implode(',', $this->parameters);
     }

--- a/src/Fieldtypes/Assets/MimetypesRule.php
+++ b/src/Fieldtypes/Assets/MimetypesRule.php
@@ -3,11 +3,12 @@
 namespace Statamic\Fieldtypes\Assets;
 
 use Illuminate\Contracts\Validation\Rule;
+use Statamic\Contracts\GraphQL\CastableToValidationString;
 use Statamic\Facades\Asset;
 use Statamic\Statamic;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class MimetypesRule implements Rule
+class MimetypesRule implements CastableToValidationString, Rule
 {
     protected $parameters;
 
@@ -47,7 +48,7 @@ class MimetypesRule implements Rule
         return str_replace(':values', implode(', ', $this->parameters), __((Statamic::isCpRoute() ? 'statamic::' : '').'validation.mimetypes'));
     }
 
-    public function __toString()
+    public function toGqlValidationString(): string
     {
         return 'mimetypes:'.implode(',', $this->parameters);
     }

--- a/src/Fieldtypes/Assets/SizeBasedRule.php
+++ b/src/Fieldtypes/Assets/SizeBasedRule.php
@@ -3,10 +3,11 @@
 namespace Statamic\Fieldtypes\Assets;
 
 use Illuminate\Contracts\Validation\Rule;
+use Statamic\Contracts\GraphQL\CastableToValidationString;
 use Statamic\Facades\Asset;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-abstract class SizeBasedRule implements Rule
+abstract class SizeBasedRule implements CastableToValidationString, Rule
 {
     protected $parameters;
 
@@ -67,7 +68,7 @@ abstract class SizeBasedRule implements Rule
         return false;
     }
 
-    public function __toString()
+    public function toGqlValidationString(): string
     {
         return 'size:'.implode(',', $this->parameters);
     }

--- a/src/GraphQL/Types/FormType.php
+++ b/src/GraphQL/Types/FormType.php
@@ -3,6 +3,7 @@
 namespace Statamic\GraphQL\Types;
 
 use Statamic\Contracts\Forms\Form;
+use Statamic\Contracts\GraphQL\CastableToValidationString;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Value;
 
@@ -42,11 +43,11 @@ class FormType extends \Rebing\GraphQL\Support\Type
                                     return $rule;
                                 }
 
-                                if ($rule instanceof \Stringable) {
-                                    return (string) $rule;
+                                if ($rule instanceof CastableToValidationString) {
+                                    return $rule->toGqlValidationString();
                                 }
 
-                                return $rule;
+                                return get_class($rule).'::class';
                             });
                         })
                         ->all();

--- a/tests/Feature/GraphQL/FormTest.php
+++ b/tests/Feature/GraphQL/FormTest.php
@@ -6,6 +6,7 @@ use Facades\Statamic\API\ResourceAuthorizer;
 use Facades\Statamic\Fields\BlueprintRepository;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Contracts\GraphQL\CastableToValidationString;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Form;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -333,6 +334,8 @@ GQL;
                     'dimensions:1024',
                     'size:1000',
                     'image:jpeg',
+                    'new Tests\Feature\GraphQL\TestValidationRuleWithToString',
+                    'new Tests\Feature\GraphQL\TestValidationRuleWithoutToString',
                 ],
             ],
         ]);
@@ -359,6 +362,8 @@ GQL;
                             'dimensions:1024',
                             'size:1000',
                             'image:jpeg',
+                            'thevalidationrule:foo,bar',
+                            'Tests\\Feature\\GraphQL\\TestValidationRuleWithoutToString::class',
                             'array',
                             'nullable',
                         ],
@@ -366,4 +371,16 @@ GQL;
                 ],
             ]]);
     }
+}
+
+class TestValidationRuleWithToString implements CastableToValidationString
+{
+    public function toGqlValidationString(): string
+    {
+        return 'thevalidationrule:foo,bar';
+    }
+}
+
+class TestValidationRuleWithoutToString
+{
 }


### PR DESCRIPTION
This follows #11781. After merging had second thoughts about it.
Rather than just checking for `__toString`, I thought it it should be a bit more explicit, so it now uses a contract and dedicated method.
The fall back is now the class name with `::class` suffix.
