### PR TITLE
[5.x] Fix storing submissions of forms with 'files' fieldtypes even when disabled

### DIFF
--- a/src/Forms/DeleteTemporaryAttachments.php
+++ b/src/Forms/DeleteTemporaryAttachments.php
@@ -31,6 +31,8 @@ class DeleteTemporaryAttachments implements ShouldQueue
                 $this->submission->remove($field->handle());
             });
 
-        $this->submission->saveQuietly();
+        if ($this->submission->form()->store()) {
+            $this->submission->saveQuietly();
+        }
     }
 }

--- a/tests/Forms/SendEmailsTest.php
+++ b/tests/Forms/SendEmailsTest.php
@@ -119,8 +119,6 @@ class SendEmailsTest extends TestCase
     #[Test]
     public function delete_attachments_job_only_saves_submission_when_enabled()
     {
-        Bus::fake();
-
         $form = tap(FacadesForm::make('attachments_test')->email([
             'from' => 'first@sender.com',
             'to' => 'first@recipient.com',

--- a/tests/Forms/SendEmailsTest.php
+++ b/tests/Forms/SendEmailsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Forms;
 use Illuminate\Support\Facades\Bus;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Contracts\Forms\SubmissionRepository;
 use Statamic\Facades\Form as FacadesForm;
 use Statamic\Facades\Site;
 use Statamic\Forms\DeleteTemporaryAttachments;
@@ -113,6 +114,31 @@ class SendEmailsTest extends TestCase
             ]),
             new DeleteTemporaryAttachments($submission),
         ]);
+    }
+
+    #[Test]
+    public function delete_attachments_job_only_saves_submission_when_enabled()
+    {
+        Bus::fake();
+
+        $form = tap(FacadesForm::make('attachments_test')->email([
+            'from' => 'first@sender.com',
+            'to' => 'first@recipient.com',
+            'foo' => 'bar',
+        ]))->save();
+
+        $form
+            ->store(false)
+            ->blueprint()
+            ->ensureField('attachments', ['type' => 'files'])->save();
+
+        $submission = $form->makeSubmission();
+
+        (new DeleteTemporaryAttachments($submission))->handle();
+
+        $submissions = app(SubmissionRepository::class)->all();
+
+        $this->assertEmpty($submissions);
     }
 
     #[Test]


### PR DESCRIPTION
This PR fixes an issue where submissions are being saved, even though the storing of them has been disabled. This only occurres when the form has a files field in it and happens when sending out the form emails.

fixes #10987 