### PR TITLE
[5.x] Fix facade PhpDocs for better understanding by Laravel Idea

### DIFF
--- a/src/Facades/Blink.php
+++ b/src/Facades/Blink.php
@@ -24,7 +24,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static mixed once($key, callable $callable)
  * @method static mixed|\Spatie\Blink\Blink store($name = 'default')
  *
- * @see Statamic\Support\Blink
+ * @see \Statamic\Support\Blink
  */
 class Blink extends Facade
 {

--- a/src/Facades/Blueprint.php
+++ b/src/Facades/Blueprint.php
@@ -25,7 +25,7 @@ use Statamic\Fields\BlueprintRepository;
  * @method static \Illuminate\Support\Collection getAdditionalNamespaces()
  *
  * @see \Statamic\Fields\BlueprintRepository
- * @see \Statamic\Fields\Blueprint
+ * @link \Statamic\Fields\Blueprint
  */
 class Blueprint extends Facade
 {

--- a/src/Facades/Collection.php
+++ b/src/Facades/Collection.php
@@ -22,7 +22,7 @@ use Statamic\Contracts\Entries\CollectionRepository;
  * @method static \Illuminate\Support\Collection getComputedCallbacks($collection)
  *
  * @see CollectionRepository
- * @see \Statamic\Entries\Collection
+ * @link \Statamic\Entries\Collection
  */
 class Collection extends Facade
 {

--- a/src/Facades/Entry.php
+++ b/src/Facades/Entry.php
@@ -26,9 +26,9 @@ use Statamic\Contracts\Entries\EntryRepository;
  * @method static void updateParents(\Statamic\Entries\Collection $collection, $ids = null)
  *
  * @see \Statamic\Stache\Repositories\EntryRepository
- * @see \Statamic\Stache\Query\EntryQueryBuilder
- * @see \Statamic\Entries\EntryCollection
- * @see \Statamic\Entries\Entry
+ * @link \Statamic\Stache\Query\EntryQueryBuilder
+ * @link \Statamic\Entries\EntryCollection
+ * @link \Statamic\Entries\Entry
  */
 class Entry extends Facade
 {

--- a/src/Facades/Fieldset.php
+++ b/src/Facades/Fieldset.php
@@ -19,7 +19,7 @@ use Statamic\Fields\FieldsetRepository;
  * @method static void addNamespace(string $namespace, string $directory)
  *
  * @see \Statamic\Fields\FieldsetRepository
- * @see \Statamic\Fields\Fieldset
+ * @link \Statamic\Fields\Fieldset
  */
 class Fieldset extends Facade
 {

--- a/src/Facades/Form.php
+++ b/src/Facades/Form.php
@@ -20,7 +20,7 @@ use Statamic\Forms\Exporters\ExporterRepository;
  * @method static ExporterRepository exporters()
  *
  * @see \Statamic\Contracts\Forms\FormRepository
- * @see \Statamic\Forms\Form
+ * @link \Statamic\Forms\Form
  */
 class Form extends Facade
 {

--- a/src/Facades/FormSubmission.php
+++ b/src/Facades/FormSubmission.php
@@ -19,7 +19,7 @@ use Statamic\Contracts\Forms\SubmissionRepository;
  * @method static SubmissionContract make()
  *
  * @see \Statamic\Contracts\Forms\SubmissionRepository
- * @see \Statamic\Forms\Submission
+ * @link \Statamic\Forms\Submission
  */
 class FormSubmission extends Facade
 {

--- a/src/Facades/GlobalSet.php
+++ b/src/Facades/GlobalSet.php
@@ -14,7 +14,7 @@ use Statamic\Contracts\Globals\GlobalRepository;
  * @method static void delete(\Statamic\Contracts\Globals\GlobalSet $global)
  *
  * @see \Statamic\Stache\Repositories\GlobalRepository
- * @see \Statamic\Globals\GlobalSet
+ * @link \Statamic\Globals\GlobalSet
  */
 class GlobalSet extends Facade
 {

--- a/src/Facades/GlobalVariables.php
+++ b/src/Facades/GlobalVariables.php
@@ -14,7 +14,7 @@ use Statamic\Contracts\Globals\GlobalVariablesRepository;
  * @method static void delete(\Statamic\Globals\Variables $variable)
  *
  * @see \Statamic\Stache\Repositories\GlobalVariablesRepository
- * @see \Statamic\Globals\Variables
+ * @link \Statamic\Globals\Variables
  */
 class GlobalVariables extends Facade
 {

--- a/src/Facades/Revision.php
+++ b/src/Facades/Revision.php
@@ -14,7 +14,7 @@ use Statamic\Contracts\Revisions\RevisionRepository;
  * @method static void delete(\Statamic\Contracts\Revisions\Revision $revision)
  *
  * @see \Statamic\Revisions\RevisionRepository
- * @see \Statamic\Revisions\Revision
+ * @link \Statamic\Revisions\Revision
  */
 class Revision extends Facade
 {

--- a/src/Facades/Role.php
+++ b/src/Facades/Role.php
@@ -15,7 +15,7 @@ use Statamic\Contracts\Auth\RoleRepository;
  * @method static void delete(\Statamic\Contracts\Auth\Role $role)
  *
  * @see \Statamic\Contracts\Auth\RoleRepository
- * @see \Statamic\Auth\Role
+ * @link \Statamic\Auth\Role
  */
 class Role extends Facade
 {

--- a/src/Facades/Search.php
+++ b/src/Facades/Search.php
@@ -15,7 +15,7 @@ use Statamic\Contracts\Search\Searchable;
  * @method static void deleteFromIndexes(Searchable $searchable)
  *
  * @see \Statamic\Search\Search
- * @see \Statamic\Search\Index
+ * @link \Statamic\Search\Index
  */
 class Search extends Facade
 {

--- a/src/Facades/StaticCache.php
+++ b/src/Facades/StaticCache.php
@@ -21,7 +21,7 @@ use Statamic\StaticCaching\StaticCacheManager;
  * @method static void includeJs()
  *
  * @see StaticCacheManager
- * @see Cacher
+ * @link Cacher
  */
 class StaticCache extends Facade
 {

--- a/src/Facades/Structure.php
+++ b/src/Facades/Structure.php
@@ -13,7 +13,7 @@ use Statamic\Contracts\Structures\StructureRepository;
  * @method static void delete(Structure $structure)
  *
  * @see \Statamic\Contracts\Structures\StructureRepository
- * @see \Statamic\Structures\Structure
+ * @link \Statamic\Structures\Structure
  */
 class Structure extends Facade
 {

--- a/src/Facades/Taxonomy.php
+++ b/src/Facades/Taxonomy.php
@@ -20,7 +20,7 @@ use Statamic\Contracts\Taxonomies\TaxonomyRepository;
  * @method static additionalPreviewTargets(string $handle)
  *
  * @see \Statamic\Stache\Repositories\TaxonomyRepository
- * @see \Statamic\Taxonomies\Taxonomy
+ * @link \Statamic\Taxonomies\Taxonomy
  */
 class Taxonomy extends Facade
 {

--- a/src/Facades/Term.php
+++ b/src/Facades/Term.php
@@ -24,7 +24,7 @@ use Statamic\Taxonomies\TermCollection;
  * @method static \Illuminate\Support\Collection applySubstitutions($items)
  *
  * @see \Statamic\Contracts\Taxonomies\TermRepository
- * @see \Statamic\Taxonomies\Term
+ * @link \Statamic\Taxonomies\Term
  */
 class Term extends Facade
 {

--- a/src/Facades/User.php
+++ b/src/Facades/User.php
@@ -24,7 +24,7 @@ use Statamic\OAuth\Provider;
  * @method static void computed(string|array $field, ?\Closure $callback = null)
  *
  * @see \Statamic\Contracts\Auth\UserRepository
- * @see \Statamic\Auth\User
+ * @link \Statamic\Auth\User
  */
 class User extends Facade
 {

--- a/src/Facades/UserGroup.php
+++ b/src/Facades/UserGroup.php
@@ -14,7 +14,7 @@ use Statamic\Contracts\Auth\UserGroupRepository;
  * @method static \Statamic\Fields\Blueprint blueprint()
  *
  * @see \Statamic\Contracts\Auth\UserGroupRepository
- * @see \Statamic\Auth\UserGroup
+ * @link \Statamic\Auth\UserGroup
  */
 class UserGroup extends Facade
 {


### PR DESCRIPTION
Hi. Laravel Idea plugin for PhpStorm uses `@see` phpDocs for facades to determine the classes hidden under this facade. And many `@see` tags in your facades create some issues(https://github.com/laravel-idea/plugin/issues/1195), so I propose to change `@see` to `@link` for classes that are not under this facade, but just linked to the logic.