### PR TITLE
[6.x] Adds Component Tag Syntax Support to Antlers

### DIFF
--- a/src/View/Antlers/Language/Parser/ComponentCompiler.php
+++ b/src/View/Antlers/Language/Parser/ComponentCompiler.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Statamic\View\Antlers\Language\Parser;
+
+use Illuminate\Support\Str;
+use Stillat\BladeParser\Nodes\Components\ComponentNode;
+use Stillat\BladeParser\Parser\DocumentParser;
+
+class ComponentCompiler
+{
+    protected array $statamicTags = ['statamic', 's'];
+
+    public function compile($template)
+    {
+        if (! Str::contains($template, ['<s-', '<s:', '<statamic-', '<statamic:'])) {
+            return $template;
+        }
+
+        return (new DocumentParser())
+            ->registerCustomComponentTags($this->statamicTags)
+            ->onlyParseComponents()
+            ->parseTemplate($template)
+            ->toDocument()
+            ->getRootNodes()
+            ->pipe(fn ($nodes) => $this->compileNodes($nodes));
+    }
+
+    protected function compileNodes($nodes)
+    {
+        return $nodes
+            ->map(function ($node) {
+                if (! $node instanceof ComponentNode) {
+                    return $node->unescapedContent;
+                }
+
+                if (! in_array(mb_strtolower($node->componentPrefix), $this->statamicTags)) {
+                    return $node->outerDocumentContent;
+                }
+
+                if ($node->isClosingTag && ! $node->isSelfClosing) {
+                    return '';
+                }
+
+                return $this->compileComponent($node);
+            })
+            ->join('');
+    }
+
+    protected function compileComponent(ComponentNode $component)
+    {
+        if ($component->isSelfClosing) {
+            return "{{ %$component->innerContent /}}";
+        }
+
+        $innerContent = $this->compileNodes($component->getNodes());
+
+        return "{{ %$component->innerContent }}$innerContent{{ /%$component->innerContent }}";
+    }
+}

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -333,6 +333,8 @@ class RuntimeParser implements Parser
      */
     protected function renderText($text, $data = [])
     {
+        $text = $this->componentCompiler->compile($text);
+
         $this->parseStack += 1;
         $text = $this->runPreParserCallbacks($text);
 
@@ -716,8 +718,6 @@ INFO;
 
     public function parse($text, $data = [])
     {
-        $text = $this->componentCompiler->compile($text);
-
         if ($this->shouldIsolate()) {
             return $this->cloneRuntimeParser()->renderText($text, $data);
         }

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -23,6 +23,7 @@ use Statamic\View\Antlers\Language\Lexer\AntlersLexer;
 use Statamic\View\Antlers\Language\Nodes\AbstractNode;
 use Statamic\View\Antlers\Language\Nodes\AntlersNode;
 use Statamic\View\Antlers\Language\Nodes\Position;
+use Statamic\View\Antlers\Language\Parser\ComponentCompiler;
 use Statamic\View\Antlers\Language\Parser\DocumentParser;
 use Statamic\View\Antlers\Language\Parser\LanguageKeywords;
 use Statamic\View\Antlers\Language\Parser\LanguageParser;
@@ -117,12 +118,16 @@ class RuntimeParser implements Parser
      */
     private $isolateRuntimes = false;
 
+    protected $componentCompiler;
+
     public function __construct(DocumentParser $documentParser, NodeProcessor $nodeProcessor, AntlersLexer $lexer, LanguageParser $antlersParser)
     {
         $this->documentParser = $documentParser;
         $this->nodeProcessor = $nodeProcessor;
         $this->antlersLexer = $lexer;
         $this->antlersParser = $antlersParser;
+
+        $this->componentCompiler = new ComponentCompiler();
     }
 
     /**
@@ -711,6 +716,8 @@ INFO;
 
     public function parse($text, $data = [])
     {
+        $text = $this->componentCompiler->compile($text);
+
         if ($this->shouldIsolate()) {
             return $this->cloneRuntimeParser()->renderText($text, $data);
         }

--- a/tests/Antlers/Parser/ComponentTagsTest.php
+++ b/tests/Antlers/Parser/ComponentTagsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Antlers\Parser;
+
+use Facades\Tests\Factories\EntryFactory;
+use Statamic\Facades\Collection;
+use Statamic\Tags\Tags;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\Antlers\ParserTestCase;
+
+class ComponentTagsTest extends ParserTestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Collection::make('pages')
+            ->routes(['en' => '{slug}'])
+            ->save();
+
+        for ($i = 1; $i <= 5; $i++) {
+            EntryFactory::collection('pages')
+                ->id("page-$i")
+                ->data([
+                    'title' => "Page: $i",
+                ])
+                ->create();
+        }
+    }
+
+    public function test_component_tags_are_parsed()
+    {
+        $template = <<<'ANTLERS'
+<s:collection:pages>
+    {{ title }}.
+</s:collection:pages>
+ANTLERS;
+
+        $this->assertSame(
+            'Page: 1. Page: 2. Page: 3. Page: 4. Page: 5.',
+            (string) str($this->renderString($template))->squish(),
+        );
+    }
+
+    public function test_component_tags_with_dynamic_parameters_are_parsed()
+    {
+        $template = <<<'ANTLERS'
+<s:collection :from="collection_name">{{ title }}.</s:collection>
+ANTLERS;
+
+        $result = $this->renderString($template, [
+            'collection_name' => 'pages',
+        ]);
+
+        $this->assertSame(
+            'Page: 1.Page: 2.Page: 3.Page: 4.Page: 5.',
+            $result,
+        );
+    }
+
+    public function test_component_tags_with_parameters_are_parsed()
+    {
+        $template = <<<'ANTLERS'
+<s:collection:pages limit="1">{{ title }}</s:collection:pages>
+ANTLERS;
+
+        $this->assertSame(
+            'Page: 1',
+            $this->renderString($template),
+        );
+    }
+
+    public function test_self_closing_component_tags_are_parsed()
+    {
+        (new class extends Tags
+        {
+            protected static $handle = 'the_tag';
+
+            public function index()
+            {
+                if ($this->isPair) {
+                    return 'Paired!';
+                }
+
+                return 'Self-Closing!';
+            }
+        })::register();
+
+        $this->assertSame('Self-Closing!', $this->renderString('<s:the_tag />'));
+        $this->assertSame('Paired!', $this->renderString('<s:the_tag> </s:the_tag>'));
+    }
+
+    public function test_nested_component_tags_are_parsed()
+    {
+        $template = <<<'ANTLERS'
+<s:collection:pages sort="title:asc">
+    Before: {{ title }}
+
+    <nested><s:collection:pages sort="title:desc" limit="2">{{ title }}</s:collection:pages></nested>
+
+    After: {{ title }}
+</s:collection:pages>
+ANTLERS;
+
+        $expected = <<<'RESULT'
+Before: Page: 1 <nested>Page: 5Page: 4</nested> After: Page: 1 Before: Page: 2 <nested>Page: 5Page: 4</nested> After: Page: 2 Before: Page: 3 <nested>Page: 5Page: 4</nested> After: Page: 3 Before: Page: 4 <nested>Page: 5Page: 4</nested> After: Page: 4 Before: Page: 5 <nested>Page: 5Page: 4</nested> After: Page: 5
+RESULT;
+
+        $this->assertSame(
+            $expected,
+            (string) str($this->renderString($template))->squish(),
+        );
+    }
+}


### PR DESCRIPTION
This PR adds Antlers Component Tag syntax support to Antlers, allowing for templates like:

```antlers
<s:collection:pages>
    {{ title }}
</s:collection:pages>
```

With params:

```antlers
<s:collection:pages as="pages">
    {{ pages }}
        {{ title }}
    {{ /pages }}
</s:collection:pages>
```

This syntax is similar to what is already supported by the Blade integration, with the exception that parameters/attributes dynamic variables, syntax, etc. follows the _Antlers_ rules instead of Blade's. Docs PR to come! :)