### PR TITLE
[5.x] Corrects Antlers error logging with PHP nodes

### DIFF
--- a/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
+++ b/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
@@ -216,6 +216,7 @@ class GlobalRuntimeState
 
     public static function resetGlobalState()
     {
+        self::$templateFileStack = [];
         self::$shareVariablesTemplateTrigger = '';
         self::$layoutVariables = [];
         self::$containsLayout = false;

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1218,7 +1218,9 @@ class NodeProcessor
                                 'User content Antlers PHP tag.'
                             );
                         } else {
-                            Log::warning('PHP Node evaluated in user content: '.$node->name->name, [
+                            $logContent = $node->rawStart.$node->innerContent().$node->rawEnd;
+
+                            Log::warning('PHP Node evaluated in user content: '.$logContent, [
                                 'file' => GlobalRuntimeState::$currentExecutionFile,
                                 'trace' => GlobalRuntimeState::$templateFileStack,
                                 'content' => $node->innerContent(),
@@ -2456,7 +2458,7 @@ class NodeProcessor
 
     protected function evaluateAntlersPhpNode(PhpExecutionNode $node)
     {
-        if (! GlobalRuntimeState::$allowPhpInContent == false && GlobalRuntimeState::$isEvaluatingUserData) {
+        if (! GlobalRuntimeState::$allowPhpInContent && GlobalRuntimeState::$isEvaluatingUserData) {
             return StringUtilities::sanitizePhp($node->content);
         }
 

--- a/tests/Antlers/Runtime/PhpEnabledTest.php
+++ b/tests/Antlers/Runtime/PhpEnabledTest.php
@@ -2,9 +2,13 @@
 
 namespace Tests\Antlers\Runtime;
 
+use Illuminate\Support\Facades\Log;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Text;
+use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
 use Statamic\View\Antlers\Language\Runtime\RuntimeConfiguration;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
 use Tests\Antlers\ParserTestCase;
@@ -513,8 +517,8 @@ EOT;
     public function test_assignments_from_php_nodes()
     {
         $template = <<<'EOT'
-{{? 
-    $value_one = 100; 
+{{?
+    $value_one = 100;
     $value_two = 0;
 ?}}
 
@@ -532,5 +536,77 @@ EOT;
         $result = $this->renderString($template, [], true);
         $this->assertStringContainsString('<value_one: 1125>', $result);
         $this->assertStringContainsString('<value_two: 1025>', $result);
+    }
+
+    public function test_disabled_php_echo_node_inside_user_values()
+    {
+        $textFieldtype = new Text();
+        $field = new Field('text_field', [
+            'type' => 'text',
+            'antlers' => true,
+        ]);
+
+        $textContent = <<<'TEXT'
+Text: {{$ Str::upper('hello, world.') $}}
+TEXT;
+
+        $textFieldtype->setField($field);
+        $value = new Value($textContent, 'text_field', $textFieldtype);
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->with("PHP Node evaluated in user content: {{\$ Str::upper('hello, world.') \$}}", [
+                'file' => null,
+                'trace' => [],
+                'content' => " Str::upper('hello, world.') ",
+            ]);
+
+        $result = $this->renderString('{{ text_field }}', ['text_field' => $value]);
+
+        $this->assertSame('Text: ', $result);
+
+        GlobalRuntimeState::$allowPhpInContent = true;
+
+        $result = $this->renderString('{{ text_field }}', ['text_field' => $value]);
+
+        $this->assertSame('Text: HELLO, WORLD.', $result);
+
+        GlobalRuntimeState::$allowPhpInContent = false;
+    }
+
+    public function test_disabled_php_node_inside_user_values()
+    {
+        $textFieldtype = new Text();
+        $field = new Field('text_field', [
+            'type' => 'text',
+            'antlers' => true,
+        ]);
+
+        $textContent = <<<'TEXT'
+Text: {{? echo Str::upper('hello, world.') ?}}
+TEXT;
+
+        $textFieldtype->setField($field);
+        $value = new Value($textContent, 'text_field', $textFieldtype);
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->with("PHP Node evaluated in user content: {{? echo Str::upper('hello, world.') ?}}", [
+                'file' => null,
+                'trace' => [],
+                'content' => " echo Str::upper('hello, world.') ",
+            ]);
+
+        $result = $this->renderString('{{ text_field }}', ['text_field' => $value]);
+
+        $this->assertSame('Text: ', $result);
+
+        GlobalRuntimeState::$allowPhpInContent = true;
+
+        $result = $this->renderString('{{ text_field }}', ['text_field' => $value]);
+
+        $this->assertSame('Text: HELLO, WORLD.', $result);
+
+        GlobalRuntimeState::$allowPhpInContent = false;
     }
 }


### PR DESCRIPTION
This PR corrects a null-reference error that can occur when PHP is disabled within user-supplied content. Currently, it will throw an exception related to an invalid property reference, instead of logging the error as intended.