### PR TITLE
[5.x] Correct issue with nested noparse and partials

### DIFF
--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -314,6 +314,11 @@ class RuntimeParser implements Parser
         return class_exists(ViewException::class) || class_exists('Spatie\LaravelIgnition\Exceptions\ViewException');
     }
 
+    protected function shouldCacheRenderNodes($text)
+    {
+        return ! str_contains($text, '/noparse');
+    }
+
     /**
      * Parses and renders the input text, with the provided runtime data.
      *
@@ -350,7 +355,7 @@ class RuntimeParser implements Parser
             $parseText = $this->sanitizePhp($text);
             $cacheSlug = md5($parseText);
 
-            if (! array_key_exists($cacheSlug, self::$standardRenderNodeCache)) {
+            if (! array_key_exists($cacheSlug, self::$standardRenderNodeCache) || ! $this->shouldCacheRenderNodes($text)) {
                 $this->documentParser->setIsVirtual($this->view == '');
 
                 if (strlen($this->view) > 0) {

--- a/tests/Antlers/Runtime/NoparseTest.php
+++ b/tests/Antlers/Runtime/NoparseTest.php
@@ -2,11 +2,16 @@
 
 namespace Tests\Antlers\Runtime;
 
+use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
+use Statamic\View\Antlers\Language\Runtime\NodeProcessor;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
 use Tests\Antlers\ParserTestCase;
+use Tests\FakesViews;
 
 class NoparseTest extends ParserTestCase
 {
+    use FakesViews;
+
     public function test_noparse_ignores_braces_entirely()
     {
         $template = <<<'EOT'
@@ -141,5 +146,40 @@ the title
 EOT;
 
         $this->assertSame($expected, StringUtilities::normalizeLineEndings(trim($this->renderString($template, ['title' => 'the title']))));
+    }
+
+    public function test_noparse_in_nested_partials_renders_correctly()
+    {
+        $template = <<<'EOT'
+    {{ partial:partial_a }}
+        {{ partial:partial_a }}
+            {{ noparse }}inside noparse{{ /noparse }}
+        {{ /partial:partial_a }}
+    {{ /partial:partial_a }}
+
+    {{ partial:partial_a }}
+        {{ partial:partial_a }}
+            {{ noparse }}inside noparse{{ /noparse }}
+        {{ /partial:partial_a }}
+    {{ /partial:partial_a }}
+
+    {{ partial:partial_a }}
+        {{ partial:partial_a }}
+            {{ noparse }}inside noparse{{ /noparse }}
+        {{ /partial:partial_a }}
+    {{ /partial:partial_a }}
+EOT;
+
+        GlobalRuntimeState::$peekCallbacks[] = function ($processor, $nodes) {
+            NodeProcessor::$break = true;
+        };
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('partial_a', '{{ slot }}');
+
+        $actual = StringUtilities::normalizeLineEndings(trim($this->renderString($template)));
+
+        $occurrences = substr_count($actual, 'inside noparse');
+        $this->assertEquals(3, $occurrences, "Expected 'inside noparse' to appear exactly 3 times");
     }
 }


### PR DESCRIPTION
This PR fixes #11485 by disabling the runtime node cache for content that contains `noparse` blocks. Admittedly this is a workaround to help address this edge case.

A proper fix would be much more time intensive and may require significant changes to how things work. I chose to disable the cache for now after going down many rabbit holes and stopping to think through the time investment vs. results.