### PR TITLE
[6.x] Allow PHP Tags in Antlers to Override any Variable

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -2454,51 +2454,53 @@ class NodeProcessor
         return ob_get_clean();
     }
 
-    protected function evaluateAntlersPhpNode(PhpExecutionNode $node)
+    protected function evaluateAntlersPhpNode(PhpExecutionNode $___node)
     {
         if (! GlobalRuntimeState::$allowPhpInContent == false && GlobalRuntimeState::$isEvaluatingUserData) {
-            return StringUtilities::sanitizePhp($node->content);
+            return StringUtilities::sanitizePhp($___node->content);
         }
 
-        $phpBuffer = '';
+        $___phpBuffer = '';
 
-        if ($node->isEchoNode == false) {
-            $phpBuffer = $node->content;
+        if ($___node->isEchoNode == false) {
+            $___phpBuffer = $___node->content;
 
-            if (! Str::contains($node->content, $this->validPhpOpenTags)) {
-                $phpBuffer = '<?php '.$node->content.' ?>';
+            if (! Str::contains($___node->content, $this->validPhpOpenTags)) {
+                $___phpBuffer = '<?php '.$___node->content.' ?>';
             }
         } else {
-            $phpBuffer = '<?php echo '.$node->content.'; ?>';
+            $___phpBuffer = '<?php echo '.$___node->content.'; ?>';
         }
 
-        $phpRuntimeAssignments = [];
+        $___phpRuntimeAssignments = [];
         ob_start();
 
         try {
             extract($this->getActiveData());
             $___antlersVarBefore = get_defined_vars();
-            eval('?>'.$phpBuffer.'<?php ');
+            eval('?>'.$___phpBuffer.'<?php ');
             $___antlersPhpExecutionResult = ob_get_clean();
 
-            if (! $node->isEchoNode) {
+            if (! $___node->isEchoNode) {
                 $___antlersVarAfter = get_defined_vars();
 
-                foreach ($___antlersVarAfter as $varKey => $varValue) {
-                    if (! array_key_exists($varKey, $___antlersVarBefore) || array_key_exists($varKey, $this->previousAssignments) || array_key_exists($varKey, $this->runtimeAssignments)) {
-                        $phpRuntimeAssignments[$varKey] = $varValue;
+                foreach ($___antlersVarAfter as $___varKey => $___varValue) {
+                    if (str_starts_with($___varKey, '___')) {
+                        continue;
                     }
+
+                    $___phpRuntimeAssignments[$___varKey] = $___varValue;
                 }
             }
         } catch (ParseError $e) {
-            throw new SyntaxError("{$e->getMessage()} on line {$e->getLine()} of:\n\n{$phpBuffer}");
+            throw new SyntaxError("{$e->getMessage()} on line {$e->getLine()} of:\n\n{$___phpBuffer}");
         }
 
-        if (! $node->isEchoNode && ! empty($phpRuntimeAssignments)) {
-            unset($phpRuntimeAssignments['___antlersVarBefore']);
-            unset($phpRuntimeAssignments['___antlersPhpExecutionResult']);
+        if (! $___node->isEchoNode && ! empty($___phpRuntimeAssignments)) {
+            unset($___phpRuntimeAssignments['___antlersVarBefore']);
+            unset($___phpRuntimeAssignments['___antlersPhpExecutionResult']);
 
-            $this->processAssignments($phpRuntimeAssignments);
+            $this->processAssignments($___phpRuntimeAssignments);
         }
 
         return $___antlersPhpExecutionResult;


### PR DESCRIPTION
This PR fixes #11222 by allowing developers to override any variable when using the `{{? ... ?}}` or `{{$ $}}` PHP tags. With the changes in this PR, the following will now be possible without having to explicitly assign the variable first:

```antlers
{{?
    // This will now update $theVariableName without an explicit assignment.
    array_unshift($theVariableName, 'The Value');
?}}

{{ theVariableName}} ... {{ /theVariableName }}
```

While this is technically a bug fix, I am targeting `6.x`+ as it is a significant behavior change that could impact existing projects.