### PR TITLE
[5.x] Add `moveQuietly` method to `Asset` class

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -775,6 +775,13 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
         return $this;
     }
 
+    public function moveQuietly($folder, $filename = null)
+    {
+        $this->withEvents = false;
+
+        return $this->move(...func_get_args());
+    }
+
     /**
      * Replace an asset and/or its references where necessary.
      *

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1106,6 +1106,54 @@ class AssetTest extends TestCase
     }
 
     #[Test]
+    public function it_can_be_moved_to_another_folder_quietly()
+    {
+        Storage::fake('local');
+        $disk = Storage::disk('local');
+        $disk->put('old/asset.txt', 'The asset contents');
+        $container = Facades\AssetContainer::make('test')->disk('local');
+        Facades\AssetContainer::shouldReceive('save')->with($container);
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test')->andReturn($container);
+        $asset = $container->makeAsset('old/asset.txt')->data(['foo' => 'bar']);
+        $asset->save();
+        $oldMeta = $disk->get('old/.meta/asset.txt.yaml');
+        $disk->assertExists('old/asset.txt');
+        $disk->assertExists('old/.meta/asset.txt.yaml');
+        $this->assertEquals([
+            'old/asset.txt',
+        ], $container->files()->all());
+        $this->assertEquals([
+            'old/asset.txt' => ['foo' => 'bar'],
+        ], $container->assets('/', true)->keyBy->path()->map(function ($item) {
+            return $item->data()->all();
+        })->all());
+
+        Event::fake();
+        $return = $asset->moveQuietly('new');
+
+        $this->assertEquals($asset, $return);
+        $disk->assertMissing('old/asset.txt');
+        $disk->assertMissing('old/.meta/asset.txt.yaml');
+        $disk->assertExists('new/asset.txt');
+        $disk->assertExists('new/.meta/asset.txt.yaml');
+        $this->assertEquals($oldMeta, $disk->get('new/.meta/asset.txt.yaml'));
+        $this->assertEquals([
+            'new/asset.txt',
+        ], $container->files()->all());
+        $this->assertEquals([
+            'new/asset.txt' => ['foo' => 'bar'],
+        ], $container->assets('/', true)->keyBy->path()->map(function ($item) {
+            return $item->data()->all();
+        })->all());
+        $this->assertEquals([
+            'old', // the empty directory doesnt actually get deleted
+            'new',
+            'new/asset.txt',
+        ], $container->contents()->cached()->keys()->all());
+        Event::assertNotDispatched(AssetSaved::class);
+    }
+
+    #[Test]
     public function it_can_be_moved_to_another_folder_with_a_new_filename()
     {
         Storage::fake('local');


### PR DESCRIPTION
This pull request adds a `moveQuietly` method to the `Asset` class, allowing developers to move assets without the unnecessary overhead of events.

Useful when moving assets on mass, where you don't want to update search indexes or clear the Glide cache when each asset is moved.