### PR TITLE
[5.x] Prepare value & operator before passing to Eloquent Query Builder

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -167,6 +167,10 @@ abstract class EloquentQueryBuilder implements Builder
             return $this;
         }
 
+        [$value, $operator] = $this->prepareValueAndOperator(
+            $value, $operator, func_num_args() === 2
+        );
+
         $this->builder->where($this->column($column), $operator, $value, $boolean);
 
         return $this;


### PR DESCRIPTION
This pull request partially fixes statamic/eloquent-driver#424, by ensuring that the value and operator are handled properly before being passed to the Eloquent Query Builder.

## The Problem

Currently, when you're storing entries in the database, attempting to query a column with a value matching an operator will result in an error:

```php
Entry::query()->where('site', 'is')->get();
```

```
InvalidArgumentException 
Illegal operator and value combination. 
at vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:945
```

The query works as expected when querying the model directly, or when using the Stache query builder. `is` simply becomes the value when a third argument hasn't been provided.

This fix goes alongside ... which adjusts how the `EloquentQueryBuilder::where()` method is called. 
