### PR TITLE
[5.x] Checks for Closure instances instead of is_callable inside Route::statamic(...)

### DIFF
--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -46,9 +46,9 @@ class FrontendController extends Controller
         $view = Arr::pull($params, 'view');
         $data = Arr::pull($params, 'data');
 
-        throw_if(is_callable($view) && $data, new \Exception('Parameter [$data] not supported with [$view] closure!'));
+        throw_if(($view instanceof Closure) && $data, new \Exception('Parameter [$data] not supported with [$view] closure!'));
 
-        if (is_callable($view)) {
+        if ($view instanceof Closure) {
             $resolvedView = static::resolveRouteClosure($view, $params);
         }
 

--- a/tests/Routing/RoutesTest.php
+++ b/tests/Routing/RoutesTest.php
@@ -151,6 +151,8 @@ class RoutesTest extends TestCase
                 });
 
             });
+
+            Route::statamic('/callables-test', 'auth');
         });
     }
 
@@ -595,6 +597,17 @@ class RoutesTest extends TestCase
         $this->get('/basic-route-with-data')
             ->assertOk()
             ->assertSee('Custom layout');
+    }
+
+    #[Test]
+    public function it_checks_for_closure_instances_instead_of_callables()
+    {
+        $this->viewShouldReturnRaw('auth', 'Hello, world.');
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+
+        $this->get('/callables-test')
+            ->assertOk()
+            ->assertSee('Hello, world.');
     }
 }
 


### PR DESCRIPTION
This PR fixes #11808 by checking if passed views to `Route::statamic('/the-url', 'the_view')` are `Closure` instances instead of calling `is_callable`.

Globally available functions, such as `auth`, will return `true` when using `is_callable`, making those names unusable as view names.