### PR TITLE
[5.x] Add an option to rawurlencode to not ignore forward slashes

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1932,8 +1932,12 @@ class CoreModifiers extends Modifier
      *
      * @return string
      */
-    public function rawurlencode($value)
+    public function rawurlencode($value, $params)
     {
+        if (! Arr::get($params, 0, true)) {
+            return rawurlencode($value);
+        }
+
         return implode('/', array_map('rawurlencode', explode('/', $value)));
     }
 

--- a/tests/Antlers/Runtime/CoreModifiersTest.php
+++ b/tests/Antlers/Runtime/CoreModifiersTest.php
@@ -80,6 +80,7 @@ class CoreModifiersTest extends ParserTestCase
             ],
             'remove_left_var' => 'https://',
             'test_currency_symbol' => '£32.00',
+            'test_url_encode' => 'please and thank you/Mommy',
         ];
     }
 
@@ -564,6 +565,12 @@ EOT;
         $this->assertSame('No', $this->renderString($template, ['variable' => []], true));
         $this->assertSame('No', $this->renderString($template, ['variable' => collect()], true));
         $this->assertSame('Yes', $this->renderString($template, ['variable' => ['One']], true));
+    }
+
+    public function test_rawurlencode()
+    {
+        $this->assertSame('please%20and%20thank%20you/Mommy', $this->resultOf('{{ test_url_encode | rawurlencode }}'));
+        $this->assertSame('please%20and%20thank%20you%2FMommy', $this->resultOf('{{ test_url_encode | rawurlencode(false) }}'));
     }
 }
 


### PR DESCRIPTION
This PR adds a param to the `rawurlencode` modified to _not_ ignore forward slashes.

So:

`{{ "please and thank you/Mommy" | rawurlencode }}`
returns
`please%20and%20thank%20you/Mommy`

`{{ "please and thank you/Mommy" | rawurlencode(false) }}`
returns
`please%20and%20thank%20you%2FMommy`

I did it this way to ensure its not a breaking change, however it would be better if the function simply always did this (or for the default to be that it does).

Closes https://github.com/statamic/cms/issues/11470