### PR TITLE
[5.x] Render markdown after antlers when smartypants is enabled

### DIFF
--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -390,4 +390,9 @@ abstract class Fieldtype implements Arrayable
     {
         return [];
     }
+
+    public function shouldParseAntlersFromRawString(): bool
+    {
+        return false;
+    }
 }

--- a/src/Fields/Value.php
+++ b/src/Fields/Value.php
@@ -82,11 +82,14 @@ class Value implements ArrayAccess, IteratorAggregate, JsonSerializable
             $raw = $this->fieldtype->field()?->defaultValue() ?? null;
         }
 
-        $value = $this->shallow
+        return $this->getAugmentedValue($raw);
+    }
+
+    private function getAugmentedValue($raw)
+    {
+        return $this->shallow
             ? $this->fieldtype->shallowAugment($raw)
             : $this->fieldtype->augment($raw);
-
-        return $value;
     }
 
     private function iteratorValue()
@@ -150,9 +153,19 @@ class Value implements ArrayAccess, IteratorAggregate, JsonSerializable
         }
 
         if ($shouldParseAntlers) {
+            if ($parseFromRawString = $this->fieldtype->shouldParseAntlersFromRawString()) {
+                $value = $this->raw();
+            }
+
             $value = (new DocumentTransformer())->correct($value);
 
-            return $parser->parse($value, $variables);
+            $parsed = $parser->parse($value, $variables);
+
+            if (! $parseFromRawString) {
+                return $parsed;
+            }
+
+            return $this->getAugmentedValue($parsed);
         }
 
         if (Str::contains($value, '{')) {

--- a/src/Fieldtypes/Markdown.php
+++ b/src/Fieldtypes/Markdown.php
@@ -198,4 +198,9 @@ class Markdown extends Fieldtype
             'previewUrl' => cp_route('markdown.preview'),
         ];
     }
+
+    public function shouldParseAntlersFromRawString(): bool
+    {
+        return $this->config('smartypants', false);
+    }
 }

--- a/tests/Fieldtypes/MarkdownTest.php
+++ b/tests/Fieldtypes/MarkdownTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades;
 use Statamic\Fields\Field;
+use Statamic\Fields\Value;
 use Statamic\Fieldtypes\Markdown;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -168,6 +169,24 @@ EOT;
 EOT;
 
         $this->assertEquals($expected, $this->fieldtype()->augment($markdown));
+    }
+
+    #[Test]
+    public function it_converts_to_smartypants_after_antlers_is_parsed()
+    {
+        $md = $this->fieldtype(['smartypants' => true, 'antlers' => true]);
+
+        $value = <<<'EOT'
+{{ "this is a string" | replace(" is ", " isnt ") | reverse }}
+EOT;
+
+        $value = new Value($value, 'markdown', $md);
+
+        $expected = <<<'EOT'
+<p>gnirts a tnsi siht</p>
+EOT;
+
+        $this->assertEqualsTrimmed($expected, $value->antlersValue(app(\Statamic\Contracts\View\Antlers\Parser::class), []));
     }
 
     private function fieldtype($config = [])


### PR DESCRIPTION
This PR updates the logic in Value::antlersValue to allow for antlers parsing on the raw value of the field, after which the field itself is augmented.

This ensures that on the markdown field smartypants takes effect after antlers, preventing any antlers errors.

Closes https://github.com/statamic/cms/issues/11302