### PR TITLE
[5.x] Entries fieldtype: Only show "Allow Creating" option when using stack selector

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -95,6 +95,9 @@ class Entries extends Relationship
                         'instructions' => __('statamic::fieldtypes.entries.config.create'),
                         'type' => 'toggle',
                         'default' => true,
+                        'if' => [
+                            'mode' => 'default',
+                        ],
                     ],
                     'collections' => [
                         'display' => __('Collections'),


### PR DESCRIPTION
Right now, the "Allow Creating" option is only used in the stack selector mode, since you can't create options in the select/typeahead modes.

To avoid confusion, this pull request will hide the option in the blueprint builder _unless_ the stack selector mode is configured.

Closes #11789.