### PR TITLE
[5.x] Static Cache Middleware - skip cache if new header is set

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -184,6 +184,7 @@ class Cache
             $response->headers->has('X-Statamic-Draft')
             || $response->headers->has('X-Statamic-Private')
             || $response->headers->has('X-Statamic-Protected')
+            || $response->headers->has('X-Statamic-No-Static-Cache')
         ) {
             return false;
         }

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -184,7 +184,7 @@ class Cache
             $response->headers->has('X-Statamic-Draft')
             || $response->headers->has('X-Statamic-Private')
             || $response->headers->has('X-Statamic-Protected')
-            || $response->headers->has('X-Statamic-No-Static-Cache')
+            || $response->headers->has('X-Statamic-Uncacheable')
         ) {
             return false;
         }


### PR DESCRIPTION
We do not have a way to determine ourselves if something should be skipped or not.

One option would have been to add `X-Statamic-Draft` to the headers, but this seemed "dirty". A new header allows us to skip the cache conditionally: `X-Statamic-No-Static-Cache` and would work well for others as well - it's clear, to-the-point, and distinct.

Our use case: we do NOT want to cache 404 responses in some instances - so we want to add that header where applicable.

Considered also `X-Statamic-Skip-Static-Cache`, but opted for shorter version with "No" instead of "Skip". Also considered `X-Statamic-No-Cache`, but thought that might be confused with Nocache (a separate implementation).