### PR TITLE
[5.x] Add filterNotIn to Assets tag

### DIFF
--- a/src/Tags/Assets.php
+++ b/src/Tags/Assets.php
@@ -191,8 +191,24 @@ class Assets extends Tags
         return $this->output();
     }
 
+    /**
+     * Filter out assets from a requested folder.
+     */
+    private function filterNotIn()
+    {
+        if ($not_in = $this->params->get('not_in')) {
+            $regex = '#^('.$not_in.')#';
+
+            $this->assets = $this->assets->reject(function ($path) use ($regex) {
+                return preg_match($regex, $path);
+            });
+        }
+    }
+
     private function output()
     {
+        $this->filterNotIn();
+
         $this->sort();
         $this->limit();
 


### PR DESCRIPTION
Add "not_in" parameter to assets tag to filter by using a regular expression, and will be matched against the file path.

For example: not_in="(.*?)logo"

`{{ assets container="images not_in="(.*?)logo" }}`

This is similar to "not_in" at https://statamic.dev/tags/get_files