### PR TITLE
[5.x] Perform null check on data in video fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/VideoFieldtype.vue
+++ b/resources/js/components/fieldtypes/VideoFieldtype.vue
@@ -89,7 +89,7 @@ export default {
         },
 
         isEmbeddable() {
-            return this.isUrl && this.data.includes('youtube') || this.data.includes('vimeo') || this.data.includes('youtu.be');
+            return this.isUrl && this.data?.includes('youtube') || this.data?.includes('vimeo') || this.data?.includes('youtu.be');
         },
 
         isInvalid() {
@@ -106,10 +106,10 @@ export default {
 
         isVideo() {
             return ! this.isEmbeddable && (
-                this.data.includes('.mp4') ||
-                this.data.includes('.ogv') ||
-                this.data.includes('.mov') ||
-                this.data.includes('.webm')
+                this.data?.includes('.mp4') ||
+                this.data?.includes('.ogv') ||
+                this.data?.includes('.mov') ||
+                this.data?.includes('.webm')
             )
         }
     },


### PR DESCRIPTION
When editing a multi site, when using the Video fieldtype, making a change on the child version of the page, then using the "Sites" area in the sidebar to change to the Origin, shows the video appear on the Origin version. You can make changes to any other field, and save them, but the Video does not save unless its value is completely updated.

Using Statamic 5.56.0, you can test this with: https://github.com/martyf/statamic-localisation

1. On EN site, create a new Entry
2. Add a Replicator Set, and fill out the Text field
3. Save
5. Use the Sites in the Sidebar to switch to the DE, edit the replicator Text
6. Save
7. Do a full page refresh, and make sure you're on the DE page.
8. Add a Video to the set
9. Save, but stay on the page
10. Using the "Sites" section on the right of the editor, switch to EN
11. The "Text" should show the correct language, and the Video is still populated
12. Change the "Text"
13. Save
14. Full page refresh: the video is now gone

This can also be replicated just by using the "Video" fieldtype outside a replicator.

The trigger seems to be going from DE to EN (i.e. child to Origin). Going from EN to DE (Origin to child) works as expected.

This PR addresses this issue by correcting a JS behaviour. When the Entry is switched from child to Origin, the `data` property becomes null - however tests for `isVideo` and `isEmbeddable` both are expecting `data` to have access to the `includes` function. 

This update optionally chains the `includes` check, so that it correctly fails (and doesn't throw JS errors). This resolves the issue described above.