### PR TITLE
Added the option to add renderers to markdown parsers

### DIFF
--- a/src/Markdown/Parser.php
+++ b/src/Markdown/Parser.php
@@ -15,6 +15,7 @@ class Parser
 
     protected $converter;
     protected $extensions = [];
+    protected $renderers = [];
     protected $config = [];
 
     public function __construct(array $config = [])
@@ -41,6 +42,10 @@ class Parser
             $env->addExtension($ext);
         }
 
+        foreach ($this->renderers() as $ren) {
+            $env->addRenderer(...$ren);
+        }
+
         return $this->converter = $converter;
     }
 
@@ -54,6 +59,15 @@ class Parser
         $this->converter = null;
 
         $this->extensions[] = $closure;
+
+        return $this;
+    }
+
+    public function addRenderers(Closure $closure): self
+    {
+        $this->converter = null;
+
+        $this->renderers[] = $closure;
 
         return $this;
     }
@@ -74,6 +88,19 @@ class Parser
         }
 
         return $exts;
+    }
+
+    public function renderers(): array
+    {
+        $renderers = [];
+
+        foreach ($this->renderers as $closure) {
+            foreach ($closure() as $renderer) {
+                $renderers[] = $renderer;
+            }
+        }
+
+        return $renderers;
     }
 
     public function withStatamicDefaults()
@@ -149,6 +176,10 @@ class Parser
 
         foreach ($this->extensions as $ext) {
             $parser->addExtensions($ext);
+        }
+
+        foreach ($this->renderers as $ren) {
+            $parser->addRenderers($ren);
         }
 
         return $parser;

--- a/tests/Markdown/Fixtures/HeadingRenderer.php
+++ b/tests/Markdown/Fixtures/HeadingRenderer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Markdown\Fixtures;
+
+use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+
+class HeadingRenderer implements NodeRendererInterface
+{
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    {
+        if (! ($node instanceof Heading)) {
+            throw new \InvalidArgumentException('Incompatible node type: '.get_class($node));
+        }
+
+        return "<h1 data-custom-renderer>{$childRenderer->renderNodes($node->children())}</h1>";
+    }
+}

--- a/tests/Markdown/Fixtures/LinkRenderer.php
+++ b/tests/Markdown/Fixtures/LinkRenderer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Markdown\Fixtures;
+
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link as InlineLink;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+
+class LinkRenderer implements NodeRendererInterface
+{
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    {
+        if (! ($node instanceof InlineLink)) {
+            throw new \InvalidArgumentException('Incompatible node type: '.get_class($node));
+        }
+
+        return "<a data-custom-renderer href=\"{$node->getUrl()}\" title=\"{$node->getTitle()}\">{$childRenderer->renderNodes($node->children())}</a>";
+    }
+}

--- a/tests/Markdown/ParserTest.php
+++ b/tests/Markdown/ParserTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Markdown;
 
+use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Markdown;
 use Tests\TestCase;
@@ -54,6 +56,12 @@ class ParserTest extends TestCase
             return new Fixtures\SmileyExtension;
         });
 
+        $this->parser->addRenderers(function () {
+            return [
+                [Link::class, new Fixtures\LinkRenderer],
+            ];
+        });
+
         $this->assertEquals("\n", $this->parser->config('renderer/block_separator'));
         $this->assertEquals("\n", $this->parser->config('renderer/inner_separator'));
         $this->assertEquals('allow', $this->parser->config('html_input'));
@@ -71,11 +79,33 @@ class ParserTest extends TestCase
             return new Fixtures\FrownyExtension;
         });
 
+        $newParser->addRenderers(function () {
+            return [
+                [Heading::class, new Fixtures\HeadingRenderer],
+            ];
+        });
+
         $this->assertNotSame($this->parser, $newParser);
         $this->assertEquals("\n", $newParser->config('renderer/block_separator'));
         $this->assertEquals('foo', $newParser->config('renderer/inner_separator'));
         $this->assertEquals('strip', $newParser->config('html_input'));
         $this->assertCount(2, $newParser->extensions());
         $this->assertCount(1, $this->parser->extensions());
+        $this->assertCount(2, $newParser->renderers());
+        $this->assertCount(1, $this->parser->renderers());
+    }
+
+    #[Test]
+    public function it_uses_custom_renderers()
+    {
+        $this->assertEquals("<p><a href=\"http://example.com\">test</a></p>\n", $this->parser->parse('[test](http://example.com)'));
+
+        $this->parser->addRenderers(function () {
+            return [
+                [Link::class, new Fixtures\LinkRenderer],
+            ];
+        });
+
+        $this->assertEquals("<p><a data-custom-renderer href=\"http://example.com\" title=\"\">test</a></p>\n", $this->parser->parse('[test](http://example.com)'));
     }
 }


### PR DESCRIPTION
Hey,

This is an attempt to add a new feature that allows developers to add custom markdown Renderers when creating or extending markdown parsers, see: https://commonmark.thephpleague.com/2.7/customization/rendering/

This PR is a fix for #11825 and a follow up to a [discord thread](https://discord.com/channels/489818810157891584/1377250507596234763).

As of today, the Markdown Parser only keeps tracks of custom extensions when creating or copying parsers, making it impossible to add custom renderers. This can be very useful for customizing how the html is rendered, for example if you already have a blade component for your table, link, headers, etc and which to reuse them directly with your markdown.

I added a simple test with a LinkRenderer that adds some attributes and extended the newInstance test to ensure renderers are copied over. I mostly just copy and pasted the code implemented for how extensions were saved and did the same for renderers.

Ran the tests locally and seems to be working just fine. I'm opened to suggestions.