### PR TITLE
Null check for fieldActions within replicator

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Field.vue
+++ b/resources/js/components/fieldtypes/replicator/Field.vue
@@ -159,7 +159,7 @@ export default {
         },
 
         shouldShowFieldActions() {
-            return !this.isInsideConfigFields && this.fieldActions.length > 0;
+            return !this.isInsideConfigFields && this.fieldActions?.length > 0;
         },
 
         fieldActions() {


### PR DESCRIPTION
Fields within a replicator throw a TypeError:
```TypeError: can't access property "length", this.fieldActions is undefined```

This PR updates the offending function to conditionally check the length using `this.fieldActions?.length`