### PR TITLE
[5.x] Allow stache stores to be removed

### DIFF
--- a/src/Stache/Stache.php
+++ b/src/Stache/Stache.php
@@ -60,6 +60,13 @@ class Stache
         return $this;
     }
 
+    public function removeStore(string $store)
+    {
+        $this->stores->forget($store);
+
+        return $this;
+    }
+
     public function stores()
     {
         return $this->stores;

--- a/tests/Stache/StacheTest.php
+++ b/tests/Stache/StacheTest.php
@@ -62,6 +62,24 @@ class StacheTest extends TestCase
     }
 
     #[Test]
+    public function stores_can_be_removed()
+    {
+        $this->stache->sites(['en']); // store expects the stache to have site(s)
+        $this->assertTrue($this->stache->stores()->isEmpty());
+
+        $this->stache->registerStore(
+            new CollectionsStore($this->stache, \Mockery::mock(Filesystem::class))
+        );
+
+        $return = $this->stache->removeStore('collections');
+
+        $this->assertEquals($this->stache, $return);
+        tap($this->stache->stores(), function ($stores) {
+            $this->assertEquals(0, $stores->count());
+        });
+    }
+
+    #[Test]
     public function multiple_stores_can_be_registered_at_once()
     {
         $this->stache->sites(['en']); // store expects the stache to have site(s)


### PR DESCRIPTION
When using the eloquent driver with split configurations and running `stache:warm`, stache stores that aren't file driven are still registered and warmed. Most of the time this is not noticeable as theres no data, but when you have lots of entries with terms it creates the associations and this is a big bottleneck.

This PR adds the ability to remove registered stache stores, which allows the eloquent driver to remove them.

See: https://github.com/statamic/eloquent-driver/pull/433

