### PR TITLE
[5.x] Fix create/edit CP nav descendants not properly triggering active status

### DIFF
--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -282,12 +282,20 @@ class NavItem
     }
 
     /**
-     * Check if this nav item was ever a child before user preferences were applied.
-     *
-     * @param  bool|null  $isChild
-     * @return mixed
+     * Check if current url is a restful descendant.
      */
-    protected function wasOriginallyChild()
+    protected function currentUrlIsRestfulDescendant(): bool
+    {
+        return (bool) Str::endsWith(request()->url(), [
+            '/create',
+            '/edit',
+        ]);
+    }
+
+    /**
+     * Check if this nav item was ever a child before user preferences were applied.
+     */
+    protected function wasOriginallyChild(): bool
     {
         return (bool) $this->wasOriginallyChild;
     }
@@ -382,8 +390,12 @@ class NavItem
         // If the current URL is not explicitly referenced in the CP nav,
         // and if this item is/was ever a child nav item,
         // then check against URL heirarchy conventions using regex pattern.
-        if ($this->currentUrlIsNotExplicitlyReferencedInNav() && $this->wasOriginallyChild()) {
-            return $this->isActiveByPattern($this->active);
+        if ($this->currentUrlIsNotExplicitlyReferencedInNav()) {
+            switch (true) {
+                case $this->currentUrlIsRestfulDescendant():
+                case $this->wasOriginallyChild():
+                    return $this->isActiveByPattern($this->active);
+            }
         }
 
         return request()->url() === URL::removeQueryAndFragment($this->url);

--- a/tests/CP/Navigation/ActiveNavItemTest.php
+++ b/tests/CP/Navigation/ActiveNavItemTest.php
@@ -197,6 +197,25 @@ class ActiveNavItemTest extends TestCase
     }
 
     #[Test]
+    public function it_resolves_core_children_closure_and_can_check_when_parent_and_descendant_of_parent_item_is_active()
+    {
+        Facades\Collection::make('pages')->title('Pages')->save();
+        Facades\Collection::make('articles')->title('Articles')->save();
+
+        $this
+            ->prepareNavCaches()
+            ->get('http://localhost/cp/collections/create')
+            ->assertStatus(200);
+
+        $collections = $this->buildAndGetItem('Content', 'Collections');
+
+        $this->assertTrue($collections->isActive());
+        $this->assertInstanceOf(Collection::class, $collections->children());
+        $this->assertFalse($collections->children()->keyBy->display()->get('Pages')->isActive());
+        $this->assertFalse($collections->children()->keyBy->display()->get('Articles')->isActive());
+    }
+
+    #[Test]
     public function it_resolves_core_children_closure_and_can_check_when_parent_and_descendant_of_child_item_is_active()
     {
         Facades\Collection::make('pages')->title('Pages')->save();


### PR DESCRIPTION
For example, if you go to create a collection at `/cp/collections/create`, it wasn't triggering active status on the `Collections` item...

![CleanShot 2025-05-30 at 16 16 13](https://github.com/user-attachments/assets/f7b5f4ce-fe67-4b33-8d7c-3aca3259f4a8)

But now it does...

![CleanShot 2025-05-30 at 16 16 52](https://github.com/user-attachments/assets/184411cf-92db-4018-ba16-bdfbebe74d2e)