### PR TITLE
[6.x] Normalize and configure trailing slashes in URLs

### DIFF
--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -345,16 +345,20 @@ class URL
     }
 
     /**
-     * Normalize trailing slashes (trims by default, but can be enforced onto end).
+     * Normalize trailing slashes before query and fragment (trims by default, but can be enforced).
      */
     public function normalizeTrailingSlashes(string $url): string
     {
-        if ($url === '/') {
-            return $url;
+        $parts = str($url)->split(pattern: '/([?#])/', flags: PREG_SPLIT_DELIM_CAPTURE)->all();
+
+        $url = array_shift($parts);
+
+        $queryAndFragments = implode($parts);
+
+        if (static::$enforceTrailingSlashes) {
+            $url = Str::ensureRight($url, '/');
         }
 
-        return static::$enforceTrailingSlashes
-            ? Str::ensureRight($url, '/')
-            : rtrim($url, '/');
+        return $url.$queryAndFragments;
     }
 }

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -355,8 +355,14 @@ class URL
 
         $queryAndFragments = implode($parts);
 
+        if (in_array($url, ['', '/']) && ! $queryAndFragments) {
+            return '/';
+        }
+
         if (static::$enforceTrailingSlashes) {
             $url = Str::ensureRight($url, '/');
+        } else {
+            $url = Str::removeRight($url, '/');
         }
 
         return $url.$queryAndFragments;

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -349,10 +349,11 @@ class URL
      */
     public function normalizeTrailingSlashes(string $url): string
     {
-        $parts = str($url)->split(pattern: '/([?#])/', flags: PREG_SPLIT_DELIM_CAPTURE)->all();
+        $parts = str($url)
+            ->split(pattern: '/([?#])/', flags: PREG_SPLIT_DELIM_CAPTURE)
+            ->all();
 
         $url = array_shift($parts);
-
         $queryAndFragments = implode($parts);
 
         if (in_array($url, ['', '/']) && ! $queryAndFragments) {

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -14,10 +14,19 @@ use Statamic\Support\Str;
  */
 class URL
 {
+    private static $enforceTrailingSlashes = false;
     private static $externalUriCache = [];
 
     /**
-     * Removes occurrences of "//" in a $path (except when part of a protocol)
+     * Enforce trailing slashes service provider helper.
+     */
+    public function enforceTrailingSlashes(bool $bool = true): void
+    {
+        static::$enforceTrailingSlashes = $bool;
+    }
+
+    /**
+     * Removes occurrences of "//" in a $path (except when part of a protocol).
      * Alias of Path::tidy().
      *
      * @param  string  $url  URL to remove "//" from
@@ -333,5 +342,19 @@ class URL
         $url = Str::before($url, '#'); // Remove anchor fragment
 
         return $url;
+    }
+
+    /**
+     * Normalize trailing slashes (trims by default, but can be enforced onto end).
+     */
+    public function normalizeTrailingSlashes(string $url): string
+    {
+        if ($url === '/') {
+            return $url;
+        }
+
+        return static::$enforceTrailingSlashes
+            ? Str::ensureRight($url, '/')
+            : rtrim($url, '/');
     }
 }

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -240,4 +240,51 @@ class UrlTest extends TestCase
         $this->assertEquals('https://example.com/about', URL::removeQueryAndFragment('https://example.com/about?foo=bar&baz=qux'));
         $this->assertEquals('https://example.com/about', URL::removeQueryAndFragment('https://example.com/about?foo=bar&baz=qux#anchor'));
     }
+
+    #[Test]
+    #[DataProvider('enforceTrailingSlashesProvider')]
+    public function enforces_trailing_slashes($url, $expected)
+    {
+        URL::enforceTrailingSlashes();
+
+        $this->assertSame($expected, URL::normalizeTrailingSlashes($url));
+    }
+
+    public static function enforceTrailingSlashesProvider()
+    {
+        return [
+            ['', '/'],
+            ['/', '/'],
+
+            ['?query', '/?query'],
+            ['#anchor', '/#anchor'],
+            ['?foo=bar&baz=qux', '/?foo=bar&baz=qux'],
+            ['?foo=bar&baz=qux#anchor', '/?foo=bar&baz=qux#anchor'],
+
+            ['/?query', '/?query'],
+            ['/#anchor', '/#anchor'],
+            ['/?foo=bar&baz=qux', '/?foo=bar&baz=qux'],
+            ['/?foo=bar&baz=qux#anchor', '/?foo=bar&baz=qux#anchor'],
+
+            ['https://example.com?query', 'https://example.com/?query'],
+            ['https://example.com#anchor', 'https://example.com/#anchor'],
+            ['https://example.com?foo=bar&baz=qux', 'https://example.com/?foo=bar&baz=qux'],
+            ['https://example.com?foo=bar&baz=qux#anchor', 'https://example.com/?foo=bar&baz=qux#anchor'],
+
+            ['https://example.com/?query', 'https://example.com/?query'],
+            ['https://example.com/#anchor', 'https://example.com/#anchor'],
+            ['https://example.com/?foo=bar&baz=qux', 'https://example.com/?foo=bar&baz=qux'],
+            ['https://example.com/?foo=bar&baz=qux#anchor', 'https://example.com/?foo=bar&baz=qux#anchor'],
+
+            ['https://example.com/about?query', 'https://example.com/about/?query'],
+            ['https://example.com/about#anchor', 'https://example.com/about/#anchor'],
+            ['https://example.com/about?foo=bar&baz=qux', 'https://example.com/about/?foo=bar&baz=qux'],
+            ['https://example.com/about?foo=bar&baz=qux#anchor', 'https://example.com/about/?foo=bar&baz=qux#anchor'],
+
+            ['https://example.com/about/?query', 'https://example.com/about/?query'],
+            ['https://example.com/about/#anchor', 'https://example.com/about/#anchor'],
+            ['https://example.com/about/?foo=bar&baz=qux', 'https://example.com/about/?foo=bar&baz=qux'],
+            ['https://example.com/about/?foo=bar&baz=qux#anchor', 'https://example.com/about/?foo=bar&baz=qux#anchor'],
+        ];
+    }
 }

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -9,6 +9,13 @@ use Tests\TestCase;
 
 class UrlTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        URL::enforceTrailingSlashes(false);
+
+        parent::tearDown();
+    }
+
     protected function resolveApplicationConfiguration($app)
     {
         parent::resolveApplicationConfiguration($app);

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -339,4 +339,18 @@ class UrlTest extends TestCase
             ['https://example.com/about/?foo=bar&baz=qux#anchor', 'https://example.com/about?foo=bar&baz=qux#anchor'],
         ];
     }
+
+    #[Test]
+    public function it_can_configure_and_unconfigure_enforcing_of_trailing_slashes()
+    {
+        $this->assertSame('https://example.com?query', URL::normalizeTrailingSlashes('https://example.com?query'));
+
+        URL::enforceTrailingSlashes();
+
+        $this->assertSame('https://example.com/?query', URL::normalizeTrailingSlashes('https://example.com?query'));
+
+        URL::enforceTrailingSlashes(false);
+
+        $this->assertSame('https://example.com?query', URL::normalizeTrailingSlashes('https://example.com?query'));
+    }
 }

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -294,4 +294,49 @@ class UrlTest extends TestCase
             ['https://example.com/about/?foo=bar&baz=qux#anchor', 'https://example.com/about/?foo=bar&baz=qux#anchor'],
         ];
     }
+
+    #[Test]
+    #[DataProvider('removeTrailingSlashesProvider')]
+    public function removes_trailing_slashes($url, $expected)
+    {
+        $this->assertSame($expected, URL::normalizeTrailingSlashes($url));
+    }
+
+    public static function removeTrailingSlashesProvider()
+    {
+        return [
+            ['', '/'],
+            ['/', '/'],
+
+            ['?query', '?query'],
+            ['#anchor', '#anchor'],
+            ['?foo=bar&baz=qux', '?foo=bar&baz=qux'],
+            ['?foo=bar&baz=qux#anchor', '?foo=bar&baz=qux#anchor'],
+
+            ['/?query', '?query'],
+            ['/#anchor', '#anchor'],
+            ['/?foo=bar&baz=qux', '?foo=bar&baz=qux'],
+            ['/?foo=bar&baz=qux#anchor', '?foo=bar&baz=qux#anchor'],
+
+            ['https://example.com?query', 'https://example.com?query'],
+            ['https://example.com#anchor', 'https://example.com#anchor'],
+            ['https://example.com?foo=bar&baz=qux', 'https://example.com?foo=bar&baz=qux'],
+            ['https://example.com?foo=bar&baz=qux#anchor', 'https://example.com?foo=bar&baz=qux#anchor'],
+
+            ['https://example.com/?query', 'https://example.com?query'],
+            ['https://example.com/#anchor', 'https://example.com#anchor'],
+            ['https://example.com/?foo=bar&baz=qux', 'https://example.com?foo=bar&baz=qux'],
+            ['https://example.com/?foo=bar&baz=qux#anchor', 'https://example.com?foo=bar&baz=qux#anchor'],
+
+            ['https://example.com/about?query', 'https://example.com/about?query'],
+            ['https://example.com/about#anchor', 'https://example.com/about#anchor'],
+            ['https://example.com/about?foo=bar&baz=qux', 'https://example.com/about?foo=bar&baz=qux'],
+            ['https://example.com/about?foo=bar&baz=qux#anchor', 'https://example.com/about?foo=bar&baz=qux#anchor'],
+
+            ['https://example.com/about/?query', 'https://example.com/about?query'],
+            ['https://example.com/about/#anchor', 'https://example.com/about#anchor'],
+            ['https://example.com/about/?foo=bar&baz=qux', 'https://example.com/about?foo=bar&baz=qux'],
+            ['https://example.com/about/?foo=bar&baz=qux#anchor', 'https://example.com/about?foo=bar&baz=qux#anchor'],
+        ];
+    }
 }


### PR DESCRIPTION
This PR adds the ability to enforce trailing slashes in URLs via `URL::enforceTrailingSlashes()`, which has been asked for a fair bit.

The idea is to make Statamic normalize trailing slashes in URLs (ie. remove them by default, or add them if the above is configured), while respecting URL query and fragment at the end of any given URL.

If an addon needs to enforce trailing slashes for one specfic use case only, you can pass a `true`/`false` bool into `URL::enforceTrailingSlashes($bool)` control flow around this new functionality across all URL output.

References:

https://github.com/statamic/ideas/issues/1293
https://github.com/statamic/ssg/issues/65
https://github.com/statamic/seo-pro/issues/387