### PR TITLE
[5.x] Throw 404 response when OAuth provider doesn't exist

### DIFF
--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -35,6 +35,10 @@ class OAuthController
     {
         $oauth = OAuth::provider($provider);
 
+        if (! $oauth) {
+            throw new NotFoundHttpException();
+        }
+
         try {
             $providerUser = $oauth->getSocialiteUser();
         } catch (InvalidStateException $e) {

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\OAuth;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
@@ -16,6 +17,10 @@ class OAuthController
     {
         $referer = $request->headers->get('referer');
         $guard = config('statamic.users.guards.web', 'web');
+
+        if (! OAuth::providers()->has($provider)) {
+            throw new NotFoundHttpException();
+        }
 
         if (Str::startsWith(parse_url($referer)['path'], Str::ensureLeft(config('statamic.cp.route'), '/'))) {
             $guard = config('statamic.users.guards.cp', 'web');


### PR DESCRIPTION
This pull request adds a check to Statamic's OAuth routes to ensure the passed provider has been configured, otherwise it should throw a 404 (was previously throwing a 500 error).

Fixes #11842.