### PR TITLE
[5.x] Detect recursion when augmenting Entries

### DIFF
--- a/src/Exceptions/RecursiveAugmentationException.php
+++ b/src/Exceptions/RecursiveAugmentationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Statamic\Exceptions;
+
+class RecursiveAugmentationException extends \Exception
+{
+}


### PR DESCRIPTION
This PR adds recursive augmentation detection. The current scope of this detection is Entries, but will apply to anything that utilizes `HasOrigin`.

This recursive behavior can be re-created when attempting to reference augmented values within computed callbacks (see #11853). This PR does not fix the underlying issue here, but makes it easier to detect and debug.