### PR TITLE
Fix/asset upload remove single quote

### DIFF
--- a/src/Assets/AssetUploader.php
+++ b/src/Assets/AssetUploader.php
@@ -89,6 +89,8 @@ class AssetUploader extends Uploader
             '?' => '-',
             '*' => '-',
             '%' => '-',
+            "'" => '-',
+            "--" => '-',
         ];
 
         return (string) Str::of(urldecode($string))

--- a/tests/Assets/AssetUploaderTest.php
+++ b/tests/Assets/AssetUploaderTest.php
@@ -31,6 +31,8 @@ class AssetUploaderTest extends TestCase
             'question marks' => ['one?two.jpg', 'one-two.jpg'],
             'asterisks' => ['one*two.jpg', 'one-two.jpg'],
             'percentage' => ['one%two.jpg', 'one-two.jpg'],
+            'single quote' => ["one'two'three.jpg", 'one-two-three.jpg'],
+            'double dash' => ['one--two--three.jpg', 'one-two-three.jpg'],
             'ascii' => ['fòô-bàř', 'foo-bar'],
         ];
     }


### PR DESCRIPTION
Fixes #11857

Replaces single quotes in file names with a dash, replaces double dashes with a single dash.

`this-'file'-name.jpg` would have become `this--file--name.jpg` without handling the double dashes.

Handling double dashes will return `this-file-name.jpg`.

It would also be possible to use `slug()` but that would also replace underscores with dashes but.
