### PR TITLE
[5.x] Fix Custom Set Icons not working if path contains a dot (.)

### DIFF
--- a/resources/js/components/SvgIcon.vue
+++ b/resources/js/components/SvgIcon.vue
@@ -43,7 +43,9 @@ export default {
                 directory = directory+'/'+folder;
             }
 
-            return data_get(this.$config.get('customSvgIcons') || {}, `${directory}.${file}`);
+            let svgIcons = this.$config.get('customSvgIcons')[directory] ?? [];
+
+            return svgIcons[file] ?? null;
         },
     },
 


### PR DESCRIPTION
This PR fixes an issue with the `svg-icon` component not showing the icon if the path contains a dot somewhere.

In my case, the site directory on the staging server is the name of the full domain, which of course, contains a dot. E.g. ``example.com``.

The global helper function ``data_get()`` splits strings by ``.`` leading the function to not work as expected.

fixes #11864 