### PR TITLE
[5.x] Fix read-only state of roles and groups fields

### DIFF
--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -227,11 +227,11 @@ class UsersController extends CpController
         $blueprint = $user->blueprint();
 
         if (! User::current()->can('assign roles')) {
-            $blueprint->ensureField('roles', ['visibility' => 'read_only']);
+            $blueprint->ensureFieldHasConfig('roles', ['visibility' => 'read_only']);
         }
 
         if (! User::current()->can('assign user groups')) {
-            $blueprint->ensureField('groups', ['visibility' => 'read_only']);
+            $blueprint->ensureFieldHasConfig('groups', ['visibility' => 'read_only']);
         }
 
         if (User::current()->isSuper() && User::current()->id() !== $user->id()) {

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -227,11 +227,11 @@ class UsersController extends CpController
         $blueprint = $user->blueprint();
 
         if (! User::current()->can('assign roles')) {
-            $blueprint->ensureFieldHasConfig('roles', ['visibility' => 'read_only']);
+            $blueprint->ensureFieldHasConfig('roles', ['visibility' => 'hidden']);
         }
 
         if (! User::current()->can('assign user groups')) {
-            $blueprint->ensureFieldHasConfig('groups', ['visibility' => 'read_only']);
+            $blueprint->ensureFieldHasConfig('groups', ['visibility' => 'hidden']);
         }
 
         if (User::current()->isSuper() && User::current()->id() !== $user->id()) {


### PR DESCRIPTION
I noticed that the `user_roles` and `user_groups` fields in the user blueprint aren't displayed as `read_only` even if a user doesn't have the `assign roles` and `assign user groups` permissions. This PR fixes that. It's only a UI fix, as the `UsersController` already guards the fields from being updated without the appropriate permissions.

**Before:**
![CleanShot 2025-06-11 at 19 06 09@2x](https://github.com/user-attachments/assets/df651d97-60e3-4314-9eab-fdc66751130b)

**After:**
![CleanShot 2025-06-11 at 19 06 39@2x](https://github.com/user-attachments/assets/de52f8c7-f5ba-4529-a234-5c32a5c1f5f1)

I actually went a step further and decided to hide the fields instead of making them read-only. I think this is more appropriate. Users without permission to change their role and group shouldn't be able to see those fields at all. It's just confusing.

