### PR TITLE
[5.x] Prevent null in strtolower()

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -160,7 +160,7 @@ abstract class EloquentQueryBuilder implements Builder
             return $this->whereNested($column, $boolean);
         }
 
-        if (strtolower($operator) == 'like') {
+        if ($operator !== null && strtolower($operator) == 'like') {
             $grammar = $this->builder->getConnection()->getQueryGrammar();
             $this->builder->whereRaw('LOWER('.$grammar->wrap($this->column($column)).') LIKE ?', strtolower($value), $boolean);
 


### PR DESCRIPTION
Since PHP 8.2, passing null to parameter #1 ($string) of type string in strtolower() is deprecated, this throws the error. A simple not null check fixes the problem.
