### PR TITLE
[5.x] Fix issues with Blade nav tag compiler

### DIFF
--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -5,7 +5,6 @@ namespace Statamic\Providers;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\View as ViewFactory;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 use Illuminate\View\View;
 use Statamic\Contracts\View\Antlers\Parser as ParserContract;
 use Statamic\Facades\Site;
@@ -178,18 +177,17 @@ if (! isset(\$view)) { \$view = []; }
                 $nested = '$children';
             }
 
-            $recursiveChildren = <<<'PHP'
-@include('compiled__views::'.$__currentStatamicNavView, array_merge(get_defined_vars(), [
-    'depth' => ($depth ?? 0) + 1,
-    '__statamicOverrideTagResultValue' => #varName#,
-]))
+            return <<<PHP
+<?php
+    echo \$___statamicNavCallback(
+        array_merge(get_defined_vars(), [
+            'depth' => (\$depth ?? 0) + 1,
+            '__statamicOverrideTagResultValue' => $nested,
+        ]),
+        \$___statamicNavCallback
+    );
+?>
 PHP;
-
-            $recursiveChildren = Str::swap([
-                '#varName#' => $nested,
-            ], $recursiveChildren);
-
-            return Blade::compileString($recursiveChildren);
         });
 
     }

--- a/src/View/Blade/Concerns/CompilesNavs.php
+++ b/src/View/Blade/Concerns/CompilesNavs.php
@@ -12,13 +12,20 @@ trait CompilesNavs
         $viewName = '___nav'.sha1($component->outerDocumentContent);
 
         $compiled = (new StatamicTagCompiler())
-            ->prependCompiledContent('$__currentStatamicNavView = \''.$viewName.'\';')
-            ->appendCompiledContent('unset($__currentStatamicNavView);')
             ->setInterceptNav(false)
             ->compile($component->outerDocumentContent);
 
-        file_put_contents(storage_path('framework/views/'.$viewName.'.blade.php'), $compiled);
+        return <<<PHP
+<?php \$___statamicNavCallback = function (\$___scope, \$___statamicNavCallback) {
+    extract(\$___scope);
+    ob_start();
+?>$compiled<?php
+    return ob_get_clean();
+};
 
-        return '@include(\'compiled__views::'.$viewName.'\', get_defined_vars())';
+echo \$___statamicNavCallback(get_defined_vars(), \$___statamicNavCallback);
+unset(\$___statamicNavCallback);
+?>
+PHP;
     }
 }

--- a/tests/View/Blade/AntlersComponents/NavCompilerTest.php
+++ b/tests/View/Blade/AntlersComponents/NavCompilerTest.php
@@ -232,4 +232,63 @@ EXPECTED;
             Blade::render($template)
         );
     }
+
+    #[Test]
+    public function it_supports_imported_classes_and_functions()
+    {
+        $template = <<<'BLADE'
+@use (Statamic\Support\Html)
+
+<ul>
+<s:nav:main as="the_items">
+@foreach ($the_items as $item)
+<li>{{ Html::entities($item['title']) }}</li>
+@endforeach
+</s:nav:main>
+</ul>
+BLADE;
+
+        $expected = <<<'EXPECTED'
+<ul>
+<li>Home</li>
+<li>About</li>
+<li>Projects</li>
+<li>Contact</li>
+</ul>
+EXPECTED;
+
+        $this->assertSame(
+            $expected,
+            Blade::render($template),
+        );
+    }
+
+    #[Test]
+    public function it_doesnt_mangle_php_inside_nav_tag()
+    {
+        $template = <<<'BLADE'
+<ul>
+<s:nav:main as="the_items">
+@foreach ($the_items as $item)
+@php $theValue = $item['title'].'-value'; @endphp
+<li>{{ $theValue }}</li>
+@endforeach
+</s:nav:main>
+</ul>
+BLADE;
+
+        $expected = <<<'EXPECTED'
+<ul>
+<li>Home-value</li>
+<li>About-value</li>
+<li>Projects-value</li>
+<li>Contact-value</li>
+</ul>
+EXPECTED;
+
+        $this->assertSame(
+            $expected,
+            Blade::render($template),
+        );
+    }
 }


### PR DESCRIPTION
This PR fixes #11806.

## Problem

The current implementation of the `nav` compiler will create a temporary file and include that behind the scenes, which worked in supporting recursive children. However, this causes issues when importing classes or functions, as this information would be lost inside the hidden temporary file.

Additionally, because the current implementation triggers a Blade compilating in creating that temporary file, it can mess with the internal raw block state, causing placeholder strings like `@__raw_block_1__@` to appear in the output.

## The Fix

This PR addresses both issues by refactoring away the temporary file, and instead inlines the compiled navigation code in a function. Recursive navigation support is maintained by simply calling that compiled function instead of including a hidden view.