### PR TITLE
[5.x] Ensure propagating entries respects saveQuietly

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -436,8 +436,8 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
         if ($isNew && ! $this->hasOrigin() && $this->collection()->propagate()) {
             $this->collection()->sites()
                 ->reject($this->site()->handle())
-                ->each(function ($siteHandle) {
-                    $this->makeLocalization($siteHandle)->save();
+                ->each(function ($siteHandle) use ($withEvents) {
+                    $this->makeLocalization($siteHandle)->{$withEvents ? 'save' : 'saveQuietly'}();
                 });
         }
 

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -1445,7 +1445,7 @@ class EntryTest extends TestCase
     }
 
     #[Test]
-    public function it_propagates_entry_if_configured()
+    public function it_doesnt_fire_events_when_propagating_entry_and_saved_quietly()
     {
         Event::fake();
 
@@ -1467,42 +1467,42 @@ class EntryTest extends TestCase
             ->locale('en')
             ->collection($collection);
 
-        $return = $entry->save();
+        $return = $entry->saveQuietly();
 
         $this->assertIsObject($fr = $entry->descendants()->get('fr'));
         $this->assertIsObject($de = $entry->descendants()->get('de'));
         $this->assertNull($entry->descendants()->get('es')); // collection not configured for this site
 
-        Event::assertDispatchedTimes(EntrySaving::class, 3);
-        Event::assertDispatched(EntrySaving::class, function ($event) use ($entry) {
+        Event::assertDispatchedTimes(EntrySaving::class, 0);
+        Event::assertNotDispatched(EntrySaving::class, function ($event) use ($entry) {
             return $event->entry === $entry;
         });
-        Event::assertDispatched(EntrySaving::class, function ($event) use ($fr) {
+        Event::assertNotDispatched(EntrySaving::class, function ($event) use ($fr) {
             return $event->entry === $fr;
         });
-        Event::assertDispatched(EntrySaving::class, function ($event) use ($de) {
+        Event::assertNotDispatched(EntrySaving::class, function ($event) use ($de) {
             return $event->entry === $de;
         });
 
-        Event::assertDispatchedTimes(EntryCreated::class, 3);
-        Event::assertDispatched(EntryCreated::class, function ($event) use ($entry) {
+        Event::assertDispatchedTimes(EntryCreated::class, 0);
+        Event::assertNotDispatched(EntryCreated::class, function ($event) use ($entry) {
             return $event->entry === $entry;
         });
-        Event::assertDispatched(EntryCreated::class, function ($event) use ($fr) {
+        Event::assertNotDispatched(EntryCreated::class, function ($event) use ($fr) {
             return $event->entry === $fr;
         });
-        Event::assertDispatched(EntryCreated::class, function ($event) use ($de) {
+        Event::assertNotDispatched(EntryCreated::class, function ($event) use ($de) {
             return $event->entry === $de;
         });
 
-        Event::assertDispatchedTimes(EntrySaved::class, 3);
-        Event::assertDispatched(EntrySaved::class, function ($event) use ($entry) {
+        Event::assertDispatchedTimes(EntrySaved::class, 0);
+        Event::assertNotDispatched(EntrySaved::class, function ($event) use ($entry) {
             return $event->entry === $entry;
         });
-        Event::assertDispatched(EntrySaved::class, function ($event) use ($fr) {
+        Event::assertNotDispatched(EntrySaved::class, function ($event) use ($fr) {
             return $event->entry === $fr;
         });
-        Event::assertDispatched(EntrySaved::class, function ($event) use ($de) {
+        Event::assertNotDispatched(EntrySaved::class, function ($event) use ($de) {
             return $event->entry === $de;
         });
     }

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -1445,6 +1445,69 @@ class EntryTest extends TestCase
     }
 
     #[Test]
+    public function it_propagates_entry_if_configured()
+    {
+        Event::fake();
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+            'es' => ['name' => 'Spanish', 'locale' => 'es_ES', 'url' => 'http://test.com/es/'],
+            'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
+        ]);
+
+        $collection = (new Collection)
+            ->handle('pages')
+            ->propagate(true)
+            ->sites(['en', 'fr', 'de'])
+            ->save();
+
+        $entry = (new Entry)
+            ->id('a')
+            ->locale('en')
+            ->collection($collection);
+
+        $return = $entry->save();
+
+        $this->assertIsObject($fr = $entry->descendants()->get('fr'));
+        $this->assertIsObject($de = $entry->descendants()->get('de'));
+        $this->assertNull($entry->descendants()->get('es')); // collection not configured for this site
+
+        Event::assertDispatchedTimes(EntrySaving::class, 3);
+        Event::assertDispatched(EntrySaving::class, function ($event) use ($entry) {
+            return $event->entry === $entry;
+        });
+        Event::assertDispatched(EntrySaving::class, function ($event) use ($fr) {
+            return $event->entry === $fr;
+        });
+        Event::assertDispatched(EntrySaving::class, function ($event) use ($de) {
+            return $event->entry === $de;
+        });
+
+        Event::assertDispatchedTimes(EntryCreated::class, 3);
+        Event::assertDispatched(EntryCreated::class, function ($event) use ($entry) {
+            return $event->entry === $entry;
+        });
+        Event::assertDispatched(EntryCreated::class, function ($event) use ($fr) {
+            return $event->entry === $fr;
+        });
+        Event::assertDispatched(EntryCreated::class, function ($event) use ($de) {
+            return $event->entry === $de;
+        });
+
+        Event::assertDispatchedTimes(EntrySaved::class, 3);
+        Event::assertDispatched(EntrySaved::class, function ($event) use ($entry) {
+            return $event->entry === $entry;
+        });
+        Event::assertDispatched(EntrySaved::class, function ($event) use ($fr) {
+            return $event->entry === $fr;
+        });
+        Event::assertDispatched(EntrySaved::class, function ($event) use ($de) {
+            return $event->entry === $de;
+        });
+    }
+
+    #[Test]
     public function it_doesnt_fire_events_when_propagating_entry_and_saved_quietly()
     {
         Event::fake();


### PR DESCRIPTION
When using saveQuietly() and the automatically propagate entries setting in on a collection, the new entries are currently save()-d (loudly).

This PR ensures the save method used respects the one used on the initial entry.