### PR TITLE
[5.x] Added key in case of import field

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -631,7 +631,9 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
             return collect($section['fields'] ?? [])->map(function ($field, $fieldIndex) use ($sectionIndex) {
                 return $field + ['fieldIndex' => $fieldIndex, 'sectionIndex' => $sectionIndex];
             });
-        })->keyBy('handle');
+        })->keyBy(function ($field) {
+            return $field['import'] ?? $field['handle'];
+        });
     }
 
     protected function ensureFieldInTabHasConfig($handle, $tab, $config)


### PR DESCRIPTION
This PR proposes a fix for https://github.com/statamic/cms/issues/11878.

When a field is an import from a fieldset, it doesn't have a `handle`, which results in an empty array key.
This fix uses the import name as the key instead, preventing issues caused by empty keys.