### PR TITLE
[5.x] Ensure nav blueprint graphql types are registered

### DIFF
--- a/src/GraphQL/TypeRegistrar.php
+++ b/src/GraphQL/TypeRegistrar.php
@@ -17,6 +17,7 @@ use Statamic\GraphQL\Types\FormType;
 use Statamic\GraphQL\Types\GlobalSetInterface;
 use Statamic\GraphQL\Types\JsonArgument;
 use Statamic\GraphQL\Types\LabeledValueType;
+use Statamic\GraphQL\Types\NavPageInterface;
 use Statamic\GraphQL\Types\NavTreeBranchType;
 use Statamic\GraphQL\Types\NavType;
 use Statamic\GraphQL\Types\PageInterface;
@@ -71,6 +72,7 @@ class TypeRegistrar
         AssetInterface::addTypes();
         GlobalSetInterface::addTypes();
         UserType::addTypes();
+        NavPageInterface::addTypes();
 
         $this->registered = true;
     }

--- a/src/GraphQL/Types/NavPageInterface.php
+++ b/src/GraphQL/Types/NavPageInterface.php
@@ -5,6 +5,7 @@ namespace Statamic\GraphQL\Types;
 use Rebing\GraphQL\Support\InterfaceType;
 use Statamic\Contracts\Structures\Nav;
 use Statamic\Facades\GraphQL;
+use Statamic\Facades\Nav as NavAPI;
 use Statamic\Support\Str;
 
 class NavPageInterface extends InterfaceType
@@ -19,8 +20,6 @@ class NavPageInterface extends InterfaceType
 
     public function fields(): array
     {
-        $this->nav->blueprint()->addGqlTypes();
-
         if ($fields = $this->nav->blueprint()->fields()->toGql()->all()) {
             return $fields;
         }
@@ -35,5 +34,12 @@ class NavPageInterface extends InterfaceType
     public static function buildName(Nav $nav): string
     {
         return 'NavPage_'.Str::studly($nav->handle());
+    }
+
+    public static function addTypes()
+    {
+        GraphQL::addTypes(NavAPI::all()->each(function ($nav) {
+            optional($nav->blueprint())->addGqlTypes();
+        })->mapInto(NavBasicPageType::class)->all());
     }
 }


### PR DESCRIPTION
When using GraphQL to query a nav which has a replicator in the blueprint, you get an error showing the type has not been defined.

This PR ensures the types get registered and the error goes away.

I tried doing this using the types() method on the interface but it didn't seem to get called.