### PR TITLE
[5.x] Add `hasField` method to `Fieldset`

### DIFF
--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -108,6 +108,11 @@ class Fieldset
         return $this->fields()->get($handle);
     }
 
+    public function hasField($field)
+    {
+        return $this->fields()->has($field);
+    }
+
     public function isNamespaced(): bool
     {
         return Str::contains($this->handle(), '::');

--- a/tests/Fields/FieldsetTest.php
+++ b/tests/Fields/FieldsetTest.php
@@ -168,6 +168,32 @@ class FieldsetTest extends TestCase
     }
 
     #[Test]
+    public function it_can_check_if_has_field()
+    {
+        FieldsetRepository::shouldReceive('find')
+            ->with('partial')
+            ->andReturn((new Fieldset)->setContents([
+                'fields' => [
+                    ['handle' => 'two', 'field' => ['type' => 'text']],
+                ],
+            ]))
+            ->once();
+
+        $fieldset = new Fieldset;
+
+        $fieldset->setContents([
+            'fields' => [
+                ['handle' => 'one', 'field' => ['type' => 'text']],
+                ['import' => 'partial'],
+            ],
+        ]);
+
+        $this->assertTrue($fieldset->hasField('one'));
+        $this->assertTrue($fieldset->hasField('two'));
+        $this->assertFalse($fieldset->hasField('three'));
+    }
+
+    #[Test]
     public function gets_blueprints_importing_fieldset()
     {
         $fieldset = Fieldset::make('seo')->setContents(['fields' => [


### PR DESCRIPTION
This pull request adds a `hasField` method to the `Fieldset` class, mirroring the `Blueprint@hasField` method. 

I was working with fieldsets earlier and I tried to call `->hasField()` only to realise that method currently only exists on the `Blueprint` class.