### PR TITLE
[5.x] Fix authorization error when creating globals

### DIFF
--- a/src/Policies/GlobalSetPolicy.php
+++ b/src/Policies/GlobalSetPolicy.php
@@ -36,6 +36,11 @@ class GlobalSetPolicy
         // handled by before()
     }
 
+    public function store($user)
+    {
+        // handled by before()
+    }
+
     public function view($user, $set)
     {
         $user = User::fromUser($user);


### PR DESCRIPTION
This pull request fixes an issue where non-super-users weren't able to create globals, even when they had the `configure globals` permission.

They could access the create page, but would receive an authorization error when submitting the create form.

Fixes #11849.