### PR TITLE
[5.x] Corrects issue serializing/deserializing "resolvingValues"

### DIFF
--- a/src/Data/HasOrigin.php
+++ b/src/Data/HasOrigin.php
@@ -7,7 +7,7 @@ use Statamic\Facades\Blink;
 
 trait HasOrigin
 {
-    private $resolvingValues = false;
+    protected $resolvingValues = false;
 
     /**
      * @var string

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -1109,6 +1109,6 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
             $this->slug = $slug($this);
         }
 
-        return array_keys(Arr::except(get_object_vars($this), ['cachedKeys', 'computedCallbackCache', 'siteCache', 'augmentationReferenceKey']));
+        return array_keys(Arr::except(get_object_vars($this), ['cachedKeys', 'computedCallbackCache', 'siteCache', 'augmentationReferenceKey', 'resolvingValues']));
     }
 }

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -2698,4 +2698,31 @@ class EntryTest extends TestCase
 
         $entry->values();
     }
+
+    #[Test]
+    public function entries_can_be_serialized_after_resolving_values()
+    {
+        $entry = EntryFactory::id('entry-id')
+            ->collection('test')
+            ->slug('entry-slug')
+            ->create();
+
+        $customEntry = CustomEntry::fromEntry($entry);
+
+        $serialized = serialize($customEntry);
+        $unserialized = unserialize($serialized);
+
+        $this->assertSame('entry-slug', $unserialized->slug);
+    }
+}
+
+class CustomEntry extends Entry
+{
+    public static function fromEntry(Entry $entry)
+    {
+        return (new static)
+            ->slug($entry->slug)
+            ->collection($entry->collection)
+            ->data($entry->data);
+    }
 }


### PR DESCRIPTION
This PR fixes #11887 

When deserializing/serializing an entry instance to a class that _extends_ file entry, such as the Eloquent driver's entry instance, we will run into an issue when attempting to repopulate the `$resolvingValues` variable.

This PR addresses it in two ways:

* Adjusts the visibility of `$resolvingValues` from private to protected, so any other classes that may use the `HasOrigin` trait do not run into issues
* Adjusted the base Entry class's `__sleep` method to exclude the `resolvingValues` value
