### PR TITLE
[5.x] Extend `get` modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -836,6 +836,11 @@ class CoreModifiers extends Modifier
         // Get the requested variable, which is the first parameter.
         $var = Arr::get($params, 0);
 
+        // If the requested value is a collection, we convert it to an array.
+        if ($value instanceof Collection) {
+            $value = $value->all();
+        }
+
         // If the requested value is an array, we'll grab the index or just the first one.
         if (is_array($value)) {
             $value = Arr::get($value, $var ?? 0);

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -833,9 +833,12 @@ class CoreModifiers extends Modifier
      */
     public function get($value, $params)
     {
-        // If the requested value is an array, we'll just grab the first one.
+        // Get the requested variable, which is the first parameter.
+        $var = Arr::get($params, 0);
+
+        // If the requested value is an array, we'll grab the index or just the first one.
         if (is_array($value)) {
-            $value = Arr::get($value, 0);
+            $value = Arr::get($value, $var ?? 0);
         }
 
         // If it's not already an object, we'll assume we have an ID and get that.
@@ -845,9 +848,6 @@ class CoreModifiers extends Modifier
         if (! $item) {
             return $value;
         }
-
-        // Get the requested variable, which is the first parameter.
-        $var = Arr::get($params, 0);
 
         // Convert the item to an array, since we'll want access to all the
         // available data. Then grab the requested variable from there.

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Data\Augmentable;
+use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Compare;
@@ -836,7 +837,18 @@ class CoreModifiers extends Modifier
         // Get the requested variable, which is the first parameter.
         $var = Arr::get($params, 0);
 
-        // If the requested value is a collection, we convert it to an array.
+        // If the requested value is a query builder and no variable is requested,
+        // we'll resolve the query and return the result as an array
+        if ($value instanceof Builder && $var === null) {
+            return $value->get()->all();
+        }
+
+        // If the requested value is a query builder, we'll resolve it
+        if ($value instanceof Builder) {
+            $value = $value->get()->all();
+        }
+
+        // If the requested value is a collection, we'll convert it to an array.
         if ($value instanceof Collection) {
             $value = $value->all();
         }

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -828,9 +828,7 @@ class CoreModifiers extends Modifier
     }
 
     /**
-     * Get any variable from a relationship.
-     *
-     * @return string
+     * Get any variable from a relationship, an array, a collection or a query builder.
      */
     public function get($value, $params)
     {

--- a/tests/Modifiers/GetTest.php
+++ b/tests/Modifiers/GetTest.php
@@ -30,6 +30,23 @@ class GetTest extends TestCase
     }
 
     #[Test]
+    public function it_returns_the_requested_index_from_a_collection(): void
+    {
+        $modified = $this->modify(collect(['You shall not pass!', 'Fool of a Took']), [1]);
+        $this->assertEquals('Fool of a Took', $modified);
+
+        $modified = $this->modify(collect(['one' => 'You shall not pass!', 'two' => 'Fool of a Took']), ['two']);
+        $this->assertEquals('Fool of a Took', $modified);
+    }
+
+    #[Test]
+    public function it_returns_the_first_item_from_a_collection_if_no_index_is_given(): void
+    {
+        $modified = $this->modify(['You', 'shall', 'not pass!']);
+        $this->assertEquals('You', $modified);
+    }
+
+    #[Test]
     public function it_returns_the_existing_value_if_no_object_can_be_resolved(): void
     {
         $modified = $this->modify('You shall not pass!');

--- a/tests/Modifiers/GetTest.php
+++ b/tests/Modifiers/GetTest.php
@@ -13,7 +13,17 @@ class GetTest extends TestCase
     use PreventSavingStacheItemsToDisk;
 
     #[Test]
-    public function it_returns_the_first_item_from_an_array(): void
+    public function it_returns_the_requested_index_from_an_array(): void
+    {
+        $modified = $this->modify(['You shall not pass!', 'Fool of a Took'], [1]);
+        $this->assertEquals('Fool of a Took', $modified);
+
+        $modified = $this->modify(['one' => 'You shall not pass!', 'two' => 'Fool of a Took'], ['two']);
+        $this->assertEquals('Fool of a Took', $modified);
+    }
+
+    #[Test]
+    public function it_returns_the_first_item_from_an_array_if_no_index_is_given(): void
     {
         $modified = $this->modify(['You', 'shall', 'not pass!']);
         $this->assertEquals('You', $modified);

--- a/tests/Modifiers/GetTest.php
+++ b/tests/Modifiers/GetTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Modifiers;
+
+use Facades\Tests\Factories\EntryFactory;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Modifiers\Modify;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class GetTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_returns_the_first_item_from_an_array(): void
+    {
+        $modified = $this->modify(['You', 'shall', 'not pass!']);
+        $this->assertEquals('You', $modified);
+    }
+
+    #[Test]
+    public function it_returns_the_existing_value_if_no_object_can_be_resolved(): void
+    {
+        $modified = $this->modify('You shall not pass!');
+        $this->assertEquals('You shall not pass!', $modified);
+    }
+
+    #[Test]
+    public function it_returns_the_requested_variable_from_the_array_representation_of_an_augmentable_object(): void
+    {
+        $id = '1234';
+        $entry = EntryFactory::collection('blog')
+            ->id($id)
+            ->data(['title' => 'Famous Gandalf quotes'])
+            ->create();
+
+        $modified = $this->modify($entry, ['title']);
+        $this->assertEquals('Famous Gandalf quotes', $modified);
+
+        $modified = $this->modify($id, ['title']);
+        $this->assertEquals('Famous Gandalf quotes', $modified);
+    }
+
+    #[Test]
+    public function it_returns_the_requested_variable_from_the_array_representation_of_a_plain_object(): void
+    {
+        $object = new class
+        {
+            public string $title = 'Famous Gandalf quotes';
+
+            public function toArray(): array
+            {
+                return ['title' => $this->title];
+            }
+        };
+
+        $modified = $this->modify($object, ['title']);
+        $this->assertEquals('Famous Gandalf quotes', $modified);
+    }
+
+    #[Test]
+    public function it_returns_the_requested_variable_by_method_from_a_plain_object(): void
+    {
+        $object = new class
+        {
+            public function title(): string
+            {
+                return 'Famous Gandalf quotes';
+            }
+
+            public function toArray(): array
+            {
+                return [];
+            }
+        };
+
+        $modified = $this->modify($object, ['title']);
+        $this->assertEquals('Famous Gandalf quotes', $modified);
+    }
+
+    #[Test]
+    public function it_returns_the_existing_value_if_the_requested_variable_can_not_be_resolved_in_an_object(): void
+    {
+        $object = new class
+        {
+            public function toArray(): array
+            {
+                return [];
+            }
+        };
+
+        $modified = $this->modify($object, ['title']);
+        $this->assertEquals($object, $modified);
+    }
+
+    private function modify($value, array $params = [])
+    {
+        return Modify::value($value)->get($params)->fetch();
+    }
+}

--- a/tests/Modifiers/GetTest.php
+++ b/tests/Modifiers/GetTest.php
@@ -4,6 +4,7 @@ namespace Modifiers;
 
 use Facades\Tests\Factories\EntryFactory;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Entry;
 use Statamic\Modifiers\Modify;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -11,6 +12,22 @@ use Tests\TestCase;
 class GetTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_resolves_a_query_builder(): void
+    {
+        $collection = 'blog';
+        $entry = EntryFactory::collection($collection)
+            ->data(['title' => 'Famous Gandalf quotes'])
+            ->create();
+
+        $modified = $this->modify(Entry::query()->where('collection', $collection));
+        $this->assertTrue(is_array($modified));
+        $this->assertEquals($entry, $modified[0]);
+
+        $modified = $this->modify(Entry::query()->where('collection', $collection), [0]);
+        $this->assertEquals($entry, $modified);
+    }
 
     #[Test]
     public function it_returns_the_requested_index_from_an_array(): void


### PR DESCRIPTION
This PR extends the existing `get` modifier and:
- Adds Tests for existing `get` modifier logic (separate commit)
- Adds support for a specific index when modifying an array (e.g. `entries_as_array | get(1)` or `address_as_array | get('street')`)
- Adds support for Collections (same behavior as for arrays)
- Adds support for Query Builders. They get resolved and return the whole result or (if given) a specific index, like for arrays