### PR TITLE
[5.x] Fix Overflow buttons preview

### DIFF
--- a/resources/css/elements/buttons.css
+++ b/resources/css/elements/buttons.css
@@ -32,7 +32,7 @@ button {
 
 /*  Default, non-primary action button */
 .btn, .btn-default {
-    @apply text-gray-800 dark:text-dark-150 shadow-button;
+    @apply text-gray-800 dark:text-dark-150 shadow-button min-w-0;
     background: linear-gradient(180deg, #fff, #f9fafb);
     background-clip: padding-box;
     border: 1px solid #D3DDE7;

--- a/resources/css/elements/buttons.css
+++ b/resources/css/elements/buttons.css
@@ -32,7 +32,7 @@ button {
 
 /*  Default, non-primary action button */
 .btn, .btn-default {
-    @apply text-gray-800 dark:text-dark-150 shadow-button min-w-0;
+    @apply text-gray-800 dark:text-dark-150 shadow-button;
     background: linear-gradient(180deg, #fff, #f9fafb);
     background-clip: padding-box;
     border: 1px solid #D3DDE7;

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -118,16 +118,16 @@
 
                                 <div v-if="collectionHasRoutes" :class="{ 'hi': !shouldShowSidebar }">
 
-                                    <div class="p-3 flex items-center space-x-2 rtl:space-x-reverse" v-if="showLivePreviewButton || showVisitUrlButton">
+                                    <div class="p-3 flex flex-wrap items-center gap-2 rtl:space-x-reverse" v-if="showLivePreviewButton || showVisitUrlButton">
                                         <button
-                                            class="flex items-center justify-center btn w-full"
+                                            class="flex flex-1 items-center justify-center btn px-2"
                                             v-if="showLivePreviewButton"
                                             @click="openLivePreview">
                                             <svg-icon name="light/synchronize" class="h-4 w-4 rtl:ml-2 ltr:mr-2 shrink-0" />
                                             <span>{{ __('Live Preview') }}</span>
                                         </button>
                                         <a
-                                            class="flex items-center justify-center btn w-full"
+                                            class="flex flex-1 items-center justify-center btn px-2"
                                             v-if="showVisitUrlButton"
                                             :href="permalink"
                                             target="_blank">

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -112,16 +112,16 @@
 
                                 <div :class="{ 'hi': !shouldShowSidebar }">
 
-                                    <div class="p-3 flex items-center space-x-2" v-if="showLivePreviewButton || showVisitUrlButton">
+                                    <div class="p-3 flex flex-wrap items-center gap-2" v-if="showLivePreviewButton || showVisitUrlButton">
                                         <button
-                                            class="flex items-center justify-center btn w-full"
+                                            class="flex flex-1 items-center justify-center btn px-2"
                                             v-if="showLivePreviewButton"
                                             @click="openLivePreview">
                                             <svg-icon name="light/synchronize" class="h-4 w-4 rtl:ml-2 ltr:mr-2 shrink-0" />
                                             <span>{{ __('Live Preview') }}</span>
                                         </button>
                                         <a
-                                            class="flex items-center justify-center btn w-full"
+                                            class="flex flex-1 items-center justify-center btn px-2"
                                             v-if="showVisitUrlButton"
                                             :href="permalink"
                                             target="_blank">


### PR DESCRIPTION
Overriding the browser's internal `min-width` for buttons, allowing them to shrink.

Fixes https://github.com/statamic/cms/issues/11847 