### PR TITLE
[5.x] Detect recursion when augmenting Entries (#11854)

### DIFF
--- a/src/Data/HasOrigin.php
+++ b/src/Data/HasOrigin.php
@@ -2,13 +2,10 @@
 
 namespace Statamic\Data;
 
-use Statamic\Exceptions\RecursiveAugmentationException;
 use Statamic\Facades\Blink;
 
 trait HasOrigin
 {
-    private $resolvingValues = false;
-
     /**
      * @var string
      */
@@ -34,32 +31,13 @@ trait HasOrigin
             ->merge($computedKeys);
     }
 
-    private function guardRecursiveAugmentation()
-    {
-        if ($this->resolvingValues) {
-            $className = get_class($this);
-            throw new RecursiveAugmentationException("Recursion detected while augmenting [{$className}] with ID [{$this->id}].");
-        }
-
-        $this->resolvingValues = true;
-    }
-
-    private function ungardRecursiveAugmentation()
-    {
-        $this->resolvingValues = false;
-    }
-
     public function values()
     {
-        $this->guardRecursiveAugmentation();
-
         $originFallbackValues = method_exists($this, 'getOriginFallbackValues') ? $this->getOriginFallbackValues() : collect();
 
         $originValues = $this->hasOrigin() ? $this->origin()->values() : collect();
 
         $computedData = method_exists($this, 'computedData') ? $this->computedData() : [];
-
-        $this->ungardRecursiveAugmentation();
 
         return collect()
             ->merge($originFallbackValues)

--- a/src/Exceptions/RecursiveAugmentationException.php
+++ b/src/Exceptions/RecursiveAugmentationException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Statamic\Exceptions;
-
-class RecursiveAugmentationException extends \Exception
-{
-}

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -29,7 +29,6 @@ use Statamic\Events\EntryDeleted;
 use Statamic\Events\EntryDeleting;
 use Statamic\Events\EntrySaved;
 use Statamic\Events\EntrySaving;
-use Statamic\Exceptions\RecursiveAugmentationException;
 use Statamic\Facades;
 use Statamic\Facades\Blink;
 use Statamic\Fields\Blueprint;
@@ -2678,24 +2677,5 @@ class EntryTest extends TestCase
 
         $this->assertEquals('A', $entry->getSupplement('bar'));
         $this->assertEquals('B', $clone->getSupplement('bar'));
-    }
-
-    #[Test]
-    public function it_detects_recursive_augmentation()
-    {
-        $this->expectException(RecursiveAugmentationException::class);
-        $this->expectExceptionMessage('Recursion detected while augmenting [Statamic\Entries\Entry] with ID [entry-id]');
-
-        \Statamic\Facades\Collection::computed('test', 'the_value', function ($entry) {
-            // Trigger recursion that will bypass without computed values.
-            return $entry->routeData();
-        });
-
-        $entry = EntryFactory::id('entry-id')
-            ->collection('test')
-            ->slug('entry-slug')
-            ->create();
-
-        $entry->values();
     }
 }


### PR DESCRIPTION
This PR fixes #11892 by reverting the changes #11854  and removes the need for #11888