### PR TITLE
[6.x] Fix ensure field has config

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -645,7 +645,7 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
 
         // If field is deferred as an ensured field, we'll need to update it instead
         if (! isset($fields[$handle]) && isset($this->ensuredFields[$handle])) {
-            return $this->ensureEnsuredFieldConfig($handle, $config);
+            return $this->ensureEnsuredFieldHasConfig($handle, $config);
         }
 
         $fieldKey = $fields[$handle]['fieldIndex'];
@@ -666,7 +666,7 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
         return $this->resetBlueprintCache()->resetFieldsCache();
     }
 
-    protected function ensureEnsuredFieldConfig($handle, $config)
+    protected function ensureEnsuredFieldHasConfig($handle, $config)
     {
         if (! isset($this->ensuredFields[$handle])) {
             return $this;

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -643,6 +643,11 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
             return $this;
         }
 
+        // If field is deferred as an ensured field, we'll need to update it instead
+        if (! isset($fields[$handle]) && isset($this->ensuredFields[$handle])) {
+            return $this->ensureEnsuredFieldConfig($handle, $config);
+        }
+
         $fieldKey = $fields[$handle]['fieldIndex'];
         $sectionKey = $fields[$handle]['sectionIndex'];
 
@@ -657,6 +662,19 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
             $existingConfig = Arr::get($field, 'field', []);
             $this->contents['tabs'][$tab]['sections'][$sectionKey]['fields'][$fieldKey]['field'] = array_merge($existingConfig, $config);
         }
+
+        return $this->resetBlueprintCache()->resetFieldsCache();
+    }
+
+    protected function ensureEnsuredFieldConfig($handle, $config)
+    {
+        if (! isset($this->ensuredFields[$handle])) {
+            return $this;
+        }
+
+        $existingConfig = Arr::get($this->ensuredFields[$handle], 'config', []);
+
+        $this->ensuredFields[$handle]['config'] = array_merge($existingConfig, $config);
 
         return $this->resetBlueprintCache()->resetFieldsCache();
     }

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -666,7 +666,7 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
         return $this->resetBlueprintCache()->resetFieldsCache();
     }
 
-    protected function ensureEnsuredFieldHasConfig($handle, $config)
+    private function ensureEnsuredFieldHasConfig($handle, $config)
     {
         if (! isset($this->ensuredFields[$handle])) {
             return $this;

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -896,6 +896,41 @@ class BlueprintTest extends TestCase
     // todo: duplicate or tweak above test but make the target field not in the first section.
 
     #[Test]
+    public function it_can_ensure_an_deferred_ensured_field_has_specific_config()
+    {
+        $blueprint = (new Blueprint)->setContents(['tabs' => [
+            'tab_one' => [
+                'sections' => [
+                    [
+                        'fields' => [
+                            ['handle' => 'title', 'field' => ['type' => 'text']],
+                        ],
+                    ],
+                ],
+            ],
+        ]]);
+
+        // Let's say somewhere else in the code ensures an `author` field
+        $blueprint->ensureField('author', ['type' => 'text', 'do_not_touch_other_config' => true, 'foo' => 'bar']);
+
+        // Then later, we try to ensure that `author` field has config, we should be able to successfully modify that deferred field
+        $fields = $blueprint
+            ->ensureFieldHasConfig('author', ['foo' => 'baz', 'visibility' => 'read_only'])
+            ->fields();
+
+        $this->assertEquals(['type' => 'text'], $fields->get('title')->config());
+
+        $expectedConfig = [
+            'type' => 'text',
+            'do_not_touch_other_config' => true,
+            'foo' => 'baz',
+            'visibility' => 'read_only',
+        ];
+
+        $this->assertEquals($expectedConfig, $fields->get('author')->config());
+    }
+
+    #[Test]
     public function it_merges_previously_undefined_keys_into_the_config_when_ensuring_a_field_exists_and_it_already_exists()
     {
         $blueprint = (new Blueprint)->setContents(['tabs' => [


### PR DESCRIPTION
This PR fixes an oversight exposed by https://github.com/statamic/cms/pull/11867.

If you try to `ensureFieldHasConfig()` on a previously ensured field, that field's config is stored in a different place in the Blueprint object (ie. `$this->ensuredFields` instead of `$this->contents`), therefore the config needs to be updated accordingly.

This is causing some newer tests on our `master` branch to fail, which is how I found the issue.