### PR TITLE
[5.x] Add blueprint repository hook

### DIFF
--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -8,6 +8,7 @@ use Statamic\Facades\Blink;
 use Statamic\Facades\File;
 use Statamic\Facades\Path;
 use Statamic\Facades\YAML;
+use Statamic\Hooks\CP\Blueprint as BlueprintHook;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
@@ -257,6 +258,9 @@ class BlueprintRepository
 
     protected function makeBlueprintFromFile($path, $namespace = null)
     {
+        $hook = (new BlueprintHook())->makeFromFile($path, $namespace);
+        [$path, $namespace] = [$hook->path, $hook->namespace];
+
         return Blink::store(self::BLINK_FROM_FILE)->once($path, function () use ($path, $namespace) {
             if (! $namespace || ! isset($this->additionalNamespaces[$namespace])) {
                 [$namespace, $handle] = $this->getNamespaceAndHandle(

--- a/src/Hooks/CP/Blueprint.php
+++ b/src/Hooks/CP/Blueprint.php
@@ -12,7 +12,7 @@ class Blueprint
     {
         $payload = $this->runHooksWith('makeFromFile', [
             'namespace' => $namespace,
-            'path' => $path
+            'path' => $path,
         ]);
 
         return $payload;

--- a/src/Hooks/CP/Blueprint.php
+++ b/src/Hooks/CP/Blueprint.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Statamic\Hooks\CP;
+
+use Statamic\Support\Traits\Hookable;
+
+class Blueprint
+{
+    use Hookable;
+
+    public function makeFromFile($path, $namespace)
+    {
+        $payload = $this->runHooksWith('makeFromFile', [
+            'namespace' => $namespace,
+            'path' => $path
+        ]);
+
+        return $payload;
+    }
+}


### PR DESCRIPTION
We are exploring ways to reuse one blueprint in multiple collections to allow us to split up (otherwise identical) content into more collections for better performance, permission-control and usability. We want to avoid copy-pasting the blueprint file.

This PR introduces a hook to the `makeBlueprintFromFile` function in the BlueprintRepository. This would allow to change the path of the blueprint file and therefore use a different blueprint for an entry than its actually intended one.

## Example

Say I have a collection `pages` with a blueprint `page`. I now need another collection `subpages` where the blueprint `page` should actually be identical with the one from `pages`. I can now add a hook like this:

```php
Blueprint::hook('makeFromFile', function ($payload, $next) {
    if ($payload->namespace === "collections/subpages") {
        $payload->namespace = "collections/pages";
        $payload->path = str_replace("subpages/page.yaml", "pages/page.yaml", $payload->path);
    }

    return $next($payload);
});
```

What do you think?