### PR TITLE
[6.x] Return `null` for non-public methods in PathDataManger

### DIFF
--- a/src/View/Antlers/Language/Runtime/PathDataManager.php
+++ b/src/View/Antlers/Language/Runtime/PathDataManager.php
@@ -860,7 +860,9 @@ class PathDataManager
         }
 
         if (is_object($this->reducedVar) && method_exists($this->reducedVar, Str::camel($varPath))) {
-            $this->reducedVar = call_user_func_array([$this->reducedVar, Str::camel($varPath)], []);
+            $reflectionMethod = new \ReflectionMethod($this->reducedVar, Str::camel($varPath));
+
+            $this->reducedVar = $reflectionMethod->isPublic() ? call_user_func_array([$this->reducedVar, Str::camel($varPath)], []) : null;
             $this->resolvedPath[] = '{method:'.$varPath.'}';
 
             if ($doCompact) {

--- a/tests/Antlers/Runtime/DataRetrieverTest.php
+++ b/tests/Antlers/Runtime/DataRetrieverTest.php
@@ -76,4 +76,38 @@ class DataRetrieverTest extends ParserTestCase
         $value = $this->getPathValue('page[view:nested:nested1:nested2]', $data);
         $this->assertSame(12345, $value);
     }
+
+    public function test_object_methods_are_retrieved()
+    {
+        $data = [
+            'view' => [
+                'object' => new class
+                {
+                    public function publicMethod()
+                    {
+                        return 'Hello Public World!';
+                    }
+
+                    protected function protectedMethod()
+                    {
+                        return 'Hello Protected World!';
+                    }
+
+                    private function privateMethod()
+                    {
+                        return 'Hello Private World!';
+                    }
+                },
+            ],
+        ];
+
+        $value = $this->getPathValue('view.object.public_method', $data);
+        $this->assertSame('Hello Public World!', $value);
+
+        $value = $this->getPathValue('view.object.protected_method', $data);
+        $this->assertNull($value);
+
+        $value = $this->getPathValue('view.object.private_method', $data);
+        $this->assertNull($value);
+    }
 }


### PR DESCRIPTION
While working on adding support for object properties in the PathDataManager, [Jason instructed me to handle non-public properties to return `null` rather than throwing an error](https://github.com/statamic/cms/pull/11697#issuecomment-2821690596).

I think we should do that for non-public methods on objects as well.