### PR TITLE
[5.x] Fix casing on dropdown item

### DIFF
--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -109,7 +109,7 @@
                     :text="__('Edit Entry')"
                     :redirect="branch.edit_url" />
                 <dropdown-item
-                    :text="__('Edit nav item')"
+                    :text="__('Edit Nav item')"
                     @click="editPage(branch, vm, vm.store)" />
                 <dropdown-item
                     v-if="depth < maxDepth"


### PR DESCRIPTION
We added an edit button to the navigation items in #11822. 

However, in reviewing #11903, I realised that we introduced a duplicate translation due to `Nav` being lowercase instead of title case like we're doing elsewhere. 