### PR TITLE
[6.x] Updater widget

### DIFF
--- a/resources/js/components/updater/UpdaterWidget.vue
+++ b/resources/js/components/updater/UpdaterWidget.vue
@@ -1,81 +1,33 @@
-<script>
-import Listing from '../Listing.vue';
-import { Widget, Badge } from '@statamic/ui';
+<script setup>
+import { Widget, Badge, Listing, Icon, Tooltip } from '@statamic/ui';
+import { ref } from 'vue';
 
-export default {
-    mixins: [Listing],
-
-    components: {
-        Badge,
-        Widget,
-    },
-
-    props: {
-        count: Number,
-        hasStatamicUpdate: Boolean,
-        updatableAddons: Object,
-    },
-
-    data() {
-        return {
-            cols: [
-                { label: 'Package', field: 'name', visible: true },
-                { label: 'Current', field: 'current_version', visible: true },
-                { label: 'Latest', field: 'latest_version', visible: true },
-            ],
-            items: [],
-            currentPage: 1,
-        };
-    },
-
-    methods: {
-        getItems() {
-            const items = [];
-
-            if (this.hasStatamicUpdate) {
-                items.push({ name: 'Statamic Core', type: 'core', slug: 'statamic' });
-            }
-
-            Object.entries(this.updatableAddons || {}).forEach(([slug, name]) => {
-                items.push({ name, type: 'addon', slug });
-            });
-
-            return items;
-        },
-    },
-
-    created() {
-        this.items = this.getItems();
-    },
-};
+defineProps({
+    items: Object,
+});
 </script>
 
 <template>
-    <Widget :title="__('Updates')" icon="updates">
-        <data-list v-if="items.length" :rows="items" :columns="cols" :sort="false">
-            <data-list-table unstyled class="[&_td]:p-0.5 [&_td]:text-sm [&_thead]:hidden">
-                <template #cell-name="{ row: update }">
-                    <a :href="cp_url(`updater/${update.slug}`)" class="flex items-center gap-2">
-                        <span>{{ update.name.name || update.name }}</span>
-                        <Badge size="sm" pill color="green" text="2" />
-                    </a>
-                </template>
-            </data-list-table>
-        </data-list>
-
-        <p v-else class="p-3 text-center text-sm text-gray-600">
-            {{ __('Everything is up to date.') }}
-        </p>
-
-        <template #actions>
-            <data-list-pagination
-                v-if="meta.last_page != 1"
-                :resource-meta="meta"
-                @page-selected="selectPage"
-                :scroll-to-top="false"
-                :show-page-links="false"
-            />
-            <slot name="actions" />
-        </template>
-    </Widget>
+    <Listing :items="items" v-slot="{ items }">
+        <Widget :title="__('Updates')" icon="updates">
+            <table v-if="items.length" class="">
+                <tr v-for="update in items" class="text-sm">
+                    <td class="py-1 pr-4 leading-tight">
+                        <a :href="update.url" class="flex items-center gap-2" v-text="update.name" />
+                    </td>
+                    <td>
+                        <Badge pill variant="flat" :color="update.critical ? 'red' : 'green'" :text="update.count" />
+                        <Tooltip :text="__('Critical')">
+                            <div class="inline-flex">
+                                <Icon v-if="update.critical" name="warning-diamond" color="red" />
+                            </div>
+                        </Tooltip>
+                    </td>
+                </tr>
+            </table>
+            <p v-else class="p-3 text-center text-sm text-gray-600">
+                {{ __('Everything is up to date.') }}
+            </p>
+        </Widget>
+    </Listing>
 </template>

--- a/resources/views/widgets/updater.blade.php
+++ b/resources/views/widgets/updater.blade.php
@@ -1,6 +1,1 @@
-<updater-widget
-    :count="{{ $count }}"
-    :has-statamic-update="{{ json_encode($hasStatamicUpdate) }}"
-    :updatable-addons="{{ json_encode($updatableAddons) }}"
-    :initial-per-page="{{ $limit }}"
-></updater-widget>
+<updater-widget :items="{{ json_encode($items) }}"></updater-widget>

--- a/src/Updater/UpdatesOverview.php
+++ b/src/Updater/UpdatesOverview.php
@@ -116,12 +116,11 @@ class UpdatesOverview
      */
     protected function checkForAddonUpdates()
     {
-        Addon::all()
+        $this->addons = Addon::all()
             ->reject->isLatestVersion()
-            ->each(function ($addon) {
-                $this->addons[$addon->marketplaceSlug()] = $addon->name();
-                $this->count++;
-            });
+            ->map->id()
+            ->values()
+            ->all();
 
         return $this;
     }

--- a/src/Widgets/Updater.php
+++ b/src/Widgets/Updater.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Widgets;
 
+use Facades\Statamic\Marketplace\Marketplace;
 use Facades\Statamic\Updater\UpdatesOverview;
+use Statamic\Facades\Addon;
 use Statamic\Facades\User;
 
 class Updater extends Widget
@@ -18,11 +20,26 @@ class Updater extends Widget
             return;
         }
 
-        $count = UpdatesOverview::count();
-        $hasStatamicUpdate = UpdatesOverview::hasStatamicUpdate();
-        $updatableAddons = UpdatesOverview::updatableAddons();
-        $limit = $this->config('limit', 5);
+        $items = collect(UpdatesOverview::updatableAddons())->map(function ($id) {
+            $addon = Addon::get($id);
 
-        return view('statamic::widgets.updater', compact('count', 'hasStatamicUpdate', 'updatableAddons', 'limit'));
+            return [
+                'name' => $addon->name(),
+                'count' => $addon->changelog()->availableUpdatesCount(),
+                'critical' => false,
+                'url' => cp_route('updater.product', $addon->slug()),
+            ];
+        });
+
+        if (UpdatesOverview::hasStatamicUpdate()) {
+            $items->push([
+                'name' => 'Statamic Core',
+                'count' => Marketplace::statamic()->changelog()->availableUpdatesCount(),
+                'critical' => false,
+                'url' => cp_route('updater.product', 'statamic'),
+            ]);
+        }
+
+        return view('statamic::widgets.updater', compact('items'));
     }
 }


### PR DESCRIPTION
Updates the updater widget to use the new widget design which shows the number of updates.
If an update is flagged as critical the badge will show as red. The UI works but there's no way to flag a release at the moment.


![CleanShot 2025-06-30 at 17 12 05](https://github.com/user-attachments/assets/4abfa017-1604-49ad-a548-4ffccce95f83)
