### PR TITLE
[6.x] Publish form adjustments

### DIFF
--- a/resources/js/components/actions/ConfirmableAction.vue
+++ b/resources/js/components/actions/ConfirmableAction.vue
@@ -110,10 +110,10 @@ defineExpose({
             v-if="action.fields.length"
             name="confirm-action"
             :blueprint="fieldset"
+            v-model="values"
             :values="values"
             :meta="action.meta"
             :errors="errors"
-            @updated="values = $event"
         >
             <FieldsProvider :fields="action.fields">
                 <PublishFields />

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -303,15 +303,12 @@
 import EditorActions from './EditorActions.vue';
 import FocalPointEditor from './FocalPointEditor.vue';
 import PdfViewer from './PdfViewer.vue';
-import HasHiddenFields from '../../publish/HasHiddenFields';
 import { pick, flatten } from 'lodash-es';
 import { Dropdown, DropdownMenu, DropdownItem, PublishContainer, PublishTabs } from '@statamic/ui';
 import ItemActions from '@statamic/components/actions/ItemActions.vue';
 
 export default {
     emits: ['previous', 'next', 'saved', 'closed', 'action-completed'],
-
-    mixins: [HasHiddenFields],
 
     components: {
         Dropdown,
@@ -526,7 +523,7 @@ export default {
             const url = cp_url(`assets/${utf8btoa(this.id)}`);
 
             this.$axios
-                .patch(url, this.visibleValues)
+                .patch(url, this.$refs.container.store.visibleValues)
                 .then((response) => {
                     this.$emit('saved', response.data.asset);
                     this.$toast.success(__('Saved'));

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -215,11 +215,11 @@
                         :name="publishContainer"
                         :reference="id"
                         :blueprint="fieldset"
-                        :values="values"
+                        :model-value="values"
                         :extra-values="extraValues"
                         :meta="meta"
                         :errors="errors"
-                        @updated="values = { ...$event, focus: values.focus }"
+                        @update:model-value="values = { ...$event, focus: values.focus }"
                     >
                         <div class="h-1/2 w-full overflow-scroll sm:p-4 md:h-full md:w-1/3 md:grow md:pt-px">
                             <div v-if="saving" class="loading">

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -76,7 +76,7 @@
             :name="publishContainer"
             :reference="initialReference"
             :blueprint="fieldset"
-            :values="values"
+            v-model="values"
             :extra-values="extraValues"
             :meta="meta"
             :origin-values="originValues"
@@ -87,8 +87,6 @@
             :localized-fields="localizedFields"
             :track-dirty-state="trackDirtyState"
             :sync-field-confirmation-text="syncFieldConfirmationText"
-            @updated="values = $event"
-            @update:visible-values="visibleValues = $event"
         >
             <LivePreview
                 :enabled="isPreviewing"
@@ -544,12 +542,9 @@ export default {
                         storeName: this.publishContainer,
                     }),
                     new Request(this.actions.save, this.method, {
-                        ...this.visibleValues,
-                        ...{
-                            _blueprint: this.fieldset.handle,
-                            _localized: this.localizedFields,
-                            _parent: this.parent,
-                        },
+                        _blueprint: this.fieldset.handle,
+                        _localized: this.localizedFields,
+                        _parent: this.parent,
                     }),
                     new AfterSaveHooks('entry', {
                         collection: this.collectionHandle,

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -88,6 +88,7 @@
             :track-dirty-state="trackDirtyState"
             :sync-field-confirmation-text="syncFieldConfirmationText"
             @updated="values = $event"
+            @update:visible-values="visibleValues = $event"
         >
             <LivePreview
                 :enabled="isPreviewing"
@@ -249,7 +250,6 @@ import PublishActions from './PublishActions.vue';
 import SaveButtonOptions from '../publish/SaveButtonOptions.vue';
 import RevisionHistory from '../revision-history/History.vue';
 import HasPreferences from '../data-list/HasPreferences';
-import HasHiddenFields from '../publish/HasHiddenFields';
 import HasActions from '../publish/HasActions';
 import striptags from 'striptags';
 import clone from '@statamic/util/clone.js';
@@ -285,7 +285,7 @@ let errors = ref({});
 let container = null;
 
 export default {
-    mixins: [HasPreferences, HasHiddenFields, HasActions],
+    mixins: [HasPreferences, HasActions],
 
     components: {
         Button,
@@ -359,6 +359,7 @@ export default {
             fieldset: this.initialFieldset,
             title: this.initialTitle,
             values: clone(this.initialValues),
+            visibleValues: {},
             meta: clone(this.initialMeta),
             extraValues: clone(this.initialExtraValues),
             localizations: clone(this.initialLocalizations),

--- a/resources/js/components/field-actions/FieldActionModal.vue
+++ b/resources/js/components/field-actions/FieldActionModal.vue
@@ -17,10 +17,9 @@
                     v-if="hasFields && !resolving"
                     :name="containerName"
                     :blueprint="blueprint"
-                    :values="values"
+                    v-model="values"
                     :meta="meta"
                     :errors="errors"
-                    @updated="values = $event"
                 >
                     <FieldsProvider :fields="blueprint.tabs[0].fields">
                         <PublishFields />

--- a/resources/js/components/field-conditions/ShowField.js
+++ b/resources/js/components/field-conditions/ShowField.js
@@ -11,7 +11,9 @@ export default class {
 
     showField(field, dottedKey) {
         let dottedFieldPath = dottedKey || field.handle;
-        let dottedPrefix = dottedKey ? dottedKey.replace(new RegExp('\.' + field.handle + '$'), '') : '';
+
+        let dottedPrefix =
+            dottedKey && dottedKey.includes('.') ? dottedKey.replace(new RegExp('\.' + field.handle + '$'), '') : '';
 
         // If we know the field is to permanently hidden, bypass validation.
         if (field.visibility === 'hidden' || this.shouldForceHiddenField(dottedFieldPath)) {

--- a/resources/js/components/fieldtypes/RevealerFieldtype.vue
+++ b/resources/js/components/fieldtypes/RevealerFieldtype.vue
@@ -45,7 +45,7 @@ export default {
         },
 
         fieldPath() {
-            return this.fieldPathPrefix || this.handle;
+            return this.fieldPathPrefix ? `${this.fieldPathPrefix}.${this.handle}` : this.handle;
         },
     },
 

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -49,15 +49,13 @@
             :name="publishContainer"
             :reference="initialReference"
             :blueprint="fieldset"
-            :values="values"
+            v-model="values"
             :meta="meta"
             :errors="errors"
             :site="site"
             :localized-fields="localizedFields"
             :is-root="isRoot"
             :sync-field-confirmation-text="syncFieldConfirmationText"
-            @updated="values = $event"
-            @update:visible-values="visibleValues = $event"
         >
             <PublishTabs />
         </PublishContainer>
@@ -202,11 +200,8 @@ export default {
                         storeName: this.publishContainer,
                     }),
                     new Request(this.actions.save, this.method, {
-                        ...this.visibleValues,
-                        ...{
-                            _blueprint: this.fieldset.handle,
-                            _localized: this.localizedFields,
-                        }
+                        _blueprint: this.fieldset.handle,
+                        _localized: this.localizedFields,
                     }),
                     new AfterSaveHooks('global-set', {
                         globalSet: this.initialHandle,

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -57,6 +57,7 @@
             :is-root="isRoot"
             :sync-field-confirmation-text="syncFieldConfirmationText"
             @updated="values = $event"
+            @update:visible-values="visibleValues = $event"
         >
             <PublishTabs />
         </PublishContainer>
@@ -65,7 +66,6 @@
 
 <script>
 import SiteSelector from '../SiteSelector.vue';
-import HasHiddenFields from '../publish/HasHiddenFields';
 import clone from '@statamic/util/clone.js';
 import { Button, Dropdown, DropdownItem, DropdownMenu, Header } from '@statamic/ui';
 import PublishContainer from '@statamic/components/ui/Publish/Container.vue';
@@ -80,8 +80,6 @@ let errors = ref({});
 let container = null;
 
 export default {
-    mixins: [HasHiddenFields],
-
     components: {
         PublishComponents,
         PublishContainer,
@@ -128,6 +126,7 @@ export default {
             fieldset: this.initialFieldset,
             title: this.initialTitle,
             values: clone(this.initialValues),
+            visibleValues: {},
             meta: clone(this.initialMeta),
             localizations: clone(this.initialLocalizations),
             localizedFields: this.initialLocalizedFields,

--- a/resources/js/components/preferences/EditForm.vue
+++ b/resources/js/components/preferences/EditForm.vue
@@ -3,12 +3,11 @@
         ref="container"
         :name="name"
         :blueprint="blueprint"
-        :values="currentValues"
+        v-model="currentValues"
         reference="collection"
         :meta="meta"
         :errors="errors"
         :read-only="readOnly"
-        @updated="currentValues = $event"
     >
         <div>
             <Header :title="title" icon="preferences">

--- a/resources/js/components/publish/HasHiddenFields.js
+++ b/resources/js/components/publish/HasHiddenFields.js
@@ -1,5 +1,5 @@
 import Values from './Values.js';
-import { pick } from 'lodash-es';
+import { pickBy } from 'lodash-es';
 
 export default {
     computed: {
@@ -16,7 +16,7 @@ export default {
         },
 
         visibleValues() {
-            let omittableFields = Object.keys(pick(this.hiddenFields, (field) => field.omitValue));
+            let omittableFields = Object.keys(pickBy(this.hiddenFields, (field) => field.omitValue));
 
             return new Values(this.values, this.jsonSubmittingFields).except(omittableFields);
         },

--- a/resources/js/components/sites/EditForm.vue
+++ b/resources/js/components/sites/EditForm.vue
@@ -5,10 +5,9 @@
         name="sites"
         reference="sites"
         :blueprint="blueprint"
-        :values="values"
+        v-model="values"
         :meta="meta"
         :errors="errors"
-        @updated="values = $event"
     >
         <Header :title="pageTitle" icon="site">
             <Button type="submit" variant="primary" @click="submit">{{ __('Save') }}</Button>

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -64,7 +64,7 @@
             :name="publishContainer"
             :reference="initialReference"
             :blueprint="fieldset"
-            :values="values"
+            v-model="values"
             :meta="meta"
             :origin-values="originValues"
             :origin-meta="originMeta"
@@ -73,8 +73,6 @@
             :site="site"
             :localized-fields="localizedFields"
             :sync-field-confirmation-text="syncFieldConfirmationText"
-            @updated="values = $event"
-            @update:visible-values="visibleValues = $event"
         >
             <LivePreview
                 :enabled="isPreviewing"
@@ -339,12 +337,9 @@ export default {
                         storeName: this.publishContainer,
                     }),
                     new Request(this.actions.save, this.method, {
-                        ...this.visibleValues,
-                        ...{
-                            _blueprint: this.fieldset.handle,
-                            published: this.published,
-                            _localized: this.localizedFields,
-                        },
+                        _blueprint: this.fieldset.handle,
+                        published: this.published,
+                        _localized: this.localizedFields,
                     }),
                     new AfterSaveHooks('entry', {
                         taxonomy: this.taxonomyHandle,

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -74,6 +74,7 @@
             :localized-fields="localizedFields"
             :sync-field-confirmation-text="syncFieldConfirmationText"
             @updated="values = $event"
+            @update:visible-values="visibleValues = $event"
         >
             <LivePreview
                 :enabled="isPreviewing"
@@ -125,7 +126,6 @@
 <script>
 import SaveButtonOptions from '../publish/SaveButtonOptions.vue';
 import HasPreferences from '../data-list/HasPreferences';
-import HasHiddenFields from '../publish/HasHiddenFields';
 import HasActions from '../publish/HasActions';
 import striptags from 'striptags';
 import clone from '@statamic/util/clone.js';
@@ -154,7 +154,7 @@ let errors = ref({});
 let container = null;
 
 export default {
-    mixins: [HasPreferences, HasHiddenFields, HasActions],
+    mixins: [HasPreferences, HasActions],
 
     components: {
         ItemActions,
@@ -211,6 +211,7 @@ export default {
             fieldset: this.initialFieldset,
             title: this.initialTitle,
             values: clone(this.initialValues),
+            visibleValues: {},
             meta: clone(this.initialMeta),
             localizations: clone(this.initialLocalizations),
             localizedFields: this.initialLocalizedFields,

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -11,7 +11,7 @@ import { watch, provide, getCurrentInstance, ref, onBeforeUnmount } from 'vue';
 import Component from '@statamic/components/Component.js';
 import { getActivePinia } from 'pinia';
 
-const emit = defineEmits(['updated']);
+const emit = defineEmits(['updated', 'updated:visibleValues']);
 
 const container = getCurrentInstance();
 
@@ -103,6 +103,12 @@ watch(
         if (props.trackDirtyState) dirty();
         emit('updated', values);
     },
+    { deep: true },
+);
+
+watch(
+    () => store.visibleValues,
+    (values) => emit('updated:visibleValues', values),
     { deep: true },
 );
 

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -11,7 +11,7 @@ import { watch, provide, getCurrentInstance, ref, onBeforeUnmount } from 'vue';
 import Component from '@statamic/components/Component.js';
 import { getActivePinia } from 'pinia';
 
-const emit = defineEmits(['updated', 'updated:visibleValues']);
+const emit = defineEmits(['updated', 'update:visibleValues']);
 
 const container = getCurrentInstance();
 
@@ -108,7 +108,7 @@ watch(
 
 watch(
     () => store.visibleValues,
-    (values) => emit('updated:visibleValues', values),
+    (values) => emit('update:visibleValues', values),
     { deep: true },
 );
 

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -26,7 +26,7 @@ const props = defineProps({
     blueprint: {
         type: Object,
     },
-    values: {
+    modelValue: {
         type: Object,
         default: () => ({}),
     },
@@ -75,7 +75,7 @@ const props = defineProps({
 });
 
 const store = usePublishContainerStore(props.name, {
-    values: props.values,
+    values: props.modelValue,
     extraValues: props.extraValues,
     meta: props.meta,
     originValues: props.originValues,
@@ -91,7 +91,7 @@ const store = usePublishContainerStore(props.name, {
 const components = ref([]);
 
 watch(
-    () => props.values,
+    () => props.modelValue,
     (values) => store.setValues(values),
     { deep: true },
 );
@@ -197,5 +197,5 @@ function saved() {
 </script>
 
 <template>
-    <slot :values="values" />
+    <slot />
 </template>

--- a/resources/js/components/ui/Publish/Field.vue
+++ b/resources/js/components/ui/Publish/Field.vue
@@ -68,12 +68,16 @@ const values = computed(() => {
     return fieldPathPrefix ? data_get(store.values, fieldPathPrefix) : store.values;
 });
 
+const visibleValues = computed(() => {
+    return fieldPathPrefix ? data_get(store.visibleValues, fieldPathPrefix) : store.visibleValues;
+});
+
 const extraValues = computed(() => {
     return fieldPathPrefix ? data_get(store.extraValues, fieldPathPrefix) : store.extraValues;
 });
 
 const shouldShowField = computed(() => {
-    return new ShowField(store, values.value, extraValues.value).showField(props.config, fullPath.value);
+    return new ShowField(store, visibleValues.value, extraValues.value).showField(props.config, fullPath.value);
 });
 
 const shouldShowLabelText = computed(() => !props.config.hide_display);

--- a/resources/js/components/ui/Publish/Form.vue
+++ b/resources/js/components/ui/Publish/Form.vue
@@ -55,7 +55,7 @@ function save() {
         .provide({ container, errors, saving })
         .through([
             new BeforeSaveHooks('entry'),
-            new Request(props.submitUrl, props.submitMethod, { values: values.value }),
+            new Request(props.submitUrl, props.submitMethod),
             new AfterSaveHooks('entry'),
         ])
         .then((response) => {
@@ -87,11 +87,10 @@ onUnmounted(() => saveKeyBinding.destroy());
         ref="container"
         :name="containerName"
         :blueprint="blueprint"
-        :values="values"
         :meta="meta"
         :errors="errors"
         :read-only="readOnly"
-        @updated="values = $event"
+        v-model="values"
     >
         <Tabs />
     </Container>

--- a/resources/js/components/ui/Publish/SavePipeline.js
+++ b/resources/js/components/ui/Publish/SavePipeline.js
@@ -58,18 +58,20 @@ class Start extends Step {
 export class Request extends Step {
     #url;
     #method;
-    #data;
+    #extraData;
 
-    constructor(url, method, data) {
+    constructor(url, method, extraData) {
         super();
         this.#url = url;
         this.#method = method.toLowerCase();
-        this.#data = data;
+        this.#extraData = extraData;
     }
 
     handle(payload) {
         return new Promise((resolve, reject) => {
-            return axios[this.#method](this.#url, this.#data)
+            const data = { ...container.value.store.visibleValues, ...this.#extraData };
+
+            return axios[this.#method](this.#url, data)
                 .then((response) => {
                     if (container && response.data.data?.hasOwnProperty('values')) {
                         container.value.store.setValues(

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -12,11 +12,11 @@ const { blueprint, store } = injectContainerContext();
 const tab = injectTabContext();
 const sections = tab.sections;
 const visibleSections = computed(() => {
-   return sections.filter(section => {
-       return section.fields.some((field) => {
-           return new ShowField(store, store.values, store.extraValues).showField(field, field.handle);
-       });
-   });
+    return sections.filter((section) => {
+        return section.fields.some((field) => {
+            return new ShowField(store, store.visibleValues, store.extraValues).showField(field, field.handle);
+        });
+    });
 });
 
 function renderInstructions(instructions) {

--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -60,10 +60,10 @@
 
 <script>
 import ChangePassword from './ChangePassword.vue';
-import HasHiddenFields from '../publish/HasHiddenFields';
 import HasActions from '../publish/HasActions';
 import TwoFactor from '@statamic/components/two-factor/TwoFactor.vue';
 import clone from '@statamic/util/clone.js';
+import resetValuesFromResponse from '@statamic/util/resetValuesFromResponse.js';
 import {
     Button,
     Dropdown,
@@ -84,7 +84,7 @@ let errors = ref({});
 let container = null;
 
 export default {
-    mixins: [HasHiddenFields, HasActions],
+    mixins: [HasActions],
 
     components: {
         ItemActions,
@@ -161,7 +161,7 @@ export default {
         afterActionSuccessfullyCompleted(response) {
             if (response.data) {
                 this.title = response.data.title;
-                this.values = this.resetValuesFromResponse(response.data.values);
+                this.values = resetValuesFromResponse(response.data.values, this.$refs.container.store);
             }
         },
     },

--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -49,10 +49,9 @@
             :name="publishContainer"
             :reference="initialReference"
             :blueprint="fieldset"
-            :values="values"
+            v-model="values"
             :meta="meta"
             :errors="errors"
-            @updated="values = $event"
         >
             <PublishTabs />
         </PublishContainer>
@@ -77,7 +76,7 @@ import {
 } from '@statamic/ui';
 import ItemActions from '@statamic/components/actions/ItemActions.vue';
 import { SavePipeline } from '@statamic/exports.js';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 const { Pipeline, Request, BeforeSaveHooks, AfterSaveHooks, PipelineStopped } = SavePipeline;
 
 let saving = ref(false);
@@ -147,7 +146,7 @@ export default {
                         container: this.$refs.container,
                         storeName: this.publishContainer,
                     }),
-                    new Request(this.actions.save, this.method, this.visibleValues),
+                    new Request(this.actions.save, this.method),
                     new AfterSaveHooks('user', {
                         reference: this.initialReference,
                     }),
@@ -165,6 +164,10 @@ export default {
                 this.values = this.resetValuesFromResponse(response.data.values);
             }
         },
+    },
+
+    created() {
+        container = computed(() => this.$refs.container);
     },
 
     mounted() {

--- a/resources/js/stores/publish-container.js
+++ b/resources/js/stores/publish-container.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia';
+import Values from '@statamic/components/publish/Values.js';
 
 export const usePublishContainerStore = function (name, initial) {
     return defineStore(name, {
@@ -23,6 +24,14 @@ export const usePublishContainerStore = function (name, initial) {
             reference: initial.reference,
             readOnly: initial.readOnly,
         }),
+        getters: {
+            visibleValues: (state) => {
+                const omittable = Object.keys(state.hiddenFields).filter(
+                    (field) => state.hiddenFields[field].omitValue,
+                );
+                return new Values(state.values, state.jsonSubmittingFields).except(omittable);
+            },
+        },
         actions: {
             setFieldValue(payload) {
                 const { handle, value } = payload;


### PR DESCRIPTION
- PublishContainer's Pinia store calculates the visibleFields.
- PublishContainer's `values` prop is changed to `modelValue` so you can do `v-model="values"`.
- The visible values should have been getting submitted to the server, but weren't. The nicest way we found to do that while avoiding two v-models was for the `Request` pipeline step to automatically grab the visibleValues from the store. The pipeline step now just accepts _extra_ data.
- Fix showField logic. In v5 it expected the dottedKey to only be passed when nested. In v6 is was always being passed. It makes sense for it to always be passed, so add some logic to only do the needed thing if the key had a dot.
- Use visibleValues in showField logic. This fixed an issue where if had a conditional field based on another conditional field it wouldn't cascade correctly when you edit the first field.