### PR TITLE
[5.x] Class "DB" not found issue

### DIFF
--- a/src/Auth/Eloquent/UserGroup.php
+++ b/src/Auth/Eloquent/UserGroup.php
@@ -4,6 +4,7 @@ namespace Statamic\Auth\Eloquent;
 
 use Statamic\Auth\File\UserGroup as FileUserGroup;
 use Statamic\Facades\User;
+use Illuminate\Support\Facades\DB;
 
 class UserGroup extends FileUserGroup
 {
@@ -50,7 +51,7 @@ class UserGroup extends FileUserGroup
 
     protected function getUserIds()
     {
-        return \DB::connection(config('statamic.users.database'))
+        return DB::connection(config('statamic.users.database'))
             ->table(config('statamic.users.tables.group_user', 'group_user'))
             ->where('group_id', $this->id())
             ->pluck('user_id');

--- a/src/Auth/Eloquent/UserGroup.php
+++ b/src/Auth/Eloquent/UserGroup.php
@@ -2,9 +2,9 @@
 
 namespace Statamic\Auth\Eloquent;
 
+use Illuminate\Support\Facades\DB;
 use Statamic\Auth\File\UserGroup as FileUserGroup;
 use Statamic\Facades\User;
-use Illuminate\Support\Facades\DB;
 
 class UserGroup extends FileUserGroup
 {


### PR DESCRIPTION
When using a fresh Statamic installation configured with Eloquent for user management in a Laravel >=11 environment, an exception "DB class not found" is thrown after creating a user group. It appears this issue can be resolved by explicitly importing the DB facade via a use Illuminate\Support\Facades\DB; statement. 

![CleanShot 2025-07-01 at 12 33 05@2x](https://github.com/user-attachments/assets/ec5b1665-2782-4a83-b33a-b4f6a1449121)

