### PR TITLE
[5.x] Prompt to update search indexes when installing starter kits

### DIFF
--- a/src/Console/Commands/StarterKitInstall.php
+++ b/src/Console/Commands/StarterKitInstall.php
@@ -32,7 +32,8 @@ class StarterKitInstall extends Command
         { --without-user : Install without creating user }
         { --force : Force install and allow dependency errors }
         { --cli-install : Installing from CLI Tool }
-        { --clear-site : Clear site before installing }';
+        { --clear-site : Clear site before installing }
+        { --update-search : Update search index(es) after installing }';
 
     /**
      * The console command description.
@@ -78,6 +79,10 @@ class StarterKitInstall extends Command
             $this->components->error($exception->getMessage());
 
             return 1;
+        }
+
+        if ($this->shouldUpdateSearchIndex()) {
+            $this->updateSearchIndex();
         }
 
         // Temporary prompt to inform user of updated CLI tool. The newest version has better messaging
@@ -135,6 +140,35 @@ class StarterKitInstall extends Command
     protected function clearSite(): void
     {
         $this->call('statamic:site:clear', ['--no-interaction' => true]);
+
+        Prompt::interactive($this->input->isInteractive());
+    }
+
+    /**
+     * Check if should update search index.
+     */
+    protected function shouldUpdateSearchIndex(): bool
+    {
+        if ($this->option('update-search')) {
+            return true;
+        } elseif ($this->input->isInteractive()) {
+            return confirm('Would you like to update your search index(es) as well?', false);
+        }
+
+        return false;
+    }
+
+    /**
+     * Update search index, and re-set prompt interactivity for future prompts.
+     *
+     * See: https://github.com/statamic/cli/issues/62
+     */
+    protected function updateSearchIndex(): void
+    {
+        $this->call('statamic:search:update', [
+            '--all' => true,
+            '--no-interaction' => true,
+        ]);
 
         Prompt::interactive($this->input->isInteractive());
     }

--- a/src/Search/Null/NullSearchables.php
+++ b/src/Search/Null/NullSearchables.php
@@ -2,10 +2,17 @@
 
 namespace Statamic\Search\Null;
 
+use Illuminate\Support\LazyCollection;
+
 class NullSearchables
 {
     public function contains()
     {
         return false;
+    }
+
+    public function lazy(): LazyCollection
+    {
+        return LazyCollection::make();
     }
 }

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -1639,6 +1639,63 @@ EOT;
         $this->assertComposerJsonHasPackageVersion('require', 'bobsled/speed-calculator', '^1.0.0');
     }
 
+    #[Test]
+    public function it_doesnt_update_search_index_by_default_when_installed_non_interactively()
+    {
+        Search::shouldReceive('indexes')->never();
+
+        $this
+            ->installCoolRunnings()
+            ->assertSuccessful();
+
+        $this->assertFileExists(base_path('copied.md'));
+    }
+
+    #[Test]
+    public function it_updates_search_index_when_update_search_flag_is_passed()
+    {
+        Search::shouldReceive('indexes')
+            ->once()
+            ->andReturn([]);
+
+        $this
+            ->installCoolRunnings(['--update-search' => true])
+            ->assertSuccessful();
+
+        $this->assertFileExists(base_path('copied.md'));
+    }
+
+    #[Test]
+    public function it_doesnt_update_search_index_by_default_when_installed_interactively()
+    {
+        Search::shouldReceive('indexes')->never();
+
+        $this
+            ->installCoolRunningsInteractively()
+            ->expectsConfirmation('Clear site first?', 'no')
+            ->expectsConfirmation('Would you like to update your search index(es) as well?', 'no')
+            ->doesntExpectOutput('statamic:search:update')
+            ->assertSuccessful();
+
+        $this->assertFileExists(base_path('copied.md'));
+    }
+
+    #[Test]
+    public function it_updates_search_index_when_installed_interactively_confirmed()
+    {
+        Search::shouldReceive('indexes')
+            ->once()
+            ->andReturn([]);
+
+        $this
+            ->installCoolRunningsInteractively()
+            ->expectsConfirmation('Clear site first?', 'no')
+            ->expectsConfirmation('Would you like to update your search index(es) as well?', 'yes')
+            ->assertSuccessful();
+
+        $this->assertFileExists(base_path('copied.md'));
+    }
+
     private function kitRepoPath($path = null)
     {
         return Path::tidy(collect([base_path('repo/cool-runnings'), $path])->filter()->implode('/'));

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -14,6 +14,7 @@ use Statamic\Console\Commands\StarterKitInstall as InstallCommand;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Config;
 use Statamic\Facades\Path;
+use Statamic\Facades\Search;
 use Statamic\Facades\YAML;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
@@ -495,7 +496,8 @@ EOT;
 
         $this
             ->installCoolRunningsInteractively(['--without-user' => true])
-            ->expectsConfirmation('Clear site first?', 'yes');
+            ->expectsConfirmation('Clear site first?', 'yes')
+            ->expectsConfirmation('Would you like to update your search index(es) as well?', 'no');
 
         $this->assertFileExists(base_path('content/collections/pages/home.md'));
         $this->assertFileDoesNotExist(base_path('content/collections/pages/contact.md'));
@@ -1692,6 +1694,7 @@ EOT;
         return $this->installCoolRunningsInteractively(array_merge($options, [
             '--clear-site' => true,   // skip clear site prompt
             '--without-user' => true, // skip create user prompt
+            '--update-search' => true, // skip update search index prompt
         ]), $customHttpFake);
     }
 


### PR DESCRIPTION
If you copy new content into an site via the filesystem _after_ your search index has already been generated, new entries won't show up in the CP search results until you run `php please search:update`.

To help the user, this PR adds optional prompt to update search index(es) immediately after installing a starter kit:

![CleanShot 2025-07-03 at 23 49 41](https://github.com/user-attachments/assets/e55e3988-a2e7-4f06-bf18-fd622716a6d6)
