### PR TITLE
[5.x] Loosen type check in `Tree::move()`

### DIFF
--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -310,7 +310,7 @@ abstract class Tree implements Contract, Localization
     {
         $parent = optional($this->find($entry)->parent());
 
-        if ($parent->id() === $target || $parent->isRoot() && is_null($target)) {
+        if ($parent->id() == $target || $parent->isRoot() && is_null($target)) {
             return $this;
         }
 


### PR DESCRIPTION
This pull request relaxes the strict type check in `Tree::move()` where it returns early when the entry's parent is already the given parent.

This fixes an issue with the Eloquent Driver, when using revisions and integer IDs, where the `$parent->id()` would be an integer and the `$target` would end up being a string.

Fixes statamic/eloquent-driver#458
