### PR TITLE
[5.x] Prevent group fieldtype from filtering out `false` values

### DIFF
--- a/src/Fieldtypes/Group.php
+++ b/src/Fieldtypes/Group.php
@@ -7,8 +7,8 @@ use Statamic\Fields\Fields;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Values;
 use Statamic\GraphQL\Types\GroupType;
-use Statamic\Support\Str;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class Group extends Fieldtype
 {

--- a/src/Fieldtypes/Group.php
+++ b/src/Fieldtypes/Group.php
@@ -8,6 +8,7 @@ use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Values;
 use Statamic\GraphQL\Types\GroupType;
 use Statamic\Support\Str;
+use Statamic\Support\Arr;
 
 class Group extends Fieldtype
 {
@@ -50,7 +51,9 @@ class Group extends Fieldtype
 
     public function process($data)
     {
-        return $this->fields()->addValues($data ?? [])->process()->values()->filter()->all();
+        $values = $this->fields()->addValues($data ?? [])->process()->values()->all();
+
+        return Arr::removeNullValues($values);
     }
 
     public function preProcess($data)


### PR DESCRIPTION
This pull request fixes an issue where the Group fieldtype was incorrectly filtering out `false` values. It should only be filtering out `null` values.

Fixes #11926
Caused by #11788