### PR TITLE
[5.x] Fix group fieldtype child field validation rules when using {this} within a replicator/grid

### DIFF
--- a/src/Fieldtypes/Group.php
+++ b/src/Fieldtypes/Group.php
@@ -78,7 +78,7 @@ class Group extends Fieldtype
             ->addValues((array) $this->field->value())
             ->validator()
             ->withContext([
-                'prefix' => $this->field->handle().'.',
+                'prefix' => $this->field->validationContext('prefix'),
             ])
             ->rules();
 


### PR DESCRIPTION
The `group` fieldtype currently has its context set using:
```php
$this->field->handle().'.'
```

Which is fine when group is used outside of a replicator.

However, if you use a group within a replicator/grid, validation rules of the child fields of the group fail to run correctly.

For example, this Blueprint (you can put this in a clean install in the Pages collection):
```yaml
title: 'Group Fix Blueprint'
tabs:
  main:
    display: Main
    sections:
      - fields:
          - handle: title
            field:
              type: text
              required: true
              localizable: false
              validate:
                - required
          - handle: my_replicator
            field:
              type: replicator
              display: Replicator
              localizable: false
              sets:
                new_set_group:
                  display: 'New Set Group'
                  sets:
                    new_set:
                      display: 'New Set'
                      fields:
                        - handle: my_group
                          field:
                            type: group
                            display: Group
                            localizable: false
                            fields:
                              - handle: change_validation
                                field:
                                  options:
                                    - key: 'Yes'
                                      value: null
                                    - key: 'No'
                                      value: null
                                  type: select
                                  display: 'Change validation'
                                  localizable: false
                                  width: 33
                                  default: 'Yes'
                              - handle: my_text_field
                                field:
                                  type: text
                                  display: 'Text Field'
                                  localizable: false
                                  width: 66
                                  validate:
                                    - 'exclude_unless:{this}.my_group.change_validation,Yes'
  sidebar:
    display: Sidebar
    sections:
      - fields:
          - handle: slug
            field:
              type: slug
              localizable: true
              validate: 'max:200'
          - handle: parent
            field:
              type: entries
              collections:
                - pages
              max_items: 1
              listable: false
              localizable: true
```

Within the Replicator, there is a Group. Within the Group is a Select field that changes the validation behaviour of the Text Field.

The issue is that the `{this}` is not being correctly handled.

The validation rules that are generated for this Blueprint are:
```php
array:8 [▼
  "title" => array:1 [▼
    0 => "required"
  ]
  "my_replicator" => array:2 [▼
    0 => "array"
    1 => "nullable"
  ]
  "my_replicator.0.my_group" => array:2 [▼
    0 => "array"
    1 => "nullable"
  ]
  "my_replicator.0.my_group.change_validation" => array:1 [▼
    0 => "nullable"
  ]
  "my_replicator.0.my_group.my_text_field" => array:2 [▼
    0 => "exclude_unless:my_group.my_group.change_validation,Yes"
    1 => "nullable"
  ]
  "published" => array:1 [▼
    0 => "nullable"
  ]
  "slug" => array:3 [▼
    0 => "max:200"
    1 => "nullable"
    2 => Statamic\Rules\Slug {#4718}
  ]
  "parent" => array:3 [▼
    0 => "array"
    1 => "max:1"
    2 => "nullable"
  ]
]
```

Notice the rules for `my_text_field` are wrong:
`exclude_unless:my_group.my_group.change_validation,Yes`

This is incorrect:
- uses the `my_group` handle as the context
- missing the reference to `my_replicator`
- missing the index

The expected rule is:
`exclude_unless:my_replicator.0.my_group.change_validation,Yes`

This PR uses the same logic from the replicator/grid fieldtypes to correctly allow child fields within a group within a replicator to have the correct rules applied.

If you were to create a new Entry with the above Blueprint, add two items, the rules generated will correctly become:
```php
array:11 [▼
  "title" => array:1 [▶]
  "my_replicator" => array:2 [▶]
  "my_replicator.0.my_group" => array:2 [▶]
  "my_replicator.0.my_group.change_validation" => array:1 [▶]
  "my_replicator.0.my_group.my_text_field" => array:2 [▼
    0 => "exclude_unless:my_replicator.0.my_group.change_validation,Yes"
    1 => "nullable"
  ]
  "my_replicator.1.my_group" => array:2 [▶]
  "my_replicator.1.my_group.change_validation" => array:1 [▶]
  "my_replicator.1.my_group.my_text_field" => array:2 [▼
    0 => "exclude_unless:my_replicator.1.my_group.change_validation,Yes"
    1 => "nullable"
  ]
  "published" => array:1 [▶]
  "slug" => array:3 [▶]
  "parent" => array:3 [▶]
]
```