### PR TITLE
[6.x] Composition API support for fieldtypes

### DIFF
--- a/resources/js/components/field-actions/HasFieldActions.js
+++ b/resources/js/components/field-actions/HasFieldActions.js
@@ -1,11 +1,13 @@
-import FieldAction from './FieldAction';
+import toFieldActions from './toFieldActions.js';
 
 export default {
     computed: {
         fieldActions() {
-            return [...this.$fieldActions.get(this.$options.name), ...this.internalFieldActions]
-                .map((action) => new FieldAction(action, this.fieldActionPayload))
-                .filter((action) => action.visible);
+            return toFieldActions(
+                this.fieldActionBinding,
+                this.fieldActionPayload,
+                this.internalFieldActions,
+            );
         },
 
         internalFieldActions() {
@@ -15,5 +17,9 @@ export default {
         fieldActionPayload() {
             return {};
         },
+
+        fieldActionBinding() {
+            return this.config.type + '-fieldtype';
+        }
     },
 };

--- a/resources/js/components/field-actions/toFieldActions.js
+++ b/resources/js/components/field-actions/toFieldActions.js
@@ -1,0 +1,7 @@
+import FieldAction from './FieldAction.js';
+
+export default function toFieldActions(binding, payload, extraActions = []) {
+    return [...Statamic.$fieldActions.get(binding), ...extraActions]
+        .map((action) => new FieldAction(action, payload))
+        .filter((action) => action.visible);
+}

--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -1,9 +1,11 @@
 <script>
 import HasFieldActions from '../field-actions/HasFieldActions';
 import debounce from '@statamic/util/debounce.js';
+import props from './props.js';
+import emits from './emits.js';
 
 export default {
-    emits: ['update:value', 'focus', 'blur', 'meta-updated', 'replicator-preview-updated'],
+    emits,
 
     mixins: [HasFieldActions],
 
@@ -18,39 +20,7 @@ export default {
         },
     },
 
-    props: {
-        value: {
-            required: true,
-        },
-        config: {
-            type: Object,
-            default: () => {
-                return {};
-            },
-        },
-        handle: {
-            type: String,
-            required: true,
-        },
-        meta: {
-            type: Object,
-            default: () => {
-                return {};
-            },
-        },
-        readOnly: {
-            type: Boolean,
-            default: false,
-        },
-        showFieldPreviews: {
-            type: Boolean,
-            default: false,
-        },
-        namePrefix: String,
-        fieldPathPrefix: String,
-        metaPathPrefix: String,
-        id: String,
-    },
+    props,
 
     methods: {
         update(value) {
@@ -96,6 +66,7 @@ export default {
             return prefix.split('.');
         },
 
+        // Deprecated, use `this.id`/`props.id` instead
         fieldId() {
             return this.id;
         },

--- a/resources/js/components/fieldtypes/TextFieldtype.vue
+++ b/resources/js/components/fieldtypes/TextFieldtype.vue
@@ -1,3 +1,24 @@
+<script setup>
+import { Input } from '@statamic/ui';
+import { Fieldtype } from 'statamic';
+
+const emit = defineEmits(Fieldtype.emits);
+const props = defineProps(Fieldtype.props);
+const {
+    name,
+    isReadOnly,
+    update,
+    updateDebounced,
+    expose
+} = Fieldtype.use(emit, props);
+
+function inputUpdated(value) {
+    return !props.config.debounce ? update(value) : updateDebounced(value);
+}
+
+defineExpose(expose);
+</script>
+
 <template>
     <Input
         ref="input"
@@ -20,26 +41,3 @@
         @blur="$emit('blur')"
     />
 </template>
-
-<script>
-import Fieldtype from './Fieldtype.vue';
-import { Input } from '@statamic/ui';
-
-export default {
-    mixins: [Fieldtype],
-
-    components: {
-        Input,
-    },
-
-    methods: {
-        inputUpdated(value) {
-            if (!this.config.debounce) {
-                return this.update(value);
-            }
-
-            this.updateDebounced(value);
-        },
-    },
-};
-</script>

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -286,6 +286,10 @@ export default {
                 // storeName: this.storeName,
             };
         },
+
+        fieldActionBinding() {
+            return 'bard-fieldtype-set';
+        }
     },
 
     methods: {

--- a/resources/js/components/fieldtypes/emits.js
+++ b/resources/js/components/fieldtypes/emits.js
@@ -1,0 +1,7 @@
+export default [
+    'update:value',
+    'focus',
+    'blur',
+    'meta-updated',
+    'replicator-preview-updated',
+];

--- a/resources/js/components/fieldtypes/fieldtype.js
+++ b/resources/js/components/fieldtypes/fieldtype.js
@@ -1,0 +1,113 @@
+import debounce from '@statamic/util/debounce.js';
+import mixin from './Fieldtype.vue';
+import emits from './emits.js';
+import props from './props.js';
+import { computed, watch } from 'vue';
+import FieldAction from '@statamic/components/field-actions/FieldAction.js';
+import toFieldActions from '@statamic/components/field-actions/toFieldActions.js';
+
+const use = function(emit, props) {
+    const name = computed(() => {
+        if (props.namePrefix) {
+            return `${props.namePrefix}[${props.handle}]`;
+        }
+
+        return props.handle;
+    });
+
+    const isReadOnly = computed(() => {
+        return (
+            props.readOnly ||
+            props.config.visibility === 'read_only' ||
+            props.config.visibility === 'computed' ||
+            false
+        );
+    });
+
+    const replicatorPreview = computed(() => {
+        if (!props.showFieldPreviews || !props.config.replicator_preview) return;
+
+        return props.value;
+    });
+
+    const fieldPathKeys = computed(() => {
+        const prefix = props.fieldPathPrefix || props.handle;
+
+        return prefix.split('.');
+    });
+
+    const update = (value) => {
+        emit('update:value', value);
+    };
+
+    const updateDebounced = debounce(function (value) {
+        update(value);
+    }, 150);
+
+    const updateMeta = (value) => {
+        emit('update:meta', value);
+    };
+
+    const fieldActionPayload = computed(() => ({
+        // vm: this,
+        // fieldPathPrefix: this.fieldPathPrefix,
+        // handle: this.handle,
+        value: props.value,
+        // config: this.config,
+        // meta: this.meta,
+        update,
+        // updateMeta: this.updateMeta,
+        // isReadOnly: this.isReadOnly,
+        // store: this.fieldActionStore,
+        // storeName: this.fieldActionStoreName,
+    }));
+
+    const fieldActionBinding = computed(() => `${props.config.type}-fieldtype`);
+
+    const defineFieldActions = (actions) => {
+        return [
+            ...Statamic.$fieldActions.get(fieldActionBinding.value),
+            ...actions
+        ]
+            .map((action) => new FieldAction(action, fieldActionPayload.value))
+            .filter((action) => action.visible);
+    };
+
+    const fieldActions = computed(() => {
+        return toFieldActions(
+            `${props.config.type}-fieldtype`,
+            fieldActionPayload.value,
+        );
+    });
+
+    watch(replicatorPreview, (text) => {
+        if (!props.showFieldPreviews || !props.config.replicator_preview) return;
+
+        emit('replicator-preview-updated', text);
+    }, { immediate: true });
+
+    const expose = {
+        handle: props.handle,
+        name,
+    };
+
+    return {
+        name,
+        isReadOnly,
+        replicatorPreview,
+        fieldPathKeys,
+        defineFieldActions,
+        fieldActions,
+        update,
+        updateDebounced,
+        updateMeta,
+        expose,
+    };
+}
+
+export default {
+    use,
+    emits,
+    props,
+    mixin
+};

--- a/resources/js/components/fieldtypes/props.js
+++ b/resources/js/components/fieldtypes/props.js
@@ -1,0 +1,34 @@
+
+export default {
+    value: {
+        required: true,
+    },
+    config: {
+        type: Object,
+        default: () => {
+            return {};
+        },
+    },
+    handle: {
+        type: String,
+        required: true,
+    },
+    meta: {
+        type: Object,
+        default: () => {
+            return {};
+        },
+    },
+    readOnly: {
+        type: Boolean,
+        default: false,
+    },
+    showFieldPreviews: {
+        type: Boolean,
+        default: false,
+    },
+    namePrefix: String,
+    fieldPathPrefix: String,
+    metaPathPrefix: String,
+    id: String,
+};

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -18,6 +18,7 @@ import { Motion } from 'motion-v';
 import { injectContainerContext } from '@statamic/components/ui/Publish/Container.vue';
 import PreviewHtml from '@statamic/components/fieldtypes/replicator/PreviewHtml.js';
 import FieldAction from '@statamic/components/field-actions/FieldAction.js';
+import toFieldActions from '@statamic/components/field-actions/toFieldActions.js';
 
 const emit = defineEmits(['collapsed', 'expanded', 'duplicated', 'removed']);
 
@@ -73,9 +74,7 @@ const fieldActionPayload = computed(() => ({
 }));
 
 const fieldActions = computed(() => {
-    return [...Statamic.$fieldActions.get('replicator-fieldtype-set')]
-        .map((action) => new FieldAction(action, fieldActionPayload.value))
-        .filter((action) => action.visible);
+    return toFieldActions('replicator-fieldtype-set', fieldActionPayload.value);
 });
 
 const previewText = computed(() => {

--- a/resources/js/exports.js
+++ b/resources/js/exports.js
@@ -1,4 +1,5 @@
-export { default as Fieldtype } from './components/fieldtypes/Fieldtype.vue';
+export { default as Fieldtype } from './components/fieldtypes/fieldtype.js';
+export { default as FieldtypeMixin } from './components/fieldtypes/Fieldtype.vue';
 export { default as IndexFieldtype } from './components/fieldtypes/IndexFieldtype.vue';
 export { default as BardToolbarButton } from './components/fieldtypes/bard/ToolbarButton.vue';
 export { default as Listing } from './components/Listing.vue';


### PR DESCRIPTION
This adds a way for developers to write fieldtypes using Vue's composition API.

The `Fieldtype` was doing a lot of heavy lifting in the options API, but it can't do it all via composition.
