### PR TITLE
[5.x] Fix active state for nav items with implicit children

### DIFF
--- a/src/CP/Navigation/CoreNav.php
+++ b/src/CP/Navigation/CoreNav.php
@@ -194,8 +194,7 @@ class CoreNav
             ->route('updater')
             ->icon('loading-bar')
             ->view('statamic::nav.updates')
-            ->can('view updates')
-            ->children(true);
+            ->can('view updates');
 
         Nav::tools('Addons')
             ->route('addons.index')

--- a/src/CP/Navigation/CoreNav.php
+++ b/src/CP/Navigation/CoreNav.php
@@ -194,7 +194,8 @@ class CoreNav
             ->route('updater')
             ->icon('loading-bar')
             ->view('statamic::nav.updates')
-            ->can('view updates');
+            ->can('view updates')
+            ->children(true);
 
         Nav::tools('Addons')
             ->route('addons.index')

--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -293,6 +293,14 @@ class NavItem
     }
 
     /**
+     * Check if we should assume nested URL conventions for active state on children.
+     */
+    protected function doesntHaveExplicitChildren(): bool
+    {
+        return (bool) ! $this->children;
+    }
+
+    /**
      * Check if this nav item was ever a child before user preferences were applied.
      */
     protected function wasOriginallyChild(): bool
@@ -393,6 +401,7 @@ class NavItem
         if ($this->currentUrlIsNotExplicitlyReferencedInNav()) {
             switch (true) {
                 case $this->currentUrlIsRestfulDescendant():
+                case $this->doesntHaveExplicitChildren():
                 case $this->wasOriginallyChild():
                     return $this->isActiveByPattern($this->active);
             }

--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -20,6 +20,7 @@ class NavItem
     protected $url;
     protected $icon;
     protected $children;
+    protected $hasImplicitChildren;
     protected $isChild;
     protected $wasOriginallyChild;
     protected $authorization;
@@ -232,6 +233,14 @@ class NavItem
             return $this->children;
         }
 
+        if ($items === true) {
+            $this->hasImplicitChildren = true;
+
+            return $this;
+        } elseif ($items) {
+            $this->hasImplicitChildren = false;
+        }
+
         if (is_callable($items)) {
             $this->children = $items;
 
@@ -290,6 +299,14 @@ class NavItem
             '/create',
             '/edit',
         ]);
+    }
+
+    /**
+     * Check if this nav item has implicit children by assuming nested URL conventions.
+     */
+    protected function hasImplicitChildren(): bool
+    {
+        return (bool) $this->hasImplicitChildren;
     }
 
     /**
@@ -393,6 +410,7 @@ class NavItem
         if ($this->currentUrlIsNotExplicitlyReferencedInNav()) {
             switch (true) {
                 case $this->currentUrlIsRestfulDescendant():
+                case $this->hasImplicitChildren():
                 case $this->wasOriginallyChild():
                     return $this->isActiveByPattern($this->active);
             }

--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -20,7 +20,6 @@ class NavItem
     protected $url;
     protected $icon;
     protected $children;
-    protected $hasImplicitChildren;
     protected $isChild;
     protected $wasOriginallyChild;
     protected $authorization;
@@ -233,14 +232,6 @@ class NavItem
             return $this->children;
         }
 
-        if ($items === true) {
-            $this->hasImplicitChildren = true;
-
-            return $this;
-        } elseif ($items) {
-            $this->hasImplicitChildren = false;
-        }
-
         if (is_callable($items)) {
             $this->children = $items;
 
@@ -299,14 +290,6 @@ class NavItem
             '/create',
             '/edit',
         ]);
-    }
-
-    /**
-     * Check if this nav item has implicit children by assuming nested URL conventions.
-     */
-    protected function hasImplicitChildren(): bool
-    {
-        return (bool) $this->hasImplicitChildren;
     }
 
     /**
@@ -410,7 +393,6 @@ class NavItem
         if ($this->currentUrlIsNotExplicitlyReferencedInNav()) {
             switch (true) {
                 case $this->currentUrlIsRestfulDescendant():
-                case $this->hasImplicitChildren():
                 case $this->wasOriginallyChild():
                     return $this->isActiveByPattern($this->active);
             }

--- a/tests/CP/Navigation/ActiveNavItemTest.php
+++ b/tests/CP/Navigation/ActiveNavItemTest.php
@@ -537,6 +537,25 @@ class ActiveNavItemTest extends TestCase
     }
 
     #[Test]
+    public function active_nav_descendant_url_still_functions_properly_when_parent_item_has_no_children()
+    {
+        Facades\CP\Nav::extend(function ($nav) {
+            $nav->tools('Schopify')->url('/cp/totally-custom-url');
+        });
+
+        $this
+            ->prepareNavCaches()
+            ->get('http://localhost/cp/totally-custom-url/deeper/descendant')
+            ->assertStatus(200);
+
+        $toolsItems = $this->build()->get('Tools');
+
+        $this->assertTrue($this->getItemByDisplay($toolsItems, 'Schopify')->isActive());
+        $this->assertFalse($this->getItemByDisplay($toolsItems, 'Addons')->isActive());
+        $this->assertFalse($this->getItemByDisplay($toolsItems, 'Utilities')->isActive());
+    }
+
+    #[Test]
     public function active_nav_check_still_functions_properly_when_custom_nav_extension_hijacks_a_core_item_child()
     {
         Facades\Collection::make('pages')->title('Pages')->save();


### PR DESCRIPTION
Likely during [this refactor](https://github.com/statamic/cms/pull/8880), we introduced a small regression around checking active state on nav items with implicit children via nested URLs.

For example, when you visit `/cp/updater/seo-pro`, it is not properly making the `Updates` nav item active. This PR fixes that.

![CleanShot 2025-07-08 at 10 21 40](https://github.com/user-attachments/assets/5be9f390-6721-4453-bca3-4e82687d75eb)