### PR TITLE
[6.x] Provide a dev asset build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,17 @@ jobs:
       - name: Compile assets
         run: npm run build
 
+      - name: Compile dev assets
+        run: npm run build-dev
+
       - name: Compile frontend assets
         run: npm run frontend-build
 
       - name: Create dist zip
         run: cd resources && tar -czvf dist.tar.gz dist
+
+      - name: Create dist-dev zip
+        run: cd resources && tar -czvf dist-dev.tar.gz dist-dev
 
       - name: Create dist-frontend zip
         run: cd resources && tar -czvf dist-frontend.tar.gz dist-frontend
@@ -59,6 +65,16 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./resources/dist.tar.gz
           asset_name: dist.tar.gz
+          asset_content_type: application/tar+gz
+
+      - name: Upload dist-dev zip to release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./resources/dist-dev.tar.gz
+          asset_name: dist-dev.tar.gz
           asset_content_type: application/tar+gz
 
       - name: Upload dist-frontend zip to release

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 .php-cs-fixer.cache
 tests/Fakes/Composer/Package/test-package/composer.json
 resources/dist
+resources/dist-dev
 resources/dist-frontend
 composer.lock
 .env

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,10 @@
                 "path": "resources/dist"
             },
             {
+                "url": "https://github.com/statamic/cms/releases/download/{$version}/dist-dev.tar.gz",
+                "path": "resources/dist-dev"
+            },
+            {
                 "url": "https://github.com/statamic/cms/releases/download/{$version}/dist-frontend.tar.gz",
                 "path": "resources/dist-frontend"
             }

--- a/config/cp.php
+++ b/config/cp.php
@@ -153,5 +153,5 @@ return [
     |
     */
 
-    'enable_development_build' => false,
+    'enable_development_build' => env('STATAMIC_ENABLE_DEVELOPMENT_BUILD', false),
 ];

--- a/config/cp.php
+++ b/config/cp.php
@@ -140,4 +140,18 @@ return [
     'thumbnail_presets' => [
         // 'medium' => 800,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Development Build
+    |--------------------------------------------------------------------------
+    |
+    | The Control Panel's asset build will be minified and have Vue DevTools
+    | disabled. You may choose to use a development build, which is useful
+    | while building custom Vue components or debugging. You must also
+    | publish the assets. You should not enable this in production.
+    |
+    */
+
+    'enable_development_build' => false,
 ];

--- a/config/cp.php
+++ b/config/cp.php
@@ -140,18 +140,4 @@ return [
     'thumbnail_presets' => [
         // 'medium' => 800,
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Development Build
-    |--------------------------------------------------------------------------
-    |
-    | The Control Panel's asset build will be minified and have Vue DevTools
-    | disabled. You may choose to use a development build, which is useful
-    | while building custom Vue components or debugging. You must also
-    | publish the assets. You should not enable this in production.
-    |
-    */
-
-    'enable_development_build' => env('STATAMIC_ENABLE_DEVELOPMENT_BUILD', false),
 ];

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "rm -rf resources/dist/build && vite",
     "build": "vite build",
+    "build-dev": "vite build --mode development",
     "svgo": "svgo -f ./resources/svg/  -r",
     "test": "vitest run",
     "test-watch": "npm run test -- --watch --notify",

--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -89,7 +89,21 @@ class Install extends Command
         $this->call('vendor:publish', ['--tag' => 'statamic-cp', '--force' => true]);
         $this->call('vendor:publish', ['--tag' => 'statamic-frontend', '--force' => true]);
 
+        if ($this->shouldPublishDevAssets()) {
+            $this->call('vendor:publish', ['--tag' => 'statamic-cp-dev', '--force' => true]);
+        }
+
         return $this;
+    }
+
+    private function shouldPublishDevAssets(): bool
+    {
+        // We only want to re-publish the dev assets if they were manually published before.
+        // If the path is a symlink, we'll assume they've linked to the assets anyway, so don't override it.
+
+        return config('app.debug')
+            && is_dir($path = public_path('vendor/statamic/cp-dev'))
+            && ! is_link($path);
     }
 
     protected function clearViews()

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -59,6 +59,10 @@ class AppServiceProvider extends ServiceProvider
         ], 'statamic-cp');
 
         $this->publishes([
+            "{$this->root}/resources/dist-dev" => public_path('vendor/statamic/cp-dev'),
+        ], 'statamic-cp-dev');
+
+        $this->publishes([
             "{$this->root}/resources/dist-frontend" => public_path('vendor/statamic/frontend'),
         ], 'statamic-frontend');
 

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -293,7 +293,11 @@ class Statamic
     {
         return Vite::getFacadeRoot()
             ->useHotFile('vendor/statamic/cp/hot')
-            ->useBuildDirectory('vendor/statamic/cp/build');
+            ->useBuildDirectory(
+                config('statamic.cp.enable_development_build', false)
+                    ? 'vendor/statamic/cp-dev/build'
+                    : 'vendor/statamic/cp/build'
+            );
     }
 
     public static function dateFormat()

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -294,7 +294,7 @@ class Statamic
         return Vite::getFacadeRoot()
             ->useHotFile('vendor/statamic/cp/hot')
             ->useBuildDirectory(
-                config('statamic.cp.enable_development_build', false)
+                config('app.debug') && is_dir(public_path('vendor/statamic/cp-dev'))
                     ? 'vendor/statamic/cp-dev/build'
                     : 'vendor/statamic/cp/build'
             );

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,8 +7,11 @@ import { visualizer } from 'rollup-plugin-visualizer';
 import svgLoader from 'vite-svg-loader';
 import path from 'path';
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
     const env = loadEnv(mode, process.cwd(), '');
+    const isRunningBuild = command === 'build';
+    const isProdBuild = isRunningBuild && mode === 'production';
+    const isProdDevBuild = isRunningBuild && mode === 'development';
 
     return {
         base: './',
@@ -18,7 +21,7 @@ export default defineConfig(({ mode }) => {
                 valetTls: env.VALET_TLS,
                 input: ['resources/css/app.css', 'resources/js/index.js'],
                 refresh: true,
-                publicDirectory: 'resources/dist',
+                publicDirectory: isProdDevBuild ? 'resources/dist-dev' : 'resources/dist',
                 hotFile: 'resources/dist/hot',
             }),
             vue(),
@@ -37,7 +40,15 @@ export default defineConfig(({ mode }) => {
             },
         },
         optimizeDeps: { include: ['vue'] },
-        build: { rollupOptions: { output: { plugins: [visualizer({ filename: 'bundle-stats.html' })] } } },
+        build: {
+            rollupOptions: {
+                output: { plugins: [visualizer({ filename: 'bundle-stats.html' })] }
+            },
+            minify: isProdBuild
+        },
         test: { environment: 'jsdom', setupFiles: 'resources/js/tests/setup.js' },
+        define: {
+            __VUE_PROD_DEVTOOLS__: isProdDevBuild,
+        }
     };
 });


### PR DESCRIPTION
In Vue 3, Vue Devtools are disabled. This PR introduces an opt-in dev build so you can use Vue Devtools and see un-minified code, which is useful during development of custom CP Vue components.

Your app must have debug mode enabled:
```env
APP_DEBUG=true
```

And the dev build must either be published:
```
php artisan vendor:publish --tag=statamic-cp-dev
```
Or, be symlinked:
```
ln -s /path/to/vendor/statamic/cms/resources/dist-dev public/vendor/statamic/cp-dev
```

You should obviously not commit these or use this on production.