### PR TITLE
Use `app.locale` as fallback when there is no explicit site locale

### DIFF
--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -138,7 +138,7 @@ class Sites
             'default' => [
                 'name' => '{{ config:app:name }}',
                 'url' => '/',
-                'locale' => 'en_US',
+                'locale' => '{{ config:app:locale }}',
             ],
         ];
     }

--- a/tests/Sites/SitesConfigTest.php
+++ b/tests/Sites/SitesConfigTest.php
@@ -73,12 +73,11 @@ class SitesConfigTest extends TestCase
         Site::swap(new Sites);
 
         $this->assertCount(1, Site::all());
-
         $this->assertSame('default', Site::default()->handle());
         $this->assertSame(config('app.name'), Site::default()->name());
         $this->assertSame('/', Site::default()->url());
-        $this->assertSame('en_US', Site::default()->locale());
-        $this->assertSame('en', Site::default()->lang());
+        $this->assertSame(config('app.locale'), Site::default()->locale());
+        $this->assertSame(config('app.locale'), Site::default()->lang());
     }
 
     #[Test]


### PR DESCRIPTION
This PR changes the site fallback locale to the `app.locale` config setting instead of the hard coded `en_US`. This avoids the awkward situation where a locale is still `en_US` while your app locale is something else if `resources/sites.yaml` is absent/multi site is disabled.