### PR TITLE
[5.x] Fix antlers issue when template data is a collection

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -517,7 +517,7 @@ class NodeProcessor
 
         if (GlobalRuntimeState::$traceTagAssignments) {
             if (! empty(GlobalRuntimeState::$tracedRuntimeAssignments)) {
-                $data = array_merge(GlobalRuntimeState::$tracedRuntimeAssignments, $data);
+                $data = array_merge(GlobalRuntimeState::$tracedRuntimeAssignments, (is_object($data) && ($data instanceof Arrayable) ? $data->toArray() : $data));
             }
         }
 


### PR DESCRIPTION
Fixes an issue where array_merge would have failed if the $data variable is a Collection. It needs to be always an array