### PR TITLE
[5.x] Add optional fallback for missing keys in `{{ trans }}` tag

### DIFF
--- a/src/Tags/Trans.php
+++ b/src/Tags/Trans.php
@@ -13,8 +13,14 @@ class Trans extends Tags
     {
         $key = $this->params->get('key', $tag);
         $locale = $this->params->pull('locale') ?? $this->params->pull('site');
+        $fallback = $this->params->get('fallback');
         $params = $this->params->all();
 
-        return __($key, $params, $locale);
+        $translation = __($key, $params, $locale);
+        if ($fallback && $translation === $key) {
+            return __($fallback, $params, $locale);
+        } else {
+            return $translation;
+        }
     }
 }

--- a/tests/Tags/TransTagTest.php
+++ b/tests/Tags/TransTagTest.php
@@ -38,4 +38,18 @@ class TransTagTest extends TestCase
         $this->assertEquals('Bonjour, Bob', $this->parse('{{ trans key="package::messages.hello_name" name="Bob" locale="fr" }}'));
         $this->assertEquals('Bonjour, Bob', $this->parse('{{ trans key="package::messages.hello_name" name="Bob" site="fr" }}'));
     }
+
+    #[Test]
+    public function it_falls_back_to_fallback_for_missing_key()
+    {
+        $this->assertEquals('Fallback', $this->parse('{{ trans key="package::messages.does_not_exist" fallback="Fallback" }}'));
+        $this->assertEquals('Bonjour', $this->parse('{{ trans key="package::messages.does_not_exist" fallback="package::messages.hello" locale="fr" }}'));
+    }
+
+    #[Test]
+    public function it_applies_replacement_to_fallbacks()
+    {
+        $this->assertEquals('Fallback Bob', $this->parse('{{ trans key="package::messages.does_not_exist" name="Bob" fallback="Fallback :name" }}'));
+        $this->assertEquals('Bonjour, Bob', $this->parse('{{ trans key="package::messages.does_not_exist" name="Bob" fallback="package::messages.hello_name" locale="fr" }}'));
+    }
 }


### PR DESCRIPTION
We're currently building a larger site with dynamic user-supplied translations. Lots of them are missing and we needed a mechanism for displaying a fallback translation if the requested key does not exist. Thought this might be useful to have in the core tag :)

### Before

```antlers
{{ trans key="messages.does_not_exist" }}
Output: messages.does_not_exist
```

### After

```antlers
{{ trans key="messages.does_not_exist" fallback="Literal fallback" }}
Output: Literal fallback

{{ trans key="messages.does_not_exist" fallback="messages.fallback_key" }}
Output: Fallback from existing key
```
