### PR TITLE
[5.x] Allow classes to extend Parser

### DIFF
--- a/src/Markdown/Parser.php
+++ b/src/Markdown/Parser.php
@@ -185,7 +185,7 @@ class Parser
 
     public function newInstance(array $config = [])
     {
-        $parser = new self(array_replace_recursive($this->config, $config));
+        $parser = new static(array_replace_recursive($this->config, $config));
 
         foreach ($this->extensions as $ext) {
             $parser->addExtensions($ext);

--- a/tests/Markdown/ParserTest.php
+++ b/tests/Markdown/ParserTest.php
@@ -5,6 +5,8 @@ namespace Tests\Markdown;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Fields\Field;
+use Statamic\Fields\Value;
 use Statamic\Markdown;
 use Tests\TestCase;
 
@@ -127,5 +129,31 @@ class ParserTest extends TestCase
         $this->assertCount(1, $this->parser->extensions());
         $this->assertCount(2, $newParser->renderers());
         $this->assertCount(1, $this->parser->renderers());
+    }
+
+    #[Test]
+    public function it_returns_instances_of_custom_parsers()
+    {
+        $markdown = new \Statamic\Fieldtypes\Markdown;
+        $field = new Field('test', [
+            'type' => 'markdown',
+            'parser' => 'custom',
+        ]);
+
+        $markdown->setField($field);
+
+        $markdownValue = new Value('A Test', 'test', $markdown);
+
+        $customParser = new class extends Markdown\Parser
+        {
+            public function parse(string $markdown): string
+            {
+                return strtolower($markdown);
+            }
+        };
+
+        \Statamic\Facades\Markdown::extend('custom', fn () => $customParser);
+
+        $this->assertSame('a test', $markdownValue->value());
     }
 }


### PR DESCRIPTION
This PR adjusts the behavior of `newInstance` within the Markdown `Parser` class, allowing custom classes to extend the parser class. By returning `new static`, methods like `withAutoLinks`, `withAutoLineBreaks`, etc., will now return instances of the current class in the class hierarchy.

I stumbled across this when attempting to extend the parser to modify the raw markdown before it was sent through the parent parser's `parse` method.