### PR TITLE
[5.x] Addon Manifest improvements

### DIFF
--- a/src/Extend/Addon.php
+++ b/src/Extend/Addon.php
@@ -244,101 +244,6 @@ final class Addon
     }
 
     /**
-     * The marketplace variant ID of the addon.
-     *
-     * @param  int  $id
-     * @return int
-     */
-    public function marketplaceId($id = null)
-    {
-        if (! $this->hasMarketplaceData && func_num_args() === 0) {
-            app(Manifest::class)->fetchPackageDataFromMarketplace();
-
-            return Facades\Addon::get($this->id)->marketplaceId();
-        }
-
-        return $id
-            ? $this->marketplaceId = $id
-            : $this->marketplaceId;
-    }
-
-    /**
-     * The marketplace slug of the addon.
-     *
-     * @param  string  $slug
-     * @return string
-     */
-    public function marketplaceSlug($slug = null)
-    {
-        if (! $this->hasMarketplaceData && func_num_args() === 0) {
-            app(Manifest::class)->fetchPackageDataFromMarketplace();
-
-            return Facades\Addon::get($this->id)->marketplaceSlug();
-        }
-
-        return $slug
-            ? $this->marketplaceSlug = $slug
-            : $this->marketplaceSlug;
-    }
-
-    /**
-     * The marketplace URL.
-     *
-     * @param  string  $url
-     * @return string
-     */
-    public function marketplaceUrl($url = null)
-    {
-        if (! $this->hasMarketplaceData && func_num_args() === 0) {
-            app(Manifest::class)->fetchPackageDataFromMarketplace();
-
-            return Facades\Addon::get($this->id)->marketplaceUrl();
-        }
-
-        return $url
-            ? $this->marketplaceUrl = $url
-            : $this->marketplaceUrl;
-    }
-
-    /**
-     * The marketplace slug of the addon's seller.
-     *
-     * @param  string  $slug
-     * @return string
-     */
-    public function marketplaceSellerSlug($slug = null)
-    {
-        if (! $this->hasMarketplaceData && func_num_args() === 0) {
-            app(Manifest::class)->fetchPackageDataFromMarketplace();
-
-            return Facades\Addon::get($this->id)->marketplaceSellerSlug();
-        }
-
-        return $slug
-            ? $this->marketplaceSellerSlug = $slug
-            : $this->marketplaceSellerSlug;
-    }
-
-    /**
-     * Whether the addon is commercial.
-     *
-     * @param  bool  $isCommercial
-     * @return bool
-     */
-    public function isCommercial($isCommercial = null)
-    {
-        if (! $this->hasMarketplaceData && func_num_args() === 0) {
-            app(Manifest::class)->fetchPackageDataFromMarketplace();
-
-            return Facades\Addon::get($this->id)->isCommercial();
-        }
-
-        return $isCommercial
-            ? $this->isCommercial = $isCommercial
-            : $this->isCommercial;
-    }
-
-    /**
      * The handle of the addon.
      *
      * For referencing in YAML, etc.
@@ -450,39 +355,20 @@ final class Addon
         return new AddonChangelog($this);
     }
 
-    /**
-     * The latest version of the addon (via marketplace).
-     *
-     * @param  string|null  $latestVersion
-     * @return string|null
-     */
-    public function latestVersion($latestVersion = null)
-    {
-        if (! $this->hasMarketplaceData && func_num_args() === 0) {
-            app(Manifest::class)->fetchPackageDataFromMarketplace();
-
-            return Facades\Addon::get($this->id)->latestVersion();
-        }
-
-        return $latestVersion
-            ? $this->latestVersion = $latestVersion
-            : $this->latestVersion;
-    }
-
     public function isLatestVersion()
     {
         if (Str::startsWith($this->version, 'dev-') || Str::endsWith($this->version, '-dev')) {
             return true;
         }
 
-        if (! $latestVersion = $this->latestVersion()) {
+        if (! $this->latestVersion()) {
             return true;
         }
 
         $versionParser = new VersionParser;
 
         $version = $versionParser->normalize($this->version);
-        $latestVersion = $versionParser->normalize($latestVersion);
+        $latestVersion = $versionParser->normalize($this->latestVersion());
 
         return version_compare($version, $latestVersion, '=');
     }
@@ -507,6 +393,12 @@ final class Addon
         }
 
         if (empty($args)) {
+            if (! $this->hasMarketplaceData && in_array($method, ['marketplaceId', 'marketplaceSlug', 'marketplaceUrl', 'marketplaceSellerSlug', 'isCommercial', 'latestVersion'])) {
+                app(Manifest::class)->fetchPackageDataFromMarketplace();
+
+                return Facades\Addon::get($this->id)->$method();
+            }
+
             return $this->$method;
         }
 

--- a/src/Extend/Manifest.php
+++ b/src/Extend/Manifest.php
@@ -54,6 +54,7 @@ class Manifest extends PackageManifest
             'slug' => $statamic['slug'] ?? null,
             'editions' => $statamic['editions'] ?? [],
             'version' => Str::removeLeft($package['version'], 'v'),
+            'raw_version' => $package['version'],
             'namespace' => $namespace,
             'autoload' => $autoload,
             'provider' => $provider,
@@ -79,7 +80,7 @@ class Manifest extends PackageManifest
             ->map(function (array $package) {
                 return [
                     'package' => $package['id'],
-                    'version' => $package['version'], // todo: we strip off the 'v' when building the manifest, but the api doesn't expect that, so we *might* (in some cases) need to add it back
+                    'version' => $package['raw_version'],
                     'edition' => config('statamic.editions.addons.'.$package['id']),
                 ];
             })

--- a/src/Extend/Manifest.php
+++ b/src/Extend/Manifest.php
@@ -4,6 +4,7 @@ namespace Statamic\Extend;
 
 use Facades\Statamic\Marketplace\Marketplace;
 use Illuminate\Foundation\PackageManifest;
+use Illuminate\Support\Facades\Facade;
 use ReflectionClass;
 use Statamic\Facades\File;
 use Statamic\Support\Arr;
@@ -48,20 +49,10 @@ class Manifest extends PackageManifest
         $statamic = $json['extra']['statamic'] ?? [];
         $author = $json['authors'][0] ?? null;
 
-        $edition = config('statamic.editions.addons.'.$package['name']);
-
-        $marketplaceData = Marketplace::package($package['name'], $package['version'], $edition);
-
         return [
             'id' => $package['name'],
             'slug' => $statamic['slug'] ?? null,
             'editions' => $statamic['editions'] ?? [],
-            'marketplaceId' => data_get($marketplaceData, 'id', null),
-            'marketplaceSlug' => data_get($marketplaceData, 'slug', null),
-            'marketplaceUrl' => data_get($marketplaceData, 'url', null),
-            'marketplaceSellerSlug' => data_get($marketplaceData, 'seller', null),
-            'isCommercial' => data_get($marketplaceData, 'is_commercial', false),
-            'latestVersion' => data_get($marketplaceData, 'latest_version', null),
             'version' => Str::removeLeft($package['version'], 'v'),
             'namespace' => $namespace,
             'autoload' => $autoload,
@@ -80,5 +71,37 @@ class Manifest extends PackageManifest
     public function addons()
     {
         return collect($this->getManifest());
+    }
+
+    public function fetchPackageDataFromMarketplace()
+    {
+        $packages = $this->addons()
+            ->map(function (array $package) {
+                return [
+                    'package' => $package['id'],
+                    'version' => $package['version'], // todo: we strip off the 'v' when building the manifest, but the api doesn't expect that, so we *might* (in some cases) need to add it back
+                    'edition' => config('statamic.editions.addons.'.$package['id']),
+                ];
+            })
+            ->values()
+            ->all();
+
+        $marketplaceData = Marketplace::packages($packages);
+
+        $this->write($this->manifest = $this->addons()->map(function (array $package) use ($marketplaceData) {
+            $marketplaceData = $marketplaceData->get($package['id']);
+
+            return [
+                ...$package,
+                'marketplaceId' => data_get($marketplaceData, 'id'),
+                'marketplaceSlug' => data_get($marketplaceData, 'slug'),
+                'marketplaceUrl' => data_get($marketplaceData, 'url'),
+                'marketplaceSellerSlug' => data_get($marketplaceData, 'seller'),
+                'isCommercial' => data_get($marketplaceData, 'is_commercial', false),
+                'latestVersion' => data_get($marketplaceData, 'latest_version'),
+            ];
+        })->all());
+
+        Facade::clearResolvedInstance(AddonRepository::class);
     }
 }

--- a/src/Marketplace/Client.php
+++ b/src/Marketplace/Client.php
@@ -44,14 +44,25 @@ class Client
         }
     }
 
+    public function get(string $endpoint, array $params = [])
+    {
+        return $this->request('GET', $endpoint, $params);
+    }
+
+    public function post(string $endpoint, array $params = [])
+    {
+        return $this->request('POST', $endpoint, $params);
+    }
+
     /**
      * Send API request.
      *
+     * @param  string  $method
      * @param  string  $endpoint
-     * @param  arra  $params
+     * @param  array  $params
      * @return mixed
      */
-    public function get($endpoint, $params = [])
+    private function request(string $method, string $endpoint, array $params = [])
     {
         $lock = $this->lock(static::LOCK_KEY, 10);
 
@@ -61,8 +72,8 @@ class Client
         try {
             $lock->block(5);
 
-            return $this->cache()->rememberWithExpiration($key, function () use ($endpoint, $params) {
-                $response = Guzzle::request('GET', $endpoint, [
+            return $this->cache()->rememberWithExpiration($key, function () use ($method, $endpoint, $params) {
+                $response = Guzzle::request($method, $endpoint, [
                     'verify' => $this->verifySsl,
                     'query' => $params,
                 ]);

--- a/src/Marketplace/Client.php
+++ b/src/Marketplace/Client.php
@@ -57,9 +57,6 @@ class Client
     /**
      * Send API request.
      *
-     * @param  string  $method
-     * @param  string  $endpoint
-     * @param  array  $params
      * @return mixed
      */
     private function request(string $method, string $endpoint, array $params = [])

--- a/src/Marketplace/Client.php
+++ b/src/Marketplace/Client.php
@@ -72,7 +72,7 @@ class Client
             return $this->cache()->rememberWithExpiration($key, function () use ($method, $endpoint, $params) {
                 $response = Guzzle::request($method, $endpoint, [
                     'verify' => $this->verifySsl,
-                    'query' => $params,
+                    ($method === 'GET' ? 'query' : 'json') => $params,
                 ]);
 
                 $json = json_decode($response->getBody(), true);

--- a/src/Marketplace/Marketplace.php
+++ b/src/Marketplace/Marketplace.php
@@ -11,25 +11,18 @@ use Statamic\Statamic;
 
 class Marketplace
 {
-    public function package($package, $version = null, $edition = null)
+    public function packages(array $packages)
     {
-        $uri = "packages/$package/$version";
+        $uri = 'packages';
+        $hash = md5(json_encode($packages));
 
-        if ($edition) {
-            $uri .= "?edition=$edition";
-        }
-
-        return Cache::rememberWithExpiration("marketplace-$uri", function () use ($uri) {
-            $fallback = [5 => null];
-
+        return Cache::rememberWithExpiration("marketplace-$uri-$hash", function () use ($uri, $packages, $hash) {
             try {
-                if (! $response = Client::get($uri)) {
-                    return $fallback;
-                }
+                $response = Client::post($uri, ['packages' => $packages]);
 
-                return [60 => $response['data']];
+                return [60 => collect($response['data'])];
             } catch (RequestException $e) {
-                return $fallback;
+                return [5 => collect()];
             }
         });
     }

--- a/src/Marketplace/Marketplace.php
+++ b/src/Marketplace/Marketplace.php
@@ -16,7 +16,7 @@ class Marketplace
         $uri = 'packages';
         $hash = md5(json_encode($packages));
 
-        return Cache::rememberWithExpiration("marketplace-$uri-$hash", function () use ($uri, $packages, $hash) {
+        return Cache::rememberWithExpiration("marketplace-$uri-$hash", function () use ($uri, $packages) {
             try {
                 $response = Client::post($uri, ['packages' => $packages]);
 

--- a/tests/Extend/AddonTest.php
+++ b/tests/Extend/AddonTest.php
@@ -279,6 +279,7 @@ class AddonTest extends TestCase
             'developerUrl' => 'http://test-developer.com',
             'version' => '1.0',
             'editions' => ['foo', 'bar'],
+            'marketplaceId' => null,
         ], $attributes));
     }
 }


### PR DESCRIPTION
This pull request improves how Statamic generates addon manifests. 

Instead of sending API requests whenever the application is booted, API requests will now only be sent as Marketplace data is needed. 

We're now bundling all packages into a single API request, rather than separate requests for each package.