### PR TITLE
[5.x] Fix: entry redirect to @child fails if no child exists

### DIFF
--- a/src/Routing/ResolveRedirect.php
+++ b/src/Routing/ResolveRedirect.php
@@ -96,7 +96,7 @@ class ResolveRedirect
             : $parent->pages()->all();
 
         if ($children->isEmpty()) {
-            return null;
+            return 404;
         }
 
         return $children->first();

--- a/tests/Routing/ResolveRedirectTest.php
+++ b/tests/Routing/ResolveRedirectTest.php
@@ -139,7 +139,7 @@ class ResolveRedirectTest extends TestCase
         $parent->shouldReceive('pages')->andReturn($pages);
 
         $this->assertSame(404, $resolver('@child', $parent));
-        $this->assertSame(null, $resolver->item('@child', $parent));
+        $this->assertSame(404, $resolver->item('@child', $parent));
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #11952 
This pull request fixes a bug where an entry configured to redirect to its first child throws an exception if no child entries exist.
According to the [docs](https://statamic.dev/collections#redirects), the expected behavior is to return a 404 page when no children are present.