### PR TITLE
[6.x] Deprecations

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -821,14 +821,6 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
         return $this->in($locale) !== null;
     }
 
-    /** @deprecated */
-    public function addLocalization($entry)
-    {
-        $entry->origin($this);
-
-        return $this;
-    }
-
     public function makeLocalization($site)
     {
         $localization = Facades\Entry::make()

--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -78,19 +78,6 @@ class ApiController extends Controller
     }
 
     /**
-     * Filter, sort, and paginate query for API resource output.
-     *
-     * @param  \Statamic\Query\Builder  $query
-     * @return \Statamic\Extensions\Pagination\LengthAwarePaginator
-     *
-     * @deprecated
-     */
-    protected function filterSortAndPaginate($query)
-    {
-        return $this->updateAndPaginate($query);
-    }
-
-    /**
      * Filter, sort, scope, and paginate query for API resource output.
      *
      * @param  \Statamic\Query\Builder  $query

--- a/src/Providers/CacheServiceProvider.php
+++ b/src/Providers/CacheServiceProvider.php
@@ -37,15 +37,6 @@ class CacheServiceProvider extends ServiceProvider
     private function extendFileStore()
     {
         $this->app->booting(function () {
-            /** @deprecated */
-            Cache::extend('statamic', function () {
-                return Cache::repository(new FileStore(
-                    $this->app['files'],
-                    $this->app['config']['cache.stores.file']['path'],
-                    $this->app['config']['cache.stores.file']['permission'] ?? null
-                ), $this->app['config']['cache.stores.file']);
-            });
-
             // Don't extend the file store if it's already being extended.
             $creators = (fn () => $this->customCreators)->call(Cache::getFacadeRoot());
             if (isset($creators['file'])) {

--- a/src/StarterKits/ExportableModule.php
+++ b/src/StarterKits/ExportableModule.php
@@ -97,15 +97,13 @@ class ExportableModule extends Module
      */
     protected function ensureNotExportingComposerJson(): self
     {
-        // Here we'll ensure both `export_as` values and keys are included,
-        // because we want to make sure `composer.json` is referenced on either end.
-        $flattenedExportPaths = $this->exportPaths();
+        $paths = $this->exportPaths();
 
-        if ($flattenedExportPaths->contains('starter-kit.yaml')) {
+        if ($paths->contains('starter-kit.yaml')) {
             throw new StarterKitException('Cannot export [starter-kit.yaml] config.');
         }
 
-        if ($flattenedExportPaths->contains('composer.json')) {
+        if ($paths->contains('composer.json')) {
             throw new StarterKitException('Cannot export [composer.json]. Please use `dependencies` array.');
         }
 

--- a/src/StarterKits/ExportableModule.php
+++ b/src/StarterKits/ExportableModule.php
@@ -36,14 +36,6 @@ class ExportableModule extends Module
                 from: $path,
                 starterKitPath: $starterKitPath,
             ));
-
-        $this
-            ->exportAsPaths()
-            ->each(fn ($to, $from) => $this->exportRelativePath(
-                from: $from,
-                to: $to,
-                starterKitPath: $starterKitPath,
-            ));
     }
 
     public function versionDependencies(): self
@@ -107,10 +99,7 @@ class ExportableModule extends Module
     {
         // Here we'll ensure both `export_as` values and keys are included,
         // because we want to make sure `composer.json` is referenced on either end.
-        $flattenedExportPaths = $this
-            ->exportPaths()
-            ->merge($this->exportAsPaths())
-            ->merge($this->exportAsPaths()->keys());
+        $flattenedExportPaths = $this->exportPaths();
 
         if ($flattenedExportPaths->contains('starter-kit.yaml')) {
             throw new StarterKitException('Cannot export [starter-kit.yaml] config.');
@@ -132,7 +121,6 @@ class ExportableModule extends Module
     {
         $this
             ->exportPaths()
-            ->merge($this->exportAsPaths()->keys())
             ->reject(fn ($path) => $this->files->exists(base_path($path)))
             ->each(function ($path) {
                 throw new StarterKitException("Cannot export [{$path}], because it does not exist in your app.");

--- a/src/StarterKits/Exporter.php
+++ b/src/StarterKits/Exporter.php
@@ -205,7 +205,6 @@ class Exporter
 
         $normalizedModuleKeyOrder = [
             'export_paths',
-            'export_as',
             'dependencies',
             'dependencies_dev',
             'modules',

--- a/src/StarterKits/InstallableModule.php
+++ b/src/StarterKits/InstallableModule.php
@@ -104,18 +104,9 @@ final class InstallableModule extends Module
      */
     protected function installableFiles(): Collection
     {
-        $installableFromExportPaths = $this
+        return $this
             ->exportPaths()
             ->flatMap(fn ($path) => $this->expandExportDirectoriesToFiles($path));
-
-        $installableFromExportAsPaths = $this
-            ->exportAsPaths()
-            ->flip()
-            ->flatMap(fn ($to, $from) => $this->expandExportDirectoriesToFiles($to, $from));
-
-        return collect()
-            ->merge($installableFromExportPaths)
-            ->merge($installableFromExportAsPaths);
     }
 
     /**
@@ -196,7 +187,6 @@ final class InstallableModule extends Module
     {
         $this
             ->exportPaths()
-            ->merge($this->exportAsPaths())
             ->reject(fn ($path) => $this->files->exists($this->installableFilesPath($path)))
             ->each(function ($path) {
                 throw new StarterKitException("Starter kit path [{$path}] does not exist.");

--- a/src/StarterKits/Module.php
+++ b/src/StarterKits/Module.php
@@ -63,18 +63,6 @@ abstract class Module
     }
 
     /**
-     * Get `export_as` paths (to be renamed on install) as collection from config.
-     *
-     * This is only here for backwards compatibility. Use new `export` folder convention instead.
-     *
-     * @deprecated
-     */
-    protected function exportAsPaths(): Collection
-    {
-        return collect($this->config('export_as') ?? []);
-    }
-
-    /**
      * Ensure nested module config is not empty.
      *
      * @throws StarterKitException

--- a/src/StarterKits/Module.php
+++ b/src/StarterKits/Module.php
@@ -70,7 +70,6 @@ abstract class Module
     protected function ensureModuleConfigNotEmpty(): self
     {
         $hasConfig = $this->config()->has('export_paths')
-            || $this->config()->has('export_as')
             || $this->config()->has('dependencies')
             || $this->config()->has('dependencies_dev')
             || $this->config()->has('modules');

--- a/tests/StarterKits/ExportTest.php
+++ b/tests/StarterKits/ExportTest.php
@@ -130,42 +130,6 @@ class ExportTest extends TestCase
     }
 
     #[Test]
-    public function it_can_still_export_as_to_different_destination_path_for_backwards_compatibility()
-    {
-        $paths = $this->cleanPaths([
-            base_path('README.md'),
-            base_path('test-folder'),
-        ]);
-
-        $this->files->put(base_path('README.md'), 'This is readme for the new site!');
-        $this->files->makeDirectory(base_path('test-folder'));
-        $this->files->put(base_path('test-folder/one.txt'), 'One.');
-        $this->files->put(base_path('test-folder/two.txt'), 'Two.');
-
-        $this->setExportPaths([], [
-            'README.md' => 'README-new-site.md',
-            'test-folder' => 'test-renamed-folder',
-        ]);
-
-        $this->assertFileDoesNotExist($renamedFile = $this->exportPath('README-new-site.md'));
-        $this->assertFileDoesNotExist($renamedFolder = $this->exportPath('test-renamed-folder'));
-
-        $this->exportCoolRunnings();
-
-        $this->assertFileExists($renamedFile);
-        $this->assertFileExists($renamedFolder);
-
-        $this->assertFileDoesNotExist($this->exportPath('README.md')); // This got renamed above
-        $this->assertFileDoesNotExist($this->exportPath('test-folder')); // This got renamed above
-
-        $this->assertFileHasContent('This is readme for the new site!', $renamedFile);
-        $this->assertFileHasContent('One.', $renamedFolder.'/one.txt');
-        $this->assertFileHasContent('Two.', $renamedFolder.'/two.txt');
-
-        $this->cleanPaths($paths);
-    }
-
-    #[Test]
     public function it_can_clear_target_export_path_with_clear_option()
     {
         $paths = $this->cleanPaths([
@@ -593,15 +557,15 @@ EOT
                     ],
                 ],
                 'ssg' => [
-                    'export_as' => [
-                        'resources/views/welcome.blade.php' => 'resources/views/you-are-so-welcome.blade.php',
+                    'export_paths' => [
+                        'resources/views/welcome.blade.php',
                     ],
                 ],
             ],
         ]);
 
         $this->assertFileDoesNotExist($filesystemsConfig = $this->exportPath('config/filesystems.php'));
-        $this->assertFileDoesNotExist($welcomeView = $this->exportPath('resources/views/you-are-so-welcome.blade.php'));
+        $this->assertFileDoesNotExist($welcomeView = $this->exportPath('resources/views/welcome.blade.php'));
 
         $this->exportCoolRunnings();
 
@@ -623,8 +587,8 @@ EOT
                     ],
                     'modules' => [
                         'ssg' => [
-                            'export_as' => [
-                                'resources/views/welcome.blade.php' => 'resources/views/you-are-so-welcome.blade.php',
+                            'export_paths' => [
+                                'resources/views/welcome.blade.php',
                             ],
                         ],
                     ],
@@ -633,7 +597,7 @@ EOT
         ]);
 
         $this->assertFileDoesNotExist($filesystemsConfig = $this->exportPath('config/filesystems.php'));
-        $this->assertFileDoesNotExist($welcomeView = $this->exportPath('resources/views/you-are-so-welcome.blade.php'));
+        $this->assertFileDoesNotExist($welcomeView = $this->exportPath('resources/views/welcome.blade.php'));
 
         $this->exportCoolRunnings();
 
@@ -657,8 +621,8 @@ EOT
                             ],
                         ],
                         'react' => [
-                            'export_as' => [
-                                'resources/views/welcome.blade.php' => 'resources/views/you-are-so-welcome.blade.php',
+                            'export_paths' => [
+                                'resources/views/welcome.blade.php',
                             ],
                         ],
                     ],
@@ -667,7 +631,7 @@ EOT
         ]);
 
         $this->assertFileDoesNotExist($filesystemsConfig = $this->exportPath('config/filesystems.php'));
-        $this->assertFileDoesNotExist($welcomeView = $this->exportPath('resources/views/you-are-so-welcome.blade.php'));
+        $this->assertFileDoesNotExist($welcomeView = $this->exportPath('resources/views/welcome.blade.php'));
 
         $this->exportCoolRunnings();
 
@@ -698,8 +662,8 @@ EOT
                             ],
                         ],
                         'react' => [
-                            'export_as' => [
-                                'resources/views/welcome.blade.php' => 'resources/views/you-are-so-welcome.blade.php',
+                            'export_paths' => [
+                                'resources/views/welcome.blade.php',
                             ],
                         ],
                     ],
@@ -709,7 +673,7 @@ EOT
 
         $this->assertFileDoesNotExist($filesystemsConfig = $this->exportPath('config/filesystems.php'));
         $this->assertFileDoesNotExist($appConfig = $this->exportPath('config/app.php'));
-        $this->assertFileDoesNotExist($welcomeView = $this->exportPath('resources/views/you-are-so-welcome.blade.php'));
+        $this->assertFileDoesNotExist($welcomeView = $this->exportPath('resources/views/welcome.blade.php'));
 
         $this->exportCoolRunnings();
 
@@ -1044,11 +1008,6 @@ EOT
                     'resources/views/welcome.blade.php',
                 ],
             ]],
-            'export as paths' => [[
-                'export_as' => [
-                    'resources/views/welcome.blade.php' => 'resources/js/vue.js',
-                ],
-            ]],
             'dependencies' => [[
                 'dependencies' => [
                     'statamic/seo-pro' => '^1.0',
@@ -1091,25 +1050,11 @@ EOT
                     'non-existent.txt',
                 ],
             ]],
-            'top level export as from' => [[
-                'export_as' => [
-                    'non-existent.txt' => 'resources/views/welcome.blade.php',
-                ],
-            ]],
             'module export' => [[
                 'modules' => [
                     'seo' => [
                         'export_paths' => [
                             'non-existent.txt',
-                        ],
-                    ],
-                ],
-            ]],
-            'module export as from' => [[
-                'modules' => [
-                    'seo' => [
-                        'export_as' => [
-                            'non-existent.txt' => 'resources/views/welcome.blade.php',
                         ],
                     ],
                 ],
@@ -1121,19 +1066,6 @@ EOT
                             'vue' => [
                                 'export_paths' => [
                                     'non-existent.txt',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ]],
-            'select module export as from' => [[
-                'modules' => [
-                    'js' => [
-                        'options' => [
-                            'vue' => [
-                                'export_as' => [
-                                    'non-existent.txt' => 'resources/views/welcome.blade.php',
                                 ],
                             ],
                         ],
@@ -1235,39 +1167,11 @@ EOT
                     'starter-kit.yaml',
                 ],
             ]],
-            'top level export as from' => [[
-                'export_as' => [
-                    'starter-kit.yaml' => 'resources/views/welcome.blade.php',
-                ],
-            ]],
-            'top level export as to' => [[
-                'export_as' => [
-                    'resources/views/welcome.blade.php' => 'starter-kit.yaml',
-                ],
-            ]],
             'module export' => [[
                 'modules' => [
                     'seo' => [
                         'export_paths' => [
                             'starter-kit.yaml',
-                        ],
-                    ],
-                ],
-            ]],
-            'module export as from' => [[
-                'modules' => [
-                    'seo' => [
-                        'export_as' => [
-                            'starter-kit.yaml' => 'resources/views/welcome.blade.php',
-                        ],
-                    ],
-                ],
-            ]],
-            'module export as to' => [[
-                'modules' => [
-                    'seo' => [
-                        'export_as' => [
-                            'resources/views/welcome.blade.php' => 'starter-kit.yaml',
                         ],
                     ],
                 ],
@@ -1279,32 +1183,6 @@ EOT
                             'vue' => [
                                 'export_paths' => [
                                     'starter-kit.yaml',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ]],
-            'select module export as from' => [[
-                'modules' => [
-                    'js' => [
-                        'options' => [
-                            'vue' => [
-                                'export_as' => [
-                                    'starter-kit.yaml' => 'resources/views/welcome.blade.php',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ]],
-            'select module export as to' => [[
-                'modules' => [
-                    'js' => [
-                        'options' => [
-                            'vue' => [
-                                'export_as' => [
-                                    'resources/views/welcome.blade.php' => 'starter-kit.yaml',
                                 ],
                             ],
                         ],
@@ -1334,39 +1212,11 @@ EOT
                     'composer.json',
                 ],
             ]],
-            'top level export as from' => [[
-                'export_as' => [
-                    'composer.json' => 'resources/views/welcome.blade.php',
-                ],
-            ]],
-            'top level export as to' => [[
-                'export_as' => [
-                    'resources/views/welcome.blade.php' => 'composer.json',
-                ],
-            ]],
             'module export' => [[
                 'modules' => [
                     'seo' => [
                         'export_paths' => [
                             'composer.json',
-                        ],
-                    ],
-                ],
-            ]],
-            'module export as from' => [[
-                'modules' => [
-                    'seo' => [
-                        'export_as' => [
-                            'composer.json' => 'resources/views/welcome.blade.php',
-                        ],
-                    ],
-                ],
-            ]],
-            'module export as to' => [[
-                'modules' => [
-                    'seo' => [
-                        'export_as' => [
-                            'resources/views/welcome.blade.php' => 'composer.json',
                         ],
                     ],
                 ],
@@ -1378,32 +1228,6 @@ EOT
                             'vue' => [
                                 'export_paths' => [
                                     'composer.json',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ]],
-            'select module export as from' => [[
-                'modules' => [
-                    'js' => [
-                        'options' => [
-                            'vue' => [
-                                'export_as' => [
-                                    'composer.json' => 'resources/views/welcome.blade.php',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ]],
-            'select module export as to' => [[
-                'modules' => [
-                    'js' => [
-                        'options' => [
-                            'vue' => [
-                                'export_as' => [
-                                    'resources/views/welcome.blade.php' => 'composer.json',
                                 ],
                             ],
                         ],
@@ -1681,13 +1505,9 @@ PACKAGE);
         }
     }
 
-    private function setExportPaths($paths, $exportAs = null)
+    private function setExportPaths($paths)
     {
         $config['export_paths'] = $paths;
-
-        if ($exportAs) {
-            $config['export_as'] = $exportAs;
-        }
 
         $this->setConfig($config);
     }

--- a/tests/StarterKits/ExportTest.php
+++ b/tests/StarterKits/ExportTest.php
@@ -1279,14 +1279,12 @@ EOT
                         'statamic/ssg',
                     ],
                     'prompt' => false,
-                    'export_as' => [
-                        'README.md' => 'README-new-site.md',
-                    ],
                     'dependencies' => [
                         'statamic/seo-pro',
                     ],
                     'export_paths' => [
                         'resources/views',
+                        'README.md',
                     ],
                 ],
                 'js' => [
@@ -1315,14 +1313,12 @@ EOT
                     ],
                 ],
             ],
-            'export_as' => [
-                'test-folder' => 'test-renamed-folder',
-            ],
             'dependencies_dev' => [
                 'statamic/ssg',
             ],
             'export_paths' => [
                 'config/filesystems.php',
+                'test-folder',
             ],
         ]);
 
@@ -1331,9 +1327,7 @@ EOT
         $this->assertConfigSameOrder([
             'export_paths' => [
                 'config/filesystems.php',
-            ],
-            'export_as' => [
-                'test-folder' => 'test-renamed-folder',
+                'test-folder',
             ],
             'dependencies_dev' => [
                 'statamic/ssg' => '^0.4.0',
@@ -1343,9 +1337,7 @@ EOT
                     'prompt' => false,
                     'export_paths' => [
                         'resources/views',
-                    ],
-                    'export_as' => [
-                        'README.md' => 'README-new-site.md',
+                        'README.md',
                     ],
                     'dependencies' => [
                         'statamic/seo-pro' => '^2.2',

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -119,38 +119,6 @@ class InstallTest extends TestCase
     }
 
     #[Test]
-    public function it_still_installs_from_export_as_paths_for_backwards_compatibility()
-    {
-        $this->setConfig([
-            'export_as' => [
-                'README.md' => 'README-for-new-site.md',
-                'original-dir' => 'renamed-dir',
-            ],
-        ]);
-
-        $this->assertFileDoesNotExist($this->kitVendorPath());
-        $this->assertComposerJsonDoesntHave('repositories');
-        $this->assertFileDoesNotExist($renamedFile = base_path('README.md'));
-        $this->assertFileDoesNotExist($renamedFolder = base_path('original-dir'));
-
-        $this->installCoolRunnings();
-
-        $this->assertFalse(Blink::has('starter-kit-repository-added'));
-        $this->assertFileDoesNotExist($this->kitVendorPath());
-        $this->assertFileDoesNotExist(base_path('composer.json.bak'));
-        $this->assertComposerJsonDoesntHave('repositories');
-        $this->assertFileExists($renamedFile);
-        $this->assertFileExists($renamedFolder);
-
-        $this->assertFileDoesNotExist(base_path('README-for-new-site.md')); // This was renamed back to original path on install
-        $this->assertFileDoesNotExist(base_path('renamed-dir')); // This was renamed back to original path on install
-
-        $this->assertFileHasContent('This readme should get installed to README.md.', $renamedFile);
-        $this->assertFileHasContent('One.', $renamedFolder.'/one.txt');
-        $this->assertFileHasContent('Two.', $renamedFolder.'/two.txt');
-    }
-
-    #[Test]
     public function it_installs_from_github()
     {
         $this->assertFileDoesNotExist($this->kitVendorPath());
@@ -921,8 +889,8 @@ EOT;
                 ],
                 'jamaica' => [
                     'prompt' => false, // Setting `prompt: false` normally skips confirmation and ensures it always gets installed
-                    'export_as' => [
-                        'resources/css/theme.css' => 'resources/css/jamaica.css',
+                    'export_paths' => [
+                        'resources/css/jamaica.css',
                     ],
                 ],
                 'js' => [
@@ -972,7 +940,7 @@ EOT;
         $this->assertFileExists(base_path('resources/css/seo.css'));
         $this->assertFileExists(base_path('resources/css/hockey.css'));
         $this->assertFileDoesNotExist(base_path('resources/css/bobsled.css'));
-        $this->assertFileExists(base_path('resources/css/theme.css'));
+        $this->assertFileExists(base_path('resources/css/jamaica.css'));
         $this->assertComposerJsonHasPackageVersion('require', 'statamic/seo-pro', '^0.2.0');
         $this->assertComposerJsonDoesntHave('bobsled/speed-calculator');
         $this->assertFileDoesNotExist(base_path('resources/js/react.js'));
@@ -1005,8 +973,8 @@ EOT;
                     ],
                 ],
                 'jamaica' => [
-                    'export_as' => [
-                        'resources/css/theme.css' => 'resources/css/jamaica.css',
+                    'export_paths' => [
+                        'resources/css/jamaica.css',
                     ],
                 ],
                 'js' => [
@@ -1051,7 +1019,7 @@ EOT;
         $this->assertFileDoesNotExist(base_path('copied.md'));
         $this->assertFileDoesNotExist(base_path('resources/css/seo.css'));
         $this->assertFileDoesNotExist(base_path('resources/css/bobsled.css'));
-        $this->assertFileDoesNotExist(base_path('resources/css/theme.css'));
+        $this->assertFileDoesNotExist(base_path('resources/css/jamaica.css'));
         $this->assertFileDoesNotExist(base_path('resources/js/react.js'));
         $this->assertFileDoesNotExist(base_path('resources/js/vue.js'));
         $this->assertFileDoesNotExist(base_path('resources/js/svelte.js'));
@@ -1072,7 +1040,7 @@ EOT;
         $this->assertFileExists(base_path('copied.md'));
         $this->assertFileExists(base_path('resources/css/seo.css'));
         $this->assertFileDoesNotExist(base_path('resources/css/bobsled.css'));
-        $this->assertFileExists(base_path('resources/css/theme.css'));
+        $this->assertFileExists(base_path('resources/css/jamaica.css'));
         $this->assertFileDoesNotExist(base_path('resources/js/react.js'));
         $this->assertFileExists(base_path('resources/js/vue.js'));
         $this->assertFileDoesNotExist(base_path('resources/js/svelte.js'));
@@ -1577,8 +1545,8 @@ EOT;
                     ],
                 ],
                 'jamaica' => [
-                    'export_as' => [
-                        'resources/css/theme.css' => 'resources/css/jamaica.css',
+                    'export_paths' => [
+                        'resources/css/jamaica.css',
                     ],
                     'modules' => [
                         'bobsled' => [
@@ -1634,7 +1602,7 @@ EOT;
         $this->assertFileDoesNotExist(base_path('resources/js/mootools.js'));
         $this->assertFileDoesNotExist(base_path('resources/css/hockey.css'));
         $this->assertFileDoesNotExist(base_path('resources/dictionaries/players.yaml'));
-        $this->assertFileExists(base_path('resources/css/theme.css'));
+        $this->assertFileExists(base_path('resources/css/jamaica.css'));
         $this->assertFileExists(base_path('resources/css/bobsled.css'));
         $this->assertComposerJsonHasPackageVersion('require', 'bobsled/speed-calculator', '^1.0.0');
     }

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -832,8 +832,8 @@ EOT;
                     ],
                 ],
                 'jamaica' => [
-                    'export_as' => [
-                        'resources/css/theme.css' => 'resources/css/jamaica.css',
+                    'export_paths' => [
+                        'resources/css/jamaica.css',
                     ],
                 ],
             ],
@@ -842,7 +842,7 @@ EOT;
         $this->assertFileDoesNotExist(base_path('copied.md'));
         $this->assertFileDoesNotExist(base_path('resources/css/seo.css'));
         $this->assertFileDoesNotExist(base_path('resources/css/bobsled.css'));
-        $this->assertFileDoesNotExist(base_path('resources/css/theme.css'));
+        $this->assertFileDoesNotExist(base_path('resources/css/jamaica.css'));
         $this->assertComposerJsonDoesntHave('statamic/seo-pro');
         $this->assertComposerJsonDoesntHave('bobsled/speed-calculator');
 
@@ -851,7 +851,7 @@ EOT;
         $this->assertFileExists(base_path('copied.md'));
         $this->assertFileDoesNotExist(base_path('resources/css/seo.css'));
         $this->assertFileDoesNotExist(base_path('resources/css/bobsled.css'));
-        $this->assertFileDoesNotExist(base_path('resources/css/theme.css'));
+        $this->assertFileDoesNotExist(base_path('resources/css/jamaica.css'));
         $this->assertComposerJsonDoesntHave('statamic/seo-pro');
         $this->assertComposerJsonDoesntHave('bobsled/speed-calculator');
     }
@@ -1356,11 +1356,6 @@ EOT;
             'export paths' => [[
                 'export_paths' => [
                     'copied.md',
-                ],
-            ]],
-            'export as paths' => [[
-                'export_as' => [
-                    'copied.md' => 'resources/js/vue.js',
                 ],
             ]],
             'dependencies' => [[


### PR DESCRIPTION
This pull request follows on from #11612, removing deprecated features from past versions. 

* Removed the `filterSortAndPaginate` method from the `ApiController`. Deprecated in https://github.com/statamic/cms/pull/10893
* Removed the `export_as` option from starter kits, in favour of the `export` option. Deprecated in #11119
* Removed our custom `statamic` cache store. Deprecated in #10362
* Removed the `addLocalization` method from the `Entry` class, in favour of the `makeLocalization` method. Deprecated in #8505