### PR TITLE
[5.x] Add command to clear asset_meta and asset_container_contents caches

### DIFF
--- a/src/Console/Commands/AssetsCacheClear.php
+++ b/src/Console/Commands/AssetsCacheClear.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Statamic\Console\Commands;
+
+use Illuminate\Console\Command;
+use Statamic\Assets\Asset;
+use Statamic\Assets\AssetContainerContents;
+use Statamic\Console\RunsInPlease;
+
+use function Laravel\Prompts\spin;
+
+class AssetsCacheClear extends Command
+{
+    use RunsInPlease;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'statamic:assets:clear-cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear the asset meta and folder cache';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! config()->has('cache.stores.asset_meta') && ! config()->has('cache.stores.asset_container_contents')) {
+            $this->components->error('You do not have any custom asset cache stores.');
+
+            return 0;
+        }
+
+        if (config()->has('cache.stores.asset_meta')) {
+            spin(callback: fn () => Asset::make()->cacheStore()->flush(), message: 'Clearing the asset meta cache...');
+
+            $this->components->info('Your asset meta cache is now so very, very empty.');
+        }
+
+        if (config()->has('cache.stores.asset_container_contents')) {
+            spin(callback: fn () => (new AssetContainerContents)->cacheStore()->flush(), message: 'Clearing the asset folder cache...');
+
+            $this->components->info('Your asset folder cache is now so very, very empty.');
+        }
+    }
+}

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -11,6 +11,7 @@ class ConsoleServiceProvider extends ServiceProvider
     protected $commands = [
         Commands\ListCommand::class,
         Commands\AddonsDiscover::class,
+        Commands\AssetsCacheClear::class,
         Commands\AssetsGeneratePresets::class,
         Commands\AssetsMeta::class,
         Commands\GlideClear::class,


### PR DESCRIPTION
I thought it might be nice to add `php please assets:clear-cache` for those of us who are using custom asset meta and container contents stores, giving a one-stop command to clear both caches.