### PR TITLE
[6.x] Fix missing asset meta

### DIFF
--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -145,9 +145,9 @@ class AssetRepository implements Contract
 
         $cache->save();
 
-        $store->save($asset);
-
         $asset->writeMeta($asset->generateMeta());
+
+        $store->save($asset);
     }
 
     public function delete($asset)


### PR DESCRIPTION
This PR is a possible fix for https://github.com/statamic/cms/issues/11961 and https://github.com/statamic/cms/issues/8641

It updates Assets to generate meta then update the store, in case the store is using some of the meta data.