### PR TITLE
[5.x] Make asset GraphQL type always nullable

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -442,7 +442,7 @@ class Field implements Arrayable
             $type = ['type' => $type];
         }
 
-        if ($this->isRequired() && ! $this->hasSometimesRule()) {
+        if ($this->isRequired() && ! $this->hasSometimesRule() && $this->config['type'] !== 'assets') {
             $type['type'] = GraphQL::nonNull($type['type']);
         }
 


### PR DESCRIPTION
Fixes #11974.

When a user deletes an asset via the asset browser, it can lead to an asset field becoming null even though it is required by its blueprint. This creates a 500 error in the GraphQL endpoint and brings the entire page down.

This PR is a suggestion for a quick and easy fix by just making asset fields always nullable, regardless of whether they are set as `required` in their blueprint. Within the Control Panel, the field continues to be required, but as the asset deletion logic is able to squeeze a null into the asset field, its GraphQL type should be nullable.