### PR TITLE
[5.x] Fix ordering nulls before non-nulls

### DIFF
--- a/src/Support/Comparator.php
+++ b/src/Support/Comparator.php
@@ -33,9 +33,10 @@ class Comparator
     {
         // something is null
         if (is_null($one) || is_null($two)) {
-            if (is_null($one) && ! is_null($two)) {
+            // place nulls after non-nulls
+            if (! is_null($one) && is_null($two)) {
                 return 1;
-            } elseif (! is_null($one) && is_null($two)) {
+            } elseif (is_null($one) && ! is_null($two)) {
                 return -1;
             }
 


### PR DESCRIPTION
When adding fields to an existing blueprint, the newly created fields will have a value of null.  When ordering by the newly created field you'd expect those without values would be placed after those with values.  This PR changes the comparison between nulls and non-nulls so that nulls are placed after non-nulls.

I realize this is a large change in that it could affect a lot, but I believe the way this functions now is not desired or expected behavior.

---

Example where this matters:
- Create a new collection "Posts"
- Create a few entries in the collection
- Add a toggle field "Featured Post"
- Toggle the field on an older post
- Retrieve the entries ordering by the "Featured Post" field:
```php
Entry::query()
  ->where('collection', 'posts')
  ->where('published', true)
  ->orderBy('featured_post', 'desc')
  ->first();
```
- Notice you will always get the posts where the featured post field is set to null because they are considered a greater value

---

Also in favor of this change, if you create an array in PHP and sort it you get the expected orders - with null coming after non-null:
```php
$values = [false, true, null, 0, 1, '1', 0];

sort($values);
// $values = [false, null, 0, "0", true, 1, "1"];

rsort($values);
// $values = [true, 1, "1", false, null, 0, "0"];
```


