### PR TITLE
[5.x] Allow static warm to use insecure by default with config key

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -150,13 +150,16 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here you may define the queue name and connection
-    | that will be used when warming the static cache.
+    | that will be used when warming the static cache and
+    | optionally set the "--insecure" flag by default.
     |
     */
 
     'warm_queue' => env('STATAMIC_STATIC_WARM_QUEUE'),
 
     'warm_queue_connection' => env('STATAMIC_STATIC_WARM_QUEUE_CONNECTION'),
+
+    'warm_insecure' => env('STATAMIC_STATIC_WARM_INSECURE', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -257,7 +257,7 @@ class StaticWarm extends Command
 
     private function shouldVerifySsl(): bool
     {
-        if ($this->option('insecure')) {
+        if ($this->option('insecure') || config('statamic.static_caching.warm_insecure')) {
             return false;
         }
 


### PR DESCRIPTION
Since it's likely that your entire environment would be "insecure", it only makes sense to be able to configure this globally.

This allows you to set the following in your server's host file and ignore SSL errors:

```
127.0.0.1 mydomain.com
```