### PR TITLE
[5.x] Fix docs link in template fieldtype

### DIFF
--- a/resources/lang/ar/fieldtypes.php
+++ b/resources/lang/ar/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'اكتب واضغط ↩ Enter',
     'taggable.title' => 'قابل للوسم',
     'taxonomies.title' => 'تصنيفات',
-    'template.config.blueprint' => 'إضافة خيار "رسم إلى مخطط". تعرف على المزيد في [التوثيق](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'إضافة خيار "رسم إلى مخطط". تعرف على المزيد في [التوثيق](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'عرض القوالب فقط في هذا المجلد.',
     'template.config.hide_partials' => 'نادرًا ما تكون الجزئيات معدة للاستخدام كقوالب.',
     'template.title' => 'قالب',

--- a/resources/lang/az/fieldtypes.php
+++ b/resources/lang/az/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Yazın və ↩ Enter düyməsini basın.',
     'taggable.title' => 'Etiketlənə bilən',
     'taxonomies.title' => 'Taksonomiyalar',
-    'template.config.blueprint' => '"Plan-a xəritə əlavə et" seçimini əlavə edir. Daha çox məlumat üçün [sənədi](https://statamic.dev/views#inferring-templates-from-entry-blueprints) oxuyun.',
+    'template.config.blueprint' => '"Plan-a xəritə əlavə et" seçimini əlavə edir. Daha çox məlumat üçün [sənədi](https://statamic.dev/views#map-templates-to-entry-blueprints) oxuyun.',
     'template.config.folder' => 'Yalnız bu qovluqdakı şablonları göstərin.',
     'template.config.hide_partials' => 'Parçalar nadir hallarda şablon kimi istifadə olunmaq üçün nəzərdə tutulur.',
     'template.title' => 'Şablon',

--- a/resources/lang/cs/fieldtypes.php
+++ b/resources/lang/cs/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Napište a stiskněte ↩ Enter',
     'taggable.title' => 'Označení',
     'taxonomies.title' => 'Taxonomie',
-    'template.config.blueprint' => 'Přidá možnost „mapovat k plánu“. Další informace najdete v [dokumentaci](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Přidá možnost „mapovat k plánu“. Další informace najdete v [dokumentaci](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Zobrazit pouze šablony v této složce.',
     'template.config.hide_partials' => 'Skrýt všechny části šablony.',
     'template.title' => 'Šablona',

--- a/resources/lang/da/fieldtypes.php
+++ b/resources/lang/da/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Skriv og tryk på ↩ Enter',
     'taggable.title' => 'Tagbar',
     'taxonomies.title' => 'Taksonomier',
-    'template.config.blueprint' => 'Tilføjer en &quot;kort til blueprint&quot; mulighed. Få flere oplysninger i [dokumentationen](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Tilføjer en &quot;kort til blueprint&quot; mulighed. Få flere oplysninger i [dokumentationen](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Vis kun skabeloner i denne mappe.',
     'template.config.hide_partials' => 'Partials er sjældent beregnet til at blive brugt som templates.',
     'template.title' => 'Skabelon',

--- a/resources/lang/de/fieldtypes.php
+++ b/resources/lang/de/fieldtypes.php
@@ -177,7 +177,7 @@ return [
     'taggable.config.placeholder' => 'Tippen und ↩ Enter drücken',
     'taggable.title' => 'Tags',
     'taxonomies.title' => 'Taxonomien',
-    'template.config.blueprint' => 'Fügt die Option „Korrespondiert mit Blueprint“ hinzu. Erfahre mehr in der [Dokumentation](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Fügt die Option „Korrespondiert mit Blueprint“ hinzu. Erfahre mehr in der [Dokumentation](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Nur Templates aus diesem Ordner anzeigen.',
     'template.config.hide_partials' => 'Partials sind selten als Templates gedacht.',
     'template.title' => 'Template',

--- a/resources/lang/de_CH/fieldtypes.php
+++ b/resources/lang/de_CH/fieldtypes.php
@@ -177,7 +177,7 @@ return [
     'taggable.config.placeholder' => 'Tippen und ↩ Enter drücken',
     'taggable.title' => 'Tags',
     'taxonomies.title' => 'Taxonomien',
-    'template.config.blueprint' => 'Fügt die Option «Korrespondiert mit Blueprint» hinzu. Erfahre mehr in der [Dokumentation](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Fügt die Option «Korrespondiert mit Blueprint» hinzu. Erfahre mehr in der [Dokumentation](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Nur Templates aus diesem Ordner anzeigen.',
     'template.config.hide_partials' => 'Partials sind selten als Templates gedacht.',
     'template.title' => 'Template',

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -177,7 +177,7 @@ return [
     'taggable.config.placeholder' => 'Type and press ↩ Enter',
     'taggable.title' => 'Taggable',
     'taxonomies.title' => 'Taxonomies',
-    'template.config.blueprint' => 'Adds a "map to blueprint" option. Learn more in the [documentation](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Adds a "map to blueprint" option. Learn more in the [documentation](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Only show templates in this folder.',
     'template.config.hide_partials' => 'Partials are rarely intended to be used as templates.',
     'template.title' => 'Template',

--- a/resources/lang/es/fieldtypes.php
+++ b/resources/lang/es/fieldtypes.php
@@ -176,7 +176,7 @@ return [
     'taggable.config.placeholder' => 'Escribe y pulsa ↩ Enter',
     'taggable.title' => 'Taggable',
     'taxonomies.title' => 'Taxonomías',
-    'template.config.blueprint' => 'Agrega una opción de "mapa a plano". Obtenga más información en la [documentación](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Agrega una opción de "mapa a plano". Obtenga más información en la [documentación](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Solo mostrar plantillas en esta carpeta.',
     'template.config.hide_partials' => 'Los parciales rara vez están destinados a ser utilizados como plantillas.',
     'template.title' => 'Plantilla',

--- a/resources/lang/et/fieldtypes.php
+++ b/resources/lang/et/fieldtypes.php
@@ -177,7 +177,7 @@ return [
     'taggable.config.placeholder' => 'Sisesta ja vajuta ↩ Enter',
     'taggable.title' => 'Sildistatav',
     'taxonomies.title' => 'Taksonoomiad',
-    'template.config.blueprint' => 'Lisab valiku "Infer from Blueprint". Lisateavet leiad [dokumentatsioonist](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Lisab valiku "Infer from Blueprint". Lisateavet leiad [dokumentatsioonist](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Kuva ainult selles kaustas olevad mallid.',
     'template.config.hide_partials' => 'Osalised vaated on harva mõeldud mallidena kasutamiseks.',
     'template.title' => 'Mall',

--- a/resources/lang/fa/fieldtypes.php
+++ b/resources/lang/fa/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'متن خود را بنویسید و اینتر ↩ را بزنید',
     'taggable.title' => 'برچسب‌زن',
     'taxonomies.title' => 'تکسنومی‌ها',
-    'template.config.blueprint' => 'گزینه‌ای جهت "مپ کردن به بلوپرینت یا طرح" اضافه می‌شود. جهت اطلاعات بیشتر به [مستندات](https://statamic.dev/views#inferring-templates-from-entry-blueprints) رجوع شود.',
+    'template.config.blueprint' => 'گزینه‌ای جهت "مپ کردن به بلوپرینت یا طرح" اضافه می‌شود. جهت اطلاعات بیشتر به [مستندات](https://statamic.dev/views#map-templates-to-entry-blueprints) رجوع شود.',
     'template.config.folder' => 'تنها قالب‌های داخل این پوشه نمایان باشند.',
     'template.config.hide_partials' => 'پارشیال‌ها قابلیت استفاده بجای قالب‌ها را دارند اما با پیچیدگی خاص خود.',
     'template.title' => 'قالب',

--- a/resources/lang/fr/fieldtypes.php
+++ b/resources/lang/fr/fieldtypes.php
@@ -177,7 +177,7 @@ return [
     'taggable.config.placeholder' => 'Saisissez et appuyez sur ↩ Entrée',
     'taggable.title' => 'Taggable',
     'taxonomies.title' => 'Taxonomies',
-    'template.config.blueprint' => 'Ajoute une option "Mapper au Blueprint". Pour en savoir plus, consultez la [documentation](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Ajoute une option "Mapper au Blueprint". Pour en savoir plus, consultez la [documentation](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Affichez uniquement les modèles de ce dossier.',
     'template.config.hide_partials' => 'Les partiels sont rarement destinés à être utilisés comme modèles.',
     'template.title' => 'Template',

--- a/resources/lang/hu/fieldtypes.php
+++ b/resources/lang/hu/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Írja be, és nyomja meg az ↩ Enter billentyűt',
     'taggable.title' => 'Címkézhető',
     'taxonomies.title' => 'Taxonómiák',
-    'template.config.blueprint' => 'Hozzáad egy "Blueprint térkép" opciót. Tudj meg többet a dokumentációból [documentation](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Hozzáad egy "Blueprint térkép" opciót. Tudj meg többet a dokumentációból [documentation](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Csak a sablonok megjelenítése ebben a mappában.',
     'template.config.hide_partials' => 'A részsablonok (partials) ritkán alkalmasak sablonként való használatra.',
     'template.title' => 'Sablon',

--- a/resources/lang/id/fieldtypes.php
+++ b/resources/lang/id/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Ketik dan tekan ↩ Enter',
     'taggable.title' => 'Taggable',
     'taxonomies.title' => 'Taxonomies',
-    'template.config.blueprint' => 'Menambahkan opsi &quot;petakan ke cetak biru&quot;. Pelajari lebih lanjut dalam [dokumentasi](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Menambahkan opsi &quot;petakan ke cetak biru&quot;. Pelajari lebih lanjut dalam [dokumentasi](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Hanya tampilkan templat dalam folder ini.',
     'template.config.hide_partials' => 'Parsial jarang dimaksudkan untuk digunakan sebagai template.',
     'template.title' => 'Template',

--- a/resources/lang/it/fieldtypes.php
+++ b/resources/lang/it/fieldtypes.php
@@ -174,7 +174,7 @@ return [
     'taggable.config.placeholder' => 'Digita e premi ↩ Invio',
     'taggable.title' => 'Taggable',
     'taxonomies.title' => 'Tassonomie',
-    'template.config.blueprint' => 'Aggiunge l\'opzione "_map to blueprint_". Per saperne di più, consultare la [documentazione](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Aggiunge l\'opzione "_map to blueprint_". Per saperne di più, consultare la [documentazione](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Mostra solo i template di questa cartella.',
     'template.config.hide_partials' => 'I parziali sono raramente utilizzati come template.',
     'template.title' => 'Template',

--- a/resources/lang/ja/fieldtypes.php
+++ b/resources/lang/ja/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'を入力して ↩ Enter を押します',
     'taggable.title' => 'タグ付け可能',
     'taxonomies.title' => 'タクソノミー',
-    'template.config.blueprint' => '「ブループリントにマップ」オプションを追加します。詳細については、[ドキュメント](https://statamic.dev/views#inferring-templates-from-entry-blueprints)をご覧ください。',
+    'template.config.blueprint' => '「ブループリントにマップ」オプションを追加します。詳細については、[ドキュメント](https://statamic.dev/views#map-templates-to-entry-blueprints)をご覧ください。',
     'template.config.folder' => 'このフォルダー内のテンプレートのみを表示します。',
     'template.config.hide_partials' => 'パーシャルがテンプレートとして使用されることを目的とすることはほとんどありません。',
     'template.title' => 'テンプレート',

--- a/resources/lang/ms/fieldtypes.php
+++ b/resources/lang/ms/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Taip dan tekan ↩ Enter',
     'taggable.title' => 'Boleh tag',
     'taxonomies.title' => 'Taksonomi',
-    'template.config.blueprint' => 'Menambah pilihan &quot;peta ke pelan tindakan&quot;. Ketahui lebih lanjut dalam [dokumentasi](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Menambah pilihan &quot;peta ke pelan tindakan&quot;. Ketahui lebih lanjut dalam [dokumentasi](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Hanya tunjukkan templat dalam folder ini.',
     'template.config.hide_partials' => 'Sebahagian separa dimaksudkan untuk digunakan sebagai templat.',
     'template.title' => 'templat',

--- a/resources/lang/nb/fieldtypes.php
+++ b/resources/lang/nb/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Skriv og trykk ↩ Enter',
     'taggable.title' => 'Kan merkes',
     'taxonomies.title' => 'Taksonomier',
-    'template.config.blueprint' => 'Legger til et "koble til blueprint" valg. Les mer om dette i [dokumentasjonen](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Legger til et "koble til blueprint" valg. Les mer om dette i [dokumentasjonen](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Vis bare maler i denne mappen.',
     'template.config.hide_partials' => 'Delreplikaer er sjeldent ment for bruk som maler.',
     'template.title' => 'Mal',

--- a/resources/lang/nl/fieldtypes.php
+++ b/resources/lang/nl/fieldtypes.php
@@ -176,7 +176,7 @@ return [
     'taggable.config.placeholder' => 'Type en druk op ↩ Enter',
     'taggable.title' => 'Taggable',
     'taxonomies.title' => 'Taxonomies',
-    'template.config.blueprint' => 'Voegt een "toekennen aan blueprint" optie toe. Lees meer in de [documentatie](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Voegt een "toekennen aan blueprint" optie toe. Lees meer in de [documentatie](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Toon alleen templates in deze map.',
     'template.config.hide_partials' => 'Partials zijn zelden bedoeld om als templates te worden gebruikt.',
     'template.title' => 'Template',

--- a/resources/lang/pl/fieldtypes.php
+++ b/resources/lang/pl/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Wpisz i naciśnij ↩ Enter',
     'taggable.title' => 'Tagowalny',
     'taxonomies.title' => 'Taksonomie',
-    'template.config.blueprint' => 'Dodaje opcję „mapuj do blueprintu”. Dowiedz się więcej w [dokumentacji](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Dodaje opcję „mapuj do blueprintu”. Dowiedz się więcej w [dokumentacji](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Pokaż tylko szablony w tym folderze.',
     'template.config.hide_partials' => 'Fragmenty są rzadko przeznaczone do użycia jako szablony.',
     'template.title' => 'Szablon',

--- a/resources/lang/pt/fieldtypes.php
+++ b/resources/lang/pt/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Digite e pressione ↩ Enter',
     'taggable.title' => 'Taggable',
     'taxonomies.title' => 'Taxonomies',
-    'template.config.blueprint' => 'Adiciona uma opção &quot;map to blueprint&quot;. Saiba mais na [documentação](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Adiciona uma opção &quot;map to blueprint&quot;. Saiba mais na [documentação](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Mostrar somente modelos nesta pasta.',
     'template.config.hide_partials' => 'As parciais raramente se destinam a ser utilizadas como modelos.',
     'template.title' => 'Template',

--- a/resources/lang/pt_BR/fieldtypes.php
+++ b/resources/lang/pt_BR/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Digite e pressione ↩ Enter',
     'taggable.title' => 'Tagável',
     'taxonomies.title' => 'Taxonomias',
-    'template.config.blueprint' => 'Adiciona uma opção &quot;map to blueprint&quot;. Saiba mais na [documentação](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Adiciona uma opção &quot;map to blueprint&quot;. Saiba mais na [documentação](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Mostrar somente modelos nesta pasta.',
     'template.config.hide_partials' => 'Parciais raramente são usados como modelos.',
     'template.title' => 'Modelo',

--- a/resources/lang/ru/fieldtypes.php
+++ b/resources/lang/ru/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Введите и нажмите ↩ Enter',
     'taggable.title' => 'Taggable',
     'taxonomies.title' => 'Таксономии',
-    'template.config.blueprint' => 'Добавляет опцию «Сопоставить с чертежом». Узнайте больше в [документации](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Добавляет опцию «Сопоставить с чертежом». Узнайте больше в [документации](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Показывать только шаблоны в этой папке.',
     'template.config.hide_partials' => 'Части редко предназначены для использования в качестве шаблонов.',
     'template.title' => 'Шаблон',

--- a/resources/lang/sl/fieldtypes.php
+++ b/resources/lang/sl/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Vnesite in pritisnite ↩ Enter',
     'taggable.title' => 'Taggable',
     'taxonomies.title' => 'Taxonomies',
-    'template.config.blueprint' => 'Doda možnost »preslikava v načrt«. Več o tem v [dokumentaciji](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Doda možnost »preslikava v načrt«. Več o tem v [dokumentaciji](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Pokaži samo predloge v tej mapi.',
     'template.config.hide_partials' => 'Udeleženci so redko namenjeni uporabi kot predloge.',
     'template.title' => 'Template',

--- a/resources/lang/sv/fieldtypes.php
+++ b/resources/lang/sv/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Skriv och tryck på ↩ Enter',
     'taggable.title' => 'Etikett',
     'taxonomies.title' => 'Taxonomier',
-    'template.config.blueprint' => 'Lägger till ett &quot;karta till ritning&quot;-alternativ. Läs mer i [dokumentationen](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Lägger till ett &quot;karta till ritning&quot;-alternativ. Läs mer i [dokumentationen](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Visa endast mallar i den här mappen.',
     'template.config.hide_partials' => 'Partialer är sällan avsedda att användas som mallar.',
     'template.title' => 'Mall',

--- a/resources/lang/tr/fieldtypes.php
+++ b/resources/lang/tr/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Yazın ve ↩ Enter tuşuna basın',
     'taggable.title' => 'Etiketlenebilir',
     'taxonomies.title' => 'Taksonomiler',
-    'template.config.blueprint' => 'Bir "plana eşle" seçeneği ekler. [Belgelerde](https://statamic.dev/views#inferring-templates-from-entry-blueprints) daha fazla bilgi edinin.',
+    'template.config.blueprint' => 'Bir "plana eşle" seçeneği ekler. [Belgelerde](https://statamic.dev/views#map-templates-to-entry-blueprints) daha fazla bilgi edinin.',
     'template.config.folder' => 'Yalnızca bu klasördeki şablonları göster.',
     'template.config.hide_partials' => 'Kısmi bölümlerin nadiren şablon olarak kullanılması amaçlanmıştır.',
     'template.title' => 'Şablon',

--- a/resources/lang/uk/fieldtypes.php
+++ b/resources/lang/uk/fieldtypes.php
@@ -175,7 +175,7 @@ return [
     'taggable.config.placeholder' => 'Введіть та натисніть ↩ Enter',
     'taggable.title' => 'Теги',
     'taxonomies.title' => 'Таксономії',
-    'template.config.blueprint' => 'Додає опцію "карта до блакитного друку". Дізнайтеся більше в [документації](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Додає опцію "карта до блакитного друку". Дізнайтеся більше в [документації](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Показувати лише шаблони в цій папці.',
     'template.config.hide_partials' => 'Часткові рідко призначені для використання як шаблони.',
     'template.title' => 'Шаблон',

--- a/resources/lang/vi/fieldtypes.php
+++ b/resources/lang/vi/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => 'Nhập và nhấn ↩ Enter',
     'taggable.title' => 'Có thể gắn thẻ',
     'taxonomies.title' => 'Phân loại',
-    'template.config.blueprint' => 'Thêm tùy chọn &quot;bản đồ đến bản thiết kế&quot;. Tìm hiểu thêm trong [tài liệu](https://statamic.dev/views#inferring-templates-from-entry-blueprints).',
+    'template.config.blueprint' => 'Thêm tùy chọn &quot;bản đồ đến bản thiết kế&quot;. Tìm hiểu thêm trong [tài liệu](https://statamic.dev/views#map-templates-to-entry-blueprints).',
     'template.config.folder' => 'Chỉ hiển thị các mẫu trong thư mục này.',
     'template.config.hide_partials' => 'Các phần này hiếm khi được dùng làm mẫu.',
     'template.title' => 'Mẫu',

--- a/resources/lang/zh_CN/fieldtypes.php
+++ b/resources/lang/zh_CN/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => '输入并按 ↩ Enter',
     'taggable.title' => '可标记',
     'taxonomies.title' => '分类',
-    'template.config.blueprint' => '添加“映射到蓝图”选项。更多信息请参阅[文档](https://statamic.dev/views#inferring-templates-from-entry-blueprints)。',
+    'template.config.blueprint' => '添加“映射到蓝图”选项。更多信息请参阅[文档](https://statamic.dev/views#map-templates-to-entry-blueprints)。',
     'template.config.folder' => '仅显示此文件夹中的模板。',
     'template.config.hide_partials' => '部分将很少用作模板。',
     'template.title' => '模板',

--- a/resources/lang/zh_TW/fieldtypes.php
+++ b/resources/lang/zh_TW/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'taggable.config.placeholder' => '输入并按 ↩ Enter',
     'taggable.title' => '可標記',
     'taxonomies.title' => '分類',
-    'template.config.blueprint' => '添加“映射到蓝图”选项。更多信息请参阅[文档](https://statamic.dev/views#inferring-templates-from-entry-blueprints)。',
+    'template.config.blueprint' => '添加“映射到蓝图”选项。更多信息请参阅[文档](https://statamic.dev/views#map-templates-to-entry-blueprints)。',
     'template.config.folder' => '仅显示此文件夹中的模板。',
     'template.config.hide_partials' => '「部分」很少會用於作為樣板使用。',
     'template.title' => '樣板',


### PR DESCRIPTION
This pull request fixes a broken link in the help text for one of the Template fieldtype's config options. Not related to an issue, just something I stumbled upon.