### PR TITLE
[6.x] Optimize Blueprint JSON Payload

### DIFF
--- a/resources/js/components/fieldtypes/withDefaultConfig.js
+++ b/resources/js/components/fieldtypes/withDefaultConfig.js
@@ -1,0 +1,5 @@
+export default function withDefaultConfig(type, config) {
+    const { common, types } = Statamic.$config.get('fieldtypeConfigs');
+
+    return { ...common, ...types[type], ...config }
+}

--- a/resources/js/components/ui/Publish/Field.vue
+++ b/resources/js/components/ui/Publish/Field.vue
@@ -5,6 +5,7 @@ import { injectFieldsContext } from './FieldsProvider.vue';
 import { Field, Icon, Tooltip, Label } from '@statamic/ui';
 import FieldActions from '@statamic/components/field-actions/FieldActions.vue';
 import ShowField from '@statamic/components/field-conditions/ShowField.js';
+import withDefaultConfig from '@statamic/components/fieldtypes/withDefaultConfig.js';
 
 const props = defineProps({
     config: {
@@ -34,10 +35,11 @@ const {
     setHiddenField,
 } = injectContainerContext();
 const { fieldPathPrefix, metaPathPrefix } = injectFieldsContext();
-const handle = props.config.handle;
+const config = computed(() => withDefaultConfig(props.config.type, props.config));
+const handle = config.value.handle;
 
 const fieldtypeComponent = computed(() => {
-    return `${props.config.component || props.config.type}-fieldtype`;
+    return `${config.value.component || config.value.type}-fieldtype`;
 });
 
 const fieldtypeComponentExists = computed(() => {
@@ -54,7 +56,7 @@ const meta = computed(() => {
 const errors = computed(() => containerErrors.value[fullPath.value]);
 const fieldId = computed(() => `field_${fullPath.value.replaceAll('.', '_')}`);
 const namePrefix = '';
-const isRequired = computed(() => props.config.required);
+const isRequired = computed(() => config.value.required);
 const fieldtype = useTemplateRef('fieldtype');
 
 const fieldActions = computed(() => {
@@ -62,7 +64,7 @@ const fieldActions = computed(() => {
 });
 
 const shouldShowFieldActions = computed(() => {
-    return props.config.actions && fieldActions.value?.length > 0;
+    return config.value.actions && fieldActions.value?.length > 0;
 });
 
 function valueUpdated(value) {
@@ -108,10 +110,10 @@ const shouldShowField = computed(() => {
         hiddenFields.value,
         revealerFields.value,
         setHiddenField
-    ).showField(props.config, fullPath.value);
+    ).showField(config.value, fullPath.value);
 });
 
-const shouldShowLabelText = computed(() => !props.config.hide_display);
+const shouldShowLabelText = computed(() => !config.value.hide_display);
 
 const shouldShowLabel = computed(
     () =>
@@ -120,14 +122,14 @@ const shouldShowLabel = computed(
         isSyncable.value, // Need to see the icon
 );
 
-const isLocalizable = computed(() => props.config.localizable);
+const isLocalizable = computed(() => config.value.localizable);
 
 const isReadOnly = computed(() => {
     if (containerReadOnly.value) return true;
 
     if (isTrackingOriginValues.value && isSyncable.value && !isLocalizable.value) return true;
 
-    return isLocked.value || props.config.visibility === 'read_only' || false;
+    return isLocked.value || config.value.visibility === 'read_only' || false;
 });
 
 const isLocked = computed(() => false); // todo
@@ -144,7 +146,7 @@ const isSynced = computed(() => isSyncable.value && !localizedFields.value.inclu
 const isNested = computed(() => fullPath.value.includes('.'));
 const wrapperComponent = computed(() => {
     // Todo: Find a way to not need to hard code this.
-    if (props.config.type === 'dictionary_fields') return 'div';
+    if (config.value.type === 'dictionary_fields') return 'div';
 
     return asConfig.value && !isNested.value ? 'card' : 'div';
 });

--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -61,6 +61,13 @@ abstract class Fieldtype implements Arrayable
         return $this;
     }
 
+    public function removeField()
+    {
+        $this->field = null;
+
+        return $this;
+    }
+
     public function field(): ?Field
     {
         return $this->field;
@@ -343,13 +350,9 @@ abstract class Fieldtype implements Arrayable
 
     public function config(?string $key = null, $fallback = null)
     {
-        if (! $this->field) {
-            return $fallback;
-        }
-
         $config = $this->configFields()->all()
             ->map->defaultValue()
-            ->merge($this->field->config());
+            ->merge($this->field?->config() ?? []);
 
         return $key
             ? ($config->get($key) ?? $fallback)

--- a/src/Fields/FieldtypeRepository.php
+++ b/src/Fields/FieldtypeRepository.php
@@ -17,7 +17,7 @@ class FieldtypeRepository
     public function find($handle)
     {
         if (isset($this->fieldtypes[$handle])) {
-            return clone $this->fieldtypes[$handle];
+            return (clone $this->fieldtypes[$handle])->removeField();
         }
 
         if (! ($fieldtypes = $this->classes())->has($handle)) {
@@ -37,6 +37,11 @@ class FieldtypeRepository
         return $this->classes()->map(function ($class) {
             return $class::handle();
         });
+    }
+
+    public function all()
+    {
+        return $this->handles()->map(fn ($handle) => $this->find($handle));
     }
 
     public function makeSelectableInForms($handle)


### PR DESCRIPTION
For publish pages with a ton of fields (typically using a gigantic Replicator as a page builder) there has been performance issues. For example, the initial page load takes a long time. Not the server response - but the actual render. This seemed to be due to the gigantic blueprint that gets sent down the wire and then parsing the JSON makes the page struggle.

This is because each field's config contains all the necessary keys, even the default values for things that weren't explicitly defined. For example:

```js
{
  "type": "text",
  "display": "...",
  "instructions": "...",
  "instructions_position": "above",
  "listable": true,
  "visibility": "visible",
  "sortable": true,
  // etc
}
```

There's a lot of redundant stuff in there. This PR excludes any default values from being in there and instead merges them in later.

In one test example, the blueprint JSON went from 872.08 KB to 367.75 KB.

Looks like the real culprit is the `meta` data though. It's even bigger than `blueprint`. That'll take some thought because it's a two way binding.