### PR TITLE
[5.x] Fix AddonTestCase path for Windows

### DIFF
--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -27,7 +27,7 @@ abstract class AddonTestCase extends OrchestraTestCase
 
         if (isset($uses[PreventsSavingStacheItemsToDisk::class])) {
             $reflection = new ReflectionClass($this);
-            $this->fakeStacheDirectory = Str::before(dirname($reflection->getFileName()), '/tests').'/tests/__fixtures__/dev-null';
+            $this->fakeStacheDirectory = Str::before(dirname($reflection->getFileName()), DIRECTORY_SEPARATOR.'tests').'/tests/__fixtures__/dev-null';
 
             $this->preventSavingStacheItemsToDisk();
         }


### PR DESCRIPTION
Ran into this issue while testing the eloquent driver on Windows.  The `fakeStacheDirectory` is not set up properly because the `Str::before` call is looking for a forward slash while on Windows the path returned by `$reflection->getFileName()` contains back slashes.  Using `DIRECTORY_SEPARATOR` instead of forward slash solves this issue.