### PR TITLE
[6.x] Collapsible blueprint sections

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -60,6 +60,46 @@
                     <label v-text="__('Instructions')" />
                     <input type="text" class="input-text" v-model="editingSection.instructions" />
                 </div>
+                <div class="form-group w-full">
+                    <publish-field-meta
+                        :config="{
+                            handle: 'collapsible',
+                            type: 'toggle',
+                            default: false,
+                            inline_label: 'Collapsible',
+                        }"
+                        :initial-value="editingSection.collapsible"
+                        v-slot="{ meta, value, config }"
+                    >
+                        <toggle-fieldtype
+                            handle="collapsible"
+                            :config="config"
+                            :meta="meta"
+                            :value="value"
+                            @update:value="editingSection.collapsible = $event"
+                        />
+                    </publish-field-meta>
+                </div> 
+                <div class="form-group w-full" v-if="editingSection.collapsible">
+                    <publish-field-meta
+                        :config="{
+                            handle: 'collapsed_by_default',
+                            type: 'toggle',
+                            default: false,
+                            inline_label: 'Collapsed by Default',
+                        }"
+                        :initial-value="editingSection.collapsed_by_default"
+                        v-slot="{ meta, value, config }"
+                    >
+                        <toggle-fieldtype
+                            handle="collapsed_by_default"
+                            :config="config"
+                            :meta="meta"
+                            :value="value"
+                            @update:value="editingSection.collapsed_by_default = $event"
+                        />
+                    </publish-field-meta>
+                </div>
                 <div class="form-group w-full" v-if="showHandleField">
                     <label v-text="__('Icon')" />
                     <publish-field-meta
@@ -201,6 +241,8 @@ export default {
                 instructions: this.section.instructions,
                 icon: this.section.icon,
                 hide: this.section.hide,
+                collapsible: this.section.collapsible,
+                collapsed_by_default: this.section.collapsed_by_default,
             };
         },
 

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -79,24 +79,24 @@
                             @update:value="editingSection.collapsible = $event"
                         />
                     </publish-field-meta>
-                </div> 
+                </div>
                 <div class="form-group w-full" v-if="editingSection.collapsible">
                     <publish-field-meta
                         :config="{
-                            handle: 'collapsed_by_default',
+                            handle: 'collapsed',
                             type: 'toggle',
                             default: false,
                             inline_label: 'Collapsed by Default',
                         }"
-                        :initial-value="editingSection.collapsed_by_default"
+                        :initial-value="editingSection.collapsed"
                         v-slot="{ meta, value, config }"
                     >
                         <toggle-fieldtype
-                            handle="collapsed_by_default"
+                            handle="collapsed"
                             :config="config"
                             :meta="meta"
                             :value="value"
-                            @update:value="editingSection.collapsed_by_default = $event"
+                            @update:value="editingSection.collapsed = $event"
                         />
                     </publish-field-meta>
                 </div>
@@ -242,7 +242,7 @@ export default {
                 icon: this.section.icon,
                 hide: this.section.hide,
                 collapsible: this.section.collapsible,
-                collapsed_by_default: this.section.collapsed_by_default,
+                collapsed: this.section.collapsed,
             };
         },
 

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -60,45 +60,17 @@
                     <label v-text="__('Instructions')" />
                     <input type="text" class="input-text" v-model="editingSection.instructions" />
                 </div>
-                <div class="form-group w-full">
-                    <publish-field-meta
-                        :config="{
-                            handle: 'collapsible',
-                            type: 'toggle',
-                            default: false,
-                            inline_label: 'Collapsible',
-                        }"
-                        :initial-value="editingSection.collapsible"
-                        v-slot="{ meta, value, config }"
-                    >
-                        <toggle-fieldtype
-                            handle="collapsible"
-                            :config="config"
-                            :meta="meta"
-                            :value="value"
-                            @update:value="editingSection.collapsible = $event"
-                        />
-                    </publish-field-meta>
+                <div class="form-group field-w-50">
+                    <div class="flex items-center gap-2">
+                        <Switch v-model="editingSection.collapsible" />
+                        <Heading :text="__('Collapsible')" />
+                    </div>
                 </div>
-                <div class="form-group w-full" v-if="editingSection.collapsible">
-                    <publish-field-meta
-                        :config="{
-                            handle: 'collapsed',
-                            type: 'toggle',
-                            default: false,
-                            inline_label: 'Collapsed by Default',
-                        }"
-                        :initial-value="editingSection.collapsed"
-                        v-slot="{ meta, value, config }"
-                    >
-                        <toggle-fieldtype
-                            handle="collapsed"
-                            :config="config"
-                            :meta="meta"
-                            :value="value"
-                            @update:value="editingSection.collapsed = $event"
-                        />
-                    </publish-field-meta>
+                <div class="form-group field-w-50" v-if="editingSection.collapsible">
+                    <div class="flex items-center gap-2">
+                        <Switch v-model="editingSection.collapsed" />
+                        <Heading :text="__('Collapsed by default')" />
+                    </div>
                 </div>
                 <div class="form-group w-full" v-if="showHandleField">
                     <label v-text="__('Icon')" />
@@ -134,6 +106,7 @@
 <script>
 import Fields from './Fields.vue';
 import CanDefineLocalizable from '../fields/CanDefineLocalizable';
+import { Switch, Heading } from '@statamic/ui';
 
 export default {
     mixins: [CanDefineLocalizable],
@@ -144,6 +117,8 @@ export default {
 
     components: {
         Fields,
+        Switch,
+        Heading,
     },
 
     props: {

--- a/resources/js/components/blueprints/Sections.vue
+++ b/resources/js/components/blueprints/Sections.vue
@@ -91,6 +91,8 @@ export default {
                 _id: uniqid(),
                 display: this.newSectionText,
                 instructions: null,
+                collapsible: false,
+                collapsed_by_default: false,
                 icon: null,
                 hide: null,
                 handle: snake_case(this.newSectionText),

--- a/resources/js/components/blueprints/Sections.vue
+++ b/resources/js/components/blueprints/Sections.vue
@@ -92,7 +92,7 @@ export default {
                 display: this.newSectionText,
                 instructions: null,
                 collapsible: false,
-                collapsed_by_default: false,
+                collapsed: false,
                 icon: null,
                 hide: null,
                 handle: snake_case(this.newSectionText),

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -28,7 +28,7 @@ const visibleSections = computed(() => {
     });
 });
 const collapsedSections = ref(
-    sections.map(section => section.collapsible && section.collapsed_by_default),
+    sections.map(section => section.collapsible && section.collapsed)
 );
 
 function renderInstructions(instructions) {

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { injectTabContext } from './TabProvider.vue';
-import { Panel, PanelHeader, Heading, Subheading, Card, Icon } from '@statamic/ui';
+import { Panel, PanelHeader, Heading, Subheading, Card } from '@statamic/ui';
 import FieldsProvider from './FieldsProvider.vue';
 import Fields from './Fields.vue';
 import ShowField from '@statamic/components/field-conditions/ShowField.js';
@@ -54,14 +54,6 @@ function maybeToggleSection(id) {
             <PanelHeader class="relative" v-if="section.display" @click="maybeToggleSection(i)">
                 <Heading :text="__(section.display)" />
                 <Subheading v-if="section.instructions" :text="renderInstructions(section.instructions)" />
-                <Icon
-                    v-if="section.collapsible"
-                    name="ui/chevron-right"
-                    class="absolute right-4.5 top-0 bottom-0 my-auto size-6 cursor-pointer transition-transform duration-[250ms]"
-                    :class="{
-                        'rotate-90': !collapsedSections[i]
-                    }"
-                />
             </PanelHeader>
             <Motion
                 layout

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -6,7 +6,7 @@ import Fields from './Fields.vue';
 import ShowField from '@statamic/components/field-conditions/ShowField.js';
 import { injectContainerContext } from './Container.vue';
 import markdown from '@statamic/util/markdown.js';
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import { Primitive } from 'reka-ui';
 import { Motion } from 'motion-v';
 

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -27,9 +27,6 @@ const visibleSections = computed(() => {
         });
     });
 });
-const collapsedSections = ref(
-    sections.map(section => section.collapsible && section.collapsed)
-);
 
 function renderInstructions(instructions) {
     return instructions ? markdown(__(instructions), { openLinksInNewTabs: true }) : '';
@@ -40,7 +37,7 @@ function maybeToggleSection(id) {
         return;
     }
 
-    collapsedSections.value[id] = !collapsedSections.value[id];
+    sections[id].collapsed = !sections[id].collapsed;
 }
 </script>
 
@@ -58,8 +55,8 @@ function maybeToggleSection(id) {
             <Motion
                 layout
                 class="overflow-hidden"
-                :initial="{ height: collapsedSections[i] ? '0px' : 'auto' }"
-                :animate="{ height: collapsedSections[i] ? '0px' : 'auto' }"
+                :initial="{ height: section.collapsed ? '0px' : 'auto' }"
+                :animate="{ height: section.collapsed ? '0px' : 'auto' }"
                 :transition="{ duration: 0.25, type: 'tween' }"
             >
                 <Primitive :as="asConfig ? 'div' : Card">

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -32,12 +32,10 @@ function renderInstructions(instructions) {
     return instructions ? markdown(__(instructions), { openLinksInNewTabs: true }) : '';
 }
 
-function maybeToggleSection(id) {
-    if (!sections[id].collapsible) {
-        return;
+function toggleSection(id) {
+    if (sections[id].collapsible) {
+        sections[id].collapsed = !sections[id].collapsed;
     }
-
-    sections[id].collapsed = !sections[id].collapsed;
 }
 </script>
 
@@ -48,7 +46,7 @@ function maybeToggleSection(id) {
             :key="i"
             :class="asConfig ? 'mb-12' : 'mb-6'"
         >
-            <PanelHeader class="relative" v-if="section.display" @click="maybeToggleSection(i)">
+            <PanelHeader class="relative" v-if="section.display" @click="toggleSection(i)">
                 <Heading :text="__(section.display)" />
                 <Subheading v-if="section.instructions" :text="renderInstructions(section.instructions)" />
             </PanelHeader>

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -46,7 +46,7 @@ function toggleSection(id) {
             :key="i"
             :class="asConfig ? 'mb-12' : 'mb-6'"
         >
-            <PanelHeader class="relative" v-if="section.display" @click="toggleSection(i)">
+            <PanelHeader v-if="section.display" @click="toggleSection(i)">
                 <Heading :text="__(section.display)" />
                 <Subheading v-if="section.instructions" :text="renderInstructions(section.instructions)" />
             </PanelHeader>

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -60,11 +60,11 @@ function maybeToggleSection(id) {
                 :transition="{ duration: 0.25, type: 'tween' }"
             >
                 <Primitive :as="asConfig ? 'div' : Card">
-                        <FieldsProvider :fields="section.fields">
-                            <slot :section="section">
-                                <Fields />
-                            </slot>
-                        </FieldsProvider>
+                    <FieldsProvider :fields="section.fields">
+                        <slot :section="section">
+                            <Fields />
+                        </slot>
+                    </FieldsProvider>
                 </Primitive>
             </Motion>
         </Panel>

--- a/src/Fields/Section.php
+++ b/src/Fields/Section.php
@@ -23,6 +23,16 @@ class Section
         return $this->contents['instructions'] ?? null;
     }
 
+    public function collapsible(): bool
+    {
+        return $this->contents['collapsible'] ?? false;
+    }
+
+    public function collapsedByDefault(): bool
+    {
+        return $this->contents['collapsed_by_default'] ?? false;
+    }
+
     public function contents(): array
     {
         return $this->contents;
@@ -38,6 +48,8 @@ class Section
         return Arr::removeNullValues([
             'display' => $this->display(),
             'instructions' => $this->instructions(),
+            'collapsible' => $this->collapsible(),
+            'collapsed_by_default' => $this->collapsedByDefault(),
         ]) + [
             'fields' => $this->fields()->toPublishArray(),
         ];

--- a/src/Fields/Section.php
+++ b/src/Fields/Section.php
@@ -23,14 +23,14 @@ class Section
         return $this->contents['instructions'] ?? null;
     }
 
-    public function collapsible(): bool
+    public function collapsible(): ?bool
     {
-        return $this->contents['collapsible'] ?? false;
+        return $this->contents['collapsible'] ?? null;
     }
 
-    public function collapsedByDefault(): bool
+    public function collapsedByDefault(): ?bool
     {
-        return $this->contents['collapsed_by_default'] ?? false;
+        return $this->contents['collapsed_by_default'] ?? null;
     }
 
     public function contents(): array

--- a/src/Fields/Section.php
+++ b/src/Fields/Section.php
@@ -23,14 +23,14 @@ class Section
         return $this->contents['instructions'] ?? null;
     }
 
-    public function collapsible(): ?bool
+    public function collapsible(): bool
     {
-        return $this->contents['collapsible'] ?? null;
+        return $this->contents['collapsible'] ?? false;
     }
 
-    public function collapsed(): ?bool
+    public function collapsed(): bool
     {
-        return $this->contents['collapsed'] ?? null;
+        return $this->collapsible() && $this->contents['collapsed'] ?? false;
     }
 
     public function contents(): array

--- a/src/Fields/Section.php
+++ b/src/Fields/Section.php
@@ -28,9 +28,9 @@ class Section
         return $this->contents['collapsible'] ?? null;
     }
 
-    public function collapsedByDefault(): ?bool
+    public function collapsed(): ?bool
     {
-        return $this->contents['collapsed_by_default'] ?? null;
+        return $this->contents['collapsed'] ?? null;
     }
 
     public function contents(): array
@@ -49,7 +49,7 @@ class Section
             'display' => $this->display(),
             'instructions' => $this->instructions(),
             'collapsible' => $this->collapsible(),
-            'collapsed_by_default' => $this->collapsedByDefault(),
+            'collapsed' => $this->collapsed(),
         ]) + [
             'fields' => $this->fields()->toPublishArray(),
         ];

--- a/src/Fields/Section.php
+++ b/src/Fields/Section.php
@@ -48,8 +48,8 @@ class Section
         return Arr::removeNullValues([
             'display' => $this->display(),
             'instructions' => $this->instructions(),
-            'collapsible' => $this->collapsible(),
-            'collapsed' => $this->collapsed(),
+            'collapsible' => $this->collapsible() ?: null,
+            'collapsed' => $this->collapsed() ?: null,
         ]) + [
             'fields' => $this->fields()->toPublishArray(),
         ];

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -102,8 +102,8 @@ trait ManagesBlueprints
             return Arr::removeNullValues([
                 'display' => $section['display'] ?? null,
                 'instructions' => $section['instructions'] ?? null,
-                'collapsible' => $section['collapsible'] ?? null,
-                'collapsed' => $section['collapsed'] ?? null,
+                'collapsible' => ($collapsible = $section['collapsible']) ?: null,
+                'collapsed' => ($collapsible && $section['collapsed']) ?: null,
                 'fields' => collect($section['fields'])
                     ->map(fn ($field) => FieldTransformer::fromVue($field))
                     ->all(),

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -102,8 +102,8 @@ trait ManagesBlueprints
             return Arr::removeNullValues([
                 'display' => $section['display'] ?? null,
                 'instructions' => $section['instructions'] ?? null,
-                'collapsible' => $section['collapsible'] ?? false,
-                'collapsed_by_default' => $section['collapsed_by_default'] ?? false,
+                'collapsible' => $section['collapsible'] ?? null,
+                'collapsed_by_default' => $section['collapsed_by_default'] ?? null,
                 'fields' => collect($section['fields'])
                     ->map(fn ($field) => FieldTransformer::fromVue($field))
                     ->all(),

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -102,8 +102,8 @@ trait ManagesBlueprints
             return Arr::removeNullValues([
                 'display' => $section['display'] ?? null,
                 'instructions' => $section['instructions'] ?? null,
-                'collapsible' => ($collapsible = $section['collapsible']) ?: null,
-                'collapsed' => ($collapsible && $section['collapsed']) ?: null,
+                'collapsible' => ($collapsible = $section['collapsible'] ?? null) ?: null,
+                'collapsed' => ($collapsible && $section['collapsed'] ?? null) ?: null,
                 'fields' => collect($section['fields'])
                     ->map(fn ($field) => FieldTransformer::fromVue($field))
                     ->all(),

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -103,7 +103,7 @@ trait ManagesBlueprints
                 'display' => $section['display'] ?? null,
                 'instructions' => $section['instructions'] ?? null,
                 'collapsible' => $section['collapsible'] ?? null,
-                'collapsed_by_default' => $section['collapsed_by_default'] ?? null,
+                'collapsed' => $section['collapsed'] ?? null,
                 'fields' => collect($section['fields'])
                     ->map(fn ($field) => FieldTransformer::fromVue($field))
                     ->all(),
@@ -140,7 +140,7 @@ trait ManagesBlueprints
             'display' => $section->display(),
             'instructions' => $section->instructions(),
             'collapsible' => $section->collapsible(),
-            'collapsed_by_default' => $section->collapsedByDefault(),
+            'collapsed' => $section->collapsed(),
         ]) + [
             'fields' => collect($section->contents()['fields'] ?? [])->map(function ($field, $i) use ($tab, $sectionIndex) {
                 return array_merge(FieldTransformer::toVue($field), ['_id' => $tab->handle().'-'.$sectionIndex.'-'.$i]);

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -102,6 +102,8 @@ trait ManagesBlueprints
             return Arr::removeNullValues([
                 'display' => $section['display'] ?? null,
                 'instructions' => $section['instructions'] ?? null,
+                'collapsible' => $section['collapsible'] ?? false,
+                'collapsed_by_default' => $section['collapsed_by_default'] ?? false,
                 'fields' => collect($section['fields'])
                     ->map(fn ($field) => FieldTransformer::fromVue($field))
                     ->all(),
@@ -137,6 +139,8 @@ trait ManagesBlueprints
         return Arr::removeNullValues([
             'display' => $section->display(),
             'instructions' => $section->instructions(),
+            'collapsible' => $section->collapsible(),
+            'collapsed_by_default' => $section->collapsedByDefault(),
         ]) + [
             'fields' => collect($section->contents()['fields'] ?? [])->map(function ($field, $i) use ($tab, $sectionIndex) {
                 return array_merge(FieldTransformer::toVue($field), ['_id' => $tab->handle().'-'.$sectionIndex.'-'.$i]);


### PR DESCRIPTION
This PR resolves:
- https://github.com/statamic/ideas/issues/1033

Adds two toggles to the section editor:
<img width="735" height="453" alt="image" src="https://github.com/user-attachments/assets/c1d0f278-bb7d-478f-84d4-2fabd5f254ee" />

And results in the following UI:
![chrome-capture-2025-07-24](https://github.com/user-attachments/assets/79395bb2-fae9-44c6-abbd-dca337487e4a)