### PR TITLE
[5.x] Escape redirect in user tag

### DIFF
--- a/src/Tags/Concerns/RendersForms.php
+++ b/src/Tags/Concerns/RendersForms.php
@@ -104,7 +104,7 @@ trait RendersForms
     {
         return collect($meta)
             ->map(function ($value, $key) {
-                return sprintf('<input type="hidden" name="_%s" value="%s" />', $key, $value);
+                return sprintf('<input type="hidden" name="_%s" value="%s" />', $key, e($value));
             })
             ->implode("\n");
     }


### PR DESCRIPTION
This fixes an issue where the user tag's hidden form fields could contain unescaped values.
