### PR TITLE
[5.x] Fix incorrect boolean in eloquent whereNotBetween

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -292,7 +292,7 @@ abstract class EloquentQueryBuilder implements Builder
 
     public function whereNotBetween($column, $values, $boolean = 'and')
     {
-        return $this->whereBetween($column, $values, 'or', true);
+        return $this->whereBetween($column, $values, $boolean, true);
     }
 
     public function orWhereNotBetween($column, $values)


### PR DESCRIPTION
I stumbled across this bug - whereNotBetween in the base eloquent query builder is always being forced to 'or' incorrectly.