### PR TITLE
[5.x] Ensure time passed to eloquent whereTime is hh::mm::ss

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -374,6 +374,12 @@ abstract class EloquentQueryBuilder implements Builder
             $value, $operator, func_num_args() === 2
         );
 
+        if (! ($value instanceof DateTimeInterface)) {
+            $value = Carbon::parse($value);
+        }
+
+        $value = $value->format('H:i:s'); // we only care about the time part
+
         $this->builder->whereTime($this->column($column), $operator, $value, $boolean);
 
         return $this;


### PR DESCRIPTION
I noticed a difference between the eloquent whereTime and stache whereTime implementations. 

With stache you can pass something like `->whereTime('09:00')` and it works but with eloquent it fails as it expects `->whereTime('09:00:00')`. 

This PR updates the eloquent version to align with the stache.