### PR TITLE
[5.x] Apply bottom padding to main nav

### DIFF
--- a/resources/css/components/nav-main.css
+++ b/resources/css/components/nav-main.css
@@ -3,15 +3,23 @@
    ========================================================================== */
 
 .nav-main {
-    @apply hidden select-none bg-white shadow h-screen absolute rtl:right-0 ltr:left-0 overflow-scroll w-56;
+    @apply hidden select-none bg-white shadow absolute rtl:right-0 ltr:left-0 overflow-scroll w-56;
     @apply dark:bg-dark-800 dark:shadow-dark;
 
     transition: all .3s;
+    height: calc(100dvh - 52px);
+    .showing-license-banner & {
+        height: calc(100dvh - 105px);
+    }
 
     h6 { @apply mt-6; }
 
     ul {
         @apply list-none p-0 mt-0;
+    }
+
+    ul:last-child {
+        @apply pb-8;
     }
 
     li {
@@ -70,10 +78,6 @@
 @screen md {
     .nav-main {
         @apply fixed flex bg-transparent shadow-none overflow-auto rtl:border-l ltr:border-r dark:border-dark-900;
-        height: calc(100% - 52px);
-        .showing-license-banner & {
-            height: calc(100% - 105px);
-        }
 
         .nav-closed & {
             @apply border-0 shadow-none;


### PR DESCRIPTION
Fix the tiniest of papercuts: apply a bottom padding to the main nav. Besides the visual aspect, we've been hearing from some users that their browser won't let them click the bottom link because it's hidden behind the browser's status bar. Chrome's status bar does move out of the way helpfully, but apparently some browsers don't do that.

The bottom padding needs to be applied to the last `ul` because of flexbox reasons :/

Also applies the `100% - 52px` logic to mobile as well to make scrolling there easier.

### Before

<img width="510" height="350" alt="Screenshot 2025-08-01 at 10 40 23" src="https://github.com/user-attachments/assets/5e201800-075d-4bc3-9f6b-0027dff3ba3c" />

### After

<img width="443" height="361" alt="Screenshot 2025-08-01 at 10 43 58" src="https://github.com/user-attachments/assets/b0ed9d72-8db8-4efd-8e8b-58640998810c" />