### PR TITLE
[5.x] Fix assets:generate-presets command stdout

### DIFF
--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -125,12 +125,14 @@ class AssetsGeneratePresets extends Command
 
         if (property_exists($this, 'components')) {
             $errors = Arr::pull($counts, 'errors');
-            collect($counts)
-                ->put('errors', $errors)
-                ->each(function ($count, $preset) {
-                    $preset = $preset === 'errors' ? '<fg=red>errors</>' : $preset;
-                    $this->components->twoColumnDetail($preset, $count);
-                });
+            $countsCollection = collect($counts);
+            if ($errors !== null) {
+                $countsCollection->put('errors', $errors);
+            }
+            $countsCollection->each(function ($count, $preset) {
+                $preset = $preset === 'errors' ? '<fg=red>errors</>' : $preset;
+                $this->components->twoColumnDetail($preset, $count);
+            });
         }
 
         $this->output->newLine();

--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -125,14 +125,12 @@ class AssetsGeneratePresets extends Command
 
         if (property_exists($this, 'components')) {
             $errors = Arr::pull($counts, 'errors');
-            $countsCollection = collect($counts);
-            if ($errors !== null) {
-                $countsCollection->put('errors', $errors);
-            }
-            $countsCollection->each(function ($count, $preset) {
-                $preset = $preset === 'errors' ? '<fg=red>errors</>' : $preset;
-                $this->components->twoColumnDetail($preset, $count);
-            });
+            collect($counts)
+                ->when($errors, fn ($counts) => $counts->put('errors', $errors))
+                ->each(function ($count, $preset) {
+                    $preset = $preset === 'errors' ? '<fg=red>errors</>' : $preset;
+                    $this->components->twoColumnDetail($preset, $count);
+                });
         }
 
         $this->output->newLine();


### PR DESCRIPTION
This PR fixes generate presets command stdout.

Running `sail artisan statamic:assets:generate-presets`
It adds an _errors_ line even if there's no error

```bash
Generating presets for Medias...
 ┌ Generating cp_thumbnail_small_portrait for picture.png... ┐
 │ ████████████████████████████████████████████████████████████   │
 └───────────────────────────────────────────────────── 1141/1141 ┘

 [✔] 1141 images generated for 163 assets.

  medium ................................................................ 163  
  medium2x .............................................................. 163  
  small ................................................................. 163  
  small2x ............................................................... 163  
  thumbnail ............................................................. 163  
  thumbnail2x ........................................................... 163  
  cp_thumbnail_small_portrait ............................................ 22  
  cp_thumbnail_small_landscape .......................................... 128  
  cp_thumbnail_small_square .............................................. 13  
  errors ....................................................................
```
