### PR TITLE
[5.x] Add missing gap in between text in Link Asset

### DIFF
--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -36,20 +36,31 @@
             />
 
             <!-- Asset select -->
-            <assets-fieldtype
-                v-if="option === 'asset'"
-                ref="assets"
-                handle="asset"
-                :value="selectedAssets"
-                :config="meta.asset.config"
-                :meta="meta.asset.meta"
-                @input="assetsSelected"
-                @meta-updated="meta.asset.meta = $event"
-            />
+            <div class="assets-fieldtype" v-if="option === 'asset'">
+                <assets-fieldtype
+                    ref="assets"
+                    handle="asset"
+                    :value="selectedAssets"
+                    :config="meta.asset.config"
+                    :meta="meta.asset.meta"
+                    @input="assetsSelected"
+                    @meta-updated="meta.asset.meta = $event"
+                />
+            </div>
 
         </div>
     </div>
 </template>
+
+<style scoped>
+:deep(.assets-fieldtype) {
+    .assets-fieldtype-picker {
+        border: 0;
+        padding: 0;
+        background: none;
+    }
+}
+</style>
 
 <script>
 import PositionsSelectOptions from '../../mixins/PositionsSelectOptions';

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -42,7 +42,7 @@
                         <svg-icon name="folder-image" class="w-4 h-4 text-gray-800 dark:text-dark-150"></svg-icon>
                         {{ __('Browse') }}
                     </button>
-                    <p class="flex-1 asset-upload-control" v-if="canUpload">
+                    <p class="flex-1 asset-upload-control flex flex-row gap-1" v-if="canUpload">
                         <button type="button" class="upload-text-button" @click.prevent="uploadFile">
                             {{ __('Upload file') }}
                         </button>

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -42,7 +42,7 @@
                         <svg-icon name="folder-image" class="w-4 h-4 text-gray-800 dark:text-dark-150"></svg-icon>
                         {{ __('Browse') }}
                     </button>
-                    <p class="flex-1 asset-upload-control flex flex-row gap-1" v-if="canUpload">
+                    <p class="flex-1 asset-upload-control" v-if="canUpload">
                         <button type="button" class="upload-text-button" @click.prevent="uploadFile">
                             {{ __('Upload file') }}
                         </button>


### PR DESCRIPTION
Fixes #12013 

This PR adds a gap in between the text at the bottom of the Link field when choosing an Asset to link to.

Before:

<img width="545" height="160" alt="image" src="https://github.com/user-attachments/assets/3302ba92-9a65-49b1-bb99-33afcd15cd6c" />

After:

<img width="534" height="152" alt="image" src="https://github.com/user-attachments/assets/c8591e68-24fa-42bd-8035-94524de5a105" />