### PR TITLE
[5.x] Cast toggle fieldtype queryable value to boolean

### DIFF
--- a/src/Fieldtypes/Toggle.php
+++ b/src/Fieldtypes/Toggle.php
@@ -69,4 +69,9 @@ class Toggle extends Fieldtype
     {
         return new ToggleFilter($this);
     }
+
+    public function toQueryableValue($value)
+    {
+        return (bool) $value;
+    }
 }

--- a/tests/Fieldtypes/ToggleTest.php
+++ b/tests/Fieldtypes/ToggleTest.php
@@ -28,4 +28,14 @@ class ToggleTest extends TestCase
         $this->assertFalse($field->process(false));
         $this->assertNull($field->process(null));
     }
+
+    #[Test]
+    public function queryable_value_is_a_boolean()
+    {
+        $field = (new Toggle)->setField(new Field('test', ['type' => 'toggle']));
+
+        $this->assertTrue($field->toQueryableValue(true));
+        $this->assertFalse($field->toQueryableValue(false));
+        $this->assertFalse($field->toQueryableValue(null));
+    }
 }


### PR DESCRIPTION
This makes sure that any nulls are converted to false for any queries. See #11976
