### PR TITLE
[5.x] Add support for nocache parameter on Antlers partial tag

### DIFF
--- a/src/Tags/Partial.php
+++ b/src/Tags/Partial.php
@@ -3,6 +3,7 @@
 namespace Statamic\Tags;
 
 use Illuminate\Support\HtmlString;
+use Statamic\StaticCaching\NoCache\Session;
 
 class Partial extends Tags
 {
@@ -25,6 +26,12 @@ class Partial extends Tags
             '__frontmatter' => $this->params->all(),
             'slot' => $this->isPair ? $this->getSlotContent() : null,
         ]);
+
+        if ($this->params->get('nocache', false)) {
+            $nocache = app(Session::class);
+
+            return $nocache->pushView($this->viewName($partial), $variables)->placeholder();
+        }
 
         return view($this->viewName($partial), $variables)
             ->withoutExtractions()

--- a/tests/Tags/PartialTagsTest.php
+++ b/tests/Tags/PartialTagsTest.php
@@ -165,4 +165,16 @@ class PartialTagsTest extends TestCase
             $partial,
         );
     }
+
+    #[Test]
+    public function it_supports_not_rendering_with_nocache()
+    {
+        $this->viewShouldReturnRaw('test', 'This is a partial');
+
+        $partial = $this->partialTag('test', 'nocache="false"');
+        $region = app(Session::class)->regions()->first();
+
+        $this->assertEquals('This is a partial', $partial);
+        $this->assertNull($region);
+    }
 }

--- a/tests/Tags/PartialTagsTest.php
+++ b/tests/Tags/PartialTagsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Tags;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Parse;
+use Statamic\StaticCaching\NoCache\Session;
 use Tests\FakesViews;
 use Tests\TestCase;
 
@@ -144,6 +145,24 @@ class PartialTagsTest extends TestCase
         $this->assertEquals(
             'the partial content with baz',
             $this->partialTag('mypartial', 'foo="baz" unless="false"')
+        );
+    }
+
+    #[Test]
+    public function it_supports_rendering_with_nocache()
+    {
+        $this->viewShouldReturnRaw('test', 'This is a partial');
+
+        $partial = $this->partialTag('test', 'nocache="true"');
+        $region = app(Session::class)->regions()->first();
+
+        $this->assertNotEquals('This is a partial', $partial);
+        $this->assertEquals(
+            vsprintf('<span class="nocache" data-nocache="%s">%s</span>', [
+                $region->key(),
+                'NOCACHE_PLACEHOLDER',
+            ]),
+            $partial,
         );
     }
 }


### PR DESCRIPTION
Simple PR to add the ability to shorten this:

```antlers
{{ nocache }}
  {{ partial:myview }}
{{ /nocache }}
```

to this:
```antlers
{{ partial:myview nocache="true" }}
```