### PR TITLE
[5.x] Support multiple defaults for checkboxes fieldtype

### DIFF
--- a/src/Fieldtypes/Checkboxes.php
+++ b/src/Fieldtypes/Checkboxes.php
@@ -40,7 +40,7 @@ class Checkboxes extends Fieldtype
                     'default' => [
                         'display' => __('Default Value'),
                         'instructions' => __('statamic::messages.fields_default_instructions'),
-                        'type' => 'text',
+                        'type' => 'taggable',
                     ],
                 ],
             ],


### PR DESCRIPTION
Simplest PR ever, changing the default value field on the checkboxes config from text to taggable allows for multiple options to be preselected as defaults.  No other changes needed!  And it is backwards compatible with only a single default option set.

I tried for a good bit to come up with a test that could cover this but I think the defaults functionality is mostly on the Vue side so not easily testable?  I did test it locally and it works perfectly in all scenarios.