### PR TITLE
[5.x] Ensure orderByDesc uses column() function in eloquent query builder

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -447,6 +447,13 @@ abstract class EloquentQueryBuilder implements Builder
         return $this;
     }
 
+    public function orderByDesc($column)
+    {
+        $this->builder->orderBy($this->column($column), 'desc');
+
+        return $this;
+    }
+
     public function reorder($column = null, $direction = 'asc')
     {
         if ($column) {


### PR DESCRIPTION
This PR ensures orderbydesc() on the eloquent query builder uses this->column() so any json/mapping columns are applied.

This is something I noticed wasn't working on my current project, so there is no related issue.