### PR TITLE
[5.x] Fix nav padding, only apply to last <ul>

### DIFF
--- a/resources/css/components/nav-main.css
+++ b/resources/css/components/nav-main.css
@@ -18,7 +18,7 @@
         @apply list-none p-0 mt-0;
     }
 
-    ul:last-child {
+    .nav-main-inner > ul:last-child {
         @apply pb-8;
     }
 


### PR DESCRIPTION
This fixes #12023,  a regression introduced in https://github.com/statamic/cms/pull/12012.