### PR TITLE
[5.x] Support pluck() on eloquent query builder

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -77,6 +77,17 @@ abstract class EloquentQueryBuilder implements Builder
         return $items;
     }
 
+    public function pluck($column, $key = null)
+    {
+        $items = $this->get();
+
+        if (! $key) {
+            return $items->map(fn($item) => $item->{$column})->values();
+        }
+
+        return $items->mapWithKeys(fn($item) => [$item->{$key} => $item->{$column}]);
+    }
+
     public function first()
     {
         return $this->get()->first();

--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -82,10 +82,10 @@ abstract class EloquentQueryBuilder implements Builder
         $items = $this->get();
 
         if (! $key) {
-            return $items->map(fn($item) => $item->{$column})->values();
+            return $items->map(fn ($item) => $item->{$column})->values();
         }
 
-        return $items->mapWithKeys(fn($item) => [$item->{$key} => $item->{$column}]);
+        return $items->mapWithKeys(fn ($item) => [$item->{$key} => $item->{$column}]);
     }
 
     public function first()


### PR DESCRIPTION
This PR adds support for pluck() on the base eloquent query builder to bring parity with the stache builder.

This allows you to do queries like:

```php
\Statamic\Facades\Entry::query()->pluck('title');
```

instead of 

```php
\Statamic\Facades\Entry::query()->get()->pluck('title');
```