### PR TITLE
[5.x] Antlers: Corrects parser error with shorthand array syntax

### DIFF
--- a/src/View/Antlers/Language/Parser/PathParser.php
+++ b/src/View/Antlers/Language/Parser/PathParser.php
@@ -211,7 +211,15 @@ class PathParser
                 }
             }
 
-            if ($this->isParsingString == false && $this->cur == self::LeftBracket) {
+            if (
+                $this->isParsingString == false && $this->cur == self::LeftBracket &&
+                (
+                    ctype_alnum($this->prev) ||
+                    $this->prev == DocumentParser::LeftBrace ||
+                    $this->prev == DocumentParser::RightBracket ||
+                    $this->prev == DocumentParser::Punctuation_FullStop
+                )
+            ) {
                 if (! empty($currentChars)) {
                     $pathNode = new PathNode();
                     $pathNode->name = implode($currentChars);

--- a/tests/Antlers/Fixtures/MethodClasses/ArrayClass.php
+++ b/tests/Antlers/Fixtures/MethodClasses/ArrayClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\Antlers\Fixtures\MethodClasses;
+
+class ArrayClass
+{
+    public function join($data)
+    {
+        return collect($data)->join(' ');
+    }
+}

--- a/tests/Antlers/Runtime/ArraysTest.php
+++ b/tests/Antlers/Runtime/ArraysTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Antlers\Runtime;
 
 use PHPUnit\Framework\Attributes\Test;
+use Tests\Antlers\Fixtures\MethodClasses\ArrayClass;
 use Tests\Antlers\ParserTestCase;
 
 class ArraysTest extends ParserTestCase
@@ -425,5 +426,23 @@ EOT;
     public function test_arrays_as_the_tag_name()
     {
         $this->assertSame('array', $this->renderString('{{ [1, 2, 3, 4] | type_of }}', [], true));
+    }
+
+    public function test_shorthand_arrays_inside_method_calls()
+    {
+        $this->assertSame('one two three', $this->renderString(
+            "{{ instance->join(['one', 'two', 'three']) }}", [
+                'instance' => new ArrayClass,
+            ]));
+
+        $this->assertSame('one two three', $this->renderString(
+            "{{ instance:join(['one', 'two', 'three']) }}", [
+                'instance' => new ArrayClass,
+            ]));
+
+        $this->assertSame('one two three', $this->renderString(
+            "{{ instance.join(['one', 'two', 'three']) }}", [
+                'instance' => new ArrayClass,
+            ]));
     }
 }


### PR DESCRIPTION
This PR resolves a parser error when using the shorthand array syntax within method calls at the beginning of an Antlers tag/block.

Before this change, the following would throw an error:

```antlers
{{ object:method(['some', 'args']) }}
```

This PR adjusts the `PathParser` allowing the syntax to work without resorting to the following workarounds:

```antlers
{{ ; object:method(['some', 'args']) }}
{{ object:method(arr('some', 'args')) }}
```