### PR TITLE
[5.x] Show path when searching assets

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -129,7 +129,7 @@
                                     <div class="flex items-center w-fit-content group">
                                         <asset-thumbnail :asset="asset" :square="true" class="w-8 h-8 rtl:ml-2 ltr:mr-2 cursor-pointer" @click.native.stop="$emit('edit-asset', asset)" />
                                         <label :for="checkboxId" class="cursor-pointer select-none group-hover:text-blue normal-nums" @click.stop="$emit('edit-asset', asset)">
-                                            {{ asset.basename }}
+                                            {{ searchQuery ? asset.path : asset.basename }}
                                         </label>
                                     </div>
                                 </template>

--- a/src/Http/Resources/CP/Assets/FolderAsset.php
+++ b/src/Http/Resources/CP/Assets/FolderAsset.php
@@ -13,6 +13,7 @@ class FolderAsset extends JsonResource
         return [
             'id' => $this->id(),
             'basename' => $this->basename(),
+            'path' => $this->path(),
             'extension' => $this->extension(),
             'url' => $this->absoluteUrl(),
             'size_formatted' => Str::fileSizeForHumans($this->size(), 0),


### PR DESCRIPTION
Previously, when searching for assets, you'd have to click into each asset to figure out where it lives. 

However, if you have lots of folders and assets with potentially similar filenames, this becomes a bit of an issue. This PR aims to fix that by showing the path of an asset during search.

Closes #1258.