### PR TITLE
[5.x] Prevent zeros being filtered out in Array fieldtype

### DIFF
--- a/src/Fieldtypes/Arr.php
+++ b/src/Fieldtypes/Arr.php
@@ -108,14 +108,14 @@ class Arr extends Fieldtype
 
         if ($this->config('expand')) {
             return collect($data)
-                ->when($this->isKeyed(), fn ($items) => $items->filter())
+                ->when($this->isKeyed(), fn ($items) => $items->reject(fn ($value) => is_null($value)))
                 ->map(fn ($value, $key) => ['key' => $key, 'value' => $value])
                 ->values()
                 ->all();
         }
 
         if ($this->isKeyed()) {
-            return collect($data)->filter()->all();
+            return collect($data)->reject(fn ($value) => is_null($value))->all();
         }
 
         return $data;


### PR DESCRIPTION
This pull request fixes an issue where "0" values were being filtered out when saving Array fields.

Fixes #12038.