### PR TITLE
[6.x] Elevated session updates

### DIFF
--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -53,6 +53,7 @@ class Impersonate extends Action
 
             $guard->login($users->first());
             session()->put('statamic_impersonated_by', $impersonator->getKey());
+            session()->forget('statamic_elevated_session');
             Toast::success(__('You are now impersonating').' '.$impersonated->name());
 
             ImpersonationStarted::dispatch($impersonator, $impersonated);

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -130,6 +130,8 @@ class UsersController extends CpController
         $this->authorizePro();
         $this->authorize('create', UserContract::class);
 
+        $this->requireElevatedSession();
+
         $blueprint = User::blueprint();
         $blueprint->ensureFieldHasConfig('email', ['validate' => 'required']);
 
@@ -224,6 +226,8 @@ class UsersController extends CpController
 
         $this->authorize('edit', $user);
 
+        $this->requireElevatedSession();
+
         $blueprint = $user->blueprint();
 
         if (! User::current()->can('assign roles')) {
@@ -281,6 +285,8 @@ class UsersController extends CpController
         throw_unless($user = User::find($user), new NotFoundHttpException);
 
         $this->authorize('edit', $user);
+
+        $this->requireElevatedSession();
 
         $fields = $user->blueprint()->fields()->except(['password'])->addValues($request->except('id'));
 

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -167,6 +167,8 @@ class UsersController extends CpController
         $this->authorizePro();
         $this->authorize('create', UserContract::class);
 
+        $this->requireElevatedSession();
+
         $blueprint = User::blueprint();
 
         $fields = $blueprint->fields()->except(['roles', 'groups'])->addValues($request->all());

--- a/tests/Actions/ImpersonateTest.php
+++ b/tests/Actions/ImpersonateTest.php
@@ -2,16 +2,17 @@
 
 namespace Tests\Actions;
 
-use Carbon\Carbon;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\User;
+use Tests\ElevatesSessions;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 #[Group('elevated-session')]
 class ImpersonateTest extends TestCase
 {
+    use ElevatesSessions;
     use PreventSavingStacheItemsToDisk;
 
     private function impersonate($user)
@@ -22,11 +23,6 @@ class ImpersonateTest extends TestCase
             'selections' => [$user->id()],
             'values' => [],
         ]);
-    }
-
-    private function withElevatedSession(?Carbon $time = null)
-    {
-        return $this->session(['statamic_elevated_session' => ($time ?? now())->timestamp]);
     }
 
     #[Test]

--- a/tests/Actions/ImpersonateTest.php
+++ b/tests/Actions/ImpersonateTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Actions;
+
+use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\User;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+#[Group('elevated-session')]
+class ImpersonateTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    private function impersonate($user)
+    {
+        return $this->post(cp_route('users.actions.run'), [
+            'action' => 'impersonate',
+            'context' => [],
+            'selections' => [$user->id()],
+            'values' => [],
+        ]);
+    }
+
+    private function withElevatedSession(?Carbon $time = null)
+    {
+        return $this->session(['statamic_elevated_session' => ($time ?? now())->timestamp]);
+    }
+
+    #[Test]
+    public function it_authenticates_as_another_user_and_clears_elevated_session()
+    {
+        $impersonator = tap(User::make()->email('admin@example.com')->makeSuper()->password('secret1'))->save();
+        $impersonated = tap(User::make()->email('user@example.com')->password('secret2'))->save();
+
+        $this->actingAs($impersonator)->withElevatedSession();
+
+        $this->assertEquals($impersonator->id(), auth()->id());
+        $this->assertTrue(request()->hasElevatedSession());
+
+        $this->impersonate($impersonated);
+
+        $this->assertEquals($impersonated->id(), auth()->id());
+        $this->assertFalse(request()->hasElevatedSession());
+    }
+}

--- a/tests/Auth/ElevatedSessionTest.php
+++ b/tests/Auth/ElevatedSessionTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Auth;
 
-use Carbon\Carbon;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
@@ -11,12 +10,14 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\User;
 use Statamic\Http\Middleware\CP\RequireElevatedSession;
 use Statamic\Notifications\ElevatedSessionVerificationCode;
+use Tests\ElevatesSessions;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 #[Group('elevated-session')]
 class ElevatedSessionTest extends TestCase
 {
+    use ElevatesSessions;
     use PreventSavingStacheItemsToDisk;
 
     private $user;
@@ -40,11 +41,6 @@ class ElevatedSessionTest extends TestCase
                 return 'ok';
             })->middleware(RequireElevatedSession::class);
         });
-    }
-
-    private function withElevatedSession(?Carbon $time = null)
-    {
-        return $this->session(['statamic_elevated_session' => ($time ?? now())->timestamp]);
     }
 
     #[Test]

--- a/tests/ElevatesSessions.php
+++ b/tests/ElevatesSessions.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests;
+
+use Carbon\Carbon;
+
+trait ElevatesSessions
+{
+    private function withElevatedSession(?Carbon $time = null)
+    {
+        return $this->session(['statamic_elevated_session' => ($time ?? now())->timestamp]);
+    }
+}

--- a/tests/ElevatesSessions.php
+++ b/tests/ElevatesSessions.php
@@ -3,11 +3,29 @@
 namespace Tests;
 
 use Carbon\Carbon;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Testing\TestResponse;
 
 trait ElevatesSessions
 {
-    private function withElevatedSession(?Carbon $time = null)
+    protected function actingAsWithElevatedSession(Authenticatable $user, ?Carbon $time = null)
+    {
+        return $this->actingAs($user)->withElevatedSession($time);
+    }
+
+    protected function withElevatedSession(?Carbon $time = null)
     {
         return $this->session(['statamic_elevated_session' => ($time ?? now())->timestamp]);
+    }
+
+    protected function addElevatedSessionMacros()
+    {
+        TestResponse::macro('assertRedirectToConfirmPasswordForElevatedSession', function () {
+            return $this->assertRedirect(route('statamic.cp.confirm-password'));
+        });
+
+        TestResponse::macro('assertElevatedSessionRequiredJsonResponse', function () {
+            return $this->assertJson(['message' => 'Requires an elevated session.'])->assertStatus(403);
+        });
     }
 }

--- a/tests/Feature/Users/CreateUserTest.php
+++ b/tests/Feature/Users/CreateUserTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Feature\Users;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\User;
+use Tests\ElevatesSessions;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+#[Group('elevated-session')]
+class CreateUserTest extends TestCase
+{
+    use ElevatesSessions;
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_shows_the_form()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'create users']]);
+        $me = tap(User::make()->email('admin@domain.com')->assignRole('test'))->save();
+
+        $this
+            ->actingAsWithElevatedSession($me)
+            ->get(route('statamic.cp.users.create'))
+            ->assertOk();
+    }
+
+    #[Test]
+    public function it_requires_an_elevated_session()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'create users']]);
+        $me = tap(User::make()->email('admin@domain.com')->assignRole('test'))->save();
+
+        $this
+            ->actingAs($me)
+            ->get(route('statamic.cp.users.create'))
+            ->assertRedirectToConfirmPasswordForElevatedSession();
+    }
+}

--- a/tests/Feature/Users/StoreUserTest.php
+++ b/tests/Feature/Users/StoreUserTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Feature\Users;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\User;
+use Tests\ElevatesSessions;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+#[Group('elevated-session')]
+class StoreUserTest extends TestCase
+{
+    use ElevatesSessions;
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    private function store($data = [])
+    {
+        return $this->postJson(route('statamic.cp.users.store'), array_merge([
+            'email' => 'test@domain.com',
+            'invitation' => ['send' => false],
+        ], $data));
+    }
+
+    #[Test]
+    public function it_creates_a_user()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'create users']]);
+        $me = tap(User::make()->email('admin@domain.com')->assignRole('test'))->save();
+
+        $this
+            ->actingAsWithElevatedSession($me)
+            ->store()
+            ->assertOk();
+    }
+
+    #[Test]
+    public function it_requires_an_elevated_session()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'create users']]);
+        $me = tap(User::make()->email('admin@domain.com')->assignRole('test'))->save();
+
+        $this
+            ->actingAs($me)
+            ->store()
+            ->assertElevatedSessionRequiredJsonResponse();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,6 +31,10 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             $this->preventSavingStacheItemsToDisk();
         }
 
+        if (isset($uses[ElevatesSessions::class])) {
+            $this->addElevatedSessionMacros();
+        }
+
         if ($this->shouldFakeVersion) {
             \Facades\Statamic\Version::shouldReceive('get')->zeroOrMoreTimes()->andReturn('3.0.0-testing');
             $this->addToAssertionCount(-1); // Dont want to assert this


### PR DESCRIPTION
- When impersonating another user, clear the elevated session state. This will force the user to elevate their session where necessary.
- Require an elevated session when editing users.
