### PR TITLE
[6.x] Ability to exclude searchable from `'searchables' => 'all'`

### DIFF
--- a/src/Search/ProvidesSearchables.php
+++ b/src/Search/ProvidesSearchables.php
@@ -18,4 +18,6 @@ interface ProvidesSearchables
     public function contains($searchable): bool;
 
     public function find(array $keys): Collection;
+
+    public function includedInAll(): bool;
 }

--- a/src/Search/Searchables.php
+++ b/src/Search/Searchables.php
@@ -30,7 +30,9 @@ class Searchables
         $providers = collect(Arr::wrap($this->index->config()['searchables'] ?? []));
 
         if ($providers->contains('all')) {
-            return $manager->providers()->map(fn ($_, $key) => $manager->make($key, $this->index, ['*']));
+            return $manager->providers()
+                ->filter->includedInAll()
+                ->map(fn ($_, $key) => $manager->make($key, $this->index, ['*']));
         }
 
         return $providers

--- a/src/Search/Searchables/Provider.php
+++ b/src/Search/Searchables/Provider.php
@@ -50,6 +50,11 @@ abstract class Provider implements ProvidesSearchables
         return $this;
     }
 
+    public function includedInAll(): bool
+    {
+        return true;
+    }
+
     protected function usesWildcard()
     {
         return in_array('*', $this->keys);

--- a/tests/Search/SearchablesTest.php
+++ b/tests/Search/SearchablesTest.php
@@ -100,6 +100,39 @@ class SearchablesTest extends TestCase
     }
 
     #[Test]
+    public function all_searchables_doesnt_include_searchable_where_included_in_all_is_false()
+    {
+        app(Providers::class)->register($entries = Mockery::mock(Entries::class)->makePartial());
+        app(Providers::class)->register($terms = Mockery::mock(Terms::class)->makePartial());
+        app(Providers::class)->register($assets = Mockery::mock(Assets::class)->makePartial());
+        app(Providers::class)->register($users = Mockery::mock(Users::class)->makePartial());
+
+        $entries->shouldReceive('provide')->andReturn(collect([$entryA = Entry::make(), $entryB = Entry::make()]));
+        $terms->shouldReceive('provide')->andReturn(collect([$termA = Term::make(), $termB = Term::make()]));
+        $assets->shouldReceive('provide')->andReturn(collect([$assetA = Asset::make(), $assetB = Asset::make()]));
+
+        $users->shouldReceive('includedInAll')->andReturn(false);
+        $users->shouldReceive('provide')->andReturn(collect([$userA = User::make(), $userB = User::make()]));
+
+        $searchables = $this->makeSearchables(['searchables' => 'all']);
+
+        $everythingApartFromUsers = [
+            $entryA,
+            $entryB,
+            $termA,
+            $termB,
+            $assetA,
+            $assetB,
+        ];
+
+        $items = $searchables->all();
+        $this->assertInstanceOf(Collection::class, $items);
+        $this->assertEquals($everythingApartFromUsers, $items->all());
+        $this->assertFalse($searchables->contains($userA));
+        $this->assertFalse($searchables->contains($userB));
+    }
+
+    #[Test]
     public function it_gets_searchables_from_specific_providers()
     {
         app(Providers::class)->register($entries = Mockery::mock(Entries::class)->makePartial());


### PR DESCRIPTION
This pull request allows searchables to opt-out of being included in search indexes with `'searchables' => 'all'`. 

They can opt-out by returning `false` from `includedInAll`:

```php
public function includedInAll(): bool
{
    return true;
}
```