### PR TITLE
[6.x] Fix windows test

### DIFF
--- a/tests/Composer/ComposerTest.php
+++ b/tests/Composer/ComposerTest.php
@@ -36,6 +36,13 @@ class ComposerTest extends TestCase
 
     public function tearDown(): void
     {
+        // If the test was skipped, avoid trying to clean up. The setUp would've never happened.
+        if (! $this->files) {
+            parent::tearDown();
+
+            return;
+        }
+
         $this->files->deleteDirectory($this->basePath('tmp'));
         $this->files->deleteDirectory($this->basePath('vendor'));
         $this->files->delete($this->basePath('composer.json'));


### PR DESCRIPTION
PHPUnit 11.5.32 started breaking a test because of [this commit](https://github.com/sebastianbergmann/phpunit/commit/9eb51ff0bb709b35716fe1131b2253281265e11f).

The tearDown was still being run which threw an exception. I think the exception was always happening, but it previously got ignored because the test was skipped.

This PR avoids the tear down if set up never ran.