### PR TITLE
[5.x] Fix windows test

### DIFF
--- a/tests/Composer/ComposerTest.php
+++ b/tests/Composer/ComposerTest.php
@@ -36,6 +36,13 @@ class ComposerTest extends TestCase
 
     public function tearDown(): void
     {
+        // If the test was skipped, avoid trying to clean up. The setUp would've never happened.
+        if (! $this->files) {
+            parent::tearDown();
+
+            return;
+        }
+
         $this->files->deleteDirectory($this->basePath('tmp'));
         $this->files->deleteDirectory($this->basePath('vendor'));
         $this->files->delete($this->basePath('composer.json'));


### PR DESCRIPTION
This pull request backports #12046 into 5.x, as Windows tests are [failing there as well](https://github.com/statamic/cms/actions/runs/16921780940/job/47949379499).