### PR TITLE
[6.x] Update `ueberdosis/tiptap-php` to `^2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/lock": "^7.0.3",
         "symfony/var-exporter": "^7.0.3",
         "symfony/yaml": "^7.0.3",
-        "ueberdosis/tiptap-php": "^1.4",
+        "ueberdosis/tiptap-php": "^2.0",
         "voku/portable-ascii": "^2.0.2",
         "wilderborn/partyline": "^1.0"
     },

--- a/src/Fieldtypes/Bard/LinkMark.php
+++ b/src/Fieldtypes/Bard/LinkMark.php
@@ -17,6 +17,10 @@ class LinkMark extends Link
                 'rel' => '',
                 'target' => '_blank',
             ],
+            'allowedProtocols' => [
+                'http', 'https', 'ftp', 'ftps', 'mailto', 'tel', 'callto', 'sms', 'cid', 'xmpp', 'statamic', 'entry', 'asset',
+            ],
+            'isAllowedUri' => fn ($uri) => $this->isAllowedUri($uri),
         ];
     }
 


### PR DESCRIPTION
This pull request updates `ueberdosis/tiptap-php` to `^2.0`. You can find [the changelog here](https://github.com/ueberdosis/tiptap-php/releases/tag/2.0.0).

The update only contains two breaking changes:

* Custom protocols (like our `statamic`, `entry` and `asset` ones) now need to be added to an allow list.
    * https://github.com/ueberdosis/tiptap-php/pull/70
* Removes some wrapper logic around lists and `<p>` tags
    * https://github.com/ueberdosis/tiptap-php/pull/71

Closes https://github.com/statamic/ideas/issues/1355.