### PR TITLE
[6.x] Fix error when building addon with multiple input files

### DIFF
--- a/resources/js/package/vite-plugin.js
+++ b/resources/js/package/vite-plugin.js
@@ -11,32 +11,43 @@ const statamic = function (options) {
             config.build.rollupOptions.external = config.build.rollupOptions.external || [];
             config.build.rollupOptions.output = config.build.rollupOptions.output || {};
 
-            // Add Vue and all Statamic modules as external
-            const existingExternal = config.build.rollupOptions.external;
-            config.build.rollupOptions.external = [
-                ...existingExternal,
-                'vue',
-                // Match @statamic/cms and any subpath
-                /^@statamic\/cms(\/.*)?$/,
-            ];
-
-            // Set up globals for browser usage
-            const existingGlobals = config.build.rollupOptions.output.globals || {};
-            config.build.rollupOptions.output.globals = {
-                ...existingGlobals,
-                'vue': 'Vue',
-                '@statamic/cms': '__STATAMIC__.core',
-                '@statamic/cms/ui': '__STATAMIC__.ui',
-                '@statamic/cms/bard': '__STATAMIC__.bard',
-                '@statamic/cms/save-pipeline': '__STATAMIC__.savePipeline',
-            };
-
-            // Set default format if not specified
-            if (!config.build.rollupOptions.output.format) {
-                config.build.rollupOptions.output.format = 'iife';
-            }
-
             return config;
+        },
+
+        configResolved(resolvedConfig) {
+            const inputs = resolvedConfig.build?.rollupOptions?.input;
+            const hasMultipleInputs = (Array.isArray(inputs) && inputs.length > 1) ||
+                (typeof inputs === 'object' && inputs !== null && !Array.isArray(inputs) && Object.keys(inputs).length > 1);
+
+            if (hasMultipleInputs) {
+                // For multiple inputs, just disable inlineDynamicImports
+                resolvedConfig.build.rollupOptions.output.inlineDynamicImports = false;
+            } else {
+                // Single input - set up as external modules for addon development
+                const existingExternal = resolvedConfig.build.rollupOptions.external;
+                resolvedConfig.build.rollupOptions.external = [
+                    ...existingExternal,
+                    'vue',
+                    // Match @statamic/cms and any subpath
+                    /^@statamic\/cms(\/.*)?$/,
+                ];
+
+                // Set up globals for browser usage
+                const existingGlobals = resolvedConfig.build.rollupOptions.output.globals || {};
+                resolvedConfig.build.rollupOptions.output.globals = {
+                    ...existingGlobals,
+                    'vue': 'Vue',
+                    '@statamic/cms': '__STATAMIC__.core',
+                    '@statamic/cms/ui': '__STATAMIC__.ui',
+                    '@statamic/cms/bard': '__STATAMIC__.bard',
+                    '@statamic/cms/save-pipeline': '__STATAMIC__.savePipeline',
+                };
+
+                // Set default format if not specified
+                if (!resolvedConfig.build.rollupOptions.output.format) {
+                    resolvedConfig.build.rollupOptions.output.format = 'iife';
+                }
+            }
         }
     };
 };


### PR DESCRIPTION
Right now, when an addon has multiple input files (eg. JS & CSS), you get an error when running `vite build`:

```js
export default defineConfig({
    plugins: [
        statamic(),
        laravel({
            hotFile: 'resources/dist/hot',
            publicDirectory: 'resources/dist',
            input: ['resources/js/cp.js', 'resources/css/cp.css'],
        }),
    ],
});
```

```
Invalid value for option "output.inlineDynamicImports" - multiple inputs are not supported when "output.inlineDynamicImports" is true.
```

### The Issue

It looks like Vite automatically enables `inlineDynamicImports` in certain build scenarios, but this conflicts with multiple entry points.

The problem is logical: with multiple inputs, Rollup (Vite's bundler) needs to create multiple output files, but `inlineDynamicImports` tries to inline everything into a single bundler. Rollup can't decide which output file should contain the inlined imports.

### The Fix

To address this, I've updated our Vite plugin to detect multiple inputs and handle them appropriately:

- Multiple inputs: Disable `inlineDynamicImports` to allow code-splitting and let the build system handle the rest naturally.
- Single input: Keep existing behaviour with externalized Statamic modules and IIFE format

The detection runs in the `configResolved` hook after all plugins have processed their configs, ensuring we catch inputs from the Laravel plugin correctly.

---

Related: #12049