### PR TITLE
[6.x] Adjust tabindex ordering on CP auth login view

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -46,15 +46,15 @@
                                     tabindex="2"
                                 />
                                 <template #actions>
-                                    <a href="{{ cp_route('password.request') }}" class="text-blue-400 text-sm hover:text-blue-600" tabindex="3">
+                                    <a href="{{ cp_route('password.request') }}" class="text-blue-400 text-sm hover:text-blue-600" tabindex="5">
                                         {{ __('Forgot password?') }}
                                     </a>
                                 </template>
                             </ui-field>
 
-                            <ui-checkbox-item name="remember" :label="__('Remember me')" />
+                            <ui-checkbox-item name="remember" :label="__('Remember me')" tabindex="4" />
 
-                            <ui-button type="submit" variant="primary" :disabled="busy" :text="__('Continue')" />
+                            <ui-button type="submit" variant="primary" :disabled="busy" :text="__('Continue')" tabindex="5" />
 
                         </form>
                     @endif


### PR DESCRIPTION
This is a slightly controversial one as there's multiple viewpoints here... but from a priority point of view, I believe this is an enhancement to make keyboard access more streamlined.

The tabindex on the login view for the CP is currently confusing with its priority of options. For a user using the keyboard, they'll have:
1. Email address
2. Password
3. Password reset link
4. Remember me
5. Submit

The issue with this tabindex is that one may assume the priority here is logging in, and that will be the email, password, remember me and submit. 

If someone has forgotten their password, they'll be more actively looking for the reset password link - and one could argue that that is a lower priority than the other elements, so making it last is a valid way to approach this.

This PR proposes:
1. Email address
2. Password
3. Remember me
4. Submit
5. Password reset link

This is the controversial point: keeping it better tied to the password field makes logical sense too - but then requires an extra tab to key to "remember me".

I appreciate there are pros and cons to each way of doing things - but thought this could help improve the keyboard experience to stay focused on logging in first, then helping withe password reset.

For improved focusing, #12057 was added to focus on the actual checkbox, and not the block element itself.