### PR TITLE
[6.x] Change the primary button color from black to the defined primary color

### DIFF
--- a/resources/css/ui.css
+++ b/resources/css/ui.css
@@ -1,5 +1,5 @@
 @theme inline {
-    --color-primary: var(--color-zinc-800);
+    --color-primary: var(--color-blue-600);
     --color-primary-border: color-mix(in oklch, var(--color-primary) 100%, black 20%);
     --color-primary-hover: color-mix(in oklch, var(--color-primary) 100%, black 30%);
     --color-primary-gap: color-mix(in oklch, var(--color-primary) 100%, black 50%);

--- a/resources/js/components/ui/Button/Button.vue
+++ b/resources/js/components/ui/Button/Button.vue
@@ -35,7 +35,7 @@ const buttonClasses = computed(() => {
                 ],
                 primary: [
                     'bg-linear-to-b from-primary/90 to-primary hover:bg-primary-hover text-white border border-primary-border shadow-ui-md inset-shadow-2xs inset-shadow-white/25 [&_svg]:text-gray-400',
-                    'dark:from-gray-700 dark:to-gray-800 dark:hover:from-gray-600 dark:text-white dark:[&_svg]:text-white/50',
+                    'dark:[&_svg]:text-white/50',
                 ],
                 danger: 'bg-linear-to-b from-red-500/90 to-red-500 hover:bg-red-500/90 text-white border border-red-600 inset-shadow-2xs inset-shadow-red-300 [&_svg]:text-red-200 disabled:text-red-200',
                 filled: 'bg-gray-100 hover:bg-gray-200 hover:text-gray-900 dark:hover:text-white dark:bg-gray-700/80 dark:hover:bg-gray-700 [&_svg]:text-gray-700 dark:[&_svg]:text-gray-300',


### PR DESCRIPTION
Related to #12071. We'd discussed this internally before and it was probably on the cards anyway.
This also removes the hard-coded dark mode classes in favor of the primary color.