### PR TITLE
[6.x] Update Duplicate IDs page

### DIFF
--- a/resources/views/duplicates.blade.php
+++ b/resources/views/duplicates.blade.php
@@ -6,40 +6,36 @@
 @section('title', __('Duplicate IDs'))
 
 @section('content')
-
-<header class="mb-6">
-    <div class="flex items-center justify-between">
-        <h1>{{ __('Duplicate IDs') }}</h1>
-    </div>
-</header>
+<ui-header icon="duplicate" :title="__('Duplicate IDs')"></ui-header>
 
 @if ($duplicates->isEmpty())
-    <div class="card flex items-center">
-        {{ __('No items with duplicate IDs.') }}
-    </div>
+    <div
+        class="rounded-lg border border-dashed border-gray-300 p-6 text-center text-gray-500"
+        v-text="__('No items with duplicate IDs.')"
+    />
 @endif
 
 @foreach ($duplicates as $id => $paths)
-    <h6 class="mt-8">{{ $id }}</h6>
-
-    <div class="card mt-2 p-0">
-        <table class="data-table">
-            @foreach ($paths as $path)
-                <tr>
-                    <td class="font-mono text-xs">
-                        {{ $path }}
-                    </td>
-                    <td class="text-2xs ltr:text-right rtl:text-left">
-                        <form method="POST" action="{{ cp_route('duplicates.regenerate') }}">
-                            @csrf
-                            <input type="hidden" name="path" value="{{ $path }}" />
-                            <button class="text-blue">{{ __('Regenerate') }}</button>
-                        </form>
-                    </td>
-                </tr>
-            @endforeach
-        </table>
-    </div>
+    <ui-panel heading="{{ $id }}">
+        <ui-card class="py-0!">
+            <ui-table>
+                @foreach ($paths as $path)
+                    <ui-table-row>
+                        <ui-table-cell class="font-mono">
+                            {{ $path }}
+                        </ui-table-cell>
+                        <ui-table-cell class="flex items-center justify-end">
+                            <form method="POST" action="{{ cp_route('duplicates.regenerate') }}">
+                                @csrf
+                                <input type="hidden" name="path" value="{{ $path }}" />
+                                <ui-button size="sm">{{ __('Regenerate') }}</ui-button>
+                            </form>
+                        </ui-table-cell>
+                    </ui-table-row>
+                @endforeach
+            </ui-table>
+        </ui-card>
+    </ui-panel>
 @endforeach
 
 @stop

--- a/resources/views/nav/duplicates.blade.php
+++ b/resources/views/nav/duplicates.blade.php
@@ -2,8 +2,8 @@
     <a href="{{ $item->url() }}" class="flex items-center gap-3 {{ $item->isActive() ? 'active' : '' }}">
         <i>{!! $item->svg() !!}</i>
         <span>{{ __($item->name()) }}</span>
-        <span class="badge-sm bg-red-500 dark:bg-blue-900">
+        <ui-badge color="red" size="sm" variant="flat" pill>
             {{ Statamic\Facades\Stache::duplicates()->count() }}
-        </span>
+        </ui-badge>
     </a>
 </li>

--- a/src/CP/Navigation/CoreNav.php
+++ b/src/CP/Navigation/CoreNav.php
@@ -273,7 +273,7 @@ class CoreNav
         if (Stache::duplicates()->isNotEmpty()) {
             Nav::tools('Duplicate IDs')
                 ->route('duplicates')
-                ->icon('duplicate-ids')
+                ->icon('duplicate')
                 ->view('statamic::nav.duplicates')
                 ->can('resolve duplicate ids');
         }


### PR DESCRIPTION
This pull request updates the Duplicate IDs page to the new design:

<img width="1013" height="301" alt="CleanShot 2025-08-22 at 12 32 54" src="https://github.com/user-attachments/assets/957a32b0-3cdb-4d6f-b352-ddf29607e26b" />

It also adds an icon to the nav item and updates the badge to match the new design. However, this has caused the text to wrap, which we probably don't want.

<img width="185" height="236" alt="CleanShot 2025-08-22 at 12 33 09" src="https://github.com/user-attachments/assets/bca8eaf6-1cd9-42be-8c01-3c5b539b69f4" />

Fixes #12076