### PR TITLE
[6.x] Fix destructive buttons

### DIFF
--- a/resources/js/components/collections/DeleteEntryConfirmation.vue
+++ b/resources/js/components/collections/DeleteEntryConfirmation.vue
@@ -24,7 +24,7 @@ const shouldDeleteChildren = ref(false);
                     <Button variant="ghost" :text="__('Cancel')" />
                 </ModalClose>
                 <Button
-                    variant="primary"
+                    variant="danger"
                     :text="__('Delete')"
                     @click="$emit('confirm', shouldDeleteChildren)"
                 />

--- a/resources/js/components/collections/DeleteLocalizationConfirmation.vue
+++ b/resources/js/components/collections/DeleteLocalizationConfirmation.vue
@@ -13,7 +13,7 @@
                     :name="name"
                     @click="behavior = 'delete'"
                     value="delete"
-                    :variant="behavior === 'delete' ? 'primary' : 'default'"
+                    :variant="behavior === 'delete' ? 'danger' : 'default'"
                     :text="__('Delete')"
                 />
 
@@ -35,7 +35,7 @@
                     @click="$emit('cancel')"
                     :text="__('Cancel')"
                 />
-                <Button variant="primary" @click="confirm" :text="__('Confirm')" />
+                <Button variant="danger" @click="confirm" :text="__('Confirm')" />
             </div>
         </template>
     </Modal>


### PR DESCRIPTION
Some delete buttons were using primary buttons when they should be using danger buttons. Related to #12071

For example, go to `/cp/collections/pages/` and enable the tree view by setting the Max Depth to 2 in `/cp/collections/pages/edit`, then go back and delete a page from the tree view. Previous to this pull request the "delete" button would be in a primary color rather than danger/red.