### PR TITLE
[6.x] Fix missing logo on auth pages

### DIFF
--- a/resources/views/components/outside-logo.blade.php
+++ b/resources/views/components/outside-logo.blade.php
@@ -1,5 +1,5 @@
 <div class="logo relative z-10 md:pt-18">
-    @if (isset($customLogo))
+    @if (isset($customLogo) && $customLogo !== false)
         <img
             src="{{ $customLogo }}"
             alt="{{ config('statamic.cp.custom_cms_name') }}"
@@ -10,7 +10,7 @@
             alt="{{ config('statamic.cp.custom_cms_name') }}"
             class="white-label-logo hidden dark:block"
         />
-    @elseif (isset($customLogoText))
+    @elseif (isset($customLogoText) && ! empty($customLogoText))
         <div class="mx-auto mb-8 max-w-xs text-center text-lg font-medium opacity-50">{{ $customLogoText }}</div>
     @else
         @cp_svg('ui/statamic-logo-lime', 'h-6')

--- a/src/View/Components/OutsideLogo.php
+++ b/src/View/Components/OutsideLogo.php
@@ -24,9 +24,11 @@ class OutsideLogo extends Component
         }
 
         $config = config('statamic.cp.custom_logo_url');
+
         if ($dark && config('statamic.cp.custom_dark_logo_url')) {
             $config = config('statamic.cp.custom_dark_logo_url');
         }
+
         if ($text && config('statamic.cp.custom_logo_text')) {
             $config = config('statamic.cp.custom_logo_text');
         }


### PR DESCRIPTION
This pull request fixes an issue on auth pages where the logo might appear missing if `$customLogo` or `$customLogoText` is `false`, as opposed to `null`. 

I wasn't able to reproduce it locally myself, but someone else was. Even though we were both testing on a fresh Statamic site.

When I run (new \Statamic\View\Components\OutsideLogo)->render()->getData()` in `php artisan tinker`, I get an array of nulls:

<img width="558" height="254" alt="CleanShot 2025-08-22 at 12 46 56" src="https://github.com/user-attachments/assets/2be1cd11-1e8d-47c3-b0bc-f05391f2c04a" />

However, when someone on Discord ran it, they got an array of `false` values:

<img width="942" height="202" alt="image" src="https://github.com/user-attachments/assets/41b39341-a7b6-400a-80d8-6b9db95e7e51" />

I'm not entirely sure how its `false` for them, but `null` for me, but this PR should handle both cases.