### PR TITLE
[6.x] Fix infinite loop on collection index

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -61,25 +61,36 @@
                 </ui-panel-header>
 
                 <ui-card class="h-40">
-                    <ui-listing :items="collection.entries" :columns="collection.columns">
-                        <table class="w-full [&_td]:p-0.5 [&_td]:text-sm">
-                            <ui-listing-table-head sr-only />
-                            <ui-listing-table-body>
-                                <template #cell-title="{ row: entry }" class="w-full">
-                                    <div class="flex items-center gap-2">
-                                        <StatusIndicator :status="entry.status" />
-                                        <a :href="entry.edit_url" class="line-clamp-1 overflow-hidden text-ellipsis" :text="entry.title" />
-                                    </div>
-                                </template>
-                                <template #cell-date="{ row: entry }" v-if="collection.dated">
-                                    <div class="text-end font-mono text-xs text-gray-500 ps-6">
-                                        <date-time :of="entry.date" date-only />
-                                    </div>
-                                </template>
-                            </ui-listing-table-body>
-                        </table>
+                    <ui-listing :url="collection.entries_listing_url" :per-page="5" :columns="collection.columns">
+                        <template #initializing>
+                            <div class="flex flex-col gap-[6px] justify-between p-0.5">
+                                <ui-skeleton class="h-[19px] w-full" />
+                                <ui-skeleton class="h-[19px] w-full" />
+                                <ui-skeleton class="h-[19px] w-full" />
+                                <ui-skeleton class="h-[19px] w-full" />
+                                <ui-skeleton class="h-[19px] w-full" />
+                            </div>
+                        </template>
+                        <template #default="{ items }">
+                            <table v-if="items.length" class="w-full [&_td]:p-0.5 [&_td]:text-sm">
+                                <ui-listing-table-head sr-only />
+                                <ui-listing-table-body>
+                                    <template #cell-title="{ row: entry }" class="w-full">
+                                        <div class="flex items-center gap-2">
+                                            <StatusIndicator :status="entry.status" />
+                                            <a :href="entry.edit_url" class="line-clamp-1 overflow-hidden text-ellipsis" :text="entry.title" />
+                                        </div>
+                                    </template>
+                                    <template #cell-date="{ row: entry }" v-if="collection.dated">
+                                        <div class="text-end font-mono text-xs text-gray-500 ps-6">
+                                            <date-time :of="entry.date.date" date-only />
+                                        </div>
+                                    </template>
+                                </ui-listing-table-body>
+                            </table>
+                            <ui-subheading v-else class="text-center h-full flex items-center justify-center">{{ __('Nothing to see here, yet.') }}</ui-subheading>
+                        </template>
                     </ui-listing>
-                    <ui-subheading v-if="collection.entries.length === 0" class="text-center h-full flex items-center justify-center">{{ __('Nothing to see here, yet.') }}</ui-subheading>
                 </ui-card>
 
                 <ui-panel-footer class="flex items-center gap-6 text-sm text-gray-600">

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -15,6 +15,7 @@ use Statamic\Facades\Scope;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Http\Resources\CP\Entries\ListedEntry;
 use Statamic\Rules\Handle;
 use Statamic\Statamic;
 use Statamic\Structures\CollectionStructure;
@@ -59,7 +60,6 @@ class CollectionsController extends CpController
             return [
                 'id' => $collection->handle(),
                 'title' => $collection->title(),
-                'entries' => $collection->queryEntries()->where('site', Site::selected())->orderBy('date', 'desc')->limit(5)->get(),
                 'entries_count' => $collection->queryEntries()->where('site', Site::selected())->count(),
                 'published_entries_count' => $collection->queryEntries()->where('site', Site::selected())->where('status', 'published')->count(),
                 'draft_entries_count' => $collection->queryEntries()->where('site', Site::selected())->where('status', 'draft')->count(),
@@ -73,6 +73,7 @@ class CollectionsController extends CpController
                 'edit_url' => $collection->editUrl(),
                 'delete_url' => $collection->deleteUrl(),
                 'entries_url' => cp_route('collections.show', $collection->handle()),
+                'entries_listing_url' => cp_route('collections.entries.index', $collection->handle()),
                 'create_entry_url' => $collection->createEntryUrl(Site::selected()),
                 'url' => $collection->absoluteUrl(Site::selected()->handle()),
                 'blueprints_url' => cp_route('blueprints.collections.index', $collection->handle()),


### PR DESCRIPTION
This PR fixes an issue on some sites when accessing the collection index would trigger an infinite loop.

This was happening because we were passing `Entry` instances to the view, which then needed to serialize them to JSON for the Vue component. 

However, in doing that, it meant that the `Entry` instance would be augmented, which would cause related entries to be augmented and go around and around in circles.

To fix this, entries are now being loaded from the listing endpoint, rather than a prop.