### PR TITLE
[6.x] The sidebar width should be just wide enough to accommodate badges without wrapping

### DIFF
--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -5,7 +5,7 @@
     @apply flex flex-col gap-6 py-6 px-3 text-sm antialiased select-none;
     /* Same as the main element, accounting for the header with a class of h-14, which is the same as 3.5rem */
     @apply h-[calc(100vh-3.5rem)];
-    @apply overflow-y-auto fixed top-14 left-0 w-46;
+    @apply overflow-y-auto fixed top-14 left-0 w-48;
     @apply [&_svg]:text-gray-500 dark:[&_svg]:text-gray-500/85;
     /* Only inset because we don't wand to transition the color when we switch between light/dark mode */
     transition: inset 0.3s ease-in-out;


### PR DESCRIPTION
Related to #12084

The sidebar width should be wide enough to accommodate badges without wrapping. This change accommodates duplicate IDs appearing with double digits

This is what happens currently:

![2025-08-22 at 18 01 50@2x](https://github.com/user-attachments/assets/c1ef7180-770b-4bc5-afd6-87611057b473)

I can think of 3 different solutions for this wrapping problem…

1. Change it to `flex-wrap: wrap;`, as below, (which I'm pretty sure we don't want)
![2025-08-22 at 16 47 59@2x](https://github.com/user-attachments/assets/eb6d8841-4e5f-4088-a9c4-97a8b368b371)
2. Make the flex gap very slightly smaller
3. Make the width of the sidebar very slightly wider—literally going from `w-46` to `w-48` to account for a badge with double digits

I think (3) makes the most sense, since Duplicate IDs with a badge is the longest sidebar item we have, so that should see us through.

This is the sidebar with solution 3
![2025-08-22 at 18 03 14@2x](https://github.com/user-attachments/assets/3af7654a-dffc-468e-a390-75968ac2fa40)
