### PR TITLE
[6.x] Fix the assets toolbar-padding

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -97,7 +97,7 @@
                         />
 
                         <Panel v-else :class="{ 'relative overflow-x-auto overscroll-x-contain': mode === 'table' }">
-                            <PanelHeader class="flex items-center justify-between p-1!">
+                            <PanelHeader class="flex items-center justify-between px-1!">
                                 <Breadcrumbs
                                     v-if="!restrictFolderNavigation"
                                     :path="path"


### PR DESCRIPTION
Don't inadvertently affect the vertical padding now that we've correctly aligned buttons in PanelHeaders and make the headers the same height whether buttons are present or not