### PR TITLE
[6.x] Modal: Fix open state not being emitted to parent component

### DIFF
--- a/resources/js/components/ui/Modal/Modal.vue
+++ b/resources/js/components/ui/Modal/Modal.vue
@@ -2,7 +2,7 @@
 import { cva } from 'cva';
 import { hasComponent } from '@/composables/has-component.js';
 import { DialogContent, DialogOverlay, DialogPortal, DialogRoot, DialogTitle, DialogTrigger } from 'reka-ui';
-import { getCurrentInstance, ref, watch } from 'vue';
+import { computed, getCurrentInstance, ref, watch } from 'vue';
 
 const emit = defineEmits(['update:open']);
 
@@ -28,7 +28,7 @@ const modalClasses = cva({
 })({});
 
 const instance = getCurrentInstance();
-const isUsingOpenProp = instance && instance.vnode.props?.length > 0 && 'open' in instance.vnode.props;
+const isUsingOpenProp = computed(() => instance && instance.vnode.props?.length > 0 && 'open' in instance.vnode.props);
 
 const open = ref(props.open);
 


### PR DESCRIPTION
This pull request fixes an issue where a modal's open state wouldn't be correctly emitted to the parent component, causing differences in state between the Modal's `open` prop and the `open` prop on the Reka dialog.

I noticed this with the "Customize Columns" modal on listings. If you open it, close it and try to open it again, it won't re-open.