### PR TITLE
[6.x] Selecting an asset when `max_files: 1` should close the stack

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -28,6 +28,7 @@
                     :preferences-prefix="preferencesPrefix"
                     v-model:search-query="searchQuery"
                     @request-completed="listingRequestCompleted"
+                    @update:selections="$emit('selections-updated', $event)"
                 >
                     <template #initializing>
                         <slot name="initializing">

--- a/resources/js/components/assets/Selector.vue
+++ b/resources/js/components/assets/Selector.vue
@@ -138,9 +138,12 @@ export default {
     },
 
     watch: {
-        browserSelections(selections) {
-            if (this.maxFiles === 1 && selections.length === 1) {
-                this.select();
+        browserSelections: {
+            deep: true,
+            handler: function (selections) {
+                if (this.maxFiles === 1 && selections.length === 1) {
+                    this.select();
+                }
             }
         },
     },


### PR DESCRIPTION
This pull request fixes an issue where the asset selector stack wouldn't close after selecting an asset when `max_files: 1`.

The watcher needs to be a deep watcher and the selections state from the `Listing` component wasn't updating the state in the `Selector` so I've added an event listener there.

Fixes #12109