### PR TITLE
[6.x] Fix "Create" button in relationship fieldtypes

### DIFF
--- a/resources/js/components/inputs/relationship/CreateButton.vue
+++ b/resources/js/components/inputs/relationship/CreateButton.vue
@@ -1,12 +1,18 @@
 <template>
     <div>
-        <ui-dropdown :disabled="creatables.length === 1">
+        <ui-button
+            v-if="creatables.length === 1"
+            :icon="icon"
+            :text="text"
+            variant="filled"
+            @click="create"
+        />
+        <ui-dropdown v-else>
             <template #trigger>
                 <ui-button
                     :icon="icon"
                     :text="text"
                     variant="filled"
-                    @click="create"
                 />
             </template>
             <ui-dropdown-menu>


### PR DESCRIPTION
This pull request fixes various issues with the "Create" button in relationship fieldtypes:

* The dropdown was showing when there was only one creatable.
* When there's multiple creatables, the stack would open at the same time as the dropdown

Fixes #12103