### PR TITLE
[6.x] Fix carbon deprecation warning

### DIFF
--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Stache\Stores;
 
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
 use Statamic\Entries\GetDateFromPath;
 use Statamic\Entries\GetSlugFromPath;
 use Statamic\Entries\GetSuffixFromPath;


### PR DESCRIPTION
Prevents these Carbon deprecation warnings from being logged.

```
createFromFormat() $time parameter will only accept string or integer for 1-letter format representing a numeric unit in the next version in /path/to/vendor/nesbot/carbon/src/Carbon/Traits/Creator.php on line 653
```

Dates were being stored in the Stache as `Carbon\Carbon` instances. The following condition was supposed to catch them and return early but didn't because they expected `Illuminate\Support\Carbon` instances. Then they'd make it to `Carbon::createFromFormat()` which caused the error.

https://github.com/statamic/cms/blob/32dc12dd05168b8d79bb00bcc53075a5ad0ac68d/src/Fieldtypes/Date.php#L349-L354
