### PR TITLE
[6.x] Fix dist-package tar location

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: cd resources && tar -czvf dist-frontend.tar.gz dist-frontend
 
       - name: Create dist-package zip
-        run: cd resources && tar -czvf dist-package.tar.gz js/package
+        run: cd resources && tar -czvf dist-package.tar.gz -C js/package .
 
       - name: Get Changelog
         id: changelog


### PR DESCRIPTION
The tar included the package directory. This PR prevents the nesting.

```diff
-vendor/statamic/cms/resources/dist-package/index.js
+vendor/statamic/cms/resources/dist-package/package/index.js
```