### PR TITLE
[6.x] Correctly translate instructions for a ui-field

### DIFF
--- a/resources/js/components/ui/Field.vue
+++ b/resources/js/components/ui/Field.vue
@@ -53,7 +53,7 @@ const classes = computed(() =>
     })({ ...props }),
 );
 
-const instructions = computed(() => props.instructions ? markdown(props.instructions, { openLinksInNewTabs: true }) : null);
+const instructions = computed(() => props.instructions ? markdown(__(props.instructions), { openLinksInNewTabs: true }) : null);
 const wrapperComponent = computed(() => props.as === 'card' ? Card : 'div');
 </script>
 


### PR DESCRIPTION
Fields are not currently being translated. 

In the `Publish/Field.vue`, the display is correctly enclosed with `__(config.display)` to translate the display label.

For instructions, this was missing.

This became an issue when using localisation strings in a package: they would not be translated, and would fallback to the localisation key being used. 

This PR translates the instructions before being passed to through `markdown`.