### PR TITLE
[6.x] Combobox: Hide chevron icon unless there are options to pick from

### DIFF
--- a/resources/js/components/ui/Combobox.vue
+++ b/resources/js/components/ui/Combobox.vue
@@ -320,8 +320,8 @@ defineExpose({
                         </button>
 
                         <div class="flex gap-1.5 items-center ms-1">
-                            <Button icon="x" variant="ghost" size="xs" round v-if="clearable && modelValue" @click="clear" />
-                            <Icon name="ui/chevron-down" />
+                            <Button v-if="clearable && modelValue" icon="x" variant="ghost" size="xs" round @click="clear" />
+                            <Icon v-if="options.length || ignoreFilter" name="ui/chevron-down" />
                         </div>
                     </ComboboxTrigger>
                 </ComboboxAnchor>


### PR DESCRIPTION
Currently, the chevron icon is shown even when the dropdown isn't used (eg. in the case of the Taggable fieldtype where all options are added via the input).

This PR adds a condition to the icon so its only shown when there are actually options.