### PR TITLE
[6.x] Fix bard toolbar style regression

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -73,6 +73,7 @@
                                 :bard="this"
                                 :config="config"
                                 :editor="editor"
+                                variant="floating"
                             />
                         </div>
                         </bubble-menu>

--- a/resources/js/components/fieldtypes/bard/ToolbarButton.vue
+++ b/resources/js/components/fieldtypes/bard/ToolbarButton.vue
@@ -1,13 +1,14 @@
 <template>
     <Button
-        class="px-2! group"
-        variant="subtle"
+        class="px-2!"
+        :class="{ active, group: variant === 'floating' }"
+        :variant="variant === 'floating' ? 'subtle' : 'ghost'"
         size="sm"
         :aria-label="button.text"
         v-tooltip="button.text"
         @click="button.command(editor, button.args)"
     >
-        <ui-icon :name="button.svg" v-if="button.svg" class="size-3.5! group-hover:text-white" :class="{ 'text-yellow-300!': active }" />
+        <ui-icon :name="button.svg" v-if="button.svg" class="size-3.5! " :class="{ 'group-hover:text-white text-yellow-300!': active && variant === 'floating' }" />
         <div class="flex items-center" v-html="button.html" v-if="button.html" />
     </Button>
 </template>
@@ -22,6 +23,7 @@ export default {
     props: {
         button: Object,
         active: Boolean,
+        variant: String,
         config: Object,
         bard: {},
         editor: {},


### PR DESCRIPTION
Fix a style regression with the regular toolbar introduced in PR #12121.

<img width="347" height="144" alt="Bildschirmfoto 2025-08-24 um 19 32 49" src="https://github.com/user-attachments/assets/5e78c423-2e87-4c6b-aa22-d4380451544f" />