### PR TITLE
[6.x] Fix alignment of tab name & chevron in blueprint builder

### DIFF
--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -1,5 +1,5 @@
 <template>
-    <TabTrigger :name="tab._id" class="blueprint-tab">
+    <TabTrigger :name="tab._id" class="blueprint-tab flex items-center">
         <Icon
             v-if="tab.icon"
             :name="iconName(tab.icon)"

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -4,7 +4,7 @@
             <Tabs v-model="currentTab" :unmount-on-hide="false">
                 <div v-if="!singleTab && tabs.length > 0" class="flex items-center justify-between gap-x-2 mb-6">
                     <TabList class="flex-1">
-                        <div ref="tabs" class="flex-1">
+                        <div ref="tabs" class="flex-1 flex items-center">
                             <BlueprintTab
                                 ref="tab"
                                 v-for="tab in tabs"


### PR DESCRIPTION
Fixes #12139

## Before

<img width="188" height="71" alt="CleanShot 2025-08-25 at 11 53 49" src="https://github.com/user-attachments/assets/476a294b-6239-4525-89ed-47e7f9974f9d" />


## After

<img width="188" height="71" alt="CleanShot 2025-08-25 at 11 53 39" src="https://github.com/user-attachments/assets/d022c9ee-aa2a-4235-a630-eb893518ba50" />
