### PR TITLE
[6.x] Fix error when publishing localization

### DIFF
--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -232,6 +232,7 @@ defineExpose({
     values,
     saving,
     saved,
+    dirty,
     revealerFields,
     setFieldValue,
     clearDirtyState,


### PR DESCRIPTION
This pull request fixes an error when publishing a localization. Fixes #12153.

Currently, when you localize an entry and attempt to publish it, a console error will be thrown, due to the fact we're calling the publish container's `dirty` method without it being exposed.

```
chunk-OSCZLWFV.js?v=0b52453d:2642 Uncaught TypeError: this.$refs.container?.dirty is not a function
    at Proxy.desyncField (PublishForm.vue:808:35)
    at Proxy.setFieldValue (PublishForm.vue:785:38)
    at _createVNode.onUpdate:modelValue._cache.<computed>._cache.<computed> (PublishForm.vue:127:58)
    at callWithErrorHandling (chunk-OSCZLWFV.js?v=0b52453d:2573:19)
    at callWithAsyncErrorHandling (chunk-OSCZLWFV.js?v=0b52453d:2580:17)
    at emit (chunk-OSCZLWFV.js?v=0b52453d:8834:5)
    at _createBlock.onUpdate:modelValue._cache.<computed>._cache.<computed> (Switch.vue:57:30)
```

https://github.com/statamic/cms/blob/21b269fdcf7cf38e0f7861ee3ff0d34e2fccda3b/resources/js/components/entries/PublishForm.vue#L805-L809