### PR TITLE
[6.x] Fix combobox dropdown not showing in modals

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -229,11 +229,9 @@
             @confirm="createLocalization(localizing)"
         >
             <div class="publish-fields">
-                <div class="form-group publish-field field-w-full">
-                    <label v-text="__('Origin')" />
-                    <ui-description class="mt-2" :text="__('messages.entry_origin_instructions')" />
+                <ui-field class="form-group field-w-100" :label="__('Origin')" :instructions="__('messages.entry_origin_instructions')">
                     <Select class="w-full" v-model="selectedOrigin" :options="originOptions" placeholder="" />
-                </div>
+                </ui-field>
             </div>
         </confirmation-modal>
 

--- a/resources/js/components/ui/Combobox.vue
+++ b/resources/js/components/ui/Combobox.vue
@@ -10,6 +10,7 @@ import {
     ComboboxTrigger,
     ComboboxPortal,
     ComboboxViewport,
+    FocusScope,
 } from 'reka-ui';
 import { computed, nextTick, onMounted, ref, useAttrs, useSlots, useTemplateRef, watch } from 'vue';
 import { Button, Icon, Badge } from '@/components/ui';
@@ -336,33 +337,35 @@ defineExpose({
                         ]"
                         @escape-key-down="nextTick(() => $refs.trigger.$el.focus())"
                     >
-                        <ComboboxViewport>
-                            <ComboboxEmpty class="py-2 text-sm">
-                                <slot name="no-options" v-bind="{ searchQuery }">
-                                    {{ __('No options available.') }}
-                                </slot>
-                            </ComboboxEmpty>
+                        <FocusScope asChild trapped>
+                            <ComboboxViewport>
+                                <ComboboxEmpty class="py-2 text-sm">
+                                    <slot name="no-options" v-bind="{ searchQuery }">
+                                        {{ __('No options available.') }}
+                                    </slot>
+                                </ComboboxEmpty>
 
-                            <ComboboxItem
-                                v-if="filteredOptions"
-                                v-for="(option, index) in filteredOptions"
-                                :key="index"
-                                :value="getOptionValue(option)"
-                                :text-value="getOptionLabel(option)"
-                                :class="itemClasses({ size: size, selected: isSelected(option) })"
-                                as="button"
-                                @select="() => {
-                                    dropdownOpen = !closeOnSelect;
-                                    if (closeOnSelect) $refs.trigger.$el.focus();
-                                }"
-                            >
-                                <slot name="option" v-bind="option">
-                                    <img v-if="option.image" :src="option.image" class="size-5 rounded-full" />
-                                    <span v-if="labelHtml" v-html="getOptionLabel(option)" />
-                                    <span v-else>{{ __(getOptionLabel(option)) }}</span>
-                                </slot>
-                            </ComboboxItem>
-                        </ComboboxViewport>
+                                <ComboboxItem
+                                    v-if="filteredOptions"
+                                    v-for="(option, index) in filteredOptions"
+                                    :key="index"
+                                    :value="getOptionValue(option)"
+                                    :text-value="getOptionLabel(option)"
+                                    :class="itemClasses({ size: size, selected: isSelected(option) })"
+                                    as="button"
+                                    @select="() => {
+                                        dropdownOpen = !closeOnSelect;
+                                        if (closeOnSelect) $refs.trigger.$el.focus();
+                                    }"
+                                >
+                                    <slot name="option" v-bind="option">
+                                        <img v-if="option.image" :src="option.image" class="size-5 rounded-full" />
+                                        <span v-if="labelHtml" v-html="getOptionLabel(option)" />
+                                        <span v-else>{{ __(getOptionLabel(option)) }}</span>
+                                    </slot>
+                                </ComboboxItem>
+                            </ComboboxViewport>
+                        </FocusScope>
                     </ComboboxContent>
                 </ComboboxPortal>
             </ComboboxRoot>


### PR DESCRIPTION
This pull request fixes an issue where it wasn't possible to open the combobox's dropdown inside a modal. [According to this comment](https://github.com/unovue/reka-ui/issues/1170#issuecomment-2617817040), you need to wrap `ComboboxViewport` in `FocusScope` for it to display properly.

Fixes #12157.