### PR TITLE
[6.x] Fix default published state of new nav items

### DIFF
--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -415,6 +415,7 @@ export default {
                 id: uniqid(),
                 title: values.title,
                 url: values.url,
+                status: null,
             };
 
             this.publishInfo[page.id] = {


### PR DESCRIPTION
This pull request fixes an issue where new nav items would show as "published" until you refresh the page, where they correctly show as a "draft". Fixes #12156.

This is happening because the `StatusIndicator`'s `status` prop defaults to `status` when no value is provided:

https://github.com/statamic/cms/blob/2ddc8c2b0b7fdbe327bb9bf8e53aa401e44dd617/resources/js/components/ui/StatusIndicator.vue#L9

New nav items only have `id`, `title`, `url` keys. Whereas, existing nav items have some additional keys, like `status` (which is `null` for URL items), `can_delete`, `children`, etc.

This PR fixes the issue by adding a `status` key to the object, but we could alternatively fix it by doing something like `page.status ?? null` here:

https://github.com/statamic/cms/blob/2ddc8c2b0b7fdbe327bb9bf8e53aa401e44dd617/resources/js/components/structures/Branch.vue#L8