### PR TITLE
[6.x] Fix error on listings when query parse 

### DIFF
--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -244,6 +244,9 @@ function setParameters(params) {
     if (params.hasOwnProperty('filters')) {
         activeFilters.value = params.filters ? JSON.parse(utf8atob(params.filters)) : {};
     }
+    if (params.hasOwnProperty('site')) {
+        activeFilters.value = { ...activeFilters.value, site: { site: params.site } };
+    }
 }
 
 const parameters = computed(() => {

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -244,9 +244,6 @@ function setParameters(params) {
     if (params.hasOwnProperty('filters')) {
         activeFilters.value = params.filters ? JSON.parse(utf8atob(params.filters)) : {};
     }
-    if (params.hasOwnProperty('site')) {
-        activeFilters.value = { ...activeFilters.value, site: { site: params.site } };
-    }
 }
 
 const parameters = computed(() => {

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -230,16 +230,20 @@ const activeFilterBadgeCount = computed(() => {
 });
 
 function setParameters(params) {
-    currentPage.value = parseInt(params.page);
-    perPage.value = parseInt(params.perPage);
-    sortColumn.value = params.sort;
-    sortDirection.value = params.order;
-    searchQuery.value = params.search;
-    columns.value = columns.value.map((column) => ({
-        ...column,
-        visible: params.columns.split(',').includes(column.field),
-    }));
-    activeFilters.value = params.filters ? JSON.parse(utf8atob(params.filters)) : {};
+    if (params.hasOwnProperty('page')) currentPage.value = parseInt(params.page);
+    if (params.hasOwnProperty('perPage')) perPage.value = parseInt(params.perPage);
+    if (params.hasOwnProperty('sort')) sortColumn.value = params.sort;
+    if (params.hasOwnProperty('order')) sortDirection.value = params.order;
+    if (params.hasOwnProperty('search')) searchQuery.value = params.search;
+    if (params.hasOwnProperty('columns')) {
+        columns.value = columns.value.map((column) => ({
+            ...column,
+            visible: params.columns.split(',').includes(column.field),
+        }));
+    }
+    if (params.hasOwnProperty('filters')) {
+        activeFilters.value = params.filters ? JSON.parse(utf8atob(params.filters)) : {};
+    }
 }
 
 const parameters = computed(() => {


### PR DESCRIPTION
This PR attempts to fix #12104, where the `Listing` component would error out when the URL contains non-listing query parameters.

For example: visiting `/cp/collections/pages?foo=bar` and using "List" view would result in a `TypeError`.

This PR fixes it by only setting listing parameters when those parameters actually exist in the `params` object (the URL's query params).
