### PR TITLE
[6.x] Add version to `@statamic/cms` package

### DIFF
--- a/resources/js/package/package.json
+++ b/resources/js/package/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@statamic/cms",
+    "version": "0.0.0",
     "dependencies": {
         "@vitejs/plugin-vue": "^6.0.0"
     },


### PR DESCRIPTION
This pull request adds a `version` property to the `package.json` of our `@statamic/cms` package, fixing an issue when attempting to install it using Yarn.

If we really wanted to, we could make it dynamic and change it every time we tag a release, but for now, we should be able to get away with `0.0.0`.

Closes #12075.