### PR TITLE
[6.x] Match the text color of Bard fields with markdown fields

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -256,7 +256,7 @@
     }
 
     .bard-fieldtype .bard-content {
-        @apply text-gray-600 dark:text-gray-300;
+        @apply text-gray-900 dark:text-gray-300;
         blockquote,
         ol,
         p,


### PR DESCRIPTION
Simple one number change so they both match up. I chose 900 rather than 600 because it felt more legible to me

Before:
![2025-08-26 at 15 25 12@2x](https://github.com/user-attachments/assets/3f1cdb40-02ac-4333-8dd5-d6b4d4e899db)

After:
![2025-08-26 at 15 36 38@2x](https://github.com/user-attachments/assets/d514797b-3c1e-4466-b40b-9add067b6f7c)
