### PR TITLE
[6.x] Lock laravel/framework temporarily

### DIFF
--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -21,7 +21,6 @@ use Statamic\Tags\FluentTag;
 
 class Statamic
 {
-    // making a change to trigger test
     const CORE_SLUG = 'statamic';
     const PACKAGE = 'statamic/cms';
 


### PR DESCRIPTION
It seems that https://github.com/laravel/framework/pull/56684 has caused a bunch of stuff to start breaking.

```
TypeError: event(): Return value must be of type ?array, false returned
```

In all the spots where we're expecting events to return false, its breaking as now `event()`'s return type is `?array`. I think this is a mistake. Pretty sure Laravel itself was relying on that behavior. We copied it the pattern from them.

I've opened an issue: https://github.com/laravel/framework/issues/56771
and a PR: https://github.com/laravel/framework/pull/56773


```
TypeError: csrf_token(): Return value must be of type string, null 
```

The csrf token is sometimes null.

Someone has opened a PR: https://github.com/laravel/framework/pull/56768