### PR TITLE
[6.x] Change marketplace link to open in new tab as per icon

### DIFF
--- a/resources/views/addons/index.blade.php
+++ b/resources/views/addons/index.blade.php
@@ -7,7 +7,7 @@
 
 @section('content')
     <ui-header title="{{ __('Addons') }}" icon="addons">
-        <ui-button variant="primary" :text="__('Browse the Marketplace')" href="https://statamic.com/addons" icon="external-link"></ui-button>
+        <ui-button variant="primary" :text="__('Browse the Marketplace')" href="https://statamic.com/addons" icon="external-link" target="_blank"></ui-button>
     </ui-header>
 
     <addon-list :initial-rows="{{ json_encode($addons) }}" :initial-columns="{{ json_encode($columns) }}"></addon-list>


### PR DESCRIPTION
Added `target="blank"` as per the icon implies