### PR TITLE
[6.x] Unlock laravel/framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "composer/semver": "^3.4",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "james-heinrich/getid3": "^1.9.21",
-        "laravel/framework": "^11.34 || ^12.0 <12.26.0",
+        "laravel/framework": "^11.34 || ^12.0",
         "laravel/prompts": "^0.3.0",
         "league/commonmark": "^2.2",
         "league/csv": "^9.0",


### PR DESCRIPTION
Laravel was locked in #12179 to prevent errors when doing a composer update.

12.26.2 has been tagged which has the appropriate fixes so this PR unlocks the constraint.