### PR TITLE
[6.x] Fix modal open prop usage

### DIFF
--- a/resources/js/components/ui/Modal/Modal.vue
+++ b/resources/js/components/ui/Modal/Modal.vue
@@ -41,7 +41,7 @@ watch(
 // so it can update its state, which eventually gets passed down as a prop.
 // Otherwise, update the local state.
 function updateOpen(value) {
-    if (isUsingOpenProp) {
+    if (isUsingOpenProp.value) {
         emit('update:open', value);
         return;
     }


### PR DESCRIPTION
isUsingOpenProp was converted to a computed in #12106 . It needs `.value` now otherwise it's always true.

You can use modals in two ways. Either with `v-model:open` or the `ModalClose` component.


With prop:

```vue
<script setup>
const open = ref(false);
</script>
<template>
  <ui-modal v-model:open="open">
    <template #trigger><button>Open</button></template>
    Modal contents
    <button @click="open = false">Close</button>
  </ui-modal>
</template>
```

With close component

```vue
<script setup>
//
</script>
<template>
  <ui-modal>
    <template #trigger><button>Open</button></template>
    Modal contents
    <ui-modal-close><button>Close</button></ui-modal-close>
  </ui-modal>
</template>
```

When you are using the *non-prop* way - the `updateOpen` method was never updating `open` because `isUsingOpenProp` was always true and returning early, even if you didn't use the prop.
