### PR TITLE
[6.x] Generate dist tar differently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: cd resources && tar -czvf dist-frontend.tar.gz dist-frontend
 
       - name: Create dist-package zip
-        run: cd resources && tar -czvf dist-package.tar.gz -C js/package .
+        run: cd resources/js/package && tar -czvf ../../dist-package.tar.gz *
 
       - name: Get Changelog
         id: changelog


### PR DESCRIPTION
This fixes an issue where you would see an error when updating to 6.0.0-alpha.2.

```
In TarDownloader.php line 32:

  Extraction from phar "/Users/jason/Sites/Throwaway/statamic5-to-6/vendor/composer/tmp-a8f0d63920d718d60b676de17c82051b.gz" failed: Cannot extract
   ".", internal error
```

The issue seemed to be with the tar command using `.` that it would include a `.` directory in the listing and that's where it errored out.

The new command avoids this listing.

In alpha 1 the tar contained paths like these:
  - `js/package/ui.js`
  - `js/package/package.json`
  - `js/package/types/util/clone.d.ts`

This caused unwanted nested directories. #12120 attempted to fix it, but resulted in paths like these:
- `./`
- `./ui.js`
- `./package.json`
- `./types/util/clone.d.ts`

This PR results in paths like these:

- `ui.js`
- `package.json`
- `types/util/clone.d.ts`