### PR TITLE
[6.x] Automatically run vite build watch

### DIFF
--- a/resources/js/package/vite-plugin.js
+++ b/resources/js/package/vite-plugin.js
@@ -1,4 +1,5 @@
 import vue from '@vitejs/plugin-vue';
+import { spawn } from 'child_process';
 
 const statamic = function (options) {
     return {
@@ -19,6 +20,22 @@ const statamic = function (options) {
         },
 
         configResolved(resolvedConfig) {
+            if (resolvedConfig.command === 'serve') {
+                console.log('\x1b[33m[Statamic] Vite dev server current not supported. Automatically running "vite build --watch" instead...\x1b[0m');
+
+                const child = spawn('npx', ['vite', 'build', '--watch'], {
+                    stdio: 'inherit',
+                    cwd: process.cwd()
+                });
+
+                child.on('error', (err) => {
+                    console.error('Failed to start vite build --watch:', err);
+                    process.exit(1);
+                });
+
+                process.exit(0);
+            }
+
             resolvedConfig.build.rollupOptions.plugins = resolvedConfig.build.rollupOptions.plugins || [];
             resolvedConfig.build.rollupOptions.plugins.push({
                 name: 'statamic-global-externals',

--- a/resources/js/package/vite-plugin.js
+++ b/resources/js/package/vite-plugin.js
@@ -5,23 +5,11 @@ const statamic = function (options) {
     return {
         name: 'statamic',
 
-        config(config) {
-            // Ensure rollupOptions exists
-            config.build = config.build || {};
-            config.build.rollupOptions = config.build.rollupOptions || {};
-            config.build.rollupOptions.external = config.build.rollupOptions.external || [];
-            config.build.rollupOptions.output = config.build.rollupOptions.output || {};
-
-            // Add Vue as external
-            const existingExternal = config.build.rollupOptions.external;
-            config.build.rollupOptions.external = [...existingExternal, 'vue'];
-
-            return config;
-        },
-
-        configResolved(resolvedConfig) {
-            if (resolvedConfig.command === 'serve') {
+        config(config, { command }) {
+            // Check for force-server environment variable as alternative
+            if (command === 'serve' && !process.env.STATAMIC_FORCE_SERVER) {
                 console.log('\x1b[33m[Statamic] Vite dev server current not supported. Automatically running "vite build --watch" instead...\x1b[0m');
+                console.log('\x1b[90m[Statamic] Use STATAMIC_FORCE_SERVER=1 to bypass this behavior.\x1b[0m');
 
                 const child = spawn('npx', ['vite', 'build', '--watch'], {
                     stdio: 'inherit',
@@ -36,6 +24,20 @@ const statamic = function (options) {
                 process.exit(0);
             }
 
+            // Ensure rollupOptions exists
+            config.build = config.build || {};
+            config.build.rollupOptions = config.build.rollupOptions || {};
+            config.build.rollupOptions.external = config.build.rollupOptions.external || [];
+            config.build.rollupOptions.output = config.build.rollupOptions.output || {};
+
+            // Add Vue as external
+            const existingExternal = config.build.rollupOptions.external;
+            config.build.rollupOptions.external = [...existingExternal, 'vue'];
+
+            return config;
+        },
+
+        configResolved(resolvedConfig) {
             resolvedConfig.build.rollupOptions.plugins = resolvedConfig.build.rollupOptions.plugins || [];
             resolvedConfig.build.rollupOptions.plugins.push({
                 name: 'statamic-global-externals',

--- a/resources/js/package/vite-plugin.js
+++ b/resources/js/package/vite-plugin.js
@@ -6,7 +6,6 @@ const statamic = function (options) {
         name: 'statamic',
 
         config(config, { command }) {
-            // Check for force-server environment variable as alternative
             if (command === 'serve' && !process.env.STATAMIC_FORCE_SERVER) {
                 console.log('\x1b[33m[Statamic] Vite dev server current not supported. Automatically running "vite build --watch" instead...\x1b[0m');
                 console.log('\x1b[90m[Statamic] Use STATAMIC_FORCE_SERVER=1 to bypass this behavior.\x1b[0m');

--- a/resources/js/package/vite-plugin.js
+++ b/resources/js/package/vite-plugin.js
@@ -6,9 +6,9 @@ const statamic = function (options) {
         name: 'statamic',
 
         config(config, { command }) {
-            if (command === 'serve' && !process.env.STATAMIC_FORCE_SERVER) {
+            if (command === 'serve' && !process.env.STATAMIC_FORCE_SERVE) {
                 console.log('\x1b[33m[Statamic] Vite dev server current not supported. Automatically running "vite build --watch" instead...\x1b[0m');
-                console.log('\x1b[90m[Statamic] Use STATAMIC_FORCE_SERVER=1 to bypass this behavior.\x1b[0m');
+                console.log('\x1b[90m[Statamic] Use STATAMIC_FORCE_SERVE=1 to bypass this behavior.\x1b[0m');
 
                 const child = spawn('npx', ['vite', 'build', '--watch'], {
                     stdio: 'inherit',


### PR DESCRIPTION
There's currently an issue where components don't resolve correctly when running `vite`. But running `vite build` works fine.

This PR will automatically run `vite build --watch` and output a warning.

This is temporary until the issue is resolved. You will still need to use a symlink.

If you really want to run the server (maybe for debugging the hotfile etc) you can use an environment variable.

```
STATAMIC_FORCE_SERVE=1 vite
```
