### PR TITLE
[5.x] Prevent null parse_url deprecation warning

### DIFF
--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -15,7 +15,7 @@ class OAuthController
 {
     public function redirectToProvider(Request $request, string $provider)
     {
-        $referer = $request->headers->get('referer');
+        $referer = $request->headers->get('referer') ?? '';
         $guard = config('statamic.users.guards.web', 'web');
 
         if (! OAuth::providers()->has($provider)) {


### PR DESCRIPTION
This PR repairs a possible *null* in parse_url() argument.

PHP Deprecated
parse_url(): Passing null to parameter # 1 ($url) of type string is deprecated
