### PR TITLE
[6.x] UI accent color theme config

### DIFF
--- a/config/cp.php
+++ b/config/cp.php
@@ -112,6 +112,9 @@ return [
         // 'success' => Color::Green[400],
         // 'danger' => Color::Red[600],
 
+        // 'ui-accent' => Color::Zinc[800],
+        // 'dark-ui-accent' => Color::Zinc[200],
+
         // 'body-bg' => Color::Zinc[100],
         // 'body-border' => Color::Transparent,
         // 'dark-body-bg' => Color::Zinc[900],

--- a/resources/css/ui.css
+++ b/resources/css/ui.css
@@ -26,6 +26,9 @@
     --color-dark-content-bg: var(--theme-color-dark-content-bg);
     --color-dark-content-border: var(--theme-color-dark-content-border);
     --color-global-header-bg: var(--theme-color-gray-800);
+    --color-ui-accent: var(--theme-color-ui-accent);
+    --color-dark-ui-accent: var(--theme-color-dark-ui-accent);
+
 
 
     /* Temp */

--- a/resources/js/components/ui/Checkbox/Item.vue
+++ b/resources/js/components/ui/Checkbox/Item.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { CheckboxIndicator, CheckboxRoot, useId } from 'reka-ui';
 import { computed } from 'vue';
+import { cva } from 'cva';
 
 const props = defineProps({
     align: { type: String, default: 'start', validator: (value) => ['start', 'center'].includes(value) },
@@ -21,34 +22,53 @@ const emit = defineEmits(['update:modelValue']);
 const id = useId();
 
 const checkboxClasses = computed(() => {
-    const sizes = {
-        sm: 'size-3.75',
-        base: 'size-4',
-    };
-
-    return `shadow-ui-xs mt-0.5 ${sizes[props.size]} cursor-default rounded-sm border border-gray-300 bg-white dark:bg-gray-600 dark:border-gray-900 data-[state=checked]:border-gray-900 data-[state=checked]:bg-gray-900 dark:border-none dark:data-[state=checked]:bg-gray-400 dark:data-[state=checked]:border-gray-700 dark:data-[disabled]:bg-gray-800 dark:data-[disabled]:border-gray-700 dark:data-[disabled]:text-gray-400 dark:data-[disabled]:cursor-not-allowed shrink-0`;
+    return cva({
+        base: [
+            'shadow-ui-xs mt-0.5 cursor-default rounded-sm border border-gray-300 bg-white',
+            'dark:bg-gray-400 dark:border-gray-900',
+            'data-[state=checked]:border-ui-accent data-[state=checked]:bg-ui-accent',
+            'dark:border-none dark:data-[state=checked]:bg-dark-ui-accent dark:data-[state=checked]:border-dark-ui-accent',
+            'dark:data-[disabled]:bg-dark-ui-accent/60 dark:data-[disabled]:border-dark-ui-accent/70',
+            'dark:data-[disabled]:text-gray-400 dark:data-[disabled]:cursor-not-allowed',
+            'shrink-0'
+        ],
+        variants: {
+            size: {
+                sm: 'size-3.75',
+                base: 'size-4',
+            },
+        },
+    })({ ...props });
 });
 
 const containerClasses = computed(() => {
-    return `flex items-${props.align} gap-2`;
+    return cva({
+        base: 'flex gap-2',
+        variants: {
+            align: {
+                start: 'items-start',
+                center: 'items-center',
+            },
+        },
+    })({ ...props });
 });
 
 const conditionalProps = computed(() => {
     const props_obj = {};
-    
+
     if (props.modelValue !== null) {
         props_obj.modelValue = props.modelValue;
     }
-    
+
     // Only add aria-describedby if description exists AND it's not a solo checkbox
     if (props.description && !props.solo) {
         props_obj['aria-describedby'] = `${id}-description`;
     }
-    
+
     if (props.solo && (props.label || props.value)) {
         props_obj['aria-label'] = props.label || props.value;
     }
-    
+
     return props_obj;
 });
 </script>
@@ -65,20 +85,9 @@ const conditionalProps = computed(() => {
             :class="checkboxClasses"
             :tabindex="tabindex"
         >
-            <CheckboxIndicator
-                class="relative flex h-full w-full items-center justify-center text-white dark:text-gray-900"
-            >
-                <svg viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg" class="size-2.5" aria-hidden="true">
-                    <path
-                        d="M9 1L3.5 6.5L1 4"
-                        stroke="currentColor"
-                        stroke-width="1.5"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                    />
-                </svg>
+            <CheckboxIndicator class="relative flex h-full w-full items-center justify-center text-white">
+                <svg viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg" class="size-2.5" aria-hidden="true"><path d="M9 1L3.5 6.5L1 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg>
             </CheckboxIndicator>
-            <!-- Screen reader text for checkbox state -->
             <span class="sr-only">
                 {{ modelValue ? 'Checked' : 'Unchecked' }}
             </span>
@@ -87,7 +96,7 @@ const conditionalProps = computed(() => {
             <label class="text-sm font-normal antialiased" :for="id">
                 <slot>{{ label || value }}</slot>
             </label>
-            <p v-if="description" :id="`${id}-description`" class="mt-0.5 block text-xs leading-snug text-gray-500 dark:text-gray-400">{{ description }}</p>
+            <p v-if="description" :id="`${id}-description`" class="mt-0.5 block text-xs leading-snug text-gray-500 dark:text-gray-200">{{ description }}</p>
         </div>
     </div>
 </template>

--- a/resources/js/components/ui/Radio/Item.vue
+++ b/resources/js/components/ui/Radio/Item.vue
@@ -16,14 +16,23 @@ const id = useId();
         <RadioGroupItem
             :id
             :value="value"
-            class="shadow-ui-xs mt-0.5 size-4 cursor-default rounded-full focus:focus-outline border border-gray-300 bg-white outline-hidden data-[active=true]:border-gray-900 data-[active=true]:bg-gray-900 dark:border-none dark:data-[active=true]:bg-white"
+            class="
+                shadow-ui-xs mt-0.5 size-4 cursor-default rounded-full
+                focus:focus-outline border border-gray-300 dark:border-none bg-white outline-hidden
+                data-[state=checked]:border-ui-accent
+                dark:bg-gray-400 dark:data-[state=checked]:border-none dark:data-[state=checked]:bg-gray-300
+            "
         >
             <RadioGroupIndicator
-                class="relative flex h-full w-full items-center justify-center border border-black rounded-[50%] after:block after:h-[0.5rem] after:w-[0.5rem] after:rounded-[50%] after:bg-black after:content-[''] dark:after:bg-gray-800"
+                class="
+                    relative flex h-full w-full items-center justify-center rounded-[50%]
+                    border border-ui-accent after:block after:h-[0.5rem] after:w-[0.5rem] after:rounded-[50%]
+                    after:bg-ui-accent after:content-[''] dark:border-none dark:after:bg-dark-ui-accent
+                "
             />
         </RadioGroupItem>
         <label class="flex flex-col" :for="id">
-            <span class="text-sm font-normal text-gray-600 antialiased dark:text-gray-400">
+            <span class="text-sm font-normal text-gray-600 antialiased dark:text-gray-200">
                 <slot>{{ label || value }}</slot>
             </span>
             <span v-if="description" class="mt-0.5 block text-xs leading-snug text-gray-500">{{ description }}</span>

--- a/src/CP/Color.php
+++ b/src/CP/Color.php
@@ -347,6 +347,8 @@ class Color
             'content-border' => self::Zinc[200],
             'dark-content-bg' => self::Zinc[900],
             'dark-content-border' => self::Zinc[950],
+            'ui-accent' => self::Zinc[800],
+            'dark-ui-accent' => self::Zinc[950],
         ];
     }
 


### PR DESCRIPTION
Now if you want to customize the accent color for your form inputs (e.g. checkboxes and radios), you can.

```php
// config/statamic/cp.php
'theme' => [
    //...
    'ui-accent' => Color::Blue[600],
    'dark-ui-accent' => Color::Cyan[600],
    //...
];
```