### PR TITLE
[6.x] Configurable progress bar color

### DIFF
--- a/config/cp.php
+++ b/config/cp.php
@@ -121,6 +121,8 @@ return [
         // 'content-border' => Color::Zinc[200],
         // 'dark-content-bg' => Color::Zinc[900],
         // 'dark-content-border' => Color::Zinc[950],
+
+        // 'progress-bar' => Color::Volt,
     ],
 
     /*

--- a/resources/css/components/progress.css
+++ b/resources/css/components/progress.css
@@ -4,17 +4,9 @@
 }
 
 #nprogress .bar {
-    @apply fixed top-0 w-full bg-blue ltr:left-0 rtl:right-0;
-    height: 2px;
+    @apply fixed top-0 w-full bg-progress-bar start-0;
+    height: 1px;
     z-index: 10000; /*  above global-header */
-}
-
-/* Fancy blur effect */
-#nprogress .peg {
-    @apply absolute block h-full w-full opacity-100 ltr:right-0 rtl:left-0;
-    box-shadow:
-        0 0 5px var(--color-blue),
-        0 0 2px var(--color-blue);
 }
 
 .nprogress-custom-parent {

--- a/resources/css/ui.css
+++ b/resources/css/ui.css
@@ -15,7 +15,7 @@
     --color-gray-800: var(--theme-color-gray-800);
     --color-gray-850: var(--theme-color-gray-850);
     --color-gray-900: var(--theme-color-gray-900);
-    --color-gray-950: var(--color-zinc-950);
+    --color-gray-950: var(--theme-color-zinc-950);
     --color-volt: oklch(93.86% 0.2018 122.24);
 
     --color-body-bg: var(--theme-color-body-bg);
@@ -26,6 +26,7 @@
     --color-dark-content-bg: var(--theme-color-dark-content-bg);
     --color-dark-content-border: var(--theme-color-dark-content-border);
     --color-global-header-bg: var(--theme-color-gray-800);
+    --color-progress-bar: var(--theme-color-progress-bar);
 
 
     /* Temp */

--- a/src/CP/Color.php
+++ b/src/CP/Color.php
@@ -320,6 +320,7 @@ class Color
     public const White = '#fff';
     public const Black = '#000';
     public const Transparent = 'transparent';
+    public const Volt = 'oklch(93.86% 0.2018 122.24)';
 
     public static function defaults(): array
     {
@@ -347,6 +348,7 @@ class Color
             'content-border' => self::Zinc[200],
             'dark-content-bg' => self::Zinc[900],
             'dark-content-border' => self::Zinc[950],
+            'progress-bar' => self::Volt,
         ];
     }
 


### PR DESCRIPTION
Now if you want to customize the progress bar (shown at the top of the page on slower loading requests), you can:

```php
// config/statamic/cp.php
'theme' => [
    //...
    'progress-bar' => Color::Purple[400],
    //...
];
```