### PR TITLE
[6.x] Remove unnecessary whitespace in bard link toolbar

### DIFF
--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="bard-link-toolbar">
         <div>
-            <div class="border-b bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-800 rounded-b-xl rounded-t-md">
+            <div class="border-b bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-800 rounded-t-md">
                 <section class="flex gap-2 items-center p-4 border-b dark:border-gray-800">
                     <ui-select
                         v-model="linkType"

--- a/resources/js/components/ui/Popover.vue
+++ b/resources/js/components/ui/Popover.vue
@@ -63,7 +63,7 @@ function updateOpen(value) {
                 :side
             >
                 <slot v-bind="slotProps" />
-                <PopoverClose>
+                <PopoverClose as-child>
                     <slot name="close" v-bind="slotProps" />
                 </PopoverClose>
                 <PopoverArrow v-if="arrow" class="fill-white stroke-gray-300" />


### PR DESCRIPTION
This pull request removes unnecessary whitespace that was showing in the Bard Link Toolbar. 

It was caused by the popover's `PopoverClose` component rendering an empty button, even when the `close` slot was empty.

This PR also fixes an issue where a border radius was being applied to the bottom of the "label/rel/open in new window" box, which was unnecessary, given the fact we have buttons below it.

Related: #12192

## Before

<img width="354" height="297" alt="CleanShot 2025-08-28 at 10 35 12" src="https://github.com/user-attachments/assets/ac99fca4-3f74-46d9-86af-d3f962b56701" />


<img width="465" height="214" alt="CleanShot 2025-08-28 at 10 35 05" src="https://github.com/user-attachments/assets/b4bf5e70-b541-4e65-8863-eace70daf642" />

## After

<img width="352" height="269" alt="CleanShot 2025-08-28 at 10 41 17" src="https://github.com/user-attachments/assets/9362a832-9019-4394-89dd-e3980c9369ce" />


<img width="516" height="192" alt="CleanShot 2025-08-28 at 10 34 36" src="https://github.com/user-attachments/assets/7a8f9ea8-8ae4-4cf9-96b2-aeeeaec136ae" />
