### PR TITLE
[6.x] Switch (Toggle) accents

### DIFF
--- a/resources/css/ui.css
+++ b/resources/css/ui.css
@@ -27,9 +27,10 @@
     --color-dark-content-border: var(--theme-color-dark-content-border);
     --color-global-header-bg: var(--theme-color-gray-800);
     --color-progress-bar: var(--theme-color-progress-bar);
-    --color-ui-accent: var(--theme-color-ui-accent, var(--color-primary));
-    --color-dark-ui-accent: var(--theme-color-dark-ui-accent, var(--color-primary));
-    --color-toggle-bg: var(--theme-color-ui-accent, var(--color-primary));
+    --color-ui-accent: var(--theme-color-ui-accent);
+    --color-dark-ui-accent: var(--theme-color-dark-ui-accent);
+    --color-toggle-bg: var(--theme-color-toggle-bg);
+    --color-dark-toggle-bg: var(--theme-color-dark-toggle-bg);
 
     /* Temp */
     --color-dark-100: #dfe1e5;

--- a/resources/css/ui.css
+++ b/resources/css/ui.css
@@ -29,8 +29,8 @@
     --color-progress-bar: var(--theme-color-progress-bar);
     --color-ui-accent: var(--theme-color-ui-accent);
     --color-dark-ui-accent: var(--theme-color-dark-ui-accent);
-    --color-toggle-bg: var(--theme-color-toggle-bg);
-    --color-dark-toggle-bg: var(--theme-color-dark-toggle-bg);
+    --color-switch-bg: var(--theme-color-switch-bg);
+    --color-dark-switch-bg: var(--theme-color-dark-switch-bg);
 
     /* Temp */
     --color-dark-100: #dfe1e5;

--- a/resources/js/components/ui/Switch.vue
+++ b/resources/js/components/ui/Switch.vue
@@ -16,8 +16,8 @@ const switchRootClasses = cva({
     base: [
         'relative flex rounded-full shrink-0 border-2',
         'transition-colors cursor-pointer',
-        'data-[state=checked]:shadow-inner data-[state=checked]:border-toggle-bg data-[state=checked]:bg-toggle-bg',
-        'dark:data-[state=checked]:border-dark-toggle-bg dark:data-[state=checked]:bg-dark-toggle-bg',
+        'data-[state=checked]:shadow-inner data-[state=checked]:border-switch-bg data-[state=checked]:bg-switch-bg',
+        'dark:data-[state=checked]:border-dark-switch-bg dark:data-[state=checked]:bg-dark-switch-bg',
         'data-[state=unchecked]:border-transparent dark:data-[state=unchecked]:border-gray-700',
         'data-[state=unchecked]:bg-gray-200 dark:data-[state=unchecked]:bg-gray-700'
     ],

--- a/src/CP/Color.php
+++ b/src/CP/Color.php
@@ -351,8 +351,8 @@ class Color
             'progress-bar' => self::Volt,
             'ui-accent' => self::Zinc[800],
             'dark-ui-accent' => self::Zinc[950],
-            'toggle-bg' => 'var(--theme-color-ui-accent)',
-            'dark-toggle-bg' => 'var(--theme-color-dark-ui-accent)',
+            'switch-bg' => 'var(--theme-color-ui-accent)',
+            'dark-switch-bg' => 'var(--theme-color-dark-ui-accent)',
         ];
     }
 

--- a/src/CP/Color.php
+++ b/src/CP/Color.php
@@ -351,8 +351,8 @@ class Color
             'progress-bar' => self::Volt,
             'ui-accent' => self::Zinc[800],
             'dark-ui-accent' => self::Zinc[950],
-            'toggle-bg' => self::Green[400],
-            'dark-toggle-bg' => self::Green[500],
+            'toggle-bg' => 'var(--theme-color-ui-accent)',
+            'dark-toggle-bg' => 'var(--theme-color-dark-ui-accent)',
         ];
     }
 


### PR DESCRIPTION
This makes switches use the ui accent color by default.

With no customizations, the toggles are black (zinc-800) now to match the primary button color.

If you define `ui-accent`, checkboxes, radios, and now toggles will use this accent color.

```php
'theme' => [
    'ui-accent' => \Statamic\CP\Color::Blue[600],
]
```

You can additionally set the `switch-bg` to make toggles different from the accent:

```php
'theme' => [
    'ui-accent' => \Statamic\CP\Color::Blue[600],
    'switch-bg' => \Statamic\CP\Color::Green[600],
]
```

In addition:
- This reverts 39037e1
- This switches (ha) the variable names to use `switch` instead of `toggle`, since `Switch` is the actual component name.
- This adds `--color-dark-switch-bg` which was being used in the component but never defined in the css.