### PR TITLE
[6.x] Fix spacer field from collapsing

### DIFF
--- a/resources/css/components/fieldtypes/spacer.css
+++ b/resources/css/components/fieldtypes/spacer.css
@@ -3,5 +3,5 @@
    ========================================================================== */
 
 .spacer-fieldtype {
-    @apply hidden @sm:invisible @sm:block;
+    @apply invisible @sm:block;
 }


### PR DESCRIPTION
Closes #12205. The spacer field was collapsing because it was being set to `display: none;` rather than `visibility:hidden;`. This fixes that