### PR TITLE
[6.x] Themeable global header

### DIFF
--- a/resources/css/components/global-header.css
+++ b/resources/css/components/global-header.css
@@ -24,15 +24,15 @@
     }
 }
 
-.site-selector {
-    /* The background of the header is already very dark, so it's distracting if you put a second dark color background on hover */
+/* .site-selector {
+    The background of the header is already very dark, so it's distracting if you put a second dark color background on hover
     div:hover {
         background: none;
     }
     [data-ui-combobox-anchor] {
         font-size: 0.9rem;
     }
-}
+} */
 
 .global-header .white-label-logo {
     max-height: 32px;

--- a/resources/css/ui.css
+++ b/resources/css/ui.css
@@ -25,7 +25,7 @@
     --color-content-border: var(--theme-color-content-border);
     --color-dark-content-bg: var(--theme-color-dark-content-bg);
     --color-dark-content-border: var(--theme-color-dark-content-border);
-    --color-global-header-bg: var(--theme-color-gray-800);
+    --color-global-header-bg: var(--theme-color-global-header-bg);
     --color-progress-bar: var(--theme-color-progress-bar);
     --color-ui-accent: var(--theme-color-ui-accent);
     --color-dark-ui-accent: var(--theme-color-dark-ui-accent);

--- a/resources/js/components/GlobalSiteSelector.vue
+++ b/resources/js/components/GlobalSiteSelector.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex h-full items-center">
+    <div class="flex h-full items-center" data-ui-global-site-selector>
         <Select
             :model-value="active"
             :options="sites"
@@ -7,18 +7,9 @@
             @update:model-value="selected"
             option-label="name"
             option-value="handle"
-            variant="filled"
-        >
-            <template #selected-option="{ option }">
-                <div class="flex items-center gap-2 text-sm font-medium text-[0.8125rem] text-gray-300 hover:text-white">
-                    <ui-icon name="globe-arrow" class="size-4" />
-                    <div class="whitespace-nowrap">{{ __(option.name) }}</div>
-                </div>
-            </template>
-            <template #option="option">
-                <div class="whitespace-nowrap" :class="{ 'text-gray-500': handle === active }">{{ __(option.name) }}</div>
-            </template>
-        </Select>
+            size="sm"
+            icon="globe-arrow"
+        />
     </div>
 </template>
 
@@ -51,3 +42,10 @@ export default {
     },
 };
 </script>
+
+<style>
+[data-ui-global-site-selector] [data-ui-combobox-trigger] {
+    background: color-mix(in srgb, var(--theme-color-global-header-bg) 70%, black 80%) !important;
+    border: transparent !important;
+}
+</style>

--- a/resources/js/components/GlobalSiteSelector.vue
+++ b/resources/js/components/GlobalSiteSelector.vue
@@ -1,13 +1,13 @@
 <template>
-    <div class="site-selector flex h-full items-center dark:border-dark-900">
+    <div class="flex h-full items-center">
         <Select
+            :model-value="active"
             :options="sites"
+            :searchable="false"
+            @update:model-value="selected"
             option-label="name"
             option-value="handle"
-            :searchable="false"
-            :model-value="active"
-            :button-appearance="false"
-            @update:model-value="selected"
+            variant="filled"
         >
             <template #selected-option="{ option }">
                 <div class="flex items-center gap-2 text-sm font-medium text-[0.8125rem] text-gray-300 hover:text-white">

--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -239,8 +239,8 @@ const modalClasses = cva({
     <DialogRoot v-model:open="open" :modal="true">
         <DialogTrigger>
             <div class="
-                data-[focus-visible]:outline-focus hover flex cursor-text items-center gap-x-1.5 group
-                rounded-md [button:has(>&)]:rounded-md bg-black/40 text-xs text-white/60 outline-none
+                data-[focus-visible]:outline-focus hover flex cursor-text items-center gap-x-1.5 group h-8
+                rounded-lg [button:has(>&)]:rounded-md bg-black/40 text-xs text-white/60 outline-none
                 border-b border-b-white/20 inset-shadow-sm inset-shadow-black/20
                 md:w-32 md:py-[calc(5/16*1rem)] md:px-2
                 hover:bg-black/45 hover:text-white/70

--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -238,10 +238,16 @@ const modalClasses = cva({
 <template>
     <DialogRoot v-model:open="open" :modal="true">
         <DialogTrigger>
-            <div class="data-[focus-visible]:outline-focus hover flex cursor-text items-center gap-x-2 rounded-md [button:has(>&)]:rounded-md bg-gray-900 text-xs text-gray-400 shadow-[0_-1px_rgba(255,255,255,0.06),0_4px_8px_rgba(0,0,0,0.05),0_1px_6px_-4px_#000] ring-1 ring-gray-900/10 outline-none hover:ring-white/10 md:w-32 md:py-[calc(5/16*1rem)] md:ps-2 md:pe-1.5 md:shadow-[0_1px_5px_-4px_rgba(19,19,22,0.4),0_2px_5px_rgba(32,42,54,0.06)]">
-                <Icon name="magnifying-glass" class="size-5 flex-none text-gray-600" />
+            <div class="
+                data-[focus-visible]:outline-focus hover flex cursor-text items-center gap-x-1.5 group
+                rounded-md [button:has(>&)]:rounded-md bg-black/40 text-xs text-white/60 outline-none
+                border-b border-b-white/20 inset-shadow-sm inset-shadow-black/20
+                md:w-32 md:py-[calc(5/16*1rem)] md:px-2
+                hover:bg-black/45 hover:text-white/70
+            ">
+                <Icon name="magnifying-glass" class="size-5 flex-none text-white/50 group-hover:text-white/70" />
                 <span class="sr-only leading-none md:not-sr-only st-text-trim-cap">Search</span>
-                <kbd class="ml-auto hidden self-center rounded bg-white/5 px-[0.3125rem] py-[0.0625rem] text-[0.625rem]/4 font-medium text-gray-400 ring-1 ring-white/7.5 [word-spacing:-0.15em] ring-inset md:block">
+                <kbd class="ml-auto hidden self-center rounded bg-white/5 px-[0.3125rem] py-[0.0625rem] text-[0.625rem]/4 font-medium text-white/60 group-hover:text-white/70 ring-1 ring-white/7.5 [word-spacing:-0.15em] ring-inset md:block">
                     <kbd class="font-sans">⌘ </kbd><kbd class="font-sans">K</kbd>
                 </kbd>
             </div>

--- a/resources/js/components/ui/Button/Button.vue
+++ b/resources/js/components/ui/Button/Button.vue
@@ -26,7 +26,7 @@ const iconOnly = computed(() => (props.icon && !hasDefaultSlot && !props.text) |
 
 const buttonClasses = computed(() => {
     const classes = cva({
-        base: 'inline-flex items-center justify-center whitespace-nowrap shrink-0 font-medium antialiased cursor-pointer no-underline disabled:text-gray-400 dark:disabled:text-gray-600 disabled:cursor-not-allowed [&_svg]:shrink-0 [&_svg]:text-gray-600 dark:[&_svg]:text-gray-500',
+        base: 'inline-flex items-center justify-center whitespace-nowrap shrink-0 font-medium antialiased cursor-pointer no-underline disabled:text-gray-400 dark:disabled:text-gray-600 disabled:cursor-not-allowed [&_svg]:shrink-0 [&_svg]:text-black [&_svg]:opacity-60 dark:[&_svg]:text-white',
         variants: {
             variant: {
                 default: [
@@ -37,9 +37,9 @@ const buttonClasses = computed(() => {
                     'bg-linear-to-b from-primary/90 to-primary hover:bg-primary-hover text-white border border-primary-border shadow-ui-md inset-shadow-2xs inset-shadow-white/25 [&_svg]:text-white [&_svg]:opacity-60',
                 ],
                 danger: 'bg-linear-to-b from-red-600/90 to-red-600 hover:bg-red-600/90 text-white border border-red-600 inset-shadow-2xs inset-shadow-red-300 [&_svg]:text-red-200 disabled:text-red-200',
-                filled: 'bg-gray-100 hover:bg-gray-200 hover:text-gray-900 dark:hover:text-white dark:bg-gray-700/80 dark:hover:bg-gray-700 [&_svg]:text-gray-700 dark:[&_svg]:text-gray-300',
-                ghost: 'bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800/50 dark:hover:text-gray-200',
-                subtle: 'bg-transparent hover:bg-gray-400/10 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700/80 dark:hover:text-gray-200 [&_svg]:text-gray-400',
+                filled: 'bg-black/5 hover:bg-black/10 hover:text-gray-900 dark:hover:text-white dark:bg-gray-700/80 dark:hover:bg-gray-700 [&_svg]:opacity-70',
+                ghost: 'bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200',
+                subtle: 'bg-transparent hover:bg-gray-400/10 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 [&_svg]:opacity-40',
             },
             size: {
                 lg: 'px-6 h-12 text-base gap-2 rounded-lg text-base',

--- a/resources/js/components/ui/Button/Button.vue
+++ b/resources/js/components/ui/Button/Button.vue
@@ -37,7 +37,7 @@ const buttonClasses = computed(() => {
                     'bg-linear-to-b from-primary/90 to-primary hover:bg-primary-hover text-white border border-primary-border shadow-ui-md inset-shadow-2xs inset-shadow-white/25 [&_svg]:text-white [&_svg]:opacity-60',
                 ],
                 danger: 'bg-linear-to-b from-red-600/90 to-red-600 hover:bg-red-600/90 text-white border border-red-600 inset-shadow-2xs inset-shadow-red-300 [&_svg]:text-red-200 disabled:text-red-200',
-                filled: 'bg-black/5 hover:bg-black/10 hover:text-gray-900 dark:hover:text-white dark:bg-gray-700/80 dark:hover:bg-gray-700 [&_svg]:opacity-70',
+                filled: 'bg-black/5 hover:bg-black/10 hover:text-gray-900 dark:hover:text-white dark:bg-white/15 dark:hover:bg-white/20 [&_svg]:opacity-70',
                 ghost: 'bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200',
                 subtle: 'bg-transparent hover:bg-gray-400/10 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 [&_svg]:opacity-40',
             },

--- a/resources/js/components/ui/Combobox.vue
+++ b/resources/js/components/ui/Combobox.vue
@@ -1,16 +1,6 @@
 <script setup>
 import { cva } from 'cva';
-import {
-    ComboboxAnchor,
-    ComboboxContent,
-    ComboboxEmpty,
-    ComboboxInput,
-    ComboboxItem,
-    ComboboxRoot,
-    ComboboxTrigger,
-    ComboboxPortal,
-    ComboboxViewport,
-} from 'reka-ui';
+import { ComboboxAnchor, ComboboxContent, ComboboxEmpty, ComboboxInput, ComboboxItem, ComboboxRoot, ComboboxTrigger, ComboboxPortal, ComboboxViewport } from 'reka-ui';
 import { computed, nextTick, onMounted, ref, useAttrs, useSlots, useTemplateRef, watch } from 'vue';
 import { Button, Icon, Badge } from '@/components/ui';
 import fuzzysort from 'fuzzysort';
@@ -20,11 +10,11 @@ const emit = defineEmits(['update:modelValue', 'search', 'selected', 'added']);
 
 const props = defineProps({
     id: { type: String },
-    buttonAppearance: { type: Boolean, default: true },
     clearable: { type: Boolean, default: false },
+    closeOnSelect: { type: Boolean, default: undefined },
     disabled: { type: Boolean, default: false },
     discreteFocusOutline: { type: Boolean, default: false },
-    flat: { type: Boolean, default: false },
+    icon: { type: String, default: null },
     ignoreFilter: { type: Boolean, default: false },
     labelHtml: { type: Boolean, default: false },
     maxSelections: { type: Number, default: null },
@@ -38,7 +28,7 @@ const props = defineProps({
     searchable: { type: Boolean, default: true },
     size: { type: String, default: 'base' },
     taggable: { type: Boolean, default: false },
-    closeOnSelect: { type: Boolean, default: undefined },
+    variant: { type: String, default: 'default' },
 });
 
 defineOptions({
@@ -48,36 +38,39 @@ defineOptions({
 const attrs = useAttrs();
 
 const triggerClasses = cva({
-    base: 'min-h-full w-full flex items-center',
+    base: 'w-full flex items-center justify-between antialiased cursor-pointer',
     variants: {
         variant: {
-            default: 'border border-gray-300 with-contrast:border-gray-500 dark:border-b-0 dark:ring-3 dark:ring-gray-900 dark:border-white/10 shadow-ui-sm dark:shadow-md focus-within:focus-outline',
-            ghost: 'border-none',
+            default: [
+                'bg-linear-to-b from-white to-gray-50 text-gray-900 border border-gray-300 shadow-ui-sm focus-within:focus-outline',
+                'dark:from-gray-850 dark:to-gray-900 dark:border-gray-700 dark:text-gray-300 dark:shadow-ui-md',
+            ],
+            filled: 'bg-black/5 hover:bg-black/10 text-gray-900 border-none dark:bg-white/15 dark:hover:bg-white/20 dark:text-white focus-within:focus-outline dark:placeholder:text-red-500/60',
+            ghost: 'bg-transparent hover:bg-gray-400/10 text-gray-900 border-none dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 focus-within:focus-outline',
+            subtle: 'bg-transparent hover:bg-gray-400/10 text-gray-500 hover:text-gray-700 border-none dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 focus-within:focus-outline',
         },
         size: {
-            base: 'text-base rounded-lg ps-3 pe-2.5 py-2 h-10 leading-[1.375rem]',
-            sm: 'text-sm rounded-md ps-2.5 pe-2 py-1.5 h-8 leading-[1.125rem]',
-            xs: 'text-xs rounded-sm ps-2 pe-1.5 py-1.5 h-6 leading-[1.125rem]',
+            lg: 'px-6 h-12 text-base rounded-lg',
+            base: 'px-4 h-10 text-sm rounded-lg',
+            sm: 'px-3 h-8 text-[0.8125rem] rounded-lg',
+            xs: 'px-2 h-6 text-xs rounded-md',
         },
         'discrete-focus-outline': {
             true: 'focus-outline-discrete',
         },
-        buttonAppearance: {
-            true: 'border border-gray-300 with-contrast:border-gray-500 dark:border-b-0 dark:ring-3 dark:ring-gray-900 dark:border-white/10 shadow-ui-sm dark:shadow-md focus-within:focus-outline',
-            false: '',
-        },
         readOnly: {
             true: 'border-dashed',
+        },
+        disabled: {
+            true: 'opacity-50 cursor-not-allowed',
         }
     },
-
 })({
+    variant: props.variant,
     size: props.size,
-    flat: props.flat,
     'discrete-focus-outline': props.discreteFocusOutline,
-    buttonAppearance: props.buttonAppearance,
-    disabled: props.disabled,
     readOnly: props.readOnly,
+    disabled: props.disabled,
 });
 
 const itemClasses = cva({
@@ -275,49 +268,53 @@ defineExpose({
     <div>
         <div class="flex">
             <ComboboxRoot
-                class="cursor-pointer"
-                v-bind="attrs"
-                ignore-filter
+                :disabled="disabled || (multiple && limitReached) || readOnly"
+                :model-value="modelValue"
                 :multiple
+                :open="dropdownOpen"
                 :reset-search-term-on-blur="false"
                 :reset-search-term-on-select="false"
-                :disabled="disabled || (multiple && limitReached) || readOnly"
-                :open="dropdownOpen"
-                :model-value="modelValue"
-                @update:open="updateDropdownOpen"
                 @update:model-value="updateModelValue"
+                @update:open="updateDropdownOpen"
+                class="cursor-pointer"
+                data-ui-combobox
+                ignore-filter
+                v-bind="attrs"
             >
-                <ComboboxAnchor :class="['w-full flex items-center justify-between gap-2 text-gray-900 dark:text-gray-300 antialiased appearance-none', $attrs.class]" data-ui-combobox-anchor>
-                    <ComboboxTrigger as="div" ref="trigger" :class="triggerClasses" @keydown.space="openOnSpace">
-                        <ComboboxInput
-                            v-if="searchable && (dropdownOpen || !modelValue || (multiple && placeholder))"
-                            ref="search"
-                            class="w-full text-gray-700 dark:text-gray-400 opacity-100 focus:outline-none placeholder-xs"
-                            type="search"
-                            :id="id"
-                            v-model="searchQuery"
-                            :placeholder
-                            autocomplete="off"
-                            @paste.prevent="onPaste"
-                            @keydown.enter.prevent="pushTaggableOption"
-                            @blur="pushTaggableOption"
-                            @keydown.space="openOnSpace"
-                        />
+                <ComboboxAnchor :class="[$attrs.class]" data-ui-combobox-anchor>
+                    <ComboboxTrigger as="div" ref="trigger" :class="triggerClasses" @keydown.space="openOnSpace" data-ui-combobox-trigger>
+                        <div class="flex-1 min-w-0">
+                            <ComboboxInput
+                                v-if="searchable && (dropdownOpen || !modelValue || (multiple && placeholder))"
+                                ref="search"
+                                class="w-full bg-transparent text-gray-700 dark:text-gray-400 opacity-100 focus:outline-none placeholder-gray-400 dark:placeholder-gray-500"
+                                type="search"
+                                :id="id"
+                                v-model="searchQuery"
+                                :placeholder
+                                autocomplete="off"
+                                @paste.prevent="onPaste"
+                                @keydown.enter.prevent="pushTaggableOption"
+                                @blur="pushTaggableOption"
+                                @keydown.space="openOnSpace"
+                            />
 
-                        <button type="button" class="flex-1 text-start truncate" v-else-if="!searchable && (dropdownOpen || !modelValue)" @keydown.space="openOnSpace">
-                            <span class="text-gray-400 dark:text-gray-500 placeholder-text-xs" v-text="placeholder" />
-                        </button>
+                            <button type="button" class="w-full text-start truncate bg-transparent cursor-pointer" v-else-if="!searchable && (dropdownOpen || !modelValue)" @keydown.space="openOnSpace" data-ui-combobox-placeholder>
+                                <span class="text-gray-400 dark:text-gray-500" v-text="placeholder" />
+                            </button>
 
-                        <button type="button" v-else class="flex-1 text-start cursor-pointer truncate" @keydown.space="openOnSpace">
-                            <slot name="selected-option" v-bind="{ option: selectedOption }">
-                                <span v-if="labelHtml" v-html="getOptionLabel(selectedOption)" />
-                                <span v-else v-text="getOptionLabel(selectedOption)" />
-                            </slot>
-                        </button>
+                            <button type="button" v-else class="w-full text-start bg-transparent truncate flex items-center gap-2 cursor-pointer" @keydown.space="openOnSpace" data-ui-combobox-selected-option>
+                                <slot name="selected-option" v-bind="{ option: selectedOption }">
+                                    <Icon v-if="icon" :name="icon" class="text-white-400 dark:text-white dark:opacity-50" />
+                                    <span v-if="labelHtml" v-html="getOptionLabel(selectedOption)" />
+                                    <span v-else v-text="getOptionLabel(selectedOption)" />
+                                </slot>
+                            </button>
+                        </div>
 
-                        <div class="flex gap-1.5 items-center ms-1">
-                            <Button v-if="clearable && modelValue" icon="x" variant="ghost" size="xs" round @click="clear" />
-                            <Icon v-if="options.length || ignoreFilter" name="ui/chevron-down" />
+                        <div class="flex gap-1.5 items-center shrink-0 ms-1.5">
+                            <Button v-if="clearable && modelValue" icon="x" variant="ghost" size="xs" round @click="clear" data-ui-combobox-clear-button />
+                            <Icon v-if="options.length || ignoreFilter" name="ui/chevron-down" class="text-gray-400 dark:text-white/40" data-ui-combobox-chevron />
                         </div>
                     </ComboboxTrigger>
                 </ComboboxAnchor>
@@ -331,9 +328,10 @@ defineExpose({
                             'max-h-[var(--reka-combobox-content-available-height)] w-[var(--reka-combobox-trigger-width)] min-w-fit',
                         ]"
                         @escape-key-down="nextTick(() => $refs.trigger.$el.focus())"
+                        data-ui-combobox-content
                     >
                         <ComboboxViewport>
-                            <ComboboxEmpty class="py-2 text-sm">
+                            <ComboboxEmpty class="py-2 text-sm" data-ui-combobox-empty>
                                 <slot name="no-options" v-bind="{ searchQuery }">
                                     {{ __('No options available.') }}
                                 </slot>
@@ -347,6 +345,7 @@ defineExpose({
                                 :text-value="getOptionLabel(option)"
                                 :class="itemClasses({ size: size, selected: isSelected(option) })"
                                 as="button"
+                                data-ui-combobox-item
                                 @select="() => {
                                     dropdownOpen = !closeOnSelect;
                                     if (closeOnSelect) $refs.trigger.$el.focus();
@@ -363,7 +362,7 @@ defineExpose({
                 </ComboboxPortal>
             </ComboboxRoot>
 
-            <div v-if="maxSelections && maxSelections !== Infinity && multiple" class="ms-2 mt-3 text-xs" :class="limitIndicatorColor">
+            <div v-if="maxSelections && maxSelections !== Infinity && multiple" class="ms-2 mt-3 text-xs" :class="limitIndicatorColor" data-ui-combobox-limit-indicator>
                 <span v-text="selectedOptions.length"></span>/<span v-text="maxSelections"></span>
             </div>
         </div>
@@ -371,6 +370,7 @@ defineExpose({
         <slot name="selected-options" v-bind="{ disabled, readOnly, getOptionLabel, getOptionValue, labelHtml, deselect }">
             <sortable-list
                 v-if="multiple"
+                data-ui-combobox-selected-options
                 item-class="sortable-item"
                 handle-class="sortable-item"
                 :distance="5"

--- a/resources/js/components/ui/Combobox.vue
+++ b/resources/js/components/ui/Combobox.vue
@@ -50,14 +50,14 @@ const attrs = useAttrs();
 const triggerClasses = cva({
     base: 'min-h-full w-full flex items-center',
     variants: {
+        variant: {
+            default: 'border border-gray-300 with-contrast:border-gray-500 dark:border-b-0 dark:ring-3 dark:ring-gray-900 dark:border-white/10 shadow-ui-sm dark:shadow-md focus-within:focus-outline',
+            ghost: 'border-none',
+        },
         size: {
             base: 'text-base rounded-lg ps-3 pe-2.5 py-2 h-10 leading-[1.375rem]',
             sm: 'text-sm rounded-md ps-2.5 pe-2 py-1.5 h-8 leading-[1.125rem]',
             xs: 'text-xs rounded-sm ps-2 pe-1.5 py-1.5 h-6 leading-[1.125rem]',
-        },
-        flat: {
-            true: 'shadow-none',
-            false: 'bg-linear-to-b from-white to-gray-50 hover:to-gray-100 dark:from-gray-800 dark:to-gray-800 dark:hover:to-gray-850 shadow-ui-sm',
         },
         'discrete-focus-outline': {
             true: 'focus-outline-discrete',
@@ -66,10 +66,6 @@ const triggerClasses = cva({
             true: 'border border-gray-300 with-contrast:border-gray-500 dark:border-b-0 dark:ring-3 dark:ring-gray-900 dark:border-white/10 shadow-ui-sm dark:shadow-md focus-within:focus-outline',
             false: '',
         },
-        // disabled: {
-        //     true: 'data-disabled:text-gray-300 data-disabled:pointer-events-none data-highlighted:outline-hidden',
-        //     false: '',
-        // },
         readOnly: {
             true: 'border-dashed',
         }

--- a/resources/js/components/ui/Select/Select.vue
+++ b/resources/js/components/ui/Select/Select.vue
@@ -8,7 +8,6 @@ const props = defineProps({
     buttonAppearance: { type: Boolean, default: true },
     clearable: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
-    flat: { type: Boolean, default: false },
     modelValue: { type: [Object, String, Number], default: null },
     optionLabel: { type: String, default: 'label' },
     options: { type: Array, default: null },
@@ -16,6 +15,7 @@ const props = defineProps({
     placeholder: { type: String, default: 'Select...' },
     readOnly: { type: Boolean, default: false },
     size: { type: String, default: 'base' },
+    variant: { type: String, default: 'default' },
 });
 
 defineOptions({
@@ -36,7 +36,6 @@ const usingOptionSlot = !!slots['option'];
         :button-appearance
         :clearable
         :disabled
-        :flat
         :model-value="modelValue"
         :option-label
         :option-value
@@ -45,6 +44,7 @@ const usingOptionSlot = !!slots['option'];
         :read-only
         :searchable="false"
         :size
+        :variant
         @update:modelValue="emit('update:modelValue', $event)"
     >
         <template #selected-option="{ option }" v-if="usingSelectedOptionSlot">

--- a/resources/js/components/ui/Select/Select.vue
+++ b/resources/js/components/ui/Select/Select.vue
@@ -5,9 +5,9 @@ import { Combobox } from '@/components/ui';
 const emit = defineEmits(['update:modelValue']);
 
 const props = defineProps({
-    buttonAppearance: { type: Boolean, default: true },
     clearable: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
+    icon: { type: String, default: null },
     modelValue: { type: [Object, String, Number], default: null },
     optionLabel: { type: String, default: 'label' },
     options: { type: Array, default: null },
@@ -33,9 +33,9 @@ const usingOptionSlot = !!slots['option'];
 <template>
     <Combobox
         v-bind="attrs"
-        :button-appearance
         :clearable
         :disabled
+        :icon
         :model-value="modelValue"
         :option-label
         :option-value

--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -105,13 +105,15 @@
             v-slot="{ text, url, icon }"
         >
             <ui-button
-                :icon="icon"
-                class="[&_svg]:size-4 -me-3"
-                variant="ghost"
+                :aria-label="text"
                 :href="url"
+                :icon="icon"
+                :round="true"
+                class="[&_svg]:size-4 -me-3"
+                size="sm"
                 target="_blank"
                 v-tooltip="text"
-                :aria-label="text"
+                variant="ghost"
             ></ui-button>
         </ui-command-palette-item>
         <x-statamic::user-dropdown />

--- a/resources/views/playground.blade.php
+++ b/resources/views/playground.blade.php
@@ -36,6 +36,31 @@
     </section>
 
     <section class="space-y-4">
+        <ui-heading size="lg">Buttons</ui-heading>
+        <div class="mb-4 flex gap-3 items-end">
+            <ui-button text="Default" />
+            <ui-button text="Primary" variant="primary" />
+            <ui-button text="Filled" variant="filled" />
+            <ui-button text="Ghost" variant="ghost" />
+            <ui-button text="Subtle" variant="subtle" />
+        </div>
+        <div class="mb-4 flex gap-3 items-end">
+            <ui-button icon="save" text="Default" />
+            <ui-button icon="save" text="Primary" variant="primary" />
+            <ui-button icon="save" text="Filled" variant="filled" />
+            <ui-button icon="save" text="Ghost" variant="ghost" />
+            <ui-button icon="save" text="Subtle" variant="subtle" />
+        </div>
+        <div class="mb-4 flex gap-3 items-end">
+            <ui-button icon="save" />
+            <ui-button icon="save" variant="primary" />
+            <ui-button icon="save" variant="filled" />
+            <ui-button icon="save" variant="ghost" />
+            <ui-button icon="save" variant="subtle" />
+        </div>
+    </section>
+
+    <section class="space-y-4">
         <ui-heading size="lg">Calendar</ui-heading>
         <div class="flex gap-6">
             <ui-card>

--- a/src/CP/Color.php
+++ b/src/CP/Color.php
@@ -348,6 +348,7 @@ class Color
             'content-border' => self::Zinc[200],
             'dark-content-bg' => self::Zinc[900],
             'dark-content-border' => self::Zinc[950],
+            'global-header-bg' => self::Zinc[800],
             'progress-bar' => self::Volt,
             'ui-accent' => self::Zinc[800],
             'dark-ui-accent' => self::Zinc[950],


### PR DESCRIPTION
Selects/Comboboxes have a simpler UI on Dark mode and now support the same `variants` as Buttons.

You can now theme the global header like so:

```
// config/statamic/cp.php
$theme => [
    'global-header-bg' => Color::Sky[800],
],
```