### PR TITLE
[6.x] Prevent session expiry modal from being dismissed

### DIFF
--- a/resources/js/components/ui/Modal/Modal.vue
+++ b/resources/js/components/ui/Modal/Modal.vue
@@ -28,7 +28,7 @@ const modalClasses = cva({
 })({});
 
 const instance = getCurrentInstance();
-const isUsingOpenProp = computed(() => instance && instance.vnode.props?.length > 0 && 'open' in instance.vnode.props);
+const isUsingOpenProp = computed(() => instance?.vnode.props?.hasOwnProperty('open'));
 
 const open = ref(props.open);
 


### PR DESCRIPTION
This pull request fixes an issue where it was possible to dismiss the session expiry modal, despite forcing the modal to remain open [via the `open` prop](https://github.com/statamic/cms/blob/master/resources/js/components/SessionExpiry.vue#L5).

It looks like the `isUsingOpenProp` logic (which is used to determine if the open state should bubble up to the parent or remain within the Modal) was always returning `false`, even when the `open` prop was present.

I've fixed the issue by refactoring the check to use `hasOwnProperty()` instead.

Fixes #12219.