### PR TITLE
[6.x] Clearer WCAG 2.2 Messaging

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -209,7 +209,7 @@ return [
     'preference_favorites_instructions' => 'Shortcuts that will be shown when opening the global search bar. You may alternatively visit the page and use the pin icon at the top to add it to this list.',
     'preference_locale_instructions' => 'The preferred language for the control panel.',
     'preference_start_page_instructions' => 'The page to be shown when logging into the control panel.',
-    'preference_strict_accessibility_instructions' => 'We\'ve designed the control panel to meet the majority of WCAG 2.2 guidelines by default, but here you can choose to enforce stricter rules, including high border contrast.',
+    'preference_strict_accessibility_instructions' => 'We\'ve designed the control panel with accessibility in mind, aiming to meet WCAG 2.2 guidelines where possible. Enable this option to apply stricter accessibility rules, which currently simply adds a higher contrast to form borders.',
     'publish_actions_create_revision' => 'A revision will be created based on the working copy. The current revision will not change.',
     'publish_actions_current_becomes_draft_because_scheduled' => 'Since the current revision is published and you\'ve selected a date in the future, once you submit, the revision will act like a draft until the selected date.',
     'publish_actions_publish' => 'Changes to the working copy will be applied to the entry and it will be published immediately.',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -209,7 +209,7 @@ return [
     'preference_favorites_instructions' => 'Shortcuts that will be shown when opening the global search bar. You may alternatively visit the page and use the pin icon at the top to add it to this list.',
     'preference_locale_instructions' => 'The preferred language for the control panel.',
     'preference_start_page_instructions' => 'The page to be shown when logging into the control panel.',
-    'preference_strict_accessibility_instructions' => 'We\'ve designed the control panel with accessibility in mind, aiming to meet WCAG 2.2 guidelines where possible. Enable this option to apply stricter accessibility rules, which currently simply adds a higher contrast to form borders.',
+    'preference_strict_accessibility_instructions' => 'We\'ve designed the control panel with accessibility in mind, aiming to meet WCAG 2.2 guidelines where possible. Enable this option to apply stricter accessibility rules by increasing form border contrast.',
     'publish_actions_create_revision' => 'A revision will be created based on the working copy. The current revision will not change.',
     'publish_actions_current_becomes_draft_because_scheduled' => 'Since the current revision is published and you\'ve selected a date in the future, once you submit, the revision will act like a draft until the selected date.',
     'publish_actions_publish' => 'Changes to the working copy will be applied to the entry and it will be published immediately.',

--- a/src/Preferences/CorePreferences.php
+++ b/src/Preferences/CorePreferences.php
@@ -28,7 +28,7 @@ class CorePreferences
         Preference::register('strict_accessibility', [
             'type' => 'toggle',
             'display' => __('Strict WCAG 2.2 Conformity'),
-            'instructions' => __('statamic::messages.preference_strict_accessibility_instructions').'<br><a href="https://www.w3.org/WAI/WCAG2AA-Conformance" title="Explanation of WCAG 2 Level AA conformance" class="inline-block mt-3"><img height="32" width="88" src="https://www.w3.org/WAI/WCAG22/wcag2.2AA" alt="Level AA conformance, W3C WAI Web Content Accessibility Guidelines 2.2"></a>',
+            'instructions' => __('statamic::messages.preference_strict_accessibility_instructions'),
             'variant' => 'inline',
         ]);
 

--- a/src/Preferences/CorePreferences.php
+++ b/src/Preferences/CorePreferences.php
@@ -27,7 +27,7 @@ class CorePreferences
 
         Preference::register('strict_accessibility', [
             'type' => 'toggle',
-            'display' => __('Strict WCAG 2.2 Conformity'),
+            'display' => __('Stricter WCAG 2.2 Mode'),
             'instructions' => __('statamic::messages.preference_strict_accessibility_instructions'),
             'variant' => 'inline',
         ]);


### PR DESCRIPTION
Even though we're trying to hit WCAG 2.2 everywhere, it's a huge task and strict compliance won't happen soon, so I've cleared up the messaging here and removed that glorious badge.

I've also been more explicit about what this toggle does, because I don't want our intentions to be misunderstood.