### PR TITLE
[6.x] Add `:dismissible="false"` to other modal in `SessionExpiry.vue`

### DIFF
--- a/resources/js/components/SessionExpiry.vue
+++ b/resources/js/components/SessionExpiry.vue
@@ -11,7 +11,7 @@
             <Button @click="extend" variant="primary" icon="rewind" :text="__('Extend Session')" class="w-full" />
         </Modal>
 
-        <Modal :title="__('Resume Your Session')" :open="isShowingLogin" height="auto" class="max-w-[500px]!">
+        <Modal :title="__('Resume Your Session')" :open="isShowingLogin" height="auto" class="max-w-[500px]!" :dismissable="false">
             <div v-if="isUsingOauth" class="space-y-3">
                 <ui-description v-text="__('messages.session_expiry_new_window')" />
                 <ui-button variant="primary" class="w-full" :href="oauthProvider.loginUrl" target="_blank" :text="__('Log in with :provider', { provider: oauthProvider.label })" />


### PR DESCRIPTION
We added `:dismissible="false"` to the session expiry modals in #12223, but we missed one. This PR adds it, even if it isn't _technically_ required as we're not listening to the `update:open` event.