### PR TITLE
[5.x] Fix blueprint blink cache issue

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -190,13 +190,6 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
             ->args(func_get_args());
     }
 
-    public function freshBlueprint()
-    {
-        Blink::forget("entry-{$this->id()}-blueprint");
-
-        return $this->blueprint();
-    }
-
     public function collectionHandle()
     {
         return $this->collection;

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -9,6 +9,7 @@ use Statamic\CP\Breadcrumbs;
 use Statamic\Exceptions\BlueprintNotFoundException;
 use Statamic\Facades\Action;
 use Statamic\Facades\Asset;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Facades\Stache;
@@ -93,7 +94,8 @@ class EntriesController extends CpController
 
         $entry = $entry->fromWorkingCopy();
 
-        $blueprint = $entry->freshBlueprint();
+        Blink::forget("entry-{$entry->id()}-blueprint");
+        $blueprint = $entry->blueprint();
 
         if (! $blueprint) {
             throw new BlueprintNotFoundException($entry->value('blueprint'), 'collections/'.$collection->handle());


### PR DESCRIPTION
I'm doing some heavy blueprint manipulation on a site and ran into an issue with the blueprint blink cache that would cause `EntryBlueprintFound` events to not be dispatched after an entry has been saved for the first time. 

`EntryBlueprintFound` events are only dispatched once per request. Once the blueprint is in the blink cache, it will be used on subsequent requests. See the [blueprint method](https://github.com/statamic/cms/blob/498f28981d0c83d28c301e6a00392c1f55c567f0/src/Entries/Entry.php#L156-L190) here.

This is a simple listener that I'm using in the videos below to showcase the issue:

```php
<?php

namespace App\Listeners;

use Statamic\Events\EntryBlueprintFound;

class ModifyBlueprint
{
    public function handle(EntryBlueprintFound $event): void
    {
        $instructions = $event->entry ? 'Editing entry' : 'Creating entry';

        $event->blueprint->ensureFieldHasConfig('title', [
            'instructions' => $instructions,
        ]);
    }
}
```

## The bug

When creating an entry, the instructions say, `Creating entry`. So far, so good. But once the entry is saved, the instructions fall back to the instructions saved in the blueprint yaml rather than using the instructions `Editing entry` as set in the listener.

https://github.com/user-attachments/assets/545e5a69-353c-43d3-a3ba-63f683d58138

## The fix

This issue can easily be resolved by clearing the blueprint blink cache when the edit route is loaded after the entry has been saved. Honestly, I'm not quite sure if this is a great solution. It feels more like a workaround. 

https://github.com/user-attachments/assets/229472b8-47ce-4248-b2c4-60b1f32ada43

## Other approach

Another approach is to also dispatch the `EntryBlueprintFound` event when the blink cache is loaded. But this kind of defeats the purpose of the blink cache.

```php
if (Blink::has($key)) {
    $blueprint = Blink::get($key);
    EntryBlueprintFound::dispatch($blueprint, $this);
    return $blueprint;
}
```

## How to reproduce

I was able to reproduce this bug on a fresh installation. [See this repo here.](https://github.com/aerni/statamic-blueprint-cache-issue) 

1. Create a user
2. Visit the `theatres` colleciton in the CP
3. Create a new theatre -> notice the `Entry creating` instructions on the title field
4. Save entry with cmd + s -> Notice the instructions disappear instead of reading `Entry created`

https://github.com/user-attachments/assets/73600ad0-82f8-4658-bc2a-93cd5132f3e2

### What causes the bug

I tracked the issue down to a query in the `AppServiceProvider` of my site. If you remove the query, the blueprint fields are ensured as expected.

```php
Entry::query()
    ->where('collection', 'theatres')
    ->get()
    ->each(function ($entry) {
        //
    });
```

### A potential solution for this scenario

The bug can also be fixed by clearing the Blink cache directly in the service provider. But I'm not sure this is a good solution either.

```php
Entry::query()
    ->where('collection', 'theatres')
    ->get()
    ->each(function ($entry) {
        Blink::forget("entry-{$entry->id()}-blueprint");
    });
```

## A similar bug

I noticed a similar blueprint caching bug when a blueprint contains a `parent` field. This is the case with structured collections or if the blueprint contains a `parent` entries fieldtype.

Check out the `Pages` collection. The title instructions will always read `Entry creating`. Even when editing an existing entry. This is likely the underlying issue as in the theatres collection, as the pages collection is queried by the `parent` entries fieldtype. 

However, the fix provided in this PR doesn't solve the issue in this scenario.

https://github.com/user-attachments/assets/ad600002-f404-465b-9633-af8d091a8dd6
