### PR TITLE
[6.x] Table fixes for Safari and Firefox

### DIFF
--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -52,6 +52,12 @@
     font-weight: 425;
 }
 
+/* UTILITIES / DECORATION / SHADOWS
+=================================================== */
+@utility shadow-sm-b {
+    box-shadow: 0 3px 2px -1px hsl(0deg 0% 90%), 0 1px 2px hsl(0deg 0% 90%);
+}
+
 /* UTILITIES / STATES
 =================================================== */
 /* Here we typically need a negative outline-offset because of the inner shadow on inputs */
@@ -130,7 +136,7 @@
     @apply bg-white/85 backdrop-blur-sm;
 }
 
-/* UTILITIES / STATES / DECORATION / MASK BACKGROUND
+/* UTILITIES / DECORATION / MASK BACKGROUND
 =================================================== */
 /* Notes...
 
@@ -181,7 +187,7 @@
     }
 }
 
-/* UTILITIES / STATES / DECORATION / ARCHIECTURAL LINES
+/* UTILITIES / DECORATION / ARCHIECTURAL LINES
 =================================================== */
 /* Notes...
 
@@ -283,7 +289,7 @@
     }
 }
 
-/* UTILITIES / STATES / DECORATION / CHECKERBOARD
+/* UTILITIES / DECORATION / CHECKERBOARD
 =================================================== */
 @utility bg-checkerboard {
     --checkerboard-light: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 0h12v12H0zm12 12h12v12H12z' fill='%23f3f4f6'/%3E%3C/svg%3E");

--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -56,6 +56,9 @@
 =================================================== */
 @utility shadow-sm-b {
     box-shadow: 0 3px 2px -1px hsl(0deg 0% 90%), 0 1px 2px hsl(0deg 0% 90%);
+    &:where(.dark, .dark *) {
+        box-shadow: unset;
+    }
 }
 
 /* UTILITIES / STATES

--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -1,7 +1,6 @@
 /* ==========================================================================
    TABLES
    ========================================================================== */
-
 .data-table {
     @apply w-full max-w-full outline-hidden text-gray-500 antialiased border-separate border-spacing-y-0 min-w-full overflow-x-auto text-start;
 
@@ -29,7 +28,7 @@
     }
 
     tbody {
-        @apply text-sm shadow-sm rounded-xl outline-none;
+        @apply text-sm shadow-sm-b rounded-xl outline-none;
         .contained & {
             @apply shadow-none rounded-none;
         }
@@ -41,18 +40,22 @@
                     @apply ltr:rounded-tl-xl rtl:rounded-tr-xl;
                 }
 
+                td {
+                    @apply border-t border-t-gray-200 dark:border-gray-700;
+                }
+
                 td:last-child,
                 th:last-child {
                     @apply ltr:rounded-tr-xl rtl:rounded-tl-xl;
-                }
-
-                td {
-                    @apply border-0;
                 }
             }
 
             &:last-child {
                 @apply border-none;
+
+                td {
+                    @apply border-b border-b-gray-200 dark:border-gray-700;
+                }
 
                 td:first-child,
                 th:first-child {
@@ -73,6 +76,12 @@
                 @apply bg-white dark:bg-gray-900;
                 @apply pl-4.5 pr-2.5 py-3 border-t border-gray-200 dark:border-white/10;
                 @apply text-gray-900 dark:text-gray-200;
+                &:first-child {
+                    @apply border-s border-s-gray-200 dark:border-gray-700;
+                }
+                &:last-child {
+                    @apply border-e border-e-gray-200 dark:border-gray-700;
+                }
             }
 
             /* When the row is hovered, change the background of all its cells to a hover state color */

--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -29,7 +29,7 @@
     }
 
     tbody {
-        @apply text-sm bg-white dark:bg-gray-900 shadow-sm rounded-xl outline-none;
+        @apply text-sm dark:bg-gray-900 shadow-sm rounded-xl outline-none;
         .contained & {
             @apply shadow-none rounded-none;
         }
@@ -65,17 +65,19 @@
                 }
             }
 
-            &:hover {
-                @apply bg-gray-50 dark:bg-white/2.5;
-            }
-
             th {
                 @apply py-2 ltr:pr-4 rtl:pl-4;
             }
 
             td {
+                @apply bg-white;
                 @apply pl-4.5 pr-2.5 py-3 border-t border-gray-200 dark:border-white/10;
                 @apply text-gray-900 dark:text-gray-200;
+            }
+
+            /* When the row is hovered, change the background of all its cells to a hover state color */
+            &:has(:hover) td {
+                @apply bg-gray-50 dark:bg-white/2.5;
             }
         }
 

--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -29,7 +29,7 @@
     }
 
     tbody {
-        @apply text-sm dark:bg-gray-900 shadow-sm rounded-xl outline-none;
+        @apply text-sm shadow-sm rounded-xl outline-none;
         .contained & {
             @apply shadow-none rounded-none;
         }
@@ -70,7 +70,7 @@
             }
 
             td {
-                @apply bg-white;
+                @apply bg-white dark:bg-gray-900;
                 @apply pl-4.5 pr-2.5 py-3 border-t border-gray-200 dark:border-white/10;
                 @apply text-gray-900 dark:text-gray-200;
             }

--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -41,7 +41,7 @@
                 }
 
                 td {
-                    @apply border-t border-t-gray-200 dark:border-gray-700;
+                    @apply border-t border-t-gray-200 dark:border-t-gray-800;
                 }
 
                 td:last-child,
@@ -54,7 +54,7 @@
                 @apply border-none;
 
                 td {
-                    @apply border-b border-b-gray-200 dark:border-gray-700;
+                    @apply border-b border-b-gray-200 dark:border-b-gray-800;
                 }
 
                 td:first-child,
@@ -77,10 +77,10 @@
                 @apply pl-4.5 pr-2.5 py-3 border-t border-gray-200 dark:border-white/10;
                 @apply text-gray-900 dark:text-gray-200;
                 &:first-child {
-                    @apply border-s border-s-gray-200 dark:border-gray-700;
+                    @apply border-s border-s-gray-200 dark:border-s-gray-800;
                 }
                 &:last-child {
-                    @apply border-e border-e-gray-200 dark:border-gray-700;
+                    @apply border-e border-e-gray-200 dark:border-e-gray-800;
                 }
             }
 


### PR DESCRIPTION
This fixes table border-radius for Firefox, along with a hover state adjustment.
It also improves things for Safari.
This closes #12070

## Firefox

In Firefox’s implementation, tbody’s background and border properties aren’t rendered as a box, so border-radius has no visual effect.
Instead, I've styled the tds.

## Safari

Similar to Firefox, in WebKit (Safari), any background, borders, or box-shadow applied to tbody are simply ignored — the browser paints only the table itself and its cells. Instead, our only option is to style the tds with borders instead of shadows. I've added an alternative shadow for browsers like Chrome to compensate for the new border.

