### PR TITLE
[6.x] Remove unnecessary margin from globals publish form

### DIFF
--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -15,7 +15,6 @@
 
             <SiteSelector
                 v-if="showLocalizationSelector"
-                class="ltr:mr-4 rtl:ml-4"
                 :sites="localizations"
                 :value="site"
                 @input="localizationSelected"


### PR DESCRIPTION
This PR removes unnecessary margin between the site selector and the "Save" button on the global set publish form. Spacing is applied automatically by the `ui-header` component.

## Before 

<img width="872" height="92" alt="CleanShot 2025-08-29 at 18 07 40" src="https://github.com/user-attachments/assets/04159ec6-12b8-4594-9b17-ffa12fbc5bd3" />


## After

<img width="872" height="92" alt="CleanShot 2025-08-29 at 18 07 01" src="https://github.com/user-attachments/assets/7ff50717-7576-41b5-9641-e80a59c54e6c" />
