### PR TITLE
[6.x] Add `cursor-pointer` to replicator set headers & set picker

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -18,7 +18,7 @@
                 :class="{ 'rounded-b-none border-gray-200 dark:border-white/10': !collapsed }"
             >
                 <Icon data-drag-handle name="ui/handles" class="size-4 cursor-grab text-gray-400" v-if="!isReadOnly" />
-                <button type="button" class="flex flex-1 items-center gap-4 p-2 min-w-0" @click="toggleCollapsedState">
+                <button type="button" class="flex flex-1 items-center gap-4 p-2 min-w-0 cursor-pointer" @click="toggleCollapsedState">
                     <Badge variant="flat" size="lg">
                         <span v-if="isSetGroupVisible" class="flex items-center gap-2">
                             {{ __(setGroup.display) }}

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -142,7 +142,7 @@ function destroy() {
                     class="size-4 cursor-grab text-gray-400"
                     v-if="!readOnly"
                 />
-                <button type="button" class="flex flex-1 items-center gap-4 p-2 min-w-0" @click="toggleCollapsedState">
+                <button type="button" class="flex flex-1 items-center gap-4 p-2 min-w-0 cursor-pointer" @click="toggleCollapsedState">
                     <Badge variant="flat" size="lg">
                         <span v-if="isSetGroupVisible" class="flex items-center gap-2">
                             {{ __(setGroup.display) }}

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -29,7 +29,7 @@
                     data-set-picker-search-input
                 />
                 <div v-if="showGroupBreadcrumb" class="flex items-center font-medium text-gray-700 dark:text-gray-300 gap-1">
-                    <button @click="unselectGroup" class="hover:text-gray-900 dark:hover:text-white">
+                    <button @click="unselectGroup" class="hover:text-gray-900 dark:hover:text-white cursor-pointer">
                         {{ __('Groups') }}
                     </button>
                     <ui-icon name="ui/chevron-right" class="size-4" />


### PR DESCRIPTION
This pull request adds the `cursor-pointer` class to Bard/Replicator set headers, as well as the "Groups" breadcrumb text in the Replicator set picker.