### PR TITLE
[6.x] Date Fieldtype: Prevent dashed border showing in non-read-only state

### DIFF
--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -114,7 +114,8 @@ const getInputLabel = (part) => {
                         'text-gray-600 dark:text-gray-300',
                         'shadow-ui-sm not-prose h-10 rounded-lg px-2 disabled:shadow-none',
                         'data-invalid:border-red-500',
-                        'disabled:shadow-none disabled:opacity-50 read-only:border-dashed'
+                        'disabled:shadow-none disabled:opacity-50',
+                        readOnly ? 'border-dashed' : '',
                     ]"
                     :aria-invalid="isInvalid"
                     role="textbox"

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -90,7 +90,8 @@ const calendarEvents = computed(() => ({
                         'leading-[1.375rem] text-gray-600 dark:text-gray-300',
                         'shadow-ui-sm not-prose h-10 rounded-lg py-2 px-3 disabled:shadow-none',
                         'data-invalid:border-red-500',
-                        'disabled:shadow-none disabled:opacity-50 read-only:border-dashed'
+                        'disabled:shadow-none disabled:opacity-50',
+                        readOnly ? 'border-dashed' : '',
                     ]"
                 >
                     <DateRangePickerTrigger v-if="!inline">


### PR DESCRIPTION
This pull request fixes a bug I introduced in #12127, where the `border-dashed` class was being applied, even without the field being read-only.

I _believe_ this was happening because the `read-only:` modifier only works on inputs, not divs. This PR fixes it by applying the class conditionally, based on JS.