### PR TITLE
[6.x] Command palette `keys` API and display

### DIFF
--- a/resources/js/components/CommandPalette.js
+++ b/resources/js/components/CommandPalette.js
@@ -14,9 +14,9 @@ class Command {
         this.url = command.url;
         this.openNewTab = command.openNewTab ?? false;
         this.action = command.action;
+        this.keys = command.keys;
         this.prioritize = command.prioritize ?? false;
         this.trackRecent = command.trackRecent ?? false;
-        this.keys = command.keys;
 
         this.#validate();
     }

--- a/resources/js/components/CommandPalette.js
+++ b/resources/js/components/CommandPalette.js
@@ -16,6 +16,7 @@ class Command {
         this.action = command.action;
         this.prioritize = command.prioritize ?? false;
         this.trackRecent = command.trackRecent ?? false;
+        this.keys = command.keys;
 
         this.#validate();
     }

--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -112,6 +112,10 @@ function normalizeItem(item) {
         item.text = item.text.join(' » ');
     }
 
+    if (typeof item.keys === 'string') {
+        item.keys = Statamic.$keys.render(item.keys).map(key => key.toUpperCase());
+    }
+
     return item;
 }
 

--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -319,7 +319,8 @@ const modalClasses = cva({
                                             :icon="item.icon"
                                             :href="item.url"
                                             :open-new-tab="item.openNewTab"
-                                            :badge="item.keys || item.badge"
+                                            :badge="item.badge"
+                                            :keys="item.keys"
                                             :removable="isRecentItem(item)"
                                             @remove="removeRecentItem"
                                         >

--- a/resources/js/components/command-palette/Item.vue
+++ b/resources/js/components/command-palette/Item.vue
@@ -8,6 +8,7 @@ const props = defineProps({
     icon: { type: String, default: null },
     text: { type: String, default: null },
     badge: { type: String, default: null },
+    keys: { type: Array, default: null },
     removable: { type: Boolean, default: false },
 });
 
@@ -57,6 +58,7 @@ function click(event) {
             <template v-else>{{ text }}</template>
         </div>
         <Badge v-if="badge" :text="badge" variant="flat" />
+        <Badge v-if="keys" v-for="key in keys" :key="key" :text="key" variant="flat" />
         <Icon
             v-if="removable"
             name="x"

--- a/resources/js/components/keys/Keys.js
+++ b/resources/js/components/keys/Keys.js
@@ -19,19 +19,21 @@ export default class Keys {
         return new GlobalBinding(this.globals).bind(bindings, callback);
     }
 
-    parse(bindings) {
+    render(bindings) {
         if (Array.isArray(bindings)) {
             bindings = bindings[0];
         }
 
         return bindings.toLowerCase().split('+').map(key => {
             switch(key) {
+                case "command":
                 case "cmd":
-                    return "command";
+                    return "⌘";
+                case "control":
                 case "ctrl":
-                    return "control";
+                    return "^";
                 case "mod":
-                    return "command"; // TODO: handle normalizing 'mod' cross platform
+                    return "⌘"; // TODO: handle normalizing 'mod' cross platform
                 default:
                     return key;
             }

--- a/resources/js/components/keys/Keys.js
+++ b/resources/js/components/keys/Keys.js
@@ -18,4 +18,23 @@ export default class Keys {
     bindGlobal(bindings, callback) {
         return new GlobalBinding(this.globals).bind(bindings, callback);
     }
+
+    parse(bindings) {
+        if (Array.isArray(bindings)) {
+            bindings = bindings[0];
+        }
+
+        return bindings.toLowerCase().split('+').map(key => {
+            switch(key) {
+                case "cmd":
+                    return "command";
+                case "ctrl":
+                    return "control";
+                case "mod":
+                    return "command"; // TODO: handle normalizing 'mod' cross platform
+                default:
+                    return key;
+            }
+        });
+    }
 }

--- a/resources/js/components/ui/CommandPalette/Item.vue
+++ b/resources/js/components/ui/CommandPalette/Item.vue
@@ -9,6 +9,8 @@ const props = defineProps({
     url: { type: String },
     action: { type: Function },
     openNewTab: { type: Boolean },
+    badge: { type: String },
+    keys: { type: String },
     trackRecent: { type: Boolean },
     prioritize: { type: Boolean },
 });
@@ -26,5 +28,7 @@ onUnmounted(() => command.remove());
         :text="text"
         :url="url"
         :action="action"
+        :badge="badge"
+        :keys="keys"
     />
 </template>

--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -44,6 +44,7 @@
                 :text="__('Save')"
                 icon="save"
                 :action="save"
+                keys="mod+s"
                 prioritize
                 v-slot="{ text, action }"
             >


### PR DESCRIPTION
This PR adds command palette `keys` API for displaying hotkeys on actions, etc.

<img width="836" height="242" alt="CleanShot 2025-08-30 at 01 07 01" src="https://github.com/user-attachments/assets/1dc97a6e-c9c0-4eb5-bae9-5c39f925d8c1" />

Right now this just adds cosmetic badges, using the same keybinding conventions as mousetrap (what we use under the hood with `$keys.bindGlobal()`, etc.

Do we want the command palette itself to create keybindings, or just continue to display keybindings, leaving the actual binding to be handled externally?