### PR TITLE
[5.x] Translate additional blueprint titles

### DIFF
--- a/resources/views/blueprints/index.blade.php
+++ b/resources/views/blueprints/index.blade.php
@@ -190,7 +190,7 @@
                 <td>
                     <div class="flex items-center">
                         <div class="w-4 h-4 rtl:ml-4 ltr:mr-4">@cp_svg('icons/light/blueprint')</div>
-                        <a href="{{ cp_route('blueprints.edit', [$blueprint['namespace'], $blueprint['handle']]) }}">{{ $blueprint['title'] }}</a>
+                        <a href="{{ cp_route('blueprints.edit', [$blueprint['namespace'], $blueprint['handle']]) }}">{{ __($blueprint['title']) }}</a>
                     </div>
                 </td>
                 <th class="actions-column">


### PR DESCRIPTION
For localisation of addons, using a language key as a title to ensure it can be fully translated.

However, on the Blueprints view, under the 'additional' blueprints populated from `Blueprint::getRenderableAdditionalNamespaces()`, the titles are not translated, resulting in the key being shown instead.

This PR corrects this for v5.