### PR TITLE
[6.x] Translate additional blueprint titles

### DIFF
--- a/resources/views/blueprints/index.blade.php
+++ b/resources/views/blueprints/index.blade.php
@@ -258,7 +258,7 @@
                             <td>
                                 <div class="flex items-center gap-2">
                                     <ui-icon name="blueprints" class="text-gray-500 me-1" />
-                                    <a href="{{ cp_route('blueprints.additional.edit', [$blueprint['namespace'], $blueprint['handle']]) }}" v-pre>{{ $blueprint['title'] }}</a>
+                                    <a href="{{ cp_route('blueprints.additional.edit', [$blueprint['namespace'], $blueprint['handle']]) }}" v-pre>{{ __($blueprint['title']) }}</a>
                                 </div>
                             </td>
                             <td class="actions-column">


### PR DESCRIPTION
For localisation of addons, using a language key as a title to ensure it can be fully translated.

However, on the Blueprints view, under the 'additional' blueprints populated from `Blueprint::getRenderableAdditionalNamespaces()`, the titles are not translated, resulting in the key being shown instead.

This PR corrects this for v6.