### PR TITLE
[6.x] Add `resources/dist-package` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tests/Fakes/Composer/Package/test-package/composer.json
 resources/dist
 resources/dist-dev
 resources/dist-frontend
+resources/dist-package
 resources/js/package/types
 resources/js/package/vite-plugin/tailwind-exclusions.css
 composer.lock


### PR DESCRIPTION
This pull request adds the `resources/dist-package` to `.gitgnore` to ensure it isn't accidentally committed to Git.