### PR TITLE
[5.x] Corrects issue with unless conditions.

### DIFF
--- a/src/View/Antlers/Language/Nodes/AntlersNode.php
+++ b/src/View/Antlers/Language/Nodes/AntlersNode.php
@@ -312,6 +312,8 @@ class AntlersNode extends AbstractNode
         $instance->rawEnd = $this->rawEnd;
         $instance->startPosition = $this->startPosition;
         $instance->endPosition = $this->endPosition;
+        $instance->interpolationRegions = $this->interpolationRegions;
+        $instance->processedInterpolationRegions = $this->processedInterpolationRegions;
 
         return $instance;
     }

--- a/tests/Antlers/Runtime/UnlessTest.php
+++ b/tests/Antlers/Runtime/UnlessTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Antlers\Runtime;
 
+use Illuminate\Support\Str;
 use Tests\Antlers\ParserTestCase;
 
 class UnlessTest extends ParserTestCase
@@ -16,5 +17,20 @@ EOT;
             'first' => false,
             'last' => false,
         ]));
+    }
+
+    public function test_unless_with_vars()
+    {
+        $template = <<<'EOT'
+{{ the_var = 1 }}
+
+{{ unless {the_var} }}true{{ else }}false{{ /unless }}
+{{ if ! {the_var} }}true{{ else }}false{{ /if }}
+EOT;
+
+        $this->assertSame(
+            'false false',
+            Str::squish($this->renderString($template))
+        );
     }
 }


### PR DESCRIPTION
This PR fixes #12247 

Internally, the parser rewrites unless blocks:

```antlers
{{ unless { the_var } }}
    ...
{{ /unless }}
```

into its corresponding `if` statement:

```antlers
{{ if ! ({ the_var }) }}
    ...
{{ /if }}
```

After investigation, it was discovered that the interpolated regions produced by the nested `{ the_var }` syntax was not being copied to the rewritten node. This PR copies this information, allowing the `unless` node to work correctly in this situation.
