### PR TITLE
[5.x] Resolving PHP Warning and PHP Notice errors

### DIFF
--- a/src/Imaging/Attributes.php
+++ b/src/Imaging/Attributes.php
@@ -41,8 +41,20 @@ class Attributes
 
     private function imageAttributes(string $path)
     {
-        [$width, $height] = getimagesize($this->prefixPath($path));
-
+        $fullPath = $this->prefixPath($path);
+    
+        if (!file_exists($fullPath)) {
+            return ['width' => 0, 'height' => 0];
+        }
+    
+        $size = @getimagesize($fullPath);
+    
+        if ($size === false) {
+            return ['width' => 0, 'height' => 0];
+        }
+    
+        [$width, $height] = $size;
+    
         return compact('width', 'height');
     }
 


### PR DESCRIPTION
In recent days, we started monitoring error log from one of our apps. During that timeframe we received loads of these errors:

PHP Notice
getimagesize(): Error reading from /storage/statamic/attributes-cache/da9235a6-02a6-4c00-8de5-5bd5b851c6c8-2.png!

and

PHP Warning
getimagesize(/storage/statamic/attributes-cache/img/IMG_NAME.jpg): Failed to open stream: No such file or directory

I tried to resolve it via this PR, but I am not sure, if this is the right way.