### PR TITLE
[6.x] Cache flattened permissions

### DIFF
--- a/src/Auth/Permissions.php
+++ b/src/Auth/Permissions.php
@@ -3,6 +3,7 @@
 namespace Statamic\Auth;
 
 use Facades\Statamic\Auth\CorePermissions;
+use Statamic\Facades\Blink;
 
 class Permissions
 {
@@ -136,6 +137,10 @@ class Permissions
 
     public function flattened()
     {
-        return collect($this->permissions)->flatMap->flattened();
+        $blink = 'flattened-permissions'.md5(json_encode($this->permissions));
+
+        return Blink::once($blink, function () {
+            return collect($this->permissions)->flatMap->flattened();
+        });
     }
 }

--- a/src/Auth/Permissions.php
+++ b/src/Auth/Permissions.php
@@ -3,7 +3,6 @@
 namespace Statamic\Auth;
 
 use Facades\Statamic\Auth\CorePermissions;
-use Statamic\Facades\Blink;
 
 class Permissions
 {
@@ -12,6 +11,7 @@ class Permissions
     protected $groups = [];
     protected $pendingGroup = null;
     protected $booted = false;
+    private $flattened;
 
     public function boot()
     {
@@ -137,10 +137,6 @@ class Permissions
 
     public function flattened()
     {
-        $blink = 'flattened-permissions'.md5(json_encode($this->permissions));
-
-        return Blink::once($blink, function () {
-            return collect($this->permissions)->flatMap->flattened();
-        });
+        return $this->flattened ??= collect($this->permissions)->flatMap->flattened();
     }
 }


### PR DESCRIPTION
This pull request "blinks" the return value of `Permissions@flattened()`, which improves CP performance significantly on some sites.

`Permissions@flattened()` was added in #11516. Performance issues were reported on [Discord](https://discord.com/channels/489818810157891584/1408132171452911696/1408504777079521370).