### PR TITLE
[6.x] Fix focal point editor

### DIFF
--- a/resources/js/components/assets/Editor/FocalPointEditor.vue
+++ b/resources/js/components/assets/Editor/FocalPointEditor.vue
@@ -1,8 +1,8 @@
 <template>
     <portal name="focal-point">
         <div class="focal-point">
-            <div class="focal-point-toolbox card p-0">
-                <div class="p-4">
+            <Card class="focal-point-toolbox" inset>
+                <div class="p-6">
                     <Heading size="xl">{{ __('Focal Point') }}</Heading>
                     <Subheading>{{ __('messages.focal_point_instructions') }}</Subheading>
                     <div class="focal-point-image">
@@ -46,7 +46,7 @@
                 <h6 class="rounded-b bg-gray-100  p-4 text-center  dark:bg-dark-800">
                     {{ __('messages.focal_point_previews_are_examples') }}
                 </h6>
-            </div>
+            </Card>
             <div v-for="n in 9" :key="n" :class="`frame frame-${n}`">
                 <focal-point-preview-frame
                     v-if="imageDimensions"
@@ -62,11 +62,12 @@
 </template>
 
 <script>
-import { Heading, Subheading, Button } from '@/components/ui';
+import { Card, Heading, Subheading, Button } from '@/components/ui';
 import FocalPointPreviewFrame from './FocalPointPreviewFrame.vue';
 
 export default {
     components: {
+        Card,
         Heading,
         Subheading,
         Button,


### PR DESCRIPTION
This PR fixes an issue where the card in the focal point editor was missing a background colour, due to it using the `card` class which no longer exists.

Fixes #12254.

## Before

<img width="569" height="625" alt="CleanShot 2025-09-02 at 10 25 39" src="https://github.com/user-attachments/assets/7559ad5e-052a-4063-9858-e3a175781a0b" />


## After

<img width="569" height="625" alt="CleanShot 2025-09-02 at 10 25 23" src="https://github.com/user-attachments/assets/f8cc0d5d-f59b-4e4a-a85d-d0965a08a5ab" />
