### PR TITLE
[6.x] Prevent sections without titles being collapsed

### DIFF
--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -32,6 +32,10 @@ function renderInstructions(instructions) {
     return instructions ? markdown(__(instructions), { openLinksInNewTabs: true }) : '';
 }
 
+function isCollapsed(section) {
+    return section.display && section.collapsed;
+}
+
 function toggleSection(id) {
     if (sections[id].collapsible) {
         sections[id].collapsed = !sections[id].collapsed;
@@ -51,9 +55,9 @@ function toggleSection(id) {
                 <Subheading v-if="section.instructions" :text="renderInstructions(section.instructions)" />
             </PanelHeader>
             <Motion
-                :class="{ 'overflow-hidden': section.collapsed }"
-                :initial="{ height: section.collapsed ? '0px' : 'auto' }"
-                :animate="{ height: section.collapsed ? '0px' : 'auto' }"
+                :class="{ 'overflow-hidden': isCollapsed(section) }"
+                :initial="{ height: isCollapsed(section) ? '0px' : 'auto' }"
+                :animate="{ height: isCollapsed(section) ? '0px' : 'auto' }"
                 :transition="{ duration: 0.25, type: 'tween' }"
             >
                 <div class="p-px">


### PR DESCRIPTION
Currently, if you mark a section as "collapsed by default" and leave the "display" text empty, an empty card will be rendered on the publish form with no way to expand:

<img width="1253" height="55" alt="CleanShot 2025-09-02 at 10 41 05" src="https://github.com/user-attachments/assets/80b1fc3c-102a-45cf-97ec-fd37e12650e8" />

This pull request fixes it by preventing sections from being auto-collapsed when a display title is missing.

Fixes #12255