### PR TITLE
[6.x] Login custom logo width

### DIFF
--- a/resources/views/components/outside-logo.blade.php
+++ b/resources/views/components/outside-logo.blade.php
@@ -1,4 +1,4 @@
-<div class="logo relative z-10 max-w-[300px] md:pt-18">
+<div class="logo relative z-10 max-w-3/4 md:pt-18">
     @if ($customLogo)
         <img
             src="{{ $customLogo }}"

--- a/resources/views/components/outside-logo.blade.php
+++ b/resources/views/components/outside-logo.blade.php
@@ -1,4 +1,4 @@
-<div class="logo relative z-10 md:pt-18">
+<div class="logo relative z-10 max-w-[300px] md:pt-18">
     @if ($customLogo)
         <img
             src="{{ $customLogo }}"


### PR DESCRIPTION
This sets a default max-width of `75%` on the logo area, which is used for custom logos. `max-w-[300px]` used to be set on the container in v5, but now it's `max-w-[400px]` since the component itself is wider.

So this makes custom logo `max-width` a little more palatable, being slightly narrower than the card.

I've set this to a % value so it also works well on mobile.