### PR TITLE
[6.x] Avoid saving theme preference when unauthenticated

### DIFF
--- a/resources/js/components/Preference.js
+++ b/resources/js/components/Preference.js
@@ -16,14 +16,10 @@ export default class Preference {
     }
 
     set(key, value) {
-        if (!Statamic.$config.get('user')) return;
-
         return this.commitOnSuccessAndReturnPromise(axios.post(this.url, { key, value }));
     }
 
     append(key, value) {
-        if (!Statamic.$config.get('user')) return;
-
         return this.commitOnSuccessAndReturnPromise(axios.post(this.url, { key, value, append: true }));
     }
 
@@ -32,8 +28,6 @@ export default class Preference {
     }
 
     remove(key, value = null, cleanup = true) {
-        if (!Statamic.$config.get('user')) return;
-
         return this.commitOnSuccessAndReturnPromise(axios.delete(`${this.url}/${key}`, { data: { value, cleanup } }));
     }
 

--- a/resources/js/components/Preference.js
+++ b/resources/js/components/Preference.js
@@ -16,10 +16,14 @@ export default class Preference {
     }
 
     set(key, value) {
+        if (!Statamic.$config.get('user')) return;
+
         return this.commitOnSuccessAndReturnPromise(axios.post(this.url, { key, value }));
     }
 
     append(key, value) {
+        if (!Statamic.$config.get('user')) return;
+
         return this.commitOnSuccessAndReturnPromise(axios.post(this.url, { key, value, append: true }));
     }
 
@@ -28,6 +32,8 @@ export default class Preference {
     }
 
     remove(key, value = null, cleanup = true) {
+        if (!Statamic.$config.get('user')) return;
+
         return this.commitOnSuccessAndReturnPromise(axios.delete(`${this.url}/${key}`, { data: { value, cleanup } }));
     }
 

--- a/resources/js/components/Theme.js
+++ b/resources/js/components/Theme.js
@@ -61,13 +61,13 @@ export default class Theme {
 
     #savePreference(preference) {
         if (preference === 'auto') {
-            if (Statamic.$preferences.has('theme')) {
+            if (Statamic.$config.get('user') && Statamic.$preferences.has('theme')) {
                 Statamic.$preferences.remove('theme');
             }
 
             localStorage.removeItem('statamic.theme');
         } else {
-            if (Statamic.$preferences.get('theme') !== preference) {
+            if (Statamic.$config.get('user') && Statamic.$preferences.get('theme') !== preference) {
                 Statamic.$preferences.set('theme', preference);
             }
 


### PR DESCRIPTION
Currently, when you visit the login page (or another auth page), Statamic will make a network request to save the `theme` preference.`

However, since you're unauthenticated, the request fails:

<img width="1215" height="56" alt="CleanShot 2025-09-02 at 11 53 22" src="https://github.com/user-attachments/assets/428dcfeb-d9c9-4b8b-9af5-6f5cb60c45f5" />

This PR avoids saving the `theme` preference unless there's an authenticated user.