### PR TITLE
[6.x] Fix border color in dark mode empty states

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -28,7 +28,7 @@
                 <template v-slot:empty-state>
                     <ui-subheading
                         v-text="__('Drag and drop fields below.')"
-                        class="rounded-xl min-h-16 flex items-center justify-center border border-dashed border-gray-300 p-3 text-center w-full"
+                        class="rounded-xl min-h-16 flex items-center justify-center border border-dashed border-gray-300 dark:border-gray-700 p-3 text-center w-full"
                     />
                 </template>
             </Fields>

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -677,7 +677,7 @@ autoApplyState();
 
         <div
             v-if="!items.length"
-            class="rounded-lg border border-dashed border-gray-300 p-6 text-center text-gray-500"
+            class="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 p-6 text-center text-gray-500"
             v-text="__('No results')"
         />
 


### PR DESCRIPTION
This pull request fixes a minor issue in dark mode, where the border color of empty states is white, instead of a dark-mode-y color.

This PR fixes it for empty listings & new blueprint sections.

## Before
<img width="1012" height="193" alt="CleanShot 2025-09-02 at 12 21 24" src="https://github.com/user-attachments/assets/f3f911e3-da87-41b0-8cd0-973fc8cbdfff" />
<img width="1034" height="219" alt="CleanShot 2025-09-02 at 12 20 58" src="https://github.com/user-attachments/assets/f0204349-5dbd-4b10-9555-4d9cd498d79c" />

## After
<img width="1012" height="193" alt="CleanShot 2025-09-02 at 12 21 43" src="https://github.com/user-attachments/assets/52b6efcd-ec00-477c-867d-6abf6c90b809" />
<img width="1034" height="219" alt="CleanShot 2025-09-02 at 12 20 48" src="https://github.com/user-attachments/assets/e52d4426-d27d-46b6-8621-a8603ca734c6" />
