### PR TITLE
[6.x] Fix date column in collection widget

### DIFF
--- a/resources/js/components/entries/CollectionWidget.vue
+++ b/resources/js/components/entries/CollectionWidget.vue
@@ -83,7 +83,7 @@ function formatDate(value) {
                             <template #cell-date="{ row: entry, isColumnVisible }">
                                 <div
                                     class="text-end font-mono text-xs whitespace-nowrap text-gray-500 antialiased px-2"
-                                    v-html="formatDate(entry.date?.date)"
+                                    v-html="formatDate(entry.date.date)"
                                     v-if="isColumnVisible('date')"
                                 />
                             </template>


### PR DESCRIPTION
This pull request fixes an issue with the Collection widget, where the `date` column would show today's date, rather than the entry's date.

For example:

```php
// config/statamic/cp.php

'widgets' => [
    ['type' => 'collection', 'collection' => 'articles', 'fields' => ['date']],
],
```

## Before

<img width="799" height="254" alt="CleanShot 2025-09-02 at 12 36 04" src="https://github.com/user-attachments/assets/d2654313-f6fe-4e54-b4bd-479285cae1e9" />


## After

<img width="800" height="242" alt="CleanShot 2025-09-02 at 12 35 51" src="https://github.com/user-attachments/assets/0f8e3bd7-1869-44f4-869a-e4a03f2fa043" />
