### PR TITLE
[6.x] Improve the difference between the `data-ui-subheading` and the heading

### DIFF
--- a/resources/js/components/ui/Heading.vue
+++ b/resources/js/components/ui/Heading.vue
@@ -21,7 +21,7 @@ const tag = computed(() => {
 });
 
 const classes = cva({
-    base: 'font-medium [&:has(+[data-ui-subheading])]:mb-0.5 antialiased flex items-center gap-2',
+    base: 'font-medium [&:has(+[data-ui-subheading])]:mb-0.5 [&:has(+[data-ui-subheading])]:text-gray-950 antialiased flex items-center gap-2',
     variants: {
         size: {
             base: 'text-sm tracking-tight text-gray-700 dark:text-white',

--- a/resources/js/components/ui/Input/GroupPrepend.vue
+++ b/resources/js/components/ui/Input/GroupPrepend.vue
@@ -9,7 +9,7 @@ const props = defineProps({
         :class="[
             'flex items-center justify-center',
             'shadow-ui-sm disabled:shadow-none',
-            'border border-gray-300 border-e-0 bg-gray-50 text-gray-600 antialiased dark:border-white/10 dark:bg-gray-950 dark:text-gray-300',
+            'border border-gray-300 bg-gray-50 text-gray-600 antialiased dark:border-white/10 dark:bg-gray-950 dark:text-gray-300',
             'rounded-s-lg px-3 text-sm leading-[1.375rem] shrink-0',
         ]"
         data-ui-input-group-prepend

--- a/resources/js/components/ui/Input/GroupPrepend.vue
+++ b/resources/js/components/ui/Input/GroupPrepend.vue
@@ -9,7 +9,7 @@ const props = defineProps({
         :class="[
             'flex items-center justify-center',
             'shadow-ui-sm disabled:shadow-none',
-            'border border-gray-300 bg-gray-50 text-gray-600 antialiased dark:border-white/10 dark:bg-gray-950 dark:text-gray-300',
+            'border border-gray-300 border-e-0 bg-gray-50 text-gray-600 antialiased dark:border-white/10 dark:bg-gray-950 dark:text-gray-300',
             'rounded-s-lg px-3 text-sm leading-[1.375rem] shrink-0',
         ]"
         data-ui-input-group-prepend

--- a/resources/js/components/ui/Label.vue
+++ b/resources/js/components/ui/Label.vue
@@ -15,7 +15,7 @@ const props = defineProps({
 
 <template>
     <label
-        class="flex justify-between mb-1.5 text-sm font-medium [&_button]:font-medium text-gray-900 select-none dark:text-gray-300"
+        class="flex justify-between mb-1.5 text-sm font-medium [&_button]:font-medium text-gray-950 select-none dark:text-gray-300"
         data-ui-label
         :for="for"
     >


### PR DESCRIPTION
Currently, the `data-ui-subheading` that's inside `data-ui-panel-header` is a very similar color to its title above, which makes it hard to distinguish between the two.

To replicate this:

1. Edit a blueprint
2. Open up a Bard field
3. Scroll down to "Editor Settings" where you'll find an example of a `data-ui-subheading` sitting inside a `data-ui-panel-header`

![1 - Current Instructions](https://github.com/user-attachments/assets/28a20f32-5647-4bc0-b6f8-cb9fbdbf54fc)

My initial idea was to make the `data-ui-subheading` lighter, but considering the grey panel behind it, if it were made any lighter than its current `text-grey-600`, then it would not pass AA color contrast.

My second idea was to simply make the `data-ui-panel-header` title text darker, but I also think this isn't great because now it is too similar to the field titles inside the main white area.

Therefore, I think the best option would be to make the title in the `data-ui-panel-header` title darker only when it is followed by a subheading, to provide some contrast. I'm using a simple CSS `:has` rule to test for this.

![2 - testing for a subheading](https://github.com/user-attachments/assets/f210d2c9-8908-4cf4-9f7c-22dc6b211d48)

The difference between a normal `data-ui-panel-header` title and one with a subheading is pretty indistinguishable, but now the `data-ui-subheading` looks more readable.