### PR TITLE
[6.x] Prevent Live Preview panels from blending into the background

### DIFF
--- a/resources/css/components/preview.css
+++ b/resources/css/components/preview.css
@@ -20,7 +20,7 @@
 }
 
 .live-preview-editor {
-    @apply relative flex h-full bg-gray-200 dark:bg-dark-800;
+    @apply relative flex h-full bg-white dark:bg-dark-800;
     z-index: 3;
 }
 


### PR DESCRIPTION
This closes #12229. The live preview panel blends into the `data-ui-panel-header`
I think the best solution is to make the live preview background white.

Some other things could be tidied up with Live Preview, but we can tackle that later/separately