### PR TITLE
Fix the toast notification position from sometimes breaking

### DIFF
--- a/resources/css/components/notifications.css
+++ b/resources/css/components/notifications.css
@@ -9,7 +9,7 @@
 }
 
 .toasted-container {
-    @apply items-start;
+    @apply items-start fixed;
 }
 
 .toasted-container .toasted.statamic {


### PR DESCRIPTION
This fixes the position of toasts from breaking in rare occasions, like this in the background:

![2025-09-02 at 16 40 01@2x](https://github.com/user-attachments/assets/82c78176-78b3-4b18-85dc-60bbe43d6e86)

I think this happens because the element that handles the position of `.toasted-container` throws some inline CSS that doesn't always seem to apply `position:fixed;` correctly. It's possible that it conflicts with something; it's difficult to tell.

Anyway, the solution is easy enough, I've added `@apply fixed` to our internal CSS, which ensures this always renders as `position: fixed`

This is a challenging one to recreate, but this is what has worked for me…

1. Edit a blueprint
2. Open up a field type—this seems to work more consistently if you haven't previously opened up said-fieldtype
3. Hit `cmd + s`. Bonus points if you hit it repeatedly, so you see a cascade of notifications behaving this way, like in my screenshot