### PR TITLE
[6.x] Only render publish section headers when display is set or collapsible is enabled

### DIFF
--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -49,7 +49,7 @@ function toggleSection(id) {
                 { 'pb-0': section.collapsed }
             ]"
         >
-            <PanelHeader @click="toggleSection(i)" class="flex justify-between">
+            <PanelHeader v-if="section.display || section.collapsible" @click="toggleSection(i)" class="flex justify-between">
                 <div>
                     <Heading :text="__(section.display)" />
                     <Subheading v-if="section.instructions" :text="renderInstructions(section.instructions)" />


### PR DESCRIPTION
This pull request fixes an issue where the `<PanelHeader>` component for a publish section would be rendered even if the section doesn't have display text set or `collapsible` enabled.

Caused by #12260.

## Before

<img width="1247" height="539" alt="CleanShot 2025-09-03 at 12 27 06" src="https://github.com/user-attachments/assets/526579ab-20cd-40db-bb52-399068908c14" />


## After

<img width="1243" height="517" alt="CleanShot 2025-09-03 at 12 26 52" src="https://github.com/user-attachments/assets/2a7ff23b-7ceb-412e-a6d7-3409cca7ecff" />
