### PR TITLE
[6.x] Fix errors from BardFieldtype when closing Live Preview

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -378,8 +378,8 @@ export default {
     },
 
     beforeUnmount() {
-        this.editor.destroy();
-        this.escBinding.destroy();
+        this.editor?.destroy();
+        this.escBinding?.destroy();
     },
 
     watch: {


### PR DESCRIPTION
When you close the Live Preview with a Bard field present, you'll notice a console error coming from the `BardFieldtype.vue` component:

```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'destroy')
    at Proxy.beforeUnmount (BardFieldtype.vue:381:21)
```

After taking a look, it seems like when the Live Preview is closed, the `BardFieldtype.vue` component is unmounted, mounted, unmounted, then mounted again:

<img width="1873" height="203" alt="CleanShot 2025-09-03 at 12 55 53" src="https://github.com/user-attachments/assets/7354d514-d3d6-437f-bf03-c0e3d008c374" />

The console error seems to occur on the last unmount, probably because the previous mount hasn't finished loading yet (it's an asynchronous function).

This pull request fixes the issue by only calling `destroy()` on the editor & escape bindings if they're set.

Fixes #12270