### PR TITLE
[5.x] Prevent duplicate queries on collection structure

### DIFF
--- a/src/Structures/CollectionStructure.php
+++ b/src/Structures/CollectionStructure.php
@@ -72,8 +72,8 @@ class CollectionStructure extends Structure
             throw new \Exception("Duplicate entry [{$entryId}] in [{$this->collection()->handle()}] collection's structure.");
         }
 
-        $thisCollectionsEntries = Blink::once('collection-structure-tree-entries::'.$this->collection()->handle().'::'.$locale, fn () => $this->collection()->queryEntries()->where('site', $locale)->get())
-            ->pluck('id');
+        $thisCollectionsEntries = Blink::once('collection-structure-tree-entries::'.$this->handle().'::'.$locale, fn () => $this->collection()->queryEntries())
+            ->where('site', $locale)->pluck('id');
 
         $otherCollectionEntries = $entryIds->diff($thisCollectionsEntries);
 


### PR DESCRIPTION
See https://github.com/statamic/eloquent-driver/issues/495 for background.

The CollectionStructure validateTree method is being called multiple times on a page and querying all collection entries when it does. This is a significant performance bottleneck. 

This PR updates it to be blinked so we only query once.

I'm sure I've missed somewhere this blink cache needs cleared...