### PR TITLE
[6.x] Make `container` available in custom field conditions

### DIFF
--- a/resources/js/components/field-conditions/ShowField.js
+++ b/resources/js/components/field-conditions/ShowField.js
@@ -3,13 +3,14 @@ import { data_get } from '@/bootstrap/globals.js';
 import { nextTick } from 'vue';
 
 export default class {
-    constructor(values, extraValues, rootValues, revealerValues, hiddenFields, setHiddenField) {
+    constructor(values, extraValues, rootValues, revealerValues, hiddenFields, setHiddenField, extraPayload) {
         this.values = values;
         this.extraValues = { ...extraValues, ...revealerValues };
         this.rootValues = rootValues;
         this.revealerValues = revealerValues;
         this.hiddenFields = hiddenFields;
         this.setHiddenField = setHiddenField;
+        this.extraPayload = extraPayload || {};
     }
 
     showField(field, dottedKey) {
@@ -30,7 +31,7 @@ export default class {
         }
 
         // Use validation to determine whether field should be shown.
-        let validator = new Validator(field, { ...this.values, ...this.extraValues }, this.rootValues, dottedFieldPath, Object.keys(this.revealerValues));
+        let validator = new Validator(field, { ...this.values, ...this.extraValues }, this.rootValues, dottedFieldPath, Object.keys(this.revealerValues), this.extraPayload);
         let passes = validator.passesConditions();
 
         // If the field is configured to always save, never omit value.

--- a/resources/js/components/field-conditions/Validator.js
+++ b/resources/js/components/field-conditions/Validator.js
@@ -15,11 +15,12 @@ const isEmpty = (value) => {
 const isString = (str) => str != null && typeof str.valueOf() === 'string';
 
 export default class {
-    constructor(field, values, rootValues, currentFieldPath, revealerFields) {
+    constructor(field, values, rootValues, currentFieldPath, revealerFields, extraPayload) {
         this.field = field;
         this.values = values;
         this.currentFieldPath = currentFieldPath;
         this.revealerFields = revealerFields;
+        this.extraPayload = extraPayload;
         this.rootValues = rootValues || false;
         this.passOnAny = false;
         this.showOnPass = true;
@@ -263,6 +264,7 @@ export default class {
             values: this.values,
             root: this.rootValues,
             fieldPath: this.currentFieldPath,
+            ...this.extraPayload,
         });
 
         return this.showOnPass ? passes : !passes;

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -223,7 +223,6 @@ const provided = {
     previews,
     syncField,
     desyncField,
-    container,
     components,
     asConfig: toRef(() => props.asConfig),
     isTrackingOriginValues: computed(() => !!props.originValues),

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -203,7 +203,7 @@ function pushComponent(name, { props }) {
     return component;
 }
 
-provideContainerContext({
+const provided = {
     name: toRef(() => props.name),
     parentContainer,
     blueprint: toRef(() => props.blueprint),
@@ -234,7 +234,9 @@ provideContainerContext({
     setRevealerField,
     unsetRevealerField,
     setHiddenField,
-});
+};
+
+provideContainerContext({ ...provided, container: provided });
 
 defineExpose({
     name: props.name,

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -253,9 +253,6 @@ defineExpose({
     setExtraValues,
 });
 
-// Backwards compatibility.
-provide('publishContainer', getCurrentInstance()); // temporarily used by ShowField.js
-
 // The following are shims to make things temporarily work.
 function saving() {}
 function saved() {

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -6,15 +6,13 @@ export const [injectContainerContext, provideContainerContext, containerContextK
 
 <script setup>
 import uniqid from 'uniqid';
-import { watch, provide, getCurrentInstance, ref, computed, toRef } from 'vue';
+import { watch, ref, computed, toRef } from 'vue';
 import Component from '@/components/Component.js';
 import Tabs from './Tabs.vue';
 import Values from '@/components/publish/Values.js';
 import { data_get } from '@/bootstrap/globals.js';
 
 const emit = defineEmits(['update:modelValue', 'update:visibleValues', 'update:modifiedFields']);
-
-const container = getCurrentInstance();
 
 const props = defineProps({
     name: {

--- a/resources/js/components/ui/Publish/Field.vue
+++ b/resources/js/components/ui/Publish/Field.vue
@@ -32,6 +32,7 @@ const {
     setFieldMeta,
     hiddenFields,
     setHiddenField,
+    container,
 } = injectContainerContext();
 const { fieldPathPrefix, metaPathPrefix } = injectFieldsContext();
 const handle = props.config.handle;
@@ -114,7 +115,8 @@ const shouldShowField = computed(() => {
         containerVisibleValues.value,
         revealerValues.value,
         hiddenFields.value,
-        setHiddenField
+        setHiddenField,
+        { container },
     ).showField(props.config, fullPath.value);
 });
 

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -10,7 +10,7 @@ import { computed } from 'vue';
 import { Primitive } from 'reka-ui';
 import { Motion } from 'motion-v';
 
-const { blueprint, container, visibleValues, extraValues, revealerValues, asConfig, hiddenFields, setHiddenField } = injectContainerContext();
+const { blueprint, container, visibleValues, extraValues, revealerValues, asConfig, hiddenFields, setHiddenField, container } = injectContainerContext();
 const tab = injectTabContext();
 const sections = tab.sections;
 const visibleSections = computed(() => {
@@ -22,7 +22,8 @@ const visibleSections = computed(() => {
                 visibleValues.value,
                 revealerValues.value,
                 hiddenFields.value,
-                setHiddenField
+                setHiddenField,
+                { container }
             ).showField(field, field.handle);
         });
     });

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -10,7 +10,7 @@ import { computed } from 'vue';
 import { Primitive } from 'reka-ui';
 import { Motion } from 'motion-v';
 
-const { blueprint, container, visibleValues, extraValues, revealerValues, asConfig, hiddenFields, setHiddenField, container } = injectContainerContext();
+const { blueprint, container, visibleValues, extraValues, revealerValues, asConfig, hiddenFields, setHiddenField } = injectContainerContext();
 const tab = injectTabContext();
 const sections = tab.sections;
 const visibleSections = computed(() => {

--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -8,7 +8,7 @@ import ElementContainer from '@/components/ElementContainer.vue';
 import ShowField from '@/components/field-conditions/ShowField.js';
 
 const slots = useSlots();
-const { blueprint, visibleValues, extraValues, revealerValues, errors, hiddenFields, setHiddenField } = injectContainerContext();
+const { blueprint, visibleValues, extraValues, revealerValues, errors, hiddenFields, setHiddenField, container } = injectContainerContext();
 const tabs = ref(blueprint.value.tabs);
 const width = ref(null);
 const sidebarTab = computed(() => tabs.value.find((tab) => tab.handle === 'sidebar'));
@@ -25,7 +25,8 @@ const visibleMainTabs = computed(() => {
                     visibleValues.value,
                     revealerValues.value,
                     hiddenFields.value,
-                    setHiddenField
+                    setHiddenField,
+                    { container }
                 ).showField(field, field.handle);
             });
         });

--- a/resources/js/tests/FieldConditionsValidator.test.js
+++ b/resources/js/tests/FieldConditionsValidator.test.js
@@ -82,7 +82,8 @@ let showField = function(config, dottedFieldPath = null) {
         Store.values,
         Store.revealerValues,
         Store.hiddenFields,
-        Store.setHiddenField
+        Store.setHiddenField,
+        { foo: 'bar' }
     ).showField(config, dottedFieldPath);
 }
 
@@ -463,9 +464,10 @@ test('it can call a custom function', () => {
         favorite_animals: ['cats', 'dogs'],
     });
 
-    Statamic.$conditions.add('reallyLovesAnimals', function ({ target, params, values }) {
+    Statamic.$conditions.add('reallyLovesAnimals', function ({ target, params, values, foo }) {
         expect(target).toBe(null);
         expect(params).toEqual([]);
+        expect(foo).toEqual('bar');
         return values.favorite_animals.length > 3;
     });
 


### PR DESCRIPTION
This pull request makes the publish container available in custom field conditions. Field conditions can use any of the variables/functions [provided by the `Container` component](https://github.com/statamic/cms/blob/master/resources/js/components/ui/Publish/Container.vue#L206).

Example:

```js
Statamic.$conditions.add('test', function ({ container }) {
    return container.site.value === 'en';
});
``` 