### PR TITLE
[6.x] Add display text to fallback blueprint section

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -154,8 +154,22 @@ class AppServiceProvider extends ServiceProvider
             return (new \Statamic\Fields\BlueprintRepository)
                 ->setDirectory(resource_path('blueprints'))
                 ->setFallback('default', function () {
-                    return \Statamic\Facades\Blueprint::makeFromFields([
-                        'content' => ['type' => 'markdown', 'localizable' => true],
+                    return \Statamic\Facades\Blueprint::make()->setContents([
+                        'tabs' => [
+                            'main' => [
+                                'sections' => [
+                                    [
+                                        'display' => __('Content'),
+                                        'fields' => [
+                                            [
+                                                'handle' => 'content',
+                                                'field' => ['type' => 'markdown', 'localizable' => true],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
                     ]);
                 });
         });


### PR DESCRIPTION
The fallback blueprint didn't have display text define on the section.

This defaults it to "Content".

You'd see it when creating a colleciton and creating an entry without explicitly creating a blueprint.
