### PR TITLE
[5.x] Make UpdateAssetReferences overwritable

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -794,13 +794,13 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
         // until after the `AssetReplaced` event is fired. We still want to fire events
         // like `AssetDeleted` and `AssetSaved` though, so that other listeners will
         // get triggered (for cache invalidation, clearing of glide cache, etc.)
-        UpdateAssetReferencesSubscriber::disable();
+        app(UpdateAssetReferencesSubscriber::class)::disable();
 
         if ($deleteOriginal) {
             $originalAsset->delete();
         }
 
-        UpdateAssetReferencesSubscriber::enable();
+        app(UpdateAssetReferencesSubscriber::class)::enable();
 
         AssetReplaced::dispatch($originalAsset, $this);
 


### PR DESCRIPTION
We're currently exploring ways to build an asset index that tracks asset usage throughout the cms, to make updating references more performant in a system with a large amount of entries. In a lot of ways the current structure makes that very easy by overwriting/extending some parts of the `UpdateAssetReferences` subscriber.

However, when replacing an asset, the Asset class temporarily disables the Subscriber to not react to the `AssetDeleted` event, if the "delete old asset"-option is enabled. Unfortunately this doesn't affect my custom class, that I've bound in a service provider.

So, this PR simply changes these `enable()` and `disable()` calls to use the service container 😇 

If you have any other ideas/suggestions on how to solve this instead, I'm happy for any input.