### PR TITLE
[6.x] Third-party fieldtypes should be able to use first-party icons

### DIFF
--- a/resources/js/components/blueprints/RegularField.vue
+++ b/resources/js/components/blueprints/RegularField.vue
@@ -6,7 +6,7 @@
                 <div class="flex flex-1 items-center py-2">
                     <ui-icon
                         class="size-4 me-2 text-gray-500"
-                        :name="field.icon.startsWith('<svg') ? field.icon : `fieldtype-${field.icon}`"
+                        :name="field.icon"
                         v-tooltip="tooltipText"
                     />
                     <div class="flex items-center gap-2">

--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -40,7 +40,7 @@
                                 @click="select(fieldtype)"
                                 :title="fieldtype.text"
                             >
-                                <ui-icon :name="fieldtype.icon.startsWith('<svg') ? fieldtype.icon : `fieldtype-${fieldtype.icon}`" class="text-gray-500 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-gray-100" />
+                                <ui-icon :name="fieldtype.icon" class="text-gray-500 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-gray-100" />
                                 <span class="text-sm text-gray-700 dark:text-gray-300 group-hover:text-gray-900 dark:group-hover:text-gray-100" v-text="fieldtype.text" />
                             </button>
                             </div>

--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -309,7 +309,7 @@ abstract class Fieldtype implements Arrayable
 
     public function icon()
     {
-        return $this->icon ?? $this->handle();
+        return $this->icon ?? "fieldtype-{$this->handle()}";
     }
 
     public function process($data)

--- a/src/Fieldtypes/Floatval.php
+++ b/src/Fieldtypes/Floatval.php
@@ -9,7 +9,6 @@ use Statamic\Query\Scopes\Filters\Fields\Floatval as FloatFilter;
 class Floatval extends Fieldtype
 {
     protected $categories = ['number'];
-    protected $icon = 'float';
     protected $rules = ['numeric'];
     protected static $handle = 'float';
 

--- a/src/Fieldtypes/Html.php
+++ b/src/Fieldtypes/Html.php
@@ -7,7 +7,6 @@ use Statamic\Fields\Fieldtype;
 class Html extends Fieldtype
 {
     protected $categories = ['special'];
-    protected $icon = 'html';
 
     protected function configFieldItems(): array
     {

--- a/src/Fieldtypes/Icon.php
+++ b/src/Fieldtypes/Icon.php
@@ -12,7 +12,7 @@ use Statamic\Support\Str;
 class Icon extends Fieldtype
 {
     protected $categories = ['media'];
-    protected $icon = 'icon_picker';
+    protected $icon = 'fieldtype-icon_picker';
 
     protected static $customSvgIcons = [];
 

--- a/src/Fieldtypes/Taxonomies.php
+++ b/src/Fieldtypes/Taxonomies.php
@@ -13,7 +13,7 @@ class Taxonomies extends Relationship
     protected $canCreate = false;
     protected $canSearch = false;
     protected $statusIcons = false;
-    protected $icon = 'taxonomy';
+    protected $icon = 'fieldtype-taxonomy';
 
     protected function toItemArray($id, $site = null)
     {

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -35,7 +35,7 @@ class Terms extends Relationship
     protected $canSearch = true;
     protected $statusIcons = false;
     protected $taggable = true;
-    protected $icon = 'taxonomy';
+    protected $icon = 'fieldtype-taxonomy';
     protected $formComponent = 'term-publish-form';
 
     protected $formComponentProps = [


### PR DESCRIPTION
In v5, it was possible for third-party fieldtypes to use first-party icons, like `earth`.

However, that's not currently possible in v6, due to the `FieldtypeSelector` and `RegularField` components assuming all fieldtype icons are prefixed with `fieldtype-`.

This PR fixes it by moving that assumption to `Fieldtype@icon`, which allows third-party fieldtypes to specify a custom addon, otherwise, it'll try and use `fieldtype-{handle}`.

Fixes #12279.