### PR TITLE
[6.x] Combobox item separation

### DIFF
--- a/resources/js/components/ui/Combobox.vue
+++ b/resources/js/components/ui/Combobox.vue
@@ -326,6 +326,7 @@ defineExpose({
                         :class="[
                             'shadow-ui-sm z-100 rounded-lg border border-gray-200 bg-white p-2 dark:border-white/10 dark:bg-gray-800',
                             'max-h-[var(--reka-combobox-content-available-height)] w-[var(--reka-combobox-trigger-width)] min-w-fit',
+                            '[&_[data-reka-combobox-viewport]]:grid [&_[data-reka-combobox-viewport]]:gap-1'
                         ]"
                         @escape-key-down="nextTick(() => $refs.trigger.$el.focus())"
                         data-ui-combobox-content


### PR DESCRIPTION
This closes #12221 and adds a tiny bit of visual distinction between dropdown items. This is most noticeable when preventing a _selected_ item and the rest of the items from colliding into each other.

I'm targeting the data attribute here that Reka renders because I'm not sure if it's possible to reach inside it.
This affects all comboboxes, but that's intentional.