### PR TITLE
[6.x] Fix German entry count translation

### DIFF
--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -446,7 +446,7 @@
     "Entry saved": "Eintrag gespeichert",
     "Entry schedule reached": "Zeitplan für Eintrag erreicht",
     "Entry unpublished|Entries unpublished": "Eintrag nicht veröffentlicht|Einträge nicht veröffentlicht",
-    "entry_count": "Anzahl der Einträge",
+    "entry_count": ":count Einträge",
     "equals": "ist gleich",
     "Equals": "Gleich",
     "Escape Markup": "Markup escapen",

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -446,7 +446,7 @@
     "Entry saved": "Eintrag gespeichert",
     "Entry schedule reached": "Zeitplan für Eintrag erreicht",
     "Entry unpublished|Entries unpublished": "Eintrag nicht veröffentlicht|Einträge nicht veröffentlicht",
-    "entry_count": "Anzahl der Einträge",
+    "entry_count": ":count Einträge",
     "equals": "ist gleich",
     "Equals": "Gleich",
     "Escape Markup": "Markup escapen",


### PR DESCRIPTION
The entry count in German currently doesn't have a `:count` variable, but the original English one does. This fixes it so the entry count is displayed properly in German.

<img width="323" height="176" alt="Screenshot 2025-09-04 at 23 05 24" src="https://github.com/user-attachments/assets/be685652-ac4c-4182-90ca-e5b58e5d5ddb" />

<img width="302" height="161" alt="Screenshot 2025-09-04 at 23 05 35" src="https://github.com/user-attachments/assets/f96e9b24-524c-4f47-9a3c-88e323db3ec9" />
