### PR TITLE
[6.x] Differentiate dangerous actions in bulk actions toolbar

### DIFF
--- a/resources/js/components/ui/Listing/BulkActions.vue
+++ b/resources/js/components/ui/Listing/BulkActions.vue
@@ -55,7 +55,13 @@ function actionFailed(response) {
                     :text="__n(`Deselect :count item|Deselect all :count items`, selections.length)"
                     @click="clearSelections"
                 />
-                <Button v-for="action in actions" :key="action.handle" :text="__(action.title)" @click="action.run" />
+                <Button
+                    v-for="action in actions"
+                    :key="action.handle"
+                    :text="__(action.title)"
+                    :variant="action.dangerous ? 'danger' : 'default'"
+                    @click="action.run"
+                />
             </ButtonGroup>
             </div>
         </Motion>


### PR DESCRIPTION
Currently, dangerous actions don't look any different to non-dangerous actions in the bulk actions toolbar. This PR ensures dangerous actions use the `danger` variant on the `Button` component.

Closes #12295.

## Before
<img width="454" height="89" alt="CleanShot 2025-09-05 at 09 41 19" src="https://github.com/user-attachments/assets/d52a7f86-b46c-4e68-b1a2-4691d20b2474" />


## After

<img width="454" height="89" alt="CleanShot 2025-09-05 at 09 41 07" src="https://github.com/user-attachments/assets/0c264ae9-bc5c-4e1b-9e2f-fccf66b6b4d7" />
