### PR TITLE
[6.x] Focal Point Editor tweaks

### DIFF
--- a/resources/js/components/assets/Editor/FocalPointEditor.vue
+++ b/resources/js/components/assets/Editor/FocalPointEditor.vue
@@ -24,11 +24,11 @@
                 <div class="mb-4 flex items-center justify-center text-sm">
                     <div class="mx-4 flex items-center">
                         <div class="ltr:mr-1 rtl:ml-1">X</div>
-                        <div class="value">{{ x }}<sup>%</sup></div>
+                        <div class="value">{{ x }}%</div>
                     </div>
                     <div class="mx-4 flex items-center">
                         <div class="ltr:mr-1 rtl:ml-1">Y</div>
-                        <div class="value">{{ y }}<sup>%</sup></div>
+                        <div class="value">{{ y }}%</div>
                     </div>
                     <div class="mx-4 flex items-center">
                         <div class="ltr:mr-1 rtl:ml-1">Z</div>

--- a/resources/js/components/assets/Editor/FocalPointEditor.vue
+++ b/resources/js/components/assets/Editor/FocalPointEditor.vue
@@ -37,7 +37,7 @@
                 </div>
                 <div class="px-4">
                     <input type="range" v-model="z" min="1" max="10" step="0.1" class="mb-4 w-full" />
-                    <div class="mb-4 flex flex-wrap items-center justify-center space-x-2">
+                    <div class="mb-4 flex flex-wrap items-center justify-center gap-2">
                         <Button :text="__('Cancel')" @click="close" />
                         <Button :text="__('Reset')" @click="reset" />
                         <Button variant="primary" :text="__('Finish')" @click="select" />


### PR DESCRIPTION
This pull request changes two things in the Focal Point Editor:

* Fixes the vertical spacing between buttons
  * Fixes #12290
* Removes `<sup>` around percentages
  *  Claude says the % signs shouldn't be <sup> symbols because they're not mathematic exponents.
  * They represent percentage positions or coordinates, not mathematical powers. The % sign here indicates a percentage value, not a superscript notation. 
  * Fixes #12289