### PR TITLE
[6.x] Make active buttons in a group field type look pressed rather than a primary button

### DIFF
--- a/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
@@ -9,7 +9,7 @@
             :read-only="isReadOnly"
             :text="option.label || option.value"
             :value="option.value"
-            :variant="value == option.value ? 'depressed' : 'default'"
+            :variant="value == option.value ? 'pressed' : 'default'"
             @click="updateSelectedOption(option.value)"
         />
     </ButtonGroup>

--- a/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/ButtonGroupFieldtype.vue
@@ -9,7 +9,7 @@
             :read-only="isReadOnly"
             :text="option.label || option.value"
             :value="option.value"
-            :variant="value == option.value ? 'primary' : 'default'"
+            :variant="value == option.value ? 'depressed' : 'default'"
             @click="updateSelectedOption(option.value)"
         />
     </ButtonGroup>

--- a/resources/js/components/ui/Button/Button.vue
+++ b/resources/js/components/ui/Button/Button.vue
@@ -41,8 +41,8 @@ const buttonClasses = computed(() => {
                 ghost: 'bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200',
                 subtle: 'bg-transparent hover:bg-gray-400/10 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 [&_svg]:opacity-40',
                 depressed: [
-                    'bg-gray-100 text-gray-900 border border-gray-400 shadow-none',
-                    'dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600',
+                    'bg-linear-to-b from-gray-100 to-gray-100 text-gray-900 border border-gray-300 inset-shadow-sm/10',
+                    'dark:from-gray-950 dark:to-gray-950 dark:text-white dark:border-white/10',
                 ],
             },
             size: {

--- a/resources/js/components/ui/Button/Button.vue
+++ b/resources/js/components/ui/Button/Button.vue
@@ -40,7 +40,7 @@ const buttonClasses = computed(() => {
                 filled: 'bg-black/5 hover:bg-black/10 hover:text-gray-900 dark:hover:text-white dark:bg-white/15 dark:hover:bg-white/20 [&_svg]:opacity-70',
                 ghost: 'bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200',
                 subtle: 'bg-transparent hover:bg-gray-400/10 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 [&_svg]:opacity-40',
-                depressed: [
+                pressed: [
                     'bg-linear-to-b from-gray-100 to-gray-100 text-gray-900 border border-gray-300 inset-shadow-sm/10',
                     'dark:from-gray-950 dark:to-gray-950 dark:text-white dark:border-white/10',
                 ],
@@ -59,7 +59,7 @@ const buttonClasses = computed(() => {
                 danger: 'in-data-ui-button-group:border-s-0 in-data-ui-button-group:border-e [:is([data-ui-button-group]>&:last-child,_[data-ui-button-group]_:last-child>&)]:border-e-0 in-data-ui-button-group:border-red-600',
                 filled: 'in-data-ui-button-group:border-e [:is([data-ui-button-group]>&:last-child,_[data-ui-button-group]_:last-child>&)]:border-e-0 in-data-ui-button-group:border-gray-300/70',
                 ghost: '',
-                depressed: 'in-data-ui-button-group:border-s-0 [:is([data-ui-button-group]>&:first-child,_[data-ui-button-group]_:first-child>&)]:border-s-[1px]',
+                pressed: 'in-data-ui-button-group:border-s-0 [:is([data-ui-button-group]>&:first-child,_[data-ui-button-group]_:first-child>&)]:border-s-[1px]',
             },
             iconOnly: { true: 'px-0 gap-0' },
             round: { true: 'rounded-full' },

--- a/resources/js/components/ui/Button/Button.vue
+++ b/resources/js/components/ui/Button/Button.vue
@@ -59,6 +59,7 @@ const buttonClasses = computed(() => {
                 danger: 'in-data-ui-button-group:border-s-0 in-data-ui-button-group:border-e [:is([data-ui-button-group]>&:last-child,_[data-ui-button-group]_:last-child>&)]:border-e-0 in-data-ui-button-group:border-red-600',
                 filled: 'in-data-ui-button-group:border-e [:is([data-ui-button-group]>&:last-child,_[data-ui-button-group]_:last-child>&)]:border-e-0 in-data-ui-button-group:border-gray-300/70',
                 ghost: '',
+                depressed: 'in-data-ui-button-group:border-s-0 [:is([data-ui-button-group]>&:first-child,_[data-ui-button-group]_:first-child>&)]:border-s-[1px]',
             },
             iconOnly: { true: 'px-0 gap-0' },
             round: { true: 'rounded-full' },

--- a/resources/js/components/ui/Button/Button.vue
+++ b/resources/js/components/ui/Button/Button.vue
@@ -40,6 +40,10 @@ const buttonClasses = computed(() => {
                 filled: 'bg-black/5 hover:bg-black/10 hover:text-gray-900 dark:hover:text-white dark:bg-white/15 dark:hover:bg-white/20 [&_svg]:opacity-70',
                 ghost: 'bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200',
                 subtle: 'bg-transparent hover:bg-gray-400/10 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 [&_svg]:opacity-40',
+                depressed: [
+                    'bg-gray-100 text-gray-900 border border-gray-400 shadow-none',
+                    'dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600',
+                ],
             },
             size: {
                 lg: 'px-6 h-12 text-base gap-2 rounded-lg text-base',


### PR DESCRIPTION
This closes #12294.

I've added a new "pressed" button variant and added it to the Button Group field type.

Buttons still stick out, but not so much that it's distracting.

Before:
![2025-09-05 at 11 44 45@2x](https://github.com/user-attachments/assets/ed479342-78db-4aff-aec9-9d0892b1c987)

After:
![2025-09-05 at 11 44 27@2x](https://github.com/user-attachments/assets/7bedb8ff-377d-4237-b0bd-ed78d3de3940)
