### PR TITLE
[6.x] Fix errors not showing on two factor setup modal

### DIFF
--- a/resources/js/components/two-factor/Setup.vue
+++ b/resources/js/components/two-factor/Setup.vue
@@ -40,8 +40,8 @@ function confirm() {
             setupModalOpen.value = false;
             recoveryCodesModalOpen.value = true;
         })
-        .catch((error) => {
-            error.value = error.response.data.errors.code[0];
+        .catch((e) => {
+            error.value = e.response.data.errors.code[0];
         });
 }
 

--- a/resources/js/components/ui/Field.vue
+++ b/resources/js/components/ui/Field.vue
@@ -14,7 +14,7 @@ const props = defineProps({
     disabled: { type: Boolean, default: false },
     readOnly: { type: Boolean, default: false },
     error: { type: String },
-    errors: { type: Object, default: (props) => (props.error ? [props.error] : []) },
+    errors: { type: Object },
     id: { type: String },
     instructions: { type: String, default: '' },
     instructionsBelow: { type: Boolean, default: false },
@@ -55,6 +55,14 @@ const classes = computed(() =>
 
 const instructions = computed(() => props.instructions ? markdown(__(props.instructions), { openLinksInNewTabs: true }) : null);
 const wrapperComponent = computed(() => props.as === 'card' ? Card : 'div');
+
+const errors = computed(() => {
+    if (props.error) {
+        return [props.error];
+    }
+
+    return props.errors;
+});
 </script>
 
 <template>


### PR DESCRIPTION
When you submit the two factor setup modal with an invalid code, a validation error is thrown, however it isn't being shown properly.

This PR fixes that by...

* Avoiding a variable conflict in `Setup.vue` where there are two `errors` defined
* Ensuring the `error` prop is reactive (eg. when the prop value changes, the error is actually reflected in the UI)