### PR TITLE
[6.x] Fix permission labels not being localized correctly

### DIFF
--- a/src/Providers/CpServiceProvider.php
+++ b/src/Providers/CpServiceProvider.php
@@ -106,8 +106,8 @@ class CpServiceProvider extends ServiceProvider
 
         $router->middlewareGroup('statamic.cp.authenticated', [
             \Statamic\Http\Middleware\CP\AuthenticateSession::class,
-            \Statamic\Http\Middleware\CP\Authorize::class,
             \Statamic\Http\Middleware\CP\Localize::class,
+            \Statamic\Http\Middleware\CP\Authorize::class,
             \Statamic\Http\Middleware\CP\SelectedSite::class,
             \Statamic\Http\Middleware\CP\BootPermissions::class,
             \Statamic\Http\Middleware\CP\BootPreferences::class,


### PR DESCRIPTION
This pull request fixes an issue where permission labels weren't being localized correctly, due to permissions being booted _before_ the user's locale was set.

The `Authorize` middleware ended up calling `Permissions::boot()`, which now has a `if ($this->booted)` conditional, preventing it from being called multiple times.

Related: #11516
Fixes #12312