### PR TITLE
[6.x] Add translations in command palette

### DIFF
--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -245,7 +245,7 @@ const modalClasses = cva({
                 hover:bg-black/45 hover:text-white/70
             ">
                 <Icon name="magnifying-glass" class="size-5 flex-none text-white/50 group-hover:text-white/70" />
-                <span class="sr-only leading-none md:not-sr-only st-text-trim-cap">Search</span>
+                <span class="sr-only leading-none md:not-sr-only st-text-trim-cap">{{ __('Search') }}</span>
                 <kbd class="ml-auto hidden self-center rounded bg-white/5 px-[0.3125rem] py-[0.0625rem] text-[0.625rem]/4 font-medium text-white/60 group-hover:text-white/70 ring-1 ring-white/7.5 [word-spacing:-0.15em] ring-inset md:block">
                     <kbd class="font-sans">⌘ </kbd><kbd class="font-sans">K</kbd>
                 </kbd>

--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -328,11 +328,11 @@ const modalClasses = cva({
                                 <div class="flex items-center gap-1.5">
                                     <Icon name="up-square" class="size-4 text-gray-500" />
                                     <Icon name="down-square" class="size-4 text-gray-500" />
-                                    <span class="text-sm text-gray-600 dark:text-gray-500">Navigate</span>
+                                    <span class="text-sm text-gray-600 dark:text-gray-500">{{ __('Navigate') }}</span>
                                 </div>
                                 <div class="flex items-center gap-1.5">
                                     <Icon name="return-square" class="size-4 text-gray-500" />
-                                    <span class="text-sm text-gray-600 dark:text-gray-500">Select</span>
+                                    <span class="text-sm text-gray-600 dark:text-gray-500">{{ __('Select') }}</span>
                                 </div>
                             </footer>
                         </ComboboxContent>


### PR DESCRIPTION
With my minimal knowledge, I have tried to make the two words translatable.

<img width="366" height="188" alt="Bildschirmfoto 2025-09-05 um 16 24 37" src="https://github.com/user-attachments/assets/94d97bab-0dcb-4086-950f-529e492e5034" />
