### PR TITLE
[6.x] Invert text colour of Markdown Cheatsheet in dark mode

### DIFF
--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -151,7 +151,7 @@
                             class="absolute top-4 end-4"
                             @click="showCheatsheet = false"
                         />
-                        <div class="prose prose-zinc prose-headings:font-medium mx-auto my-8 max-w-3xl">
+                        <div class="prose dark:prose-invert prose-zinc prose-headings:font-medium mx-auto my-8 max-w-3xl">
                             <h2 v-text="__('Markdown Cheatsheet')"></h2>
                             <div v-html="__('markdown.cheatsheet')"></div>
                         </div>

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -151,7 +151,7 @@
                             class="absolute top-4 end-4"
                             @click="showCheatsheet = false"
                         />
-                        <div class="prose dark:prose-invert prose-zinc prose-headings:font-medium mx-auto my-8 max-w-3xl">
+                        <div class="prose dark:prose-invert prose-zinc prose-headings:font-medium prose-code:!text-white mx-auto my-8 max-w-3xl">
                             <h2 v-text="__('Markdown Cheatsheet')"></h2>
                             <div v-html="__('markdown.cheatsheet')"></div>
                         </div>


### PR DESCRIPTION
This pull request inverts the default styles of the Tailwind Typography plugin in dark mode. 

It also fixes an issue where code in the code blocks isn't visible due to `code` being set to black in `base.css`. I've added an override in the Markdown Cheatsheet to ensure it's white.

Fixes #12307