### PR TITLE
[6.x] Pass placeholder to search input as a string, not a variable

### DIFF
--- a/resources/js/components/ui/Listing/Search.vue
+++ b/resources/js/components/ui/Listing/Search.vue
@@ -22,7 +22,7 @@ defineExpose({ focus });
             icon="magnifying-glass"
             id="listings-search"
             variant="light"
-            :placeholder="__('Search')"
+            :placeholder="__('Search...')"
             :value="searchQuery"
             :disabled="reorderable"
             @input="searchQueryUpdated"


### PR DESCRIPTION
Currently, the `Search...` string isn't picked up by the `translator` command because we're passing it as a variable and not a string. This PR fixes that.

Fixes #12321