### PR TITLE
[6.x] Fix missing translation in Assets & Files fieldtypes

### DIFF
--- a/resources/js/components/fieldtypes/FilesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FilesFieldtype.vue
@@ -22,7 +22,7 @@
                 <div class="border border-gray-400 dark:border-gray-700 border-dashed rounded-xl p-4 flex flex-col @2xs:flex-row items-center gap-4" :class="{ 'rounded-b-none': value.length }">
                     <div class="text-sm text-gray-600 dark:text-gray-400 flex items-center flex-1">
                         <ui-icon name="upload-cloud" class="size-5 text-gray-500 me-2" />
-                        <span v-text="__('Drag & drop here or&nbsp;')" />
+                        <span v-text="`${__('Drag & drop here or')}&nbsp;`" />
                         <button type="button" class="underline underline-offset-2 cursor-pointer hover:text-black dark:hover:text-gray-200" @click.prevent="uploadFile">
                             {{ __('choose a file') }}
                         </button>

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -46,7 +46,7 @@
 
                     <div class="text-sm text-gray-600 dark:text-gray-400 flex items-center flex-1" v-if="canUpload">
                         <ui-icon name="upload-cloud" class="size-5 text-gray-500 me-2" />
-                        <span v-text="__('Drag & drop here or&nbsp;')" />
+                        <span v-text="`${__('Drag & drop here or')}&nbsp;`" />
                         <button type="button" class="underline underline-offset-2 cursor-pointer hover:text-black dark:hover:text-gray-200" @click.prevent="uploadFile">
                             {{ __('choose a file') }}
                         </button>


### PR DESCRIPTION
This pull request fixes an issue where the `Drag & drop here or` string wasn't being recognised by the `translator` command due to the fact it contained a non-breaking space. 

This PR fixes it by moving the non-breaking space out of the translation.

Fixes #12299