### PR TITLE
[6.x] Take `initialPerPage` into account when rendering widget skeleton

### DIFF
--- a/resources/js/components/entries/CollectionWidget.vue
+++ b/resources/js/components/entries/CollectionWidget.vue
@@ -55,11 +55,7 @@ function formatDate(value) {
         <template #initializing>
             <Widget v-bind="widgetProps">
                 <div class="flex flex-col gap-[9px] justify-between py-3 px-4">
-                    <ui-skeleton class="h-[19px] w-full" />
-                    <ui-skeleton class="h-[19px] w-full" />
-                    <ui-skeleton class="h-[19px] w-full" />
-                    <ui-skeleton class="h-[19px] w-full" />
-                    <ui-skeleton class="h-[19px] w-full" />
+                    <ui-skeleton v-for="i in initialPerPage" class="h-[19px] w-full" />
                 </div>
             </Widget>
         </template>

--- a/resources/js/components/forms/FormWidget.vue
+++ b/resources/js/components/forms/FormWidget.vue
@@ -46,11 +46,7 @@ function formatDate(value) {
         <template #initializing>
             <Widget v-bind="widgetProps">
                 <div class="flex flex-col gap-4 justify-between p-4">
-                    <ui-skeleton class="h-3 w-full" />
-                    <ui-skeleton class="h-3 w-full" />
-                    <ui-skeleton class="h-3 w-full" />
-                    <ui-skeleton class="h-3 w-full" />
-                    <ui-skeleton class="h-3 w-full" />
+                    <ui-skeleton v-for="i in initialPerPage" class="h-3 w-full" />
                 </div>
             </Widget>
         </template>


### PR DESCRIPTION
Although the widgets default to 5 items per page, if you configure a higher limit, the transition from "loading skeleton -> listing w/ actual items" moves things about quite a bit.

## Before

https://github.com/user-attachments/assets/1d509334-16b5-4977-81f7-37442d33f095


## After


https://github.com/user-attachments/assets/592ca59d-3c9b-45be-97cd-f92309f9ae3d

