### PR TITLE
[6.x] Adjust the sidebar position for RTL mode

### DIFF
--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -5,7 +5,7 @@
     @apply flex flex-col gap-6 py-6 px-3 text-sm antialiased select-none;
     /* Same as the main element, accounting for the header with a class of h-14, which is the same as 3.5rem */
     @apply h-[calc(100vh-3.5rem)];
-    @apply overflow-y-auto fixed top-14 left-0 w-48;
+    @apply overflow-y-auto fixed start-0 top-14 w-48;
     @apply [&_svg]:text-gray-500 dark:[&_svg]:text-gray-500/85;
     /* Only inset because we don't wand to transition the color when we switch between light/dark mode */
     transition: inset 0.3s ease-in-out;
@@ -49,13 +49,13 @@
         /* Always visible but off-screen by default */
         @apply flex;
         /* Start off-screen to the left */
-        @apply -left-46;
+        @apply -start-46;
     }
 
     .nav-open .nav-main {
         @apply bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-2xl;
         /* Slide in from the left */
-        @apply left-0;
+        @apply start-0;
     }
 }
 
@@ -92,6 +92,6 @@ main {
 }
 
 /* Mirrors that have been appended to the body should appear on top of everything. (Portals are 4) */
-body > .draggable-mirror {
+body>.draggable-mirror {
     z-index: 5;
 }

--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -5,7 +5,7 @@
     @apply flex flex-col gap-6 py-6 px-3 text-sm antialiased select-none;
     /* Same as the main element, accounting for the header with a class of h-14, which is the same as 3.5rem */
     @apply h-[calc(100vh-3.5rem)];
-    @apply overflow-y-auto fixed start-0 top-14 w-48;
+    @apply overflow-y-auto fixed top-14 start-0 w-48;
     @apply [&_svg]:text-gray-500 dark:[&_svg]:text-gray-500/85;
     /* Only inset because we don't wand to transition the color when we switch between light/dark mode */
     transition: inset 0.3s ease-in-out;
@@ -92,6 +92,6 @@ main {
 }
 
 /* Mirrors that have been appended to the body should appear on top of everything. (Portals are 4) */
-body>.draggable-mirror {
+body > .draggable-mirror {
     z-index: 5;
 }


### PR DESCRIPTION
As mentioned in #12328, the sidebar position is on the wrong side when using RTL mode, included is a before and after screenshot:


**Before:**
<img width="3720" height="2688" alt="Screen Shot 2025-09-06 at 15 09 21" src="https://github.com/user-attachments/assets/335ae349-a8fd-4322-a5d6-9259bda474d0" />

<br/>

**After:**
<img width="3720" height="2688" alt="Screen Shot 2025-09-06 at 15 08 01" src="https://github.com/user-attachments/assets/5c8e7b7d-ceb4-4daf-8a9c-b590d5c25a77" />

