### PR TITLE
[6.x] Allow localization to be selected from ComboBox

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -612,10 +612,6 @@ export default {
         },
 
         localizationSelected(localization) {
-            if (typeof localization === "string") {
-                localization = this.localizations.find(el => el.handle === localization)
-            }
-            
             if (!this.canSave) {
                 if (localization.exists) this.editLocalization(localization);
                 return;

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -612,6 +612,10 @@ export default {
         },
 
         localizationSelected(localization) {
+            if (typeof localization === "string") {
+                localization = this.localizations.find(el => el.handle === localization)
+            }
+            
             if (!this.canSave) {
                 if (localization.exists) this.editLocalization(localization);
                 return;

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -33,7 +33,7 @@ const activeLocalization = computed(() => {
                     option-value="handle"
                     option-label="name"
                     :model-value="activeLocalization?.handle"
-                    @update:modelValue="$emit('selected', $event)"
+                    @update:modelValue="$emit('selected', localizations.find(l => l.handle === $event))"
                 >
                     <template #option="option">
                         <Localization :localization="option" :localizing />


### PR DESCRIPTION
Closes #12336 

When using the ComboBox, only the locale handle is passed to the `localizationSelected()` function, so when it checks for properties like `localization.exists` then it breaks.

The update adds a quick check to see if only the handle (string) was passed to the function and if so, it finds the correct localization object from the list.