### PR TITLE
[6.x] Fix translation in Code Fieldtype

### DIFF
--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -61,6 +61,7 @@ return [
     'code.config.mode' => 'Choose language for syntax highlighting.',
     'code.config.mode_selectable' => 'Whether the mode can be changed by the user.',
     'code.config.rulers' => 'Configure vertical rulers to help with indentation.',
+    'code.config.rulers_value_header' => 'Line Style (dashed or solid)',
     'code.config.theme' => 'Choose your preferred theme.',
     'code.title' => 'Code',
     'collections.title' => 'Collections',

--- a/src/Fieldtypes/Code.php
+++ b/src/Fieldtypes/Code.php
@@ -123,7 +123,7 @@ class Code extends Fieldtype
                         'instructions' => __('statamic::fieldtypes.code.config.rulers'),
                         'type' => 'array',
                         'key_header' => __('Columns'),
-                        'value_header' => __('Line Style (dashed or solid)'),
+                        'value_header' => __('statamic::fieldtypes.code.config.rulers_value_header'),
                         'add_button' => __('Add Ruler'),
                         'width' => '50',
                     ],


### PR DESCRIPTION
This pull request moves the "Line Style (dashed or solid)" string used in one of the Code Fieldtype's config options to `fieldtypes.php`, as the parenthesises seem to throw off the translator.

Fixes #12339. 