### PR TITLE
Left align table heads e.g. Checkbox field type key/value headings

### DIFF
--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -15,6 +15,7 @@
         display: table-cell;
         position: sticky;
         top: -1px;
+        text-align: left;
 
         &:first-child {
             @apply rounded-ss-lg ps-3;


### PR DESCRIPTION
I think this was probably an oversight since a value wasn't explicitly set. This PR simply left-aligns table heads, which feels a bit neater, considering almost everything else is left-aligned.

I was almost in two minds, since on the one hand it's easier to grasp the heading when it's in the middle—especially when the table is wide. But on the whole, I think the neatness of it being left-aligned works better.

Before:
![2025-09-08 at 10 42 29@2x](https://github.com/user-attachments/assets/4d6d6b33-ea32-4aaf-8aa0-c4217b844665)

After:
![2025-09-08 at 10 47 19@2x](https://github.com/user-attachments/assets/330e9896-f0bd-467c-bc56-153ef6150b8d)
