### PR TITLE
[5.x] Prevent PSR-4 warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,13 @@
             "src/helpers.php",
             "src/namespaced_helpers.php",
             "src/View/Blade/helpers.php"
+        ],
+        "exclude-from-classmap": [
+            "tests/Auth/Eloquent/__migrations__/**",
+            "tests/StarterKits/__fixtures__/**",
+            "tests/Translator/__fixtures__/**",
+            "tests/Console/Kernel.php",
+            "src/Console/Please/app-kernel.php"
         ]
     },
     "autoload-dev": {

--- a/tests/CP/StartPageTest.php
+++ b/tests/CP/StartPageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CP;
+namespace Tests\CP;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\File;

--- a/tests/Fieldtypes/ListTest.php
+++ b/tests/Fieldtypes/ListTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fieldtypes;
+namespace Tests\Fieldtypes;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Fields\Field;

--- a/tests/Fieldtypes/TaggableTest.php
+++ b/tests/Fieldtypes/TaggableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Fieldtypes;
+namespace Tests\Fieldtypes;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Fields\Field;

--- a/tests/Modifiers/ResolveTest.php
+++ b/tests/Modifiers/ResolveTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Modifiers;
+namespace Tests\Modifiers;
 
 use Facades\Tests\Factories\EntryFactory;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Policies/AssetContainerPolicyTest.php
+++ b/tests/Policies/AssetContainerPolicyTest.php
@@ -5,7 +5,6 @@ namespace Tests\Policies;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Assets\AssetContainer as ContainerContract;
 use Statamic\Facades\AssetContainer;
-use Tests\Policies\PolicyTestCase;
 
 class AssetContainerPolicyTest extends PolicyTestCase
 {

--- a/tests/Policies/AssetContainerPolicyTest.php
+++ b/tests/Policies/AssetContainerPolicyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Policies;
+namespace Tests\Policies;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Assets\AssetContainer as ContainerContract;

--- a/tests/Policies/AssetFolderPolicyTest.php
+++ b/tests/Policies/AssetFolderPolicyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Policies;
+namespace Tests\Policies;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Policies/AssetFolderPolicyTest.php
+++ b/tests/Policies/AssetFolderPolicyTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestWith;
 use Statamic\Contracts\Assets\AssetFolder;
 use Statamic\Facades\AssetContainer;
-use Tests\Policies\PolicyTestCase;
 
 class AssetFolderPolicyTest extends PolicyTestCase
 {


### PR DESCRIPTION
This pull request fixes the namespace of various tests and excludes fixtures from Composer's classmap, ensuring it doesn't try and autoload them.

These changes prevent Composer's warnings around PSR-4 autoloading:

<img width="1706" height="569" alt="CleanShot 2025-09-08 at 11 18 18" src="https://github.com/user-attachments/assets/e802f2fd-2e49-4ed0-a592-6c6e83a5028e" />
