### PR TITLE
[6.x] Make sure field actions do not inherit bottom margin

### DIFF
--- a/resources/js/components/ui/Field.vue
+++ b/resources/js/components/ui/Field.vue
@@ -62,7 +62,7 @@ const wrapperComponent = computed(() => props.as === 'card' ? Card : 'div');
         <div
             v-if="$slots.actions"
             :class="[
-                'flex items-center gap-x-1',
+                'flex items-center gap-x-1 mb-0',
                 props.label || $slots.label ? 'justify-between' : 'justify-end',
             ]"
             data-ui-field-header


### PR DESCRIPTION
This closes #12332. Ideally, extra actions should be in a separate container so their height does not affect anything to the left, but this was a more straightforward fix for now.

Before:
![2025-09-08 at 11 36 19@2x](https://github.com/user-attachments/assets/7fdcf49e-b5f2-40d0-8209-c43770b2a8c9)

After:
![2025-09-08 at 11 36 00@2x](https://github.com/user-attachments/assets/ba63db11-bfd8-4c0b-8183-ad9c991db38e)