### PR TITLE
[6.x] Checkboxes fieldtype: Option value should be a "label"

### DIFF
--- a/src/Fieldtypes/Checkboxes.php
+++ b/src/Fieldtypes/Checkboxes.php
@@ -25,6 +25,7 @@ class Checkboxes extends Fieldtype
                         'instructions' => __('statamic::fieldtypes.checkboxes.config.options'),
                         'type' => 'array',
                         'expand' => true,
+                        'value_header' => __('Label').' ('.__('Optional').')',
                         'field' => [
                             'type' => 'text',
                         ],


### PR DESCRIPTION
The default "Value" heading doesn't make much sense, so I've added a `value_header` to the options field to make it `Label (Optional)`, like similar fieldtypes (button group, select, etc).

<img width="1244" height="205" alt="CleanShot 2025-09-08 at 12 27 01" src="https://github.com/user-attachments/assets/de04bd1f-722b-4971-99e7-16bccdf6a0ed" />


Closes #12341.