### PR TITLE
[6.x] Integer fieldtype: Adjust config field widths

### DIFF
--- a/src/Fieldtypes/Integer.php
+++ b/src/Fieldtypes/Integer.php
@@ -21,7 +21,7 @@ class Integer extends Fieldtype
                         'display' => __('Placeholder'),
                         'instructions' => __('statamic::fieldtypes.text.config.placeholder'),
                         'type' => 'text',
-                        'width' => '50',
+                        'width' => '100',
                     ],
                     'prepend' => [
                         'display' => __('Prepend'),


### PR DESCRIPTION
This PR gives the "Placeholder" config field 100% width, so the Prepend/Append fields are 50% next to each other. Suggested by #12338.

## Before
<img width="1666" height="351" alt="CleanShot 2025-09-08 at 12 40 04" src="https://github.com/user-attachments/assets/a0a8aa1c-b95f-46f5-9a06-3c6851b23696" />

## After
<img width="1666" height="351" alt="CleanShot 2025-09-08 at 12 39 48" src="https://github.com/user-attachments/assets/2a720136-487b-4bce-ac80-fcfefa7d5c45" />
