### PR TITLE
[6.x] Popovers shouldn't use fixed widths, to account for localization

### DIFF
--- a/resources/js/components/fieldtypes/bard/LinkToolbarButton.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbarButton.vue
@@ -1,5 +1,5 @@
 <template>
-    <Popover ref="popover" class="!w-84" :inset="true" v-model:open="showingToolbar">
+    <Popover ref="popover" class="!size-min" :inset="true" v-model:open="showingToolbar">
         <template #trigger>
             <Button
                 class="px-2!"
@@ -15,7 +15,7 @@
         </template>
         <link-toolbar
             v-if="linkAttrs !== null"
-            class="w-84"
+            class="min-w-84 size-min"
             ref="toolbar"
             :link-attrs="linkAttrs"
             :config="config"

--- a/resources/js/components/two-factor/TwoFactor.vue
+++ b/resources/js/components/two-factor/TwoFactor.vue
@@ -69,7 +69,7 @@ function disable() {
 </script>
 
 <template>
-    <Popover side="bottom" class="!w-lg" v-model:open="popoverOpen">
+    <Popover side="bottom" class="min-w-lg !size-min" v-model:open="popoverOpen">
         <template #trigger>
             <Button v-text="__('Two Factor Authentication')" />
         </template>


### PR DESCRIPTION
This pull request removes the fixed widths from the 2FA and Bard Link popovers, in favour of a `min-width` & `width: min-content`. 

This fixes various issues where localized strings would cause the contents of the popover to overflow the "container".

Fixes #12308
Fixes #12310

## Before
<img width="379" height="266" alt="CleanShot 2025-09-08 at 12 55 32" src="https://github.com/user-attachments/assets/a1b2a255-345f-4a90-9051-52e2cbd9fbbf" />
<img width="709" height="247" alt="CleanShot 2025-09-08 at 12 55 46" src="https://github.com/user-attachments/assets/9169059f-71f0-42de-8c4d-a2d187775796" />


## After
<img width="351" height="267" alt="CleanShot 2025-09-08 at 12 56 24" src="https://github.com/user-attachments/assets/65776cc0-1d92-4e17-91d2-51ff559db7f4" />

<img width="709" height="247" alt="CleanShot 2025-09-08 at 12 56 04" src="https://github.com/user-attachments/assets/3ca380c2-c8fe-4ab7-a79b-636bafb06346" />
