### PR TITLE
[6.x] Separate the string 'Expand' for better translations

### DIFF
--- a/src/Fieldtypes/Arr.php
+++ b/src/Fieldtypes/Arr.php
@@ -37,7 +37,7 @@ class Arr extends Fieldtype
                 'fields' => [
                     'expand' => [
                         'type' => 'toggle',
-                        'display' => __('Expand'),
+                        'display' => __('Expanded format'),
                         'instructions' => __('statamic::fieldtypes.array.config.expand'),
                     ],
                 ],


### PR DESCRIPTION
The '__('Expand')' is used in the collection tree as button labels for expand/collapse and in the Array field type as label title for the last option 'Whether to save the array in the expanded format. Use this if you intend to have numeric values.'

In German, there is no suitable word that is correct for both and also fits the combination collapse/expand well.

Therefore, I suggest renaming the label title in the array field type slightly.

<img width="702" height="211" alt="Bildschirmfoto 2025-09-08 um 11 20 12" src="https://github.com/user-attachments/assets/3a28951b-7e0d-4d11-bb51-88502e876a94" />
<img width="334" height="337" alt="Bildschirmfoto 2025-09-08 um 11 20 31" src="https://github.com/user-attachments/assets/1475e5a5-d4f8-4736-90b7-423ef18ea153" />
