### PR TITLE
[6.x] Fix too many backticks in markdown cheatsheet

### DIFF
--- a/resources/css/elements/base.css
+++ b/resources/css/elements/base.css
@@ -115,6 +115,16 @@
     }
 }
 
+/* Prevent tailwind typography from adding backticks around code elements */
+@utility prose {
+    code {
+        &::before,
+        &::after {
+            content: none;
+        }
+    }
+}
+
 code {
     /* Take the UI accent for code color/background. Use relative colors to 1) Make sure the text color is not too bright and 2) Create a light background */
     color: hsl(from var(--theme-color-ui-accent) h l 18);

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -151,7 +151,7 @@
                             class="absolute top-4 end-4"
                             @click="showCheatsheet = false"
                         />
-                        <div class="prose dark:prose-invert prose-zinc prose-headings:font-medium prose-pre:prose-code:!text-white prose-code:before:hidden prose-code:after:hidden mx-auto my-8 max-w-3xl">
+                        <div class="prose dark:prose-invert prose-zinc prose-headings:font-medium prose-pre:prose-code:!text-white mx-auto my-8 max-w-3xl">
                             <h2 v-text="__('Markdown Cheatsheet')"></h2>
                             <div v-html="__('markdown.cheatsheet')"></div>
                         </div>


### PR DESCRIPTION
This PR fixes an issue where too many backticks are displayed in the backticks example in the Markdown Cheatsheet.

This PR also fixes an issue introduced in #12322 where inline code would be white. The `text-white` class should only be applied to proper code blocks.

Fixes #12355.

## Before

<img width="806" height="304" alt="CleanShot 2025-09-08 at 14 41 18" src="https://github.com/user-attachments/assets/b9e26628-8fa1-4e00-8fc7-33f62e9f9140" />


## After

<img width="806" height="304" alt="CleanShot 2025-09-08 at 14 41 04" src="https://github.com/user-attachments/assets/d94251d7-15be-4af1-99e6-44462a8d2b27" />
