### PR TITLE
[6.x] Separate the string 'Link' for better translations

### DIFF
--- a/resources/js/components/blueprints/LinkFields.vue
+++ b/resources/js/components/blueprints/LinkFields.vue
@@ -44,7 +44,7 @@
                         class="w-full mt-6"
                         variant="primary"
                         :disabled="!reference"
-                        :text="__('Link')"
+                        :text="__('Link Field')"
                         @click="linkField"
                     />
 
@@ -87,7 +87,7 @@
                         class="w-full mt-6"
                         variant="primary"
                         :disabled="!fieldset"
-                        :text="__('Link')"
+                        :text="__('Link Fieldset')"
                         @click="linkFieldset"
                     />
                 </div>


### PR DESCRIPTION
The '__('Link')' is used in the Bard toolbar as label for the link icon and in the blueprint editor on the buttons when linking a field or fieldset.

In German, there is no good word that fits both cases and matches other topics in the CP.

'Link' as 'Link' would be good for Bard, but when using it in the 'Link Fields' tab, 'Verknüpfen' is the better options. Although the translation 'Link' is not completely wrong, 'Verknüpfen' is used throughout other topics in the CP. So it would be a harmonisation.

Therefore, I suggest renaming the buttons in the 'Link Fields' tab slightly.

Using 'Link' as 'Link' has a second benefit, if you label a display label in a blueprint as 'Link': In V5, this was automatically translated as 'Verknüpfen' and sometimes that doesn't work for the label name, but for making all sorts of other links as described above. Hope you see what I mean.

<img width="532" height="242" alt="Bildschirmfoto 2025-09-08 um 11 19 55" src="https://github.com/user-attachments/assets/d2067b60-a889-4b01-baf5-b32634b18d17" />

<img width="427" height="583" alt="Bildschirmfoto 2025-09-08 um 11 19 44" src="https://github.com/user-attachments/assets/6d9242d8-e6d7-45f5-ba46-7e5ec8867373" />
