### PR TITLE
[6.x] Fix nested revealer fields

### DIFF
--- a/resources/js/components/ui/Publish/Field.vue
+++ b/resources/js/components/ui/Publish/Field.vue
@@ -108,12 +108,26 @@ const extraValues = computed(() => {
     return fieldPathPrefix.value ? data_get(containerExtraValues.value, fieldPathPrefix.value) : containerExtraValues.value;
 });
 
+const relevantRevealerValues = computed(() => {
+    return Object.keys(revealerValues.value).reduce((obj, key) => {
+        if (!fieldPathPrefix.value) {
+            obj[key] = revealerValues.value[key];
+        }
+
+        if (key.startsWith(fieldPathPrefix.value)) {
+            obj[key.replace(`${fieldPathPrefix.value}.`, '')] = revealerValues.value[key];
+        }
+
+        return obj;
+    }, {});
+});
+
 const shouldShowField = computed(() => {
     return new ShowField(
         visibleValues.value,
         extraValues.value,
         containerVisibleValues.value,
-        revealerValues.value,
+        relevantRevealerValues.value,
         hiddenFields.value,
         setHiddenField,
         { container },


### PR DESCRIPTION
This pull request attempts to fix an issue where Revealer fields weren't working in nested fieldtypes like Bard & Replicator.

This was happening because the `revealerValues` object we're getting from the `Container` and passing to `ShowField` looks like this:

```js
{
  replicator.0.revealer: true
}
```

However, when the field condition validator attempts to get the field's value, it fails, because it's trying to find a value using the revealer's field handle, not its "full dotted path".

This PR fixes it by only passing the "relative" revealer values to `ShowField` and flattening the keys to just the field handles. 

Fixes #12099.