### PR TITLE
[6.x] Bring back entry_count translation

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -18,7 +18,7 @@
                     <div class="flex items-center gap-1.5">
                         <ui-heading size="lg" :text="__(collection.title)" :href="collection.available_in_selected_site ? collection.entries_url : collection.edit_url" />
                         <span class="text-sm text-gray-600">
-                            ({{ __('entry_count', { count: collection.entries_count }) }})
+                            ({{ __('messages.entry_count', { count: collection.entries_count }) }})
                         </span>
                     </div>
                     <aside class="flex items-center gap-2">

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -79,6 +79,7 @@ return [
     'elevated_session_verification_code_sent' => 'Verification code has been sent to your email.',
     'email_utility_configuration_description' => 'Mail settings are configured in <code>:path</code>',
     'email_utility_description' => 'Check email configuration settings and send test emails.',
+    'entry_count' => ':count entries',
     'entry_origin_instructions' => 'The new localization will inherit values from the entry in the selected site.',
     'expect_root_instructions' => 'Consider the first page in the tree a "root" or "home" page.',
     'field_conditions_always_save_instructions' => 'Always save field value, even if the field is hidden.',


### PR DESCRIPTION
It was removed in #12306. It wouldn't get picked up by the translator tool because it was missing a prefix.
