### PR TITLE
[6.x] Table styling

### DIFF
--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -2,116 +2,115 @@
    Table Fieldtype
    ========================================================================== */
 
-.table-contained {
+   .table-contained {
     @apply relative mb-4 w-full rounded-lg border text-gray shadow-ui-sm outline-hidden dark:border-dark-900 dark:text-dark-150 text-start;
     border-collapse: separate;
     border-spacing: 0;
     table-layout: fixed;
-}
 
-.table-contained thead {
-    th {
-        @apply z-10 border-b bg-gray-50 p-2 text-sm font-medium text-gray-900 dark:border-dark-900 dark:bg-gray-800 dark:text-gray-100 not-last:border-e;
-        display: table-cell;
-        position: sticky;
-        top: -1px;
-        text-align: left;
+    thead {
+        th {
+            @apply z-10 border-b bg-gray-50 p-2 text-sm font-medium text-gray-900 dark:border-dark-900 dark:bg-gray-800 dark:text-gray-100 not-last:border-e;
+            display: table-cell;
+            position: sticky;
+            top: -1px;
+            text-align: left;
 
-        &:first-child {
-            @apply rounded-ss-lg ps-3;
-        }
+            &:first-child {
+                @apply rounded-ss-lg ps-3;
+            }
 
-        &:last-child {
-            @apply rounded-se-lg border-s-0;
-        }
+            &:last-child {
+                @apply rounded-se-lg border-s-0;
+            }
 
-        &.grid-drag-handle-header {
-            @apply w-3;
-        }
-    }
-}
-
-.table-contained [data-ui-control] {
-    @apply block w-full max-w-full rounded-none appearance-none border p-2;
-    @apply border-none bg-white text-sm shadow-none outline-hidden;
-    &:focus {
-        @apply bg-gray-100 inset-shadow-xs ring-0 dark:bg-gray-700;
-    }
-}
-
-
-.table-contained tbody {
-    @apply outline-hidden;
-
-    tr {
-        @apply outline-hidden;
-    }
-
-    th {
-        @apply bg-gray-50 p-2 text-sm font-medium text-gray-700 text-start border-r border-b border-gray-200 dark:border-dark-900 dark:bg-gray-700 dark:text-gray-100;
-    }
-
-    tr:first-child th {
-        @apply rounded-tl-lg;
-    }
-
-    tr:last-child th {
-        @apply border-b-0 rounded-bl-lg;
-    }
-
-    td {
-        @apply border-b p-0 dark:border-dark-900 border-e;
-
-        &:first-child.grid-cell {
-            @apply ps-4;
-        }
-
-        &:last-child {
-            @apply border-e-0;
-        }
-
-        &.table-drag-handle {
-            @apply w-3 p-2 bg-white dark:bg-gray-800;
-            &:hover {
-                @apply bg-gray-100 dark:bg-gray-700;
+            &.grid-drag-handle-header {
+                @apply w-3;
             }
         }
     }
 
-    tr:first-child td:last-child {
-        @apply rounded-se-lg overflow-hidden;
-    }
-
-    tr:last-child td {
-        @apply border-b-0 overflow-hidden;
-        &:first-child {
-            @apply rounded-es-lg;
+    tbody {
+        @apply outline-hidden;
+    
+        tr {
+            @apply outline-hidden;
         }
-        &:last-child {
-            @apply rounded-ee-lg;
+    
+        th {
+            @apply bg-gray-50 p-2 text-sm font-medium text-gray-700 text-start border-r border-b border-gray-200 dark:border-dark-900 dark:bg-gray-700 dark:text-gray-100;
+        }
+    
+        tr:first-child th {
+            @apply rounded-tl-lg;
+        }
+    
+        tr:last-child th {
+            @apply border-b-0 rounded-bl-lg;
+        }
+    
+        td {
+            @apply border-b p-0 dark:border-dark-900 border-e;
+    
+            &:first-child.grid-cell {
+                @apply ps-4;
+            }
+    
+            &:last-child {
+                @apply border-e-0;
+            }
+    
+            &.table-drag-handle {
+                @apply w-3 p-2 bg-white dark:bg-gray-800;
+                &:hover {
+                    @apply bg-gray-100 dark:bg-gray-700;
+                }
+            }
+        }
+    
+        tr:first-child td:last-child {
+            @apply rounded-se-lg overflow-hidden;
+        }
+    
+        tr:last-child td {
+            @apply border-b-0 overflow-hidden;
+            &:first-child {
+                @apply rounded-es-lg;
+            }
+            &:last-child {
+                @apply rounded-ee-lg;
+            }
+        }
+
+        tr.draggable-source--is-dragging td {
+            @apply bg-gray-100 dark:bg-gray-800;
+        }
+
+        > tbody:first-child tr:first-child td:first-child {
+            @apply rounded-tl-lg;
+        }
+
+        > tbody:first-child tr:first-child td:last-child {
+            @apply rounded-tr-lg;
         }
     }
 
-    tr.draggable-source--is-dragging td {
-        @apply bg-gray-100 dark:bg-gray-800;
+    [data-ui-control] {
+        @apply block w-full max-w-full rounded-none appearance-none border p-2;
+        @apply border-none bg-white text-sm shadow-none outline-hidden;
+        &:focus {
+            @apply bg-gray-100 inset-shadow-xs ring-0 dark:bg-gray-700;
+        }
     }
-}
 
-.table-contained > tbody:first-child tr:first-child td:first-child {
-    @apply rounded-tl-lg;
-}
-
-.table-contained > tbody:first-child tr:first-child td:last-child {
-    @apply rounded-tr-lg;
-}
-
-.table-contained .row-controls {
-    @apply w-8 text-center ps-0;
-    vertical-align: middle;
-    &:focus-within {
-        @apply bg-gray-200 dark:bg-gray-700;
-        button {
-            @apply outline-hidden ring-0;
+    .row-controls {
+        @apply w-8 text-center ps-0;
+        vertical-align: middle;
+        &:focus-within {
+            @apply bg-gray-200 dark:bg-gray-700;
+            button {
+                @apply outline-hidden ring-0;
+            }
         }
     }
 }

--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -1,13 +1,13 @@
 /* ==========================================================================
-   Table Fieldtype
-   ========================================================================== */
+Table Fieldtype
+========================================================================== */
 
-   .table-contained {
+.table-contained {
     @apply relative mb-4 w-full rounded-lg border text-gray shadow-ui-sm outline-hidden dark:border-dark-900 dark:text-dark-150 text-start;
     border-collapse: separate;
     border-spacing: 0;
     table-layout: fixed;
-
+    
     thead {
         th {
             @apply z-10 border-b bg-gray-50 p-2 text-sm font-medium text-gray-900 dark:border-dark-900 dark:bg-gray-800 dark:text-gray-100 not-last:border-e;
@@ -15,51 +15,51 @@
             position: sticky;
             top: -1px;
             text-align: left;
-
+            
             &:first-child {
                 @apply rounded-ss-lg ps-3;
             }
-
+            
             &:last-child {
                 @apply rounded-se-lg border-s-0;
             }
-
+            
             &.grid-drag-handle-header {
                 @apply w-3;
             }
         }
     }
-
+    
     tbody {
         @apply outline-hidden;
-    
+        
         tr {
             @apply outline-hidden;
         }
-    
+        
         th {
             @apply bg-gray-50 p-2 text-sm font-medium text-gray-700 text-start border-r border-b border-gray-200 dark:border-dark-900 dark:bg-gray-700 dark:text-gray-100;
         }
-    
+        
         tr:first-child th {
             @apply rounded-tl-lg;
         }
-    
+        
         tr:last-child th {
             @apply border-b-0 rounded-bl-lg;
         }
-    
+        
         td {
             @apply border-b p-0 dark:border-dark-900 border-e;
-    
+            
             &:first-child.grid-cell {
                 @apply ps-4;
             }
-    
+            
             &:last-child {
                 @apply border-e-0;
             }
-    
+            
             &.table-drag-handle {
                 @apply w-3 p-2 bg-white dark:bg-gray-800;
                 &:hover {
@@ -67,11 +67,11 @@
                 }
             }
         }
-    
+        
         tr:first-child td:last-child {
             @apply rounded-se-lg overflow-hidden;
         }
-    
+        
         tr:last-child td {
             @apply border-b-0 overflow-hidden;
             &:first-child {
@@ -81,20 +81,20 @@
                 @apply rounded-ee-lg;
             }
         }
-
+        
         tr.draggable-source--is-dragging td {
             @apply bg-gray-100 dark:bg-gray-800;
         }
-
+        
         > tbody:first-child tr:first-child td:first-child {
             @apply rounded-tl-lg;
         }
-
+        
         > tbody:first-child tr:first-child td:last-child {
             @apply rounded-tr-lg;
         }
     }
-
+    
     [data-ui-control] {
         @apply block w-full max-w-full rounded-none appearance-none border p-2;
         @apply border-none bg-white text-sm shadow-none outline-hidden;
@@ -102,7 +102,7 @@
             @apply bg-gray-100 inset-shadow-xs ring-0 dark:bg-gray-700;
         }
     }
-
+    
     .row-controls {
         @apply w-8 text-center ps-0;
         vertical-align: middle;

--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -107,7 +107,7 @@ Table Fieldtype
         @apply w-8 text-center ps-0;
         vertical-align: middle;
         &:focus-within {
-            @apply bg-gray-200 dark:bg-gray-700;
+            @apply bg-gray-100 dark:bg-gray-700;
             button {
                 @apply outline-hidden ring-0;
             }

--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -33,20 +33,37 @@ Table Fieldtype
     tbody {
         @apply outline-hidden dark:bg-gray-800;
 
-        tr {
-            @apply outline-hidden;
-        }
-
         th {
             @apply bg-gray-50 p-2 text-sm font-medium text-gray-700 text-start border-r border-b border-gray-200 dark:border-dark-900 dark:bg-gray-700 dark:text-gray-100;
+
+            tr:first-child & {
+                @apply rounded-tl-lg;
+            }
+            tr:last-child & {
+                @apply border-b-0 rounded-bl-lg;
+            }
         }
 
-        tr:first-child th {
-            @apply rounded-tl-lg;
-        }
+        tr {
+            @apply outline-hidden;
 
-        tr:last-child th {
-            @apply border-b-0 rounded-bl-lg;
+            &:first-child td:last-child {
+                @apply overflow-hidden;
+            }
+
+            &:last-child td {
+                @apply border-b-0 overflow-hidden;
+                &:first-child {
+                    @apply rounded-es-lg;
+                }
+                &:last-child {
+                    @apply rounded-ee-lg;
+                }
+            }
+
+            &.draggable-source--is-dragging td {
+                @apply bg-gray-100 dark:bg-gray-800;
+            }
         }
 
         td {
@@ -68,30 +85,13 @@ Table Fieldtype
             }
         }
 
-        tr:first-child td:last-child {
-            @apply overflow-hidden;
-        }
-
-        tr:last-child td {
-            @apply border-b-0 overflow-hidden;
-            &:first-child {
-                @apply rounded-es-lg;
+        > tbody:first-child tr:first-child {
+            td:first-child {
+                @apply rounded-tl-lg;
             }
-            &:last-child {
-                @apply rounded-ee-lg;
+            td:last-child {
+                @apply rounded-tr-lg;
             }
-        }
-
-        tr.draggable-source--is-dragging td {
-            @apply bg-gray-100 dark:bg-gray-800;
-        }
-
-        > tbody:first-child tr:first-child td:first-child {
-            @apply rounded-tl-lg;
-        }
-
-        > tbody:first-child tr:first-child td:last-child {
-            @apply rounded-tr-lg;
         }
     }
 

--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -69,7 +69,7 @@ Table Fieldtype
         }
 
         tr:first-child td:last-child {
-            @apply rounded-se-lg overflow-hidden;
+            @apply overflow-hidden;
         }
 
         tr:last-child td {

--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -7,7 +7,7 @@ Table Fieldtype
     border-collapse: separate;
     border-spacing: 0;
     table-layout: fixed;
-    
+
     thead {
         th {
             @apply z-10 border-b bg-gray-50 p-2 text-sm font-medium text-gray-900 dark:border-dark-900 dark:bg-gray-800 dark:text-gray-100 not-last:border-e;
@@ -15,51 +15,51 @@ Table Fieldtype
             position: sticky;
             top: -1px;
             text-align: left;
-            
+
             &:first-child {
                 @apply rounded-ss-lg ps-3;
             }
-            
+
             &:last-child {
                 @apply rounded-se-lg border-s-0;
             }
-            
+
             &.grid-drag-handle-header {
                 @apply w-3;
             }
         }
     }
-    
+
     tbody {
         @apply outline-hidden;
-        
+
         tr {
             @apply outline-hidden;
         }
-        
+
         th {
             @apply bg-gray-50 p-2 text-sm font-medium text-gray-700 text-start border-r border-b border-gray-200 dark:border-dark-900 dark:bg-gray-700 dark:text-gray-100;
         }
-        
+
         tr:first-child th {
             @apply rounded-tl-lg;
         }
-        
+
         tr:last-child th {
             @apply border-b-0 rounded-bl-lg;
         }
-        
+
         td {
             @apply border-b p-0 dark:border-dark-900 border-e;
-            
+
             &:first-child.grid-cell {
                 @apply ps-4;
             }
-            
+
             &:last-child {
                 @apply border-e-0;
             }
-            
+
             &.table-drag-handle {
                 @apply w-3 p-2 bg-white dark:bg-gray-800;
                 &:hover {
@@ -67,11 +67,11 @@ Table Fieldtype
                 }
             }
         }
-        
+
         tr:first-child td:last-child {
             @apply rounded-se-lg overflow-hidden;
         }
-        
+
         tr:last-child td {
             @apply border-b-0 overflow-hidden;
             &:first-child {
@@ -81,20 +81,20 @@ Table Fieldtype
                 @apply rounded-ee-lg;
             }
         }
-        
+
         tr.draggable-source--is-dragging td {
             @apply bg-gray-100 dark:bg-gray-800;
         }
-        
+
         > tbody:first-child tr:first-child td:first-child {
             @apply rounded-tl-lg;
         }
-        
+
         > tbody:first-child tr:first-child td:last-child {
             @apply rounded-tr-lg;
         }
     }
-    
+
     [data-ui-control] {
         @apply block w-full max-w-full rounded-none appearance-none border p-2;
         @apply border-none bg-white text-sm shadow-none outline-hidden;
@@ -102,7 +102,7 @@ Table Fieldtype
             @apply bg-gray-100 inset-shadow-xs ring-0 dark:bg-gray-700;
         }
     }
-    
+
     .row-controls {
         @apply w-8 text-center ps-0;
         vertical-align: middle;

--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -3,14 +3,14 @@ Table Fieldtype
 ========================================================================== */
 
 .table-contained {
-    @apply relative mb-4 w-full rounded-lg border text-gray shadow-ui-sm outline-hidden dark:border-dark-900 dark:text-dark-150 text-start;
+    @apply relative mb-4 w-full rounded-lg border text-gray shadow-ui-sm outline-hidden dark:border-gray-700 dark:text-dark-150 text-start;
     border-collapse: separate;
     border-spacing: 0;
     table-layout: fixed;
 
     thead {
         th {
-            @apply z-10 border-b bg-gray-50 p-2 text-sm font-medium text-gray-900 dark:border-dark-900 dark:bg-gray-800 dark:text-gray-100 not-last:border-e;
+            @apply z-10 border-b bg-gray-50 p-2 text-sm font-medium text-gray-900 dark:border-gray-800 dark:border-b-gray-700 dark:bg-gray-900 dark:text-gray-100 not-last:border-e;
             display: table-cell;
             position: sticky;
             top: -1px;
@@ -31,7 +31,7 @@ Table Fieldtype
     }
 
     tbody {
-        @apply outline-hidden;
+        @apply outline-hidden dark:bg-gray-800;
 
         tr {
             @apply outline-hidden;

--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -52,6 +52,11 @@
     font-weight: 425;
 }
 
+@utility input-text {
+    width: 100%;
+    @apply p-2 text-gray-900;
+}
+
 /* UTILITIES / DECORATION / SHADOWS
 =================================================== */
 @utility shadow-sm-b {

--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -54,7 +54,8 @@
 
 @utility input-text {
     width: 100%;
-    @apply p-2 text-gray-900;
+    /* e.g. in a Bard table */
+    @apply p-2 text-gray-900 dark:text-gray-100;
 }
 
 /* UTILITIES / DECORATION / SHADOWS

--- a/resources/css/elements/base.css
+++ b/resources/css/elements/base.css
@@ -36,7 +36,7 @@
     /* Explicitly show focus without needing to tab for buttons inside modals, e.g. Assets > cancel button on delete modal */
     [data-dismissable-layer] button:focus,
     /* and then a global selector for focus-visible everywhere else (except where the focus-within class will handle the focus outline target instead) */
-    :not([class*='focus-within'] *) {
+    :not([class*='focus-within'] > *) {
         :focus-visible& {
             outline-width: var(--focus-outline-width);
             outline-offset: var(--focus-outline-offset);


### PR DESCRIPTION
This closes #12318.

This commit:

- Brings back `.input-text` which is used in some array-like fields
- Tidies up `table.css`
- Adds some dark mode consideration for tables

Before:
![2025-09-09 at 15 45 19@2x](https://github.com/user-attachments/assets/b042ca04-b6b8-4dc1-a7b7-cfddfae837a9)

After:
![2025-09-09 at 15 44 57@2x](https://github.com/user-attachments/assets/27a1c037-ad21-4689-b733-ad1bfd0d4774)
