### PR TITLE
[6.x] Add some gap between Bard icons, for when they are "pressed"

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -19,7 +19,7 @@
                         @close="toggleFullscreen"
                     >
                         <div class="bard-fixed-toolbar border-0" v-if="!readOnly && showFixedToolbar">
-                            <div class="no-select flex flex-1 flex-wrap items-center" v-if="toolbarIsFixed">
+                            <div class="no-select flex flex-1 flex-wrap items-center gap-1" v-if="toolbarIsFixed">
                                 <component
                                     v-for="button in visibleButtons(buttons)"
                                     :key="button.name"
@@ -35,7 +35,7 @@
                     </publish-field-fullscreen-header>
 
                     <div class="bard-fixed-toolbar flex items-center justify-between rounded-t-xl border-b border-gray-300 bg-gray-50 px-2 py-1 dark:border-white/10 dark:bg-gray-950" v-if="!readOnly && showFixedToolbar && !fullScreenMode">
-                        <div class="no-select flex flex-1 flex-wrap items-center" v-if="toolbarIsFixed">
+                        <div class="no-select flex flex-1 flex-wrap items-center gap-1" v-if="toolbarIsFixed">
                             <component
                                 v-for="button in visibleButtons(buttons)"
                                 :key="button.name"


### PR DESCRIPTION
A gap is needed here so the buttons don't blend into each other when in a "pressed" state

Before:
![2025-09-09 at 15 50 17@2x](https://github.com/user-attachments/assets/5ad590f8-771b-41df-8038-734a95b0972d)

After:
![2025-09-09 at 15 50 05@2x](https://github.com/user-attachments/assets/b3b35694-7acb-4641-93a9-b28e7a37dc93)
