### PR TITLE
[6.x] Fix uploading via the asset fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -8,7 +8,7 @@
 
         <uploader
             ref="uploader"
-            :container="container.handle"
+            :container="container.id"
             :enabled="canUpload"
             :path="folder"
             @updated="uploadsUpdated"


### PR DESCRIPTION
This pull request fixes an issue where the container handle wasn't being passed to the `Uploader` component correctly. This was caused by refactoring in https://github.com/statamic/cms/commit/78e7df19b366e129721edbc6841193fbc3633c56, where `container` became an object, rather than a string and I referenced `.handle` instead of `.id`.

Fixes #12374