### PR TITLE
[6.x] Improve licensing layout and fix little dot

### DIFF
--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -61,6 +61,18 @@
     }
 }
 
+/* UTILITIES / DECORATION / OTHER
+=================================================== */
+/* e.g. /cp/utilities/licensing */
+@utility little-dot {
+    border-radius:7px;
+    display:inline-block;
+    height:7px;
+    position:relative;
+    width:7px;
+    flex-shrink:0
+}
+
 /* UTILITIES / STATES
 =================================================== */
 /* Here we typically need a negative outline-offset because of the inner shadow on inputs */

--- a/resources/views/licensing.blade.php
+++ b/resources/views/licensing.blade.php
@@ -55,7 +55,7 @@
                     <ui-table class="w-full">
                         <ui-table-row>
                             <ui-table-cell class="w-64 font-bold">
-                                <span class="little-dot {{ $site->valid() ? 'bg-green-600' : 'bg-red-700' }} me-2"></span>
+                                <span class="little-dot {{ $site->valid() ? 'bg-green-500 dark:bg-green-600' : 'bg-red-500 dark:bg-red-600' }} me-2"></span>
                                 {{ $site->key() ?? __('No license key') }}
                             </ui-table-cell>
                             <ui-table-cell class="relative">
@@ -83,7 +83,7 @@
                     <ui-table class="w-full">
                         <ui-table-row>
                             <ui-table-cell class="w-64 font-bold">
-                                <span class="little-dot {{ $statamic->valid() ? 'bg-green-600' : 'bg-red-700' }} me-2"></span>
+                                <span class="little-dot {{ $statamic->valid() ? 'bg-green-500 dark:bg-green-600' : 'bg-red-500 dark:bg-red-600' }} me-2"></span>
                                 {{ __('Statamic') }}
 
                                 @if ($statamic->pro())
@@ -112,7 +112,7 @@
                             @foreach ($addons as $addon)
                                 <ui-table-row>
                                     <ui-table-cell class="w-64 me-2">
-                                        <span class="little-dot {{ $addon->valid() ? 'bg-green-600' : 'bg-red-700' }} me-2"></span>
+                                        <span class="little-dot {{ $addon->valid() ? 'bg-green-500 dark:bg-green-600' : 'bg-red-500 dark:bg-red-600' }} me-2"></span>
                                         <span class="font-bold">
                                             <a href="{{ $addon->addon()->marketplaceUrl() }}" class="underline">
                                                 {{ $addon->name() }}
@@ -140,7 +140,7 @@
                             @foreach ($unlistedAddons as $addon)
                                 <ui-table-row>
                                     <ui-table-cell class="w-64 font-bold me-2">
-                                        <span class="little-dot bg-green-500 me-2"></span>
+                                        <span class="little-dot bg-green-500 dark:bg-green-600 me-2"></span>
                                         {{ $addon->name() }}
                                     </ui-table-cell>
                                     <ui-table-cell>{{ $addon->version() }}</ui-table-cell>

--- a/resources/views/licensing.blade.php
+++ b/resources/views/licensing.blade.php
@@ -140,7 +140,7 @@
                             @foreach ($unlistedAddons as $addon)
                                 <ui-table-row>
                                     <ui-table-cell class="w-64 font-bold me-2">
-                                        <span class="little-dot bg-green-600 me-2"></span>
+                                        <span class="little-dot bg-green-500 me-2"></span>
                                         {{ $addon->name() }}
                                     </ui-table-cell>
                                     <ui-table-cell>{{ $addon->version() }}</ui-table-cell>

--- a/resources/views/licensing.blade.php
+++ b/resources/views/licensing.blade.php
@@ -55,7 +55,9 @@
                     <ui-table class="w-full">
                         <ui-table-row>
                             <ui-table-cell class="w-64 font-bold">
-                                <span class="little-dot {{ $site->valid() ? 'bg-green-500 dark:bg-green-600' : 'bg-red-500 dark:bg-red-600' }} me-2"></span>
+                                <div class="flex gap-3">
+                                    <span class="little-dot {{ $site->valid() ? 'bg-green-500 dark:bg-green-600' : 'bg-red-500 dark:bg-red-600' }} me-2"></span>
+                                </div>
                                 {{ $site->key() ?? __('No license key') }}
                             </ui-table-cell>
                             <ui-table-cell class="relative">
@@ -83,14 +85,18 @@
                     <ui-table class="w-full">
                         <ui-table-row>
                             <ui-table-cell class="w-64 font-bold">
-                                <span class="little-dot {{ $statamic->valid() ? 'bg-green-500 dark:bg-green-600' : 'bg-red-500 dark:bg-red-600' }} me-2"></span>
-                                {{ __('Statamic') }}
+                                <div class="flex gap-3">
+                                    <span class="little-dot mt-[0.45rem] {{ $statamic->valid() ? 'bg-green-500 dark:bg-green-600' : 'bg-red-500 dark:bg-red-600' }}"></span>
+                                    <span>
+                                        {{ __('Statamic') }}
 
-                                @if ($statamic->pro())
-                                    <span class="text-pink">{{ __('Pro') }}</span>
-                                @else
-                                    {{ __('Free') }}
-                                @endif
+                                        @if ($statamic->pro())
+                                            <span class="text-pink">{{ __('Pro') }}</span>
+                                        @else
+                                            {{ __('Free') }}
+                                        @endif
+                                    </span>
+                                </div>
                             </ui-table-cell>
                             <ui-table-cell>{{ $statamic->version() }}</ui-table-cell>
                             <ui-table-cell class="text-end">
@@ -111,18 +117,19 @@
                         <ui-table class="w-full">
                             @foreach ($addons as $addon)
                                 <ui-table-row>
-                                    <ui-table-cell class="w-64 me-2">
-                                        <span class="little-dot {{ $addon->valid() ? 'bg-green-500 dark:bg-green-600' : 'bg-red-500 dark:bg-red-600' }} me-2"></span>
-                                        <span class="font-bold">
-                                            <a href="{{ $addon->addon()->marketplaceUrl() }}" class="underline">
-                                                {{ $addon->name() }}
-                                            </a>
-                                        </span>
-                                        @if ($addon->edition())
-                                            <ui-badge>
-                                                {{ $addon->edition() ?? '' }}
-                                            </ui-badge>
-                                        @endif
+                                    <ui-table-cell class="w-64">
+                                        <div class="flex gap-3">
+                                            <span class="little-dot mt-[0.45rem] {{ $addon->valid() ? 'bg-green-500 dark:bg-green-600' : 'bg-red-500 dark:bg-red-600' }}"></span>
+                                            <span class="font-bold">
+                                                <a href="{{ $addon->addon()->marketplaceUrl() }}" class="underline">{{ $addon->name() }}</a>
+                                            </span>
+                                            @if ($addon->edition())
+                                                <div>
+                                                    <ui-badge>
+                                                        {{ $addon->edition() ?? '' }}
+                                                    </ui-badge>
+                                                </div>
+                                            @endif
                                     </ui-table-cell>
                                     <ui-table-cell>{{ $addon->version() }}</ui-table-cell>
                                     <ui-table-cell class="text-red-700 text-end">{{ $addon->invalidReason() }}</ui-table-cell>
@@ -139,9 +146,11 @@
                         <ui-table class="w-full">
                             @foreach ($unlistedAddons as $addon)
                                 <ui-table-row>
-                                    <ui-table-cell class="w-64 font-bold me-2">
-                                        <span class="little-dot bg-green-500 dark:bg-green-600 me-2"></span>
-                                        {{ $addon->name() }}
+                                    <ui-table-cell class="w-64">
+                                        <div class="flex gap-3">
+                                            <span class="little-dot bg-green-500 dark:bg-green-600 me-2"></span>
+                                            {{ $addon->name() }}
+                                        </div>
                                     </ui-table-cell>
                                     <ui-table-cell>{{ $addon->version() }}</ui-table-cell>
                                 </ui-table-row>

--- a/resources/views/licensing.blade.php
+++ b/resources/views/licensing.blade.php
@@ -124,7 +124,7 @@
                                                 <a href="{{ $addon->addon()->marketplaceUrl() }}" class="underline">{{ $addon->name() }}</a>
                                             </span>
                                             @if ($addon->edition())
-                                                <div>
+                                                <div class="ms-auto">
                                                     <ui-badge>
                                                         {{ $addon->edition() ?? '' }}
                                                     </ui-badge>


### PR DESCRIPTION
This closes #12297 in addition to improving the vertical alignment

- I brought back the `.little-dot` class as a TW utility and updated the colors to match V6 including dark mode.
- I also improved the vertical alignment of dots/the add-on name, so if the licence name is long and it wraps, it stays in line

before:
![2025-09-10 at 10 12 02@2x](https://github.com/user-attachments/assets/d4afd42e-3c7b-40d6-a3e3-98111d0cea57)

and after:
![2025-09-10 at 10 07 13@2x](https://github.com/user-attachments/assets/2957c7b4-ecfe-4ce1-956a-6e409beb36ba)
