### PR TITLE
[6.x] Asset button text alignment

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -48,7 +48,7 @@
                         <ui-icon name="upload-cloud" class="size-5 text-gray-500 me-2" />
                         <div>
                             <span class="leading-tight" v-text="`${__('Drag & drop here or')}&nbsp;`" />
-                            <button type="button" class="underline underline-offset-2 cursor-pointer hover:text-black dark:hover:text-gray-200" @click.prevent="uploadFile">
+                            <button type="button" class="text-left underline underline-offset-2 cursor-pointer hover:text-black dark:hover:text-gray-200" @click.prevent="uploadFile">
                                 {{ __('choose a file') }}.
                             </button>
                         </div>


### PR DESCRIPTION
This closes #12380 by correcting the "choose a file" alignment, aligning it to the left for when there is very little space. This is naturally centered because user agent stylesheets apply `text-align: center` to buttons by default.

Before:
![2025-09-10 at 10 42 59@2x](https://github.com/user-attachments/assets/ad910812-5dd2-4de4-a6cf-63f36fbc725a)

After:
![2025-09-10 at 10 42 44@2x](https://github.com/user-attachments/assets/d7d75a97-db9f-47ba-8f15-f4ba38e52064)

