### PR TITLE
[6.x] Assets Fieldtype: Clicking on filename should select asset

### DIFF
--- a/resources/js/components/assets/AssetManager.vue
+++ b/resources/js/components/assets/AssetManager.vue
@@ -11,7 +11,6 @@
         :initial-columns="columns"
         @navigated="navigate"
         @selections-updated="updateSelections"
-        @asset-doubleclicked="editAsset"
         @edit-asset="editAsset"
     />
 </template>

--- a/resources/js/components/assets/Selector.vue
+++ b/resources/js/components/assets/Selector.vue
@@ -15,7 +15,6 @@
                     allow-selecting-existing-upload
                     :allow-bulk-actions="false"
                     @selections-updated="selectionsUpdated"
-                    @asset-doubleclicked="select"
                     @edit-asset="toggleAssetSelection"
                     @initialized="focusSearchInput"
                 >

--- a/resources/js/components/assets/Selector.vue
+++ b/resources/js/components/assets/Selector.vue
@@ -16,6 +16,7 @@
                     :allow-bulk-actions="false"
                     @selections-updated="selectionsUpdated"
                     @asset-doubleclicked="select"
+                    @edit-asset="toggleAssetSelection"
                     @initialized="focusSearchInput"
                 >
                     <template #initializing>
@@ -169,6 +170,12 @@ export default {
          */
         selectionsUpdated(selections) {
             this.browserSelections = selections;
+        },
+
+        toggleAssetSelection(asset) {
+            this.browserSelections = this.browserSelections.includes(asset.id)
+                ? this.browserSelections.filter(id => id !== asset.id)
+                : [...this.browserSelections, asset.id];
         },
 
         focusSearchInput() {


### PR DESCRIPTION
This pull request fixes an issue where clicking on an asset's filename in the asset selector wouldn't actually select the asset.

When an asset's filename is clicked, the `Assets/Browser/Table` component emits an `edit-asset` event, which is usually responsible for opening the asset editor stack, but in this case, we can listen to it to toggle selection instead.

Fixes #12377.