### PR TITLE
[6.x] Asset UI tweaks

### DIFF
--- a/resources/js/components/assets/Browser/Grid.vue
+++ b/resources/js/components/assets/Browser/Grid.vue
@@ -53,7 +53,7 @@
                     </Context>
                 </ItemActions>
             </div>
-            <div v-if="creatingFolder" class="group/folder relative">
+            <div v-if="creatingFolder" class="group/folder relative p-1">
                 <div class="group h-[66px] w-[80px]">
                     <ui-icon name="ui/folder" class="size-full text-blue-400/90 hover:text-blue-400" />
 
@@ -63,7 +63,7 @@
                         :start-with-edit-mode="true"
                         submit-mode="enter"
                         :placeholder="__('New Folder')"
-                        class="flex w-[80px] items-center justify-center overflow-hidden text-center font-mono text-xs text-ellipsis whitespace-nowrap text-gray-500"
+                        class="flex w-[80px] items-center justify-center overflow-hidden mt-2 text-center font-mono text-xs text-ellipsis whitespace-nowrap text-gray-500"
                         @submit="$emit('create-folder', newFolderName)"
                         @cancel="
                             () => {

--- a/resources/js/components/assets/Browser/Grid.vue
+++ b/resources/js/components/assets/Browser/Grid.vue
@@ -34,7 +34,7 @@
                             <button @dblclick="selectFolder(folder.path)" class="group h-[66px] w-[80px]">
                                 <ui-icon name="ui/folder" class="size-full text-blue-400/90 hover:text-blue-400" />
                                 <div
-                                    class="overflow-hidden text-center font-mono text-xs text-ellipsis whitespace-nowrap text-gray-500"
+                                    class="overflow-hidden mt-2 text-center font-mono text-xs text-ellipsis whitespace-nowrap text-gray-500"
                                     v-text="folder.basename"
                                     :title="folder.basename"
                                 />

--- a/resources/js/components/assets/Browser/Grid.vue
+++ b/resources/js/components/assets/Browser/Grid.vue
@@ -62,7 +62,7 @@
                         v-model:modelValue="newFolderName"
                         :start-with-edit-mode="true"
                         submit-mode="enter"
-                        :placeholder="__('New Folder')"
+                        :placeholder="__('new-folder')"
                         class="flex w-[80px] items-center justify-center overflow-hidden mt-2 text-center font-mono text-xs text-ellipsis whitespace-nowrap text-gray-500"
                         @submit="$emit('create-folder', newFolderName)"
                         @cancel="


### PR DESCRIPTION
A few tweaks to how asset names and folders are displayed, correcting alignment, adding some margin to the names, and changing the default "new-folder" to lowercase with dashes

Before:
![2025-09-10 at 11 35 40@2x](https://github.com/user-attachments/assets/ac006ce1-712e-48af-bc52-6032e2719b11)

After:
![2025-09-10 at 11 35 13@2x](https://github.com/user-attachments/assets/6646a777-e2b4-49a8-a54b-49c62fcf0b43)
