### PR TITLE
[5.x] Require `spatie/error-solutions` instead of `spatie/ignition`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "rebing/graphql-laravel": "^9.8",
         "rhukster/dom-sanitizer": "^1.0.6",
         "spatie/blink": "^1.3",
-        "spatie/ignition": "^1.15.1",
+        "spatie/error-solutions": "^2.0",
         "statamic/stringy": "^3.1.2",
         "stillat/blade-parser": "^1.10.1 || ^2.0",
         "symfony/lock": "^6.4",


### PR DESCRIPTION
This pull request replaces our `spatie/ignition` dependency with `spatie/error-solutions` to avoid potential dependency conflicts with users of the Flare error tracking service.

We aren't using Ignition's classes anywhere, but we are using classes provided by the `error-solutions` package.

Related: https://github.com/statamic/ideas/issues/1367