### PR TITLE
[5.x] Fix casing of "Edit Nav item" dropdown item

### DIFF
--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -109,7 +109,7 @@
                     :text="__('Edit Entry')"
                     :redirect="branch.edit_url" />
                 <dropdown-item
-                    :text="__('Edit Nav item')"
+                    :text="__('Edit Nav Item')"
                     @click="editPage(branch, vm, vm.store)" />
                 <dropdown-item
                     v-if="depth < maxDepth"


### PR DESCRIPTION
I thought I had already fixed this (in #11907), but looks like I only fixed the casing of `nav` and not `item`. This PR corrects the casing of `item`.

Fixes #12386.