### PR TITLE
[6.x] Fix discarding nav items

### DIFF
--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -70,6 +70,7 @@ import { Heading, Button, PublishContainer, Icon } from '@/components/ui';
 import { flatten } from 'lodash-es';
 import { computed, ref } from 'vue';
 import { Pipeline, Request } from '@/components/ui/Publish/SavePipeline.js';
+import { clone } from '@/bootstrap/globals.js';
 
 let saving = ref(false);
 let errors = ref({});
@@ -270,7 +271,7 @@ export default {
         },
 
         emitPublishInfoUpdated(isNew) {
-            this.$emit('publish-info-updated', {
+            this.$emit('publish-info-updated', clone({
                 values: this.values,
                 originValues: this.originValues,
                 meta: this.meta,
@@ -279,7 +280,7 @@ export default {
                 localizedFields: this.localizedFields,
                 entry: this.entry,
                 new: isNew,
-            });
+            }));
         },
     },
 

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -91,6 +91,7 @@
 import { dragContext, Draggable, walkTreeData } from '@he-tree/vue';
 import TreeBranch from './Branch.vue';
 import { PanelHeader, Panel, Icon } from '@/components/ui';
+import { clone } from '@/bootstrap/globals.js';
 
 export default {
     components: {
@@ -160,7 +161,7 @@ export default {
         this.collapsedState = this.getCollapsedState();
 
         this.getPages().then(() => {
-            this.initialPages = this.pages;
+            this.initialPages = clone(this.pages);
         });
 
         this.$keys.bindGlobal(['mod+s'], (e) => {


### PR DESCRIPTION
This pull request fixes two issues around discarding nav items:

* When you edit a nav item, close out of the page editor, then go to edit it again, your previous changes remain.
* When you edit or re-order nav items, then discard your changes, nothing is discarded.

Fixes #12151.