### PR TITLE
feat: Add `min`, `max`, and `step` attributes to Integer fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/IntegerFieldtype.vue
+++ b/resources/js/components/fieldtypes/IntegerFieldtype.vue
@@ -8,6 +8,8 @@
         :is-read-only="isReadOnly"
         :id="fieldId"
         :min="config.min"
+        :max="config.max"
+        :step="config.step"
         :prepend="__(config.prepend)"
         :append="__(config.append)"
         :placeholder="__(config.placeholder)"

--- a/resources/views/extend/forms/fields/integer.antlers.html
+++ b/resources/views/extend/forms/fields/integer.antlers.html
@@ -3,6 +3,9 @@
     name="{{ handle }}"
     value="{{ value }}"
     {{ if placeholder }}placeholder="{{ placeholder }}"{{ /if }}
+    {{ if min }}min="{{ min }}"{{ /if }}
+    {{ if max }}max="{{ max }}"{{ /if }}
+    {{ if step }}step="{{ step }}"{{ /if }}
     {{ if character_limit }}maxlength="{{ character_limit }}"{{ /if }}
     {{ if autocomplete }}autocomplete="{{ autocomplete }}"{{ /if }}
     {{ if js_driver }}{{ js_attributes }}{{ /if }}

--- a/src/Fieldtypes/Integer.php
+++ b/src/Fieldtypes/Integer.php
@@ -22,6 +22,21 @@ class Integer extends Fieldtype
                         'instructions' => __('statamic::fieldtypes.text.config.placeholder'),
                         'type' => 'text',
                     ],
+                    'min' => [
+                        'display' => __('Minimum Value'),
+                        'instructions' => __('The minimum allowed value.'),
+                        'type' => 'integer',
+                    ],
+                    'max' => [
+                        'display' => __('Maximum Value'),
+                        'instructions' => __('The maximum allowed value.'),
+                        'type' => 'integer',
+                    ],
+                    'step' => [
+                        'display' => __('Step'),
+                        'instructions' => __('The interval between valid numbers.'),
+                        'type' => 'integer',
+                    ],
                     'default' => [
                         'display' => __('Default Value'),
                         'instructions' => __('statamic::messages.fields_default_instructions'),
@@ -48,6 +63,14 @@ class Integer extends Fieldtype
         ];
     }
 
+    public function viewData($data)
+    {
+        return [
+            'min'  => $this->config('min'),
+            'max'  => $this->config('max'),
+            'step' => $this->config('step'),
+        ];
+    }
     public function preProcess($data)
     {
         if ($data === null) {
@@ -82,6 +105,14 @@ class Integer extends Fieldtype
 
         if ($min = $this->config('min')) {
             $rules[] = 'min:'.$min;
+        }
+
+        if ($max = $this->config('max')) {
+            $rules[] = 'max:'.$max;
+        }
+
+        if ($step = $this->config('step')) {
+            $rules[] = 'multiple_of:'.$step;
         }
 
         return $rules;


### PR DESCRIPTION
Addresses statamic/ideas#1368 and statamic/ideas#1092

This PR introduces support for the native HTML `min`, `max`, and `step` attributes to the Integer fieldtype:
- Adds `min`, `max`, and `step` options to the blueprint builder UI.
- Renders the attributes in the field's HTML view.
- Renders the attributes in the field's Vue rendering.

## Important note

I've done my best to follow the existing patterns in the codebase, but as I'm not deeply familiar with all of Statamic's architecture and do not currently have time to test my changes in a sandbox.
However, since the changes seem pretty straightforward, I thought it best to still create a PR with this message included; please excuse me for the break in protocol.

Thanks!

