### PR TITLE
[6.x] Change from text-balance to text-pretty

### DIFF
--- a/resources/js/components/ui/Subheading.vue
+++ b/resources/js/components/ui/Subheading.vue
@@ -8,7 +8,7 @@ const props = defineProps({
 });
 
 const classes = cva({
-    base: 'text-gray-600 text-balance tracking-tight dark:text-gray-400 [&_code]:text-xs [&_code]:bg-gray-600/10 [&_code]:rounded-sm [&_code]:px-1 [&_code]:py-0.5',
+    base: 'text-gray-600 text-pretty tracking-tight dark:text-gray-400 [&_code]:text-xs [&_code]:bg-gray-600/10 [&_code]:rounded-sm [&_code]:px-1 [&_code]:py-0.5',
     variants: {
         size: {
             sm: 'text-xs',


### PR DESCRIPTION
As written in https://github.com/statamic/cms/discussions/12093#discussioncomment-14315516 I suggests changing subheadings to text-pretty instead of text-balance.

<img width="517" height="304" alt="Bildschirmfoto 2025-09-11 um 11 05 55" src="https://github.com/user-attachments/assets/bdc387e0-c217-450a-92f2-5a5cb34d7543" />

<img width="527" height="316" alt="Bildschirmfoto 2025-09-11 um 11 06 34" src="https://github.com/user-attachments/assets/254c40a9-47fd-4156-b80c-babab3506bb0" />

<img width="526" height="314" alt="Bildschirmfoto 2025-09-11 um 11 06 13" src="https://github.com/user-attachments/assets/4b6539c9-5ddd-4068-a247-8c62f1de2de9" />
