### PR TITLE
[6.x] Fix position of revisions "View History" button

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -138,7 +138,6 @@
                                         icon="history"
                                         :text="__('View History')"
                                         size="xs"
-                                        class="-me-4"
                                     />
                                 </PanelHeader>
                                 <Card class="space-y-2">


### PR DESCRIPTION
Fixes #12402

## Before
<img width="350" height="170" alt="CleanShot 2025-09-11 at 12 05 02" src="https://github.com/user-attachments/assets/460963a1-fb4c-4bda-a372-e85a1e97f0d8" />


## After

<img width="350" height="170" alt="CleanShot 2025-09-11 at 12 04 50" src="https://github.com/user-attachments/assets/72d4e6e5-ca55-41bf-b6a4-a5743a3d7a40" />
