### PR TITLE
[6.x] Fix locales dictionary on Windows

### DIFF
--- a/src/Dictionaries/Locales.php
+++ b/src/Dictionaries/Locales.php
@@ -17,7 +17,7 @@ class Locales extends BasicDictionary
 
     protected function getItems(): array
     {
-        $output = Process::run(['locale', '-a']);
+        $output = Process::run($this->buildLocalesCommand());
 
         return collect(explode(PHP_EOL, $output))
             ->map(fn ($locale) => Str::before($locale, '.'))
@@ -27,5 +27,19 @@ class Locales extends BasicDictionary
             ->values()
             ->map(fn ($locale) => ['name' => $locale])
             ->all();
+    }
+
+    private function buildLocalesCommand(): array
+    {
+        if (windows_os()) {
+            return [
+                'powershell',
+                '-NoProfile',
+                '-Command',
+                '[System.Globalization.CultureInfo]::GetCultures([System.Globalization.CultureTypes]::InstalledWin32Cultures) | ForEach-Object { $_.Name }',
+            ];
+        }
+
+        return ['locale', '-a'];
     }
 }


### PR DESCRIPTION
This pull request fixes the locale dictionary on Windows.

We're using `locale -a` to get a list of installed locales on macOS and Linux, however that command doesn't exist on Windows so we need to use a different one installed.

While PHP _does_ have a `ResourceBundle::getLocales()` method, it returns _all_ locales, not just the ones installed on the current system.

Fixes #12393.