### PR TITLE
[6.x] Breadcrumb hover padding

### DIFF
--- a/resources/views/partials/global-header.blade.php
+++ b/resources/views/partials/global-header.blade.php
@@ -57,7 +57,7 @@
         <div class="items-center gap-2 hidden md:flex" data-global-header-breadcrumbs>
             @foreach($breadcrumbs as $breadcrumb)
                 <span class="text-gray-500">/</span>
-                <ui-button href="{{ $breadcrumb->url() }}" text="{{ __($breadcrumb->text()) }}" size="sm" variant="ghost"></ui-button>
+                <ui-button href="{{ $breadcrumb->url() }}" text="{{ __($breadcrumb->text()) }}" size="sm" variant="ghost" class="px-2! mr-1.75"></ui-button>
                 @if($breadcrumb->hasLinks() || $breadcrumb->createUrl())
                     <ui-dropdown v-cloak class="relative" aria-label="{{ __('More options for') }} {{ __($breadcrumb->text()) }}">
                         <template #trigger>


### PR DESCRIPTION
This improves the hover state/space for the breadcrumbs.

## Before

Currently, when you hover over a breadcrumb item, the hover state overlaps the dropdown next to it
 
![before-hover](https://github.com/user-attachments/assets/89ab3916-58b8-40d4-b559-3415335fe84f)

## After

Now there is a gap between the button and the dropdown, which looks neater, and also improves the dropdown hover target

![after-hover](https://github.com/user-attachments/assets/2399c111-21f4-4513-b76c-f5779fe2af34)
