### PR TITLE
[6.x] Fix field label tooltip

### DIFF
--- a/resources/js/components/ui/Publish/Field.vue
+++ b/resources/js/components/ui/Publish/Field.vue
@@ -216,7 +216,7 @@ const fieldtypeComponentEvents = computed(() => ({
             <template #label v-if="shouldShowLabel">
                 <Label :for="fieldId" :required="isRequired">
                     <template v-if="shouldShowLabelText">
-                        <Tooltip :text="config.handle" :delay="1000">
+                        <Tooltip :text="config.handle" :delay="1000" as="span">
                             {{ __(config.display) }}
                         </Tooltip>
                     </template>


### PR DESCRIPTION
This pull request fixes the tooltip when hovering on field labels. Looks like it was caused by ea5d9cb.

Closes #12404