### PR TITLE
[6.x] Fix double svg in icon component

### DIFF
--- a/resources/js/components/ui/Icon/Icon.vue
+++ b/resources/js/components/ui/Icon/Icon.vue
@@ -8,6 +8,7 @@ const props = defineProps({
 });
 
 const svgContent = ref('');
+const iconComponent = computed(() => ({ template: svgContent.value }));
 
 const loadIcon = async () => {
     if (props.name.startsWith('<svg')) {
@@ -65,9 +66,9 @@ watch(
 </script>
 
 <template>
-    <svg
+    <component
         v-if="svgContent"
-        v-html="svgContent"
+        :is="iconComponent"
         :class="['size-4 shrink-0']"
         v-bind="$attrs"
     />


### PR DESCRIPTION
In #12286 the Icon.vue component changed from using async components to an svg in the template. This unintentionally caused a double svg.

This PR goes back to an anonymous component so the svg is rendered as-is.
