### PR TITLE
[6.x] Tone down global search background opacity so it works better with different colors

### DIFF
--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -239,7 +239,7 @@ const modalClasses = cva({
         <DialogTrigger>
             <div class="
                 data-[focus-visible]:outline-focus hover flex cursor-text items-center gap-x-1.5 group h-8
-                rounded-lg [button:has(>&)]:rounded-md bg-black/40 text-xs text-white/60 outline-none
+                rounded-lg [button:has(>&)]:rounded-md bg-black/15 text-xs text-white/70 outline-none
                 border-b border-b-white/20 inset-shadow-sm inset-shadow-black/20
                 md:w-32 md:py-[calc(5/16*1rem)] md:px-2
                 hover:bg-black/45 hover:text-white/70


### PR DESCRIPTION
This PR makes the global search bar less opaque so it's more subtle with global header theming

## Before
![2025-09-11 at 15 58 22@2x](https://github.com/user-attachments/assets/140f305c-bc13-4a2e-be7b-1892605664a7)

## After
![2025-09-11 at 15 56 34@2x](https://github.com/user-attachments/assets/03f77399-562c-486d-954d-c72510cdd850)

## Before (default black theme)
![2025-09-11 at 15 59 02@2x](https://github.com/user-attachments/assets/455802d8-1ac3-4e6e-974d-cb69188441e8)

## After (default black theme)

![2025-09-11 at 15 55 09@2x](https://github.com/user-attachments/assets/f3c57383-4b67-4bda-86d2-978b6566ac63)
