### PR TITLE
[6.x] Allow spatie error solutions v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "rebing/graphql-laravel": "^9.8",
         "rhukster/dom-sanitizer": "^1.0.6",
         "spatie/blink": "^1.3",
-        "spatie/error-solutions": "^2.0",
+        "spatie/error-solutions": "^1.0 || ^2.0",
         "statamic/stringy": "^3.1.2",
         "stillat/blade-parser": "^2.0",
         "symfony/lock": "^7.0.3",


### PR DESCRIPTION
Continuation of #12385. Since most sites require spatie/laravel-ignition, we need to support v1 of error-solutions. Ignition still requires v1.
