### PR TITLE
[6.x] Fix licensing table

### DIFF
--- a/resources/views/licensing.blade.php
+++ b/resources/views/licensing.blade.php
@@ -130,6 +130,7 @@
                                                     </ui-badge>
                                                 </div>
                                             @endif
+                                        </div>
                                     </ui-table-cell>
                                     <ui-table-cell>{{ $addon->version() }}</ui-table-cell>
                                     <ui-table-cell class="text-red-700 text-end">{{ $addon->invalidReason() }}</ui-table-cell>


### PR DESCRIPTION
## Before

<img width="1406" height="313" alt="CleanShot 2025-09-13 at 17 11 15" src="https://github.com/user-attachments/assets/96e4e433-6fdc-406d-8a10-a7be9efc392b" />


## After

<img width="1409" height="398" alt="CleanShot 2025-09-13 at 17 11 04" src="https://github.com/user-attachments/assets/bafef671-e6a1-4fc7-a70c-7deeec4a6725" />
