### PR TITLE
[6.x] Optimize PageTree performance issues with larger collections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@davidenke/marked-text-renderer": "^3.0.0",
         "@floating-ui/dom": "^1.6.0",
-        "@he-tree/vue": "^2.8.2",
+        "@he-tree/vue": "^2.10.0-beta.2",
         "@hoppscotch/vue-toasted": "^0.1.0",
         "@internationalized/date": "^3.7.0",
         "@shopify/draggable": "^1.0.0-beta.12",
@@ -851,9 +851,9 @@
       }
     },
     "node_modules/@he-tree/vue": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@he-tree/vue/-/vue-2.9.4.tgz",
-      "integrity": "sha512-n8yycL4fk46mlg6sIkcdSZmSCRvdzqj7Ts14ulKXLqmyR6NyTSnP6O9pj6dPk2S2wJIuX2Ad6MOzpg0qDhlBXA==",
+      "version": "2.10.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@he-tree/vue/-/vue-2.10.0-beta.2.tgz",
+      "integrity": "sha512-YiJx+6HyBW8svUGLZZ2z0QWztFv4BezAoOpkis+mrIp+uUn1YUiA/UrgrIZNPcp5Smx9BiGXedl6J60YFfSuXQ==",
       "license": "MIT",
       "dependencies": {
         "@he-tree/dnd-utils": "^0.1.0-alpha.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@davidenke/marked-text-renderer": "^3.0.0",
     "@floating-ui/dom": "^1.6.0",
-    "@he-tree/vue": "^2.8.2",
+    "@he-tree/vue": "^2.10.0-beta.2",
     "@hoppscotch/vue-toasted": "^0.1.0",
     "@internationalized/date": "^3.7.0",
     "@shopify/draggable": "^1.0.0-beta.12",

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -27,6 +27,7 @@
                     :indent="24"
                     :dir="direction"
                     :node-key="(stat) => stat.data.id"
+                    :dragOverThrottleInterval="30"
                     :each-droppable="eachDroppable"
                     :root-droppable="rootDroppable"
                     :max-level="maxDepth"


### PR DESCRIPTION
Fixes #12245

I submitted a PR at https://github.com/phphe/he-tree/pull/159 and the author has added a configurable `dragOverThrottleInterval` prop in `2.10.0-beta.2` to throttle the underlying dragover event. This should restore v5 performance.

![Image](https://github.com/user-attachments/assets/278796a5-0b22-491b-9fa1-49f961fe7619)