### PR TITLE
[6.x] Textareas should autosize

### DIFF
--- a/packages/ui/src/Textarea.vue
+++ b/packages/ui/src/Textarea.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { cva } from 'cva';
 import CharacterCounter from './CharacterCounter.vue';
+import autosize from 'autosize/dist/autosize.js';
+import { nextTick, onBeforeUnmount, onMounted, useTemplateRef } from 'vue';
 
 defineEmits(['update:modelValue']);
 
@@ -35,11 +37,21 @@ const classes = cva({
         },
     },
 })({ ...props });
+
+const textarea = useTemplateRef('textarea');
+
+onMounted(() => {
+    autosize(textarea.value);
+    setTimeout(() => nextTick(() => autosize.update(textarea.value)), 1);
+});
+
+onBeforeUnmount(() => autosize.destroy(textarea.value));
 </script>
 
 <template>
     <div class="group/input relative block w-full" data-ui-input>
         <textarea
+            ref="textarea"
             :class="classes"
             :rows="rows"
             :id="id"


### PR DESCRIPTION
This pull request brings back the autosizing of textarea inputs, like we had in v5. 

Although, I'm not sure how this behaviour works alongside the `resize` prop, which enables the "dragger" thing in the bottom right corner.

Fixes #12432.

## Before
<img width="1220" height="176" alt="CleanShot 2025-09-15 at 11 00 33" src="https://github.com/user-attachments/assets/b4c45d8d-9f6e-483a-aa33-5dcddf14d0eb" />



## After

<img width="1216" height="408" alt="CleanShot 2025-09-15 at 10 59 54" src="https://github.com/user-attachments/assets/22b178b1-39da-4f84-beba-1422aec0f64b" />
