### PR TITLE
[6.x] Fix icon in field settings stack

### DIFF
--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -5,7 +5,7 @@
         </div>
 
         <header v-if="!loading" class="flex items-center justify-between pl-3">
-            <Heading :text="__(values.display) || __(config.display) || config.handle" size="lg" :icon="fieldtype.icon.startsWith('<svg') ? fieldtype.icon : `fieldtype-${fieldtype.icon}`" />
+            <Heading :text="__(values.display) || __(config.display) || config.handle" size="lg" :icon="fieldtype.icon" />
             <div class="flex items-center gap-3">
                 <Button variant="ghost" :text="__('Cancel')" @click.prevent="close" />
                 <Button variant="primary" @click.prevent="commit()" :text="__('Apply')" />


### PR DESCRIPTION
This pull request fixes an issue where fieldtype icons weren't being displayed in the field setting stack. 

Related to #12291

## Before

<img width="189" height="53" alt="CleanShot 2025-09-15 at 11 34 22" src="https://github.com/user-attachments/assets/f9ebc601-fcf2-4c40-b267-7d10911f84dd" />


## After

<img width="189" height="53" alt="CleanShot 2025-09-15 at 11 33 54" src="https://github.com/user-attachments/assets/485eb2dc-45bc-4738-afac-3c1fc8c5d172" />
