### PR TITLE
[6.x] Validation error shouldn't be thrown when asset container has value

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -817,7 +817,7 @@ class Bard extends Replicator
 
             public function validate(string $attribute, mixed $value, Closure $fail): void
             {
-                if (in_array('image', $this->data['buttons'])) {
+                if (empty($value) && in_array('image', $this->data['buttons'])) {
                     $fail('statamic::validation.bard_container_required_by_button')->translate();
                 }
             }


### PR DESCRIPTION
This pull request fixes an issue where the validation error introduced in #12238 would be thrown even when an asset container was selected.

Partially fixes #12426.