### PR TITLE
[6.x] Fix Grid fieldtype's table mode

### DIFF
--- a/resources/js/components/fieldtypes/grid/Cell.vue
+++ b/resources/js/components/fieldtypes/grid/Cell.vue
@@ -1,15 +1,15 @@
 <template>
     <td class="grid-cell" :class="classes" :width="width">
-        <PublishField :config="field" />
+        <Field :config="field" />
     </td>
 </template>
 
 <script>
-import { PublishField } from '@ui';
+import { PublishField as Field } from '@ui';
 
 export default {
     components: {
-        PublishField,
+        Field,
     },
 
     props: {


### PR DESCRIPTION
This pull request fixes an issue where fields weren't rendering in the Grid fieldtype's table mode, due to the wrong `Field` component being imported.