### PR TITLE
[6.x] Add `cursor-pointer` to Create Form links

### DIFF
--- a/packages/ui/src/EmptyState/Item.vue
+++ b/packages/ui/src/EmptyState/Item.vue
@@ -31,7 +31,7 @@ const hasSlot = !!slots.default;
         <component
             :is="hasSlot ? 'div' : (href ? 'a' : 'button')"
             :href="href"
-            class="w-full flex gap-2 px-3 pt-4 pb-5.5 items-start hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md group"
+            class="w-full flex gap-2 px-3 pt-4 pb-5.5 items-start hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md group cursor-pointer"
         >
             <Icon :name="icon" class="size-6 me-4 mt-1 text-gray-400" />
             <div class="flex-1 mb-4 md:mb-0 me-6 text-start">


### PR DESCRIPTION
This pull request adds the `cursor-pointer` class to create form items, ensuring the same cursor style is used on `<button>` elements as `<a>` elements.