### PR TITLE
[6.x] "Imported from: ..." translation should include variable

### DIFF
--- a/resources/js/components/blueprints/RegularField.vue
+++ b/resources/js/components/blueprints/RegularField.vue
@@ -12,7 +12,7 @@
                     <div class="flex items-center gap-2">
                         <button class="cursor-pointer overflow-hidden text-ellipsis text-sm hover:text-blue-600" type="button" v-text="__(labelText)" @click="$emit('edit')" />
                         <ui-icon v-if="isReferenceField" name="link" class="text-gray-400" />
-                        <span v-if="isReferenceField" class="text-gray-500 font-mono text-2xs cursor-help" v-text="__('field')" v-tooltip="__('Imported from: ') + field.field_reference" />
+                        <span v-if="isReferenceField" class="text-gray-500 font-mono text-2xs cursor-help" v-text="__('field')" v-tooltip="__('Imported from: :reference', { reference: field.field_reference })" />
                     </div>
                 </div>
                 <div class="flex items-center gap-2">


### PR DESCRIPTION
The translation in #12441 wasn't working due to it not including the leading space.

However, we probably shouldn't be concatenating things onto translations like this. The translation should include the reference.

