### PR TITLE
[6.x] Fix adding nav items from empty state

### DIFF
--- a/resources/js/components/navigation/View.vue
+++ b/resources/js/components/navigation/View.vue
@@ -89,7 +89,7 @@
                         icon="fieldtype-link"
                         :heading="__('Link to URL')"
                         :description="__('messages.navigation_link_to_url_instructions')"
-                        @click="linkPage"
+                        @click="linkPage()"
                     />
 
                     <EmptyStateItem

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -1,10 +1,10 @@
 <template>
     <div>
-        <div v-if="!loading && pages.length == 0" class="no-results flex w-full items-center">
+        <div v-if="!loading && treeData.length == 0" class="no-results flex w-full items-center">
             <slot name="empty" />
         </div>
 
-        <ui-panel v-show="pages.length">
+        <ui-panel v-show="treeData.length">
             <div class="loading card" v-if="loading">
                 <Icon name="loading" />
             </div>


### PR DESCRIPTION
This pull request fixes two issues when adding nav items from the empty state:

* An error would be thrown when attempting to add a link from URL. 
  * Without the parentheses, the click event was being passed as the item's parent, which was breaking things. We were using the parentheses in v5.
* After adding a nav item, the empty state would continue to show and the tree would stay hidden.
  * This is because we were checking the length of `pages` (the initial, committed state), rather than `treeData` (the WIP state v-modelled to the tree)